### PR TITLE
Patch snowflake-sqlalchemy for sqlalchemy>=1.4.42

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1376,6 +1376,15 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             depends[depends.index("snowflake-connector-python <3")] = "snowflake-connector-python <3.0.0"
             depends[depends.index("sqlalchemy <2")] = "sqlalchemy >=1.4.0,<2.0.0"
 
+        # https://github.com/conda-forge/snowflake-sqlalchemy-feedstock/pull/15
+        if record_name == "snowflake-sqlalchemy" and "sqlalchemy >=1.4.0,<2.0.0" in record["depends"] and record.get("timestamp", 0) <= 1666005807652:
+            depends = record["depends"]
+            depends[depends.index("sqlalchemy >=1.4.0,<2.0.0")] = "sqlalchemy >=1.4.0,<1.4.42"
+
+        if record_name == "snowflake-sqlalchemy" and "sqlalchemy <2" in record["depends"] and record.get("timestamp", 0) <= 1666005807652:
+            depends = record["depends"]
+            depends[depends.index("sqlalchemy <2")] = "sqlalchemy <1.4.42"
+
         # tzlocal 3.0 needs Python 3.9 (or backports.zoneinfo)
         # fixed in https://github.com/conda-forge/tzlocal-feedstock/pull/10
         if record_name == "tzlocal" and record["version"] == "3.0" and "python >=3.6" in record["depends"]:


### PR DESCRIPTION
The latest sqlalchemy release (1.4.42) breaks snowflake-sqlalchemy. This PR adds an upper bound constraint for affected versions of `snowflake-sqlalchemy`.

https://github.com/conda-forge/snowflake-sqlalchemy-feedstock/pull/15

The diff is as follows:

```
python recipe/show_diff.py
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata.json.bz2
noarch::snowflake-sqlalchemy-1.2.3-pyh9f0ad1d_0.tar.bz2
-    "sqlalchemy <2"
+    "sqlalchemy <1.4.42"
noarch::snowflake-sqlalchemy-1.2.4-pyh9f0ad1d_0.tar.bz2
-    "sqlalchemy <2"
+    "sqlalchemy <1.4.42"
noarch::snowflake-sqlalchemy-1.2.5-pyhd8ed1ab_0.tar.bz2
-    "sqlalchemy >=1.4.0,<2.0.0"
+    "sqlalchemy >=1.4.0,<1.4.42"
noarch::snowflake-sqlalchemy-1.3.1-pyhd8ed1ab_0.tar.bz2
-    "sqlalchemy >=1.4.0,<2.0.0"
+    "sqlalchemy >=1.4.0,<1.4.42"
noarch::snowflake-sqlalchemy-1.3.1-pyhd8ed1ab_1.tar.bz2
-    "sqlalchemy >=1.4.0,<2.0.0"
+    "sqlalchemy >=1.4.0,<1.4.42"
noarch::snowflake-sqlalchemy-1.3.2-pyhd8ed1ab_0.tar.bz2
-    "sqlalchemy >=1.4.0,<2.0.0"
+    "sqlalchemy >=1.4.0,<1.4.42"
noarch::snowflake-sqlalchemy-1.3.3-pyhd8ed1ab_0.tar.bz2
-    "sqlalchemy >=1.4.0,<2.0.0"
+    "sqlalchemy >=1.4.0,<1.4.42"
noarch::snowflake-sqlalchemy-1.3.4-pyhd8ed1ab_0.tar.bz2
-    "sqlalchemy >=1.4.0,<2.0.0"
+    "sqlalchemy >=1.4.0,<1.4.42"
noarch::snowflake-sqlalchemy-1.4.0-pyhd8ed1ab_0.tar.bz2
-    "sqlalchemy >=1.4.0,<2.0.0"
+    "sqlalchemy >=1.4.0,<1.4.42"
noarch::snowflake-sqlalchemy-1.4.1-pyhd8ed1ab_0.tar.bz2
-    "sqlalchemy >=1.4.0,<2.0.0"
+    "sqlalchemy >=1.4.0,<1.4.42"
noarch::snowflake-sqlalchemy-1.4.2-pyhd8ed1ab_0.tar.bz2
-    "sqlalchemy >=1.4.0,<2.0.0"
+    "sqlalchemy >=1.4.0,<1.4.42"
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata.json.bz2
```


<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
