### PR TITLE
Patch taurus upper bound for sardana <3.2

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -685,6 +685,13 @@ def _gen_new_index(repodata, subdir):
                 i = record['depends'].index('chemfiles-lib 0.10.*')
                 record['depends'][i] = 'chemfiles-lib >=0.10.1,<0.11'
 
+        # sardana <3.2 (meaning 3.0 and 3.1) should depend on taurus <5
+        # https://github.com/conda-forge/sardana-feedstock/pull/8
+        if record_name == "sardana" and record['version'].startswith(('3.0.', '3.1.')):
+            if 'taurus >=4.7.0' in record['depends']:
+                i = record['depends'].index('taurus >=4.7.0')
+                record['depends'][i] = 'taurus >=4.7.0,<5'
+
         # fix deps with wrong names
         if record_name in proj4_fixes:
             _rename_dependency(fn, record, "proj.4", "proj4")


### PR DESCRIPTION
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

Taurus 5 broke sardana <3.2.
I pushed a new build to fix the latest version (3.1.3): https://github.com/conda-forge/sardana-feedstock/pull/8
But that doesn't seem to be the proper way to fix such issue. conda is still installing the previous build by default: https://github.com/conda/conda/issues/11140

Patching the repodata seems to be the way to fix all existing sardana packages.
