### PR TITLE
`conda-content-trust` is incompatible with `cryptography=41.0.0`

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -3044,8 +3044,8 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             _replace_pin("werkzeug >=1.0,<3.0", "werkzeug >=1.0,<2.3", record["depends"], record)
             record["depends"].remove("importlib-metadata >=1")
 
-        if record_name == "conda-content-trust" and record["version"] == "0.1.3" and record.get("timestamp", 0) < 1685589411000:
-            _replace_pin("cryptography", "cryptography <41.0.0", record["depends"], record)
+        if record_name == "conda-content-trust" and record.get("timestamp", 0) < 1685589411000:  # 2023-06-01
+            _replace_pin("cryptography", "cryptography <41.0.0a0", record["depends"], record)
 
     return index
 

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -3044,6 +3044,9 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             _replace_pin("werkzeug >=1.0,<3.0", "werkzeug >=1.0,<2.3", record["depends"], record)
             record["depends"].remove("importlib-metadata >=1")
 
+        if record_name == "conda-content-trust" and record["version"] == "0.1.3" and record.get("timestamp", 0) < 1685589411000:
+            _replace_pin("cryptography", "cryptography <41.0.0", record["depends"], record)
+
     return index
 
 


### PR DESCRIPTION
Checklist
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

Xref https://github.com/conda/conda-content-trust/issues/56

<details open>
<summary><code>python show_diff.py</code></summary>

```diff
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata.json.bz2
noarch::conda-content-trust-0.1.3-pyhd8ed1ab_0.tar.bz2
-    "cryptography",
+    "cryptography <41.0.0",
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata.json.bz2
```

</details>