### PR TITLE
Pin abseil-cpp retroactively

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -511,6 +511,10 @@ def _gen_new_index(repodata, subdir):
             i = record['depends'].index('snappy >=1.1.7,<1.1.8.0a0')
             record['depends'][i] = 'snappy >=1.1.7,<2.0.0.0a0'
 
+        if 'abseil-cpp' in deps:
+            i = record['depends'].index('abseil-cpp')
+            record['depends'][i] = 'abseil-cpp =20190808'
+
         # remove features for openjdk and rb2
         if ("track_features" in record and
                 record['track_features'] is not None):

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: conda-forge-repodata-patches
-  version: 20200226
+  version: 20200305
 
 source:
   path: .


### PR DESCRIPTION
Abseil has no ABI compatability at all: https://abseil.io/about/compatibility

There is a new release https://github.com/conda-forge/abseil-cpp-feedstock/pull/9 where we will introduce a matching `run_exports`.

I will also make a PR to conda-forge-pinning.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
