### PR TITLE
sphinx_rtd_theme<=1.1 requires sphinx<6

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1653,6 +1653,14 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             deps = record["depends"]
             _replace_pin("python >=3.7", "python >=3.8", deps, record)
 
+        # sphinx_rtd_theme<=1.1 requires sphinx<6
+        if record_name == "sphinx_rtd_theme" and pkg_resources.parse_version(record["version"]) < pkg_resources.parse_version("1.1.0"):
+            deps = record["depends"]
+            _replace_pin("sphinx >=1.6", "sphinx >=1.6,<6", deps, record)
+            _replace_pin("sphinx", "sphinx <6", deps, record)
+            if not any(x.startswith("sphinx") for x in deps):
+                deps.append("sphinx <6")
+
         # Retroactively pin a max version of openlibm for julia 1.6.* and 1.7.*:
         # https://github.com/conda-forge/julia-feedstock/issues/169
         # timestamp: 29 December 2021 (osx-64/julia-1.7.1-h132cb31_1.tar.bz2) (+ 1)


### PR DESCRIPTION
This was fixed in the feedstock repo in https://github.com/conda-forge/sphinx_rtd_theme-feedstock/pull/24.

The changes in the arrow metadata are unrelated to my changes.

Diff:

<details>

```
noarch::sphinx_rtd_theme-0.4.0-py_1.tar.bz2
-    "python"
+    "python",
+    "sphinx <6"
noarch::sphinx_rtd_theme-0.4.1-py_0.tar.bz2
-    "python"
+    "python",
+    "sphinx <6"
noarch::sphinx_rtd_theme-0.4.2-py_0.tar.bz2
-    "python"
+    "python",
+    "sphinx <6"
noarch::sphinx_rtd_theme-0.4.3-py_0.tar.bz2
-    "python"
+    "python",
+    "sphinx <6"
noarch::sphinx_rtd_theme-0.5.0-pyh9f0ad1d_0.tar.bz2
-    "sphinx"
+    "sphinx <6"
noarch::sphinx_rtd_theme-0.5.1-pyhd3deb0d_0.tar.bz2
-    "sphinx"
+    "sphinx <6"
noarch::sphinx_rtd_theme-0.5.2-pyhd8ed1ab_0.tar.bz2
-    "sphinx"
+    "sphinx <6"
noarch::sphinx_rtd_theme-0.5.2-pyhd8ed1ab_1.tar.bz2
-    "sphinx >=1.6"
+    "sphinx >=1.6,<6"
noarch::sphinx_rtd_theme-1.0.0-pyhd8ed1ab_0.tar.bz2
-    "sphinx >=1.6"
+    "sphinx >=1.6,<6"
linux-64::sphinx_rtd_theme-0.1.9-py27_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27mu"
-  ],
-    "python 2.7*"
+    "python 2.7*",
+    "sphinx <6"
-  "version": "0.1.9"
+  "version": "0.1.9",
+  "constrains": [
+    "python_abi * *_cp27mu"
+  ]
linux-64::sphinx_rtd_theme-0.1.9-py34_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp34m"
-  ],
-    "python 3.4*"
+    "python 3.4*",
+    "sphinx <6"
-  "version": "0.1.9"
+  "version": "0.1.9",
+  "constrains": [
+    "python_abi * *_cp34m"
+  ]
linux-64::sphinx_rtd_theme-0.1.9-py35_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp35m"
-  ],
-    "python 3.5*"
+    "python 3.5*",
+    "sphinx <6"
-  "version": "0.1.9"
+  "version": "0.1.9",
+  "constrains": [
+    "python_abi * *_cp35m"
+  ]
linux-64::sphinx_rtd_theme-0.2.1-py27_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27mu"
-  ],
-    "python 2.7*"
+    "python 2.7*",
+    "sphinx <6"
-  "version": "0.2.1"
+  "version": "0.2.1",
+  "constrains": [
+    "python_abi * *_cp27mu"
+  ]
linux-64::sphinx_rtd_theme-0.2.1-py35_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp35m"
-  ],
-    "python 3.5*"
+    "python 3.5*",
+    "sphinx <6"
-  "version": "0.2.1"
+  "version": "0.2.1",
+  "constrains": [
+    "python_abi * *_cp35m"
+  ]
linux-64::sphinx_rtd_theme-0.2.1-py36_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-    "python 3.6*"
+    "python 3.6*",
+    "sphinx <6"
-  "version": "0.2.1"
+  "version": "0.2.1",
+  "constrains": [
+    "python_abi * *_cp36m"
+  ]
linux-64::sphinx_rtd_theme-0.2.2-py27_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27mu"
-  ],
-    "python 2.7*"
+    "python 2.7*",
+    "sphinx <6"
-  "version": "0.2.2"
+  "version": "0.2.2",
+  "constrains": [
+    "python_abi * *_cp27mu"
+  ]
linux-64::sphinx_rtd_theme-0.2.2-py35_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp35m"
-  ],
-    "python 3.5*"
+    "python 3.5*",
+    "sphinx <6"
-  "version": "0.2.2"
+  "version": "0.2.2",
+  "constrains": [
+    "python_abi * *_cp35m"
+  ]
linux-64::sphinx_rtd_theme-0.2.2-py36_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-    "python 3.6*"
+    "python 3.6*",
+    "sphinx <6"
-  "version": "0.2.2"
+  "version": "0.2.2",
+  "constrains": [
+    "python_abi * *_cp36m"
+  ]
linux-64::sphinx_rtd_theme-0.2.3-py27_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27mu"
-  ],
-    "python 2.7*"
+    "python 2.7*",
+    "sphinx <6"
-  "version": "0.2.3"
+  "version": "0.2.3",
+  "constrains": [
+    "python_abi * *_cp27mu"
+  ]
linux-64::sphinx_rtd_theme-0.2.3-py35_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp35m"
-  ],
-    "python 3.5*"
+    "python 3.5*",
+    "sphinx <6"
-  "version": "0.2.3"
+  "version": "0.2.3",
+  "constrains": [
+    "python_abi * *_cp35m"
+  ]
linux-64::sphinx_rtd_theme-0.2.3-py36_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-    "python 3.6*"
+    "python 3.6*",
+    "sphinx <6"
-  "version": "0.2.3"
+  "version": "0.2.3",
+  "constrains": [
+    "python_abi * *_cp36m"
+  ]
linux-64::sphinx_rtd_theme-0.2.4-py27_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27mu"
-  ],
-    "python 2.7*"
+    "python 2.7*",
+    "sphinx <6"
-  "version": "0.2.4"
+  "version": "0.2.4",
+  "constrains": [
+    "python_abi * *_cp27mu"
+  ]
linux-64::sphinx_rtd_theme-0.2.4-py35_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp35m"
-  ],
-    "python 3.5*"
+    "python 3.5*",
+    "sphinx <6"
-  "version": "0.2.4"
+  "version": "0.2.4",
+  "constrains": [
+    "python_abi * *_cp35m"
+  ]
linux-64::sphinx_rtd_theme-0.2.4-py36_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-    "python 3.6*"
+    "python 3.6*",
+    "sphinx <6"
-  "version": "0.2.4"
+  "version": "0.2.4",
+  "constrains": [
+    "python_abi * *_cp36m"
+  ]
linux-64::sphinx_rtd_theme-0.3.0-py27_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27mu"
-  ],
-    "python 2.7*"
+    "python 2.7*",
+    "sphinx <6"
-  "version": "0.3.0"
+  "version": "0.3.0",
+  "constrains": [
+    "python_abi * *_cp27mu"
+  ]
linux-64::sphinx_rtd_theme-0.3.0-py35_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp35m"
-  ],
-    "python 3.5*"
+    "python 3.5*",
+    "sphinx <6"
-  "version": "0.3.0"
+  "version": "0.3.0",
+  "constrains": [
+    "python_abi * *_cp35m"
+  ]
linux-64::sphinx_rtd_theme-0.3.0-py36_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-    "python 3.6*"
+    "python 3.6*",
+    "sphinx <6"
-  "version": "0.3.0"
+  "version": "0.3.0",
+  "constrains": [
+    "python_abi * *_cp36m"
+  ]
linux-64::sphinx_rtd_theme-0.3.1-py27_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27mu"
-  ],
-    "python >=2.7,<2.8.0a0"
+    "python >=2.7,<2.8.0a0",
+    "sphinx <6"
-  "version": "0.3.1"
+  "version": "0.3.1",
+  "constrains": [
+    "python_abi * *_cp27mu"
+  ]
linux-64::sphinx_rtd_theme-0.3.1-py35_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp35m"
-  ],
-    "python >=3.5,<3.6.0a0"
+    "python >=3.5,<3.6.0a0",
+    "sphinx <6"
-  "version": "0.3.1"
+  "version": "0.3.1",
+  "constrains": [
+    "python_abi * *_cp35m"
+  ]
linux-64::sphinx_rtd_theme-0.3.1-py36_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-    "python >=3.6,<3.7.0a0"
+    "python >=3.6,<3.7.0a0",
+    "sphinx <6"
-  "version": "0.3.1"
+  "version": "0.3.1",
+  "constrains": [
+    "python_abi * *_cp36m"
+  ]
linux-64::sphinx_rtd_theme-0.4.0-py27_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27mu"
-  ],
-    "python >=2.7,<2.8.0a0"
+    "python >=2.7,<2.8.0a0",
+    "sphinx <6"
-  "version": "0.4.0"
+  "version": "0.4.0",
+  "constrains": [
+    "python_abi * *_cp27mu"
+  ]
linux-64::sphinx_rtd_theme-0.4.0-py35_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp35m"
-  ],
-    "python >=3.5,<3.6.0a0"
+    "python >=3.5,<3.6.0a0",
+    "sphinx <6"
-  "version": "0.4.0"
+  "version": "0.4.0",
+  "constrains": [
+    "python_abi * *_cp35m"
+  ]
linux-64::sphinx_rtd_theme-0.4.0-py36_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-    "python >=3.6,<3.7.0a0"
+    "python >=3.6,<3.7.0a0",
+    "sphinx <6"
-  "version": "0.4.0"
+  "version": "0.4.0",
+  "constrains": [
+    "python_abi * *_cp36m"
+  ]
linux-64::arrow-cpp-10.0.1-ha770c72_5_cpu.conda
-  "version": "10.0.1"
+  "version": "10.0.1",
+  "constrains": [
+    "arrow-cpp-proc * cpu"
+  ]
linux-64::arrow-cpp-10.0.1-ha770c72_5_cuda.conda
-  "version": "10.0.1"
+  "version": "10.0.1",
+  "constrains": [
+    "arrow-cpp-proc * cpu"
+  ]
linux-64::arrow-cpp-10.0.1-ha770c72_6_cpu.conda
-  "version": "10.0.1"
+  "version": "10.0.1",
+  "constrains": [
+    "arrow-cpp-proc * cpu"
+  ]
linux-64::arrow-cpp-10.0.1-ha770c72_6_cuda.conda
-  "version": "10.0.1"
+  "version": "10.0.1",
+  "constrains": [
+    "arrow-cpp-proc * cpu"
+  ]
linux-64::pyarrow-10.0.1-py310h633f555_5_cpu.conda
-    "apache-arrow-proc =*=cpu"
+    "apache-arrow-proc =*=cpu",
+    "arrow-cpp-proc * cpu"
linux-64::pyarrow-10.0.1-py310h633f555_6_cpu.conda
-    "apache-arrow-proc =*=cpu"
+    "apache-arrow-proc =*=cpu",
+    "arrow-cpp-proc * cpu"
linux-64::pyarrow-10.0.1-py310hc81d9b2_5_cuda.conda
-    "cudatoolkit >=10.2"
+    "cudatoolkit >=10.2",
+    "arrow-cpp-proc * cpu"
linux-64::pyarrow-10.0.1-py310hc81d9b2_6_cuda.conda
-    "apache-arrow-proc =*=cuda"
+    "apache-arrow-proc =*=cuda",
+    "arrow-cpp-proc * cpu"
linux-64::pyarrow-10.0.1-py311h3ce6b28_5_cuda.conda
-    "cudatoolkit >=10.2"
+    "cudatoolkit >=10.2",
+    "arrow-cpp-proc * cpu"
linux-64::pyarrow-10.0.1-py311h3ce6b28_6_cuda.conda
-    "apache-arrow-proc =*=cuda"
+    "apache-arrow-proc =*=cuda",
+    "arrow-cpp-proc * cpu"
linux-64::pyarrow-10.0.1-py311hbdf6286_5_cpu.conda
-    "apache-arrow-proc =*=cpu"
+    "apache-arrow-proc =*=cpu",
+    "arrow-cpp-proc * cpu"
linux-64::pyarrow-10.0.1-py311hbdf6286_6_cpu.conda
-    "apache-arrow-proc =*=cpu"
+    "apache-arrow-proc =*=cpu",
+    "arrow-cpp-proc * cpu"
linux-64::pyarrow-10.0.1-py38h0feaef1_5_cuda.conda
-    "cudatoolkit >=10.2"
+    "cudatoolkit >=10.2",
+    "arrow-cpp-proc * cpu"
linux-64::pyarrow-10.0.1-py38h0feaef1_6_cuda.conda
-    "apache-arrow-proc =*=cuda"
+    "apache-arrow-proc =*=cuda",
+    "arrow-cpp-proc * cpu"
linux-64::pyarrow-10.0.1-py38hf05218d_5_cpu.conda
-    "apache-arrow-proc =*=cpu"
+    "apache-arrow-proc =*=cpu",
+    "arrow-cpp-proc * cpu"
linux-64::pyarrow-10.0.1-py38hf05218d_6_cpu.conda
-    "apache-arrow-proc =*=cpu"
+    "apache-arrow-proc =*=cpu",
+    "arrow-cpp-proc * cpu"
linux-64::pyarrow-10.0.1-py39hf0ef2fd_5_cpu.conda
-    "apache-arrow-proc =*=cpu"
+    "apache-arrow-proc =*=cpu",
+    "arrow-cpp-proc * cpu"
linux-64::pyarrow-10.0.1-py39hf0ef2fd_6_cpu.conda
-    "apache-arrow-proc =*=cpu"
+    "apache-arrow-proc =*=cpu",
+    "arrow-cpp-proc * cpu"
linux-64::pyarrow-10.0.1-py39hfa3bf44_5_cuda.conda
-    "cudatoolkit >=10.2"
+    "cudatoolkit >=10.2",
+    "arrow-cpp-proc * cpu"
linux-64::pyarrow-10.0.1-py39hfa3bf44_6_cuda.conda
-    "apache-arrow-proc =*=cuda"
+    "apache-arrow-proc =*=cuda",
+    "arrow-cpp-proc * cpu"
linux-aarch64::arrow-cpp-10.0.1-h8af1aa0_5_cpu.conda
-  "version": "10.0.1"
+  "version": "10.0.1",
+  "constrains": [
+    "arrow-cpp-proc * cpu"
+  ]
linux-aarch64::arrow-cpp-10.0.1-h8af1aa0_6_cpu.conda
-  "version": "10.0.1"
+  "version": "10.0.1",
+  "constrains": [
+    "arrow-cpp-proc * cpu"
+  ]
linux-aarch64::pyarrow-10.0.1-py310h5fe3fae_5_cpu.conda
-    "apache-arrow-proc =*=cpu"
+    "apache-arrow-proc =*=cpu",
+    "arrow-cpp-proc * cpu"
linux-aarch64::pyarrow-10.0.1-py310h5fe3fae_6_cpu.conda
-    "apache-arrow-proc =*=cpu"
+    "apache-arrow-proc =*=cpu",
+    "arrow-cpp-proc * cpu"
linux-aarch64::pyarrow-10.0.1-py311h0ce3e70_5_cpu.conda
-    "apache-arrow-proc =*=cpu"
+    "apache-arrow-proc =*=cpu",
+    "arrow-cpp-proc * cpu"
linux-aarch64::pyarrow-10.0.1-py311h0ce3e70_6_cpu.conda
-    "apache-arrow-proc =*=cpu"
+    "apache-arrow-proc =*=cpu",
+    "arrow-cpp-proc * cpu"
linux-aarch64::pyarrow-10.0.1-py38hb6b66db_5_cpu.conda
-    "apache-arrow-proc =*=cpu"
+    "apache-arrow-proc =*=cpu",
+    "arrow-cpp-proc * cpu"
linux-aarch64::pyarrow-10.0.1-py38hb6b66db_6_cpu.conda
-    "apache-arrow-proc =*=cpu"
+    "apache-arrow-proc =*=cpu",
+    "arrow-cpp-proc * cpu"
linux-aarch64::pyarrow-10.0.1-py39h19c4130_5_cpu.conda
-    "apache-arrow-proc =*=cpu"
+    "apache-arrow-proc =*=cpu",
+    "arrow-cpp-proc * cpu"
linux-aarch64::pyarrow-10.0.1-py39h19c4130_6_cpu.conda
-    "apache-arrow-proc =*=cpu"
+    "apache-arrow-proc =*=cpu",
+    "arrow-cpp-proc * cpu"
linux-ppc64le::arrow-cpp-10.0.1-ha3edaa6_5_cpu.conda
-  "version": "10.0.1"
+  "version": "10.0.1",
+  "constrains": [
+    "arrow-cpp-proc * cpu"
+  ]
linux-ppc64le::arrow-cpp-10.0.1-ha3edaa6_6_cpu.conda
-  "version": "10.0.1"
+  "version": "10.0.1",
+  "constrains": [
+    "arrow-cpp-proc * cpu"
+  ]
linux-ppc64le::pyarrow-10.0.1-py310ha2e63e8_5_cpu.conda
-    "apache-arrow-proc =*=cpu"
+    "apache-arrow-proc =*=cpu",
+    "arrow-cpp-proc * cpu"
linux-ppc64le::pyarrow-10.0.1-py310ha2e63e8_6_cpu.conda
-    "apache-arrow-proc =*=cpu"
+    "apache-arrow-proc =*=cpu",
+    "arrow-cpp-proc * cpu"
linux-ppc64le::pyarrow-10.0.1-py311h20fc1d9_5_cpu.conda
-    "apache-arrow-proc =*=cpu"
+    "apache-arrow-proc =*=cpu",
+    "arrow-cpp-proc * cpu"
linux-ppc64le::pyarrow-10.0.1-py311h20fc1d9_6_cpu.conda
-    "apache-arrow-proc =*=cpu"
+    "apache-arrow-proc =*=cpu",
+    "arrow-cpp-proc * cpu"
linux-ppc64le::pyarrow-10.0.1-py38he0fac02_5_cpu.conda
-    "apache-arrow-proc =*=cpu"
+    "apache-arrow-proc =*=cpu",
+    "arrow-cpp-proc * cpu"
linux-ppc64le::pyarrow-10.0.1-py38he0fac02_6_cpu.conda
-    "apache-arrow-proc =*=cpu"
+    "apache-arrow-proc =*=cpu",
+    "arrow-cpp-proc * cpu"
linux-ppc64le::pyarrow-10.0.1-py39hb616d87_5_cpu.conda
-    "apache-arrow-proc =*=cpu"
+    "apache-arrow-proc =*=cpu",
+    "arrow-cpp-proc * cpu"
linux-ppc64le::pyarrow-10.0.1-py39hb616d87_6_cpu.conda
-    "apache-arrow-proc =*=cpu"
+    "apache-arrow-proc =*=cpu",
+    "arrow-cpp-proc * cpu"
osx-64::sphinx_rtd_theme-0.1.9-py27_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27m"
-  ],
-    "python 2.7*"
+    "python 2.7*",
+    "sphinx <6"
-  "version": "0.1.9"
+  "version": "0.1.9",
+  "constrains": [
+    "python_abi * *_cp27m"
+  ]
osx-64::sphinx_rtd_theme-0.1.9-py34_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp34m"
-  ],
-    "python 3.4*"
+    "python 3.4*",
+    "sphinx <6"
-  "version": "0.1.9"
+  "version": "0.1.9",
+  "constrains": [
+    "python_abi * *_cp34m"
+  ]
osx-64::sphinx_rtd_theme-0.1.9-py35_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp35m"
-  ],
-    "python 3.5*"
+    "python 3.5*",
+    "sphinx <6"
-  "version": "0.1.9"
+  "version": "0.1.9",
+  "constrains": [
+    "python_abi * *_cp35m"
+  ]
osx-64::sphinx_rtd_theme-0.1.9-py36_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-    "python 3.6*"
+    "python 3.6*",
+    "sphinx <6"
-  "version": "0.1.9"
+  "version": "0.1.9",
+  "constrains": [
+    "python_abi * *_cp36m"
+  ]
osx-64::sphinx_rtd_theme-0.2.1-py27_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27m"
-  ],
-    "python 2.7*"
+    "python 2.7*",
+    "sphinx <6"
-  "version": "0.2.1"
+  "version": "0.2.1",
+  "constrains": [
+    "python_abi * *_cp27m"
+  ]
osx-64::sphinx_rtd_theme-0.2.1-py35_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp35m"
-  ],
-    "python 3.5*"
+    "python 3.5*",
+    "sphinx <6"
-  "version": "0.2.1"
+  "version": "0.2.1",
+  "constrains": [
+    "python_abi * *_cp35m"
+  ]
osx-64::sphinx_rtd_theme-0.2.1-py36_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-    "python 3.6*"
+    "python 3.6*",
+    "sphinx <6"
-  "version": "0.2.1"
+  "version": "0.2.1",
+  "constrains": [
+    "python_abi * *_cp36m"
+  ]
osx-64::sphinx_rtd_theme-0.2.2-py27_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27m"
-  ],
-    "python 2.7*"
+    "python 2.7*",
+    "sphinx <6"
-  "version": "0.2.2"
+  "version": "0.2.2",
+  "constrains": [
+    "python_abi * *_cp27m"
+  ]
osx-64::sphinx_rtd_theme-0.2.2-py35_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp35m"
-  ],
-    "python 3.5*"
+    "python 3.5*",
+    "sphinx <6"
-  "version": "0.2.2"
+  "version": "0.2.2",
+  "constrains": [
+    "python_abi * *_cp35m"
+  ]
osx-64::sphinx_rtd_theme-0.2.2-py36_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-    "python 3.6*"
+    "python 3.6*",
+    "sphinx <6"
-  "version": "0.2.2"
+  "version": "0.2.2",
+  "constrains": [
+    "python_abi * *_cp36m"
+  ]
osx-64::sphinx_rtd_theme-0.2.3-py27_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27m"
-  ],
-    "python 2.7*"
+    "python 2.7*",
+    "sphinx <6"
-  "version": "0.2.3"
+  "version": "0.2.3",
+  "constrains": [
+    "python_abi * *_cp27m"
+  ]
osx-64::sphinx_rtd_theme-0.2.3-py35_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp35m"
-  ],
-    "python 3.5*"
+    "python 3.5*",
+    "sphinx <6"
-  "version": "0.2.3"
+  "version": "0.2.3",
+  "constrains": [
+    "python_abi * *_cp35m"
+  ]
osx-64::sphinx_rtd_theme-0.2.3-py36_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-    "python 3.6*"
+    "python 3.6*",
+    "sphinx <6"
-  "version": "0.2.3"
+  "version": "0.2.3",
+  "constrains": [
+    "python_abi * *_cp36m"
+  ]
osx-64::sphinx_rtd_theme-0.2.4-py27_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27m"
-  ],
-    "python 2.7*"
+    "python 2.7*",
+    "sphinx <6"
-  "version": "0.2.4"
+  "version": "0.2.4",
+  "constrains": [
+    "python_abi * *_cp27m"
+  ]
osx-64::sphinx_rtd_theme-0.2.4-py35_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp35m"
-  ],
-    "python 3.5*"
+    "python 3.5*",
+    "sphinx <6"
-  "version": "0.2.4"
+  "version": "0.2.4",
+  "constrains": [
+    "python_abi * *_cp35m"
+  ]
osx-64::sphinx_rtd_theme-0.2.4-py36_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-    "python 3.6*"
+    "python 3.6*",
+    "sphinx <6"
-  "version": "0.2.4"
+  "version": "0.2.4",
+  "constrains": [
+    "python_abi * *_cp36m"
+  ]
osx-64::sphinx_rtd_theme-0.3.0-py27_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27m"
-  ],
-    "python 2.7*"
+    "python 2.7*",
+    "sphinx <6"
-  "version": "0.3.0"
+  "version": "0.3.0",
+  "constrains": [
+    "python_abi * *_cp27m"
+  ]
osx-64::sphinx_rtd_theme-0.3.0-py35_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp35m"
-  ],
-    "python 3.5*"
+    "python 3.5*",
+    "sphinx <6"
-  "version": "0.3.0"
+  "version": "0.3.0",
+  "constrains": [
+    "python_abi * *_cp35m"
+  ]
osx-64::sphinx_rtd_theme-0.3.0-py36_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-    "python 3.6*"
+    "python 3.6*",
+    "sphinx <6"
-  "version": "0.3.0"
+  "version": "0.3.0",
+  "constrains": [
+    "python_abi * *_cp36m"
+  ]
osx-64::sphinx_rtd_theme-0.3.1-py27_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27m"
-  ],
-    "python >=2.7,<2.8.0a0"
+    "python >=2.7,<2.8.0a0",
+    "sphinx <6"
-  "version": "0.3.1"
+  "version": "0.3.1",
+  "constrains": [
+    "python_abi * *_cp27m"
+  ]
osx-64::sphinx_rtd_theme-0.3.1-py35_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp35m"
-  ],
-    "python >=3.5,<3.6.0a0"
+    "python >=3.5,<3.6.0a0",
+    "sphinx <6"
-  "version": "0.3.1"
+  "version": "0.3.1",
+  "constrains": [
+    "python_abi * *_cp35m"
+  ]
osx-64::sphinx_rtd_theme-0.3.1-py36_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-    "python >=3.6,<3.7.0a0"
+    "python >=3.6,<3.7.0a0",
+    "sphinx <6"
-  "version": "0.3.1"
+  "version": "0.3.1",
+  "constrains": [
+    "python_abi * *_cp36m"
+  ]
osx-64::sphinx_rtd_theme-0.4.0-py27_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27m"
-  ],
-    "python >=2.7,<2.8.0a0"
+    "python >=2.7,<2.8.0a0",
+    "sphinx <6"
-  "version": "0.4.0"
+  "version": "0.4.0",
+  "constrains": [
+    "python_abi * *_cp27m"
+  ]
osx-64::sphinx_rtd_theme-0.4.0-py35_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp35m"
-  ],
-    "python >=3.5,<3.6.0a0"
+    "python >=3.5,<3.6.0a0",
+    "sphinx <6"
-  "version": "0.4.0"
+  "version": "0.4.0",
+  "constrains": [
+    "python_abi * *_cp35m"
+  ]
osx-64::sphinx_rtd_theme-0.4.0-py36_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-    "python >=3.6,<3.7.0a0"
+    "python >=3.6,<3.7.0a0",
+    "sphinx <6"
-  "version": "0.4.0"
+  "version": "0.4.0",
+  "constrains": [
+    "python_abi * *_cp36m"
+  ]
osx-64::arrow-cpp-10.0.1-h694c41f_5_cpu.conda
-  "version": "10.0.1"
+  "version": "10.0.1",
+  "constrains": [
+    "arrow-cpp-proc * cpu"
+  ]
osx-64::arrow-cpp-10.0.1-h694c41f_6_cpu.conda
-  "version": "10.0.1"
+  "version": "10.0.1",
+  "constrains": [
+    "arrow-cpp-proc * cpu"
+  ]
osx-64::pyarrow-10.0.1-py310h435aefc_5_cpu.conda
-    "apache-arrow-proc =*=cpu"
+    "apache-arrow-proc =*=cpu",
+    "arrow-cpp-proc * cpu"
osx-64::pyarrow-10.0.1-py310h435aefc_6_cpu.conda
-    "apache-arrow-proc =*=cpu"
+    "apache-arrow-proc =*=cpu",
+    "arrow-cpp-proc * cpu"
osx-64::pyarrow-10.0.1-py311hb17b21d_5_cpu.conda
-    "apache-arrow-proc =*=cpu"
+    "apache-arrow-proc =*=cpu",
+    "arrow-cpp-proc * cpu"
osx-64::pyarrow-10.0.1-py311hb17b21d_6_cpu.conda
-    "apache-arrow-proc =*=cpu"
+    "apache-arrow-proc =*=cpu",
+    "arrow-cpp-proc * cpu"
osx-64::pyarrow-10.0.1-py38h5866706_5_cpu.conda
-    "apache-arrow-proc =*=cpu"
+    "apache-arrow-proc =*=cpu",
+    "arrow-cpp-proc * cpu"
osx-64::pyarrow-10.0.1-py38h5866706_6_cpu.conda
-    "apache-arrow-proc =*=cpu"
+    "apache-arrow-proc =*=cpu",
+    "arrow-cpp-proc * cpu"
osx-64::pyarrow-10.0.1-py39h56e7202_5_cpu.conda
-    "apache-arrow-proc =*=cpu"
+    "apache-arrow-proc =*=cpu",
+    "arrow-cpp-proc * cpu"
osx-64::pyarrow-10.0.1-py39h56e7202_6_cpu.conda
-    "apache-arrow-proc =*=cpu"
+    "apache-arrow-proc =*=cpu",
+    "arrow-cpp-proc * cpu"
osx-arm64::arrow-cpp-10.0.1-hce30654_5_cpu.conda
-  "version": "10.0.1"
+  "version": "10.0.1",
+  "constrains": [
+    "arrow-cpp-proc * cpu"
+  ]
osx-arm64::arrow-cpp-10.0.1-hce30654_6_cpu.conda
-  "version": "10.0.1"
+  "version": "10.0.1",
+  "constrains": [
+    "arrow-cpp-proc * cpu"
+  ]
osx-arm64::pyarrow-10.0.1-py310h89f3c6b_5_cpu.conda
-    "apache-arrow-proc =*=cpu"
+    "apache-arrow-proc =*=cpu",
+    "arrow-cpp-proc * cpu"
osx-arm64::pyarrow-10.0.1-py310h89f3c6b_6_cpu.conda
-    "apache-arrow-proc =*=cpu"
+    "apache-arrow-proc =*=cpu",
+    "arrow-cpp-proc * cpu"
osx-arm64::pyarrow-10.0.1-py311h1e679ab_5_cpu.conda
-    "apache-arrow-proc =*=cpu"
+    "apache-arrow-proc =*=cpu",
+    "arrow-cpp-proc * cpu"
osx-arm64::pyarrow-10.0.1-py311h1e679ab_6_cpu.conda
-    "apache-arrow-proc =*=cpu"
+    "apache-arrow-proc =*=cpu",
+    "arrow-cpp-proc * cpu"
osx-arm64::pyarrow-10.0.1-py38h32b283d_5_cpu.conda
-    "apache-arrow-proc =*=cpu"
+    "apache-arrow-proc =*=cpu",
+    "arrow-cpp-proc * cpu"
osx-arm64::pyarrow-10.0.1-py38h32b283d_6_cpu.conda
-    "apache-arrow-proc =*=cpu"
+    "apache-arrow-proc =*=cpu",
+    "arrow-cpp-proc * cpu"
osx-arm64::pyarrow-10.0.1-py39hfdcab31_5_cpu.conda
-    "apache-arrow-proc =*=cpu"
+    "apache-arrow-proc =*=cpu",
+    "arrow-cpp-proc * cpu"
osx-arm64::pyarrow-10.0.1-py39hfdcab31_6_cpu.conda
-    "apache-arrow-proc =*=cpu"
+    "apache-arrow-proc =*=cpu",
+    "arrow-cpp-proc * cpu"
win-32::sphinx_rtd_theme-0.1.9-py27_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27m"
-  ],
-    "python 2.7*"
+    "python 2.7*",
+    "sphinx <6"
-  "version": "0.1.9"
+  "version": "0.1.9",
+  "constrains": [
+    "python_abi * *_cp27m"
+  ]
win-32::sphinx_rtd_theme-0.1.9-py34_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp34m"
-  ],
-    "python 3.4*"
+    "python 3.4*",
+    "sphinx <6"
-  "version": "0.1.9"
+  "version": "0.1.9",
+  "constrains": [
+    "python_abi * *_cp34m"
+  ]
win-32::sphinx_rtd_theme-0.1.9-py35_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp35m"
-  ],
-    "python 3.5*"
+    "python 3.5*",
+    "sphinx <6"
-  "version": "0.1.9"
+  "version": "0.1.9",
+  "constrains": [
+    "python_abi * *_cp35m"
+  ]
win-32::sphinx_rtd_theme-0.1.9-py36_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-    "python 3.6*"
+    "python 3.6*",
+    "sphinx <6"
-  "version": "0.1.9"
+  "version": "0.1.9",
+  "constrains": [
+    "python_abi * *_cp36m"
+  ]
win-32::sphinx_rtd_theme-0.2.1-py27_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27m"
-  ],
-    "python 2.7*"
+    "python 2.7*",
+    "sphinx <6"
-  "version": "0.2.1"
+  "version": "0.2.1",
+  "constrains": [
+    "python_abi * *_cp27m"
+  ]
win-32::sphinx_rtd_theme-0.2.1-py35_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp35m"
-  ],
-    "python 3.5*"
+    "python 3.5*",
+    "sphinx <6"
-  "version": "0.2.1"
+  "version": "0.2.1",
+  "constrains": [
+    "python_abi * *_cp35m"
+  ]
win-32::sphinx_rtd_theme-0.2.1-py36_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-    "python 3.6*"
+    "python 3.6*",
+    "sphinx <6"
-  "version": "0.2.1"
+  "version": "0.2.1",
+  "constrains": [
+    "python_abi * *_cp36m"
+  ]
win-32::sphinx_rtd_theme-0.2.2-py27_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27m"
-  ],
-    "python 2.7*"
+    "python 2.7*",
+    "sphinx <6"
-  "version": "0.2.2"
+  "version": "0.2.2",
+  "constrains": [
+    "python_abi * *_cp27m"
+  ]
win-32::sphinx_rtd_theme-0.2.2-py35_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp35m"
-  ],
-    "python 3.5*"
+    "python 3.5*",
+    "sphinx <6"
-  "version": "0.2.2"
+  "version": "0.2.2",
+  "constrains": [
+    "python_abi * *_cp35m"
+  ]
win-32::sphinx_rtd_theme-0.2.2-py36_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-    "python 3.6*"
+    "python 3.6*",
+    "sphinx <6"
-  "version": "0.2.2"
+  "version": "0.2.2",
+  "constrains": [
+    "python_abi * *_cp36m"
+  ]
win-32::sphinx_rtd_theme-0.2.3-py27_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27m"
-  ],
-    "python 2.7*"
+    "python 2.7*",
+    "sphinx <6"
-  "version": "0.2.3"
+  "version": "0.2.3",
+  "constrains": [
+    "python_abi * *_cp27m"
+  ]
win-32::sphinx_rtd_theme-0.2.3-py35_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp35m"
-  ],
-    "python 3.5*"
+    "python 3.5*",
+    "sphinx <6"
-  "version": "0.2.3"
+  "version": "0.2.3",
+  "constrains": [
+    "python_abi * *_cp35m"
+  ]
win-32::sphinx_rtd_theme-0.2.3-py36_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-    "python 3.6*"
+    "python 3.6*",
+    "sphinx <6"
-  "version": "0.2.3"
+  "version": "0.2.3",
+  "constrains": [
+    "python_abi * *_cp36m"
+  ]
win-32::sphinx_rtd_theme-0.2.4-py27_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27m"
-  ],
-    "python 2.7*"
+    "python 2.7*",
+    "sphinx <6"
-  "version": "0.2.4"
+  "version": "0.2.4",
+  "constrains": [
+    "python_abi * *_cp27m"
+  ]
win-32::sphinx_rtd_theme-0.2.4-py35_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp35m"
-  ],
-    "python 3.5*"
+    "python 3.5*",
+    "sphinx <6"
-  "version": "0.2.4"
+  "version": "0.2.4",
+  "constrains": [
+    "python_abi * *_cp35m"
+  ]
win-32::sphinx_rtd_theme-0.2.4-py36_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-    "python 3.6*"
+    "python 3.6*",
+    "sphinx <6"
-  "version": "0.2.4"
+  "version": "0.2.4",
+  "constrains": [
+    "python_abi * *_cp36m"
+  ]
win-32::sphinx_rtd_theme-0.3.0-py27_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27m"
-  ],
-    "python 2.7*"
+    "python 2.7*",
+    "sphinx <6"
-  "version": "0.3.0"
+  "version": "0.3.0",
+  "constrains": [
+    "python_abi * *_cp27m"
+  ]
win-32::sphinx_rtd_theme-0.3.0-py35_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp35m"
-  ],
-    "python 3.5*"
+    "python 3.5*",
+    "sphinx <6"
-  "version": "0.3.0"
+  "version": "0.3.0",
+  "constrains": [
+    "python_abi * *_cp35m"
+  ]
win-32::sphinx_rtd_theme-0.3.0-py36_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-    "python 3.6*"
+    "python 3.6*",
+    "sphinx <6"
-  "version": "0.3.0"
+  "version": "0.3.0",
+  "constrains": [
+    "python_abi * *_cp36m"
+  ]
win-64::sphinx_rtd_theme-0.1.9-py27_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27m"
-  ],
-    "python 2.7*"
+    "python 2.7*",
+    "sphinx <6"
-  "version": "0.1.9"
+  "version": "0.1.9",
+  "constrains": [
+    "python_abi * *_cp27m"
+  ]
win-64::sphinx_rtd_theme-0.1.9-py34_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp34m"
-  ],
-    "python 3.4*"
+    "python 3.4*",
+    "sphinx <6"
-  "version": "0.1.9"
+  "version": "0.1.9",
+  "constrains": [
+    "python_abi * *_cp34m"
+  ]
win-64::sphinx_rtd_theme-0.1.9-py35_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp35m"
-  ],
-    "python 3.5*"
+    "python 3.5*",
+    "sphinx <6"
-  "version": "0.1.9"
+  "version": "0.1.9",
+  "constrains": [
+    "python_abi * *_cp35m"
+  ]
win-64::sphinx_rtd_theme-0.1.9-py36_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-    "python 3.6*"
+    "python 3.6*",
+    "sphinx <6"
-  "version": "0.1.9"
+  "version": "0.1.9",
+  "constrains": [
+    "python_abi * *_cp36m"
+  ]
win-64::sphinx_rtd_theme-0.2.1-py27_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27m"
-  ],
-    "python 2.7*"
+    "python 2.7*",
+    "sphinx <6"
-  "version": "0.2.1"
+  "version": "0.2.1",
+  "constrains": [
+    "python_abi * *_cp27m"
+  ]
win-64::sphinx_rtd_theme-0.2.1-py35_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp35m"
-  ],
-    "python 3.5*"
+    "python 3.5*",
+    "sphinx <6"
-  "version": "0.2.1"
+  "version": "0.2.1",
+  "constrains": [
+    "python_abi * *_cp35m"
+  ]
win-64::sphinx_rtd_theme-0.2.1-py36_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-    "python 3.6*"
+    "python 3.6*",
+    "sphinx <6"
-  "version": "0.2.1"
+  "version": "0.2.1",
+  "constrains": [
+    "python_abi * *_cp36m"
+  ]
win-64::sphinx_rtd_theme-0.2.2-py27_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27m"
-  ],
-    "python 2.7*"
+    "python 2.7*",
+    "sphinx <6"
-  "version": "0.2.2"
+  "version": "0.2.2",
+  "constrains": [
+    "python_abi * *_cp27m"
+  ]
win-64::sphinx_rtd_theme-0.2.2-py35_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp35m"
-  ],
-    "python 3.5*"
+    "python 3.5*",
+    "sphinx <6"
-  "version": "0.2.2"
+  "version": "0.2.2",
+  "constrains": [
+    "python_abi * *_cp35m"
+  ]
win-64::sphinx_rtd_theme-0.2.2-py36_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-    "python 3.6*"
+    "python 3.6*",
+    "sphinx <6"
-  "version": "0.2.2"
+  "version": "0.2.2",
+  "constrains": [
+    "python_abi * *_cp36m"
+  ]
win-64::sphinx_rtd_theme-0.2.3-py27_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27m"
-  ],
-    "python 2.7*"
+    "python 2.7*",
+    "sphinx <6"
-  "version": "0.2.3"
+  "version": "0.2.3",
+  "constrains": [
+    "python_abi * *_cp27m"
+  ]
win-64::sphinx_rtd_theme-0.2.3-py35_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp35m"
-  ],
-    "python 3.5*"
+    "python 3.5*",
+    "sphinx <6"
-  "version": "0.2.3"
+  "version": "0.2.3",
+  "constrains": [
+    "python_abi * *_cp35m"
+  ]
win-64::sphinx_rtd_theme-0.2.3-py36_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-    "python 3.6*"
+    "python 3.6*",
+    "sphinx <6"
-  "version": "0.2.3"
+  "version": "0.2.3",
+  "constrains": [
+    "python_abi * *_cp36m"
+  ]
win-64::sphinx_rtd_theme-0.2.4-py27_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27m"
-  ],
-    "python 2.7*"
+    "python 2.7*",
+    "sphinx <6"
-  "version": "0.2.4"
+  "version": "0.2.4",
+  "constrains": [
+    "python_abi * *_cp27m"
+  ]
win-64::sphinx_rtd_theme-0.2.4-py35_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp35m"
-  ],
-    "python 3.5*"
+    "python 3.5*",
+    "sphinx <6"
-  "version": "0.2.4"
+  "version": "0.2.4",
+  "constrains": [
+    "python_abi * *_cp35m"
+  ]
win-64::sphinx_rtd_theme-0.2.4-py36_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-    "python 3.6*"
+    "python 3.6*",
+    "sphinx <6"
-  "version": "0.2.4"
+  "version": "0.2.4",
+  "constrains": [
+    "python_abi * *_cp36m"
+  ]
win-64::sphinx_rtd_theme-0.3.0-py27_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27m"
-  ],
-    "python 2.7*"
+    "python 2.7*",
+    "sphinx <6"
-  "version": "0.3.0"
+  "version": "0.3.0",
+  "constrains": [
+    "python_abi * *_cp27m"
+  ]
win-64::sphinx_rtd_theme-0.3.0-py35_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp35m"
-  ],
-    "python 3.5*"
+    "python 3.5*",
+    "sphinx <6"
-  "version": "0.3.0"
+  "version": "0.3.0",
+  "constrains": [
+    "python_abi * *_cp35m"
+  ]
win-64::sphinx_rtd_theme-0.3.0-py36_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-    "python 3.6*"
+    "python 3.6*",
+    "sphinx <6"
-  "version": "0.3.0"
+  "version": "0.3.0",
+  "constrains": [
+    "python_abi * *_cp36m"
+  ]
win-64::sphinx_rtd_theme-0.3.1-py27_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27m"
-  ],
-    "python >=2.7,<2.8.0a0"
+    "python >=2.7,<2.8.0a0",
+    "sphinx <6"
-  "version": "0.3.1"
+  "version": "0.3.1",
+  "constrains": [
+    "python_abi * *_cp27m"
+  ]
win-64::sphinx_rtd_theme-0.3.1-py35_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp35m"
-  ],
-    "python >=3.5,<3.6.0a0"
+    "python >=3.5,<3.6.0a0",
+    "sphinx <6"
-  "version": "0.3.1"
+  "version": "0.3.1",
+  "constrains": [
+    "python_abi * *_cp35m"
+  ]
win-64::sphinx_rtd_theme-0.3.1-py36_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-    "python >=3.6,<3.7.0a0"
+    "python >=3.6,<3.7.0a0",
+    "sphinx <6"
-  "version": "0.3.1"
+  "version": "0.3.1",
+  "constrains": [
+    "python_abi * *_cp36m"
+  ]
win-64::sphinx_rtd_theme-0.4.0-py27_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27m"
-  ],
-    "python >=2.7,<2.8.0a0"
+    "python >=2.7,<2.8.0a0",
+    "sphinx <6"
-  "version": "0.4.0"
+  "version": "0.4.0",
+  "constrains": [
+    "python_abi * *_cp27m"
+  ]
win-64::sphinx_rtd_theme-0.4.0-py35_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp35m"
-  ],
-    "python >=3.5,<3.6.0a0"
+    "python >=3.5,<3.6.0a0",
+    "sphinx <6"
-  "version": "0.4.0"
+  "version": "0.4.0",
+  "constrains": [
+    "python_abi * *_cp35m"
+  ]
win-64::sphinx_rtd_theme-0.4.0-py36_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-    "python >=3.6,<3.7.0a0"
+    "python >=3.6,<3.7.0a0",
+    "sphinx <6"
-  "version": "0.4.0"
+  "version": "0.4.0",
+  "constrains": [
+    "python_abi * *_cp36m"
+  ]
win-64::arrow-cpp-10.0.1-h57928b3_5_cpu.conda
-  "version": "10.0.1"
+  "version": "10.0.1",
+  "constrains": [
+    "arrow-cpp-proc * cpu"
+  ]
win-64::arrow-cpp-10.0.1-h57928b3_5_cuda.conda
-  "version": "10.0.1"
+  "version": "10.0.1",
+  "constrains": [
+    "arrow-cpp-proc * cpu"
+  ]
win-64::arrow-cpp-10.0.1-h57928b3_6_cpu.conda
-  "version": "10.0.1"
+  "version": "10.0.1",
+  "constrains": [
+    "arrow-cpp-proc * cpu"
+  ]
win-64::arrow-cpp-10.0.1-h57928b3_6_cuda.conda
-  "version": "10.0.1"
+  "version": "10.0.1",
+  "constrains": [
+    "arrow-cpp-proc * cpu"
+  ]
win-64::pyarrow-10.0.1-py310hb5fce52_5_cuda.conda
-    "cudatoolkit >=10.2"
+    "cudatoolkit >=10.2",
+    "arrow-cpp-proc * cpu"
win-64::pyarrow-10.0.1-py310hb5fce52_6_cuda.conda
-    "cudatoolkit >=10.2"
+    "cudatoolkit >=10.2",
+    "arrow-cpp-proc * cpu"
win-64::pyarrow-10.0.1-py310hd1a9178_5_cpu.conda
-    "apache-arrow-proc =*=cpu"
+    "apache-arrow-proc =*=cpu",
+    "arrow-cpp-proc * cpu"
win-64::pyarrow-10.0.1-py310hd1a9178_6_cpu.conda
-    "apache-arrow-proc =*=cpu"
+    "apache-arrow-proc =*=cpu",
+    "arrow-cpp-proc * cpu"
win-64::pyarrow-10.0.1-py311h6a6099b_5_cpu.conda
-    "apache-arrow-proc =*=cpu"
+    "apache-arrow-proc =*=cpu",
+    "arrow-cpp-proc * cpu"
win-64::pyarrow-10.0.1-py311h6a6099b_6_cpu.conda
-    "apache-arrow-proc =*=cpu"
+    "apache-arrow-proc =*=cpu",
+    "arrow-cpp-proc * cpu"
win-64::pyarrow-10.0.1-py311h87682fd_5_cuda.conda
-    "cudatoolkit >=10.2"
+    "cudatoolkit >=10.2",
+    "arrow-cpp-proc * cpu"
win-64::pyarrow-10.0.1-py311h87682fd_6_cuda.conda
-    "cudatoolkit >=10.2"
+    "cudatoolkit >=10.2",
+    "arrow-cpp-proc * cpu"
win-64::pyarrow-10.0.1-py38hc2f90da_5_cuda.conda
-    "cudatoolkit >=10.2"
+    "cudatoolkit >=10.2",
+    "arrow-cpp-proc * cpu"
win-64::pyarrow-10.0.1-py38hc2f90da_6_cuda.conda
-    "cudatoolkit >=10.2"
+    "cudatoolkit >=10.2",
+    "arrow-cpp-proc * cpu"
win-64::pyarrow-10.0.1-py38hc72dcf3_5_cpu.conda
-    "apache-arrow-proc =*=cpu"
+    "apache-arrow-proc =*=cpu",
+    "arrow-cpp-proc * cpu"
win-64::pyarrow-10.0.1-py38hc72dcf3_6_cpu.conda
-    "apache-arrow-proc =*=cpu"
+    "apache-arrow-proc =*=cpu",
+    "arrow-cpp-proc * cpu"
win-64::pyarrow-10.0.1-py39h91da4d1_5_cuda.conda
-    "cudatoolkit >=10.2"
+    "cudatoolkit >=10.2",
+    "arrow-cpp-proc * cpu"
win-64::pyarrow-10.0.1-py39h91da4d1_6_cuda.conda
-    "cudatoolkit >=10.2"
+    "cudatoolkit >=10.2",
+    "arrow-cpp-proc * cpu"
win-64::pyarrow-10.0.1-py39hdb2b141_5_cpu.conda
-    "apache-arrow-proc =*=cpu"
+    "apache-arrow-proc =*=cpu",
+    "arrow-cpp-proc * cpu"
win-64::pyarrow-10.0.1-py39hdb2b141_6_cpu.conda
-    "apache-arrow-proc =*=cpu"
+    "apache-arrow-proc =*=cpu",
+    "arrow-cpp-proc * cpu"
```

</details>
