### PR TITLE
patch old versions of flax

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -3282,6 +3282,7 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             and record.get("timestamp", 0) < 1692133728000
         ):
             _replace_pin("jax >=0.3.2", "jax >=0.3.2,<0.4.14", record["depends"], record)
+            _replace_pin("jax >=0.2.6", "jax >=0.2.6,<0.4.14", record["depends"], record)
 
     return index
 


### PR DESCRIPTION
Follow up #500. This PR patches other old versions of flax. The reason is as the same as #500.

Checklist
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

```diff
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata.json.bz2
noarch::flax-0.3.2-pyhd8ed1ab_0.tar.bz2
-    "jax >=0.2.6",
+    "jax >=0.2.6,<0.4.14",
noarch::flax-0.3.3-pyhd8ed1ab_0.tar.bz2
-    "jax >=0.2.6",
+    "jax >=0.2.6,<0.4.14",
noarch::flax-0.3.4-pyhd8ed1ab_0.tar.bz2
-    "jax >=0.2.6",
+    "jax >=0.2.6,<0.4.14",
noarch::flax-0.3.5-pyhd8ed1ab_0.tar.bz2
-    "jax >=0.2.6",
+    "jax >=0.2.6,<0.4.14",
noarch::flax-0.3.6-pyhd8ed1ab_0.tar.bz2
-    "jax >=0.2.6",
+    "jax >=0.2.6,<0.4.14",
noarch::flax-0.4.0-pyhd8ed1ab_0.tar.bz2
-    "jax >=0.2.6",
+    "jax >=0.2.6,<0.4.14",
noarch::flax-0.4.1-pyhd8ed1ab_0.tar.bz2
-    "jax >=0.2.6",
+    "jax >=0.2.6,<0.4.14",
noarch::flax-0.5.0-pyhd8ed1ab_0.tar.bz2
-    "jax >=0.2.6",
+    "jax >=0.2.6,<0.4.14",
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata.json.bz2
```