### PR TITLE
Print "Downloading: ..." messages to stderr

### DIFF
--- a/recipe/show_diff.py
+++ b/recipe/show_diff.py
@@ -4,6 +4,7 @@ import bz2
 import difflib
 import json
 import os
+import sys
 import urllib
 
 from gen_patch_json import _gen_new_index, _gen_patch_instructions, SUBDIRS
@@ -53,10 +54,10 @@ def do_subdir(subdir, raw_repodata_path, ref_repodata_path):
 
 def download_subdir(subdir, raw_repodata_path, ref_repodata_path):
     raw_url = f"{BASE_URL}/{subdir}/repodata_from_packages.json.bz2"
-    print("Downloading:", raw_url)
+    print("Downloading:", raw_url, file=sys.stderr)
     urllib.request.urlretrieve(raw_url, raw_repodata_path)
     ref_url = f"{BASE_URL}/{subdir}/repodata.json.bz2"
-    print("Downloading:", ref_url)
+    print("Downloading:", ref_url, file=sys.stderr)
     urllib.request.urlretrieve(ref_url, ref_repodata_path)
 
 


### PR DESCRIPTION
This makes it possible to run `./show_diff.py > repodata.diff` without polluting the output with `Downloading: ...` messages.

This is useful for large diffs.