### PR TITLE
Remove erroneous pyopenssl dependency from new version of stomp.py

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1810,6 +1810,18 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             _replace_pin("python-dateutil >=2.7.3", "python-dateutil >=2.8.1", record["depends"], record)
             _replace_pin("pytz >=2017.2", "pytz >=2020.1", record["depends"], record)
 
+        # stomp.py 8.0.1 build 0 has an erroneous dependency on pyopenssl.
+        if record_name == "stomp.py" and (
+                record["version"] == "8.0.1" and
+                record["build_number"] == 0):
+            depends = record["depends"]
+            new_depends = []
+            for dep in depends:
+                dep_name = dep.split()[0]
+                if dep_name != "pyopenssl":
+                    new_depends.append(dep)
+            record["depends"] = new_depends
+
         if (record_name == "keyring" and
                 record["version"] == "23.6.0" and
                 record["build_number"] == 0):


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

cc @beckermr 
