### PR TITLE
BUG make sure to restrict noarch depfinder packages to py<3.10

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -3044,6 +3044,26 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             _replace_pin("werkzeug >=1.0,<3.0", "werkzeug >=1.0,<2.3", record["depends"], record)
             record["depends"].remove("importlib-metadata >=1")
 
+        # noarch depfinder packages are broken for python >=3.10
+        if (
+            record_name == "depfinder"
+            and record.get("timestamp", 0) < 1658449202098
+            and subdir == "noarch"
+            and any(
+                "<3.10" not in dep
+                for dep in record.get("depends", [])
+                if dep.startswith("python ")
+            )
+        ):
+            pind = None
+            for i, dep in enumerate(record.get("depends", [])):
+                if dep.startswith("python "):
+                    pind = i
+                    break
+
+            if pind is not None and "<3.10" not in record["depends"][pind]:
+                record["depends"][pind] = record["depends"][pind] + ",<3.10"
+
     return index
 
 

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -3047,10 +3047,10 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
         # noarch depfinder packages are broken for python >=3.10
         if (
             record_name == "depfinder"
-            and record.get("timestamp", 0) < 1658449202098
+            and record.get("timestamp", 0) < 1659704295850
             and subdir == "noarch"
             and any(
-                "<3.10" not in dep
+                "<" not in dep
                 for dep in record.get("depends", [])
                 if dep.startswith("python ")
             )
@@ -3061,7 +3061,7 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                     pind = i
                     break
 
-            if pind is not None and "<3.10" not in record["depends"][pind]:
+            if pind is not None:
                 record["depends"][pind] = record["depends"][pind] + ",<3.10"
 
     return index


### PR DESCRIPTION
Checklist
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

related to https://github.com/conda-forge/depfinder-feedstock/issues/40