### PR TITLE
Add "libpython >=2.2" to aesara-base win-*/2.7.4_1

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1630,6 +1630,15 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             if record.get("timestamp", 0) <= 1654360235233:
                 _replace_pin("scipy >=0.14,<1.8.0", "scipy >=0.14", record["depends"], record)
 
+        if record_name == "aesara-base":
+            if (
+                pkg_resources.parse_version(record["version"]) ==
+                pkg_resources.parse_version("2.7.4")
+            ) and (
+                record["build_number"] == 1 and subdir.startswith("win-")
+            ):
+                record["depends"].append("libpython >=2.0")
+
         if record_name == "requests" and (
             pkg_resources.parse_version(record["version"]) >=
             pkg_resources.parse_version("2.26.0") and

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1637,7 +1637,7 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             ) and (
                 record["build_number"] == 1 and subdir.startswith("win-")
             ):
-                record["depends"].append("libpython >=2.0")
+                record["depends"].append("libpython >=2.2")
 
         if record_name == "requests" and (
             pkg_resources.parse_version(record["version"]) >=


### PR DESCRIPTION
Closes https://github.com/conda-forge/aesara-feedstock/issues/87

Made draft pending confirmation of the version pin.

@conda-forge/aesara 

```diff
$ ./show_diff.py --use-cache
win-64::aesara-base-2.7.4-py310h5588dad_1.tar.bz2
-    "typing_extensions"
+    "typing_extensions",
+    "libpython >=2.2"
win-64::aesara-base-2.7.4-py37h03978a9_1.tar.bz2
-    "typing_extensions"
+    "typing_extensions",
+    "libpython >=2.2"
win-64::aesara-base-2.7.4-py37h4c0cbd9_1.tar.bz2
-    "typing_extensions"
+    "typing_extensions",
+    "libpython >=2.2"
win-64::aesara-base-2.7.4-py38haa244fe_1.tar.bz2
-    "typing_extensions"
+    "typing_extensions",
+    "libpython >=2.2"
win-64::aesara-base-2.7.4-py39hcbf5309_1.tar.bz2
-    "typing_extensions"
+    "typing_extensions",
+    "libpython >=2.2"
```

