### PR TITLE
Pin python>=3.8 for zipp 3.16.0

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -960,6 +960,14 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             if record['version'] == "3.7.0" and record['build'] == "pyhd8ed1ab_0":
                 i = record['depends'].index('python >=3.6')
                 record['depends'][i] = 'python >=3.7'
+            # zipp >=3.16 requires python >=3.8 but it was missed
+            # https://github.com/conda-forge/zipp-feedstock/pull/43
+            if (
+                record['version'] == "3.16.0" and record['build'] == "pyhd8ed1ab_0" 
+                and record.get("timestamp", 0) < 1689035633000
+            ):
+                i = record['depends'].index('python >=3.7')
+                record['depends'][i] = 'python >=3.8'
 
         # fix deps with wrong names
         if record_name in proj4_fixes:


### PR DESCRIPTION
Checklist
* [x] Ran `python show_diff.py` and posted the output as part of the PR.

```
noarch::lbnightlytools-3.0.56-pyhd8ed1ab_0.conda
-    "python =2.7|>=3.6",
+    "python ==2.7.*|>=3.6",
noarch::zipp-3.16.0-pyhd8ed1ab_0.conda
-    "python >=3.7"
+    "python >=3.8"
```

(n.b., the `lbnightlytools` changes appear to be related to #444)

* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->


See conda-forge/zipp-feedstock#43
