### PR TITLE
fix apscheduler's tzlocal pin

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -963,7 +963,7 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             # zipp >=3.16 requires python >=3.8 but it was missed
             # https://github.com/conda-forge/zipp-feedstock/pull/43
             if (
-                record['version'] == "3.16.0" and record['build'] == "pyhd8ed1ab_0" 
+                record['version'] == "3.16.0" and record['build'] == "pyhd8ed1ab_0"
                 and record.get("timestamp", 0) < 1689035633000
             ):
                 i = record['depends'].index('python >=3.7')
@@ -3026,7 +3026,7 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             record_name == "emmet-core" and
             record["version"] < "0.58.0" or
             (
-                record["version"] == "0.58.0" and 
+                record["version"] == "0.58.0" and
                 record["build_number"] == 0
             )
         ):
@@ -3035,12 +3035,12 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
 
         if (
             record_name == "emmet-core" and
-            record["version"] == "0.58.0" and 
+            record["version"] == "0.58.0" and
             record["build_number"] == 2
         ):
             _replace_pin("pydantic >=2", "pydantic >=1.10.2,<2",
                          record["depends"], record)
-        
+
         # scikit-image 0.20.0 needs scipy scipy >=1.8,<1.9.2 for python <= 3.9
         # Fixed in https://github.com/conda-forge/scikit-image-feedstock/pull/102
         if (
@@ -3155,6 +3155,17 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
 
             if pind is not None:
                 record["depends"][pind] = record["depends"][pind] + ",<3.10"
+
+        # apscheduler 3.8.1 through 3.10.1 has incorrect version restiction for tzlocal
+        if (
+            record_name == "apscheduler"
+            and record.get("timestamp", 0) < 1689345788000
+            and pkg_resources.parse_version(record["version"]) >= pkg_resources.parse_version("3.8.1")
+            and pkg_resources.parse_version(record["version"]) <= pkg_resources.parse_version("3.10.1")
+        ):
+            _replace_pin("tzlocal >=2.0,<3.0", "tzlocal >=2.0,!=3.*", record["depends"], record)
+
+
 
     return index
 


### PR DESCRIPTION
Checklist
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

Fixes https://github.com/conda-forge/apscheduler-feedstock/issues/34

And the diff from `show_diff.py`:

```
linux-64::apscheduler-3.8.1-py310hff52083_1.tar.bz2
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
linux-64::apscheduler-3.8.1-py37h89c1867_0.tar.bz2
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
linux-64::apscheduler-3.8.1-py37h89c1867_1.tar.bz2
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
linux-64::apscheduler-3.8.1-py37h9c2f6ca_0.tar.bz2
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
linux-64::apscheduler-3.8.1-py37h9c2f6ca_1.tar.bz2
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
linux-64::apscheduler-3.8.1-py38h578d9bd_0.tar.bz2
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
linux-64::apscheduler-3.8.1-py38h578d9bd_1.tar.bz2
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
linux-64::apscheduler-3.8.1-py39hf3d152e_0.tar.bz2
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
linux-64::apscheduler-3.8.1-py39hf3d152e_1.tar.bz2
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
linux-64::apscheduler-3.9.1-py310hff52083_0.tar.bz2
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
linux-64::apscheduler-3.9.1-py37h89c1867_0.tar.bz2
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
linux-64::apscheduler-3.9.1-py37h9c2f6ca_0.tar.bz2
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
linux-64::apscheduler-3.9.1-py38h578d9bd_0.tar.bz2
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
linux-64::apscheduler-3.9.1-py39hf3d152e_0.tar.bz2
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
linux-64::apscheduler-3.9.1.post1-py310hff52083_0.tar.bz2
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
linux-64::apscheduler-3.9.1.post1-py311h38be061_0.tar.bz2
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
linux-64::apscheduler-3.9.1.post1-py38h373033e_0.tar.bz2
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
linux-64::apscheduler-3.9.1.post1-py38h578d9bd_0.tar.bz2
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
linux-64::apscheduler-3.9.1.post1-py39h4162558_0.tar.bz2
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
linux-64::apscheduler-3.9.1.post1-py39hf3d152e_0.tar.bz2
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
linux-64::apscheduler-3.10.1-py310hff52083_0.conda
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
linux-64::apscheduler-3.10.1-py311h38be061_0.conda
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
linux-64::apscheduler-3.10.1-py38h373033e_0.conda
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
linux-64::apscheduler-3.10.1-py38h578d9bd_0.conda
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
linux-64::apscheduler-3.10.1-py39h4162558_0.conda
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
linux-64::apscheduler-3.10.1-py39hf3d152e_0.conda
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata.json.bz2
osx-64::apscheduler-3.8.1-py310h2ec42d9_1.tar.bz2
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
osx-64::apscheduler-3.8.1-py37h5186d4c_0.tar.bz2
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
osx-64::apscheduler-3.8.1-py37h5186d4c_1.tar.bz2
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
osx-64::apscheduler-3.8.1-py37hf985489_0.tar.bz2
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
osx-64::apscheduler-3.8.1-py37hf985489_1.tar.bz2
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
osx-64::apscheduler-3.8.1-py38h50d1736_0.tar.bz2
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
osx-64::apscheduler-3.8.1-py38h50d1736_1.tar.bz2
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
osx-64::apscheduler-3.8.1-py39h6e9494a_0.tar.bz2
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
osx-64::apscheduler-3.8.1-py39h6e9494a_1.tar.bz2
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
osx-64::apscheduler-3.9.1-py310h2ec42d9_0.tar.bz2
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
osx-64::apscheduler-3.9.1-py37h5186d4c_0.tar.bz2
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
osx-64::apscheduler-3.9.1-py37hf985489_0.tar.bz2
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
osx-64::apscheduler-3.9.1-py38h50d1736_0.tar.bz2
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
osx-64::apscheduler-3.9.1-py39h6e9494a_0.tar.bz2
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
osx-64::apscheduler-3.9.1.post1-py310h2ec42d9_0.tar.bz2
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
osx-64::apscheduler-3.9.1.post1-py311h6eed73b_0.tar.bz2
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
osx-64::apscheduler-3.9.1.post1-py38h25b0044_0.tar.bz2
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
osx-64::apscheduler-3.9.1.post1-py38h50d1736_0.tar.bz2
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
osx-64::apscheduler-3.9.1.post1-py39h43b90dd_0.tar.bz2
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
osx-64::apscheduler-3.9.1.post1-py39h6e9494a_0.tar.bz2
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
osx-64::apscheduler-3.10.1-py310h2ec42d9_0.conda
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
osx-64::apscheduler-3.10.1-py311h6eed73b_0.conda
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
osx-64::apscheduler-3.10.1-py38h25b0044_0.conda
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
osx-64::apscheduler-3.10.1-py38h50d1736_0.conda
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
osx-64::apscheduler-3.10.1-py39h43b90dd_0.conda
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
osx-64::apscheduler-3.10.1-py39h6e9494a_0.conda
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata.json.bz2
osx-arm64::apscheduler-3.9.1-py310hbe9552e_0.tar.bz2
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
osx-arm64::apscheduler-3.9.1-py38h10201cd_0.tar.bz2
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
osx-arm64::apscheduler-3.9.1-py39h2804cbe_0.tar.bz2
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
osx-arm64::apscheduler-3.9.1.post1-py310hbe9552e_0.tar.bz2
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
osx-arm64::apscheduler-3.9.1.post1-py311h267d04e_0.tar.bz2
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
osx-arm64::apscheduler-3.9.1.post1-py38h10201cd_0.tar.bz2
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
osx-arm64::apscheduler-3.9.1.post1-py39h2804cbe_0.tar.bz2
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
osx-arm64::apscheduler-3.10.1-py310hbe9552e_0.conda
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
osx-arm64::apscheduler-3.10.1-py311h267d04e_0.conda
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
osx-arm64::apscheduler-3.10.1-py38h10201cd_0.conda
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
osx-arm64::apscheduler-3.10.1-py39h2804cbe_0.conda
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata.json.bz2
win-64::apscheduler-3.8.1-py310h5588dad_1.tar.bz2
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
win-64::apscheduler-3.8.1-py37h03978a9_0.tar.bz2
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
win-64::apscheduler-3.8.1-py37h03978a9_1.tar.bz2
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
win-64::apscheduler-3.8.1-py37h4c0cbd9_0.tar.bz2
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
win-64::apscheduler-3.8.1-py37h4c0cbd9_1.tar.bz2
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
win-64::apscheduler-3.8.1-py38haa244fe_0.tar.bz2
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
win-64::apscheduler-3.8.1-py38haa244fe_1.tar.bz2
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
win-64::apscheduler-3.8.1-py39hcbf5309_0.tar.bz2
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
win-64::apscheduler-3.8.1-py39hcbf5309_1.tar.bz2
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
win-64::apscheduler-3.9.1-py310h5588dad_0.tar.bz2
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
win-64::apscheduler-3.9.1-py37h03978a9_0.tar.bz2
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
win-64::apscheduler-3.9.1-py37h4c0cbd9_0.tar.bz2
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
win-64::apscheduler-3.9.1-py38haa244fe_0.tar.bz2
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
win-64::apscheduler-3.9.1-py39hcbf5309_0.tar.bz2
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
win-64::apscheduler-3.9.1.post1-py310h5588dad_0.tar.bz2
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
win-64::apscheduler-3.9.1.post1-py311h1ea47a8_0.tar.bz2
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
win-64::apscheduler-3.9.1.post1-py38h32ec214_0.tar.bz2
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
win-64::apscheduler-3.9.1.post1-py38haa244fe_0.tar.bz2
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
win-64::apscheduler-3.9.1.post1-py39h0d475fb_0.tar.bz2
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
win-64::apscheduler-3.9.1.post1-py39hcbf5309_0.tar.bz2
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
win-64::apscheduler-3.10.1-py310h5588dad_0.conda
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
win-64::apscheduler-3.10.1-py311h1ea47a8_0.conda
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
win-64::apscheduler-3.10.1-py38h32ec214_0.conda
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
win-64::apscheduler-3.10.1-py38haa244fe_0.conda
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
win-64::apscheduler-3.10.1-py39h0d475fb_0.conda
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
win-64::apscheduler-3.10.1-py39hcbf5309_0.conda
-    "tzlocal >=2.0,<3.0"
+    "tzlocal >=2.0,!=3.*"
```
