### PR TITLE
sphinxcontrib-bibtex: patch prematurely uploaded 2.6.0 and 2.6.1 packages

### DIFF
--- a/recipe/patch_yaml/sphinxcontrib-bibtex.yaml
+++ b/recipe/patch_yaml/sphinxcontrib-bibtex.yaml
@@ -1,0 +1,22 @@
+# fixing repodata issues caused by
+#  - https://github.com/conda-forge/sphinxcontrib-bibtex-feedstock/pull/25
+#  - https://github.com/conda-forge/sphinxcontrib-bibtex-feedstock/pull/26
+#  - https://github.com/conda-forge/sphinxcontrib-bibtex-feedstock/pull/28
+if:
+  name: sphinxcontrib-bibtex
+  version_in:
+    - "2.6.0"
+    - "2.6.1"
+  timestamp_lt: 1693156161000
+  has_depends: "python >=3.6"
+then:
+  - replace_depends:
+      old: "python >=3.6"
+      new: "python >=3.7"
+  - replace_depends:
+      old: "sphinx >=2.1"
+      new: "sphinx >=3.5"
+  - replace_depends:
+      old: "docutils >=0.8"
+      new: "docutils >=0.8,!=0.18.*,!=0.19.*"
+  - remove_depends: dataclasses


### PR DESCRIPTION
Ohh this yaml patching is actually quite nice 😄. Been away for two years or so and suddenly everything is so fancy and shiny 😬

```diff
Read 56 total patch yaml docs
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/noarch/repodata.json.bz2
noarch::sphinxcontrib-bibtex-2.6.0-pyhd8ed1ab_0.conda
-    "dataclasses",
-    "docutils >=0.8",
+    "docutils >=0.8,!=0.18.*,!=0.19.*",
-    "python >=3.6",
-    "sphinx >=2.1"
+    "python >=3.7",
+    "sphinx >=3.5"
noarch::sphinxcontrib-bibtex-2.6.1-pyhd8ed1ab_0.conda
-    "dataclasses",
-    "docutils >=0.8",
+    "docutils >=0.8,!=0.18.*,!=0.19.*",
-    "python >=3.6",
-    "sphinx >=2.1"
+    "python >=3.7",
+    "sphinx >=3.5"
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-armv7l/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-aarch64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/linux-ppc64le/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/osx-arm64/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-32/repodata.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata_from_packages.json.bz2
Downloading: https://conda.anaconda.org/conda-forge/win-64/repodata.json.bz2
```

Diff seems good to me, @jakirkham, @AA-Turner, @chohner can you please double-check?

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/patch_yaml/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here --!>
