### PR TITLE
Add upper bound to flatbuffers

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -589,6 +589,12 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             i = record['depends'].index('keras >=2.6,<3')
             record['depends'][i] = 'keras >=2.6,<2.7'
 
+        if ((record.get('timestamp', 0) < 1670685160000) and
+                any(dep == "flatbuffers >=2"
+                    for dep in record.get('depends', ()))):
+            i = record["depends"].index("flatbuffers >=2")
+            record["depends"][i] = "flatbuffers >=2,<3.0.0.0a0"
+
         if record_name == "pyarrow":
             if not any(dep.split(' ')[0] == "arrow-cpp-proc" for dep in record.get('constrains', ())):
                 if 'constrains' in record:


### PR DESCRIPTION
xref: https://github.com/conda-forge/tensorflow-feedstock/issues/290

Fixed in feedstock: 
- 2.x.x a little stricter https://github.com/conda-forge/flatbuffers-feedstock/pull/36
- 22.x.x https://github.com/conda-forge/flatbuffers-feedstock/pull/35
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
