### PR TITLE
Fix xeus-python recipes

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1115,6 +1115,14 @@ def _gen_new_index(repodata, subdir):
             depends = record["depends"]
             depends[depends.index("jupyter_client")] = "jupyter_client <7.0"
 
+        # Fix missing dependency for xeus-python and xeus-python-static
+        # Fixed upstream in https://github.com/conda-forge/xeus-python-feedstock/pull/123
+        # and https://github.com/conda-forge/xeus-python-static-feedstock/pull/15
+        if record_name == "xeus-python" and record["version"] == "0.13.0" and record["build_number"] == 0:
+            record["depends"].append("xeus-python-shell >=0.1.5,<0.2")
+        if record_name == "xeus-python-static" and record["version"] == "0.13.0" and record["build_number"] == 0:
+            record["depends"].append("xeus-python-shell >=0.1.5,<0.2")
+
         # replace =2.7 with ==2.7.* for compatibility with older conda
         new_deps = []
         changed = False


### PR DESCRIPTION
```
linux-64::xeus-python-0.13.0-py37h4b46df4_0.tar.bz2
-    "zeromq >=4.3.4,<4.4.0a0"
+    "zeromq >=4.3.4,<4.4.0a0",
+    "xeus-python-shell >=0.1.5,<0.2"
linux-64::xeus-python-0.13.0-py38hcf90354_0.tar.bz2
-    "zeromq >=4.3.4,<4.4.0a0"
+    "zeromq >=4.3.4,<4.4.0a0",
+    "xeus-python-shell >=0.1.5,<0.2"
linux-64::xeus-python-0.13.0-py39h1aaad98_0.tar.bz2
-    "zeromq >=4.3.4,<4.4.0a0"
+    "zeromq >=4.3.4,<4.4.0a0",
+    "xeus-python-shell >=0.1.5,<0.2"
linux-64::xeus-python-static-0.13.0-py37h800ade6_0.tar.bz2
-    "python_abi 3.7.* *_cp37m"
+    "python_abi 3.7.* *_cp37m",
+    "xeus-python-shell >=0.1.5,<0.2"
linux-64::xeus-python-static-0.13.0-py38h6662623_0.tar.bz2
-    "python_abi 3.8.* *_cp38"
+    "python_abi 3.8.* *_cp38",
+    "xeus-python-shell >=0.1.5,<0.2"
linux-64::xeus-python-static-0.13.0-py39hfc0bc81_0.tar.bz2
-    "python_abi 3.9.* *_cp39"
+    "python_abi 3.9.* *_cp39",
+    "xeus-python-shell >=0.1.5,<0.2"
```