### PR TITLE
Ensure uproot always depends on the same version of uproot_base

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1103,6 +1103,12 @@ def _gen_new_index(repodata, subdir):
         if record_name == "tzlocal" and record["version"] == "3.0" and "python >=3.6" in record["depends"]:
             _replace_pin("python >=3.6", "python >=3.9", deps, record)
 
+        if record_name == "uproot" and record["version"].startswith("4.0."):
+            _replace_pin('uproot-base', f"uproot-base {record['version']}", deps, record)
+
+        if record_name == "uproot" and record["version"] == "4.1.0" and record["build_number"] == 0:
+            _replace_pin('uproot-base', f"uproot-base {record['version']}", deps, record)
+
         # replace =2.7 with ==2.7.* for compatibility with older conda
         new_deps = []
         changed = False


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Uproot is a feedstock with multiple outputs where `uproot_base` contains the code and `uproot` adds optional dependencies. During the update to `uproot 4.0.0` the pinning between the two was lost. This has been fixed in https://github.com/conda-forge/uproot-feedstock/pull/90

<details><summary>Click to see diff</summary>
<p>

```diff
$ python recipe/show_diff.py
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata.json.bz2
noarch::uproot-4.0.0-pyhd8ed1ab_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.0",
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata.json.bz2
linux-64::uproot-4.0.0-py36h5fab9bb_1.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.0",
linux-64::uproot-4.0.0-py36hd000896_1.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.0",
linux-64::uproot-4.0.0-py37h89c1867_1.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.0",
linux-64::uproot-4.0.0-py38h578d9bd_1.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.0",
linux-64::uproot-4.0.0-py39hf3d152e_1.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.0",
linux-64::uproot-4.0.1-py36h5fab9bb_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.1",
linux-64::uproot-4.0.1-py36hd000896_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.1",
linux-64::uproot-4.0.1-py37h89c1867_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.1",
linux-64::uproot-4.0.1-py38h578d9bd_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.1",
linux-64::uproot-4.0.1-py39hf3d152e_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.1",
linux-64::uproot-4.0.10-py36h5fab9bb_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.10",
linux-64::uproot-4.0.10-py37h89c1867_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.10",
linux-64::uproot-4.0.10-py37h9c2f6ca_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.10",
linux-64::uproot-4.0.10-py38h578d9bd_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.10",
linux-64::uproot-4.0.10-py39hf3d152e_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.10",
linux-64::uproot-4.0.11-py36h5fab9bb_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.11",
linux-64::uproot-4.0.11-py37h89c1867_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.11",
linux-64::uproot-4.0.11-py37h9c2f6ca_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.11",
linux-64::uproot-4.0.11-py38h578d9bd_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.11",
linux-64::uproot-4.0.11-py39hf3d152e_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.11",
linux-64::uproot-4.0.2-py36h5fab9bb_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.2",
linux-64::uproot-4.0.2-py36hd000896_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.2",
linux-64::uproot-4.0.2-py37h89c1867_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.2",
linux-64::uproot-4.0.2-py38h578d9bd_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.2",
linux-64::uproot-4.0.2-py39hf3d152e_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.2",
linux-64::uproot-4.0.3-py36h5fab9bb_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.3",
linux-64::uproot-4.0.3-py36hd000896_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.3",
linux-64::uproot-4.0.3-py37h89c1867_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.3",
linux-64::uproot-4.0.3-py38h578d9bd_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.3",
linux-64::uproot-4.0.3-py39hf3d152e_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.3",
linux-64::uproot-4.0.4-py36h5fab9bb_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.4",
linux-64::uproot-4.0.4-py36hd000896_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.4",
linux-64::uproot-4.0.4-py37h89c1867_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.4",
linux-64::uproot-4.0.4-py38h578d9bd_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.4",
linux-64::uproot-4.0.4-py39hf3d152e_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.4",
linux-64::uproot-4.0.5-py36h5fab9bb_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.5",
linux-64::uproot-4.0.5-py36hd000896_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.5",
linux-64::uproot-4.0.5-py37h89c1867_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.5",
linux-64::uproot-4.0.5-py38h578d9bd_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.5",
linux-64::uproot-4.0.5-py39hf3d152e_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.5",
linux-64::uproot-4.0.6-py36h5fab9bb_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.6",
linux-64::uproot-4.0.6-py36hd000896_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.6",
linux-64::uproot-4.0.6-py37h89c1867_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.6",
linux-64::uproot-4.0.6-py38h578d9bd_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.6",
linux-64::uproot-4.0.6-py39hf3d152e_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.6",
linux-64::uproot-4.0.7-py36h5fab9bb_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.7",
linux-64::uproot-4.0.7-py36hd000896_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.7",
linux-64::uproot-4.0.7-py37h89c1867_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.7",
linux-64::uproot-4.0.7-py37h9c2f6ca_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.7",
linux-64::uproot-4.0.7-py38h578d9bd_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.7",
linux-64::uproot-4.0.7-py39hf3d152e_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.7",
linux-64::uproot-4.0.8-py36h5fab9bb_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.8",
linux-64::uproot-4.0.8-py36hd000896_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.8",
linux-64::uproot-4.0.8-py37h89c1867_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.8",
linux-64::uproot-4.0.8-py37h9c2f6ca_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.8",
linux-64::uproot-4.0.8-py38h578d9bd_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.8",
linux-64::uproot-4.0.8-py39hf3d152e_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.8",
linux-64::uproot-4.0.9-py36h5fab9bb_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.9",
linux-64::uproot-4.0.9-py36hd000896_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.9",
linux-64::uproot-4.0.9-py37h89c1867_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.9",
linux-64::uproot-4.0.9-py37h9c2f6ca_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.9",
linux-64::uproot-4.0.9-py38h578d9bd_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.9",
linux-64::uproot-4.0.9-py39hf3d152e_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.9",
linux-64::uproot-4.1.0-py36h5fab9bb_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.1.0",
linux-64::uproot-4.1.0-py37h89c1867_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.1.0",
linux-64::uproot-4.1.0-py37h9c2f6ca_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.1.0",
linux-64::uproot-4.1.0-py38h578d9bd_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.1.0",
linux-64::uproot-4.1.0-py39hf3d152e_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.1.0",
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata.json.bz2
linux-aarch64::uproot-4.0.0-py36h2e20a7f_1.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.0",
linux-aarch64::uproot-4.0.0-py36h704843e_1.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.0",
linux-aarch64::uproot-4.0.0-py37hd9ded2f_1.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.0",
linux-aarch64::uproot-4.0.0-py38h2063c64_1.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.0",
linux-aarch64::uproot-4.0.0-py39ha65689a_1.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.0",
linux-aarch64::uproot-4.0.1-py36h2e20a7f_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.1",
linux-aarch64::uproot-4.0.1-py36h704843e_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.1",
linux-aarch64::uproot-4.0.1-py37hd9ded2f_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.1",
linux-aarch64::uproot-4.0.1-py38h2063c64_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.1",
linux-aarch64::uproot-4.0.1-py39ha65689a_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.1",
linux-aarch64::uproot-4.0.10-py36h704843e_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.10",
linux-aarch64::uproot-4.0.10-py37h4bcbb9b_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.10",
linux-aarch64::uproot-4.0.10-py37hd9ded2f_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.10",
linux-aarch64::uproot-4.0.10-py38h2063c64_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.10",
linux-aarch64::uproot-4.0.10-py39ha65689a_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.10",
linux-aarch64::uproot-4.0.11-py36h704843e_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.11",
linux-aarch64::uproot-4.0.11-py37h4bcbb9b_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.11",
linux-aarch64::uproot-4.0.11-py37hd9ded2f_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.11",
linux-aarch64::uproot-4.0.11-py38h2063c64_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.11",
linux-aarch64::uproot-4.0.11-py39ha65689a_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.11",
linux-aarch64::uproot-4.0.2-py36h2e20a7f_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.2",
linux-aarch64::uproot-4.0.2-py36h704843e_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.2",
linux-aarch64::uproot-4.0.2-py37hd9ded2f_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.2",
linux-aarch64::uproot-4.0.2-py38h2063c64_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.2",
linux-aarch64::uproot-4.0.2-py39ha65689a_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.2",
linux-aarch64::uproot-4.0.3-py36h2e20a7f_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.3",
linux-aarch64::uproot-4.0.3-py36h704843e_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.3",
linux-aarch64::uproot-4.0.3-py37hd9ded2f_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.3",
linux-aarch64::uproot-4.0.3-py38h2063c64_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.3",
linux-aarch64::uproot-4.0.3-py39ha65689a_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.3",
linux-aarch64::uproot-4.0.4-py36h2e20a7f_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.4",
linux-aarch64::uproot-4.0.4-py36h704843e_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.4",
linux-aarch64::uproot-4.0.4-py37hd9ded2f_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.4",
linux-aarch64::uproot-4.0.4-py38h2063c64_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.4",
linux-aarch64::uproot-4.0.4-py39ha65689a_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.4",
linux-aarch64::uproot-4.0.5-py36h2e20a7f_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.5",
linux-aarch64::uproot-4.0.5-py36h704843e_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.5",
linux-aarch64::uproot-4.0.5-py37hd9ded2f_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.5",
linux-aarch64::uproot-4.0.5-py38h2063c64_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.5",
linux-aarch64::uproot-4.0.5-py39ha65689a_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.5",
linux-aarch64::uproot-4.0.6-py36h2e20a7f_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.6",
linux-aarch64::uproot-4.0.6-py36h704843e_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.6",
linux-aarch64::uproot-4.0.6-py37hd9ded2f_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.6",
linux-aarch64::uproot-4.0.6-py38h2063c64_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.6",
linux-aarch64::uproot-4.0.6-py39ha65689a_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.6",
linux-aarch64::uproot-4.0.7-py36h2e20a7f_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.7",
linux-aarch64::uproot-4.0.7-py36h704843e_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.7",
linux-aarch64::uproot-4.0.7-py37h4bcbb9b_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.7",
linux-aarch64::uproot-4.0.7-py37hd9ded2f_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.7",
linux-aarch64::uproot-4.0.7-py38h2063c64_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.7",
linux-aarch64::uproot-4.0.7-py39ha65689a_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.7",
linux-aarch64::uproot-4.0.8-py36h2e20a7f_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.8",
linux-aarch64::uproot-4.0.8-py36h704843e_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.8",
linux-aarch64::uproot-4.0.8-py37h4bcbb9b_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.8",
linux-aarch64::uproot-4.0.8-py37hd9ded2f_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.8",
linux-aarch64::uproot-4.0.8-py38h2063c64_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.8",
linux-aarch64::uproot-4.0.8-py39ha65689a_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.8",
linux-aarch64::uproot-4.0.9-py36h2e20a7f_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.9",
linux-aarch64::uproot-4.0.9-py36h704843e_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.9",
linux-aarch64::uproot-4.0.9-py37h4bcbb9b_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.9",
linux-aarch64::uproot-4.0.9-py37hd9ded2f_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.9",
linux-aarch64::uproot-4.0.9-py38h2063c64_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.9",
linux-aarch64::uproot-4.0.9-py39ha65689a_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.9",
linux-aarch64::uproot-4.1.0-py36h704843e_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.1.0",
linux-aarch64::uproot-4.1.0-py37h4bcbb9b_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.1.0",
linux-aarch64::uproot-4.1.0-py37hd9ded2f_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.1.0",
linux-aarch64::uproot-4.1.0-py38h2063c64_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.1.0",
linux-aarch64::uproot-4.1.0-py39ha65689a_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.1.0",
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata.json.bz2
linux-ppc64le::adios2-2.7.1-mpi_mpich_py36ha1d8cba_0.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
linux-ppc64le::adios2-2.7.1-mpi_mpich_py37hac56ba2_0.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
linux-ppc64le::adios2-2.7.1-mpi_mpich_py38h3c87899_0.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
linux-ppc64le::uproot-4.0.0-py36h270354c_1.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.0",
linux-ppc64le::uproot-4.0.0-py36he7cccf2_1.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.0",
linux-ppc64le::uproot-4.0.0-py37h35e4cab_1.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.0",
linux-ppc64le::uproot-4.0.0-py38hf8b3453_1.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.0",
linux-ppc64le::uproot-4.0.0-py39hc1b9086_1.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.0",
linux-ppc64le::uproot-4.0.10-py36h270354c_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.10",
linux-ppc64le::uproot-4.0.10-py37h35e4cab_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.10",
linux-ppc64le::uproot-4.0.10-py37hadc05a3_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.10",
linux-ppc64le::uproot-4.0.10-py38hf8b3453_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.10",
linux-ppc64le::uproot-4.0.10-py39hc1b9086_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.10",
linux-ppc64le::uproot-4.0.11-py36h270354c_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.11",
linux-ppc64le::uproot-4.0.11-py37h35e4cab_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.11",
linux-ppc64le::uproot-4.0.11-py37hadc05a3_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.11",
linux-ppc64le::uproot-4.0.11-py38hf8b3453_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.11",
linux-ppc64le::uproot-4.0.11-py39hc1b9086_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.11",
linux-ppc64le::uproot-4.0.2-py36h270354c_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.2",
linux-ppc64le::uproot-4.0.2-py36he7cccf2_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.2",
linux-ppc64le::uproot-4.0.2-py37h35e4cab_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.2",
linux-ppc64le::uproot-4.0.2-py38hf8b3453_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.2",
linux-ppc64le::uproot-4.0.2-py39hc1b9086_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.2",
linux-ppc64le::uproot-4.0.3-py36h270354c_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.3",
linux-ppc64le::uproot-4.0.3-py36he7cccf2_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.3",
linux-ppc64le::uproot-4.0.3-py37h35e4cab_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.3",
linux-ppc64le::uproot-4.0.3-py38hf8b3453_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.3",
linux-ppc64le::uproot-4.0.3-py39hc1b9086_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.3",
linux-ppc64le::uproot-4.0.4-py36h270354c_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.4",
linux-ppc64le::uproot-4.0.4-py36he7cccf2_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.4",
linux-ppc64le::uproot-4.0.4-py37h35e4cab_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.4",
linux-ppc64le::uproot-4.0.4-py38hf8b3453_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.4",
linux-ppc64le::uproot-4.0.4-py39hc1b9086_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.4",
linux-ppc64le::uproot-4.0.5-py36h270354c_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.5",
linux-ppc64le::uproot-4.0.5-py36he7cccf2_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.5",
linux-ppc64le::uproot-4.0.5-py37h35e4cab_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.5",
linux-ppc64le::uproot-4.0.5-py38hf8b3453_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.5",
linux-ppc64le::uproot-4.0.5-py39hc1b9086_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.5",
linux-ppc64le::uproot-4.0.6-py36h270354c_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.6",
linux-ppc64le::uproot-4.0.6-py36he7cccf2_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.6",
linux-ppc64le::uproot-4.0.6-py37h35e4cab_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.6",
linux-ppc64le::uproot-4.0.6-py38hf8b3453_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.6",
linux-ppc64le::uproot-4.0.6-py39hc1b9086_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.6",
linux-ppc64le::uproot-4.0.7-py36h270354c_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.7",
linux-ppc64le::uproot-4.0.7-py36he7cccf2_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.7",
linux-ppc64le::uproot-4.0.7-py37h35e4cab_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.7",
linux-ppc64le::uproot-4.0.7-py38hf8b3453_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.7",
linux-ppc64le::uproot-4.0.7-py39hc1b9086_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.7",
linux-ppc64le::uproot-4.0.8-py36h270354c_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.8",
linux-ppc64le::uproot-4.0.8-py36he7cccf2_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.8",
linux-ppc64le::uproot-4.0.8-py37h35e4cab_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.8",
linux-ppc64le::uproot-4.0.8-py37hadc05a3_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.8",
linux-ppc64le::uproot-4.0.8-py38hf8b3453_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.8",
linux-ppc64le::uproot-4.0.8-py39hc1b9086_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.8",
linux-ppc64le::uproot-4.0.9-py36he7cccf2_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.9",
linux-ppc64le::uproot-4.0.9-py38hf8b3453_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.9",
linux-ppc64le::uproot-4.0.9-py39hc1b9086_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.9",
linux-ppc64le::uproot-4.1.0-py36h270354c_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.1.0",
linux-ppc64le::uproot-4.1.0-py37h35e4cab_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.1.0",
linux-ppc64le::uproot-4.1.0-py37hadc05a3_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.1.0",
linux-ppc64le::uproot-4.1.0-py38hf8b3453_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.1.0",
linux-ppc64le::uproot-4.1.0-py39hc1b9086_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.1.0",
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata.json.bz2
osx-64::uproot-4.0.0-py36h5dafb3c_1.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.0",
osx-64::uproot-4.0.0-py36h79c6626_1.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.0",
osx-64::uproot-4.0.0-py37hf985489_1.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.0",
osx-64::uproot-4.0.0-py38h50d1736_1.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.0",
osx-64::uproot-4.0.0-py39h6e9494a_1.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.0",
osx-64::uproot-4.0.1-py36h5dafb3c_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.1",
osx-64::uproot-4.0.1-py36h79c6626_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.1",
osx-64::uproot-4.0.1-py37hf985489_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.1",
osx-64::uproot-4.0.1-py38h50d1736_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.1",
osx-64::uproot-4.0.1-py39h6e9494a_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.1",
osx-64::uproot-4.0.10-py36h79c6626_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.10",
osx-64::uproot-4.0.10-py37h5186d4c_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.10",
osx-64::uproot-4.0.10-py37hf985489_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.10",
osx-64::uproot-4.0.10-py38h50d1736_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.10",
osx-64::uproot-4.0.10-py39h6e9494a_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.10",
osx-64::uproot-4.0.11-py36h79c6626_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.11",
osx-64::uproot-4.0.11-py37h5186d4c_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.11",
osx-64::uproot-4.0.11-py37hf985489_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.11",
osx-64::uproot-4.0.11-py38h50d1736_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.11",
osx-64::uproot-4.0.11-py39h6e9494a_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.11",
osx-64::uproot-4.0.2-py36h5dafb3c_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.2",
osx-64::uproot-4.0.2-py36h79c6626_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.2",
osx-64::uproot-4.0.2-py37hf985489_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.2",
osx-64::uproot-4.0.2-py38h50d1736_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.2",
osx-64::uproot-4.0.2-py39h6e9494a_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.2",
osx-64::uproot-4.0.3-py36h5dafb3c_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.3",
osx-64::uproot-4.0.3-py36h79c6626_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.3",
osx-64::uproot-4.0.3-py37hf985489_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.3",
osx-64::uproot-4.0.3-py38h50d1736_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.3",
osx-64::uproot-4.0.3-py39h6e9494a_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.3",
osx-64::uproot-4.0.4-py36h5dafb3c_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.4",
osx-64::uproot-4.0.4-py36h79c6626_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.4",
osx-64::uproot-4.0.4-py37hf985489_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.4",
osx-64::uproot-4.0.4-py38h50d1736_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.4",
osx-64::uproot-4.0.4-py39h6e9494a_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.4",
osx-64::uproot-4.0.5-py36h5dafb3c_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.5",
osx-64::uproot-4.0.5-py36h79c6626_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.5",
osx-64::uproot-4.0.5-py37hf985489_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.5",
osx-64::uproot-4.0.5-py38h50d1736_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.5",
osx-64::uproot-4.0.5-py39h6e9494a_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.5",
osx-64::uproot-4.0.6-py36h5dafb3c_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.6",
osx-64::uproot-4.0.6-py36h79c6626_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.6",
osx-64::uproot-4.0.6-py37hf985489_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.6",
osx-64::uproot-4.0.6-py38h50d1736_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.6",
osx-64::uproot-4.0.6-py39h6e9494a_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.6",
osx-64::uproot-4.0.7-py36h5dafb3c_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.7",
osx-64::uproot-4.0.7-py36h79c6626_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.7",
osx-64::uproot-4.0.7-py37h5186d4c_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.7",
osx-64::uproot-4.0.7-py37hf985489_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.7",
osx-64::uproot-4.0.7-py38h50d1736_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.7",
osx-64::uproot-4.0.7-py39h6e9494a_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.7",
osx-64::uproot-4.0.8-py36h5dafb3c_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.8",
osx-64::uproot-4.0.8-py36h79c6626_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.8",
osx-64::uproot-4.0.8-py37h5186d4c_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.8",
osx-64::uproot-4.0.8-py37hf985489_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.8",
osx-64::uproot-4.0.8-py38h50d1736_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.8",
osx-64::uproot-4.0.8-py39h6e9494a_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.8",
osx-64::uproot-4.0.9-py36h5dafb3c_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.9",
osx-64::uproot-4.0.9-py36h79c6626_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.9",
osx-64::uproot-4.0.9-py37h5186d4c_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.9",
osx-64::uproot-4.0.9-py37hf985489_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.9",
osx-64::uproot-4.0.9-py39h6e9494a_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.9",
osx-64::uproot-4.1.0-py36h79c6626_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.1.0",
osx-64::uproot-4.1.0-py37h5186d4c_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.1.0",
osx-64::uproot-4.1.0-py37hf985489_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.1.0",
osx-64::uproot-4.1.0-py38h50d1736_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.1.0",
osx-64::uproot-4.1.0-py39h6e9494a_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.1.0",
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata.json.bz2
win-64::uproot-4.0.0-py36ha15d459_1.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.0",
win-64::uproot-4.0.0-py37h03978a9_1.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.0",
win-64::uproot-4.0.0-py38haa244fe_1.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.0",
win-64::uproot-4.0.0-py39hcbf5309_1.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.0",
win-64::uproot-4.0.1-py36ha15d459_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.1",
win-64::uproot-4.0.1-py37h03978a9_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.1",
win-64::uproot-4.0.1-py38haa244fe_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.1",
win-64::uproot-4.0.1-py39hcbf5309_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.1",
win-64::uproot-4.0.10-py36ha15d459_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.10",
win-64::uproot-4.0.10-py37h03978a9_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.10",
win-64::uproot-4.0.10-py38haa244fe_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.10",
win-64::uproot-4.0.10-py39hcbf5309_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.10",
win-64::uproot-4.0.11-py36ha15d459_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.11",
win-64::uproot-4.0.11-py37h03978a9_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.11",
win-64::uproot-4.0.11-py38haa244fe_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.11",
win-64::uproot-4.0.11-py39hcbf5309_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.11",
win-64::uproot-4.0.2-py36ha15d459_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.2",
win-64::uproot-4.0.2-py37h03978a9_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.2",
win-64::uproot-4.0.2-py38haa244fe_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.2",
win-64::uproot-4.0.2-py39hcbf5309_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.2",
win-64::uproot-4.0.3-py36ha15d459_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.3",
win-64::uproot-4.0.3-py37h03978a9_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.3",
win-64::uproot-4.0.3-py38haa244fe_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.3",
win-64::uproot-4.0.3-py39hcbf5309_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.3",
win-64::uproot-4.0.4-py36ha15d459_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.4",
win-64::uproot-4.0.4-py37h03978a9_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.4",
win-64::uproot-4.0.4-py38haa244fe_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.4",
win-64::uproot-4.0.4-py39hcbf5309_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.4",
win-64::uproot-4.0.5-py36ha15d459_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.5",
win-64::uproot-4.0.5-py37h03978a9_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.5",
win-64::uproot-4.0.5-py38haa244fe_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.5",
win-64::uproot-4.0.5-py39hcbf5309_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.5",
win-64::uproot-4.0.6-py36ha15d459_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.6",
win-64::uproot-4.0.6-py37h03978a9_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.6",
win-64::uproot-4.0.6-py38haa244fe_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.6",
win-64::uproot-4.0.6-py39hcbf5309_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.6",
win-64::uproot-4.0.7-py36ha15d459_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.7",
win-64::uproot-4.0.7-py37h03978a9_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.7",
win-64::uproot-4.0.7-py38haa244fe_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.7",
win-64::uproot-4.0.7-py39hcbf5309_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.7",
win-64::uproot-4.0.8-py36ha15d459_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.8",
win-64::uproot-4.0.8-py37h03978a9_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.8",
win-64::uproot-4.0.8-py38haa244fe_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.8",
win-64::uproot-4.0.8-py39hcbf5309_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.8",
win-64::uproot-4.0.9-py36ha15d459_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.9",
win-64::uproot-4.0.9-py37h03978a9_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.9",
win-64::uproot-4.0.9-py38haa244fe_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.9",
win-64::uproot-4.0.9-py39hcbf5309_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.0.9",
win-64::uproot-4.1.0-py36ha15d459_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.1.0",
win-64::uproot-4.1.0-py37h03978a9_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.1.0",
win-64::uproot-4.1.0-py38haa244fe_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.1.0",
win-64::uproot-4.1.0-py39hcbf5309_0.tar.bz2
-    "uproot-base",
+    "uproot-base 4.1.0",
```

</p>
</details>
