### PR TITLE
Prevent incompatible 'agate' versions with py311

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1822,6 +1822,16 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             elif record["version"] == "0.7.14":
                 _replace_pin("python >=2.7", "python >=2.7,<3.10", deps, record)
 
+        # Retroactively pin Python <3.11 for older versions of Agate since they
+        # import collections.Sequence instead of collections.abc.Sequence.
+        # Upstream fix: <https://github.com/wireservice/agate/pull/737>
+        if record_name == "agate" and subdir == "noarch" and record.get("timestamp", 0) < 1683708375000:
+            pversion = pkg_resources.parse_version(record['version'])
+            fixed_version = pkg_resources.parse_version("1.6.3")
+            if pversion < fixed_version:
+                _replace_pin("python", "python <3.11", deps, record)
+                _replace_pin("python >=3.6", "python >=3.6,<3.11", deps, record)
+
         # Properly depend on clangdev 5.0.0 flang* for flang 5.0
         if record_name == "flang":
             deps = record["depends"]


### PR DESCRIPTION
On https://github.com/conda-forge/dbt-snowflake-feedstock/pull/8 I had a failed build due to Python 3.11 interacting with Agate. Most builds of Agate are arch-specific, but there are a few noarch versions which import the deprecated `collections.Sequence`, leading to failure on import since Python 3.11.

This PR adds a `python <3.11` to these noarch packages in order to prevent this situation.

Checklist
* [X] Ran `python show_diff.py` and posted the output as part of the PR.
* [X] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

```diff
noarch::agate-1.6.0-py_3.tar.bz2
-    "python",
+    "python <3.11",
noarch::agate-1.6.1-pyhd8ed1ab_0.tar.bz2
-    "python >=3.6",
+    "python >=3.6,<3.11",
noarch::agate-1.6.2-pyhd8ed1ab_0.tar.bz2
-    "python >=3.6",
+    "python >=3.6,<3.11",
noarch::agate-1.6.2-pyhd8ed1ab_1.tar.bz2
-    "python >=3.6",
+    "python >=3.6,<3.11",
noarch::lbnightlytools-3.0.52-pyhd8ed1ab_0.conda
-    "python =2.7|>=3.6",
+    "python ==2.7.*|>=3.6",
```

I think the last diff is just noise.