### PR TITLE
Relax `cuda-version`'s constraints

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -981,10 +981,15 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
         if i >= 0:
             deps[i] = "cudatoolkit >=11.2,<12.0a0"
 
-        if record_name == "cuda-version" and record.get('timestamp', 0) < 1681952850000:
+        if record_name == "cuda-version" and record['build_number'] < 2 and record.get('timestamp', 0) < 1683211961000:
             cuda_major_minor = ".".join(record["version"].split(".")[:2])
             constrains = record.get('constrains', [])
-            constrains.append(f"cudatoolkit {cuda_major_minor}")
+            for i, c in enumerate(constrains):
+                if c.startswith('cudatoolkit'):
+                    constrains[i] = f'cudatoolkit {cuda_major_minor}|{cuda_major_minor}.*'
+                    break
+            else:
+                constrains.append( f'cudatoolkit {cuda_major_minor}|{cuda_major_minor}.*' )
             record['constrains'] = constrains
 
         if record_name == "ucx" and record.get('timestamp', 0) < 1682924400000:


### PR DESCRIPTION
Close https://github.com/conda-forge/cuda-version-feedstock/issues/7. 

Follow-up of #435. This fix is the same as #445 for UCX. The new build (2) has fixed the issue: https://github.com/conda-forge/cuda-version-feedstock/pull/8, so this PR is the [remaining step](https://github.com/conda-forge/cuda-version-feedstock/issues/7#issuecomment-1533978965).

cc: @conda-forge/cuda-version @beckermr @jakirkham 

Checklist
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

```diff
$ python show_diff.py --subdirs noarch --use-cache
noarch::cuda-version-10.0-h09276fa_0.conda
-    "cudatoolkit 10.0"
+    "cudatoolkit 10.0|10.0.*"
noarch::cuda-version-10.0-h09276fa_1.conda
-    "cudatoolkit 10.0",
+    "cudatoolkit 10.0|10.0.*",
noarch::cuda-version-10.1-h322b37e_0.conda
-    "cudatoolkit 10.1"
+    "cudatoolkit 10.1|10.1.*"
noarch::cuda-version-10.1-h322b37e_1.conda
-    "cudatoolkit 10.1"
+    "cudatoolkit 10.1|10.1.*"
noarch::cuda-version-10.2-h4767cc1_0.conda
-    "cudatoolkit 10.2"
+    "cudatoolkit 10.2|10.2.*"
noarch::cuda-version-10.2-h4767cc1_1.conda
-    "cudatoolkit 10.2",
+    "cudatoolkit 10.2|10.2.*",
noarch::cuda-version-11.0-h6b8d8af_0.conda
-    "cudatoolkit 11.0"
+    "cudatoolkit 11.0|11.0.*"
noarch::cuda-version-11.0-h6b8d8af_1.conda
-    "cudatoolkit 11.0"
+    "cudatoolkit 11.0|11.0.*"
noarch::cuda-version-11.1-hdbd7af8_0.conda
-    "cudatoolkit 11.1"
+    "cudatoolkit 11.1|11.1.*"
noarch::cuda-version-11.1-hdbd7af8_1.conda
-    "cudatoolkit 11.1"
+    "cudatoolkit 11.1|11.1.*"
noarch::cuda-version-11.2-hb11dac2_0.conda
-    "cudatoolkit 11.2"
+    "cudatoolkit 11.2|11.2.*"
noarch::cuda-version-11.2-hb11dac2_1.conda
-    "cudatoolkit 11.2",
+    "cudatoolkit 11.2|11.2.*",
noarch::cuda-version-11.3-hbc958af_0.conda
-    "cudatoolkit 11.3"
+    "cudatoolkit 11.3|11.3.*"
noarch::cuda-version-11.3-hbc958af_1.conda
-    "cudatoolkit 11.3",
+    "cudatoolkit 11.3|11.3.*",
noarch::cuda-version-11.4-hfb901f2_0.conda
-    "cudatoolkit 11.4"
+    "cudatoolkit 11.4|11.4.*"
noarch::cuda-version-11.4-hfb901f2_1.conda
-    "cudatoolkit 11.4"
+    "cudatoolkit 11.4|11.4.*"
noarch::cuda-version-11.5-h6c6c5af_0.conda
-    "cudatoolkit 11.5"
+    "cudatoolkit 11.5|11.5.*"
noarch::cuda-version-11.5-h6c6c5af_1.conda
-    "cudatoolkit 11.5"
+    "cudatoolkit 11.5|11.5.*"
noarch::cuda-version-11.6-hca96458_0.conda
-    "cudatoolkit 11.6"
+    "cudatoolkit 11.6|11.6.*"
noarch::cuda-version-11.6-hca96458_1.conda
-    "cudatoolkit 11.6",
+    "cudatoolkit 11.6|11.6.*",
noarch::cuda-version-11.7-h67201e3_0.conda
-    "cudatoolkit 11.7"
+    "cudatoolkit 11.7|11.7.*"
noarch::cuda-version-11.7-h67201e3_1.conda
-    "cudatoolkit 11.7",
+    "cudatoolkit 11.7|11.7.*",
noarch::cuda-version-11.8-h70ddcb2_0.conda
-    "cudatoolkit 11.8"
+    "cudatoolkit 11.8|11.8.*"
noarch::cuda-version-11.8-h70ddcb2_1.conda
-    "cudatoolkit 11.8",
+    "cudatoolkit 11.8|11.8.*",
noarch::cuda-version-12.0-hffde075_0.conda
-    "cudatoolkit 12.0"
+    "cudatoolkit 12.0|12.0.*"
noarch::cuda-version-12.0-hffde075_1.conda
-    "cudatoolkit 12.0"
+    "cudatoolkit 12.0|12.0.*"
noarch::cuda-version-12.0.0-hd8ed1ab_0.conda
-    "cudatoolkit 12.0"
+    "cudatoolkit 12.0|12.0.*"
noarch::cuda-version-12.1-h1d6eff3_0.conda
-    "cudatoolkit 12.1"
+    "cudatoolkit 12.1|12.1.*"
noarch::cuda-version-12.1-h1d6eff3_1.conda
-    "cudatoolkit 12.1",
+    "cudatoolkit 12.1|12.1.*",
noarch::cuda-version-9.2-h5693e3d_0.conda
-    "cudatoolkit 9.2"
+    "cudatoolkit 9.2|9.2.*"
noarch::cuda-version-9.2-h5693e3d_1.conda
-    "cudatoolkit 9.2",
+    "cudatoolkit 9.2|9.2.*",
```