### PR TITLE
Pinning bokeh to version 1 in versions of jupyterlab-nvdashboard that didn't explicitly set this

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -494,6 +494,13 @@ def _gen_new_index(repodata, subdir):
                     record['constrains'].append("arrow-cpp-proc * cpu")
                 else:
                     record['constrains'] = ["arrow-cpp-proc * cpu"]
+        
+        # jupyerlab-nvdashboard-0.1.11 (all builds)
+        # depends on "bokeh" should be "bokeh <2"
+        if record_name == 'jupyterlab-nvdashboard':
+            if 'bokeh' in record['depends']:
+                i = record['depends'].index('bokeh')
+                record['depends'][i] = 'bokeh <2'
 
         # distributed <2.11.0 does not work with msgpack-python >=1.0
         # newer versions of distributed require at least msgpack-python >=0.6.0


### PR DESCRIPTION
Patching some old 0.1.11 builds of jupyterlab-nvdashboard to pin the Bokeh version below 2.

I discussed this issue with @jakirkham back on issue [jupyterlab-nvdashboard issue 66](https://github.com/rapidsai/jupyterlab-nvdashboard/issues/66) several months ago.

I noticed it still occasionally causes problems when installing jupyterlab-nvdashboard into some existing conda environments.

Note this is my first attempt at a patch - I don't know what I'm doing and haven't tested this (I don't know how) - I just copy-pasted existing code and looked at other PRs. Hoping to get some tips on the PR so I can confirm it is in a good state before being truly ready to merge. Apologies for my ignorance of the process.