### PR TITLE
Limit older conda-build releases to conda <4.13.0

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1514,6 +1514,22 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             # released 1.1.0
             _replace_pin("svt-av1", "svt-av1 <1.0.0a0", record["depends"], record)
 
+        # Code removed in conda 4.13.0 broke older conda-build releases;
+        # x-ref issue: conda/conda-build#4481
+        if record_name == "conda-build" and (
+                pkg_resources.parse_version(record["version"]) <=
+                pkg_resources.parse_version("3.21.7") or
+                # backported fix in 3.21.8, build 1
+                # (PR: conda-forge/conda-build-feedstock#176)
+                record["version"] == "3.21.8" and record["build_number"] == 0
+                ):
+            for i, dep in enumerate(record["depends"]):
+                dep_name, *dep_other = dep.split()
+                if dep_name == "conda" and ",<" not in dep:
+                    record["depends"][i] = "{} {}<4.13.0".format(
+                        dep_name, dep_other[0] + "," if dep_other else ""
+                        )
+
     return index
 
 


### PR DESCRIPTION
Conda 4.13.0 removed some deprecated code that broke older releases of conda-build (xref: conda/conda-build#4481).  A patch was back-ported to conda-build 3.21.8 build 1 (conda-forge/conda-build-feedstock#176), but older versions need repodata patching so they don't unexpectedly break.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
