### PR TITLE
Add fix for lal-711 run_constrained metadata

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -840,6 +840,17 @@ def _gen_new_index(repodata, subdir):
         ):
             _add_pybind11_abi_constraint(fn, record)
 
+        # add *lal>=7.1.1 as run_constrained for liblal-7.1.1
+        if (
+            record_name == "liblal"
+            and record['version'] == "7.1.1"
+            and record['build_number'] in (0, 1, 2, 100, 101, 102)
+        ):
+            record.setdefault('constrains', []).extend((
+                "lal >=7.1.1",
+                "python-lal >=7.1.1",
+            ))
+
     return index
 
 


### PR DESCRIPTION
This PR adds a block to fix the missing `run_constrained` metadata for liblal-711, I have no idea whether this is correctly done.

See https://github.com/conda-forge/admin-requests/pull/227

cc @chrisburr, @beckermr

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
