### PR TITLE
Patch merged intake-esm v2023.4.20 that dropped support for Python 3.8

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -2821,6 +2821,7 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             record_name == "intake-esm"
             and record["version"] == "2023.4.20"
             and record["build_number"] == 0
+            and record.get("timestamp", 0) < 1682227052000
         ):
             _replace_pin("python >=3.8", "python >=3.9", record["depends"], record)
 

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -2815,6 +2815,15 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
            ):
             _replace_pin("python >=3.6", "python >=3.8", record["depends"], record)
 
+        # intake-esm v2023.4.20 dropped support for Python 3.8 but build 0 didn't update
+        # the Python version pin. 
+        if (
+            record_name == "intake-esm"
+            and record["version"] == "2023.4.20"
+            and record["build_number"] == 0
+        ):
+            _replace_pin("python >=3.8", "python >=3.9", record["depends"], record)
+
     return index
 
 


### PR DESCRIPTION
Checklist
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->


```diff
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata.json.bz2
noarch::intake-esm-2023.4.20-pyhd8ed1ab_0.conda
-    "python >=3.8",
+    "python >=3.9",
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata.json.bz2
```
