### PR TITLE
Patch qgis 3.28.1 build 0 with correct GDAL 3.6 pinning

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1730,6 +1730,15 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
         ):
             _replace_pin("gdal", "gdal >=3.6.0,<3.7.0a0", record["depends"], record)
 
+        # Fix qgis 3.28.1 build 0 which didn't properly set GDAL 3.6 pin
+        # See issue at https://github.com/conda-forge/qgis-feedstock/issues/276
+        if (
+            record_name == "qgis"
+            and record["version"] == "3.28.1"
+            and record["build_number"] == 0
+        ):
+            _replace_pin("gdal", "gdal >=3.6.0,<3.7.0a0", record["depends"], record)
+
         # Fix depends for pytest-flake8-1.1.1 https://github.com/conda-forge/pytest-flake8-feedstock/pull/21
         if record_name == "pytest-flake8" and record["version"] == "1.1.1" and record["build_number"] == 0:
             _replace_pin("python >=3.5", "python >=3.7", record["depends"], record)


### PR DESCRIPTION
Recent [libgdal36 migration](https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/3770) removed the pins for GDAL in QGIS, causing an error like libgdal.so.32: cannot open shared object file: No such file or directory due to mismatch in GDAL version used in build vs runtime. This adds the proper gdal >=3.6.0,<3.7.0a0 pin so that QGIS versions built with GDAL 3.6 can only be installed with GDAL 3.6.

Similar to https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/366

Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

Patches: https://github.com/conda-forge/qgis-feedstock/pull/274
Closes: https://github.com/conda-forge/qgis-feedstock/issues/276
Similar to: https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/366

cc: @weiji14

Relevant diff when running python show_diff.py (Windows builds failed with 'out of memory' so they don't exist):
```
linux-64::qgis-3.28.1-py310h3c18fa3_0.tar.bz2
-    "gdal",
+    "gdal >=3.6.0,<3.7.0a0",
linux-64::qgis-3.28.1-py311hf5d26d0_0.tar.bz2
-    "gdal",
+    "gdal >=3.6.0,<3.7.0a0",
linux-64::qgis-3.28.1-py38hbecbac2_0.tar.bz2
-    "gdal",
+    "gdal >=3.6.0,<3.7.0a0",
linux-64::qgis-3.28.1-py39ha366a5a_0.tar.bz2
-    "gdal",
+    "gdal >=3.6.0,<3.7.0a0",
osx-64::qgis-3.28.1-py310h05cb66a_0.conda
-    "gdal",
+    "gdal >=3.6.0,<3.7.0a0",
osx-64::qgis-3.28.1-py311he4927b1_0.conda
-    "gdal",
+    "gdal >=3.6.0,<3.7.0a0",
osx-64::qgis-3.28.1-py38h5ae8a72_0.conda
-    "gdal",
+    "gdal >=3.6.0,<3.7.0a0",
osx-64::qgis-3.28.1-py39hda9d10f_0.conda
-    "gdal",
+    "gdal >=3.6.0,<3.7.0a0",
```