### PR TITLE
Pin arrow 1.0.1 builds < 17 to numpy <1.20

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -529,11 +529,15 @@ def _gen_new_index(repodata, subdir):
             if "aws-sdk-cpp" in record['depends']:
                 i = record['depends'].index('aws-sdk-cpp')
                 record['depends'][i] = 'aws-sdk-cpp 1.7.164'
-            if record.get("build") and record.get("build").endswith("14_cuda"):
-                if 'constrains' in record:
-                    record['constrains'].append("numpy <1.20")
-                else:
-                    record['constrains'] = ["numpy <1.20"]
+
+            # arrow 1.0.1 cuda builds < 18 are incompatible with numpy 1.20
+            if record.get("version") == "1.0.1":
+                cuda_build = re.match(".+_([\d]{1,3})_cuda$", record.get("build", ""))
+                if cuda_build and int(cuda_build.groups()[0]) < 18:
+                    if 'constrains' in record:
+                        record['constrains'].append("numpy <1.20")
+                    else:
+                        record['constrains'] = ["numpy <1.20"]
 
         if record_name == "pyarrow":
             if not any(dep.split(' ')[0] == "arrow-cpp-proc" for dep in record.get('constrains', ())):
@@ -541,11 +545,15 @@ def _gen_new_index(repodata, subdir):
                     record['constrains'].append("arrow-cpp-proc * cpu")
                 else:
                     record['constrains'] = ["arrow-cpp-proc * cpu"]
-            if record.get("build") and record.get("build").endswith("14_cuda"):
-                if 'constrains' in record:
-                    record['constrains'].append("numpy <1.20")
-                else:
-                    record['constrains'] = ["numpy <1.20"]
+
+            # arrow 1.0.1 cuda builds < 18 are incompatible with numpy 1.20
+            if record.get("version") == "1.0.1":
+                cuda_build = re.match(".+_([\d]{1,3})_cuda$", record.get("build", ""))
+                if cuda_build and int(cuda_build.groups()[0]) < 18:
+                    if 'constrains' in record:
+                        record['constrains'].append("numpy <1.20")
+                    else:
+                        record['constrains'] = ["numpy <1.20"]
 
         if record_name == "kartothek":
             if record["version"] in ["3.15.0", "3.15.1", "3.16.0"] \

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -531,13 +531,11 @@ def _gen_new_index(repodata, subdir):
                 record['depends'][i] = 'aws-sdk-cpp 1.7.164'
 
             # arrow 1.0.1 builds < 17 are incompatible with numpy 1.20
-            if record.get("version") == "1.0.1":
-                build_number_capture = re.match(".+_([\d]{1,3})_[a-z]{1,4}$", record.get("build", ""))
-                if build_number_capture and int(build_number_capture.groups()[0]) < 17:
-                    if 'constrains' in record:
-                        record['constrains'].append("numpy <1.20")
-                    else:
-                        record['constrains'] = ["numpy <1.20"]
+            if record.get("version") == "1.0.1" and record.get("build_number") < 17:
+                if 'constrains' in record:
+                    record['constrains'].append("numpy <1.20")
+                else:
+                    record['constrains'] = ["numpy <1.20"]
 
         if record_name == "pyarrow":
             if not any(dep.split(' ')[0] == "arrow-cpp-proc" for dep in record.get('constrains', ())):
@@ -547,13 +545,11 @@ def _gen_new_index(repodata, subdir):
                     record['constrains'] = ["arrow-cpp-proc * cpu"]
 
             # arrow 1.0.1 builds < 17 are incompatible with numpy 1.20
-            if record.get("version") == "1.0.1":
-                build_number_capture = re.match(".+_([\d]{1,3})_[a-z]{1,4}$", record.get("build", ""))
-                if build_number_capture and int(build_number_capture.groups()[0]) < 17:
-                    if 'constrains' in record:
-                        record['constrains'].append("numpy <1.20")
-                    else:
-                        record['constrains'] = ["numpy <1.20"]
+            if record.get("version") == "1.0.1" and record.get("build_number") < 17:
+                if 'constrains' in record:
+                    record['constrains'].append("numpy <1.20")
+                else:
+                    record['constrains'] = ["numpy <1.20"]
 
         if record_name == "kartothek":
             if record["version"] in ["3.15.0", "3.15.1", "3.16.0"] \

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -529,6 +529,11 @@ def _gen_new_index(repodata, subdir):
             if "aws-sdk-cpp" in record['depends']:
                 i = record['depends'].index('aws-sdk-cpp')
                 record['depends'][i] = 'aws-sdk-cpp 1.7.164'
+            if record.get("build") and record.get("build").endswith("14_cuda"):
+                if 'constrains' in record:
+                    record['constrains'].append("numpy <1.20")
+                else:
+                    record['constrains'] = ["numpy <1.20"]
 
         if record_name == "pyarrow":
             if not any(dep.split(' ')[0] == "arrow-cpp-proc" for dep in record.get('constrains', ())):
@@ -536,6 +541,11 @@ def _gen_new_index(repodata, subdir):
                     record['constrains'].append("arrow-cpp-proc * cpu")
                 else:
                     record['constrains'] = ["arrow-cpp-proc * cpu"]
+            if record.get("build") and record.get("build").endswith("14_cuda"):
+                if 'constrains' in record:
+                    record['constrains'].append("numpy <1.20")
+                else:
+                    record['constrains'] = ["numpy <1.20"]
 
         if record_name == "kartothek":
             if record["version"] in ["3.15.0", "3.15.1", "3.16.0"] \

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -530,10 +530,10 @@ def _gen_new_index(repodata, subdir):
                 i = record['depends'].index('aws-sdk-cpp')
                 record['depends'][i] = 'aws-sdk-cpp 1.7.164'
 
-            # arrow 1.0.1 cuda builds < 18 are incompatible with numpy 1.20
+            # arrow 1.0.1 builds < 17 are incompatible with numpy 1.20
             if record.get("version") == "1.0.1":
-                cuda_build = re.match(".+_([\d]{1,3})_cuda$", record.get("build", ""))
-                if cuda_build and int(cuda_build.groups()[0]) < 18:
+                build_number_capture = re.match(".+_([\d]{1,3})_[a-z]{1,4}$", record.get("build", ""))
+                if build_number_capture and int(build_number_capture.groups()[0]) < 17:
                     if 'constrains' in record:
                         record['constrains'].append("numpy <1.20")
                     else:
@@ -546,10 +546,10 @@ def _gen_new_index(repodata, subdir):
                 else:
                     record['constrains'] = ["arrow-cpp-proc * cpu"]
 
-            # arrow 1.0.1 cuda builds < 18 are incompatible with numpy 1.20
+            # arrow 1.0.1 builds < 17 are incompatible with numpy 1.20
             if record.get("version") == "1.0.1":
-                cuda_build = re.match(".+_([\d]{1,3})_cuda$", record.get("build", ""))
-                if cuda_build and int(cuda_build.groups()[0]) < 18:
+                build_number_capture = re.match(".+_([\d]{1,3})_[a-z]{1,4}$", record.get("build", ""))
+                if build_number_capture and int(build_number_capture.groups()[0]) < 17:
                     if 'constrains' in record:
                         record['constrains'].append("numpy <1.20")
                     else:


### PR DESCRIPTION
Arrow-cpp and pyarrow 1.0.1 builds prior to `*_17` are not fully compatible with numpy 1.20. This PR constrains these builds to numpy <1.20. Below is one example of what can happen in environments without this constraint. The expectation is that this code would create a pyarrow array.

```python
import pyarrow as pa
import numpy as np

pa.array(np.array([0,1]))
---------------------------------------------------------------------------
ArrowTypeError                            Traceback (most recent call last)
<ipython-input-8-dd455cbf81db> in <module>
      2 import numpy as np
      3
----> 4 pa.array(np.array([0,1]))

~/conda/envs/arrow-numpy/lib/python3.7/site-packages/pyarrow/array.pxi in pyarrow.lib.array()

~/conda/envs/arrow-numpy/lib/python3.7/site-packages/pyarrow/array.pxi in pyarrow.lib._ndarray_to_array()

~/conda/envs/arrow-numpy/lib/python3.7/site-packages/pyarrow/array.pxi in pyarrow.lib._ndarray_to_type()

~/conda/envs/arrow-numpy/lib/python3.7/site-packages/pyarrow/error.pxi in pyarrow.lib.check_status()

ArrowTypeError: Did not pass numpy.dtype object
```

```
conda list | grep "arrow\|numpy"
# packages in environment at /home/nicholasb/conda/envs/arrow-numpy:
arrow-cpp                 1.0.1           py37h2318771_14_cuda    conda-forge
numpy                     1.20.0           py37haa41c4c_0    conda-forge
pyarrow                   1.0.1           py37hbeecfa9_14_cuda    conda-forge
```

cc @jakirkham 