### PR TITLE
Fix version pins for jaxtyping

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1318,6 +1318,19 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             deps = record.get("depends", [])
             _replace_pin("python >=3.8", "python >=3.9", deps, record)
 
+        if record_name == "jaxtyping":
+            deps = record.get("depends", [])
+            if (record["version"], record["build"]) == ("0.2.20", "pyhd8ed1ab_0"):
+                _replace_pin("python >=3.7", "python >=3.9", deps, record)
+            if (record["version"], record["build"]) in (
+                ("0.2.19", "pyhd8ed1ab_0"),
+                ("0.2.18", "pyhd8ed1ab_0"),
+                ("0.2.15", "pyhd8ed1ab_0"),
+                ("0.2.14", "pyhd8ed1ab_0"),
+                ("0.2.13", "pyhd8ed1ab_0"),
+            ):
+                _replace_pin("python >=3.7", "python >=3.8", deps, record)
+
         # Patch bokeh version restrictions on older panels.
         if record_name == "panel":
             deps = record.get("depends", [])


### PR DESCRIPTION
Checklist
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

````
❯ python recipe/show_diff.py
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata.json.bz2
noarch::jaxtyping-0.2.13-pyhd8ed1ab_0.conda
-    "python >=3.7",
+    "python >=3.8",
noarch::jaxtyping-0.2.14-pyhd8ed1ab_0.conda
-    "python >=3.7",
+    "python >=3.8",
noarch::jaxtyping-0.2.15-pyhd8ed1ab_0.conda
-    "python >=3.7",
+    "python >=3.8",
noarch::jaxtyping-0.2.18-pyhd8ed1ab_0.conda
-    "python >=3.7",
+    "python >=3.8",
noarch::jaxtyping-0.2.19-pyhd8ed1ab_0.conda
-    "python >=3.7",
+    "python >=3.8",
noarch::jaxtyping-0.2.20-pyhd8ed1ab_0.conda
-    "python >=3.7",
+    "python >=3.9",
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata_from_packages.json.bz2lert@GCRAZGDL1124
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata.json.bz2
````

See https://github.com/conda-forge/jaxtyping-feedstock/pull/14

ping @conda-forge/jaxtyping 