### PR TITLE
Fix libspatialindex pin

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -279,6 +279,10 @@ def _gen_new_index(repodata, subdir):
         if "ntl" in deps and record_name != "sage":
             _rename_dependency(fn, record, "ntl", "ntl 10.3.0")
 
+        deps = record.get("depends", ())
+        if "libspatialindex" in deps:
+            _rename_dependency(fn, record, "libspatialindex", "libspatialindex 1.8")
+
         # FIXME: disable patching-out blas_openblas feature
         # because hotfixes are not applied to gcc7 label
         # causing inconsistent behavior
@@ -325,6 +329,35 @@ def _rename_dependency(fn, record, old_name, new_name):
 
 
 def _fix_libgfortran(fn, record):
+    depends = record.get("depends", ())
+    dep_idx = next(
+        (q for q, dep in enumerate(depends)
+         if dep.split(' ')[0] == "libgfortran"),
+        None
+    )
+    if dep_idx is not None:
+        # make sure respect minimum versions still there
+        # 'libgfortran'         -> >=3.0.1,<4.0.0.a0
+        # 'libgfortran ==3.0.1' -> ==3.0.1
+        # 'libgfortran >=3.0'   -> >=3.0,<4.0.0.a0
+        # 'libgfortran >=3.0.1' -> >=3.0.1,<4.0.0.a0
+        if ("==" in depends[dep_idx]) or ("<" in depends[dep_idx]):
+            pass
+        elif depends[dep_idx] == "libgfortran":
+            depends[dep_idx] = "libgfortran >=3.0.1,<4.0.0.a0"
+            record['depends'] = depends
+        elif ">=3.0.1" in depends[dep_idx]:
+            depends[dep_idx] = "libgfortran >=3.0.1,<4.0.0.a0"
+            record['depends'] = depends
+        elif ">=3.0" in depends[dep_idx]:
+            depends[dep_idx] = "libgfortran >=3.0,<4.0.0.a0"
+            record['depends'] = depends
+        elif ">=4" in depends[dep_idx]:
+            # catches all of 4.*
+            depends[dep_idx] = "libgfortran >=4.0.0,<5.0.0.a0"
+            record['depends'] = depends
+
+def _fix_libnetcdf(fn, record):
     depends = record.get("depends", ())
     dep_idx = next(
         (q for q, dep in enumerate(depends)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: conda-forge-repodata-patches
-  version: 20190212
+  version: 20190318
 
 source:
   path: .


### PR DESCRIPTION
This is probably not correct but I wanted to send something to start a conversation.

The problem is, we never pinned `libspatialindex` in the past b/c there weren't new versions of it, the project seemed dead. However, thanks to @hobu, the project is back and we have new versions! So, before merging [`libspatialindex 1.9.0`](https://github.com/conda-forge/libspatialindex-feedstock/pull/18), we need to fix the unpinned packages we have to make sure they won't pull version `1.9.0` and break things.