### PR TITLE
Revert "Exclude libxml2 2.9.11 and 2.9.12 in lxml"

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1761,13 +1761,6 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
         if record_name == "guiqwt" and record["version"] in ("3.0.5", "3.0.7") and record["build_number"] in (0, 1):
             _replace_pin("qtpy >=1.3", "qtpy >=1.3,<2.0", record["depends"], record)
 
-        # exclude libxml2 2.9.11 and 2.9.12 due to https://bugs.launchpad.net/lxml/+bug/1928795
-        # https://github.com/conda-forge/lxml-feedstock/issues/75
-        if record_name == "lxml" and record.get("timestamp", 0) <= 1649691000000: # 4.8.0 build 2 and prior
-            for i, dep in enumerate(record["depends"]):
-                if dep.startswith("libxml2 >=2.9."):
-                    record["depends"][i] = f"{dep},!=2.9.11,!=2.9.12"
-
         if record_name == "qt" and (pkg_resources.parse_version(record["version"])
                 <= pkg_resources.parse_version("5.12.9")) and subdir == "linux-64":
             _replace_pin("openssl", "openssl <3", record["depends"], record)


### PR DESCRIPTION
This reverts commit 57091510e053de919f2ba8537aa92fa967c3f73b.

As mentioned here https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/362#issuecomment-1347555968, this patch is no longer needed. Additionally, it is causing a lot of issues for both me, colleagues, and others (@wolfv and @ruben-arts [reported it on Gitter](https://gitter.im/conda-forge/conda-forge.github.io?at=63933e882b937b1a2eb26494)).

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
