### PR TITLE
Pin gct at x.x.x

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -869,6 +869,9 @@ def _gen_new_index(repodata, subdir):
             i = record['depends'].index('pythia8')
             record['depends'][i] = 'pythia8 >=8.240,<8.300.0a0'
 
+        # gct should have been pinned at x.x.x rather than x.x
+        _replace_pin('gct >=6.2.1550507116,<6.3.0a0', "gct >=6.2.1550507116,<6.2.1550507117", deps, record)
+
         # remove features for openjdk and rb2
         if ("track_features" in record and
                 record['track_features'] is not None):


### PR DESCRIPTION
The feedstock has been fixed in https://github.com/conda-forge/gct-feedstock/pull/5

<details><summary>Click for diff</summary>
<p>

```
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata.json.bz2
linux-64::cgsi-gsoap-1.3.11-h7c3e21f_3.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::cgsi-gsoap-1.3.11-h876a3cc_2.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::cgsi-gsoap-1.3.11-hc0f3447_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::cgsi-gsoap-1.3.11-he1b5a44_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::dcap-2.47.12-h6ffcb39_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::dcap-2.47.12-h810856c_2.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::dcap-2.47.12-h8cbf542_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::dcap-2.47.12-hd35416c_3.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::gfal2-2.16.2-h0b19a1f_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::gfal2-2.16.3-h9d57a96_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::gfal2-2.16.4-h0b19a1f_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::gfal2-2.17.1-h0b19a1f_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::gfal2-2.17.2-he6f68f7_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::gfal2-2.17.3-hce9acd5_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::gfal2-2.17.3-he6f68f7_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::gfal2-2.18.0-hce9acd5_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::gfal2-2.18.1-h222f431_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::gfal2-2.18.1-hce9acd5_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::gfal2-2.18.2-h222f431_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::gfal2-2.18.2-h222f431_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::gfal2-2.19.0-h13c04c2_2.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::gfal2-2.19.0-h2073588_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::gfal2-2.19.0-hc59f63d_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::gfal2-2.19.1-h13c04c2_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::gfal2-2.19.2-h13c04c2_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::gfal2-2.20.0-h1f80e55_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::gfal2-2.20.0-h8fb145e_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::gfal2-2.20.1-h1f80e55_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::gfal2-2.20.2-h1f80e55_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::htcondor-8.9.3-hfd73749_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::libcondor_utils-8.9.10-h84da495_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::libcondor_utils-8.9.10-haa0fcd8_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::libcondor_utils-8.9.11-h722fe0d_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::libcondor_utils-8.9.11-h722fe0d_2.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::libcondor_utils-8.9.11-haa0fcd8_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::libcondor_utils-8.9.13-h722fe0d_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::libcondor_utils-8.9.3-hae2777f_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::libcondor_utils-8.9.3-hae2777f_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::libcondor_utils-8.9.4-hae2777f_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::libcondor_utils-8.9.5-h0636c6a_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::libcondor_utils-8.9.5-h0636c6a_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::libcondor_utils-8.9.5-h0636c6a_2.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::libcondor_utils-8.9.5-ha92cf40_3.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::libcondor_utils-8.9.7-h9cd45e6_2.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::libcondor_utils-8.9.8-h9cd45e6_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::libcondor_utils-8.9.9-h84da495_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::libcondor_utils-8.9.9-h84da495_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::libcondor_utils-8.9.9-h84da495_2.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::libcondor_utils-8.9.9-h84da495_3.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::libcondor_utils-9.0.0-h6d110fb_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::libcondor_utils-9.0.0-h722fe0d_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::libcondor_utils-9.0.1-h6d110fb_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::libcondor_utils-9.0.1-h6d110fb_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::libcondor_utils-9.0.2-h6d110fb_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::libcondor_utils-9.0.3-h6d110fb_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::libcondor_utils-9.0.4-h6d110fb_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::libcondor_utils-9.0.5-h6d110fb_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::libcondor_utils-9.0.6-h09e176a_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::libcondor_utils-9.0.6-h09e176a_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::libcondor_utils-9.0.6-h09e176a_2.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::libcondor_utils-9.0.7-h09e176a_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::libcondor_utils-9.0.8-h09e176a_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::libcondor_utils-9.0.9-h09e176a_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::libcondor_utils-9.1.0-h6d110fb_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::libcondor_utils-9.1.1-h6d110fb_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::libcondor_utils-9.1.2-h6d110fb_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::libcondor_utils-9.1.3-h6d110fb_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::libcondor_utils-9.2.0-h09e176a_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::libcondor_utils-9.2.0-h09e176a_2.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::libcondor_utils-9.2.0-h6d110fb_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::myproxy-6.2.6-h1a494a6_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::myproxy-6.2.6-hae0e180_2.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::myproxy-6.2.6-hb63b18a_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::myproxy-6.2.6-hcd33eae_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::netcdf-fortran-4.5.4-mpi_mpich_h1364a43_0.tar.bz2
-    "mpich >=3.4,<3.5.0a0"
+    "mpich >=3.4,<4.0.0a0"
linux-64::nordugrid-arc-6.10.1-py36h2408eb9_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::nordugrid-arc-6.10.1-py37he710136_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::nordugrid-arc-6.10.1-py38h4e7a8fd_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::nordugrid-arc-6.10.1-py39h5ba6e9b_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::nordugrid-arc-6.10.2-py36h2408eb9_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::nordugrid-arc-6.10.2-py36h2408eb9_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::nordugrid-arc-6.10.2-py36hde41983_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::nordugrid-arc-6.10.2-py37hac5f057_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::nordugrid-arc-6.10.2-py37he710136_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::nordugrid-arc-6.10.2-py37he710136_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::nordugrid-arc-6.10.2-py38h4e7a8fd_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::nordugrid-arc-6.10.2-py38h4e7a8fd_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::nordugrid-arc-6.10.2-py39h5ba6e9b_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::nordugrid-arc-6.10.2-py39h5ba6e9b_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::nordugrid-arc-6.11.0-py36h2408eb9_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::nordugrid-arc-6.11.0-py36hde41983_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::nordugrid-arc-6.11.0-py37hac5f057_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::nordugrid-arc-6.11.0-py37he710136_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::nordugrid-arc-6.11.0-py38h4e7a8fd_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::nordugrid-arc-6.11.0-py39h5ba6e9b_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::nordugrid-arc-6.12.0-py36h2408eb9_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::nordugrid-arc-6.12.0-py36h2408eb9_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::nordugrid-arc-6.12.0-py36hde41983_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::nordugrid-arc-6.12.0-py37hac5f057_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::nordugrid-arc-6.12.0-py37hac5f057_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::nordugrid-arc-6.12.0-py37he710136_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::nordugrid-arc-6.12.0-py37he710136_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::nordugrid-arc-6.12.0-py38h4e7a8fd_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::nordugrid-arc-6.12.0-py38h4e7a8fd_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::nordugrid-arc-6.12.0-py39h5ba6e9b_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::nordugrid-arc-6.12.0-py39h5ba6e9b_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::nordugrid-arc-6.13.0-py36h2408eb9_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::nordugrid-arc-6.13.0-py36h36067e2_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::nordugrid-arc-6.13.0-py37h9639c1f_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::nordugrid-arc-6.13.0-py37hac5f057_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::nordugrid-arc-6.13.0-py37hbd025bc_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::nordugrid-arc-6.13.0-py37he710136_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::nordugrid-arc-6.13.0-py38h4e7a8fd_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::nordugrid-arc-6.13.0-py38he6a428e_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::nordugrid-arc-6.13.0-py39h5ba6e9b_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::nordugrid-arc-6.13.0-py39he7f02fc_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::nordugrid-arc-6.14.0-py37h24436a8_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::nordugrid-arc-6.14.0-py37h3943c3c_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::nordugrid-arc-6.14.0-py38h7f133e7_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::nordugrid-arc-6.14.0-py39h598e57a_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::nordugrid-arc-6.6.0-py27h810f38a_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::nordugrid-arc-6.6.0-py36h12870f5_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::nordugrid-arc-6.6.0-py36h720dcbd_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::nordugrid-arc-6.6.0-py36h720dcbd_2.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::nordugrid-arc-6.6.0-py37h04533e7_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::nordugrid-arc-6.6.0-py37h04533e7_2.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::nordugrid-arc-6.6.0-py37h0b72734_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::nordugrid-arc-6.6.0-py38h3501bcc_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::nordugrid-arc-6.6.0-py38h3501bcc_2.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::nordugrid-arc-6.6.0-py38hd916450_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::nordugrid-arc-6.7.0-py36h720dcbd_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::nordugrid-arc-6.7.0-py36h720dcbd_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::nordugrid-arc-6.7.0-py37h04533e7_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::nordugrid-arc-6.7.0-py37h04533e7_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::nordugrid-arc-6.7.0-py38h3501bcc_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::nordugrid-arc-6.7.0-py38h3501bcc_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::nordugrid-arc-6.7.0-py39hca6ba81_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::nordugrid-arc-6.8.0-py36h4f48863_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::nordugrid-arc-6.8.0-py37h4819a6c_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::nordugrid-arc-6.8.0-py38hf9050d6_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::nordugrid-arc-6.8.0-py39ha9b8d36_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::nordugrid-arc-6.9.0-py36h4f48863_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::nordugrid-arc-6.9.0-py36h79d4b58_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::nordugrid-arc-6.9.0-py37h4819a6c_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::nordugrid-arc-6.9.0-py37had67ebd_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::nordugrid-arc-6.9.0-py38h0eb77c6_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::nordugrid-arc-6.9.0-py38hf9050d6_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::nordugrid-arc-6.9.0-py39h7be0378_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::nordugrid-arc-6.9.0-py39ha9b8d36_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::srm-ifce-1.24.4-h1918567_2.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::srm-ifce-1.24.4-h1918567_3.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::srm-ifce-1.24.4-haa990c0_4.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::srm-ifce-1.24.5-h6a173cf_2.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::srm-ifce-1.24.5-h9da80fa_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::srm-ifce-1.24.5-h9da80fa_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-64::triqs_tprf-3.0.0-py37ha9ac67e_3.tar.bz2
-    "mpich >=3.3.2,<3.4.0a0",
+    "mpich >=3.3.2,<4.0.0a0",
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata.json.bz2
linux-aarch64::cgsi-gsoap-1.3.11-h1d91377_2.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-aarch64::cgsi-gsoap-1.3.11-hc12dc33_3.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-aarch64::dcap-2.47.12-h068fd6a_3.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-aarch64::dcap-2.47.12-hb27a016_2.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-aarch64::gfal2-2.18.2-h24cbb39_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-aarch64::gfal2-2.19.0-h4e8e17d_2.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-aarch64::gfal2-2.19.0-h5b52bfc_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-aarch64::gfal2-2.19.0-h68db98b_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-aarch64::gfal2-2.19.1-h4e8e17d_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-aarch64::gfal2-2.19.2-h4e8e17d_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-aarch64::gfal2-2.20.0-h32dea9a_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-aarch64::gfal2-2.20.0-h800c28a_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-aarch64::gfal2-2.20.1-h32dea9a_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-aarch64::gfal2-2.20.2-h32dea9a_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-aarch64::myproxy-6.2.6-h4c45cb4_2.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-aarch64::myproxy-6.2.6-hedfde9b_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-aarch64::netcdf-fortran-4.5.4-mpi_mpich_h73dc111_0.tar.bz2
-    "mpich >=3.4,<3.5.0a0"
+    "mpich >=3.4,<4.0.0a0"
linux-aarch64::nordugrid-arc-6.10.2-py36ha0979cd_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-aarch64::nordugrid-arc-6.10.2-py36hea6e7b3_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-aarch64::nordugrid-arc-6.10.2-py37h5a0f755_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-aarch64::nordugrid-arc-6.10.2-py37hcbf6507_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-aarch64::nordugrid-arc-6.10.2-py38hbe72161_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-aarch64::nordugrid-arc-6.10.2-py39h01c793c_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-aarch64::nordugrid-arc-6.11.0-py36ha0979cd_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-aarch64::nordugrid-arc-6.11.0-py37h5a0f755_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-aarch64::nordugrid-arc-6.11.0-py37hcbf6507_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-aarch64::nordugrid-arc-6.11.0-py38hbe72161_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-aarch64::nordugrid-arc-6.12.0-py36ha0979cd_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-aarch64::nordugrid-arc-6.12.0-py36hea6e7b3_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-aarch64::nordugrid-arc-6.12.0-py36hea6e7b3_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-aarch64::nordugrid-arc-6.12.0-py37hcbf6507_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-aarch64::nordugrid-arc-6.12.0-py38hbe72161_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-aarch64::nordugrid-arc-6.12.0-py38hbe72161_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-aarch64::nordugrid-arc-6.12.0-py39h01c793c_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-aarch64::nordugrid-arc-6.12.0-py39h01c793c_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-aarch64::nordugrid-arc-6.14.0-py37h1771c39_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-aarch64::nordugrid-arc-6.14.0-py37h54097b7_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-aarch64::nordugrid-arc-6.14.0-py38h176402b_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-aarch64::nordugrid-arc-6.14.0-py39ha1c2c60_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-aarch64::srm-ifce-1.24.4-h48ae755_3.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-aarch64::srm-ifce-1.24.4-h7da838a_4.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-aarch64::srm-ifce-1.24.5-h6bed747_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-aarch64::srm-ifce-1.24.5-h6bed747_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-aarch64::srm-ifce-1.24.5-ha86951d_2.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata.json.bz2
linux-ppc64le::cgsi-gsoap-1.3.11-h6ed317e_3.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-ppc64le::cgsi-gsoap-1.3.11-hc2f0735_2.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-ppc64le::dcap-2.47.12-h3d6c4c6_3.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-ppc64le::dcap-2.47.12-hb757787_2.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-ppc64le::gfal2-2.18.2-hfb10a53_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-ppc64le::gfal2-2.19.0-h29a8f13_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-ppc64le::gfal2-2.19.0-h7b03761_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-ppc64le::gfal2-2.19.0-h829670e_2.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-ppc64le::gfal2-2.19.1-h829670e_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-ppc64le::gfal2-2.19.2-h829670e_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-ppc64le::gfal2-2.20.0-h487f21e_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-ppc64le::gfal2-2.20.0-he386ba5_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-ppc64le::gfal2-2.20.1-he386ba5_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-ppc64le::gfal2-2.20.2-he386ba5_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-ppc64le::myproxy-6.2.6-h31180f2_2.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-ppc64le::myproxy-6.2.6-h51de1b8_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-ppc64le::nordugrid-arc-6.10.2-py36h0ce30d7_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-ppc64le::nordugrid-arc-6.10.2-py36hef17d14_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-ppc64le::nordugrid-arc-6.10.2-py37h9585aa0_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-ppc64le::nordugrid-arc-6.10.2-py37hf3eed16_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-ppc64le::nordugrid-arc-6.10.2-py38h0d4bf41_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-ppc64le::nordugrid-arc-6.10.2-py39h113e502_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-ppc64le::nordugrid-arc-6.11.0-py36h0ce30d7_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-ppc64le::nordugrid-arc-6.11.0-py36hef17d14_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-ppc64le::nordugrid-arc-6.11.0-py37h9585aa0_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-ppc64le::nordugrid-arc-6.11.0-py37hf3eed16_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-ppc64le::nordugrid-arc-6.11.0-py38h0d4bf41_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-ppc64le::nordugrid-arc-6.11.0-py39h113e502_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-ppc64le::nordugrid-arc-6.12.0-py36h0ce30d7_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-ppc64le::nordugrid-arc-6.12.0-py36h0ce30d7_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-ppc64le::nordugrid-arc-6.12.0-py36hef17d14_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-ppc64le::nordugrid-arc-6.12.0-py37h9585aa0_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-ppc64le::nordugrid-arc-6.12.0-py37h9585aa0_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-ppc64le::nordugrid-arc-6.12.0-py37hf3eed16_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-ppc64le::nordugrid-arc-6.12.0-py37hf3eed16_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-ppc64le::nordugrid-arc-6.12.0-py38h0d4bf41_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-ppc64le::nordugrid-arc-6.12.0-py38h0d4bf41_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-ppc64le::nordugrid-arc-6.12.0-py39h113e502_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-ppc64le::nordugrid-arc-6.12.0-py39h113e502_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-ppc64le::nordugrid-arc-6.13.0-py36h0ce30d7_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-ppc64le::nordugrid-arc-6.13.0-py36ha59457d_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-ppc64le::nordugrid-arc-6.13.0-py37h837c58f_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-ppc64le::nordugrid-arc-6.13.0-py37h9585aa0_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-ppc64le::nordugrid-arc-6.13.0-py37hd3711db_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-ppc64le::nordugrid-arc-6.13.0-py37hf3eed16_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-ppc64le::nordugrid-arc-6.13.0-py38h0d4bf41_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-ppc64le::nordugrid-arc-6.13.0-py38h726b1fa_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-ppc64le::nordugrid-arc-6.13.0-py39h113e502_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-ppc64le::nordugrid-arc-6.13.0-py39h5031811_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-ppc64le::nordugrid-arc-6.14.0-py37ha5a21c1_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-ppc64le::nordugrid-arc-6.14.0-py37he061a38_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-ppc64le::nordugrid-arc-6.14.0-py38h6bd1bec_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-ppc64le::nordugrid-arc-6.14.0-py39hb0f8fe0_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-ppc64le::srm-ifce-1.24.4-hab2fa68_4.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-ppc64le::srm-ifce-1.24.4-hbf1aaca_3.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-ppc64le::srm-ifce-1.24.5-h5213e8c_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-ppc64le::srm-ifce-1.24.5-h5213e8c_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
linux-ppc64le::srm-ifce-1.24.5-h839158f_2.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata.json.bz2
osx-64::cgsi-gsoap-1.3.11-h0b3f5a6_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
osx-64::cgsi-gsoap-1.3.11-h0f8828b_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
osx-64::cgsi-gsoap-1.3.11-h944e745_2.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
osx-64::cgsi-gsoap-1.3.11-h946b130_3.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
osx-64::cgsi-gsoap-1.3.11-hb4e54c4_2.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
osx-64::conduit-0.8.0-py36hec5f891_0.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
osx-64::conduit-0.8.0-py37hb77c8a2_0.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
osx-64::conduit-0.8.0-py38h9ad073c_0.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
osx-64::conduit-0.8.0-py39h16e84d1_0.tar.bz2
-    "mpich >=3.4,<3.5.0a0",
+    "mpich >=3.4,<4.0.0a0",
osx-64::dcap-2.47.12-h018274a_2.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
osx-64::dcap-2.47.12-h40676f4_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
osx-64::dcap-2.47.12-h5ea53dc_2.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
osx-64::dcap-2.47.12-hadb22e3_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
osx-64::dcap-2.47.12-hb660d76_3.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
osx-64::gfal2-2.16.2-h052c31c_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
osx-64::gfal2-2.16.3-h052c31c_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
osx-64::gfal2-2.16.4-h052c31c_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
osx-64::gfal2-2.17.1-hbf46c15_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
osx-64::gfal2-2.17.2-h6d8fb7c_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
osx-64::gfal2-2.17.3-h05927f6_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
osx-64::gfal2-2.17.3-haa6fc1b_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
osx-64::gfal2-2.18.0-h05927f6_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
osx-64::gfal2-2.18.1-h05927f6_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
osx-64::gfal2-2.18.1-hf23c568_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
osx-64::gfal2-2.18.2-h61fe49c_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
osx-64::gfal2-2.18.2-h87e1bae_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
osx-64::gfal2-2.18.2-he1104bc_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
osx-64::gfal2-2.19.0-h7d87502_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
osx-64::gfal2-2.19.0-haa5923f_2.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
osx-64::gfal2-2.19.0-hbe9b908_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
osx-64::gfal2-2.19.1-hf73b1cf_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
osx-64::gfal2-2.19.2-hf73b1cf_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
osx-64::gfal2-2.20.0-hb15e1aa_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
osx-64::gfal2-2.20.0-hbdfc938_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
osx-64::gfal2-2.20.1-hc5feaaf_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
osx-64::gfal2-2.20.2-hc5feaaf_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
osx-64::netcdf-fortran-4.5.4-mpi_mpich_h29158c3_0.tar.bz2
-    "mpich >=3.4,<3.5.0a0"
+    "mpich >=3.4,<4.0.0a0"
osx-64::srm-ifce-1.24.4-h26ff78c_2.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
osx-64::srm-ifce-1.24.4-h26ff78c_3.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
osx-64::srm-ifce-1.24.4-he8db970_3.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
osx-64::srm-ifce-1.24.4-hf992733_4.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
osx-64::srm-ifce-1.24.5-h53d357d_1.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
osx-64::srm-ifce-1.24.5-h718c821_0.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
osx-64::srm-ifce-1.24.5-he1d9a56_2.tar.bz2
-    "gct >=6.2.1550507116,<6.3.0a0",
+    "gct >=6.2.1550507116,<6.2.1550507117",
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata.json.bz2
osx-arm64::netcdf-fortran-4.5.4-mpi_mpich_h0ff5fcd_0.tar.bz2
-    "mpich >=3.4,<3.5.0a0"
+    "mpich >=3.4,<4.0.0a0"
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata.json.bz2
```

</p>
</details>
