### PR TITLE
Fix jupyterlab constraint for jupyterlab-git

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -930,9 +930,16 @@ def _gen_new_index(repodata, subdir):
         # Old versions of Gazebo depend on boost-cpp >= 1.71,
         # but they are actually incompatible with any boost-cpp >= 1.72
         # https://github.com/conda-forge/gazebo-feedstock/issues/52
-        if (record_name == "gazebo" and 
+        if (record_name == "gazebo" and
                 record.get('timestamp', 0) < 1583200976700):
             _replace_pin('boost-cpp >=1.71', 'boost-cpp >=1.71.0,<1.71.1.0a0', deps, record)
+
+        # Version constraints for jupyterlab in jupyterlab-git<=0.23.0 were incorrect.
+        # These have been corrected in PR
+        # https://github.com/conda-forge/jupyterlab-git-feedstock/pull/27
+        if record_name == "jupyterlab-git" and "jupyterlab >=2.0.0" in record["depends"]:
+            i = record["depends"].index("jupyterlab >=2.0.0")
+            record["depends"][i] = "jupyterlab >=2.0.0,<3.0.0"
 
     return index
 


### PR DESCRIPTION
jupyterlab-git < 0.22.0 was not supporting JupyterLab v3, but it was not specifying this constraint

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
