### PR TITLE
Package 'click' >= 8.1.0 breaks older 'distributed' < 2022.4.0

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -618,6 +618,12 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                 i = record['depends'].index('click >=6.6')
                 record['depends'][i] = 'click >=6.6,<8.0.0'
 
+            # click 8.1.0. broke distributed prior to 2022.4.0.
+            v2022_4_0 = pkg_resources.parse_version('2022.4.0')
+            if pversion < v2022_4_0 and 'click >=6.6' in record['depends']:
+                i = record['depends'].index('click >=6.6')
+                record['depends'][i] = 'click >=6.6,<8.1.0'
+                
             # Older versions of distributed break with tornado 6.2.
             # See https://github.com/dask/distributed/pull/6668 for more details.
             v2022_6_1 = pkg_resources.parse_version('2022.6.1')


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
The reason for this upper bound `click` version pinning for old `distributed` is because any version of `distributed` before 2022.4.0 is incompatible with `click >= 8.1.0`. It produces an error: `ImportError: cannot import name '_unicodefun' from 'click'`.

But without the upper bound, conda will simply install the latest `click` version (currently `8.1.3`), and things will break.


Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<details><summary>Output of running: `python show_diff.py`</summary><p>

```
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata.json.bz2
noarch::distributed-2022.2.1-pyhd8ed1ab_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
noarch::distributed-2022.3.0-pyhd8ed1ab_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata.json.bz2
linux-64::distributed-2021.10.0-py37h89c1867_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.10.0-py37h9c2f6ca_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.10.0-py38h578d9bd_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.10.0-py39hf3d152e_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.11.0-py310hff52083_1.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.11.0-py37h89c1867_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.11.0-py37h89c1867_1.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.11.0-py37h9c2f6ca_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.11.0-py37h9c2f6ca_1.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.11.0-py38h578d9bd_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.11.0-py38h578d9bd_1.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.11.0-py39hf3d152e_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.11.0-py39hf3d152e_1.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.11.1-py310hff52083_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.11.1-py37h89c1867_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.11.1-py37h9c2f6ca_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.11.1-py38h578d9bd_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.11.1-py39hf3d152e_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.11.2-py310hff52083_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.11.2-py37h89c1867_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.11.2-py37h9c2f6ca_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.11.2-py38h578d9bd_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.11.2-py39hf3d152e_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.12.0-py310hff52083_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.12.0-py37h89c1867_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.12.0-py37h9c2f6ca_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.12.0-py38h578d9bd_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.12.0-py39hf3d152e_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.5.0-py37h89c1867_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.5.0-py37h9c2f6ca_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.5.0-py38h578d9bd_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.5.0-py39hf3d152e_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.5.1-py37h89c1867_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.5.1-py37h9c2f6ca_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.5.1-py38h578d9bd_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.5.1-py39hf3d152e_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.6.0-py37h89c1867_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.6.0-py37h9c2f6ca_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.6.0-py38h578d9bd_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.6.0-py39hf3d152e_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.6.1-py37h89c1867_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.6.1-py37h9c2f6ca_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.6.1-py38h578d9bd_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.6.1-py39hf3d152e_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.6.2-py37h89c1867_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.6.2-py37h9c2f6ca_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.6.2-py38h578d9bd_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.6.2-py39hf3d152e_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.7.0-py37h89c1867_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.7.0-py37h9c2f6ca_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.7.0-py38h578d9bd_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.7.0-py39hf3d152e_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.7.1-py37h89c1867_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.7.1-py37h9c2f6ca_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.7.1-py38h578d9bd_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.7.1-py39hf3d152e_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.7.2-py37h89c1867_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.7.2-py37h9c2f6ca_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.7.2-py38h578d9bd_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.7.2-py39hf3d152e_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.8.0-py37h89c1867_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.8.0-py37h9c2f6ca_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.8.0-py38h578d9bd_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.8.0-py39hf3d152e_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.8.1-py37h89c1867_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.8.1-py37h9c2f6ca_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.8.1-py38h578d9bd_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.8.1-py39hf3d152e_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.9.0-py37h89c1867_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.9.0-py37h9c2f6ca_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.9.0-py38h578d9bd_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.9.0-py39hf3d152e_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.9.1-py37h89c1867_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.9.1-py37h9c2f6ca_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.9.1-py38h578d9bd_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2021.9.1-py39hf3d152e_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2022.1.0-py310hff52083_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2022.1.0-py37h89c1867_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2022.1.0-py37h9c2f6ca_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2022.1.0-py38h578d9bd_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2022.1.0-py39hf3d152e_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2022.1.1-py310hff52083_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2022.1.1-py37h89c1867_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2022.1.1-py37h9c2f6ca_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2022.1.1-py38h578d9bd_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2022.1.1-py39hf3d152e_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2022.2.0-py310hff52083_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2022.2.0-py37h89c1867_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2022.2.0-py37h9c2f6ca_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2022.2.0-py38h578d9bd_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-64::distributed-2022.2.0-py39hf3d152e_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata.json.bz2
linux-aarch64::distributed-2021.10.0-py37h4bcbb9b_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.10.0-py37hd9ded2f_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.10.0-py38h2063c64_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.10.0-py39ha65689a_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.11.0-py310hbbe02a8_1.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.11.0-py37h4bcbb9b_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.11.0-py37h4bcbb9b_1.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.11.0-py37hd9ded2f_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.11.0-py37hd9ded2f_1.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.11.0-py38h2063c64_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.11.0-py38h2063c64_1.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.11.0-py39ha65689a_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.11.0-py39ha65689a_1.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.11.1-py310hbbe02a8_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.11.1-py37h4bcbb9b_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.11.1-py37hd9ded2f_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.11.1-py38h2063c64_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.11.1-py39ha65689a_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.11.2-py310hbbe02a8_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.11.2-py37h4bcbb9b_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.11.2-py37hd9ded2f_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.11.2-py38h2063c64_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.11.2-py39ha65689a_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.12.0-py310hbbe02a8_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.12.0-py37h4bcbb9b_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.12.0-py37hd9ded2f_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.12.0-py38h2063c64_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.12.0-py39ha65689a_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.5.0-py37h4bcbb9b_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.5.0-py37hd9ded2f_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.5.0-py38h2063c64_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.5.0-py39ha65689a_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.5.1-py37h4bcbb9b_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.5.1-py37hd9ded2f_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.5.1-py38h2063c64_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.5.1-py39ha65689a_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.6.0-py37h4bcbb9b_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.6.0-py37hd9ded2f_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.6.0-py38h2063c64_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.6.0-py39ha65689a_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.6.1-py37h4bcbb9b_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.6.1-py37hd9ded2f_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.6.1-py38h2063c64_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.6.1-py39ha65689a_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.6.2-py37h4bcbb9b_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.6.2-py37hd9ded2f_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.6.2-py38h2063c64_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.6.2-py39ha65689a_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.7.0-py37h4bcbb9b_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.7.0-py37hd9ded2f_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.7.0-py38h2063c64_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.7.0-py39ha65689a_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.7.1-py37h4bcbb9b_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.7.1-py37hd9ded2f_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.7.1-py38h2063c64_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.7.1-py39ha65689a_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.7.2-py37h4bcbb9b_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.7.2-py37hd9ded2f_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.7.2-py38h2063c64_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.7.2-py39ha65689a_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.8.0-py37h4bcbb9b_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.8.0-py37hd9ded2f_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.8.0-py38h2063c64_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.8.0-py39ha65689a_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.8.1-py37h4bcbb9b_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.8.1-py37hd9ded2f_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.8.1-py38h2063c64_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.8.1-py39ha65689a_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.9.0-py37h4bcbb9b_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.9.0-py37hd9ded2f_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.9.0-py38h2063c64_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.9.0-py39ha65689a_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.9.1-py37h4bcbb9b_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.9.1-py37hd9ded2f_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.9.1-py38h2063c64_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2021.9.1-py39ha65689a_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2022.1.0-py310hbbe02a8_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2022.1.0-py37h4bcbb9b_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2022.1.0-py37hd9ded2f_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2022.1.0-py38h2063c64_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2022.1.0-py39ha65689a_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2022.1.1-py310hbbe02a8_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2022.1.1-py37h4bcbb9b_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2022.1.1-py37hd9ded2f_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2022.1.1-py38h2063c64_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2022.1.1-py39ha65689a_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2022.2.0-py310hbbe02a8_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2022.2.0-py37h4bcbb9b_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2022.2.0-py37hd9ded2f_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2022.2.0-py38h2063c64_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-aarch64::distributed-2022.2.0-py39ha65689a_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata.json.bz2
linux-ppc64le::distributed-2021.10.0-py37h35e4cab_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.10.0-py37hadc05a3_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.10.0-py38hf8b3453_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.10.0-py39hc1b9086_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.11.0-py310hd032262_1.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.11.0-py37h35e4cab_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.11.0-py37h35e4cab_1.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.11.0-py37hadc05a3_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.11.0-py37hadc05a3_1.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.11.0-py38hf8b3453_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.11.0-py38hf8b3453_1.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.11.0-py39hc1b9086_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.11.0-py39hc1b9086_1.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.11.1-py310hd032262_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.11.1-py37h35e4cab_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.11.1-py37hadc05a3_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.11.1-py38hf8b3453_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.11.1-py39hc1b9086_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.11.2-py310hd032262_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.11.2-py37h35e4cab_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.11.2-py37hadc05a3_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.11.2-py38hf8b3453_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.11.2-py39hc1b9086_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.12.0-py310hd032262_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.12.0-py37h35e4cab_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.12.0-py37hadc05a3_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.12.0-py38hf8b3453_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.12.0-py39hc1b9086_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.5.0-py37h35e4cab_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.5.0-py37hadc05a3_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.5.0-py38hf8b3453_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.5.0-py39hc1b9086_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.5.1-py37h35e4cab_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.5.1-py37hadc05a3_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.5.1-py38hf8b3453_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.5.1-py39hc1b9086_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.6.0-py37h35e4cab_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.6.0-py37hadc05a3_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.6.0-py38hf8b3453_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.6.0-py39hc1b9086_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.6.1-py37h35e4cab_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.6.1-py37hadc05a3_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.6.1-py38hf8b3453_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.6.1-py39hc1b9086_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.6.2-py37h35e4cab_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.6.2-py37hadc05a3_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.6.2-py38hf8b3453_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.6.2-py39hc1b9086_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.7.0-py37h35e4cab_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.7.0-py37hadc05a3_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.7.0-py38hf8b3453_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.7.0-py39hc1b9086_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.7.1-py37h35e4cab_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.7.1-py37hadc05a3_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.7.1-py38hf8b3453_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.7.1-py39hc1b9086_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.7.2-py37h35e4cab_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.7.2-py37hadc05a3_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.7.2-py38hf8b3453_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.7.2-py39hc1b9086_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.8.0-py37h35e4cab_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.8.0-py37hadc05a3_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.8.0-py38hf8b3453_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.8.0-py39hc1b9086_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.8.1-py37h35e4cab_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.8.1-py37hadc05a3_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.8.1-py38hf8b3453_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.8.1-py39hc1b9086_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.9.0-py37h35e4cab_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.9.0-py37hadc05a3_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.9.0-py38hf8b3453_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.9.0-py39hc1b9086_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.9.1-py37h35e4cab_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.9.1-py37hadc05a3_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.9.1-py38hf8b3453_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2021.9.1-py39hc1b9086_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2022.1.0-py310hd032262_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2022.1.0-py37h35e4cab_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2022.1.0-py37hadc05a3_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2022.1.0-py38hf8b3453_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2022.1.0-py39hc1b9086_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2022.1.1-py310hd032262_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2022.1.1-py37h35e4cab_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2022.1.1-py37hadc05a3_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2022.1.1-py38hf8b3453_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2022.1.1-py39hc1b9086_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2022.2.0-py310hd032262_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2022.2.0-py37h35e4cab_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2022.2.0-py37hadc05a3_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2022.2.0-py38hf8b3453_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
linux-ppc64le::distributed-2022.2.0-py39hc1b9086_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata.json.bz2
osx-64::distributed-2021.10.0-py37h5186d4c_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.10.0-py37hf985489_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.10.0-py38h50d1736_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.10.0-py39h6e9494a_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.11.0-py310h2ec42d9_1.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.11.0-py37h5186d4c_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.11.0-py37h5186d4c_1.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.11.0-py37hf985489_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.11.0-py37hf985489_1.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.11.0-py38h50d1736_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.11.0-py38h50d1736_1.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.11.0-py39h6e9494a_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.11.0-py39h6e9494a_1.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.11.1-py310h2ec42d9_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.11.1-py37h5186d4c_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.11.1-py37hf985489_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.11.1-py38h50d1736_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.11.1-py39h6e9494a_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.11.2-py310h2ec42d9_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.11.2-py37h5186d4c_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.11.2-py37hf985489_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.11.2-py38h50d1736_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.11.2-py39h6e9494a_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.12.0-py310h2ec42d9_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.12.0-py37h5186d4c_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.12.0-py37hf985489_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.12.0-py38h50d1736_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.12.0-py39h6e9494a_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.5.0-py37h5186d4c_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.5.0-py37hf985489_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.5.0-py38h50d1736_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.5.0-py39h6e9494a_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.5.1-py37h5186d4c_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.5.1-py37hf985489_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.5.1-py38h50d1736_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.5.1-py39h6e9494a_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.6.0-py37h5186d4c_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.6.0-py37hf985489_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.6.0-py38h50d1736_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.6.0-py39h6e9494a_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.6.1-py37h5186d4c_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.6.1-py37hf985489_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.6.1-py38h50d1736_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.6.1-py39h6e9494a_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.6.2-py37h5186d4c_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.6.2-py37hf985489_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.6.2-py38h50d1736_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.6.2-py39h6e9494a_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.7.0-py37h5186d4c_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.7.0-py37hf985489_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.7.0-py38h50d1736_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.7.0-py39h6e9494a_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.7.1-py37h5186d4c_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.7.1-py37hf985489_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.7.1-py38h50d1736_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.7.1-py39h6e9494a_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.7.2-py37h5186d4c_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.7.2-py37hf985489_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.7.2-py38h50d1736_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.7.2-py39h6e9494a_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.8.0-py37h5186d4c_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.8.0-py37hf985489_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.8.0-py38h50d1736_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.8.0-py39h6e9494a_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.8.1-py37h5186d4c_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.8.1-py37hf985489_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.8.1-py38h50d1736_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.8.1-py39h6e9494a_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.9.0-py37h5186d4c_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.9.0-py37hf985489_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.9.0-py38h50d1736_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.9.0-py39h6e9494a_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.9.1-py37h5186d4c_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.9.1-py37hf985489_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.9.1-py38h50d1736_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2021.9.1-py39h6e9494a_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2022.1.0-py310h2ec42d9_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2022.1.0-py37h5186d4c_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2022.1.0-py37hf985489_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2022.1.0-py38h50d1736_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2022.1.0-py39h6e9494a_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2022.1.1-py310h2ec42d9_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2022.1.1-py37h5186d4c_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2022.1.1-py37hf985489_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2022.1.1-py38h50d1736_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2022.1.1-py39h6e9494a_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2022.2.0-py310h2ec42d9_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2022.2.0-py37h5186d4c_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2022.2.0-py37hf985489_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2022.2.0-py38h50d1736_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-64::distributed-2022.2.0-py39h6e9494a_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata.json.bz2
osx-arm64::distributed-2021.10.0-py38h10201cd_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-arm64::distributed-2021.10.0-py39h2804cbe_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-arm64::distributed-2021.11.0-py310hbe9552e_1.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-arm64::distributed-2021.11.0-py38h10201cd_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-arm64::distributed-2021.11.0-py38h10201cd_1.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-arm64::distributed-2021.11.0-py39h2804cbe_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-arm64::distributed-2021.11.0-py39h2804cbe_1.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-arm64::distributed-2021.11.1-py310hbe9552e_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-arm64::distributed-2021.11.1-py38h10201cd_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-arm64::distributed-2021.11.1-py39h2804cbe_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-arm64::distributed-2021.11.2-py310hbe9552e_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-arm64::distributed-2021.11.2-py38h10201cd_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-arm64::distributed-2021.11.2-py39h2804cbe_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-arm64::distributed-2021.12.0-py310hbe9552e_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-arm64::distributed-2021.12.0-py38h10201cd_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-arm64::distributed-2021.12.0-py39h2804cbe_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-arm64::distributed-2021.5.0-py38h10201cd_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-arm64::distributed-2021.5.0-py39h2804cbe_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-arm64::distributed-2021.5.1-py38h10201cd_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-arm64::distributed-2021.5.1-py39h2804cbe_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-arm64::distributed-2021.6.0-py38h10201cd_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-arm64::distributed-2021.6.0-py39h2804cbe_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-arm64::distributed-2021.6.1-py38h10201cd_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-arm64::distributed-2021.6.1-py39h2804cbe_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-arm64::distributed-2021.6.2-py38h10201cd_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-arm64::distributed-2021.6.2-py39h2804cbe_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-arm64::distributed-2021.7.0-py38h10201cd_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-arm64::distributed-2021.7.0-py39h2804cbe_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-arm64::distributed-2021.7.1-py38h10201cd_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-arm64::distributed-2021.7.1-py39h2804cbe_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-arm64::distributed-2021.7.2-py38h10201cd_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-arm64::distributed-2021.7.2-py39h2804cbe_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-arm64::distributed-2021.8.0-py38h10201cd_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-arm64::distributed-2021.8.0-py39h2804cbe_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-arm64::distributed-2021.8.1-py38h10201cd_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-arm64::distributed-2021.8.1-py39h2804cbe_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-arm64::distributed-2021.9.0-py38h10201cd_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-arm64::distributed-2021.9.0-py39h2804cbe_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-arm64::distributed-2021.9.1-py38h10201cd_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-arm64::distributed-2021.9.1-py39h2804cbe_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-arm64::distributed-2022.1.0-py310hbe9552e_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-arm64::distributed-2022.1.0-py38h10201cd_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-arm64::distributed-2022.1.0-py39h2804cbe_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-arm64::distributed-2022.1.1-py310hbe9552e_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-arm64::distributed-2022.1.1-py38h10201cd_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-arm64::distributed-2022.1.1-py39h2804cbe_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-arm64::distributed-2022.2.0-py310hbe9552e_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-arm64::distributed-2022.2.0-py38h10201cd_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
osx-arm64::distributed-2022.2.0-py39h2804cbe_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata.json.bz2
win-64::distributed-2021.10.0-py37h03978a9_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2021.10.0-py37h4c0cbd9_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2021.10.0-py38haa244fe_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2021.10.0-py39hcbf5309_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2021.11.0-py310h5588dad_1.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2021.11.0-py37h03978a9_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2021.11.0-py37h03978a9_1.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2021.11.0-py37h4c0cbd9_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2021.11.0-py37h4c0cbd9_1.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2021.11.0-py38haa244fe_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2021.11.0-py38haa244fe_1.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2021.11.0-py39hcbf5309_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2021.11.0-py39hcbf5309_1.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2021.11.1-py310h5588dad_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2021.11.1-py37h03978a9_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2021.11.1-py37h4c0cbd9_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2021.11.1-py38haa244fe_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2021.11.1-py39hcbf5309_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2021.11.2-py310h5588dad_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2021.11.2-py37h03978a9_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2021.11.2-py37h4c0cbd9_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2021.11.2-py38haa244fe_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2021.11.2-py39hcbf5309_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2021.12.0-py310h5588dad_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2021.12.0-py37h03978a9_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2021.12.0-py37h4c0cbd9_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2021.12.0-py38haa244fe_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2021.12.0-py39hcbf5309_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2021.5.0-py37h03978a9_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2021.5.0-py38haa244fe_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2021.5.0-py39hcbf5309_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2021.5.1-py37h03978a9_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2021.5.1-py38haa244fe_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2021.5.1-py39hcbf5309_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2021.6.0-py37h03978a9_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2021.6.0-py38haa244fe_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2021.6.0-py39hcbf5309_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2021.6.1-py37h03978a9_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2021.6.1-py38haa244fe_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2021.6.1-py39hcbf5309_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2021.6.2-py37h03978a9_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2021.6.2-py38haa244fe_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2021.6.2-py39hcbf5309_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2021.7.0-py37h03978a9_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2021.7.0-py38haa244fe_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2021.7.0-py39hcbf5309_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2021.7.1-py37h03978a9_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2021.7.1-py38haa244fe_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2021.7.1-py39hcbf5309_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2021.7.2-py37h03978a9_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2021.7.2-py38haa244fe_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2021.7.2-py39hcbf5309_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2021.8.0-py37h03978a9_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2021.8.0-py37h4c0cbd9_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2021.8.0-py38haa244fe_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2021.8.0-py39hcbf5309_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2021.8.1-py37h03978a9_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2021.8.1-py37h4c0cbd9_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2021.8.1-py38haa244fe_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2021.8.1-py39hcbf5309_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2021.9.0-py37h03978a9_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2021.9.0-py37h4c0cbd9_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2021.9.0-py38haa244fe_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2021.9.0-py39hcbf5309_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2021.9.1-py37h03978a9_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2021.9.1-py37h4c0cbd9_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2021.9.1-py38haa244fe_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2021.9.1-py39hcbf5309_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2022.1.0-py310h5588dad_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2022.1.0-py37h03978a9_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2022.1.0-py37h4c0cbd9_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2022.1.0-py38haa244fe_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2022.1.0-py39hcbf5309_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2022.1.1-py310h5588dad_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2022.1.1-py37h03978a9_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2022.1.1-py37h4c0cbd9_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2022.1.1-py38haa244fe_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2022.1.1-py39hcbf5309_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2022.2.0-py310h5588dad_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2022.2.0-py37h03978a9_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2022.2.0-py37h4c0cbd9_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2022.2.0-py38haa244fe_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
win-64::distributed-2022.2.0-py39hcbf5309_0.tar.bz2
-    "click >=6.6",
+    "click >=6.6,<8.1.0",
```

</p></details>

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
