### PR TITLE
Fix `pennylane-lightning-gpu` v0.29.0 build 0

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1124,7 +1124,8 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
         if (
             record_name == "pennylane-lightning-gpu" and
             record["version"] == "0.29.0" and
-            record['build_number'] == 0
+            record['build_number'] == 0 and
+            record.get("timestamp", 0) < 1680553268000
         ):
             _replace_pin("pennylane", "pennylane >=0.28.0", record["depends"], record)
 

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1119,6 +1119,15 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                     deps.append("tbb <2021.0.0a0")
                     break
 
+        # pennylane-lightning-gpu 0.29.0 requires pennylane>=0.28.0, but build 0 left it unspecified,
+        # fixed in https://github.com/conda-forge/pennylane-lightning-gpu-feedstock/pull/2
+        if (
+            record_name == "pennylane-lightning-gpu" and
+            record["version"] == "0.29.0" and
+            record['build_number'] == 0
+        ):
+            _replace_pin("pennylane", "pennylane >=0.28.0", record["depends"], record)
+
         # cuTENSOR 1.3.x is binary incompatible with 1.2.x. Let's just pin exactly since
         # it appears semantic versioning is not guaranteed.
         _replace_pin("cutensor >=1.2.2.5,<2.0a0", "cutensor ==1.2.2.5", deps, record)


### PR DESCRIPTION
Checklist
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

```
$ python show_diff.py --subdirs linux-64 --use-cache
linux-64::pennylane-lightning-gpu-0.29.0-py310hbe3ad0c_0.conda
-    "pennylane",
+    "pennylane >=0.28.0",
linux-64::pennylane-lightning-gpu-0.29.0-py38hca921df_0.conda
-    "pennylane",
+    "pennylane >=0.28.0",
linux-64::pennylane-lightning-gpu-0.29.0-py39hcf40d7a_0.conda
-    "pennylane",
+    "pennylane >=0.28.0",
```

cc: @conda-forge/pennylane-lightning-gpu for vis