### PR TITLE
Patch GMT 6.4.0 builds 3, 4, 5 with correct GDAL 3.6 pinning

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1674,6 +1674,15 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                 new_deps.append(dep)
             record["depends"] = new_deps
 
+        # Fix gmt 6.4.0 builds 3, 4, 5 which didn't properly set GDAL 3.6 pin
+        # See issue at https://github.com/GenericMappingTools/pygmt/issues/2215
+        if (
+            record_name == "gmt"
+            and record["version"] == "6.4.0"
+            and record["build_number"] in [3, 4, 5]
+        ):
+            _replace_pin("gdal", "gdal >=3.6.0,<3.7.0a0", record["depends"], record)
+
         # Fix depends for pytest-flake8-1.1.1 https://github.com/conda-forge/pytest-flake8-feedstock/pull/21
         if record_name == "pytest-flake8" and record["version"] == "1.1.1" and record["build_number"] == 0:
             _replace_pin("python >=3.5", "python >=3.7", record["depends"], record)


### PR DESCRIPTION
Recent [libgdal36 migration](https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/3770) removed the pins for GDAL in GMT, causing an error like `libgdal.so.32: cannot open shared object file: No such file or directory` due to mismatch in GDAL version used in build vs runtime. This adds the proper `gdal >=3.6.0,<3.7.0a0` pin so that GMT versions built with GDAL 3.6 can only be installed with GDAL 3.6.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Patches https://github.com/conda-forge/gmt-feedstock/pull/226, https://github.com/conda-forge/gmt-feedstock/pull/230 and https://github.com/conda-forge/gmt-feedstock/pull/231.
Closes https://github.com/GenericMappingTools/pygmt/issues/2215.

<!--
Please add any other relevant info below:
-->

Relevant diff when running `python show_diff.py`:

```diff
linux-64::gmt-6.4.0-h8b1eae8_4.conda
-    "gdal",
+    "gdal >=3.6.0,<3.7.0a0",
linux-64::gmt-6.4.0-h8b1eae8_5.conda
-    "gdal",
+    "gdal >=3.6.0,<3.7.0a0",
osx-64::gmt-6.4.0-h09a9948_3.conda
-    "gdal",
+    "gdal >=3.6.0,<3.7.0a0",
osx-64::gmt-6.4.0-h46ce199_4.conda
-    "gdal",
+    "gdal >=3.6.0,<3.7.0a0",
osx-64::gmt-6.4.0-h46ce199_5.conda
-    "gdal",
+    "gdal >=3.6.0,<3.7.0a0",
osx-arm64::gmt-6.4.0-h1d82dbe_3.conda
-    "gdal",
+    "gdal >=3.6.0,<3.7.0a0",
osx-arm64::gmt-6.4.0-h37daf58_4.conda
-    "gdal",
+    "gdal >=3.6.0,<3.7.0a0",
osx-arm64::gmt-6.4.0-h37daf58_5.conda
-    "gdal",
+    "gdal >=3.6.0,<3.7.0a0",
win-64::gmt-6.4.0-h379bcb0_3.conda
-    "gdal",
+    "gdal >=3.6.0,<3.7.0a0",
win-64::gmt-6.4.0-h5e9ae33_4.conda
-    "gdal",
+    "gdal >=3.6.0,<3.7.0a0",
win-64::gmt-6.4.0-h5e9ae33_5.conda
-    "gdal",
+    "gdal >=3.6.0,<3.7.0a0",
```