### PR TITLE
Add Python >=3.8 lower limit to satpy 0.37.0 and 0.37.1 build 0

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1948,6 +1948,15 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                         parts[1] = parts[1] + ",<5a0"
                     record["depends"][i] = " ".join(parts)
 
+        if (
+                record_name == "satpy"
+                and record.get("timestamp", 0) <= 1665672000000
+                and record["build_number"] == 0
+                and (pkg_resources.parse_version(record["version"]) == pkg_resources.parse_version("0.37.0")
+                or pkg_resources.parse_version(record["version"]) == pkg_resources.parse_version("0.37.1"))
+                ):
+            _replace_pin("python >=3.7", "python >=3.8", record["depends"], record)
+
     return index
 
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

Satpy dropped Python 3.7 support back in May but we forgot to update the limit on the Python dependency on the conda-forge package. This patches that. I could understand not merging this if conda-forge's official position is to drop Python 3.7 support.