### PR TITLE
Add missing constraint to markupsafe 2.1.0 build 0

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1216,6 +1216,16 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                 i = record['depends'].index(markupsafe)
                 record['depends'][i] = 'markupsafe >=0.23,<2'
 
+        # To complement the above, markupsafe introduced a run constraint to
+        # only accept jinja2>=3 with markupsafe >=2.1. However, this constraint
+        # is missing from the build 0 of markupsafe 2.1.0 so one could still
+        # install markupsafe 2.1.0 from conda-forge and jinja2 from defaults.
+        # We add that run constraint to the build that was missing it.
+        if record_name == "markupsafe" and \
+            pkg_resources.parse_version(record["version"]) == pkg_resources.parse_version("2.1.0") and \
+            not any("jinja2" in constraint for constraint in record.get("constrains", [])):
+            record["constrains"] = record.get("constrains", []) + ["jinja2 >=3"]
+
         # Version constraints for jupyterlab in jupyterlab-git<=0.22.0 were incorrect.
         # These have been corrected in PR
         # https://github.com/conda-forge/jupyterlab-git-feedstock/pull/27
@@ -1619,7 +1629,6 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             pkg_resources.parse_version("2.7.1")):
             if record.get("timestamp", 0) <= 1654360235233:
                 _replace_pin("scipy >=0.14,<1.8.0", "scipy >=0.14", record["depends"], record)
-
 
     return index
 


### PR DESCRIPTION
markupsafe 2.1.0 build 0 is missing a constraint that was introduced in build 1. This allows installation of markupsafe 2.1.0 with jinja2=2 from the defaults channel.

I guess this cannot happen when strict channel priority is set but should it be fixed anyway?

Fixes https://github.com/conda-forge/markupsafe-feedstock/issues/29

@conda-forge/markupsafe @xylar please have a look :)

<details>
show_diff.py produces the following output for me:

<pre>
noarch::dropbox-11.32.0-pyhd8ed1ab_0.tar.bz2
-    "python =2.7|>=3.4",
+    "python ==2.7.*|>=3.4",
linux-64::markupsafe-2.1.0-py310h5764c6d_0.tar.bz2
-  "version": "2.1.0"
+  "version": "2.1.0",
+  "constrains": [
+    "jinja2 >=3"
+  ]
linux-64::markupsafe-2.1.0-py37h0313132_0.tar.bz2
-  "version": "2.1.0"
+  "version": "2.1.0",
+  "constrains": [
+    "jinja2 >=3"
+  ]
linux-64::markupsafe-2.1.0-py37h540881e_0.tar.bz2
-  "version": "2.1.0"
+  "version": "2.1.0",
+  "constrains": [
+    "jinja2 >=3"
+  ]
linux-64::markupsafe-2.1.0-py38h0a891b7_0.tar.bz2
-  "version": "2.1.0"
+  "version": "2.1.0",
+  "constrains": [
+    "jinja2 >=3"
+  ]
linux-64::markupsafe-2.1.0-py39hb9d737c_0.tar.bz2
-  "version": "2.1.0"
+  "version": "2.1.0",
+  "constrains": [
+    "jinja2 >=3"
+  ]
linux-aarch64::markupsafe-2.1.0-py310hdc54845_0.tar.bz2
-  "version": "2.1.0"
+  "version": "2.1.0",
+  "constrains": [
+    "jinja2 >=3"
+  ]
linux-aarch64::markupsafe-2.1.0-py37hb829d83_0.tar.bz2
-  "version": "2.1.0"
+  "version": "2.1.0",
+  "constrains": [
+    "jinja2 >=3"
+  ]
linux-aarch64::markupsafe-2.1.0-py37heeccf27_0.tar.bz2
-  "version": "2.1.0"
+  "version": "2.1.0",
+  "constrains": [
+    "jinja2 >=3"
+  ]
linux-aarch64::markupsafe-2.1.0-py38h81aae68_0.tar.bz2
-  "version": "2.1.0"
+  "version": "2.1.0",
+  "constrains": [
+    "jinja2 >=3"
+  ]
linux-aarch64::markupsafe-2.1.0-py39hb9a1dbb_0.tar.bz2
-  "version": "2.1.0"
+  "version": "2.1.0",
+  "constrains": [
+    "jinja2 >=3"
+  ]
linux-ppc64le::markupsafe-2.1.0-py310h93ff066_0.tar.bz2
-  "version": "2.1.0"
+  "version": "2.1.0",
+  "constrains": [
+    "jinja2 >=3"
+  ]
linux-ppc64le::markupsafe-2.1.0-py37h322088c_0.tar.bz2
-  "version": "2.1.0"
+  "version": "2.1.0",
+  "constrains": [
+    "jinja2 >=3"
+  ]
linux-ppc64le::markupsafe-2.1.0-py37hbdc9092_0.tar.bz2
-  "version": "2.1.0"
+  "version": "2.1.0",
+  "constrains": [
+    "jinja2 >=3"
+  ]
linux-ppc64le::markupsafe-2.1.0-py38h6e87771_0.tar.bz2
-  "version": "2.1.0"
+  "version": "2.1.0",
+  "constrains": [
+    "jinja2 >=3"
+  ]
linux-ppc64le::markupsafe-2.1.0-py39h9ca6cee_0.tar.bz2
-  "version": "2.1.0"
+  "version": "2.1.0",
+  "constrains": [
+    "jinja2 >=3"
+  ]

osx-64::markupsafe-2.1.0-py310h1961e1f_0.tar.bz2
-  "version": "2.1.0"
+  "version": "2.1.0",
+  "constrains": [
+    "jinja2 >=3"
+  ]
osx-64::markupsafe-2.1.0-py37h69ee0a8_0.tar.bz2
-  "version": "2.1.0"
+  "version": "2.1.0",
+  "constrains": [
+    "jinja2 >=3"
+  ]
osx-64::markupsafe-2.1.0-py37h9205ac6_0.tar.bz2
-  "version": "2.1.0"
+  "version": "2.1.0",
+  "constrains": [
+    "jinja2 >=3"
+  ]
osx-64::markupsafe-2.1.0-py38hed1de0f_0.tar.bz2
-  "version": "2.1.0"
+  "version": "2.1.0",
+  "constrains": [
+    "jinja2 >=3"
+  ]
osx-64::markupsafe-2.1.0-py39h63b48b0_0.tar.bz2
-  "version": "2.1.0"
+  "version": "2.1.0",
+  "constrains": [
+    "jinja2 >=3"
+  ]
osx-arm64::markupsafe-2.1.0-py310hf8d0d8f_0.tar.bz2
-  "version": "2.1.0"
+  "version": "2.1.0",
+  "constrains": [
+    "jinja2 >=3"
+  ]
osx-arm64::markupsafe-2.1.0-py38h33210d7_0.tar.bz2
-  "version": "2.1.0"
+  "version": "2.1.0",
+  "constrains": [
+    "jinja2 >=3"
+  ]
osx-arm64::markupsafe-2.1.0-py39hb18efdd_0.tar.bz2
-  "version": "2.1.0"
+  "version": "2.1.0",
+  "constrains": [
+    "jinja2 >=3"
+  ]
win-64::markupsafe-2.1.0-py310he2412df_0.tar.bz2
-  "version": "2.1.0"
+  "version": "2.1.0",
+  "constrains": [
+    "jinja2 >=3"
+  ]
win-64::markupsafe-2.1.0-py37h179b583_0.tar.bz2
-  "version": "2.1.0"
+  "version": "2.1.0",
+  "constrains": [
+    "jinja2 >=3"
+  ]
win-64::markupsafe-2.1.0-py37hcc03f2d_0.tar.bz2
-  "version": "2.1.0"
+  "version": "2.1.0",
+  "constrains": [
+    "jinja2 >=3"
+  ]
win-64::markupsafe-2.1.0-py38h294d835_0.tar.bz2
-  "version": "2.1.0"
+  "version": "2.1.0",
+  "constrains": [
+    "jinja2 >=3"
+  ]
win-64::markupsafe-2.1.0-py39hb82d6ee_0.tar.bz2
-  "version": "2.1.0"
+  "version": "2.1.0",
+  "constrains": [
+    "jinja2 >=3"
+  ]
</pre>

I don't think the dropbox change has anything to do with my changes here.
</details>