### PR TITLE
Limit keras to <2.7 in tensorflow-base

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -566,6 +566,10 @@ def _gen_new_index(repodata, subdir):
             if record.get('timestamp', 0) < 1607959235411 and any(dep.split(' ')[0] == 'numpy' for dep in record.get('depends', ())):
                 _pin_stricter(fn, record, "numpy", "x", "1.20")
 
+        if record_name == "tensorflow-base" and record["version"] == "2.6.0":
+            i = record['depends'].index('keras >=2.6,<3')
+            record['depends'][i] = 'keras >=2.6,<2.7'
+
         if record_name == "pyarrow":
             if not any(dep.split(' ')[0] == "arrow-cpp-proc" for dep in record.get('constrains', ())):
                 if 'constrains' in record:


### PR DESCRIPTION
This is needed as keras 2.7 is incompatible with tensorflow 2.6, see https://github.com/keras-team/keras/issues/15579. This has been fixed in the 2.6.2 builds of tensorflow thus we only need to fix the 2.6.0 builds.


Diff: 

<details>

```
% python show_diff.py
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata.json.bz2
linux-64::tensorflow-base-2.6.0-cpu_py37hc5ef7b8_2.tar.bz2
-    "keras >=2.6,<3",
+    "keras >=2.6,<2.7",
linux-64::tensorflow-base-2.6.0-cpu_py38h4611ba2_2.tar.bz2
-    "keras >=2.6,<3",
+    "keras >=2.6,<2.7",
linux-64::tensorflow-base-2.6.0-cpu_py39h7e79a0b_2.tar.bz2
-    "keras >=2.6,<3",
+    "keras >=2.6,<2.7",
linux-64::tensorflow-base-2.6.0-cuda102py37hbd7ce69_2.tar.bz2
-    "keras >=2.6,<3",
+    "keras >=2.6,<2.7",
linux-64::tensorflow-base-2.6.0-cuda102py38h3f41ba3_2.tar.bz2
-    "keras >=2.6,<3",
+    "keras >=2.6,<2.7",
linux-64::tensorflow-base-2.6.0-cuda102py39h747ea68_2.tar.bz2
-    "keras >=2.6,<3",
+    "keras >=2.6,<2.7",
linux-64::tensorflow-base-2.6.0-cuda110py37hb8f09f9_2.tar.bz2
-    "keras >=2.6,<3",
+    "keras >=2.6,<2.7",
linux-64::tensorflow-base-2.6.0-cuda110py38h937a041_2.tar.bz2
-    "keras >=2.6,<3",
+    "keras >=2.6,<2.7",
linux-64::tensorflow-base-2.6.0-cuda110py39hd7afca0_2.tar.bz2
-    "keras >=2.6,<3",
+    "keras >=2.6,<2.7",
linux-64::tensorflow-base-2.6.0-cuda111py37h95189bc_2.tar.bz2
-    "keras >=2.6,<3",
+    "keras >=2.6,<2.7",
linux-64::tensorflow-base-2.6.0-cuda111py38h152c24c_2.tar.bz2
-    "keras >=2.6,<3",
+    "keras >=2.6,<2.7",
linux-64::tensorflow-base-2.6.0-cuda111py39he6e9a3f_2.tar.bz2
-    "keras >=2.6,<3",
+    "keras >=2.6,<2.7",
linux-64::tensorflow-base-2.6.0-cuda112py37hd5a5b6b_2.tar.bz2
-    "keras >=2.6,<3",
+    "keras >=2.6,<2.7",
linux-64::tensorflow-base-2.6.0-cuda112py38heae9c4c_2.tar.bz2
-    "keras >=2.6,<3",
+    "keras >=2.6,<2.7",
linux-64::tensorflow-base-2.6.0-cuda112py39h0b4cdfd_2.tar.bz2
-    "keras >=2.6,<3",
+    "keras >=2.6,<2.7",
linux-64::tensorflow-base-2.6.0-py36h312d151_0.tar.bz2
-    "keras >=2.6,<3",
+    "keras >=2.6,<2.7",
linux-64::tensorflow-base-2.6.0-py37h4c77830_1.tar.bz2
-    "keras >=2.6,<3",
+    "keras >=2.6,<2.7",
linux-64::tensorflow-base-2.6.0-py37he2fe834_0.tar.bz2
-    "keras >=2.6,<3",
+    "keras >=2.6,<2.7",
linux-64::tensorflow-base-2.6.0-py38h83f5f1d_0.tar.bz2
-    "keras >=2.6,<3",
+    "keras >=2.6,<2.7",
linux-64::tensorflow-base-2.6.0-py38he1e5d52_1.tar.bz2
-    "keras >=2.6,<3",
+    "keras >=2.6,<2.7",
linux-64::tensorflow-base-2.6.0-py39h23a8cbf_0.tar.bz2
-    "keras >=2.6,<3",
+    "keras >=2.6,<2.7",
linux-64::tensorflow-base-2.6.0-py39he745eb5_1.tar.bz2
-    "keras >=2.6,<3",
+    "keras >=2.6,<2.7",
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata.json.bz2
osx-64::tensorflow-base-2.6.0-py36ha9b9f1f_0.tar.bz2
-    "keras >=2.6,<3",
+    "keras >=2.6,<2.7",
osx-64::tensorflow-base-2.6.0-py37h05ab19a_0.tar.bz2
-    "keras >=2.6,<3",
+    "keras >=2.6,<2.7",
osx-64::tensorflow-base-2.6.0-py37hfa03454_1.tar.bz2
-    "keras >=2.6,<3",
+    "keras >=2.6,<2.7",
osx-64::tensorflow-base-2.6.0-py38h1615122_1.tar.bz2
-    "keras >=2.6,<3",
+    "keras >=2.6,<2.7",
osx-64::tensorflow-base-2.6.0-py38h8860697_0.tar.bz2
-    "keras >=2.6,<3",
+    "keras >=2.6,<2.7",
osx-64::tensorflow-base-2.6.0-py39h7588def_1.tar.bz2
-    "keras >=2.6,<3",
+    "keras >=2.6,<2.7",
osx-64::tensorflow-base-2.6.0-py39h9e0eb93_0.tar.bz2
-    "keras >=2.6,<3",
+    "keras >=2.6,<2.7",
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata.json.bz2
osx-arm64::tensorflow-base-2.6.0-py38h2df1d7c_0.tar.bz2
-    "keras >=2.6,<3",
+    "keras >=2.6,<2.7",
osx-arm64::tensorflow-base-2.6.0-py38hb029846_1.tar.bz2
-    "keras >=2.6,<3",
+    "keras >=2.6,<2.7",
osx-arm64::tensorflow-base-2.6.0-py39h34a2d98_0.tar.bz2
-    "keras >=2.6,<3",
+    "keras >=2.6,<2.7",
osx-arm64::tensorflow-base-2.6.0-py39h8978855_1.tar.bz2
-    "keras >=2.6,<3",
+    "keras >=2.6,<2.7",
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata.json.bz2
```

</details>