### PR TITLE
Fix duet-python deps

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1730,6 +1730,9 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                 if dep == 'grpcio >=1.46.3':
                     record["depends"][i] = "grpcio >=1.48.0"
 
+        if (record_name == "duet-python" and record["version"] in ["0.2.4", "0.2.5", "0.2.6", "0.2.7"]):
+          _replace_pin("typing-extensions", "typing-extensions ==3.10.0", record["depends"], record)
+
     return index
 
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
This was missed originally.` typing-extensions ==3.10.0` is correct but it's currently only `typing-extensions`.
Feedstock: https://github.com/conda-forge/duet-python-feedstock
Upstream: https://github.com/google/duet/blob/v0.2.5/requirements.txt