### PR TITLE
patch both xarray and erddapy for pandas 2.0

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1598,15 +1598,15 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
         # Xarray <=2023.2.0 doesn't support pandas 2.0.
         # https://github.com/pydata/xarray/issues/7716
         if record_name == "xarray" and packaging.version.Version(record["version"]) <= packaging.version.Version("2023.1.0"):
-            _replace_pin("pandas >=1.3", "pandas >=1.3,<2", deps, record)
+            _replace_pin("pandas >=1.3", "pandas >=1.3,<2a0", deps, record)
 
         if record_name == "xarray" and packaging.version.Version(record["version"]) == packaging.version.Version("2023.2.0"):
-            _replace_pin("pandas >=1.4", "pandas >=1.4,<2", deps, record)
+            _replace_pin("pandas >=1.4", "pandas >=1.4,<2a0", deps, record)
 
-        # erddapy doesn't support pandas 2.0 yet.
+        # erddapy <=1.3 doesn't support pandas 2.0.
         # https://github.com/ioos/erddapy/issues/299
         if record_name == "erddapy" and packaging.version.Version(record["version"]) < packaging.version.Version("1.3"):
-            _replace_pin("pandas >=0.20.3", "pandas >=0.20.3,<2", deps, record)
+            _replace_pin("pandas >=0.20.3", "pandas >=0.20.3,<2a0", deps, record)
 
         # Rioxarray 0.14.0 dropped Python 3.8 and rasterio 1.1, need to patch
         # first build to use a minimum of Python 3.9 and rasterio 1.2

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -11,6 +11,7 @@ import sys
 import tqdm
 import re
 import requests
+import packaging.version
 import pkg_resources
 
 from get_license_family import get_license_family
@@ -1593,6 +1594,16 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
         # https://github.com/conda-forge/xarray-feedstock/pull/66
         if record_name == "xarray" and record["version"] == "0.19.0":
             _replace_pin("python >=3.6", "python >=3.7", deps, record)
+
+        # Xarray <=2023.1.0 doesn't support pandas 2.0 yet.
+        # https://github.com/pydata/xarray/issues/7716
+        if record_name == "xarray" and packaging.version.Version(record["version"]) < packaging.version.Version("2023.3.0"):
+            _replace_pin("pandas >=1.3", "pandas >=1.3,<2", deps, record)
+
+        # erddapy doesn't support pandas 2.0 yet.
+        # https://github.com/ioos/erddapy/issues/299
+        if record_name == "erddapy" and packaging.version.Version(record["version"]) < packaging.version.Version("1.3"):
+            _replace_pin("pandas >=0.20.3", "pandas >=0.20.3,<2", deps, record)
 
         # Rioxarray 0.14.0 dropped Python 3.8 and rasterio 1.1, need to patch
         # first build to use a minimum of Python 3.9 and rasterio 1.2

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1595,10 +1595,13 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
         if record_name == "xarray" and record["version"] == "0.19.0":
             _replace_pin("python >=3.6", "python >=3.7", deps, record)
 
-        # Xarray <=2023.1.0 doesn't support pandas 2.0 yet.
+        # Xarray <=2023.2.0 doesn't support pandas 2.0.
         # https://github.com/pydata/xarray/issues/7716
-        if record_name == "xarray" and packaging.version.Version(record["version"]) < packaging.version.Version("2023.3.0"):
+        if record_name == "xarray" and packaging.version.Version(record["version"]) <= packaging.version.Version("2023.1.0"):
             _replace_pin("pandas >=1.3", "pandas >=1.3,<2", deps, record)
+
+        if record_name == "xarray" and packaging.version.Version(record["version"]) == packaging.version.Version("2023.2.0"):
+            _replace_pin("pandas >=1.4", "pandas >=1.4,<2", deps, record)
 
         # erddapy doesn't support pandas 2.0 yet.
         # https://github.com/ioos/erddapy/issues/299

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,6 +20,7 @@ requirements:
     - requests
     - tqdm
     - license-expression
+    - packaging
   host:
   run:
 


### PR DESCRIPTION
Checklist
* [X] Ran `python show_diff.py` and posted the output as part of the PR.
* [X] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

```
noarch::erddapy-0.6.0-py_0.tar.bz2
-    "pandas >=0.20.3",
+    "pandas >=0.20.3,<2",
noarch::erddapy-0.7.0-py_0.tar.bz2
-    "pandas >=0.20.3",
+    "pandas >=0.20.3,<2",
noarch::erddapy-0.7.1-py_0.tar.bz2
-    "pandas >=0.20.3",
+    "pandas >=0.20.3,<2",
noarch::erddapy-0.7.2-py_0.tar.bz2
-    "pandas >=0.20.3",
+    "pandas >=0.20.3,<2",
noarch::erddapy-0.8.0-pyhd8ed1ab_0.tar.bz2
-    "pandas >=0.20.3",
+    "pandas >=0.20.3,<2",
noarch::erddapy-0.9.0-pyhd8ed1ab_0.tar.bz2
-    "pandas >=0.20.3",
+    "pandas >=0.20.3,<2",
noarch::erddapy-1.0.0-pyhd8ed1ab_0.tar.bz2
-    "pandas >=0.20.3",
+    "pandas >=0.20.3,<2",
noarch::erddapy-1.1.0-pyhd8ed1ab_0.tar.bz2
-    "pandas >=0.20.3",
+    "pandas >=0.20.3,<2",
noarch::erddapy-1.1.1-pyhd8ed1ab_0.tar.bz2
-    "pandas >=0.20.3",
+    "pandas >=0.20.3,<2",
noarch::erddapy-1.2.0-pyhd8ed1ab_0.tar.bz2
-    "pandas >=0.20.3",
+    "pandas >=0.20.3,<2",
noarch::erddapy-1.2.1-pyhd8ed1ab_0.tar.bz2
-    "pandas >=0.20.3",
+    "pandas >=0.20.3,<2",
noarch::xarray-2022.10.0-pyhd8ed1ab_0.tar.bz2
-    "pandas >=1.3",
+    "pandas >=1.3,<2",
noarch::xarray-2022.11.0-pyhd8ed1ab_0.tar.bz2
-    "pandas >=1.3",
+    "pandas >=1.3,<2",
noarch::pmgr-2.1.2-pyhd8ed1ab_0.conda
-    "mysqlclient =1.3.12|>=2.0.3",
+    "mysqlclient ==1.3.12.*|>=2.0.3",
noarch::xarray-2022.12.0-pyhd8ed1ab_0.conda
-    "pandas >=1.3",
+    "pandas >=1.3,<2",
noarch::xarray-2023.1.0-pyhd8ed1ab_0.conda
-    "pandas >=1.3",
+    "pandas >=1.3,<2",

```