### PR TITLE
BUG do not remove ruby features

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -865,8 +865,11 @@ def _gen_new_index(repodata, subdir):
             record['depends'][i] = 'pythia8 >=8.240,<8.300.0a0'
 
         # remove features for openjdk and rb2
-        if ("track_features" in record and
-                record['track_features'] is not None):
+        if (
+            "track_features" in record
+            and record['track_features'] is not None
+            and record_name != "ruby"
+        ):
             for feat in record["track_features"].split():
                 if feat.startswith(("rb2", "openjdk")):
                     record["track_features"] = _extract_track_feature(
@@ -1211,7 +1214,7 @@ def _gen_new_index(repodata, subdir):
         # retroactively pin dask dependency for older version of dask-sql as it is now being pinned
         # https://github.com/dask-contrib/dask-sql/issues/302
         if record_name == "dask-sql":
-            dask_sql_map = {"0.1.0rc2": "2.26.0", "0.1.2": "2.30.0", "0.2.0": "2.30.0", "0.2.2": "2.30.0", 
+            dask_sql_map = {"0.1.0rc2": "2.26.0", "0.1.2": "2.30.0", "0.2.0": "2.30.0", "0.2.2": "2.30.0",
                             "0.3.0": "2021.1.0", "0.3.1": "2021.2.0", "0.3.2": "2021.4.0", "0.3.3": "2021.4.1",
                             "0.3.4": "2021.4.1", "0.3.6": "2021.5.0", "0.3.9": "2021.8.0", "0.4.0": "2021.10.0"}
             if record["version"] in ["0.1.0rc2", "0.1.2", "0.2.0", "0.2.2", "0.3.0", "0.3.1"]:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

It turns out we have been removing the feature attached to different ruby versions for a long time. This PR fixes the bug in the repodata patching to restore it. 

xref: https://github.com/conda-forge/ruby-feedstock/issues/90

cc @conda-forge/core @conda-forge/ruby

<!--
Please add any other relevant info below:
-->

Here is the diff

```
$ python recipe/show_diff.py 
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata.json.bz2
linux-64::ruby-2.3.3-0.tar.bz2
+  "track_features": "rb233",
linux-64::ruby-2.4.1-0.tar.bz2
+  "track_features": "rb241",
linux-64::ruby-2.4.2-0.tar.bz2
+  "track_features": "rb242",
linux-64::ruby-2.4.2-1.tar.bz2
+  "track_features": "rb242",
linux-64::ruby-2.4.2-2.tar.bz2
+  "track_features": "rb242",
linux-64::ruby-2.4.3-0.tar.bz2
+  "track_features": "rb243",
linux-64::ruby-2.4.4-0.tar.bz2
+  "track_features": "rb244",
linux-64::ruby-2.4.4-h0825b16_1.tar.bz2
+  "track_features": "rb244",
linux-64::ruby-2.4.4-h54e3902_1001.tar.bz2
+  "track_features": "rb244",
linux-64::ruby-2.4.5-h48a8d5d_1002.tar.bz2
+  "track_features": "rb245",
linux-64::ruby-2.4.5-h48a8d5d_1003.tar.bz2
+  "track_features": "rb245",
linux-64::ruby-2.4.5-h54e3902_1000.tar.bz2
+  "track_features": "rb245",
linux-64::ruby-2.4.5-haa072f8_1001.tar.bz2
+  "track_features": "rb245",
linux-64::ruby-2.4.5-hfe99ee1_1001.tar.bz2
+  "track_features": "rb245",
linux-64::ruby-2.5.5-h48a8d5d_0.tar.bz2
+  "track_features": "rb255",
linux-64::ruby-2.5.5-h48a8d5d_1.tar.bz2
+  "track_features": "rb25",
linux-64::ruby-2.5.7-h305c5c1_0.tar.bz2
+  "track_features": "rb25",
linux-64::ruby-2.5.7-he592edb_2.tar.bz2
+  "track_features": "rb25",
linux-64::ruby-2.5.7-he88a7e3_1.tar.bz2
+  "track_features": "rb25",
linux-64::ruby-2.6.3-hda29b87_0.tar.bz2
+  "track_features": "rb26",
linux-64::ruby-2.6.5-h305c5c1_0.tar.bz2
+  "track_features": "rb26",
linux-64::ruby-2.6.6-he592edb_2.tar.bz2
+  "track_features": "rb26",
linux-64::ruby-2.6.6-he88a7e3_1.tar.bz2
+  "track_features": "rb26",
linux-64::ruby-2.6.6-hebe951e_0.tar.bz2
+  "track_features": "rb26",
linux-64::ruby-2.7.2-h0b71e51_0.tar.bz2
+  "track_features": "rb27",
linux-64::ruby-2.7.2-h0b71e51_1.tar.bz2
+  "track_features": "rb27",
linux-64::ruby-2.7.2-h0b71e51_2.tar.bz2
+  "track_features": "rb27",
linux-64::ruby-2.7.2-h86e321c_4.tar.bz2
+  "track_features": "rb27",
linux-64::ruby-2.7.2-h86e321c_5.tar.bz2
+  "track_features": "rb27",
linux-64::ruby-2.7.2-h86e321c_6.tar.bz2
+  "track_features": "rb27",
linux-64::ruby-2.7.2-h86e321c_7.tar.bz2
+  "track_features": "rb27",
linux-64::ruby-2.7.2-he592edb_3.tar.bz2
+  "track_features": "rb27",
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata.json.bz2
linux-aarch64::ruby-2.4.5-h48a8d5d_1002.tar.bz2
+  "track_features": "rb245",
linux-aarch64::ruby-2.4.5-h48a8d5d_1003.tar.bz2
+  "track_features": "rb245",
linux-aarch64::ruby-2.4.5-hfe99ee1_1001.tar.bz2
+  "track_features": "rb245",
linux-aarch64::ruby-2.5.5-h48a8d5d_0.tar.bz2
+  "track_features": "rb255",
linux-aarch64::ruby-2.5.5-h48a8d5d_1.tar.bz2
+  "track_features": "rb25",
linux-aarch64::ruby-2.5.7-h305c5c1_0.tar.bz2
+  "track_features": "rb25",
linux-aarch64::ruby-2.5.7-h4f61043_1.tar.bz2
+  "track_features": "rb25",
linux-aarch64::ruby-2.5.7-h9a605c1_2.tar.bz2
+  "track_features": "rb25",
linux-aarch64::ruby-2.6.3-hda29b87_0.tar.bz2
+  "track_features": "rb26",
linux-aarch64::ruby-2.6.5-h305c5c1_0.tar.bz2
+  "track_features": "rb26",
linux-aarch64::ruby-2.6.6-h4f61043_1.tar.bz2
+  "track_features": "rb26",
linux-aarch64::ruby-2.6.6-h9a605c1_2.tar.bz2
+  "track_features": "rb26",
linux-aarch64::ruby-2.6.6-hebe951e_0.tar.bz2
+  "track_features": "rb26",
linux-aarch64::ruby-2.7.2-h3fc8c45_4.tar.bz2
+  "track_features": "rb27",
linux-aarch64::ruby-2.7.2-h3fc8c45_5.tar.bz2
+  "track_features": "rb27",
linux-aarch64::ruby-2.7.2-h3fc8c45_6.tar.bz2
+  "track_features": "rb27",
linux-aarch64::ruby-2.7.2-h3fc8c45_7.tar.bz2
+  "track_features": "rb27",
linux-aarch64::ruby-2.7.2-h82393f8_3.tar.bz2
+  "track_features": "rb27",
linux-aarch64::ruby-2.7.2-h9a605c1_3.tar.bz2
+  "track_features": "rb27",
linux-aarch64::ruby-2.7.2-hd541762_0.tar.bz2
+  "track_features": "rb27",
linux-aarch64::ruby-2.7.2-he3d551f_1.tar.bz2
+  "track_features": "rb27",
linux-aarch64::ruby-2.7.2-he3d551f_2.tar.bz2
+  "track_features": "rb27",
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata.json.bz2
linux-ppc64le::ruby-2.4.5-h5148a6c_1002.tar.bz2
+  "track_features": "rb245",
linux-ppc64le::ruby-2.4.5-h5148a6c_1003.tar.bz2
+  "track_features": "rb245",
linux-ppc64le::ruby-2.4.5-h6eeaf35_1001.tar.bz2
+  "track_features": "rb245",
linux-ppc64le::ruby-2.5.5-h5148a6c_0.tar.bz2
+  "track_features": "rb255",
linux-ppc64le::ruby-2.5.5-h5148a6c_1.tar.bz2
+  "track_features": "rb25",
linux-ppc64le::ruby-2.5.7-h0e6bad5_1.tar.bz2
+  "track_features": "rb25",
linux-ppc64le::ruby-2.5.7-h751cfdf_2.tar.bz2
+  "track_features": "rb25",
linux-ppc64le::ruby-2.5.7-hbf02937_0.tar.bz2
+  "track_features": "rb25",
linux-ppc64le::ruby-2.6.3-h5148a6c_0.tar.bz2
+  "track_features": "rb26",
linux-ppc64le::ruby-2.6.5-hbf02937_0.tar.bz2
+  "track_features": "rb26",
linux-ppc64le::ruby-2.6.6-h0e6bad5_1.tar.bz2
+  "track_features": "rb26",
linux-ppc64le::ruby-2.6.6-h6fd65d8_0.tar.bz2
+  "track_features": "rb26",
linux-ppc64le::ruby-2.6.6-h751cfdf_2.tar.bz2
+  "track_features": "rb26",
linux-ppc64le::ruby-2.7.2-h751cfdf_3.tar.bz2
+  "track_features": "rb27",
linux-ppc64le::ruby-2.7.2-ha4e8978_5.tar.bz2
+  "track_features": "rb27",
linux-ppc64le::ruby-2.7.2-ha4e8978_6.tar.bz2
+  "track_features": "rb27",
linux-ppc64le::ruby-2.7.2-ha4e8978_7.tar.bz2
+  "track_features": "rb27",
linux-ppc64le::ruby-2.7.2-hc0c9bf3_0.tar.bz2
+  "track_features": "rb27",
linux-ppc64le::ruby-2.7.2-hc0c9bf3_1.tar.bz2
+  "track_features": "rb27",
linux-ppc64le::ruby-2.7.2-hc0c9bf3_2.tar.bz2
+  "track_features": "rb27",
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata.json.bz2
osx-64::ruby-2.3.3-0.tar.bz2
+  "track_features": "rb233",
osx-64::ruby-2.4.1-0.tar.bz2
+  "track_features": "rb241",
osx-64::ruby-2.4.2-0.tar.bz2
+  "track_features": "rb242",
osx-64::ruby-2.4.2-1.tar.bz2
+  "track_features": "rb242",
osx-64::ruby-2.4.2-2.tar.bz2
+  "track_features": "rb242",
osx-64::ruby-2.4.3-0.tar.bz2
+  "track_features": "rb243",
osx-64::ruby-2.4.4-0.tar.bz2
+  "track_features": "rb244",
osx-64::ruby-2.4.4-h0825b16_1.tar.bz2
+  "track_features": "rb244",
osx-64::ruby-2.4.4-hcc41e92_1001.tar.bz2
+  "track_features": "rb244",
osx-64::ruby-2.4.5-h28fbfb0_1002.tar.bz2
+  "track_features": "rb245",
osx-64::ruby-2.4.5-h28fbfb0_1003.tar.bz2
+  "track_features": "rb245",
osx-64::ruby-2.4.5-h3d91b9f_1001.tar.bz2
+  "track_features": "rb245",
osx-64::ruby-2.4.5-hcc41e92_1000.tar.bz2
+  "track_features": "rb245",
osx-64::ruby-2.4.5-hf4e25d5_1001.tar.bz2
+  "track_features": "rb245",
osx-64::ruby-2.5.5-h28fbfb0_0.tar.bz2
+  "track_features": "rb255",
osx-64::ruby-2.5.5-h28fbfb0_1.tar.bz2
+  "track_features": "rb25",
osx-64::ruby-2.5.7-h7556230_1.tar.bz2
+  "track_features": "rb25",
osx-64::ruby-2.5.7-h7f52a13_0.tar.bz2
+  "track_features": "rb25",
osx-64::ruby-2.5.7-hf0cbd5d_2.tar.bz2
+  "track_features": "rb25",
osx-64::ruby-2.6.3-h59af721_0.tar.bz2
+  "track_features": "rb26",
osx-64::ruby-2.6.5-h7f52a13_0.tar.bz2
+  "track_features": "rb26",
osx-64::ruby-2.6.6-h24dd4e1_0.tar.bz2
+  "track_features": "rb26",
osx-64::ruby-2.6.6-h7556230_1.tar.bz2
+  "track_features": "rb26",
osx-64::ruby-2.6.6-hf0cbd5d_2.tar.bz2
+  "track_features": "rb26",
osx-64::ruby-2.7.2-h1c0b240_4.tar.bz2
+  "track_features": "rb27",
osx-64::ruby-2.7.2-h1c0b240_5.tar.bz2
+  "track_features": "rb27",
osx-64::ruby-2.7.2-h1c0b240_6.tar.bz2
+  "track_features": "rb27",
osx-64::ruby-2.7.2-h1c0b240_7.tar.bz2
+  "track_features": "rb27",
osx-64::ruby-2.7.2-h36135d8_3.tar.bz2
+  "track_features": "rb27",
osx-64::ruby-2.7.2-h6c43213_0.tar.bz2
+  "track_features": "rb27",
osx-64::ruby-2.7.2-h6c43213_1.tar.bz2
+  "track_features": "rb27",
osx-64::ruby-2.7.2-h6c43213_2.tar.bz2
+  "track_features": "rb27",
osx-64::ruby-2.7.2-h76fc513_3.tar.bz2
+  "track_features": "rb27",
osx-64::ruby-2.7.2-hf0cbd5d_3.tar.bz2
+  "track_features": "rb27",
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata.json.bz2
osx-arm64::ruby-2.7.2-h39ff962_4.tar.bz2
+  "track_features": "rb27",
osx-arm64::ruby-2.7.2-h39ff962_5.tar.bz2
+  "track_features": "rb27",
osx-arm64::ruby-2.7.2-h39ff962_6.tar.bz2
+  "track_features": "rb27",
osx-arm64::ruby-2.7.2-h39ff962_7.tar.bz2
+  "track_features": "rb27",
osx-arm64::ruby-2.7.2-h6b02988_3.tar.bz2
+  "track_features": "rb27",
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata.json.bz2
win-64::ruby-2.7.2-h1d9c0f5_6.tar.bz2
+  "track_features": "rb27",
win-64::ruby-2.7.2-h1d9c0f5_7.tar.bz2
+  "track_features": "rb27",
win-64::ruby-2.7.2-h8b1b97a_0.tar.bz2
+  "track_features": "rb27",
win-64::ruby-2.7.2-h8b1b97a_1.tar.bz2
+  "track_features": "rb27",
win-64::ruby-2.7.2-h8b1b97a_2.tar.bz2
+  "track_features": "rb27",
win-64::ruby-2.7.2-h8b1b97a_3.tar.bz2
+  "track_features": "rb27",
win-64::ruby-2.7.2-h8b1b97a_4.tar.bz2
+  "track_features": "rb27",
win-64::ruby-2.7.2-h8b1b97a_5.tar.bz2
+  "track_features": "rb27",
win-64::ruby-2.7.2-h8b1b97a_6.tar.bz2
+  "track_features": "rb27",
```
