### PR TITLE
Require `requests >=2.20.0` in `anaconda-client` 1.11.0

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1837,6 +1837,20 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                 if dep_name == "conda":
                     record["depends"][i] = "conda >=4.8,<5"
 
+        # Bump minimum `requests` requirement of `anaconda-client` 1.11.0
+        #
+        # https://github.com/conda-forge/anaconda-client-feedstock/pull/35
+        if record_name == "anaconda-client" and (
+            pkg_resources.parse_version(record["version"]) ==
+            pkg_resources.parse_version("1.11.0")):
+
+            i = -1
+            deps = record["depends"]
+            with suppress(ValueError):
+                i = deps.index("requests >=2.9.1")
+            if i >= 0:
+                deps[i] = "requests >=2.20.0"
+
         if record_name == "aesara" and (
             pkg_resources.parse_version(record["version"]) >
             pkg_resources.parse_version("2.4.0") and


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

<hr>

xref: https://github.com/conda-forge/anaconda-client-feedstock/pull/35
xref: https://github.com/conda-forge/anaconda-client-feedstock/pull/33#discussion_r1022108852