### PR TITLE
pin conda-libmamba-solver's req on libmambapy to 0.22.*

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1417,6 +1417,10 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             new_depends += ["click ==8.0.4", "__linux"]
             record["depends"] = new_depends
 
+        # libmamba 0.22 introduces API breaking changes
+        # conda-libmamba-solver 22.3.1 and prior are not compatible
+        if record_name == "conda-libmamba-solver" and record.get("timestamp", 0) <= 1650455037727:
+            _replace_pin("libmambapy >=0.22", "libmambapy 0.22.*", record["depends"], record)
     return index
 
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

The upcoming libmamba 0.23 will introduce API breaking changes. Patching requirement here to ensure users of the new solver don't update too early.

cc @wolfv @jezdez 