### PR TITLE
Add a patch to constrain 'openmm < 7.6' for 'parmed < 3.4.3'

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -761,7 +761,9 @@ def _gen_new_index(repodata, subdir):
         if (record_name == "parmed" and
             (pkg_resources.parse_version(record["version"]) <
              pkg_resources.parse_version("3.4.3"))):
-            record['depends'].append("openmm <7.6")
+            new_constrains = record.get('constrains', [])
+            new_constrains.append("openmm <7.6")
+            record['constrains'] = new_constrains
 
 
         # FIXME: disable patching-out blas_openblas feature

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -755,6 +755,15 @@ def _gen_new_index(repodata, subdir):
             i = record['depends'].index('astunparse')
             record['depends'][i] = 'astunparse <=1.6.2'
 
+        # With release of openmm 7.6 it changed package structure, breaking
+        # parmed. This is fixed for 3.4.3, but older builds should get
+        # a pin to prevent breaks for now.
+        if (record_name == "parmed" and
+            (pkg_resources.parse_version(record["version"]) <
+             pkg_resources.parse_version("3.4.3"))):
+            record['depends'].append("openmm <7.6")
+
+
         # FIXME: disable patching-out blas_openblas feature
         # because hotfixes are not applied to gcc7 label
         # causing inconsistent behavior


### PR DESCRIPTION
As a part of the [openmm 7.6 release](https://github.com/openmm/openmm/releases/tag/7.6.0), their package namespace was restructured. As a result [ParmEd broke](https://github.com/ParmEd/ParmEd/issues/1185), which [has been fixed for 3.4.3](https://github.com/ParmEd/ParmEd/issues/1185#issuecomment-909282874). 

As mentioned in the linked comment @swails (recipe-maintainer) still expressed interest to prevent older builds being broken by updating, which this patch should do.

output from `show_diff.py`
```diff
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata.json.bz2
linux-64::libnetcdf-4.8.1-mpi_mpich_h044de9c_0.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
linux-64::libnetcdf-4.8.1-mpi_mpich_h319fa22_1.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
linux-64::parmed-3.2.0-py36ha03b18c_4.tar.bz2
-    "python_abi 3.6 *_pypy36_pp73"
+    "python_abi 3.6 *_pypy36_pp73",
+    "openmm <7.6"
linux-64::parmed-3.2.0-py36hc4f0c31_4.tar.bz2
-    "python_abi 3.6.* *_cp36m"
+    "python_abi 3.6.* *_cp36m",
+    "openmm <7.6"
linux-64::parmed-3.2.0-py37h3340039_4.tar.bz2
-    "python_abi 3.7.* *_cp37m"
+    "python_abi 3.7.* *_cp37m",
+    "openmm <7.6"
linux-64::parmed-3.2.0-py37hc99cbb1_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp37m"
-  ],
-    "python >=3.7,<3.8.0a0"
+    "python >=3.7,<3.8.0a0",
+    "openmm <7.6"
-  "version": "3.2.0"
+  "version": "3.2.0",
+  "constrains": [
+    "python_abi * *_cp37m"
+  ]
linux-64::parmed-3.2.0-py37hc99cbb1_1.tar.bz2
-  "constrains": [
-    "python_abi * *_cp37m"
-  ],
-    "python >=3.7,<3.8.0a0"
+    "python >=3.7,<3.8.0a0",
+    "openmm <7.6"
-  "version": "3.2.0"
+  "version": "3.2.0",
+  "constrains": [
+    "python_abi * *_cp37m"
+  ]
linux-64::parmed-3.2.0-py37hcd2ae1e_4.tar.bz2
-    "python_abi 3.7.* *_cp37m"
+    "python_abi 3.7.* *_cp37m",
+    "openmm <7.6"
linux-64::parmed-3.2.0-py37he1b5a44_2.tar.bz2
-  "constrains": [
-    "python_abi * *_cp37m"
-  ],
-    "python >=3.7,<3.8.0a0"
+    "python >=3.7,<3.8.0a0",
+    "openmm <7.6"
-  "version": "3.2.0"
+  "version": "3.2.0",
+  "constrains": [
+    "python_abi * *_cp37m"
+  ]
linux-64::parmed-3.2.0-py37he226ad3_4.tar.bz2
-    "python_abi 3.7 *_pypy37_pp73"
+    "python_abi 3.7 *_pypy37_pp73",
+    "openmm <7.6"
linux-64::parmed-3.2.0-py38h709712a_4.tar.bz2
-    "python_abi 3.8.* *_cp38"
+    "python_abi 3.8.* *_cp38",
+    "openmm <7.6"
linux-64::parmed-3.2.0-py38h950e882_4.tar.bz2
-    "python_abi 3.8.* *_cp38"
+    "python_abi 3.8.* *_cp38",
+    "openmm <7.6"
linux-64::parmed-3.2.0-py38hc99cbb1_1.tar.bz2
-  "constrains": [
-    "python_abi * *_cp38"
-  ],
-    "python >=3.8,<3.9.0a0"
+    "python >=3.8,<3.9.0a0",
+    "openmm <7.6"
-  "version": "3.2.0"
+  "version": "3.2.0",
+  "constrains": [
+    "python_abi * *_cp38"
+  ]
linux-64::parmed-3.2.0-py38he1b5a44_2.tar.bz2
-  "constrains": [
-    "python_abi * *_cp38"
-  ],
-    "python >=3.8,<3.9.0a0"
+    "python >=3.8,<3.9.0a0",
+    "openmm <7.6"
-  "version": "3.2.0"
+  "version": "3.2.0",
+  "constrains": [
+    "python_abi * *_cp38"
+  ]
linux-64::parmed-3.2.0-py39he80948d_4.tar.bz2
-    "python_abi 3.9.* *_cp39"
+    "python_abi 3.9.* *_cp39",
+    "openmm <7.6"
linux-64::parmed-3.2.0-py39hf149a3a_4.tar.bz2
-    "python_abi 3.9.* *_cp39"
+    "python_abi 3.9.* *_cp39",
+    "openmm <7.6"
linux-64::parmed-3.3.0-py36ha03b18c_0.tar.bz2
-    "python_abi 3.6 *_pypy36_pp73"
+    "python_abi 3.6 *_pypy36_pp73",
+    "openmm <7.6"
linux-64::parmed-3.3.0-py36hc4f0c31_0.tar.bz2
-    "python_abi 3.6.* *_cp36m"
+    "python_abi 3.6.* *_cp36m",
+    "openmm <7.6"
linux-64::parmed-3.3.0-py37hcd2ae1e_0.tar.bz2
-    "python_abi 3.7.* *_cp37m"
+    "python_abi 3.7.* *_cp37m",
+    "openmm <7.6"
linux-64::parmed-3.3.0-py37he226ad3_0.tar.bz2
-    "python_abi 3.7 *_pypy37_pp73"
+    "python_abi 3.7 *_pypy37_pp73",
+    "openmm <7.6"
linux-64::parmed-3.3.0-py38h709712a_0.tar.bz2
-    "python_abi 3.8.* *_cp38"
+    "python_abi 3.8.* *_cp38",
+    "openmm <7.6"
linux-64::parmed-3.3.0-py39he80948d_0.tar.bz2
-    "python_abi 3.9.* *_cp39"
+    "python_abi 3.9.* *_cp39",
+    "openmm <7.6"
linux-64::parmed-3.4.0-py36ha03b18c_0.tar.bz2
-    "python_abi 3.6 *_pypy36_pp73"
+    "python_abi 3.6 *_pypy36_pp73",
+    "openmm <7.6"
linux-64::parmed-3.4.0-py36ha03b18c_1.tar.bz2
-    "python_abi 3.6 *_pypy36_pp73"
+    "python_abi 3.6 *_pypy36_pp73",
+    "openmm <7.6"
linux-64::parmed-3.4.0-py36hc4f0c31_0.tar.bz2
-    "python_abi 3.6.* *_cp36m"
+    "python_abi 3.6.* *_cp36m",
+    "openmm <7.6"
linux-64::parmed-3.4.0-py36hc4f0c31_1.tar.bz2
-    "python_abi 3.6.* *_cp36m"
+    "python_abi 3.6.* *_cp36m",
+    "openmm <7.6"
linux-64::parmed-3.4.0-py37hcd2ae1e_0.tar.bz2
-    "python_abi 3.7.* *_cp37m"
+    "python_abi 3.7.* *_cp37m",
+    "openmm <7.6"
linux-64::parmed-3.4.0-py37hcd2ae1e_1.tar.bz2
-    "python_abi 3.7.* *_cp37m"
+    "python_abi 3.7.* *_cp37m",
+    "openmm <7.6"
linux-64::parmed-3.4.0-py37he226ad3_0.tar.bz2
-    "python_abi 3.7 *_pypy37_pp73"
+    "python_abi 3.7 *_pypy37_pp73",
+    "openmm <7.6"
linux-64::parmed-3.4.0-py37he226ad3_1.tar.bz2
-    "python_abi 3.7 *_pypy37_pp73"
+    "python_abi 3.7 *_pypy37_pp73",
+    "openmm <7.6"
linux-64::parmed-3.4.0-py38h709712a_0.tar.bz2
-    "python_abi 3.8.* *_cp38"
+    "python_abi 3.8.* *_cp38",
+    "openmm <7.6"
linux-64::parmed-3.4.0-py38h709712a_1.tar.bz2
-    "python_abi 3.8.* *_cp38"
+    "python_abi 3.8.* *_cp38",
+    "openmm <7.6"
linux-64::parmed-3.4.0-py39he80948d_0.tar.bz2
-    "python_abi 3.9.* *_cp39"
+    "python_abi 3.9.* *_cp39",
+    "openmm <7.6"
linux-64::parmed-3.4.0-py39he80948d_1.tar.bz2
-    "python_abi 3.9.* *_cp39"
+    "python_abi 3.9.* *_cp39",
+    "openmm <7.6"
linux-64::parmed-3.4.1-py36ha03b18c_0.tar.bz2
-    "python_abi 3.6 *_pypy36_pp73"
+    "python_abi 3.6 *_pypy36_pp73",
+    "openmm <7.6"
linux-64::parmed-3.4.1-py36hc4f0c31_0.tar.bz2
-    "python_abi 3.6.* *_cp36m"
+    "python_abi 3.6.* *_cp36m",
+    "openmm <7.6"
linux-64::parmed-3.4.1-py37hcd2ae1e_0.tar.bz2
-    "python_abi 3.7.* *_cp37m"
+    "python_abi 3.7.* *_cp37m",
+    "openmm <7.6"
linux-64::parmed-3.4.1-py37he226ad3_0.tar.bz2
-    "python_abi 3.7 *_pypy37_pp73"
+    "python_abi 3.7 *_pypy37_pp73",
+    "openmm <7.6"
linux-64::parmed-3.4.1-py38h709712a_0.tar.bz2
-    "python_abi 3.8.* *_cp38"
+    "python_abi 3.8.* *_cp38",
+    "openmm <7.6"
linux-64::parmed-3.4.1-py39he80948d_0.tar.bz2
-    "python_abi 3.9.* *_cp39"
+    "python_abi 3.9.* *_cp39",
+    "openmm <7.6"
linux-64::parmed-3.4.2-py36hc4f0c31_0.tar.bz2
-    "python_abi 3.6.* *_cp36m"
+    "python_abi 3.6.* *_cp36m",
+    "openmm <7.6"
linux-64::parmed-3.4.2-py37hcd2ae1e_0.tar.bz2
-    "python_abi 3.7.* *_cp37m"
+    "python_abi 3.7.* *_cp37m",
+    "openmm <7.6"
linux-64::parmed-3.4.2-py37he226ad3_0.tar.bz2
-    "python_abi 3.7 *_pypy37_pp73"
+    "python_abi 3.7 *_pypy37_pp73",
+    "openmm <7.6"
linux-64::parmed-3.4.2-py38h709712a_0.tar.bz2
-    "python_abi 3.8.* *_cp38"
+    "python_abi 3.8.* *_cp38",
+    "openmm <7.6"
linux-64::parmed-3.4.2-py39he80948d_0.tar.bz2
-    "python_abi 3.9.* *_cp39"
+    "python_abi 3.9.* *_cp39",
+    "openmm <7.6"
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata.json.bz2
linux-aarch64::libnetcdf-4.8.1-mpi_mpich_ha39a207_1.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
linux-aarch64::libnetcdf-4.8.1-mpi_mpich_hc7d4b01_0.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
linux-aarch64::parmed-3.3.0-py36h143fd24_0.tar.bz2
-    "python_abi 3.6 *_pypy36_pp73"
+    "python_abi 3.6 *_pypy36_pp73",
+    "openmm <7.6"
linux-aarch64::parmed-3.3.0-py36h86e9a40_0.tar.bz2
-    "python_abi 3.6.* *_cp36m"
+    "python_abi 3.6.* *_cp36m",
+    "openmm <7.6"
linux-aarch64::parmed-3.3.0-py37h5d5c557_0.tar.bz2
-    "python_abi 3.7 *_pypy37_pp73"
+    "python_abi 3.7 *_pypy37_pp73",
+    "openmm <7.6"
linux-aarch64::parmed-3.3.0-py37had24c86_0.tar.bz2
-    "python_abi 3.7.* *_cp37m"
+    "python_abi 3.7.* *_cp37m",
+    "openmm <7.6"
linux-aarch64::parmed-3.3.0-py38h0119ad3_0.tar.bz2
-    "python_abi 3.8.* *_cp38"
+    "python_abi 3.8.* *_cp38",
+    "openmm <7.6"
linux-aarch64::parmed-3.3.0-py39h99ab00b_0.tar.bz2
-    "python_abi 3.9.* *_cp39"
+    "python_abi 3.9.* *_cp39",
+    "openmm <7.6"
linux-aarch64::parmed-3.4.0-py36h143fd24_1.tar.bz2
-    "python_abi 3.6 *_pypy36_pp73"
+    "python_abi 3.6 *_pypy36_pp73",
+    "openmm <7.6"
linux-aarch64::parmed-3.4.0-py36h86e9a40_1.tar.bz2
-    "python_abi 3.6.* *_cp36m"
+    "python_abi 3.6.* *_cp36m",
+    "openmm <7.6"
linux-aarch64::parmed-3.4.0-py37h5d5c557_1.tar.bz2
-    "python_abi 3.7 *_pypy37_pp73"
+    "python_abi 3.7 *_pypy37_pp73",
+    "openmm <7.6"
linux-aarch64::parmed-3.4.0-py37had24c86_1.tar.bz2
-    "python_abi 3.7.* *_cp37m"
+    "python_abi 3.7.* *_cp37m",
+    "openmm <7.6"
linux-aarch64::parmed-3.4.0-py38h0119ad3_1.tar.bz2
-    "python_abi 3.8.* *_cp38"
+    "python_abi 3.8.* *_cp38",
+    "openmm <7.6"
linux-aarch64::parmed-3.4.0-py39h99ab00b_1.tar.bz2
-    "python_abi 3.9.* *_cp39"
+    "python_abi 3.9.* *_cp39",
+    "openmm <7.6"
linux-aarch64::parmed-3.4.1-py36h143fd24_0.tar.bz2
-    "python_abi 3.6 *_pypy36_pp73"
+    "python_abi 3.6 *_pypy36_pp73",
+    "openmm <7.6"
linux-aarch64::parmed-3.4.1-py36h86e9a40_0.tar.bz2
-    "python_abi 3.6.* *_cp36m"
+    "python_abi 3.6.* *_cp36m",
+    "openmm <7.6"
linux-aarch64::parmed-3.4.1-py37h5d5c557_0.tar.bz2
-    "python_abi 3.7 *_pypy37_pp73"
+    "python_abi 3.7 *_pypy37_pp73",
+    "openmm <7.6"
linux-aarch64::parmed-3.4.1-py37had24c86_0.tar.bz2
-    "python_abi 3.7.* *_cp37m"
+    "python_abi 3.7.* *_cp37m",
+    "openmm <7.6"
linux-aarch64::parmed-3.4.1-py38h0119ad3_0.tar.bz2
-    "python_abi 3.8.* *_cp38"
+    "python_abi 3.8.* *_cp38",
+    "openmm <7.6"
linux-aarch64::parmed-3.4.1-py39h99ab00b_0.tar.bz2
-    "python_abi 3.9.* *_cp39"
+    "python_abi 3.9.* *_cp39",
+    "openmm <7.6"
linux-aarch64::parmed-3.4.2-py36h86e9a40_0.tar.bz2
-    "python_abi 3.6.* *_cp36m"
+    "python_abi 3.6.* *_cp36m",
+    "openmm <7.6"
linux-aarch64::parmed-3.4.2-py37h5d5c557_0.tar.bz2
-    "python_abi 3.7 *_pypy37_pp73"
+    "python_abi 3.7 *_pypy37_pp73",
+    "openmm <7.6"
linux-aarch64::parmed-3.4.2-py37had24c86_0.tar.bz2
-    "python_abi 3.7.* *_cp37m"
+    "python_abi 3.7.* *_cp37m",
+    "openmm <7.6"
linux-aarch64::parmed-3.4.2-py38h0119ad3_0.tar.bz2
-    "python_abi 3.8.* *_cp38"
+    "python_abi 3.8.* *_cp38",
+    "openmm <7.6"
linux-aarch64::parmed-3.4.2-py39h99ab00b_0.tar.bz2
-    "python_abi 3.9.* *_cp39"
+    "python_abi 3.9.* *_cp39",
+    "openmm <7.6"
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata.json.bz2
linux-ppc64le::libnetcdf-4.8.1-mpi_mpich_h1e35a92_1.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
linux-ppc64le::libnetcdf-4.8.1-mpi_mpich_ha8dd75b_0.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
linux-ppc64le::parmed-3.3.0-py36h08d3667_0.tar.bz2
-    "python_abi 3.6.* *_cp36m"
+    "python_abi 3.6.* *_cp36m",
+    "openmm <7.6"
linux-ppc64le::parmed-3.3.0-py36hdee431b_0.tar.bz2
-    "python_abi 3.6 *_pypy36_pp73"
+    "python_abi 3.6 *_pypy36_pp73",
+    "openmm <7.6"
linux-ppc64le::parmed-3.3.0-py37hc9b93fd_0.tar.bz2
-    "python_abi 3.7.* *_cp37m"
+    "python_abi 3.7.* *_cp37m",
+    "openmm <7.6"
linux-ppc64le::parmed-3.3.0-py37hfc837b7_0.tar.bz2
-    "python_abi 3.7 *_pypy37_pp73"
+    "python_abi 3.7 *_pypy37_pp73",
+    "openmm <7.6"
linux-ppc64le::parmed-3.3.0-py38ha35a538_0.tar.bz2
-    "python_abi 3.8.* *_cp38"
+    "python_abi 3.8.* *_cp38",
+    "openmm <7.6"
linux-ppc64le::parmed-3.3.0-py39had50986_0.tar.bz2
-    "python_abi 3.9.* *_cp39"
+    "python_abi 3.9.* *_cp39",
+    "openmm <7.6"
linux-ppc64le::parmed-3.4.0-py36h08d3667_1.tar.bz2
-    "python_abi 3.6.* *_cp36m"
+    "python_abi 3.6.* *_cp36m",
+    "openmm <7.6"
linux-ppc64le::parmed-3.4.0-py36hdee431b_1.tar.bz2
-    "python_abi 3.6 *_pypy36_pp73"
+    "python_abi 3.6 *_pypy36_pp73",
+    "openmm <7.6"
linux-ppc64le::parmed-3.4.0-py37hc9b93fd_1.tar.bz2
-    "python_abi 3.7.* *_cp37m"
+    "python_abi 3.7.* *_cp37m",
+    "openmm <7.6"
linux-ppc64le::parmed-3.4.0-py37hfc837b7_1.tar.bz2
-    "python_abi 3.7 *_pypy37_pp73"
+    "python_abi 3.7 *_pypy37_pp73",
+    "openmm <7.6"
linux-ppc64le::parmed-3.4.0-py38ha35a538_1.tar.bz2
-    "python_abi 3.8.* *_cp38"
+    "python_abi 3.8.* *_cp38",
+    "openmm <7.6"
linux-ppc64le::parmed-3.4.0-py39had50986_1.tar.bz2
-    "python_abi 3.9.* *_cp39"
+    "python_abi 3.9.* *_cp39",
+    "openmm <7.6"
linux-ppc64le::parmed-3.4.1-py36h08d3667_0.tar.bz2
-    "python_abi 3.6.* *_cp36m"
+    "python_abi 3.6.* *_cp36m",
+    "openmm <7.6"
linux-ppc64le::parmed-3.4.1-py36hdee431b_0.tar.bz2
-    "python_abi 3.6 *_pypy36_pp73"
+    "python_abi 3.6 *_pypy36_pp73",
+    "openmm <7.6"
linux-ppc64le::parmed-3.4.1-py37hc9b93fd_0.tar.bz2
-    "python_abi 3.7.* *_cp37m"
+    "python_abi 3.7.* *_cp37m",
+    "openmm <7.6"
linux-ppc64le::parmed-3.4.1-py37hfc837b7_0.tar.bz2
-    "python_abi 3.7 *_pypy37_pp73"
+    "python_abi 3.7 *_pypy37_pp73",
+    "openmm <7.6"
linux-ppc64le::parmed-3.4.1-py38ha35a538_0.tar.bz2
-    "python_abi 3.8.* *_cp38"
+    "python_abi 3.8.* *_cp38",
+    "openmm <7.6"
linux-ppc64le::parmed-3.4.1-py39had50986_0.tar.bz2
-    "python_abi 3.9.* *_cp39"
+    "python_abi 3.9.* *_cp39",
+    "openmm <7.6"
linux-ppc64le::parmed-3.4.2-py36h08d3667_0.tar.bz2
-    "python_abi 3.6.* *_cp36m"
+    "python_abi 3.6.* *_cp36m",
+    "openmm <7.6"
linux-ppc64le::parmed-3.4.2-py37hc9b93fd_0.tar.bz2
-    "python_abi 3.7.* *_cp37m"
+    "python_abi 3.7.* *_cp37m",
+    "openmm <7.6"
linux-ppc64le::parmed-3.4.2-py37hfc837b7_0.tar.bz2
-    "python_abi 3.7 *_pypy37_pp73"
+    "python_abi 3.7 *_pypy37_pp73",
+    "openmm <7.6"
linux-ppc64le::parmed-3.4.2-py38ha35a538_0.tar.bz2
-    "python_abi 3.8.* *_cp38"
+    "python_abi 3.8.* *_cp38",
+    "openmm <7.6"
linux-ppc64le::parmed-3.4.2-py39had50986_0.tar.bz2
-    "python_abi 3.9.* *_cp39"
+    "python_abi 3.9.* *_cp39",
+    "openmm <7.6"
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata.json.bz2
osx-64::libnetcdf-4.8.1-mpi_mpich_h312eb28_0.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
osx-64::libnetcdf-4.8.1-mpi_mpich_hf13189e_1.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
osx-64::parmed-3.2.0-py36h22858aa_4.tar.bz2
-    "python_abi 3.6.* *_cp36m"
+    "python_abi 3.6.* *_cp36m",
+    "openmm <7.6"
osx-64::parmed-3.2.0-py36h704b0d9_4.tar.bz2
-    "python_abi 3.6 *_pypy36_pp73"
+    "python_abi 3.6 *_pypy36_pp73",
+    "openmm <7.6"
osx-64::parmed-3.2.0-py37h0d3f06a_4.tar.bz2
-    "python_abi 3.7 *_pypy37_pp73"
+    "python_abi 3.7 *_pypy37_pp73",
+    "openmm <7.6"
osx-64::parmed-3.2.0-py37h4a8c4bd_2.tar.bz2
-  "constrains": [
-    "python_abi * *_cp37m"
-  ],
-    "python >=3.7,<3.8.0a0"
+    "python >=3.7,<3.8.0a0",
+    "openmm <7.6"
-  "version": "3.2.0"
+  "version": "3.2.0",
+  "constrains": [
+    "python_abi * *_cp37m"
+  ]
osx-64::parmed-3.2.0-py37h54c7649_4.tar.bz2
-    "python_abi 3.7.* *_cp37m"
+    "python_abi 3.7.* *_cp37m",
+    "openmm <7.6"
osx-64::parmed-3.2.0-py37hdadc0f0_4.tar.bz2
-    "python_abi 3.7.* *_cp37m"
+    "python_abi 3.7.* *_cp37m",
+    "openmm <7.6"
osx-64::parmed-3.2.0-py38h0a5c65b_4.tar.bz2
-    "python_abi 3.8.* *_cp38"
+    "python_abi 3.8.* *_cp38",
+    "openmm <7.6"
osx-64::parmed-3.2.0-py38h11c0d25_4.tar.bz2
-    "python_abi 3.8.* *_cp38"
+    "python_abi 3.8.* *_cp38",
+    "openmm <7.6"
osx-64::parmed-3.2.0-py38h4a8c4bd_2.tar.bz2
-  "constrains": [
-    "python_abi * *_cp38"
-  ],
-    "python >=3.8,<3.9.0a0"
+    "python >=3.8,<3.9.0a0",
+    "openmm <7.6"
-  "version": "3.2.0"
+  "version": "3.2.0",
+  "constrains": [
+    "python_abi * *_cp38"
+  ]
osx-64::parmed-3.2.0-py39h81cd7d3_4.tar.bz2
-    "python_abi 3.9.* *_cp39"
+    "python_abi 3.9.* *_cp39",
+    "openmm <7.6"
osx-64::parmed-3.2.0-py39ha36be7a_4.tar.bz2
-    "python_abi 3.9.* *_cp39"
+    "python_abi 3.9.* *_cp39",
+    "openmm <7.6"
osx-64::parmed-3.3.0-py36h89d5895_0.tar.bz2
-    "python_abi 3.6 *_pypy36_pp73"
+    "python_abi 3.6 *_pypy36_pp73",
+    "openmm <7.6"
osx-64::parmed-3.3.0-py36hb100763_0.tar.bz2
-    "python_abi 3.6.* *_cp36m"
+    "python_abi 3.6.* *_cp36m",
+    "openmm <7.6"
osx-64::parmed-3.3.0-py37h48c69f3_0.tar.bz2
-    "python_abi 3.7 *_pypy37_pp73"
+    "python_abi 3.7 *_pypy37_pp73",
+    "openmm <7.6"
osx-64::parmed-3.3.0-py37h9af6487_0.tar.bz2
-    "python_abi 3.7.* *_cp37m"
+    "python_abi 3.7.* *_cp37m",
+    "openmm <7.6"
osx-64::parmed-3.3.0-py38h91a8764_0.tar.bz2
-    "python_abi 3.8.* *_cp38"
+    "python_abi 3.8.* *_cp38",
+    "openmm <7.6"
osx-64::parmed-3.3.0-py39h219cf5c_0.tar.bz2
-    "python_abi 3.9.* *_cp39"
+    "python_abi 3.9.* *_cp39",
+    "openmm <7.6"
osx-64::parmed-3.4.0-py36h89d5895_0.tar.bz2
-    "python_abi 3.6 *_pypy36_pp73"
+    "python_abi 3.6 *_pypy36_pp73",
+    "openmm <7.6"
osx-64::parmed-3.4.0-py36h89d5895_1.tar.bz2
-    "python_abi 3.6 *_pypy36_pp73"
+    "python_abi 3.6 *_pypy36_pp73",
+    "openmm <7.6"
osx-64::parmed-3.4.0-py36hb100763_0.tar.bz2
-    "python_abi 3.6.* *_cp36m"
+    "python_abi 3.6.* *_cp36m",
+    "openmm <7.6"
osx-64::parmed-3.4.0-py36hb100763_1.tar.bz2
-    "python_abi 3.6.* *_cp36m"
+    "python_abi 3.6.* *_cp36m",
+    "openmm <7.6"
osx-64::parmed-3.4.0-py37h48c69f3_0.tar.bz2
-    "python_abi 3.7 *_pypy37_pp73"
+    "python_abi 3.7 *_pypy37_pp73",
+    "openmm <7.6"
osx-64::parmed-3.4.0-py37h48c69f3_1.tar.bz2
-    "python_abi 3.7 *_pypy37_pp73"
+    "python_abi 3.7 *_pypy37_pp73",
+    "openmm <7.6"
osx-64::parmed-3.4.0-py37h9af6487_0.tar.bz2
-    "python_abi 3.7.* *_cp37m"
+    "python_abi 3.7.* *_cp37m",
+    "openmm <7.6"
osx-64::parmed-3.4.0-py37h9af6487_1.tar.bz2
-    "python_abi 3.7.* *_cp37m"
+    "python_abi 3.7.* *_cp37m",
+    "openmm <7.6"
osx-64::parmed-3.4.0-py38h91a8764_0.tar.bz2
-    "python_abi 3.8.* *_cp38"
+    "python_abi 3.8.* *_cp38",
+    "openmm <7.6"
osx-64::parmed-3.4.0-py38h91a8764_1.tar.bz2
-    "python_abi 3.8.* *_cp38"
+    "python_abi 3.8.* *_cp38",
+    "openmm <7.6"
osx-64::parmed-3.4.0-py39h219cf5c_0.tar.bz2
-    "python_abi 3.9.* *_cp39"
+    "python_abi 3.9.* *_cp39",
+    "openmm <7.6"
osx-64::parmed-3.4.0-py39h219cf5c_1.tar.bz2
-    "python_abi 3.9.* *_cp39"
+    "python_abi 3.9.* *_cp39",
+    "openmm <7.6"
osx-64::parmed-3.4.1-py36h8e3f739_0.tar.bz2
-    "python_abi 3.6 *_pypy36_pp73"
+    "python_abi 3.6 *_pypy36_pp73",
+    "openmm <7.6"
osx-64::parmed-3.4.1-py36hefe7e0e_0.tar.bz2
-    "python_abi 3.6.* *_cp36m"
+    "python_abi 3.6.* *_cp36m",
+    "openmm <7.6"
osx-64::parmed-3.4.1-py37ha70e663_0.tar.bz2
-    "python_abi 3.7 *_pypy37_pp73"
+    "python_abi 3.7 *_pypy37_pp73",
+    "openmm <7.6"
osx-64::parmed-3.4.1-py37hd8d24ac_0.tar.bz2
-    "python_abi 3.7.* *_cp37m"
+    "python_abi 3.7.* *_cp37m",
+    "openmm <7.6"
osx-64::parmed-3.4.1-py38ha048514_0.tar.bz2
-    "python_abi 3.8.* *_cp38"
+    "python_abi 3.8.* *_cp38",
+    "openmm <7.6"
osx-64::parmed-3.4.1-py39h9fcab8e_0.tar.bz2
-    "python_abi 3.9.* *_cp39"
+    "python_abi 3.9.* *_cp39",
+    "openmm <7.6"
osx-64::parmed-3.4.2-py36hefe7e0e_0.tar.bz2
-    "python_abi 3.6.* *_cp36m"
+    "python_abi 3.6.* *_cp36m",
+    "openmm <7.6"
osx-64::parmed-3.4.2-py37ha70e663_0.tar.bz2
-    "python_abi 3.7 *_pypy37_pp73"
+    "python_abi 3.7 *_pypy37_pp73",
+    "openmm <7.6"
osx-64::parmed-3.4.2-py37hd8d24ac_0.tar.bz2
-    "python_abi 3.7.* *_cp37m"
+    "python_abi 3.7.* *_cp37m",
+    "openmm <7.6"
osx-64::parmed-3.4.2-py38ha048514_0.tar.bz2
-    "python_abi 3.8.* *_cp38"
+    "python_abi 3.8.* *_cp38",
+    "openmm <7.6"
osx-64::parmed-3.4.2-py39h9fcab8e_0.tar.bz2
-    "python_abi 3.9.* *_cp39"
+    "python_abi 3.9.* *_cp39",
+    "openmm <7.6"
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata.json.bz2
osx-arm64::libnetcdf-4.8.1-mpi_mpich_hc1bce26_0.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
osx-arm64::libnetcdf-4.8.1-mpi_mpich_hcc2321e_1.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata.json.bz2
win-64::parmed-3.2.0-py36h6111442_4.tar.bz2
-    "vs2015_runtime >=14.16.27012"
+    "vs2015_runtime >=14.16.27012",
+    "openmm <7.6"
win-64::parmed-3.2.0-py37h9303ea8_4.tar.bz2
-    "vs2015_runtime >=14.16.27012"
+    "vs2015_runtime >=14.16.27012",
+    "openmm <7.6"
win-64::parmed-3.2.0-py37ha2e4c6b_4.tar.bz2
-    "vs2015_runtime >=14.16.27012"
+    "vs2015_runtime >=14.16.27012",
+    "openmm <7.6"
win-64::parmed-3.2.0-py37he025d50_2.tar.bz2
-  "constrains": [
-    "python_abi * *_cp37m"
-  ],
-    "vc >=14.1,<15.0a0"
+    "vc >=14.1,<15.0a0",
+    "openmm <7.6"
-  "version": "3.2.0"
+  "version": "3.2.0",
+  "constrains": [
+    "python_abi * *_cp37m"
+  ]
win-64::parmed-3.2.0-py38h6a66eb0_4.tar.bz2
-    "vs2015_runtime >=14.16.27012"
+    "vs2015_runtime >=14.16.27012",
+    "openmm <7.6"
win-64::parmed-3.2.0-py38he025d50_2.tar.bz2
-  "constrains": [
-    "python_abi * *_cp38"
-  ],
-    "vc >=14.1,<15.0a0"
+    "vc >=14.1,<15.0a0",
+    "openmm <7.6"
-  "version": "3.2.0"
+  "version": "3.2.0",
+  "constrains": [
+    "python_abi * *_cp38"
+  ]
win-64::parmed-3.2.0-py38heb73c8a_4.tar.bz2
-    "vs2015_runtime >=14.16.27012"
+    "vs2015_runtime >=14.16.27012",
+    "openmm <7.6"
win-64::parmed-3.2.0-py39h5cc5705_4.tar.bz2
-    "vs2015_runtime >=14.16.27012"
+    "vs2015_runtime >=14.16.27012",
+    "openmm <7.6"
win-64::parmed-3.2.0-py39hceb70db_4.tar.bz2
-    "vs2015_runtime >=14.16.27012"
+    "vs2015_runtime >=14.16.27012",
+    "openmm <7.6"
win-64::parmed-3.3.0-py36h6111442_0.tar.bz2
-    "vs2015_runtime >=14.16.27012"
+    "vs2015_runtime >=14.16.27012",
+    "openmm <7.6"
win-64::parmed-3.3.0-py37ha2e4c6b_0.tar.bz2
-    "vs2015_runtime >=14.16.27012"
+    "vs2015_runtime >=14.16.27012",
+    "openmm <7.6"
win-64::parmed-3.3.0-py38heb73c8a_0.tar.bz2
-    "vs2015_runtime >=14.16.27012"
+    "vs2015_runtime >=14.16.27012",
+    "openmm <7.6"
win-64::parmed-3.3.0-py39h5cc5705_0.tar.bz2
-    "vs2015_runtime >=14.16.27012"
+    "vs2015_runtime >=14.16.27012",
+    "openmm <7.6"
win-64::parmed-3.4.0-py36h6111442_0.tar.bz2
-    "vs2015_runtime >=14.16.27012"
+    "vs2015_runtime >=14.16.27012",
+    "openmm <7.6"
win-64::parmed-3.4.0-py36h6111442_1.tar.bz2
-    "vs2015_runtime >=14.16.27012"
+    "vs2015_runtime >=14.16.27012",
+    "openmm <7.6"
win-64::parmed-3.4.0-py37ha2e4c6b_0.tar.bz2
-    "vs2015_runtime >=14.16.27012"
+    "vs2015_runtime >=14.16.27012",
+    "openmm <7.6"
win-64::parmed-3.4.0-py37ha2e4c6b_1.tar.bz2
-    "vs2015_runtime >=14.16.27012"
+    "vs2015_runtime >=14.16.27012",
+    "openmm <7.6"
win-64::parmed-3.4.0-py38heb73c8a_0.tar.bz2
-    "vs2015_runtime >=14.16.27012"
+    "vs2015_runtime >=14.16.27012",
+    "openmm <7.6"
win-64::parmed-3.4.0-py38heb73c8a_1.tar.bz2
-    "vs2015_runtime >=14.16.27012"
+    "vs2015_runtime >=14.16.27012",
+    "openmm <7.6"
win-64::parmed-3.4.0-py39h5cc5705_0.tar.bz2
-    "vs2015_runtime >=14.16.27012"
+    "vs2015_runtime >=14.16.27012",
+    "openmm <7.6"
win-64::parmed-3.4.0-py39h5cc5705_1.tar.bz2
-    "vs2015_runtime >=14.16.27012"
+    "vs2015_runtime >=14.16.27012",
+    "openmm <7.6"
win-64::parmed-3.4.1-py36h6111442_0.tar.bz2
-    "vs2015_runtime >=14.16.27012"
+    "vs2015_runtime >=14.16.27012",
+    "openmm <7.6"
win-64::parmed-3.4.1-py37ha2e4c6b_0.tar.bz2
-    "vs2015_runtime >=14.16.27012"
+    "vs2015_runtime >=14.16.27012",
+    "openmm <7.6"
win-64::parmed-3.4.1-py38heb73c8a_0.tar.bz2
-    "vs2015_runtime >=14.16.27012"
+    "vs2015_runtime >=14.16.27012",
+    "openmm <7.6"
win-64::parmed-3.4.1-py39h5cc5705_0.tar.bz2
-    "vs2015_runtime >=14.16.27012"
+    "vs2015_runtime >=14.16.27012",
+    "openmm <7.6"
win-64::parmed-3.4.2-py36h6111442_0.tar.bz2
-    "vs2015_runtime >=14.16.27012"
+    "vs2015_runtime >=14.16.27012",
+    "openmm <7.6"
win-64::parmed-3.4.2-py37ha2e4c6b_0.tar.bz2
-    "vs2015_runtime >=14.16.27012"
+    "vs2015_runtime >=14.16.27012",
+    "openmm <7.6"
win-64::parmed-3.4.2-py38heb73c8a_0.tar.bz2
-    "vs2015_runtime >=14.16.27012"
+    "vs2015_runtime >=14.16.27012",
+    "openmm <7.6"
win-64::parmed-3.4.2-py39h5cc5705_0.tar.bz2
-    "vs2015_runtime >=14.16.27012"
+    "vs2015_runtime >=14.16.27012",
+    "openmm <7.6"
```

cc: @chrisbarnettster, @simonbray, @tsenapathi, @jaimergp, @swails (recipe-maintainers on the conda-forge/parmed-feedstock) 