### PR TITLE
Patch jsonschema dependency for altair

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -2369,6 +2369,25 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
         ):
             record["depends"].append("bottleneck")
 
+        # altair 4.2.0 and below are incompatible with jsonschema>=4.17 when certain
+        # other packages are installed; this was fixed in
+        # https://github.com/conda-forge/altair-feedstock/pull/41
+        if (
+            record_name == "altair"
+            and pkg_resources.parse_version(record["version"]).major == 4
+            and record.get("timestamp", 0) <= 1673569551000
+        ):
+
+            if pkg_resources.parse_version(record["version"]) < pkg_resources.parse_version("4.2.0"):
+                _replace_pin("jsonschema", "jsonschema <4.17", record["depends"], record)
+
+            if pkg_resources.parse_version(record["version"]) == pkg_resources.parse_version("4.2.0"):
+                _replace_pin("jsonschema >=3.0", "jsonschema >=3.0,<4.17", record["depends"], record)
+                
+                # this also applies the fix from https://github.com/conda-forge/altair-feedstock/pull/40
+                _replace_pin("jsonschema", "jsonschema >=3.0,<4.17", record["depends"], record)
+
+
     return index
 
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

`altair<=4.2.0` is incompatible with `jsonschema>=4.17` when certain other packages are installed (e.g., `rfc3339`, `rfc3986`).

This was fixed in the feedstock in https://github.com/conda-forge/altair-feedstock/pull/41. 

I'm also applying the patch from https://github.com/conda-forge/altair-feedstock/pull/40 to the `altair-4.2.0-pyhd8ed1ab_0` build, which added a `jsonschema >=3.0` pin.

Diff:

```
noarch::altair-4.0.0-py_0.tar.bz2
-    "jsonschema",
+    "jsonschema <4.17",
noarch::altair-4.0.1-py_0.tar.bz2
-    "jsonschema",
+    "jsonschema <4.17",
noarch::altair-4.1.0-py_0.tar.bz2
-    "jsonschema",
+    "jsonschema <4.17",
noarch::altair-4.1.0-py_1.tar.bz2
-    "jsonschema",
+    "jsonschema <4.17",
noarch::altair-4.2.0-pyhd8ed1ab_0.tar.bz2
-    "jsonschema",
+    "jsonschema >=3.0,<4.17",
noarch::altair-4.2.0-pyhd8ed1ab_1.tar.bz2
-    "jsonschema >=3.0",
+    "jsonschema >=3.0,<4.17",

```

I didn't patch older versions (<4), because they're more than 3 years old and I can't reproduce the underlying issue.

cc @ocefpaf

