### PR TITLE
tzlocal 3.0 needs python 3.9

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1077,6 +1077,11 @@ def _gen_new_index(repodata, subdir):
             depends[depends.index("snowflake-connector-python <3")] = "snowflake-connector-python <3.0.0"
             depends[depends.index("sqlalchemy <2")] = "sqlalchemy >=1.4.0,<2.0.0"
 
+        # tzlocal 3.0 needs Python 3.9 (or backports.zoneinfo)
+        # fixed in https://github.com/conda-forge/tzlocal-feedstock/pull/10
+        if record_name == "tzlocal" and record["version"] == "3.0" and "python >=3.6" in record["depends"]:
+            _replace_pin("python >=3.6", "python >=3.9", deps, record)
+
         # replace =2.7 with ==2.7.* for compatibility with older conda
         new_deps = []
         changed = False


### PR DESCRIPTION
The current build of tzlocal 3.0 needs python 3.9 (or backports.zoneinfo). In this patch here, I'm requiring python>=3.9. 

I'm adding the backports.zoneinfo dependency for python<3.9 in https://github.com/conda-forge/tzlocal-feedstock/pull/10

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->


Diff:

```
% python show_diff.py 
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata.json.bz2
noarch::dropbox-11.16.0-pyhd8ed1ab_0.tar.bz2
-    "python =2.7|>=3.4",
+    "python ==2.7.*|>=3.4",
noarch::tzlocal-3.0-pyhd8ed1ab_0.tar.bz2
-    "python >=3.6"
+    "python >=3.9"
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata.json.bz2
linux-64::dakota-6.14.0-py38h9f736be_1.tar.bz2
-    "liblapack >=3.8.0,<3.9.0a0",
+    "liblapack >=3.8.0,<4.0.0a0",
-    "openmpi >=4.0.5,<4.1.0a0",
+    "openmpi >=4.0.5,<5.0.0a0",
linux-64::dakota-6.14.0-py39h5f72919_1.tar.bz2
-    "liblapack >=3.8.0,<3.9.0a0",
+    "liblapack >=3.8.0,<4.0.0a0",
-    "openmpi >=4.0.5,<4.1.0a0",
+    "openmpi >=4.0.5,<5.0.0a0",
linux-64::mpi4py-3.1.0-py36h7b8b12a_0.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
linux-64::mpi4py-3.1.0-py37h1e5cb63_0.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
linux-64::mpi4py-3.1.0-py37hb7498f7_0.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
linux-64::mpi4py-3.1.0-py38he865349_0.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
linux-64::mpi4py-3.1.0-py39h6438238_0.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
linux-64::plumed-2.7.2-mpi_mpich_hc4d6106_1.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
linux-64::plumed-2.7.2-mpi_mpich_hc4d6106_2.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata.json.bz2
linux-aarch64::mpi4py-3.1.0-py36h282ea70_0.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
linux-aarch64::mpi4py-3.1.0-py37h4dc0dbf_0.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
linux-aarch64::mpi4py-3.1.0-py37h6dc2f3d_0.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
linux-aarch64::mpi4py-3.1.0-py38h3e93bed_0.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
linux-aarch64::mpi4py-3.1.0-py39hfc356f9_0.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
linux-aarch64::plumed-2.7.2-mpi_mpich_hba48204_1.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
linux-aarch64::plumed-2.7.2-mpi_mpich_hba48204_2.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata.json.bz2
linux-ppc64le::mpi4py-3.1.0-py36h0aecef9_0.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
linux-ppc64le::mpi4py-3.1.0-py37h7004f36_0.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
linux-ppc64le::mpi4py-3.1.0-py37hc2416af_0.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
linux-ppc64le::mpi4py-3.1.0-py38hb5cbab6_0.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
linux-ppc64le::mpi4py-3.1.0-py39hb8de56a_0.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
linux-ppc64le::plumed-2.7.2-mpi_mpich_h85f196e_1.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
linux-ppc64le::plumed-2.7.2-mpi_mpich_h85f196e_2.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata.json.bz2
osx-64::mpi4py-3.1.0-py36h642157f_0.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
osx-64::mpi4py-3.1.0-py37h45bc384_0.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
osx-64::mpi4py-3.1.0-py37hae0e78a_0.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
osx-64::mpi4py-3.1.0-py38hcd6a4d3_0.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
osx-64::mpi4py-3.1.0-py39ha81d895_0.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
osx-64::plumed-2.7.2-mpi_mpich_ha4917de_1.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
osx-64::plumed-2.7.2-mpi_mpich_ha4917de_2.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata.json.bz2
osx-arm64::mpi4py-3.1.0-py38hf5adb80_0.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
osx-arm64::mpi4py-3.1.0-py39hee4813e_0.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata.json.bz2
```