### PR TITLE
Remove broken moviepy 1.0.3 build

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -31,6 +31,7 @@ SUBDIRS = (
 
 REMOVALS = {
     "noarch": (
+        "moviepy-1.0.3-pyhd8ed1ab_0.tar.bz2",
         "sendgrid-5.3.0-py_0.tar.bz2",
     ),
     "linux-64": (


### PR DESCRIPTION
This package had an incorrect `.patch` version applied, causing it to fail. I have a fix for the patch file (https://github.com/conda-forge/moviepy-feedstock/pull/17), but it's taking a while to get merged so let's just yank the broken build for now to prevent people from running into this problem.