### PR TITLE
Fix pytorch pin for torchvision 0.11.2

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -530,6 +530,14 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                 else:
                     record['depends'] = ["typing_extensions"]
 
+        if record_name == "torchvision" and record["version"] == "0.11.2":
+            if 'pytorch * cpu*' in record['depends']:
+                i = record['depends'].index('pytorch * cpu*')
+                record['depends'][i] = 'pytorch 1.10.* cpu*'
+            elif 'pytorch * cuda*' in record['depends']:
+                i = record['depends'].index('pytorch * cuda*')
+                record['depends'][i] = 'pytorch 1.10.* cuda*'
+
         if record_name == "typer" and record.get('timestamp', 0) < 1609873200000:
             # https://github.com/conda-forge/typer-feedstock/issues/5
             if any(dep.split(' ')[0] == "click" for dep in record.get('depends', ())):


### PR DESCRIPTION
This has already been applied to the package in https://github.com/conda-forge/torchvision-feedstock/pull/42 but the build number 2 packages are still available with a too-open pin. As they are not broken, I would like to keep them there and only fix the metadata.

cc @conda-forge/torchvision @hmaarrfk 

Diff output:

<details>

```
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata.json.bz2
noarch::docxcompose-1.4.0-pyhd8ed1ab_0.conda
-    "python =2.7|>3.5",
+    "python ==2.7.*|>3.5",
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata.json.bz2
linux-64::torchvision-0.11.2-cpu_py37hff16761_2.tar.bz2
-    "pytorch * cpu*"
+    "pytorch 1.10.* cpu*"
linux-64::torchvision-0.11.2-cpu_py38hc2f561f_2.tar.bz2
-    "pytorch * cpu*"
+    "pytorch 1.10.* cpu*"
linux-64::torchvision-0.11.2-cpu_py39h5f8393d_2.tar.bz2
-    "pytorch * cpu*"
+    "pytorch 1.10.* cpu*"
linux-64::torchvision-0.11.2-cuda102py37h2175baf_2.tar.bz2
-    "pytorch * cuda*"
+    "pytorch 1.10.* cuda*"
linux-64::torchvision-0.11.2-cuda102py38hb2751a7_2.tar.bz2
-    "pytorch * cuda*"
+    "pytorch 1.10.* cuda*"
linux-64::torchvision-0.11.2-cuda102py39hb6eee95_2.tar.bz2
-    "pytorch * cuda*"
+    "pytorch 1.10.* cuda*"
linux-64::torchvision-0.11.2-cuda110py37h1841594_2.tar.bz2
-    "pytorch * cuda*"
+    "pytorch 1.10.* cuda*"
linux-64::torchvision-0.11.2-cuda110py38h569664f_2.tar.bz2
-    "pytorch * cuda*"
+    "pytorch 1.10.* cuda*"
linux-64::torchvision-0.11.2-cuda110py39h2d900a0_2.tar.bz2
-    "pytorch * cuda*"
+    "pytorch 1.10.* cuda*"
linux-64::torchvision-0.11.2-cuda111py37hdbd1bee_2.tar.bz2
-    "pytorch * cuda*"
+    "pytorch 1.10.* cuda*"
linux-64::torchvision-0.11.2-cuda111py38h6947b77_2.tar.bz2
-    "pytorch * cuda*"
+    "pytorch 1.10.* cuda*"
linux-64::torchvision-0.11.2-cuda111py39h732779e_2.tar.bz2
-    "pytorch * cuda*"
+    "pytorch 1.10.* cuda*"
linux-64::torchvision-0.11.2-cuda112py37hf793565_2.tar.bz2
-    "pytorch * cuda*"
+    "pytorch 1.10.* cuda*"
linux-64::torchvision-0.11.2-cuda112py38h5133249_2.tar.bz2
-    "pytorch * cuda*"
+    "pytorch 1.10.* cuda*"
linux-64::torchvision-0.11.2-cuda112py39h14c6492_2.tar.bz2
-    "pytorch * cuda*"
+    "pytorch 1.10.* cuda*"
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata.json.bz2
osx-64::torchvision-0.11.2-cpu_py37h35ea4dc_2.tar.bz2
-    "pytorch * cpu*"
+    "pytorch 1.10.* cpu*"
osx-64::torchvision-0.11.2-cpu_py38h686086e_2.tar.bz2
-    "pytorch * cpu*"
+    "pytorch 1.10.* cpu*"
osx-64::torchvision-0.11.2-cpu_py39h7c5a76e_2.tar.bz2
-    "pytorch * cpu*"
+    "pytorch 1.10.* cpu*"
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata.json.bz2
osx-arm64::torchvision-0.11.2-cpu_py38h700cb6d_2.tar.bz2
-    "pytorch * cpu*"
+    "pytorch 1.10.* cpu*"
osx-arm64::torchvision-0.11.2-cpu_py39h85ba581_2.tar.bz2
-    "pytorch * cpu*"
+    "pytorch 1.10.* cpu*"
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata.json.bz2
```

</details>