### PR TITLE
ENH make ctng activation conflict with new compilers

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -658,6 +658,19 @@ def _gen_new_index(repodata, subdir):
             new_constrains.append("sysroot_" + subdir + " ==99999999999")
             record["constrains"] = new_constrains
 
+        # all ctng activation packages that don't depend on the sysroot_*
+        # packages are not compatible with the new sysroot_*-based compilers
+        if (
+            subdir in ["linux-64", "linux-aarch64", "linux-ppc64le"]
+            and record_name in [
+                "gcc_" + subdir, "gxx_" + subdir, "gfortran_" + subdir,
+                "binutils_" + subdir, "gcc_bootstrap_" + subdir]
+            and not any(__r.startswith("sysroot_") for __r in record.get("depends", []))
+        ):
+            new_constrains = record.get('constrains', [])
+            new_constrains.append("sysroot_" + subdir + " ==99999999999")
+            record["constrains"] = new_constrains
+
         # old CDTs with the conda_cos6 or conda_cos7 name in the sysroot need to
         # conflict with the new CDT and compiler packages
         # all of the new CDTs and compilers depend on the sysroot_{subdir} packages


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

here is the diff

<details>

```diff
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata.json.bz2
linux-64::binutils_linux-64-2.31.1-h6176602_0.tar.bz2
-  "version": "2.31.1"
+  "version": "2.31.1",
+  "constrains": [
+    "sysroot_linux-64 ==99999999999"
+  ]
linux-64::binutils_linux-64-2.31.1-h6176602_10.tar.bz2
-  "version": "2.31.1"
+  "version": "2.31.1",
+  "constrains": [
+    "sysroot_linux-64 ==99999999999"
+  ]
linux-64::binutils_linux-64-2.31.1-h6176602_11.tar.bz2
-  "version": "2.31.1"
+  "version": "2.31.1",
+  "constrains": [
+    "sysroot_linux-64 ==99999999999"
+  ]
linux-64::binutils_linux-64-2.31.1-h6176602_12.tar.bz2
-  "version": "2.31.1"
+  "version": "2.31.1",
+  "constrains": [
+    "sysroot_linux-64 ==99999999999"
+  ]
linux-64::binutils_linux-64-2.31.1-h6176602_13.tar.bz2
-  "version": "2.31.1"
+  "version": "2.31.1",
+  "constrains": [
+    "sysroot_linux-64 ==99999999999"
+  ]
linux-64::binutils_linux-64-2.31.1-h6176602_14.tar.bz2
-  "version": "2.31.1"
+  "version": "2.31.1",
+  "constrains": [
+    "sysroot_linux-64 ==99999999999"
+  ]
linux-64::binutils_linux-64-2.31.1-h6176602_9.tar.bz2
-  "version": "2.31.1"
+  "version": "2.31.1",
+  "constrains": [
+    "sysroot_linux-64 ==99999999999"
+  ]
linux-64::binutils_linux-64-2.33.1-h9595d00_15.tar.bz2
-  "version": "2.33.1"
+  "version": "2.33.1",
+  "constrains": [
+    "sysroot_linux-64 ==99999999999"
+  ]
linux-64::binutils_linux-64-2.33.1-h9595d00_16.tar.bz2
-  "version": "2.33.1"
+  "version": "2.33.1",
+  "constrains": [
+    "sysroot_linux-64 ==99999999999"
+  ]
linux-64::binutils_linux-64-2.33.1-h9595d00_17.tar.bz2
-  "version": "2.33.1"
+  "version": "2.33.1",
+  "constrains": [
+    "sysroot_linux-64 ==99999999999"
+  ]
linux-64::binutils_linux-64-2.34-hc952b39_18.tar.bz2
-  "version": "2.34"
+  "version": "2.34",
+  "constrains": [
+    "sysroot_linux-64 ==99999999999"
+  ]
linux-64::binutils_linux-64-2.34-hc952b39_19.tar.bz2
-  "version": "2.34"
+  "version": "2.34",
+  "constrains": [
+    "sysroot_linux-64 ==99999999999"
+  ]
linux-64::binutils_linux-64-2.34-hc952b39_20.tar.bz2
-  "version": "2.34"
+  "version": "2.34",
+  "constrains": [
+    "sysroot_linux-64 ==99999999999"
+  ]
linux-64::gcc_bootstrap_linux-64-7.3.0-h64e4fec_12.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-64 ==99999999999"
+  ]
linux-64::gcc_bootstrap_linux-64-7.3.0-h64e4fec_13.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-64 ==99999999999"
+  ]
linux-64::gcc_bootstrap_linux-64-7.3.0-h64e4fec_14.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-64 ==99999999999"
+  ]
linux-64::gcc_bootstrap_linux-64-7.3.0-h64e4fec_15.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-64 ==99999999999"
+  ]
linux-64::gcc_bootstrap_linux-64-7.3.0-h64e4fec_16.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-64 ==99999999999"
+  ]
linux-64::gcc_bootstrap_linux-64-7.3.0-h64e4fec_17.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-64 ==99999999999"
+  ]
linux-64::gcc_bootstrap_linux-64-7.3.0-h64e4fec_18.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-64 ==99999999999"
+  ]
linux-64::gcc_bootstrap_linux-64-7.5.0-h49b1cff_19.tar.bz2
-  "version": "7.5.0"
+  "version": "7.5.0",
+  "constrains": [
+    "sysroot_linux-64 ==99999999999"
+  ]
linux-64::gcc_bootstrap_linux-64-7.5.0-h49b1cff_20.tar.bz2
-  "version": "7.5.0"
+  "version": "7.5.0",
+  "constrains": [
+    "sysroot_linux-64 ==99999999999"
+  ]
linux-64::gcc_linux-64-7.3.0-h553295d_0.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-64 ==99999999999"
+  ]
linux-64::gcc_linux-64-7.3.0-h553295d_10.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-64 ==99999999999"
+  ]
linux-64::gcc_linux-64-7.3.0-h553295d_11.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-64 ==99999999999"
+  ]
linux-64::gcc_linux-64-7.3.0-h553295d_12.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-64 ==99999999999"
+  ]
linux-64::gcc_linux-64-7.3.0-h553295d_13.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-64 ==99999999999"
+  ]
linux-64::gcc_linux-64-7.3.0-h553295d_14.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-64 ==99999999999"
+  ]
linux-64::gcc_linux-64-7.3.0-h553295d_15.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-64 ==99999999999"
+  ]
linux-64::gcc_linux-64-7.3.0-h553295d_16.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-64 ==99999999999"
+  ]
linux-64::gcc_linux-64-7.3.0-h553295d_17.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-64 ==99999999999"
+  ]
linux-64::gcc_linux-64-7.3.0-h553295d_18.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-64 ==99999999999"
+  ]
linux-64::gcc_linux-64-7.3.0-h553295d_3.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-64 ==99999999999"
+  ]
linux-64::gcc_linux-64-7.3.0-h553295d_6.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-64 ==99999999999"
+  ]
linux-64::gcc_linux-64-7.3.0-h553295d_7.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-64 ==99999999999"
+  ]
linux-64::gcc_linux-64-7.3.0-h553295d_8.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-64 ==99999999999"
+  ]
linux-64::gcc_linux-64-7.3.0-h553295d_9.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-64 ==99999999999"
+  ]
linux-64::gcc_linux-64-7.5.0-h09487f9_19.tar.bz2
-  "version": "7.5.0"
+  "version": "7.5.0",
+  "constrains": [
+    "sysroot_linux-64 ==99999999999"
+  ]
linux-64::gcc_linux-64-7.5.0-h09487f9_20.tar.bz2
-  "version": "7.5.0"
+  "version": "7.5.0",
+  "constrains": [
+    "sysroot_linux-64 ==99999999999"
+  ]
linux-64::gfortran_linux-64-7.3.0-h553295d_0.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-64 ==99999999999"
+  ]
linux-64::gfortran_linux-64-7.3.0-h553295d_10.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-64 ==99999999999"
+  ]
linux-64::gfortran_linux-64-7.3.0-h553295d_11.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-64 ==99999999999"
+  ]
linux-64::gfortran_linux-64-7.3.0-h553295d_12.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-64 ==99999999999"
+  ]
linux-64::gfortran_linux-64-7.3.0-h553295d_13.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-64 ==99999999999"
+  ]
linux-64::gfortran_linux-64-7.3.0-h553295d_14.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-64 ==99999999999"
+  ]
linux-64::gfortran_linux-64-7.3.0-h553295d_15.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-64 ==99999999999"
+  ]
linux-64::gfortran_linux-64-7.3.0-h553295d_16.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-64 ==99999999999"
+  ]
linux-64::gfortran_linux-64-7.3.0-h553295d_17.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-64 ==99999999999"
+  ]
linux-64::gfortran_linux-64-7.3.0-h553295d_18.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-64 ==99999999999"
+  ]
linux-64::gfortran_linux-64-7.3.0-h553295d_9.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-64 ==99999999999"
+  ]
linux-64::gfortran_linux-64-7.5.0-h09487f9_19.tar.bz2
-  "version": "7.5.0"
+  "version": "7.5.0",
+  "constrains": [
+    "sysroot_linux-64 ==99999999999"
+  ]
linux-64::gfortran_linux-64-7.5.0-h09487f9_20.tar.bz2
-  "version": "7.5.0"
+  "version": "7.5.0",
+  "constrains": [
+    "sysroot_linux-64 ==99999999999"
+  ]
linux-64::gxx_linux-64-7.3.0-h553295d_0.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-64 ==99999999999"
+  ]
linux-64::gxx_linux-64-7.3.0-h553295d_10.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-64 ==99999999999"
+  ]
linux-64::gxx_linux-64-7.3.0-h553295d_11.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-64 ==99999999999"
+  ]
linux-64::gxx_linux-64-7.3.0-h553295d_12.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-64 ==99999999999"
+  ]
linux-64::gxx_linux-64-7.3.0-h553295d_13.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-64 ==99999999999"
+  ]
linux-64::gxx_linux-64-7.3.0-h553295d_14.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-64 ==99999999999"
+  ]
linux-64::gxx_linux-64-7.3.0-h553295d_15.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-64 ==99999999999"
+  ]
linux-64::gxx_linux-64-7.3.0-h553295d_16.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-64 ==99999999999"
+  ]
linux-64::gxx_linux-64-7.3.0-h553295d_17.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-64 ==99999999999"
+  ]
linux-64::gxx_linux-64-7.3.0-h553295d_18.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-64 ==99999999999"
+  ]
linux-64::gxx_linux-64-7.3.0-h553295d_3.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-64 ==99999999999"
+  ]
linux-64::gxx_linux-64-7.3.0-h553295d_7.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-64 ==99999999999"
+  ]
linux-64::gxx_linux-64-7.3.0-h553295d_8.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-64 ==99999999999"
+  ]
linux-64::gxx_linux-64-7.3.0-h553295d_9.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-64 ==99999999999"
+  ]
linux-64::gxx_linux-64-7.5.0-h09487f9_19.tar.bz2
-  "version": "7.5.0"
+  "version": "7.5.0",
+  "constrains": [
+    "sysroot_linux-64 ==99999999999"
+  ]
linux-64::gxx_linux-64-7.5.0-h09487f9_20.tar.bz2
-  "version": "7.5.0"
+  "version": "7.5.0",
+  "constrains": [
+    "sysroot_linux-64 ==99999999999"
+  ]
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata.json.bz2
linux-aarch64::binutils_linux-aarch64-2.29.1-h1dbaa89_10.tar.bz2
-  "version": "2.29.1"
+  "version": "2.29.1",
+  "constrains": [
+    "sysroot_linux-aarch64 ==99999999999"
+  ]
linux-aarch64::binutils_linux-aarch64-2.29.1-h1dbaa89_11.tar.bz2
-  "version": "2.29.1"
+  "version": "2.29.1",
+  "constrains": [
+    "sysroot_linux-aarch64 ==99999999999"
+  ]
linux-aarch64::binutils_linux-aarch64-2.29.1-h1dbaa89_12.tar.bz2
-  "version": "2.29.1"
+  "version": "2.29.1",
+  "constrains": [
+    "sysroot_linux-aarch64 ==99999999999"
+  ]
linux-aarch64::binutils_linux-aarch64-2.29.1-h1dbaa89_13.tar.bz2
-  "version": "2.29.1"
+  "version": "2.29.1",
+  "constrains": [
+    "sysroot_linux-aarch64 ==99999999999"
+  ]
linux-aarch64::binutils_linux-aarch64-2.29.1-h1dbaa89_14.tar.bz2
-  "version": "2.29.1"
+  "version": "2.29.1",
+  "constrains": [
+    "sysroot_linux-aarch64 ==99999999999"
+  ]
linux-aarch64::binutils_linux-aarch64-2.29.1-h1dbaa89_16.tar.bz2
-  "version": "2.29.1"
+  "version": "2.29.1",
+  "constrains": [
+    "sysroot_linux-aarch64 ==99999999999"
+  ]
linux-aarch64::binutils_linux-aarch64-2.29.1-h1dbaa89_17.tar.bz2
-  "version": "2.29.1"
+  "version": "2.29.1",
+  "constrains": [
+    "sysroot_linux-aarch64 ==99999999999"
+  ]
linux-aarch64::binutils_linux-aarch64-2.29.1-h1dbaa89_9.tar.bz2
-  "version": "2.29.1"
+  "version": "2.29.1",
+  "constrains": [
+    "sysroot_linux-aarch64 ==99999999999"
+  ]
linux-aarch64::binutils_linux-aarch64-2.33.1-h6122985_15.tar.bz2
-  "version": "2.33.1"
+  "version": "2.33.1",
+  "constrains": [
+    "sysroot_linux-aarch64 ==99999999999"
+  ]
linux-aarch64::binutils_linux-aarch64-2.34-h9fe6929_18.tar.bz2
-  "version": "2.34"
+  "version": "2.34",
+  "constrains": [
+    "sysroot_linux-aarch64 ==99999999999"
+  ]
linux-aarch64::binutils_linux-aarch64-2.34-h9fe6929_19.tar.bz2
-  "version": "2.34"
+  "version": "2.34",
+  "constrains": [
+    "sysroot_linux-aarch64 ==99999999999"
+  ]
linux-aarch64::binutils_linux-aarch64-2.34-h9fe6929_20.tar.bz2
-  "version": "2.34"
+  "version": "2.34",
+  "constrains": [
+    "sysroot_linux-aarch64 ==99999999999"
+  ]
linux-aarch64::gcc_bootstrap_linux-aarch64-7.3.0-hcca6e79_12.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-aarch64 ==99999999999"
+  ]
linux-aarch64::gcc_bootstrap_linux-aarch64-7.3.0-hcca6e79_13.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-aarch64 ==99999999999"
+  ]
linux-aarch64::gcc_bootstrap_linux-aarch64-7.3.0-hcca6e79_14.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-aarch64 ==99999999999"
+  ]
linux-aarch64::gcc_bootstrap_linux-aarch64-7.3.0-hcca6e79_16.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-aarch64 ==99999999999"
+  ]
linux-aarch64::gcc_bootstrap_linux-aarch64-7.3.0-hcca6e79_17.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-aarch64 ==99999999999"
+  ]
linux-aarch64::gcc_bootstrap_linux-aarch64-7.3.0-hcca6e79_18.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-aarch64 ==99999999999"
+  ]
linux-aarch64::gcc_bootstrap_linux-aarch64-7.5.0-h9f7e54d_19.tar.bz2
-  "version": "7.5.0"
+  "version": "7.5.0",
+  "constrains": [
+    "sysroot_linux-aarch64 ==99999999999"
+  ]
linux-aarch64::gcc_bootstrap_linux-aarch64-7.5.0-h9f7e54d_20.tar.bz2
-  "version": "7.5.0"
+  "version": "7.5.0",
+  "constrains": [
+    "sysroot_linux-aarch64 ==99999999999"
+  ]
linux-aarch64::gcc_linux-aarch64-7.3.0-h98564e2_10.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-aarch64 ==99999999999"
+  ]
linux-aarch64::gcc_linux-aarch64-7.3.0-h98564e2_11.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-aarch64 ==99999999999"
+  ]
linux-aarch64::gcc_linux-aarch64-7.3.0-h98564e2_12.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-aarch64 ==99999999999"
+  ]
linux-aarch64::gcc_linux-aarch64-7.3.0-h98564e2_13.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-aarch64 ==99999999999"
+  ]
linux-aarch64::gcc_linux-aarch64-7.3.0-h98564e2_14.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-aarch64 ==99999999999"
+  ]
linux-aarch64::gcc_linux-aarch64-7.3.0-h98564e2_15.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-aarch64 ==99999999999"
+  ]
linux-aarch64::gcc_linux-aarch64-7.3.0-h98564e2_16.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-aarch64 ==99999999999"
+  ]
linux-aarch64::gcc_linux-aarch64-7.3.0-h98564e2_17.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-aarch64 ==99999999999"
+  ]
linux-aarch64::gcc_linux-aarch64-7.3.0-h98564e2_18.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-aarch64 ==99999999999"
+  ]
linux-aarch64::gcc_linux-aarch64-7.3.0-h98564e2_9.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-aarch64 ==99999999999"
+  ]
linux-aarch64::gcc_linux-aarch64-7.5.0-h926d122_19.tar.bz2
-  "version": "7.5.0"
+  "version": "7.5.0",
+  "constrains": [
+    "sysroot_linux-aarch64 ==99999999999"
+  ]
linux-aarch64::gcc_linux-aarch64-7.5.0-h926d122_20.tar.bz2
-  "version": "7.5.0"
+  "version": "7.5.0",
+  "constrains": [
+    "sysroot_linux-aarch64 ==99999999999"
+  ]
linux-aarch64::gfortran_linux-aarch64-7.3.0-h98564e2_10.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-aarch64 ==99999999999"
+  ]
linux-aarch64::gfortran_linux-aarch64-7.3.0-h98564e2_11.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-aarch64 ==99999999999"
+  ]
linux-aarch64::gfortran_linux-aarch64-7.3.0-h98564e2_12.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-aarch64 ==99999999999"
+  ]
linux-aarch64::gfortran_linux-aarch64-7.3.0-h98564e2_13.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-aarch64 ==99999999999"
+  ]
linux-aarch64::gfortran_linux-aarch64-7.3.0-h98564e2_14.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-aarch64 ==99999999999"
+  ]
linux-aarch64::gfortran_linux-aarch64-7.3.0-h98564e2_15.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-aarch64 ==99999999999"
+  ]
linux-aarch64::gfortran_linux-aarch64-7.3.0-h98564e2_16.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-aarch64 ==99999999999"
+  ]
linux-aarch64::gfortran_linux-aarch64-7.3.0-h98564e2_17.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-aarch64 ==99999999999"
+  ]
linux-aarch64::gfortran_linux-aarch64-7.3.0-h98564e2_18.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-aarch64 ==99999999999"
+  ]
linux-aarch64::gfortran_linux-aarch64-7.3.0-h98564e2_9.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-aarch64 ==99999999999"
+  ]
linux-aarch64::gfortran_linux-aarch64-7.5.0-h926d122_19.tar.bz2
-  "version": "7.5.0"
+  "version": "7.5.0",
+  "constrains": [
+    "sysroot_linux-aarch64 ==99999999999"
+  ]
linux-aarch64::gfortran_linux-aarch64-7.5.0-h926d122_20.tar.bz2
-  "version": "7.5.0"
+  "version": "7.5.0",
+  "constrains": [
+    "sysroot_linux-aarch64 ==99999999999"
+  ]
linux-aarch64::gxx_linux-aarch64-7.3.0-h98564e2_10.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-aarch64 ==99999999999"
+  ]
linux-aarch64::gxx_linux-aarch64-7.3.0-h98564e2_11.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-aarch64 ==99999999999"
+  ]
linux-aarch64::gxx_linux-aarch64-7.3.0-h98564e2_12.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-aarch64 ==99999999999"
+  ]
linux-aarch64::gxx_linux-aarch64-7.3.0-h98564e2_13.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-aarch64 ==99999999999"
+  ]
linux-aarch64::gxx_linux-aarch64-7.3.0-h98564e2_14.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-aarch64 ==99999999999"
+  ]
linux-aarch64::gxx_linux-aarch64-7.3.0-h98564e2_15.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-aarch64 ==99999999999"
+  ]
linux-aarch64::gxx_linux-aarch64-7.3.0-h98564e2_16.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-aarch64 ==99999999999"
+  ]
linux-aarch64::gxx_linux-aarch64-7.3.0-h98564e2_17.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-aarch64 ==99999999999"
+  ]
linux-aarch64::gxx_linux-aarch64-7.3.0-h98564e2_18.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-aarch64 ==99999999999"
+  ]
linux-aarch64::gxx_linux-aarch64-7.3.0-h98564e2_9.tar.bz2
-  "version": "7.3.0"
+  "version": "7.3.0",
+  "constrains": [
+    "sysroot_linux-aarch64 ==99999999999"
+  ]
linux-aarch64::gxx_linux-aarch64-7.5.0-h926d122_19.tar.bz2
-  "version": "7.5.0"
+  "version": "7.5.0",
+  "constrains": [
+    "sysroot_linux-aarch64 ==99999999999"
+  ]
linux-aarch64::gxx_linux-aarch64-7.5.0-h926d122_20.tar.bz2
-  "version": "7.5.0"
+  "version": "7.5.0",
+  "constrains": [
+    "sysroot_linux-aarch64 ==99999999999"
+  ]
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata.json.bz2
linux-ppc64le::binutils_linux-ppc64le-2.31.1-he53550c_10.tar.bz2
-  "version": "2.31.1"
+  "version": "2.31.1",
+  "constrains": [
+    "sysroot_linux-ppc64le ==99999999999"
+  ]
linux-ppc64le::binutils_linux-ppc64le-2.31.1-he53550c_11.tar.bz2
-  "version": "2.31.1"
+  "version": "2.31.1",
+  "constrains": [
+    "sysroot_linux-ppc64le ==99999999999"
+  ]
linux-ppc64le::binutils_linux-ppc64le-2.31.1-he53550c_12.tar.bz2
-  "version": "2.31.1"
+  "version": "2.31.1",
+  "constrains": [
+    "sysroot_linux-ppc64le ==99999999999"
+  ]
linux-ppc64le::binutils_linux-ppc64le-2.31.1-he53550c_13.tar.bz2
-  "version": "2.31.1"
+  "version": "2.31.1",
+  "constrains": [
+    "sysroot_linux-ppc64le ==99999999999"
+  ]
linux-ppc64le::binutils_linux-ppc64le-2.31.1-he53550c_14.tar.bz2
-  "version": "2.31.1"
+  "version": "2.31.1",
+  "constrains": [
+    "sysroot_linux-ppc64le ==99999999999"
+  ]
linux-ppc64le::binutils_linux-ppc64le-2.31.1-he53550c_9.tar.bz2
-  "version": "2.31.1"
+  "version": "2.31.1",
+  "constrains": [
+    "sysroot_linux-ppc64le ==99999999999"
+  ]
linux-ppc64le::binutils_linux-ppc64le-2.33.1-h959c939_15.tar.bz2
-  "version": "2.33.1"
+  "version": "2.33.1",
+  "constrains": [
+    "sysroot_linux-ppc64le ==99999999999"
+  ]
linux-ppc64le::binutils_linux-ppc64le-2.33.1-h959c939_16.tar.bz2
-  "version": "2.33.1"
+  "version": "2.33.1",
+  "constrains": [
+    "sysroot_linux-ppc64le ==99999999999"
+  ]
linux-ppc64le::binutils_linux-ppc64le-2.33.1-h959c939_17.tar.bz2
-  "version": "2.33.1"
+  "version": "2.33.1",
+  "constrains": [
+    "sysroot_linux-ppc64le ==99999999999"
+  ]
linux-ppc64le::binutils_linux-ppc64le-2.34-heaf459e_18.tar.bz2
-  "version": "2.34"
+  "version": "2.34",
+  "constrains": [
+    "sysroot_linux-ppc64le ==99999999999"
+  ]
linux-ppc64le::binutils_linux-ppc64le-2.34-heaf459e_19.tar.bz2
-  "version": "2.34"
+  "version": "2.34",
+  "constrains": [
+    "sysroot_linux-ppc64le ==99999999999"
+  ]
linux-ppc64le::binutils_linux-ppc64le-2.34-heaf459e_20.tar.bz2
-  "version": "2.34"
+  "version": "2.34",
+  "constrains": [
+    "sysroot_linux-ppc64le ==99999999999"
+  ]
linux-ppc64le::gcc_bootstrap_linux-ppc64le-8.2.0-h582eaef_12.tar.bz2
-  "version": "8.2.0"
+  "version": "8.2.0",
+  "constrains": [
+    "sysroot_linux-ppc64le ==99999999999"
+  ]
linux-ppc64le::gcc_bootstrap_linux-ppc64le-8.2.0-h582eaef_13.tar.bz2
-  "version": "8.2.0"
+  "version": "8.2.0",
+  "constrains": [
+    "sysroot_linux-ppc64le ==99999999999"
+  ]
linux-ppc64le::gcc_bootstrap_linux-ppc64le-8.2.0-h582eaef_14.tar.bz2
-  "version": "8.2.0"
+  "version": "8.2.0",
+  "constrains": [
+    "sysroot_linux-ppc64le ==99999999999"
+  ]
linux-ppc64le::gcc_bootstrap_linux-ppc64le-8.2.0-h582eaef_15.tar.bz2
-  "version": "8.2.0"
+  "version": "8.2.0",
+  "constrains": [
+    "sysroot_linux-ppc64le ==99999999999"
+  ]
linux-ppc64le::gcc_bootstrap_linux-ppc64le-8.2.0-h582eaef_16.tar.bz2
-  "version": "8.2.0"
+  "version": "8.2.0",
+  "constrains": [
+    "sysroot_linux-ppc64le ==99999999999"
+  ]
linux-ppc64le::gcc_bootstrap_linux-ppc64le-8.2.0-h582eaef_17.tar.bz2
-  "version": "8.2.0"
+  "version": "8.2.0",
+  "constrains": [
+    "sysroot_linux-ppc64le ==99999999999"
+  ]
linux-ppc64le::gcc_bootstrap_linux-ppc64le-8.2.0-h582eaef_18.tar.bz2
-  "version": "8.2.0"
+  "version": "8.2.0",
+  "constrains": [
+    "sysroot_linux-ppc64le ==99999999999"
+  ]
linux-ppc64le::gcc_bootstrap_linux-ppc64le-8.2.0-h582eaef_19.tar.bz2
-  "version": "8.2.0"
+  "version": "8.2.0",
+  "constrains": [
+    "sysroot_linux-ppc64le ==99999999999"
+  ]
linux-ppc64le::gcc_bootstrap_linux-ppc64le-8.4.0-haed7c51_20.tar.bz2
-  "version": "8.4.0"
+  "version": "8.4.0",
+  "constrains": [
+    "sysroot_linux-ppc64le ==99999999999"
+  ]
linux-ppc64le::gcc_linux-ppc64le-8.2.0-h9f3bcec_10.tar.bz2
-  "version": "8.2.0"
+  "version": "8.2.0",
+  "constrains": [
+    "sysroot_linux-ppc64le ==99999999999"
+  ]
linux-ppc64le::gcc_linux-ppc64le-8.2.0-h9f3bcec_11.tar.bz2
-  "version": "8.2.0"
+  "version": "8.2.0",
+  "constrains": [
+    "sysroot_linux-ppc64le ==99999999999"
+  ]
linux-ppc64le::gcc_linux-ppc64le-8.2.0-h9f3bcec_12.tar.bz2
-  "version": "8.2.0"
+  "version": "8.2.0",
+  "constrains": [
+    "sysroot_linux-ppc64le ==99999999999"
+  ]
linux-ppc64le::gcc_linux-ppc64le-8.2.0-h9f3bcec_13.tar.bz2
-  "version": "8.2.0"
+  "version": "8.2.0",
+  "constrains": [
+    "sysroot_linux-ppc64le ==99999999999"
+  ]
linux-ppc64le::gcc_linux-ppc64le-8.2.0-h9f3bcec_14.tar.bz2
-  "version": "8.2.0"
+  "version": "8.2.0",
+  "constrains": [
+    "sysroot_linux-ppc64le ==99999999999"
+  ]
linux-ppc64le::gcc_linux-ppc64le-8.2.0-h9f3bcec_15.tar.bz2
-  "version": "8.2.0"
+  "version": "8.2.0",
+  "constrains": [
+    "sysroot_linux-ppc64le ==99999999999"
+  ]
linux-ppc64le::gcc_linux-ppc64le-8.2.0-h9f3bcec_16.tar.bz2
-  "version": "8.2.0"
+  "version": "8.2.0",
+  "constrains": [
+    "sysroot_linux-ppc64le ==99999999999"
+  ]
linux-ppc64le::gcc_linux-ppc64le-8.2.0-h9f3bcec_17.tar.bz2
-  "version": "8.2.0"
+  "version": "8.2.0",
+  "constrains": [
+    "sysroot_linux-ppc64le ==99999999999"
+  ]
linux-ppc64le::gcc_linux-ppc64le-8.2.0-h9f3bcec_18.tar.bz2
-  "version": "8.2.0"
+  "version": "8.2.0",
+  "constrains": [
+    "sysroot_linux-ppc64le ==99999999999"
+  ]
linux-ppc64le::gcc_linux-ppc64le-8.2.0-h9f3bcec_19.tar.bz2
-  "version": "8.2.0"
+  "version": "8.2.0",
+  "constrains": [
+    "sysroot_linux-ppc64le ==99999999999"
+  ]
linux-ppc64le::gcc_linux-ppc64le-8.2.0-h9f3bcec_9.tar.bz2
-  "version": "8.2.0"
+  "version": "8.2.0",
+  "constrains": [
+    "sysroot_linux-ppc64le ==99999999999"
+  ]
linux-ppc64le::gcc_linux-ppc64le-8.4.0-h96fe1e1_20.tar.bz2
-  "version": "8.4.0"
+  "version": "8.4.0",
+  "constrains": [
+    "sysroot_linux-ppc64le ==99999999999"
+  ]
linux-ppc64le::gfortran_linux-ppc64le-8.2.0-h9f3bcec_10.tar.bz2
-  "version": "8.2.0"
+  "version": "8.2.0",
+  "constrains": [
+    "sysroot_linux-ppc64le ==99999999999"
+  ]
linux-ppc64le::gfortran_linux-ppc64le-8.2.0-h9f3bcec_11.tar.bz2
-  "version": "8.2.0"
+  "version": "8.2.0",
+  "constrains": [
+    "sysroot_linux-ppc64le ==99999999999"
+  ]
linux-ppc64le::gfortran_linux-ppc64le-8.2.0-h9f3bcec_12.tar.bz2
-  "version": "8.2.0"
+  "version": "8.2.0",
+  "constrains": [
+    "sysroot_linux-ppc64le ==99999999999"
+  ]
linux-ppc64le::gfortran_linux-ppc64le-8.2.0-h9f3bcec_13.tar.bz2
-  "version": "8.2.0"
+  "version": "8.2.0",
+  "constrains": [
+    "sysroot_linux-ppc64le ==99999999999"
+  ]
linux-ppc64le::gfortran_linux-ppc64le-8.2.0-h9f3bcec_14.tar.bz2
-  "version": "8.2.0"
+  "version": "8.2.0",
+  "constrains": [
+    "sysroot_linux-ppc64le ==99999999999"
+  ]
linux-ppc64le::gfortran_linux-ppc64le-8.2.0-h9f3bcec_15.tar.bz2
-  "version": "8.2.0"
+  "version": "8.2.0",
+  "constrains": [
+    "sysroot_linux-ppc64le ==99999999999"
+  ]
linux-ppc64le::gfortran_linux-ppc64le-8.2.0-h9f3bcec_16.tar.bz2
-  "version": "8.2.0"
+  "version": "8.2.0",
+  "constrains": [
+    "sysroot_linux-ppc64le ==99999999999"
+  ]
linux-ppc64le::gfortran_linux-ppc64le-8.2.0-h9f3bcec_17.tar.bz2
-  "version": "8.2.0"
+  "version": "8.2.0",
+  "constrains": [
+    "sysroot_linux-ppc64le ==99999999999"
+  ]
linux-ppc64le::gfortran_linux-ppc64le-8.2.0-h9f3bcec_18.tar.bz2
-  "version": "8.2.0"
+  "version": "8.2.0",
+  "constrains": [
+    "sysroot_linux-ppc64le ==99999999999"
+  ]
linux-ppc64le::gfortran_linux-ppc64le-8.2.0-h9f3bcec_19.tar.bz2
-  "version": "8.2.0"
+  "version": "8.2.0",
+  "constrains": [
+    "sysroot_linux-ppc64le ==99999999999"
+  ]
linux-ppc64le::gfortran_linux-ppc64le-8.2.0-h9f3bcec_9.tar.bz2
-  "version": "8.2.0"
+  "version": "8.2.0",
+  "constrains": [
+    "sysroot_linux-ppc64le ==99999999999"
+  ]
linux-ppc64le::gfortran_linux-ppc64le-8.4.0-h96fe1e1_20.tar.bz2
-  "version": "8.4.0"
+  "version": "8.4.0",
+  "constrains": [
+    "sysroot_linux-ppc64le ==99999999999"
+  ]
linux-ppc64le::gxx_linux-ppc64le-8.2.0-h9f3bcec_10.tar.bz2
-  "version": "8.2.0"
+  "version": "8.2.0",
+  "constrains": [
+    "sysroot_linux-ppc64le ==99999999999"
+  ]
linux-ppc64le::gxx_linux-ppc64le-8.2.0-h9f3bcec_11.tar.bz2
-  "version": "8.2.0"
+  "version": "8.2.0",
+  "constrains": [
+    "sysroot_linux-ppc64le ==99999999999"
+  ]
linux-ppc64le::gxx_linux-ppc64le-8.2.0-h9f3bcec_12.tar.bz2
-  "version": "8.2.0"
+  "version": "8.2.0",
+  "constrains": [
+    "sysroot_linux-ppc64le ==99999999999"
+  ]
linux-ppc64le::gxx_linux-ppc64le-8.2.0-h9f3bcec_13.tar.bz2
-  "version": "8.2.0"
+  "version": "8.2.0",
+  "constrains": [
+    "sysroot_linux-ppc64le ==99999999999"
+  ]
linux-ppc64le::gxx_linux-ppc64le-8.2.0-h9f3bcec_14.tar.bz2
-  "version": "8.2.0"
+  "version": "8.2.0",
+  "constrains": [
+    "sysroot_linux-ppc64le ==99999999999"
+  ]
linux-ppc64le::gxx_linux-ppc64le-8.2.0-h9f3bcec_15.tar.bz2
-  "version": "8.2.0"
+  "version": "8.2.0",
+  "constrains": [
+    "sysroot_linux-ppc64le ==99999999999"
+  ]
linux-ppc64le::gxx_linux-ppc64le-8.2.0-h9f3bcec_16.tar.bz2
-  "version": "8.2.0"
+  "version": "8.2.0",
+  "constrains": [
+    "sysroot_linux-ppc64le ==99999999999"
+  ]
linux-ppc64le::gxx_linux-ppc64le-8.2.0-h9f3bcec_17.tar.bz2
-  "version": "8.2.0"
+  "version": "8.2.0",
+  "constrains": [
+    "sysroot_linux-ppc64le ==99999999999"
+  ]
linux-ppc64le::gxx_linux-ppc64le-8.2.0-h9f3bcec_18.tar.bz2
-  "version": "8.2.0"
+  "version": "8.2.0",
+  "constrains": [
+    "sysroot_linux-ppc64le ==99999999999"
+  ]
linux-ppc64le::gxx_linux-ppc64le-8.2.0-h9f3bcec_19.tar.bz2
-  "version": "8.2.0"
+  "version": "8.2.0",
+  "constrains": [
+    "sysroot_linux-ppc64le ==99999999999"
+  ]
linux-ppc64le::gxx_linux-ppc64le-8.2.0-h9f3bcec_9.tar.bz2
-  "version": "8.2.0"
+  "version": "8.2.0",
+  "constrains": [
+    "sysroot_linux-ppc64le ==99999999999"
+  ]
linux-ppc64le::gxx_linux-ppc64le-8.4.0-h96fe1e1_20.tar.bz2
-  "version": "8.4.0"
+  "version": "8.4.0",
+  "constrains": [
+    "sysroot_linux-ppc64le ==99999999999"
+  ]
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata.json.bz2
```

</details>