### PR TITLE
Constrain urllib3 <2 for conda-lock

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1957,6 +1957,10 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                     depends[i] = " ".join(_dep_parts)
             record["depends"] = depends
 
+        if record_name == "conda-lock" and record.get("timestamp", 0) < 1685186303000:
+            assert "constrains" not in record
+            record["constrains"] = ["urllib3 <2"]
+
         if record_name == "proplot" and record.get("timestamp", 0) < 1634670686970:
             depends = record.get("depends", [])
             for i, dep in enumerate(depends):


### PR DESCRIPTION
Closes https://github.com/conda/conda-lock/issues/413

CC @mariusvniekerk 

Checklist
* [X] Ran `python show_diff.py` and posted the output as part of the PR.
* [X] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

```diff
noarch::conda-lock-0.10.0-pyhd8ed1ab_0.tar.bz2
-  "version": "0.10.0"
+  "version": "0.10.0",
+  "constrains": [
+    "urllib3 <2"
+  ]
noarch::conda-lock-0.11.0-pyhd8ed1ab_0.tar.bz2
-  "version": "0.11.0"
+  "version": "0.11.0",
+  "constrains": [
+    "urllib3 <2"
+  ]
noarch::conda-lock-0.11.1-pyhd8ed1ab_0.tar.bz2
-  "version": "0.11.1"
+  "version": "0.11.1",
+  "constrains": [
+    "urllib3 <2"
+  ]
noarch::conda-lock-0.11.2-pyhd8ed1ab_0.tar.bz2
-  "version": "0.11.2"
+  "version": "0.11.2",
+  "constrains": [
+    "urllib3 <2"
+  ]
noarch::conda-lock-0.11.3-pyhd8ed1ab_0.tar.bz2
-  "version": "0.11.3"
+  "version": "0.11.3",
+  "constrains": [
+    "urllib3 <2"
+  ]
noarch::conda-lock-0.12.0-pyhd8ed1ab_0.tar.bz2
-  "version": "0.12.0"
+  "version": "0.12.0",
+  "constrains": [
+    "urllib3 <2"
+  ]
noarch::conda-lock-0.13.0-pyhd8ed1ab_0.tar.bz2
-  "version": "0.13.0"
+  "version": "0.13.0",
+  "constrains": [
+    "urllib3 <2"
+  ]
noarch::conda-lock-0.13.1-pyhd8ed1ab_0.tar.bz2
-  "version": "0.13.1"
+  "version": "0.13.1",
+  "constrains": [
+    "urllib3 <2"
+  ]
noarch::conda-lock-0.13.1-pyhd8ed1ab_1.tar.bz2
-  "version": "0.13.1"
+  "version": "0.13.1",
+  "constrains": [
+    "urllib3 <2"
+  ]
noarch::conda-lock-0.13.2-pyhd8ed1ab_0.tar.bz2
-  "version": "0.13.2"
+  "version": "0.13.2",
+  "constrains": [
+    "urllib3 <2"
+  ]
noarch::conda-lock-0.2.2-py_0.tar.bz2
-  "version": "0.2.2"
+  "version": "0.2.2",
+  "constrains": [
+    "urllib3 <2"
+  ]
noarch::conda-lock-0.3.0-py_0.tar.bz2
-  "version": "0.3.0"
+  "version": "0.3.0",
+  "constrains": [
+    "urllib3 <2"
+  ]
noarch::conda-lock-0.4.0-py_0.tar.bz2
-  "version": "0.4.0"
+  "version": "0.4.0",
+  "constrains": [
+    "urllib3 <2"
+  ]
noarch::conda-lock-0.4.1-py_0.tar.bz2
-  "version": "0.4.1"
+  "version": "0.4.1",
+  "constrains": [
+    "urllib3 <2"
+  ]
noarch::conda-lock-0.5.0-py_0.tar.bz2
-  "version": "0.5.0"
+  "version": "0.5.0",
+  "constrains": [
+    "urllib3 <2"
+  ]
noarch::conda-lock-0.6.0-py_0.tar.bz2
-  "version": "0.6.0"
+  "version": "0.6.0",
+  "constrains": [
+    "urllib3 <2"
+  ]
noarch::conda-lock-0.7.0-py_0.tar.bz2
-  "version": "0.7.0"
+  "version": "0.7.0",
+  "constrains": [
+    "urllib3 <2"
+  ]
noarch::conda-lock-0.7.1-py_0.tar.bz2
-  "version": "0.7.1"
+  "version": "0.7.1",
+  "constrains": [
+    "urllib3 <2"
+  ]
noarch::conda-lock-0.7.2-py_0.tar.bz2
-  "version": "0.7.2"
+  "version": "0.7.2",
+  "constrains": [
+    "urllib3 <2"
+  ]
noarch::conda-lock-0.7.3-pyhd8ed1ab_0.tar.bz2
-  "version": "0.7.3"
+  "version": "0.7.3",
+  "constrains": [
+    "urllib3 <2"
+  ]
noarch::conda-lock-0.8.0-pyhd8ed1ab_0.tar.bz2
-  "version": "0.8.0"
+  "version": "0.8.0",
+  "constrains": [
+    "urllib3 <2"
+  ]
noarch::conda-lock-0.9.0-pyhd8ed1ab_0.tar.bz2
-  "version": "0.9.0"
+  "version": "0.9.0",
+  "constrains": [
+    "urllib3 <2"
+  ]
noarch::conda-lock-0.9.1-pyhd8ed1ab_0.tar.bz2
-  "version": "0.9.1"
+  "version": "0.9.1",
+  "constrains": [
+    "urllib3 <2"
+  ]
noarch::conda-lock-1.0.1-pyhd8ed1ab_0.tar.bz2
-  "version": "1.0.1"
+  "version": "1.0.1",
+  "constrains": [
+    "urllib3 <2"
+  ]
noarch::conda-lock-1.0.2-pyhd8ed1ab_0.tar.bz2
-  "version": "1.0.2"
+  "version": "1.0.2",
+  "constrains": [
+    "urllib3 <2"
+  ]
noarch::conda-lock-1.0.3-pyhd8ed1ab_0.tar.bz2
-  "version": "1.0.3"
+  "version": "1.0.3",
+  "constrains": [
+    "urllib3 <2"
+  ]
noarch::conda-lock-1.0.4-pyhd8ed1ab_0.tar.bz2
-  "version": "1.0.4"
+  "version": "1.0.4",
+  "constrains": [
+    "urllib3 <2"
+  ]
noarch::conda-lock-1.0.5-pyhd8ed1ab_0.tar.bz2
-  "version": "1.0.5"
+  "version": "1.0.5",
+  "constrains": [
+    "urllib3 <2"
+  ]
noarch::conda-lock-1.0.5-pyhd8ed1ab_1.tar.bz2
-  "version": "1.0.5"
+  "version": "1.0.5",
+  "constrains": [
+    "urllib3 <2"
+  ]
noarch::conda-lock-1.1.1-pyhd8ed1ab_0.tar.bz2
-  "version": "1.1.1"
+  "version": "1.1.1",
+  "constrains": [
+    "urllib3 <2"
+  ]
noarch::conda-lock-1.1.2-pyhd8ed1ab_0.tar.bz2
-  "version": "1.1.2"
+  "version": "1.1.2",
+  "constrains": [
+    "urllib3 <2"
+  ]
noarch::conda-lock-1.1.2-pyhd8ed1ab_1.tar.bz2
-  "version": "1.1.2"
+  "version": "1.1.2",
+  "constrains": [
+    "urllib3 <2"
+  ]
noarch::conda-lock-1.1.3-pyhd8ed1ab_0.tar.bz2
-  "version": "1.1.3"
+  "version": "1.1.3",
+  "constrains": [
+    "urllib3 <2"
+  ]
noarch::conda-lock-1.2.1-pyhd8ed1ab_0.tar.bz2
-  "version": "1.2.1"
+  "version": "1.2.1",
+  "constrains": [
+    "urllib3 <2"
+  ]
noarch::conda-lock-1.2.1-pyhd8ed1ab_1.tar.bz2
-  "version": "1.2.1"
+  "version": "1.2.1",
+  "constrains": [
+    "urllib3 <2"
+  ]
noarch::conda-lock-1.3.0-pyhd8ed1ab_0.conda
-  "version": "1.3.0"
+  "version": "1.3.0",
+  "constrains": [
+    "urllib3 <2"
+  ]
noarch::conda-lock-1.4.0-pyhd8ed1ab_0.conda
-  "version": "1.4.0"
+  "version": "1.4.0",
+  "constrains": [
+    "urllib3 <2"
+  ]
noarch::conda-lock-1.4.0-pyhd8ed1ab_1.conda
-  "version": "1.4.0"
+  "version": "1.4.0",
+  "constrains": [
+    "urllib3 <2"
+  ]
noarch::conda-lock-1.4.0-pyhd8ed1ab_2.conda
-  "version": "1.4.0"
+  "version": "1.4.0",
+  "constrains": [
+    "urllib3 <2"
+  ]
```