### PR TITLE
pin pluggy<1.1.0 in conda

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -2291,7 +2291,7 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                     dep_name, *dep_other = dep.split()
                     if dep_name.startswith("conda-libmamba-solver"):
                         record["constrains"][i] = "conda-libmamba-solver >=22.12.0"
-            if record["timestamp"] <= 1687186972730:
+            if record.get("timestamp", 0) <= 1687186972730:
                 # https://github.com/conda/conda/issues/12808
                 _replace_pin("pluggy >=1.0.0", "pluggy >=1.0.0,<1.1.0a0", deps, record)
 

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -2285,13 +2285,16 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                             dep_name, dep_other[0] + "," if dep_other else ""
                         )
 
-        if (record_name == "conda" and
-            record["version"] == "22.11.1" and
-            record["build_number"] == 0):
-            for i, dep in enumerate(record["constrains"]):
-                dep_name, *dep_other = dep.split()
-                if dep_name.startswith("conda-libmamba-solver"):
-                    record["constrains"][i] = "conda-libmamba-solver >=22.12.0"
+        if record_name == "conda":
+            if record["version"] == "22.11.1" and record["build_number"] == 0:
+                for i, dep in enumerate(record["constrains"]):
+                    dep_name, *dep_other = dep.split()
+                    if dep_name.startswith("conda-libmamba-solver"):
+                        record["constrains"][i] = "conda-libmamba-solver >=22.12.0"
+            if record["timestamp"] <= 1687186972730:
+                _replace_pin("pluggy >=1.0.0", "pluggy >=1.0.0,<1.1.0a0", deps, record)
+
+
         if record_name == "mamba" and (
             pkg_resources.parse_version(record["version"]) <
             pkg_resources.parse_version("0.24.0") or (
@@ -2348,7 +2351,7 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                         record,
                     )
                 else:
-                    # old versions depended on urllib3 via requests;
+                    # old versions depended on urllib3 via requests; 
                     # requests 2.30+ allows urllib3 2.x
                     for lower_bound in (">=2.9.1", ">=2.0", ">=2.20.0"):
                         _replace_pin(

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -2292,6 +2292,7 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                     if dep_name.startswith("conda-libmamba-solver"):
                         record["constrains"][i] = "conda-libmamba-solver >=22.12.0"
             if record["timestamp"] <= 1687186972730:
+                # https://github.com/conda/conda/issues/12808
                 _replace_pin("pluggy >=1.0.0", "pluggy >=1.0.0,<1.1.0a0", deps, record)
 
 


### PR DESCRIPTION
Checklist
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

pluggy 1.1.0 released today breaks `conda` plugin system and prevents its usage.  See https://github.com/conda/conda/issues/12808