### PR TITLE
Patch rioxarray 0.14.0 build 0 with correct Python and rasterio pin

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1594,6 +1594,13 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
         if record_name == "xarray" and record["version"] == "0.19.0":
             _replace_pin("python >=3.6", "python >=3.7", deps, record)
 
+        # Rioxarray 0.14.0 dropped Python 3.8 and rasterio 1.1, need to patch
+        # first build to use a minimum of Python 3.9 and rasterio 1.2
+        # See https://github.com/conda-forge/rioxarray-feedstock/pull/70
+        if record_name == "rioxarray" and record["version"] == "0.14.0":
+            _replace_pin("python >=3.8", "python >=3.9", deps, record)
+            _replace_pin("rasterio >=1.1.1", "python >=1.2", deps, record)
+
         # tensorboard had incorrect dependencies between 2.4.0 and 2.6.0
         if record_name == "tensorboard" and record["version"] in ("2.4.0", "2.4.1", "2.5.0", "2.6.0"):
             _replace_pin("google-auth-oauthlib 0.4.1", "google-auth-oauthlib >=0.4.1,<0.5", deps, record)

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1597,7 +1597,11 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
         # Rioxarray 0.14.0 dropped Python 3.8 and rasterio 1.1, need to patch
         # first build to use a minimum of Python 3.9 and rasterio 1.2
         # See https://github.com/conda-forge/rioxarray-feedstock/pull/70
-        if record_name == "rioxarray" and record["version"] == "0.14.0":
+        if (
+            record_name == "rioxarray"
+            and record["version"] == "0.14.0"
+            and record.get("timestamp", 0) < 1679524270000
+        ):
             _replace_pin("python >=3.8", "python >=3.9", deps, record)
             _replace_pin("rasterio >=1.1.1", "python >=1.2", deps, record)
 

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1603,7 +1603,7 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             and record.get("timestamp", 0) < 1679524270000
         ):
             _replace_pin("python >=3.8", "python >=3.9", deps, record)
-            _replace_pin("rasterio >=1.1.1", "python >=1.2", deps, record)
+            _replace_pin("rasterio >=1.1.1", "rasterio >=1.2", deps, record)
 
         # tensorboard had incorrect dependencies between 2.4.0 and 2.6.0
         if record_name == "tensorboard" and record["version"] in ("2.4.0", "2.4.1", "2.5.0", "2.6.0"):


### PR DESCRIPTION
Rioxarray 0.14.0 removed support for Python 3.8 and rasterio 1.1, causing an error like `TypeError: 'type' object is not subscriptable` when trying to `import rioxarray` in Python 3.8 that doesn't support certain Python 3.9+ only type hints (https://github.com/corteva/rioxarray/pull/643). Setting the proper `python >-3.9` and `rasterio >=1.2` minimum pin to prevent that error.

Checklist
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

Output of `python show_diff.py` from https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=678389&view=logs&j=656edd35-690f-5c53-9ba3-09c10d0bea97&t=e5c8ab1d-8ff9-5cae-b332-e15ae582ed2d&l=253

```diff
+ python show_diff.py
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata.json.bz2
noarch::rioxarray-0.14.0-pyhd8ed1ab_0.conda
-    "python >=3.8",
-    "rasterio >=1.1.1",
+    "python >=3.9",
+    "rasterio >=1.2",
```

Xref https://github.com/conda-forge/rioxarray-feedstock/pull/70