### PR TITLE
emmet-core requires pydantic <2

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -3017,7 +3017,7 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                 record["build_number"] == 0
             )
         ):
-            _replace_pin("pydantic >=1.10.2", "pydantic <2",
+            _replace_pin("pydantic >=1.10.2", "pydantic >=1.10.2,<2",
                          record["depends"], record)
 
         if (
@@ -3025,7 +3025,7 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             record["version"] == "0.58.0" and 
             record["build_number"] == 2
         ):
-            _replace_pin("pydantic >=2", "pydantic <2",
+            _replace_pin("pydantic >=2", "pydantic >=1.10.2,<2",
                          record["depends"], record)
         
         # scikit-image 0.20.0 needs scipy scipy >=1.8,<1.9.2 for python <= 3.9

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -3008,6 +3008,26 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
            ):
             _replace_pin("python >=3.6", "python >=3.8", record["depends"], record)
 
+        # emmet-core <=0.58.0 needs pydantic <2
+        if (
+            record_name == "emmet-core" and
+            record["version"] < "0.58.0" or
+            (
+                record["version"] == "0.58.0 and 
+                record["build_number"] == 0
+            )
+        ):
+            _replace_pin("pydantic >=1.10.2", "pydantic <2",
+                         record["depends"], record)
+
+        if (
+            record_name == "emmet-core" and
+            record["version"] == "0.58.0" and 
+            record["build_number"] == 2
+        ):
+            _replace_pin("pydantic >=2", "pydantic <2",
+                         record["depends"], record)
+        
         # scikit-image 0.20.0 needs scipy scipy >=1.8,<1.9.2 for python <= 3.9
         # Fixed in https://github.com/conda-forge/scikit-image-feedstock/pull/102
         if (

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -3013,7 +3013,7 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             record_name == "emmet-core" and
             record["version"] < "0.58.0" or
             (
-                record["version"] == "0.58.0 and 
+                record["version"] == "0.58.0" and 
                 record["build_number"] == 0
             )
         ):


### PR DESCRIPTION
Checklist
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->
