### PR TITLE
Patch notebook < 7 dependencies for jupyter_client and pyzmq

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1712,7 +1712,11 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
         # all versions of Notebook < 7 should at least pin to 
         # jupyter_client < 8 and pyzmq < 25 as in
         # https://github.com/jupyter/notebook/pull/6749
-        if record_name == "notebook" and int(record["version"].split(".", 1)[0]) < 7:
+        if (
+            record_name == "notebook" 
+            and int(record["version"].split(".", 1)[0]) < 7
+            and record.get("timestamp", 0 < 1691084500000)
+            ):
             if "jupyter_client>=5.3.4" in record["depends"]:
                 i = record["depends"].index("jupyter_client>=5.3.4")
                 record["depends"][i] = "jupyter_client >=5.3.4,<8"


### PR DESCRIPTION
Checklist
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

Having trouble running this script due to issues with conda/conda_build. After installing the conda_build with `pip` it pulled [2.1.5](https://pypi.org/project/conda-build/) and the following is the error message I am running into:
```
(repodata_notebook_cf) ➜ rosio@Rosios-MacBook-Pro  ~/Desktop/code/conda-forge/conda-forge-repodata-patches-feedstock/recipe git:(notebook_patch) python show_diff.py    
Traceback (most recent call last):
  File "/Users/me/Desktop/code/conda-forge/conda-forge-repodata-patches-feedstock/recipe/show_diff.py", line 12, in <module>
    from conda_build.index import _apply_instructions
  File "/Users/me/osx64/miniconda3/lib/python3.9/site-packages/conda_build/index.py", line 14, in <module>
    from conda_build.utils import file_info, get_lock, try_acquire_locks
  File "/Users/me/osx64/miniconda3/lib/python3.9/site-packages/conda_build/utils.py", line 27, in <module>
    from .conda_interface import md5_file, unix_path_to_win, win_path_to_unix
  File "/Users/me/osx64/miniconda3/lib/python3.9/site-packages/conda_build/conda_interface.py", line 9, in <module>
    from conda import compat, plan  # NOQA
ImportError: cannot import name 'compat' from 'conda' (/Users/me/osx64/miniconda3/lib/python3.9/site-packages/conda/__init__.py)
```