### PR TITLE
remove botocore 1.21.0 build 0

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -30,6 +30,7 @@ SUBDIRS = (
 
 REMOVALS = {
     "noarch": (
+        "botocore-1.21.0-pyhd8ed1ab_0.tar.bz2",
         "sendgrid-5.3.0-py_0.tar.bz2",
     ),
     "linux-64": (


### PR DESCRIPTION
I screwed up and merged the version bump before tightening the python requirements (which was done in build 1)
don't want weird environments using build 0 to be possible

Is this better here or https://github.com/conda-forge/admin-requests/tree/master/broken ?

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
