### PR TITLE
Fix to constraining `jinja2 <3` to `markupsafe <2`

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1203,8 +1203,14 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
         # incompatibilities with markupsafe >=2.1 and we are constraining
         # markupsafe <2 to be on the safe side
         # https://github.com/pallets/jinja/issues/1585
-        if record_name == "jinja2" and record['version'].startswith(
-                ('2.9.', '2.10.', '2.11.')):
+        # The constrain was added in 2.11.3 build 1 so we don't want builds
+        # after that.
+        version = record["version"]
+        build = record["build_number"]
+        if record_name == "jinja2" and \
+                (version.startswith(('2.9.', '2.10.')) or 
+                 version in ('2.10', '2.11.0', '2.11.1', '2.11.2') or
+                 (version == '2.11.3' and build == 0)):
             markupsafe = 'markupsafe >=0.23'
             if markupsafe in record['depends']:
                 i = record['depends'].index(markupsafe)


### PR DESCRIPTION
These were missed in
https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/238

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* Bumped the build number (if the version is unchanged)
* Reset the build number to `0` (if the version changed)
* [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
