### PR TITLE
revert blas_openblas feature patches

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -258,16 +258,19 @@ def _patch_repodata(repodata, subdir):
             depends = record["depends"]
             depends.append("_r-mutex 1.* anacondar_1")
             instructions["packages"][fn]["depends"] = depends
-        if record_name == "blas" and record["track_features"] == "blas_openblas":
-            instructions["packages"][fn]["track_features"] = None
-        if "features" in record:
-            if "blas_openblas" in record["features"]:
-                # remove blas_openblas feature
-                instructions["packages"][fn]["features"] = _extract_feature(record, "blas_openblas")
-                if not any(d.startswith("blas ") for d in record["depends"]):
-                    depends = record['depends']
-                    depends.append("blas 1.* openblas")
-                    instructions["packages"][fn]["depends"] = depends
+        # FIXME: disable patching-out blas_openblas feature
+        # because hotfixes are not applied to gcc7 label
+        # causing inconsistent behavior
+        # if record_name == "blas" and record["track_features"] == "blas_openblas":
+        #     instructions["packages"][fn]["track_features"] = None
+        # if "features" in record:
+            # if "blas_openblas" in record["features"]:
+            #     # remove blas_openblas feature
+            #     instructions["packages"][fn]["features"] = _extract_feature(record, "blas_openblas")
+            #     if not any(d.startswith("blas ") for d in record["depends"]):
+            #         depends = record['depends']
+            #         depends.append("blas 1.* openblas")
+            #         instructions["packages"][fn]["depends"] = depends
         if "track_features" in record:
             for feat in record["track_features"].split():
                 if feat.startswith(("rb2", "openjdk")):

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: conda-forge-repodata-patches
-  version: 20180828
+  version: 20181205
 
 source:
   path: .


### PR DESCRIPTION
since only the main channel (no labels) is hotfixed, this results in inconsistent installation behavior for the gcc7 channel where blas still has `track_features`.

As it is now, new builds on main *must* remove the `blas_openblas` feature to be installed, and builds on gcc7 *must not* remove the `blas_openblas` feature, which is likely to cause problems.

This should be temporary, as when the gcc7 channel is promoted to main, the hotfix should be able to go back in, or we can wait for one of the other blas 2.x proposals to remove track_features.


<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->