### PR TITLE
Fix missing py-tools-ds.similarity module in arosics >1.0.6,<1.2.0.

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -953,15 +953,19 @@ def _gen_new_index(repodata, subdir):
 
         # Old versions of arosics do not work with py-tools-ds>=0.16.0 due to the an import of the
         # py-tools-ds.similarity module which was removed in py-tools-ds 0.16.0. In arosics>=1.2.0, this import does
-        # not exist anymore, i.e., newer versions of arosics work together with all py-tools-ds>0.14.28 versions.
+        # not exist anymore, i.e., newer versions of arosics work together with all py-tools-ds>=0.15.8 / 0.15.10
+        # versions.
         # No additional PR in the arosics feedstock should be needed.
         if (record_name == "arosics" and
-                record["version"] in ["0.9.22", "0.9.23", "0.9.24", "0.9.25", "0.9.26",
-                                      "1.0.0", "1.0.1", "1.0.2", "1.0.3", "1.0.4", "1.0.5", "1.0.6",
-                                      "1.1.0", "1.1.1"] and
-                "py-tools-ds >=0.14.28" in record["depends"]):
-            i = record["depends"].index("py-tools-ds >=0.14.28")
-            record["depends"][i] = "py-tools-ds >=0.14.28,<=0.15.11"
+                record["version"] == "1.0.6" and
+                "py-tools-ds >=0.15.8" in record["depends"]):
+            i = record["depends"].index("py-tools-ds >=0.15.8")
+            record["depends"][i] = "py-tools-ds >=0.15.8,<=0.15.11"
+        if (record_name == "arosics" and
+                record["version"] in ["1.1.0", "1.1.1"] and
+                "py-tools-ds >=0.15.10" in record["depends"]):
+            i = record["depends"].index("py-tools-ds >=0.15.10")
+            record["depends"][i] = "py-tools-ds >=0.15.10,<=0.15.11"
 
     return index
 


### PR DESCRIPTION
I just realized that https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/136 did not cover the arosics versions >=1.06, <1.2.0. Sorry for that, I do this for the first time. These versions are now covered here.

Here are the diffs:

```
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata.json.bz2
linux-64::arosics-1.0.6-py36h9f0ad1d_0.tar.bz2
-    "py-tools-ds >=0.15.8",
+    "py-tools-ds >=0.15.8,<=0.15.11",
linux-64::arosics-1.0.6-py37hc8dfbb8_0.tar.bz2
-    "py-tools-ds >=0.15.8",
+    "py-tools-ds >=0.15.8,<=0.15.11",
linux-64::arosics-1.0.6-py38h32f6830_0.tar.bz2
-    "py-tools-ds >=0.15.8",
+    "py-tools-ds >=0.15.8,<=0.15.11",
linux-64::arosics-1.1.0-py36h5fab9bb_0.tar.bz2
-    "py-tools-ds >=0.15.10",
+    "py-tools-ds >=0.15.10,<=0.15.11",
linux-64::arosics-1.1.0-py37h89c1867_0.tar.bz2
-    "py-tools-ds >=0.15.10",
+    "py-tools-ds >=0.15.10,<=0.15.11",
linux-64::arosics-1.1.0-py38h578d9bd_0.tar.bz2
-    "py-tools-ds >=0.15.10",
+    "py-tools-ds >=0.15.10,<=0.15.11",
linux-64::arosics-1.1.1-py36h5fab9bb_0.tar.bz2
-    "py-tools-ds >=0.15.10",
+    "py-tools-ds >=0.15.10,<=0.15.11",
linux-64::arosics-1.1.1-py37h89c1867_0.tar.bz2
-    "py-tools-ds >=0.15.10",
+    "py-tools-ds >=0.15.10,<=0.15.11",
linux-64::arosics-1.1.1-py38h578d9bd_0.tar.bz2
-    "py-tools-ds >=0.15.10",
+    "py-tools-ds >=0.15.10,<=0.15.11",
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata.json.bz2
osx-64::arosics-1.0.6-py36h9f0ad1d_0.tar.bz2
-    "py-tools-ds >=0.15.8",
+    "py-tools-ds >=0.15.8,<=0.15.11",
osx-64::arosics-1.0.6-py37hc8dfbb8_0.tar.bz2
-    "py-tools-ds >=0.15.8",
+    "py-tools-ds >=0.15.8,<=0.15.11",
osx-64::arosics-1.0.6-py38h32f6830_0.tar.bz2
-    "py-tools-ds >=0.15.8",
+    "py-tools-ds >=0.15.8,<=0.15.11",
osx-64::arosics-1.1.0-py36h79c6626_0.tar.bz2
-    "py-tools-ds >=0.15.10",
+    "py-tools-ds >=0.15.10,<=0.15.11",
osx-64::arosics-1.1.0-py37hf985489_0.tar.bz2
-    "py-tools-ds >=0.15.10",
+    "py-tools-ds >=0.15.10,<=0.15.11",
osx-64::arosics-1.1.0-py38h50d1736_0.tar.bz2
-    "py-tools-ds >=0.15.10",
+    "py-tools-ds >=0.15.10,<=0.15.11",
osx-64::arosics-1.1.1-py36h79c6626_0.tar.bz2
-    "py-tools-ds >=0.15.10",
+    "py-tools-ds >=0.15.10,<=0.15.11",
osx-64::arosics-1.1.1-py37hf985489_0.tar.bz2
-    "py-tools-ds >=0.15.10",
+    "py-tools-ds >=0.15.10,<=0.15.11",
osx-64::arosics-1.1.1-py38h50d1736_0.tar.bz2
-    "py-tools-ds >=0.15.10",
+    "py-tools-ds >=0.15.10,<=0.15.11",
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata.json.bz2
win-64::arosics-1.0.6-py36h9f0ad1d_0.tar.bz2
-    "py-tools-ds >=0.15.8",
+    "py-tools-ds >=0.15.8,<=0.15.11",
win-64::arosics-1.0.6-py37hc8dfbb8_0.tar.bz2
-    "py-tools-ds >=0.15.8",
+    "py-tools-ds >=0.15.8,<=0.15.11",
win-64::arosics-1.0.6-py38h32f6830_0.tar.bz2
-    "py-tools-ds >=0.15.8",
+    "py-tools-ds >=0.15.8,<=0.15.11",
win-64::arosics-1.1.0-py36ha15d459_0.tar.bz2
-    "py-tools-ds >=0.15.10",
+    "py-tools-ds >=0.15.10,<=0.15.11",
win-64::arosics-1.1.0-py37h03978a9_0.tar.bz2
-    "py-tools-ds >=0.15.10",
+    "py-tools-ds >=0.15.10,<=0.15.11",
win-64::arosics-1.1.0-py38haa244fe_0.tar.bz2
-    "py-tools-ds >=0.15.10",
+    "py-tools-ds >=0.15.10,<=0.15.11",
win-64::arosics-1.1.1-py36ha15d459_0.tar.bz2
-    "py-tools-ds >=0.15.10",
+    "py-tools-ds >=0.15.10,<=0.15.11",
win-64::arosics-1.1.1-py37h03978a9_0.tar.bz2
-    "py-tools-ds >=0.15.10",
+    "py-tools-ds >=0.15.10,<=0.15.11",
win-64::arosics-1.1.1-py38haa244fe_0.tar.bz2
-    "py-tools-ds >=0.15.10",
+    "py-tools-ds >=0.15.10,<=0.15.11",

```
