### PR TITLE
Add script to check proposed changes to repodata

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -14,7 +14,7 @@ import requests
 from get_license_family import get_license_family
 
 CHANNEL_NAME = "conda-forge"
-CHANNEL_ALIAS = "https://conda-web.anaconda.org"
+CHANNEL_ALIAS = "https://conda.anaconda.org"
 SUBDIRS = (
     "noarch",
     "linux-64",
@@ -747,7 +747,7 @@ def main():
         subdirs = SUBDIRS
     for subdir in tqdm.tqdm(subdirs, desc="Downloading repodata"):
         repodata_url = "/".join(
-            (CHANNEL_ALIAS, CHANNEL_NAME, subdir, "repodata.json"))
+            (CHANNEL_ALIAS, CHANNEL_NAME, subdir, "repodata_from_packages.json"))
         response = requests.get(repodata_url)
         response.raise_for_status()
         repodatas[subdir] = response.json()

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -569,9 +569,6 @@ def _gen_new_index(repodata, subdir):
             full_pkg_name = fn.replace('.tar.bz2', '')
             if full_pkg_name in OSX_SDK_FIXES:
                 _set_osx_virt_min(fn, record, OSX_SDK_FIXES[full_pkg_name])
-    print("python ABI changes")
-    for change in changes:
-        print(change)
     return index
 
 

--- a/recipe/readme.md
+++ b/recipe/readme.md
@@ -1,4 +1,4 @@
-This scheme is ultimately meant to generate one file per subdir, ``patch_instructions.json``.  That file has entries by
+This scheme generates one file per subdir, ``patch_instructions.json``.  This file has entries
 
 ```
 instructions = {
@@ -9,10 +9,37 @@ instructions = {
     }
 ```
 
-```revoke``` and ```remove``` are lists of filenames.  ```remove``` makes the file not show up in the index (it may still be downloadable with a direct URL to the file).  ```revoke``` makes packages uninstallable by adding an unsatisfiable dependency.  This can be made installable by including a channel that has that package (to be created by @jjhelmus).
+``remove`` are lists of filenames that will not show up in the index but may still be downloadable with a direct URL to the file.
 
 ``packages`` is a dictionary, where keys are package filenames.  Values are dictionaries similar to the contents of each package in repodata.json.  Any values in provided in ``packages`` here overwrite the values in repodata.json.  Any value set to None is removed.
 
-A tool on our end will download this package when it sees updates to it, and will apply the patch_instructions.json to the repodata for the static repodata mirror that @kalefranz has proposed.
+A tool downloads this package when it sees updates to it, and apples the ``patch_instructions.json``
+to the repodata of the conda-forge channel on anaconda.org
 
-cc @conda-forge/core - I tried to add everyone to maintainers.  My apologies if I overlooked anyone.
+The ``show_diff.py`` script in this directory can be used to test out
+modifications to ``gen_patch_json.py``.  This scripts shows the difference
+between the package records currently available on anaconda.org/conda-forge and those
+produced from the patch instructions produced by ``gen_patch_json.py``.
+
+Usage is:
+
+```
+usage: show_diff.py [-h] [--subdirs [SUBDIRS [SUBDIRS ...]]] [--use-cache]
+
+show repodata changes from the current gen_patch_json
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --subdirs [SUBDIRS [SUBDIRS ...]]
+                        subdir(s) show, default is all
+  --use-cache           use cached repodata files, rather than downloading
+                        them
+
+```
+
+Repodata is cached in a ``cache`` directory in the current directory or in the
+path specified by the ``CACHE_DIR`` environment variable.
+
+Typically ``show_diff.py`` is run without any argument to download the
+necessary repodata followed by repeated calls to ``show_diff.py --use-cache``
+to test out changes to the ``gen_patch_json.py`` script.

--- a/recipe/show_diff.py
+++ b/recipe/show_diff.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+
+import bz2
+import difflib
+import json
+import os
+import urllib
+
+from gen_patch_json import _gen_new_index, _gen_patch_instructions, SUBDIRS
+
+from conda_build.index import _apply_instructions
+
+CACHE_DIR = os.environ.get("CACHE_DIR", "cache")
+BASE_URL = "https://conda.anaconda.org/conda-forge"
+
+
+def show_record_diffs(subdir, ref_repodata, new_repodata):
+    for name, ref_pkg in ref_repodata["packages"].items():
+        new_pkg = new_repodata["packages"][name]
+        # license_family gets added for new packages, ignore it in the diff
+        ref_pkg.pop("license_family", None)
+        new_pkg.pop("license_family", None)
+        if ref_pkg == new_pkg:
+            continue
+        print(f"{subdir}::{name}")
+        ref_lines = json.dumps(ref_pkg, indent=2).splitlines()
+        new_lines = json.dumps(new_pkg, indent=2).splitlines()
+        for l in difflib.unified_diff(ref_lines, new_lines, n=0, lineterm=''):
+            if l.startswith('+++') or l.startswith('---') or l.startswith('@@'):
+                continue
+            print(l)
+
+
+def do_subdir(subdir, raw_repodata_path, ref_repodata_path):
+    with bz2.open(raw_repodata_path) as fh:
+        raw_repodata = json.load(fh)
+    with bz2.open(ref_repodata_path) as fh:
+        ref_repodata = json.load(fh)
+    new_index = _gen_new_index(raw_repodata, subdir)
+    instructions = _gen_patch_instructions(raw_repodata['packages'], new_index, subdir)
+    new_repodata = _apply_instructions(subdir, raw_repodata, instructions)
+    show_record_diffs(subdir, ref_repodata, new_repodata)
+
+
+def download_subdir(subdir, raw_repodata_path, ref_repodata_path):
+    raw_url = f"{BASE_URL}/{subdir}/repodata_from_packages.json.bz2"
+    print("Downloading:", raw_url)
+    urllib.request.urlretrieve(raw_url, raw_repodata_path)
+    ref_url = f"{BASE_URL}/{subdir}/repodata.json.bz2"
+    print("Downloading:", ref_url)
+    urllib.request.urlretrieve(ref_url, ref_repodata_path)
+
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser(
+        description="show repodata changes from the current gen_patch_json")
+    parser.add_argument(
+        '--subdirs', nargs='*', default=None,
+        help='subdir(s) show, default is all')
+    parser.add_argument(
+        '--use-cache', action='store_true',
+        help='use cached repodata files, rather than downloading them')
+    args = parser.parse_args()
+
+    if args.subdirs is None:
+        subdirs = SUBDIRS
+    else:
+        subdirs = args.subdirs
+
+    for subdir in subdirs:
+        subdir_dir = os.path.join(CACHE_DIR, subdir)
+        if not os.path.exists(subdir_dir):
+            os.makedirs(subdir_dir)
+        raw_repodata_path = os.path.join(subdir_dir, "repodata_from_packages.json.bz2")
+        ref_repodata_path = os.path.join(subdir_dir, "repodata.json.bz2")
+        if not args.use_cache:
+            download_subdir(subdir, raw_repodata_path, ref_repodata_path)
+        do_subdir(subdir, raw_repodata_path, ref_repodata_path)


### PR DESCRIPTION
Adds a `show_diff.py` script that shows the differences in package record between applying the patch instructions generated from the local `gen_patch_json.py` script and the those in the repodata from anaconda.org.

This is helpful to verify that local changes will have the desired effect on repodata.