### PR TITLE
Patch `packaging`'s `pyparsing` dependency

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -527,6 +527,15 @@ def _gen_new_index(repodata, subdir):
                 i = record['depends'].index('zstandard')
                 record['depends'][i] = 'zstandard <0.15'
 
+        if record_name == "packaging" and record["version"] in ["21.1", "21.2"]:
+            # https://github.com/conda-forge/packaging-feedstock/pull/21
+            deps = record["depends"]
+            i = -1
+            with suppress(ValueError):
+                i = deps.index("pyparsing >=2.0.2")
+            if i >= 0:
+                deps[i] = "pyparsing >=2.0.2,<3"
+
         if record_name == "vs2015_runtime" and record.get('timestamp', 0) < 1633470721000:
             pversion = pkg_resources.parse_version(record['version'])
             vs2019_version = pkg_resources.parse_version('14.29.30037')


### PR DESCRIPTION
This needs to have an upper bound of `3`, but was missed updating.

From `show_diff.py`:

```diff
noarch::packaging-21.2-pyhd8ed1ab_0.tar.bz2
-    "pyparsing >=2.0.2",
+    "pyparsing >=2.0.2,<3",
```

xref: https://github.com/conda-forge/packaging-feedstock/pull/21

cc @conda-forge/packaging @krassowski

<hr>

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
