### PR TITLE
ENH patch numba dep for ngmix

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -859,6 +859,18 @@ def _gen_new_index(repodata, subdir):
         if any(dep.startswith("pari >=2.13.2") for dep in deps) and record.get('timestamp', 0) < 1625642169000:
             record["depends"].append("pari * *_single")
 
+        # patch out bad numba for ngmix
+        if (
+            record_name == "ngmix"
+            and not any(
+                ("!=0.54.0" in dp and "numba" in dp)
+                for dp in record.get("depends", [])
+            )
+        ):
+            deps = record.get("depends", [])
+            deps.append("numba !=0.54.0")
+            record["depends"] = deps
+
         if record_name in llvm_pkgs:
             new_constrains = record.get('constrains', [])
             version = record["version"]


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Here is the diff:

<details>

```
$ python recipe/show_diff.py 
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata.json.bz2
noarch::lbnightlytools-3.0.39-pyhd8ed1ab_0.tar.bz2
-    "python =2.7|>=3.6",
+    "python ==2.7.*|>=3.6",
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata.json.bz2
linux-64::clang-12.0.1-ha770c72_4.tar.bz2
-  "version": "12.0.1"
+  "version": "12.0.1",
+  "constrains": [
+    "libclang 12.0.1.*",
+    "clang-tools 12.0.1.*",
+    "llvm 12.0.1.*",
+    "llvm-tools 12.0.1.*",
+    "llvmdev 12.0.1.*"
+  ]
linux-64::clang-tools-12.0.1-default_ha53f305_4.tar.bz2
-    "clangdev 12.0.1"
+    "clangdev 12.0.1",
+    "libclang 12.0.1.*",
+    "clang 12.0.1.*",
+    "llvm 12.0.1.*",
+    "llvm-tools 12.0.1.*",
+    "llvmdev 12.0.1.*"
linux-64::libclang-12.0.1-default_ha53f305_4.tar.bz2
-  "version": "12.0.1"
+  "version": "12.0.1",
+  "constrains": [
+    "clang 12.0.1.*",
+    "clang-tools 12.0.1.*",
+    "llvm 12.0.1.*",
+    "llvm-tools 12.0.1.*",
+    "llvmdev 12.0.1.*"
+  ]
linux-64::ngmix-1.2.1-py27_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27mu"
-  ],
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
-  "version": "1.2.1"
+  "version": "1.2.1",
+  "constrains": [
+    "python_abi * *_cp27mu"
+  ]
linux-64::ngmix-1.2.1-py36_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
-  "version": "1.2.1"
+  "version": "1.2.1",
+  "constrains": [
+    "python_abi * *_cp36m"
+  ]
linux-64::ngmix-1.2.1-py37_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp37m"
-  ],
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
-  "version": "1.2.1"
+  "version": "1.2.1",
+  "constrains": [
+    "python_abi * *_cp37m"
+  ]
linux-64::ngmix-1.3.0-py27_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27mu"
-  ],
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
-  "version": "1.3.0"
+  "version": "1.3.0",
+  "constrains": [
+    "python_abi * *_cp27mu"
+  ]
linux-64::ngmix-1.3.0-py36_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
-  "version": "1.3.0"
+  "version": "1.3.0",
+  "constrains": [
+    "python_abi * *_cp36m"
+  ]
linux-64::ngmix-1.3.0-py37_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp37m"
-  ],
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
-  "version": "1.3.0"
+  "version": "1.3.0",
+  "constrains": [
+    "python_abi * *_cp37m"
+  ]
linux-64::ngmix-1.3.1-py27_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27mu"
-  ],
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
-  "version": "1.3.1"
+  "version": "1.3.1",
+  "constrains": [
+    "python_abi * *_cp27mu"
+  ]
linux-64::ngmix-1.3.1-py36_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
-  "version": "1.3.1"
+  "version": "1.3.1",
+  "constrains": [
+    "python_abi * *_cp36m"
+  ]
linux-64::ngmix-1.3.1-py37_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp37m"
-  ],
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
-  "version": "1.3.1"
+  "version": "1.3.1",
+  "constrains": [
+    "python_abi * *_cp37m"
+  ]
linux-64::ngmix-1.3.2-py27_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27mu"
-  ],
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
-  "version": "1.3.2"
+  "version": "1.3.2",
+  "constrains": [
+    "python_abi * *_cp27mu"
+  ]
linux-64::ngmix-1.3.2-py36_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
-  "version": "1.3.2"
+  "version": "1.3.2",
+  "constrains": [
+    "python_abi * *_cp36m"
+  ]
linux-64::ngmix-1.3.2-py37_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp37m"
-  ],
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
-  "version": "1.3.2"
+  "version": "1.3.2",
+  "constrains": [
+    "python_abi * *_cp37m"
+  ]
linux-64::ngmix-1.3.3-py27_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27mu"
-  ],
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
-  "version": "1.3.3"
+  "version": "1.3.3",
+  "constrains": [
+    "python_abi * *_cp27mu"
+  ]
linux-64::ngmix-1.3.3-py36_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
-  "version": "1.3.3"
+  "version": "1.3.3",
+  "constrains": [
+    "python_abi * *_cp36m"
+  ]
linux-64::ngmix-1.3.3-py37_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp37m"
-  ],
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
-  "version": "1.3.3"
+  "version": "1.3.3",
+  "constrains": [
+    "python_abi * *_cp37m"
+  ]
linux-64::ngmix-1.3.4-py27_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27mu"
-  ],
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
-  "version": "1.3.4"
+  "version": "1.3.4",
+  "constrains": [
+    "python_abi * *_cp27mu"
+  ]
linux-64::ngmix-1.3.4-py36_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
-  "version": "1.3.4"
+  "version": "1.3.4",
+  "constrains": [
+    "python_abi * *_cp36m"
+  ]
linux-64::ngmix-1.3.4-py37_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp37m"
-  ],
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
-  "version": "1.3.4"
+  "version": "1.3.4",
+  "constrains": [
+    "python_abi * *_cp37m"
+  ]
linux-64::ngmix-1.3.5-py27_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27mu"
-  ],
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
-  "version": "1.3.5"
+  "version": "1.3.5",
+  "constrains": [
+    "python_abi * *_cp27mu"
+  ]
linux-64::ngmix-1.3.5-py36_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
-  "version": "1.3.5"
+  "version": "1.3.5",
+  "constrains": [
+    "python_abi * *_cp36m"
+  ]
linux-64::ngmix-1.3.5-py37_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp37m"
-  ],
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
-  "version": "1.3.5"
+  "version": "1.3.5",
+  "constrains": [
+    "python_abi * *_cp37m"
+  ]
linux-64::ngmix-1.3.6-py27_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27mu"
-  ],
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
-  "version": "1.3.6"
+  "version": "1.3.6",
+  "constrains": [
+    "python_abi * *_cp27mu"
+  ]
linux-64::ngmix-1.3.6-py36_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
-  "version": "1.3.6"
+  "version": "1.3.6",
+  "constrains": [
+    "python_abi * *_cp36m"
+  ]
linux-64::ngmix-1.3.6-py37_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp37m"
-  ],
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
-  "version": "1.3.6"
+  "version": "1.3.6",
+  "constrains": [
+    "python_abi * *_cp37m"
+  ]
linux-64::ngmix-1.3.7-py27_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27mu"
-  ],
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
-  "version": "1.3.7"
+  "version": "1.3.7",
+  "constrains": [
+    "python_abi * *_cp27mu"
+  ]
linux-64::ngmix-1.3.7-py36_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
-  "version": "1.3.7"
+  "version": "1.3.7",
+  "constrains": [
+    "python_abi * *_cp36m"
+  ]
linux-64::ngmix-1.3.7-py36h9f0ad1d_1.tar.bz2
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
linux-64::ngmix-1.3.7-py37_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp37m"
-  ],
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
-  "version": "1.3.7"
+  "version": "1.3.7",
+  "constrains": [
+    "python_abi * *_cp37m"
+  ]
linux-64::ngmix-1.3.7-py37hc8dfbb8_1.tar.bz2
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
linux-64::ngmix-1.3.7-py38_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp38"
-  ],
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
-  "version": "1.3.7"
+  "version": "1.3.7",
+  "constrains": [
+    "python_abi * *_cp38"
+  ]
linux-64::ngmix-1.3.7-py38h32f6830_1.tar.bz2
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
linux-64::ngmix-1.3.8-py36h5fab9bb_1.tar.bz2
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
linux-64::ngmix-1.3.8-py36h9f0ad1d_0.tar.bz2
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
linux-64::ngmix-1.3.8-py37h89c1867_1.tar.bz2
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
linux-64::ngmix-1.3.8-py37hc8dfbb8_0.tar.bz2
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
linux-64::ngmix-1.3.8-py38h32f6830_0.tar.bz2
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
linux-64::ngmix-1.3.8-py38h578d9bd_1.tar.bz2
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
linux-64::ngmix-1.3.8-py39hf3d152e_1.tar.bz2
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
linux-64::ngmix-1.3.9-py36h5fab9bb_0.tar.bz2
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
linux-64::ngmix-1.3.9-py37h89c1867_0.tar.bz2
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
linux-64::ngmix-1.3.9-py38h578d9bd_0.tar.bz2
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
linux-64::ngmix-1.3.9-py39hf3d152e_0.tar.bz2
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
linux-64::ngmix-2.0.0-py36h5fab9bb_0.tar.bz2
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
linux-64::ngmix-2.0.0-py36h5fab9bb_1.tar.bz2
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
linux-64::ngmix-2.0.0-py37h89c1867_0.tar.bz2
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
linux-64::ngmix-2.0.0-py37h89c1867_1.tar.bz2
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
linux-64::ngmix-2.0.0-py38h578d9bd_0.tar.bz2
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
linux-64::ngmix-2.0.0-py38h578d9bd_1.tar.bz2
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
linux-64::ngmix-2.0.0-py39hf3d152e_0.tar.bz2
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
linux-64::ngmix-2.0.0-py39hf3d152e_1.tar.bz2
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
linux-64::ngmix-2.0.1-py36h5fab9bb_0.tar.bz2
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
linux-64::ngmix-2.0.1-py37h89c1867_0.tar.bz2
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
linux-64::ngmix-2.0.1-py38h578d9bd_0.tar.bz2
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
linux-64::ngmix-2.0.1-py39hf3d152e_0.tar.bz2
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata.json.bz2
linux-aarch64::clang-12.0.1-h8af1aa0_4.tar.bz2
-  "version": "12.0.1"
+  "version": "12.0.1",
+  "constrains": [
+    "libclang 12.0.1.*",
+    "clang-tools 12.0.1.*",
+    "llvm 12.0.1.*",
+    "llvm-tools 12.0.1.*",
+    "llvmdev 12.0.1.*"
+  ]
linux-aarch64::clang-tools-12.0.1-default_h4839fef_4.tar.bz2
-    "clangdev 12.0.1"
+    "clangdev 12.0.1",
+    "libclang 12.0.1.*",
+    "clang 12.0.1.*",
+    "llvm 12.0.1.*",
+    "llvm-tools 12.0.1.*",
+    "llvmdev 12.0.1.*"
linux-aarch64::libclang-12.0.1-default_h4839fef_4.tar.bz2
-  "version": "12.0.1"
+  "version": "12.0.1",
+  "constrains": [
+    "clang 12.0.1.*",
+    "clang-tools 12.0.1.*",
+    "llvm 12.0.1.*",
+    "llvm-tools 12.0.1.*",
+    "llvmdev 12.0.1.*"
+  ]
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata.json.bz2
linux-ppc64le::clang-12.0.1-ha3edaa6_4.tar.bz2
-  "version": "12.0.1"
+  "version": "12.0.1",
+  "constrains": [
+    "libclang 12.0.1.*",
+    "clang-tools 12.0.1.*",
+    "llvm 12.0.1.*",
+    "llvm-tools 12.0.1.*",
+    "llvmdev 12.0.1.*"
+  ]
linux-ppc64le::clang-tools-12.0.1-default_hf0ebb0c_4.tar.bz2
-    "clangdev 12.0.1"
+    "clangdev 12.0.1",
+    "libclang 12.0.1.*",
+    "clang 12.0.1.*",
+    "llvm 12.0.1.*",
+    "llvm-tools 12.0.1.*",
+    "llvmdev 12.0.1.*"
linux-ppc64le::libclang-12.0.1-default_hf0ebb0c_4.tar.bz2
-  "version": "12.0.1"
+  "version": "12.0.1",
+  "constrains": [
+    "clang 12.0.1.*",
+    "clang-tools 12.0.1.*",
+    "llvm 12.0.1.*",
+    "llvm-tools 12.0.1.*",
+    "llvmdev 12.0.1.*"
+  ]
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata.json.bz2
osx-64::clang-12.0.1-h694c41f_4.tar.bz2
-  "version": "12.0.1"
+  "version": "12.0.1",
+  "constrains": [
+    "libclang 12.0.1.*",
+    "clang-tools 12.0.1.*",
+    "llvm 12.0.1.*",
+    "llvm-tools 12.0.1.*",
+    "llvmdev 12.0.1.*"
+  ]
osx-64::clang-tools-12.0.1-default_he082bbe_4.tar.bz2
-    "clangdev 12.0.1"
+    "clangdev 12.0.1",
+    "libclang 12.0.1.*",
+    "clang 12.0.1.*",
+    "llvm 12.0.1.*",
+    "llvm-tools 12.0.1.*",
+    "llvmdev 12.0.1.*"
osx-64::libclang-12.0.1-default_he082bbe_4.tar.bz2
-  "version": "12.0.1"
+  "version": "12.0.1",
+  "constrains": [
+    "clang 12.0.1.*",
+    "clang-tools 12.0.1.*",
+    "llvm 12.0.1.*",
+    "llvm-tools 12.0.1.*",
+    "llvmdev 12.0.1.*"
+  ]
osx-64::ngmix-1.2.1-py27_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27m"
-  ],
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
-  "version": "1.2.1"
+  "version": "1.2.1",
+  "constrains": [
+    "python_abi * *_cp27m"
+  ]
osx-64::ngmix-1.2.1-py36_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
-  "version": "1.2.1"
+  "version": "1.2.1",
+  "constrains": [
+    "python_abi * *_cp36m"
+  ]
osx-64::ngmix-1.2.1-py37_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp37m"
-  ],
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
-  "version": "1.2.1"
+  "version": "1.2.1",
+  "constrains": [
+    "python_abi * *_cp37m"
+  ]
osx-64::ngmix-1.3.0-py27_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27m"
-  ],
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
-  "version": "1.3.0"
+  "version": "1.3.0",
+  "constrains": [
+    "python_abi * *_cp27m"
+  ]
osx-64::ngmix-1.3.0-py36_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
-  "version": "1.3.0"
+  "version": "1.3.0",
+  "constrains": [
+    "python_abi * *_cp36m"
+  ]
osx-64::ngmix-1.3.0-py37_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp37m"
-  ],
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
-  "version": "1.3.0"
+  "version": "1.3.0",
+  "constrains": [
+    "python_abi * *_cp37m"
+  ]
osx-64::ngmix-1.3.1-py27_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27m"
-  ],
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
-  "version": "1.3.1"
+  "version": "1.3.1",
+  "constrains": [
+    "python_abi * *_cp27m"
+  ]
osx-64::ngmix-1.3.1-py36_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
-  "version": "1.3.1"
+  "version": "1.3.1",
+  "constrains": [
+    "python_abi * *_cp36m"
+  ]
osx-64::ngmix-1.3.1-py37_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp37m"
-  ],
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
-  "version": "1.3.1"
+  "version": "1.3.1",
+  "constrains": [
+    "python_abi * *_cp37m"
+  ]
osx-64::ngmix-1.3.2-py27_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27m"
-  ],
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
-  "version": "1.3.2"
+  "version": "1.3.2",
+  "constrains": [
+    "python_abi * *_cp27m"
+  ]
osx-64::ngmix-1.3.2-py36_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
-  "version": "1.3.2"
+  "version": "1.3.2",
+  "constrains": [
+    "python_abi * *_cp36m"
+  ]
osx-64::ngmix-1.3.2-py37_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp37m"
-  ],
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
-  "version": "1.3.2"
+  "version": "1.3.2",
+  "constrains": [
+    "python_abi * *_cp37m"
+  ]
osx-64::ngmix-1.3.3-py27_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27m"
-  ],
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
-  "version": "1.3.3"
+  "version": "1.3.3",
+  "constrains": [
+    "python_abi * *_cp27m"
+  ]
osx-64::ngmix-1.3.3-py36_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
-  "version": "1.3.3"
+  "version": "1.3.3",
+  "constrains": [
+    "python_abi * *_cp36m"
+  ]
osx-64::ngmix-1.3.3-py37_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp37m"
-  ],
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
-  "version": "1.3.3"
+  "version": "1.3.3",
+  "constrains": [
+    "python_abi * *_cp37m"
+  ]
osx-64::ngmix-1.3.4-py27_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27m"
-  ],
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
-  "version": "1.3.4"
+  "version": "1.3.4",
+  "constrains": [
+    "python_abi * *_cp27m"
+  ]
osx-64::ngmix-1.3.4-py36_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
-  "version": "1.3.4"
+  "version": "1.3.4",
+  "constrains": [
+    "python_abi * *_cp36m"
+  ]
osx-64::ngmix-1.3.4-py37_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp37m"
-  ],
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
-  "version": "1.3.4"
+  "version": "1.3.4",
+  "constrains": [
+    "python_abi * *_cp37m"
+  ]
osx-64::ngmix-1.3.5-py27_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27m"
-  ],
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
-  "version": "1.3.5"
+  "version": "1.3.5",
+  "constrains": [
+    "python_abi * *_cp27m"
+  ]
osx-64::ngmix-1.3.5-py36_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
-  "version": "1.3.5"
+  "version": "1.3.5",
+  "constrains": [
+    "python_abi * *_cp36m"
+  ]
osx-64::ngmix-1.3.5-py37_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp37m"
-  ],
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
-  "version": "1.3.5"
+  "version": "1.3.5",
+  "constrains": [
+    "python_abi * *_cp37m"
+  ]
osx-64::ngmix-1.3.6-py27_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27m"
-  ],
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
-  "version": "1.3.6"
+  "version": "1.3.6",
+  "constrains": [
+    "python_abi * *_cp27m"
+  ]
osx-64::ngmix-1.3.6-py36_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
-  "version": "1.3.6"
+  "version": "1.3.6",
+  "constrains": [
+    "python_abi * *_cp36m"
+  ]
osx-64::ngmix-1.3.6-py37_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp37m"
-  ],
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
-  "version": "1.3.6"
+  "version": "1.3.6",
+  "constrains": [
+    "python_abi * *_cp37m"
+  ]
osx-64::ngmix-1.3.7-py27_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27m"
-  ],
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
-  "version": "1.3.7"
+  "version": "1.3.7",
+  "constrains": [
+    "python_abi * *_cp27m"
+  ]
osx-64::ngmix-1.3.7-py36_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
-  "version": "1.3.7"
+  "version": "1.3.7",
+  "constrains": [
+    "python_abi * *_cp36m"
+  ]
osx-64::ngmix-1.3.7-py36h9f0ad1d_1.tar.bz2
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
osx-64::ngmix-1.3.7-py37_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp37m"
-  ],
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
-  "version": "1.3.7"
+  "version": "1.3.7",
+  "constrains": [
+    "python_abi * *_cp37m"
+  ]
osx-64::ngmix-1.3.7-py37hc8dfbb8_1.tar.bz2
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
osx-64::ngmix-1.3.7-py38_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp38"
-  ],
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
-  "version": "1.3.7"
+  "version": "1.3.7",
+  "constrains": [
+    "python_abi * *_cp38"
+  ]
osx-64::ngmix-1.3.7-py38h32f6830_1.tar.bz2
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
osx-64::ngmix-1.3.8-py36h79c6626_1.tar.bz2
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
osx-64::ngmix-1.3.8-py36h9f0ad1d_0.tar.bz2
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
osx-64::ngmix-1.3.8-py37hc8dfbb8_0.tar.bz2
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
osx-64::ngmix-1.3.8-py37hf985489_1.tar.bz2
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
osx-64::ngmix-1.3.8-py38h32f6830_0.tar.bz2
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
osx-64::ngmix-1.3.8-py38h50d1736_1.tar.bz2
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
osx-64::ngmix-1.3.8-py39h6e9494a_1.tar.bz2
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
osx-64::ngmix-1.3.9-py36h79c6626_0.tar.bz2
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
osx-64::ngmix-1.3.9-py37hf985489_0.tar.bz2
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
osx-64::ngmix-1.3.9-py38h50d1736_0.tar.bz2
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
osx-64::ngmix-1.3.9-py39h6e9494a_0.tar.bz2
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
osx-64::ngmix-2.0.0-py36h79c6626_0.tar.bz2
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
osx-64::ngmix-2.0.0-py36h79c6626_1.tar.bz2
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
osx-64::ngmix-2.0.0-py37hf985489_0.tar.bz2
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
osx-64::ngmix-2.0.0-py37hf985489_1.tar.bz2
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
osx-64::ngmix-2.0.0-py38h50d1736_0.tar.bz2
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
osx-64::ngmix-2.0.0-py38h50d1736_1.tar.bz2
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
osx-64::ngmix-2.0.0-py39h6e9494a_0.tar.bz2
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
osx-64::ngmix-2.0.0-py39h6e9494a_1.tar.bz2
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
osx-64::ngmix-2.0.1-py36h79c6626_0.tar.bz2
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
osx-64::ngmix-2.0.1-py37hf985489_0.tar.bz2
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
osx-64::ngmix-2.0.1-py38h50d1736_0.tar.bz2
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
osx-64::ngmix-2.0.1-py39h6e9494a_0.tar.bz2
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata.json.bz2
osx-arm64::clang-12.0.1-hce30654_4.tar.bz2
-  "version": "12.0.1"
+  "version": "12.0.1",
+  "constrains": [
+    "libclang 12.0.1.*",
+    "clang-tools 12.0.1.*",
+    "llvm 12.0.1.*",
+    "llvm-tools 12.0.1.*",
+    "llvmdev 12.0.1.*"
+  ]
osx-arm64::clang-tools-12.0.1-default_h2cfa9b4_4.tar.bz2
-    "clangdev 12.0.1"
+    "clangdev 12.0.1",
+    "libclang 12.0.1.*",
+    "clang 12.0.1.*",
+    "llvm 12.0.1.*",
+    "llvm-tools 12.0.1.*",
+    "llvmdev 12.0.1.*"
osx-arm64::libclang-12.0.1-default_h2cfa9b4_4.tar.bz2
-  "version": "12.0.1"
+  "version": "12.0.1",
+  "constrains": [
+    "clang 12.0.1.*",
+    "clang-tools 12.0.1.*",
+    "llvm 12.0.1.*",
+    "llvm-tools 12.0.1.*",
+    "llvmdev 12.0.1.*"
+  ]
osx-arm64::ngmix-2.0.0-py38h10201cd_1.tar.bz2
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
osx-arm64::ngmix-2.0.0-py39h2804cbe_1.tar.bz2
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
osx-arm64::ngmix-2.0.1-py38h10201cd_0.tar.bz2
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
osx-arm64::ngmix-2.0.1-py39h2804cbe_0.tar.bz2
-    "scipy"
+    "scipy",
+    "numba !=0.54.0"
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata.json.bz2
win-64::clang-12.0.1-h8e541a6_4.tar.bz2
-  "version": "12.0.1"
+  "version": "12.0.1",
+  "constrains": [
+    "libclang 12.0.1.*",
+    "clang-tools 12.0.1.*",
+    "llvm 12.0.1.*",
+    "llvm-tools 12.0.1.*",
+    "llvmdev 12.0.1.*"
+  ]
win-64::clang-tools-12.0.1-default_h81446c8_4.tar.bz2
-    "clangdev 12.0.1"
+    "clangdev 12.0.1",
+    "libclang 12.0.1.*",
+    "clang 12.0.1.*",
+    "llvm 12.0.1.*",
+    "llvm-tools 12.0.1.*",
+    "llvmdev 12.0.1.*"
win-64::libclang-12.0.1-default_h81446c8_4.tar.bz2
-  "version": "12.0.1"
+  "version": "12.0.1",
+  "constrains": [
+    "clang 12.0.1.*",
+    "clang-tools 12.0.1.*",
+    "llvm 12.0.1.*",
+    "llvm-tools 12.0.1.*",
+    "llvmdev 12.0.1.*"
+  ]

```
</details>

Lots of unrelated stuff but the ngmix lines look correct!

This patches out the bug I reported here: https://github.com/numba/numba/issues/7355
