### PR TITLE
Patch automerged anndata 0.9.0 that dropped support for Python 3.7

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -2804,6 +2804,17 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                 _pin_looser(fn, record, "curl", upper_bound="9.0")
                 _pin_looser(fn, record, "libcurl", upper_bound="9.0")
 
+        # anndata 0.9.0 dropped support for Python 3.7 but build 0 didn't
+        # update the Python pin. Fixed for build_number 1 in
+        # https://github.com/conda-forge/anndata-feedstock/pull/28
+        if (
+            record_name == "anndata"
+            and record["version"] == "0.9.0"
+            and record["build_number"] == 0
+            and record.get("timestamp", 0) < 1681324213000
+           ):
+            _replace_pin("python >=3.6", "python >=3.8", record["depends"], record)
+
     return index
 
 


### PR DESCRIPTION
Checklist
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

```
noarch::anndata-0.9.0-pyhd8ed1ab_0.conda
-    "python >=3.6",
+    "python >=3.8",
```

---

Sequence of events:

* anndata 0.9.0 dropped support for Python 3.7 https://github.com/scverse/anndata/pull/820
* anndata 0.9.0 PR was automerged without updating the Python pin https://github.com/conda-forge/anndata-feedstock/pull/27
* The new anndata 0.9.0 broke Python 3.7 conda envs https://github.com/TileDB-Inc/tiledbsoma-feedstock/pull/11#issuecomment-1505612493
* I bumped the Python pin for version 0.9.0 build number 1 https://github.com/conda-forge/anndata-feedstock/pull/28
* Modeled this PR off of PR #392 