### PR TITLE
bayesian-optimization: Increase minimum python version, pin colorama version

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -672,7 +672,7 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                         deps,
                         record
                     )
-        
+
         # In 1.4.1 bayesian-optimization fixes colors not displaying correctly on windows.
         # This is done using colorama, however the function used by colorama was only introduced in
         # colorama 0.4.6, which is only available for python >=3.7

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -672,7 +672,26 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                         deps,
                         record
                     )
+        
+        # In 1.4.1 bayesian-optimization fixes colors not displaying correctly on windows.
+        # This is done using colorama, however the function used by colorama was only introduced in
+        # colorama 0.4.6, which is only available for python >=3.7
+        if record_name == 'bayesian-optimization' and record.get('timestamp') < 1676994963000:
+            if record["version"] == "1.4.1" or (record["version"] == "1.4.2" and record["build_number"] == 0):
+                python_pinning = [
+                    x for x in record['depends'] if x.startswith('python')
+                ]
+                for pinning in python_pinning:
+                    _replace_pin(pinning, 'python >=3.7', record['depends'], record)
+                
+                colorama_pinning = [
+                    x for x in record['depends'] if x.startswith('colorama')
+                ]
+                for pinning in colorama_pinning:
+                    _replace_pin(pinning, 'colorama >=0.4.6', record['depends'], record)
+                
 
+            
         if record_name == 'ratelimiter':
             if record.get('timestamp', 0) < 1667804400000 and subdir == "noarch":  # noarch builds prior to 2022/11/7
                 python_pinning = [

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -689,8 +689,6 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                 ]
                 for pinning in colorama_pinning:
                     _replace_pin(pinning, 'colorama >=0.4.6', record['depends'], record)
-                
-
             
         if record_name == 'ratelimiter':
             if record.get('timestamp', 0) < 1667804400000 and subdir == "noarch":  # noarch builds prior to 2022/11/7


### PR DESCRIPTION
In `1.4.1`, `bayesian-optimization` fixes colors not displaying correctly on windows. This is done using `colorama`, however the function used by colorama was only introduced in `colorama 0.4.6`, which is only available for `python >=3.7`.

c.f. fmfn/BayesianOptimization#397

Checklist
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications are bound by `python -c "import time; print(f'{time.time():.0f}000')"`

Ouput of `show_diff.py`:

```
$ python show_diff.py                                       
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata.json.bz2
noarch::bayesian-optimization-1.4.1-pyhd8ed1ab_0.conda
-    "colorama",
+    "colorama >=0.4.6",
-    "python >=3.6",
+    "python >=3.7",
noarch::bayesian-optimization-1.4.2-pyhd8ed1ab_0.conda
-    "colorama",
+    "colorama >=0.4.6",
-    "python >=3.6",
+    "python >=3.7",
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata.json.bz2
```
