### PR TITLE
Fix aesara-base's broken setuptools pin

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1685,6 +1685,8 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                 record["build_number"] == 1 and subdir.startswith("win-")
             ):
                 record["depends"].append("libpython >=2.2")
+            if record["version"] in ["2.7.8", "2.7.9"]:
+                _replace_pin('setuptools >=45.0.0', 'setuptools >=48.0.0', deps, record)
 
         if record_name == "requests" and (
             pkg_resources.parse_version(record["version"]) >=

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1686,7 +1686,7 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             ):
                 record["depends"].append("libpython >=2.2")
             if record["version"] in ["2.7.8", "2.7.9"]:
-                _replace_pin('setuptools >=45.0.0', 'setuptools >=48.0.0', deps, record)
+                _replace_pin('setuptools >=45.0.0', 'setuptools >=48.0.0,<65', deps, record)
 
         if record_name == "requests" and (
             pkg_resources.parse_version(record["version"]) >=

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1688,7 +1688,7 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                 pkg_resources.parse_version(record["version"]) <=
                 pkg_resources.parse_version("2.7.3")
             ):
-                record["depends"].append("setuptools !=65")
+                _replace_pin('setuptools', 'setuptools !=65.*', deps, record)
 
         if record_name == "aesara-base":
             if (
@@ -1699,14 +1699,14 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             ):
                 record["depends"].append("libpython >=2.2")
             if record["version"] in ["2.7.8", "2.7.9"]:
-                _replace_pin('setuptools >=45.0.0', 'setuptools >=48.0.0,!=65', deps, record)
+                _replace_pin('setuptools >=45.0.0', 'setuptools >=48.0.0,!=65.*', deps, record)
             if (
                 pkg_resources.parse_version(record["version"]) >=
                 pkg_resources.parse_version("2.7.4") and
                 pkg_resources.parse_version(record["version"]) <=
                 pkg_resources.parse_version("2.7.7")
             ):
-                record["depends"].append("setuptools !=65")
+                record["depends"].append("setuptools !=65.*")
 
         if record_name == "requests" and (
             pkg_resources.parse_version(record["version"]) >=

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1682,6 +1682,13 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             pkg_resources.parse_version("2.7.1")):
             if record.get("timestamp", 0) <= 1654360235233:
                 _replace_pin("scipy >=0.14,<1.8.0", "scipy >=0.14", record["depends"], record)
+            if (
+                pkg_resources.parse_version(record["version"]) >=
+                pkg_resources.parse_version("2.5.0") and
+                pkg_resources.parse_version(record["version"]) <=
+                pkg_resources.parse_version("2.7.3")
+            ):
+                record["depends"].append("setuptools !=65")
 
         if record_name == "aesara-base":
             if (
@@ -1692,7 +1699,14 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             ):
                 record["depends"].append("libpython >=2.2")
             if record["version"] in ["2.7.8", "2.7.9"]:
-                _replace_pin('setuptools >=45.0.0', 'setuptools >=48.0.0,<65', deps, record)
+                _replace_pin('setuptools >=45.0.0', 'setuptools >=48.0.0,!=65', deps, record)
+            if (
+                pkg_resources.parse_version(record["version"]) >=
+                pkg_resources.parse_version("2.7.4") and
+                pkg_resources.parse_version(record["version"]) <=
+                pkg_resources.parse_version("2.7.7")
+            ):
+                record["depends"].append("setuptools !=65")
 
         if record_name == "requests" and (
             pkg_resources.parse_version(record["version"]) >=

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1688,7 +1688,7 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                 pkg_resources.parse_version(record["version"]) <=
                 pkg_resources.parse_version("2.7.3")
             ):
-                _replace_pin('setuptools', 'setuptools !=65.*', deps, record)
+                _replace_pin('setuptools', 'setuptools !=65.0.*', deps, record)
 
         if record_name == "aesara-base":
             if (
@@ -1699,14 +1699,14 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             ):
                 record["depends"].append("libpython >=2.2")
             if record["version"] in ["2.7.8", "2.7.9"]:
-                _replace_pin('setuptools >=45.0.0', 'setuptools >=48.0.0,!=65.*', deps, record)
+                _replace_pin('setuptools >=45.0.0', 'setuptools >=48.0.0,!=65.0.*', deps, record)
             if (
                 pkg_resources.parse_version(record["version"]) >=
                 pkg_resources.parse_version("2.7.4") and
                 pkg_resources.parse_version(record["version"]) <=
                 pkg_resources.parse_version("2.7.7")
             ):
-                record["depends"].append("setuptools !=65.*")
+                record["depends"].append("setuptools !=65.0.*")
 
         if record_name == "requests" and (
             pkg_resources.parse_version(record["version"]) >=


### PR DESCRIPTION
See https://github.com/conda-forge/aesara-feedstock/issues/102

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<details>

<summary> <b>Original diff</b> (see comment below for the new one) </summary>

<!--
Please add any other relevant info below:
-->
```diff
linux-64::aesara-base-2.7.8-py310hff52083_0.tar.bz2
-    "setuptools >=45.0.0",
+    "setuptools >=48.0.0",
linux-64::aesara-base-2.7.8-py37h89c1867_0.tar.bz2
-    "setuptools >=45.0.0",
+    "setuptools >=48.0.0",
linux-64::aesara-base-2.7.8-py38h578d9bd_0.tar.bz2
-    "setuptools >=45.0.0",
+    "setuptools >=48.0.0",
linux-64::aesara-base-2.7.8-py39hf3d152e_0.tar.bz2
-    "setuptools >=45.0.0",
+    "setuptools >=48.0.0",
linux-64::aesara-base-2.7.9-py310hff52083_0.tar.bz2
-    "setuptools >=45.0.0",
+    "setuptools >=48.0.0",
linux-64::aesara-base-2.7.9-py310hff52083_1.tar.bz2
-    "setuptools >=45.0.0",
+    "setuptools >=48.0.0",
linux-64::aesara-base-2.7.9-py37h89c1867_0.tar.bz2
-    "setuptools >=45.0.0",
+    "setuptools >=48.0.0",
linux-64::aesara-base-2.7.9-py37h89c1867_1.tar.bz2
-    "setuptools >=45.0.0",
+    "setuptools >=48.0.0",
linux-64::aesara-base-2.7.9-py38h373033e_1.tar.bz2
-    "setuptools >=45.0.0",
+    "setuptools >=48.0.0",
linux-64::aesara-base-2.7.9-py38h578d9bd_0.tar.bz2
-    "setuptools >=45.0.0",
+    "setuptools >=48.0.0",
linux-64::aesara-base-2.7.9-py38h578d9bd_1.tar.bz2
-    "setuptools >=45.0.0",
+    "setuptools >=48.0.0",
linux-64::aesara-base-2.7.9-py39h4162558_1.tar.bz2
-    "setuptools >=45.0.0",
+    "setuptools >=48.0.0",
linux-64::aesara-base-2.7.9-py39hf3d152e_0.tar.bz2
-    "setuptools >=45.0.0",
+    "setuptools >=48.0.0",
linux-64::aesara-base-2.7.9-py39hf3d152e_1.tar.bz2
-    "setuptools >=45.0.0",
+    "setuptools >=48.0.0",
osx-64::aesara-base-2.7.8-py310h2ec42d9_0.tar.bz2
-    "setuptools >=45.0.0",
+    "setuptools >=48.0.0",
osx-64::aesara-base-2.7.8-py37hf985489_0.tar.bz2
-    "setuptools >=45.0.0",
+    "setuptools >=48.0.0",
osx-64::aesara-base-2.7.8-py39h6e9494a_0.tar.bz2
-    "setuptools >=45.0.0",
+    "setuptools >=48.0.0",
osx-64::aesara-base-2.7.9-py310h2ec42d9_0.tar.bz2
-    "setuptools >=45.0.0",
+    "setuptools >=48.0.0",
osx-64::aesara-base-2.7.9-py310h2ec42d9_1.tar.bz2
-    "setuptools >=45.0.0",
+    "setuptools >=48.0.0",
osx-64::aesara-base-2.7.9-py37hf985489_0.tar.bz2
-    "setuptools >=45.0.0",
+    "setuptools >=48.0.0",
osx-64::aesara-base-2.7.9-py37hf985489_1.tar.bz2
-    "setuptools >=45.0.0",
+    "setuptools >=48.0.0",
osx-64::aesara-base-2.7.9-py38h25b0044_1.tar.bz2
-    "setuptools >=45.0.0",
+    "setuptools >=48.0.0",
osx-64::aesara-base-2.7.9-py38h50d1736_0.tar.bz2
-    "setuptools >=45.0.0",
+    "setuptools >=48.0.0",
osx-64::aesara-base-2.7.9-py38h50d1736_1.tar.bz2
-    "setuptools >=45.0.0",
+    "setuptools >=48.0.0",
osx-64::aesara-base-2.7.9-py39h43b90dd_1.tar.bz2
-    "setuptools >=45.0.0",
+    "setuptools >=48.0.0",
osx-64::aesara-base-2.7.9-py39h6e9494a_0.tar.bz2
-    "setuptools >=45.0.0",
+    "setuptools >=48.0.0",
osx-64::aesara-base-2.7.9-py39h6e9494a_1.tar.bz2
-    "setuptools >=45.0.0",
+    "setuptools >=48.0.0",
osx-arm64::aesara-base-2.7.8-py310hbe9552e_0.tar.bz2
-    "setuptools >=45.0.0",
+    "setuptools >=48.0.0",
osx-arm64::aesara-base-2.7.8-py38h10201cd_0.tar.bz2
-    "setuptools >=45.0.0",
+    "setuptools >=48.0.0",
osx-arm64::aesara-base-2.7.8-py39h2804cbe_0.tar.bz2
-    "setuptools >=45.0.0",
+    "setuptools >=48.0.0",
osx-arm64::aesara-base-2.7.9-py310hbe9552e_0.tar.bz2
-    "setuptools >=45.0.0",
+    "setuptools >=48.0.0",
osx-arm64::aesara-base-2.7.9-py310hbe9552e_1.tar.bz2
-    "setuptools >=45.0.0",
+    "setuptools >=48.0.0",
osx-arm64::aesara-base-2.7.9-py38h10201cd_0.tar.bz2
-    "setuptools >=45.0.0",
+    "setuptools >=48.0.0",
osx-arm64::aesara-base-2.7.9-py38h10201cd_1.tar.bz2
-    "setuptools >=45.0.0",
+    "setuptools >=48.0.0",
osx-arm64::aesara-base-2.7.9-py39h2804cbe_0.tar.bz2
-    "setuptools >=45.0.0",
+    "setuptools >=48.0.0",
osx-arm64::aesara-base-2.7.9-py39h2804cbe_1.tar.bz2
-    "setuptools >=45.0.0",
+    "setuptools >=48.0.0",
win-64::aesara-base-2.7.8-py310h5588dad_0.tar.bz2
-    "setuptools >=45.0.0",
+    "setuptools >=48.0.0",
win-64::aesara-base-2.7.8-py37h03978a9_0.tar.bz2
-    "setuptools >=45.0.0",
+    "setuptools >=48.0.0",
win-64::aesara-base-2.7.8-py38haa244fe_0.tar.bz2
-    "setuptools >=45.0.0",
+    "setuptools >=48.0.0",
win-64::aesara-base-2.7.8-py39hcbf5309_0.tar.bz2
-    "setuptools >=45.0.0",
+    "setuptools >=48.0.0",
win-64::aesara-base-2.7.9-py310h5588dad_0.tar.bz2
-    "setuptools >=45.0.0",
+    "setuptools >=48.0.0",
win-64::aesara-base-2.7.9-py310h5588dad_1.tar.bz2
-    "setuptools >=45.0.0",
+    "setuptools >=48.0.0",
win-64::aesara-base-2.7.9-py37h03978a9_0.tar.bz2
-    "setuptools >=45.0.0",
+    "setuptools >=48.0.0",
win-64::aesara-base-2.7.9-py37h03978a9_1.tar.bz2
-    "setuptools >=45.0.0",
+    "setuptools >=48.0.0",
win-64::aesara-base-2.7.9-py38h32ec214_1.tar.bz2
-    "setuptools >=45.0.0",
+    "setuptools >=48.0.0",
win-64::aesara-base-2.7.9-py38haa244fe_0.tar.bz2
-    "setuptools >=45.0.0",
+    "setuptools >=48.0.0",
win-64::aesara-base-2.7.9-py38haa244fe_1.tar.bz2
-    "setuptools >=45.0.0",
+    "setuptools >=48.0.0",
win-64::aesara-base-2.7.9-py39h0d475fb_1.tar.bz2
-    "setuptools >=45.0.0",
+    "setuptools >=48.0.0",
win-64::aesara-base-2.7.9-py39hcbf5309_0.tar.bz2
-    "setuptools >=45.0.0",
+    "setuptools >=48.0.0",
win-64::aesara-base-2.7.9-py39hcbf5309_1.tar.bz2
-    "setuptools >=45.0.0",
+    "setuptools >=48.0.0",
```

</details>