### PR TITLE
For plotly add run_constrained ipywidgets <8

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1314,6 +1314,18 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                 "python-lal >=7.1.1",
             ))
 
+        if (
+            record_name == "plotly"
+            and ((pkg_resources.parse_version(record["version"])
+                < pkg_resources.parse_version("5.11.0")
+                ) or (record["version"] == "5.11.0" and record["build_number"] <= 0))
+        ):
+            # The new ipywidgets 8 breaks Plotly, so add a run_constrained requirement.
+            # <https://github.com/conda-forge/plotly-feedstock/issues/115>
+            record.setdefault('constrains', []).extend((
+                "ipywidgets <8.0.0",
+            ))
+
         # Version constraints for azure-storage-common in azure-storage-file
         # 2.1.0 build 0 were incorrect.  These have been corrected in
         # https://github.com/conda-forge/azure-storage-file-feedstock/pull/8


### PR DESCRIPTION
As described in https://github.com/plotly/plotly.py/issues/3686, past and current versions of Plotly are incompatible with `ipywidgets` v8.0.0 and above. This patch adds a `run_constrained` of `ipywidgets <8` for all previous Plotly builds. This goes together with https://github.com/conda-forge/plotly-feedstock/pull/116, which adds a `run_constrained` to the current build.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
