### PR TITLE
Ensure incompatible builds of cling are not installed with clad

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1193,6 +1193,13 @@ def _gen_new_index(repodata, subdir):
         if record_name == "auto-sklearn":
             _rename_dependency(fn, record, "dask-core", "dask")
 
+        # Only some build of clad work with cling, if there isn't a constraint mark it as conflicting
+        if record_name == "clad":
+            new_constrains = record.get('constrains', [])
+            if all("cling " not in x for x in new_constrains):
+                new_constrains.append("cling ==99999999999")
+            record["constrains"] = new_constrains
+
         # libcugraph 0.19.0 is compatible with the new calver based version 21.x
         if record_name == "cupy":
             _replace_pin("libcugraph >=0.19.0,<1.0a0", "libcugraph >=0.19.0", record.get("constrains", []), record, target='constrains')


### PR DESCRIPTION
<details>
  <summary>Show diff</summary>
  
  ```diff
    $ python show_diff.py                                                                                                                                                         (base)
  Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata_from_packages.json.bz2
  Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata.json.bz2
  Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata_from_packages.json.bz2
  Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata.json.bz2
  linux-64::clad-0.7-h21b1b72_0.tar.bz2
  -  "version": "0.7"
  +  "version": "0.7",
  +  "constrains": [
  +    "cling ==99999999999"
  +  ]
  linux-64::clad-0.7-h2806271_0.tar.bz2
  -  "version": "0.7"
  +  "version": "0.7",
  +  "constrains": [
  +    "cling ==99999999999"
  +  ]
  linux-64::clad-0.7-h931d95a_0.tar.bz2
  -  "version": "0.7"
  +  "version": "0.7",
  +  "constrains": [
  +    "cling ==99999999999"
  +  ]
  linux-64::clad-0.7-ha8e435e_0.tar.bz2
  -  "version": "0.7"
  +  "version": "0.7",
  +  "constrains": [
  +    "cling ==99999999999"
  +  ]
  linux-64::clad-0.7-hd7828ce_0.tar.bz2
  -  "version": "0.7"
  +  "version": "0.7",
  +  "constrains": [
  +    "cling ==99999999999"
  +  ]
  linux-64::clad-0.7-he5547e1_0.tar.bz2
  -  "version": "0.7"
  +  "version": "0.7",
  +  "constrains": [
  +    "cling ==99999999999"
  +  ]
  linux-64::clad-0.8-h21b1b72_0.tar.bz2
  -  "version": "0.8"
  +  "version": "0.8",
  +  "constrains": [
  +    "cling ==99999999999"
  +  ]
  linux-64::clad-0.8-h2806271_0.tar.bz2
  -  "version": "0.8"
  +  "version": "0.8",
  +  "constrains": [
  +    "cling ==99999999999"
  +  ]
  linux-64::clad-0.8-h931d95a_0.tar.bz2
  -  "version": "0.8"
  +  "version": "0.8",
  +  "constrains": [
  +    "cling ==99999999999"
  +  ]
  linux-64::clad-0.8-ha8e435e_0.tar.bz2
  -  "version": "0.8"
  +  "version": "0.8",
  +  "constrains": [
  +    "cling ==99999999999"
  +  ]
  linux-64::clad-0.8-hd7828ce_0.tar.bz2
  -  "version": "0.8"
  +  "version": "0.8",
  +  "constrains": [
  +    "cling ==99999999999"
  +  ]
  linux-64::clad-0.8-he5547e1_0.tar.bz2
  -  "version": "0.8"
  +  "version": "0.8",
  +  "constrains": [
  +    "cling ==99999999999"
  +  ]
  linux-64::clad-0.9-h21b1b72_0.tar.bz2
  -  "version": "0.9"
  +  "version": "0.9",
  +  "constrains": [
  +    "cling ==99999999999"
  +  ]
  linux-64::clad-0.9-h2806271_0.tar.bz2
  -  "version": "0.9"
  +  "version": "0.9",
  +  "constrains": [
  +    "cling ==99999999999"
  +  ]
  linux-64::clad-0.9-h931d95a_0.tar.bz2
  -  "version": "0.9"
  +  "version": "0.9",
  +  "constrains": [
  +    "cling ==99999999999"
  +  ]
  linux-64::clad-0.9-ha8e435e_0.tar.bz2
  -  "version": "0.9"
  +  "version": "0.9",
  +  "constrains": [
  +    "cling ==99999999999"
  +  ]
  linux-64::clad-0.9-hd7828ce_0.tar.bz2
  -  "version": "0.9"
  +  "version": "0.9",
  +  "constrains": [
  +    "cling ==99999999999"
  +  ]
  linux-64::clad-0.9-he5547e1_0.tar.bz2
  -  "version": "0.9"
  +  "version": "0.9",
  +  "constrains": [
  +    "cling ==99999999999"
  +  ]
  Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata_from_packages.json.bz2
  Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata.json.bz2
  Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata_from_packages.json.bz2
  Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata.json.bz2
  Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata_from_packages.json.bz2
  Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata.json.bz2
  Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata_from_packages.json.bz2
  Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata.json.bz2
  osx-64::clad-0.7-h08d83fe_0.tar.bz2
  -  "version": "0.7"
  +  "version": "0.7",
  +  "constrains": [
  +    "cling ==99999999999"
  +  ]
  osx-64::clad-0.7-h1f7e29e_0.tar.bz2
  -  "version": "0.7"
  +  "version": "0.7",
  +  "constrains": [
  +    "cling ==99999999999"
  +  ]
  osx-64::clad-0.7-h7a3f9cc_0.tar.bz2
  -  "version": "0.7"
  +  "version": "0.7",
  +  "constrains": [
  +    "cling ==99999999999"
  +  ]
  osx-64::clad-0.7-h84c25f9_0.tar.bz2
  -  "version": "0.7"
  +  "version": "0.7",
  +  "constrains": [
  +    "cling ==99999999999"
  +  ]
  osx-64::clad-0.7-hcb29bf3_0.tar.bz2
  -  "version": "0.7"
  +  "version": "0.7",
  +  "constrains": [
  +    "cling ==99999999999"
  +  ]
  osx-64::clad-0.7-hfb4f5e5_0.tar.bz2
  -  "version": "0.7"
  +  "version": "0.7",
  +  "constrains": [
  +    "cling ==99999999999"
  +  ]
  osx-64::clad-0.8-h0996fb3_0.tar.bz2
  -  "version": "0.8"
  +  "version": "0.8",
  +  "constrains": [
  +    "cling ==99999999999"
  +  ]
  osx-64::clad-0.8-h49b72cb_0.tar.bz2
  -  "version": "0.8"
  +  "version": "0.8",
  +  "constrains": [
  +    "cling ==99999999999"
  +  ]
  osx-64::clad-0.8-h4ae45d7_0.tar.bz2
  -  "version": "0.8"
  +  "version": "0.8",
  +  "constrains": [
  +    "cling ==99999999999"
  +  ]
  osx-64::clad-0.8-h72c431f_0.tar.bz2
  -  "version": "0.8"
  +  "version": "0.8",
  +  "constrains": [
  +    "cling ==99999999999"
  +  ]
  osx-64::clad-0.8-hc9fa203_0.tar.bz2
  -  "version": "0.8"
  +  "version": "0.8",
  +  "constrains": [
  +    "cling ==99999999999"
  +  ]
  osx-64::clad-0.8-hd6f7a54_0.tar.bz2
  -  "version": "0.8"
  +  "version": "0.8",
  +  "constrains": [
  +    "cling ==99999999999"
  +  ]
  osx-64::clad-0.9-h0996fb3_0.tar.bz2
  -  "version": "0.9"
  +  "version": "0.9",
  +  "constrains": [
  +    "cling ==99999999999"
  +  ]
  osx-64::clad-0.9-h49b72cb_0.tar.bz2
  -  "version": "0.9"
  +  "version": "0.9",
  +  "constrains": [
  +    "cling ==99999999999"
  +  ]
  osx-64::clad-0.9-h4ae45d7_0.tar.bz2
  -  "version": "0.9"
  +  "version": "0.9",
  +  "constrains": [
  +    "cling ==99999999999"
  +  ]
  osx-64::clad-0.9-h72c431f_0.tar.bz2
  -  "version": "0.9"
  +  "version": "0.9",
  +  "constrains": [
  +    "cling ==99999999999"
  +  ]
  osx-64::clad-0.9-hc9fa203_0.tar.bz2
  -  "version": "0.9"
  +  "version": "0.9",
  +  "constrains": [
  +    "cling ==99999999999"
  +  ]
  osx-64::clad-0.9-hd6f7a54_0.tar.bz2
  -  "version": "0.9"
  +  "version": "0.9",
  +  "constrains": [
  +    "cling ==99999999999"
  +  ]
  Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata_from_packages.json.bz2
  Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata.json.bz2
  Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata_from_packages.json.bz2
  Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata.json.bz2
  Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata_from_packages.json.bz2
  Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata.json.bz2
  win-64::clad-0.7-h1db6e46_0.tar.bz2
  -  "version": "0.7"
  +  "version": "0.7",
  +  "constrains": [
  +    "cling ==99999999999"
  +  ]
  win-64::clad-0.7-h3352cc6_0.tar.bz2
  -  "version": "0.7"
  +  "version": "0.7",
  +  "constrains": [
  +    "cling ==99999999999"
  +  ]
  win-64::clad-0.7-h36ed3c1_0.tar.bz2
  -  "version": "0.7"
  +  "version": "0.7",
  +  "constrains": [
  +    "cling ==99999999999"
  +  ]
  win-64::clad-0.7-h7df8e60_0.tar.bz2
  -  "version": "0.7"
  +  "version": "0.7",
  +  "constrains": [
  +    "cling ==99999999999"
  +  ]
  win-64::clad-0.7-h9ed7824_0.tar.bz2
  -  "version": "0.7"
  +  "version": "0.7",
  +  "constrains": [
  +    "cling ==99999999999"
  +  ]
  win-64::clad-0.7-hffce1b2_0.tar.bz2
  -  "version": "0.7"
  +  "version": "0.7",
  +  "constrains": [
  +    "cling ==99999999999"
  +  ]
  win-64::clad-0.8-h1db6e46_0.tar.bz2
  -  "version": "0.8"
  +  "version": "0.8",
  +  "constrains": [
  +    "cling ==99999999999"
  +  ]
  win-64::clad-0.8-h3352cc6_0.tar.bz2
  -  "version": "0.8"
  +  "version": "0.8",
  +  "constrains": [
  +    "cling ==99999999999"
  +  ]
  win-64::clad-0.8-h36ed3c1_0.tar.bz2
  -  "version": "0.8"
  +  "version": "0.8",
  +  "constrains": [
  +    "cling ==99999999999"
  +  ]
  win-64::clad-0.8-h7df8e60_0.tar.bz2
  -  "version": "0.8"
  +  "version": "0.8",
  +  "constrains": [
  +    "cling ==99999999999"
  +  ]
  win-64::clad-0.8-h9ed7824_0.tar.bz2
  -  "version": "0.8"
  +  "version": "0.8",
  +  "constrains": [
  +    "cling ==99999999999"
  +  ]
  win-64::clad-0.8-hffce1b2_0.tar.bz2
  -  "version": "0.8"
  +  "version": "0.8",
  +  "constrains": [
  +    "cling ==99999999999"
  +  ]
  win-64::clad-0.9-h1db6e46_0.tar.bz2
  -  "version": "0.9"
  +  "version": "0.9",
  +  "constrains": [
  +    "cling ==99999999999"
  +  ]
  win-64::clad-0.9-h3352cc6_0.tar.bz2
  -  "version": "0.9"
  +  "version": "0.9",
  +  "constrains": [
  +    "cling ==99999999999"
  +  ]
  win-64::clad-0.9-h36ed3c1_0.tar.bz2
  -  "version": "0.9"
  +  "version": "0.9",
  +  "constrains": [
  +    "cling ==99999999999"
  +  ]
  win-64::clad-0.9-h7df8e60_0.tar.bz2
  -  "version": "0.9"
  +  "version": "0.9",
  +  "constrains": [
  +    "cling ==99999999999"
  +  ]
  win-64::clad-0.9-h9ed7824_0.tar.bz2
  -  "version": "0.9"
  +  "version": "0.9",
  +  "constrains": [
  +    "cling ==99999999999"
  +  ]
  win-64::clad-0.9-hffce1b2_0.tar.bz2
  -  "version": "0.9"
  +  "version": "0.9",
  +  "constrains": [
  +    "cling ==99999999999"
  +  ]
  ```
</details>