### PR TITLE
Fix conda-libmamba-solver constraint for conda 22.11.1 build 0

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1860,6 +1860,13 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                     record["depends"][i] = "{} {}<4.13.0".format(
                         dep_name, dep_other[0] + "," if dep_other else ""
                         )
+        if (record_name == "conda" and
+            record["version"] == "22.11.1" and
+            record["build_number"] == 0):
+            for i, dep in enumerate(record["constrains"]):
+                dep_name, *dep_other = dep.split()
+                if dep_name.startswith("conda-libmamba-solver"):
+                    record["constrains"][i] = "conda-libmamba-solver >=22.12.0"
         if record_name == "mamba" and (
             pkg_resources.parse_version(record["version"]) <
             pkg_resources.parse_version("0.24.0") or (


### PR DESCRIPTION
Previous constraint referred to a non-existent version.