### PR TITLE
Use a more strict pinning for foonathan-memory

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1753,6 +1753,11 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             for i, dep in enumerate(record["depends"]):
                 if dep == 'grpcio >=1.46.3':
                     record["depends"][i] = "grpcio >=1.48.0"
+                    
+        # Different patch versions of foonathan-memory have different library names
+        # See https://github.com/conda-forge/foonathan-memory-feedstock/pull/7
+        if has_dep(record, "foonathan-memory") and record.get('timestamp', 0) < 1661242172938:
+            _pin_stricter(fn, record, "foonathan-memory", "x.x.x")
 
     return index
 


### PR DESCRIPTION
See https://github.com/conda-forge/foonathan-memory-feedstock/pull/7 for the rationale. In a nutshell, a different library name is used for each patch version.

Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
