### PR TITLE
Add bottleneck as a dependency in calliope v0.6.9

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -2330,6 +2330,18 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                     deps[i] += ",<1.21.0a0"
                     break
 
+        # Fix missing dependency in Calliope that is required by some methods in
+        # xarray=2022.3, but is not a dependency in their recipe.
+        # This was fixed in https://github.com/conda-forge/calliope-feedstock/pull/30
+        # This patches build 0 with the right information too.
+        if (
+            record_name == "calliope"
+            and record.get("timestamp", 0) <= 1673531497000
+            and record["build_number"] == 0
+            and pkg_resources.parse_version(record["version"]) == pkg_resources.parse_version("0.6.9")
+        ):
+            record["depends"].append("bottleneck")
+
     return index
 
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
