### PR TITLE
CUDA Enhanced Compatibility patch for 11.2+

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import, division, print_function
 
 from collections import defaultdict
+from contextlib import suppress
 import copy
 import json
 import os
@@ -685,6 +686,12 @@ def _gen_new_index(repodata, subdir):
         deps = record.get("depends", ())
         if "ntl" in deps and record_name != "sage":
             _rename_dependency(fn, record, "ntl", "ntl 10.3.0")
+
+        i = -1
+        with suppress(ValueError):
+            i = deps.index("cudatoolkit 11.2|11.2.*")
+        if i >= 0:
+            deps[i] = "cudatoolkit >=11.2,<12"
 
         if "libiconv >=1.15,<1.16.0a0" in deps:
             _pin_looser(fn, record, "libiconv", upper_bound="1.17.0")

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -691,7 +691,7 @@ def _gen_new_index(repodata, subdir):
         with suppress(ValueError):
             i = deps.index("cudatoolkit 11.2|11.2.*")
         if i >= 0:
-            deps[i] = "cudatoolkit >=11.2,<12"
+            deps[i] = "cudatoolkit >=11.2,<12.0a0"
 
         if "libiconv >=1.15,<1.16.0a0" in deps:
             _pin_looser(fn, record, "libiconv", upper_bound="1.17.0")


### PR DESCRIPTION
Hotfix packages that constrain `cudatoolkit` to 11.2 so that they can use 11.2+ up to, but excluding 12. This way users can more easily compose libraries that use some 11 version (at least 11.2) together. Also relaxes the build and maintenance requirements around CUDA packages.

cc @isuruf @kkraus14 @leofang @raydouglass (for awareness)

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
