### PR TITLE
add upper bound on pyflakes to python-lang.-server

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -483,10 +483,10 @@ def _gen_new_index(repodata, subdir):
         # included explicitly in 0.31.10+
         # https://github.com/conda-forge/python-language-server-feedstock/pull/50
         version = record['version']
-        pversion = pkg_resources.parse_version(version)
-        v0_31_9 = pkg_resources.parse_version('0.31.9')
-        if record_name == 'python-language-server' and pversion <= v0_31_9:
-            if 'pyflakes >=1.6.0' in record['depends']:
+        if record_name == 'python-language-server':
+            pversion = pkg_resources.parse_version(version)
+            v0_31_9 = pkg_resources.parse_version('0.31.9')
+            if pversion <= v0_31_9 and 'pyflakes >=1.6.0' in record['depends']:
                 i = record['depends'].index('pyflakes >=1.6.0')
                 record['depends'][i] = 'pyflakes >=1.6.0,<2.2.0'
 

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -10,6 +10,7 @@ import sys
 import tqdm
 import re
 import requests
+import pkg_resources
 
 from get_license_family import get_license_family
 
@@ -477,6 +478,17 @@ def _gen_new_index(repodata, subdir):
             if 'msgpack-python' in record['depends']:
                 i = record['depends'].index('msgpack-python')
                 record['depends'][i] = 'msgpack-python <1.0.0'
+
+        # python-language-server <=0.31.9 requires pyflakes <2.2.2
+        # included explicitly in 0.31.10+
+        # https://github.com/conda-forge/python-language-server-feedstock/pull/50
+        version = record['version']
+        pversion = pkg_resources.parse_version(version)
+        v0_31_9 = pkg_resources.parse_version('0.31.9')
+        if record_name == 'python-language-server' and pversion <= v0_31_9:
+            if 'pyflakes >=1.6.0' in record['depends']:
+                i = record['depends'].index('pyflakes >=1.6.0')
+                record['depends'][i] = 'pyflakes >=1.6.0,<2.2.0'
 
         # fix deps with wrong names
         if record_name in proj4_fixes:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,6 +16,7 @@ build:
 requirements:
   build:
     - python 3.*
+    - setuptools
     - requests
     - tqdm
     - license-expression


### PR DESCRIPTION
Add an upper bound on pyflakes <2.2.2 to the python-language-server
packages below version 0.31.10.