### PR TITLE
Make existing python and python-dependent packages depend on python_abi

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -332,6 +332,14 @@ def get_python_abi(version, subdir):
     return "cp*"
 
 
+# Workaround for https://github.com/conda/conda-build/pull/3868
+def remove_python_abi(record):
+    if not has_dep(record, 'python_abi'):
+        return
+    depends = record.get('depends', [])
+    record['depends'] = [dep for dep in depends if dep.split(" ")[0] != "python_abi"]
+
+
 changes = set([])
 
 def add_python_abi(record, subdir):
@@ -420,7 +428,9 @@ def _gen_new_index(repodata, subdir):
     for fn, record in index.items():
         record_name = record["name"]
 
-        if subdir != 'noarch':
+        if subdir == 'noarch':
+            remove_python_abi(record)
+        else:
             add_python_abi(record, subdir)
 
         # remove dependency from constrains for twisted

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -306,6 +306,10 @@ def _gen_patch_instructions(index, new_index, subdir):
     return instructions
 
 
+def has_dep(record, name):
+    return any(dep.split(' ')[0] == name for dep in record.get('depends', ()))
+
+
 def _gen_new_index(repodata, subdir):
     """Make any changes to the index by adjusting the values directly.
 
@@ -350,6 +354,11 @@ def _gen_new_index(repodata, subdir):
     proj4_fixes = {"cartopy", "cdo", "gdal", "libspatialite", "pynio", "qgis"}
     for fn, record in index.items():
         record_name = record["name"]
+
+        # Make existing python and python-dependent packages conflict with pypy
+        if record_name == "python" or (has_dep(record, 'python') and not has_dep(record, 'pypy')):
+            new_constrains = record.get('constrains', [])
+            new_constrains.append('pypy <0a0')
 
         # remove dependency from constrains for twisted
         if record_name == "twisted":

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -14,14 +14,14 @@ import requests
 CHANNEL_NAME = "conda-forge"
 CHANNEL_ALIAS = "https://conda-web.anaconda.org"
 SUBDIRS = (
-    "noarch",
+    #"noarch",
     "linux-64",
-    "linux-armv7l",
-    "linux-aarch64",
-    "linux-ppc64le",
-    "osx-64",
-    "win-32",
-    "win-64",
+    #"linux-armv7l",
+    #"linux-aarch64",
+    #"linux-ppc64le",
+    #"osx-64",
+    #"win-32",
+    #"win-64",
 )
 
 REMOVALS = {
@@ -334,6 +334,8 @@ def get_python_abi(version, subdir):
 
 # Workaround for https://github.com/conda/conda-build/pull/3868
 def remove_python_abi(record):
+    if record['name'] in ['python', 'python_abi', 'pypy']:
+        return
     if not has_dep(record, 'python_abi'):
         return
     depends = record.get('depends', [])

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: conda-forge-repodata-patches
-  version: 20200126
+  version: 20200131
   
 source:
   path: .

--- a/recipe/test_gen_patch_json.py
+++ b/recipe/test_gen_patch_json.py
@@ -1,5 +1,5 @@
-from gen_patch_json import _gen_patch_instructions, REMOVALS
-
+from gen_patch_json import _gen_patch_instructions, REMOVALS, add_python_abi
+import copy
 
 def test_gen_patch_instructions():
     index = {
@@ -27,3 +27,65 @@ def test_gen_patch_instructions():
         'c': {'addthis': 'yes'}}
 
     assert inst['remove'] == list(REMOVALS['osx-64'])
+
+
+def test_add_python_abi():
+    conditions = {
+        'python >=2.7,<2.8.0a0': 'cp27mu',
+        'python 3.5.*': 'cp35m',
+        'python >=3.8.0a,<3.9.0a0': 'cp38',
+        'python 3.5*': 'cp35m',
+        'python 2.7*': 'cp27mu',
+        'python >=3.6': 'cp*',
+        'python >=3.7,<3.8.0a0': 'cp37m',
+        'python >=2.7,<3': 'cp*',
+        'python >=3.5,<3.6.0a0': 'cp35m',
+        'python 3.7.*': 'cp37m',
+        'python 2.6*': 'cp26mu',
+        'python': 'cp*',
+        'python 2.7.*': 'cp27mu',
+        'python 3.6*': 'cp36m',
+        'python >=3.8,<3.9.0a0': 'cp38',
+        'python 3.8.*': 'cp38',
+        'python 3.6.*': 'cp36m',
+        'python >=3.6.1': 'cp*',
+        'python >=3.5': 'cp*',
+        'python >=3.4': 'cp*',
+        'python <3': 'cp27mu',
+        'python 3.4*': 'cp34m',
+        'python >=2.7,<3.5': 'cp*',
+        'python >=3.6,<3.7.0a0': 'cp36m',
+        'python >=2.7': 'cp*',
+        'python >=3.3': 'cp*',
+    }
+    for condition, tag in conditions.items():
+        record_orig = {
+            "name": "foo",
+            "depends": [f"{condition}"],
+        }
+        record = copy.deepcopy(record_orig)
+        add_python_abi(record, "linux-64")
+        print(record, condition, tag)
+        assert record["constrains"] == [f"python_abi * {tag}"]
+
+        record = copy.deepcopy(record_orig)
+        add_python_abi(record, "osx-64")
+        if tag == "cp27mu" or tag == "cp26mu":
+            assert record["constrains"] == [f"python_abi * {tag[:-1]}"]
+        else:
+            assert record["constrains"] == [f"python_abi * {tag}"]
+
+    python_record = {
+        "name": "python",
+        "version": "3.6.8",
+    }
+    add_python_abi(python_record, "osx-64")
+    assert python_record["constrains"] == [f"python_abi * cp36m"]
+
+    exact_record = {
+        "name": "foo",
+        "depends": ["python 3.6.7 h12312"],
+    }
+    add_python_abi(exact_record, "osx-64")
+    assert exact_record["constrains"] == []
+


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
