### PR TITLE
Fix depends of python-benedict version 0.25.0

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1365,6 +1365,21 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                         _dep_parts = list(_dep_parts) + ["<3.5.0a0"]
                     depends[i] = " ".join(_dep_parts)
                 record["depends"] = depends
+
+        # Fix depends for python-benedict 0.25.0, see https://github.com/conda-forge/python-benedict-feedstock/pull/11
+        if record_name == "python-benedict" and record["version"] == "0.25.0" and record["build_number"] == 0:
+            _replace_pin("ftfy", "ftfy >=6.0.0,<7.0.0", record["depends"], record)
+            _replace_pin("mailchecker", "mailchecker >=4.1.0,<5.0.0", record["depends"], record)
+            _replace_pin("phonenumbers", "phonenumbers >=8.12.0,<9.0.0", record["depends"], record)
+            _replace_pin("python >=3.4", "python >=3.6", record["depends"], record)
+            _replace_pin("python-dateutil", "python-dateutil >=2.8.0,<3.0.0", record["depends"], record)
+            _replace_pin("python-fsutil", "python-fsutil >=0.6.0,<1.0.0", record["depends"], record)
+            _replace_pin("python-slugify", "python-slugify >=6.0.1,<7.0.0", record["depends"], record)
+            _replace_pin("pyyaml", "pyyaml >=6.0,<7.0", record["depends"], record)
+            _replace_pin("requests", "requests >=2.26.0,<3.0.0", record["depends"], record)
+            record["depends"].remove("six")
+            _replace_pin("toml", "toml >=0.10.2,<1.0.0", record["depends"], record)
+            _replace_pin("xmltodict", "xmltodict >=0.12.0,<1.0.0", record["depends"], record)
     return index
 
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

I ran `pip check` on one of our internal packages and it told me the requirements of [python-benedict](https://github.com/conda-forge/python-benedict-feedstock) did not match, so I made the PR https://github.com/conda-forge/python-benedict-feedstock/pull/11 to update them. However this new build number is not used, as it requirements are obviously a lot stricter. I followed the instructions at https://conda-forge.org/docs/maintainer/updating_pkgs.html#removing-broken-packages to create this PR and also patch the requirements of the initial bump number.

<!--
Please add any other relevant info below:
-->
Here is the diff:
```shell
python show_diff.py
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata.json.bz2
noarch::python-benedict-0.25.0-pyhd8ed1ab_0.tar.bz2
-    "ftfy",
-    "mailchecker",
-    "phonenumbers",
-    "python >=3.4",
-    "python-dateutil",
-    "python-fsutil",
-    "python-slugify",
-    "pyyaml",
-    "requests",
-    "six",
-    "toml",
-    "xmltodict"
+    "ftfy >=6.0.0,<7.0.0",
+    "mailchecker >=4.1.0,<5.0.0",
+    "phonenumbers >=8.12.0,<9.0.0",
+    "python >=3.6",
+    "python-dateutil >=2.8.0,<3.0.0",
+    "python-fsutil >=0.6.0,<1.0.0",
+    "python-slugify >=6.0.1,<7.0.0",
+    "pyyaml >=6.0,<7.0",
+    "requests >=2.26.0,<3.0.0",
+    "toml >=0.10.2,<1.0.0",
+    "xmltodict >=0.12.0,<1.0.0"
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata.json.bz2
```