### PR TITLE
Pin cuTENSOR 1.2.2.5 exactly

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -734,6 +734,11 @@ def _gen_new_index(repodata, subdir):
                     deps.append("tbb <2021.0.0a0")
                     break
 
+        # cuTENSOR 1.3.x is binary incompatible with 1.2.x. Let's just pin exactly since
+        # it appears semantic versioning is not guaranteed.
+        if any(dep.startswith("cutensor >=1.2.2.5,<2.0a0") for dep in deps):
+            _replace_pin("cutensor >=1.2.2.5,<2.0a0", "cutensor =1.2.2.5", deps, record)
+
         # ROOT 6.22.6 contained an ABI break, we'll always pin on patch releases from now on
         if has_dep(record, "root_base"):
             for i, dep in enumerate(deps):

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -736,8 +736,8 @@ def _gen_new_index(repodata, subdir):
 
         # cuTENSOR 1.3.x is binary incompatible with 1.2.x. Let's just pin exactly since
         # it appears semantic versioning is not guaranteed.
-        if any(dep.startswith("cutensor >=1.2.2.5,<2.0a0") for dep in deps):
-            _replace_pin("cutensor >=1.2.2.5,<2.0a0", "cutensor =1.2.2.5", deps, record)
+        _replace_pin("cutensor >=1.2.2.5,<2.0a0", "cutensor =1.2.2.5", deps, record)
+        _replace_pin("cutensor >=1.2.2.5,<2.0a0", "cutensor =1.2.2.5", record.get("constrains", []), record, target='constrains')
 
         # ROOT 6.22.6 contained an ABI break, we'll always pin on patch releases from now on
         if has_dep(record, "root_base"):
@@ -1038,11 +1038,13 @@ def _add_pybind11_abi_constraint(fn, record):
     record["constrains"] = constrains
 
 
-def _replace_pin(old_pin, new_pin, deps, record):
-    """Replace an exact pin with a new one."""
+def _replace_pin(old_pin, new_pin, deps, record, target='depends'):
+    """Replace an exact pin with a new one. deps and target must match."""
+    if target not in ('depends', 'constrains'):
+        raise ValueError
     if old_pin in deps:
-        i = record['depends'].index(old_pin)
-        record['depends'][i] = new_pin
+        i = record[target].index(old_pin)
+        record[target][i] = new_pin
 
 def _rename_dependency(fn, record, old_name, new_name):
     depends = record["depends"]


### PR DESCRIPTION
To prepare for https://github.com/conda-forge/cutensor-feedstock/issues/11. Currently we only release one version (1.2.2.5) on Conda-Forge, so this should be sufficient.

cc: @jakirkham @mnicely

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
