### PR TITLE
Fix isort Python pin

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -2424,6 +2424,18 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                 # this also applies the fix from https://github.com/conda-forge/altair-feedstock/pull/40
                 _replace_pin("jsonschema", "jsonschema >=3.0,<4.17", record["depends"], record)
 
+        # isort dropped support for python 3.6 in version 5.11.0 and dropped support
+        # for python 3.7 in version 5.12.0, but did not update the dependency in their recipe
+        # Fixed in https://github.com/conda-forge/isort-feedstock/pull/78
+        if record_name == "isort":
+            pversion = pkg_resources.parse_version(record["version"])
+            five_eleven_zero = pkg_resources.parse_version("5.11.0")
+            five_twelve_zero = pkg_resources.parse_version("5.12.0")
+            if pversion >= five_eleven_zero and pversion < five_twelve_zero:
+                _replace_pin("python >=3.6,<4.0", "python >=3.7,<4.0", record["depends"], record)
+            elif pversion == five_twelve_zero:
+                _replace_pin("python >=3.6,<4.0", "python >=3.8,<4.0", record["depends"], record)
+
 
     return index
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
isort 5.11.0 dropped support for Python 3.6 ([release](https://github.com/PyCQA/isort/releases/tag/5.11.0)) and isort 5.12.0 dropped support for Python 3.7 ([release](https://github.com/PyCQA/isort/releases/tag/5.12.0)). In neither case did they update the Python pin in isort-feedstock. This has been since been fixed: https://github.com/conda-forge/isort-feedstock/pull/78. This PR patches the affected versions. Below is the output of `show_diff.py`:

```
noarch::isort-5.11.1-pyhd8ed1ab_0.conda
-    "python >=3.6,<4.0",
+    "python >=3.7,<4.0",
noarch::isort-5.11.2-pyhd8ed1ab_0.conda
-    "python >=3.6,<4.0",
+    "python >=3.7,<4.0",
noarch::isort-5.11.3-pyhd8ed1ab_0.conda
-    "python >=3.6,<4.0",
+    "python >=3.7,<4.0",
noarch::isort-5.11.4-pyhd8ed1ab_0.conda
-    "python >=3.6,<4.0",
+    "python >=3.7,<4.0",
noarch::isort-5.11.4-pyhd8ed1ab_1.conda
-    "python >=3.6,<4.0",
+    "python >=3.7,<4.0",
noarch::isort-5.12.0-pyhd8ed1ab_0.conda
-    "python >=3.6,<4.0",
+    "python >=3.8,<4.0",
```

This correctly patches all affected versions. Note that isort-5.11.0 was never published to Conda Forge, and isort-5.12.0-pyhd8ed1ab_1 contains the fix already. Thank you for reviewing this contribution, cheers!

<!--
Please add any other relevant info below:
-->
