### PR TITLE
fix for ipython-vs-jedi issue

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -506,15 +506,8 @@ def _gen_new_index(repodata, subdir):
 
         if record_name == "ipython" and record.get('timestamp', 0) < 1609621539000:
             # https://github.com/conda-forge/ipython-feedstock/issues/127
-            if record["version"] in ["7.18.0"]:
-                i = record['depends'].index('jedi >=0.16')
-                record['depends'][i] = 'jedi >=0.10,<0.18'
-            else:
-                # before conda-forge/ipython-feedstock#110 (7.18.0), this has been 0.10 for years, see
-                # https://github.com/conda-forge/ipython-feedstock/blame/a487716d78710c4f8998654c63000cb5c3402910/recipe/meta.yaml#L30
-                # and returned to that with conda-forge/ipython-feedstock#111 (7.18.1)
-                i = record['depends'].index('jedi >=0.10')
-                record['depends'][i] = 'jedi >=0.10,<0.18'
+            if any(dep.split(' ')[0] == "jedi" for dep in record.get('constrains', ())):
+                record['depends'].append('jedi <0.18')
 
         if record_name == "kartothek" and record.get('timestamp', 0) < 1611565264000:
             # https://github.com/conda-forge/kartothek-feedstock/issues/36

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -506,7 +506,7 @@ def _gen_new_index(repodata, subdir):
 
         if record_name == "ipython" and record.get('timestamp', 0) < 1609621539000:
             # https://github.com/conda-forge/ipython-feedstock/issues/127
-            if any(dep.split(' ')[0] == "jedi" for dep in record.get('constrains', ())):
+            if any(dep.split(' ')[0] == "jedi" for dep in record.get('depends', ())):
                 record['depends'].append('jedi <0.18')
 
         if record_name == "kartothek" and record.get('timestamp', 0) < 1611565264000:

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -504,6 +504,18 @@ def _gen_new_index(repodata, subdir):
                 else:
                     record['constrains'] = ["typing_extensions"]
 
+        if record_name == "ipython" and record.get('timestamp', 0) < 1609621539000:
+            # https://github.com/conda-forge/ipython-feedstock/issues/127
+            if record["version"] in ["7.18.0"]:
+                i = record['depends'].index('jedi >=0.16')
+                record['depends'][i] = 'jedi >=0.10,<0.18'
+            else:
+                # before conda-forge/ipython-feedstock#110 (7.18.0), this has been 0.10 for years, see
+                # https://github.com/conda-forge/ipython-feedstock/blame/a487716d78710c4f8998654c63000cb5c3402910/recipe/meta.yaml#L30
+                # and returned to that with conda-forge/ipython-feedstock#111 (7.18.1)
+                i = record['depends'].index('jedi >=0.10')
+                record['depends'][i] = 'jedi >=0.10,<0.18'
+
         if record_name == "kartothek" and record.get('timestamp', 0) < 1611565264000:
             # https://github.com/conda-forge/kartothek-feedstock/issues/36
             if "zstandard" in record['depends']:


### PR DESCRIPTION
Fixes https://github.com/conda-forge/ipython-feedstock/issues/127

Not sure what `record['timestamp']` stands for exactly, but I took the timestamp of https://github.com/conda-forge/ipython-feedstock/commit/dfe311106f184ff708b91c769c66735f54a6ff5c, which I think should be safe (as everything after that has correct metadata).

Also, it seems the `records['depends']` needs to contain the exact record from the `meta.yaml` file? I tried to fix more than just the very most recent `ipython` version, hence a bit of logic since the `jedi` dependency was bumped with https://github.com/conda-forge/ipython-feedstock/pull/110 but then returned to `>=0.10` with https://github.com/conda-forge/ipython-feedstock/pull/111

CC @CJ-Wright @jakirkham @bollwyvl