### PR TITLE
Pin libthrift 0.14 stricter

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -638,6 +638,9 @@ def _gen_new_index(repodata, subdir):
         if 'libffi' in deps and record.get('timestamp', 0) < 1605980936031:
             _rename_dependency(fn, record, "libffi", "libffi <3.3.0.a0")
 
+        if ('libthrift >=0.14.0,<0.15.0a0' in deps or 'libthrift >=0.14.1,<0.15.0a0' in deps) and record.get('timestamp', 0) < 1615295782045:
+            _pin_stricter(fn, record, "libthrift", "x.x.x")
+
         if 'libffi >=3.2.1,<4.0a0' in deps and record.get('timestamp', 0) < 1605980936031:
             _pin_stricter(fn, record, "libffi", "x.x")
 


### PR DESCRIPTION
With 0.14 they added the patch level to the SONAME, fixed in feedstock: https://github.com/conda-forge/thrift-cpp-feedstock/pull/56

Diff: https://gist.github.com/xhochy/be9405c016c9db7687ac1b862c298be4