### PR TITLE
Update comment about Iris and NetCDF4.

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -846,10 +846,9 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
         if record_name == "airflow-with-async":
             _rename_dependency(fn, record, "evenlet", "eventlet")
 
-        # Current implementation in iris allows for frequent SegFaults
-        # when netCDF4>1.6.0; iris devs are working on a solution and
-        # discussing it in https://github.com/SciTools/iris/issues/5016
-        # but a wide repodata patch is needed before a permanent solution
+        # iris<3.4.1 is not thread safe with netCDF4>1.6.0. Iris v3.4.1
+        #  introduces a fix that allows it to work with the later versions of
+        #  NetCDF4 in a thread safe manner.
         iris_deps = [
             "netcdf4 <1.6.1",
         ]


### PR DESCRIPTION
Checklist
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications are bound by `python -c "import time; print(f'{time.time():.0f}000')"`

### Time-stamp

`1676995230000`

### `python show_diff.py`

```
Traceback (most recent call last):
  File "REDACTED/conda-forge-repodata-patches-feedstock/recipe/show_diff.py", line 10, in <module>
    from gen_patch_json import _gen_new_index, _gen_patch_instructions, SUBDIRS
  File "REDACTED/conda-forge-repodata-patches-feedstock/recipe/gen_patch_json.py", line 16, in <module>
    from get_license_family import get_license_family
  File "REDACTED/conda-forge-repodata-patches-feedstock/recipe/get_license_family.py", line 1, in <module>
    import license_expression
ModuleNotFoundError: No module named 'license_expression'

```