### PR TITLE
Ensure old sphinx versions don't pull in incompatible docutils

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1217,6 +1217,12 @@ def _gen_new_index(repodata, subdir):
             if record["version"] in ["0.3.4", "0.3.6", "0.3.9", "0.4.0"]:
                 _replace_pin("dask >=2.19.0,!=2021.3.0", f"dask =={dask_sql_map[record['version']]}", deps, record)
 
+        # Retroactively pin a max version of docutils for sphinx 3.x. 0.17 broke 3.x as noted upstream:
+        # https://github.com/sphinx-doc/sphinx/commit/025f26cd5dba57dfb6a8a036708da120001c6768
+        if record_name == "sphinx" and record["version"].startswith("3."):
+            deps = record["depends"]
+            _replace_pin("docutils >=0.12", "docutils >=0.12,<0.17", deps, record)
+
         # replace =2.7 with ==2.7.* for compatibility with older conda
         new_deps = []
         changed = False

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1217,9 +1217,9 @@ def _gen_new_index(repodata, subdir):
             if record["version"] in ["0.3.4", "0.3.6", "0.3.9", "0.4.0"]:
                 _replace_pin("dask >=2.19.0,!=2021.3.0", f"dask =={dask_sql_map[record['version']]}", deps, record)
 
-        # Retroactively pin a max version of docutils for sphinx 3.x. 0.17 broke 3.x as noted upstream:
+        # Retroactively pin a max version of docutils for sphinx 3.x and 2.x since 0.17 broke things as noted upstream:
         # https://github.com/sphinx-doc/sphinx/commit/025f26cd5dba57dfb6a8a036708da120001c6768
-        if record_name == "sphinx" and record["version"].startswith("3."):
+        if record_name == "sphinx" and (record["version"].startswith("3.") or record["version"].startswith("2.")):
             deps = record["depends"]
             _replace_pin("docutils >=0.12", "docutils >=0.12,<0.17", deps, record)
 


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

Right now this is allowing Sphinx 3.5.3 and docutils 0.18 to be installed together on Python 3.10--and it does NOT work.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Diff:
```
❯ ./show_diff.py
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata.json.bz2
noarch::py-dom-xpath-six-0.2.3-pyhd8ed1ab_0.tar.bz2
-    "python =2.7|>=3.6"
+    "python ==2.7.*|>=3.6"
noarch::sphinx-3.0.0-py_0.tar.bz2
-    "docutils >=0.12",
+    "docutils >=0.12,<0.17",
noarch::sphinx-3.0.1-py_0.tar.bz2
-    "docutils >=0.12",
+    "docutils >=0.12,<0.17",
noarch::sphinx-3.0.2-py_0.tar.bz2
-    "docutils >=0.12",
+    "docutils >=0.12,<0.17",
noarch::sphinx-3.0.3-py_0.tar.bz2
-    "docutils >=0.12",
+    "docutils >=0.12,<0.17",
noarch::sphinx-3.0.4-py_0.tar.bz2
-    "docutils >=0.12",
+    "docutils >=0.12,<0.17",
noarch::sphinx-3.1.0-py_0.tar.bz2
-    "docutils >=0.12",
+    "docutils >=0.12,<0.17",
noarch::sphinx-3.1.1-py_0.tar.bz2
-    "docutils >=0.12",
+    "docutils >=0.12,<0.17",
noarch::sphinx-3.1.2-py_0.tar.bz2
-    "docutils >=0.12",
+    "docutils >=0.12,<0.17",
noarch::sphinx-3.2.0-py_0.tar.bz2
-    "docutils >=0.12",
+    "docutils >=0.12,<0.17",
noarch::sphinx-3.2.1-py_0.tar.bz2
-    "docutils >=0.12",
+    "docutils >=0.12,<0.17",
noarch::sphinx-3.3.0-pyhd8ed1ab_0.tar.bz2
-    "docutils >=0.12",
+    "docutils >=0.12,<0.17",
noarch::sphinx-3.3.1-pyhd8ed1ab_0.tar.bz2
-    "docutils >=0.12",
+    "docutils >=0.12,<0.17",
noarch::sphinx-3.3.1-pyhd8ed1ab_1.tar.bz2
-    "docutils >=0.12",
+    "docutils >=0.12,<0.17",
noarch::sphinx-3.4.0-pyhd8ed1ab_0.tar.bz2
-    "docutils >=0.12",
+    "docutils >=0.12,<0.17",
noarch::sphinx-3.4.1-pyhd8ed1ab_0.tar.bz2
-    "docutils >=0.12",
+    "docutils >=0.12,<0.17",
noarch::sphinx-3.4.2-pyhd8ed1ab_0.tar.bz2
-    "docutils >=0.12",
+    "docutils >=0.12,<0.17",
noarch::sphinx-3.4.3-pyhd8ed1ab_0.tar.bz2
-    "docutils >=0.12",
+    "docutils >=0.12,<0.17",
noarch::sphinx-3.5.0-pyhd8ed1ab_0.tar.bz2
-    "docutils >=0.12",
+    "docutils >=0.12,<0.17",
noarch::sphinx-3.5.1-pyhd8ed1ab_0.tar.bz2
-    "docutils >=0.12",
+    "docutils >=0.12,<0.17",
noarch::sphinx-3.5.2-pyhd8ed1ab_0.tar.bz2
-    "docutils >=0.12",
+    "docutils >=0.12,<0.17",
noarch::sphinx-3.5.3-pyhd8ed1ab_0.tar.bz2
-    "docutils >=0.12",
+    "docutils >=0.12,<0.17",
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata.json.bz2
```