### PR TITLE
Fix guiqwt 3.0.5 and 3.0.7 requirements

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1660,6 +1660,11 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
         # https://github.com/PierreRaybaut/guidata/issues/54
         if record_name == "guidata" and record["version"] == "1.7.9" and record["build_number"] == 0:
             _replace_pin("qtpy >=1.3", "qtpy >=1.3,<2.0", record["depends"], record)
+        # guiqwt 3.0.5 and 3.0.7 not compatible with qtpy >=2.0.0
+        # (previous versions didn't depend on it)
+        # https://github.com/conda-forge/guiqwt-feedstock/issues/21
+        if record_name == "guiqwt" and record["version"] in ("3.0.5", "3.0.7") and record["build_number"] in (0, 1):
+            _replace_pin("qtpy >=1.3", "qtpy >=1.3,<2.0", record["depends"], record)
 
         # older versions of dask-cuda do not work on non-UNIX operating systems and must be constrained to UNIX
         # issues in click 8.1.0 cause failures for older versions of dask-cuda


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)

This is the same issue as for `guidata` that was patched [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/342)
Versions 3.0.5 and 3.0.7 are not compatible with qtpy>=2.0 (previous versions 3.0.3 and 3.0.4 didn't depend on it).
There is no 3.0.6 on conda-forge.
I didn't use a timestamp as it was for only 2 versions.

Fix https://github.com/conda-forge/guiqwt-feedstock/issues/21

```
$ python show_diff.py --use-cache
linux-64::guiqwt-3.0.5-py36h7c3b610_0.tar.bz2
-    "qtpy >=1.3",
+    "qtpy >=1.3,<2.0",
linux-64::guiqwt-3.0.5-py36hd87012b_1.tar.bz2
-    "qtpy >=1.3",
+    "qtpy >=1.3,<2.0",
linux-64::guiqwt-3.0.5-py37h10a2094_1.tar.bz2
-    "qtpy >=1.3",
+    "qtpy >=1.3,<2.0",
linux-64::guiqwt-3.0.5-py37h9fdb41a_0.tar.bz2
-    "qtpy >=1.3",
+    "qtpy >=1.3,<2.0",
linux-64::guiqwt-3.0.5-py38h0ef3d22_1.tar.bz2
-    "qtpy >=1.3",
+    "qtpy >=1.3,<2.0",
linux-64::guiqwt-3.0.5-py38hc5bc63f_0.tar.bz2
-    "qtpy >=1.3",
+    "qtpy >=1.3,<2.0",
linux-64::guiqwt-3.0.5-py39h9cfe711_1.tar.bz2
-    "qtpy >=1.3",
+    "qtpy >=1.3,<2.0",
linux-64::guiqwt-3.0.7-py310hb5077e9_1.tar.bz2
-    "qtpy >=1.3",
+    "qtpy >=1.3,<2.0",
linux-64::guiqwt-3.0.7-py36h0cdc3f0_0.tar.bz2
-    "qtpy >=1.3",
+    "qtpy >=1.3,<2.0",
linux-64::guiqwt-3.0.7-py37he8f5f7f_0.tar.bz2
-    "qtpy >=1.3",
+    "qtpy >=1.3,<2.0",
linux-64::guiqwt-3.0.7-py37he8f5f7f_1.tar.bz2
-    "qtpy >=1.3",
+    "qtpy >=1.3,<2.0",
linux-64::guiqwt-3.0.7-py38h43a58ef_0.tar.bz2
-    "qtpy >=1.3",
+    "qtpy >=1.3,<2.0",
linux-64::guiqwt-3.0.7-py38h43a58ef_1.tar.bz2
-    "qtpy >=1.3",
+    "qtpy >=1.3,<2.0",
linux-64::guiqwt-3.0.7-py39hde0f152_0.tar.bz2
-    "qtpy >=1.3",
+    "qtpy >=1.3,<2.0",
linux-64::guiqwt-3.0.7-py39hde0f152_1.tar.bz2
-    "qtpy >=1.3",
+    "qtpy >=1.3,<2.0",
osx-64::guiqwt-3.0.5-py36h70595fc_1.tar.bz2
-    "qtpy >=1.3",
+    "qtpy >=1.3,<2.0",
osx-64::guiqwt-3.0.5-py36h72eec15_0.tar.bz2
-    "qtpy >=1.3",
+    "qtpy >=1.3,<2.0",
osx-64::guiqwt-3.0.5-py37h6d0141a_0.tar.bz2
-    "qtpy >=1.3",
+    "qtpy >=1.3,<2.0",
osx-64::guiqwt-3.0.5-py37h9b0e0a3_1.tar.bz2
-    "qtpy >=1.3",
+    "qtpy >=1.3,<2.0",
osx-64::guiqwt-3.0.5-py38h6be0db6_0.tar.bz2
-    "qtpy >=1.3",
+    "qtpy >=1.3,<2.0",
osx-64::guiqwt-3.0.5-py38hcf432d8_1.tar.bz2
-    "qtpy >=1.3",
+    "qtpy >=1.3,<2.0",
osx-64::guiqwt-3.0.5-py39hbafd028_1.tar.bz2
-    "qtpy >=1.3",
+    "qtpy >=1.3,<2.0",
osx-64::guiqwt-3.0.7-py310hdd25497_1.tar.bz2
-    "qtpy >=1.3",
+    "qtpy >=1.3,<2.0",
osx-64::guiqwt-3.0.7-py36he43235d_0.tar.bz2
-    "qtpy >=1.3",
+    "qtpy >=1.3,<2.0",
osx-64::guiqwt-3.0.7-py37h5b83a90_0.tar.bz2
-    "qtpy >=1.3",
+    "qtpy >=1.3,<2.0",
osx-64::guiqwt-3.0.7-py37h5b83a90_1.tar.bz2
-    "qtpy >=1.3",
+    "qtpy >=1.3,<2.0",
osx-64::guiqwt-3.0.7-py38ha53d530_0.tar.bz2
-    "qtpy >=1.3",
+    "qtpy >=1.3,<2.0",
osx-64::guiqwt-3.0.7-py38ha53d530_1.tar.bz2
-    "qtpy >=1.3",
+    "qtpy >=1.3,<2.0",
osx-64::guiqwt-3.0.7-py39h4d6be9b_0.tar.bz2
-    "qtpy >=1.3",
+    "qtpy >=1.3,<2.0",
osx-64::guiqwt-3.0.7-py39h4d6be9b_1.tar.bz2
-    "qtpy >=1.3",
+    "qtpy >=1.3,<2.0",
win-64::guiqwt-3.0.5-py36h2ba58a2_1.tar.bz2
-    "qtpy >=1.3",
+    "qtpy >=1.3,<2.0",
win-64::guiqwt-3.0.5-py36h70bd76a_0.tar.bz2
-    "qtpy >=1.3",
+    "qtpy >=1.3,<2.0",
win-64::guiqwt-3.0.5-py37h380d39b_1.tar.bz2
-    "qtpy >=1.3",
+    "qtpy >=1.3,<2.0",
win-64::guiqwt-3.0.5-py37h759d0f6_0.tar.bz2
-    "qtpy >=1.3",
+    "qtpy >=1.3,<2.0",
win-64::guiqwt-3.0.5-py38h07472f2_0.tar.bz2
-    "qtpy >=1.3",
+    "qtpy >=1.3,<2.0",
win-64::guiqwt-3.0.5-py38hfefc98e_1.tar.bz2
-    "qtpy >=1.3",
+    "qtpy >=1.3,<2.0",
win-64::guiqwt-3.0.5-py39h79958ce_1.tar.bz2
-    "qtpy >=1.3",
+    "qtpy >=1.3,<2.0",
win-64::guiqwt-3.0.7-py310hf0c6b8f_1.tar.bz2
-    "qtpy >=1.3",
+    "qtpy >=1.3,<2.0",
win-64::guiqwt-3.0.7-py36h345bdb7_0.tar.bz2
-    "qtpy >=1.3",
+    "qtpy >=1.3,<2.0",
win-64::guiqwt-3.0.7-py37h75c0890_0.tar.bz2
-    "qtpy >=1.3",
+    "qtpy >=1.3,<2.0",
win-64::guiqwt-3.0.7-py37h75c0890_1.tar.bz2
-    "qtpy >=1.3",
+    "qtpy >=1.3,<2.0",
win-64::guiqwt-3.0.7-py38h029a070_0.tar.bz2
-    "qtpy >=1.3",
+    "qtpy >=1.3,<2.0",
win-64::guiqwt-3.0.7-py38h029a070_1.tar.bz2
-    "qtpy >=1.3",
+    "qtpy >=1.3,<2.0",
win-64::guiqwt-3.0.7-py39h79958ce_0.tar.bz2
-    "qtpy >=1.3",
+    "qtpy >=1.3,<2.0",
win-64::guiqwt-3.0.7-py39h79958ce_1.tar.bz2
-    "qtpy >=1.3",
+    "qtpy >=1.3,<2.0",
```

As this feedstock seems abandoned, I opened an issue to add myself as maintainer: https://github.com/conda-forge/guiqwt-feedstock/pull/23