### PR TITLE
Fix boost-cpp constraints for old Gazebo builds

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -900,7 +900,7 @@ def _gen_new_index(repodata, subdir):
         # https://github.com/conda-forge/gazebo-feedstock/issues/52
         if (record_name == "gazebo" and 
                 record.get('timestamp', 0) < 1583200976700):
-            _pin_stricter(fn, record, "boost-cpp", "x.x")
+            _replace_pin('boost-cpp >=1.71', 'boost-cpp >=1.71.0,<1.71.1.0a0', deps, record)
 
     return index
 

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -895,6 +895,13 @@ def _gen_new_index(repodata, subdir):
             i = record['depends'].index('azure-storage-common >=1.3.0,<1.4.0')
             record['depends'][i] = 'azure-storage-common >=2.1,<3.0'
 
+        # Old versions of Gazebo depend on boost-cpp >= 1.71,
+        # but they are actually incompatible with any boost-cpp >= 1.72
+        # https://github.com/conda-forge/gazebo-feedstock/issues/52
+        if (record_name == "gazebo" and 
+                record.get('timestamp', 0) < 1583200976700):
+            _pin_stricter(fn, record, "boost-cpp", "x.x")
+
     return index
 
 


### PR DESCRIPTION
Fix https://github.com/conda-forge/gazebo-feedstock/issues/52 .

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.
