### PR TITLE
fix etils python pin

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -2909,6 +2909,13 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             record.get("timestamp", 0) <= 1680784303548
         ):
             _replace_pin("sqlalchemy <2.0.0", "sqlalchemy >=2.0.0", record["depends"], record)
+            
+        if (
+            record_name == "etils" and
+            record["version"].startswith("1.") and
+            record.get("timestamp", 0) < 1683949458062
+        ):
+            _replace_pin("python >=3.7", "python >=3.8", record["depends"], record)
 
     return index
 


### PR DESCRIPTION
Checklist
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

fix https://github.com/conda-forge/etils-feedstock/issues/10

<details><summary>python show_diff.py</summary>
<p>
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata.json.bz2
noarch::etils-1.0.0-pyhd8ed1ab_0.conda

```diff
noarch::etils-1.0.0-pyhd8ed1ab_0.conda
-    "python >=3.7"
+    "python >=3.8"
noarch::etils-1.1.0-pyhd8ed1ab_0.conda
-    "python >=3.7"
+    "python >=3.8"
noarch::etils-1.1.1-pyhd8ed1ab_0.conda
-    "python >=3.7"
+    "python >=3.8"
noarch::etils-1.2.0-pyhd8ed1ab_0.conda
-    "python >=3.7"
+    "python >=3.8"
noarch::etils-1.3.0-pyhd8ed1ab_0.conda
-    "python >=3.7"
+    "python >=3.8"
```

</p>
</details> 