### PR TITLE
Pin openh264 harder in 2.3.0

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1830,8 +1830,10 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                     new_deps.append(dep)
             record["depends"] = new_deps
 
-        if any(depend.startswith("openh264 >=2.3.0,<2.4")
-               for depend in record['depends']):
+        if (any(depend.startswith("openh264 >=2.3.0,<2.4")
+                for depend in record['depends']) or
+            any(depend.startswith("openh264 >=2.3.1,<2.4")
+                for depend in record['depends'])):
             _pin_stricter(fn, record, "openh264", "x.x.x")
 
         if (record_name == "thrift_sasl" and

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1830,6 +1830,10 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                     new_deps.append(dep)
             record["depends"] = new_deps
 
+        if any(depend.startswith("openh264 >=2.3.0,<2.4")
+               for depend in record['depends']):
+            _pin_stricter(fn, record, "openh264", "x.x.x")
+
         if (record_name == "thrift_sasl" and
                 record["version"] == "0.4.3" and
                 record["build_number"] == 0):


### PR DESCRIPTION
<details>

```patch
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata.json.bz2
linux-64::clang-15.0.1-ha770c72_0.tar.bz2
-  "version": "15.0.1"
+  "version": "15.0.1",
+  "constrains": [
+    "clang-tools 15.0.1.*",
+    "llvm 15.0.1.*",
+    "llvm-tools 15.0.1.*",
+    "llvmdev 15.0.1.*"
+  ]
linux-64::clang-tools-15.0.1-default_h2e3cab8_0.tar.bz2
-    "clangdev 15.0.1"
+    "clangdev 15.0.1",
+    "clang 15.0.1.*",
+    "llvm 15.0.1.*",
+    "llvm-tools 15.0.1.*",
+    "llvmdev 15.0.1.*"
linux-64::ffmpeg-4.4.2-gpl_h45a1190_107.tar.bz2
-    "openh264 >=2.3.0,<2.4.0a0",
+    "openh264 >=2.3.0,<2.3.1.0a0",
linux-64::ffmpeg-4.4.2-gpl_hfe78399_107.tar.bz2
-    "openh264 >=2.3.0,<2.4.0a0",
+    "openh264 >=2.3.0,<2.3.1.0a0",
linux-64::ffmpeg-4.4.2-lgpl_h5c13f96_7.tar.bz2
-    "openh264 >=2.3.0,<2.4.0a0",
+    "openh264 >=2.3.0,<2.3.1.0a0",
linux-64::ffmpeg-4.4.2-lgpl_hf13199f_7.tar.bz2
-    "openh264 >=2.3.0,<2.4.0a0",
+    "openh264 >=2.3.0,<2.3.1.0a0",
linux-64::ffmpeg-5.1.0-gpl_h45a1190_101.tar.bz2
-    "openh264 >=2.3.0,<2.4.0a0",
+    "openh264 >=2.3.0,<2.3.1.0a0",
linux-64::ffmpeg-5.1.0-gpl_hfe78399_101.tar.bz2
-    "openh264 >=2.3.0,<2.4.0a0",
+    "openh264 >=2.3.0,<2.3.1.0a0",
linux-64::ffmpeg-5.1.0-lgpl_h5c13f96_1.tar.bz2
-    "openh264 >=2.3.0,<2.4.0a0",
+    "openh264 >=2.3.0,<2.3.1.0a0",
linux-64::ffmpeg-5.1.0-lgpl_hf13199f_1.tar.bz2
-    "openh264 >=2.3.0,<2.4.0a0",
+    "openh264 >=2.3.0,<2.3.1.0a0",
linux-64::ffmpeg-5.1.1-gpl_hfe78399_101.tar.bz2
-    "openh264 >=2.3.0,<2.4.0a0",
+    "openh264 >=2.3.0,<2.3.1.0a0",
linux-64::ffmpeg-5.1.1-lgpl_h5c13f96_1.tar.bz2
-    "openh264 >=2.3.0,<2.4.0a0",
+    "openh264 >=2.3.0,<2.3.1.0a0",
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata.json.bz2
linux-aarch64::clang-15.0.1-h8af1aa0_0.tar.bz2
-  "version": "15.0.1"
+  "version": "15.0.1",
+  "constrains": [
+    "clang-tools 15.0.1.*",
+    "llvm 15.0.1.*",
+    "llvm-tools 15.0.1.*",
+    "llvmdev 15.0.1.*"
+  ]
linux-aarch64::clang-tools-15.0.1-default_ha7bf5e6_0.tar.bz2
-    "clangdev 15.0.1"
+    "clangdev 15.0.1",
+    "clang 15.0.1.*",
+    "llvm 15.0.1.*",
+    "llvm-tools 15.0.1.*",
+    "llvmdev 15.0.1.*"
linux-aarch64::ffmpeg-4.4.2-gpl_h4289b67_107.tar.bz2
-    "openh264 >=2.3.0,<2.4.0a0",
+    "openh264 >=2.3.0,<2.3.1.0a0",
linux-aarch64::ffmpeg-4.4.2-gpl_h7bca69d_107.tar.bz2
-    "openh264 >=2.3.0,<2.4.0a0",
+    "openh264 >=2.3.0,<2.3.1.0a0",
linux-aarch64::ffmpeg-4.4.2-lgpl_h5f16938_7.tar.bz2
-    "openh264 >=2.3.0,<2.4.0a0",
+    "openh264 >=2.3.0,<2.3.1.0a0",
linux-aarch64::ffmpeg-4.4.2-lgpl_h683d94b_7.tar.bz2
-    "openh264 >=2.3.0,<2.4.0a0",
+    "openh264 >=2.3.0,<2.3.1.0a0",
linux-aarch64::ffmpeg-5.1.0-gpl_h4289b67_101.tar.bz2
-    "openh264 >=2.3.0,<2.4.0a0",
+    "openh264 >=2.3.0,<2.3.1.0a0",
linux-aarch64::ffmpeg-5.1.0-gpl_h7bca69d_101.tar.bz2
-    "openh264 >=2.3.0,<2.4.0a0",
+    "openh264 >=2.3.0,<2.3.1.0a0",
linux-aarch64::ffmpeg-5.1.0-lgpl_h5f16938_1.tar.bz2
-    "openh264 >=2.3.0,<2.4.0a0",
+    "openh264 >=2.3.0,<2.3.1.0a0",
linux-aarch64::ffmpeg-5.1.0-lgpl_h683d94b_1.tar.bz2
-    "openh264 >=2.3.0,<2.4.0a0",
+    "openh264 >=2.3.0,<2.3.1.0a0",
linux-aarch64::ffmpeg-5.1.1-gpl_h4289b67_101.tar.bz2
-    "openh264 >=2.3.0,<2.4.0a0",
+    "openh264 >=2.3.0,<2.3.1.0a0",
linux-aarch64::ffmpeg-5.1.1-lgpl_h683d94b_1.tar.bz2
-    "openh264 >=2.3.0,<2.4.0a0",
+    "openh264 >=2.3.0,<2.3.1.0a0",
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata.json.bz2
linux-ppc64le::clang-15.0.1-ha3edaa6_0.tar.bz2
-  "version": "15.0.1"
+  "version": "15.0.1",
+  "constrains": [
+    "clang-tools 15.0.1.*",
+    "llvm 15.0.1.*",
+    "llvm-tools 15.0.1.*",
+    "llvmdev 15.0.1.*"
+  ]
linux-ppc64le::clang-tools-15.0.1-default_h1896e6d_0.tar.bz2
-    "clangdev 15.0.1"
+    "clangdev 15.0.1",
+    "clang 15.0.1.*",
+    "llvm 15.0.1.*",
+    "llvm-tools 15.0.1.*",
+    "llvmdev 15.0.1.*"
linux-ppc64le::ffmpeg-4.4.2-gpl_h1fe4f10_107.tar.bz2
-    "openh264 >=2.3.0,<2.4.0a0",
+    "openh264 >=2.3.0,<2.3.1.0a0",
linux-ppc64le::ffmpeg-4.4.2-gpl_hb6e85f8_107.tar.bz2
-    "openh264 >=2.3.0,<2.4.0a0",
+    "openh264 >=2.3.0,<2.3.1.0a0",
linux-ppc64le::ffmpeg-4.4.2-lgpl_h08c3af9_7.tar.bz2
-    "openh264 >=2.3.0,<2.4.0a0",
+    "openh264 >=2.3.0,<2.3.1.0a0",
linux-ppc64le::ffmpeg-4.4.2-lgpl_h10a5cfd_7.tar.bz2
-    "openh264 >=2.3.0,<2.4.0a0",
+    "openh264 >=2.3.0,<2.3.1.0a0",
linux-ppc64le::ffmpeg-5.1.0-gpl_h1fe4f10_101.tar.bz2
-    "openh264 >=2.3.0,<2.4.0a0",
+    "openh264 >=2.3.0,<2.3.1.0a0",
linux-ppc64le::ffmpeg-5.1.0-gpl_hb6e85f8_101.tar.bz2
-    "openh264 >=2.3.0,<2.4.0a0",
+    "openh264 >=2.3.0,<2.3.1.0a0",
linux-ppc64le::ffmpeg-5.1.0-lgpl_h08c3af9_1.tar.bz2
-    "openh264 >=2.3.0,<2.4.0a0",
+    "openh264 >=2.3.0,<2.3.1.0a0",
linux-ppc64le::ffmpeg-5.1.0-lgpl_h10a5cfd_1.tar.bz2
-    "openh264 >=2.3.0,<2.4.0a0",
+    "openh264 >=2.3.0,<2.3.1.0a0",
linux-ppc64le::ffmpeg-5.1.1-gpl_h1fe4f10_101.tar.bz2
-    "openh264 >=2.3.0,<2.4.0a0",
+    "openh264 >=2.3.0,<2.3.1.0a0",
linux-ppc64le::ffmpeg-5.1.1-lgpl_h08c3af9_1.tar.bz2
-    "openh264 >=2.3.0,<2.4.0a0",
+    "openh264 >=2.3.0,<2.3.1.0a0",
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata.json.bz2
osx-64::clang-15.0.1-h694c41f_0.tar.bz2
-  "version": "15.0.1"
+  "version": "15.0.1",
+  "constrains": [
+    "clang-tools 15.0.1.*",
+    "llvm 15.0.1.*",
+    "llvm-tools 15.0.1.*",
+    "llvmdev 15.0.1.*"
+  ]
osx-64::clang-tools-15.0.1-default_h20dc2f0_0.tar.bz2
-    "clangdev 15.0.1"
+    "clangdev 15.0.1",
+    "clang 15.0.1.*",
+    "llvm 15.0.1.*",
+    "llvm-tools 15.0.1.*",
+    "llvmdev 15.0.1.*"
osx-64::ffmpeg-4.4.2-gpl_h381bf92_107.tar.bz2
-    "openh264 >=2.3.0,<2.4.0a0",
+    "openh264 >=2.3.0,<2.3.1.0a0",
osx-64::ffmpeg-4.4.2-gpl_h5a1d76f_107.tar.bz2
-    "openh264 >=2.3.0,<2.4.0a0",
+    "openh264 >=2.3.0,<2.3.1.0a0",
osx-64::ffmpeg-4.4.2-lgpl_h13201bc_7.tar.bz2
-    "openh264 >=2.3.0,<2.4.0a0",
+    "openh264 >=2.3.0,<2.3.1.0a0",
osx-64::ffmpeg-4.4.2-lgpl_heab96f6_7.tar.bz2
-    "openh264 >=2.3.0,<2.4.0a0",
+    "openh264 >=2.3.0,<2.3.1.0a0",
osx-64::ffmpeg-5.1.0-gpl_h381bf92_101.tar.bz2
-    "openh264 >=2.3.0,<2.4.0a0",
+    "openh264 >=2.3.0,<2.3.1.0a0",
osx-64::ffmpeg-5.1.0-gpl_h5a1d76f_101.tar.bz2
-    "openh264 >=2.3.0,<2.4.0a0",
+    "openh264 >=2.3.0,<2.3.1.0a0",
osx-64::ffmpeg-5.1.0-lgpl_h13201bc_1.tar.bz2
-    "openh264 >=2.3.0,<2.4.0a0",
+    "openh264 >=2.3.0,<2.3.1.0a0",
osx-64::ffmpeg-5.1.0-lgpl_heab96f6_1.tar.bz2
-    "openh264 >=2.3.0,<2.4.0a0",
+    "openh264 >=2.3.0,<2.3.1.0a0",
osx-64::ffmpeg-5.1.1-gpl_h5a1d76f_101.tar.bz2
-    "openh264 >=2.3.0,<2.4.0a0",
+    "openh264 >=2.3.0,<2.3.1.0a0",
osx-64::ffmpeg-5.1.1-lgpl_h13201bc_1.tar.bz2
-    "openh264 >=2.3.0,<2.4.0a0",
+    "openh264 >=2.3.0,<2.3.1.0a0",
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata.json.bz2
osx-arm64::clang-15.0.1-hce30654_0.tar.bz2
-  "version": "15.0.1"
+  "version": "15.0.1",
+  "constrains": [
+    "clang-tools 15.0.1.*",
+    "llvm 15.0.1.*",
+    "llvm-tools 15.0.1.*",
+    "llvmdev 15.0.1.*"
+  ]
osx-arm64::clang-tools-15.0.1-default_h9e54d93_0.tar.bz2
-    "clangdev 15.0.1"
+    "clangdev 15.0.1",
+    "clang 15.0.1.*",
+    "llvm 15.0.1.*",
+    "llvm-tools 15.0.1.*",
+    "llvmdev 15.0.1.*"
osx-arm64::ffmpeg-4.4.2-gpl_hf4fd261_107.tar.bz2
-    "openh264 >=2.3.0,<2.4.0a0",
+    "openh264 >=2.3.0,<2.3.1.0a0",
osx-arm64::ffmpeg-4.4.2-gpl_hfdc7bce_107.tar.bz2
-    "openh264 >=2.3.0,<2.4.0a0",
+    "openh264 >=2.3.0,<2.3.1.0a0",
osx-arm64::ffmpeg-4.4.2-lgpl_h4c4a6e0_7.tar.bz2
-    "openh264 >=2.3.0,<2.4.0a0",
+    "openh264 >=2.3.0,<2.3.1.0a0",
osx-arm64::ffmpeg-4.4.2-lgpl_hb6097fc_7.tar.bz2
-    "openh264 >=2.3.0,<2.4.0a0",
+    "openh264 >=2.3.0,<2.3.1.0a0",
osx-arm64::ffmpeg-5.1.0-gpl_hf4fd261_101.tar.bz2
-    "openh264 >=2.3.0,<2.4.0a0",
+    "openh264 >=2.3.0,<2.3.1.0a0",
osx-arm64::ffmpeg-5.1.0-gpl_hfdc7bce_101.tar.bz2
-    "openh264 >=2.3.0,<2.4.0a0",
+    "openh264 >=2.3.0,<2.3.1.0a0",
osx-arm64::ffmpeg-5.1.0-lgpl_h4c4a6e0_1.tar.bz2
-    "openh264 >=2.3.0,<2.4.0a0",
+    "openh264 >=2.3.0,<2.3.1.0a0",
osx-arm64::ffmpeg-5.1.0-lgpl_hb6097fc_1.tar.bz2
-    "openh264 >=2.3.0,<2.4.0a0",
+    "openh264 >=2.3.0,<2.3.1.0a0",
osx-arm64::ffmpeg-5.1.1-gpl_hfdc7bce_101.tar.bz2
-    "openh264 >=2.3.0,<2.4.0a0",
+    "openh264 >=2.3.0,<2.3.1.0a0",
osx-arm64::ffmpeg-5.1.1-lgpl_h4c4a6e0_1.tar.bz2
-    "openh264 >=2.3.0,<2.4.0a0",
+    "openh264 >=2.3.0,<2.3.1.0a0",
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata.json.bz2
win-64::clang-15.0.1-h8e541a6_0.tar.bz2
-  "version": "15.0.1"
+  "version": "15.0.1",
+  "constrains": [
+    "clang-tools 15.0.1.*",
+    "llvm 15.0.1.*",
+    "llvm-tools 15.0.1.*",
+    "llvmdev 15.0.1.*"
+  ]
win-64::clang-tools-15.0.1-default_h66ee7f4_0.tar.bz2
-    "clangdev 15.0.1"
+    "clangdev 15.0.1",
+    "clang 15.0.1.*",
+    "llvm 15.0.1.*",
+    "llvm-tools 15.0.1.*",
+    "llvmdev 15.0.1.*"
win-64::ffmpeg-4.4.2-gpl_h36dc936_107.tar.bz2
-    "openh264 >=2.3.0,<2.4.0a0",
+    "openh264 >=2.3.0,<2.3.1.0a0",
win-64::ffmpeg-4.4.2-gpl_hbb6702b_107.tar.bz2
-    "openh264 >=2.3.0,<2.4.0a0",
+    "openh264 >=2.3.0,<2.3.1.0a0",
win-64::ffmpeg-4.4.2-lgpl_h8e85fd5_7.tar.bz2
-    "openh264 >=2.3.0,<2.4.0a0",
+    "openh264 >=2.3.0,<2.3.1.0a0",
win-64::ffmpeg-4.4.2-lgpl_hc6f5158_7.tar.bz2
-    "openh264 >=2.3.0,<2.4.0a0",
+    "openh264 >=2.3.0,<2.3.1.0a0",
win-64::ffmpeg-5.1.0-gpl_h36dc936_101.tar.bz2
-    "openh264 >=2.3.0,<2.4.0a0",
+    "openh264 >=2.3.0,<2.3.1.0a0",
win-64::ffmpeg-5.1.0-gpl_hbb6702b_101.tar.bz2
-    "openh264 >=2.3.0,<2.4.0a0",
+    "openh264 >=2.3.0,<2.3.1.0a0",
win-64::ffmpeg-5.1.0-lgpl_h8e85fd5_1.tar.bz2
-    "openh264 >=2.3.0,<2.4.0a0",
+    "openh264 >=2.3.0,<2.3.1.0a0",
win-64::ffmpeg-5.1.0-lgpl_hc6f5158_1.tar.bz2
-    "openh264 >=2.3.0,<2.4.0a0",
+    "openh264 >=2.3.0,<2.3.1.0a0",
win-64::ffmpeg-5.1.1-gpl_h7b28927_101.tar.bz2
-    "openh264 >=2.3.0,<2.4.0a0",
+    "openh264 >=2.3.0,<2.3.1.0a0",
win-64::ffmpeg-5.1.1-lgpl_h3b4b236_1.tar.bz2
-    "openh264 >=2.3.0,<2.4.0a0",
+    "openh264 >=2.3.0,<2.3.1.0a0",
```
</details>

xref: https://github.com/conda-forge/openh264-feedstock/pull/20
or
xref: https://github.com/conda-forge/openh264-feedstock/pull/21
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
