### PR TITLE
patch flang 5.0.0 to add proper clangdev * flang*

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1297,6 +1297,13 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             elif record["version"] == "0.7.14":
                 _replace_pin("python >=2.7", "python >=2.7,<3.10", deps, record)
 
+        # Properly depend on clangdev 5.0.0 flang* for flang 5.0
+        if record_name == "flang":
+            deps = record["depends"]
+            if  record['version'] == "5.0.0":
+                deps += ["clangdev * flang*"]
+
+
         if record_name == "tsnecuda":
             # These have dependencies like
             # - libfaiss * *_cuda


### PR DESCRIPTION
This is the diff:

```
linux-64::flang-5.0.0-1.tar.bz2
-    "openmp ==5.0.0"
+    "openmp ==5.0.0",
+    "clangdev * flang*"
linux-64::flang-5.0.0-20180101.tar.bz2
-    "openmp ==5.0.0"
+    "openmp ==5.0.0",
+    "clangdev * flang*"
linux-64::flang-5.0.0-20180207.tar.bz2
-    "openmp ==5.0.0"
+    "openmp ==5.0.0",
+    "clangdev * flang*"
linux-64::flang-5.0.0-20180208.tar.bz2
-    "openmp ==5.0.0"
+    "openmp ==5.0.0",
+    "clangdev * flang*"
linux-64::flang-5.0.0-hfc679d8_20180525.tar.bz2
-    "openmp 5.0.0"
+    "openmp 5.0.0",
+    "clangdev * flang*"
linux-64::hypre-2.24.0-mpi_mpich_h0faba72_0.tar.bz2
-    "mpich >=3.3.2,<3.4.0a0"
+    "mpich >=3.3.2,<4.0.0a0"
linux-64::hypre-2.24.0-mpi_openmpi_h3e9f1a4_0.tar.bz2
-    "openmpi >=4.0.5,<4.1.0a0"
+    "openmpi >=4.0.5,<5.0.0a0"
win-64::flang-5.0.0-he025d50_20180525.tar.bz2
-    "vc >=14,<15.0a0"
+    "vc >=14,<15.0a0",
+    "clangdev * flang*"
win-64::flang-5.0.0-vc14_1.tar.bz2
-    "vc 14"
+    "vc 14",
+    "clangdev * flang*"
win-64::flang-5.0.0-vc14_20180101.tar.bz2
-    "vc 14"
+    "vc 14",
+    "clangdev * flang*"
win-64::flang-5.0.0-vc14_20180207.tar.bz2
-    "vc 14"
+    "vc 14",
+    "clangdev * flang*"
win-64::flang-5.0.0-vc14_20180208.tar.bz2
-    "vc 14"
+    "vc 14",
+    "clangdev * flang*"
```