### PR TITLE
fix libstdcxx requirement for libmamba 0.23.3 for linux-aarch64 as well

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1456,7 +1456,7 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
         if record_name == "conda-libmamba-solver" and record.get("timestamp", 0) <= 1650455037727:
             _replace_pin("libmambapy >=0.22", "libmambapy 0.22.*", record["depends"], record)
 
-        if subdir in ["linux-64", "linux-aarch64"] and \
+        if subdir in ["linux-64", "linux-aarch64", "linux-ppc64le"] and \
             record_name in {"libmamba", "libmambapy"} \
             and record.get("version", 0) == "0.23.3":
             _replace_pin("libstdcxx-ng >=10.3.0", "libstdcxx-ng >=12.1.0", record["depends"], record)

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1456,7 +1456,7 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
         if record_name == "conda-libmamba-solver" and record.get("timestamp", 0) <= 1650455037727:
             _replace_pin("libmambapy >=0.22", "libmambapy 0.22.*", record["depends"], record)
 
-        if subdir == "linux-64" and \
+        if subdir in ["linux-64", "linux-aarch64"] and \
             record_name in {"libmamba", "libmambapy"} \
             and record.get("version", 0) == "0.23.3":
             _replace_pin("libstdcxx-ng >=10.3.0", "libstdcxx-ng >=12.1.0", record["depends"], record)


### PR DESCRIPTION
This is a follow-up for https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/264. Apparently the same bug exists on linux-aarch64

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
