### PR TITLE
patch xpublish for pydantic<2

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1623,6 +1623,15 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                     i = record["depends"].index(wrong_version)
                     record["depends"][i] = right_version
 
+        if record_name == "xpublish":
+            # Pydantic is an indirect dependency, fixed upstream, and v2.0 broken xpublish 0.3.0.
+            # xref.: https://github.com/xpublish-community/xpublish/pull/215
+            if (
+                record.get("timestamp", 0) <= 1689955085000
+                and pkg_resources.parse_version(record["version"]) == pkg_resources.parse_version("0.3.0")
+            ):
+                record["depends"].append("pydantic<2")
+
         # Old versions of Gazebo depend on boost-cpp >= 1.71,
         # but they are actually incompatible with any boost-cpp >= 1.72
         # https://github.com/conda-forge/gazebo-feedstock/issues/52


### PR DESCRIPTION
Checklist
* [X] Ran `python show_diff.py` and posted the output as part of the PR.
* [X] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->


Diff:

```
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata.json.bz2
noarch::xpublish-0.3.0-pyhd8ed1ab_0.conda
-    "zarr"
+    "zarr",
+    "pydantic<2"
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata.json.bz2
linux-64::clad-1.2-clang8_h502a2d1_0.conda
-    "libllvm8 8.0.1 hc9558a2_0",
+    "libllvm8 >=8.0.1,<8.1.0a0",
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata.json.bz2
osx-64::clad-1.2-clang8_hcb76d2d_0.conda
-    "libllvm8 8.0.1 h770b8ee_0"
+    "libllvm8 >=8.0.1,<8.1.0a0"
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata.json.bz2
```

The `libllvm8` change seems to be an artifact from some other change.