### PR TITLE
Patch for `cuda-python` 11.7.1

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -823,11 +823,6 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                 if dep.startswith("cuda-python"):
                     record["constrains"][i] = "cuda-python >=11.6,<11.7.1"
                     break
-        if (record_name == "cuda-python"
-            and pkg_resources.parse_version(record["version"]) == pkg_resources.parse_version("11.7.1")
-            and record['build_number'] == 0):
-            # add run_exports
-            deps.append("cuda-python >=11.7.1,<12.0a0")
 
         if record.get('timestamp', 0) < 1663795137000:
             if any(dep.startswith("arpack >=3.7") for dep in deps):

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -823,6 +823,11 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                 if dep.startswith("cuda-python"):
                     record["constrains"][i] = "cuda-python >=11.6,<11.7.1"
                     break
+        if (record_name == "cuda-python"
+            and pkg_resources.parse_version(record["version"]) == pkg_resources.parse_version("11.7.1")
+            and record['build_number'] == 0):
+            # add run_exports
+            deps.append("cuda-python >=11.7.1,<12.0a0")
 
         if record.get('timestamp', 0) < 1663795137000:
             if any(dep.startswith("arpack >=3.7") for dep in deps):

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -808,7 +808,7 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
         if i >= 0:
             deps[i] = "cudatoolkit >=11.2,<12.0a0"
 
-        # cuda-python 11.7.1 is ABI-breaking, currently it impacts rmm & numba
+        # cuda-python 11.7.1 is ABI-breaking, currently it impacts only rmm
         if record_name == "rmm":
             if pkg_resources.parse_version(record["version"]) < pkg_resources.parse_version("22.08"):
                 # these were built with cuda-python <= 11.7.0
@@ -817,12 +817,6 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                 and record['build_number'] == 0):
                 # this is built with cuda-python 11.7.1
                 _replace_pin("cuda-python >=11.7,<12.0a0", "cuda-python >=11.7.1,<12.0a0", deps, record)
-        if (record_name == "numba"
-            and pkg_resources.parse_version(record["version"]) <= pkg_resources.parse_version("0.56.2")):
-            for i, dep in enumerate(record.get("constrains", [])):
-                if dep.startswith("cuda-python"):
-                    record["constrains"][i] = "cuda-python >=11.6,<11.7.1"
-                    break
 
         if record.get('timestamp', 0) < 1663795137000:
             if any(dep.startswith("arpack >=3.7") for dep in deps):


### PR DESCRIPTION
Part of fixing https://github.com/conda-forge/cuda-python-feedstock/issues/15.

I did a quick search and it seems currently only `rmm` and `numba` depend on `cuda-python`.

See the diff here:
<details><summary>CLICK ME</summary>

```diff
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata.json.bz2
linux-64::numba-0.55.2-py310ha5257ce_0.tar.bz2
-    "cuda-python >=11.6",
+    "cuda-python >=11.6,<11.7.1",
linux-64::numba-0.55.2-py37h43839f2_0.tar.bz2
-    "cuda-python >=11.6",
+    "cuda-python >=11.6,<11.7.1",
linux-64::numba-0.55.2-py38hdc3674a_0.tar.bz2
-    "cuda-python >=11.6",
+    "cuda-python >=11.6,<11.7.1",
linux-64::numba-0.55.2-py39h66db6d7_0.tar.bz2
-    "cuda-python >=11.6",
+    "cuda-python >=11.6,<11.7.1",
linux-64::numba-0.56.2-py310ha5257ce_0.tar.bz2
-    "cuda-python >=11.6",
+    "cuda-python >=11.6,<11.7.1",
linux-64::numba-0.56.2-py310ha5257ce_1.tar.bz2
-    "cuda-python >=11.6",
+    "cuda-python >=11.6,<11.7.1",
linux-64::numba-0.56.2-py37hf081915_0.tar.bz2
-    "cuda-python >=11.6",
+    "cuda-python >=11.6,<11.7.1",
linux-64::numba-0.56.2-py37hf081915_1.tar.bz2
-    "cuda-python >=11.6",
+    "cuda-python >=11.6,<11.7.1",
linux-64::numba-0.56.2-py38h9a4aae9_0.tar.bz2
-    "cuda-python >=11.6",
+    "cuda-python >=11.6,<11.7.1",
linux-64::numba-0.56.2-py38h9a4aae9_1.tar.bz2
-    "cuda-python >=11.6",
+    "cuda-python >=11.6,<11.7.1",
linux-64::numba-0.56.2-py39h61ddf18_0.tar.bz2
-    "cuda-python >=11.6"
+    "cuda-python >=11.6,<11.7.1"
linux-64::numba-0.56.2-py39h61ddf18_1.tar.bz2
-    "cuda-python >=11.6",
+    "cuda-python >=11.6,<11.7.1",
linux-64::rmm-22.06.00-py310h1de6c43_0.tar.bz2
-    "cuda-python >=11.7,<12.0a0",
+    "cuda-python >=11.7,<11.7.1.0a0",
linux-64::rmm-22.06.00-py38h81e7143_0.tar.bz2
-    "cuda-python >=11.7,<12.0a0",
+    "cuda-python >=11.7,<11.7.1.0a0",
linux-64::rmm-22.06.00-py39hbcfe0b2_0.tar.bz2
-    "cuda-python >=11.7,<12.0a0",
+    "cuda-python >=11.7,<11.7.1.0a0",
linux-64::rmm-22.08.00-py310h1de6c43_0.tar.bz2
-    "cuda-python >=11.7,<12.0a0",
+    "cuda-python >=11.7.1,<12.0a0",
linux-64::rmm-22.08.00-py38h81e7143_0.tar.bz2
-    "cuda-python >=11.7,<12.0a0",
+    "cuda-python >=11.7.1,<12.0a0",
linux-64::rmm-22.08.00-py39hbcfe0b2_0.tar.bz2
-    "cuda-python >=11.7,<12.0a0",
+    "cuda-python >=11.7.1,<12.0a0",
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata.json.bz2
linux-aarch64::numba-0.55.2-py310h7e061d2_0.tar.bz2
-    "cuda-python >=11.6",
+    "cuda-python >=11.6,<11.7.1",
linux-aarch64::numba-0.55.2-py37hea1f400_0.tar.bz2
-    "cuda-python >=11.6",
+    "cuda-python >=11.6,<11.7.1",
linux-aarch64::numba-0.55.2-py38h90f1751_0.tar.bz2
-    "cuda-python >=11.6"
+    "cuda-python >=11.6,<11.7.1"
linux-aarch64::numba-0.55.2-py39h780101b_0.tar.bz2
-    "cuda-python >=11.6",
+    "cuda-python >=11.6,<11.7.1",
linux-aarch64::numba-0.56.2-py310h7e061d2_0.tar.bz2
-    "cuda-python >=11.6"
+    "cuda-python >=11.6,<11.7.1"
linux-aarch64::numba-0.56.2-py310h7e061d2_1.tar.bz2
-    "cuda-python >=11.6"
+    "cuda-python >=11.6,<11.7.1"
linux-aarch64::numba-0.56.2-py37h1c995b0_0.tar.bz2
-    "cuda-python >=11.6",
+    "cuda-python >=11.6,<11.7.1",
linux-aarch64::numba-0.56.2-py37h1c995b0_1.tar.bz2
-    "cuda-python >=11.6"
+    "cuda-python >=11.6,<11.7.1"
linux-aarch64::numba-0.56.2-py38h4c0ec4d_0.tar.bz2
-    "cuda-python >=11.6",
+    "cuda-python >=11.6,<11.7.1",
linux-aarch64::numba-0.56.2-py38h4c0ec4d_1.tar.bz2
-    "cuda-python >=11.6",
+    "cuda-python >=11.6,<11.7.1",
linux-aarch64::numba-0.56.2-py39h58e5d4c_0.tar.bz2
-    "cuda-python >=11.6",
+    "cuda-python >=11.6,<11.7.1",
linux-aarch64::numba-0.56.2-py39h58e5d4c_1.tar.bz2
-    "cuda-python >=11.6",
+    "cuda-python >=11.6,<11.7.1",
linux-aarch64::rmm-22.06.00-py310h9691930_0.tar.bz2
-    "cuda-python >=11.7,<12.0a0",
+    "cuda-python >=11.7,<11.7.1.0a0",
linux-aarch64::rmm-22.06.00-py38h9c9d46e_0.tar.bz2
-    "cuda-python >=11.7,<12.0a0",
+    "cuda-python >=11.7,<11.7.1.0a0",
linux-aarch64::rmm-22.06.00-py39hebf1436_0.tar.bz2
-    "cuda-python >=11.7,<12.0a0",
+    "cuda-python >=11.7,<11.7.1.0a0",
linux-aarch64::rmm-22.08.00-py310h9691930_0.tar.bz2
-    "cuda-python >=11.7,<12.0a0",
+    "cuda-python >=11.7.1,<12.0a0",
linux-aarch64::rmm-22.08.00-py38h9c9d46e_0.tar.bz2
-    "cuda-python >=11.7,<12.0a0",
+    "cuda-python >=11.7.1,<12.0a0",
linux-aarch64::rmm-22.08.00-py39hebf1436_0.tar.bz2
-    "cuda-python >=11.7,<12.0a0",
+    "cuda-python >=11.7.1,<12.0a0",
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata.json.bz2
linux-ppc64le::numba-0.55.2-py310h782a0c3_0.tar.bz2
-    "cuda-python >=11.6",
+    "cuda-python >=11.6,<11.7.1",
linux-ppc64le::numba-0.55.2-py37h483c640_0.tar.bz2
-    "cuda-python >=11.6",
+    "cuda-python >=11.6,<11.7.1",
linux-ppc64le::numba-0.55.2-py38h4c6250a_0.tar.bz2
-    "cuda-python >=11.6",
+    "cuda-python >=11.6,<11.7.1",
linux-ppc64le::numba-0.55.2-py39ha474065_0.tar.bz2
-    "cuda-python >=11.6"
+    "cuda-python >=11.6,<11.7.1"
linux-ppc64le::rmm-22.06.00-py310hadc03bd_0.tar.bz2
-    "cuda-python >=11.7,<12.0a0",
+    "cuda-python >=11.7,<11.7.1.0a0",
linux-ppc64le::rmm-22.06.00-py38habd7850_0.tar.bz2
-    "cuda-python >=11.7,<12.0a0",
+    "cuda-python >=11.7,<11.7.1.0a0",
linux-ppc64le::rmm-22.06.00-py39hb0a7ebe_0.tar.bz2
-    "cuda-python >=11.7,<12.0a0",
+    "cuda-python >=11.7,<11.7.1.0a0",
linux-ppc64le::rmm-22.08.00-py310hadc03bd_0.tar.bz2
-    "cuda-python >=11.7,<12.0a0",
+    "cuda-python >=11.7.1,<12.0a0",
linux-ppc64le::rmm-22.08.00-py38habd7850_0.tar.bz2
-    "cuda-python >=11.7,<12.0a0",
+    "cuda-python >=11.7.1,<12.0a0",
linux-ppc64le::rmm-22.08.00-py39hb0a7ebe_0.tar.bz2
-    "cuda-python >=11.7,<12.0a0",
+    "cuda-python >=11.7.1,<12.0a0",
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata.json.bz2
osx-64::numba-0.55.2-py310hab1bff6_0.tar.bz2
-    "cuda-python >=11.6",
+    "cuda-python >=11.6,<11.7.1",
osx-64::numba-0.55.2-py37h7687b59_0.tar.bz2
-    "cuda-python >=11.6",
+    "cuda-python >=11.6,<11.7.1",
osx-64::numba-0.55.2-py38h1f551d2_0.tar.bz2
-    "cuda-python >=11.6"
+    "cuda-python >=11.6,<11.7.1"
osx-64::numba-0.55.2-py39hc37845d_0.tar.bz2
-    "cuda-python >=11.6",
+    "cuda-python >=11.6,<11.7.1",
osx-64::numba-0.56.2-py310h62db5c2_0.tar.bz2
-    "cuda-python >=11.6",
+    "cuda-python >=11.6,<11.7.1",
osx-64::numba-0.56.2-py310h62db5c2_1.tar.bz2
-    "cuda-python >=11.6",
+    "cuda-python >=11.6,<11.7.1",
osx-64::numba-0.56.2-py37h7da6166_0.tar.bz2
-    "cuda-python >=11.6",
+    "cuda-python >=11.6,<11.7.1",
osx-64::numba-0.56.2-py37h7da6166_1.tar.bz2
-    "cuda-python >=11.6",
+    "cuda-python >=11.6,<11.7.1",
osx-64::numba-0.56.2-py38hab356c4_0.tar.bz2
-    "cuda-python >=11.6"
+    "cuda-python >=11.6,<11.7.1"
osx-64::numba-0.56.2-py38hab356c4_1.tar.bz2
-    "cuda-python >=11.6",
+    "cuda-python >=11.6,<11.7.1",
osx-64::numba-0.56.2-py39hf6b9d82_0.tar.bz2
-    "cuda-python >=11.6",
+    "cuda-python >=11.6,<11.7.1",
osx-64::numba-0.56.2-py39hf6b9d82_1.tar.bz2
-    "cuda-python >=11.6",
+    "cuda-python >=11.6,<11.7.1",
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata.json.bz2
osx-arm64::numba-0.55.2-py310ha67b2a8_0.tar.bz2
-    "cuda-python >=11.6",
+    "cuda-python >=11.6,<11.7.1",
osx-arm64::numba-0.55.2-py38h25e2f74_0.tar.bz2
-    "cuda-python >=11.6",
+    "cuda-python >=11.6,<11.7.1",
osx-arm64::numba-0.55.2-py39hc0d1af8_0.tar.bz2
-    "cuda-python >=11.6",
+    "cuda-python >=11.6,<11.7.1",
osx-arm64::numba-0.56.2-py310h3124f1e_0.tar.bz2
-    "cuda-python >=11.6",
+    "cuda-python >=11.6,<11.7.1",
osx-arm64::numba-0.56.2-py310h3124f1e_1.tar.bz2
-    "cuda-python >=11.6",
+    "cuda-python >=11.6,<11.7.1",
osx-arm64::numba-0.56.2-py38h947a10e_0.tar.bz2
-    "cuda-python >=11.6",
+    "cuda-python >=11.6,<11.7.1",
osx-arm64::numba-0.56.2-py38h947a10e_1.tar.bz2
-    "cuda-python >=11.6"
+    "cuda-python >=11.6,<11.7.1"
osx-arm64::numba-0.56.2-py39h251cc7c_0.tar.bz2
-    "cuda-python >=11.6",
+    "cuda-python >=11.6,<11.7.1",
osx-arm64::numba-0.56.2-py39h251cc7c_1.tar.bz2
-    "cuda-python >=11.6"
+    "cuda-python >=11.6,<11.7.1"
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata.json.bz2
win-64::numba-0.55.2-py310h77579ad_0.tar.bz2
-    "cuda-python >=11.6",
+    "cuda-python >=11.6,<11.7.1",
win-64::numba-0.55.2-py37hc29f945_0.tar.bz2
-    "cuda-python >=11.6",
+    "cuda-python >=11.6,<11.7.1",
win-64::numba-0.55.2-py38h860efb6_0.tar.bz2
-    "cuda-python >=11.6",
+    "cuda-python >=11.6,<11.7.1",
win-64::numba-0.55.2-py39hb8cd55e_0.tar.bz2
-    "cuda-python >=11.6",
+    "cuda-python >=11.6,<11.7.1",
win-64::numba-0.56.2-py310h19bcfe9_0.tar.bz2
-    "cuda-python >=11.6",
+    "cuda-python >=11.6,<11.7.1",
win-64::numba-0.56.2-py310h19bcfe9_1.tar.bz2
-    "cuda-python >=11.6",
+    "cuda-python >=11.6,<11.7.1",
win-64::numba-0.56.2-py37h9c05cb2_0.tar.bz2
-    "cuda-python >=11.6"
+    "cuda-python >=11.6,<11.7.1"
win-64::numba-0.56.2-py37h9c05cb2_1.tar.bz2
-    "cuda-python >=11.6",
+    "cuda-python >=11.6,<11.7.1",
win-64::numba-0.56.2-py38h3873db4_0.tar.bz2
-    "cuda-python >=11.6",
+    "cuda-python >=11.6,<11.7.1",
win-64::numba-0.56.2-py38h3873db4_1.tar.bz2
-    "cuda-python >=11.6",
+    "cuda-python >=11.6,<11.7.1",
win-64::numba-0.56.2-py39h99ae161_0.tar.bz2
-    "cuda-python >=11.6",
+    "cuda-python >=11.6,<11.7.1",
win-64::numba-0.56.2-py39h99ae161_1.tar.bz2
-    "cuda-python >=11.6"
+    "cuda-python >=11.6,<11.7.1"
```

</p>
</details>

cc: @kkraus14 @jakirkham @conda-forge/rmm @conda-forge/numba @conda-forge/cuda-python 

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
