### PR TITLE
Add missing gcsfs dependency to minimalkv

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1010,6 +1010,9 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
         if any(dep.startswith("pari >=2.13.2") for dep in deps) and record.get('timestamp', 0) < 1625642169000:
             record["depends"].append("pari * *_single")
 
+        if record_name == "minimalkv" and record['version'] == '1.4.0' and record['build_number'] == 0:
+            record["depends"].append("gcsfs")
+
         # patch out bad numba for ngmix
         if (
             record_name == "ngmix"


### PR DESCRIPTION
The 1.4.0 release is missing a dependency on gcsfs. The build was already updated via https://github.com/conda-forge/minimalkv-feedstock/pull/13, this adds it to the existing build 0.

Diff: https://gist.github.com/xhochy/fdc5038f97a9731780862e3bb65603c8