### PR TITLE
Use tighter pin on vector-classes for root_base

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -778,6 +778,10 @@ def _gen_new_index(repodata, subdir):
                 elif ">=6.22.6," in dep:
                     deps.append("root_base <6.22.7a0")
 
+        if record_name == "root_base":
+            # ROOT requires vector-classes to be the exact same version as the one used for the build
+            _replace_pin('vector-classes >=1.4.1,<1.5.0a0', 'vector-classes >=1.4.1,<1.4.2a0', deps, record)
+
         _replace_pin('libunwind >=1.2.1,<1.3.0a0', 'libunwind >=1.2.1,<2.0.0a0', deps, record)
         _replace_pin('snappy >=1.1.7,<1.1.8.0a0', 'snappy >=1.1.7,<2.0.0.0a0', deps, record)
         _replace_pin('ncurses >=6.1,<6.2.0a0', 'ncurses >=6.1,<6.3.0a0', deps, record)


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Fixes this error:
```
The versions of libVc.a (1.4.1) and Vc/version.h (1.4.2) are incompatible. Aborting.
Aborted
```

Real fix for future builds: https://github.com/conda-forge/vector-classes-feedstock/pull/5

Diff:
```diff
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata.json.bz2
linux-64::cupy-9.2.0-py36h0fc7315_0.tar.bz2
-    "cutensor >=1.2.2.5,<2.0a0",
+    "cutensor =1.2.2.5",
linux-64::cupy-9.2.0-py36h1930939_0.tar.bz2
-    "cutensor >=1.2.2.5,<2.0a0",
+    "cutensor =1.2.2.5",
linux-64::cupy-9.2.0-py36h25573b8_0.tar.bz2
-    "cutensor >=1.2.2.5,<2.0a0",
+    "cutensor =1.2.2.5",
linux-64::cupy-9.2.0-py36h4790a05_0.tar.bz2
-    "cutensor >=1.2.2.5,<2.0a0",
+    "cutensor =1.2.2.5",
linux-64::cupy-9.2.0-py36h7454194_0.tar.bz2
-    "cutensor >=1.2.2.5,<2.0a0",
+    "cutensor =1.2.2.5",
linux-64::cupy-9.2.0-py37h11477cf_0.tar.bz2
-    "cutensor >=1.2.2.5,<2.0a0",
+    "cutensor =1.2.2.5",
linux-64::cupy-9.2.0-py37h3c5eebb_0.tar.bz2
-    "cutensor >=1.2.2.5,<2.0a0",
+    "cutensor =1.2.2.5",
linux-64::cupy-9.2.0-py37h464e165_0.tar.bz2
-    "cutensor >=1.2.2.5,<2.0a0",
+    "cutensor =1.2.2.5",
linux-64::cupy-9.2.0-py37h4fdb0f7_0.tar.bz2
-    "cutensor >=1.2.2.5,<2.0a0",
+    "cutensor =1.2.2.5",
linux-64::cupy-9.2.0-py37h56ca915_0.tar.bz2
-    "cutensor >=1.2.2.5,<2.0a0",
+    "cutensor =1.2.2.5",
linux-64::cupy-9.2.0-py37hc0aaff5_0.tar.bz2
-    "cutensor >=1.2.2.5,<2.0a0",
+    "cutensor =1.2.2.5",
linux-64::cupy-9.2.0-py37hc16ada3_0.tar.bz2
-    "cutensor >=1.2.2.5,<2.0a0",
+    "cutensor =1.2.2.5",
linux-64::cupy-9.2.0-py37hc6e7f7d_0.tar.bz2
-    "cutensor >=1.2.2.5,<2.0a0",
+    "cutensor =1.2.2.5",
linux-64::cupy-9.2.0-py37hfc113e4_0.tar.bz2
-    "cutensor >=1.2.2.5,<2.0a0",
+    "cutensor =1.2.2.5",
linux-64::cupy-9.2.0-py37hfed0110_0.tar.bz2
-    "cutensor >=1.2.2.5,<2.0a0",
+    "cutensor =1.2.2.5",
linux-64::cupy-9.2.0-py38h14045e6_0.tar.bz2
-    "cutensor >=1.2.2.5,<2.0a0",
+    "cutensor =1.2.2.5",
linux-64::cupy-9.2.0-py38h5546af9_0.tar.bz2
-    "cutensor >=1.2.2.5,<2.0a0",
+    "cutensor =1.2.2.5",
linux-64::cupy-9.2.0-py38h9c1f86d_0.tar.bz2
-    "cutensor >=1.2.2.5,<2.0a0",
+    "cutensor =1.2.2.5",
linux-64::cupy-9.2.0-py38ha69542f_0.tar.bz2
-    "cutensor >=1.2.2.5,<2.0a0",
+    "cutensor =1.2.2.5",
linux-64::cupy-9.2.0-py38hc350bd8_0.tar.bz2
-    "cutensor >=1.2.2.5,<2.0a0",
+    "cutensor =1.2.2.5",
linux-64::cupy-9.2.0-py39h53c10af_0.tar.bz2
-    "cutensor >=1.2.2.5,<2.0a0",
+    "cutensor =1.2.2.5",
linux-64::cupy-9.2.0-py39h55859a9_0.tar.bz2
-    "cutensor >=1.2.2.5,<2.0a0",
+    "cutensor =1.2.2.5",
linux-64::cupy-9.2.0-py39h81a3557_0.tar.bz2
-    "cutensor >=1.2.2.5,<2.0a0",
+    "cutensor =1.2.2.5",
linux-64::cupy-9.2.0-py39h835a156_0.tar.bz2
-    "cutensor >=1.2.2.5,<2.0a0",
+    "cutensor =1.2.2.5",
linux-64::cupy-9.2.0-py39hb309dcf_0.tar.bz2
-    "cutensor >=1.2.2.5,<2.0a0",
+    "cutensor =1.2.2.5",
linux-64::graph-tool-2.40-py36hf3098de_0.tar.bz2
-    "expat >=2.2.10,<2.3.0a0",
+    "expat >=2.2.10,<3.0.0a0",
linux-64::graph-tool-2.40-py37h6056006_0.tar.bz2
-    "expat >=2.2.10,<2.3.0a0",
+    "expat >=2.2.10,<3.0.0a0",
linux-64::graph-tool-2.40-py38h9a62468_0.tar.bz2
-    "expat >=2.2.10,<2.3.0a0",
+    "expat >=2.2.10,<3.0.0a0",
linux-64::graph-tool-2.40-py39hc2c1061_0.tar.bz2
-    "expat >=2.2.10,<2.3.0a0",
+    "expat >=2.2.10,<3.0.0a0",
linux-64::root_base-6.24.0-py36h4c722a5_1.tar.bz2
-    "vector-classes >=1.4.1,<1.5.0a0",
+    "vector-classes >=1.4.1,<1.4.2a0",
linux-64::root_base-6.24.0-py36haaeb575_0.tar.bz2
-    "vector-classes >=1.4.1,<1.5.0a0",
+    "vector-classes >=1.4.1,<1.4.2a0",
linux-64::root_base-6.24.0-py36hee22603_2.tar.bz2
-    "vector-classes >=1.4.1,<1.5.0a0",
+    "vector-classes >=1.4.1,<1.4.2a0",
linux-64::root_base-6.24.0-py37h5eaaf48_1.tar.bz2
-    "vector-classes >=1.4.1,<1.5.0a0",
+    "vector-classes >=1.4.1,<1.4.2a0",
linux-64::root_base-6.24.0-py37hcecb4a1_2.tar.bz2
-    "vector-classes >=1.4.1,<1.5.0a0",
+    "vector-classes >=1.4.1,<1.4.2a0",
linux-64::root_base-6.24.0-py37hf7c91a4_0.tar.bz2
-    "vector-classes >=1.4.1,<1.5.0a0",
+    "vector-classes >=1.4.1,<1.4.2a0",
linux-64::root_base-6.24.0-py38h07e97b3_0.tar.bz2
-    "vector-classes >=1.4.1,<1.5.0a0",
+    "vector-classes >=1.4.1,<1.4.2a0",
linux-64::root_base-6.24.0-py38hbbb968d_2.tar.bz2
-    "vector-classes >=1.4.1,<1.5.0a0",
+    "vector-classes >=1.4.1,<1.4.2a0",
linux-64::root_base-6.24.0-py38hf651459_1.tar.bz2
-    "vector-classes >=1.4.1,<1.5.0a0",
+    "vector-classes >=1.4.1,<1.4.2a0",
linux-64::root_base-6.24.0-py39h3756da3_1.tar.bz2
-    "vector-classes >=1.4.1,<1.5.0a0",
+    "vector-classes >=1.4.1,<1.4.2a0",
linux-64::root_base-6.24.0-py39h73983c3_2.tar.bz2
-    "vector-classes >=1.4.1,<1.5.0a0",
+    "vector-classes >=1.4.1,<1.4.2a0",
linux-64::root_base-6.24.0-py39h9c0239e_0.tar.bz2
-    "vector-classes >=1.4.1,<1.5.0a0",
+    "vector-classes >=1.4.1,<1.4.2a0",
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata.json.bz2
linux-aarch64::root_base-6.24.0-py36h228d4c7_2.tar.bz2
-    "vector-classes >=1.4.1,<1.5.0a0",
+    "vector-classes >=1.4.1,<1.4.2a0",
linux-aarch64::root_base-6.24.0-py36h5f90ee3_0.tar.bz2
-    "vector-classes >=1.4.1,<1.5.0a0",
+    "vector-classes >=1.4.1,<1.4.2a0",
linux-aarch64::root_base-6.24.0-py37h7dd90e1_2.tar.bz2
-    "vector-classes >=1.4.1,<1.5.0a0",
+    "vector-classes >=1.4.1,<1.4.2a0",
linux-aarch64::root_base-6.24.0-py37hd8ea93a_0.tar.bz2
-    "vector-classes >=1.4.1,<1.5.0a0",
+    "vector-classes >=1.4.1,<1.4.2a0",
linux-aarch64::root_base-6.24.0-py37hed1d754_1.tar.bz2
-    "vector-classes >=1.4.1,<1.5.0a0",
+    "vector-classes >=1.4.1,<1.4.2a0",
linux-aarch64::root_base-6.24.0-py38h89f413e_2.tar.bz2
-    "vector-classes >=1.4.1,<1.5.0a0",
+    "vector-classes >=1.4.1,<1.4.2a0",
linux-aarch64::root_base-6.24.0-py38hd04b882_0.tar.bz2
-    "vector-classes >=1.4.1,<1.5.0a0",
+    "vector-classes >=1.4.1,<1.4.2a0",
linux-aarch64::root_base-6.24.0-py39h8af4600_0.tar.bz2
-    "vector-classes >=1.4.1,<1.5.0a0",
+    "vector-classes >=1.4.1,<1.4.2a0",
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata.json.bz2
linux-ppc64le::cupy-9.2.0-py36h883fed4_0.tar.bz2
-    "cutensor >=1.2.2.5,<2.0a0",
+    "cutensor =1.2.2.5",
linux-ppc64le::cupy-9.2.0-py37hb59e34e_0.tar.bz2
-    "cutensor >=1.2.2.5,<2.0a0",
+    "cutensor =1.2.2.5",
linux-ppc64le::cupy-9.2.0-py37hdf97375_0.tar.bz2
-    "cutensor >=1.2.2.5,<2.0a0",
+    "cutensor =1.2.2.5",
linux-ppc64le::cupy-9.2.0-py38h1bc5b83_0.tar.bz2
-    "cutensor >=1.2.2.5,<2.0a0",
+    "cutensor =1.2.2.5",
linux-ppc64le::cupy-9.2.0-py39h9b85191_0.tar.bz2
-    "cutensor >=1.2.2.5,<2.0a0",
+    "cutensor =1.2.2.5",
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata.json.bz2
osx-64::graph-tool-2.40-py37h85a0b66_0.tar.bz2
-    "expat >=2.2.10,<2.3.0a0",
+    "expat >=2.2.10,<3.0.0a0",
osx-64::graph-tool-2.40-py38hdc09010_0.tar.bz2
-    "expat >=2.2.10,<2.3.0a0",
+    "expat >=2.2.10,<3.0.0a0",
osx-64::graph-tool-2.40-py39h01f136a_0.tar.bz2
-    "expat >=2.2.10,<2.3.0a0",
+    "expat >=2.2.10,<3.0.0a0",
osx-64::root_base-6.24.0-py36h3308b38_0.tar.bz2
-    "vector-classes >=1.4.1,<1.5.0a0",
+    "vector-classes >=1.4.1,<1.4.2a0",
osx-64::root_base-6.24.0-py36hce550fe_1.tar.bz2
-    "vector-classes >=1.4.1,<1.5.0a0",
+    "vector-classes >=1.4.1,<1.4.2a0",
osx-64::root_base-6.24.0-py36he7afe7f_2.tar.bz2
-    "vector-classes >=1.4.1,<1.5.0a0",
+    "vector-classes >=1.4.1,<1.4.2a0",
osx-64::root_base-6.24.0-py37h1fff5c3_0.tar.bz2
-    "vector-classes >=1.4.1,<1.5.0a0",
+    "vector-classes >=1.4.1,<1.4.2a0",
osx-64::root_base-6.24.0-py37ha5bcdf2_2.tar.bz2
-    "vector-classes >=1.4.1,<1.5.0a0",
+    "vector-classes >=1.4.1,<1.4.2a0",
osx-64::root_base-6.24.0-py37hf159980_1.tar.bz2
-    "vector-classes >=1.4.1,<1.5.0a0",
+    "vector-classes >=1.4.1,<1.4.2a0",
osx-64::root_base-6.24.0-py38h9fb3dc4_0.tar.bz2
-    "vector-classes >=1.4.1,<1.5.0a0",
+    "vector-classes >=1.4.1,<1.4.2a0",
osx-64::root_base-6.24.0-py38hc87488e_2.tar.bz2
-    "vector-classes >=1.4.1,<1.5.0a0",
+    "vector-classes >=1.4.1,<1.4.2a0",
osx-64::root_base-6.24.0-py38hcaf2d5a_1.tar.bz2
-    "vector-classes >=1.4.1,<1.5.0a0",
+    "vector-classes >=1.4.1,<1.4.2a0",
osx-64::root_base-6.24.0-py39h7a34c14_2.tar.bz2
-    "vector-classes >=1.4.1,<1.5.0a0",
+    "vector-classes >=1.4.1,<1.4.2a0",
osx-64::root_base-6.24.0-py39ha6f6e8d_0.tar.bz2
-    "vector-classes >=1.4.1,<1.5.0a0",
+    "vector-classes >=1.4.1,<1.4.2a0",
osx-64::root_base-6.24.0-py39hcccae89_1.tar.bz2
-    "vector-classes >=1.4.1,<1.5.0a0",
+    "vector-classes >=1.4.1,<1.4.2a0",
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata.json.bz2
osx-arm64::root_base-6.24.0-py38h21e4016_0.tar.bz2
-    "vector-classes >=1.4.1,<1.5.0a0",
+    "vector-classes >=1.4.1,<1.4.2a0",
osx-arm64::root_base-6.24.0-py39hdf834e2_0.tar.bz2
-    "vector-classes >=1.4.1,<1.5.0a0",
+    "vector-classes >=1.4.1,<1.4.2a0",
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata.json.bz2
win-64::cupy-9.2.0-py36h4641266_0.tar.bz2
-    "cutensor >=1.2.2.5,<2.0a0"
+    "cutensor =1.2.2.5"
win-64::cupy-9.2.0-py36hc806ef2_0.tar.bz2
-    "cutensor >=1.2.2.5,<2.0a0"
+    "cutensor =1.2.2.5"
win-64::cupy-9.2.0-py36he6cd523_0.tar.bz2
-    "cutensor >=1.2.2.5,<2.0a0"
+    "cutensor =1.2.2.5"
win-64::cupy-9.2.0-py36hfdd5185_0.tar.bz2
-    "cutensor >=1.2.2.5,<2.0a0",
+    "cutensor =1.2.2.5",
win-64::cupy-9.2.0-py37h72a7169_0.tar.bz2
-    "cutensor >=1.2.2.5,<2.0a0",
+    "cutensor =1.2.2.5",
win-64::cupy-9.2.0-py37h9ef161e_0.tar.bz2
-    "cutensor >=1.2.2.5,<2.0a0"
+    "cutensor =1.2.2.5"
win-64::cupy-9.2.0-py37hee0cbde_0.tar.bz2
-    "cutensor >=1.2.2.5,<2.0a0"
+    "cutensor =1.2.2.5"
win-64::cupy-9.2.0-py37hfe954b4_0.tar.bz2
-    "cutensor >=1.2.2.5,<2.0a0",
+    "cutensor =1.2.2.5",
win-64::cupy-9.2.0-py38h5fb355a_0.tar.bz2
-    "cutensor >=1.2.2.5,<2.0a0",
+    "cutensor =1.2.2.5",
win-64::cupy-9.2.0-py38h66fa806_0.tar.bz2
-    "cutensor >=1.2.2.5,<2.0a0",
+    "cutensor =1.2.2.5",
win-64::cupy-9.2.0-py38h8737d37_0.tar.bz2
-    "cutensor >=1.2.2.5,<2.0a0",
+    "cutensor =1.2.2.5",
win-64::cupy-9.2.0-py38hf95616d_0.tar.bz2
-    "cutensor >=1.2.2.5,<2.0a0"
+    "cutensor =1.2.2.5"
win-64::cupy-9.2.0-py39h58dc777_0.tar.bz2
-    "cutensor >=1.2.2.5,<2.0a0",
+    "cutensor =1.2.2.5",
win-64::cupy-9.2.0-py39h5d933e2_0.tar.bz2
-    "cutensor >=1.2.2.5,<2.0a0",
+    "cutensor =1.2.2.5",
win-64::cupy-9.2.0-py39hb2679a4_0.tar.bz2
-    "cutensor >=1.2.2.5,<2.0a0",
+    "cutensor =1.2.2.5",
win-64::cupy-9.2.0-py39hc474d4a_0.tar.bz2
-    "cutensor >=1.2.2.5,<2.0a0",
+    "cutensor =1.2.2.5",
win-64::tiledb-py-0.9.0-py36_vc14hdd3148d_2.tar.bz2
-  "features": "vc14",
win-64::tiledb-py-0.9.0-py37_vc14h756c2e0_2.tar.bz2
-  "features": "vc14",
win-64::tiledb-py-0.9.0-py38_vc14h528aa4e_2.tar.bz2
-  "features": "vc14",
win-64::tiledb-py-0.9.0-py39_vc14he219d82_2.tar.bz2
-  "features": "vc14",
win-64::tiledb-py-0.9.1-py36_vc14hdd3148d_3.tar.bz2
-  "features": "vc14",
win-64::tiledb-py-0.9.1-py37_vc14h756c2e0_3.tar.bz2
-  "features": "vc14",
win-64::tiledb-py-0.9.1-py38_vc14h528aa4e_3.tar.bz2
-  "features": "vc14",
win-64::tiledb-py-0.9.1-py39_vc14he219d82_3.tar.bz2
-  "features": "vc14",
```