### PR TITLE
avoid installing python-slugify with slugify (or awesome-slugify)

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -2361,6 +2361,13 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                 "gxx_linux-64 !=9.5.0",
             ))
 
+        # `python-slugify` clobbers these other, unmaintained `slugify`s in lib and bin
+        if record_name == "python-slugify":
+            record.setdefault('constrains', []).extend([
+                "slugify <0",
+                "awesome-slugify <0",
+            ])
+
         # Flake8 6 removed some deprecated option parsing APIs and broke these plugins
         if ((record_name == 'flake8-copyright'
              and pkg_resources.parse_version(record['version']) <= pkg_resources.parse_version('0.2.3'))


### PR DESCRIPTION
Checklist
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications are bound by `python -c "import time; print(f'{time.time():.0f}000')"`

References:
- https://github.com/conda-forge/python-slugify-feedstock/issues/33

```diff
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata.json.bz2
noarch::python-slugify-1.2.5-py_1.tar.bz2
-  "version": "1.2.5"
+  "version": "1.2.5",
+  "constrains": [
+    "slugify <0",
+    "awesome-slugify <0"
+  ]
noarch::python-slugify-1.2.6-py_0.tar.bz2
-  "version": "1.2.6"
+  "version": "1.2.6",
+  "constrains": [
+    "slugify <0",
+    "awesome-slugify <0"
+  ]
noarch::python-slugify-2.0.0-py_0.tar.bz2
-  "version": "2.0.0"
+  "version": "2.0.0",
+  "constrains": [
+    "slugify <0",
+    "awesome-slugify <0"
+  ]
noarch::python-slugify-2.0.1-py_0.tar.bz2
-  "version": "2.0.1"
+  "version": "2.0.1",
+  "constrains": [
+    "slugify <0",
+    "awesome-slugify <0"
+  ]
noarch::python-slugify-3.0.0-py_0.tar.bz2
-  "version": "3.0.0"
+  "version": "3.0.0",
+  "constrains": [
+    "slugify <0",
+    "awesome-slugify <0"
+  ]
noarch::python-slugify-3.0.1-py_0.tar.bz2
-  "version": "3.0.1"
+  "version": "3.0.1",
+  "constrains": [
+    "slugify <0",
+    "awesome-slugify <0"
+  ]
noarch::python-slugify-3.0.2-py_0.tar.bz2
-  "version": "3.0.2"
+  "version": "3.0.2",
+  "constrains": [
+    "slugify <0",
+    "awesome-slugify <0"
+  ]
noarch::python-slugify-3.0.3-py_0.tar.bz2
-  "version": "3.0.3"
+  "version": "3.0.3",
+  "constrains": [
+    "slugify <0",
+    "awesome-slugify <0"
+  ]
noarch::python-slugify-3.0.5-py_0.tar.bz2
-  "version": "3.0.5"
+  "version": "3.0.5",
+  "constrains": [
+    "slugify <0",
+    "awesome-slugify <0"
+  ]
noarch::python-slugify-3.0.6-py_0.tar.bz2
-  "version": "3.0.6"
+  "version": "3.0.6",
+  "constrains": [
+    "slugify <0",
+    "awesome-slugify <0"
+  ]
noarch::python-slugify-4.0.0-py_0.tar.bz2
-  "version": "4.0.0"
+  "version": "4.0.0",
+  "constrains": [
+    "slugify <0",
+    "awesome-slugify <0"
+  ]
noarch::python-slugify-4.0.0-pyh9f0ad1d_1.tar.bz2
-  "version": "4.0.0"
+  "version": "4.0.0",
+  "constrains": [
+    "slugify <0",
+    "awesome-slugify <0"
+  ]
noarch::python-slugify-4.0.1-pyh9f0ad1d_0.tar.bz2
-  "version": "4.0.1"
+  "version": "4.0.1",
+  "constrains": [
+    "slugify <0",
+    "awesome-slugify <0"
+  ]
noarch::python-slugify-5.0.0-pyhd8ed1ab_0.tar.bz2
-  "version": "5.0.0"
+  "version": "5.0.0",
+  "constrains": [
+    "slugify <0",
+    "awesome-slugify <0"
+  ]
noarch::python-slugify-5.0.2-pyhd8ed1ab_0.tar.bz2
-  "version": "5.0.2"
+  "version": "5.0.2",
+  "constrains": [
+    "slugify <0",
+    "awesome-slugify <0"
+  ]
noarch::python-slugify-6.0.1-pyhd8ed1ab_0.tar.bz2
-  "version": "6.0.1"
+  "version": "6.0.1",
+  "constrains": [
+    "slugify <0",
+    "awesome-slugify <0"
+  ]
noarch::python-slugify-6.1.0-pyhd8ed1ab_0.tar.bz2
-  "version": "6.1.0"
+  "version": "6.1.0",
+  "constrains": [
+    "slugify <0",
+    "awesome-slugify <0"
+  ]
noarch::python-slugify-6.1.1-pyhd8ed1ab_0.tar.bz2
-  "version": "6.1.1"
+  "version": "6.1.1",
+  "constrains": [
+    "slugify <0",
+    "awesome-slugify <0"
+  ]
noarch::python-slugify-6.1.2-pyhd8ed1ab_0.tar.bz2
-  "version": "6.1.2"
+  "version": "6.1.2",
+  "constrains": [
+    "slugify <0",
+    "awesome-slugify <0"
+  ]
noarch::python-slugify-7.0.0-pyhd8ed1ab_0.conda
-  "version": "7.0.0"
+  "version": "7.0.0",
+  "constrains": [
+    "slugify <0",
+    "awesome-slugify <0"
+  ]
noarch::python-slugify-8.0.0-pyhd8ed1ab_0.conda
-  "version": "8.0.0"
+  "version": "8.0.0",
+  "constrains": [
+    "slugify <0",
+    "awesome-slugify <0"
+  ]
noarch::python-slugify-8.0.1-pyhd8ed1ab_0.conda
-  "version": "8.0.1"
+  "version": "8.0.1",
+  "constrains": [
+    "slugify <0",
+    "awesome-slugify <0"
+  ]
linux-64::python-slugify-1.2.1-py27_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27mu"
-  ],
-  "version": "1.2.1"
+  "version": "1.2.1",
+  "constrains": [
+    "python_abi * *_cp27mu",
+    "slugify <0",
+    "awesome-slugify <0"
+  ]
linux-64::python-slugify-1.2.1-py27_1.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27mu"
-  ],
-  "version": "1.2.1"
+  "version": "1.2.1",
+  "constrains": [
+    "python_abi * *_cp27mu",
+    "slugify <0",
+    "awesome-slugify <0"
+  ]
linux-64::python-slugify-1.2.1-py34_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp34m"
-  ],
-  "version": "1.2.1"
+  "version": "1.2.1",
+  "constrains": [
+    "python_abi * *_cp34m",
+    "slugify <0",
+    "awesome-slugify <0"
+  ]
linux-64::python-slugify-1.2.1-py35_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp35m"
-  ],
-  "version": "1.2.1"
+  "version": "1.2.1",
+  "constrains": [
+    "python_abi * *_cp35m",
+    "slugify <0",
+    "awesome-slugify <0"
+  ]
linux-64::python-slugify-1.2.1-py35_1.tar.bz2
-  "constrains": [
-    "python_abi * *_cp35m"
-  ],
-  "version": "1.2.1"
+  "version": "1.2.1",
+  "constrains": [
+    "python_abi * *_cp35m",
+    "slugify <0",
+    "awesome-slugify <0"
+  ]
linux-64::python-slugify-1.2.1-py36_1.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-  "version": "1.2.1"
+  "version": "1.2.1",
+  "constrains": [
+    "python_abi * *_cp36m",
+    "slugify <0",
+    "awesome-slugify <0"
+  ]
linux-64::python-slugify-1.2.4-py27_1.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27mu"
-  ],
-  "version": "1.2.4"
+  "version": "1.2.4",
+  "constrains": [
+    "python_abi * *_cp27mu",
+    "slugify <0",
+    "awesome-slugify <0"
+  ]
linux-64::python-slugify-1.2.4-py35_1.tar.bz2
-  "constrains": [
-    "python_abi * *_cp35m"
-  ],
-  "version": "1.2.4"
+  "version": "1.2.4",
+  "constrains": [
+    "python_abi * *_cp35m",
+    "slugify <0",
+    "awesome-slugify <0"
+  ]
linux-64::python-slugify-1.2.4-py36_1.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-  "version": "1.2.4"
+  "version": "1.2.4",
+  "constrains": [
+    "python_abi * *_cp36m",
+    "slugify <0",
+    "awesome-slugify <0"
+  ]
linux-64::python-slugify-1.2.5-py27_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27mu"
-  ],
-  "version": "1.2.5"
+  "version": "1.2.5",
+  "constrains": [
+    "python_abi * *_cp27mu",
+    "slugify <0",
+    "awesome-slugify <0"
+  ]
linux-64::python-slugify-1.2.5-py35_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp35m"
-  ],
-  "version": "1.2.5"
+  "version": "1.2.5",
+  "constrains": [
+    "python_abi * *_cp35m",
+    "slugify <0",
+    "awesome-slugify <0"
+  ]
linux-64::python-slugify-1.2.5-py36_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-  "version": "1.2.5"
+  "version": "1.2.5",
+  "constrains": [
+    "python_abi * *_cp36m",
+    "slugify <0",
+    "awesome-slugify <0"
+  ]
osx-64::python-slugify-1.2.1-py27_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27m"
-  ],
-  "version": "1.2.1"
+  "version": "1.2.1",
+  "constrains": [
+    "python_abi * *_cp27m",
+    "slugify <0",
+    "awesome-slugify <0"
+  ]
osx-64::python-slugify-1.2.1-py27_1.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27m"
-  ],
-  "version": "1.2.1"
+  "version": "1.2.1",
+  "constrains": [
+    "python_abi * *_cp27m",
+    "slugify <0",
+    "awesome-slugify <0"
+  ]
osx-64::python-slugify-1.2.1-py34_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp34m"
-  ],
-  "version": "1.2.1"
+  "version": "1.2.1",
+  "constrains": [
+    "python_abi * *_cp34m",
+    "slugify <0",
+    "awesome-slugify <0"
+  ]
osx-64::python-slugify-1.2.1-py35_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp35m"
-  ],
-  "version": "1.2.1"
+  "version": "1.2.1",
+  "constrains": [
+    "python_abi * *_cp35m",
+    "slugify <0",
+    "awesome-slugify <0"
+  ]
osx-64::python-slugify-1.2.1-py35_1.tar.bz2
-  "constrains": [
-    "python_abi * *_cp35m"
-  ],
-  "version": "1.2.1"
+  "version": "1.2.1",
+  "constrains": [
+    "python_abi * *_cp35m",
+    "slugify <0",
+    "awesome-slugify <0"
+  ]
osx-64::python-slugify-1.2.1-py36_1.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-  "version": "1.2.1"
+  "version": "1.2.1",
+  "constrains": [
+    "python_abi * *_cp36m",
+    "slugify <0",
+    "awesome-slugify <0"
+  ]
osx-64::python-slugify-1.2.4-py27_1.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27m"
-  ],
-  "version": "1.2.4"
+  "version": "1.2.4",
+  "constrains": [
+    "python_abi * *_cp27m",
+    "slugify <0",
+    "awesome-slugify <0"
+  ]
osx-64::python-slugify-1.2.4-py35_1.tar.bz2
-  "constrains": [
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata.json.bz2
-    "python_abi * *_cp35m"
-  ],
-  "version": "1.2.4"
+  "version": "1.2.4",
+  "constrains": [
+    "python_abi * *_cp35m",
+    "slugify <0",
+    "awesome-slugify <0"
+  ]
osx-64::python-slugify-1.2.4-py36_1.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-  "version": "1.2.4"
+  "version": "1.2.4",
+  "constrains": [
+    "python_abi * *_cp36m",
+    "slugify <0",
+    "awesome-slugify <0"
+  ]
osx-64::python-slugify-1.2.5-py27_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27m"
-  ],
-  "version": "1.2.5"
+  "version": "1.2.5",
+  "constrains": [
+    "python_abi * *_cp27m",
+    "slugify <0",
+    "awesome-slugify <0"
+  ]
osx-64::python-slugify-1.2.5-py35_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp35m"
-  ],
-  "version": "1.2.5"
+  "version": "1.2.5",
+  "constrains": [
+    "python_abi * *_cp35m",
+    "slugify <0",
+    "awesome-slugify <0"
+  ]
osx-64::python-slugify-1.2.5-py36_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-  "version": "1.2.5"
+  "version": "1.2.5",
+  "constrains": [
+    "python_abi * *_cp36m",
+    "slugify <0",
+    "awesome-slugify <0"
+  ]
win-32::python-slugify-1.2.1-py27_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27m"
-  ],
-  "version": "1.2.1"
+  "version": "1.2.1",
+  "constrains": [
+    "python_abi * *_cp27m",
+    "slugify <0",
+    "awesome-slugify <0"
+  ]
win-32::python-slugify-1.2.1-py27_1.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27m"
-  ],
-  "version": "1.2.1"
+  "version": "1.2.1",
+  "constrains": [
+    "python_abi * *_cp27m",
+    "slugify <0",
+    "awesome-slugify <0"
+  ]
win-32::python-slugify-1.2.1-py34_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp34m"
-  ],
-  "version": "1.2.1"
+  "version": "1.2.1",
+  "constrains": [
+    "python_abi * *_cp34m",
+    "slugify <0",
+    "awesome-slugify <0"
+  ]
win-32::python-slugify-1.2.1-py35_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp35m"
-  ],
-  "version": "1.2.1"
+  "version": "1.2.1",
+  "constrains": [
+    "python_abi * *_cp35m",
+    "slugify <0",
+    "awesome-slugify <0"
+  ]
win-32::python-slugify-1.2.1-py35_1.tar.bz2
-  "constrains": [
-    "python_abi * *_cp35m"
-  ],
-  "version": "1.2.1"
+  "version": "1.2.1",
+  "constrains": [
+    "python_abi * *_cp35m",
+    "slugify <0",
+    "awesome-slugify <0"
+  ]
win-32::python-slugify-1.2.1-py36_1.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-  "version": "1.2.1"
+  "version": "1.2.1",
+  "constrains": [
+    "python_abi * *_cp36m",
+    "slugify <0",
+    "awesome-slugify <0"
+  ]
win-32::python-slugify-1.2.4-py27_1.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27m"
-  ],
-  "version": "1.2.4"
+  "version": "1.2.4",
+  "constrains": [
+    "python_abi * *_cp27m",
+    "slugify <0",
+    "awesome-slugify <0"
+  ]
win-32::python-slugify-1.2.4-py35_1.tar.bz2
-  "constrains": [
-    "python_abi * *_cp35m"
-  ],
-  "version": "1.2.4"
+  "version": "1.2.4",
+  "constrains": [
+    "python_abi * *_cp35m",
+    "slugify <0",
+    "awesome-slugify <0"
+  ]
win-32::python-slugify-1.2.4-py36_1.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-  "version": "1.2.4"
+  "version": "1.2.4",
+  "constrains": [
+    "python_abi * *_cp36m",
+    "slugify <0",
+    "awesome-slugify <0"
+  ]
win-32::python-slugify-1.2.5-py27_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27m"
-  ],
-  "version": "1.2.5"
+  "version": "1.2.5",
+  "constrains": [
+    "python_abi * *_cp27m",
+    "slugify <0",
+    "awesome-slugify <0"
+  ]
win-32::python-slugify-1.2.5-py35_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp35m"
-  ],
-  "version": "1.2.5"
+  "version": "1.2.5",
+  "constrains": [
+    "python_abi * *_cp35m",
+    "slugify <0",
+    "awesome-slugify <0"
+  ]
win-32::python-slugify-1.2.5-py36_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-  "version": "1.2.5"
+  "version": "1.2.5",
+  "constrains": [
+    "python_abi * *_cp36m",
+    "slugify <0",
+    "awesome-slugify <0"
+  ]
win-64::python-slugify-1.2.1-py27_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27m"
-  ],
-  "version": "1.2.1"
+  "version": "1.2.1",
+  "constrains": [
+    "python_abi * *_cp27m",
+    "slugify <0",
+    "awesome-slugify <0"
+  ]
win-64::python-slugify-1.2.1-py27_1.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27m"
-  ],
-  "version": "1.2.1"
+  "version": "1.2.1",
+  "constrains": [
+    "python_abi * *_cp27m",
+    "slugify <0",
+    "awesome-slugify <0"
+  ]
win-64::python-slugify-1.2.1-py34_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp34m"
-  ],
-  "version": "1.2.1"
+  "version": "1.2.1",
+  "constrains": [
+    "python_abi * *_cp34m",
+    "slugify <0",
+    "awesome-slugify <0"
+  ]
win-64::python-slugify-1.2.1-py35_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp35m"
-  ],
-  "version": "1.2.1"
+  "version": "1.2.1",
+  "constrains": [
+    "python_abi * *_cp35m",
+    "slugify <0",
+    "awesome-slugify <0"
+  ]
win-64::python-slugify-1.2.1-py35_1.tar.bz2
-  "constrains": [
-    "python_abi * *_cp35m"
-  ],
-  "version": "1.2.1"
+  "version": "1.2.1",
+  "constrains": [
+    "python_abi * *_cp35m",
+    "slugify <0",
+    "awesome-slugify <0"
+  ]
win-64::python-slugify-1.2.1-py36_1.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-  "version": "1.2.1"
+  "version": "1.2.1",
+  "constrains": [
+    "python_abi * *_cp36m",
+    "slugify <0",
+    "awesome-slugify <0"
+  ]
win-64::python-slugify-1.2.4-py27_1.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27m"
-  ],
-  "version": "1.2.4"
+  "version": "1.2.4",
+  "constrains": [
+    "python_abi * *_cp27m",
+    "slugify <0",
+    "awesome-slugify <0"
+  ]
win-64::python-slugify-1.2.4-py35_1.tar.bz2
-  "constrains": [
-    "python_abi * *_cp35m"
-  ],
-  "version": "1.2.4"
+  "version": "1.2.4",
+  "constrains": [
+    "python_abi * *_cp35m",
+    "slugify <0",
+    "awesome-slugify <0"
+  ]
win-64::python-slugify-1.2.4-py36_1.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-  "version": "1.2.4"
+  "version": "1.2.4",
+  "constrains": [
+    "python_abi * *_cp36m",
+    "slugify <0",
+    "awesome-slugify <0"
+  ]
win-64::python-slugify-1.2.5-py27_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27m"
-  ],
-  "version": "1.2.5"
+  "version": "1.2.5",
+  "constrains": [
+    "python_abi * *_cp27m",
+    "slugify <0",
+    "awesome-slugify <0"
+  ]
win-64::python-slugify-1.2.5-py35_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp35m"
-  ],
-  "version": "1.2.5"
+  "version": "1.2.5",
+  "constrains": [
+    "python_abi * *_cp35m",
+    "slugify <0",
+    "awesome-slugify <0"
+  ]
win-64::python-slugify-1.2.5-py36_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-  "version": "1.2.5"
+  "version": "1.2.5",
+  "constrains": [
+    "python_abi * *_cp36m",
+    "slugify <0",
+    "awesome-slugify <0"
+  ]

```