### PR TITLE
Hotfix `altgraph` `0.11.0+` to use `setuptools`

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1274,6 +1274,21 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                 new_constrains.append("cling ==99999999999")
             record["constrains"] = new_constrains
 
+        # altgraph 0.11.0 and newer make use of `pkg_resources`, but
+        # some of the packages previously did not include `setuptools` as
+        # a requirement. This has since been fixed for new `altgraph` packages.
+        # Though older packages need this added as well via a hot-fix.
+        # So handle this here.
+        if (record_name == "altgraph"
+                and record.get("timestamp", 0) <= 1650870000000
+                and (
+                    pkg_resources.parse_version(record["version"]) >=
+                    pkg_resources.parse_version("0.11.0")
+                )):
+            new_depends = record.get("depends", [])
+            new_depends.append("setuptools")
+            record["depends"] = new_depends
+
         # libcugraph 0.19.0 is compatible with the new calver based version 21.x
         if record_name == "cupy":
             _replace_pin("libcugraph >=0.19.0,<1.0a0", "libcugraph >=0.19.0", record.get("constrains", []), record, target='constrains')


### PR DESCRIPTION
Needed as they use `pkg_resources`.

xref: https://github.com/conda-forge/altgraph-feedstock/pull/9

cc @conda-forge/altgraph

<hr>

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
