### PR TITLE
Hotfix `panel` packages to constrain `setuptools`

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1048,6 +1048,21 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                 new_depends.append("setuptools <60.0.0")
             record["depends"] = new_depends
 
+        # setuptools started raising a warning when using `LooseVersion` from distutils
+        # since packages don't tend to pin setuptools, this raises warnings in old versions
+        # https://github.com/conda-forge/conda-forge.github.io/issues/1575
+        if (
+            record_name == "panel"
+            and record.get("timestamp", 0) < 1648623600000  # 2022-03-30
+        ):
+            new_depends = record.get("depends", [])
+            if "setuptools" in new_depends:
+                i = new_depends.index("setuptools")
+                new_depends[i] = "setuptools >=42,<61"
+            else:
+                new_depends.append("setuptools >=42,<61")
+            record["depends"] = new_depends
+
         # old CDTs with the conda_cos6 or conda_cos7 name in the sysroot need to
         # conflict with the new CDT and compiler packages
         # all of the new CDTs and compilers depend on the sysroot_{subdir} packages


### PR DESCRIPTION
Hotfixes `panel` packages to require & constrain `setuptools` ( https://github.com/conda-forge/panel-feedstock/pull/48 )

cc @conda-forge/panel

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
