### PR TITLE
fix pyarrow depending on incorrect version of libstdcxx-ng

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -601,6 +601,11 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             # The underlying issue is https://github.com/numpy/numpy/issues/17913
             if record.get('timestamp', 0) < 1607959235411 and any(dep.split(' ')[0] == 'numpy' for dep in record.get('depends', ())):
                 _pin_stricter(fn, record, "numpy", "x", "1.20")
+            # these versions actually require symbols only present in libstdc++ >=12
+            if subdir == 'linux-64' and 'cpu' in record['build'] and (record['version'], record['build_number']) in [('8.0.0', 1), ('7.0.0', 6), ('6.0.1', 18)]:
+                for i, dep in enumerate(record['depends']):
+                    if dep.split(' ')[0] == 'libstdcxx-ng':
+                        record['depends'][i] = 'libstdcxx-ng >=12'
 
         if record_name == "kartothek":
             if record["version"] in ["3.15.0", "3.15.1", "3.16.0"] \


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
