### PR TITLE
Fix python lower bound dependency for `dill`

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -2425,7 +2425,6 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                 _replace_pin("jsonschema", "jsonschema >=3.0,<4.17", record["depends"], record)
 
 
-
     return index
 
 

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -482,16 +482,6 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
     for fn, record in index.items():
         record_name = record["name"]
 
-        if record_name == "dill":
-            pversion = pkg_resources.parse_version(record["version"])
-            zero_three_five = pkg_resources.parse_version("0.3.5")
-            zero_three_six = pkg_resources.parse_version("0.3.6")
-
-            if (pversion >= zero_three_five and pversion < zero_three_six) or (
-                pversion == zero_three_six and record["build"].endswith("_0")
-            ):
-                _replace_pin("python >=3.5", "python >=3.7", record["depends"], record)
-
         if record_name == "great-expectations" and record.get("timestamp", 0) < 1616454000000:
             old_constrains = record.get("constrains", [])
             new_constrains = [f"{constraint},<1.4" if constraint == "sqlalchemy >=1.2" else constraint for constraint in old_constrains]
@@ -2389,6 +2379,18 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             and pkg_resources.parse_version(record["version"]) == pkg_resources.parse_version("0.6.9")
         ):
             record["depends"].append("bottleneck")
+
+        # Dill dropped support for python <3.7 starting in version 0.3.5
+        # Fixed in https://github.com/conda-forge/dill-feedstock/pull/35
+        if record_name == "dill":
+            pversion = pkg_resources.parse_version(record["version"])
+            zero_three_five = pkg_resources.parse_version("0.3.5")
+            zero_three_six = pkg_resources.parse_version("0.3.6")
+
+            if (pversion >= zero_three_five and pversion < zero_three_six) or (
+                pversion == zero_three_six and record["build"].endswith("_0")
+            ):
+                _replace_pin("python >=3.5", "python >=3.7", record["depends"], record)
 
     return index
 

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -482,6 +482,16 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
     for fn, record in index.items():
         record_name = record["name"]
 
+        if record_name == "dill":
+            pversion = pkg_resources.parse_version(record["version"])
+            zero_three_five = pkg_resources.parse_version("0.3.5")
+            zero_three_six = pkg_resources.parse_version("0.3.6")
+
+            if (pversion >= zero_three_five and pversion < zero_three_six) or (
+                pversion == zero_three_six and record["build"].endswith("_0")
+            ):
+                _replace_pin("python >=3.5", "python >=3.7", record["depends"], record)
+
         if record_name == "great-expectations" and record.get("timestamp", 0) < 1616454000000:
             old_constrains = record.get("constrains", [])
             new_constrains = [f"{constraint},<1.4" if constraint == "sqlalchemy >=1.2" else constraint for constraint in old_constrains]


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Hello! Firstly, thank you for reviewing this contribution. Versions of the python package `dill` publishing on conda-forge starting from 0.3.5 till 0.3.6-pyhd8ed1ab_0 fail to correctly specify a lower python dependency bound of >=3.7, instead specifying >=3.5. This has since been resolved in the "_1" build of version 0.3.6. However, the incorrect versions still are published in forge without being yanked/recalled.

These are the affected versions:
* [noarch/dill-0.3.6-pyhd8ed1ab_0.tar.bz2](https://anaconda.org/conda-forge/dill/0.3.6/download/noarch/dill-0.3.6-pyhd8ed1ab_0.tar.bz2)
* [noarch/dill-0.3.5.1-pyhd8ed1ab_0.tar.bz2](https://anaconda.org/conda-forge/dill/0.3.5.1/download/noarch/dill-0.3.5.1-pyhd8ed1ab_0.tar.bz2)
* [noarch/dill-0.3.5-pyhd8ed1ab_0.tar.bz2](https://anaconda.org/conda-forge/dill/0.3.5/download/noarch/dill-0.3.5-pyhd8ed1ab_0.tar.bz2)

See the docs here which indicate the lower bound for each of the above respective versions:
* https://pypi.org/project/dill/0.3.6/
* https://pypi.org/project/dill/0.3.5.1/
* https://pypi.org/project/dill/0.3.5/

If used with Python < 3.7, importing `dill` causes the following error.
```
ImportError: cannot import name 'ClassMethodDescriptorType'
```