### PR TITLE
Add track features to the pytorch cpu builds to deprioritize them

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1468,6 +1468,15 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                                     if not c.startswith("qt ")]
             record["constrains"].append("qt 5.15.2|5.15.3|5.15.4")
 
+        if record_name == "pytorch" and \
+                record["version"] == "1.11.0" and \
+                record["build_number"] <= 1:
+            if record['build'].startswith('cpu'):
+                record["track_features"] = "pytorch-cpu"
+            if record['build'].startswith('cuda'):
+                if '__cuda' not in record['depends']:
+                    record['depends'].append('__cuda')
+
         # tifffile 2022.2.2 and more recent versions requires python >=3.8.
         # See https://github.com/conda-forge/tifffile-feedstock/issues/93
         # Fixed in https://github.com/conda-forge/tifffile-feedstock/pull/94


### PR DESCRIPTION
Should be merged in conjunction with: https://github.com/conda-forge/pytorch-cpu-feedstock/pull/105


Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
