### PR TITLE
Require libcxx<15 for current versions of cppyy

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -2548,6 +2548,26 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             new_constrains.append("jpeg <0.0.0a")
             record["constrains"] = new_constrains
 
+        # cppyy <3 uses a version of Cling that is based on Clang 9. libcxx 15
+        # headers for macOS do not compile with such an old Clang anymore, see
+        # https://github.com/conda-forge/libcxx-feedstock/issues/111
+        # So, if there's is no "<" pin on libcxx already, we add a "<15".
+        if (
+            record_name == "cppyy" and
+            pkg_resources.parse_version(record["version"]) < pkg_resources.parse_version("3.0.0")
+        ):
+            depends = record.get("depends", [])
+            for i, depend in enumerate(depends):
+                if depend.split()[0] == "libcxx":
+                    if "<" not in depend:
+                        if " " not in depend:
+                            depend += " "
+                        else:
+                            depend += ","
+                        depend += "<15"
+                    depends[i] = depend
+            record["depends"] = depends
+
     return index
 
 

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -2554,7 +2554,8 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
         # So, if there's is no "<" pin on libcxx already, we add a "<15".
         if (
             record_name == "cppyy" and
-            pkg_resources.parse_version(record["version"]) < pkg_resources.parse_version("3.0.0")
+            pkg_resources.parse_version(record["version"]) < pkg_resources.parse_version("3.0.0") and
+            record.get("timestamp", 0) < 1678353800000
         ):
             depends = record.get("depends", [])
             for i, depend in enumerate(depends):


### PR DESCRIPTION
cppyy relies on a version of Cling that is based on Clang 9. Recent versions of libcxx >= 15 are not compatible with Clang 9 anymore, see https://github.com/conda-forge/libcxx-feedstock/issues/111

Checklist
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications are bound by `python -c "import time; print(f'{time.time():.0f}000')"` ~~**I don't understand what this means.**~~

Output of `show_diff.py`:
<details>
<pre>
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata.json.bz2
linux-64::gfortran_impl_osx-64-10.4.0-h30ebab5_28.conda
-{
-  "build": "h30ebab5_28",
-  "build_number": 28,
-  "depends": [
-    "gmp >=6.2.1,<7.0a0",
-    "isl >=0.25,<0.26.0a0",
-    "libgcc-ng >=12",
-    "libiconv >=1.17,<2.0a0",
-    "libstdcxx-ng >=12",
-    "libzlib >=1.2.13,<1.3.0a0",
-    "mpc >=1.3.1,<2.0a0",
-    "mpfr >=4.1.0,<5.0a0",
-    "zlib"
-  ],
-  "license": "GPL-3.0-only WITH GCC-exception-3.1",
-  "md5": "3d22515c98db8a0d183d2086d917eb24",
-  "name": "gfortran_impl_osx-64",
-  "sha256": "d469a94797d410cfc99e47d7177f59edbbbe1d03993143b6044ff291bd14a3b4",
-  "size": 19767504,
-  "subdir": "linux-64",
-  "timestamp": 1676698797978,
-  "version": "10.4.0"
-}
+{}
linux-64::gfortran_impl_osx-64-11.3.0-h7451c75_28.conda
-{
-  "build": "h7451c75_28",
-  "build_number": 28,
-  "depends": [
-    "gmp >=6.2.1,<7.0a0",
-    "isl >=0.25,<0.26.0a0",
-    "libgcc-ng >=12",
-    "libiconv >=1.17,<2.0a0",
-    "libstdcxx-ng >=12",
-    "libzlib >=1.2.13,<1.3.0a0",
-    "mpc >=1.3.1,<2.0a0",
-    "mpfr >=4.1.0,<5.0a0",
-    "zlib"
-  ],
-  "license": "GPL-3.0-only WITH GCC-exception-3.1",
-  "md5": "700a23909869d636c860d74caac28cee",
-  "name": "gfortran_impl_osx-64",
-  "sha256": "c50eaca95a59c90404d583e936c3aaaf511173a965ae76dbd6b68309cabe9b5e",
-  "size": 21468133,
-  "subdir": "linux-64",
-  "timestamp": 1676699054914,
-  "version": "11.3.0"
-}
+{}
linux-64::gfortran_impl_osx-64-11.3.0-h7451c75_29.conda
-{
-  "build": "h7451c75_29",
-  "build_number": 29,
-  "depends": [
-    "gmp >=6.2.1,<7.0a0",
-    "isl >=0.25,<0.26.0a0",
-    "libgcc-ng >=12",
-    "libiconv >=1.17,<2.0a0",
-    "libstdcxx-ng >=12",
-    "libzlib >=1.2.13,<1.3.0a0",
-    "mpc >=1.3.1,<2.0a0",
-    "mpfr >=4.1.0,<5.0a0",
-    "zlib"
-  ],
-  "license": "GPL-3.0-only WITH GCC-exception-3.1",
-  "md5": "0d3af1c279c6841cb4398c8f78b3922f",
-  "name": "gfortran_impl_osx-64",
-  "sha256": "403efa675ed13efa0b87dc0ad6b7348af7f529fc24b099f10c34fcffa552c56c",
-  "size": 21608997,
-  "subdir": "linux-64",
-  "timestamp": 1677871190837,
-  "version": "11.3.0"
-}
+{}
linux-64::gfortran_impl_osx-64-12.2.0-hd4e675f_29.conda
-{
-  "build": "hd4e675f_29",
-  "build_number": 29,
-  "depends": [
-    "gmp >=6.2.1,<7.0a0",
-    "isl >=0.25,<0.26.0a0",
-    "libgcc-ng >=12",
-    "libiconv >=1.17,<2.0a0",
-    "libstdcxx-ng >=12",
-    "libzlib >=1.2.13,<1.3.0a0",
-    "mpc >=1.3.1,<2.0a0",
-    "mpfr >=4.1.0,<5.0a0",
-    "zlib"
-  ],
-  "license": "GPL-3.0-only WITH GCC-exception-3.1",
-  "md5": "1292a82705f4e3a733bf568de3f4e839",
-  "name": "gfortran_impl_osx-64",
-  "sha256": "f438ea97db8af03c0399daa5d010caa2d394a6d2feffce39021447ff42f53952",
-  "size": 23681919,
-  "subdir": "linux-64",
-  "timestamp": 1677871473013,
-  "version": "12.2.0"
-}
+{}
linux-64::gfortran_impl_osx-64-9.5.0-hf9f8a66_28.conda
-{
-  "build": "hf9f8a66_28",
-  "build_number": 28,
-  "depends": [
-    "gmp >=6.2.1,<7.0a0",
-    "isl >=0.25,<0.26.0a0",
-    "libgcc-ng >=12",
-    "libiconv >=1.17,<2.0a0",
-    "libstdcxx-ng >=12",
-    "libzlib >=1.2.13,<1.3.0a0",
-    "mpc >=1.3.1,<2.0a0",
-    "mpfr >=4.1.0,<5.0a0",
-    "zlib"
-  ],
-  "license": "GPL-3.0-only WITH GCC-exception-3.1",
-  "md5": "eeb85021ae6c19dd66582dbfe46805ee",
-  "name": "gfortran_impl_osx-64",
-  "sha256": "726f61d2950ad3d67aec981c09ba6b44f32cbaafa114ef6ecc44d062d15dbb9d",
-  "size": 18289508,
-  "subdir": "linux-64",
-  "timestamp": 1676698738216,
-  "version": "9.5.0"
-}
+{}
linux-64::gfortran_impl_osx-arm64-10.3.0-h00ceda5_28.conda
-{
-  "build": "h00ceda5_28",
-  "build_number": 28,
-  "depends": [
-    "gmp >=6.2.1,<7.0a0",
-    "isl >=0.25,<0.26.0a0",
-    "libgcc-ng >=12",
-    "libiconv >=1.17,<2.0a0",
-    "libstdcxx-ng >=12",
-    "libzlib >=1.2.13,<1.3.0a0",
-    "mpc >=1.3.1,<2.0a0",
-    "mpfr >=4.1.0,<5.0a0",
-    "zlib"
-  ],
-  "license": "GPL-3.0-only WITH GCC-exception-3.1",
-  "md5": "53a7c76f57152b6fa1b72b50eec72c93",
-  "name": "gfortran_impl_osx-arm64",
-  "sha256": "7c6cc037de5a8f344ccfc743b7d9d2b9982c901956e5f60698eceb10fb42bc3a",
-  "size": 19632723,
-  "subdir": "linux-64",
-  "timestamp": 1676698789993,
-  "version": "10.3.0"
-}
+{}
linux-64::gfortran_impl_osx-arm64-11.3.0-h654ad5e_28.conda
-{
-  "build": "h654ad5e_28",
-  "build_number": 28,
-  "depends": [
-    "gmp >=6.2.1,<7.0a0",
-    "isl >=0.25,<0.26.0a0",
-    "libgcc-ng >=12",
-    "libiconv >=1.17,<2.0a0",
-    "libstdcxx-ng >=12",
-    "libzlib >=1.2.13,<1.3.0a0",
-    "mpc >=1.3.1,<2.0a0",
-    "mpfr >=4.1.0,<5.0a0",
-    "zlib"
-  ],
-  "license": "GPL-3.0-only WITH GCC-exception-3.1",
-  "md5": "9bed594efa857059129e12714ddcef34",
-  "name": "gfortran_impl_osx-arm64",
-  "sha256": "4e7ab4966f4e63afb2c1d1d25734a3a1ffce83183eca05b36996ed100dce8f8e",
-  "size": 22448880,
-  "subdir": "linux-64",
-  "timestamp": 1676699166629,
-  "version": "11.3.0"
-}
+{}
linux-64::gfortran_impl_osx-arm64-11.3.0-h654ad5e_29.conda
-{
-  "build": "h654ad5e_29",
-  "build_number": 29,
-  "depends": [
-    "gmp >=6.2.1,<7.0a0",
-    "isl >=0.25,<0.26.0a0",
-    "libgcc-ng >=12",
-    "libiconv >=1.17,<2.0a0",
-    "libstdcxx-ng >=12",
-    "libzlib >=1.2.13,<1.3.0a0",
-    "mpc >=1.3.1,<2.0a0",
-    "mpfr >=4.1.0,<5.0a0",
-    "zlib"
-  ],
-  "license": "GPL-3.0-only WITH GCC-exception-3.1",
-  "md5": "71f90029ddfca2034a49ffc6aa9d899d",
-  "name": "gfortran_impl_osx-arm64",
-  "sha256": "2320308458f2281dafd9629136bc643d85b9c582e4aab8329c8333d2fbada5c3",
-  "size": 22476405,
-  "subdir": "linux-64",
-  "timestamp": 1677870994537,
-  "version": "11.3.0"
-}
+{}
linux-64::gfortran_impl_osx-arm64-12.2.0-he68c095_29.conda
-{
-  "build": "he68c095_29",
-  "build_number": 29,
-  "depends": [
-    "gmp >=6.2.1,<7.0a0",
-    "isl >=0.25,<0.26.0a0",
-    "libgcc-ng >=12",
-    "libiconv >=1.17,<2.0a0",
-    "libstdcxx-ng >=12",
-    "libzlib >=1.2.13,<1.3.0a0",
-    "mpc >=1.3.1,<2.0a0",
-    "mpfr >=4.1.0,<5.0a0",
-    "zlib"
-  ],
-  "license": "GPL-3.0-only WITH GCC-exception-3.1",
-  "md5": "2f927835a5fc9a71202be4632c64e804",
-  "name": "gfortran_impl_osx-arm64",
-  "sha256": "b3edd06d5f172b647156572d2dd0521b12a1fb98fa8980c0ed1a0beb97819da1",
-  "size": 23854972,
-  "subdir": "linux-64",
-  "timestamp": 1677871063171,
-  "version": "12.2.0"
-}
+{}
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata.json.bz2
linux-aarch64::gfortran_impl_osx-64-10.4.0-h97dbcf2_28.conda
-{
-  "build": "h97dbcf2_28",
-  "build_number": 28,
-  "depends": [
-    "gmp >=6.2.1,<7.0a0",
-    "isl >=0.25,<0.26.0a0",
-    "libgcc-ng >=12",
-    "libiconv >=1.17,<2.0a0",
-    "libstdcxx-ng >=12",
-    "libzlib >=1.2.13,<1.3.0a0",
-    "mpc >=1.3.1,<2.0a0",
-    "mpfr >=4.1.0,<5.0a0",
-    "zlib"
-  ],
-  "license": "GPL-3.0-only WITH GCC-exception-3.1",
-  "md5": "c1ac6378d4ea4db24a6faefec544ba4e",
-  "name": "gfortran_impl_osx-64",
-  "sha256": "dcee1b1fa5561990908173bd8a9748c6c94e01cc56a85bc3ce508a92cd609c9e",
-  "size": 19726326,
-  "subdir": "linux-aarch64",
-  "timestamp": 1676698903999,
-  "version": "10.4.0"
-}
+{}
linux-aarch64::gfortran_impl_osx-64-11.3.0-h2de92ef_28.conda
-{
-  "build": "h2de92ef_28",
-  "build_number": 28,
-  "depends": [
-    "gmp >=6.2.1,<7.0a0",
-    "isl >=0.25,<0.26.0a0",
-    "libgcc-ng >=12",
-    "libiconv >=1.17,<2.0a0",
-    "libstdcxx-ng >=12",
-    "libzlib >=1.2.13,<1.3.0a0",
-    "mpc >=1.3.1,<2.0a0",
-    "mpfr >=4.1.0,<5.0a0",
-    "zlib"
-  ],
-  "license": "GPL-3.0-only WITH GCC-exception-3.1",
-  "md5": "8b40bf0a267ad3423bdfc996ae9a28e9",
-  "name": "gfortran_impl_osx-64",
-  "sha256": "c17325f93b233e9558c1dff5d5597920513d6eaadca93e7c1414f08633516a83",
-  "size": 21520576,
-  "subdir": "linux-aarch64",
-  "timestamp": 1676698966417,
-  "version": "11.3.0"
-}
+{}
linux-aarch64::gfortran_impl_osx-64-11.3.0-h2de92ef_29.conda
-{
-  "build": "h2de92ef_29",
-  "build_number": 29,
-  "depends": [
-    "gmp >=6.2.1,<7.0a0",
-    "isl >=0.25,<0.26.0a0",
-    "libgcc-ng >=12",
-    "libiconv >=1.17,<2.0a0",
-    "libstdcxx-ng >=12",
-    "libzlib >=1.2.13,<1.3.0a0",
-    "mpc >=1.3.1,<2.0a0",
-    "mpfr >=4.1.0,<5.0a0",
-    "zlib"
-  ],
-  "license": "GPL-3.0-only WITH GCC-exception-3.1",
-  "md5": "6d411c0bc49f847400a7161abc9475ab",
-  "name": "gfortran_impl_osx-64",
-  "sha256": "001bb7b6527ccee9301e856a33ccf66848e66141aca59c796e25b10914b70f6c",
-  "size": 21223957,
-  "subdir": "linux-aarch64",
-  "timestamp": 1677871168255,
-  "version": "11.3.0"
-}
+{}
linux-aarch64::gfortran_impl_osx-64-12.2.0-hb50c013_29.conda
-{
-  "build": "hb50c013_29",
-  "build_number": 29,
-  "depends": [
-    "gmp >=6.2.1,<7.0a0",
-    "isl >=0.25,<0.26.0a0",
-    "libgcc-ng >=12",
-    "libiconv >=1.17,<2.0a0",
-    "libstdcxx-ng >=12",
-    "libzlib >=1.2.13,<1.3.0a0",
-    "mpc >=1.3.1,<2.0a0",
-    "mpfr >=4.1.0,<5.0a0",
-    "zlib"
-  ],
-  "license": "GPL-3.0-only WITH GCC-exception-3.1",
-  "md5": "5d68399b93c1383536db0880be0c1d39",
-  "name": "gfortran_impl_osx-64",
-  "sha256": "46ebcb5844636650f3a3ecd4f7c41425dde5b38d003dfc0818559713d3b7c9cb",
-  "size": 23387067,
-  "subdir": "linux-aarch64",
-  "timestamp": 1677871287235,
-  "version": "12.2.0"
-}
+{}
linux-aarch64::gfortran_impl_osx-64-9.5.0-hc4703f9_28.conda
-{
-  "build": "hc4703f9_28",
-  "build_number": 28,
-  "depends": [
-    "gmp >=6.2.1,<7.0a0",
-    "isl >=0.25,<0.26.0a0",
-    "libgcc-ng >=12",
-    "libiconv >=1.17,<2.0a0",
-    "libstdcxx-ng >=12",
-    "libzlib >=1.2.13,<1.3.0a0",
-    "mpc >=1.3.1,<2.0a0",
-    "mpfr >=4.1.0,<5.0a0",
-    "zlib"
-  ],
-  "license": "GPL-3.0-only WITH GCC-exception-3.1",
-  "md5": "816a4702bcaa75731b2993c3688cec89",
-  "name": "gfortran_impl_osx-64",
-  "sha256": "19f1bac7bfd80c52bbd3d7806d7f9a2df3827d77ec98486056b4a34f3a0eb255",
-  "size": 18383078,
-  "subdir": "linux-aarch64",
-  "timestamp": 1676698954830,
-  "version": "9.5.0"
-}
+{}
linux-aarch64::gfortran_impl_osx-arm64-10.3.0-h6f949af_28.conda
-{
-  "build": "h6f949af_28",
-  "build_number": 28,
-  "depends": [
-    "gmp >=6.2.1,<7.0a0",
-    "isl >=0.25,<0.26.0a0",
-    "libgcc-ng >=12",
-    "libiconv >=1.17,<2.0a0",
-    "libstdcxx-ng >=12",
-    "libzlib >=1.2.13,<1.3.0a0",
-    "mpc >=1.3.1,<2.0a0",
-    "mpfr >=4.1.0,<5.0a0",
-    "zlib"
-  ],
-  "license": "GPL-3.0-only WITH GCC-exception-3.1",
-  "md5": "9cd62b3b55c666e0edf9e80578485623",
-  "name": "gfortran_impl_osx-arm64",
-  "sha256": "f2d826e211a1805a63d8d053c4a2ca942b0047e4d1c1da87367e7f80df73630e",
-  "size": 20304824,
-  "subdir": "linux-aarch64",
-  "timestamp": 1676698982169,
-  "version": "10.3.0"
-}
+{}
linux-aarch64::gfortran_impl_osx-arm64-11.3.0-hdf91a70_28.conda
-{
-  "build": "hdf91a70_28",
-  "build_number": 28,
-  "depends": [
-    "gmp >=6.2.1,<7.0a0",
-    "isl >=0.25,<0.26.0a0",
-    "libgcc-ng >=12",
-    "libiconv >=1.17,<2.0a0",
-    "libstdcxx-ng >=12",
-    "libzlib >=1.2.13,<1.3.0a0",
-    "mpc >=1.3.1,<2.0a0",
-    "mpfr >=4.1.0,<5.0a0",
-    "zlib"
-  ],
-  "license": "GPL-3.0-only WITH GCC-exception-3.1",
-  "md5": "04d297ea106a106e181c154717ad94eb",
-  "name": "gfortran_impl_osx-arm64",
-  "sha256": "a477c25b8e791c8f993af9014a0358dc0972b7027c85d7c117a02a42adbb4c12",
-  "size": 22069290,
-  "subdir": "linux-aarch64",
-  "timestamp": 1676699085064,
-  "version": "11.3.0"
-}
+{}
linux-aarch64::gfortran_impl_osx-arm64-11.3.0-hdf91a70_29.conda
-{
-  "build": "hdf91a70_29",
-  "build_number": 29,
-  "depends": [
-    "gmp >=6.2.1,<7.0a0",
-    "isl >=0.25,<0.26.0a0",
-    "libgcc-ng >=12",
-    "libiconv >=1.17,<2.0a0",
-    "libstdcxx-ng >=12",
-    "libzlib >=1.2.13,<1.3.0a0",
-    "mpc >=1.3.1,<2.0a0",
-    "mpfr >=4.1.0,<5.0a0",
-    "zlib"
-  ],
-  "license": "GPL-3.0-only WITH GCC-exception-3.1",
-  "md5": "6abd9cfbd52e2aba3d469ec237648734",
-  "name": "gfortran_impl_osx-arm64",
-  "sha256": "1af21deb890489da403dfae105f021c5e1b21c61d55e5c64952354fd94556cc7",
-  "size": 22370948,
-  "subdir": "linux-aarch64",
-  "timestamp": 1677871146433,
-  "version": "11.3.0"
-}
+{}
linux-aarch64::gfortran_impl_osx-arm64-12.2.0-hd4d5ca6_29.conda
-{
-  "build": "hd4d5ca6_29",
-  "build_number": 29,
-  "depends": [
-    "gmp >=6.2.1,<7.0a0",
-    "isl >=0.25,<0.26.0a0",
-    "libgcc-ng >=12",
-    "libiconv >=1.17,<2.0a0",
-    "libstdcxx-ng >=12",
-    "libzlib >=1.2.13,<1.3.0a0",
-    "mpc >=1.3.1,<2.0a0",
-    "mpfr >=4.1.0,<5.0a0",
-    "zlib"
-  ],
-  "license": "GPL-3.0-only WITH GCC-exception-3.1",
-  "md5": "a082db85972f59f81ebfcd49f1176eb7",
-  "name": "gfortran_impl_osx-arm64",
-  "sha256": "a57aacd9ea829f99a94d2979fd1a7aa3756f970e5a657ad7c6501f3a84e99360",
-  "size": 23595339,
-  "subdir": "linux-aarch64",
-  "timestamp": 1677871266500,
-  "version": "12.2.0"
-}
+{}
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata.json.bz2
linux-ppc64le::gfortran_impl_osx-64-11.3.0-hd9565dc_29.conda
-{
-  "build": "hd9565dc_29",
-  "build_number": 29,
-  "depends": [
-    "gmp >=6.2.1,<7.0a0",
-    "isl >=0.25,<0.26.0a0",
-    "libgcc-ng >=12",
-    "libiconv >=1.17,<2.0a0",
-    "libstdcxx-ng >=12",
-    "libzlib >=1.2.13,<1.3.0a0",
-    "mpc >=1.3.1,<2.0a0",
-    "mpfr >=4.1.0,<5.0a0",
-    "zlib"
-  ],
-  "license": "GPL-3.0-only WITH GCC-exception-3.1",
-  "md5": "8de9e209bfe2bd15757ff04aa16c3355",
-  "name": "gfortran_impl_osx-64",
-  "sha256": "f852ee37017e12f309e4d11126a2ad80082f94feb2c893b470f3d7e6a9336bc1",
-  "size": 23307926,
-  "subdir": "linux-ppc64le",
-  "timestamp": 1677872067261,
-  "version": "11.3.0"
-}
+{}
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata.json.bz2
osx-64::cppyy-1.4.11-py27h770b8ee_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27m"
-  ],
-    "libcxx >=4.0.1",
+    "libcxx >=4.0.1,<15",
-  "version": "1.4.11"
+  "version": "1.4.11",
+  "constrains": [
+    "python_abi * *_cp27m"
+  ]
osx-64::cppyy-1.4.11-py36h770b8ee_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-    "libcxx >=4.0.1",
+    "libcxx >=4.0.1,<15",
-  "version": "1.4.11"
+  "version": "1.4.11",
+  "constrains": [
+    "python_abi * *_cp36m"
+  ]
osx-64::cppyy-1.4.11-py37h770b8ee_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp37m"
-  ],
-    "libcxx >=4.0.1",
+    "libcxx >=4.0.1,<15",
-  "version": "1.4.11"
+  "version": "1.4.11",
+  "constrains": [
+    "python_abi * *_cp37m"
+  ]
osx-64::cppyy-1.4.12-py27h770b8ee_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27m"
-  ],
-    "libcxx >=4.0.1",
+    "libcxx >=4.0.1,<15",
-  "version": "1.4.12"
+  "version": "1.4.12",
+  "constrains": [
+    "python_abi * *_cp27m"
+  ]
osx-64::cppyy-1.4.12-py36h770b8ee_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-    "libcxx >=4.0.1",
+    "libcxx >=4.0.1,<15",
-  "version": "1.4.12"
+  "version": "1.4.12",
+  "constrains": [
+    "python_abi * *_cp36m"
+  ]
osx-64::cppyy-1.4.12-py37h770b8ee_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp37m"
-  ],
-    "libcxx >=4.0.1",
+    "libcxx >=4.0.1,<15",
-  "version": "1.4.12"
+  "version": "1.4.12",
+  "constrains": [
+    "python_abi * *_cp37m"
+  ]
osx-64::cppyy-1.5.1-py27h770b8ee_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27m"
-  ],
-    "libcxx >=4.0.1",
+    "libcxx >=4.0.1,<15",
-  "version": "1.5.1"
+  "version": "1.5.1",
+  "constrains": [
+    "python_abi * *_cp27m"
+  ]
osx-64::cppyy-1.5.1-py36h770b8ee_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-    "libcxx >=4.0.1",
+    "libcxx >=4.0.1,<15",
-  "version": "1.5.1"
+  "version": "1.5.1",
+  "constrains": [
+    "python_abi * *_cp36m"
+  ]
osx-64::cppyy-1.5.1-py37h770b8ee_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp37m"
-  ],
-    "libcxx >=4.0.1",
+    "libcxx >=4.0.1,<15",
-  "version": "1.5.1"
+  "version": "1.5.1",
+  "constrains": [
+    "python_abi * *_cp37m"
+  ]
osx-64::cppyy-1.5.4-py27ha1b3eb9_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27m"
-  ],
-    "libcxx >=9.0.0",
+    "libcxx >=9.0.0,<15",
-  "version": "1.5.4"
+  "version": "1.5.4",
+  "constrains": [
+    "python_abi * *_cp27m"
+  ]
osx-64::cppyy-1.5.4-py27ha1b3eb9_1.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27m"
-  ],
-    "libcxx >=9.0.0",
+    "libcxx >=9.0.0,<15",
-  "version": "1.5.4"
+  "version": "1.5.4",
+  "constrains": [
+    "python_abi * *_cp27m"
+  ]
osx-64::cppyy-1.5.4-py27ha1b3eb9_2.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27m"
-  ],
-    "libcxx >=9.0.0",
+    "libcxx >=9.0.0,<15",
-  "version": "1.5.4"
+  "version": "1.5.4",
+  "constrains": [
+    "python_abi * *_cp27m"
+  ]
osx-64::cppyy-1.5.4-py36ha1b3eb9_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-    "libcxx >=9.0.0",
+    "libcxx >=9.0.0,<15",
-  "version": "1.5.4"
+  "version": "1.5.4",
+  "constrains": [
+    "python_abi * *_cp36m"
+  ]
osx-64::cppyy-1.5.4-py36ha1b3eb9_1.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-    "libcxx >=9.0.0",
+    "libcxx >=9.0.0,<15",
-  "version": "1.5.4"
+  "version": "1.5.4",
+  "constrains": [
+    "python_abi * *_cp36m"
+  ]
osx-64::cppyy-1.5.4-py36ha1b3eb9_2.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-    "libcxx >=9.0.0",
+    "libcxx >=9.0.0,<15",
-  "version": "1.5.4"
+  "version": "1.5.4",
+  "constrains": [
+    "python_abi * *_cp36m"
+  ]
osx-64::cppyy-1.5.4-py37ha1b3eb9_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp37m"
-  ],
-    "libcxx >=9.0.0",
+    "libcxx >=9.0.0,<15",
-  "version": "1.5.4"
+  "version": "1.5.4",
+  "constrains": [
+    "python_abi * *_cp37m"
+  ]
osx-64::cppyy-1.5.4-py37ha1b3eb9_1.tar.bz2
-  "constrains": [
-    "python_abi * *_cp37m"
-  ],
-    "libcxx >=9.0.0",
+    "libcxx >=9.0.0,<15",
-  "version": "1.5.4"
+  "version": "1.5.4",
+  "constrains": [
+    "python_abi * *_cp37m"
+  ]
osx-64::cppyy-1.5.4-py37ha1b3eb9_2.tar.bz2
-  "constrains": [
-    "python_abi * *_cp37m"
-  ],
-    "libcxx >=9.0.0",
+    "libcxx >=9.0.0,<15",
-  "version": "1.5.4"
+  "version": "1.5.4",
+  "constrains": [
+    "python_abi * *_cp37m"
+  ]
osx-64::cppyy-1.5.5-py27hd0e5c4b_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27m"
-  ],
-    "libcxx >=9.0.0",
+    "libcxx >=9.0.0,<15",
-  "version": "1.5.5"
+  "version": "1.5.5",
+  "constrains": [
+    "python_abi * *_cp27m"
+  ]
osx-64::cppyy-1.5.5-py36hd0e5c4b_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-    "libcxx >=9.0.0",
+    "libcxx >=9.0.0,<15",
-  "version": "1.5.5"
+  "version": "1.5.5",
+  "constrains": [
+    "python_abi * *_cp36m"
+  ]
osx-64::cppyy-1.5.5-py37hd0e5c4b_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp37m"
-  ],
-    "libcxx >=9.0.0",
+    "libcxx >=9.0.0,<15",
-  "version": "1.5.5"
+  "version": "1.5.5",
+  "constrains": [
+    "python_abi * *_cp37m"
+  ]
osx-64::cppyy-1.5.5-py38hd0e5c4b_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp38"
-  ],
-    "libcxx >=9.0.0",
+    "libcxx >=9.0.0,<15",
-  "version": "1.5.5"
+  "version": "1.5.5",
+  "constrains": [
+    "python_abi * *_cp38"
+  ]
osx-64::cppyy-1.5.7-py27hd0e5c4b_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27m"
-  ],
-    "libcxx >=9.0.0",
+    "libcxx >=9.0.0,<15",
-  "version": "1.5.7"
+  "version": "1.5.7",
+  "constrains": [
+    "python_abi * *_cp27m"
+  ]
osx-64::cppyy-1.5.7-py36hd0e5c4b_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-    "libcxx >=9.0.0",
+    "libcxx >=9.0.0,<15",
-  "version": "1.5.7"
+  "version": "1.5.7",
+  "constrains": [
+    "python_abi * *_cp36m"
+  ]
osx-64::cppyy-1.5.7-py37hd0e5c4b_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp37m"
-  ],
-    "libcxx >=9.0.0",
+    "libcxx >=9.0.0,<15",
-  "version": "1.5.7"
+  "version": "1.5.7",
+  "constrains": [
+    "python_abi * *_cp37m"
+  ]
osx-64::cppyy-1.5.7-py38hd0e5c4b_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp38"
-  ],
-    "libcxx >=9.0.0",
+    "libcxx >=9.0.0,<15",
-  "version": "1.5.7"
+  "version": "1.5.7",
+  "constrains": [
+    "python_abi * *_cp38"
+  ]
osx-64::cppyy-1.6.1-py27hd0e5c4b_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp27m"
-  ],
-    "libcxx >=9.0.1",
+    "libcxx >=9.0.1,<15",
-  "version": "1.6.1"
+  "version": "1.6.1",
+  "constrains": [
+    "python_abi * *_cp27m"
+  ]
osx-64::cppyy-1.6.1-py36hd0e5c4b_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp36m"
-  ],
-    "libcxx >=9.0.1",
+    "libcxx >=9.0.1,<15",
-  "version": "1.6.1"
+  "version": "1.6.1",
+  "constrains": [
+    "python_abi * *_cp36m"
+  ]
osx-64::cppyy-1.6.1-py37hd0e5c4b_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp37m"
-  ],
-    "libcxx >=9.0.1",
+    "libcxx >=9.0.1,<15",
-  "version": "1.6.1"
+  "version": "1.6.1",
+  "constrains": [
+    "python_abi * *_cp37m"
+  ]
osx-64::cppyy-1.6.1-py38hd0e5c4b_0.tar.bz2
-  "constrains": [
-    "python_abi * *_cp38"
-  ],
-    "libcxx >=9.0.1",
+    "libcxx >=9.0.1,<15",
-  "version": "1.6.1"
+  "version": "1.6.1",
+  "constrains": [
+    "python_abi * *_cp38"
+  ]
osx-64::cppyy-1.6.2-py36h6e7b999_0.tar.bz2
-    "libcxx >=9.0.1",
+    "libcxx >=9.0.1,<15",
osx-64::cppyy-1.6.2-py36h6e7b999_1.tar.bz2
-    "libcxx >=9.0.1",
+    "libcxx >=9.0.1,<15",
osx-64::cppyy-1.6.2-py36hdbf766d_1.tar.bz2
-    "libcxx >=9.0.1",
+    "libcxx >=9.0.1,<15",
osx-64::cppyy-1.6.2-py37hffbbd7b_0.tar.bz2
-    "libcxx >=9.0.1",
+    "libcxx >=9.0.1,<15",
osx-64::cppyy-1.6.2-py37hffbbd7b_1.tar.bz2
-    "libcxx >=9.0.1",
+    "libcxx >=9.0.1,<15",
osx-64::cppyy-1.6.2-py38h0258158_0.tar.bz2
-    "libcxx >=9.0.1",
+    "libcxx >=9.0.1,<15",
osx-64::cppyy-1.6.2-py38h0258158_1.tar.bz2
-    "libcxx >=9.0.1",
+    "libcxx >=9.0.1,<15",
osx-64::cppyy-1.8.2-py36hfe150b7_0.tar.bz2
-    "libcxx >=10.0.1",
+    "libcxx >=10.0.1,<15",
osx-64::cppyy-1.8.2-py37hefa4c2e_0.tar.bz2
-    "libcxx >=10.0.1",
+    "libcxx >=10.0.1,<15",
osx-64::cppyy-1.8.2-py38h85ca872_0.tar.bz2
-    "libcxx >=10.0.1",
+    "libcxx >=10.0.1,<15",
osx-64::cppyy-1.8.3-py36hfe150b7_0.tar.bz2
-    "libcxx >=10.0.1",
+    "libcxx >=10.0.1,<15",
osx-64::cppyy-1.8.3-py37hefa4c2e_0.tar.bz2
-    "libcxx >=10.0.1",
+    "libcxx >=10.0.1,<15",
osx-64::cppyy-1.8.3-py38h85ca872_0.tar.bz2
-    "libcxx >=10.0.1",
+    "libcxx >=10.0.1,<15",
osx-64::cppyy-1.8.4-py36hfe150b7_0.tar.bz2
-    "libcxx >=10.0.1",
+    "libcxx >=10.0.1,<15",
osx-64::cppyy-1.8.4-py36hfe150b7_1.tar.bz2
-    "libcxx >=10.0.1",
+    "libcxx >=10.0.1,<15",
osx-64::cppyy-1.8.4-py37hefa4c2e_0.tar.bz2
-    "libcxx >=10.0.1",
+    "libcxx >=10.0.1,<15",
osx-64::cppyy-1.8.4-py37hefa4c2e_1.tar.bz2
-    "libcxx >=10.0.1",
+    "libcxx >=10.0.1,<15",
osx-64::cppyy-1.8.4-py38h85ca872_0.tar.bz2
-    "libcxx >=10.0.1",
+    "libcxx >=10.0.1,<15",
osx-64::cppyy-1.8.4-py38h85ca872_1.tar.bz2
-    "libcxx >=10.0.1",
+    "libcxx >=10.0.1,<15",
osx-64::cppyy-1.8.4-py39h94ee030_1.tar.bz2
-    "libcxx >=10.0.1",
+    "libcxx >=10.0.1,<15",
osx-64::cppyy-1.8.5-py36h6c7bed3_0.tar.bz2
-    "libcxx >=10.0.1",
+    "libcxx >=10.0.1,<15",
osx-64::cppyy-1.8.5-py37ha77b94d_0.tar.bz2
-    "libcxx >=10.0.1",
+    "libcxx >=10.0.1,<15",
osx-64::cppyy-1.8.5-py38hdd08b85_0.tar.bz2
-    "libcxx >=10.0.1",
+    "libcxx >=10.0.1,<15",
osx-64::cppyy-1.8.5-py39h8073fd8_0.tar.bz2
-    "libcxx >=10.0.1",
+    "libcxx >=10.0.1,<15",
osx-64::cppyy-1.9.2-py36h8e60dbb_0.tar.bz2
-    "libcxx >=11.0.0",
+    "libcxx >=11.0.0,<15",
osx-64::cppyy-1.9.2-py37h961c435_0.tar.bz2
-    "libcxx >=11.0.0",
+    "libcxx >=11.0.0,<15",
osx-64::cppyy-1.9.2-py38he16efe4_0.tar.bz2
-    "libcxx >=11.0.0",
+    "libcxx >=11.0.0,<15",
osx-64::cppyy-1.9.2-py39he5cc61f_0.tar.bz2
-    "libcxx >=11.0.0",
+    "libcxx >=11.0.0,<15",
osx-64::cppyy-1.9.3-py36hb0a5edd_0.tar.bz2
-    "libcxx >=11.0.1",
+    "libcxx >=11.0.1,<15",
osx-64::cppyy-1.9.3-py36hb0a5edd_1.tar.bz2
-    "libcxx >=11.0.1",
+    "libcxx >=11.0.1,<15",
osx-64::cppyy-1.9.3-py37h52e4389_0.tar.bz2
-    "libcxx >=11.0.1",
+    "libcxx >=11.0.1,<15",
osx-64::cppyy-1.9.3-py37h52e4389_1.tar.bz2
-    "libcxx >=11.0.1",
+    "libcxx >=11.0.1,<15",
osx-64::cppyy-1.9.3-py38he0a5bda_0.tar.bz2
-    "libcxx >=11.0.1",
+    "libcxx >=11.0.1,<15",
osx-64::cppyy-1.9.3-py38he0a5bda_1.tar.bz2
-    "libcxx >=11.0.1",
+    "libcxx >=11.0.1,<15",
osx-64::cppyy-1.9.3-py39h318bac5_0.tar.bz2
-    "libcxx >=11.0.1",
+    "libcxx >=11.0.1,<15",
osx-64::cppyy-1.9.3-py39h318bac5_1.tar.bz2
-    "libcxx >=11.0.1",
+    "libcxx >=11.0.1,<15",
osx-64::cppyy-1.9.5-py36h8ececbe_0.tar.bz2
-    "libcxx >=11.1.0",
+    "libcxx >=11.1.0,<15",
osx-64::cppyy-1.9.5-py37h565ea34_0.tar.bz2
-    "libcxx >=11.1.0",
+    "libcxx >=11.1.0,<15",
osx-64::cppyy-1.9.5-py38h9fc273b_0.tar.bz2
-    "libcxx >=11.1.0",
+    "libcxx >=11.1.0,<15",
osx-64::cppyy-1.9.5-py39h9091b6e_0.tar.bz2
-    "libcxx >=11.1.0",
+    "libcxx >=11.1.0,<15",
osx-64::cppyy-2.0.0-py36h8ececbe_0.tar.bz2
-    "libcxx >=11.1.0",
+    "libcxx >=11.1.0,<15",
osx-64::cppyy-2.0.0-py37h565ea34_0.tar.bz2
-    "libcxx >=11.1.0",
+    "libcxx >=11.1.0,<15",
osx-64::cppyy-2.0.0-py38h9fc273b_0.tar.bz2
-    "libcxx >=11.1.0",
+    "libcxx >=11.1.0,<15",
osx-64::cppyy-2.0.0-py39h9091b6e_0.tar.bz2
-    "libcxx >=11.1.0",
+    "libcxx >=11.1.0,<15",
osx-64::cppyy-2.1.0-py36h8ececbe_0.tar.bz2
-    "libcxx >=11.1.0",
+    "libcxx >=11.1.0,<15",
osx-64::cppyy-2.1.0-py37h565ea34_0.tar.bz2
-    "libcxx >=11.1.0",
+    "libcxx >=11.1.0,<15",
osx-64::cppyy-2.1.0-py38h9fc273b_0.tar.bz2
-    "libcxx >=11.1.0",
+    "libcxx >=11.1.0,<15",
osx-64::cppyy-2.1.0-py39h9091b6e_0.tar.bz2
-    "libcxx >=11.1.0",
+    "libcxx >=11.1.0,<15",
osx-64::cppyy-2.2.0-py310h4d7ceab_1.tar.bz2
-    "libcxx >=11.1.0",
+    "libcxx >=11.1.0,<15",
osx-64::cppyy-2.2.0-py37h565ea34_0.tar.bz2
-    "libcxx >=11.1.0",
+    "libcxx >=11.1.0,<15",
osx-64::cppyy-2.2.0-py37h565ea34_1.tar.bz2
-    "libcxx >=11.1.0",
+    "libcxx >=11.1.0,<15",
osx-64::cppyy-2.2.0-py38h9fc273b_0.tar.bz2
-    "libcxx >=11.1.0",
+    "libcxx >=11.1.0,<15",
osx-64::cppyy-2.2.0-py38h9fc273b_1.tar.bz2
-    "libcxx >=11.1.0",
+    "libcxx >=11.1.0,<15",
osx-64::cppyy-2.2.0-py39h9091b6e_0.tar.bz2
-    "libcxx >=11.1.0",
+    "libcxx >=11.1.0,<15",
osx-64::cppyy-2.2.0-py39h9091b6e_1.tar.bz2
-    "libcxx >=11.1.0",
+    "libcxx >=11.1.0,<15",
osx-64::cppyy-2.3.0-py310h18eb9a4_0.tar.bz2
-    "libcxx >=12.0.1",
+    "libcxx >=12.0.1,<15",
osx-64::cppyy-2.3.0-py37h5d3c1f3_0.tar.bz2
-    "libcxx >=12.0.1",
+    "libcxx >=12.0.1,<15",
osx-64::cppyy-2.3.0-py38hb78c1f4_0.tar.bz2
-    "libcxx >=12.0.1",
+    "libcxx >=12.0.1,<15",
osx-64::cppyy-2.3.0-py39h529a003_0.tar.bz2
-    "libcxx >=12.0.1",
+    "libcxx >=12.0.1,<15",
osx-64::cppyy-2.3.1-py310h18eb9a4_0.tar.bz2
-    "libcxx >=12.0.1",
+    "libcxx >=12.0.1,<15",
osx-64::cppyy-2.3.1-py37h5d3c1f3_0.tar.bz2
-    "libcxx >=12.0.1",
+    "libcxx >=12.0.1,<15",
osx-64::cppyy-2.3.1-py38hb78c1f4_0.tar.bz2
-    "libcxx >=12.0.1",
+    "libcxx >=12.0.1,<15",
osx-64::cppyy-2.3.1-py39h529a003_0.tar.bz2
-    "libcxx >=12.0.1",
+    "libcxx >=12.0.1,<15",
osx-64::cppyy-2.4.0-py310h6643f1e_0.tar.bz2
-    "libcxx >=13.0.1",
+    "libcxx >=13.0.1,<15",
osx-64::cppyy-2.4.0-py37h5f0b87f_0.tar.bz2
-    "libcxx >=13.0.1",
+    "libcxx >=13.0.1,<15",
osx-64::cppyy-2.4.0-py38hb821a46_0.tar.bz2
-    "libcxx >=13.0.1",
+    "libcxx >=13.0.1,<15",
osx-64::cppyy-2.4.0-py39hc3fd8fb_0.tar.bz2
-    "libcxx >=13.0.1",
+    "libcxx >=13.0.1,<15",
osx-64::cppyy-2.4.1-py310h8adbfe9_0.tar.bz2
-    "libcxx >=14.0.4",
+    "libcxx >=14.0.4,<15",
osx-64::cppyy-2.4.1-py37h90a126e_0.tar.bz2
-    "libcxx >=14.0.4",
+    "libcxx >=14.0.4,<15",
osx-64::cppyy-2.4.1-py38h50a8761_0.tar.bz2
-    "libcxx >=14.0.4",
+    "libcxx >=14.0.4,<15",
osx-64::cppyy-2.4.1-py38hc107acb_0.tar.bz2
-    "libcxx >=14.0.4",
+    "libcxx >=14.0.4,<15",
osx-64::cppyy-2.4.1-py39h0f23c8e_0.tar.bz2
-    "libcxx >=14.0.4",
+    "libcxx >=14.0.4,<15",
osx-64::cppyy-2.4.1-py39hd6adb53_0.tar.bz2
-    "libcxx >=14.0.4",
+    "libcxx >=14.0.4,<15",
osx-64::cppyy-2.4.2-py310h8adbfe9_0.conda
-    "libcxx >=14.0.6",
+    "libcxx >=14.0.6,<15",
osx-64::cppyy-2.4.2-py38h50a8761_0.conda
-    "libcxx >=14.0.6",
+    "libcxx >=14.0.6,<15",
osx-64::cppyy-2.4.2-py38hc107acb_0.conda
-    "libcxx >=14.0.6",
+    "libcxx >=14.0.6,<15",
osx-64::cppyy-2.4.2-py39h0f23c8e_0.conda
-    "libcxx >=14.0.6",
+    "libcxx >=14.0.6,<15",
osx-64::cppyy-2.4.2-py39hd6adb53_0.conda
-    "libcxx >=14.0.6",
+    "libcxx >=14.0.6,<15",
osx-64::gfortran_impl_osx-64-10.4.0-hb520ba8_28.conda
-{
-  "build": "hb520ba8_28",
-  "build_number": 28,
-  "depends": [
-    "gmp >=6.2.1,<7.0a0",
-    "isl >=0.25,<0.26.0a0",
-    "libcxx >=14.0.6",
-    "libgfortran-devel_osx-64 10.4.0.*",
-    "libgfortran5 >=10.4.0",
-    "libiconv >=1.17,<2.0a0",
-    "libzlib >=1.2.13,<1.3.0a0",
-    "mpc >=1.3.1,<2.0a0",
-    "mpfr >=4.1.0,<5.0a0",
-    "zlib"
-  ],
-  "license": "GPL-3.0-only WITH GCC-exception-3.1",
-  "md5": "91f21a7d9dd81c53d29fa2490b2fecc5",
-  "name": "gfortran_impl_osx-64",
-  "sha256": "b56d6df1484df3728ff72642074cbd91f7850d81b43bdc8f992282751fff516a",
-  "size": 17401125,
-  "subdir": "osx-64",
-  "timestamp": 1676701225144,
-  "version": "10.4.0"
-}
+{}
osx-64::gfortran_impl_osx-64-11.3.0-h1f927f5_28.conda
-{
-  "build": "h1f927f5_28",
-  "build_number": 28,
-  "depends": [
-    "gmp >=6.2.1,<7.0a0",
-    "isl >=0.25,<0.26.0a0",
-    "libcxx >=14.0.6",
-    "libgfortran-devel_osx-64 11.3.0.*",
-    "libgfortran5 >=11.3.0",
-    "libiconv >=1.17,<2.0a0",
-    "libzlib >=1.2.13,<1.3.0a0",
-    "mpc >=1.3.1,<2.0a0",
-    "mpfr >=4.1.0,<5.0a0",
-    "zlib"
-  ],
-  "license": "GPL-3.0-only WITH GCC-exception-3.1",
-  "md5": "65f90cb5d4a1a0623749d6891c5f232a",
-  "name": "gfortran_impl_osx-64",
-  "sha256": "68e6faad9e112fe9322729e6df33268725c90b83cc0ff7c3725785a320c9338d",
-  "size": 18351818,
-  "subdir": "osx-64",
-  "timestamp": 1676700855766,
-  "version": "11.3.0"
-}
+{}
osx-64::gfortran_impl_osx-64-11.3.0-h1f927f5_29.conda
-{
-  "build": "h1f927f5_29",
-  "build_number": 29,
-  "depends": [
-    "gmp >=6.2.1,<7.0a0",
-    "isl >=0.25,<0.26.0a0",
-    "libcxx >=14.0.6",
-    "libgfortran-devel_osx-64 11.3.0.*",
-    "libgfortran5 >=11.3.0",
-    "libiconv >=1.17,<2.0a0",
-    "libzlib >=1.2.13,<1.3.0a0",
-    "mpc >=1.3.1,<2.0a0",
-    "mpfr >=4.1.0,<5.0a0",
-    "zlib"
-  ],
-  "license": "GPL-3.0-only WITH GCC-exception-3.1",
-  "md5": "71ea37225f6166c4b41ad9330e5a5903",
-  "name": "gfortran_impl_osx-64",
-  "sha256": "52c05a6a20c0306b8874ad5757c8aa90b0f166bb2b371c9fbd3ff4c77b622f81",
-  "size": 18461245,
-  "subdir": "osx-64",
-  "timestamp": 1677873880111,
-  "version": "11.3.0"
-}
+{}
osx-64::gfortran_impl_osx-64-12.2.0-h158f68b_29.conda
-{
-  "build": "h158f68b_29",
-  "build_number": 29,
-  "depends": [
-    "gmp >=6.2.1,<7.0a0",
-    "isl >=0.25,<0.26.0a0",
-    "libcxx >=14.0.6",
-    "libgfortran-devel_osx-64 12.2.0.*",
-    "libgfortran5 >=12.2.0",
-    "libiconv >=1.17,<2.0a0",
-    "libzlib >=1.2.13,<1.3.0a0",
-    "mpc >=1.3.1,<2.0a0",
-    "mpfr >=4.1.0,<5.0a0",
-    "zlib"
-  ],
-  "license": "GPL-3.0-only WITH GCC-exception-3.1",
-  "md5": "b6f9d08b3b63cbbe7961dd6661ecfda3",
-  "name": "gfortran_impl_osx-64",
-  "sha256": "5d3a0fcf4f78341411ed936b08350e0adea9788946477c47a7a36120d9ac632e",
-  "size": 20224712,
-  "subdir": "osx-64",
-  "timestamp": 1677873701323,
-  "version": "12.2.0"
-}
+{}
osx-64::gfortran_impl_osx-64-9.5.0-he506f9a_28.conda
-{
-  "build": "he506f9a_28",
-  "build_number": 28,
-  "depends": [
-    "gmp >=6.2.1,<7.0a0",
-    "isl >=0.25,<0.26.0a0",
-    "libcxx >=14.0.6",
-    "libgfortran-devel_osx-64 9.5.0.*",
-    "libgfortran5 >=9.5.0",
-    "libiconv >=1.17,<2.0a0",
-    "libzlib >=1.2.13,<1.3.0a0",
-    "mpc >=1.3.1,<2.0a0",
-    "mpfr >=4.1.0,<5.0a0",
-    "zlib"
-  ],
-  "license": "GPL-3.0-only WITH GCC-exception-3.1",
-  "md5": "c4aecee87ca1df697b1d1bf8c868fd1e",
-  "name": "gfortran_impl_osx-64",
-  "sha256": "d5bb2a2bdd6cb66115c77c2d0c650aaf48f1ffe0200b865b2bb0848279d14b87",
-  "size": 16267684,
-  "subdir": "osx-64",
-  "timestamp": 1676700444375,
-  "version": "9.5.0"
-}
+{}
osx-64::gfortran_impl_osx-arm64-10.3.0-h2f81028_28.conda
-{
-  "build": "h2f81028_28",
-  "build_number": 28,
-  "depends": [
-    "gmp >=6.2.1,<7.0a0",
-    "isl >=0.25,<0.26.0a0",
-    "libcxx >=14.0.6",
-    "libiconv >=1.17,<2.0a0",
-    "libzlib >=1.2.13,<1.3.0a0",
-    "mpc >=1.3.1,<2.0a0",
-    "mpfr >=4.1.0,<5.0a0",
-    "zlib"
-  ],
-  "license": "GPL-3.0-only WITH GCC-exception-3.1",
-  "md5": "64f4c597ecb02beb9221891a6c25da68",
-  "name": "gfortran_impl_osx-arm64",
-  "sha256": "c27f1b184959297ab35b90e6e92edc8f188fdec3c2a6450679d78a022f0a1006",
-  "size": 16466822,
-  "subdir": "osx-64",
-  "timestamp": 1676700063561,
-  "version": "10.3.0"
-}
+{}
osx-64::gfortran_impl_osx-arm64-11.3.0-h05a1a03_28.conda
-{
-  "build": "h05a1a03_28",
-  "build_number": 28,
-  "depends": [
-    "gmp >=6.2.1,<7.0a0",
-    "isl >=0.25,<0.26.0a0",
-    "libcxx >=14.0.6",
-    "libiconv >=1.17,<2.0a0",
-    "libzlib >=1.2.13,<1.3.0a0",
-    "mpc >=1.3.1,<2.0a0",
-    "mpfr >=4.1.0,<5.0a0",
-    "zlib"
-  ],
-  "license": "GPL-3.0-only WITH GCC-exception-3.1",
-  "md5": "b9babce968150b5c81170f06e4abad34",
-  "name": "gfortran_impl_osx-arm64",
-  "sha256": "f472d52696839d669a07bed50644e5d365c4d75bff178836afb04f973de3f234",
-  "size": 17683615,
-  "subdir": "osx-64",
-  "timestamp": 1676700844328,
-  "version": "11.3.0"
-}
+{}
osx-64::gfortran_impl_osx-arm64-11.3.0-h05a1a03_29.conda
-{
-  "build": "h05a1a03_29",
-  "build_number": 29,
-  "depends": [
-    "gmp >=6.2.1,<7.0a0",
-    "isl >=0.25,<0.26.0a0",
-    "libcxx >=14.0.6",
-    "libiconv >=1.17,<2.0a0",
-    "libzlib >=1.2.13,<1.3.0a0",
-    "mpc >=1.3.1,<2.0a0",
-    "mpfr >=4.1.0,<5.0a0",
-    "zlib"
-  ],
-  "license": "GPL-3.0-only WITH GCC-exception-3.1",
-  "md5": "14db49f23726ee90025744145c6795fa",
-  "name": "gfortran_impl_osx-arm64",
-  "sha256": "7f4bf970f59421a194d7a3b38547f4fa4138cf739048ec8f5d011753114aeabd",
-  "size": 17517767,
-  "subdir": "osx-64",
-  "timestamp": 1677872330163,
-  "version": "11.3.0"
-}
+{}
osx-64::gfortran_impl_osx-arm64-12.2.0-h0373089_29.conda
-{
-  "build": "h0373089_29",
-  "build_number": 29,
-  "depends": [
-    "gmp >=6.2.1,<7.0a0",
-    "isl >=0.25,<0.26.0a0",
-    "libcxx >=14.0.6",
-    "libiconv >=1.17,<2.0a0",
-    "libzlib >=1.2.13,<1.3.0a0",
-    "mpc >=1.3.1,<2.0a0",
-    "mpfr >=4.1.0,<5.0a0",
-    "zlib"
-  ],
-  "license": "GPL-3.0-only WITH GCC-exception-3.1",
-  "md5": "2afbc0d4668ad65633a7e877c5f3eff9",
-  "name": "gfortran_impl_osx-arm64",
-  "sha256": "c07aec55448c132ad3df797f8859f98b8593f2455e18192361c0d44fe4f1a7e5",
-  "size": 18894425,
-  "subdir": "osx-64",
-  "timestamp": 1677872662469,
-  "version": "12.2.0"
-}
+{}
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata.json.bz2
osx-arm64::cppyy-2.0.0-py38h19c8891_0.tar.bz2
-    "libcxx >=11.1.0",
+    "libcxx >=11.1.0,<15",
osx-arm64::cppyy-2.0.0-py39h4b3dcc7_0.tar.bz2
-    "libcxx >=11.1.0",
+    "libcxx >=11.1.0,<15",
osx-arm64::cppyy-2.1.0-py38h19c8891_0.tar.bz2
-    "libcxx >=11.1.0",
+    "libcxx >=11.1.0,<15",
osx-arm64::cppyy-2.1.0-py39h4b3dcc7_0.tar.bz2
-    "libcxx >=11.1.0",
+    "libcxx >=11.1.0,<15",
osx-arm64::cppyy-2.2.0-py310hb102586_1.tar.bz2
-    "libcxx >=11.1.0",
+    "libcxx >=11.1.0,<15",
osx-arm64::cppyy-2.2.0-py38h19c8891_0.tar.bz2
-    "libcxx >=11.1.0",
+    "libcxx >=11.1.0,<15",
osx-arm64::cppyy-2.2.0-py38h19c8891_1.tar.bz2
-    "libcxx >=11.1.0",
+    "libcxx >=11.1.0,<15",
osx-arm64::cppyy-2.2.0-py39h4b3dcc7_0.tar.bz2
-    "libcxx >=11.1.0",
+    "libcxx >=11.1.0,<15",
osx-arm64::cppyy-2.2.0-py39h4b3dcc7_1.tar.bz2
-    "libcxx >=11.1.0",
+    "libcxx >=11.1.0,<15",
osx-arm64::cppyy-2.3.0-py310h08e1e5a_0.tar.bz2
-    "libcxx >=12.0.1",
+    "libcxx >=12.0.1,<15",
osx-arm64::cppyy-2.3.0-py38h3e79208_0.tar.bz2
-    "libcxx >=12.0.1",
+    "libcxx >=12.0.1,<15",
osx-arm64::cppyy-2.3.0-py39h66f9a8f_0.tar.bz2
-    "libcxx >=12.0.1",
+    "libcxx >=12.0.1,<15",
osx-arm64::cppyy-2.3.1-py310h08e1e5a_0.tar.bz2
-    "libcxx >=12.0.1",
+    "libcxx >=12.0.1,<15",
osx-arm64::cppyy-2.3.1-py38h3e79208_0.tar.bz2
-    "libcxx >=12.0.1",
+    "libcxx >=12.0.1,<15",
osx-arm64::cppyy-2.3.1-py39h66f9a8f_0.tar.bz2
-    "libcxx >=12.0.1",
+    "libcxx >=12.0.1,<15",
osx-arm64::cppyy-2.4.0-py310h33ac7ce_0.tar.bz2
-    "libcxx >=13.0.1",
+    "libcxx >=13.0.1,<15",
osx-arm64::cppyy-2.4.0-py38h1090362_0.tar.bz2
-    "libcxx >=13.0.1",
+    "libcxx >=13.0.1,<15",
osx-arm64::cppyy-2.4.0-py39hf859ce0_0.tar.bz2
-    "libcxx >=13.0.1",
+    "libcxx >=13.0.1,<15",
osx-arm64::cppyy-2.4.1-py310hb5ae986_0.tar.bz2
-    "libcxx >=14.0.4",
+    "libcxx >=14.0.4,<15",
osx-arm64::cppyy-2.4.1-py38ha0a36c9_0.tar.bz2
-    "libcxx >=14.0.4",
+    "libcxx >=14.0.4,<15",
osx-arm64::cppyy-2.4.1-py39ha7f5e1b_0.tar.bz2
-    "libcxx >=14.0.4",
+    "libcxx >=14.0.4,<15",
osx-arm64::cppyy-2.4.2-py310hb5ae986_0.conda
-    "libcxx >=14.0.6",
+    "libcxx >=14.0.6,<15",
osx-arm64::cppyy-2.4.2-py38ha0a36c9_0.conda
-    "libcxx >=14.0.6",
+    "libcxx >=14.0.6,<15",
osx-arm64::cppyy-2.4.2-py39ha7f5e1b_0.conda
-    "libcxx >=14.0.6",
+    "libcxx >=14.0.6,<15",
osx-arm64::gfortran_impl_osx-64-11.3.0-hdc8cc4b_28.conda
-{
-  "build": "hdc8cc4b_28",
-  "build_number": 28,
-  "depends": [
-    "gmp >=6.2.1,<7.0a0",
-    "isl >=0.25,<0.26.0a0",
-    "libcxx >=14.0.6",
-    "libiconv >=1.17,<2.0a0",
-    "libzlib >=1.2.13,<1.3.0a0",
-    "mpc >=1.3.1,<2.0a0",
-    "mpfr >=4.1.0,<5.0a0",
-    "zlib"
-  ],
-  "license": "GPL-3.0-only WITH GCC-exception-3.1",
-  "md5": "1cde5b77edf0b01558a5b0888d979ceb",
-  "name": "gfortran_impl_osx-64",
-  "sha256": "ccc34935eeced05c99e9140fbb8ed1a4b6baf7ff38fc0c7ec2dbf45b9399ea70",
-  "size": 15901723,
-  "subdir": "osx-arm64",
-  "timestamp": 1676700946405,
-  "version": "11.3.0"
-}
+{}
osx-arm64::gfortran_impl_osx-64-11.3.0-hdc8cc4b_29.conda
-{
-  "build": "hdc8cc4b_29",
-  "build_number": 29,
-  "depends": [
-    "gmp >=6.2.1,<7.0a0",
-    "isl >=0.25,<0.26.0a0",
-    "libcxx >=14.0.6",
-    "libiconv >=1.17,<2.0a0",
-    "libzlib >=1.2.13,<1.3.0a0",
-    "mpc >=1.3.1,<2.0a0",
-    "mpfr >=4.1.0,<5.0a0",
-    "zlib"
-  ],
-  "license": "GPL-3.0-only WITH GCC-exception-3.1",
-  "md5": "497a299b6d804d899ef37f92872b2ac0",
-  "name": "gfortran_impl_osx-64",
-  "sha256": "7fef1decc57bc9b92ffd4d1f8b80aa73d8ff140881f2538691a0570d8a0ebb79",
-  "size": 16093530,
-  "subdir": "osx-arm64",
-  "timestamp": 1677874027464,
-  "version": "11.3.0"
-}
+{}
osx-arm64::gfortran_impl_osx-64-12.2.0-h0d5c2df_29.conda
-{
-  "build": "h0d5c2df_29",
-  "build_number": 29,
-  "depends": [
-    "gmp >=6.2.1,<7.0a0",
-    "isl >=0.25,<0.26.0a0",
-    "libcxx >=14.0.6",
-    "libiconv >=1.17,<2.0a0",
-    "libzlib >=1.2.13,<1.3.0a0",
-    "mpc >=1.3.1,<2.0a0",
-    "mpfr >=4.1.0,<5.0a0",
-    "zlib"
-  ],
-  "license": "GPL-3.0-only WITH GCC-exception-3.1",
-  "md5": "5af8755edb4272267ad5c922a4f1cab5",
-  "name": "gfortran_impl_osx-64",
-  "sha256": "e257aa3bff2851b69106b535833ad5adb2cd196ee72185a45715f79de07f6e60",
-  "size": 17834959,
-  "subdir": "osx-arm64",
-  "timestamp": 1677873291545,
-  "version": "12.2.0"
-}
+{}
osx-arm64::gfortran_impl_osx-arm64-11.3.0-h2a9d086_28.conda
-{
-  "build": "h2a9d086_28",
-  "build_number": 28,
-  "depends": [
-    "gmp >=6.2.1,<7.0a0",
-    "isl >=0.25,<0.26.0a0",
-    "libcxx >=14.0.6",
-    "libgfortran-devel_osx-arm64 11.3.0.*",
-    "libgfortran5 >=11.3.0",
-    "libiconv >=1.17,<2.0a0",
-    "libzlib >=1.2.13,<1.3.0a0",
-    "mpc >=1.3.1,<2.0a0",
-    "mpfr >=4.1.0,<5.0a0",
-    "zlib"
-  ],
-  "license": "GPL-3.0-only WITH GCC-exception-3.1",
-  "md5": "8c70c7a0d6a95c3f064ebe64f823b65a",
-  "name": "gfortran_impl_osx-arm64",
-  "sha256": "c92dcb7f3d7f17ca1842a0ddc5c302d79e39039b85bf087bdeaaea3ad425644d",
-  "size": 15776622,
-  "subdir": "osx-arm64",
-  "timestamp": 1676702616331,
-  "version": "11.3.0"
-}
+{}
osx-arm64::gfortran_impl_osx-arm64-11.3.0-h2a9d086_29.conda
-{
-  "build": "h2a9d086_29",
-  "build_number": 29,
-  "depends": [
-    "gmp >=6.2.1,<7.0a0",
-    "isl >=0.25,<0.26.0a0",
-    "libcxx >=14.0.6",
-    "libgfortran-devel_osx-arm64 11.3.0.*",
-    "libgfortran5 >=11.3.0",
-    "libiconv >=1.17,<2.0a0",
-    "libzlib >=1.2.13,<1.3.0a0",
-    "mpc >=1.3.1,<2.0a0",
-    "mpfr >=4.1.0,<5.0a0",
-    "zlib"
-  ],
-  "license": "GPL-3.0-only WITH GCC-exception-3.1",
-  "md5": "8fe284f4aa0f3f8493c9ff90d77c57c0",
-  "name": "gfortran_impl_osx-arm64",
-  "sha256": "6fd5c1121c2cb8b5f8015047c9dc86a44f45d359cbe491b0e78f817206b2d85e",
-  "size": 15408381,
-  "subdir": "osx-arm64",
-  "timestamp": 1677874624466,
-  "version": "11.3.0"
-}
+{}
osx-arm64::gfortran_impl_osx-arm64-12.2.0-hf7539cf_29.conda
-{
-  "build": "hf7539cf_29",
-  "build_number": 29,
-  "depends": [
-    "gmp >=6.2.1,<7.0a0",
-    "isl >=0.25,<0.26.0a0",
-    "libcxx >=14.0.6",
-    "libgfortran-devel_osx-arm64 12.2.0.*",
-    "libgfortran5 >=12.2.0",
-    "libiconv >=1.17,<2.0a0",
-    "libzlib >=1.2.13,<1.3.0a0",
-    "mpc >=1.3.1,<2.0a0",
-    "mpfr >=4.1.0,<5.0a0",
-    "zlib"
-  ],
-  "license": "GPL-3.0-only WITH GCC-exception-3.1",
-  "md5": "3e00e254808a6b97e4b3ec18be7c034f",
-  "name": "gfortran_impl_osx-arm64",
-  "sha256": "1231cd0ac3272820e80e208e862ec5bfd474df2ca40cd12e47057419a2bdcb7f",
-  "size": 16222156,
-  "subdir": "osx-arm64",
-  "timestamp": 1677875854975,
-  "version": "12.2.0"
-}
+{}
</pre>
</details>