### PR TITLE
FIX: use correct units in timestamp

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -905,7 +905,7 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
         # Need to patch modest image for numpy 1.24 removal of np.float
         if (
             record_name == "modestimage" and record['version'] == '0.2' and record['build'] in {'pyhd8ed1ab_0', 'pyhd8ed1ab_1' }
-            and record.get('timestamp', 0) < 1686071355
+            and record.get('timestamp', 0) < 1686073337000
         ):
             i = record['depends'].index('numpy')
             record['depends'][i] = 'numpy <1.24'


### PR DESCRIPTION
is in milliseconds not seconds

Follow up to #465

I hard-coded the builds I wanted to fix, added the timestamp but failed to re-run the `show_diff.py` before pushing 🤦🏻 so what got merged has no effect.

Checklist
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->
