### PR TITLE
Add stricter pinning for mapgenerator

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1470,6 +1470,10 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             deps = record["depends"]
             _replace_pin("openlibm", "openlibm <0.8.0", deps, record)
 
+        # Retroactively pin a max version of matplotlib for mapgenerator 1.0.5
+        if record_name == "mapgenerator" and record["version"] == "1.0.5":
+            _replace_pin("matplotlib-base", "matplotlib-base <3.6", record["depends"], record)
+
         # Retroactively pin Python < 3.10 for some older noarch Pony packages, since Pony depends on the parser
         # module removed in 3.10: https://github.com/conda-forge/pony-feedstock/pull/20
         if record_name == "pony":

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1471,7 +1471,7 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             _replace_pin("openlibm", "openlibm <0.8.0", deps, record)
 
         # Retroactively pin a max version of matplotlib for mapgenerator 1.0.5
-        if record_name == "mapgenerator" and record["version"] == "1.0.5":
+        if record_name == "mapgenerator" and record["version"] == "1.0.5" and record["build_number"] < 1:
             _replace_pin("matplotlib-base", "matplotlib-base <3.6", record["depends"], record)
 
         # Retroactively pin Python < 3.10 for some older noarch Pony packages, since Pony depends on the parser


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Fixes conda-forge/mapgenerator-feedstock#1

<!--
Please add any other relevant info below:
-->

Mapgenerator has a unpinned matplotlib dependency. However, in the most recent release of matplotlib the `matplotlib.cbook.deprecation` API was removed, which is used by `mapgenerator`. To fix this, we should pin to `maplotlib <3.6`. 

This is described in conda-forge/mapgenerator-feedstock#1 and the build is updated in conda-forge/mapgenerator-feedstock#2.