### PR TITLE
Stricter pin for packages built against antic

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1723,6 +1723,11 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                 if dep_name == "importlib_metadata" and ">=" not in dep:
                     record["depends"][i] = "importlib_metadata >=3.6"
 
+        # The run_exports of antic on macOS were too loose. We add a stricter
+        # pin on all packages built against antic before this was fixed.
+        if record_name in ["libeantic", "e-antic"] and subdir.startswith("osx") and record.get("timestamp", 0) <= 1653062891029:
+            _pin_stricter(fn, record, "antic", "x.x.x")
+
     return index
 
 


### PR DESCRIPTION
On macOS, the C library antic is called libantic-0.2.4.dylib and libantic-0.2.5.dylib. Therefore, we require a strict pin: when built
against libantic-0.2.4.dylib, we cannot use the shared library libantic-0.2.5.dylib even though their ABI would be compatible.

There is a fix upstream to rename the dylib as recommended by Apple, i.e., call it libantic.0.dylib. Until that fix is released, the pin in the antic-feedstock is now x.x.x for macOS. However, for packages built against previous builds of antic, we need to change the pin from x.x to x.x.x.