### PR TITLE
Patch napari-svg to remove run dependency on napari

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -2265,6 +2265,15 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                 record,
             )
             _replace_pin("pandas >=1.1", "pandas >=1.3", record["depends"], record)
+        
+        # napari-svg 0.1.6 build 0 had napari added as dependency, when it's not
+        # PR to fix: https://github.com/conda-forge/napari-svg-feedstock/pull/7
+        if (
+            record_name == "napari-svg"
+            and record["version"] == "0.1.6"
+            and record["build_number"] == 0
+        ):
+            record["depends"].remove("napari")
 
     return index
 

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -2270,10 +2270,10 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
         # PR to fix: https://github.com/conda-forge/napari-svg-feedstock/pull/7
         if (
             record_name == "napari-svg"
-            and record["version"] == "0.1.6"
-            and record["build_number"] == 0
+            and record.get('timestamp', 0) < 1671814614198
         ):
-            record["depends"].remove("napari")
+            if "napari" in record["depends"]:
+                record["depends"].remove("napari")
 
     return index
 


### PR DESCRIPTION

In 0.1.6 conda-forge package of napari-svg, napari was added as a run dependency, due to bot suggestion, but it's just used in tests.
As a result, installing napari-svg pulls an ancient napari version.
The feedstock has a PR to fix this: https://github.com/conda-forge/napari-svg-feedstock/pull/7
More discussion with @jaimergp can be found here:
https://napari.zulipchat.com/#narrow/stream/309872-plugins/topic/npe2.20schema.20version/near/316595223
See also bot issue: https://github.com/regro/cf-scripts/issues/1584

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:

```
╰─ python show_diff.py                                               (cf-dev) ─╯
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata.json.bz2
noarch::napari-svg-0.1.6-pyhd8ed1ab_0.tar.bz2
-    "napari",
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata.json.bz2
```
