### PR TITLE
ENH allow to match a single space plus other chars optionally

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,12 @@ build:
   noarch: generic
   number: 0
   script:
+    - black --check patch_yaml_utils.py
+    - ruff patch_yaml_utils.py
+    - black --check test_patch_yaml_utils.py
+    - ruff test_patch_yaml_utils.py
+    - pytest -vv test_patch_yaml_utils.py
+    - pytest -vv test_gen_patch_json.py
     - python gen_patch_json.py
 
 requirements:
@@ -21,6 +27,8 @@ requirements:
     - license-expression
     - packaging
     - pyyaml
+    - black
+    - ruff
   host:
   run:
 
@@ -41,19 +49,11 @@ test:
     - license-expression
     - pytest
     - conda-build
-    - black
-    - ruff
     - pyyaml
   commands:
     {% for subdir in ("noarch", "linux-64", "linux-armv7l", "linux-ppc64le", "osx-64", "osx-arm64", "win-32", "win-64") %}
     - test -e $PREFIX/{{ subdir }}/patch_instructions.json
     {% endfor %}
-    - black --check patch_yaml_utils.py
-    - ruff patch_yaml_utils.py
-    - black --check test_patch_yaml_utils.py
-    - ruff test_patch_yaml_utils.py
-    - pytest -vv test_patch_yaml_utils.py
-    - pytest -vv test_gen_patch_json.py
     - python show_diff.py
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,6 +29,7 @@ requirements:
     - pyyaml
     - black
     - ruff
+    - pytest
   host:
   run:
 
@@ -47,9 +48,8 @@ test:
     - packaging
     - tqdm
     - license-expression
-    - pytest
-    - conda-build
     - pyyaml
+    - conda-build
   commands:
     {% for subdir in ("noarch", "linux-64", "linux-armv7l", "linux-ppc64le", "osx-64", "osx-arm64", "win-32", "win-64") %}
     - test -e $PREFIX/{{ subdir }}/patch_instructions.json

--- a/recipe/patch_yaml/README.md
+++ b/recipe/patch_yaml/README.md
@@ -12,7 +12,8 @@ Patches are specified by two main blocks.
 - The `if` block specifies a set of conditions under which the changes in the `then` block are applied.
 - The different conditions in the `if` block are combined with a logical `AND`.
 - The `if` conditions can use shell glob syntax as implemented in the python `fnmatch` module in the
-  standard library.
+  standard library. The optional "?( )" pattern from extended glob syntax is allowed to match zero or
+  one spaces.
 - Multiple patches can be in the same file using separate YAML documents (i.e., separate the data by `---`
   on a new line).
 
@@ -41,7 +42,8 @@ if:
   build_number_in: [0, 1, 2]
 
   # has specific dependencies as either a list or a single string
-  has_depends: numpy*  # matches any numpy entry with or without a version
+  has_depends: numpy*  # matches 'numpy', 'nump-blah', or 'numpy 5.6'
+  has_depends: numpy?( )*  # matches 'numpy' or 'numpy 5.6'
   has_depends: numpy  # matches "numpy" exactly (i.e., no pins)
 
   # single value for a key that should match

--- a/recipe/patch_yaml/README.md
+++ b/recipe/patch_yaml/README.md
@@ -12,8 +12,8 @@ Patches are specified by two main blocks.
 - The `if` block specifies a set of conditions under which the changes in the `then` block are applied.
 - The different conditions in the `if` block are combined with a logical `AND`.
 - The `if` conditions can use shell glob syntax as implemented in the python `fnmatch` module in the
-  standard library. The optional "?( )" pattern from extended glob syntax is allowed to match zero or
-  one spaces.
+  standard library. The optional "?( *)" pattern from extended glob syntax is allowed to match zero or
+  one sequences of spaces plus any other characters.
 - Multiple patches can be in the same file using separate YAML documents (i.e., separate the data by `---`
   on a new line).
 
@@ -43,7 +43,7 @@ if:
 
   # has specific dependencies as either a list or a single string
   has_depends: numpy*  # matches 'numpy', 'nump-blah', or 'numpy 5.6'
-  has_depends: numpy?( )*  # matches 'numpy' or 'numpy 5.6'
+  has_depends: numpy?( *)  # matches 'numpy' or 'numpy 5.6' but not 'numpy-blah'
   has_depends: numpy  # matches "numpy" exactly (i.e., no pins)
 
   # single value for a key that should match

--- a/recipe/patch_yaml_utils.py
+++ b/recipe/patch_yaml_utils.py
@@ -24,21 +24,24 @@ print("Read %d total patch yaml docs" % len(ALL_YAMLS), flush=True)
 @lru_cache(maxsize=1024)
 def _fnmatch_build_re(pat):
     repat = (
-        "(\\ )?".join([_fnmatch.translate(p)[:-2] for p in pat.split("?( )")]) + "\\Z"
+        "(?s:\\ .*)?".join([_fnmatch.translate(p)[:-2] for p in pat.split("?( *)")])
+        + "\\Z"
     )
     return re.compile(repat).match
 
 
 def fnmatch(name, pat):
     """Test whether FILENAME matches PATTERN with custom
-    allowed optional space via '?( )'.
+    allowed optional space via '?( *)'.
 
     This is useful to match single names with or without a version
     but not other packages.
 
-    For example, 'numpy*' will match 'numpy', 'numpy >=1', and 'numpy-blah >=10'.
-    OTOH, 'numpy?( )' will match only 'numpy', 'numpy >=1'.
-    'numpy' only matches 'numpy'
+    Here are various cases to illustrate how this works:
+
+      - 'numpy*' will match 'numpy', 'numpy >=1', and 'numpy-blah >=10'.
+      - 'numpy?( *)' will match only 'numpy', 'numpy >=1'.
+      - 'numpy' only matches 'numpy'
 
     **doc string below is from python stdlib**
 

--- a/recipe/test_patch_yaml_utils.py
+++ b/recipe/test_patch_yaml_utils.py
@@ -22,21 +22,15 @@ def test_test_patch_yaml_record_key():
     record = {"name": "blah", "version": "1.0.1"}
     assert not _test_patch_yaml(patch_yaml, record, None, None)
 
-    patch_yaml = {"if": {"name": "blah?( )"}}
+    patch_yaml = {"if": {"name": "blah?( *)"}}
     record = {"name": "blah"}
     assert _test_patch_yaml(patch_yaml, record, None, None)
     record = {"name": "blah "}
     assert _test_patch_yaml(patch_yaml, record, None, None)
     record = {"name": "blah blah"}
+    assert _test_patch_yaml(patch_yaml, record, None, None)
+    record = {"name": "blah-blah"}
     assert not _test_patch_yaml(patch_yaml, record, None, None)
-
-    patch_yaml = {"if": {"name": "blah?( )*"}}
-    record = {"name": "blah"}
-    assert _test_patch_yaml(patch_yaml, record, None, None)
-    record = {"name": "blah "}
-    assert _test_patch_yaml(patch_yaml, record, None, None)
-    record = {"name": "blah blah"}
-    assert _test_patch_yaml(patch_yaml, record, None, None)
 
 
 def test_test_patch_yaml_subdir():

--- a/recipe/test_patch_yaml_utils.py
+++ b/recipe/test_patch_yaml_utils.py
@@ -22,6 +22,14 @@ def test_test_patch_yaml_record_key():
     record = {"name": "blah", "version": "1.0.1"}
     assert not _test_patch_yaml(patch_yaml, record, None, None)
 
+    patch_yaml = {"if": {"name": "blah?( )"}}
+    record = {"name": "blah"}
+    assert _test_patch_yaml(patch_yaml, record, None, None)
+    record = {"name": "blah "}
+    assert _test_patch_yaml(patch_yaml, record, None, None)
+    record = {"name": "blah blah"}
+    assert not _test_patch_yaml(patch_yaml, record, None, None)
+
 
 def test_test_patch_yaml_subdir():
     record = {}

--- a/recipe/test_patch_yaml_utils.py
+++ b/recipe/test_patch_yaml_utils.py
@@ -30,6 +30,14 @@ def test_test_patch_yaml_record_key():
     record = {"name": "blah blah"}
     assert not _test_patch_yaml(patch_yaml, record, None, None)
 
+    patch_yaml = {"if": {"name": "blah?( )"}}
+    record = {"name": "blah"}
+    assert _test_patch_yaml(patch_yaml, record, None, None)
+    record = {"name": "blah "}
+    assert _test_patch_yaml(patch_yaml, record, None, None)
+    record = {"name": "blah blah"}
+    assert _test_patch_yaml(patch_yaml, record, None, None)
+
 
 def test_test_patch_yaml_subdir():
     record = {}

--- a/recipe/test_patch_yaml_utils.py
+++ b/recipe/test_patch_yaml_utils.py
@@ -30,7 +30,7 @@ def test_test_patch_yaml_record_key():
     record = {"name": "blah blah"}
     assert not _test_patch_yaml(patch_yaml, record, None, None)
 
-    patch_yaml = {"if": {"name": "blah?( )"}}
+    patch_yaml = {"if": {"name": "blah?( )*"}}
     record = {"name": "blah"}
     assert _test_patch_yaml(patch_yaml, record, None, None)
     record = {"name": "blah "}


### PR DESCRIPTION
Checklist

* [ ] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/patch_yaml/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here --!>
