### PR TITLE
Fix zarr 2.13.2's numcodecs min pin to 0.10.0

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1128,6 +1128,19 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                 new_depends.append("setuptools <60.0.0")
             record["depends"] = new_depends
 
+        # Fix numcodecs min pin to 0.10.0 for zarr 2.13.2
+        if (
+            record_name in "zarr"
+            and (
+                pkg_resources.parse_version(record["version"])
+                == pkg_resources.parse_version("2.13.2")
+            )
+        ):
+            record["depends"] = [
+                "numcodecs >=0.10.0" if dep == "numcodecs >=0.6.4" else dep
+                for dep in record.get("depends", [])
+            ]
+
         # old CDTs with the conda_cos6 or conda_cos7 name in the sysroot need to
         # conflict with the new CDT and compiler packages
         # all of the new CDTs and compilers depend on the sysroot_{subdir} packages


### PR DESCRIPTION
Follow up to PR ( https://github.com/conda-forge/zarr-feedstock/pull/69 )

<hr>

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
