### PR TITLE
Add a patch for MDTraj on python 3.8 for astunparse 1.6.3

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -673,6 +673,17 @@ def _gen_new_index(repodata, subdir):
                     _dep_parts[1] = _dep_parts[1] + ",<0.8.0"
                     record["depends"][i] = " ".join(_dep_parts)
 
+        # Integration between mdtraj and astunparse 1.6.3 on python 3.8 is
+        # broken, which was pinned for new builds in
+        # https://github.com/conda-forge/mdtraj-feedstock/pull/30 but should
+        # also be corrected on older builds
+        if (record_name == "mdtraj" and
+            "py38" in record['build'] and
+            "astunparse" in record['depends'] and
+            "astunparse <=1.6.2" not in record['depends']):
+            i = record['depends'].index('astunparse')
+            record['depends'][i] = 'astunparse <=1.6.2'
+
         # FIXME: disable patching-out blas_openblas feature
         # because hotfixes are not applied to gcc7 label
         # causing inconsistent behavior
@@ -692,7 +703,7 @@ def _gen_new_index(repodata, subdir):
         if any(dep.startswith("zstd >=1.4") for dep in deps):
             _pin_looser(fn, record, "zstd", max_pin="x.x")
 
-        # We pin MPI packages loosely so as to rely on their ABI compatibility                                    
+        # We pin MPI packages loosely so as to rely on their ABI compatibility
         if any(dep.startswith("openmpi >=4.0") for dep in deps):
             _pin_looser(fn, record, "openmpi", upper_bound="5.0")
         if any(dep.startswith("mpich >=3.3") for dep in deps):

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -678,6 +678,7 @@ def _gen_new_index(repodata, subdir):
         # https://github.com/conda-forge/mdtraj-feedstock/pull/30 but should
         # also be corrected on older builds
         if (record_name == "mdtraj" and
+            record["version"] == "1.9.5" and
             "py38" in record['build'] and
             "astunparse" in record['depends'] and
             "astunparse <=1.6.2" not in record['depends']):


### PR DESCRIPTION
Closes https://github.com/conda-forge/mdtraj-feedstock/issues/31 . The dependency combination of `astunparse=1.6.3` and `python=3.8` is broken for mdtraj (see https://github.com/mdtraj/mdtraj/issues/1613 and https://github.com/simonpercivall/astunparse/issues/43 ) For this reason mdtraj pinned astunparse to `<=1.6.2` for new python `3.8` builds (https://github.com/conda-forge/mdtraj-feedstock/pull/30). However, the current default install from conda still pulls in the broken build combination, so (hopefully) this patch should also fix that.

output from `show_diff.py`:
```diff
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata.json.bz2
linux-64::mdtraj-1.9.5-py38h4fbea22_0.tar.bz2
-    "astunparse",
+    "astunparse <=1.6.2",
linux-64::mdtraj-1.9.5-py38hbcc7ddf_0.tar.bz2
-    "astunparse",
+    "astunparse <=1.6.2",
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata.json.bz2
osx-64::mdtraj-1.9.5-py38h38e8ca5_0.tar.bz2
-    "astunparse",
+    "astunparse <=1.6.2",
osx-64::mdtraj-1.9.5-py38hcbf3f11_0.tar.bz2
-    "astunparse",
+    "astunparse <=1.6.2",
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata.json.bz2
win-64::mdtraj-1.9.5-py38h689c0bd_0.tar.bz2
-    "astunparse",
+    "astunparse <=1.6.2",

```
