### PR TITLE
add missing runs for singularity hpc

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1495,7 +1495,7 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
 
         # add missing pins for singularity-hpc
         if record_name == "singularity-hpc" and record.get("timestamp", 0) < 1652410323526:
-            record["depends"].append("jinja2, jsonschema, requests, ruamel.yaml, spython >=0.2.0")
+            record["depends"].append("jinja2", "jsonschema", "requests", "ruamel.yaml", "spython >=0.2.0")
 
     return index
 

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1493,6 +1493,10 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                     else:
                         record["depends"][i] = record["depends"][i] + ",<0.7.0.a0"
 
+        # add missing pins for singularity-hpc
+        if record_name == "singularity-hpc" and record.get("timestamp", 0) < 1652410323526:
+            record["depends"].append("jinja2, jsonschema, requests, ruamel.yaml, spython >=0.2.0")
+
     return index
 
 

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1495,7 +1495,11 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
 
         # add missing pins for singularity-hpc
         if record_name == "singularity-hpc" and record.get("timestamp", 0) < 1652410323526:
-            record["depends"].append("jinja2", "jsonschema", "requests", "ruamel.yaml", "spython >=0.2.0")
+            record["depends"].append("jinja2")
+            record["depends"].append("jsonschema")
+            record["depends"].append("requests")
+            record["depends"].append("ruamel.yaml")
+            record["depends"].append("spython >=0.2.0")
 
     return index
 


### PR DESCRIPTION
fixes https://github.com/conda-forge/singularity-hpc-feedstock/issues/22

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

---

xref: https://github.com/conda-forge/singularity-hpc-feedstock/issues/22 https://github.com/conda-forge/singularity-hpc-feedstock/issues/17 https://github.com/conda-forge/singularity-hpc-feedstock/pull/21

cc @vsoch + @nlvw 

background: some run deps were missing by accident and went unnoticed for a while. Now fixed. I am a maintainer along with vsoch.

relevant diff: 
```diff
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata.json.bz2
noarch::singularity-hpc-0.0.34-pyhd8ed1ab_0.tar.bz2
-    "python >=3.6"
+    "python >=3.6",
+    "jinja2",
+    "jsonschema",
+    "requests",
+    "ruamel.yaml",
+    "spython >=0.2.0"
noarch::singularity-hpc-0.0.37-pyhd8ed1ab_0.tar.bz2
-    "python >=3.6"
+    "python >=3.6",
+    "jinja2",
+    "jsonschema",
+    "requests",
+    "ruamel.yaml",
+    "spython >=0.2.0"
noarch::singularity-hpc-0.0.37-pyhd8ed1ab_1.tar.bz2
-    "python >=3.6"
+    "python >=3.6",
+    "jinja2",
+    "jsonschema",
+    "requests",
+    "ruamel.yaml",
+    "spython >=0.2.0"
noarch::singularity-hpc-0.0.42-pyhd8ed1ab_0.tar.bz2
-    "python >=3.6"
+    "python >=3.6",
+    "jinja2",
+    "jsonschema",
+    "requests",
+    "ruamel.yaml",
+    "spython >=0.2.0"
noarch::singularity-hpc-0.0.43-pyhd8ed1ab_0.tar.bz2
-    "python >=3.6"
+    "python >=3.6",
+    "jinja2",
+    "jsonschema",
+    "requests",
+    "ruamel.yaml",
+    "spython >=0.2.0"
noarch::singularity-hpc-0.0.44-pyhd8ed1ab_0.tar.bz2
-    "python >=3.6"
+    "python >=3.6",
+    "jinja2",
+    "jsonschema",
+    "requests",
+    "ruamel.yaml",
+    "spython >=0.2.0"
noarch::singularity-hpc-0.0.45-pyhd8ed1ab_0.tar.bz2
-    "python >=3.6"
+    "python >=3.6",
+    "jinja2",
+    "jsonschema",
+    "requests",
+    "ruamel.yaml",
+    "spython >=0.2.0"
noarch::singularity-hpc-0.0.46-pyhd8ed1ab_0.tar.bz2
-    "python >=3.6"
+    "python >=3.6",
+    "jinja2",
+    "jsonschema",
+    "requests",
+    "ruamel.yaml",
+    "spython >=0.2.0"
noarch::singularity-hpc-0.0.47-pyhd8ed1ab_0.tar.bz2
-    "python >=3.6"
+    "python >=3.6",
+    "jinja2",
+    "jsonschema",
+    "requests",
+    "ruamel.yaml",
+    "spython >=0.2.0"
noarch::singularity-hpc-0.0.48-pyhd8ed1ab_0.tar.bz2
-    "python >=3.6"
+    "python >=3.6",
+    "jinja2",
+    "jsonschema",
+    "requests",
+    "ruamel.yaml",
+    "spython >=0.2.0"
noarch::singularity-hpc-0.0.49-pyhd8ed1ab_0.tar.bz2
-    "python >=3.6"
+    "python >=3.6",
+    "jinja2",
+    "jsonschema",
+    "requests",
+    "ruamel.yaml",
+    "spython >=0.2.0"
noarch::singularity-hpc-0.0.50-pyhd8ed1ab_0.tar.bz2
-    "python >=3.6"
+    "python >=3.6",
+    "jinja2",
+    "jsonschema",
+    "requests",
+    "ruamel.yaml",
+    "spython >=0.2.0"
noarch::singularity-hpc-0.0.51-pyhd8ed1ab_0.tar.bz2
-    "python >=3.6"
+    "python >=3.6",
+    "jinja2",
+    "jsonschema",
+    "requests",
+    "ruamel.yaml",
+    "spython >=0.2.0"
noarch::singularity-hpc-0.0.52-pyhd8ed1ab_0.tar.bz2
-    "python >=3.6"
+    "python >=3.6",
+    "jinja2",
+    "jsonschema",
+    "requests",
+    "ruamel.yaml",
+    "spython >=0.2.0"
noarch::singularity-hpc-0.0.53-pyhd8ed1ab_0.tar.bz2
-    "python >=3.6"
+    "python >=3.6",
+    "jinja2",
+    "jsonschema",
+    "requests",
+    "ruamel.yaml",
+    "spython >=0.2.0"
noarch::singularity-hpc-0.0.53-pyhd8ed1ab_1.tar.bz2
-    "python >=3.6"
+    "python >=3.6",
+    "jinja2",
+    "jsonschema",
+    "requests",
+    "ruamel.yaml",
+    "spython >=0.2.0"


```

full diff (not sure why the others are showing up...):


<details>

```diff
(3.10) ngam@m142:~/Repos/conda-forge-repodata-patches-feedstock/recipe$ python3 show_diff.py 
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata.json.bz2
noarch::jsonpickle-2.2.0-pyhd8ed1ab_0.tar.bz2
-    "python =2.7|>=3.5"
+    "python ==2.7.*|>=3.5"
noarch::singularity-hpc-0.0.34-pyhd8ed1ab_0.tar.bz2
-    "python >=3.6"
+    "python >=3.6",
+    "jinja2",
+    "jsonschema",
+    "requests",
+    "ruamel.yaml",
+    "spython >=0.2.0"
noarch::singularity-hpc-0.0.37-pyhd8ed1ab_0.tar.bz2
-    "python >=3.6"
+    "python >=3.6",
+    "jinja2",
+    "jsonschema",
+    "requests",
+    "ruamel.yaml",
+    "spython >=0.2.0"
noarch::singularity-hpc-0.0.37-pyhd8ed1ab_1.tar.bz2
-    "python >=3.6"
+    "python >=3.6",
+    "jinja2",
+    "jsonschema",
+    "requests",
+    "ruamel.yaml",
+    "spython >=0.2.0"
noarch::singularity-hpc-0.0.42-pyhd8ed1ab_0.tar.bz2
-    "python >=3.6"
+    "python >=3.6",
+    "jinja2",
+    "jsonschema",
+    "requests",
+    "ruamel.yaml",
+    "spython >=0.2.0"
noarch::singularity-hpc-0.0.43-pyhd8ed1ab_0.tar.bz2
-    "python >=3.6"
+    "python >=3.6",
+    "jinja2",
+    "jsonschema",
+    "requests",
+    "ruamel.yaml",
+    "spython >=0.2.0"
noarch::singularity-hpc-0.0.44-pyhd8ed1ab_0.tar.bz2
-    "python >=3.6"
+    "python >=3.6",
+    "jinja2",
+    "jsonschema",
+    "requests",
+    "ruamel.yaml",
+    "spython >=0.2.0"
noarch::singularity-hpc-0.0.45-pyhd8ed1ab_0.tar.bz2
-    "python >=3.6"
+    "python >=3.6",
+    "jinja2",
+    "jsonschema",
+    "requests",
+    "ruamel.yaml",
+    "spython >=0.2.0"
noarch::singularity-hpc-0.0.46-pyhd8ed1ab_0.tar.bz2
-    "python >=3.6"
+    "python >=3.6",
+    "jinja2",
+    "jsonschema",
+    "requests",
+    "ruamel.yaml",
+    "spython >=0.2.0"
noarch::singularity-hpc-0.0.47-pyhd8ed1ab_0.tar.bz2
-    "python >=3.6"
+    "python >=3.6",
+    "jinja2",
+    "jsonschema",
+    "requests",
+    "ruamel.yaml",
+    "spython >=0.2.0"
noarch::singularity-hpc-0.0.48-pyhd8ed1ab_0.tar.bz2
-    "python >=3.6"
+    "python >=3.6",
+    "jinja2",
+    "jsonschema",
+    "requests",
+    "ruamel.yaml",
+    "spython >=0.2.0"
noarch::singularity-hpc-0.0.49-pyhd8ed1ab_0.tar.bz2
-    "python >=3.6"
+    "python >=3.6",
+    "jinja2",
+    "jsonschema",
+    "requests",
+    "ruamel.yaml",
+    "spython >=0.2.0"
noarch::singularity-hpc-0.0.50-pyhd8ed1ab_0.tar.bz2
-    "python >=3.6"
+    "python >=3.6",
+    "jinja2",
+    "jsonschema",
+    "requests",
+    "ruamel.yaml",
+    "spython >=0.2.0"
noarch::singularity-hpc-0.0.51-pyhd8ed1ab_0.tar.bz2
-    "python >=3.6"
+    "python >=3.6",
+    "jinja2",
+    "jsonschema",
+    "requests",
+    "ruamel.yaml",
+    "spython >=0.2.0"
noarch::singularity-hpc-0.0.52-pyhd8ed1ab_0.tar.bz2
-    "python >=3.6"
+    "python >=3.6",
+    "jinja2",
+    "jsonschema",
+    "requests",
+    "ruamel.yaml",
+    "spython >=0.2.0"
noarch::singularity-hpc-0.0.53-pyhd8ed1ab_0.tar.bz2
-    "python >=3.6"
+    "python >=3.6",
+    "jinja2",
+    "jsonschema",
+    "requests",
+    "ruamel.yaml",
+    "spython >=0.2.0"
noarch::singularity-hpc-0.0.53-pyhd8ed1ab_1.tar.bz2
-    "python >=3.6"
+    "python >=3.6",
+    "jinja2",
+    "jsonschema",
+    "requests",
+    "ruamel.yaml",
+    "spython >=0.2.0"
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata.json.bz2
linux-64::clang-9.0.1-cling_v0.9_hf01e6bc_5.tar.bz2
-  "version": "9.0.1"
+  "version": "9.0.1",
+  "constrains": [
+    "clang-tools 9.0.1.*",
+    "llvm 9.0.1.*",
+    "llvm-tools 9.0.1.*",
+    "llvmdev 9.0.1.*"
+  ]
linux-64::clang-9.0.1-default_hbe8b877_5.tar.bz2
-  "version": "9.0.1"
+  "version": "9.0.1",
+  "constrains": [
+    "clang-tools 9.0.1.*",
+    "llvm 9.0.1.*",
+    "llvm-tools 9.0.1.*",
+    "llvmdev 9.0.1.*"
+  ]
linux-64::clang-9.0.1-hcc_h82011ae_5.tar.bz2
-  "version": "9.0.1"
+  "version": "9.0.1",
+  "constrains": [
+    "clang-tools 9.0.1.*",
+    "llvm 9.0.1.*",
+    "llvm-tools 9.0.1.*",
+    "llvmdev 9.0.1.*"
+  ]
linux-64::clang-9.0.1-root_62600_h868c9f8_5.tar.bz2
-  "version": "9.0.1"
+  "version": "9.0.1",
+  "constrains": [
+    "clang-tools 9.0.1.*",
+    "llvm 9.0.1.*",
+    "llvm-tools 9.0.1.*",
+    "llvmdev 9.0.1.*"
+  ]
linux-64::clang-tools-9.0.1-cling_v0.9_h1e27157_5.tar.bz2
-    "clangdev 9.0.1"
+    "clangdev 9.0.1",
+    "clang 9.0.1.*",
+    "llvm 9.0.1.*",
+    "llvm-tools 9.0.1.*",
+    "llvmdev 9.0.1.*"
linux-64::clang-tools-9.0.1-default_hb4e5071_5.tar.bz2
-    "clangdev 9.0.1"
+    "clangdev 9.0.1",
+    "clang 9.0.1.*",
+    "llvm 9.0.1.*",
+    "llvm-tools 9.0.1.*",
+    "llvmdev 9.0.1.*"
linux-64::clang-tools-9.0.1-hcc_h17000f2_5.tar.bz2
-    "clangdev 9.0.1"
+    "clangdev 9.0.1",
+    "clang 9.0.1.*",
+    "llvm 9.0.1.*",
+    "llvm-tools 9.0.1.*",
+    "llvmdev 9.0.1.*"
linux-64::clang-tools-9.0.1-root_62600_hbecedfc_5.tar.bz2
-    "clangdev 9.0.1"
+    "clangdev 9.0.1",
+    "clang 9.0.1.*",
+    "llvm 9.0.1.*",
+    "llvm-tools 9.0.1.*",
+    "llvmdev 9.0.1.*"
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata.json.bz2
linux-aarch64::clang-9.0.1-cling_v0.9_h250126e_5.tar.bz2
-  "version": "9.0.1"
+  "version": "9.0.1",
+  "constrains": [
+    "clang-tools 9.0.1.*",
+    "llvm 9.0.1.*",
+    "llvm-tools 9.0.1.*",
+    "llvmdev 9.0.1.*"
+  ]
linux-aarch64::clang-9.0.1-default_hd38b72d_5.tar.bz2
-  "version": "9.0.1"
+  "version": "9.0.1",
+  "constrains": [
+    "clang-tools 9.0.1.*",
+    "llvm 9.0.1.*",
+    "llvm-tools 9.0.1.*",
+    "llvmdev 9.0.1.*"
+  ]
linux-aarch64::clang-9.0.1-hcc_h14310ea_5.tar.bz2
-  "version": "9.0.1"
+  "version": "9.0.1",
+  "constrains": [
+    "clang-tools 9.0.1.*",
+    "llvm 9.0.1.*",
+    "llvm-tools 9.0.1.*",
+    "llvmdev 9.0.1.*"
+  ]
linux-aarch64::clang-9.0.1-root_62600_h9b4965b_5.tar.bz2
-  "version": "9.0.1"
+  "version": "9.0.1",
+  "constrains": [
+    "clang-tools 9.0.1.*",
+    "llvm 9.0.1.*",
+    "llvm-tools 9.0.1.*",
+    "llvmdev 9.0.1.*"
+  ]
linux-aarch64::clang-tools-9.0.1-cling_v0.9_h1c6f7d2_5.tar.bz2
-    "clangdev 9.0.1"
+    "clangdev 9.0.1",
+    "clang 9.0.1.*",
+    "llvm 9.0.1.*",
+    "llvm-tools 9.0.1.*",
+    "llvmdev 9.0.1.*"
linux-aarch64::clang-tools-9.0.1-default_h39ef1d7_5.tar.bz2
-    "clangdev 9.0.1"
+    "clangdev 9.0.1",
+    "clang 9.0.1.*",
+    "llvm 9.0.1.*",
+    "llvm-tools 9.0.1.*",
+    "llvmdev 9.0.1.*"
linux-aarch64::clang-tools-9.0.1-hcc_h57aad0f_5.tar.bz2
-    "clangdev 9.0.1"
+    "clangdev 9.0.1",
+    "clang 9.0.1.*",
+    "llvm 9.0.1.*",
+    "llvm-tools 9.0.1.*",
+    "llvmdev 9.0.1.*"
linux-aarch64::clang-tools-9.0.1-root_62600_h4eed805_5.tar.bz2
-    "clangdev 9.0.1"
+    "clangdev 9.0.1",
+    "clang 9.0.1.*",
+    "llvm 9.0.1.*",
+    "llvm-tools 9.0.1.*",
+    "llvmdev 9.0.1.*"
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata.json.bz2
linux-ppc64le::clang-9.0.1-cling_v0.9_h8298d81_5.tar.bz2
-  "version": "9.0.1"
+  "version": "9.0.1",
+  "constrains": [
+    "clang-tools 9.0.1.*",
+    "llvm 9.0.1.*",
+    "llvm-tools 9.0.1.*",
+    "llvmdev 9.0.1.*"
+  ]
linux-ppc64le::clang-9.0.1-default_h7b7c3e3_5.tar.bz2
-  "version": "9.0.1"
+  "version": "9.0.1",
+  "constrains": [
+    "clang-tools 9.0.1.*",
+    "llvm 9.0.1.*",
+    "llvm-tools 9.0.1.*",
+    "llvmdev 9.0.1.*"
+  ]
linux-ppc64le::clang-9.0.1-hcc_hca2a985_5.tar.bz2
-  "version": "9.0.1"
+  "version": "9.0.1",
+  "constrains": [
+    "clang-tools 9.0.1.*",
+    "llvm 9.0.1.*",
+    "llvm-tools 9.0.1.*",
+    "llvmdev 9.0.1.*"
+  ]
linux-ppc64le::clang-9.0.1-root_62600_haddf8a2_5.tar.bz2
-  "version": "9.0.1"
+  "version": "9.0.1",
+  "constrains": [
+    "clang-tools 9.0.1.*",
+    "llvm 9.0.1.*",
+    "llvm-tools 9.0.1.*",
+    "llvmdev 9.0.1.*"
+  ]
linux-ppc64le::clang-tools-9.0.1-cling_v0.9_h91004fa_5.tar.bz2
-    "clangdev 9.0.1"
+    "clangdev 9.0.1",
+    "clang 9.0.1.*",
+    "llvm 9.0.1.*",
+    "llvm-tools 9.0.1.*",
+    "llvmdev 9.0.1.*"
linux-ppc64le::clang-tools-9.0.1-default_hbe158c7_5.tar.bz2
-    "clangdev 9.0.1"
+    "clangdev 9.0.1",
+    "clang 9.0.1.*",
+    "llvm 9.0.1.*",
+    "llvm-tools 9.0.1.*",
+    "llvmdev 9.0.1.*"
linux-ppc64le::clang-tools-9.0.1-hcc_heab48b8_5.tar.bz2
-    "clangdev 9.0.1"
+    "clangdev 9.0.1",
+    "clang 9.0.1.*",
+    "llvm 9.0.1.*",
+    "llvm-tools 9.0.1.*",
+    "llvmdev 9.0.1.*"
linux-ppc64le::clang-tools-9.0.1-root_62600_h7f5fe82_5.tar.bz2
-    "clangdev 9.0.1"
+    "clangdev 9.0.1",
+    "clang 9.0.1.*",
+    "llvm 9.0.1.*",
+    "llvm-tools 9.0.1.*",
+    "llvmdev 9.0.1.*"
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata.json.bz2
osx-64::clang-9.0.1-cling_v0.9_haab2281_5.tar.bz2
-  "version": "9.0.1"
+  "version": "9.0.1",
+  "constrains": [
+    "clang-tools 9.0.1.*",
+    "llvm 9.0.1.*",
+    "llvm-tools 9.0.1.*",
+    "llvmdev 9.0.1.*"
+  ]
osx-64::clang-9.0.1-default_ha9b4ba2_5.tar.bz2
-  "version": "9.0.1"
+  "version": "9.0.1",
+  "constrains": [
+    "clang-tools 9.0.1.*",
+    "llvm 9.0.1.*",
+    "llvm-tools 9.0.1.*",
+    "llvmdev 9.0.1.*"
+  ]
osx-64::clang-9.0.1-root_62600_hd10bec9_5.tar.bz2
-  "version": "9.0.1"
+  "version": "9.0.1",
+  "constrains": [
+    "clang-tools 9.0.1.*",
+    "llvm 9.0.1.*",
+    "llvm-tools 9.0.1.*",
+    "llvmdev 9.0.1.*"
+  ]
osx-64::clang-tools-9.0.1-cling_v0.9_hf3cb47a_5.tar.bz2
-    "clangdev 9.0.1"
+    "clangdev 9.0.1",
+    "clang 9.0.1.*",
+    "llvm 9.0.1.*",
+    "llvm-tools 9.0.1.*",
+    "llvmdev 9.0.1.*"
osx-64::clang-tools-9.0.1-default_h9ebf648_5.tar.bz2
-    "clangdev 9.0.1"
+    "clangdev 9.0.1",
+    "clang 9.0.1.*",
+    "llvm 9.0.1.*",
+    "llvm-tools 9.0.1.*",
+    "llvmdev 9.0.1.*"
osx-64::clang-tools-9.0.1-root_62600_h0c2e8e3_5.tar.bz2
-    "clangdev 9.0.1"
+    "clangdev 9.0.1",
+    "clang 9.0.1.*",
+    "llvm 9.0.1.*",
+    "llvm-tools 9.0.1.*",
+    "llvmdev 9.0.1.*"
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata.json.bz2
osx-arm64::clang-9.0.1-cling_v0.9_h44fdd34_5.tar.bz2
-  "version": "9.0.1"
+  "version": "9.0.1",
+  "constrains": [
+    "clang-tools 9.0.1.*",
+    "llvm 9.0.1.*",
+    "llvm-tools 9.0.1.*",
+    "llvmdev 9.0.1.*"
+  ]
osx-arm64::clang-9.0.1-default_h3e0e8d0_5.tar.bz2
-  "version": "9.0.1"
+  "version": "9.0.1",
+  "constrains": [
+    "clang-tools 9.0.1.*",
+    "llvm 9.0.1.*",
+    "llvm-tools 9.0.1.*",
+    "llvmdev 9.0.1.*"
+  ]
osx-arm64::clang-9.0.1-root_62600_h5aacfb9_5.tar.bz2
-  "version": "9.0.1"
+  "version": "9.0.1",
+  "constrains": [
+    "clang-tools 9.0.1.*",
+    "llvm 9.0.1.*",
+    "llvm-tools 9.0.1.*",
+    "llvmdev 9.0.1.*"
+  ]
osx-arm64::clang-tools-9.0.1-cling_v0.9_h3879569_5.tar.bz2
-    "clangdev 9.0.1"
+    "clangdev 9.0.1",
+    "clang 9.0.1.*",
+    "llvm 9.0.1.*",
+    "llvm-tools 9.0.1.*",
+    "llvmdev 9.0.1.*"
osx-arm64::clang-tools-9.0.1-default_h44db89b_5.tar.bz2
-    "clangdev 9.0.1"
+    "clangdev 9.0.1",
+    "clang 9.0.1.*",
+    "llvm 9.0.1.*",
+    "llvm-tools 9.0.1.*",
+    "llvmdev 9.0.1.*"
osx-arm64::clang-tools-9.0.1-root_62600_h0622346_5.tar.bz2
-    "clangdev 9.0.1"
+    "clangdev 9.0.1",
+    "clang 9.0.1.*",
+    "llvm 9.0.1.*",
+    "llvm-tools 9.0.1.*",
+    "llvmdev 9.0.1.*"
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata.json.bz2
win-64::clang-9.0.1-cling_v0.9_hcb30860_5.tar.bz2
-  "version": "9.0.1"
+  "version": "9.0.1",
+  "constrains": [
+    "clang-tools 9.0.1.*",
+    "llvm 9.0.1.*",
+    "llvm-tools 9.0.1.*",
+    "llvmdev 9.0.1.*"
+  ]
win-64::clang-9.0.1-default_h0b140f2_5.tar.bz2
-  "version": "9.0.1"
+  "version": "9.0.1",
+  "constrains": [
+    "clang-tools 9.0.1.*",
+    "llvm 9.0.1.*",
+    "llvm-tools 9.0.1.*",
+    "llvmdev 9.0.1.*"
+  ]
win-64::clang-tools-9.0.1-cling_v0.9_hd1e6b3a_5.tar.bz2
-    "clangdev 9.0.1"
+    "clangdev 9.0.1",
+    "clang 9.0.1.*",
+    "llvm 9.0.1.*",
+    "llvm-tools 9.0.1.*",
+    "llvmdev 9.0.1.*"
win-64::clang-tools-9.0.1-default_h7ecdb74_5.tar.bz2
-    "clangdev 9.0.1"
+    "clangdev 9.0.1",
+    "clang 9.0.1.*",
+    "llvm 9.0.1.*",
+    "llvm-tools 9.0.1.*",
+    "llvmdev 9.0.1.*"

```
</details>
