### PR TITLE
Patch pyzmq upper bound for zerorpc-python

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1485,6 +1485,11 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             _replace_pin("flake8 >=3.5", "flake8 >=4.0", record["depends"], record)
             _replace_pin("pytest >=3.5", "pytest >=7.0", record["depends"], record)
 
+        # pyzmq 23.0.0 broke zerorpc-python
+        # https://github.com/0rpc/zerorpc-python/issues/251
+        if record_name == "zerorpc-python" and record["version"] == "0.6.3":
+            _replace_pin("pyzmq >=13.1.0", "pyzmq >=13.1.0,<23.0.0", record["depends"], record)
+
         # older versions of dask-cuda do not work on non-UNIX operating systems and must be constrained to UNIX
         # issues in click 8.1.0 cause failures for older versions of dask-cuda
         if record_name == "dask-cuda" and record.get("timestamp", 0) <= 1645130882435:  # 22.2.0 and prior

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1487,7 +1487,7 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
 
         # pyzmq 23.0.0 broke zerorpc-python
         # https://github.com/0rpc/zerorpc-python/issues/251
-        if record_name == "zerorpc-python" and record["version"] == "0.6.3":
+        if record_name == "zerorpc-python" and record["version"] == "0.6.3" and record["build_number"] == 0:
             _replace_pin("pyzmq >=13.1.0", "pyzmq >=13.1.0,<23.0.0", record["depends"], record)
 
         # older versions of dask-cuda do not work on non-UNIX operating systems and must be constrained to UNIX

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1488,7 +1488,7 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
         # pyzmq 23.0.0 broke zerorpc-python
         # https://github.com/0rpc/zerorpc-python/issues/251
         if record_name == "zerorpc-python" and record["version"] == "0.6.3" and record["build_number"] == 0:
-            _replace_pin("pyzmq >=13.1.0", "pyzmq >=13.1.0,<23.0.0", record["depends"], record)
+            _replace_pin("pyzmq >=13.1.0", "pyzmq >=13.1.0,!=23.0.0", record["depends"], record)
 
         # older versions of dask-cuda do not work on non-UNIX operating systems and must be constrained to UNIX
         # issues in click 8.1.0 cause failures for older versions of dask-cuda


### PR DESCRIPTION
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.


pyzmq 23.0.0 broke zerorpc-python: https://github.com/0rpc/zerorpc-python/issues/251

```
python show_diff.py --use-cache
noarch::zerorpc-python-0.6.3-pyhd8ed1ab_0.tar.bz2
-    "pyzmq >=13.1.0"
+    "pyzmq >=13.1.0,<23.0.0"
```

The script also shows a bunch of conda changes for mamba:

```
linux-64::mamba-0.24.0-py310hf87f941_1.tar.bz2
-    "conda >=4.8",
+    "conda >=4.8,<4.13.0",
linux-64::mamba-0.24.0-py37h47bf687_1.tar.bz2
-    "conda >=4.8",
+    "conda >=4.8,<4.13.0",
...
```

This was merged 2 days ago: https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/274
Not sure why it is in the diff.