### PR TITLE
Patch distributed pre-2021.5.0 to use click pre-8

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -561,14 +561,23 @@ def _gen_new_index(repodata, subdir):
                 i = record["depends"].index("pyarrow >=0.13.0,!=0.14.0,<2")
                 record["depends"][i] = "pyarrow >=0.17.1,<2"
 
-        # distributed <2.11.0 does not work with msgpack-python >=1.0
-        # newer versions of distributed require at least msgpack-python >=0.6.0
-        # so we can fix cases where msgpack-python is unbounded
-        # https://github.com/conda-forge/distributed-feedstock/pull/114
         if record_name == 'distributed':
+            # distributed <2.11.0 does not work with msgpack-python >=1.0
+            # newer versions of distributed require at least msgpack-python >=0.6.0
+            # so we can fix cases where msgpack-python is unbounded
+            # https://github.com/conda-forge/distributed-feedstock/pull/114
             if 'msgpack-python' in record['depends']:
                 i = record['depends'].index('msgpack-python')
                 record['depends'][i] = 'msgpack-python <1.0.0'
+
+            # click 8 broke distributed prior to 2021.5.0.
+            # This has been corrected in PR:
+            # https://github.com/conda-forge/distributed-feedstock/pull/165
+            pversion = pkg_resources.parse_version(record['version'])
+            v2021_5_0 = pkg_resources.parse_version('2021.5.0')
+            if pversion < v2021_5_0 and 'click >=6.6' in record['depends']:
+                i = record['depends'].index('click >=6.6')
+                record['depends'][i] = 'click >=6.6,<8.0.0'
 
         # python-language-server <=0.31.9 requires pyflakes <2.2.2
         # included explicitly in 0.31.10+


### PR DESCRIPTION
Click 8 recently made a change that broke `distributed`. This has been fixed upstream ( https://github.com/dask/distributed/pull/4810 ) and will be in the next release. Also PR ( https://github.com/conda-forge/distributed-feedstock/pull/165 ) has been submitted for the current package. Unfortunately older releases remain broken. This fixes the version constraint for older releases.

cc @jrbourbeau

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
