### PR TITLE
fix effect of missing gtest run-export on libabseil-tests

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -2496,6 +2496,13 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             i = record["depends"].index("libabseil 20230125.0 cxx17*")
             record["depends"][i] = "libabseil 20230125 cxx17*"
 
+        # fix libabseil-tests being built without encoding a gtest run-export
+        if (record_name == "libabseil-tests"
+                and record["version"] in ("20230125.2", "20230125.3")
+                and record.get("timestamp", 0) < 1691710285000
+        ):
+            _replace_pin("gtest", "gtest >=1.13,<1.14", record["depends"], record)
+
         # Different patch versions of ipopt can be ABI incompatible
         # See https://github.com/conda-forge/ipopt-feedstock/issues/85
         if has_dep(record, "ipopt") and record.get('timestamp', 0) < 1656352053694:


### PR DESCRIPTION
As suggested by @xhochy [here](https://github.com/conda-forge/libprotobuf-feedstock/pull/170#issuecomment-1673090253).

I've left out the newest abseil 20230802.0 for now, because that was already built with the newest gtest, and all further abseil builds will have the gtest run-export (and I don't expect a new gtest soon).

Checklist
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

### Output of `python show_diff.py`

<details>

```diff
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata.json.bz2
linux-64::libabseil-tests-20230125.2-cxx17_h59595ed_0.conda
-    "gtest",
+    "gtest >=1.13,<1.14",
linux-64::libabseil-tests-20230125.2-cxx17_h59595ed_1.conda
-    "gtest",
+    "gtest >=1.13,<1.14",
linux-64::libabseil-tests-20230125.2-cxx17_h59595ed_2.conda
-    "gtest",
+    "gtest >=1.13,<1.14",
linux-64::libabseil-tests-20230125.3-cxx17_h59595ed_0.conda
-    "gtest",
+    "gtest >=1.13,<1.14",
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata.json.bz2
linux-aarch64::libabseil-tests-20230125.2-cxx17_h2f0025b_0.conda
-    "gtest",
+    "gtest >=1.13,<1.14",
linux-aarch64::libabseil-tests-20230125.2-cxx17_h2f0025b_1.conda
-    "gtest",
+    "gtest >=1.13,<1.14",
linux-aarch64::libabseil-tests-20230125.2-cxx17_h2f0025b_2.conda
-    "gtest",
+    "gtest >=1.13,<1.14",
linux-aarch64::libabseil-tests-20230125.3-cxx17_h2f0025b_0.conda
-    "gtest",
+    "gtest >=1.13,<1.14",
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata.json.bz2
linux-ppc64le::libabseil-tests-20230125.2-cxx17_h46f38da_0.conda
-    "gtest",
+    "gtest >=1.13,<1.14",
linux-ppc64le::libabseil-tests-20230125.2-cxx17_h46f38da_1.conda
-    "gtest",
+    "gtest >=1.13,<1.14",
linux-ppc64le::libabseil-tests-20230125.2-cxx17_h46f38da_2.conda
-    "gtest",
+    "gtest >=1.13,<1.14",
linux-ppc64le::libabseil-tests-20230125.3-cxx17_h46f38da_0.conda
-    "gtest",
+    "gtest >=1.13,<1.14",
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata.json.bz2
osx-64::libabseil-tests-20230125.2-cxx17_h000cb23_0.conda
-    "gtest",
+    "gtest >=1.13,<1.14",
osx-64::libabseil-tests-20230125.2-cxx17_h000cb23_1.conda
-    "gtest",
+    "gtest >=1.13,<1.14",
osx-64::libabseil-tests-20230125.2-cxx17_h000cb23_2.conda
-    "gtest",
+    "gtest >=1.13,<1.14",
osx-64::libabseil-tests-20230125.3-cxx17_h000cb23_0.conda
-    "gtest",
+    "gtest >=1.13,<1.14",
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata.json.bz2
osx-arm64::libabseil-tests-20230125.2-cxx17_h13dd4ca_0.conda
-    "gtest",
+    "gtest >=1.13,<1.14",
osx-arm64::libabseil-tests-20230125.2-cxx17_h13dd4ca_1.conda
-    "gtest",
+    "gtest >=1.13,<1.14",
osx-arm64::libabseil-tests-20230125.2-cxx17_h13dd4ca_2.conda
-    "gtest",
+    "gtest >=1.13,<1.14",
osx-arm64::libabseil-tests-20230125.3-cxx17_h13dd4ca_0.conda
-    "gtest",
+    "gtest >=1.13,<1.14",
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata.json.bz2
win-64::libabseil-tests-20230125.2-cxx17_h63175ca_0.conda
-    "gtest",
+    "gtest >=1.13,<1.14",
win-64::libabseil-tests-20230125.2-cxx17_h63175ca_1.conda
-    "gtest",
+    "gtest >=1.13,<1.14",
win-64::libabseil-tests-20230125.2-cxx17_h63175ca_2.conda
-    "gtest",
+    "gtest >=1.13,<1.14",
win-64::libabseil-tests-20230125.3-cxx17_h63175ca_0.conda
-    "gtest",
+    "gtest >=1.13,<1.14",
```

</details>