### PR TITLE
Fix incorrect constraint in `openff-units`

### DIFF
--- a/recipe/patch_yaml/openff-units-patch.yaml
+++ b/recipe/patch_yaml/openff-units-patch.yaml
@@ -1,0 +1,7 @@
+if:
+  subdir_in: noarch
+  artifact_in: openff-units-0.2.0-pyh1a96a4e_1.conda
+then:
+  - replace_depends:
+      old: "pint >=0.20.1|=0.21"
+      new: "pint >=0.20.1,=0.21"


### PR DESCRIPTION
I did a stupid thing a while back and I'm trying to fix it: https://github.com/conda-forge/openff-units-feedstock/pull/15/files#diff-f3725a55bf339595bf865fec73bda8ac99f283b0810c205442021f29c06eea9aL24-R24

This build doesn't work with Pint 0.22, which wasn't released when I first made that version, but I used `|` where I should have just used `,` so it's being brought in anyway.

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/patch_yaml/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->
  * I'm targeting a specific old build, so I don't think this is necessary. I can add a timestamp check it if desired, of course.

```
$ python show_diff.py --use-cache --subdirs noarch         15:05:52  ☁  openff-units-pint ☂ ⚡
Read 1 patch yaml docs for file cf-autotick-bot-test-package.yaml
Read 1 patch yaml docs for file interpolation.yaml
Read 1 patch yaml docs for file openff-units-patch.yaml
Read 3 total patch yaml docs
noarch::openff-units-0.2.0-pyh1a96a4e_1.conda
-    "pint >=0.20.1|=0.21",
+    "pint >=0.20.1,=0.21",