### PR TITLE
ENH patch nbconvert 5 for mistune and jinja2

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1862,6 +1862,27 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                 new_deps.append(dep)
             record["depends"] = new_deps
 
+        # jinja2 3 breaks nbconvert 5
+        # see https://github.com/conda-forge/nbconvert-feedstock/issues/81
+        # the issue there says to pin mistune <1. However some current mistune
+        # pins for v5 are <2, so going with that.
+        if (
+            record_name == "nbconvert"
+            and pkg_resources.parse_version(record["version"]).major == 5
+        ):
+            for i in range(len(record["depends"])):
+                parts = record["depends"][i].split(" ")
+                if parts[0] == "jinja2":
+                    if len(parts) == 1:
+                        parts.append("<3")
+                    elif len(parts) == 2 and "<" not in parts[1]:
+                        parts[1] = parts[1] + ",<3a0"
+                    record["depends"][i] = " ".join(parts)
+                elif parts[0] == "mistune":
+                    if len(parts) == 2 and "<" not in parts[1]:
+                        parts[1] = parts[1] + ",<2a0"
+                    record["depends"][i] = " ".join(parts)
+
     return index
 
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

closes https://github.com/conda-forge/nbconvert-feedstock/issues/81
