### PR TITLE
pin robotframework-seleniumlibrary <6.1.1 to selenium <4.10

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -2631,6 +2631,22 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                             parts = [parts[0], ">=1.12.1,<3.0.0"]
                         record[field][i] = " ".join(parts)
 
+        # selenium 4.10 removes code used by robotframework-seleniumlibrary <6.1.1
+        if (
+            record.get("timestamp", 0) <= 1686323537000
+            and record_name == "robotframework-seleniumlibrary"
+            and (
+                pkg_resources.parse_version(record["version"]) <=
+                pkg_resources.parse_version("6.1.0")
+            )
+        ):
+            for i in range(len(record["depends"])):
+                parts = record["depends"][i].split(" ")
+                if parts[0] == "selenium":
+                    if len(parts) == 2 and "<" not in parts[1]:
+                        parts[1] = parts[1] + ",<4.10"
+                    record["depends"][i] = " ".join(parts)
+
         # conda moved to calvar from semver and this broke old versions of
         # conda smithy that do on-the-fly version checks
         if (


### PR DESCRIPTION
Checklist
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
<details>
<code>
noarch::robotframework-seleniumlibrary-3.2.0-py_0.tar.bz2
-    "selenium >=2.53.6"
+    "selenium >=2.53.6,<4.10"
noarch::robotframework-seleniumlibrary-3.3.0-py_0.tar.bz2
-    "selenium >=2.53.6"
+    "selenium >=2.53.6,<4.10"
noarch::robotframework-seleniumlibrary-3.3.1-py_0.tar.bz2
-    "selenium >=2.53.6"
+    "selenium >=2.53.6,<4.10"
noarch::robotframework-seleniumlibrary-4.0.0-py_0.tar.bz2
-    "selenium >=3.8.1"
+    "selenium >=3.8.1,<4.10"
noarch::robotframework-seleniumlibrary-4.1.0-py_0.tar.bz2
-    "selenium >=3.8.1"
+    "selenium >=3.8.1,<4.10"
noarch::robotframework-seleniumlibrary-4.2.0-py_0.tar.bz2
-    "selenium >=3.8.1"
+    "selenium >=3.8.1,<4.10"
noarch::robotframework-seleniumlibrary-4.3.0-py_0.tar.bz2
-    "selenium >=3.141.0"
+    "selenium >=3.141.0,<4.10"
noarch::robotframework-seleniumlibrary-4.4.0-pyh9f0ad1d_0.tar.bz2
-    "selenium >=3.141.0"
+    "selenium >=3.141.0,<4.10"
noarch::robotframework-seleniumlibrary-4.5.0-pyh9f0ad1d_0.tar.bz2
-    "selenium >=3.141.0"
+    "selenium >=3.141.0,<4.10"
noarch::robotframework-seleniumlibrary-5.0.0-pyhd8ed1ab_1.tar.bz2
-    "selenium >=3.141.0"
+    "selenium >=3.141.0,<4.10"
noarch::robotframework-seleniumlibrary-5.0.1-pyhd8ed1ab_0.tar.bz2
-    "selenium >=3.141.0"
+    "selenium >=3.141.0,<4.10"
noarch::robotframework-seleniumlibrary-5.1.0-pyhd8ed1ab_0.tar.bz2
-    "selenium >=3.141.0"
+    "selenium >=3.141.0,<4.10"
noarch::robotframework-seleniumlibrary-5.1.1-pyhd8ed1ab_0.tar.bz2
-    "selenium >=3.141.0"
+    "selenium >=3.141.0,<4.10"
noarch::robotframework-seleniumlibrary-5.1.2-pyhd8ed1ab_0.tar.bz2
-    "selenium >=3.141.0"
+    "selenium >=3.141.0,<4.10"
noarch::robotframework-seleniumlibrary-5.1.3-pyhd8ed1ab_0.tar.bz2
-    "selenium >=3.141.0"
+    "selenium >=3.141.0,<4.10"
noarch::robotframework-seleniumlibrary-6.0.0-pyhd8ed1ab_0.tar.bz2
-    "selenium >=4.0.0"
+    "selenium >=4.0.0,<4.10"
noarch::robotframework-seleniumlibrary-6.1.0-pyhd8ed1ab_0.conda
-    "selenium >=4.0.0"
+    "selenium >=4.0.0,<4.10"

</code>
</details>

* [x] Modifications won't affect packages built in the future.

References:
- fixes https://github.com/conda-forge/robotframework-seleniumlibrary-feedstock/issues/19