### PR TITLE
Patch dependency on tbb

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -717,7 +717,7 @@ def _gen_new_index(repodata, subdir):
         # TBB 2021 (oneTBB 2021) is incompatible with previous releases.
         if has_dep(record, "tbb") and record.get('timestamp', 0) < 1614261110000:
             for i, dep in enumerate(deps):
-                if dep == "tbb" or any(dep.startswith(f"tbb >={i}") for i in range(2017, 2020)) or dep.startswith("tbb >=4.4"):
+                if dep == "tbb" or any(dep.startswith(f"tbb >={i}") for i in range(2017, 2021)) or dep.startswith("tbb >=4.4"):
                     deps.append("tbb <2021.0.0a0")
                     break
 

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -717,9 +717,7 @@ def _gen_new_index(repodata, subdir):
         # TBB 2021 (oneTBB 2021) is incompatible with previous releases.
         if has_dep(record, "tbb") and record.get('timestamp', 0) < 1614285451000:
             for i, dep in enumerate(deps):
-                if dep.split(" ")[0] != "tbb":
-                    continue
-                if dep == "tbb" or any(dep.startswith(f"tbb >={i}") for i in range(2016, 2021)):
+                if dep == "tbb" or any(dep.startswith(f"tbb >={i}") for i in range(2017, 2020)) or dep.startswith("tbb >=4.4"):
                     deps.append("tbb <2021.a0")
                     break
 

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -718,7 +718,7 @@ def _gen_new_index(repodata, subdir):
         if has_dep(record, "tbb") and record.get('timestamp', 0) < 1614261110000:
             for i, dep in enumerate(deps):
                 if dep == "tbb" or any(dep.startswith(f"tbb >={i}") for i in range(2017, 2020)) or dep.startswith("tbb >=4.4"):
-                    deps.append("tbb <2021.a0")
+                    deps.append("tbb <2021.0.0a0")
                     break
 
         _replace_pin('libunwind >=1.2.1,<1.3.0a0', 'libunwind >=1.2.1,<2.0.0a0', deps, record)

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -719,13 +719,9 @@ def _gen_new_index(repodata, subdir):
             for i, dep in enumerate(deps):
                 if dep.split(" ")[0] != "tbb":
                     continue
-                if "<" in dep:
+                if dep == "tbb" or any(dep.startswith(f"tbb >={i}") for i in range(2016, 2021)):
+                    deps.append("tbb <2021.a0")
                     break
-
-                if " " in record['depends'][i]:
-                    record['depends'][i] = record['depends'][i] + ',<2021a0'
-                else:
-                    _rename_dependency(fn, record, "tbb", "tbb <2021a0")
 
         _replace_pin('libunwind >=1.2.1,<1.3.0a0', 'libunwind >=1.2.1,<2.0.0a0', deps, record)
         _replace_pin('snappy >=1.1.7,<1.1.8.0a0', 'snappy >=1.1.7,<2.0.0.0a0', deps, record)

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -715,7 +715,7 @@ def _gen_new_index(repodata, subdir):
             _pin_looser(fn, record, "mpich", upper_bound="4.0")
 
         # TBB 2021 (oneTBB 2021) is incompatible with previous releases.
-        if has_dep(record, "tbb") and record.get('timestamp', 0) < 1614285451000:
+        if has_dep(record, "tbb") and record.get('timestamp', 0) < 1614261110000:
             for i, dep in enumerate(deps):
                 if dep == "tbb" or any(dep.startswith(f"tbb >={i}") for i in range(2017, 2020)) or dep.startswith("tbb >=4.4"):
                     deps.append("tbb <2021.a0")

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -714,6 +714,19 @@ def _gen_new_index(repodata, subdir):
         if any(dep.startswith("mpich >=3.4.1,") for dep in deps):
             _pin_looser(fn, record, "mpich", upper_bound="4.0")
 
+        # TBB 2021 (oneTBB 2021) is incompatible with previous releases.
+        if has_dep(record, "tbb") and record.get('timestamp', 0) < 1614285451000:
+            for i, dep in enumerate(deps):
+                if dep.split(" ")[0] != "tbb":
+                    continue
+                if "<" in dep:
+                    break
+
+                if " " in record['depends'][i]:
+                    record['depends'][i] = record['depends'][i] + ',<2021a0'
+                else:
+                    _rename_dependency(fn, record, "tbb", "tbb <2021a0")
+
         _replace_pin('libunwind >=1.2.1,<1.3.0a0', 'libunwind >=1.2.1,<2.0.0a0', deps, record)
         _replace_pin('snappy >=1.1.7,<1.1.8.0a0', 'snappy >=1.1.7,<2.0.0.0a0', deps, record)
         _replace_pin('ncurses >=6.1,<6.2.0a0', 'ncurses >=6.1,<6.3.0a0', deps, record)


### PR DESCRIPTION
This PR is created after the following discussions:

- https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/1227
- https://github.com/conda-forge/tbb-feedstock/pull/75

It is required for safe upgrade of TBB to oneTBB 2021 that is incompatible with previous versions: https://github.com/conda-forge/tbb-feedstock/pull/78