### PR TITLE
Ensure to constrain pytorch package, always

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1104,22 +1104,36 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
         ):
             _add_pybind11_abi_constraint(fn, record)
 
-        # do some fixes for pytorch, pytorch-cpu & gpu
-        if record_name == "pytorch" and record.get("timestamp", 0) < 1653777188:
+        if record_name == "pytorch":  #  and record.get("timestamp", 0) < 1653777188:
             pversion = pkg_resources.parse_version(record['version'])
             limit_version = pkg_resources.parse_version("1.10.0")
             if record["build"].startswith("cpu_") and pversion < limit_version:
                 if "constrains" not in record:
-                    record["constrains"] = [
-                        "pytorch-gpu = 99999999",
+                    record["constrains"] = []
+                if not any(c.startswith("pytorch-cpu")
+                           for c in record["constrains"]):
+                    record["constrains"].append(
                         f"pytorch-cpu = {record['version']}=*_{record['build_number']}"
-                    ]
+                    )
+                if not any(c.startswith("pytorch-gpu")
+                           for c in record["constrains"]):
+                    record["constrains"].append(
+                        "pytorch-gpu = 99999999"
+                    )
             if record["build"].startswith("cuda") and pversion < limit_version:
                 if "constrains" not in record:
-                    record["constrains"] = [
-                        "pytorch-cpu = 99999999",
+                    record["constrains"] = []
+                if not any(c.startswith("pytorch-gpu")
+                           for c in record["constrains"]):
+                    record["constrains"].append(
                         f"pytorch-gpu = {record['version']}=*_{record['build_number']}"
-                    ]
+                    )
+                if not any(c.startswith("pytorch-cpu")
+                           for c in record["constrains"]):
+                    record["constrains"].append(
+                        "pytorch-cpu = 99999999"
+                    )
+        # do some fixes for pytorch, pytorch-cpu & gpu
         if (
             record_name == "pytorch-cpu"
             and (

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1105,6 +1105,21 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             _add_pybind11_abi_constraint(fn, record)
 
         # do some fixes for pytorch, pytorch-cpu & gpu
+        if record_name == "pytorch" and record.get("timestamp", 0) < 1653777188:
+            pversion = pkg_resources.parse_version(record['version'])
+            limit_version = pkg_resources.parse_version("1.10.0")
+            if record["build"].startswith("cpu_") and pversion < limit_version:
+                if "constrains" not in record:
+                    record["constrains"] = [
+                        "pytorch-gpu = 99999999",
+                        f"pytorch-cpu = {record['version']}=*_{record['build_number']}"
+                    ]
+            if record["build"].startswith("cuda") and pversion < limit_version:
+                if "constrains" not in record:
+                    record["constrains"] = [
+                        "pytorch-cpu = 99999999",
+                        f"pytorch-gpu = {record['version']}=*_{record['build_number']}"
+                    ]
         if (
             record_name == "pytorch-cpu"
             and (


### PR DESCRIPTION
closes https://github.com/conda-forge/pytorch-cpu-feedstock/issues/65

Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
