### PR TITLE
pin jsonschema subpackages

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -627,6 +627,20 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             i = record['depends'].index('keras >=2.6,<3')
             record['depends'][i] = 'keras >=2.6,<2.7'
 
+        # jsonschema-with-* packages were missing a pin on the parent jsonschema
+        # https://github.com/conda-forge/jsonschema-feedstock/issues/73
+        if (
+            record.get("timestamp", 0) < 1691761503000 and
+            record["name"] in [
+                "jsonschema-with-format",
+                "jsonschema-with-format-nongpl",
+                "jsonschema-with-format-all",
+            ]
+        ):
+            for i, dep in sorted(enumerate(record["depends"])):
+                if dep.startswith("jsonschema") and "=" not in dep:
+                    record["depends"][i] = f"""{dep} =={record["version"]}"""
+
         # missing OpenSSL-distinction in tensorflow wrapper, see
         # https://github.com/conda-forge/tensorflow-feedstock/issues/295
         if (

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -637,9 +637,14 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                 "jsonschema-with-format-all",
             ]
         ):
-            for i, dep in sorted(enumerate(record["depends"])):
-                if dep.startswith("jsonschema") and "=" not in dep:
-                    record["depends"][i] = f"""{dep} =={record["version"]}"""
+            for dep_name in [
+                "jsonschema",
+                "jsonschema-with-format",
+                "jsonschema-with-format-nongpl",
+                "jsonschema-with-format-all",
+            ]:
+                if any(dep_name == dep.split(" ")[0] for dep in record["depends"]):
+                    _pin_stricter(fn, record, dep_name, "x.x.x")
 
         # missing OpenSSL-distinction in tensorflow wrapper, see
         # https://github.com/conda-forge/tensorflow-feedstock/issues/295


### PR DESCRIPTION
Checklist
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->


References:
- https://github.com/conda-forge/jsonschema-feedstock/issues/73

```
noarch::jsonschema-with-format-4.14.0-pyhd8ed1ab_0.tar.bz2
-    "jsonschema >=4.14.0,<5.0a0",
+    "jsonschema >=4.14.0,<4.14.1.0a0",
noarch::jsonschema-with-format-4.15.0-pyhd8ed1ab_0.tar.bz2
-    "jsonschema >=4.15.0,<5.0a0",
+    "jsonschema >=4.15.0,<4.15.1.0a0",
noarch::jsonschema-with-format-4.16.0-pyhd8ed1ab_0.tar.bz2
-    "jsonschema >=4.16.0,<5.0a0",
+    "jsonschema >=4.16.0,<4.16.1.0a0",
noarch::jsonschema-with-format-4.17.0-pyhd8ed1ab_0.tar.bz2
-    "jsonschema >=4.17.0,<5.0a0",
+    "jsonschema >=4.17.0,<4.17.1.0a0",
noarch::jsonschema-with-format-4.2.1-pyhd8ed1ab_1.tar.bz2
-    "jsonschema >=4.2.1,<5.0a0",
+    "jsonschema >=4.2.1,<4.2.2.0a0",
noarch::jsonschema-with-format-4.3.0-pyhd8ed1ab_0.tar.bz2
-    "jsonschema >=4.3.0,<5.0a0",
+    "jsonschema >=4.3.0,<4.3.1.0a0",
noarch::jsonschema-with-format-4.3.1-pyhd8ed1ab_0.tar.bz2
-    "jsonschema >=4.3.1,<5.0a0",
+    "jsonschema >=4.3.1,<4.3.2.0a0",
noarch::jsonschema-with-format-4.3.2-pyhd8ed1ab_0.tar.bz2
-    "jsonschema >=4.3.2,<5.0a0",
+    "jsonschema >=4.3.2,<4.3.3.0a0",
noarch::jsonschema-with-format-4.3.3-pyhd8ed1ab_0.tar.bz2
-    "jsonschema >=4.3.3,<5.0a0",
+    "jsonschema >=4.3.3,<4.3.4.0a0",
noarch::jsonschema-with-format-4.4.0-pyhd8ed1ab_0.tar.bz2
-    "jsonschema >=4.4.0,<5.0a0",
+    "jsonschema >=4.4.0,<4.4.1.0a0",
noarch::jsonschema-with-format-4.5.1-pyhd8ed1ab_0.tar.bz2
-    "jsonschema >=4.5.1,<5.0a0",
+    "jsonschema >=4.5.1,<4.5.2.0a0",
noarch::jsonschema-with-format-4.6.0-pyhd8ed1ab_0.tar.bz2
-    "jsonschema >=4.6.0,<5.0a0",
+    "jsonschema >=4.6.0,<4.6.1.0a0",
noarch::jsonschema-with-format-4.6.1-pyhd8ed1ab_0.tar.bz2
-    "jsonschema >=4.6.1,<5.0a0",
+    "jsonschema >=4.6.1,<4.6.2.0a0",
noarch::jsonschema-with-format-4.6.2-pyhd8ed1ab_0.tar.bz2
-    "jsonschema >=4.6.2,<5.0a0",
+    "jsonschema >=4.6.2,<4.6.3.0a0",
noarch::jsonschema-with-format-4.7.1-pyhd8ed1ab_0.tar.bz2
-    "jsonschema >=4.7.1,<5.0a0",
+    "jsonschema >=4.7.1,<4.7.2.0a0",
noarch::jsonschema-with-format-4.7.2-pyhd8ed1ab_0.tar.bz2
-    "jsonschema >=4.7.2,<5.0a0",
+    "jsonschema >=4.7.2,<4.7.3.0a0",
noarch::jsonschema-with-format-4.8.0-pyhd8ed1ab_0.tar.bz2
-    "jsonschema >=4.8.0,<5.0a0",
+    "jsonschema >=4.8.0,<4.8.1.0a0",
noarch::jsonschema-with-format-4.9.0-pyhd8ed1ab_0.tar.bz2
-    "jsonschema >=4.9.0,<5.0a0",
+    "jsonschema >=4.9.0,<4.9.1.0a0",
noarch::jsonschema-with-format-4.9.1-pyhd8ed1ab_0.tar.bz2
-    "jsonschema >=4.9.1,<5.0a0",
+    "jsonschema >=4.9.1,<4.9.2.0a0",
noarch::jsonschema-with-format-nongpl-4.14.0-pyhd8ed1ab_0.tar.bz2
-    "jsonschema >=4.14.0,<5.0a0",
+    "jsonschema >=4.14.0,<4.14.1.0a0",
noarch::jsonschema-with-format-nongpl-4.15.0-pyhd8ed1ab_0.tar.bz2
-    "jsonschema >=4.15.0,<5.0a0",
+    "jsonschema >=4.15.0,<4.15.1.0a0",
noarch::jsonschema-with-format-nongpl-4.16.0-pyhd8ed1ab_0.tar.bz2
-    "jsonschema >=4.16.0,<5.0a0",
+    "jsonschema >=4.16.0,<4.16.1.0a0",
noarch::jsonschema-with-format-nongpl-4.17.0-pyhd8ed1ab_0.tar.bz2
-    "jsonschema >=4.17.0,<5.0a0",
+    "jsonschema >=4.17.0,<4.17.1.0a0",
noarch::jsonschema-with-format-nongpl-4.2.1-pyhd8ed1ab_1.tar.bz2
-    "jsonschema >=4.2.1,<5.0a0",
+    "jsonschema >=4.2.1,<4.2.2.0a0",
noarch::jsonschema-with-format-nongpl-4.3.0-pyhd8ed1ab_0.tar.bz2
-    "jsonschema >=4.3.0,<5.0a0",
+    "jsonschema >=4.3.0,<4.3.1.0a0",
noarch::jsonschema-with-format-nongpl-4.3.1-pyhd8ed1ab_0.tar.bz2
-    "jsonschema >=4.3.1,<5.0a0",
+    "jsonschema >=4.3.1,<4.3.2.0a0",
noarch::jsonschema-with-format-nongpl-4.3.2-pyhd8ed1ab_0.tar.bz2
-    "jsonschema >=4.3.2,<5.0a0",
+    "jsonschema >=4.3.2,<4.3.3.0a0",
noarch::jsonschema-with-format-nongpl-4.3.3-pyhd8ed1ab_0.tar.bz2
-    "jsonschema >=4.3.3,<5.0a0",
+    "jsonschema >=4.3.3,<4.3.4.0a0",
noarch::jsonschema-with-format-nongpl-4.4.0-pyhd8ed1ab_0.tar.bz2
-    "jsonschema >=4.4.0,<5.0a0",
+    "jsonschema >=4.4.0,<4.4.1.0a0",
noarch::jsonschema-with-format-nongpl-4.5.1-pyhd8ed1ab_0.tar.bz2
-    "jsonschema >=4.5.1,<5.0a0",
+    "jsonschema >=4.5.1,<4.5.2.0a0",
noarch::jsonschema-with-format-nongpl-4.6.0-pyhd8ed1ab_0.tar.bz2
-    "jsonschema >=4.6.0,<5.0a0",
+    "jsonschema >=4.6.0,<4.6.1.0a0",
noarch::jsonschema-with-format-nongpl-4.6.1-pyhd8ed1ab_0.tar.bz2
-    "jsonschema >=4.6.1,<5.0a0",
+    "jsonschema >=4.6.1,<4.6.2.0a0",
noarch::jsonschema-with-format-nongpl-4.6.2-pyhd8ed1ab_0.tar.bz2
-    "jsonschema >=4.6.2,<5.0a0",
+    "jsonschema >=4.6.2,<4.6.3.0a0",
noarch::jsonschema-with-format-nongpl-4.7.1-pyhd8ed1ab_0.tar.bz2
-    "jsonschema >=4.7.1,<5.0a0",
+    "jsonschema >=4.7.1,<4.7.2.0a0",
noarch::jsonschema-with-format-nongpl-4.7.2-pyhd8ed1ab_0.tar.bz2
-    "jsonschema >=4.7.2,<5.0a0",
+    "jsonschema >=4.7.2,<4.7.3.0a0",
noarch::jsonschema-with-format-nongpl-4.8.0-pyhd8ed1ab_0.tar.bz2
-    "jsonschema >=4.8.0,<5.0a0",
+    "jsonschema >=4.8.0,<4.8.1.0a0",
noarch::jsonschema-with-format-nongpl-4.9.0-pyhd8ed1ab_0.tar.bz2
-    "jsonschema >=4.9.0,<5.0a0",
+    "jsonschema >=4.9.0,<4.9.1.0a0",
noarch::jsonschema-with-format-nongpl-4.9.1-pyhd8ed1ab_0.tar.bz2
-    "jsonschema >=4.9.1,<5.0a0",
+    "jsonschema >=4.9.1,<4.9.2.0a0",
noarch::jsonschema-with-format-4.17.1-pyhd8ed1ab_0.conda
-    "jsonschema >=4.17.1,<5.0a0",
+    "jsonschema >=4.17.1,<4.17.2.0a0",
noarch::jsonschema-with-format-4.17.3-pyhd8ed1ab_0.conda
-    "jsonschema >=4.17.3,<5.0a0",
+    "jsonschema >=4.17.3,<4.17.4.0a0",
noarch::jsonschema-with-format-4.18.0-pyhd8ed1ab_0.conda
-    "jsonschema >=4.18.0,<5.0a0",
+    "jsonschema >=4.18.0,<4.18.1.0a0",
noarch::jsonschema-with-format-4.18.1-pyhd8ed1ab_0.conda
-    "jsonschema >=4.18.1,<5.0a0",
+    "jsonschema >=4.18.1,<4.18.2.0a0",
noarch::jsonschema-with-format-4.18.2-pyhd8ed1ab_0.conda
-    "jsonschema >=4.18.2,<5.0a0",
+    "jsonschema >=4.18.2,<4.18.3.0a0",
noarch::jsonschema-with-format-4.18.3-pyhd8ed1ab_0.conda
-    "jsonschema >=4.18.3,<5.0a0",
+    "jsonschema >=4.18.3,<4.18.4.0a0",
noarch::jsonschema-with-format-4.18.4-pyhd8ed1ab_0.conda
-    "jsonschema >=4.18.4,<5.0a0",
+    "jsonschema >=4.18.4,<4.18.5.0a0",
noarch::jsonschema-with-format-4.18.6-pyhd8ed1ab_0.conda
-    "jsonschema >=4.18.6,<5.0a0",
+    "jsonschema >=4.18.6,<4.18.7.0a0",
noarch::jsonschema-with-format-4.19.0-pyhd8ed1ab_0.conda
-    "jsonschema >=4.19.0,<5.0a0",
+    "jsonschema >=4.19.0,<4.19.1.0a0",
noarch::jsonschema-with-format-nongpl-4.17.1-pyhd8ed1ab_0.conda
-    "jsonschema >=4.17.1,<5.0a0",
+    "jsonschema >=4.17.1,<4.17.2.0a0",
noarch::jsonschema-with-format-nongpl-4.17.3-pyhd8ed1ab_0.conda
-    "jsonschema >=4.17.3,<5.0a0",
+    "jsonschema >=4.17.3,<4.17.4.0a0",
noarch::jsonschema-with-format-nongpl-4.18.0-pyhd8ed1ab_0.conda
-    "jsonschema >=4.18.0,<5.0a0",
+    "jsonschema >=4.18.0,<4.18.1.0a0",
noarch::jsonschema-with-format-nongpl-4.18.1-pyhd8ed1ab_0.conda
-    "jsonschema >=4.18.1,<5.0a0",
+    "jsonschema >=4.18.1,<4.18.2.0a0",
noarch::jsonschema-with-format-nongpl-4.18.2-pyhd8ed1ab_0.conda
-    "jsonschema >=4.18.2,<5.0a0",
+    "jsonschema >=4.18.2,<4.18.3.0a0",
noarch::jsonschema-with-format-nongpl-4.18.3-pyhd8ed1ab_0.conda
-    "jsonschema >=4.18.3,<5.0a0",
+    "jsonschema >=4.18.3,<4.18.4.0a0",
noarch::jsonschema-with-format-nongpl-4.18.4-pyhd8ed1ab_0.conda
-    "jsonschema >=4.18.4,<5.0a0",
+    "jsonschema >=4.18.4,<4.18.5.0a0",
noarch::jsonschema-with-format-nongpl-4.18.6-pyhd8ed1ab_0.conda
-    "jsonschema >=4.18.6,<5.0a0",
+    "jsonschema >=4.18.6,<4.18.7.0a0",
noarch::jsonschema-with-format-nongpl-4.19.0-pyhd8ed1ab_0.conda
-    "jsonschema >=4.19.0,<5.0a0",
+    "jsonschema >=4.19.0,<4.19.1.0a0",

```