### PR TITLE
Fix dependencies for switch_model 2.0.4 and 2.0.5

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -13,7 +13,7 @@ import re
 import requests
 import pkg_resources
 
-# from get_license_family import get_license_family
+from get_license_family import get_license_family
 
 CHANNEL_NAME = "conda-forge"
 CHANNEL_ALIAS = "https://conda.anaconda.org"
@@ -494,10 +494,10 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             else:
                 add_python_abi(record, subdir)
 
-        # if "license" in record and "license_family" not in record and record["license"]:
-        #     family = get_license_family(record["license"])
-        #     if family:
-        #         record['license_family'] = family
+        if "license" in record and "license_family" not in record and record["license"]:
+            family = get_license_family(record["license"])
+            if family:
+                record['license_family'] = family
 
         # remove dependency from constrains for twisted
         if record_name == "twisted":


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):

Early versions of `switch_model` were marked as compatible with all versions of
`pyomo` and with no explicit version requirements for `pyutilib` (a dependency
of `pyomo`). Those packages later introduced non-backward-compatible changes 
that broke compatibility with `switch_model`. This patch prevents users from 
accidentally installing older versions of `switch_model` with incompatible versions 
of `pyomo` and `pyutilib`.

-->

<!--
Please add any other relevant info below:
-->
