### PR TITLE
add impossible constraint for older pytorch-cpu & gpu

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -993,6 +993,17 @@ def _gen_new_index(repodata, subdir):
         ):
             _add_pybind11_abi_constraint(fn, record)
 
+        if (
+            record_name == "pytorch-cpu"
+            # this version has a constraint sometimes
+            and (
+                pkg_resources.parse_version(record["version"])
+                <= pkg_resources.parse_version("1.6")
+            )):
+            record.setdefault('constrains', []).extend([
+                "pytorch-gpu 9999999999"
+            ])
+
         # add *lal>=7.1.1 as run_constrained for liblal-7.1.1
         if (
             record_name == "liblal"

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -993,16 +993,27 @@ def _gen_new_index(repodata, subdir):
         ):
             _add_pybind11_abi_constraint(fn, record)
 
+        # do some fixes for pytorch, pytorch-cpu & gpu
         if (
             record_name == "pytorch-cpu"
-            # this version has a constraint sometimes
             and (
                 pkg_resources.parse_version(record["version"])
-                <= pkg_resources.parse_version("1.6")
+                < pkg_resources.parse_version("1.6")
             )):
             record.setdefault('constrains', []).extend([
                 "pytorch-gpu 9999999999"
             ])
+
+        if (
+            record_name in ("pytorch-cpu", "pytorch-gpu")
+            and
+                pkg_resources.parse_version(record["version"])
+                == pkg_resources.parse_version("1.6")
+        ):
+            deps = record.get('depends')
+            if not(any(d.split()[0] == 'pytorch' for d in deps)):
+                record['depends'] = deps + ['pytorch 1.6']
+
 
         # add *lal>=7.1.1 as run_constrained for liblal-7.1.1
         if (


### PR DESCRIPTION
@hmaarrfk would be happy to hear your opinion here!

We had a problem where we got pytorch-cpu 1.6 to install side-by-side with pytorch-gpu 1.9

cc @adriendelsalle

```
(base) ➜  recipe git:(master) ✗ python show_diff.py --subdirs=linux-64 --use-cache
Traceback (most recent call last):
  File "/Users/wolfvollprecht/Programs/recipes/conda-forge-repodata-patches-feedstock/recipe/show_diff.py", line 82, in <module>
    do_subdir(subdir, raw_repodata_path, ref_repodata_path)
  File "/Users/wolfvollprecht/Programs/recipes/conda-forge-repodata-patches-feedstock/recipe/show_diff.py", line 42, in do_subdir
    new_index = _gen_new_index(raw_repodata, subdir)
  File "/Users/wolfvollprecht/Programs/recipes/conda-forge-repodata-patches-feedstock/recipe/gen_patch_json.py", line 1003, in _gen_new_index
    record["constrains"].append("pytorch-gpu 9999999999")
KeyError: 'constrains'
(base) ➜  recipe git:(master) ✗ python show_diff.py --subdirs=linux-64 --use-cache
linux-64::adios2-2.7.1-mpi_mpich_py36h396df76_0.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
linux-64::adios2-2.7.1-mpi_mpich_py37h0b8f802_0.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
linux-64::adios2-2.7.1-mpi_mpich_py38hf40de4c_0.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
linux-64::clang-12.0.1-ha770c72_1.tar.bz2
-  "version": "12.0.1"
+  "version": "12.0.1",
+  "constrains": [
+    "libclang 12.0.1.*",
+    "clang-tools 12.0.1.*",
+    "llvm 12.0.1.*",
+    "llvm-tools 12.0.1.*",
+    "llvmdev 12.0.1.*"
+  ]
linux-64::clang-tools-12.0.1-default_ha53f305_1.tar.bz2
-    "clangdev 12.0.1"
+    "clangdev 12.0.1",
+    "libclang 12.0.1.*",
+    "clang 12.0.1.*",
+    "llvm 12.0.1.*",
+    "llvm-tools 12.0.1.*",
+    "llvmdev 12.0.1.*"
linux-64::libclang-12.0.1-default_ha53f305_1.tar.bz2
-  "version": "12.0.1"
+  "version": "12.0.1",
+  "constrains": [
+    "clang 12.0.1.*",
+    "clang-tools 12.0.1.*",
+    "llvm 12.0.1.*",
+    "llvm-tools 12.0.1.*",
+    "llvmdev 12.0.1.*"
+  ]
linux-64::pytorch-cpu-1.0.0-py27hf484d3e_1000.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27mu"
-  ],
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "constrains": [
+    "python_abi * *_cp27mu",
+    "pytorch-gpu 9999999999"
+  ]
linux-64::pytorch-cpu-1.0.0-py27hf484d3e_1001.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27mu"
-  ],
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "constrains": [
+    "python_abi * *_cp27mu",
+    "pytorch-gpu 9999999999"
+  ]
linux-64::pytorch-cpu-1.0.0-py27hf484d3e_1002.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27mu"
-  ],
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "constrains": [
+    "python_abi * *_cp27mu",
+    "pytorch-gpu 9999999999"
+  ]
linux-64::pytorch-cpu-1.0.0-py36hf484d3e_1000.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "constrains": [
+    "python_abi * *_cp36m",
+    "pytorch-gpu 9999999999"
+  ]
linux-64::pytorch-cpu-1.0.0-py36hf484d3e_1001.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "constrains": [
+    "python_abi * *_cp36m",
+    "pytorch-gpu 9999999999"
+  ]
linux-64::pytorch-cpu-1.0.0-py36hf484d3e_1002.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "constrains": [
+    "python_abi * *_cp36m",
+    "pytorch-gpu 9999999999"
+  ]
linux-64::pytorch-cpu-1.0.0-py37hf484d3e_1001.tar.bz2
-  "constrains": [
-    "python_abi * *_cp37m"
-  ],
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "constrains": [
+    "python_abi * *_cp37m",
+    "pytorch-gpu 9999999999"
+  ]
linux-64::pytorch-cpu-1.0.0-py37hf484d3e_1002.tar.bz2
-  "constrains": [
-    "python_abi * *_cp37m"
-  ],
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "constrains": [
+    "python_abi * *_cp37m",
+    "pytorch-gpu 9999999999"
+  ]
linux-64::pytorch-cpu-1.0.1-py27hf484d3e_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27mu"
-  ],
-  "version": "1.0.1"
+  "version": "1.0.1",
+  "constrains": [
+    "python_abi * *_cp27mu",
+    "pytorch-gpu 9999999999"
+  ]
linux-64::pytorch-cpu-1.0.1-py36hf484d3e_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-  "version": "1.0.1"
+  "version": "1.0.1",
+  "constrains": [
+    "python_abi * *_cp36m",
+    "pytorch-gpu 9999999999"
+  ]
linux-64::pytorch-cpu-1.0.1-py37hf484d3e_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp37m"
-  ],
-  "version": "1.0.1"
+  "version": "1.0.1",
+  "constrains": [
+    "python_abi * *_cp37m",
+    "pytorch-gpu 9999999999"
+  ]
linux-64::pytorch-cpu-1.1.0-py27he1b5a44_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27mu"
-  ],
-  "version": "1.1.0"
+  "version": "1.1.0",
+  "constrains": [
+    "python_abi * *_cp27mu",
+    "pytorch-gpu 9999999999"
+  ]
linux-64::pytorch-cpu-1.1.0-py36he1b5a44_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-  "version": "1.1.0"
+  "version": "1.1.0",
+  "constrains": [
+    "python_abi * *_cp36m",
+    "pytorch-gpu 9999999999"
+  ]
linux-64::pytorch-cpu-1.1.0-py37he1b5a44_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp37m"
-  ],
-  "version": "1.1.0"
+  "version": "1.1.0",
+  "constrains": [
+    "python_abi * *_cp37m",
+    "pytorch-gpu 9999999999"
+  ]
linux-64::pytorch-cpu-1.6.0-cpu_py36h3ab7d31_0.tar.bz2
-  "version": "1.6.0"
+  "version": "1.6.0",
+  "constrains": [
+    "pytorch-gpu 9999999999"
+  ]
linux-64::pytorch-cpu-1.6.0-cpu_py36h3ab7d31_1.tar.bz2
-  "version": "1.6.0"
+  "version": "1.6.0",
+  "constrains": [
+    "pytorch-gpu 9999999999"
+  ]
linux-64::pytorch-cpu-1.6.0-cpu_py36h718b53a_1.tar.bz2
-  "version": "1.6.0"
+  "version": "1.6.0",
+  "constrains": [
+    "pytorch-gpu 9999999999"
+  ]
linux-64::pytorch-cpu-1.6.0-cpu_py37h718b53a_1.tar.bz2
-  "version": "1.6.0"
+  "version": "1.6.0",
+  "constrains": [
+    "pytorch-gpu 9999999999"
+  ]
linux-64::pytorch-cpu-1.6.0-cpu_py37hf072b7b_0.tar.bz2
-  "version": "1.6.0"
+  "version": "1.6.0",
+  "constrains": [
+    "pytorch-gpu 9999999999"
+  ]
linux-64::pytorch-cpu-1.6.0-cpu_py37hf072b7b_1.tar.bz2
-  "version": "1.6.0"
+  "version": "1.6.0",
+  "constrains": [
+    "pytorch-gpu 9999999999"
+  ]
linux-64::pytorch-cpu-1.6.0-cpu_py38h3369884_0.tar.bz2
-  "version": "1.6.0"
+  "version": "1.6.0",
+  "constrains": [
+    "pytorch-gpu 9999999999"
+  ]
linux-64::pytorch-cpu-1.6.0-cpu_py38h3369884_1.tar.bz2
-  "version": "1.6.0"
+  "version": "1.6.0",
+  "constrains": [
+    "pytorch-gpu 9999999999"
+  ]
linux-64::pytorch-cpu-1.6.0-cpu_py38h718b53a_1.tar.bz2
-  "version": "1.6.0"
+  "version": "1.6.0",
+  "constrains": [
+    "pytorch-gpu 9999999999"
+  ]
linux-64::pytorch-cpu-1.6.0-cpu_py39he5e7b68_1.tar.bz2
-  "version": "1.6.0"
+  "version": "1.6.0",
+  "constrains": [
+    "pytorch-gpu 9999999999"
+  ]
(base) ➜  recipe git:(master) ✗ python show_diff.py --subdirs=linux-64 --use-cache
linux-64::adios2-2.7.1-mpi_mpich_py36h396df76_0.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
linux-64::adios2-2.7.1-mpi_mpich_py37h0b8f802_0.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
linux-64::adios2-2.7.1-mpi_mpich_py38hf40de4c_0.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
linux-64::clang-12.0.1-ha770c72_1.tar.bz2
-  "version": "12.0.1"
+  "version": "12.0.1",
+  "constrains": [
+    "libclang 12.0.1.*",
+    "clang-tools 12.0.1.*",
+    "llvm 12.0.1.*",
+    "llvm-tools 12.0.1.*",
+    "llvmdev 12.0.1.*"
+  ]
linux-64::clang-tools-12.0.1-default_ha53f305_1.tar.bz2
-    "clangdev 12.0.1"
+    "clangdev 12.0.1",
+    "libclang 12.0.1.*",
+    "clang 12.0.1.*",
+    "llvm 12.0.1.*",
+    "llvm-tools 12.0.1.*",
+    "llvmdev 12.0.1.*"
linux-64::libclang-12.0.1-default_ha53f305_1.tar.bz2
-  "version": "12.0.1"
+  "version": "12.0.1",
+  "constrains": [
+    "clang 12.0.1.*",
+    "clang-tools 12.0.1.*",
+    "llvm 12.0.1.*",
+    "llvm-tools 12.0.1.*",
+    "llvmdev 12.0.1.*"
+  ]
linux-64::pytorch-cpu-1.0.0-py27hf484d3e_1000.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27mu"
-  ],
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "constrains": [
+    "python_abi * *_cp27mu",
+    "pytorch-gpu 9999999999"
+  ]
linux-64::pytorch-cpu-1.0.0-py27hf484d3e_1001.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27mu"
-  ],
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "constrains": [
+    "python_abi * *_cp27mu",
+    "pytorch-gpu 9999999999"
+  ]
linux-64::pytorch-cpu-1.0.0-py27hf484d3e_1002.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27mu"
-  ],
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "constrains": [
+    "python_abi * *_cp27mu",
+    "pytorch-gpu 9999999999"
+  ]
linux-64::pytorch-cpu-1.0.0-py36hf484d3e_1000.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "constrains": [
+    "python_abi * *_cp36m",
+    "pytorch-gpu 9999999999"
+  ]
linux-64::pytorch-cpu-1.0.0-py36hf484d3e_1001.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "constrains": [
+    "python_abi * *_cp36m",
+    "pytorch-gpu 9999999999"
+  ]
linux-64::pytorch-cpu-1.0.0-py36hf484d3e_1002.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "constrains": [
+    "python_abi * *_cp36m",
+    "pytorch-gpu 9999999999"
+  ]
linux-64::pytorch-cpu-1.0.0-py37hf484d3e_1001.tar.bz2
-  "constrains": [
-    "python_abi * *_cp37m"
-  ],
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "constrains": [
+    "python_abi * *_cp37m",
+    "pytorch-gpu 9999999999"
+  ]
linux-64::pytorch-cpu-1.0.0-py37hf484d3e_1002.tar.bz2
-  "constrains": [
-    "python_abi * *_cp37m"
-  ],
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "constrains": [
+    "python_abi * *_cp37m",
+    "pytorch-gpu 9999999999"
+  ]
linux-64::pytorch-cpu-1.0.1-py27hf484d3e_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27mu"
-  ],
-  "version": "1.0.1"
+  "version": "1.0.1",
+  "constrains": [
+    "python_abi * *_cp27mu",
+    "pytorch-gpu 9999999999"
+  ]
linux-64::pytorch-cpu-1.0.1-py36hf484d3e_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-  "version": "1.0.1"
+  "version": "1.0.1",
+  "constrains": [
+    "python_abi * *_cp36m",
+    "pytorch-gpu 9999999999"
+  ]
linux-64::pytorch-cpu-1.0.1-py37hf484d3e_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp37m"
-  ],
-  "version": "1.0.1"
+  "version": "1.0.1",
+  "constrains": [
+    "python_abi * *_cp37m",
+    "pytorch-gpu 9999999999"
+  ]
linux-64::pytorch-cpu-1.1.0-py27he1b5a44_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27mu"
-  ],
-  "version": "1.1.0"
+  "version": "1.1.0",
+  "constrains": [
+    "python_abi * *_cp27mu",
+    "pytorch-gpu 9999999999"
+  ]
linux-64::pytorch-cpu-1.1.0-py36he1b5a44_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-  "version": "1.1.0"
+  "version": "1.1.0",
+  "constrains": [
+    "python_abi * *_cp36m",
+    "pytorch-gpu 9999999999"
+  ]
linux-64::pytorch-cpu-1.1.0-py37he1b5a44_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp37m"
-  ],
-  "version": "1.1.0"
+  "version": "1.1.0",
+  "constrains": [
+    "python_abi * *_cp37m",
+    "pytorch-gpu 9999999999"
+  ]
linux-64::pytorch-cpu-1.6.0-cpu_py36h3ab7d31_0.tar.bz2
-  "version": "1.6.0"
+  "version": "1.6.0",
+  "constrains": [
+    "pytorch-gpu 9999999999"
+  ]
linux-64::pytorch-cpu-1.6.0-cpu_py36h3ab7d31_1.tar.bz2
-  "version": "1.6.0"
+  "version": "1.6.0",
+  "constrains": [
+    "pytorch-gpu 9999999999"
+  ]
linux-64::pytorch-cpu-1.6.0-cpu_py36h718b53a_1.tar.bz2
-  "version": "1.6.0"
+  "version": "1.6.0",
+  "constrains": [
+    "pytorch-gpu 9999999999"
+  ]
linux-64::pytorch-cpu-1.6.0-cpu_py37h718b53a_1.tar.bz2
-  "version": "1.6.0"
+  "version": "1.6.0",
+  "constrains": [
+    "pytorch-gpu 9999999999"
+  ]
linux-64::pytorch-cpu-1.6.0-cpu_py37hf072b7b_0.tar.bz2
-  "version": "1.6.0"
+  "version": "1.6.0",
+  "constrains": [
+    "pytorch-gpu 9999999999"
+  ]
linux-64::pytorch-cpu-1.6.0-cpu_py37hf072b7b_1.tar.bz2
-  "version": "1.6.0"
+  "version": "1.6.0",
+  "constrains": [
+    "pytorch-gpu 9999999999"
+  ]
linux-64::pytorch-cpu-1.6.0-cpu_py38h3369884_0.tar.bz2
-  "version": "1.6.0"
+  "version": "1.6.0",
+  "constrains": [
+    "pytorch-gpu 9999999999"
+  ]
linux-64::pytorch-cpu-1.6.0-cpu_py38h3369884_1.tar.bz2
-  "version": "1.6.0"
+  "version": "1.6.0",
+  "constrains": [
+    "pytorch-gpu 9999999999"
+  ]
linux-64::pytorch-cpu-1.6.0-cpu_py38h718b53a_1.tar.bz2
-  "version": "1.6.0"
+  "version": "1.6.0",
+  "constrains": [
+    "pytorch-gpu 9999999999"
+  ]
linux-64::pytorch-cpu-1.6.0-cpu_py39he5e7b68_1.tar.bz2
-  "version": "1.6.0"
+  "version": "1.6.0",
+  "constrains": [
+    "pytorch-gpu 9999999999"
+  ]
```