### PR TITLE
just bump the version

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: conda-forge-repodata-patches
-  version: 20180828
+  version: 20181205
 
 source:
   path: .


### PR DESCRIPTION
to apply hotfix to current packages

Alternative to #3 if that requires more discussion. This just rerenders the same patches so that packages with blas_openblas built since August are installable.

This isn't sustainable, though, as this will need to be re-published after every build of a package that still has the `blas_openblas` feature. And since the `gcc7` label doesn't get patched, the recipes can't remove `blas_openblas` yet.