### PR TITLE
patch hdf5 1.14.0 builds to accept 1.14.1

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1270,6 +1270,13 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
         # gct should have been pinned at x.x.x rather than x.x
         _replace_pin('gct >=6.2.1550507116,<6.3.0a0', "gct >=6.2.1550507116,<6.2.1550507117", deps, record)
 
+        # hdf5 1.14.1 fixes issues in 1.14.0
+        # it is abi-compatible, but 1.14.0 has x.x.x run_exports
+        for mpi_pin in ("", "mpi_openmpi_*", "mpi_mpich_*"):
+            before = f"hdf5 >=1.14.0,<1.14.1.0a0 {mpi_pin}".rstrip()
+            after = f"hdf5 >=1.14.0,<1.14.2.0a0 {mpi_pin}".rstrip()
+            _replace_pin(before, after, deps, record)
+
         # remove features for openjdk and rb2
         if ("track_features" in record and
                 record['track_features'] is not None):


### PR DESCRIPTION
ABI did not change, we are still mid migration

As suggested by @hmaarrfk in https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/4594

Checklist

* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

Note: I don't think this will actually work, and we should go with https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/4594 instead, because a migrator still needs to be applied to all repos already migrated to start building with 1.14.1 instead of 1.14.0, which won't get patched due to the timestamp filter.

We can still apply this patch to accept the old builds, but it does not _replace_ the 1.14.1 migration, which is still required.