### PR TITLE
patch wrong run_export for ffmpeg 4.3

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -785,7 +785,9 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
         if any(dep == "libflang" or dep.startswith("libflang >=5.0.0") for dep in deps) and record.get('timestamp', 0) < 1611789153000:
             record["depends"].append("libflang <6.0.0.a0")
 
-        if any(dep == "ffmpeg" for dep in deps) and record.get('timestamp', 0) < 1645603462892:
+        # fix run_export from packages built against 4.3; it's corrected now, but the solver
+        # may potentially still pick up an old ffmpeg-build as build dep for something else
+        if any(dep.startswith(f"ffmpeg >=4.3.{p},<5.0a0") for dep in deps for p in [0, 1, 2]):
             # https://github.com/conda-forge/ffmpeg-feedstock/pull/115#issuecomment-1020619231
             record["depends"].append("ffmpeg <4.4")
 

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -787,7 +787,7 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
 
         # fix run_export from packages built against 4.3; it's corrected now, but the solver
         # may potentially still pick up an old ffmpeg-build as build dep for something else
-        if any(dep == f"ffmpeg >=4.3.{p},<5.0a0" for dep in deps for p in [0, 1, 2]):
+        if any(dep == f"ffmpeg >=4.3.{p},<5.0a0" for dep in deps for p in [0, 1, 2]) and record.get('timestamp', 0) < 1645651093167:
             # https://github.com/conda-forge/ffmpeg-feedstock/pull/115#issuecomment-1020619231
             _pin_stricter(fn, record, "ffmpeg", "x.x")
 

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -785,6 +785,10 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
         if any(dep == "libflang" or dep.startswith("libflang >=5.0.0") for dep in deps) and record.get('timestamp', 0) < 1611789153000:
             record["depends"].append("libflang <6.0.0.a0")
 
+        if any(dep == "ffmpeg" for dep in deps) and record.get('timestamp', 0) < 1645603462892:
+            # https://github.com/conda-forge/ffmpeg-feedstock/pull/115#issuecomment-1020619231
+            record["depends"].append("ffmpeg <4.4")
+
         if any(dep.startswith("libignition-") or dep == 'libsdformat' for dep in deps):
             for dep_idx, _ in enumerate(deps):
                 dep = record['depends'][dep_idx]

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -787,9 +787,9 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
 
         # fix run_export from packages built against 4.3; it's corrected now, but the solver
         # may potentially still pick up an old ffmpeg-build as build dep for something else
-        if any(dep.startswith(f"ffmpeg >=4.3.{p},<5.0a0") for dep in deps for p in [0, 1, 2]):
+        if any(dep == f"ffmpeg >=4.3.{p},<5.0a0" for dep in deps for p in [0, 1, 2]):
             # https://github.com/conda-forge/ffmpeg-feedstock/pull/115#issuecomment-1020619231
-            record["depends"].append("ffmpeg <4.4")
+            _pin_stricter(fn, record, "ffmpeg", "x.x")
 
         if any(dep.startswith("libignition-") or dep == 'libsdformat' for dep in deps):
             for dep_idx, _ in enumerate(deps):


### PR DESCRIPTION
Following the steps outlined [here](https://github.com/conda-forge/ffmpeg-feedstock/pull/115#issuecomment-1020619231).

Timestamp will need adjusting until after the builds of https://github.com/conda-forge/ffmpeg-feedstock/pull/119 go live.