### PR TITLE
Constrain to `pandas<2` for older versions of `dask`

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -714,6 +714,18 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                         record
                     )
 
+            # older versions of dask are incompatibile with pandas=2
+            if record.get('timestamp', 0) < 1676063992630:  # releases prior to 2023.2.0
+                pandas_pinning = [x for x in record['depends'] if x.startswith('pandas')]
+                if pandas_pinning:
+                    pandas_pinning = pandas_pinning[0]
+                    _replace_pin(
+                        pandas_pinning,
+                        pandas_pinning + (",<2" if pandas_pinning[-1].isdigit() else " <2"),
+                        deps,
+                        record
+                    )
+
         # In 1.4.1 bayesian-optimization fixes colors not displaying correctly on windows.
         # This is done using colorama, however the function used by colorama was only introduced in
         # colorama 0.4.6, which is only available for python >=3.7


### PR DESCRIPTION
Older versions of `dask` are incompatible with `pandas>=2`, giving an error on import:

```python-traceback
>>> import dask.dataframe
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/datasets/charlesb/mambaforge/envs/test-dask-pandas/lib/python3.11/site-packages/dask/dataframe/__init__.py", line 4, in <module>
    from dask.dataframe import backends, dispatch, rolling
  File "/datasets/charlesb/mambaforge/envs/test-dask-pandas/lib/python3.11/site-packages/dask/dataframe/backends.py", line 22, in <module>
    from dask.dataframe.core import DataFrame, Index, Scalar, Series, _Frame
  File "/datasets/charlesb/mambaforge/envs/test-dask-pandas/lib/python3.11/site-packages/dask/dataframe/core.py", line 35, in <module>
    from dask.dataframe import methods
  File "/datasets/charlesb/mambaforge/envs/test-dask-pandas/lib/python3.11/site-packages/dask/dataframe/methods.py", line 22, in <module>
    from dask.dataframe.utils import is_dataframe_like, is_index_like, is_series_like
  File "/datasets/charlesb/mambaforge/envs/test-dask-pandas/lib/python3.11/site-packages/dask/dataframe/utils.py", line 19, in <module>
    from dask.dataframe import (  # noqa: F401 register pandas extension types
  File "/datasets/charlesb/mambaforge/envs/test-dask-pandas/lib/python3.11/site-packages/dask/dataframe/_dtypes.py", line 4, in <module>
    from dask.dataframe.extensions import make_array_nonempty, make_scalar
  File "/datasets/charlesb/mambaforge/envs/test-dask-pandas/lib/python3.11/site-packages/dask/dataframe/extensions.py", line 6, in <module>
    from dask.dataframe.accessor import (
  File "/datasets/charlesb/mambaforge/envs/test-dask-pandas/lib/python3.11/site-packages/dask/dataframe/accessor.py", line 190, in <module>
    class StringAccessor(Accessor):
  File "/datasets/charlesb/mambaforge/envs/test-dask-pandas/lib/python3.11/site-packages/dask/dataframe/accessor.py", line 276, in StringAccessor
    pd.core.strings.StringMethods,
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: module 'pandas.core.strings' has no attribute 'StringMethods'
```

This applies a `pandas<2` constraint to all `dask` packages listing `pandas` as a dependency prior to 2023.2.0, which is seemingly when this incompatibility was addressed.

cc @jakirkham @jrbourbeau 

Checklist
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->
