### PR TITLE
add upper bound for conda to mamba

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1710,6 +1710,15 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                 if dep_name == "conda":
                     record["depends"][i] = "conda >=4.8"
 
+        if record_name == "mamba" and (
+            pkg_resources.parse_version(record["version"]) ==
+            pkg_resources.parse_version("0.25.0")):
+
+            for i, dep in enumerate(record["depends"]):
+                dep_name, *dep_other = dep.split()
+                if dep_name == "conda":
+                    record["depends"][i] = "conda >=4.8,<5"
+
         if record_name == "aesara" and (
             pkg_resources.parse_version(record["version"]) >
             pkg_resources.parse_version("2.4.0") and


### PR DESCRIPTION
Unfortunately the latest conda breaks mamba -- we're working on fixing that. 
In the meantime, this PR adds an upper bound to conda for the latest mamba release (previous releases already have an upper bound as far as I can see).

https://github.com/mamba-org/mamba/issues/1950



<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
