### PR TITLE
Make fsspec==2023.3.0 need python>=3.8

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -2570,7 +2570,8 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
         if (
             record_name == "fsspec" and
             record["version"] == "2023.3.0" and
-            record["build_number"] == 0
+            record["build_number"] == 0 and
+            record.get("timestamp", 0) < 1678285727000
         ):
             _replace_pin("python >=3.6", "python >=3.8", record["depends"], record)
 

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -2565,7 +2565,16 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             new_constrains.append("jpeg <0.0.0a")
             record["constrains"] = new_constrains
             
-            
+        # fsspec ==2023.3.1 requires Python 3.8
+        # Fixed in https://github.com/conda-forge/babel-feedstock/pull/26
+        if (
+            record_name == "fsspec" and
+            record["version"] == "2023.3.0" and
+            record["build_number"] == 0
+        ):
+            _replace_pin("python >=3.6", "python >=3.8", record["depends"], record)
+
+
         # imath 3.1.7 change its SOVERSION so it is not not ABI compatible
         # with imath 3.1.4, 3.1.5, and 3.1.6
         # See https://github.com/conda-forge/imath-feedstock/issues/7


### PR DESCRIPTION
Fixes https://github.com/conda-forge/filesystem-spec-feedstock/issues/63


Checklist
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications are bound by `python -c "import time; print(f'{time.time():.0f}000')"`
