### PR TITLE
Patch up the builds of ffmpeg that are built without a run exports for svt-av1

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1154,7 +1154,7 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                 "fsspec >=0.8.0" in record["depends"]):
             i = record["depends"].index("fsspec >=0.8.0")
             record["depends"][i] = "fsspec >=0.9.0,<0.10.0"
-            
+
         # Version constraints for python and xarray in xgcm 0.7.0 build 0 were incorrect
         # Has been corrected on the feedstock in https://github.com/conda-forge/xgcm-feedstock/pull/13/files
         if (record_name == "xgcm" and record["version"] == "0.7.0" and record["build_number"] == 0):
@@ -1492,6 +1492,14 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                         _pin_stricter(fn, record, "metadetect", "x.x", "0.7.0")
                     else:
                         record["depends"][i] = record["depends"][i] + ",<0.7.0.a0"
+
+        if any(dep.startswith("svt-av1") for dep in deps):
+            # hmaarrfk -- 2022/05/18
+            # These packages were built with svt-av1 0.8.7 or 0.9
+            # These two versions of svt seem to be compatible with each
+            # other, but they are not compatible with the recently
+            # released 1.1.0
+            _replace_pin("svt-av1", "svt-av1 <1.0.0a0", record["depends"], record)
 
     return index
 


### PR DESCRIPTION
see: https://github.com/conda-forge/svt-av1-feedstock/issues/12#issuecomment-1130603936

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
