### PR TITLE
Patch babel 2.12.0 and 2.12.1 to use Python >= 3.7

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -2487,11 +2487,11 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
         ):
             _replace_pin("python >=3.7", "python >=3.9", record["depends"], record)
 
-        # babel >=0.12 requires Python 3.7, but feedstock specified >= 3.6
+        # babel >=2.12 requires Python 3.7, but feedstock specified >= 3.6
         # Fixed in https://github.com/conda-forge/babel-feedstock/pull/26
         if (
             record_name == "babel" and
-            record["version"] in {"0.12.0", "0.12.1"} and
+            record["version"] in {"2.12.0", "2.12.1"} and
             record["build_number"] == 0 and
             record.get("timestamp", 0) < 1677771669000
         ):

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -754,6 +754,18 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                 i = record['depends'].index('python >=3.6')
                 record['depends'][i] = 'python >=3.7'
 
+        # babel >=0.12 does not work with python 3.6
+        # babel >=0.12,<=0.12.1 allowed python 3.6 to be installed
+        # this fixes those versions to require python >=3.7
+        # See https://github.com/conda-forge/babel-feedstock/pull/26
+        if record_name == 'babel':
+            pversion = pkg_resources.parse_version(record['version'])
+            vmin = pkg_resources.parse_version('0.12')
+            vmax = pkg_resources.parse_version('0.12.1')
+            if vmin <= pversion <= vmax and 'python >=3.6' in record['depends']:
+                i = record['depends'].index('python >=3.6')
+                record['depends'][i] = 'python >=3.7'
+
         # python-language-server <=0.31.9 requires pyflakes <2.2.2
         # included explicitly in 0.31.10+
         # https://github.com/conda-forge/python-language-server-feedstock/pull/50

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -754,18 +754,6 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                 i = record['depends'].index('python >=3.6')
                 record['depends'][i] = 'python >=3.7'
 
-        # babel >=0.12 does not work with python 3.6
-        # babel >=0.12,<=0.12.1 allowed python 3.6 to be installed
-        # this fixes those versions to require python >=3.7
-        # See https://github.com/conda-forge/babel-feedstock/pull/26
-        if record_name == 'babel':
-            pversion = pkg_resources.parse_version(record['version'])
-            vmin = pkg_resources.parse_version('0.12')
-            vmax = pkg_resources.parse_version('0.12.1')
-            if vmin <= pversion <= vmax and 'python >=3.6' in record['depends']:
-                i = record['depends'].index('python >=3.6')
-                record['depends'][i] = 'python >=3.7'
-
         # python-language-server <=0.31.9 requires pyflakes <2.2.2
         # included explicitly in 0.31.10+
         # https://github.com/conda-forge/python-language-server-feedstock/pull/50
@@ -2499,6 +2487,15 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
         ):
             _replace_pin("python >=3.7", "python >=3.9", record["depends"], record)
 
+        # babel >=0.12 requires Python 3.7, but feedstock specified >= 3.6
+        # Fixed in https://github.com/conda-forge/babel-feedstock/pull/26
+        if (
+            record_name == "babel" and
+            record["version"] in {"0.12.0", "0.12.1"} and
+            record["build_number"] == 0 and
+            record.get("timestamp", 0) < 1677771669000
+        ):
+            _replace_pin("python >=3.6", "python >=3.7", record["depends"], record)
 
     return index
 


### PR DESCRIPTION
Checklist
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications are bound by `python -c "import time; print(f'{time.time():.0f}000')"`

Closes https://github.com/conda-forge/babel-feedstock/issues/25.