### PR TITLE
Loosen abseil run export

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -2340,6 +2340,17 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
         ):
             record["depends"].append("abseil-cpp ==20220623.0")
 
+        if (record.get("timestamp", 0) < 1684087258848
+                and any(
+                    depend.startswith("libabseil 20230125.0 cxx17*")
+                    for depend in record["depends"]
+                )
+        ):
+            # loosen abseil's run-export to major version, see
+            # https://github.com/conda-forge/abseil-cpp-feedstock/pull/63
+            i = record["depends"].index("libabseil 20230125.0 cxx17*")
+            record["depends"][i] = "libabseil 20230125 cxx17*"
+
         # Different patch versions of ipopt can be ABI incompatible
         # See https://github.com/conda-forge/ipopt-feedstock/issues/85
         if has_dep(record, "ipopt") and record.get('timestamp', 0) < 1656352053694:


### PR DESCRIPTION
The global pinning for abseil [is](https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/82c4e5c0de229cfdedcc1b1ff8b643c25f1c5593/recipe/conda_build_config.yaml#L428) at `20230125`, however our run-export in the package pinned to the minor version until [just now](https://github.com/conda-forge/abseil-cpp-feedstock/pull/63).

In combination with the fact that https://github.com/conda-forge/abseil-cpp-feedstock/pull/58 updated to libabseil 20230125.2 and now packages have been built against that (with a run-export pinning to 20230125.2), a few environments cannot resolve anymore.

This is obviously not a great situation, but at least the pinning information isn't false to the best of my understanding. There should be no ABI breaks per "major" version (which abseil calls LTS).

I see two options:
* patch the repodata (this PR)
* do a fake[^1] abseil migration for 20230125.2 

[^1]: "fake" because that's migrating something already present in the pinning, and more specific than we'd need

I realize that this touches quite a few packages, but the change should be benign and have no further impact. Also, things look perhaps scarier than they are due to the huge amount of arrow builds (4-5 maintenance branches and frequently migrated), so a lot of the below is just arrow.

CC @conda-forge/core

Checklist
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->