### PR TITLE
Add Python >= 3.7 dependency to orix 0.10.0 noarch build 0

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,0 @@
-Checklist
-
-* [ ] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/patch_yaml/README.md)).
-* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
-* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
-* [ ] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->
-
-<!-- Put any other comments or information here --!>

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -2719,6 +2719,15 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             _replace_pin("jax >=0.3.2", "jax >=0.3.2,<0.4.14", record["depends"], record)
             _replace_pin("jax >=0.2.6", "jax >=0.2.6,<0.4.14", record["depends"], record)
 
+        # orix 0.10.0 dropped Python 3.6 support but first build accidentally included 3.6 support
+        # (https://github.com/conda-forge/orix-feedstock/pull/23)
+        if (
+            record_name == "orix"
+            and record["version"] == "0.10.0"
+            and record["build_number"] == 0
+        ):
+            _replace_pin("python >=3", "python >=3.7", record["depends"], record)
+
     return index
 
 


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

orix 0.10.0 dropped Python 3.6 support but the first (noarch) build accidentally included 3.6 support. This was rectified for future builds in https://github.com/conda-forge/orix-feedstock/pull/23.

Output of `show_diff.py` after making changes to `gen_patch_json.py`:

```python
> python show_diff.py
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata.json.bz2
noarch::orix-0.10.0-pyhd8ed1ab_0.tar.bz2
-    "python >=3",
+    "python >=3.7",
noarch::verta-0.21.0-pyhd8ed1ab_0.tar.bz2
-    "python =2.7|>=3.5",
+    "python ==2.7.*|>=3.5",
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata.json.bz2
```

New output as of August 30, 2023:

```python
> python recipe/show_diff.py
================================================================================
================================================================================
noarch
noarch::orix-0.10.0-pyhd8ed1ab_0.tar.bz2
-    "python >=3",
+    "python >=3.7",
================================================================================
================================================================================
linux-64
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
osx-64
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
win-32
================================================================================
================================================================================
win-64
```

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [N/A] Bumped the build number (if the version is unchanged)
* [N/A] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
