### PR TITLE
Fix pexpect

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1704,6 +1704,18 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                         _pin_stricter(fn, record, "metadetect", "x.x", "0.7.0")
                     else:
                         record["depends"][i] = record["depends"][i] + ",<0.7.0.a0"
+        if record_name == "pexpect" and pkg_resources.parse_version(
+            "4.0"
+        ) <= pkg_resources.parse_version(
+            record["version"]
+        ) <= pkg_resources.parse_version(
+            "4.8.0"
+        ) and not any(pyXY in record["build"] for pyXY in ["py27", "py34", "py35", "py36"]):
+            if "ptyprocess >=0.5" not in record["depends"]:
+                if "ptyprocess" in record["depends"]:
+                    _replace_pin("ptyprocess", "ptyprocess >=0.5", record["depends"], record)
+                else:
+                    record["depends"].append("ptyprocess >=0.5")
         if (
             record_name == "metadetect"
             and record.get("timestamp", 0) <= 1651593228024  # 2022/05


### PR DESCRIPTION
Closes conda-forge/pexpect-feedstock#26

Attn: @ocefpaf

Sometimes when installing a package for py38 or earlier (when non-noarch is an option), the required dependency
ptyprocess is missing. Example:
<https://github.com/conda-forge/poetry-feedstock/blob/cc7b7d853791182668e2277ac4f93beaff63cb79/recipe/meta.yaml>

This also corrects cases where the ptyprocess pin ">=0.5" was missing.

pexpect has had the pin ptyprocess >=0.5 since pexpect v4.0. The ptyprocess package used to not exist on Windows, so pexpect required a "# [not win]" selector, but at some point it was made noarch. This will allow "pip check" to pass on Windows. To avoid disturbing our ancestors, we avoid patching below py36. In particular:

- Unpatched: py27, py34, py35, py36
- Patched: py37, py38
- No change: noarch

Expected impact is low since there are no direct or transitive dependencies other than "ptyprocess >=0.5", and both pexpect and ptyprocess are now noarch.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
