### PR TITLE
Pin unpinned aws-sdk-cpp in arrow-cpp builds

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -491,6 +491,10 @@ def _gen_new_index(repodata, subdir):
                 else:
                     record['constrains'] = ["arrow-cpp-proc * cpu"]
 
+            if "aws-sdk-cpp" in record['depends']:
+                i = record['depends'].index('aws-sdk-cpp')
+                record['depends'][i] = 'aws-sdk-cpp 1.7.164'
+
         if record_name == "pyarrow":
             if not any(dep.split(' ')[0] == "arrow-cpp-proc" for dep in record.get('constrains', ())):
                 if 'constrains' in record:


### PR DESCRIPTION
In older arrow-cpp builds the aws-sdk-cpp package wasn't pinned. Now that we have a new version of this package, old versions break with ABI issues.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
