### PR TITLE
add constraint to scipy to avoid broken openblas for osx-arm

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -739,11 +739,11 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             record["depends"] = depends
 
         if (record_name == "scipy" and subdir == "osx-arm64"
-                and record.get('timestamp', 0) < 1659636598216):
-            # openblas 0.3.20 is broken with osx-arm, see
-            # https://github.com/scipy/scipy/issues/16767
+                and record.get('timestamp', 0) < 1660645059386):
+            # openblas 0.3.20 & 0.3.21 are broken with osx-arm, see
+            # https://github.com/conda-forge/openblas-feedstock/issues/143
             new_constrains = record.get('constrains', [])
-            new_constrains.append("openblas <0.3.20")
+            new_constrains.append("openblas <0.3.19")
             record['constrains'] = new_constrains
 
         if record_name == "gcc_impl_{}".format(subdir):

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -738,6 +738,14 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             depends.append("_r-mutex 1.* anacondar_1")
             record["depends"] = depends
 
+        if (record_name == "scipy" and subdir == "osx-arm64"
+                and record.get('timestamp', 0) < 1659636598216):
+            # openblas 0.3.20 is broken with osx-arm, see
+            # https://github.com/scipy/scipy/issues/16767
+            new_constrains = record.get('constrains', [])
+            new_constrains.append("openblas <0.3.20")
+            record['constrains'] = new_constrains
+
         if record_name == "gcc_impl_{}".format(subdir):
             _relax_exact(fn, record, "binutils_impl_{}".format(subdir))
 


### PR DESCRIPTION
Requested by the upstream maintainers [here](https://github.com/scipy/scipy/issues/16767#issuecomment-1205207606), CC @rgommers.

Openblas 0.3.20 has been [live](https://anaconda.org/conda-forge/openblas/files) for almost 4 months, but it only has ~9000 downloads on osx-arm. I'm not excited about breaking people's environment reproducibility, but silently wrong results seem worse.

<details>
<summary>Output of <code>python show_diff.py</code></summary>

```
>python show_diff.py
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata.json.bz2
osx-arm64::scipy-1.5.2-py38h2dbcbbe_2.tar.bz2
-  "version": "1.5.2"
+  "version": "1.5.2",
+  "constrains": [
+    "openblas <0.3.20"
+  ]
osx-arm64::scipy-1.5.2-py38hdf044fb_2.tar.bz2
-  "version": "1.5.2"
+  "version": "1.5.2",
+  "constrains": [
+    "openblas <0.3.20"
+  ]
osx-arm64::scipy-1.5.2-py39h39b03cc_2.tar.bz2
-  "version": "1.5.2"
+  "version": "1.5.2",
+  "constrains": [
+    "openblas <0.3.20"
+  ]
osx-arm64::scipy-1.5.2-py39h73ea49b_2.tar.bz2
-  "version": "1.5.2"
+  "version": "1.5.2",
+  "constrains": [
+    "openblas <0.3.20"
+  ]
osx-arm64::scipy-1.5.3-py38hd0c9ec0_1.tar.bz2
-  "version": "1.5.3"
+  "version": "1.5.3",
+  "constrains": [
+    "openblas <0.3.20"
+  ]
osx-arm64::scipy-1.5.3-py38hdf044fb_0.tar.bz2
-  "version": "1.5.3"
+  "version": "1.5.3",
+  "constrains": [
+    "openblas <0.3.20"
+  ]
osx-arm64::scipy-1.5.3-py39h5060c3b_1.tar.bz2
-  "version": "1.5.3"
+  "version": "1.5.3",
+  "constrains": [
+    "openblas <0.3.20"
+  ]
osx-arm64::scipy-1.5.3-py39h73ea49b_0.tar.bz2
-  "version": "1.5.3"
+  "version": "1.5.3",
+  "constrains": [
+    "openblas <0.3.20"
+  ]
osx-arm64::scipy-1.6.0-py38hdf044fb_0.tar.bz2
-  "version": "1.6.0"
+  "version": "1.6.0",
+  "constrains": [
+    "openblas <0.3.20"
+  ]
osx-arm64::scipy-1.6.0-py39h73ea49b_0.tar.bz2
-  "version": "1.6.0"
+  "version": "1.6.0",
+  "constrains": [
+    "openblas <0.3.20"
+  ]
osx-arm64::scipy-1.6.1-py38hdf044fb_0.tar.bz2
-  "version": "1.6.1"
+  "version": "1.6.1",
+  "constrains": [
+    "openblas <0.3.20"
+  ]
osx-arm64::scipy-1.6.1-py39h73ea49b_0.tar.bz2
-  "version": "1.6.1"
+  "version": "1.6.1",
+  "constrains": [
+    "openblas <0.3.20"
+  ]
osx-arm64::scipy-1.6.2-py38hd0c9ec0_0.tar.bz2
-  "version": "1.6.2"
+  "version": "1.6.2",
+  "constrains": [
+    "openblas <0.3.20"
+  ]
osx-arm64::scipy-1.6.2-py39h5060c3b_0.tar.bz2
-  "version": "1.6.2"
+  "version": "1.6.2",
+  "constrains": [
+    "openblas <0.3.20"
+  ]
osx-arm64::scipy-1.6.3-py38hd0c9ec0_0.tar.bz2
-  "version": "1.6.3"
+  "version": "1.6.3",
+  "constrains": [
+    "openblas <0.3.20"
+  ]
osx-arm64::scipy-1.6.3-py39h5060c3b_0.tar.bz2
-  "version": "1.6.3"
+  "version": "1.6.3",
+  "constrains": [
+    "openblas <0.3.20"
+  ]
osx-arm64::scipy-1.7.0-py38hd0c9ec0_0.tar.bz2
-  "version": "1.7.0"
+  "version": "1.7.0",
+  "constrains": [
+    "openblas <0.3.20"
+  ]
osx-arm64::scipy-1.7.0-py39h5060c3b_0.tar.bz2
-  "version": "1.7.0"
+  "version": "1.7.0",
+  "constrains": [
+    "openblas <0.3.20"
+  ]
osx-arm64::scipy-1.7.1-py38hd0c9ec0_0.tar.bz2
-  "version": "1.7.1"
+  "version": "1.7.1",
+  "constrains": [
+    "openblas <0.3.20"
+  ]
osx-arm64::scipy-1.7.1-py39h5060c3b_0.tar.bz2
-  "version": "1.7.1"
+  "version": "1.7.1",
+  "constrains": [
+    "openblas <0.3.20"
+  ]
osx-arm64::scipy-1.7.2-py310h6ecf4ae_0.tar.bz2
-  "version": "1.7.2"
+  "version": "1.7.2",
+  "constrains": [
+    "openblas <0.3.20"
+  ]
osx-arm64::scipy-1.7.2-py38hd0c9ec0_0.tar.bz2
-  "version": "1.7.2"
+  "version": "1.7.2",
+  "constrains": [
+    "openblas <0.3.20"
+  ]
osx-arm64::scipy-1.7.2-py39h5060c3b_0.tar.bz2
-  "version": "1.7.2"
+  "version": "1.7.2",
+  "constrains": [
+    "openblas <0.3.20"
+  ]
osx-arm64::scipy-1.7.3-py310h6ecf4ae_0.tar.bz2
-  "version": "1.7.3"
+  "version": "1.7.3",
+  "constrains": [
+    "openblas <0.3.20"
+  ]
osx-arm64::scipy-1.7.3-py38hd0c9ec0_0.tar.bz2
-  "version": "1.7.3"
+  "version": "1.7.3",
+  "constrains": [
+    "openblas <0.3.20"
+  ]
osx-arm64::scipy-1.7.3-py39h5060c3b_0.tar.bz2
-  "version": "1.7.3"
+  "version": "1.7.3",
+  "constrains": [
+    "openblas <0.3.20"
+  ]
osx-arm64::scipy-1.8.0-py310h6ecf4ae_0.tar.bz2
-  "version": "1.8.0"
+  "version": "1.8.0",
+  "constrains": [
+    "openblas <0.3.20"
+  ]
osx-arm64::scipy-1.8.0-py310h6ecf4ae_1.tar.bz2
-  "version": "1.8.0"
+  "version": "1.8.0",
+  "constrains": [
+    "openblas <0.3.20"
+  ]
osx-arm64::scipy-1.8.0-py38hd0c9ec0_0.tar.bz2
-  "version": "1.8.0"
+  "version": "1.8.0",
+  "constrains": [
+    "openblas <0.3.20"
+  ]
osx-arm64::scipy-1.8.0-py38hd0c9ec0_1.tar.bz2
-  "version": "1.8.0"
+  "version": "1.8.0",
+  "constrains": [
+    "openblas <0.3.20"
+  ]
osx-arm64::scipy-1.8.0-py39h5060c3b_0.tar.bz2
-  "version": "1.8.0"
+  "version": "1.8.0",
+  "constrains": [
+    "openblas <0.3.20"
+  ]
osx-arm64::scipy-1.8.0-py39h5060c3b_1.tar.bz2
-  "version": "1.8.0"
+  "version": "1.8.0",
+  "constrains": [
+    "openblas <0.3.20"
+  ]
osx-arm64::scipy-1.8.1-py310hdb41229_0.tar.bz2
-  "version": "1.8.1"
+  "version": "1.8.1",
+  "constrains": [
+    "openblas <0.3.20"
+  ]
osx-arm64::scipy-1.8.1-py310hdb41229_2.tar.bz2
-  "version": "1.8.1"
+  "version": "1.8.1",
+  "constrains": [
+    "openblas <0.3.20"
+  ]
osx-arm64::scipy-1.8.1-py38h4f188a7_0.tar.bz2
-  "version": "1.8.1"
+  "version": "1.8.1",
+  "constrains": [
+    "openblas <0.3.20"
+  ]
osx-arm64::scipy-1.8.1-py38h4f188a7_2.tar.bz2
-  "version": "1.8.1"
+  "version": "1.8.1",
+  "constrains": [
+    "openblas <0.3.20"
+  ]
osx-arm64::scipy-1.8.1-py39h14896cb_0.tar.bz2
-  "version": "1.8.1"
+  "version": "1.8.1",
+  "constrains": [
+    "openblas <0.3.20"
+  ]
osx-arm64::scipy-1.8.1-py39h14896cb_2.tar.bz2
-  "version": "1.8.1"
+  "version": "1.8.1",
+  "constrains": [
+    "openblas <0.3.20"
+  ]
osx-arm64::scipy-1.9.0-py310hdb41229_0.tar.bz2
-  "version": "1.9.0"
+  "version": "1.9.0",
+  "constrains": [
+    "openblas <0.3.20"
+  ]
osx-arm64::scipy-1.9.0-py38h4f188a7_0.tar.bz2
-  "version": "1.9.0"
+  "version": "1.9.0",
+  "constrains": [
+    "openblas <0.3.20"
+  ]
osx-arm64::scipy-1.9.0-py39h14896cb_0.tar.bz2
-  "version": "1.9.0"
+  "version": "1.9.0",
+  "constrains": [
+    "openblas <0.3.20"
+  ]
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata.json.bz2
```

</details>