### PR TITLE
patch holoview <=1.14.7 to <py310

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1290,6 +1290,13 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             elif record["version"] == "0.7.14":
                 _replace_pin("python >=2.7", "python >=2.7,<3.10", deps, record)
 
+        # Retroactively pin hloviews to Python < 3.10 b/c they import Callable directly and that was removed in py310.
+        # This is already fixed in next verision of holoviews >1.14.7 (unrelease).
+        if record_name == "holoviews":
+            deps = record["depends"]
+            if  record['version'] <= "1.14.7":
+                _replace_pin("python", "python >=2.7,<3.10", deps, record)
+
         if record_name == "tsnecuda":
             # These have dependencies like
             # - libfaiss * *_cuda


### PR DESCRIPTION
It has been a while since the last time I sent a PR like this one. I appreciate someone taking a look if I got everything right.

More context in https://discourse.holoviz.org/t/datashading-is-not-available-error-with-python-3-10-2/3333

The next, still unreleased, version of holoviews fixed this issue and we should be OK limiting the patch to versions 1.14.7 and below.