### PR TITLE
transformers>=4.18 and < 4.23 can't use tokenizers >=0.13

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -574,6 +574,16 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             i = record['depends'].index('ninja')
             record['depends'].pop(i)
 
+        if (
+                record_name == "transformers"
+                and (packaging.version.parse(record['version']) < packaging.version.parse('4.23'))
+                and (packaging.version.parse(record['version']) >= packaging.version.parse('4.18'))
+                and record.get('timestamp', 0) < 1685092335000
+        ):
+            tokenizers_pin = [r for r in record["depends"] if r.startswith('tokenizers')][0]
+            i = record["depends"].index(tokenizers_pin)
+            record["depends"][i] = tokenizers_pin + ',<0.13'
+
         if record_name == "packaging" and record["version"] in ["21.1", "21.2"]:
             # https://github.com/conda-forge/packaging-feedstock/pull/21
             deps = record["depends"]


### PR DESCRIPTION
Fixes https://github.com/conda-forge/transformers-feedstock/issues/106

FYI @conda-forge/transformers 

Checklist
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<details>
Diff

```
noarch::transformers-4.18.0-pyhd8ed1ab_0.tar.bz2
-    "tokenizers >=0.11.1,!=0.11.3",
+    "tokenizers >=0.11.1,!=0.11.3,<0.13",
noarch::transformers-4.19.0-pyhd8ed1ab_0.tar.bz2
-    "tokenizers >=0.11.1,!=0.11.3",
+    "tokenizers >=0.11.1,!=0.11.3,<0.13",
noarch::transformers-4.19.1-pyhd8ed1ab_0.tar.bz2
-    "tokenizers >=0.11.1,!=0.11.3",
+    "tokenizers >=0.11.1,!=0.11.3,<0.13",
noarch::transformers-4.19.2-pyhd8ed1ab_0.tar.bz2
-    "tokenizers >=0.11.1,!=0.11.3",
+    "tokenizers >=0.11.1,!=0.11.3,<0.13",
noarch::transformers-4.19.3-pyhd8ed1ab_0.tar.bz2
-    "tokenizers >=0.11.1,!=0.11.3",
+    "tokenizers >=0.11.1,!=0.11.3,<0.13",
noarch::transformers-4.19.4-pyhd8ed1ab_0.tar.bz2
-    "tokenizers >=0.11.1,!=0.11.3",
+    "tokenizers >=0.11.1,!=0.11.3,<0.13",
noarch::transformers-4.20.0-pyhd8ed1ab_0.tar.bz2
-    "tokenizers >=0.11.1,!=0.11.3",
+    "tokenizers >=0.11.1,!=0.11.3,<0.13",
noarch::transformers-4.20.1-pyhd8ed1ab_0.tar.bz2
-    "tokenizers >=0.11.1,!=0.11.3",
+    "tokenizers >=0.11.1,!=0.11.3,<0.13",
noarch::transformers-4.21.0-pyhd8ed1ab_0.tar.bz2
-    "tokenizers >=0.11.1,!=0.11.3",
+    "tokenizers >=0.11.1,!=0.11.3,<0.13",
noarch::transformers-4.21.1-pyhd8ed1ab_0.tar.bz2
-    "tokenizers >=0.11.1,!=0.11.3",
+    "tokenizers >=0.11.1,!=0.11.3,<0.13",
noarch::transformers-4.21.2-pyhd8ed1ab_0.tar.bz2
-    "tokenizers >=0.11.1,!=0.11.3",
+    "tokenizers >=0.11.1,!=0.11.3,<0.13",
noarch::transformers-4.21.3-pyhd8ed1ab_0.tar.bz2
-    "tokenizers >=0.11.1,!=0.11.3",
+    "tokenizers >=0.11.1,!=0.11.3,<0.13",
noarch::transformers-4.22.0-pyhd8ed1ab_0.tar.bz2
-    "tokenizers >=0.11.1,!=0.11.3",
+    "tokenizers >=0.11.1,!=0.11.3,<0.13",
noarch::transformers-4.22.1-pyhd8ed1ab_0.tar.bz2
-    "tokenizers >=0.11.1,!=0.11.3",
+    "tokenizers >=0.11.1,!=0.11.3,<0.13",
noarch::transformers-4.22.2-pyhd8ed1ab_0.tar.bz2
-    "tokenizers >=0.11.1,!=0.11.3",
+    "tokenizers >=0.11.1,!=0.11.3,<0.13",
```
</details>