### PR TITLE
Patch Python requirement in jax-0.4.14

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -33,6 +33,7 @@ SUBDIRS = (
 REMOVALS = {
     "noarch": (
         "sendgrid-5.3.0-py_0.tar.bz2",
+        "jax-0.4.14-pyhd8ed1ab_0.conda",
     ),
     "linux-64": (
         "airflow-with-gcp_api-1.9.0-1.tar.bz2",

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1316,7 +1316,7 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
 
         if (record_name, record["version"], record["build"]) == ("jax", "0.4.14", "pyhd8ed1ab_0"):
             deps = record.get("depends", [])
-            deps[deps.index("python >=3.8")] = "python >=3.9"
+            _replace_pin("python >=3.8", "python >=3.9", deps, record)
 
         # Patch bokeh version restrictions on older panels.
         if record_name == "panel":

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -33,7 +33,6 @@ SUBDIRS = (
 REMOVALS = {
     "noarch": (
         "sendgrid-5.3.0-py_0.tar.bz2",
-        "jax-0.4.14-pyhd8ed1ab_0.conda",
     ),
     "linux-64": (
         "airflow-with-gcp_api-1.9.0-1.tar.bz2",
@@ -1314,6 +1313,10 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             deps = record.get("depends", [])
             deps.append("numba !=0.54.0")
             record["depends"] = deps
+
+        if (record_name, record["version"], record["build"]) == ("jax", "0.4.14", "pyhd8ed1ab_0"):
+            deps = record.get("depends", [])
+            deps[deps.index("python >=3.8")] = "python >=3.9"
 
         # Patch bokeh version restrictions on older panels.
         if record_name == "panel":


### PR DESCRIPTION
Checklist
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

See https://github.com/conda-forge/jax-feedstock/pull/123,  since 0.4.14 jax does not support Python 3.8 anymore.

ping @conda-forge/jax 

````diff
❯ ./recipe/show_diff.py
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata.json.bz2
noarch::jax-0.4.14-pyhd8ed1ab_0.conda
-    "python >=3.8",
+    "python >=3.9",
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata.json.bz2
````