### PR TITLE
Also patch older versions of snowflake-sqlachemy

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1385,6 +1385,10 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             depends = record["depends"]
             depends[depends.index("sqlalchemy <2")] = "sqlalchemy <1.4.42"
 
+        if record_name == "snowflake-sqlalchemy" and "sqlalchemy <2.0.0" in record["depends"] and record.get("timestamp", 0) <= 1666005807652:
+            depends = record["depends"]
+            depends[depends.index("sqlalchemy <2.0.0")] = "sqlalchemy <1.4.42"
+
         # tzlocal 3.0 needs Python 3.9 (or backports.zoneinfo)
         # fixed in https://github.com/conda-forge/tzlocal-feedstock/pull/10
         if record_name == "tzlocal" and record["version"] == "3.0" and "python >=3.6" in record["depends"]:


### PR DESCRIPTION
Follow up to #335.

Diff:

```
python recipe/show_diff.py 
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata.json.bz2
noarch::snowflake-sqlalchemy-1.1.18-py_0.tar.bz2
-    "sqlalchemy <2.0.0"
+    "sqlalchemy <1.4.42"
noarch::snowflake-sqlalchemy-1.2.0-py_0.tar.bz2
-    "sqlalchemy <2.0.0"
+    "sqlalchemy <1.4.42"
noarch::snowflake-sqlalchemy-1.2.1-py_0.tar.bz2
-    "sqlalchemy <2.0.0"
+    "sqlalchemy <1.4.42"
noarch::snowflake-sqlalchemy-1.2.2-pyh8c360ce_0.tar.bz2
-    "sqlalchemy <2.0.0"
+    "sqlalchemy <1.4.42"
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata.json.bz2
```

Version 1.1.19 is missing from the diff. But that's okay, because that version doesn't exist on conda-forge.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
