### PR TITLE
ENH patch latest compilers for new sysroots as well

### DIFF
--- a/recipe/.gitignore
+++ b/recipe/.gitignore
@@ -1,2 +1,3 @@
 cache
 tmp
+__pycache__

--- a/recipe/show_diff.py
+++ b/recipe/show_diff.py
@@ -10,7 +10,10 @@ from gen_patch_json import _gen_new_index, _gen_patch_instructions, SUBDIRS
 
 from conda_build.index import _apply_instructions
 
-CACHE_DIR = os.environ.get("CACHE_DIR", "cache")
+CACHE_DIR = os.environ.get(
+    "CACHE_DIR",
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), "cache")
+)
 BASE_URL = "https://conda.anaconda.org/conda-forge"
 
 
@@ -25,10 +28,10 @@ def show_record_diffs(subdir, ref_repodata, new_repodata):
         print(f"{subdir}::{name}")
         ref_lines = json.dumps(ref_pkg, indent=2).splitlines()
         new_lines = json.dumps(new_pkg, indent=2).splitlines()
-        for l in difflib.unified_diff(ref_lines, new_lines, n=0, lineterm=''):
-            if l.startswith('+++') or l.startswith('---') or l.startswith('@@'):
+        for ln in difflib.unified_diff(ref_lines, new_lines, n=0, lineterm=''):
+            if ln.startswith('+++') or ln.startswith('---') or ln.startswith('@@'):
                 continue
-            print(l)
+            print(ln)
 
 
 def do_subdir(subdir, raw_repodata_path, ref_repodata_path):


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

These patches are for the latest versions of the compilers. They won't affect the new sysroot builds (once we add a run dep on the new sysroot to them). Also, these compiler builds will be marked broken eventually once we ship the new compilers and so these patches are actually temporary. 
