### PR TITLE
pdf2image was missing a runtime dependency on poppler

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1660,6 +1660,12 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
         if has_dep(record, "ipopt") and record.get('timestamp', 0) < 1656352053694:
             _pin_stricter(fn, record, "ipopt", "x.x.x")
 
+        if record_name == "pdf2image":
+            dependencies = record["depends"]
+            if not any(dep.split(' ')[0] == "poppler" for dep in dependencies):
+                # Some versions of pdf2image are missing the runtime dependency on poppler, see https://github.com/conda-forge/pdf2image-feedstock/pull/17
+                dependencies.append("poppler")
+
     return index
 
 


### PR DESCRIPTION
it is added in https://github.com/conda-forge/pdf2image-feedstock/pull/17

There seems to be no version requirement on poppler. I tried with the
earliest version of poppler on conda-forge (0.52.0) and a basic test
went through.

`./show_diff.py` tells me that these changes will be introduced by the change:

```patch
noarch::pdf2image-1.10.0-py_0.tar.bz2
-    "python >=3"
+    "python >=3",
+    "poppler"
noarch::pdf2image-1.11.0-py_0.tar.bz2
-    "python >=3"
+    "python >=3",
+    "poppler"
noarch::pdf2image-1.12.0-py_0.tar.bz2
-    "python >=3"
+    "python >=3",
+    "poppler"
noarch::pdf2image-1.12.1-py_0.tar.bz2
-    "python >=3"
+    "python >=3",
+    "poppler"
noarch::pdf2image-1.13.0-py_0.tar.bz2
-    "python >=3"
+    "python >=3",
+    "poppler"
noarch::pdf2image-1.13.1-py_0.tar.bz2
-    "python >=3"
+    "python >=3",
+    "poppler"
noarch::pdf2image-1.14.0-pyhd8ed1ab_1.tar.bz2
-    "python >=3"
+    "python >=3",
+    "poppler"
noarch::pdf2image-1.15.0-pyhd8ed1ab_0.tar.bz2
-    "python >=3"
+    "python >=3",
+    "poppler"
noarch::pdf2image-1.15.1-pyhd8ed1ab_0.tar.bz2
-    "python >=3"
+    "python >=3",
+    "poppler"
noarch::pdf2image-1.16.0-pyhd8ed1ab_0.tar.bz2
-    "python >=3"
+    "python >=3",
+    "poppler"
noarch::pdf2image-1.9.0-py_0.tar.bz2
-    "python >=3"
+    "python >=3",
+    "poppler"
```

---

@conda-forge/pdf2image this backports https://github.com/conda-forge/pdf2image-feedstock/pull/17 to earlier builds. Please have a look :)