### PR TITLE
Fix taurus-core dependencies

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -894,7 +894,11 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
         # https://gitlab.com/taurus-org/taurus/-/issues/1290
         # It's not compatible with Python 3.11 either
         # https://gitlab.com/taurus-org/taurus/-/merge_requests/1254
-        if record_name == "taurus-core" and packaging.version.Version(record["version"]) <= packaging.version.Version("5.1.5"):
+        if (
+            record_name == "taurus-core"
+            and packaging.version.Version(record["version"]) <= packaging.version.Version("5.1.5")
+            and record.get("timestamp", 0) < 1683637693000
+        ):
             _replace_pin("pint >=0.8", "pint >=0.8,<0.21", record["depends"], record)
             _replace_pin("python >=3.6", "python >=3.6,<3.11", record["depends"], record)
 

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -890,6 +890,14 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                 i = record['depends'].index('taurus >=4.7.0')
                 record['depends'][i] = 'taurus >=4.7.0,<5'
 
+        # pint 0.21 breaks taurus <= 5.1.5
+        # https://gitlab.com/taurus-org/taurus/-/issues/1290
+        # It's not compatible with Python 3.11 either
+        # https://gitlab.com/taurus-org/taurus/-/merge_requests/1254
+        if record_name == "taurus-core" and packaging.version.Version(record["version"]) <= packaging.version.Version("5.1.5"):
+            _replace_pin("pint >=0.8", "pint >=0.8,<0.21", record["depends"], record)
+            _replace_pin("python >=3.6", "python >=3.6,<3.11", record["depends"], record)
+
         if record_name == 'zipp':
             # zipp >=3.7 requires python >=3.7 but it was missed
             # https://github.com/conda-forge/zipp-feedstock/pull/29


### PR DESCRIPTION
1. pint 0.21 broke taurus <= 5.1.5 See https://gitlab.com/taurus-org/taurus/-/issues/1290 Fixed upstream in https://gitlab.com/taurus-org/taurus/-/merge_requests/1255

2. taurus <= 5.1.5 not compatible with Python 3.11 Fixed in https://gitlab.com/taurus-org/taurus/-/merge_requests/1254

Checklist
* [X] Ran `python show_diff.py` and posted the output as part of the PR.
* [X] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

A new version of taurus (5.1.6) will soon be released to fix those 2 issues (feedstock not updated).

```
# python show_diff.py --use-cache
noarch::taurus-core-4.7.0-pyhd8ed1ab_0.tar.bz2
-    "pint >=0.8",
-    "python >=3.6"
+    "pint >=0.8,<0.21",
+    "python >=3.6,<3.11"
noarch::taurus-core-4.7.1-pyhd8ed1ab_0.tar.bz2
-    "pint >=0.8",
-    "python >=3.6"
+    "pint >=0.8,<0.21",
+    "python >=3.6,<3.11"
noarch::taurus-core-4.7.1.1-pyhd8ed1ab_0.tar.bz2
-    "pint >=0.8",
-    "python >=3.6"
+    "pint >=0.8,<0.21",
+    "python >=3.6,<3.11"
noarch::taurus-core-4.8.0-pyhd8ed1ab_0.tar.bz2
-    "pint >=0.8",
-    "python >=3.6"
+    "pint >=0.8,<0.21",
+    "python >=3.6,<3.11"
noarch::taurus-core-4.8.1-pyhd8ed1ab_0.tar.bz2
-    "pint >=0.8",
-    "python >=3.6"
+    "pint >=0.8,<0.21",
+    "python >=3.6,<3.11"
noarch::taurus-core-5.0.0-pyhd8ed1ab_0.tar.bz2
-    "pint >=0.8",
-    "python >=3.6",
+    "pint >=0.8,<0.21",
+    "python >=3.6,<3.11",
noarch::taurus-core-5.0.0.1-pyhd8ed1ab_0.tar.bz2
-    "pint >=0.8",
-    "python >=3.6",
+    "pint >=0.8,<0.21",
+    "python >=3.6,<3.11",
noarch::taurus-core-5.1.4-pyhd8ed1ab_0.tar.bz2
-    "pint >=0.8",
-    "python >=3.6",
+    "pint >=0.8,<0.21",
+    "python >=3.6,<3.11",
noarch::taurus-core-5.1.5-pyhd8ed1ab_0.conda
-    "pint >=0.8",
-    "python >=3.6",
+    "pint >=0.8,<0.21",
+    "python >=3.6,<3.11",
```

