### PR TITLE
Fix nvidia-apex constrains

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -2635,6 +2635,14 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
         ):
             _pin_stricter(fn, record, "imath", "x", upper_bound="3.1.7")
 
+        # related to https://github.com/conda-forge/nvidia-apex-feedstock/issues/29
+        if (
+            record_name == "nvidia-apex" and
+            any("=*=cuda|=*=gpu" in constr for constr in record.get("constrains", [""])) and
+            record.get("timestamp", 0) < 1678454014000
+        ):
+            record["constrains"] = ["pytorch =*=cuda*", "nvidia-apex-proc =*=cuda"]
+
     return index
 
 


### PR DESCRIPTION
- the nvidia-apex uses unsupported syntax in the constraints definition.
  This PR fixes that. See https://github.com/conda-forge/nvidia-apex-feedstock/issues/29

Checklist
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
```+ python show_diff.py
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata.json.bz2
linux-64::nvidia-apex-22.03-cuda102py310hce0d3a8_0.conda
-    "nvidia-apex-proc =*=cuda|=*=gpu",
-    "nvidia-apex-proc =*=cpu"
+    "nvidia-apex-proc =*=cuda"
linux-64::nvidia-apex-22.03-cuda102py38h73d78a8_0.conda
-    "nvidia-apex-proc =*=cuda|=*=gpu",
-    "nvidia-apex-proc =*=cpu",
-    "pytorch =*=cuda*"
+    "pytorch =*=cuda*",
+    "nvidia-apex-proc =*=cuda"
linux-64::nvidia-apex-22.03-cuda102py39h4af2978_0.conda
-    "nvidia-apex-proc =*=cuda|=*=gpu",
-    "nvidia-apex-proc =*=cpu",
-    "pytorch =*=cuda*"
+    "pytorch =*=cuda*",
+    "nvidia-apex-proc =*=cuda"
linux-64::nvidia-apex-22.03-cuda110py310h7cf977e_0.conda
-    "nvidia-apex-proc =*=cpu",
-    "nvidia-apex-proc =*=cuda|=*=gpu"
+    "nvidia-apex-proc =*=cuda"
linux-64::nvidia-apex-22.03-cuda110py38hf5749dc_0.conda
-    "nvidia-apex-proc =*=cuda|=*=gpu",
-    "nvidia-apex-proc =*=cpu",
-    "pytorch =*=cuda*"
+    "pytorch =*=cuda*",
+    "nvidia-apex-proc =*=cuda"
linux-64::nvidia-apex-22.03-cuda110py39h31ddb46_0.conda
-    "nvidia-apex-proc =*=cuda|=*=gpu",
-    "nvidia-apex-proc =*=cpu"
+    "nvidia-apex-proc =*=cuda"
linux-64::nvidia-apex-22.03-cuda111py310h11f0b9a_0.conda
-    "nvidia-apex-proc =*=cpu",
-    "nvidia-apex-proc =*=cuda|=*=gpu",
-    "pytorch =*=cuda*"
+    "pytorch =*=cuda*",
+    "nvidia-apex-proc =*=cuda"
linux-64::nvidia-apex-22.03-cuda111py38h7ba73a8_0.conda
-    "nvidia-apex-proc =*=cpu",
-    "nvidia-apex-proc =*=cuda|=*=gpu",
-    "pytorch =*=cuda*"
+    "pytorch =*=cuda*",
+    "nvidia-apex-proc =*=cuda"
linux-64::nvidia-apex-22.03-cuda111py39h2dd2c40_0.conda
-    "nvidia-apex-proc =*=cuda|=*=gpu",
-    "nvidia-apex-proc =*=cpu"
+    "nvidia-apex-proc =*=cuda"
linux-64::nvidia-apex-22.03-cuda112py310h6ec7b7f_0.conda
-    "nvidia-apex-proc =*=cuda|=*=gpu",
-    "nvidia-apex-proc =*=cpu",
-    "pytorch =*=cuda*"
+    "pytorch =*=cuda*",
+    "nvidia-apex-proc =*=cuda"
linux-64::nvidia-apex-22.03-cuda112py310hb11405b_1.conda
-    "nvidia-apex-proc =*=cpu",
-    "nvidia-apex-proc =*=cuda|=*=gpu"
+    "nvidia-apex-proc =*=cuda"
linux-64::nvidia-apex-22.03-cuda112py311h6c9afd8_1.conda
-    "nvidia-apex-proc =*=cuda|=*=gpu",
-    "nvidia-apex-proc =*=cpu",
-    "pytorch =*=cuda*"
+    "pytorch =*=cuda*",
+    "nvidia-apex-proc =*=cuda"
linux-64::nvidia-apex-22.03-cuda112py38hd717573_1.conda
-    "nvidia-apex-proc =*=cpu",
-    "nvidia-apex-proc =*=cuda|=*=gpu"
+    "nvidia-apex-proc =*=cuda"
linux-64::nvidia-apex-22.03-cuda112py38hdf64721_0.conda
-    "nvidia-apex-proc =*=cpu",
-    "nvidia-apex-proc =*=cuda|=*=gpu",
-    "pytorch =*=cuda*"
+    "pytorch =*=cuda*",
+    "nvidia-apex-proc =*=cuda"
linux-64::nvidia-apex-22.03-cuda112py39h83a068c_0.conda
-    "nvidia-apex-proc =*=cpu",
-    "nvidia-apex-proc =*=cuda|=*=gpu"
+    "nvidia-apex-proc =*=cuda"
linux-64::nvidia-apex-22.03-cuda112py39h955c134_1.conda
-    "nvidia-apex-proc =*=cuda|=*=gpu",
-    "nvidia-apex-proc =*=cpu"
+    "nvidia-apex-proc =*=cuda"
+ exit 0
```
* [x] Modifications are bound by `python -c "import time; print(f'{time.time():.0f}000')"`

Fixes https://github.com/conda-forge/nvidia-apex-feedstock/issues/29
Closes https://github.com/conda-forge/admin-requests/pull/674