### PR TITLE
hotfix distributed <2.11.0 to bound msgpack-python

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -455,6 +455,15 @@ def _gen_new_index(repodata, subdir):
             if new_constrains != record.get('constrains', ()):
                 record['constrains'] = new_constrains
 
+        # distributed <2.11.0 does not work with msgpack-python >=1.0
+        # newer versions of distributed require at least msgpack-python >=0.6.0
+        # so we can fix cases where msgpack-python is unbounded
+        # https://github.com/conda-forge/distributed-feedstock/pull/114
+        if record_name == 'distributed'
+            if 'msgpack-python' in record['depends']:
+                i = record['depends'].index('msgpack-python')
+                record['depends'][i] = 'msgpack-python <1.0.0'
+
         # fix deps with wrong names
         if record_name in proj4_fixes:
             _rename_dependency(fn, record, "proj.4", "proj4")

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -459,7 +459,7 @@ def _gen_new_index(repodata, subdir):
         # newer versions of distributed require at least msgpack-python >=0.6.0
         # so we can fix cases where msgpack-python is unbounded
         # https://github.com/conda-forge/distributed-feedstock/pull/114
-        if record_name == 'distributed'
+        if record_name == 'distributed':
             if 'msgpack-python' in record['depends']:
                 i = record['depends'].index('msgpack-python')
                 record['depends'][i] = 'msgpack-python <1.0.0'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,13 @@
 package:
   name: conda-forge-repodata-patches
-  version: 20200211
+  version: 20200226
 
 source:
   path: .
 
 build:
   noarch: generic
-  number: 2
+  number: 0
   script:
     - python gen_patch_json.py
 


### PR DESCRIPTION
Adjust the requirements of distributed <2.11.0 to bound msgpack-python
to less than 1.0.0

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
