### PR TITLE
add jaxlib hard dep on abseil for latest build

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1708,6 +1708,18 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             record.setdefault('constrains', []).extend((
                 "chardet >=3.0.2,<5",
             ))
+        
+        # jaxlib was built with grpc-cpp 1.46.4 that 
+        # was only available at abseil-cpp 20220623.0
+        # and thus it needs to be explicitily constrained
+        # no grpc-cpp fix can fix this retro 
+        if record_name == "jaxlib" and (
+            pkg_resources.parse_version(record["version"]) ==
+            pkg_resources.parse_version("0.3.15") and
+            record["build_number"] == 0
+        ):
+            record["depends"].append("abseil-cpp ==20220623.0")
+            
         # Different patch versions of ipopt can be ABI incompatible
         # See https://github.com/conda-forge/ipopt-feedstock/issues/85
         if has_dep(record, "ipopt") and record.get('timestamp', 0) < 1656352053694:

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1712,7 +1712,8 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
         # jaxlib was built with grpc-cpp 1.46.4 that 
         # was only available at abseil-cpp 20220623.0
         # and thus it needs to be explicitily constrained
-        # no grpc-cpp fix can fix this retro 
+        # no grpc-cpp fix can fix this retro
+        # fixed in https://github.com/conda-forge/jaxlib-feedstock/pull/133
         if record_name == "jaxlib" and (
             pkg_resources.parse_version(record["version"]) ==
             pkg_resources.parse_version("0.3.15") and


### PR DESCRIPTION
xref
https://github.com/conda-forge/jaxlib-feedstock/issues/132
https://github.com/conda-forge/grpc-cpp-feedstock/issues/224

jaxlib was built with grpc-cpp 1.46.4 that 
was only available at abseil-cpp 20220623.0
and thus it needs to be explicitily constrained
no grpc-cpp fix can fix this retro 
i.e. this fix didn't do the trick:
https://github.com/conda-forge/grpc-cpp-feedstock/pull/223

suggested reviewers: @h-vetinari

Fix incoming in https://github.com/conda-forge/jaxlib-feedstock/pull/133

--

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
