### PR TITLE
Pin onnx in older versions of skl2onnx

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -3088,6 +3088,15 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
         if record_name == "conda-content-trust" and record.get("timestamp", 0) < 1685589411000:  # 2023-06-01
             _replace_pin("cryptography", "cryptography <41.0.0a0", record["depends"], record)
 
+        # skl2onnx requires onnx<1.15 for versions older than 1.14.1
+        # see https://github.com/onnx/onnx/issues/5202
+        if (
+            record_name == "skl2onnx"
+            and pkg_resources.parse_version(record["version"]) < pkg_resources.parse_version("1.14.1")
+            and record.get("timestamp", 0) < 1686557425000
+        ):
+            _replace_pin("onnx >=1.2.1", "onnx >=1.2.1,<1.15", record["depends"], record)
+
         # noarch depfinder packages are broken for python >=3.10
         if (
             record_name == "depfinder"


### PR DESCRIPTION
`skl2onnx<1.14.1` requires `onnx<1.14` to work. See https://github.com/onnx/onnx/issues/5202. This was fixed with `skl2onnx=1.14.1` (which is backwards compatible with older versions of `onnx`, too).

Checklist
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

Diff

```
noarch::skl2onnx-1.10.0-pyhd8ed1ab_0.tar.bz2
-    "onnx >=1.2.1",
+    "onnx >=1.2.1,<1.14",
noarch::skl2onnx-1.10.2-pyhd8ed1ab_0.tar.bz2
-    "onnx >=1.2.1",
+    "onnx >=1.2.1,<1.14",
noarch::skl2onnx-1.10.3-pyhd8ed1ab_0.tar.bz2
-    "onnx >=1.2.1",
+    "onnx >=1.2.1,<1.14",
noarch::skl2onnx-1.10.4-pyhd8ed1ab_0.tar.bz2
-    "onnx >=1.2.1",
+    "onnx >=1.2.1,<1.14",
noarch::skl2onnx-1.11-pyhd8ed1ab_0.tar.bz2
-    "onnx >=1.2.1",
+    "onnx >=1.2.1,<1.14",
noarch::skl2onnx-1.12-pyhd8ed1ab_0.tar.bz2
-    "onnx >=1.2.1",
+    "onnx >=1.2.1,<1.14",
noarch::skl2onnx-1.13-pyhd8ed1ab_0.tar.bz2
-    "onnx >=1.2.1",
+    "onnx >=1.2.1,<1.14",
noarch::skl2onnx-1.8.0-pyhd8ed1ab_0.tar.bz2
-    "onnx >=1.2.1",
+    "onnx >=1.2.1,<1.14",
noarch::skl2onnx-1.8.0.1-pyhd8ed1ab_0.tar.bz2
-    "onnx >=1.2.1",
+    "onnx >=1.2.1,<1.14",
noarch::skl2onnx-1.8.0.1-pyhd8ed1ab_1.tar.bz2
-    "onnx >=1.2.1",
+    "onnx >=1.2.1,<1.14",
noarch::skl2onnx-1.9.0-pyhd8ed1ab_0.tar.bz2
-    "onnx >=1.2.1",
+    "onnx >=1.2.1,<1.14",
noarch::skl2onnx-1.9.1-pyhd8ed1ab_0.tar.bz2
-    "onnx >=1.2.1",
+    "onnx >=1.2.1,<1.14",
noarch::skl2onnx-1.9.2-pyhd8ed1ab_0.tar.bz2
-    "onnx >=1.2.1",
+    "onnx >=1.2.1,<1.14",
noarch::skl2onnx-1.9.3-pyhd8ed1ab_0.tar.bz2
-    "onnx >=1.2.1",
+    "onnx >=1.2.1,<1.14",
noarch::skl2onnx-1.14.0-pyhd8ed1ab_0.conda
-    "onnx >=1.2.1",
+    "onnx >=1.2.1,<1.14",

```

This list includes all versions of `skl2onnx` on conda-forge (except for 1.14.1).