### PR TITLE
Pinning conda-libmamba-solver to only current conda releases

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1959,6 +1959,10 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             elif record.get("timestamp", 0) <= 1674230331000:  # 2023-01-20
                 # conda 23.1 changed an internal SubdirData API needed with S3/FTP channels
                 _replace_pin("conda >=22.11.0", "conda >=22.11.0,<23.1.0a", record["depends"], record)
+            elif record.get("timestamp", 0) <= 1678721528000: # 2023-03-13:
+                # conda 23.3 changed an internal SubdirData API needed with S3/FTP channels
+                # conda depricated Boltons leading to a breakage in the solver api interface
+                _replace_pin("conda >=22.11.0", "conda >=22.11.0,<23.2.0a", record["depends"], record)
 
         if subdir in ["linux-64", "linux-aarch64", "linux-ppc64le"] and \
             record_name in {"libmamba", "libmambapy"} \


### PR DESCRIPTION
There are two changes in conda that cause breaking changes in conda-libmamba-solver:
 - https://github.com/conda/conda-libmamba-solver/issues/153
 - https://github.com/conda/conda-libmamba-solver/issues/152

Checklist
* [X] Ran `python show_diff.py` and posted the output as part of the PR.
* [X] Modifications are bound by `python -c "import time; print(f'{time.time():.0f}000')"`

# Output of ``python show_diff.py` 

```
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata.json.bz2
noarch::conda-libmamba-solver-23.1.0-pyhd8ed1ab_0.conda
-    "conda >=22.11.0",
+    "conda >=22.11.0,<23.2.0a",
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata.json.bz2
```