### PR TITLE
Hotfix `conda=22.11.1=0`

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1892,6 +1892,17 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                 if dep_name == "conda":
                     record["depends"][i] = "conda >=4.8,<5"
 
+        # `conda` version `22.11.1` number `0` had an incorrect
+        # `conda-libmamba-solver` constraint. This was fixed in number `1`.
+        # Here we patch the repodata to apply the same fix to number `0`.
+        #
+        # xref: https://github.com/conda-forge/conda-feedstock/pull/196
+        if (record_name == "conda" and
+            record["version"] == "22.11.1" and
+            record["build_number"] == 0):
+            i = record["constrains"].index("conda-libmamba-solver >=22.11.0")
+            record["constrains"][i] = "conda-libmamba-solver >=22.12.0"
+
         # Bump minimum `requests` requirement of `anaconda-client` 1.11.0
         #
         # https://github.com/conda-forge/anaconda-client-feedstock/pull/35


### PR DESCRIPTION
Fixes the constraint of `conda-libmamba-solver` to require `22.12.0` at a minimum in `conda=22.11.1=0`.

xref: https://github.com/conda-forge/conda-feedstock/pull/196

<hr>

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
