### PR TITLE
guard old typer-builds against incompatible click

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -510,6 +510,11 @@ def _gen_new_index(repodata, subdir):
                 else:
                     record['depends'] = ["typing_extensions"]
 
+        if record_name == "typer" and record.get('timestamp', 0) < 1609873200000:
+            # https://github.com/conda-forge/typer-feedstock/issues/5
+            if any(dep.split(' ')[0] == "click" for dep in record.get('depends', ())):
+                record['depends'].append('click <8')
+
         if record_name == "ipython" and record.get('timestamp', 0) < 1609621539000:
             # https://github.com/conda-forge/ipython-feedstock/issues/127
             if any(dep.split(' ')[0] == "jedi" for dep in record.get('depends', ())):


### PR DESCRIPTION
Fix https://github.com/conda-forge/typer-feedstock/issues/5

These packages still get preferred by the resolver, which breaks spacy et. al

CC @conda-forge/typer @conda-forge/spacy