### PR TITLE
Update pin for imath in openexr 3.1.5 build 2

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -683,13 +683,13 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                 ]
                 for pinning in python_pinning:
                     _replace_pin(pinning, 'python >=3.7', record['depends'], record)
-                
+
                 colorama_pinning = [
                     x for x in record['depends'] if x.startswith('colorama')
                 ]
                 for pinning in colorama_pinning:
                     _replace_pin(pinning, 'colorama >=0.4.6', record['depends'], record)
-            
+
         if record_name == 'ratelimiter':
             if record.get('timestamp', 0) < 1667804400000 and subdir == "noarch":  # noarch builds prior to 2022/11/7
                 python_pinning = [
@@ -2564,7 +2564,7 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             new_constrains = record.get("constrains", [])
             new_constrains.append("jpeg <0.0.0a")
             record["constrains"] = new_constrains
-            
+
         # fsspec ==2023.3.1 requires Python 3.8
         # Fixed in https://github.com/conda-forge/babel-feedstock/pull/26
         if (
@@ -2575,11 +2575,24 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
         ):
             _replace_pin("python >=3.6", "python >=3.8", record["depends"], record)
 
-
         # imath 3.1.7 change its SOVERSION so it is not not ABI compatible
         # with imath 3.1.4, 3.1.5, and 3.1.6
         # See https://github.com/conda-forge/imath-feedstock/issues/7
-        if has_dep(record, "imath") and record.get('timestamp', 0) < 1678196668497:
+        if (
+            has_dep(record, "imath") and
+            record.get('timestamp', 0) < 1678196668497
+        ):
+            _pin_stricter(fn, record, "imath", "x", upper_bound="3.1.7")
+
+        if (
+            record_name == "openexr" and
+            record["version"] == "3.1.5" and
+            # build 2 was built after the repo data patch above went into place
+            # but erroneously used an old version of imath without
+            # the stricter pin
+            record["build_number"] == 2 and
+            record.get('timestamp', 0) < 1678332917000
+        ):
             _pin_stricter(fn, record, "imath", "x", upper_bound="3.1.7")
 
     return index


### PR DESCRIPTION
see: https://github.com/conda-forge/openexr-feedstock/pull/31

basically, openexr build 2 used an old build open imath which didn't have the stricter pin in place .
Checklist
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications are bound by `python -c "import time; print(f'{time.time():.0f}000')"`
