### PR TITLE
make older vs2015_runtime conflict with ucrt

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -527,6 +527,15 @@ def _gen_new_index(repodata, subdir):
                 i = record['depends'].index('zstandard')
                 record['depends'][i] = 'zstandard <0.15'
 
+        if record_name == "vs2015_runtime" and record.get('timestamp', 0) < 1633470721000:
+            pversion = pkg_resources.parse_version(record['version'])
+            vs2019_version = pkg_resources.parse_version('14.29.30037')
+            if pversion < vs2019_version:
+                # make these conflict with ucrt
+                new_constrains = record.get("constrains", [])
+                new_constrains.append("ucrt <0a0")
+                record['constrains'] = new_constrains
+
         if record_name == "gitdb" and record['version'].startswith('4.0.') and 'smmap >=3.0.1' in record['depends']:
             i = record['depends'].index('smmap >=3.0.1')
             record['depends'][i] = 'smmap >=3.0.1,<4'


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
