### PR TITLE
fix metadata for tensorly 0.8.0+

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -2635,6 +2635,17 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
         ):
             _pin_stricter(fn, record, "imath", "x", upper_bound="3.1.7")
 
+        # tensorly 0.8.0+ need python 3.8+
+        # https://github.com/conda-forge/tensorly-feedstock/issues/12
+        # Fixed in https://github.com/conda-forge/tensorly-feedstock/pull/14
+        if (
+            record_name == "tensorly" and
+            (record["version"] == "0.8.0" or record["version"] == "0.8.1") and
+            record["build_number"] == 0 and
+            record.get("timestamp", 0) < 1678253357320
+        ):
+            _replace_pin("python >=3.6", "python >=3.8", record["depends"], record)
+
     return index
 
 


### PR DESCRIPTION
fix https://github.com/conda-forge/tensorly-feedstock/issues/12
ref https://github.com/conda-forge/tensorly-feedstock/issues/14

-- 

* [x] Didn't run `python show_diff.py` but got the info from the CI

```diff
============================== 2 passed in 1.56s ===============================
+ python show_diff.py
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata.json.bz2
noarch::tensorly-0.8.0-pyhd8ed1ab_0.conda
-    "python >=3.6",
+    "python >=3.8",
noarch::tensorly-0.8.1-pyhd8ed1ab_0.conda
-    "python >=3.6",
+    "python >=3.8",
```
* [x] Bounded by time here: https://anaconda.org/conda-forge/tensorly/files + 1
<h4 class="modal-title" id="myModalLabel" style="font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-size-adjust: auto; -webkit-text-stroke-width: 0px; text-decoration: none; box-sizing: border-box; margin: 0.2rem 0px 0.5rem; padding: 0px; color: rgb(34, 34, 34); font-family: &quot;Museo Sans Rounded&quot;, Lato, &quot;Helvetica Neue&quot;, Helvetica, Roboto, Arial, sans-serif; font-weight: 400; line-height: 1.4; text-rendering: optimizeLegibility; font-size: 1.4375rem; caret-color: rgb(34, 34, 34);">noarch/tensorly-0.8.1-pyhd8ed1ab_0.conda</h4><p class="subheader" style="font-size: 16px; font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-size-adjust: auto; -webkit-text-stroke-width: 0px; text-decoration: none; box-sizing: border-box; margin: 0.2rem 0px 0.5rem; padding: 0px; font-family: &quot;Museo Sans Rounded&quot;, Lato, &quot;Helvetica Neue&quot;, Helvetica, Roboto, Arial, sans-serif; text-rendering: optimizeLegibility; line-height: 1.4; color: rgb(111, 111, 111);">No Description</p><div style="font-size: 16px; font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-size-adjust: auto; -webkit-text-stroke-width: 0px; text-decoration: none; box-sizing: border-box; margin: 0px; padding: 0px; caret-color: rgb(34, 34, 34); color: rgb(34, 34, 34); font-family: &quot;Museo Sans Rounded&quot;, Lato, &quot;Helvetica Neue&quot;, Helvetica, Roboto, Arial, sans-serif;">

Uploaded | Wed Mar 8 05:30:03 2023
-- | --
md5 checksum | 6baea49a389ee777d60d7a9f91a9d44c
build | pyhd8ed1ab_0
depends | numpy, python >=3.6, scipy
license | BSD-3-Clause
license_family | BSD
noarch | python
subdir | noarch
target-triplet | None-any-None
timestamp | 1678253357319

</div>

--

Checklist
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications are bound by `python -c "import time; print(f'{time.time():.0f}000')"`
