### PR TITLE
Fix google-api-core 1.31.2 dependency

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1173,6 +1173,12 @@ def _gen_new_index(repodata, subdir):
         if record_name == "xeus-python-static" and record["version"] == "0.13.0" and record["build_number"] == 0:
             record["depends"].append("xeus-python-shell >=0.1.5,<0.2")
 
+        # google-api-core 1.31.2 has an incorrect version range allowed for google-auth
+        # https://github.com/conda-forge/google-api-core-feedstock/pull/74#discussion_r736929096
+        if record_name == "google-api-core" and record["version"] == "1.31.2":
+            deps = record["depends"]
+            _replace_pin("google-auth >=1.25.1,<3.0dev", "google-auth >=1.25.1,<2.0dev", deps, record)
+
         # replace =2.7 with ==2.7.* for compatibility with older conda
         new_deps = []
         changed = False


### PR DESCRIPTION
Make dependency on google-auth correctly match upstream.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Fixes `pip check` in https://github.com/conda-forge/staged-recipes/pull/16653.


<!--
Please add any other relevant info below:
-->
