### PR TITLE
Rm old pyarrow for kartothek 3.15 & 3.16

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -504,6 +504,12 @@ def _gen_new_index(repodata, subdir):
                 else:
                     record['constrains'] = ["arrow-cpp-proc * cpu"]
 
+        if record_name == "kartothek":
+            if record["version"] in ["3.15.0", "3.15.1", "3.16.0"] \
+                    and "pyarrow >=0.13.0,!=0.14.0,<2" in record["depends"]:
+                i = record["depends"].index("pyarrow >=0.13.0,!=0.14.0,<2")
+                record["depends"][i] = "pyarrow >=0.17.1,<2"
+
         # distributed <2.11.0 does not work with msgpack-python >=1.0
         # newer versions of distributed require at least msgpack-python >=0.6.0
         # so we can fix cases where msgpack-python is unbounded


### PR DESCRIPTION
From version 3.15.0 the arrow dependency was bumped to `>=0.17.1,<2` from `pyarrow >=0.13.0,!=0.14.0,<2`
but not adjusted in the feedstock.

In the feedstock it's already updated (version 3.16.0 build 1): https://github.com/conda-forge/kartothek-feedstock/issues/29

show_diff for noarch:
```diff
noarch::kartothek-3.15.0-py_0.tar.bz2
-    "pyarrow >=0.13.0,!=0.14.0,<2",
+    "pyarrow >=0.17.1,<2",
noarch::kartothek-3.15.1-py_0.tar.bz2
-    "pyarrow >=0.13.0,!=0.14.0,<2",
+    "pyarrow >=0.17.1,<2",
noarch::kartothek-3.16.0-py_0.tar.bz2
-    "pyarrow >=0.13.0,!=0.14.0,<2",
+    "pyarrow >=0.17.1,<2",
```
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
