### PR TITLE
fix: add pinning for maximum python version of ratelimiter recipe

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 # This file was generated automatically from conda-smithy. To update this configuration,
 # update the conda-forge.yml and/or the recipe/meta.yaml.
-# -*- mode: yaml -*-
+# -*- mode: jinja-yaml -*-
 
 version: 2
 

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -33,9 +33,9 @@ CONDARC
 
 
 mamba install --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3
+    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
 mamba update --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3
+    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -616,7 +616,11 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
         
         if record_name == 'ratelimiter':
             if record.get('timestamp', 0) < 1667804400000 and subdir == "noarch":  # noarch builds prior to 2022/11/7
-                _replace_pin('python', "python >=3,<3.11", record['depends'], record)
+                python_pinning = [
+                    x for x in record['depends'] if x.startswith('python')
+                ]
+                for pinning in python_pinning:
+                    _replace_pin(pinning, 'python >=3,<3.11', record['depends'], record)
         
         if record_name == 'distributed':
             # distributed <2.11.0 does not work with msgpack-python >=1.0

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -613,7 +613,11 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                         deps,
                         record
                     )
-                    
+        
+        if record_name == 'ratelimiter':
+            if record.get('timestamp', 0) < 1667804400000 and subdir == "noarch":  # noarch builds prior to 2022/11/7
+                _replace_pin('python', "python >=3,<3.11", record['depends'], record)
+        
         if record_name == 'distributed':
             # distributed <2.11.0 does not work with msgpack-python >=1.0
             # newer versions of distributed require at least msgpack-python >=0.6.0


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Ratelimiter is incompatible to Python 3.11, due to changes in the async API.
The recipe itself is already fixed and a new build was released. This patches the previous noarch version of ratelimiter.
