### PR TITLE
interpolation 2.2.4 needs packaging packaging <22.0,>=21.3

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -3152,16 +3152,6 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             _replace_pin("scipy >=1.8", "scipy >=1.8,<1.9.2",
                          record["depends"], record)
 
-        # interpolation 2.2.4 needs packaging packaging <22.0,>=21.3
-        # Fixed in https://github.com/conda-forge/interpolation-feedstock/pull/26 
-        if (
-            record_name == "interpolation" and
-            record["version"] == "2.2.4" and
-            record["build_number"] == 0
-        ):
-            _replace_pin("packaging >=21.3", "packaging <22.0,>=21.3",
-                         record["depends"], record)
-        
         # intake-esm v2023.4.20 dropped support for Python 3.8 but build 0 didn't update
         # the Python version pin.
         if (

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -3152,6 +3152,16 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
             _replace_pin("scipy >=1.8", "scipy >=1.8,<1.9.2",
                          record["depends"], record)
 
+        # interpolation 2.2.4 needs packaging packaging <22.0,>=21.3
+        # Fixed in https://github.com/conda-forge/interpolation-feedstock/pull/26 
+        if (
+            record_name == "interpolation" and
+            record["version"] == "2.2.4" and
+            record["build_number"] == 0
+        ):
+            _replace_pin("packaging >=21.3", "packaging <22.0,>=21.3",
+                         record["depends"], record)
+        
         # intake-esm v2023.4.20 dropped support for Python 3.8 but build 0 didn't update
         # the Python version pin.
         if (

--- a/recipe/patch_yaml/interpolation.yaml
+++ b/recipe/patch_yaml/interpolation.yaml
@@ -1,3 +1,5 @@
+# interpolation 2.2.4 needs packaging packaging <22.0,>=21.3
+# Fixed in https://github.com/conda-forge/interpolation-feedstock/pull/26 
 if:
   name: interpolation
   version: 2.2.4

--- a/recipe/patch_yaml/interpolation.yaml
+++ b/recipe/patch_yaml/interpolation.yaml
@@ -1,0 +1,8 @@
+if:
+  name: interpolation
+  version: 2.2.4
+  build_number: 0
+then:
+  - replace_depends:
+      old: "packaging >=21.3"
+      new: "packaging <22.0,>=21.3"


### PR DESCRIPTION
Fixed in https://github.com/conda-forge/interpolation-feedstock/pull/26

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/patch_yaml/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here --!>
