### PR TITLE
Patch `cupy` constrain

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1187,11 +1187,15 @@ def _gen_new_index(repodata, subdir):
         if record_name == "google-api-core" and record["version"] == "1.31.2":
             deps = record["depends"]
             _replace_pin("google-auth >=1.25.1,<3.0dev", "google-auth >=1.25.1,<2.0dev", deps, record)
-        
+
         # auto-sklear needs to depend on the full dask.
         # https://github.com/automl/auto-sklearn/issues/1256
         if record_name == "auto-sklearn":
             _rename_dependency(fn, record, "dask-core", "dask")
+
+        # remove libcugraph constrain to prevent cyclical dependency issues with RAPIDS
+        if record_name == "cupy":
+            _replace_pin("libcugraph >=0.19.0,<1.0a0", "libcugraph", record.get("constrains", []), record, target='constrains')
 
         # replace =2.7 with ==2.7.* for compatibility with older conda
         new_deps = []

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1193,7 +1193,7 @@ def _gen_new_index(repodata, subdir):
         if record_name == "auto-sklearn":
             _rename_dependency(fn, record, "dask-core", "dask")
 
-        # remove libcugraph constrain to prevent cyclical dependency issues with RAPIDS
+        # libcugraph 0.19.0 is compatible with the new calver based version 21.x
         if record_name == "cupy":
             _replace_pin("libcugraph >=0.19.0,<1.0a0", "libcugraph >=0.19.0", record.get("constrains", []), record, target='constrains')
 

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1195,7 +1195,7 @@ def _gen_new_index(repodata, subdir):
 
         # remove libcugraph constrain to prevent cyclical dependency issues with RAPIDS
         if record_name == "cupy":
-            _replace_pin("libcugraph >=0.19.0,<1.0a0", "libcugraph", record.get("constrains", []), record, target='constrains')
+            _replace_pin("libcugraph >=0.19.0,<1.0a0", "libcugraph >=0.19.0", record.get("constrains", []), record, target='constrains')
 
         # replace =2.7 with ==2.7.* for compatibility with older conda
         new_deps = []


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->


This PR patches `cupy` to remove the constrain on `libcugraph` to prevent cyclical dependency issues with RAPIDS.