### PR TITLE
ENH patch rubinenv for mkl

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -517,7 +517,7 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
 
         # rubin-env-nosysroot always needs mkl
         if (
-            subdir.startswith("linux-")
+            subdir == "linux-64"
             and record_name == "rubin-env-nosysroot"
             and record["version"] in ["7.0.0", "7.0.1"]
             and int(record["build_number"]) <= 3

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -515,6 +515,15 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             if new_constrains != record.get('constrains', ()):
                 record['constrains'] = new_constrains
 
+        # rubin-env-nosysroot always needs mkl
+        if (
+            subdir.startswith("linux-")
+            and record_name == "rubin-env-nosysroot"
+            and record["version"] in ["7.0.0", "7.0.1"]
+            and int(record["build_number"]) <= 3
+        ):
+            record["depends"].append("mkl")
+
         if record_name == "starlette-base":
             if not any(dep.split(' ')[0] == "starlette" for dep in record.get('constrains', ())):
                 if 'constrains' in record:


### PR DESCRIPTION
Checklist
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->
