### PR TITLE
Remove ninja run-dep from latest pytorch

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -568,7 +568,7 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                 i = record['depends'].index('zstandard')
                 record['depends'][i] = 'zstandard <0.15'
 
-        if record_name == "pytorch" and record["version"] == "1.13.1" and record.get('timestamp', 0) < 1675431752816:
+        if record_name == "pytorch" and record["version"] == "1.13.1" and record['build_number'] == 0 and record.get('timestamp', 0) < 1675431752816:
             # https://github.com/conda-forge/pytorch-cpu-feedstock/issues/161
             i = record['depends'].index('ninja')
             record['depends'].pop(i)

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -568,6 +568,11 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                 i = record['depends'].index('zstandard')
                 record['depends'][i] = 'zstandard <0.15'
 
+        if record_name == "pytorch" and record["version"] == "1.13.1" and record.get('timestamp', 0) < 1675431752816:
+            # https://github.com/conda-forge/pytorch-cpu-feedstock/issues/161
+            i = record['depends'].index('ninja')
+            record['depends'].pop(i)
+
         if record_name == "packaging" and record["version"] in ["21.1", "21.2"]:
             # https://github.com/conda-forge/packaging-feedstock/pull/21
             deps = record["depends"]


### PR DESCRIPTION
Fixes https://github.com/conda-forge/pytorch-cpu-feedstock/issues/161

~Contains the exact same commit (drive-by fix for arrow) as #396, even if both get merged, it'll only show up once.~ Rebased

### Output of `python show_diff.py`

<details>

Obviously, the `isort` stuff is not from this diff.

```diff
>python show_diff.py
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata.json.bz2
noarch::isort-5.11.5-pyhd8ed1ab_0.conda
-    "python >=3.6,<4.0",
+    "python >=3.7,<4.0",
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata.json.bz2
linux-64::pytorch-1.13.1-cpu_py310hd11e9c7_0.conda
-    "ninja",
linux-64::pytorch-1.13.1-cpu_py311h410fd25_0.conda
-    "ninja",
linux-64::pytorch-1.13.1-cpu_py38hbac4b8a_0.conda
-    "ninja",
linux-64::pytorch-1.13.1-cpu_py39h14c4022_0.conda
-    "ninja",
linux-64::pytorch-1.13.1-cuda112py310he33e0d6_200.conda
-    "ninja",
linux-64::pytorch-1.13.1-cuda112py311h13fee9e_200.conda
-    "ninja",
linux-64::pytorch-1.13.1-cuda112py38hd94e077_200.conda
-    "ninja",
linux-64::pytorch-1.13.1-cuda112py39hb0b7ed5_200.conda
-    "ninja",
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata.json.bz2
linux-aarch64::pytorch-1.13.1-cpu_py310hc80c403_0.conda
-    "ninja",
linux-aarch64::pytorch-1.13.1-cpu_py311h7bca99e_0.conda
-    "ninja",
linux-aarch64::pytorch-1.13.1-cpu_py38hf3cf3a4_0.conda
-    "ninja",
linux-aarch64::pytorch-1.13.1-cpu_py39h29ba9e4_0.conda
-    "ninja",
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata.json.bz2
osx-64::pytorch-1.13.1-cpu_py310h09eaf1a_0.conda
-    "ninja",
osx-64::pytorch-1.13.1-cpu_py311h4129fe5_0.conda
-    "ninja",
osx-64::pytorch-1.13.1-cpu_py38hc21d861_0.conda
-    "ninja",
osx-64::pytorch-1.13.1-cpu_py39h0a103a1_0.conda
-    "ninja",
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata.json.bz2
osx-arm64::pytorch-1.13.1-cpu_py310h7410233_0.conda
-    "ninja",
osx-arm64::pytorch-1.13.1-cpu_py311h98403b3_0.conda
-    "ninja",
osx-arm64::pytorch-1.13.1-cpu_py38hfb32b02_0.conda
-    "ninja",
osx-arm64::pytorch-1.13.1-cpu_py39hf1faf6a_0.conda
-    "ninja",
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata.json.bz2
```

</details>