### PR TITLE
Patch older versions of psiresp to pin dependencies

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1417,6 +1417,19 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             new_depends += ["click ==8.0.4", "__linux"]
             record["depends"] = new_depends
 
+        # Fix pins for psiresp to avoid pulling in very old QCFractal versions
+        # This is fixed from 0.4.2 onwards but should be fixed for older versions too
+        # https://github.com/lilyminium/psiresp/issues/93
+        if record_name == "psiresp" and record["version"] in ["0.3.1", "0.4.0", "0.4.1"]:
+                _replace_pin("qcfractal", "qcfractal >=0.15", record["depends"], record)
+        elif record_name == "psiresp-base":
+            if record["version"] in ["0.3.1", "0.4.0", "0.4.1"]:
+                if record["version"] == "0.3.1" and record["build_number"] == 0:
+                    record["depends"].append("pydantic >=1.9")
+                else:
+                    _replace_pin("pydantic", "pydantic >=1.9", record["depends"], record)
+                    _replace_pin("pydantic >=1.0", "pydantic >=1.9", record["depends"], record)
+
     return index
 
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

While the newest release has pinned these dependencies properly, the older versions should be patched too. 

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Relevant: https://github.com/lilyminium/psiresp/issues/93


```python
python show_diff.py
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata.json.bz2
noarch::psiresp-0.3.1-pyhd8ed1ab_0.tar.bz2
-    "qcfractal",
+    "qcfractal >=0.15",
noarch::psiresp-0.3.1-pyhd8ed1ab_1.tar.bz2
-    "qcfractal",
+    "qcfractal >=0.15",
noarch::psiresp-0.4.0-pyhd8ed1ab_0.tar.bz2
-    "qcfractal",
+    "qcfractal >=0.15",
noarch::psiresp-0.4.1-pyhd8ed1ab_0.tar.bz2
-    "qcfractal",
+    "qcfractal >=0.15",
noarch::psiresp-base-0.3.1-pyhd8ed1ab_0.tar.bz2
-    "tqdm"
+    "tqdm",
+    "pydantic >=1.9"
noarch::psiresp-base-0.3.1-pyhd8ed1ab_2.tar.bz2
-    "pydantic >=1.0",
+    "pydantic >=1.9",
noarch::psiresp-base-0.3.1-pyhd8ed1ab_3.tar.bz2
-    "pydantic >=1.0",
+    "pydantic >=1.9",
noarch::psiresp-base-0.3.1-pyhd8ed1ab_4.tar.bz2
-    "pydantic >=1.0",
+    "pydantic >=1.9",
noarch::psiresp-base-0.4.1-pyhd8ed1ab_1.tar.bz2
-    "pydantic >=1.0",
+    "pydantic >=1.9",
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata.json.bz2
```