### PR TITLE
fix openssl-collision in tensorflow wrapper package

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -606,13 +606,14 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             # osx only got built for OpenSSL 3 --> no collision of wrappers
             and subdir == "linux-64"
         ):
-            tfbase = [r for r in record["depends"] if r.startswith("tensorflow-base")][0]
-            i = record["depends"].index(tfbase)
-            # replace with less tight pin that does not go down to hash of tf-base,
-            # but keep distinction between cpu/cuda, as well as the python version
-            cpu_or_cuda = "cpu_" if ("cpu_" in tfbase) else "cuda112"  # no other CUDA ver
-            pyver = tfbase[len(f"tensorflow-base 2.11.0 {cpu_or_cuda}"):-len("h1234567_0")]
-            record["depends"][i] = f"tensorflow-base 2.11.0 {cpu_or_cuda}{pyver}*_0"
+            for dep in ["tensorflow-base", "tensorflow-estimator"]:
+                sub_pin = [r for r in record["depends"] if r.startswith(dep)][0]
+                i = record["depends"].index(sub_pin)
+                # replace with less tight pin that does not go down to hash of `dep`,
+                # but keep distinction between cpu/cuda, as well as the python version
+                cpu_or_cuda = "cpu_" if ("cpu_" in sub_pin) else "cuda112"  # no other CUDA ver
+                pyver = sub_pin[len(f"{dep} 2.11.0 {cpu_or_cuda}"):-len("h1234567_0")]
+                record["depends"][i] = f"{dep} 2.11.0 {cpu_or_cuda}{pyver}*_0"
 
         if ((record.get('timestamp', 0) < 1670685160000) and
                 any(dep == "flatbuffers >=2"


### PR DESCRIPTION
Fix https://github.com/conda-forge/tensorflow-feedstock/issues/295

Normally, it would be easier to just rebuild the feedstock, but tensorflow needed multiple weeks to be built by various collaborators, and so patching is a way more reasonable solution in this case rather than rebuilding everything on linux again.

### Output of `python show_diff.py`

<details>

```
>python show_diff.py
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata.json.bz2
linux-64::tensorflow-2.11.0-cpu_py310hd1aba9c_0.conda
-    "tensorflow-base 2.11.0 cpu_py310h8a70c67_0",
-    "tensorflow-estimator 2.11.0 cpu_py310hca2d6cb_0"
+    "tensorflow-base 2.11.0 cpu_py310*_0",
+    "tensorflow-estimator 2.11.0 cpu_py310*_0"
linux-64::tensorflow-2.11.0-cpu_py38h66f0ec1_0.conda
-    "tensorflow-base 2.11.0 cpu_py38hb03d4c4_0",
-    "tensorflow-estimator 2.11.0 cpu_py38h7af459a_0"
+    "tensorflow-base 2.11.0 cpu_py38*_0",
+    "tensorflow-estimator 2.11.0 cpu_py38*_0"
linux-64::tensorflow-2.11.0-cpu_py39h4655687_0.conda
-    "tensorflow-base 2.11.0 cpu_py39h9b4020c_0",
-    "tensorflow-estimator 2.11.0 cpu_py39hf050123_0"
+    "tensorflow-base 2.11.0 cpu_py39*_0",
+    "tensorflow-estimator 2.11.0 cpu_py39*_0"
linux-64::tensorflow-2.11.0-cuda112py310he87a039_0.conda
-    "tensorflow-base 2.11.0 cuda112py310h52da4a5_0",
-    "tensorflow-estimator 2.11.0 cuda112py310h37add04_0"
+    "tensorflow-base 2.11.0 cuda112py310*_0",
+    "tensorflow-estimator 2.11.0 cuda112py310*_0"
linux-64::tensorflow-2.11.0-cuda112py38hded6998_0.conda
-    "tensorflow-base 2.11.0 cuda112py38hed6a6ea_0",
-    "tensorflow-estimator 2.11.0 cuda112py38hf5dcc89_0"
+    "tensorflow-base 2.11.0 cuda112py38*_0",
+    "tensorflow-estimator 2.11.0 cuda112py38*_0"
linux-64::tensorflow-2.11.0-cuda112py39h01bd6f0_0.conda
-    "tensorflow-base 2.11.0 cuda112py39h1c230a5_0",
-    "tensorflow-estimator 2.11.0 cuda112py39hd320b7a_0"
+    "tensorflow-base 2.11.0 cuda112py39*_0",
+    "tensorflow-estimator 2.11.0 cuda112py39*_0"
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata.json.bz2
```

</details>