### PR TITLE
Add `click` / `__linux` constraints to older dask-cuda versions

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1402,7 +1402,7 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
         # issues in click 8.1.0 cause failures for older versions of dask-cuda
         if record_name == "dask-cuda" and record.get("timestamp", 0) <= 1645130882435:  # 22.2.0 and prior
             new_depends = record.get("depends", [])
-            new_depends += ["click <8.1", "__unix"]
+            new_depends += ["click ==8.0.4", "__unix"]
             record["depends"] = new_depends
 
     return index

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1398,6 +1398,13 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             _replace_pin("flake8 >=3.5", "flake8 >=4.0", record["depends"], record)
             _replace_pin("pytest >=3.5", "pytest >=7.0", record["depends"], record)
 
+        # older versions of dask-cuda do not work on non-UNIX operating systems and must be constrained to UNIX
+        # issues in click 8.1.0 cause failures for older versions of dask-cuda
+        if record_name == "dask-cuda" and record.get("timestamp", 0) <= 1645130882435:  # 22.2.0 and prior
+            new_depends = record.get("depends", [])
+            new_depends += ["click <8.1", "__unix"]
+            record["depends"] = new_depends
+
     return index
 
 

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1402,7 +1402,7 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
         # issues in click 8.1.0 cause failures for older versions of dask-cuda
         if record_name == "dask-cuda" and record.get("timestamp", 0) <= 1645130882435:  # 22.2.0 and prior
             new_depends = record.get("depends", [])
-            new_depends += ["click ==8.0.4", "__unix"]
+            new_depends += ["click ==8.0.4", "__linux"]
             record["depends"] = new_depends
 
     return index


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

xref: https://github.com/conda-forge/dask-cuda-feedstock/pull/9

cc @conda-forge/dask-cuda

<!--
Please add any other relevant info below:
-->
