### PR TITLE
tighten_depends metis dependency in all packages that depends on metis

### DIFF
--- a/recipe/patch_yaml/metis.yaml
+++ b/recipe/patch_yaml/metis.yaml
@@ -1,0 +1,12 @@
+# Before September 2023, metis had run_exports with max_pin x.x
+# However, it turns out that metis 5.1.1 had ABI breakage w.r.t.
+# to metis 5.1.0, so here we correct the run_dependency of
+# packages that depends on metis, see:
+# * https://github.com/conda-forge/metis-feedstock/pull/38
+if:
+  has_depends: metis >=5.1.*
+  timestamp_lt: 1693402455000
+then:
+  - tighten_depends:
+      name: metis
+      max_pin: x.x.x


### PR DESCRIPTION
As of 2023/08/29, two version of metis have been packaged on conda-forge:
* `5.1.0`
* `5.1.1`

Both version contain a `run_exports: {{ pin_subpackage('metis', max_pin='x.x') }}`. However, it emerged that there is an ABI breakage between 5.1.0 and 5.1.1 (see https://github.com/KarypisLab/METIS/issues/71#issuecomment-1696082046), so we need to:
* Update run_exports of metis to be `max_pin='x.x.x'` (see https://github.com/conda-forge/metis-feedstock/pull/38 and https://github.com/conda-forge/metis-feedstock/pull/39)
* Update old builds to only be compatible with the patch version they have been built with (this PR)

The PR is currently in draft, as I will update it once https://github.com/conda-forge/metis-feedstock/pull/38 is merged.

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/patch_yaml/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here --!>
