### PR TITLE
ENH add patch for pybind11

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -11,7 +11,7 @@ jobs:
       linux_64_:
         CONFIG: linux_64_
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: condaforge/linux-anvil-comp7
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
   timeoutInMinutes: 360
 
   steps:

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,6 +1,8 @@
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
 docker_image:
-- condaforge/linux-anvil-comp7
+- quay.io/condaforge/linux-anvil-comp7


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Here is a relevant subset of the diff

<details>

```
osx-64::pybind11-2.2.4-py35h2d50403_1.tar.bz2
-  "constrains": [
-    "python_abi * *_cp35m"
-  ],
-  "version": "2.2.4"
+  "version": "2.2.4",
+  "constrains": [
+    "python_abi * *_cp35m",
+    "pybind11-abi ==2"
+  ]
osx-64::pybind11-2.2.4-py36h04f5b5a_1000.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-  "version": "2.2.4"
+  "version": "2.2.4",
+  "constrains": [
+    "python_abi * *_cp36m",
+    "pybind11-abi ==2"
+  ]
osx-64::pybind11-2.2.4-py36h2d50403_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-  "version": "2.2.4"
+  "version": "2.2.4",
+  "constrains": [
+    "python_abi * *_cp36m",
+    "pybind11-abi ==2"
+  ]
osx-64::pybind11-2.2.4-py36h2d50403_1.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-  "version": "2.2.4"
+  "version": "2.2.4",
+  "constrains": [
+    "python_abi * *_cp36m",
+    "pybind11-abi ==2"
+  ]
osx-64::pybind11-2.2.4-py36h770b8ee_1001.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-  "version": "2.2.4"
+  "version": "2.2.4",
+  "constrains": [
+    "python_abi * *_cp36m",
+    "pybind11-abi ==2"
+  ]
osx-64::pybind11-2.2.4-py37h04f5b5a_1000.tar.bz2
-  "constrains": [
-    "python_abi * *_cp37m"
-  ],
-  "version": "2.2.4"
+  "version": "2.2.4",
+  "constrains": [
+    "python_abi * *_cp37m",
+    "pybind11-abi ==2"
+  ]
osx-64::pybind11-2.2.4-py37h2d50403_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp37m"
-  ],
-  "version": "2.2.4"
+  "version": "2.2.4",
+  "constrains": [
+    "python_abi * *_cp37m",
+    "pybind11-abi ==2"
+  ]
osx-64::pybind11-2.2.4-py37h770b8ee_1001.tar.bz2
-  "constrains": [
-    "python_abi * *_cp37m"
-  ],
-  "version": "2.2.4"
+  "version": "2.2.4",
+  "constrains": [
+    "python_abi * *_cp37m",
+    "pybind11-abi ==2"
+  ]
osx-64::pybind11-2.3.0-py27h770b8ee_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27m"
-  ],
-  "version": "2.3.0"
+  "version": "2.3.0",
+  "constrains": [
+    "python_abi * *_cp27m",
+    "pybind11-abi ==3"
+  ]
osx-64::pybind11-2.3.0-py27h770b8ee_1.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27m"
-  ],
-  "version": "2.3.0"
+  "version": "2.3.0",
+  "constrains": [
+    "python_abi * *_cp27m",
+    "pybind11-abi ==3"
+  ]
osx-64::pybind11-2.3.0-py27h770b8ee_2.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27m"
-  ],
-  "version": "2.3.0"
+  "version": "2.3.0",
+  "constrains": [
+    "python_abi * *_cp27m",
+    "pybind11-abi ==3"
+  ]
osx-64::pybind11-2.3.0-py36h770b8ee_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-  "version": "2.3.0"
+  "version": "2.3.0",
+  "constrains": [
+    "python_abi * *_cp36m",
+    "pybind11-abi ==3"
+  ]
osx-64::pybind11-2.3.0-py36h770b8ee_1.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-  "version": "2.3.0"
+  "version": "2.3.0",
+  "constrains": [
+    "python_abi * *_cp36m",
+    "pybind11-abi ==3"
+  ]
osx-64::pybind11-2.3.0-py36h770b8ee_2.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-  "version": "2.3.0"
+  "version": "2.3.0",
+  "constrains": [
+    "python_abi * *_cp36m",
+    "pybind11-abi ==3"
+  ]
osx-64::pybind11-2.3.0-py37h770b8ee_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp37m"
-  ],
-  "version": "2.3.0"
+  "version": "2.3.0",
+  "constrains": [
+    "python_abi * *_cp37m",
+    "pybind11-abi ==3"
+  ]
osx-64::pybind11-2.3.0-py37h770b8ee_1.tar.bz2
-  "constrains": [
-    "python_abi * *_cp37m"
-  ],
-  "version": "2.3.0"
+  "version": "2.3.0",
+  "constrains": [
+    "python_abi * *_cp37m",
+    "pybind11-abi ==3"
+  ]
osx-64::pybind11-2.3.0-py37h770b8ee_2.tar.bz2
-  "constrains": [
-    "python_abi * *_cp37m"
-  ],
-  "version": "2.3.0"
+  "version": "2.3.0",
+  "constrains": [
+    "python_abi * *_cp37m",
+    "pybind11-abi ==3"
+  ]
osx-64::pybind11-2.4.0-py27h770b8ee_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27m"
-  ],
-  "version": "2.4.0"
+  "version": "2.4.0",
+  "constrains": [
+    "python_abi * *_cp27m",
+    "pybind11-abi ==3"
+  ]
osx-64::pybind11-2.4.0-py36h770b8ee_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-  "version": "2.4.0"
+  "version": "2.4.0",
+  "constrains": [
+    "python_abi * *_cp36m",
+    "pybind11-abi ==3"
+  ]
osx-64::pybind11-2.4.0-py37h770b8ee_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp37m"
-  ],
-  "version": "2.4.0"
+  "version": "2.4.0",
+  "constrains": [
+    "python_abi * *_cp37m",
+    "pybind11-abi ==3"
+  ]
osx-64::pybind11-2.4.1-py27h770b8ee_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27m"
-  ],
-  "version": "2.4.1"
+  "version": "2.4.1",
+  "constrains": [
+    "python_abi * *_cp27m",
+    "pybind11-abi ==3"
+  ]
osx-64::pybind11-2.4.1-py36h770b8ee_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-  "version": "2.4.1"
+  "version": "2.4.1",
+  "constrains": [
+    "python_abi * *_cp36m",
+    "pybind11-abi ==3"
+  ]
osx-64::pybind11-2.4.1-py37h770b8ee_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp37m"
-  ],
-  "version": "2.4.1"
+  "version": "2.4.1",
+  "constrains": [
+    "python_abi * *_cp37m",
+    "pybind11-abi ==3"
+  ]
osx-64::pybind11-2.4.2-py27h770b8ee_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27m"
-  ],
-  "version": "2.4.2"
+  "version": "2.4.2",
+  "constrains": [
+    "python_abi * *_cp27m",
+    "pybind11-abi ==3"
+  ]
osx-64::pybind11-2.4.2-py36h770b8ee_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-  "version": "2.4.2"
+  "version": "2.4.2",
+  "constrains": [
+    "python_abi * *_cp36m",
+    "pybind11-abi ==3"
+  ]
osx-64::pybind11-2.4.2-py37h770b8ee_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp37m"
-  ],
-  "version": "2.4.2"
+  "version": "2.4.2",
+  "constrains": [
+    "python_abi * *_cp37m",
+    "pybind11-abi ==3"
+  ]
osx-64::pybind11-2.4.3-py27h5cd23e5_2.tar.bz2
-  "version": "2.4.3"
+  "version": "2.4.3",
+  "constrains": [
+    "pybind11-abi ==3"
+  ]
osx-64::pybind11-2.4.3-py27h5cd23e5_3.tar.bz2
-  "version": "2.4.3"
+  "version": "2.4.3",
+  "constrains": [
+    "pybind11-abi ==3"
+  ]
osx-64::pybind11-2.4.3-py27ha1b3eb9_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27m"
-  ],
-  "version": "2.4.3"
+  "version": "2.4.3",
+  "constrains": [
+    "python_abi * *_cp27m",
+    "pybind11-abi ==3"
+  ]
osx-64::pybind11-2.4.3-py27ha1b3eb9_1.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27m"
-  ],
-  "version": "2.4.3"
+  "version": "2.4.3",
+  "constrains": [
+    "python_abi * *_cp27m",
+    "pybind11-abi ==3"
+  ]
osx-64::pybind11-2.4.3-py36h06ab557_2.tar.bz2
-  "version": "2.4.3"
+  "version": "2.4.3",
+  "constrains": [
+    "pybind11-abi ==3"
+  ]
osx-64::pybind11-2.4.3-py36h06ab557_3.tar.bz2
-  "version": "2.4.3"
+  "version": "2.4.3",
+  "constrains": [
+    "pybind11-abi ==3"
+  ]
osx-64::pybind11-2.4.3-py36h863e41a_2.tar.bz2
-  "version": "2.4.3"
+  "version": "2.4.3",
+  "constrains": [
+    "pybind11-abi ==3"
+  ]
osx-64::pybind11-2.4.3-py36h863e41a_3.tar.bz2
-  "version": "2.4.3"
+  "version": "2.4.3",
+  "constrains": [
+    "pybind11-abi ==3"
+  ]
osx-64::pybind11-2.4.3-py36ha1b3eb9_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-  "version": "2.4.3"
+  "version": "2.4.3",
+  "constrains": [
+    "python_abi * *_cp36m",
+    "pybind11-abi ==3"
+  ]
osx-64::pybind11-2.4.3-py36ha1b3eb9_1.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-  "version": "2.4.3"
+  "version": "2.4.3",
+  "constrains": [
+    "python_abi * *_cp36m",
+    "pybind11-abi ==3"
+  ]
osx-64::pybind11-2.4.3-py37ha1b3eb9_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp37m"
-  ],
-  "version": "2.4.3"
+  "version": "2.4.3",
+  "constrains": [
+    "python_abi * *_cp37m",
+    "pybind11-abi ==3"
+  ]
osx-64::pybind11-2.4.3-py37ha1b3eb9_1.tar.bz2
-  "constrains": [
-    "python_abi * *_cp37m"
-  ],
-  "version": "2.4.3"
+  "version": "2.4.3",
+  "constrains": [
+    "python_abi * *_cp37m",
+    "pybind11-abi ==3"
+  ]
osx-64::pybind11-2.4.3-py37ha1cc60f_2.tar.bz2
-  "version": "2.4.3"
+  "version": "2.4.3",
+  "constrains": [
+    "pybind11-abi ==3"
+  ]
osx-64::pybind11-2.4.3-py37ha1cc60f_3.tar.bz2
-  "version": "2.4.3"
+  "version": "2.4.3",
+  "constrains": [
+    "pybind11-abi ==3"
+  ]
osx-64::pybind11-2.4.3-py38ha0d09dd_2.tar.bz2
-  "version": "2.4.3"
+  "version": "2.4.3",
+  "constrains": [
+    "pybind11-abi ==3"
+  ]
osx-64::pybind11-2.4.3-py38ha0d09dd_3.tar.bz2
-  "version": "2.4.3"
+  "version": "2.4.3",
+  "constrains": [
+    "pybind11-abi ==3"
+  ]
osx-64::pybind11-2.4.3-py38ha1b3eb9_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp38"
-  ],
-  "version": "2.4.3"
+  "version": "2.4.3",
+  "constrains": [
+    "python_abi * *_cp38",
+    "pybind11-abi ==3"
+  ]
osx-64::pybind11-2.4.3-py38ha1b3eb9_1.tar.bz2
-  "constrains": [
-    "python_abi * *_cp38"
-  ],
-  "version": "2.4.3"
+  "version": "2.4.3",
+  "constrains": [
+    "python_abi * *_cp38",
+    "pybind11-abi ==3"
+  ]
osx-64::pybind11-2.5.0-py36h06ab557_0.tar.bz2
-  "version": "2.5.0"
+  "version": "2.5.0",
+  "constrains": [
+    "pybind11-abi ==4"
+  ]
osx-64::pybind11-2.5.0-py36h1cd168d_1.tar.bz2
-  "version": "2.5.0"
+  "version": "2.5.0",
+  "constrains": [
+    "pybind11-abi ==4"
+  ]
osx-64::pybind11-2.5.0-py36h863e41a_0.tar.bz2
-  "version": "2.5.0"
+  "version": "2.5.0",
+  "constrains": [
+    "pybind11-abi ==4"
+  ]
osx-64::pybind11-2.5.0-py36hadcdec8_1.tar.bz2
-  "version": "2.5.0"
+  "version": "2.5.0",
+  "constrains": [
+    "pybind11-abi ==4"
+  ]
osx-64::pybind11-2.5.0-py37ha1cc60f_0.tar.bz2
-  "version": "2.5.0"
+  "version": "2.5.0",
+  "constrains": [
+    "pybind11-abi ==4"
+  ]
osx-64::pybind11-2.5.0-py37hb449ec0_1.tar.bz2
-  "version": "2.5.0"
+  "version": "2.5.0",
+  "constrains": [
+    "pybind11-abi ==4"
+  ]
osx-64::pybind11-2.5.0-py38h02bb52f_1.tar.bz2
-  "version": "2.5.0"
+  "version": "2.5.0",
+  "constrains": [
+    "pybind11-abi ==4"
+  ]
osx-64::pybind11-2.5.0-py38ha0d09dd_0.tar.bz2
-  "version": "2.5.0"
+  "version": "2.5.0",
+  "constrains": [
+    "pybind11-abi ==4"
+  ]
```

</details>

closes #104 
