### PR TITLE
Make sure pony doesn't install on Python 3.10

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1223,6 +1223,15 @@ def _gen_new_index(repodata, subdir):
             deps = record["depends"]
             _replace_pin("docutils >=0.12", "docutils >=0.12,<0.17", deps, record)
 
+        # Retroactively pin Python < 3.10 for some older noarch Pony packages, since Pony depends on the parser
+        # module removed in 3.10: https://github.com/conda-forge/pony-feedstock/pull/20
+        if record_name == "pony":
+            deps = record["depends"]
+            if  record['version'] == "0.7.13":
+                _replace_pin("python", "python >=2.7,<3.10", deps, record)
+            elif record["version"] == "0.7.14":
+                _replace_pin("python >=2.7", "python >=2.7,<3.10", deps, record)
+
         # replace =2.7 with ==2.7.* for compatibility with older conda
         new_deps = []
         changed = False


### PR DESCRIPTION
It needs the removed parser module.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Diff:
```
❯ python recipe/show_diff.py
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata.json.bz2
noarch::cleanlab-1.0-pyhd8ed1ab_2.tar.bz2
-    "python =2.7|>=3.4",
+    "python ==2.7.*|>=3.4",
noarch::pony-0.7.13-pyh9f0ad1d_0.tar.bz2
-    "python"
+    "python >=2.7,<3.10"
noarch::pony-0.7.14-pyhd8ed1ab_0.tar.bz2
-    "python >=2.7"
+    "python >=2.7,<3.10"
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata.json.bz2
linux-aarch64::matrixswitch-1.0.0-mpi_mpich_h478e2f9_1.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata.json.bz2
linux-ppc64le::matrixswitch-1.0.0-mpi_mpich_hb27407b_1.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata.json.bz2
```