### PR TITLE
Tighten pin on libunwind

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -851,7 +851,6 @@ def _gen_new_index(repodata, subdir):
             _replace_pin('vector-classes >=1.4.1,<1.5.0a0', 'vector-classes >=1.4.1,<1.4.2a0', deps, record)
 
         _pin_stricter(fn, record, 'libunwind', 'x.x')
-        _replace_pin('libunwind >=1.2.1,<1.3.0a0', 'libunwind >=1.2.1,<2.0.0a0', deps, record)
         _replace_pin('snappy >=1.1.7,<1.1.8.0a0', 'snappy >=1.1.7,<2.0.0.0a0', deps, record)
         _replace_pin('ncurses >=6.1,<6.2.0a0', 'ncurses >=6.1,<6.3.0a0', deps, record)
         _replace_pin('abseil-cpp', 'abseil-cpp ==20190808.*', deps, record)

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -850,7 +850,8 @@ def _gen_new_index(repodata, subdir):
             # ROOT requires vector-classes to be the exact same version as the one used for the build
             _replace_pin('vector-classes >=1.4.1,<1.5.0a0', 'vector-classes >=1.4.1,<1.4.2a0', deps, record)
 
-        _pin_stricter(fn, record, 'libunwind', 'x.x')
+        if has_dep(record, "libunwind"):
+            _pin_stricter(fn, record, 'libunwind', 'x.x')
         _replace_pin('snappy >=1.1.7,<1.1.8.0a0', 'snappy >=1.1.7,<2.0.0.0a0', deps, record)
         _replace_pin('ncurses >=6.1,<6.2.0a0', 'ncurses >=6.1,<6.3.0a0', deps, record)
         _replace_pin('abseil-cpp', 'abseil-cpp ==20190808.*', deps, record)

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -850,6 +850,7 @@ def _gen_new_index(repodata, subdir):
             # ROOT requires vector-classes to be the exact same version as the one used for the build
             _replace_pin('vector-classes >=1.4.1,<1.5.0a0', 'vector-classes >=1.4.1,<1.4.2a0', deps, record)
 
+        _replace_pin('libunwind >=1.5.0,<2.0a0', 'libunwind >=1.5.0,<1.6a0', deps, record)
         _replace_pin('libunwind >=1.2.1,<1.3.0a0', 'libunwind >=1.2.1,<2.0.0a0', deps, record)
         _replace_pin('snappy >=1.1.7,<1.1.8.0a0', 'snappy >=1.1.7,<2.0.0.0a0', deps, record)
         _replace_pin('ncurses >=6.1,<6.2.0a0', 'ncurses >=6.1,<6.3.0a0', deps, record)

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -850,7 +850,7 @@ def _gen_new_index(repodata, subdir):
             # ROOT requires vector-classes to be the exact same version as the one used for the build
             _replace_pin('vector-classes >=1.4.1,<1.5.0a0', 'vector-classes >=1.4.1,<1.4.2a0', deps, record)
 
-        _replace_pin('libunwind >=1.5.0,<2.0a0', 'libunwind >=1.5.0,<1.6a0', deps, record)
+        _pin_stricter(fn, record, 'libunwind', 'x.x')
         _replace_pin('libunwind >=1.2.1,<1.3.0a0', 'libunwind >=1.2.1,<2.0.0a0', deps, record)
         _replace_pin('snappy >=1.1.7,<1.1.8.0a0', 'snappy >=1.1.7,<2.0.0.0a0', deps, record)
         _replace_pin('ncurses >=6.1,<6.2.0a0', 'ncurses >=6.1,<6.3.0a0', deps, record)


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
In conda-forge/libunwind-feedstock#19 we decided to tighten the pin on libunwind from 'x' to 'x.x'. This PR introduces the corresponding repodata patch.

cc @jakirkham 