### PR TITLE
iris: append pin numpy!=1.24.3

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -948,6 +948,12 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             _rename_dependency(fn, record, "nc_time_axis", "nc-time-axis")
             if record["version"] in iris_updates:
                 record["depends"].extend(iris_updates[record["version"]])
+            # avoid known numpy 1.24.3 masking issues
+            # https://github.com/SciTools/iris/pull/5274 and https://github.com/SciTools/iris/issues/5329
+            pversion = pkg_resources.parse_version(record["version"])
+            v3_2_0, v3_6_0 = pkg_resources.parse_version("3.2.0"), pkg_resources.parse_version("3.6.0")
+            if v3_2_0 <= pversion < v3_6_0 and record.get("timestamp", 0) < 1684507640000:
+                _replace_pin("numpy >=1.19", "numpy >=1.19,!=1.24.3", record["depends"], record)
 
         if record_name == "nordugrid-arc" and record.get("timestamp", 0) < 1666690884000:
             record["depends"].append("glibmm-2.4 >=2.58.1")


### PR DESCRIPTION
Checklist
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<details>
<summary> Output from python show_diff.py ... </summary>

```bash
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata.json.bz2
noarch::iris-3.2.0-pyhd8ed1ab_0.tar.bz2
-    "numpy >=1.19",
+    "numpy >=1.19,!=1.24.3",
noarch::iris-3.2.0.post0-pyhd8ed1ab_0.tar.bz2
-    "numpy >=1.19",
+    "numpy >=1.19,!=1.24.3",
noarch::iris-3.2.1-pyhd8ed1ab_0.tar.bz2
-    "numpy >=1.19",
+    "numpy >=1.19,!=1.24.3",
noarch::iris-3.2.1.post0-pyhd8ed1ab_0.tar.bz2
-    "numpy >=1.19",
+    "numpy >=1.19,!=1.24.3",
noarch::iris-3.3.0-pyhd8ed1ab_0.tar.bz2
-    "numpy >=1.19",
+    "numpy >=1.19,!=1.24.3",
noarch::iris-3.3.1-pyhd8ed1ab_0.tar.bz2
-    "numpy >=1.19",
+    "numpy >=1.19,!=1.24.3",
noarch::boa-0.15.0-pyhd8ed1ab_0.conda
-{
-  "build": "pyhd8ed1ab_0",
-  "build_number": 0,
-  "depends": [
-    "conda-build >=3.24,<3.25",
-    "dataclasses",
-    "jinja2",
-    "joblib",
-    "json5",
-    "jsonschema",
-    "mamba >=1.0,<1.5",
-    "prompt_toolkit",
-    "python >=3.6",
-    "rich",
-    "ruamel.yaml",
-    "watchgod"
-  ],
-  "license": "BSD-3-Clause",
-  "md5": "dfd082721ce8f6c98e6215d48770169e",
-  "name": "boa",
-  "noarch": "python",
-  "sha256": "b52f247dc23cfb1bc086c3de52dd9674392ea12ab1c4dadc0f433cff26766fbe",
-  "size": 65518,
-  "subdir": "noarch",
-  "timestamp": 1684400222507,
-  "version": "0.15.0"
-}
+{}
noarch::iris-3.4.0-pyhd8ed1ab_0.conda
-    "numpy >=1.19",
+    "numpy >=1.19,!=1.24.3",
noarch::iris-3.4.1-pyhd8ed1ab_0.conda
-    "numpy >=1.19",
+    "numpy >=1.19,!=1.24.3",
noarch::iris-3.5.0-pyhd8ed1ab_0.conda
-    "numpy >=1.19",
+    "numpy >=1.19,!=1.24.3",
noarch::python-irodsclient-1.1.8-pyhd8ed1ab_0.conda
-    "python =2.7|>=3.6",
+    "python ==2.7.*|>=3.6",
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata.json.bz2
linux-64::clang-14.0.6-ha770c72_1.conda
-  "version": "14.0.6"
+  "version": "14.0.6",
+  "constrains": [
+    "clang-tools 14.0.6.*",
+    "llvm 14.0.6.*",
+    "llvm-tools 14.0.6.*",
+    "llvmdev 14.0.6.*"
+  ]
linux-64::clang-15.0.7-ha770c72_2.conda
-  "version": "15.0.7"
+  "version": "15.0.7",
+  "constrains": [
+    "clang-tools 15.0.7.*",
+    "llvm 15.0.7.*",
+    "llvm-tools 15.0.7.*",
+    "llvmdev 15.0.7.*"
+  ]
linux-64::clang-16.0.3-ha0738ec_2.conda
-  "version": "16.0.3"
+  "version": "16.0.3",
+  "constrains": [
+    "clang-tools 16.0.3.*",
+    "llvm 16.0.3.*",
+    "llvm-tools 16.0.3.*",
+    "llvmdev 16.0.3.*"
+  ]
linux-64::clang-16.0.4-ha0738ec_0.conda
-  "version": "16.0.4"
+  "version": "16.0.4",
+  "constrains": [
+    "clang-tools 16.0.4.*",
+    "llvm 16.0.4.*",
+    "llvm-tools 16.0.4.*",
+    "llvmdev 16.0.4.*"
+  ]
linux-64::clang-tools-14.0.6-default_h7634d5b_1.conda
-    "clangdev 14.0.6"
+    "clangdev 14.0.6",
+    "clang 14.0.6.*",
+    "llvm 14.0.6.*",
+    "llvm-tools 14.0.6.*",
+    "llvmdev 14.0.6.*"
linux-64::clang-tools-15.0.7-default_h7634d5b_2.conda
-    "clangdev 15.0.7"
+    "clangdev 15.0.7",
+    "clang 15.0.7.*",
+    "llvm 15.0.7.*",
+    "llvm-tools 15.0.7.*",
+    "llvmdev 15.0.7.*"
linux-64::clang-tools-16.0.3-default_h1cdf331_2.conda
-    "clangdev 16.0.3"
+    "clangdev 16.0.3",
+    "clang 16.0.3.*",
+    "llvm 16.0.3.*",
+    "llvm-tools 16.0.3.*",
+    "llvmdev 16.0.3.*"
linux-64::clang-tools-16.0.4-default_h1cdf331_0.conda
-    "clangdev 16.0.4"
+    "clangdev 16.0.4",
+    "clang 16.0.4.*",
+    "llvm 16.0.4.*",
+    "llvm-tools 16.0.4.*",
+    "llvmdev 16.0.4.*"
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata.json.bz2
linux-aarch64::clang-14.0.6-h8af1aa0_1.conda
-  "version": "14.0.6"
+  "version": "14.0.6",
+  "constrains": [
+    "clang-tools 14.0.6.*",
+    "llvm 14.0.6.*",
+    "llvm-tools 14.0.6.*",
+    "llvmdev 14.0.6.*"
+  ]
linux-aarch64::clang-15.0.7-h8af1aa0_2.conda
-  "version": "15.0.7"
+  "version": "15.0.7",
+  "constrains": [
+    "clang-tools 15.0.7.*",
+    "llvm 15.0.7.*",
+    "llvm-tools 15.0.7.*",
+    "llvmdev 15.0.7.*"
+  ]
linux-aarch64::clang-16.0.4-h5271726_0.conda
-  "version": "16.0.4"
+  "version": "16.0.4",
+  "constrains": [
+    "clang-tools 16.0.4.*",
+    "llvm 16.0.4.*",
+    "llvm-tools 16.0.4.*",
+    "llvmdev 16.0.4.*"
+  ]
linux-aarch64::clang-tools-14.0.6-default_hdf9a116_1.conda
-    "clangdev 14.0.6"
+    "clangdev 14.0.6",
+    "clang 14.0.6.*",
+    "llvm 14.0.6.*",
+    "llvm-tools 14.0.6.*",
+    "llvmdev 14.0.6.*"
linux-aarch64::clang-tools-15.0.7-default_hdf9a116_2.conda
-    "clangdev 15.0.7"
+    "clangdev 15.0.7",
+    "clang 15.0.7.*",
+    "llvm 15.0.7.*",
+    "llvm-tools 15.0.7.*",
+    "llvmdev 15.0.7.*"
linux-aarch64::clang-tools-16.0.4-default_h95d19f2_0.conda
-    "clangdev 16.0.4"
+    "clangdev 16.0.4",
+    "clang 16.0.4.*",
+    "llvm 16.0.4.*",
+    "llvm-tools 16.0.4.*",
+    "llvmdev 16.0.4.*"
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata.json.bz2
linux-ppc64le::clang-14.0.6-ha3edaa6_1.conda
-  "version": "14.0.6"
+  "version": "14.0.6",
+  "constrains": [
+    "clang-tools 14.0.6.*",
+    "llvm 14.0.6.*",
+    "llvm-tools 14.0.6.*",
+    "llvmdev 14.0.6.*"
+  ]
linux-ppc64le::clang-15.0.7-ha3edaa6_2.conda
-  "version": "15.0.7"
+  "version": "15.0.7",
+  "constrains": [
+    "clang-tools 15.0.7.*",
+    "llvm 15.0.7.*",
+    "llvm-tools 15.0.7.*",
+    "llvmdev 15.0.7.*"
+  ]
linux-ppc64le::clang-16.0.4-h381f82a_0.conda
-  "version": "16.0.4"
+  "version": "16.0.4",
+  "constrains": [
+    "clang-tools 16.0.4.*",
+    "llvm 16.0.4.*",
+    "llvm-tools 16.0.4.*",
+    "llvmdev 16.0.4.*"
+  ]
linux-ppc64le::clang-tools-14.0.6-default_hb66b9a5_1.conda
-    "clangdev 14.0.6"
+    "clangdev 14.0.6",
+    "clang 14.0.6.*",
+    "llvm 14.0.6.*",
+    "llvm-tools 14.0.6.*",
+    "llvmdev 14.0.6.*"
linux-ppc64le::clang-tools-15.0.7-default_hb66b9a5_2.conda
-    "clangdev 15.0.7"
+    "clangdev 15.0.7",
+    "clang 15.0.7.*",
+    "llvm 15.0.7.*",
+    "llvm-tools 15.0.7.*",
+    "llvmdev 15.0.7.*"
linux-ppc64le::clang-tools-16.0.4-default_ha79e3c0_0.conda
-    "clangdev 16.0.4"
+    "clangdev 16.0.4",
+    "clang 16.0.4.*",
+    "llvm 16.0.4.*",
+    "llvm-tools 16.0.4.*",
+    "llvmdev 16.0.4.*"
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata.json.bz2
osx-64::clang-14.0.6-h694c41f_1.conda
-  "version": "14.0.6"
+  "version": "14.0.6",
+  "constrains": [
+    "clang-tools 14.0.6.*",
+    "llvm 14.0.6.*",
+    "llvm-tools 14.0.6.*",
+    "llvmdev 14.0.6.*"
+  ]
osx-64::clang-15.0.7-h694c41f_2.conda
-  "version": "15.0.7"
+  "version": "15.0.7",
+  "constrains": [
+    "clang-tools 15.0.7.*",
+    "llvm 15.0.7.*",
+    "llvm-tools 15.0.7.*",
+    "llvmdev 15.0.7.*"
+  ]
osx-64::clang-16.0.4-hc177806_0.conda
-  "version": "16.0.4"
+  "version": "16.0.4",
+  "constrains": [
+    "clang-tools 16.0.4.*",
+    "llvm 16.0.4.*",
+    "llvm-tools 16.0.4.*",
+    "llvmdev 16.0.4.*"
+  ]
osx-64::clang-tools-14.0.6-default_hdb78580_1.conda
-    "clangdev 14.0.6"
+    "clangdev 14.0.6",
+    "clang 14.0.6.*",
+    "llvm 14.0.6.*",
+    "llvm-tools 14.0.6.*",
+    "llvmdev 14.0.6.*"
osx-64::clang-tools-15.0.7-default_hdb78580_2.conda
-    "clangdev 15.0.7"
+    "clangdev 15.0.7",
+    "clang 15.0.7.*",
+    "llvm 15.0.7.*",
+    "llvm-tools 15.0.7.*",
+    "llvmdev 15.0.7.*"
osx-64::clang-tools-16.0.4-default_h762fdd7_0.conda
-    "clangdev 16.0.4"
+    "clangdev 16.0.4",
+    "clang 16.0.4.*",
+    "llvm 16.0.4.*",
+    "llvm-tools 16.0.4.*",
+    "llvmdev 16.0.4.*"
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata.json.bz2
osx-arm64::clang-14.0.6-hce30654_1.conda
-  "version": "14.0.6"
+  "version": "14.0.6",
+  "constrains": [
+    "clang-tools 14.0.6.*",
+    "llvm 14.0.6.*",
+    "llvm-tools 14.0.6.*",
+    "llvmdev 14.0.6.*"
+  ]
osx-arm64::clang-15.0.7-hce30654_2.conda
-  "version": "15.0.7"
+  "version": "15.0.7",
+  "constrains": [
+    "clang-tools 15.0.7.*",
+    "llvm 15.0.7.*",
+    "llvm-tools 15.0.7.*",
+    "llvmdev 15.0.7.*"
+  ]
osx-arm64::clang-16.0.4-he79909e_0.conda
-  "version": "16.0.4"
+  "version": "16.0.4",
+  "constrains": [
+    "clang-tools 16.0.4.*",
+    "llvm 16.0.4.*",
+    "llvm-tools 16.0.4.*",
+    "llvmdev 16.0.4.*"
+  ]
osx-arm64::clang-tools-14.0.6-default_h5dc8d65_1.conda
-    "clangdev 14.0.6"
+    "clangdev 14.0.6",
+    "clang 14.0.6.*",
+    "llvm 14.0.6.*",
+    "llvm-tools 14.0.6.*",
+    "llvmdev 14.0.6.*"
osx-arm64::clang-tools-15.0.7-default_h5dc8d65_2.conda
-    "clangdev 15.0.7"
+    "clangdev 15.0.7",
+    "clang 15.0.7.*",
+    "llvm 15.0.7.*",
+    "llvm-tools 15.0.7.*",
+    "llvmdev 15.0.7.*"
osx-arm64::clang-tools-16.0.4-default_h07b2d96_0.conda
-    "clangdev 16.0.4"
+    "clangdev 16.0.4",
+    "clang 16.0.4.*",
+    "llvm 16.0.4.*",
+    "llvm-tools 16.0.4.*",
+    "llvmdev 16.0.4.*"
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata.json.bz2
win-64::clang-14.0.6-h8e541a6_1.conda
-  "version": "14.0.6"
+  "version": "14.0.6",
+  "constrains": [
+    "clang-tools 14.0.6.*",
+    "llvm 14.0.6.*",
+    "llvm-tools 14.0.6.*",
+    "llvmdev 14.0.6.*"
+  ]
win-64::clang-15.0.7-h8e541a6_2.conda
-  "version": "15.0.7"
+  "version": "15.0.7",
+  "constrains": [
+    "clang-tools 15.0.7.*",
+    "llvm 15.0.7.*",
+    "llvm-tools 15.0.7.*",
+    "llvmdev 15.0.7.*"
+  ]
win-64::clang-16.0.3-h3dc180e_2.conda
-  "version": "16.0.3"
+  "version": "16.0.3",
+  "constrains": [
+    "clang-tools 16.0.3.*",
+    "llvm 16.0.3.*",
+    "llvm-tools 16.0.3.*",
+    "llvmdev 16.0.3.*"
+  ]
win-64::clang-16.0.4-h3dc180e_0.conda
-  "version": "16.0.4"
+  "version": "16.0.4",
+  "constrains": [
+    "clang-tools 16.0.4.*",
+    "llvm 16.0.4.*",
+    "llvm-tools 16.0.4.*",
+    "llvmdev 16.0.4.*"
+  ]
win-64::clang-tools-14.0.6-default_h66ee7f4_1.conda
-    "clangdev 14.0.6"
+    "clangdev 14.0.6",
+    "clang 14.0.6.*",
+    "llvm 14.0.6.*",
+    "llvm-tools 14.0.6.*",
+    "llvmdev 14.0.6.*"
win-64::clang-tools-15.0.7-default_h66ee7f4_2.conda
-    "clangdev 15.0.7"
+    "clangdev 15.0.7",
+    "clang 15.0.7.*",
+    "llvm 15.0.7.*",
+    "llvm-tools 15.0.7.*",
+    "llvmdev 15.0.7.*"
win-64::clang-tools-16.0.3-default_heb8d277_2.conda
-    "clangdev 16.0.3"
+    "clangdev 16.0.3",
+    "clang 16.0.3.*",
+    "llvm 16.0.3.*",
+    "llvm-tools 16.0.3.*",
+    "llvmdev 16.0.3.*"
win-64::clang-tools-16.0.4-default_heb8d277_0.conda
-    "clangdev 16.0.4"
+    "clangdev 16.0.4",
+    "clang 16.0.4.*",
+    "llvm 16.0.4.*",
+    "llvm-tools 16.0.4.*",
+    "llvmdev 16.0.4.*"
```

</details>