### PR TITLE
Use a more strict pinning for imath

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -2547,6 +2547,12 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             new_constrains = record.get("constrains", [])
             new_constrains.append("jpeg <0.0.0a")
             record["constrains"] = new_constrains
+            
+            
+        # Different patch versions of imath can be ABI incompatible
+        # See https://github.com/conda-forge/imath-feedstock/issues/7
+        if has_dep(record, "imath") and record.get('timestamp', 0) < 1678196668497:
+            _pin_stricter(fn, record, "imath", "x.x.x")
 
     return index
 

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -2549,10 +2549,11 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             record["constrains"] = new_constrains
             
             
-        # Different patch versions of imath can be ABI incompatible
+        # imath 3.1.7 change its SOVERSION so it is not not ABI compatible
+        # with imath 3.1.4, 3.1.5, and 3.1.6
         # See https://github.com/conda-forge/imath-feedstock/issues/7
         if has_dep(record, "imath") and record.get('timestamp', 0) < 1678196668497:
-            _pin_stricter(fn, record, "imath", "x.x.x")
+            _pin_stricter(fn, record, "imath", "x", upper_bound="3.1.7")
 
     return index
 


### PR DESCRIPTION
Checklist
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications are bound by `python -c "import time; print(f'{time.time():.0f}000')"`
