### PR TITLE
ENH make sure old mpi4py-fft is incompatible with MKL

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -611,6 +611,12 @@ def _gen_new_index(repodata, subdir):
                 i = record['depends'].index('python >=3')
                 record['depends'][i] = 'python >=3.6'
 
+        # some versions mpi4py-fft are not compatible with MKL
+        # https://github.com/conda-forge/mpi4py-fft-feedstock/issues/20
+        if record_name == "mpi4py-fft" and record.get('timestamp', 0) < 1619448232206:
+            if "nomkl" not in record["depends"]:
+                record["depends"].append("nomkl")
+
         # fix deps with wrong names
         if record_name in proj4_fixes:
             _rename_dependency(fn, record, "proj.4", "proj4")


### PR DESCRIPTION
This PR fixes an issue where older versions of mpi4py-fft silently error with MKL. It should be merged once a new release of mpi4py-fft is available.

xref: https://github.com/conda-forge/mpi4py-fft-feedstock/issues/20
closes https://github.com/conda-forge/mpi4py-fft-feedstock/issues/20

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
