### PR TITLE
Add flake8<6 pin for broken plugins

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -2142,6 +2142,14 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             record.setdefault('constrains', []).extend((
                 "gxx_linux-64 !=9.5.0",
             ))
+
+        # Flake8 6 removed some deprecated option parsing APIs and broke these plugins
+        if ((record_name == 'flake8-copyright'
+             and pkg_resources.parse_version(record['version']) <= pkg_resources.parse_version('0.2.3'))
+            or (record_name == 'flake8-quotes'
+             and pkg_resources.parse_version(record['version']) <= pkg_resources.parse_version('3.3.1'))):
+            _replace_pin("flake8", "flake8 <6", record["depends"], record)
+
     return index
 
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Backporting (so to speak) https://github.com/conda-forge/flake8-copyright-feedstock/pull/5 and https://github.com/conda-forge/flake8-quotes-feedstock/pull/22.

<!--
Please add any other relevant info below:
-->

The diff:
<details>
<pre>
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata.json.bz2
noarch::flake8-copyright-0.2.0-py_1.tar.bz2
-    "flake8",
+    "flake8 <6",
noarch::flake8-copyright-0.2.2-py_0.tar.bz2
-    "flake8",
+    "flake8 <6",
noarch::flake8-copyright-0.2.3-pyhd8ed1ab_0.tar.bz2
-    "flake8",
+    "flake8 <6",
noarch::flake8-quotes-3.3.1-pyhd8ed1ab_0.tar.bz2
-    "flake8",
+    "flake8 <6",
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata.json.bz2
linux-64::flake8-copyright-0.2.0-py27_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27mu"
-  ],
-    "flake8",
+    "flake8 <6",
-  "version": "0.2.0"
+  "version": "0.2.0",
+  "constrains": [
+    "python_abi * *_cp27mu"
+  ]
linux-64::flake8-copyright-0.2.0-py34_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp34m"
-  ],
-    "flake8",
+    "flake8 <6",
-  "version": "0.2.0"
+  "version": "0.2.0",
+  "constrains": [
+    "python_abi * *_cp34m"
+  ]
linux-64::flake8-copyright-0.2.0-py35_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp35m"
-  ],
-    "flake8",
+    "flake8 <6",
-  "version": "0.2.0"
+  "version": "0.2.0",
+  "constrains": [
+    "python_abi * *_cp35m"
+  ]
linux-64::flake8-copyright-0.2.0-py36_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-    "flake8",
+    "flake8 <6",
-  "version": "0.2.0"
+  "version": "0.2.0",
+  "constrains": [
+    "python_abi * *_cp36m"
+  ]
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata.json.bz2
osx-64::flake8-copyright-0.2.0-py27_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27m"
-  ],
-    "flake8",
+    "flake8 <6",
-  "version": "0.2.0"
+  "version": "0.2.0",
+  "constrains": [
+    "python_abi * *_cp27m"
+  ]
osx-64::flake8-copyright-0.2.0-py34_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp34m"
-  ],
-    "flake8",
+    "flake8 <6",
-  "version": "0.2.0"
+  "version": "0.2.0",
+  "constrains": [
+    "python_abi * *_cp34m"
+  ]
osx-64::flake8-copyright-0.2.0-py35_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp35m"
-  ],
-    "flake8",
+    "flake8 <6",
-  "version": "0.2.0"
+  "version": "0.2.0",
+  "constrains": [
+    "python_abi * *_cp35m"
+  ]
osx-64::flake8-copyright-0.2.0-py36_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-    "flake8",
+    "flake8 <6",
-  "version": "0.2.0"
+  "version": "0.2.0",
+  "constrains": [
+    "python_abi * *_cp36m"
+  ]
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata.json.bz2
win-32::flake8-copyright-0.2.0-py27_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27m"
-  ],
-    "flake8",
+    "flake8 <6",
-  "version": "0.2.0"
+  "version": "0.2.0",
+  "constrains": [
+    "python_abi * *_cp27m"
+  ]
win-32::flake8-copyright-0.2.0-py34_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp34m"
-  ],
-    "flake8",
+    "flake8 <6",
-  "version": "0.2.0"
+  "version": "0.2.0",
+  "constrains": [
+    "python_abi * *_cp34m"
+  ]
win-32::flake8-copyright-0.2.0-py35_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp35m"
-  ],
-    "flake8",
+    "flake8 <6",
-  "version": "0.2.0"
+  "version": "0.2.0",
+  "constrains": [
+    "python_abi * *_cp35m"
+  ]
win-32::flake8-copyright-0.2.0-py36_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-    "flake8",
+    "flake8 <6",
-  "version": "0.2.0"
+  "version": "0.2.0",
+  "constrains": [
+    "python_abi * *_cp36m"
+  ]
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata.json.bz2
win-64::flake8-copyright-0.2.0-py27_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27m"
-  ],
-    "flake8",
+    "flake8 <6",
-  "version": "0.2.0"
+  "version": "0.2.0",
+  "constrains": [
+    "python_abi * *_cp27m"
+  ]
win-64::flake8-copyright-0.2.0-py34_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp34m"
-  ],
-    "flake8",
+    "flake8 <6",
-  "version": "0.2.0"
+  "version": "0.2.0",
+  "constrains": [
+    "python_abi * *_cp34m"
+  ]
win-64::flake8-copyright-0.2.0-py35_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp35m"
-  ],
-    "flake8",
+    "flake8 <6",
-  "version": "0.2.0"
+  "version": "0.2.0",
+  "constrains": [
+    "python_abi * *_cp35m"
+  ]
win-64::flake8-copyright-0.2.0-py36_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-    "flake8",
+    "flake8 <6",
-  "version": "0.2.0"
+  "version": "0.2.0",
+  "constrains": [
+    "python_abi * *_cp36m"
+  ]

</pre>
</details>