### PR TITLE
Pin Python for napari

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1822,16 +1822,19 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                 deps[i] = dep
             record["depends"] = deps
 
-        # pillow 7.1.0 and 7.1.1 break napari viewer but this wasn't dealt with til latest release
         if record_name == "napari":
             timestamp = record.get("timestamp", 0)
             if timestamp < 1642529454000:  # 2022-01-18
+                # pillow 7.1.0 and 7.1.1 break napari viewer but this wasn't dealt with til latest release
                 _replace_pin("pillow", "pillow !=7.1.0,!=7.1.1", record.get("depends", []), record)
             if timestamp < 1661793597230:  # 2022-08-29
                 _replace_pin("vispy >=0.9.4", "vispy >=0.9.4,<0.10", record.get("depends", []), record)
                 _replace_pin("vispy >=0.6.4", "vispy >=0.6.4,<0.10", record.get("depends", []), record)
-            if pkg_resources.parse_version(record["version"]) < pkg_resources.parse_version("0.4.18"):
-                _replace_pin("python >=3.8", "python >=3.8,<3.11", record.get("depends", []), record)
+            if timestamp < 1682243307685:  # 2023-04-23
+                # https://github.com/napari/napari/issues/5705#issuecomment-1502901099
+                _replace_pin("python >=3.6", "python >=3.6,<3.11.0a0", record.get("depends", []), record)
+                _replace_pin("python >=3.7", "python >=3.7,<3.11.0a0", record.get("depends", []), record)
+                _replace_pin("python >=3.8", "python >=3.8,<3.11.0a0", record.get("depends", []), record)
 
         # replace =2.7 with ==2.7.* for compatibility with older conda
         new_deps = []

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1830,6 +1830,8 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             if timestamp < 1661793597230:  # 2022-08-29
                 _replace_pin("vispy >=0.9.4", "vispy >=0.9.4,<0.10", record.get("depends", []), record)
                 _replace_pin("vispy >=0.6.4", "vispy >=0.6.4,<0.10", record.get("depends", []), record)
+            if pkg_resources.parse_version(record["version"]) < pkg_resources.parse_version("0.4.18"):
+                _replace_pin("python >=3.8", "python >=3.8,<3.11", record.get("depends", []), record)
 
         # replace =2.7 with ==2.7.* for compatibility with older conda
         new_deps = []
@@ -2797,7 +2799,7 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             new_constrains.append("cuda-cccl-impl <0.0.0a0")
             new_constrains.append(f"cuda-cccl_{subdir} <0.0.0a0")
             record['constrains'] = new_constrains
-        
+
         if record.get('timestamp', 0) < 1681344601000:
             deps = record.get("depends", [])
             if any(dep.startswith(("libcurl", "curl")) and dep.endswith("<8.0a0") for dep in deps):


### PR DESCRIPTION
This pins Python for napari, as it is not yet compartible with Python 3.11: https://github.com/napari/napari/issues/5514

Fixes https://github.com/conda-forge/napari-feedstock/issues/45

Output from show_diff.py:

```
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata.json.bz2
noarch::napari-0.4.15-pyh275ddea_1_pyqt.tar.bz2
-    "python >=3.8",
+    "python >=3.8,<3.11",
noarch::napari-0.4.15-pyh92c539f_1_pyside2.tar.bz2
-    "python >=3.8",
+    "python >=3.8,<3.11",
noarch::napari-0.4.16-pyh275ddea_0_pyqt.tar.bz2
-    "python >=3.8",
+    "python >=3.8,<3.11",
noarch::napari-0.4.16-pyh92c539f_0_pyside2.tar.bz2
-    "python >=3.8",
+    "python >=3.8,<3.11",
noarch::napari-0.4.17-pyh275ddea_0_pyqt.tar.bz2
-    "python >=3.8",
+    "python >=3.8,<3.11",
noarch::napari-0.4.17-pyh92c539f_0_pyside2.tar.bz2
-    "python >=3.8",
+    "python >=3.8,<3.11",
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata.json.bz2
```

Checklist
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->
