### PR TITLE
Gensim - add missing fuzzytm run dependency

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -2856,6 +2856,16 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             record.get("timestamp", 0) <= 1680784303548
         ):
             _replace_pin("sqlalchemy <2.0.0", "sqlalchemy >=2.0.0", record["depends"], record)
+        
+        # gensim recipe forot to include FuzzyTM (only) in version 4.3.0
+        # gensim recipe: https://github.com/conda-forge/gensim-feedstock/blob/881265555a2e772a8183ca7afd436b17980c48a7/recipe/meta.yaml
+        # gensim package reuqirements: https://github.com/RaRe-Technologies/gensim/blob/adf393cdfc9443fa96abec3996b2e134a757d24b/setup.py#L340-L345
+        if (
+            record_name == "gensim"
+            and record["version"] == "4.3.0"
+            and record["build_number"] == 1
+        ):
+            record['depends'].append("fuzzytm >= 0.4.0")
 
     return index
 


### PR DESCRIPTION
Checklist
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

How I found the error. When the bot proposed the new release for the orange3-text package, it didn't go through because of this missing package. Take a look at the building log: https://github.com/conda-forge/orange3-text-feedstock/pull/63
