### PR TITLE
Fix `ucx`'s `cudatoolkit` constraint

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -987,6 +987,15 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             constrains.append(f"cudatoolkit {cuda_major_minor}")
             record['constrains'] = constrains
 
+        if record_name == "ucx" and record.get('timestamp', 0) < 1682924400000:
+            constrains = record.get('constrains', [])
+            for i, c in enumerate(constrains):
+                if c.startswith('cudatoolkit'):
+                    v = c.split()[-1]
+                    if v != '>=11.2,<12':
+                        constrains[i] = c = f'cudatoolkit {v}|{v}.*'
+            record['constrains'] = constrains
+
         if record.get('timestamp', 0) < 1663795137000:
             if any(dep.startswith("arpack >=3.7") for dep in deps):
                 _pin_looser(fn, record, "arpack", max_pin="x.x")


### PR DESCRIPTION
Apply changes from PR ( https://github.com/conda-forge/ucx-split-feedstock/pull/123 ) to older `ucx` packages.

<hr>

Checklist
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<hr>

Fixes https://github.com/conda-forge/ucx-split-feedstock/issues/120