### PR TITLE
Constrain jupyter_events 0.5.0 dependencies.

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1446,6 +1446,25 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                 i = record["depends"].index("jupyterlab")
                 record["depends"][i] = "jupyterlab <1.0.0"
 
+        # Version constraints for dependencies in jupyter_events 0.5.0_0
+        # were insufficient.
+        # These have been corrected in PR
+        # https://github.com/conda-forge/jupyter_events-feedstock/pull/6
+        if (record_name == "jupyter_events" and record["version"] == "0.5.0"
+            and record["build_number"] == 0):
+            if "jsonschema" in record["depends"]:
+                i = record["depends"].index("jsonschema")
+                record["depends"][i] = "jsonschema >=4.3"
+            if "python-json-logger" in record["depends"]:
+                i = record["depends"].index("python-json-logger")
+                record["depends"][i] = "python-json-logger >=2.0.4"
+            if "traitlets" in record["depends"]:
+                i = record["depends"].index("traitlets")
+                record["depends"][i] = "traitlets >=5.3"
+            if "pyyaml" in record["depends"]:
+                i = record["depends"].index("pyyaml")
+                record["depends"][i] = "pyyaml >=6.0"
+
         # librmm 0.19 missed spdlog 1.7.0 in build 1
         # due to spdlog 1.7.0 not having run_exports.
         # This hotfixes those packages


### PR DESCRIPTION
jupyter_events 0.5.0_0 has insufficient constraints on its dependencies, allowing solves with older versions that break its code.  This has been fixed in build 1; this patch applies the same constraints to build 0.
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
