### PR TITLE
Patch cuDNN v8.3.2/v8.4.0 build 0

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -882,6 +882,10 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
         _replace_pin("cutensor >=1.2.2.5,<2.0a0", "cutensor ==1.2.2.5", deps, record)
         _replace_pin("cutensor >=1.2.2.5,<2.0a0", "cutensor ==1.2.2.5", record.get("constrains", []), record, target='constrains')
 
+        # cuDNN v8.3.2 works with all CUDA 11.x, but we mistakenly made conflicting pins
+        if record_name == "cudnn" and record["version"].startswith("8.3.2") and record["build"].endswith("_0"):
+            record["depends"].remove('cudatoolkit >=11.2,<12')
+
         # ROOT 6.22.6 contained an ABI break, we'll always pin on patch releases from now on
         if has_dep(record, "root_base"):
             for i, dep in enumerate(deps):

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -882,8 +882,10 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
         _replace_pin("cutensor >=1.2.2.5,<2.0a0", "cutensor ==1.2.2.5", deps, record)
         _replace_pin("cutensor >=1.2.2.5,<2.0a0", "cutensor ==1.2.2.5", record.get("constrains", []), record, target='constrains')
 
-        # cuDNN v8.3.2 works with all CUDA 11.x, but we mistakenly made conflicting pins
-        if record_name == "cudnn" and record["version"].startswith("8.3.2") and record["build"].endswith("_0"):
+        # cuDNN v8.3.2/v8.4.0 works with all CUDA 11.x, but we mistakenly made conflicting pins
+        if (record_name == "cudnn" 
+                and (record["version"].startswith("8.3.2") or record["version"].startswith("8.4.0")) 
+                and record["build"].endswith("_0")):
             record["depends"].remove('cudatoolkit >=11.2,<12')
 
         # ROOT 6.22.6 contained an ABI break, we'll always pin on patch releases from now on


### PR DESCRIPTION
cc: @conda-forge/cudnn 

v8.3.2 build 1 fixed it (https://github.com/conda-forge/cudnn-feedstock/pull/46), and v8.4.0 build 1 is being done here (https://github.com/conda-forge/cudnn-feedstock/pull/45).
```
$ python show_diff.py                  
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata.json.bz2
noarch::dropbox-11.32.0-pyhd8ed1ab_0.tar.bz2
-    "python =2.7|>=3.4",
+    "python ==2.7.*|>=3.4",
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata.json.bz2
linux-64::cudnn-8.3.2.44-hed8a83a_0.tar.bz2
-    "cudatoolkit >=11.2,<12",
linux-64::cudnn-8.4.0.27-hed8a83a_0.tar.bz2
-    "cudatoolkit >=11.2,<12",
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata.json.bz2
linux-aarch64::cudnn-8.3.2.44-h66ab864_0.tar.bz2
-    "cudatoolkit >=11.2,<12",
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata.json.bz2
linux-ppc64le::cudnn-8.3.2.44-h321de51_0.tar.bz2
-    "cudatoolkit >=11.2,<12",
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata.json.bz2
win-64::cudnn-8.3.2.44-hf5f08ae_0.tar.bz2
-    "cudatoolkit >=11.2,<12",
win-64::cudnn-8.4.0.27-hf5f08ae_0.tar.bz2
-    "cudatoolkit >=11.2,<12",
```

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
