### PR TITLE
pin zstandard's dep on zstd

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -3171,7 +3171,13 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
         ):
             _replace_pin("tzlocal >=2.0,<3.0", "tzlocal >=2.0,!=3.*", record["depends"], record)
 
-
+        if (
+            record_name == "zstandard"
+            and record.get("timestamp", 0) < 1689939052321
+            and record["version"] == "0.19.0"
+            and record["build_number"] == 1
+        ):
+            _replace_pin("zstd >=1.5.2", "zstd ==1.5.2", record["depends"], record)
 
     return index
 

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -3177,7 +3177,7 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             and record["version"] == "0.19.0"
             and record["build_number"] == 1
         ):
-            _replace_pin("zstd >=1.5.2", "zstd ==1.5.2", record["depends"], record)
+            _replace_pin("zstd >=1.5.2,<1.6.0a0", "zstd ==1.5.2", record["depends"], record)
 
     return index
 


### PR DESCRIPTION
Checklist
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [X] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

Comes from https://github.com/conda-forge/zstandard-feedstock/pull/48#issuecomment-1645405835

Used this script to verify which zstd versions where used to compile build number 1:

```python
packages = [
	"linux-64/zstandard-0.19.0-py310hdeb6495_1.conda",
	"linux-64/zstandard-0.19.0-py311hbe0fcd7_1.conda",
	"linux-64/zstandard-0.19.0-py38h5945529_1.conda",
	"linux-64/zstandard-0.19.0-py38h7b0c1cc_1.conda",
	"linux-64/zstandard-0.19.0-py39h033b22b_1.conda",
	"linux-64/zstandard-0.19.0-py39h29414ee_1.conda",
	"linux-aarch64/zstandard-0.19.0-py310hde4b81c_1.conda",
	"linux-aarch64/zstandard-0.19.0-py311hd2ac760_1.conda",
	"linux-aarch64/zstandard-0.19.0-py38h1e78bf9_1.conda",
	"linux-aarch64/zstandard-0.19.0-py38h3ce7787_1.conda",
	"linux-aarch64/zstandard-0.19.0-py39h47e299c_1.conda",
	"linux-aarch64/zstandard-0.19.0-py39hcfc283b_1.conda",
	"linux-ppc64le/zstandard-0.19.0-py310hcc13191_1.conda",
	"linux-ppc64le/zstandard-0.19.0-py311he9aaf84_1.conda",
	"linux-ppc64le/zstandard-0.19.0-py38h6067349_1.conda",
	"linux-ppc64le/zstandard-0.19.0-py38hc289334_1.conda",
	"linux-ppc64le/zstandard-0.19.0-py39h3676e51_1.conda",
	"linux-ppc64le/zstandard-0.19.0-py39he7f7b5f_1.conda",
	"osx-64/zstandard-0.19.0-py310h3cf44b0_1.conda",
	"osx-64/zstandard-0.19.0-py311hebd4beb_1.conda",
	"osx-64/zstandard-0.19.0-py38h6641759_1.conda",
	"osx-64/zstandard-0.19.0-py38h7cbeef7_1.conda",
	"osx-64/zstandard-0.19.0-py39h5bcbcff_1.conda",
	"osx-64/zstandard-0.19.0-py39hd6543e7_1.conda",
	"osx-arm64/zstandard-0.19.0-py310had9512b_1.conda",
	"osx-arm64/zstandard-0.19.0-py311hdcbfb07_1.conda",
	"osx-arm64/zstandard-0.19.0-py38h3442225_1.conda",
	"osx-arm64/zstandard-0.19.0-py39h1334381_1.conda",
	"win-64/zstandard-0.19.0-py310h0009e47_1.conda",
	"win-64/zstandard-0.19.0-py311he5d195f_1.conda",
	"win-64/zstandard-0.19.0-py38h8b24e6d_1.conda",
	"win-64/zstandard-0.19.0-py38hea8d35e_1.conda",
	"win-64/zstandard-0.19.0-py39h95af829_1.conda",
	"win-64/zstandard-0.19.0-py39hdf01746_1.conda",
]

from conda_forge_metadata.artifact_info.info_json import get_artifact_info_as_json

for artifact in packages:
	subdir, pkg = artifact.split("/")
	meta = get_artifact_info_as_json("conda-forge", subdir, pkg, backend="oci")
	for dep in meta["rendered_recipe"]["requirements"]["host"]:
		if dep.split()[0] == "zstd":
			print("ARTIFACT:", artifact, dep)

"""
Results:
ARTIFACT: linux-64/zstandard-0.19.0-py310hdeb6495_1.conda zstd 1.5.2 h6239696_4
ARTIFACT: linux-64/zstandard-0.19.0-py311hbe0fcd7_1.conda zstd 1.5.2 h6239696_4
ARTIFACT: linux-64/zstandard-0.19.0-py38h5945529_1.conda zstd 1.5.2 h6239696_4
ARTIFACT: linux-64/zstandard-0.19.0-py38h7b0c1cc_1.conda zstd 1.5.2 h6239696_4
ARTIFACT: linux-64/zstandard-0.19.0-py39h033b22b_1.conda zstd 1.5.2 h6239696_4
ARTIFACT: linux-64/zstandard-0.19.0-py39h29414ee_1.conda zstd 1.5.2 h6239696_4
ARTIFACT: linux-aarch64/zstandard-0.19.0-py310hde4b81c_1.conda zstd 1.5.2 hc1e27d5_4
ARTIFACT: linux-aarch64/zstandard-0.19.0-py311hd2ac760_1.conda zstd 1.5.2 hc1e27d5_4
ARTIFACT: linux-aarch64/zstandard-0.19.0-py38h1e78bf9_1.conda zstd 1.5.2 hc1e27d5_4
ARTIFACT: linux-aarch64/zstandard-0.19.0-py38h3ce7787_1.conda zstd 1.5.2 hc1e27d5_4
ARTIFACT: linux-aarch64/zstandard-0.19.0-py39h47e299c_1.conda zstd 1.5.2 hc1e27d5_4
ARTIFACT: linux-aarch64/zstandard-0.19.0-py39hcfc283b_1.conda zstd 1.5.2 hc1e27d5_4
ARTIFACT: linux-ppc64le/zstandard-0.19.0-py310hcc13191_1.conda zstd 1.5.2 h581a010_4
ARTIFACT: linux-ppc64le/zstandard-0.19.0-py311he9aaf84_1.conda zstd 1.5.2 h581a010_4
ARTIFACT: linux-ppc64le/zstandard-0.19.0-py38h6067349_1.conda zstd 1.5.2 h581a010_4
ARTIFACT: linux-ppc64le/zstandard-0.19.0-py38hc289334_1.conda zstd 1.5.2 h581a010_4
ARTIFACT: linux-ppc64le/zstandard-0.19.0-py39h3676e51_1.conda zstd 1.5.2 h581a010_4
ARTIFACT: linux-ppc64le/zstandard-0.19.0-py39he7f7b5f_1.conda zstd 1.5.2 h581a010_4
ARTIFACT: osx-64/zstandard-0.19.0-py310h3cf44b0_1.conda zstd 1.5.2 hfa58983_4
ARTIFACT: osx-64/zstandard-0.19.0-py311hebd4beb_1.conda zstd 1.5.2 hfa58983_4
ARTIFACT: osx-64/zstandard-0.19.0-py38h6641759_1.conda zstd 1.5.2 hfa58983_4
ARTIFACT: osx-64/zstandard-0.19.0-py38h7cbeef7_1.conda zstd 1.5.2 hfa58983_4
ARTIFACT: osx-64/zstandard-0.19.0-py39h5bcbcff_1.conda zstd 1.5.2 hfa58983_4
ARTIFACT: osx-64/zstandard-0.19.0-py39hd6543e7_1.conda zstd 1.5.2 hfa58983_4
ARTIFACT: osx-arm64/zstandard-0.19.0-py310had9512b_1.conda zstd 1.5.2 h8128057_4
ARTIFACT: osx-arm64/zstandard-0.19.0-py311hdcbfb07_1.conda zstd 1.5.2 h8128057_4
ARTIFACT: osx-arm64/zstandard-0.19.0-py38h3442225_1.conda zstd 1.5.2 h8128057_4
ARTIFACT: osx-arm64/zstandard-0.19.0-py39h1334381_1.conda zstd 1.5.2 h8128057_4
ARTIFACT: win-64/zstandard-0.19.0-py310h0009e47_1.conda zstd 1.5.2 h7755175_4
ARTIFACT: win-64/zstandard-0.19.0-py311he5d195f_1.conda zstd 1.5.2 h7755175_4
ARTIFACT: win-64/zstandard-0.19.0-py38h8b24e6d_1.conda zstd 1.5.2 h7755175_4
ARTIFACT: win-64/zstandard-0.19.0-py38hea8d35e_1.conda zstd 1.5.2 h7755175_4
ARTIFACT: win-64/zstandard-0.19.0-py39h95af829_1.conda zstd 1.5.2 h7755175_4
ARTIFACT: win-64/zstandard-0.19.0-py39hdf01746_1.conda zstd 1.5.2 h7755175_4
"""
```