### PR TITLE
Use a more strict pinning for ipopt

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1630,6 +1630,11 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             if record.get("timestamp", 0) <= 1654360235233:
                 _replace_pin("scipy >=0.14,<1.8.0", "scipy >=0.14", record["depends"], record)
 
+        # Different patch versions of ipopt cam be ABI incompatible
+        # See https://github.com/conda-forge/ipopt-feedstock/issues/85
+        if has_dep(record, "ipopt") and record.get('timestamp', 0) < 1656352053694:
+            _pin_stricter(fn, record, "ipopt", "x.x.x")
+
     return index
 
 


### PR DESCRIPTION
See https://github.com/conda-forge/ipopt-feedstock/issues/85 for more details. In a nutshell, ipopt does not promises ABI compatibility for releases with different patch version.

Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
