### PR TITLE
Add cuda-cccl conflict with thrust/cub packages.

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -2750,6 +2750,16 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             ):
                 _pin_stricter(fn, record, "numpy", "x", upper_bound="1.24")
 
+        # cuda-cccl and cuda-cccl-impl (released with CUDA 12) ship the same
+        # files as existing thrust/cub packages. These should conflict.
+        # Eventually users of thrust/cub should migrate to cuda-cccl[-impl]
+        if record_name in {"thrust", "cub"}:
+            new_constrains = record.get('constrains', [])
+            new_constrains.append("cuda-cccl <0.0.0a0")
+            new_constrains.append("cuda-cccl-impl <0.0.0a0")
+            new_constrains.append(f"cuda-cccl_{subdir} <0.0.0a0")
+            record['constrains'] = new_constrains
+
     return index
 
 


### PR DESCRIPTION
Checklist
* [x] Ran `python show_diff.py` and posted the output as part of the PR. (see below)
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->