### PR TITLE
Revised patches from #136 and #137 to fix missing py-tools-ds.similar module in old arosics versions.

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -952,20 +952,26 @@ def _gen_new_index(repodata, subdir):
                 record["depends"][i] = "jupyterlab <1.0.0"
 
         # Old versions of arosics do not work with py-tools-ds>=0.16.0 due to the an import of the
-        # py-tools-ds.similarity module which was removed in py-tools-ds 0.16.0. In arosics>=1.2.0, this import does
-        # not exist anymore, i.e., newer versions of arosics work together with all py-tools-ds>=0.15.8 / 0.15.10
-        # versions.
-        # No additional PR in the arosics feedstock should be needed.
-        if (record_name == "arosics" and
-                record["version"] == "1.0.6" and
-                "py-tools-ds >=0.15.8" in record["depends"]):
-            i = record["depends"].index("py-tools-ds >=0.15.8")
-            record["depends"][i] = "py-tools-ds >=0.15.8,<=0.15.11"
-        if (record_name == "arosics" and
-                record["version"] in ["1.1.0", "1.1.1"] and
-                "py-tools-ds >=0.15.10" in record["depends"]):
-            i = record["depends"].index("py-tools-ds >=0.15.10")
-            record["depends"][i] = "py-tools-ds >=0.15.10,<=0.15.11"
+        # py-tools-ds.similarity module which was removed in py-tools-ds 0.16.0. In arosics>=1.2.0,
+        # this import does not exist anymore, i.e., newer versions of arosics work together with all
+        # py-tools-ds>=0.14.28 /0.15.8 / 0.15.10 versions as defined below.
+        # No additional PR in the arosics feedstock is needed.
+        if record_name == "arosics":
+            if (record["version"] in ["0.9.22", "0.9.23", "0.9.24", "0.9.25", "0.9.26",
+                                      "1.0.0", "1.0.1", "1.0.2", "1.0.3", "1.0.4", "1.0.5"]
+                    and "py-tools-ds >=0.14.28" in record["depends"]):
+                i = record["depends"].index("py-tools-ds >=0.14.28")
+                record["depends"][i] = "py-tools-ds >=0.14.28,<=0.15.11"
+
+            if (record["version"] == "1.0.6" and
+                    "py-tools-ds >=0.15.8" in record["depends"]):
+                i = record["depends"].index("py-tools-ds >=0.15.8")
+                record["depends"][i] = "py-tools-ds >=0.15.8,<=0.15.11"
+
+            if (record["version"] in ["1.1.0", "1.1.1"] and
+                    "py-tools-ds >=0.15.10" in record["depends"]):
+                i = record["depends"].index("py-tools-ds >=0.15.10")
+                record["depends"][i] = "py-tools-ds >=0.15.10,<=0.15.11"
 
     return index
 


### PR DESCRIPTION
This is a revision of #136 and #137 because I noticed that the metadata changes from #137 were correctly applied (the conda package resolver respects the updated metadata) but the changes from #136 were not. I don´t know the reason for that but this PR should fix it.

@beckermr 

Below is the diff. Note that for some reason it changes `ruby-2.7.2-h82393f8_3.tar.bz2` although I did not patch it. Also it seems to have no effect to the arosics>=1.06,<=1.1.1 versions. Maybe because the patch from #137 was already correctly applied.
```
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata.json.bz2
noarch::arosics-0.9.23-pyh9f0ad1d_0.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
noarch::arosics-0.9.24-pyh9f0ad1d_0.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata.json.bz2
linux-64::arosics-0.9.24-py36h9f0ad1d_1.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
linux-64::arosics-0.9.24-py36h9f0ad1d_2.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
linux-64::arosics-0.9.24-py36h9f0ad1d_3.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
linux-64::arosics-0.9.24-py37hc8dfbb8_3.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
linux-64::arosics-0.9.24-py38h32f6830_3.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
linux-64::arosics-0.9.25-py36h9f0ad1d_0.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
linux-64::arosics-0.9.25-py37hc8dfbb8_0.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
linux-64::arosics-0.9.25-py38h32f6830_0.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
linux-64::arosics-0.9.26-py36h9f0ad1d_0.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
linux-64::arosics-0.9.26-py37hc8dfbb8_0.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
linux-64::arosics-0.9.26-py38h32f6830_0.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
linux-64::arosics-1.0.0-py36h9f0ad1d_0.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
linux-64::arosics-1.0.0-py37hc8dfbb8_0.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
linux-64::arosics-1.0.0-py38h32f6830_0.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
linux-64::arosics-1.0.1-py36h9f0ad1d_0.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
linux-64::arosics-1.0.1-py37hc8dfbb8_0.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
linux-64::arosics-1.0.1-py38h32f6830_0.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
linux-64::arosics-1.0.2-py36h9f0ad1d_0.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
linux-64::arosics-1.0.2-py37hc8dfbb8_0.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
linux-64::arosics-1.0.2-py38h32f6830_0.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
linux-64::arosics-1.0.3-py36h9f0ad1d_0.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
linux-64::arosics-1.0.3-py37hc8dfbb8_0.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
linux-64::arosics-1.0.3-py38h32f6830_0.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
linux-64::arosics-1.0.5-py36h9f0ad1d_0.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
linux-64::arosics-1.0.5-py37hc8dfbb8_0.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
linux-64::arosics-1.0.5-py38h32f6830_0.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata.json.bz2
linux-aarch64::ruby-2.7.2-h82393f8_3.tar.bz2
-  "track_features": "rb27",
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata.json.bz2
osx-64::arosics-0.9.24-py36h9f0ad1d_3.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
osx-64::arosics-0.9.24-py37hc8dfbb8_3.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
osx-64::arosics-0.9.24-py38h32f6830_3.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
osx-64::arosics-0.9.25-py36h9f0ad1d_0.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
osx-64::arosics-0.9.25-py37hc8dfbb8_0.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
osx-64::arosics-0.9.25-py38h32f6830_0.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
osx-64::arosics-0.9.26-py36h9f0ad1d_0.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
osx-64::arosics-0.9.26-py37hc8dfbb8_0.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
osx-64::arosics-0.9.26-py38h32f6830_0.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
osx-64::arosics-1.0.0-py36h9f0ad1d_0.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
osx-64::arosics-1.0.0-py37hc8dfbb8_0.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
osx-64::arosics-1.0.0-py38h32f6830_0.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
osx-64::arosics-1.0.1-py36h9f0ad1d_0.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
osx-64::arosics-1.0.1-py37hc8dfbb8_0.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
osx-64::arosics-1.0.1-py38h32f6830_0.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
osx-64::arosics-1.0.2-py36h9f0ad1d_0.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
osx-64::arosics-1.0.2-py37hc8dfbb8_0.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
osx-64::arosics-1.0.2-py38h32f6830_0.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
osx-64::arosics-1.0.3-py36h9f0ad1d_0.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
osx-64::arosics-1.0.3-py37hc8dfbb8_0.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
osx-64::arosics-1.0.3-py38h32f6830_0.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
osx-64::arosics-1.0.5-py36h9f0ad1d_0.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
osx-64::arosics-1.0.5-py37hc8dfbb8_0.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
osx-64::arosics-1.0.5-py38h32f6830_0.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
osx-64::ruby-2.7.2-h36135d8_3.tar.bz2
-  "track_features": "rb27",
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata.json.bz2
osx-arm64::ruby-2.7.2-h6b02988_3.tar.bz2
-  "track_features": "rb27",
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata.json.bz2
win-64::arosics-0.9.24-py36h9f0ad1d_3.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
win-64::arosics-0.9.24-py37hc8dfbb8_3.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
win-64::arosics-0.9.24-py38h32f6830_3.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
win-64::arosics-0.9.25-py36h9f0ad1d_0.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
win-64::arosics-0.9.25-py37hc8dfbb8_0.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
win-64::arosics-0.9.25-py38h32f6830_0.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
win-64::arosics-0.9.26-py36h9f0ad1d_0.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
win-64::arosics-0.9.26-py37hc8dfbb8_0.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
win-64::arosics-0.9.26-py38h32f6830_0.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
win-64::arosics-1.0.0-py36h9f0ad1d_0.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
win-64::arosics-1.0.0-py37hc8dfbb8_0.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
win-64::arosics-1.0.0-py38h32f6830_0.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
win-64::arosics-1.0.1-py36h9f0ad1d_0.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
win-64::arosics-1.0.1-py37hc8dfbb8_0.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
win-64::arosics-1.0.1-py38h32f6830_0.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
win-64::arosics-1.0.2-py36h9f0ad1d_0.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
win-64::arosics-1.0.2-py37hc8dfbb8_0.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
win-64::arosics-1.0.2-py38h32f6830_0.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
win-64::arosics-1.0.3-py36h9f0ad1d_0.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
win-64::arosics-1.0.3-py37hc8dfbb8_0.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
win-64::arosics-1.0.3-py38h32f6830_0.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
win-64::arosics-1.0.5-py36h9f0ad1d_0.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
win-64::arosics-1.0.5-py37hc8dfbb8_0.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",
win-64::arosics-1.0.5-py38h32f6830_0.tar.bz2
-    "py-tools-ds >=0.14.28",
+    "py-tools-ds >=0.14.28,<=0.15.11",

```
