### PR TITLE
Use `__cuda` in `nccl` repodata patch

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1068,7 +1068,7 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                 dep = deps[i]
                 if dep.startswith("cudatoolkit"):
                     spec = dep[11:]
-                    dep = f"cuda-version{spec}"
+                    dep = f"__cuda{spec}"
                 deps[i] = dep
 
         if record_name == "ucx" and record.get('timestamp', 0) < 1682924400000:


### PR DESCRIPTION
Potential revised approach of PR ( https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/467 )

<hr>

Checklist
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->
