### PR TITLE
update openlibm dep for julia versions

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1231,6 +1231,13 @@ def _gen_new_index(repodata, subdir):
         if record_name == "sphinx" and (record["version"].startswith("3.") or record["version"].startswith("2.")):
             deps = record["depends"]
             _replace_pin("docutils >=0.12", "docutils >=0.12,<0.17", deps, record)
+            
+        # Retroactively pin a max version of openlibm for julia 1.6.* and 1.7.*:
+        # https://github.com/conda-forge/julia-feedstock/issues/169
+        # timestamp: 29 December 2021 (osx-64/julia-1.7.1-h132cb31_1.tar.bz2) (+ 1)
+        if record_name == "julia" and record["version"].startswith(("1.6", "1.7")) and record.get("timestamp", 0) < 1640819858392:
+            deps = record["depends"]
+            _replace_pin("openlibm", "openlibm <0.8.0", deps, record)
 
         # Retroactively pin Python < 3.10 for some older noarch Pony packages, since Pony depends on the parser
         # module removed in 3.10: https://github.com/conda-forge/pony-feedstock/pull/20


### PR DESCRIPTION
I have no idea what I am doing. 

We want to fix this: https://github.com/conda-forge/julia-feedstock/issues/169

This is not exactly a replace_pin situation, we just need to add a pin to openlibm... but I copied from the one above it.

```            
_replace_pin("openlibm", "openlibm <0.8.0", deps, record)
```


<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
