### PR TITLE
patch pydantic pin for copier

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1785,6 +1785,12 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             depends = record["depends"]
             depends[depends.index("sqlalchemy <2.0.0")] = "sqlalchemy <1.4.42"
 
+        # copier <8.0.? not compatible with pydantic>=2
+        if record_name == "copier" and record.get("timestamp", 0) <= 1688310318000:
+            for old_pin in ["pydantic >=1.10.2", "pydantic >=1.9.0"]:
+                if old_pin in record["depends"]:
+                    _replace_pin(old_pin, f"{old_pin},<2", deps, record)
+
         # tzlocal 3.0 needs Python 3.9 (or backports.zoneinfo)
         # fixed in https://github.com/conda-forge/tzlocal-feedstock/pull/10
         if record_name == "tzlocal" and record["version"] == "3.0" and "python >=3.6" in record["depends"]:


### PR DESCRIPTION
Checklist
* [x] Ran `python show_diff.py` and posted the output as part of the PR.

```diff
noarch::copier-6.1.0-pyhd8ed1ab_0.tar.bz2
-    "pydantic >=1.9.0",
+    "pydantic >=1.9.0,<2",
noarch::copier-6.2.0-pyhd8ed1ab_0.tar.bz2
-    "pydantic >=1.10.2",
+    "pydantic >=1.10.2,<2",
noarch::copier-7.0.1-pyhd8ed1ab_0.conda
-    "pydantic >=1.10.2",
+    "pydantic >=1.10.2,<2",
noarch::copier-7.1.0-pyhd8ed1ab_0.conda
-    "pydantic >=1.10.2",
+    "pydantic >=1.10.2,<2",
noarch::copier-7.2.0-pyhd8ed1ab_0.conda
-    "pydantic >=1.10.2",
+    "pydantic >=1.10.2,<2",
noarch::copier-8.0.0-pyhd8ed1ab_0.conda
-    "pydantic >=1.10.2",
+    "pydantic >=1.10.2,<2",
```

* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

References:
- https://github.com/conda-forge/copier-feedstock/issues/9
- https://github.com/conda-forge/copier-feedstock/pull/10

:bell: @conda-forge/copier