### PR TITLE
Pin root_base tighter due to ABI break in 6.22.6

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -724,6 +724,12 @@ def _gen_new_index(repodata, subdir):
                     deps.append("tbb <2021.0.0a0")
                     break
 
+        # ROOT 6.22.6 contained an ABI break, we'll always pin on patch releases from now on
+        if has_dep(record, "root_base"):
+            for i, dep in enumerate(deps):
+                if "root_base" in dep and ">=6.22." in dep and "<6.23.0a0" in dep:
+                    deps.append("root_base <6.22.5a0")
+
         _replace_pin('libunwind >=1.2.1,<1.3.0a0', 'libunwind >=1.2.1,<2.0.0a0', deps, record)
         _replace_pin('snappy >=1.1.7,<1.1.8.0a0', 'snappy >=1.1.7,<2.0.0.0a0', deps, record)
         _replace_pin('ncurses >=6.1,<6.2.0a0', 'ncurses >=6.1,<6.3.0a0', deps, record)


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

```
$ python recipe/show_diff.py
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata.json.bz2
linux-64::fenics-dolfin-2019.1.0-py36ha6b274e_19.tar.bz2
-    "mpich >=3.4.1,<3.5.0a0",
+    "mpich >=3.4.1,<4.0.0a0",
linux-64::fenics-dolfin-2019.1.0-py37h03c9415_19.tar.bz2
-    "mpich >=3.4.1,<3.5.0a0",
+    "mpich >=3.4.1,<4.0.0a0",
linux-64::fenics-dolfin-2019.1.0-py38hf39676a_19.tar.bz2
-    "mpich >=3.4.1,<3.5.0a0",
+    "mpich >=3.4.1,<4.0.0a0",
linux-64::fenics-dolfin-2019.1.0-py39hc6fefde_19.tar.bz2
-    "mpich >=3.4.1,<3.5.0a0",
+    "mpich >=3.4.1,<4.0.0a0",
linux-64::fenics-libdolfin-2019.1.0-h5ba192a_19.tar.bz2
-    "mpich >=3.4.1,<3.5.0a0",
+    "mpich >=3.4.1,<4.0.0a0",
linux-64::fwlite-11.1.5-py36h0801a2c_0.tar.bz2
-    "tbb <2021.0.0a0"
+    "tbb <2021.0.0a0",
+    "root_base <6.22.5a0"
linux-64::fwlite-11.1.5-py36h0801a2c_1.tar.bz2
-    "tbb <2021.0.0a0"
+    "tbb <2021.0.0a0",
+    "root_base <6.22.5a0"
linux-64::fwlite-11.1.5-py36h089b670_0.tar.bz2
-    "tbb <2021.0.0a0"
+    "tbb <2021.0.0a0",
+    "root_base <6.22.5a0"
linux-64::fwlite-11.1.5-py36h089b670_1.tar.bz2
-    "tbb <2021.0.0a0"
+    "tbb <2021.0.0a0",
+    "root_base <6.22.5a0"
linux-64::fwlite-11.1.5-py36h331d8fc_2.tar.bz2
-    "tbb <2021.0.0a0"
+    "tbb <2021.0.0a0",
+    "root_base <6.22.5a0"
linux-64::fwlite-11.1.5-py36hb2a31a3_2.tar.bz2
-    "tbb <2021.0.0a0"
+    "tbb <2021.0.0a0",
+    "root_base <6.22.5a0"
linux-64::fwlite-11.1.5-py37h16b2819_2.tar.bz2
-    "tbb <2021.0.0a0"
+    "tbb <2021.0.0a0",
+    "root_base <6.22.5a0"
linux-64::fwlite-11.1.5-py37h19f5164_0.tar.bz2
-    "tbb <2021.0.0a0"
+    "tbb <2021.0.0a0",
+    "root_base <6.22.5a0"
linux-64::fwlite-11.1.5-py37h19f5164_1.tar.bz2
-    "tbb <2021.0.0a0"
+    "tbb <2021.0.0a0",
+    "root_base <6.22.5a0"
linux-64::fwlite-11.1.5-py37hd7f6ca8_0.tar.bz2
-    "tbb <2021.0.0a0"
+    "tbb <2021.0.0a0",
+    "root_base <6.22.5a0"
linux-64::fwlite-11.1.5-py37hd7f6ca8_1.tar.bz2
-    "tbb <2021.0.0a0"
+    "tbb <2021.0.0a0",
+    "root_base <6.22.5a0"
linux-64::fwlite-11.1.5-py37hec08ca0_2.tar.bz2
-    "tbb <2021.0.0a0"
+    "tbb <2021.0.0a0",
+    "root_base <6.22.5a0"
linux-64::fwlite-11.1.5-py38h768f95f_2.tar.bz2
-    "tbb <2021.0.0a0"
+    "tbb <2021.0.0a0",
+    "root_base <6.22.5a0"
linux-64::fwlite-11.1.5-py38h8d49631_2.tar.bz2
-    "tbb <2021.0.0a0"
+    "tbb <2021.0.0a0",
+    "root_base <6.22.5a0"
linux-64::fwlite-11.1.5-py38hccfd5a1_0.tar.bz2
-    "tbb <2021.0.0a0"
+    "tbb <2021.0.0a0",
+    "root_base <6.22.5a0"
linux-64::fwlite-11.1.5-py38hccfd5a1_1.tar.bz2
-    "tbb <2021.0.0a0"
+    "tbb <2021.0.0a0",
+    "root_base <6.22.5a0"
linux-64::fwlite-11.1.5-py38hfbb0779_0.tar.bz2
-    "tbb <2021.0.0a0"
+    "tbb <2021.0.0a0",
+    "root_base <6.22.5a0"
linux-64::fwlite-11.1.5-py38hfbb0779_1.tar.bz2
-    "tbb <2021.0.0a0"
+    "tbb <2021.0.0a0",
+    "root_base <6.22.5a0"
linux-64::fwlite-11.1.5-py39h622c69e_2.tar.bz2
-    "tbb <2021.0.0a0"
+    "tbb <2021.0.0a0",
+    "root_base <6.22.5a0"
linux-64::fwlite-11.1.5-py39h9d6a212_2.tar.bz2
-    "tbb <2021.0.0a0"
+    "tbb <2021.0.0a0",
+    "root_base <6.22.5a0"
linux-64::gwollum-2.4.0-h4c1f761_1.tar.bz2
-    "root_base >=6.22.0,<6.23.0a0"
+    "root_base >=6.22.0,<6.23.0a0",
+    "root_base <6.22.5a0"
linux-64::gwollum-2.4.0-h99f37a1_1.tar.bz2
-    "root_base >=6.22.0,<6.23.0a0"
+    "root_base >=6.22.0,<6.23.0a0",
+    "root_base <6.22.5a0"
linux-64::gwollum-2.4.1-h4c1f761_0.tar.bz2
-    "root_base >=6.22.0,<6.23.0a0"
+    "root_base >=6.22.0,<6.23.0a0",
+    "root_base <6.22.5a0"
linux-64::gwollum-2.4.1-h735fe92_1.tar.bz2
-    "root_base >=6.22.6,<6.23.0a0"
+    "root_base >=6.22.6,<6.23.0a0",
+    "root_base <6.22.5a0"
linux-64::gwollum-2.4.2-h735fe92_0.tar.bz2
-    "root_base >=6.22.6,<6.23.0a0"
+    "root_base >=6.22.6,<6.23.0a0",
+    "root_base <6.22.5a0"
linux-64::hammer-1.0.0-py36h4726645_6.tar.bz2
-    "yaml-cpp"
+    "yaml-cpp",
+    "root_base <6.22.5a0"
linux-64::hammer-1.0.0-py37h0dc71e4_6.tar.bz2
-    "yaml-cpp"
+    "yaml-cpp",
+    "root_base <6.22.5a0"
linux-64::hammer-1.0.0-py38hd79bb50_6.tar.bz2
-    "yaml-cpp"
+    "yaml-cpp",
+    "root_base <6.22.5a0"
linux-64::hammer-1.1.0-py36h3ba51be_1.tar.bz2
-    "yaml-cpp"
+    "yaml-cpp",
+    "root_base <6.22.5a0"
linux-64::hammer-1.1.0-py36h706a4de_2.tar.bz2
-    "yaml-cpp >=0.6.3,<0.7.0a0"
+    "yaml-cpp >=0.6.3,<0.7.0a0",
+    "root_base <6.22.5a0"
linux-64::hammer-1.1.0-py36h78ca621_1.tar.bz2
-    "yaml-cpp"
+    "yaml-cpp",
+    "root_base <6.22.5a0"
linux-64::hammer-1.1.0-py36h8a8e20c_0.tar.bz2
-    "yaml-cpp"
+    "yaml-cpp",
+    "root_base <6.22.5a0"
linux-64::hammer-1.1.0-py36hd636c90_2.tar.bz2
-    "yaml-cpp >=0.6.3,<0.7.0a0"
+    "yaml-cpp >=0.6.3,<0.7.0a0",
+    "root_base <6.22.5a0"
linux-64::hammer-1.1.0-py37h030d5a0_0.tar.bz2
-    "yaml-cpp"
+    "yaml-cpp",
+    "root_base <6.22.5a0"
linux-64::hammer-1.1.0-py37h1307a62_1.tar.bz2
-    "yaml-cpp"
+    "yaml-cpp",
+    "root_base <6.22.5a0"
linux-64::hammer-1.1.0-py37h608d65c_1.tar.bz2
-    "yaml-cpp"
+    "yaml-cpp",
+    "root_base <6.22.5a0"
linux-64::hammer-1.1.0-py37h63e3677_2.tar.bz2
-    "yaml-cpp >=0.6.3,<0.7.0a0"
+    "yaml-cpp >=0.6.3,<0.7.0a0",
+    "root_base <6.22.5a0"
linux-64::hammer-1.1.0-py37h825d14d_2.tar.bz2
-    "yaml-cpp >=0.6.3,<0.7.0a0"
+    "yaml-cpp >=0.6.3,<0.7.0a0",
+    "root_base <6.22.5a0"
linux-64::hammer-1.1.0-py38h147c6c7_1.tar.bz2
-    "yaml-cpp"
+    "yaml-cpp",
+    "root_base <6.22.5a0"
linux-64::hammer-1.1.0-py38h7556ca5_2.tar.bz2
-    "yaml-cpp >=0.6.3,<0.7.0a0"
+    "yaml-cpp >=0.6.3,<0.7.0a0",
+    "root_base <6.22.5a0"
linux-64::hammer-1.1.0-py38h780fd6d_2.tar.bz2
-    "yaml-cpp >=0.6.3,<0.7.0a0"
+    "yaml-cpp >=0.6.3,<0.7.0a0",
+    "root_base <6.22.5a0"
linux-64::hammer-1.1.0-py38h79773de_0.tar.bz2
-    "yaml-cpp"
+    "yaml-cpp",
+    "root_base <6.22.5a0"
linux-64::hammer-1.1.0-py38he591b41_1.tar.bz2
-    "yaml-cpp"
+    "yaml-cpp",
+    "root_base <6.22.5a0"
linux-64::hammer-1.1.0-py39h07062a6_2.tar.bz2
-    "yaml-cpp >=0.6.3,<0.7.0a0"
+    "yaml-cpp >=0.6.3,<0.7.0a0",
+    "root_base <6.22.5a0"
linux-64::hammer-1.1.0-py39h65cdd19_2.tar.bz2
-    "yaml-cpp >=0.6.3,<0.7.0a0"
+    "yaml-cpp >=0.6.3,<0.7.0a0",
+    "root_base <6.22.5a0"
linux-64::lhcb-simpletools-2.0-h28a5359_7.tar.bz2
-    "root_base >=6.22.0,<6.23.0a0"
+    "root_base >=6.22.0,<6.23.0a0",
+    "root_base <6.22.5a0"
linux-64::lhcb-simpletools-2.0-h87d6cf2_8.tar.bz2
-    "root_base >=6.22.2,<6.23.0a0"
+    "root_base >=6.22.2,<6.23.0a0",
+    "root_base <6.22.5a0"
linux-64::lhcb-simpletools-2.0-ha5d0403_8.tar.bz2
-    "root_base >=6.22.2,<6.23.0a0"
+    "root_base >=6.22.2,<6.23.0a0",
+    "root_base <6.22.5a0"
linux-64::lhcb-simpletools-3.0-h527afce_0.tar.bz2
-    "root_base >=6.22.2,<6.23.0a0"
+    "root_base >=6.22.2,<6.23.0a0",
+    "root_base <6.22.5a0"
linux-64::lhcb-simpletools-3.0-hc08e6c6_0.tar.bz2
-    "root_base >=6.22.2,<6.23.0a0"
+    "root_base >=6.22.2,<6.23.0a0",
+    "root_base <6.22.5a0"
linux-64::mpi4jax-0.2.13-py37h1e5cb63_0.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
linux-64::mpi4jax-0.2.13-py37h1e5cb63_1.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
linux-64::mpi4jax-0.2.13-py38he865349_0.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
linux-64::mpi4jax-0.2.13-py38he865349_1.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
linux-64::mpi4jax-0.2.13-py39h6438238_0.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
linux-64::mpi4jax-0.2.13-py39h6438238_1.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
linux-64::mpi4jax-0.2.15-py37h1e5cb63_0.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
linux-64::mpi4jax-0.2.15-py37h1e5cb63_1.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
linux-64::mpi4jax-0.2.15-py38he865349_0.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
linux-64::mpi4jax-0.2.15-py38he865349_1.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
linux-64::mpi4jax-0.2.15-py39h6438238_0.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
linux-64::mpi4jax-0.2.15-py39h6438238_1.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
linux-64::omicron-2.4.0-h20643e6_1.tar.bz2
-    "root_base >=6.22.0,<6.23.0a0"
+    "root_base >=6.22.0,<6.23.0a0",
+    "root_base <6.22.5a0"
linux-64::omicron-2.4.1-h20643e6_0.tar.bz2
-    "root_base >=6.22.0,<6.23.0a0"
+    "root_base >=6.22.0,<6.23.0a0",
+    "root_base <6.22.5a0"
linux-64::omicron-2.4.2-hb008238_0.tar.bz2
-    "root_base >=6.22.6,<6.23.0a0"
+    "root_base >=6.22.6,<6.23.0a0",
+    "root_base <6.22.5a0"
linux-64::rapidsim-1.5-h20643e6_4.tar.bz2
-    "root_base >=6.22.0,<6.23.0a0"
+    "root_base >=6.22.0,<6.23.0a0",
+    "root_base <6.22.5a0"
linux-64::rapidsim-1.5-h20643e6_5.tar.bz2
-    "root_base >=6.22.0,<6.23.0a0"
+    "root_base >=6.22.0,<6.23.0a0",
+    "root_base <6.22.5a0"
linux-64::rapidsim-1.5-h20643e6_6.tar.bz2
-    "root_base >=6.22.0,<6.23.0a0"
+    "root_base >=6.22.0,<6.23.0a0",
+    "root_base <6.22.5a0"
linux-64::root_numpy-4.8.0-py36h760e8c4_10.tar.bz2
-    "setuptools"
+    "setuptools",
+    "root_base <6.22.5a0"
linux-64::root_numpy-4.8.0-py36hae338b9_7.tar.bz2
-    "root_base >=6.22.0,<6.23.0a0"
+    "root_base >=6.22.0,<6.23.0a0",
+    "root_base <6.22.5a0"
linux-64::root_numpy-4.8.0-py36hae338b9_8.tar.bz2
-    "root_base >=6.22.0,<6.23.0a0"
+    "root_base >=6.22.0,<6.23.0a0",
+    "root_base <6.22.5a0"
linux-64::root_numpy-4.8.0-py36he1ee7cc_9.tar.bz2
-    "root_base >=6.22.2,<6.23.0a0"
+    "root_base >=6.22.2,<6.23.0a0",
+    "root_base <6.22.5a0"
linux-64::root_numpy-4.8.0-py37h3a15b83_10.tar.bz2
-    "setuptools"
+    "setuptools",
+    "root_base <6.22.5a0"
linux-64::root_numpy-4.8.0-py37h847726b_7.tar.bz2
-    "root_base >=6.22.0,<6.23.0a0"
+    "root_base >=6.22.0,<6.23.0a0",
+    "root_base <6.22.5a0"
linux-64::root_numpy-4.8.0-py37h847726b_8.tar.bz2
-    "root_base >=6.22.0,<6.23.0a0"
+    "root_base >=6.22.0,<6.23.0a0",
+    "root_base <6.22.5a0"
linux-64::root_numpy-4.8.0-py37hf81cf69_9.tar.bz2
-    "root_base >=6.22.2,<6.23.0a0"
+    "root_base >=6.22.2,<6.23.0a0",
+    "root_base <6.22.5a0"
linux-64::root_numpy-4.8.0-py38h02e4990_10.tar.bz2
-    "setuptools"
+    "setuptools",
+    "root_base <6.22.5a0"
linux-64::root_numpy-4.8.0-py38h703c09c_7.tar.bz2
-    "root_base >=6.22.0,<6.23.0a0"
+    "root_base >=6.22.0,<6.23.0a0",
+    "root_base <6.22.5a0"
linux-64::root_numpy-4.8.0-py38h703c09c_8.tar.bz2
-    "root_base >=6.22.0,<6.23.0a0"
+    "root_base >=6.22.0,<6.23.0a0",
+    "root_base <6.22.5a0"
linux-64::root_numpy-4.8.0-py38hfdf6b3b_9.tar.bz2
-    "root_base >=6.22.2,<6.23.0a0"
+    "root_base >=6.22.2,<6.23.0a0",
+    "root_base <6.22.5a0"
linux-64::root_numpy-4.8.0-py39h7b374e0_10.tar.bz2
-    "setuptools"
+    "setuptools",
+    "root_base <6.22.5a0"
linux-64::slepc-3.14.1-h44d3fa2_0.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
linux-64::slepc-3.14.2-h44d3fa2_0.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata.json.bz2
linux-aarch64::slepc-3.14.1-h8b66d5b_0.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
linux-aarch64::slepc-3.14.2-h8b66d5b_0.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata.json.bz2
linux-ppc64le::slepc-3.14.1-h3d48a8a_0.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
linux-ppc64le::slepc-3.14.2-h3d48a8a_0.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata.json.bz2
osx-64::fenics-dolfin-2019.1.0-py36h74d7543_19.tar.bz2
-    "mpich >=3.4.1,<3.5.0a0",
+    "mpich >=3.4.1,<4.0.0a0",
osx-64::fenics-dolfin-2019.1.0-py37h2fe2f07_19.tar.bz2
-    "mpich >=3.4.1,<3.5.0a0",
+    "mpich >=3.4.1,<4.0.0a0",
osx-64::fenics-dolfin-2019.1.0-py38h58f3e4a_19.tar.bz2
-    "mpich >=3.4.1,<3.5.0a0",
+    "mpich >=3.4.1,<4.0.0a0",
osx-64::fenics-dolfin-2019.1.0-py39h087ae1b_19.tar.bz2
-    "mpich >=3.4.1,<3.5.0a0",
+    "mpich >=3.4.1,<4.0.0a0",
osx-64::fenics-libdolfin-2019.1.0-ha6bb12c_19.tar.bz2
-    "mpich >=3.4.1,<3.5.0a0",
+    "mpich >=3.4.1,<4.0.0a0",
osx-64::fwlite-11.1.5-py36h7ca385a_0.tar.bz2
-    "tbb <2021.0.0a0"
+    "tbb <2021.0.0a0",
+    "root_base <6.22.5a0"
osx-64::fwlite-11.1.5-py36h7ca385a_1.tar.bz2
-    "tbb <2021.0.0a0"
+    "tbb <2021.0.0a0",
+    "root_base <6.22.5a0"
osx-64::fwlite-11.1.5-py36hb0a62d1_2.tar.bz2
-    "tbb <2021.0.0a0"
+    "tbb <2021.0.0a0",
+    "root_base <6.22.5a0"
osx-64::fwlite-11.1.5-py36hca4a138_2.tar.bz2
-    "tbb <2021.0.0a0"
+    "tbb <2021.0.0a0",
+    "root_base <6.22.5a0"
osx-64::fwlite-11.1.5-py36he1ad71d_0.tar.bz2
-    "tbb <2021.0.0a0"
+    "tbb <2021.0.0a0",
+    "root_base <6.22.5a0"
osx-64::fwlite-11.1.5-py36he1ad71d_1.tar.bz2
-    "tbb <2021.0.0a0"
+    "tbb <2021.0.0a0",
+    "root_base <6.22.5a0"
osx-64::fwlite-11.1.5-py37h1bbc7c6_2.tar.bz2
-    "tbb <2021.0.0a0"
+    "tbb <2021.0.0a0",
+    "root_base <6.22.5a0"
osx-64::fwlite-11.1.5-py37hc5614d9_0.tar.bz2
-    "tbb <2021.0.0a0"
+    "tbb <2021.0.0a0",
+    "root_base <6.22.5a0"
osx-64::fwlite-11.1.5-py37hc5614d9_1.tar.bz2
-    "tbb <2021.0.0a0"
+    "tbb <2021.0.0a0",
+    "root_base <6.22.5a0"
osx-64::fwlite-11.1.5-py37hd0dce19_0.tar.bz2
-    "tbb <2021.0.0a0"
+    "tbb <2021.0.0a0",
+    "root_base <6.22.5a0"
osx-64::fwlite-11.1.5-py37hd0dce19_1.tar.bz2
-    "tbb <2021.0.0a0"
+    "tbb <2021.0.0a0",
+    "root_base <6.22.5a0"
osx-64::fwlite-11.1.5-py37he682a72_2.tar.bz2
-    "tbb <2021.0.0a0"
+    "tbb <2021.0.0a0",
+    "root_base <6.22.5a0"
osx-64::fwlite-11.1.5-py38h187139d_0.tar.bz2
-    "tbb <2021.0.0a0"
+    "tbb <2021.0.0a0",
+    "root_base <6.22.5a0"
osx-64::fwlite-11.1.5-py38h187139d_1.tar.bz2
-    "tbb <2021.0.0a0"
+    "tbb <2021.0.0a0",
+    "root_base <6.22.5a0"
osx-64::fwlite-11.1.5-py38h5444033_2.tar.bz2
-    "tbb <2021.0.0a0"
+    "tbb <2021.0.0a0",
+    "root_base <6.22.5a0"
osx-64::fwlite-11.1.5-py38hc08b0d4_0.tar.bz2
-    "tbb <2021.0.0a0"
+    "tbb <2021.0.0a0",
+    "root_base <6.22.5a0"
osx-64::fwlite-11.1.5-py38hc08b0d4_1.tar.bz2
-    "tbb <2021.0.0a0"
+    "tbb <2021.0.0a0",
+    "root_base <6.22.5a0"
osx-64::fwlite-11.1.5-py38hde4931a_2.tar.bz2
-    "tbb <2021.0.0a0"
+    "tbb <2021.0.0a0",
+    "root_base <6.22.5a0"
osx-64::fwlite-11.1.5-py39h64113bf_2.tar.bz2
-    "tbb <2021.0.0a0"
+    "tbb <2021.0.0a0",
+    "root_base <6.22.5a0"
osx-64::fwlite-11.1.5-py39hbe050d6_2.tar.bz2
-    "tbb <2021.0.0a0"
+    "tbb <2021.0.0a0",
+    "root_base <6.22.5a0"
osx-64::gwollum-2.4.0-h3d9d9ea_1.tar.bz2
-    "root_base >=6.22.0,<6.23.0a0"
+    "root_base >=6.22.0,<6.23.0a0",
+    "root_base <6.22.5a0"
osx-64::gwollum-2.4.0-hf560e9a_1.tar.bz2
-    "root_base >=6.22.0,<6.23.0a0"
+    "root_base >=6.22.0,<6.23.0a0",
+    "root_base <6.22.5a0"
osx-64::gwollum-2.4.1-h3d9d9ea_0.tar.bz2
-    "root_base >=6.22.0,<6.23.0a0"
+    "root_base >=6.22.0,<6.23.0a0",
+    "root_base <6.22.5a0"
osx-64::gwollum-2.4.1-hb7e9568_1.tar.bz2
-    "root_base >=6.22.6,<6.23.0a0"
+    "root_base >=6.22.6,<6.23.0a0",
+    "root_base <6.22.5a0"
osx-64::gwollum-2.4.2-h98a9e19_0.tar.bz2
-    "root_base >=6.22.6,<6.23.0a0"
+    "root_base >=6.22.6,<6.23.0a0",
+    "root_base <6.22.5a0"
osx-64::hammer-1.0.0-py36he69acf2_6.tar.bz2
-    "yaml-cpp"
+    "yaml-cpp",
+    "root_base <6.22.5a0"
osx-64::hammer-1.0.0-py37hb725f39_6.tar.bz2
-    "yaml-cpp"
+    "yaml-cpp",
+    "root_base <6.22.5a0"
osx-64::hammer-1.0.0-py38had3a4e6_6.tar.bz2
-    "yaml-cpp"
+    "yaml-cpp",
+    "root_base <6.22.5a0"
osx-64::hammer-1.1.0-py36h06e3fc2_1.tar.bz2
-    "yaml-cpp"
+    "yaml-cpp",
+    "root_base <6.22.5a0"
osx-64::hammer-1.1.0-py36h0a646c1_1.tar.bz2
-    "yaml-cpp"
+    "yaml-cpp",
+    "root_base <6.22.5a0"
osx-64::hammer-1.1.0-py36h912f462_0.tar.bz2
-    "yaml-cpp"
+    "yaml-cpp",
+    "root_base <6.22.5a0"
osx-64::hammer-1.1.0-py36h944212d_2.tar.bz2
-    "yaml-cpp >=0.6.3,<0.7.0a0"
+    "yaml-cpp >=0.6.3,<0.7.0a0",
+    "root_base <6.22.5a0"
osx-64::hammer-1.1.0-py36hf198341_2.tar.bz2
-    "yaml-cpp >=0.6.3,<0.7.0a0"
+    "yaml-cpp >=0.6.3,<0.7.0a0",
+    "root_base <6.22.5a0"
osx-64::hammer-1.1.0-py37h304131f_1.tar.bz2
-    "yaml-cpp"
+    "yaml-cpp",
+    "root_base <6.22.5a0"
osx-64::hammer-1.1.0-py37h645f6ff_1.tar.bz2
-    "yaml-cpp"
+    "yaml-cpp",
+    "root_base <6.22.5a0"
osx-64::hammer-1.1.0-py37hbf82730_0.tar.bz2
-    "yaml-cpp"
+    "yaml-cpp",
+    "root_base <6.22.5a0"
osx-64::hammer-1.1.0-py37hc05ca0b_2.tar.bz2
-    "yaml-cpp >=0.6.3,<0.7.0a0"
+    "yaml-cpp >=0.6.3,<0.7.0a0",
+    "root_base <6.22.5a0"
osx-64::hammer-1.1.0-py37hdeba562_2.tar.bz2
-    "yaml-cpp >=0.6.3,<0.7.0a0"
+    "yaml-cpp >=0.6.3,<0.7.0a0",
+    "root_base <6.22.5a0"
osx-64::hammer-1.1.0-py38h3975a07_1.tar.bz2
-    "yaml-cpp"
+    "yaml-cpp",
+    "root_base <6.22.5a0"
osx-64::hammer-1.1.0-py38h82bfe0d_2.tar.bz2
-    "yaml-cpp >=0.6.3,<0.7.0a0"
+    "yaml-cpp >=0.6.3,<0.7.0a0",
+    "root_base <6.22.5a0"
osx-64::hammer-1.1.0-py38h8bd9546_0.tar.bz2
-    "yaml-cpp"
+    "yaml-cpp",
+    "root_base <6.22.5a0"
osx-64::hammer-1.1.0-py38ha36507e_1.tar.bz2
-    "yaml-cpp"
+    "yaml-cpp",
+    "root_base <6.22.5a0"
osx-64::hammer-1.1.0-py38hee329e3_2.tar.bz2
-    "yaml-cpp >=0.6.3,<0.7.0a0"
+    "yaml-cpp >=0.6.3,<0.7.0a0",
+    "root_base <6.22.5a0"
osx-64::hammer-1.1.0-py39h4b67620_2.tar.bz2
-    "yaml-cpp >=0.6.3,<0.7.0a0"
+    "yaml-cpp >=0.6.3,<0.7.0a0",
+    "root_base <6.22.5a0"
osx-64::hammer-1.1.0-py39h8018d58_2.tar.bz2
-    "yaml-cpp >=0.6.3,<0.7.0a0"
+    "yaml-cpp >=0.6.3,<0.7.0a0",
+    "root_base <6.22.5a0"
osx-64::lhcb-simpletools-2.0-h4365f91_8.tar.bz2
-    "root_base >=6.22.2,<6.23.0a0"
+    "root_base >=6.22.2,<6.23.0a0",
+    "root_base <6.22.5a0"
osx-64::lhcb-simpletools-2.0-hc21b512_7.tar.bz2
-    "root_base >=6.22.0,<6.23.0a0"
+    "root_base >=6.22.0,<6.23.0a0",
+    "root_base <6.22.5a0"
osx-64::lhcb-simpletools-2.0-hcf76191_8.tar.bz2
-    "root_base >=6.22.2,<6.23.0a0"
+    "root_base >=6.22.2,<6.23.0a0",
+    "root_base <6.22.5a0"
osx-64::lhcb-simpletools-3.0-h7a8e01a_0.tar.bz2
-    "root_base >=6.22.2,<6.23.0a0"
+    "root_base >=6.22.2,<6.23.0a0",
+    "root_base <6.22.5a0"
osx-64::lhcb-simpletools-3.0-hc0d9b8d_0.tar.bz2
-    "root_base >=6.22.2,<6.23.0a0"
+    "root_base >=6.22.2,<6.23.0a0",
+    "root_base <6.22.5a0"
osx-64::mpi4jax-0.2.13-py37h45bc384_0.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
osx-64::mpi4jax-0.2.13-py37h45bc384_1.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
osx-64::mpi4jax-0.2.13-py38hcd6a4d3_0.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
osx-64::mpi4jax-0.2.13-py38hcd6a4d3_1.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
osx-64::mpi4jax-0.2.13-py39ha81d895_0.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
osx-64::mpi4jax-0.2.13-py39ha81d895_1.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
osx-64::mpi4jax-0.2.15-py37h45bc384_0.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
osx-64::mpi4jax-0.2.15-py37h45bc384_1.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
osx-64::mpi4jax-0.2.15-py38hcd6a4d3_0.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
osx-64::mpi4jax-0.2.15-py38hcd6a4d3_1.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
osx-64::mpi4jax-0.2.15-py39ha81d895_0.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
osx-64::mpi4jax-0.2.15-py39ha81d895_1.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
osx-64::omicron-2.4.0-hfb67729_1.tar.bz2
-    "root_base >=6.22.0,<6.23.0a0"
+    "root_base >=6.22.0,<6.23.0a0",
+    "root_base <6.22.5a0"
osx-64::omicron-2.4.1-hfb67729_0.tar.bz2
-    "root_base >=6.22.0,<6.23.0a0"
+    "root_base >=6.22.0,<6.23.0a0",
+    "root_base <6.22.5a0"
osx-64::omicron-2.4.2-h49b1101_0.tar.bz2
-    "root_base >=6.22.6,<6.23.0a0"
+    "root_base >=6.22.6,<6.23.0a0",
+    "root_base <6.22.5a0"
osx-64::rapidsim-1.5-h23af3c1_4.tar.bz2
-    "root_base >=6.22.0,<6.23.0a0"
+    "root_base >=6.22.0,<6.23.0a0",
+    "root_base <6.22.5a0"
osx-64::rapidsim-1.5-h23af3c1_5.tar.bz2
-    "root_base >=6.22.0,<6.23.0a0"
+    "root_base >=6.22.0,<6.23.0a0",
+    "root_base <6.22.5a0"
osx-64::rapidsim-1.5-h23af3c1_6.tar.bz2
-    "root_base >=6.22.0,<6.23.0a0"
+    "root_base >=6.22.0,<6.23.0a0",
+    "root_base <6.22.5a0"
osx-64::root_numpy-4.8.0-py36h8ae275b_10.tar.bz2
-    "setuptools"
+    "setuptools",
+    "root_base <6.22.5a0"
osx-64::root_numpy-4.8.0-py36hac16bf8_9.tar.bz2
-    "root_base >=6.22.2,<6.23.0a0"
+    "root_base >=6.22.2,<6.23.0a0",
+    "root_base <6.22.5a0"
osx-64::root_numpy-4.8.0-py36hdb3b855_7.tar.bz2
-    "root_base >=6.22.0,<6.23.0a0"
+    "root_base >=6.22.0,<6.23.0a0",
+    "root_base <6.22.5a0"
osx-64::root_numpy-4.8.0-py36hdb3b855_8.tar.bz2
-    "root_base >=6.22.0,<6.23.0a0"
+    "root_base >=6.22.0,<6.23.0a0",
+    "root_base <6.22.5a0"
osx-64::root_numpy-4.8.0-py37h1e1fc55_7.tar.bz2
-    "root_base >=6.22.0,<6.23.0a0"
+    "root_base >=6.22.0,<6.23.0a0",
+    "root_base <6.22.5a0"
osx-64::root_numpy-4.8.0-py37h1e1fc55_8.tar.bz2
-    "root_base >=6.22.0,<6.23.0a0"
+    "root_base >=6.22.0,<6.23.0a0",
+    "root_base <6.22.5a0"
osx-64::root_numpy-4.8.0-py37h3b57464_9.tar.bz2
-    "root_base >=6.22.2,<6.23.0a0"
+    "root_base >=6.22.2,<6.23.0a0",
+    "root_base <6.22.5a0"
osx-64::root_numpy-4.8.0-py37h5a6a189_10.tar.bz2
-    "setuptools"
+    "setuptools",
+    "root_base <6.22.5a0"
osx-64::root_numpy-4.8.0-py38h827a4dc_7.tar.bz2
-    "root_base >=6.22.0,<6.23.0a0"
+    "root_base >=6.22.0,<6.23.0a0",
+    "root_base <6.22.5a0"
osx-64::root_numpy-4.8.0-py38h827a4dc_8.tar.bz2
-    "root_base >=6.22.0,<6.23.0a0"
+    "root_base >=6.22.0,<6.23.0a0",
+    "root_base <6.22.5a0"
osx-64::root_numpy-4.8.0-py38hb5d526c_9.tar.bz2
-    "root_base >=6.22.2,<6.23.0a0"
+    "root_base >=6.22.2,<6.23.0a0",
+    "root_base <6.22.5a0"
osx-64::root_numpy-4.8.0-py38hf314480_10.tar.bz2
-    "setuptools"
+    "setuptools",
+    "root_base <6.22.5a0"
osx-64::root_numpy-4.8.0-py39h250978a_10.tar.bz2
-    "setuptools"
+    "setuptools",
+    "root_base <6.22.5a0"
osx-64::slepc-3.14.1-h939d6db_0.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
osx-64::slepc-3.14.2-h939d6db_0.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata.json.bz2
```