### PR TITLE
Pin zstandard<0.15 in existing kartothek builds

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -504,6 +504,12 @@ def _gen_new_index(repodata, subdir):
                 else:
                     record['constrains'] = ["typing_extensions"]
 
+        if record_name == "kartothek" and record.get('timestamp', 0) < 1611565264:
+            # https://github.com/conda-forge/kartothek-feedstock/issues/36
+            if "zstandard" in record['depends']:
+                i = record['depends'].index('zstandard')
+                record['depends'][i] = 'zstandard <0.15'
+
         if record_name == "arrow-cpp":
             if not any(dep.split(' ')[0] == "arrow-cpp-proc" for dep in record.get('constrains', ())):
                 if 'constrains' in record:


### PR DESCRIPTION
Fixes https://github.com/conda-forge/kartothek-feedstock/issues/36, cc @conda-forge/kartothek 

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
