### PR TITLE
Use `cuda-version` w/recent `nccl` packages

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1062,6 +1062,15 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                 constrains.append( f'cudatoolkit {cuda_major_minor}|{cuda_major_minor}.*' )
             record['constrains'] = constrains
 
+        if record_name == "nccl" and 1681282800000 < record.get("timestamp", 0) < 1686034800000:
+            deps = record.get("depends", [])
+            for i in range(len(deps)):
+                dep = deps[i]
+                if dep.startswith("cudatoolkit"):
+                    spec = dep[11:]
+                    dep = f"cuda-version{spec}"
+                deps[i] = dep
+
         if record_name == "ucx" and record.get('timestamp', 0) < 1682924400000:
             constrains = record.get('constrains', [])
             for i, c in enumerate(constrains):


### PR DESCRIPTION
As recent `nccl` packages don't need anything from `cudatoolkit`, drop that dependency and simply use `cuda-version` to ensure it `nccl` is installed with the right driver. Older packages had some dependence on `cudatoolkit` so this requires 2.15.1.1+ to work.

xref: https://github.com/conda-forge/nccl-feedstock/pull/90

<hr>

Checklist
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->
