### PR TITLE
FIX: pin back modestimage's dependency on numpy to avoid removal

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -905,6 +905,7 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
         # Need to patch modest image for numpy 1.24 removal of np.float
         if (
             record_name == "modestimage" and record['version'] == '0.2' and record['build'] in {'pyhd8ed1ab_0', 'pyhd8ed1ab_1' }
+            and record.get('timestamp', 0) < 1686071355
         ):
             i = record['depends'].index('numpy')
             record['depends'][i] = 'numpy <1.24'

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -902,6 +902,13 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                 i = record['depends'].index('python >=3.6')
                 record['depends'][i] = 'python >=3.7'
 
+        # Need to patch modest image for numpy 1.24 removal of np.float
+        if (
+            record_name == "modestimage" and record['version'] == '0.2' and record['build'] in {'pyhd8ed1ab_0', 'pyhd8ed1ab_1' }
+        ):
+            i = record['depends'].index('numpy')
+            record['depends'][i] = 'numpy <1.24'
+
         # some versions mpi4py-fft are not compatible with MKL
         # https://github.com/conda-forge/mpi4py-fft-feedstock/issues/20
         if record_name == "mpi4py-fft" and record.get('timestamp', 0) < 1619448232206:


### PR DESCRIPTION
Checklist
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->


```
✔ 17:19:45 $ python show_diff.py
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata.json.bz2
noarch::modestimage-0.2-pyhd8ed1ab_0.tar.bz2
-    "numpy",
+    "numpy <1.24",
noarch::modestimage-0.2-pyhd8ed1ab_1.tar.bz2
-    "numpy",
+    "numpy <1.24",
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata.json.bz2
linux-64::graalpy-22.3.2-0_graalvm_native.conda
-  "track_features": "openjdk",
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata.json.bz2

```

https://github.com/conda-forge/modestimage-feedstock/pull/4 is PR to patch the feedstock.
