### PR TITLE
Fix version comparison in tifffile patch

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1548,9 +1548,12 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
         # tifffile 2022.2.2 and more recent versions requires python >=3.8.
         # See https://github.com/conda-forge/tifffile-feedstock/issues/93
         # Fixed in https://github.com/conda-forge/tifffile-feedstock/pull/94
-        if record_name == "tifffile":
-            if record["version"] >= "2022.2.2" and record["version"] < "2022.4.26":
-                _replace_pin("python >=3.7", "python >=3.8", record["depends"], record)
+        if (
+            record_name == "tifffile"
+            and pkg_resources.parse_version(record["version"]) >= pkg_resources.parse_version("2022.2.2")
+            and pkg_resources.parse_version(record["version"]) < pkg_resources.parse_version("2022.4.26")
+        ):
+            _replace_pin("python >=3.7", "python >=3.8", record["depends"], record)
 
         # typing-extensions 4.2.0 requires python >=3.7. Build 0 incorrectly specified >=3.6. Fixed in
         # https://github.com/conda-forge/typing_extensions-feedstock/pull/30


### PR DESCRIPTION
`tifffile=2022.4.8` is available on conda-forge as a `python=3.7` pkg,
allthough tifffile requires `python>=3.8` since version `2022.2.2`.

The previous PR #256 didn't parse the version strings, which caused
`"2022.4.8" < "2022.4.26"`  to evaluate to `False` and consequently
the patch was not applied to that version.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

#### output of show_diff.py

```
noarch::dropbox-11.33.0-pyhd8ed1ab_0.tar.bz2
-    "python =2.7|>=3.4",
+    "python ==2.7.*|>=3.4",
noarch::tifffile-2022.4.8-pyhd8ed1ab_0.tar.bz2
-    "python >=3.7"
+    "python >=3.8"
win-64::gazebo-11.11.0-h5d48ce7_8.tar.bz2
-    "libignition-common3 >=3.4.0,<3.5.0a0",
-    "libignition-fuel-tools4 >=4.0.0,<4.1.0a0",
+    "libignition-common3 >=3.4.0,<4.0.0a0",
+    "libignition-fuel-tools4 >=4.0.0,<5.0.0a0",
win-64::gazebo-11.11.0-ha1bd02b_8.tar.bz2
-    "libignition-common3 >=3.4.0,<3.5.0a0",
-    "libignition-fuel-tools4 >=4.0.0,<4.1.0a0",
+    "libignition-common3 >=3.4.0,<4.0.0a0",
+    "libignition-fuel-tools4 >=4.0.0,<5.0.0a0",
```
