### PR TITLE
constrain python to 3.8 or greater for sphinx 6.0.0

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1648,7 +1648,7 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             _replace_pin("docutils >=0.14,<0.20", "docutils >=0.18,<0.20", deps, record)
             _replace_pin("requests >=2.5.0", "requests >=2.25.0", deps, record)
 
-        # Retoractively pin a min version of Python for sphinx 6.0.0 build 0 (was fixed in build 2)
+        # Retroactively pin a min version of Python for sphinx 6.0.0 builds 0 and 1 (was fixed in build 2)
         if record_name == "sphinx" and record["version"] == "6.0.0" and record["build_number"] < 2:
             deps = record["depends"]
             _replace_pin("python >=3.7", "python >=3.8", deps, record)

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1648,6 +1648,11 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             _replace_pin("docutils >=0.14,<0.20", "docutils >=0.18,<0.20", deps, record)
             _replace_pin("requests >=2.5.0", "requests >=2.25.0", deps, record)
 
+        # Retoractively pin a min version of Python for sphinx 6.0.0 build 0 (was fixed in build 2)
+        if record_name == "sphinx" and record["version"] == "6.0.0" and record["build_number"] < 2:
+            deps = record["depends"]
+            _replace_pin("python >=3.7", "python >=3.8", deps, record)
+
         # Retroactively pin a max version of openlibm for julia 1.6.* and 1.7.*:
         # https://github.com/conda-forge/julia-feedstock/issues/169
         # timestamp: 29 December 2021 (osx-64/julia-1.7.1-h132cb31_1.tar.bz2) (+ 1)


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Related to: https://github.com/conda-forge/sphinx-feedstock/pull/138
Which closed issue: https://github.com/conda-forge/sphinx-feedstock/issues/137

<!--
Please add any other relevant info below:
-->
