### PR TITLE
Fixup mamba for conda 4.13.0

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1208,7 +1208,7 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
         version = record["version"]
         build = record["build_number"]
         if record_name == "jinja2" and \
-                (version.startswith(('2.9.', '2.10.')) or 
+                (version.startswith(('2.9.', '2.10.')) or
                  version in ('2.10', '2.11.0', '2.11.1', '2.11.2') or
                  (version == '2.11.3' and build == 0)):
             markupsafe = 'markupsafe >=0.23'
@@ -1585,8 +1585,8 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                         dep_name, dep_other[0] + "," if dep_other else ""
                         )
         if record_name == "mamba" and (
-            pkg_resources.parse_version(record["version"]) <=
-            pkg_resources.parse_version("0.24")):
+            pkg_resources.parse_version(record["version"]) <
+            pkg_resources.parse_version("0.24.0")):
 
             for i, dep in enumerate(record["depends"]):
                 dep_name, *dep_other = dep.split()
@@ -1597,7 +1597,7 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
 
         if record_name == "aesara" and (
             pkg_resources.parse_version(record["version"]) >
-            pkg_resources.parse_version("2.4.0") and 
+            pkg_resources.parse_version("2.4.0") and
             pkg_resources.parse_version(record["version"]) <=
             pkg_resources.parse_version("2.7.1")):
             if record.get("timestamp", 0) <= 1654360235233:

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1586,14 +1586,26 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                         )
         if record_name == "mamba" and (
             pkg_resources.parse_version(record["version"]) <
-            pkg_resources.parse_version("0.24.0")):
-
+            pkg_resources.parse_version("0.24.0") or (
+                (pkg_resources.parse_version(record["version"]) <
+                 pkg_resources.parse_version("0.24.0")) and (
+                     record["build_number"] == 0)
+                 )):
             for i, dep in enumerate(record["depends"]):
                 dep_name, *dep_other = dep.split()
                 if dep_name == "conda" and ",<" not in dep:
                     record["depends"][i] = "{} {}<4.13.0".format(
                         dep_name, dep_other[0] + "," if dep_other else ""
                         )
+        if record_name == "mamba" and (
+            pkg_resources.parse_version(record["version"]) ==
+            pkg_resources.parse_version("0.24.0")) and (
+                record["build_number"] == 1):
+
+            for i, dep in enumerate(record["depends"]):
+                dep_name, *dep_other = dep.split()
+                if dep_name == "conda":
+                    record["depends"][i] = "conda >=4.8"
 
         if record_name == "aesara" and (
             pkg_resources.parse_version(record["version"]) >


### PR DESCRIPTION
closes https://github.com/conda-forge/mamba-feedstock/issues/156#issuecomment-1150371557

conda 4.13.0 was erroneously disabled for mamba 0.24.0. I am proposing to repatch the latest build  to enable users to upgrade smoothly again

<details> <summary> diff </summary>

```
17:26 $ python show_diff.py
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata.json.bz2
linux-64::mamba-0.24.0-py310hf87f941_1.tar.bz2
-    "conda >=4.8,<4.13.0",
+    "conda >=4.8",
linux-64::mamba-0.24.0-py37h47bf687_1.tar.bz2
-    "conda >=4.8,<4.13.0",
+    "conda >=4.8",
linux-64::mamba-0.24.0-py37h6dacc13_1.tar.bz2
-    "conda >=4.8,<4.13.0",
+    "conda >=4.8",
linux-64::mamba-0.24.0-py38h1abaa86_1.tar.bz2
-    "conda >=4.8,<4.13.0",
+    "conda >=4.8",
linux-64::mamba-0.24.0-py39hfa8f2c8_1.tar.bz2
-    "conda >=4.8,<4.13.0",
+    "conda >=4.8",
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata.json.bz2
linux-aarch64::mamba-0.24.0-py310hcf12e44_1.tar.bz2
-    "conda >=4.8,<4.13.0",
+    "conda >=4.8",
linux-aarch64::mamba-0.24.0-py37h5fa458c_1.tar.bz2
-    "conda >=4.8,<4.13.0",
+    "conda >=4.8",
linux-aarch64::mamba-0.24.0-py37h61affeb_1.tar.bz2
-    "conda >=4.8,<4.13.0",
+    "conda >=4.8",
linux-aarch64::mamba-0.24.0-py38h0280004_1.tar.bz2
-    "conda >=4.8,<4.13.0",
+    "conda >=4.8",
linux-aarch64::mamba-0.24.0-py39hc9db4b5_1.tar.bz2
-    "conda >=4.8,<4.13.0",
+    "conda >=4.8",
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata.json.bz2
linux-ppc64le::mamba-0.24.0-py310h0d84b84_1.tar.bz2
-    "conda >=4.8,<4.13.0",
+    "conda >=4.8",
linux-ppc64le::mamba-0.24.0-py37h140ae9a_1.tar.bz2
-    "conda >=4.8,<4.13.0",
+    "conda >=4.8",
linux-ppc64le::mamba-0.24.0-py37h7999fb9_1.tar.bz2
-    "conda >=4.8,<4.13.0",
+    "conda >=4.8",
linux-ppc64le::mamba-0.24.0-py38hbb959db_1.tar.bz2
-    "conda >=4.8,<4.13.0",
+    "conda >=4.8",
linux-ppc64le::mamba-0.24.0-py39h3651b5a_1.tar.bz2
-    "conda >=4.8,<4.13.0",
+    "conda >=4.8",
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata.json.bz2
osx-64::mamba-0.24.0-py310h795411f_1.tar.bz2
-    "conda >=4.8,<4.13.0",
+    "conda >=4.8",
osx-64::mamba-0.24.0-py37he52e375_1.tar.bz2
-    "conda >=4.8,<4.13.0",
+    "conda >=4.8",
osx-64::mamba-0.24.0-py37hf471621_1.tar.bz2
-    "conda >=4.8,<4.13.0",
+    "conda >=4.8",
osx-64::mamba-0.24.0-py38h52b2510_1.tar.bz2
-    "conda >=4.8,<4.13.0",
+    "conda >=4.8",
osx-64::mamba-0.24.0-py39ha435c47_1.tar.bz2
-    "conda >=4.8,<4.13.0",
+    "conda >=4.8",
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata.json.bz2
osx-arm64::mamba-0.24.0-py310h25b57eb_1.tar.bz2
-    "conda >=4.8,<4.13.0",
+    "conda >=4.8",
osx-arm64::mamba-0.24.0-py38h3ce6457_1.tar.bz2
-    "conda >=4.8,<4.13.0",
+    "conda >=4.8",
osx-arm64::mamba-0.24.0-py39hde45b87_1.tar.bz2
-    "conda >=4.8,<4.13.0",
+    "conda >=4.8",
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata.json.bz2
win-64::mamba-0.24.0-py310h9376f3e_1.tar.bz2
-    "conda >=4.8,<4.13.0",
+    "conda >=4.8",
win-64::mamba-0.24.0-py37h13f6ddf_1.tar.bz2
-    "conda >=4.8,<4.13.0",
+    "conda >=4.8",
win-64::mamba-0.24.0-py38hecfeebb_1.tar.bz2
-    "conda >=4.8,<4.13.0",
+    "conda >=4.8",
win-64::mamba-0.24.0-py39hb3d9227_1.tar.bz2
-    "conda >=4.8,<4.13.0",
+    "conda >=4.8",
```

</details>

Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
