### PR TITLE
Pin Pillow's compatibility with libtiff stricter. Only good till 4.3

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1499,6 +1499,13 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                     else:
                         record["depends"][i] = record["depends"][i] + ",<0.7.0.a0"
 
+        if record_name == "pillow":
+            if pkg_resources.parse_version(record["version"]) < pkg_resources.parse_version("9.1.1"):
+                _pin_stricter(fn, record, "libtiff", "x", upper_bound="4.4.0")
+            if pkg_resources.parse_version(record["version"]) == pkg_resources.parse_version("9.1.1"):
+                if record["build_number"] < 1:
+                    _pin_stricter(fn, record, "libtiff", "x", upper_bound="4.4.0")
+
         # add missing pins for singularity-hpc
         if record_name == "singularity-hpc" and record.get("timestamp", 0) < 1652410323526:
             record["depends"].append("jinja2")


### PR DESCRIPTION
@conda-forge/pillow could you please review:

- https://github.com/conda-forge/pillow-feedstock/pull/119
- https://github.com/conda-forge/libtiff-feedstock/pull/76

I've tested locally on linux, that with the patches suggested on the pillow PR, things workout with the new libtiff.


Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
