### PR TITLE
Fix bad pin on root_base from #129

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -727,8 +727,12 @@ def _gen_new_index(repodata, subdir):
         # ROOT 6.22.6 contained an ABI break, we'll always pin on patch releases from now on
         if has_dep(record, "root_base"):
             for i, dep in enumerate(deps):
-                if "root_base" in dep and ">=6.22." in dep and "<6.23.0a0" in dep:
+                if not ("root_base" in dep and "<6.23.0a0" in dep):
+                    continue
+                if ">=6.22.0," in dep or ">=6.22.2," in dep or ">=6.22.4," in dep:
                     deps.append("root_base <6.22.5a0")
+                elif ">=6.22.6," in dep:
+                    deps.append("root_base <6.22.7a0")
 
         _replace_pin('libunwind >=1.2.1,<1.3.0a0', 'libunwind >=1.2.1,<2.0.0a0', deps, record)
         _replace_pin('snappy >=1.1.7,<1.1.8.0a0', 'snappy >=1.1.7,<2.0.0.0a0', deps, record)


### PR DESCRIPTION
In #129 packages built with `root_base 6.22.6` were incorrectly pined with `root_base >=6.22.6,<6.23.0a0,<6.22.5a0` making them uninstall-able. This fixes it to pin to `root_base >=6.22.6,<6.23.0a0,<6.22.7a0` instead.

See also https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/129#issuecomment-804233089.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

cc @duncanmmacleod 

```
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata.json.bz2
linux-64::fwlite-11.1.5-py36h331d8fc_2.tar.bz2
-    "root_base <6.22.5a0"
+    "root_base <6.22.7a0"
linux-64::fwlite-11.1.5-py36hb2a31a3_2.tar.bz2
-    "root_base <6.22.5a0"
+    "root_base <6.22.7a0"
linux-64::fwlite-11.1.5-py37h16b2819_2.tar.bz2
-    "root_base <6.22.5a0"
+    "root_base <6.22.7a0"
linux-64::fwlite-11.1.5-py37hec08ca0_2.tar.bz2
-    "root_base <6.22.5a0"
+    "root_base <6.22.7a0"
linux-64::fwlite-11.1.5-py38h768f95f_2.tar.bz2
-    "root_base <6.22.5a0"
+    "root_base <6.22.7a0"
linux-64::fwlite-11.1.5-py38h8d49631_2.tar.bz2
-    "root_base <6.22.5a0"
+    "root_base <6.22.7a0"
linux-64::fwlite-11.1.5-py39h622c69e_2.tar.bz2
-    "root_base <6.22.5a0"
+    "root_base <6.22.7a0"
linux-64::fwlite-11.1.5-py39h9d6a212_2.tar.bz2
-    "root_base <6.22.5a0"
+    "root_base <6.22.7a0"
linux-64::gwollum-2.4.1-h735fe92_1.tar.bz2
-    "root_base <6.22.5a0"
+    "root_base <6.22.7a0"
linux-64::gwollum-2.4.2-h735fe92_0.tar.bz2
-    "root_base <6.22.5a0"
+    "root_base <6.22.7a0"
linux-64::hammer-1.1.0-py36h706a4de_2.tar.bz2
-    "root_base <6.22.5a0"
+    "root_base <6.22.7a0"
linux-64::hammer-1.1.0-py36hd636c90_2.tar.bz2
-    "root_base <6.22.5a0"
+    "root_base <6.22.7a0"
linux-64::hammer-1.1.0-py37h63e3677_2.tar.bz2
-    "root_base <6.22.5a0"
+    "root_base <6.22.7a0"
linux-64::hammer-1.1.0-py37h825d14d_2.tar.bz2
-    "root_base <6.22.5a0"
+    "root_base <6.22.7a0"
linux-64::hammer-1.1.0-py38h7556ca5_2.tar.bz2
-    "root_base <6.22.5a0"
+    "root_base <6.22.7a0"
linux-64::hammer-1.1.0-py38h780fd6d_2.tar.bz2
-    "root_base <6.22.5a0"
+    "root_base <6.22.7a0"
linux-64::hammer-1.1.0-py39h07062a6_2.tar.bz2
-    "root_base <6.22.5a0"
+    "root_base <6.22.7a0"
linux-64::hammer-1.1.0-py39h65cdd19_2.tar.bz2
-    "root_base <6.22.5a0"
+    "root_base <6.22.7a0"
linux-64::mpi4jax-0.2.16-py37h1e5cb63_0.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
linux-64::mpi4jax-0.2.16-py37h1e5cb63_1.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
linux-64::mpi4jax-0.2.16-py38he865349_0.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
linux-64::mpi4jax-0.2.16-py38he865349_1.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
linux-64::mpi4jax-0.2.16-py39h6438238_0.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
linux-64::mpi4jax-0.2.16-py39h6438238_1.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
linux-64::omicron-2.4.2-hb008238_0.tar.bz2
-    "root_base <6.22.5a0"
+    "root_base <6.22.7a0"
linux-64::root_numpy-4.8.0-py36h760e8c4_10.tar.bz2
-    "root_base <6.22.5a0"
+    "root_base <6.22.7a0"
linux-64::root_numpy-4.8.0-py37h3a15b83_10.tar.bz2
-    "root_base <6.22.5a0"
+    "root_base <6.22.7a0"
linux-64::root_numpy-4.8.0-py38h02e4990_10.tar.bz2
-    "root_base <6.22.5a0"
+    "root_base <6.22.7a0"
linux-64::root_numpy-4.8.0-py39h7b374e0_10.tar.bz2
-    "root_base <6.22.5a0"
+    "root_base <6.22.7a0"
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata.json.bz2
osx-64::fwlite-11.1.5-py36hb0a62d1_2.tar.bz2
-    "root_base <6.22.5a0"
+    "root_base <6.22.7a0"
osx-64::fwlite-11.1.5-py36hca4a138_2.tar.bz2
-    "root_base <6.22.5a0"
+    "root_base <6.22.7a0"
osx-64::fwlite-11.1.5-py37h1bbc7c6_2.tar.bz2
-    "root_base <6.22.5a0"
+    "root_base <6.22.7a0"
osx-64::fwlite-11.1.5-py37he682a72_2.tar.bz2
-    "root_base <6.22.5a0"
+    "root_base <6.22.7a0"
osx-64::fwlite-11.1.5-py38h5444033_2.tar.bz2
-    "root_base <6.22.5a0"
+    "root_base <6.22.7a0"
osx-64::fwlite-11.1.5-py38hde4931a_2.tar.bz2
-    "root_base <6.22.5a0"
+    "root_base <6.22.7a0"
osx-64::fwlite-11.1.5-py39h64113bf_2.tar.bz2
-    "root_base <6.22.5a0"
+    "root_base <6.22.7a0"
osx-64::fwlite-11.1.5-py39hbe050d6_2.tar.bz2
-    "root_base <6.22.5a0"
+    "root_base <6.22.7a0"
osx-64::gwollum-2.4.1-hb7e9568_1.tar.bz2
-    "root_base <6.22.5a0"
+    "root_base <6.22.7a0"
osx-64::gwollum-2.4.2-h98a9e19_0.tar.bz2
-    "root_base <6.22.5a0"
+    "root_base <6.22.7a0"
osx-64::hammer-1.1.0-py36h944212d_2.tar.bz2
-    "root_base <6.22.5a0"
+    "root_base <6.22.7a0"
osx-64::hammer-1.1.0-py36hf198341_2.tar.bz2
-    "root_base <6.22.5a0"
+    "root_base <6.22.7a0"
osx-64::hammer-1.1.0-py37hc05ca0b_2.tar.bz2
-    "root_base <6.22.5a0"
+    "root_base <6.22.7a0"
osx-64::hammer-1.1.0-py37hdeba562_2.tar.bz2
-    "root_base <6.22.5a0"
+    "root_base <6.22.7a0"
osx-64::hammer-1.1.0-py38h82bfe0d_2.tar.bz2
-    "root_base <6.22.5a0"
+    "root_base <6.22.7a0"
osx-64::hammer-1.1.0-py38hee329e3_2.tar.bz2
-    "root_base <6.22.5a0"
+    "root_base <6.22.7a0"
osx-64::hammer-1.1.0-py39h4b67620_2.tar.bz2
-    "root_base <6.22.5a0"
+    "root_base <6.22.7a0"
osx-64::hammer-1.1.0-py39h8018d58_2.tar.bz2
-    "root_base <6.22.5a0"
+    "root_base <6.22.7a0"
osx-64::mpi4jax-0.2.16-py37h45bc384_0.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
osx-64::mpi4jax-0.2.16-py37h45bc384_1.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
osx-64::mpi4jax-0.2.16-py38hcd6a4d3_0.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
osx-64::mpi4jax-0.2.16-py38hcd6a4d3_1.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
osx-64::mpi4jax-0.2.16-py39ha81d895_0.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
osx-64::mpi4jax-0.2.16-py39ha81d895_1.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
osx-64::omicron-2.4.2-h49b1101_0.tar.bz2
-    "root_base <6.22.5a0"
+    "root_base <6.22.7a0"
osx-64::root_numpy-4.8.0-py36h8ae275b_10.tar.bz2
-    "root_base <6.22.5a0"
+    "root_base <6.22.7a0"
osx-64::root_numpy-4.8.0-py37h5a6a189_10.tar.bz2
-    "root_base <6.22.5a0"
+    "root_base <6.22.7a0"
osx-64::root_numpy-4.8.0-py38hf314480_10.tar.bz2
-    "root_base <6.22.5a0"
+    "root_base <6.22.7a0"
osx-64::root_numpy-4.8.0-py39h250978a_10.tar.bz2
-    "root_base <6.22.5a0"
+    "root_base <6.22.7a0"
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata.json.bz2
osx-arm64::openpmd-api-0.13.2-mpi_mpich_py38h2ad0c58_1.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
osx-arm64::openpmd-api-0.13.2-mpi_mpich_py39h91cf703_1.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata.json.bz2
win-64::tiledb-py-0.8.5-py36_vc14ha60ad30_0.tar.bz2
-  "features": "vc14",
win-64::tiledb-py-0.8.5-py37_vc14he2193c1_0.tar.bz2
-  "features": "vc14",
win-64::tiledb-py-0.8.5-py38_vc14h0fbba01_0.tar.bz2
-  "features": "vc14",
win-64::tiledb-py-0.8.5-py39_vc14h47aa9ea_0.tar.bz2
-  "features": "vc14",
```