### PR TITLE
Fix old spacy-models being pulled in for new spacy

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -621,7 +621,7 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             i = record["depends"].index("flatbuffers >=2")
             record["depends"][i] = "flatbuffers >=2,<3.0.0.0a0"
 
-        if record_name == "pyarrow":
+        if record_name == "pyarrow" and record.get('timestamp', 0) < 1675198779000:
             if not any(dep.split(' ')[0] == "arrow-cpp-proc" for dep in record.get('constrains', ())):
                 if 'constrains' in record:
                     record['constrains'].append("arrow-cpp-proc * cpu")


### PR DESCRIPTION
Fixes https://github.com/conda-forge/spacy-models-feedstock/issues/5 CC @bollwyvl

Plus a drive-by follow-up fix for #395, as there was still lots of arrow stuff in the diff. CC @xhochy @kkraus14 

### Output of `python show_diff.py`

<details>

Obviously, the `isort` stuff is not from this diff.

```diff
>python show_diff.py
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata.json.bz2
noarch::spacy-model-en_core_web_lg-2.1.0-pyh0e0b3c3_0.tar.bz2
-    "setuptools"
+    "setuptools",
+    "spacy <3"
noarch::spacy-model-en_core_web_lg-2.2.0-py_0.tar.bz2
-    "setuptools"
+    "setuptools",
+    "spacy <3"
noarch::spacy-model-en_core_web_lg-2.2.0-pyh0e0b3c3_0.tar.bz2
-    "setuptools"
+    "setuptools",
+    "spacy <3"
noarch::spacy-model-en_core_web_lg-2.2.5-py_0.tar.bz2
-    "setuptools"
+    "setuptools",
+    "spacy <3"
noarch::spacy-model-en_core_web_lg-2.3.0-pyh9f0ad1d_0.tar.bz2
-    "setuptools"
+    "setuptools",
+    "spacy <3"
noarch::spacy-model-en_core_web_lg-2.3.1-pyh9f0ad1d_0.tar.bz2
-    "setuptools"
+    "setuptools",
+    "spacy <3"
noarch::spacy-model-en_core_web_md-2.1.0-pyhdea317b_0.tar.bz2
-    "setuptools"
+    "setuptools",
+    "spacy <3"
noarch::spacy-model-en_core_web_md-2.2.0-py_0.tar.bz2
-    "setuptools"
+    "setuptools",
+    "spacy <3"
noarch::spacy-model-en_core_web_md-2.2.0-pyhdea317b_0.tar.bz2
-    "setuptools"
+    "setuptools",
+    "spacy <3"
noarch::spacy-model-en_core_web_md-2.2.5-py_0.tar.bz2
-    "setuptools"
+    "setuptools",
+    "spacy <3"
noarch::spacy-model-en_core_web_md-2.3.0-pyh9f0ad1d_0.tar.bz2
-    "setuptools"
+    "setuptools",
+    "spacy <3"
noarch::spacy-model-en_core_web_md-2.3.1-pyh9f0ad1d_0.tar.bz2
-    "setuptools"
+    "setuptools",
+    "spacy <3"
noarch::spacy-model-en_core_web_sm-2.1.0-pyh57f5928_0.tar.bz2
-    "setuptools"
+    "setuptools",
+    "spacy <3"
noarch::spacy-model-en_core_web_sm-2.2.0-py_0.tar.bz2
-    "setuptools"
+    "setuptools",
+    "spacy <3"
noarch::spacy-model-en_core_web_sm-2.2.0-pyh57f5928_0.tar.bz2
-    "setuptools"
+    "setuptools",
+    "spacy <3"
noarch::spacy-model-en_core_web_sm-2.2.5-py_0.tar.bz2
-    "setuptools"
+    "setuptools",
+    "spacy <3"
noarch::spacy-model-en_core_web_sm-2.3.0-pyh9f0ad1d_0.tar.bz2
-    "setuptools"
+    "setuptools",
+    "spacy <3"
noarch::spacy-model-en_core_web_sm-2.3.1-pyh9f0ad1d_0.tar.bz2
-    "setuptools"
+    "setuptools",
+    "spacy <3"
noarch::spacy-model-en_vectors_web_lg-2.1.0-pyh0e0b3c3_0.tar.bz2
-    "setuptools"
+    "setuptools",
+    "spacy <3"
noarch::isort-5.11.5-pyhd8ed1ab_0.conda
-    "python >=3.6,<4.0",
+    "python >=3.7,<4.0",
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata.json.bz2
```

</details>