### PR TITLE
Add exlcusion between jpeg and jpegturbo

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -2474,6 +2474,25 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
         ):
             _replace_pin("python >=3.7", "python >=3.9", record["depends"], record)
 
+        # https://github.com/conda-forge/conda-forge.github.io/issues/673
+        if (
+            record_name == "jpeg"
+            and record.get("timestamp", 0) <= 1676152037000
+            and len(record.get("constraints", [])) == 0
+        ):
+            record.setdefault('constrains', []).extend((
+                "libjpeg-turbo <0.0.0a",
+            ))
+
+        # https://github.com/conda-forge/conda-forge.github.io/issues/673
+        if (
+            record_name == "libjpeg-turbo"
+            and record.get("timestamp", 0) <= 1676152037000
+            and len(record.get("constraints", [])) == 0
+        ):
+            record.setdefault('constrains', []).extend((
+                "jpeg <0.0.0a",
+            ))
 
     return index
 

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -2477,22 +2477,28 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
         # https://github.com/conda-forge/conda-forge.github.io/issues/673
         if (
             record_name == "jpeg"
-            and record.get("timestamp", 0) <= 1676152037000
+            and record.get("timestamp", 0) <= 1676381857000
             and len(record.get("constraints", [])) == 0
         ):
-            record.setdefault('constrains', []).extend((
-                "libjpeg-turbo <0.0.0a",
-            ))
+            record.setdefault('constrains', [])
+            constrains = record['constrains']
+            if "libjpeg-turbo <0.0.0a" not in constrains:
+                constrains.extend((
+                    "libjpeg-turbo <0.0.0a",
+                ))
 
         # https://github.com/conda-forge/conda-forge.github.io/issues/673
         if (
             record_name == "libjpeg-turbo"
-            and record.get("timestamp", 0) <= 1676152037000
+            and record.get("timestamp", 0) <= 1676381857000
             and len(record.get("constraints", [])) == 0
         ):
-            record.setdefault('constrains', []).extend((
-                "jpeg <0.0.0a",
-            ))
+            record.setdefault('constrains', [])
+            constrains = record['constrains']
+            if "jpeg <0.0.0a" not in constrains:
+                constrains.extend((
+                    "jpeg <0.0.0a",
+                ))
 
     return index
 


### PR DESCRIPTION
xref: https://github.com/conda-forge/conda-forge.github.io/issues/673

<details>

```patch
linux-64::jpeg-8d-h166bdaf_1.tar.bz2
-  "version": "8d"
+  "version": "8d",
+  "constrains": [
+    "libjpeg-turbo <0.0.0a"
+  ]
linux-64::jpeg-8d-h516909a_0.tar.bz2
-  "version": "8d"
+  "version": "8d",
+  "constrains": [
+    "libjpeg-turbo <0.0.0a"
+  ]
linux-64::jpeg-9c-h14c3975_1001.tar.bz2
-  "version": "9c"
+  "version": "9c",
+  "constrains": [
+    "libjpeg-turbo <0.0.0a"
+  ]
linux-64::jpeg-9d-h36c2ea0_0.tar.bz2
-  "version": "9d"
+  "version": "9d",
+  "constrains": [
+    "libjpeg-turbo <0.0.0a"
+  ]
linux-64::jpeg-9d-h516909a_0.tar.bz2
-  "version": "9d"
+  "version": "9d",
+  "constrains": [
+    "libjpeg-turbo <0.0.0a"
+  ]
linux-64::jpeg-9e-h166bdaf_1.tar.bz2
-  "version": "9e"
+  "version": "9e",
+  "constrains": [
+    "libjpeg-turbo <0.0.0a"
+  ]
linux-64::jpeg-9e-h166bdaf_2.tar.bz2
-  "version": "9e"
+  "version": "9e",
+  "constrains": [
+    "libjpeg-turbo <0.0.0a"
+  ]
linux-64::jpeg-9e-h7f98852_0.tar.bz2
-  "version": "9e"
+  "version": "9e",
+  "constrains": [
+    "libjpeg-turbo <0.0.0a"
+  ]
linux-64::libjpeg-turbo-1.5.1-0.tar.bz2
-  "version": "1.5.1"
+  "version": "1.5.1",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
linux-64::libjpeg-turbo-1.5.2-0.tar.bz2
-  "version": "1.5.2"
+  "version": "1.5.2",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
linux-64::libjpeg-turbo-1.5.3-0.tar.bz2
-  "version": "1.5.3"
+  "version": "1.5.3",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
linux-64::libjpeg-turbo-1.5.90-0.tar.bz2
-  "version": "1.5.90"
+  "version": "1.5.90",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
linux-64::libjpeg-turbo-2.0.0-h14c3975_1000.tar.bz2
-  "version": "2.0.0"
+  "version": "2.0.0",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
linux-64::libjpeg-turbo-2.0.0-h470a237_0.tar.bz2
-  "version": "2.0.0"
+  "version": "2.0.0",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
linux-64::libjpeg-turbo-2.0.1-h14c3975_1000.tar.bz2
-  "version": "2.0.1"
+  "version": "2.0.1",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
linux-64::libjpeg-turbo-2.0.1-h470a237_0.tar.bz2
-  "version": "2.0.1"
+  "version": "2.0.1",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
linux-64::libjpeg-turbo-2.0.2-h14c3975_0.tar.bz2
-  "version": "2.0.2"
+  "version": "2.0.2",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
linux-64::libjpeg-turbo-2.0.3-h516909a_0.tar.bz2
-  "version": "2.0.3"
+  "version": "2.0.3",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
linux-64::libjpeg-turbo-2.0.3-h516909a_1.tar.bz2
-  "version": "2.0.3"
+  "version": "2.0.3",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
linux-64::libjpeg-turbo-2.0.5-h516909a_0.tar.bz2
-  "version": "2.0.5"
+  "version": "2.0.5",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
linux-64::libjpeg-turbo-2.0.5-h7f98852_0.tar.bz2
-  "version": "2.0.5"
+  "version": "2.0.5",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
linux-64::libjpeg-turbo-2.1.0-h7f98852_0.tar.bz2
-  "version": "2.1.0"
+  "version": "2.1.0",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
linux-64::libjpeg-turbo-2.1.1-h7f98852_0.tar.bz2
-  "version": "2.1.1"
+  "version": "2.1.1",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
linux-64::libjpeg-turbo-2.1.3-h166bdaf_0.tar.bz2
-  "version": "2.1.3"
+  "version": "2.1.3",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
linux-64::libjpeg-turbo-2.1.4-h166bdaf_0.tar.bz2
-  "version": "2.1.4"
+  "version": "2.1.4",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
linux-64::graalpy-22.3.1-0_graalvm_native.conda
-  "track_features": "openjdk",
linux-aarch64::jpeg-8d-h6dd45c4_0.tar.bz2
-  "version": "8d"
+  "version": "8d",
+  "constrains": [
+    "libjpeg-turbo <0.0.0a"
+  ]
linux-aarch64::jpeg-8d-h9cdd2b7_1.tar.bz2
-  "version": "8d"
+  "version": "8d",
+  "constrains": [
+    "libjpeg-turbo <0.0.0a"
+  ]
linux-aarch64::jpeg-9c-hda93590_1001.tar.bz2
-  "version": "9c"
+  "version": "9c",
+  "constrains": [
+    "libjpeg-turbo <0.0.0a"
+  ]
linux-aarch64::jpeg-9d-h6dd45c4_0.tar.bz2
-  "version": "9d"
+  "version": "9d",
+  "constrains": [
+    "libjpeg-turbo <0.0.0a"
+  ]
linux-aarch64::jpeg-9d-hfd2af3c_0.tar.bz2
-  "version": "9d"
+  "version": "9d",
+  "constrains": [
+    "libjpeg-turbo <0.0.0a"
+  ]
linux-aarch64::jpeg-9e-h3557bc0_0.tar.bz2
-  "version": "9e"
+  "version": "9e",
+  "constrains": [
+    "libjpeg-turbo <0.0.0a"
+  ]
linux-aarch64::jpeg-9e-h9cdd2b7_1.tar.bz2
-  "version": "9e"
+  "version": "9e",
+  "constrains": [
+    "libjpeg-turbo <0.0.0a"
+  ]
linux-aarch64::jpeg-9e-h9cdd2b7_2.tar.bz2
-  "version": "9e"
+  "version": "9e",
+  "constrains": [
+    "libjpeg-turbo <0.0.0a"
+  ]
linux-aarch64::libjpeg-turbo-2.0.3-h516909a_1.tar.bz2
-  "version": "2.0.3"
+  "version": "2.0.3",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
linux-aarch64::libjpeg-turbo-2.0.5-h2923d19_0.tar.bz2
-  "version": "2.0.5"
+  "version": "2.0.5",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
linux-aarch64::libjpeg-turbo-2.0.5-hf897c2e_0.tar.bz2
-  "version": "2.0.5"
+  "version": "2.0.5",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
linux-aarch64::libjpeg-turbo-2.1.0-hf897c2e_0.tar.bz2
-  "version": "2.1.0"
+  "version": "2.1.0",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
linux-aarch64::libjpeg-turbo-2.1.1-hf897c2e_0.tar.bz2
-  "version": "2.1.1"
+  "version": "2.1.1",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
linux-aarch64::libjpeg-turbo-2.1.3-h4e544f5_0.tar.bz2
-  "version": "2.1.3"
+  "version": "2.1.3",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
linux-aarch64::libjpeg-turbo-2.1.4-h4e544f5_0.tar.bz2
-  "version": "2.1.4"
+  "version": "2.1.4",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
linux-ppc64le::jpeg-8d-h6eb9509_0.tar.bz2
-  "version": "8d"
+  "version": "8d",
+  "constrains": [
+    "libjpeg-turbo <0.0.0a"
+  ]
linux-ppc64le::jpeg-8d-hb283c62_1.tar.bz2
-  "version": "8d"
+  "version": "8d",
+  "constrains": [
+    "libjpeg-turbo <0.0.0a"
+  ]
linux-ppc64le::jpeg-9c-h14c3975_1001.tar.bz2
-  "version": "9c"
+  "version": "9c",
+  "constrains": [
+    "libjpeg-turbo <0.0.0a"
+  ]
linux-ppc64le::jpeg-9d-h339bb43_0.tar.bz2
-  "version": "9d"
+  "version": "9d",
+  "constrains": [
+    "libjpeg-turbo <0.0.0a"
+  ]
linux-ppc64le::jpeg-9d-h6eb9509_0.tar.bz2
-  "version": "9d"
+  "version": "9d",
+  "constrains": [
+    "libjpeg-turbo <0.0.0a"
+  ]
linux-ppc64le::jpeg-9e-h4e0d66e_0.tar.bz2
-  "version": "9e"
+  "version": "9e",
+  "constrains": [
+    "libjpeg-turbo <0.0.0a"
+  ]
linux-ppc64le::jpeg-9e-hb283c62_1.tar.bz2
-  "version": "9e"
+  "version": "9e",
+  "constrains": [
+    "libjpeg-turbo <0.0.0a"
+  ]
linux-ppc64le::jpeg-9e-hb283c62_2.tar.bz2
-  "version": "9e"
+  "version": "9e",
+  "constrains": [
+    "libjpeg-turbo <0.0.0a"
+  ]
linux-ppc64le::libjpeg-turbo-2.0.3-h6eb9509_1.tar.bz2
-  "version": "2.0.3"
+  "version": "2.0.3",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
linux-ppc64le::libjpeg-turbo-2.0.5-h4e0d66e_0.tar.bz2
-  "version": "2.0.5"
+  "version": "2.0.5",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
linux-ppc64le::libjpeg-turbo-2.1.0-h4e0d66e_0.tar.bz2
-  "version": "2.1.0"
+  "version": "2.1.0",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
linux-ppc64le::libjpeg-turbo-2.1.1-h4e0d66e_0.tar.bz2
-  "version": "2.1.1"
+  "version": "2.1.1",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
linux-ppc64le::libjpeg-turbo-2.1.4-hb283c62_0.tar.bz2
-  "version": "2.1.4"
+  "version": "2.1.4",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
osx-64::jpeg-8d-h0b31af3_0.tar.bz2
-  "version": "8d"
+  "version": "8d",
+  "constrains": [
+    "libjpeg-turbo <0.0.0a"
+  ]
osx-64::jpeg-8d-h5eb16cf_1.tar.bz2
-  "version": "8d"
+  "version": "8d",
+  "constrains": [
+    "libjpeg-turbo <0.0.0a"
+  ]
osx-64::jpeg-9c-h1de35cc_1001.tar.bz2
-  "version": "9c"
+  "version": "9c",
+  "constrains": [
+    "libjpeg-turbo <0.0.0a"
+  ]
osx-64::jpeg-9d-h0b31af3_0.tar.bz2
-  "version": "9d"
+  "version": "9d",
+  "constrains": [
+    "libjpeg-turbo <0.0.0a"
+  ]
osx-64::jpeg-9d-hbcb3906_0.tar.bz2
-  "version": "9d"
+  "version": "9d",
+  "constrains": [
+    "libjpeg-turbo <0.0.0a"
+  ]
osx-64::jpeg-9e-h0d85af4_0.tar.bz2
-  "version": "9e"
+  "version": "9e",
+  "constrains": [
+    "libjpeg-turbo <0.0.0a"
+  ]
osx-64::jpeg-9e-h5eb16cf_1.tar.bz2
-  "version": "9e"
+  "version": "9e",
+  "constrains": [
+    "libjpeg-turbo <0.0.0a"
+  ]
osx-64::jpeg-9e-hac89ed1_2.tar.bz2
-  "version": "9e"
+  "version": "9e",
+  "constrains": [
+    "libjpeg-turbo <0.0.0a"
+  ]
osx-64::libjpeg-turbo-1.5.1-0.tar.bz2
-  "version": "1.5.1"
+  "version": "1.5.1",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
osx-64::libjpeg-turbo-1.5.2-0.tar.bz2
-  "version": "1.5.2"
+  "version": "1.5.2",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
osx-64::libjpeg-turbo-1.5.3-0.tar.bz2
-  "version": "1.5.3"
+  "version": "1.5.3",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
osx-64::libjpeg-turbo-1.5.90-0.tar.bz2
-  "version": "1.5.90"
+  "version": "1.5.90",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
osx-64::libjpeg-turbo-2.0.0-h1de35cc_1000.tar.bz2
-  "version": "2.0.0"
+  "version": "2.0.0",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
osx-64::libjpeg-turbo-2.0.0-h470a237_0.tar.bz2
-  "version": "2.0.0"
+  "version": "2.0.0",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
osx-64::libjpeg-turbo-2.0.1-h1de35cc_1000.tar.bz2
-  "version": "2.0.1"
+  "version": "2.0.1",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
osx-64::libjpeg-turbo-2.0.1-h470a237_0.tar.bz2
-  "version": "2.0.1"
+  "version": "2.0.1",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
osx-64::libjpeg-turbo-2.0.2-h1de35cc_0.tar.bz2
-  "version": "2.0.2"
+  "version": "2.0.2",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
osx-64::libjpeg-turbo-2.0.3-h01d97ff_0.tar.bz2
-  "version": "2.0.3"
+  "version": "2.0.3",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
osx-64::libjpeg-turbo-2.0.3-h01d97ff_1.tar.bz2
-  "version": "2.0.3"
+  "version": "2.0.3",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
osx-64::libjpeg-turbo-2.0.5-h0d85af4_0.tar.bz2
-  "version": "2.0.5"
+  "version": "2.0.5",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
osx-64::libjpeg-turbo-2.0.5-haf1e3a3_0.tar.bz2
-  "version": "2.0.5"
+  "version": "2.0.5",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
osx-64::libjpeg-turbo-2.1.0-h0d85af4_0.tar.bz2
-  "version": "2.1.0"
+  "version": "2.1.0",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
osx-64::libjpeg-turbo-2.1.1-h0d85af4_0.tar.bz2
-  "version": "2.1.1"
+  "version": "2.1.1",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
osx-64::libjpeg-turbo-2.1.3-hac89ed1_0.tar.bz2
-  "version": "2.1.3"
+  "version": "2.1.3",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
osx-64::libjpeg-turbo-2.1.4-hb7f2c08_0.tar.bz2
-  "version": "2.1.4"
+  "version": "2.1.4",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
osx-arm64::jpeg-8d-h1c322ee_1.tar.bz2
-  "version": "8d"
+  "version": "8d",
+  "constrains": [
+    "libjpeg-turbo <0.0.0a"
+  ]
osx-arm64::jpeg-9d-h27ca646_0.tar.bz2
-  "version": "9d"
+  "version": "9d",
+  "constrains": [
+    "libjpeg-turbo <0.0.0a"
+  ]
osx-arm64::jpeg-9e-h1c322ee_1.tar.bz2
-  "version": "9e"
+  "version": "9e",
+  "constrains": [
+    "libjpeg-turbo <0.0.0a"
+  ]
osx-arm64::jpeg-9e-h3422bc3_0.tar.bz2
-  "version": "9e"
+  "version": "9e",
+  "constrains": [
+    "libjpeg-turbo <0.0.0a"
+  ]
osx-arm64::jpeg-9e-he4db4b2_2.tar.bz2
-  "version": "9e"
+  "version": "9e",
+  "constrains": [
+    "libjpeg-turbo <0.0.0a"
+  ]
osx-arm64::libjpeg-turbo-2.0.5-h27ca646_0.tar.bz2
-  "version": "2.0.5"
+  "version": "2.0.5",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
osx-arm64::libjpeg-turbo-2.1.0-h3422bc3_0.tar.bz2
-  "version": "2.1.0"
+  "version": "2.1.0",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
osx-arm64::libjpeg-turbo-2.1.1-h3422bc3_0.tar.bz2
-  "version": "2.1.1"
+  "version": "2.1.1",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
osx-arm64::libjpeg-turbo-2.1.3-he4db4b2_0.tar.bz2
-  "version": "2.1.3"
+  "version": "2.1.3",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
osx-arm64::libjpeg-turbo-2.1.4-h1a8c8d9_0.tar.bz2
-  "version": "2.1.4"
+  "version": "2.1.4",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
win-32::libjpeg-turbo-1.5.1-vc10_0.tar.bz2
-  "version": "1.5.1"
+  "version": "1.5.1",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
win-32::libjpeg-turbo-1.5.1-vc14_0.tar.bz2
-  "version": "1.5.1"
+  "version": "1.5.1",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
win-32::libjpeg-turbo-1.5.2-vc14_0.tar.bz2
-  "version": "1.5.2"
+  "version": "1.5.2",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
win-32::libjpeg-turbo-1.5.2-vc9_0.tar.bz2
-  "version": "1.5.2"
+  "version": "1.5.2",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
win-32::libjpeg-turbo-1.5.3-vc14_0.tar.bz2
-  "version": "1.5.3"
+  "version": "1.5.3",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
win-32::libjpeg-turbo-1.5.3-vc9_0.tar.bz2
-  "version": "1.5.3"
+  "version": "1.5.3",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
win-32::libjpeg-turbo-1.5.90-vc14_0.tar.bz2
-  "version": "1.5.90"
+  "version": "1.5.90",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
win-32::libjpeg-turbo-1.5.90-vc9_0.tar.bz2
-  "version": "1.5.90"
+  "version": "1.5.90",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
win-64::jpeg-8d-h0c8e037_0.tar.bz2
-  "version": "8d"
+  "version": "8d",
+  "constrains": [
+    "libjpeg-turbo <0.0.0a"
+  ]
win-64::jpeg-8d-h8ffe710_1.tar.bz2
-  "version": "8d"
+  "version": "8d",
+  "constrains": [
+    "libjpeg-turbo <0.0.0a"
+  ]
win-64::jpeg-8d-hfa6e2cd_0.tar.bz2
-  "version": "8d"
+  "version": "8d",
+  "constrains": [
+    "libjpeg-turbo <0.0.0a"
+  ]
win-64::jpeg-9c-h0c8e037_1001.tar.bz2
-  "version": "9c"
+  "version": "9c",
+  "constrains": [
+    "libjpeg-turbo <0.0.0a"
+  ]
win-64::jpeg-9c-hfa6e2cd_1001.tar.bz2
-  "version": "9c"
+  "version": "9c",
+  "constrains": [
+    "libjpeg-turbo <0.0.0a"
+  ]
win-64::jpeg-9d-h8ffe710_0.tar.bz2
-  "version": "9d"
+  "version": "9d",
+  "constrains": [
+    "libjpeg-turbo <0.0.0a"
+  ]
win-64::jpeg-9d-he774522_0.tar.bz2
-  "version": "9d"
+  "version": "9d",
+  "constrains": [
+    "libjpeg-turbo <0.0.0a"
+  ]
win-64::jpeg-9e-h8ffe710_0.tar.bz2
-  "version": "9e"
+  "version": "9e",
+  "constrains": [
+    "libjpeg-turbo <0.0.0a"
+  ]
win-64::jpeg-9e-h8ffe710_1.tar.bz2
-  "version": "9e"
+  "version": "9e",
+  "constrains": [
+    "libjpeg-turbo <0.0.0a"
+  ]
win-64::jpeg-9e-h8ffe710_2.tar.bz2
-  "version": "9e"
+  "version": "9e",
+  "constrains": [
+    "libjpeg-turbo <0.0.0a"
+  ]
win-64::libjpeg-turbo-1.5.1-vc10_0.tar.bz2
-  "version": "1.5.1"
+  "version": "1.5.1",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
win-64::libjpeg-turbo-1.5.1-vc14_0.tar.bz2
-  "version": "1.5.1"
+  "version": "1.5.1",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
win-64::libjpeg-turbo-1.5.1-vc9_0.tar.bz2
-  "version": "1.5.1"
+  "version": "1.5.1",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
win-64::libjpeg-turbo-1.5.2-vc14_0.tar.bz2
-  "version": "1.5.2"
+  "version": "1.5.2",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
win-64::libjpeg-turbo-1.5.2-vc9_0.tar.bz2
-  "version": "1.5.2"
+  "version": "1.5.2",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
win-64::libjpeg-turbo-1.5.3-vc14_0.tar.bz2
-  "version": "1.5.3"
+  "version": "1.5.3",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
win-64::libjpeg-turbo-1.5.3-vc9_0.tar.bz2
-  "version": "1.5.3"
+  "version": "1.5.3",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
win-64::libjpeg-turbo-1.5.90-vc14_0.tar.bz2
-  "version": "1.5.90"
+  "version": "1.5.90",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
win-64::libjpeg-turbo-1.5.90-vc9_0.tar.bz2
-  "version": "1.5.90"
+  "version": "1.5.90",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
win-64::libjpeg-turbo-2.0.0-h0c8e037_0.tar.bz2
-  "version": "2.0.0"
+  "version": "2.0.0",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
win-64::libjpeg-turbo-2.0.0-h0c8e037_1000.tar.bz2
-  "version": "2.0.0"
+  "version": "2.0.0",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
win-64::libjpeg-turbo-2.0.0-hfa6e2cd_0.tar.bz2
-  "version": "2.0.0"
+  "version": "2.0.0",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
win-64::libjpeg-turbo-2.0.0-hfa6e2cd_1000.tar.bz2
-  "version": "2.0.0"
+  "version": "2.0.0",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
win-64::libjpeg-turbo-2.0.1-h0c8e037_1000.tar.bz2
-  "version": "2.0.1"
+  "version": "2.0.1",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
win-64::libjpeg-turbo-2.0.1-hfa6e2cd_1000.tar.bz2
-  "version": "2.0.1"
+  "version": "2.0.1",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
win-64::libjpeg-turbo-2.0.2-h0c8e037_0.tar.bz2
-  "version": "2.0.2"
+  "version": "2.0.2",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
win-64::libjpeg-turbo-2.0.2-hfa6e2cd_0.tar.bz2
-  "version": "2.0.2"
+  "version": "2.0.2",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
win-64::libjpeg-turbo-2.0.3-h0c8e037_0.tar.bz2
-  "version": "2.0.3"
+  "version": "2.0.3",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
win-64::libjpeg-turbo-2.0.3-h0c8e037_1.tar.bz2
-  "version": "2.0.3"
+  "version": "2.0.3",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
win-64::libjpeg-turbo-2.0.3-hfa6e2cd_0.tar.bz2
-  "version": "2.0.3"
+  "version": "2.0.3",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
win-64::libjpeg-turbo-2.0.3-hfa6e2cd_1.tar.bz2
-  "version": "2.0.3"
+  "version": "2.0.3",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
win-64::libjpeg-turbo-2.0.5-h8ffe710_0.tar.bz2
-  "version": "2.0.5"
+  "version": "2.0.5",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
win-64::libjpeg-turbo-2.0.5-he774522_0.tar.bz2
-  "version": "2.0.5"
+  "version": "2.0.5",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
win-64::libjpeg-turbo-2.1.0-h8ffe710_0.tar.bz2
-  "version": "2.1.0"
+  "version": "2.1.0",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
win-64::libjpeg-turbo-2.1.1-h8ffe710_0.tar.bz2
-  "version": "2.1.1"
+  "version": "2.1.1",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
win-64::libjpeg-turbo-2.1.3-h8ffe710_0.tar.bz2
-  "version": "2.1.3"
+  "version": "2.1.3",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
win-64::libjpeg-turbo-2.1.4-hcfcfb64_0.tar.bz2
-  "version": "2.1.4"
+  "version": "2.1.4",
+  "constrains": [
+    "jpeg <0.0.0a"
+  ]
```
</details>

Checklist
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications are bound by `python -c "import time; print(f'{time.time():.0f}000')"`
