### PR TITLE
make sure libabseil & libabseil-static are not co-installable

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1727,6 +1727,17 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                 "chardet >=3.0.2,<5",
             ))
 
+        # the first libabseil[-static] builds did not correctly ensure
+        # that they cannot be co-installed (two conditions)
+        if record_name == "libabseil" and record.get("timestamp", 0) <= 1661962873884:
+            new_constrains = record.get('constrains', [])
+            new_constrains.append("libabseil-static ==99999999999")
+            record["constrains"] = new_constrains
+        if record_name == "libabseil-static" and record.get("timestamp", 0) <= 1661962873884:
+            new_constrains = record.get('constrains', [])
+            new_constrains.append("libabseil ==99999999999")
+            record["constrains"] = new_constrains
+
         # jaxlib was built with grpc-cpp 1.46.4 that
         # was only available at abseil-cpp 20220623.0
         # and thus it needs to be explicitily constrained


### PR DESCRIPTION
An oversight in https://github.com/conda-forge/abseil-cpp-feedstock/pull/35 (and its backports), fixed in feedstock as of https://github.com/conda-forge/abseil-cpp-feedstock/pull/42.

<details>
<summary>Output of <code>python show_diff.py</code></summary>

Not sure what's happening with `noarch::diffstar` here, obviously I did not touch that one.

```
>python show_diff.py
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata.json.bz2
noarch::diffstar-0.1.0-pyhd8ed1ab_0.tar.bz2
-{
-  "build": "pyhd8ed1ab_0",
-  "build_number": 0,
-  "depends": [
-    "jax",
-    "numpy",
-    "python >=3.6"
-  ],
-  "license": "BSD-3-Clause",
-  "md5": "db4a7729347f52248b3c895217137b3b",
-  "name": "diffstar",
-  "noarch": "python",
-  "sha256": "a078e8b5926127a941380386247981f7feedde6c4068fdd3594a3750594092ac",
-  "size": 46189,
-  "subdir": "noarch",
-  "timestamp": 1661811005182,
-  "version": "0.1.0"
-}
+{}
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata.json.bz2
linux-64::libabseil-20211102.0-cxx17_h48a1fff_2.tar.bz2
-    "abseil-cpp =20211102.0"
+    "abseil-cpp =20211102.0",
+    "libabseil-static ==99999999999"
linux-64::libabseil-20220623.0-cxx17_h48a1fff_1.tar.bz2
-    "abseil-cpp =20220623.0"
+    "abseil-cpp =20220623.0",
+    "libabseil-static ==99999999999"
linux-64::libabseil-static-20211102.0-cxx11_h275f437_2.tar.bz2
-    "abseil-cpp =20211102.0"
+    "abseil-cpp =20211102.0",
+    "libabseil ==99999999999"
linux-64::libabseil-static-20211102.0-cxx14_h25cfe42_2.tar.bz2
-    "abseil-cpp =20211102.0"
+    "abseil-cpp =20211102.0",
+    "libabseil ==99999999999"
linux-64::libabseil-static-20211102.0-cxx17_hcde3526_2.tar.bz2
-    "abseil-cpp =20211102.0"
+    "abseil-cpp =20211102.0",
+    "libabseil ==99999999999"
linux-64::libabseil-static-20220623.0-cxx11_h275f437_1.tar.bz2
-    "abseil-cpp =20220623.0"
+    "abseil-cpp =20220623.0",
+    "libabseil ==99999999999"
linux-64::libabseil-static-20220623.0-cxx14_h25cfe42_1.tar.bz2
-    "abseil-cpp =20220623.0"
+    "abseil-cpp =20220623.0",
+    "libabseil ==99999999999"
linux-64::libabseil-static-20220623.0-cxx17_hcde3526_1.tar.bz2
-    "abseil-cpp =20220623.0"
+    "abseil-cpp =20220623.0",
+    "libabseil ==99999999999"
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata.json.bz2
linux-aarch64::libabseil-20211102.0-cxx17_h7d90558_2.tar.bz2
-    "abseil-cpp =20211102.0"
+    "abseil-cpp =20211102.0",
+    "libabseil-static ==99999999999"
linux-aarch64::libabseil-20220623.0-cxx17_h7d90558_1.tar.bz2
-    "abseil-cpp =20220623.0"
+    "abseil-cpp =20220623.0",
+    "libabseil-static ==99999999999"
linux-aarch64::libabseil-static-20211102.0-cxx11_hda68006_2.tar.bz2
-    "abseil-cpp =20211102.0"
+    "abseil-cpp =20211102.0",
+    "libabseil ==99999999999"
linux-aarch64::libabseil-static-20211102.0-cxx14_ha53829b_2.tar.bz2
-    "abseil-cpp =20211102.0"
+    "abseil-cpp =20211102.0",
+    "libabseil ==99999999999"
linux-aarch64::libabseil-static-20211102.0-cxx17_h6577863_2.tar.bz2
-    "abseil-cpp =20211102.0"
+    "abseil-cpp =20211102.0",
+    "libabseil ==99999999999"
linux-aarch64::libabseil-static-20220623.0-cxx11_hda68006_1.tar.bz2
-    "abseil-cpp =20220623.0"
+    "abseil-cpp =20220623.0",
+    "libabseil ==99999999999"
linux-aarch64::libabseil-static-20220623.0-cxx14_ha53829b_1.tar.bz2
-    "abseil-cpp =20220623.0"
+    "abseil-cpp =20220623.0",
+    "libabseil ==99999999999"
linux-aarch64::libabseil-static-20220623.0-cxx17_h6577863_1.tar.bz2
-    "abseil-cpp =20220623.0"
+    "abseil-cpp =20220623.0",
+    "libabseil ==99999999999"
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata.json.bz2
linux-ppc64le::libabseil-20211102.0-cxx17_he4933be_2.tar.bz2
-    "abseil-cpp =20211102.0"
+    "abseil-cpp =20211102.0",
+    "libabseil-static ==99999999999"
linux-ppc64le::libabseil-20220623.0-cxx17_he4933be_1.tar.bz2
-    "abseil-cpp =20220623.0"
+    "abseil-cpp =20220623.0",
+    "libabseil-static ==99999999999"
linux-ppc64le::libabseil-static-20211102.0-cxx11_h69410ff_2.tar.bz2
-    "abseil-cpp =20211102.0"
+    "abseil-cpp =20211102.0",
+    "libabseil ==99999999999"
linux-ppc64le::libabseil-static-20211102.0-cxx14_h0c9a2a6_2.tar.bz2
-    "abseil-cpp =20211102.0"
+    "abseil-cpp =20211102.0",
+    "libabseil ==99999999999"
linux-ppc64le::libabseil-static-20211102.0-cxx17_h4b51fd2_2.tar.bz2
-    "abseil-cpp =20211102.0"
+    "abseil-cpp =20211102.0",
+    "libabseil ==99999999999"
linux-ppc64le::libabseil-static-20220623.0-cxx11_h69410ff_1.tar.bz2
-    "abseil-cpp =20220623.0"
+    "abseil-cpp =20220623.0",
+    "libabseil ==99999999999"
linux-ppc64le::libabseil-static-20220623.0-cxx14_h0c9a2a6_1.tar.bz2
-    "abseil-cpp =20220623.0"
+    "abseil-cpp =20220623.0",
+    "libabseil ==99999999999"
linux-ppc64le::libabseil-static-20220623.0-cxx17_h4b51fd2_1.tar.bz2
-    "abseil-cpp =20220623.0"
+    "abseil-cpp =20220623.0",
+    "libabseil ==99999999999"
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata.json.bz2
osx-64::libabseil-20211102.0-cxx17_hd8326b1_2.tar.bz2
-    "abseil-cpp =20211102.0"
+    "abseil-cpp =20211102.0",
+    "libabseil-static ==99999999999"
osx-64::libabseil-20220623.0-cxx17_hd8326b1_1.tar.bz2
-    "abseil-cpp =20220623.0"
+    "abseil-cpp =20220623.0",
+    "libabseil-static ==99999999999"
osx-64::libabseil-static-20211102.0-cxx11_h6d4f7ae_2.tar.bz2
-    "abseil-cpp =20211102.0"
+    "abseil-cpp =20211102.0",
+    "libabseil ==99999999999"
osx-64::libabseil-static-20211102.0-cxx14_hae653bb_2.tar.bz2
-    "abseil-cpp =20211102.0"
+    "abseil-cpp =20211102.0",
+    "libabseil ==99999999999"
osx-64::libabseil-static-20211102.0-cxx17_h6343611_2.tar.bz2
-    "abseil-cpp =20211102.0"
+    "abseil-cpp =20211102.0",
+    "libabseil ==99999999999"
osx-64::libabseil-static-20220623.0-cxx11_h6d4f7ae_1.tar.bz2
-    "abseil-cpp =20220623.0"
+    "abseil-cpp =20220623.0",
+    "libabseil ==99999999999"
osx-64::libabseil-static-20220623.0-cxx14_hae653bb_1.tar.bz2
-    "abseil-cpp =20220623.0"
+    "abseil-cpp =20220623.0",
+    "libabseil ==99999999999"
osx-64::libabseil-static-20220623.0-cxx17_h6343611_1.tar.bz2
-    "abseil-cpp =20220623.0"
+    "abseil-cpp =20220623.0",
+    "libabseil ==99999999999"
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata.json.bz2
osx-arm64::libabseil-20211102.0-cxx17_hc0b94f3_2.tar.bz2
-    "abseil-cpp =20211102.0"
+    "abseil-cpp =20211102.0",
+    "libabseil-static ==99999999999"
osx-arm64::libabseil-20220623.0-cxx17_hc0b94f3_1.tar.bz2
-    "abseil-cpp =20220623.0"
+    "abseil-cpp =20220623.0",
+    "libabseil-static ==99999999999"
osx-arm64::libabseil-static-20211102.0-cxx11_h9218a51_2.tar.bz2
-    "abseil-cpp =20211102.0"
+    "abseil-cpp =20211102.0",
+    "libabseil ==99999999999"
osx-arm64::libabseil-static-20211102.0-cxx14_h9bab151_2.tar.bz2
-    "abseil-cpp =20211102.0"
+    "abseil-cpp =20211102.0",
+    "libabseil ==99999999999"
osx-arm64::libabseil-static-20211102.0-cxx17_he857564_2.tar.bz2
-    "abseil-cpp =20211102.0"
+    "abseil-cpp =20211102.0",
+    "libabseil ==99999999999"
osx-arm64::libabseil-static-20220623.0-cxx11_h9218a51_1.tar.bz2
-    "abseil-cpp =20220623.0"
+    "abseil-cpp =20220623.0",
+    "libabseil ==99999999999"
osx-arm64::libabseil-static-20220623.0-cxx14_h9bab151_1.tar.bz2
-    "abseil-cpp =20220623.0"
+    "abseil-cpp =20220623.0",
+    "libabseil ==99999999999"
osx-arm64::libabseil-static-20220623.0-cxx17_he857564_1.tar.bz2
-    "abseil-cpp =20220623.0"
+    "abseil-cpp =20220623.0",
+    "libabseil ==99999999999"
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata.json.bz2
win-64::libabseil-20211102.0-cxx17_hfcd0999_2.tar.bz2
-    "abseil-cpp =20211102.0"
+    "abseil-cpp =20211102.0",
+    "libabseil-static ==99999999999"
win-64::libabseil-20220623.0-cxx17_hfcd0999_1.tar.bz2
-    "abseil-cpp =20220623.0"
+    "abseil-cpp =20220623.0",
+    "libabseil-static ==99999999999"
win-64::libabseil-static-20211102.0-cxx11_h253ae9c_2.tar.bz2
-    "abseil-cpp =20211102.0"
+    "abseil-cpp =20211102.0",
+    "libabseil ==99999999999"
win-64::libabseil-static-20211102.0-cxx14_h586064d_2.tar.bz2
-    "abseil-cpp =20211102.0"
+    "abseil-cpp =20211102.0",
+    "libabseil ==99999999999"
win-64::libabseil-static-20211102.0-cxx17_hbb1881d_2.tar.bz2
-    "abseil-cpp =20211102.0"
+    "abseil-cpp =20211102.0",
+    "libabseil ==99999999999"
win-64::libabseil-static-20220623.0-cxx11_h253ae9c_1.tar.bz2
-    "abseil-cpp =20220623.0"
+    "abseil-cpp =20220623.0",
+    "libabseil ==99999999999"
win-64::libabseil-static-20220623.0-cxx14_h586064d_1.tar.bz2
-    "abseil-cpp =20220623.0"
+    "abseil-cpp =20220623.0",
+    "libabseil ==99999999999"
win-64::libabseil-static-20220623.0-cxx17_hbb1881d_1.tar.bz2
-    "abseil-cpp =20220623.0"
+    "abseil-cpp =20220623.0",
+    "libabseil ==99999999999"
```

</details>