### PR TITLE
Add fix for auto-sklearn

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1187,6 +1187,11 @@ def _gen_new_index(repodata, subdir):
         if record_name == "google-api-core" and record["version"] == "1.31.2":
             deps = record["depends"]
             _replace_pin("google-auth >=1.25.1,<3.0dev", "google-auth >=1.25.1,<2.0dev", deps, record)
+        
+        # auto-sklear needs to depend on the full dask.
+        # https://github.com/automl/auto-sklearn/issues/1256
+        if record_name == "auto-sklearn":
+            _rename_dependency(fn, record, "dask-core", "dask")
 
         # replace =2.7 with ==2.7.* for compatibility with older conda
         new_deps = []


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

This was copied from https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/dd13f6b26ab66452f4ef168444f2a7ad61fcc108/recipe/gen_patch_json.py#L688-L690 

Intend is that `auto-sklear` needs to depend on the full `dask` not only on `dask-core`.