### PR TITLE
Hot fix librmm packages missing spdlog dependency

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -951,6 +951,15 @@ def _gen_new_index(repodata, subdir):
                 i = record["depends"].index("jupyterlab")
                 record["depends"][i] = "jupyterlab <1.0.0"
 
+        # librmm 0.19 missed spdlog 1.7.0 in build 1
+        # due to spdlog 1.7.0 not having run_exports.
+        # This hotfixes those packages
+        # https://github.com/conda-forge/librmm-feedstock/pull/5
+        if (record_name == "librmm" and
+                record["version"] == "0.19.0" and
+                "spdlog =1.7.0" not in record["depends"]):
+            record["depends"].append("spdlog =1.7.0")
+
         # Old versions of arosics do not work with py-tools-ds>=0.16.0 due to the an import of the
         # py-tools-ds.similarity module which was removed in py-tools-ds 0.16.0. In arosics>=1.2.0,
         # this import does not exist anymore, i.e., newer versions of arosics work together with all


### PR DESCRIPTION
Follow up to PR ( https://github.com/conda-forge/librmm-feedstock/pull/5 )

The `spdlog` version used by `librmm` lacked `run_exports`. While subsequent `librmm` packages have been fixed to explicitly include `spdlog` and future versions of `spdlog` do have `run_exports`, the original `librmm` packages still need to be hot-fixed to include `spdlog`, which is what is done here.

cc @leofang @rlratzel @kkraus14

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
