### PR TITLE
Relax libssh2 1.x pin to >=1.8.0,<2.0.0a

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -514,6 +514,8 @@ def _gen_new_index(repodata, subdir):
         if "ntl" in deps and record_name != "sage":
             _rename_dependency(fn, record, "ntl", "ntl 10.3.0")
 
+        _relax_libssh2_1_x_pinning(fn, record)
+
         if any(dep.startswith("gf2x") for dep in deps):
             _pin_stricter(fn, record, "gf2x", "x.x")
 
@@ -691,6 +693,31 @@ def _relax_exact(fn, record, fix_dep, max_pin=None):
             else:
                 depends[dep_idx] = "{} >={}".format(*dep_parts[:2])
             record['depends'] = depends
+
+
+def _match_strict_libssh2_1_x_pin(dep):
+    if dep.startswith("libssh2 >=1.8.0,<1.9.0a0"):
+        return True
+    if dep.startswith("libssh2 >=1.8.1,<1.9.0a0"):
+        return True
+    if dep.startswith("libssh2 >=1.8.2,<1.9.0a0"):
+        return True
+    if dep.startswith("libssh2 1.8.*"):
+        return True
+
+    return False
+
+
+def _relax_libssh2_1_x_pinning(fn, record):
+    depends = record.get("depends", ())
+    dep_idx = next(
+        (q for q, dep in enumerate(depends)
+         if _match_strict_libssh2_1_x_pin(dep)),
+        None
+    )
+
+    if dep_idx is not None:
+        depends[dep_idx] = "libssh2 >=1.8.0,<2.0.0a0"
 
 
 cb_pin_regex = re.compile(r"^>=(?P<lower>\d(\.\d+)*a?),<(?P<upper>\d(\.\d+)*)a0$")


### PR DESCRIPTION
I took the conservative path and only allowed `>=1.8`, the ABI should support more but the older versions are really old.

I get the following diff for `linux-64`:
<details>

```
linux-64::curl-7.54.1-0.tar.bz2
-    "libssh2 1.8.*",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::curl-7.58.0-0.tar.bz2
-    "libssh2 1.8.*",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::curl-7.58.0-1.tar.bz2
-    "libssh2 1.8.*",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::curl-7.59.0-0.tar.bz2
-    "libssh2 1.8.*",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::curl-7.59.0-1.tar.bz2
-    "libssh2 1.8.*",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::curl-7.59.0-h93b3f91_2.tar.bz2
-    "libssh2 >=1.8.0,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::curl-7.60.0-0.tar.bz2
-    "libssh2 1.8.*",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::curl-7.61.0-h93b3f91_0.tar.bz2
-    "libssh2 >=1.8.0,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::curl-7.61.0-h93b3f91_1.tar.bz2
-    "libssh2 >=1.8.0,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::curl-7.61.0-h93b3f91_2.tar.bz2
-    "libssh2 >=1.8.0,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::curl-7.61.1-h646f8bb_1002.tar.bz2
-    "libssh2 >=1.8.0,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::curl-7.61.1-h74213dd_2.tar.bz2
-    "libssh2 >=1.8.0,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::curl-7.62.0-h646f8bb_1000.tar.bz2
-    "libssh2 >=1.8.0,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::curl-7.62.0-h74213dd_0.tar.bz2
-    "libssh2 >=1.8.0,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::curl-7.63.0-h646f8bb_1000.tar.bz2
-    "libssh2 >=1.8.0,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::curl-7.63.0-h74213dd_0.tar.bz2
-    "libssh2 >=1.8.0,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::curl-7.64.0-h33f0ec9_5.tar.bz2
-    "libssh2 >=1.8.2,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::curl-7.64.0-h646f8bb_0.tar.bz2
-    "libssh2 >=1.8.0,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::curl-7.64.0-h646f8bb_2.tar.bz2
-    "libssh2 >=1.8.0,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::curl-7.64.0-hf8cf82a_4.tar.bz2
-    "libssh2 >=1.8.2,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::curl-7.64.1-h33f0ec9_1.tar.bz2
-    "libssh2 >=1.8.2,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::curl-7.64.1-hf8cf82a_0.tar.bz2
-    "libssh2 >=1.8.2,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::curl-7.65.2-hf8cf82a_0.tar.bz2
-    "libssh2 >=1.8.2,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::curl-7.65.3-hf8cf82a_0.tar.bz2
-    "libssh2 >=1.8.2,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::curl-7.68.0-h33f0ec9_1.tar.bz2
-    "libssh2 >=1.8.2,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::curl-7.68.0-hf8cf82a_0.tar.bz2
-    "libssh2 >=1.8.2,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::curl-7.69.1-h33f0ec9_0.tar.bz2
-    "libssh2 >=1.8.2,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::gfal2-2.16.2-h0b19a1f_0.tar.bz2
-    "libssh2 >=1.8.0,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::gfal2-2.16.3-h9d57a96_0.tar.bz2
-    "libssh2 >=1.8.0,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::gfal2-2.16.4-h0b19a1f_0.tar.bz2
-    "libssh2 >=1.8.2,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::gfal2-2.17.1-h0b19a1f_0.tar.bz2
-    "libssh2 >=1.8.2,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::gfal2-2.17.2-he6f68f7_0.tar.bz2
-    "libssh2 >=1.8.2,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::gfal2-2.17.3-he6f68f7_0.tar.bz2
-    "libssh2 >=1.8.2,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::libcurl-7.61.1-h01ee5af_1002.tar.bz2
-    "libssh2 >=1.8.0,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::libcurl-7.61.1-hbdb9355_2.tar.bz2
-    "libssh2 >=1.8.0,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::libcurl-7.62.0-h01ee5af_1000.tar.bz2
-    "libssh2 >=1.8.0,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::libcurl-7.62.0-hbdb9355_0.tar.bz2
-    "libssh2 >=1.8.0,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::libcurl-7.63.0-h01ee5af_1000.tar.bz2
-    "libssh2 >=1.8.0,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::libcurl-7.63.0-hbdb9355_0.tar.bz2
-    "libssh2 >=1.8.0,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::libcurl-7.64.0-h01ee5af_0.tar.bz2
-    "libssh2 >=1.8.0,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::libcurl-7.64.0-h541490c_2.tar.bz2
-    "libssh2 >=1.8.0,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::libcurl-7.64.0-hda55be3_4.tar.bz2
-    "libssh2 >=1.8.2,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::libcurl-7.64.0-hf7181ac_5.tar.bz2
-    "libssh2 >=1.8.2,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::libcurl-7.64.1-hda55be3_0.tar.bz2
-    "libssh2 >=1.8.2,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::libcurl-7.64.1-hf7181ac_1.tar.bz2
-    "libssh2 >=1.8.2,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::libcurl-7.65.2-hda55be3_0.tar.bz2
-    "libssh2 >=1.8.2,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::libcurl-7.65.3-hda55be3_0.tar.bz2
-    "libssh2 >=1.8.2,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::libcurl-7.68.0-hda55be3_0.tar.bz2
-    "libssh2 >=1.8.2,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::libcurl-7.68.0-hf7181ac_1.tar.bz2
-    "libssh2 >=1.8.2,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::libcurl-7.69.1-hf7181ac_0.tar.bz2
-    "libssh2 >=1.8.2,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::libgit2-0.26.0-0.tar.bz2
-    "libssh2 1.8.*",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::libgit2-0.27.0-0.tar.bz2
-    "libssh2 1.8.*",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::libgit2-0.27.1-h2a9243c_0.tar.bz2
-    "libssh2 >=1.8.0,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::libgit2-0.27.2-h2a9243c_0.tar.bz2
-    "libssh2 >=1.8.0,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::libgit2-0.27.3-h2a9243c_0.tar.bz2
-    "libssh2 >=1.8.0,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::libgit2-0.27.4-h5ee2e84_0.tar.bz2
-    "libssh2 >=1.8.0,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::libgit2-0.27.5-h5ee2e84_0.tar.bz2
-    "libssh2 >=1.8.0,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::libgit2-0.27.5-hbd8068c_1000.tar.bz2
-    "libssh2 >=1.8.0,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::libgit2-0.27.7-h5ee2e84_0.tar.bz2
-    "libssh2 >=1.8.0,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::libgit2-0.27.7-hbd8068c_1000.tar.bz2
-    "libssh2 >=1.8.0,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::libgit2-0.27.8-hbd8068c_0.tar.bz2
-    "libssh2 >=1.8.0,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::libgit2-0.28.0-hbd8068c_0.tar.bz2
-    "libssh2 >=1.8.0,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::libgit2-0.28.1-hbd8068c_0.tar.bz2
-    "libssh2 >=1.8.0,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::libgit2-0.28.1-heeda6b9_1.tar.bz2
-    "libssh2 >=1.8.0,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::libgit2-0.28.2-h241e3f0_0.tar.bz2
-    "libssh2 >=1.8.2,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::libgit2-0.28.3-h241e3f0_0.tar.bz2
-    "libssh2 >=1.8.2,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::libgit2-0.28.4-h241e3f0_0.tar.bz2
-    "libssh2 >=1.8.2,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::libgit2-0.28.4-h241e3f0_1.tar.bz2
-    "libssh2 >=1.8.2,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::libgit2-0.99.0-h1e06722_0.tar.bz2
-    "libssh2 >=1.8.2,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::libgit2-1.0.0-h1e06722_0.tar.bz2
-    "libssh2 >=1.8.2,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::r-base-3.4.1-h4fe35fd_8.tar.bz2
-    "libssh2 >=1.8.0,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::r-base-3.5.1-h08e1455_1008.tar.bz2
-    "libssh2 >=1.8.2,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::r-base-3.5.1-h271c98b_1006.tar.bz2
-    "libssh2 >=1.8.2,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::r-base-3.5.1-h391c2eb_5.tar.bz2
-    "libssh2 >=1.8.0,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::r-base-3.5.1-hbc19587_1011.tar.bz2
-    "libssh2 >=1.8.2,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::r-base-3.5.1-hc461eb7_1012.tar.bz2
-    "libssh2 >=1.8.2,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::r-base-3.5.1-he45234b_1005.tar.bz2
-    "libssh2 >=1.8.0,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::r-base-3.5.1-hea2b9be_1007.tar.bz2
-    "libssh2 >=1.8.2,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::r-base-3.5.1-hfb2a302_1009.tar.bz2
-    "libssh2 >=1.8.2,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::r-base-3.5.1-hfb2a302_1010.tar.bz2
-    "libssh2 >=1.8.2,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::r-base-3.6.1-h3a67422_6.tar.bz2
-    "libssh2 >=1.8.2,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::r-base-3.6.1-h6e652e1_3.tar.bz2
-    "libssh2 >=1.8.2,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::r-base-3.6.1-h8900bf8_0.tar.bz2
-    "libssh2 >=1.8.2,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::r-base-3.6.1-h8900bf8_1.tar.bz2
-    "libssh2 >=1.8.2,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::r-base-3.6.1-h8900bf8_2.tar.bz2
-    "libssh2 >=1.8.2,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::r-base-3.6.1-hba50c9b_4.tar.bz2
-    "libssh2 >=1.8.2,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::r-base-3.6.1-hba50c9b_5.tar.bz2
-    "libssh2 >=1.8.2,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::r-base-3.6.2-h3a67422_0.tar.bz2
-    "libssh2 >=1.8.2,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::r-base-3.6.2-h7ed4ef7_1.tar.bz2
-    "libssh2 >=1.8.2,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::r-base-3.6.3-h316533a_2.tar.bz2
-    "libssh2 >=1.8.2,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::r-base-3.6.3-h7ed4ef7_0.tar.bz2
-    "libssh2 >=1.8.2,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::r-base-3.6.3-h7ed4ef7_1.tar.bz2
-    "libssh2 >=1.8.2,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::r-base-4.0.0-hdca8982_2.tar.bz2
-    "libssh2 >=1.8.2,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::r-base-4.0.0-hdca8982_3.tar.bz2
-    "libssh2 >=1.8.2,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::r-git2r-0.21.0-r341h0c37787_0.tar.bz2
-    "libssh2 1.8.*",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::r-git2r-0.21.0-r341hcb0394e_1.tar.bz2
-    "libssh2 >=1.8.0,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::r-git2r-0.23.0-r341h1b3b946_0.tar.bz2
-    "libssh2 >=1.8.0,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::r-git2r-0.23.0-r351h1b3b946_0.tar.bz2
-    "libssh2 >=1.8.0,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::r-git2r-0.23.0-r351h47c54a8_1000.tar.bz2
-    "libssh2 >=1.8.0,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::r-git2r-0.24.0-r351h47c54a8_0.tar.bz2
-    "libssh2 >=1.8.0,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::r-git2r-0.24.0-r351h47c54a8_1.tar.bz2
-    "libssh2 >=1.8.0,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::r-git2r-0.24.0-r351hcaa6aff_2.tar.bz2
-    "libssh2 >=1.8.0,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::r-git2r-0.25.1-r351h5ca76e2_0.tar.bz2
-    "libssh2 >=1.8.0,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::r-git2r-0.25.2-r351h5ca76e2_0.tar.bz2
-    "libssh2 >=1.8.1,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::r-git2r-0.26.0-r35h5ca76e2_0.tar.bz2
-    "libssh2 >=1.8.2,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::r-git2r-0.26.1-r35h5ca76e2_0.tar.bz2
-    "libssh2 >=1.8.2,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::r-git2r-0.26.1-r35h5ca76e2_1.tar.bz2
-    "libssh2 >=1.8.2,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::r-git2r-0.26.1-r35h7253d3a_1.tar.bz2
-    "libssh2 >=1.8.2,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::r-git2r-0.26.1-r36h5ca76e2_1.tar.bz2
-    "libssh2 >=1.8.2,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::r-git2r-0.26.1-r36h7253d3a_1.tar.bz2
-    "libssh2 >=1.8.2,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::r-git2r-0.26.1-r36h7253d3a_2.tar.bz2
-    "libssh2 >=1.8.2,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::r-git2r-0.26.1-r40h7253d3a_2.tar.bz2
-    "libssh2 >=1.8.2,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::r-git2r-0.27.1-r36h7253d3a_0.tar.bz2
-    "libssh2 >=1.8.2,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::r-git2r-0.27.1-r40h7253d3a_0.tar.bz2
-    "libssh2 >=1.8.2,<1.9.0a0",
+    "libssh2 >=1.8.0,<2.0.0a0",
linux-64::ssh2-python-0.10.0-0.tar.bz2
-    "libssh2 1.8.*"
+    "libssh2 >=1.8.0,<2.0.0a0"
linux-64::ssh2-python-0.11.0.post1-0.tar.bz2
-    "libssh2 1.8.*"
+    "libssh2 >=1.8.0,<2.0.0a0"
linux-64::ssh2-python-0.16.0-0.tar.bz2
-    "libssh2 1.8.*"
+    "libssh2 >=1.8.0,<2.0.0a0"
linux-64::ssh2-python-0.5.4-0.tar.bz2
-    "libssh2 1.8.*"
+    "libssh2 >=1.8.0,<2.0.0a0"
linux-64::ssh2-python-0.6.0-0.tar.bz2
-    "libssh2 1.8.*"
+    "libssh2 >=1.8.0,<2.0.0a0"
linux-64::ssh2-python-0.7.0.post4-0.tar.bz2
-    "libssh2 1.8.*"
+    "libssh2 >=1.8.0,<2.0.0a0"
linux-64::ssh2-python-0.8.0-0.tar.bz2
-    "libssh2 1.8.*"
+    "libssh2 >=1.8.0,<2.0.0a0"
```

</details>

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
