### PR TITLE
Loosen mysql-libs pinning to x.x

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -651,6 +651,9 @@ def _gen_new_index(repodata, subdir):
                 any(dep.startswith("expat >=2.3.") for dep in deps):
             _pin_looser(fn, record, "expat", max_pin="x")
 
+        if any(dep.startswith("mysql-libs >=8.0.") for dep in deps):
+            _pin_looser(fn, record, "mysql-libs", max_pin="x.x")
+            
         if 're2' in deps and record.get('timestamp', 0) < 1588349339243:
             _rename_dependency(fn, record, "re2", "re2 <2020.05.01")
 


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

This is an attempt to loosen the max pin for packages depending on `mysql-libs` following the discussion in https://github.com/conda-forge/mysql-feedstock/issues/48 and resolution in https://github.com/conda-forge/mysql-feedstock/pull/49

Please note that this is my first time submitting here and I'm not at all confident I've done it correctly. Please review carefully!

The diff can be found at https://gist.github.com/izahn/72aa3ba5fe715c13e689836e1317f09e