### PR TITLE
Fix protobuf run dependency on old libignition-msgs5 Windows packages (yaml version)

### DIFF
--- a/recipe/patch_yaml/libignition-msgs1.yaml
+++ b/recipe/patch_yaml/libignition-msgs1.yaml
@@ -1,0 +1,47 @@
+# Before 2021, libignition-msgs5 had a bug for which no dependency
+# was added on protobuf, and this can create problem when a new protobuf
+# verson is relased, see 
+# https://github.com/conda-forge/libignition-msgs1-feedstock/issues/30
+if:
+  subdir_in: win-64
+  artifact_in: libignition-msgs5-5.3.0-h13ae965_2.tar.bz2
+  timestamp_lt: 1611218248868
+then:
+  - add_depends: "libprotobuf >=3.13.0.1,<3.14.0a0"
+---
+if:
+  subdir_in: win-64
+  artifact_in: libignition-msgs5-5.3.0-h21ff451_1.tar.bz2
+  timestamp_lt: 1611218248868
+then:
+  - add_depends: "libprotobuf >=3.13.0,<3.14.0a0"
+---
+if:
+  subdir_in: win-64
+  artifact_in:
+    - libignition-msgs5-5.3.0-h21ff451_0.tar.bz2
+    - libignition-msgs5-5.1.0-h21ff451_4.tar.bz2
+  timestamp_lt: 1611218248868
+then:
+  - add_depends: "libprotobuf >=3.12.3,<3.13.0a0"
+---
+if:
+  subdir_in: win-64
+  artifact_in: libignition-msgs5-5.1.0-h21ff451_2.tar.bz2
+  timestamp_lt: 1611218248868
+then:
+  - add_depends: "libprotobuf >=3.12.1,<3.13.0a0"
+---
+if:
+  subdir_in: win-64
+  artifact_in: libignition-msgs5-5.1.0-h21ff451_1.tar.bz2
+  timestamp_lt: 1611218248868
+then:
+  - add_depends: "libprotobuf >=3.11.4,<3.12.0a0"
+---
+if:
+  subdir_in: win-64
+  artifact_in: libignition-msgs5-5.1.0-h21ff451_0.tar.bz2
+  timestamp_lt: 1611218248868
+then:
+  - add_depends: "libprotobuf >=3.11.2,<3.12.0a0"


### PR DESCRIPTION
Fix https://github.com/conda-forge/libignition-msgs1-feedstock/issues/30
Fix https://github.com/gazebosim/gazebo-classic/issues/3339 


Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/patch_yaml/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here --!>
