### PR TITLE
Add a upper bound for rhash since 1.4.4 has SOVERSION change

### DIFF
--- a/recipe/patch_yaml/rhash.yaml
+++ b/recipe/patch_yaml/rhash.yaml
@@ -1,0 +1,7 @@
+if:
+  has_depends: rhash
+  timestamp_lt: 1693428857000
+then:
+  - replace_depends:
+      old: rhash
+      new: rhash <=1.4.3


### PR DESCRIPTION
Checklist

* [ ] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/patch_yaml/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here --!>
