### PR TITLE
Fix dependencies for connexion=2.14.2 build 0

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -2958,6 +2958,18 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
         ):
             _replace_pin("python >=3.5", "python >=3.7", record["depends"], record)            
 
+        # connexion 2.14.2=0 has incorrect dependencies
+        # fixed for 2.14.2=1 in https://github.com/conda-forge/connexion-feedstock/pull/35/files
+        if (
+            record_name == "connexion"
+            and record["version"] in {"2.14.2"}
+            and record["build_number"] == 0
+            and record.get("timestamp", 0) < 1684322706000
+        ):
+            _replace_pin("python >=3.6", "python >=3.8", record["depends"], record)
+            _replace_pin("werkzeug >=1.0,<3.0", "werkzeug >=1.0,<2.3", record["depends"], record)
+            record["depends"].remove("importlib-metadata >=1")
+
     return index
 
 


### PR DESCRIPTION
This PR backports the changes made in [connexion-feedstock#35](https://github.com/conda-forge/connexion-feedstock/pull/35) to build 0 of `connexion=2.14.2`. The flask dependency from that PR was already patched in #446 

cc @xylar 

Checklist
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

Output of `python show_diff.py`:
```
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata.json.bz2
noarch::connexion-2.14.2-pyhd8ed1ab_0.conda
-    "importlib-metadata >=1",
-    "python >=3.6",
+    "python >=3.8",
-    "werkzeug >=1.0,<3.0"
+    "werkzeug >=1.0,<2.3"
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata.json.bz2
```