### PR TITLE
Pin typing-extensions 4.2.0 to python>=3.7

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1421,6 +1421,14 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
         # conda-libmamba-solver 22.3.1 and prior are not compatible
         if record_name == "conda-libmamba-solver" and record.get("timestamp", 0) <= 1650455037727:
             _replace_pin("libmambapy >=0.22", "libmambapy 0.22.*", record["depends"], record)
+
+        # typing-extensions 4.2.0 requires python >=3.7. Build 0 incorrectly specified >=3.6. Fixed in
+        # https://github.com/conda-forge/typing_extensions-feedstock/pull/30
+        if record_name in ["typing-extensions", "typing_extensions"]:
+            if record["version"] == "4.2.0" and record["build"].endswith("_0"):
+                i = record['depends'].index('python >=3.6')
+                record['depends'][i] = 'python >=3.7'
+
     return index
 
 

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1424,10 +1424,9 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
 
         # typing-extensions 4.2.0 requires python >=3.7. Build 0 incorrectly specified >=3.6. Fixed in
         # https://github.com/conda-forge/typing_extensions-feedstock/pull/30
-        if record_name in ["typing-extensions", "typing_extensions"]:
+        if record_name == "typing_extensions":
             if record["version"] == "4.2.0" and record["build"].endswith("_0"):
-                i = record['depends'].index('python >=3.6')
-                record['depends'][i] = 'python >=3.7'
+                _replace_pin("python >=3.6", "python >=3.7", deps, record)
 
     return index
 


### PR DESCRIPTION
Deals with an issue raised in/caused by https://github.com/conda-forge/typing_extensions-feedstock/pull/30

I'm not 100% sure if I composed this correctly, so feedback is very much welcome.