### PR TITLE
Add libnetcdf upper bound pin for Calliope

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -2408,17 +2408,35 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                     deps[i] += ",<1.21.0a0"
                     break
 
-        # Fix missing dependency in Calliope that is required by some methods in
-        # xarray=2022.3, but is not a dependency in their recipe.
-        # This was fixed in https://github.com/conda-forge/calliope-feedstock/pull/30
-        # This patches build 0 with the right information too.
-        if (
-            record_name == "calliope"
-            and record.get("timestamp", 0) <= 1673531497000
-            and record["build_number"] == 0
-            and pkg_resources.parse_version(record["version"]) == pkg_resources.parse_version("0.6.9")
-        ):
-            record["depends"].append("bottleneck")
+        if record_name == "calliope":
+            # Fix missing dependency in Calliope that is required by some methods in
+            # xarray=2022.3, but is not a dependency in their recipe.
+            # This was fixed in https://github.com/conda-forge/calliope-feedstock/pull/30
+            # This patches build 0 with the right information too.
+            if (
+                record.get("timestamp", 0) <= 1673531497000
+                and record["build_number"] == 0
+                and pkg_resources.parse_version(record["version"])
+                == pkg_resources.parse_version("0.6.9")
+            ):
+                record["depends"].append("bottleneck")
+
+            # Pin libnetcdf upper bound due to breaking change in version >=4.9
+            # This was fixed in https://github.com/conda-forge/calliope-feedstock/pull/32
+            # This patches build 0 of latest release and all previous versions.
+            if record.get("timestamp", 0) <= 1677053718000 and (
+                pkg_resources.parse_version(record["version"])
+                < pkg_resources.parse_version("0.6.10")
+                or (
+                    pkg_resources.parse_version(record["version"])
+                    == pkg_resources.parse_version("0.6.10")
+                    and record["build_number"] == 0
+                )
+            ):
+                if "libnetcdf" in record["depends"]:
+                    _replace_pin(
+                        "libnetcdf", "libnetcdf <4.9", record["depends"], record
+                    )
 
         # Dill dropped support for python <3.7 starting in version 0.3.5
         # Fixed in https://github.com/conda-forge/dill-feedstock/pull/35


### PR DESCRIPTION
Checklist
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications are bound by `python -c "import time; print(f'{time.time():.0f}000')"`

<details>
<summary>Output of `python show_diff.py`</summary>

```
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata.json.bz2
noarch::calliope-0.6.4-py_0.tar.bz2
-    "libnetcdf",
+    "libnetcdf <4.9",
noarch::calliope-0.6.5-py_0.tar.bz2
-    "libnetcdf",
+    "libnetcdf <4.9",
noarch::calliope-0.6.6.post1-py_0.tar.bz2
-    "libnetcdf",
+    "libnetcdf <4.9",
noarch::calliope-0.6.7-pyhd8ed1ab_0.tar.bz2
-    "libnetcdf",
+    "libnetcdf <4.9",
noarch::calliope-0.6.8-pyhd8ed1ab_0.tar.bz2
-    "libnetcdf",
+    "libnetcdf <4.9",
noarch::calliope-0.6.10-pyhd8ed1ab_0.conda
-    "libnetcdf",
+    "libnetcdf <4.9",
noarch::calliope-0.6.9-pyhd8ed1ab_0.conda
-    "libnetcdf",
+    "libnetcdf <4.9",
noarch::calliope-0.6.9-pyhd8ed1ab_1.conda
-    "libnetcdf",
+    "libnetcdf <4.9",
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata.json.bz2
linux-64::calliope-0.4.0-0.tar.bz2
-  "constrains": [
-    "pypy <0a0"
-  ],
-    "libnetcdf",
+    "libnetcdf <4.9",
-  "version": "0.4.0"
+  "version": "0.4.0",
+  "constrains": [
+    "pypy <0a0"
+  ]
linux-64::calliope-0.4.0-1.tar.bz2
-  "constrains": [
-    "pypy <0a0"
-  ],
-    "libnetcdf",
+    "libnetcdf <4.9",
-  "version": "0.4.0"
+  "version": "0.4.0",
+  "constrains": [
+    "pypy <0a0"
+  ]
linux-64::calliope-0.4.1-1.tar.bz2
-  "constrains": [
-    "pypy <0a0"
-  ],
-    "libnetcdf",
+    "libnetcdf <4.9",
-  "version": "0.4.1"
+  "version": "0.4.1",
+  "constrains": [
+    "pypy <0a0"
+  ]
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata.json.bz2
osx-64::calliope-0.4.0-0.tar.bz2
-  "constrains": [
-    "pypy <0a0"
-  ],
-    "libnetcdf",
+    "libnetcdf <4.9",
-  "version": "0.4.0"
+  "version": "0.4.0",
+  "constrains": [
+    "pypy <0a0"
+  ]
osx-64::calliope-0.4.0-1.tar.bz2
-  "constrains": [
-    "pypy <0a0"
-  ],
-    "libnetcdf",
+    "libnetcdf <4.9",
-  "version": "0.4.0"
+  "version": "0.4.0",
+  "constrains": [
+    "pypy <0a0"
+  ]
osx-64::calliope-0.4.1-1.tar.bz2
-  "constrains": [
-    "pypy <0a0"
-  ],
-    "libnetcdf",
+    "libnetcdf <4.9",
-  "version": "0.4.1"
+  "version": "0.4.1",
+  "constrains": [
+    "pypy <0a0"
+  ]
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata.json.bz2
win-32::calliope-0.4.0-0.tar.bz2
-  "constrains": [
-    "pypy <0a0"
-  ],
-    "libnetcdf",
+    "libnetcdf <4.9",
-  "version": "0.4.0"
+  "version": "0.4.0",
+  "constrains": [
+    "pypy <0a0"
+  ]
win-32::calliope-0.4.0-1.tar.bz2
-  "constrains": [
-    "pypy <0a0"
-  ],
-    "libnetcdf",
+    "libnetcdf <4.9",
-  "version": "0.4.0"
+  "version": "0.4.0",
+  "constrains": [
+    "pypy <0a0"
+  ]
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata.json.bz2
win-64::calliope-0.4.0-0.tar.bz2
-  "constrains": [
-    "pypy <0a0"
-  ],
-    "libnetcdf",
+    "libnetcdf <4.9",
-  "version": "0.4.0"
+  "version": "0.4.0",
+  "constrains": [
+    "pypy <0a0"
+  ]
win-64::calliope-0.4.0-1.tar.bz2
-  "constrains": [
-    "pypy <0a0"
-  ],
-    "libnetcdf",
+    "libnetcdf <4.9",
-  "version": "0.4.0"
+  "version": "0.4.0",
+  "constrains": [
+    "pypy <0a0"
+  ]

```
</details>
