### PR TITLE
Increase strictness for xarray and pandas compatibility

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1597,7 +1597,14 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
 
         # Xarray <=2023.2.0 doesn't support pandas 2.0.
         # https://github.com/pydata/xarray/issues/7716
-        if record_name == "xarray" and packaging.version.Version(record["version"]) <= packaging.version.Version("2023.1.0"):
+        if (
+            record_name == "xarray"
+            and packaging.version.Version(record["version"]) <= packaging.version.Version("2023.1.0")
+            and record.get("timestamp", 0) < 1680700334000
+        ):
+            _replace_pin("pandas >=1.0", "pandas >=1.0,<2a0", deps, record)
+            _replace_pin("pandas >=1.1", "pandas >=1.1,<2a0", deps, record)
+            _replace_pin("pandas >=1.2", "pandas >=1.2,<2a0", deps, record)
             _replace_pin("pandas >=1.3", "pandas >=1.3,<2a0", deps, record)
 
         if record_name == "xarray" and packaging.version.Version(record["version"]) == packaging.version.Version("2023.2.0"):


### PR DESCRIPTION
Checklist
* [x] Ran `python show_diff.py` and posted the output as part of the PR.

```
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata.json.bz2
noarch::xarray-0.19.0-pyhd8ed1ab_1.tar.bz2
-    "pandas >=1.0",
+    "pandas >=1.0,<2a0",
noarch::xarray-0.20.0-pyhd8ed1ab_0.tar.bz2
-    "pandas >=1.1",
+    "pandas >=1.1,<2a0",
noarch::xarray-0.20.1-pyhd8ed1ab_0.tar.bz2
-    "pandas >=1.1",
+    "pandas >=1.1,<2a0",
noarch::xarray-0.20.2-pyhd8ed1ab_0.tar.bz2
-    "pandas >=1.1",
+    "pandas >=1.1,<2a0",
noarch::xarray-0.21.0-pyhd8ed1ab_0.tar.bz2
-    "pandas >=1.1",
+    "pandas >=1.1,<2a0",
noarch::xarray-0.21.0-pyhd8ed1ab_1.tar.bz2
-    "pandas >=1.1",
+    "pandas >=1.1,<2a0",
noarch::xarray-0.21.1-pyhd8ed1ab_0.tar.bz2
-    "pandas >=1.1",
+    "pandas >=1.1,<2a0",
noarch::xarray-2022.3.0-pyhd8ed1ab_0.tar.bz2
-    "pandas >=1.1",
+    "pandas >=1.1,<2a0",
noarch::xarray-2022.6.0-pyhd8ed1ab_0.tar.bz2
-    "pandas >=1.1",
+    "pandas >=1.1,<2a0",
noarch::xarray-2022.6.0-pyhd8ed1ab_1.tar.bz2
-    "pandas >=1.2",
+    "pandas >=1.2,<2a0",
noarch::xarray-2022.9.0-pyhd8ed1ab_0.tar.bz2
-    "pandas >=1.2",
+    "pandas >=1.2,<2a0",
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata.json.bz2
```


* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

Without this:

```
 mamba create --name xr xarray=2022 pandas=2 --channel conda-forge --override-channels

                  __    __    __    __
                 /  \  /  \  /  \  /  \
                /    \/    \/    \/    \
███████████████/  /██/  /██/  /██/  /████████████████████████
              /  / \   / \   / \   / \  \____
             /  /   \_/   \_/   \_/   \    o \__,
            / _/                       \_____/  `
            |/
        ███╗   ███╗ █████╗ ███╗   ███╗██████╗  █████╗
        ████╗ ████║██╔══██╗████╗ ████║██╔══██╗██╔══██╗
        ██╔████╔██║███████║██╔████╔██║██████╔╝███████║
        ██║╚██╔╝██║██╔══██║██║╚██╔╝██║██╔══██╗██╔══██║
        ██║ ╚═╝ ██║██║  ██║██║ ╚═╝ ██║██████╔╝██║  ██║
        ╚═╝     ╚═╝╚═╝  ╚═╝╚═╝     ╚═╝╚═════╝ ╚═╝  ╚═╝

        mamba (1.4.1) supported by @QuantStack

        GitHub:  https://github.com/mamba-org/mamba
        Twitter: https://twitter.com/QuantStack

█████████████████████████████████████████████████████████████


Looking for: ['xarray=2022', 'pandas=2']

conda-forge/noarch                                  11.8MB @   4.3MB/s  3.1s
conda-forge/linux-64                                30.7MB @   4.7MB/s  7.8s
Transaction

  Prefix: /home/mark/mambaforge/envs/xr

  Updating specs:

   - xarray=2022
   - pandas=2


  Package               Version  Build                Channel                    Size
───────────────────────────────────────────────────────────────────────────────────────
  Install:
───────────────────────────────────────────────────────────────────────────────────────

  + _libgcc_mutex           0.1  conda_forge          conda-forge/linux-64     Cached
  + _openmp_mutex           4.5  2_gnu                conda-forge/linux-64     Cached
  + bzip2                 1.0.8  h7f98852_4           conda-forge/linux-64     Cached
  + ca-certificates   2022.12.7  ha878542_0           conda-forge/linux-64     Cached
  + ld_impl_linux-64       2.40  h41732ed_0           conda-forge/linux-64     Cached
  + libblas               3.9.0  16_linux64_openblas  conda-forge/linux-64     Cached
  + libcblas              3.9.0  16_linux64_openblas  conda-forge/linux-64     Cached
  + libexpat              2.5.0  hcb278e6_1           conda-forge/linux-64     Cached
  + libffi                3.4.2  h7f98852_5           conda-forge/linux-64     Cached
  + libgcc-ng            12.2.0  h65d4601_19          conda-forge/linux-64     Cached
  + libgfortran-ng       12.2.0  h69a702a_19          conda-forge/linux-64     Cached
  + libgfortran5         12.2.0  h337968e_19          conda-forge/linux-64     Cached
  + libgomp              12.2.0  h65d4601_19          conda-forge/linux-64     Cached
  + liblapack             3.9.0  16_linux64_openblas  conda-forge/linux-64     Cached
  + libnsl                2.0.0  h7f98852_0           conda-forge/linux-64     Cached
  + libopenblas          0.3.21  pthreads_h78a6416_3  conda-forge/linux-64     Cached
  + libsqlite            3.40.0  h753d276_0           conda-forge/linux-64     Cached
  + libstdcxx-ng         12.2.0  h46fd767_19          conda-forge/linux-64     Cached
  + libuuid              2.38.1  h0b41bf4_0           conda-forge/linux-64     Cached
  + libzlib              1.2.13  h166bdaf_4           conda-forge/linux-64     Cached
  + ncurses                 6.3  h27087fc_1           conda-forge/linux-64     Cached
  + numpy                1.24.2  py311h8e6699e_0      conda-forge/linux-64        8MB
  + openssl               3.1.0  h0b41bf4_0           conda-forge/linux-64     Cached
  + packaging              23.0  pyhd8ed1ab_0         conda-forge/noarch       Cached
  + pandas                2.0.0  py311h2872171_0      conda-forge/linux-64       15MB
  + pip                  23.0.1  pyhd8ed1ab_0         conda-forge/noarch       Cached
  + python               3.11.2  h2755cc3_0_cpython   conda-forge/linux-64       31MB
  + python-dateutil       2.8.2  pyhd8ed1ab_0         conda-forge/noarch       Cached
  + python-tzdata        2023.3  pyhd8ed1ab_0         conda-forge/noarch       Cached
  + python_abi             3.11  3_cp311              conda-forge/linux-64        6kB
  + pytz                 2023.3  pyhd8ed1ab_0         conda-forge/noarch       Cached
  + readline                8.2  h8228510_1           conda-forge/linux-64     Cached
  + setuptools           67.6.1  pyhd8ed1ab_0         conda-forge/noarch       Cached
  + six                  1.16.0  pyh6c4a22f_0         conda-forge/noarch       Cached
  + tk                   8.6.12  h27826a3_0           conda-forge/linux-64     Cached
  + tzdata                2023c  h71feb2d_0           conda-forge/noarch       Cached
  + wheel                0.40.0  pyhd8ed1ab_0         conda-forge/noarch       Cached
  + xarray             2022.9.0  pyhd8ed1ab_0         conda-forge/noarch        721kB
  + xz                    5.2.6  h166bdaf_0           conda-forge/linux-64     Cached

  Summary:

  Install: 39 packages

  Total download: 54MB

───────────────────────────────────────────────────────────────────────────────────────


Confirm changes: [Y/n] n
Aborted.
```

