### PR TITLE
Add missing __glibc dependency for libgdal

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1380,6 +1380,12 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             record["depends"].remove("six")
             _replace_pin("toml", "toml >=0.10.2,<1.0.0", record["depends"], record)
             _replace_pin("xmltodict", "xmltodict >=0.12.0,<1.0.0", record["depends"], record)
+
+        if (record_name == "libgdal"
+            and subdir == "linux-64"
+            and record["version"] == "3.4.1"
+            and record["build_number"] == 3):
+            record["depends"].insert(0, "__glibc >=2.17,<3.0.a0")
     return index
 
 


### PR DESCRIPTION
In conda-forge/gdal-feedstock#604 (build number 3 of version 3.4.1), a new sysroot for linux64 builds was introduced for gdal.
Due to confusion from the multi-output nature of the recipe, the correct sysroot dependency was included in the top-level dependencies, but missing from the `libgdal` output. As a consequence, the `libgdal` package is missing the runtime dependency on `__glibc >=2.17`.

The correct dependency was introduced for build numbers >=4 in conda-forge/gdal-feedstock#607, but build number 3 needs a repodata fix to avoid breakage on systems with older glibc.

Closes conda-forge/gdal-feedstock#606