### PR TITLE
Allow old ipykernel with newer traitlets/ipython

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1813,6 +1813,22 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                     new_deps.append(dep)
             record["depends"] = new_deps
 
+        # ipykernel >=4.0.1,<6.5.0 needs ipython_genutils. Old versions of
+        # ipython and traitlets depend on ipython_genutils so the dependency
+        # was originally satisfied indirectly. Newer versions of ipython and
+        # traitlets don't pull in ipython_genutils anymore so we need to make
+        # that dependency explicit.
+        if (record_name == "ipykernel" and
+                pkg_resources.parse_version(record["version"]) >= pkg_resources.parse_version("4.0.1") and
+                pkg_resources.parse_version(record["version"]) < pkg_resources.parse_version("6.5.0")):
+            for dep in record["depends"]:
+                if dep.startswith("ipython_genutils"):
+                    break
+            else:
+                # Any version of ipython_genutils will do. The package is not
+                # developed anymore since it has been dropped by all its consumers.
+                record["depends"].append("ipython_genutils >=0.2.0")
+
     return index
 
 

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1835,8 +1835,8 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
         # was originally satisfied indirectly. Newer versions of ipython and
         # traitlets don't pull in ipython_genutils anymore so we need to make
         # that dependency explicit.
-        if (record_name == "ipykernel" and
-                pkg_resources.parse_version(record["version"]) >= pkg_resources.parse_version("4.0.1") and
+        if (record_name == "ipykernel" and record.get("timestamp", 0) <= 1664184744000 and
+                pkg_resources.parse_version("4.0.1") <= 
                 pkg_resources.parse_version(record["version"]) < pkg_resources.parse_version("6.5.0")):
             for dep in record["depends"]:
                 if dep.startswith("ipython_genutils"):


### PR DESCRIPTION
Since 4.0.1 ipykernel uses ipython_genutils however this dependency was not made explicit in ipykernel's setup.py until ipykernel 5.5.x. Instead the dependency was at the time satisfied by pulling in ipython or traitlets which both depended on ipython_genutils.

Now, ipython and traitlets have dropped that dependency so when installing an old ipykernel with a newer ipython/traitlets, a ModuleNotFoundError is reported:

```
[...]
  File "/usr/share/miniconda/envs/test/lib/python3.7/site-packages/ipykernel/__init__.py", line 2, in <module>
    from .connect import *
  File "/usr/share/miniconda/envs/test/lib/python3.7/site-packages/ipykernel/connect.py", line 13, in <module>
    from ipython_genutils.path import filefind
ModuleNotFoundError: No module named 'ipython_genutils'
```

This happens e.g. with ipykernel 5.5.5, ipython 5.8.0, traitlets 5.4.0. This combination arises when installing and old sagelib 9.1.

Here, we fix this by making the dependency on ipython_genutils explicit for all versions of ipykernel that use it. Note that ipython_genutils has only two versions on conda-forge 0.1.0 and 0.2.0 so it should be safe to always use the latest (as ipykernel did at the time.) ipython_genutils is not developed anymore so there should not be any breaking changes in the future.