### PR TITLE
ENH make sure gfortran pulls in correct version on osx-*

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -1402,6 +1402,16 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                 new_constrains.append(f'{pkg} {version}.*')
             record['constrains'] = new_constrains
 
+        # some symlinks changed in gfortran, so we need to adjust things
+        # plus we missed a key version constraint
+        if (
+            subdir in ["osx-64", "osx-arm64"]
+            and record_name == "gfortran"
+        ):
+            for i, dep in enumerate(record["depends"]):
+                if dep == f"gfortran_{subdir}":
+                    record["depends"][i] = dep + " ==" + record["version"]
+
         # make sure the libgfortran version is bound from 3 to 4 for osx
         if subdir == "osx-64":
             _fix_libgfortran(fn, record)


### PR DESCRIPTION
Checklist
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->


<details>

```diff
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata.json.bz2
osx-64::gfortran-10.4.0-h2c809b3_0.tar.bz2
-    "gfortran_osx-64",
+    "gfortran_osx-64 ==10.4.0",
osx-64::gfortran-10.4.0-hcea11b0_0.tar.bz2
-    "gfortran_osx-64",
+    "gfortran_osx-64 ==10.4.0",
osx-64::gfortran-11.3.0-h2c809b3_0.tar.bz2
-    "gfortran_osx-64",
+    "gfortran_osx-64 ==11.3.0",
osx-64::gfortran-11.3.0-h73be676_0.tar.bz2
-    "gfortran_osx-64",
+    "gfortran_osx-64 ==11.3.0",
osx-64::gfortran-7.5.0-h94999e8_13.tar.bz2
-    "gfortran_osx-64",
+    "gfortran_osx-64 ==7.5.0",
osx-64::gfortran-7.5.0-h94999e8_14.tar.bz2
-    "gfortran_osx-64",
+    "gfortran_osx-64 ==7.5.0",
osx-64::gfortran-7.5.0-h94999e8_15.tar.bz2
-    "gfortran_osx-64",
+    "gfortran_osx-64 ==7.5.0",
osx-64::gfortran-9.3.0-h768ea0c_13.tar.bz2
-    "gfortran_osx-64",
+    "gfortran_osx-64 ==9.3.0",
osx-64::gfortran-9.3.0-h768ea0c_14.tar.bz2
-    "gfortran_osx-64",
+    "gfortran_osx-64 ==9.3.0",
osx-64::gfortran-9.3.0-h768ea0c_15.tar.bz2
-    "gfortran_osx-64",
+    "gfortran_osx-64 ==9.3.0",
osx-64::gfortran-9.5.0-h2c809b3_0.tar.bz2
-    "gfortran_osx-64",
+    "gfortran_osx-64 ==9.5.0",
osx-64::gfortran-9.5.0-hd5876dc_0.tar.bz2
-    "gfortran_osx-64",
+    "gfortran_osx-64 ==9.5.0",
osx-64::gfortran-11.3.0-h2c809b3_1.conda
-    "gfortran_osx-64",
+    "gfortran_osx-64 ==11.3.0",
osx-64::gfortran-11.4.0-h2c809b3_0.conda
-    "gfortran_osx-64",
+    "gfortran_osx-64 ==11.4.0",
osx-64::gfortran-12.2.0-h2c809b3_1.conda
-    "gfortran_osx-64",
+    "gfortran_osx-64 ==12.2.0",
osx-64::gfortran-12.3.0-h2c809b3_0.conda
-    "gfortran_osx-64",
+    "gfortran_osx-64 ==12.3.0",
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata.json.bz2
osx-arm64::gfortran-10.2.1-h462763d_13.tar.bz2
-    "gfortran_osx-arm64",
+    "gfortran_osx-arm64 ==10.2.1",
osx-arm64::gfortran-10.2.1-h462763d_14.tar.bz2
-    "gfortran_osx-arm64",
+    "gfortran_osx-arm64 ==10.2.1",
osx-arm64::gfortran-10.2.1-h462763d_15.tar.bz2
-    "gfortran_osx-arm64",
+    "gfortran_osx-arm64 ==10.2.1",
osx-arm64::gfortran-11.0.0.dev0-h85ff328_13.tar.bz2
-    "gfortran_osx-arm64",
+    "gfortran_osx-arm64 ==11.0.0.dev0",
osx-arm64::gfortran-11.0.1.dev0-h40eb566_14.tar.bz2
-    "gfortran_osx-arm64",
+    "gfortran_osx-arm64 ==11.0.1.dev0",
osx-arm64::gfortran-11.0.1.dev0-h40eb566_15.tar.bz2
-    "gfortran_osx-arm64",
+    "gfortran_osx-arm64 ==11.0.1.dev0",
osx-arm64::gfortran-11.3.0-h1ca8e4b_0.tar.bz2
-    "gfortran_osx-arm64",
+    "gfortran_osx-arm64 ==11.3.0",
osx-arm64::gfortran-11.3.0-h1ca8e4b_1.conda
-    "gfortran_osx-arm64",
+    "gfortran_osx-arm64 ==11.3.0",
osx-arm64::gfortran-11.4.0-h1ca8e4b_0.conda
-    "gfortran_osx-arm64",
+    "gfortran_osx-arm64 ==11.4.0",
osx-arm64::gfortran-12.2.0-h1ca8e4b_1.conda
-    "gfortran_osx-arm64",
+    "gfortran_osx-arm64 ==12.2.0",
osx-arm64::gfortran-12.3.0-h1ca8e4b_0.conda
-    "gfortran_osx-arm64",
+    "gfortran_osx-arm64 ==12.3.0",
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata.json.bz2
```

</details>