### PR TITLE
Patch flax for jax

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -3265,6 +3265,14 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
         ):
             _replace_pin("zstd >=1.5.2,<1.6.0a0", "zstd ==1.5.2", record["depends"], record)
 
+        # jax 0.4.14 removes jax.ShapedArray, which is imported by flax<0.6.9
+        if (
+            record_name == "flax"
+            and pkg_resources.parse_version(record["version"]) < pkg_resources.parse_version("0.6.9")
+            and record.get("timestamp", 0) < 1692133728000
+        ):
+            _replace_pin("jax >=0.3.2", "jax >=0.3.2,<0.4.14", record["depends"], record)
+
     return index
 
 


### PR DESCRIPTION
jax 0.4.14 removes jax.ShapedArray, which is imported by flax<0.6.9 (https://github.com/google/flax/commit/57a7f26ec5c2b4251d831f25f496221e3c9e6ee6). Currently, the conda-forge build for flax>=0.6.9 is not ready.

This caused failure when importing flax. See https://github.com/conda-forge/jax-md-feedstock/pull/29 and https://github.com/conda-forge/staged-recipes/pull/23048.

ping @conda-forge/flax

Checklist
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

```diff
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata.json.bz2
noarch::flax-0.5.1-pyhd8ed1ab_0.tar.bz2
-    "jax >=0.3.2",
+    "jax >=0.3.2,<0.4.14",
noarch::flax-0.5.2-pyhd8ed1ab_0.tar.bz2
-    "jax >=0.3.2",
+    "jax >=0.3.2,<0.4.14",
noarch::flax-0.6.1-pyhd8ed1ab_0.tar.bz2
-    "jax >=0.3.2",
+    "jax >=0.3.2,<0.4.14",
noarch::flax-0.6.1-pyhd8ed1ab_1.conda
-    "jax >=0.3.2",
+    "jax >=0.3.2,<0.4.14",
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata.json.bz2
```
