### PR TITLE
patch jupyter_events 0.7.0 vs jsonschema

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1726,8 +1726,6 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                 if "jsonschema-with-format-nongpl >=3.2" in record["depends"]:
                     i = record["depends"].index("jsonschema-with-format-nongpl >=3.2")
                     record["depends"][i] = "jsonschema-with-format-nongpl >=4.18.0"
-                    # this will be handled more robustly in another pin after fix in jsonschema
-                    record["depends"].append("jsonschema >=4.18.0")
                 if "referencing" not in record["depends"]:
                     record["depends"] += ["referencing"]
 

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1719,6 +1719,18 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                 i = record["depends"].index("pyyaml")
                 record["depends"][i] = "pyyaml >=6.0"
 
+        # jupyter_events 0.7.0_*_(0|1) went out with missing deps and pins
+        if record_name == "jupyter_events" and record.get("timestamp", 0) < 1691759541000:
+            version = pkg_resources.parse_version(record["version"])
+            if version == pkg_resources.parse_version("0.7.0"):
+                if "jsonschema-with-format-nongpl >=3.2" in record["depends"]:
+                    i = record["depends"].index("jsonschema-with-format-nongpl >=3.2")
+                    record["depends"][i] = "jsonschema-with-format-nongpl >=4.18.0"
+                    # this will be handled more robustly in another pin after fix in jsonschema
+                    record["depends"].append("jsonschema >=4.18.0")
+                if "referencing" not in record["depends"]:
+                    record["depends"] += ["referencing"]
+
         # librmm 0.19 missed spdlog 1.7.0 in build 1
         # due to spdlog 1.7.0 not having run_exports.
         # This hotfixes those packages


### PR DESCRIPTION
Checklist
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->


References:
- https://github.com/conda-forge/jupyter_events-feedstock/issues/17
- https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/496

```
noarch::jupyter_events-0.7.0-pyhd8ed1ab_0.conda
-    "jsonschema-with-format-nongpl >=3.2",
+    "jsonschema-with-format-nongpl >=4.18.0",
-    "traitlets >=5.3"
+    "traitlets >=5.3",
+    "referencing"
noarch::jupyter_events-0.7.0-pyhd8ed1ab_1.conda
-    "traitlets >=5.3"
+    "traitlets >=5.3",
+    "referencing"
```