### PR TITLE
Ensure `cuda-version` has a `run_constrained` on `cudatoolkit`

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -981,6 +981,10 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
         if i >= 0:
             deps[i] = "cudatoolkit >=11.2,<12.0a0"
 
+        if record_name == "cudatoolkit" and record.get('timestamp', 0) < 1681349920000:
+            cuda_major_minor = ".".join(record["version"].split(".")[:2])
+            record['depends'].append(f"cuda-version {cuda_major_minor}")
+
         if record.get('timestamp', 0) < 1663795137000:
             if any(dep.startswith("arpack >=3.7") for dep in deps):
                 _pin_looser(fn, record, "arpack", max_pin="x.x")

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -981,10 +981,10 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
         if i >= 0:
             deps[i] = "cudatoolkit >=11.2,<12.0a0"
 
-        if record_name == "cudatoolkit" and record.get('timestamp', 0) < 1681349920000:
+        if record_name == "cuda-version" and record.get('timestamp', 0) < 1681952850000:
             cuda_major_minor = ".".join(record["version"].split(".")[:2])
             constrains = record.get('constrains', [])
-            constrains.append(f"cuda-version {cuda_major_minor}")
+            constrains.append(f"cudatoolkit {cuda_major_minor}")
             record['constrains'] = constrains
 
         if record.get('timestamp', 0) < 1663795137000:

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -983,7 +983,9 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
 
         if record_name == "cudatoolkit" and record.get('timestamp', 0) < 1681349920000:
             cuda_major_minor = ".".join(record["version"].split(".")[:2])
-            record['depends'].append(f"cuda-version {cuda_major_minor}")
+            constrains = record.get('constrains', [])
+            constrains.append(f"cuda-version {cuda_major_minor}")
+            record['constrains'] = constrains
 
         if record.get('timestamp', 0) < 1663795137000:
             if any(dep.startswith("arpack >=3.7") for dep in deps):


### PR DESCRIPTION
Checklist
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

Repodata patch corresponding to ~~https://github.com/conda-forge/cudatoolkit-feedstock/pull/89~~ **UPDATE**: https://github.com/conda-forge/cuda-version-feedstock/pull/6.

cc: @jakirkham @kkraus14 @bdice @adibbley @conda-forge/cudatoolkit @conda-forge/cuda-version 

```diff
$ python show_diff.py 
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata.json.bz2
noarch::cuda-version-10.0-h09276fa_0.conda
-    "__cuda >=10"
+    "__cuda >=10",
+    "cudatoolkit 10.0"
noarch::cuda-version-10.1-h322b37e_0.conda
-    "__cuda >=10"
+    "__cuda >=10",
+    "cudatoolkit 10.1"
noarch::cuda-version-10.2-h4767cc1_0.conda
-    "__cuda >=10"
+    "__cuda >=10",
+    "cudatoolkit 10.2"
noarch::cuda-version-11.0-h6b8d8af_0.conda
-    "__cuda >=11"
+    "__cuda >=11",
+    "cudatoolkit 11.0"
noarch::cuda-version-11.1-hdbd7af8_0.conda
-    "__cuda >=11"
+    "__cuda >=11",
+    "cudatoolkit 11.1"
noarch::cuda-version-11.2-hb11dac2_0.conda
-    "__cuda >=11"
+    "__cuda >=11",
+    "cudatoolkit 11.2"
noarch::cuda-version-11.3-hbc958af_0.conda
-    "__cuda >=11"
+    "__cuda >=11",
+    "cudatoolkit 11.3"
noarch::cuda-version-11.4-hfb901f2_0.conda
-    "__cuda >=11"
+    "__cuda >=11",
+    "cudatoolkit 11.4"
noarch::cuda-version-11.5-h6c6c5af_0.conda
-    "__cuda >=11"
+    "__cuda >=11",
+    "cudatoolkit 11.5"
noarch::cuda-version-11.6-hca96458_0.conda
-    "__cuda >=11"
+    "__cuda >=11",
+    "cudatoolkit 11.6"
noarch::cuda-version-11.7-h67201e3_0.conda
-    "__cuda >=11"
+    "__cuda >=11",
+    "cudatoolkit 11.7"
noarch::cuda-version-11.8-h70ddcb2_0.conda
-    "__cuda >=11"
+    "__cuda >=11",
+    "cudatoolkit 11.8"
noarch::cuda-version-12.0-hffde075_0.conda
-    "__cuda >=12"
+    "__cuda >=12",
+    "cudatoolkit 12.0"
noarch::cuda-version-12.0.0-hd8ed1ab_0.conda
-    "__cuda >=12"
+    "__cuda >=12",
+    "cudatoolkit 12.0"
noarch::cuda-version-12.1-h1d6eff3_0.conda
-    "__cuda >=12"
+    "__cuda >=12",
+    "cudatoolkit 12.1"
noarch::cuda-version-9.2-h5693e3d_0.conda
-    "__cuda >=9"
+    "__cuda >=9",
+    "cudatoolkit 9.2"
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata.json.bz2
```