### PR TITLE
Pin libtiff to less than 4.5.0 due to abi incompatibility

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1863,6 +1863,13 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                     else:
                         record["depends"][i] = record["depends"][i] + ",<2.1.0a0"
 
+        if record.get("timestamp", 0) < 1671301008000:
+            # libtiff broke abit from 4.4 and 4.5
+            # https://github.com/conda-forge/libtiff-feedstock/pull/85
+            if any(re.match(r"libtiff >=4\.[01234].*<5.0", dep)
+                   for dep in deps):
+                _pin_stricter(fn, record, "libtiff", "x", upper_bound="4.5.0")
+
         if record_name == "pillow":
             if pkg_resources.parse_version(record["version"]) < pkg_resources.parse_version("9.1.1"):
                 _pin_stricter(fn, record, "libtiff", "x", upper_bound="4.4.0")


### PR DESCRIPTION
This is a big patch: https://github.com/conda-forge/libtiff-feedstock/pull/85

closes: https://github.com/conda-forge/libtiff-feedstock/issues/77


Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
