### PR TITLE
Constrain `pydantic <2` for all QCPortal

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -3156,6 +3156,11 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             if pind is not None:
                 record["depends"][pind] = record["depends"][pind] + ",<3.10"
 
+        if record_name == "qcportal":
+            # QCPortal does not work with Pydantic 2, and no released version has.
+            record["depends"].append("pydantic<2")
+
+
     return index
 
 

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -3177,7 +3177,9 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
 
         if record_name == "qcportal" and record.get("timestamp", 0) < 1691162578000:
             # QCPortal does not work with Pydantic 2, and no released version has.
-            _replace_pin("pydantic", "pydantic <2", record.get("depends", []), record)
+            for dep in record.get("depends", []):
+                if dep.split()[0] == "pydantic":
+                    _replace_pin(dep, f"{dep},<2.0a0", record.get("depends", []), record)
 
         # apscheduler 3.8.1 through 3.10.1 has incorrect version restiction for tzlocal
         if (

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -3175,7 +3175,7 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             if pind is not None:
                 record["depends"][pind] = record["depends"][pind] + ",<3.10"
 
-        if record_name == "qcportal":
+        if record_name == "qcportal" and record.get("timestamp", 0) < 1691162578000:
             # QCPortal does not work with Pydantic 2, and no released version has.
             record["depends"].append("pydantic<2")
 

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -3177,7 +3177,7 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
 
         if record_name == "qcportal" and record.get("timestamp", 0) < 1691162578000:
             # QCPortal does not work with Pydantic 2, and no released version has.
-            record["depends"].append("pydantic<2")
+            _replace_pin("pydantic", "pydantic <2", record.get("depends", []), record)
 
         # apscheduler 3.8.1 through 3.10.1 has incorrect version restiction for tzlocal
         if (


### PR DESCRIPTION
Checklist
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

```
$ python show_diff.py
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata.json.bz2
noarch::qcportal-0.11.0-py_0.tar.bz2
-    "requests"
+    "requests",
+    "pydantic<2"
noarch::qcportal-0.11.1-py_0.tar.bz2
-    "requests"
+    "requests",
+    "pydantic<2"
noarch::qcportal-0.11.1-py_1.tar.bz2
-    "requests"
+    "requests",
+    "pydantic<2"
noarch::qcportal-0.12.0-py_0.tar.bz2
-    "tqdm"
+    "tqdm",
+    "pydantic<2"
noarch::qcportal-0.12.1-py_0.tar.bz2
-    "tqdm"
+    "tqdm",
+    "pydantic<2"
noarch::qcportal-0.12.2-py_0.tar.bz2
-    "tqdm"
+    "tqdm",
+    "pydantic<2"
noarch::qcportal-0.12.3-py_0.tar.bz2
-    "tqdm"
+    "tqdm",
+    "pydantic<2"
noarch::qcportal-0.13.0-py_0.tar.bz2
-    "tqdm"
+    "tqdm",
+    "pydantic<2"
noarch::qcportal-0.13.1-py_0.tar.bz2
-    "tqdm"
+    "tqdm",
+    "pydantic<2"
noarch::qcportal-0.14.0-py_0.tar.bz2
-    "tqdm"
+    "tqdm",
+    "pydantic<2"
noarch::qcportal-0.14.0-py_1.tar.bz2
-    "tqdm"
+    "tqdm",
+    "pydantic<2"
noarch::qcportal-0.15.6-pyhd8ed1ab_0.tar.bz2
-    "tqdm"
+    "tqdm",
+    "pydantic<2"
noarch::qcportal-0.15.7-pyhd8ed1ab_0.tar.bz2
-    "tqdm"
+    "tqdm",
+    "pydantic<2"
noarch::qcportal-0.15.8-pyhd8ed1ab_0.tar.bz2
-    "tqdm"
+    "tqdm",
+    "pydantic<2"
noarch::qcportal-0.5.1-py_0.tar.bz2
-    "requests"
+    "requests",
+    "pydantic<2"
noarch::qcportal-0.5.2-py_0.tar.bz2
-    "requests"
+    "requests",
+    "pydantic<2"
noarch::qcportal-0.5.3-py_0.tar.bz2
-    "requests"
+    "requests",
+    "pydantic<2"
noarch::qcportal-0.5.4-py_0.tar.bz2
-    "requests"
+    "requests",
+    "pydantic<2"
noarch::qcportal-0.5.5-py_0.tar.bz2
-    "requests"
+    "requests",
+    "pydantic<2"
noarch::qcportal-0.5.6-py_0.tar.bz2
-    "requests"
+    "requests",
+    "pydantic<2"
noarch::qcportal-0.6.0-py_0.tar.bz2
-    "requests"
+    "requests",
+    "pydantic<2"
noarch::qcportal-0.7.1-py_0.tar.bz2
-    "requests"
+    "requests",
+    "pydantic<2"
noarch::qcportal-0.7.1-py_1.tar.bz2
-    "requests"
+    "requests",
+    "pydantic<2"
noarch::qcportal-0.7.2-py_0.tar.bz2
-    "requests"
+    "requests",
+    "pydantic<2"
noarch::qcportal-0.8.0-py_0.tar.bz2
-    "requests"
+    "requests",
+    "pydantic<2"
noarch::qcportal-0.8.1-py_0.tar.bz2
-    "requests"
+    "requests",
+    "pydantic<2"
noarch::qcportal-0.9.0-py_0.tar.bz2
-    "requests"
+    "requests",
+    "pydantic<2"
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata.json.bz2