### PR TITLE
convert a few patches from the core conda stack

### DIFF
--- a/recipe/patch_yaml/anaconda-client.yaml
+++ b/recipe/patch_yaml/anaconda-client.yaml
@@ -1,0 +1,77 @@
+# yaml-language-server: $schema=../patch_yaml_model.json
+# if record_name == "anaconda-client":
+#     # Bump minimum `requests` requirement of `anaconda-client` 1.11.0
+#     # https://github.com/conda-forge/anaconda-client-feedstock/pull/35
+#     if (
+#     parse_version(record["version"]) ==
+#     parse_version("1.11.0")):
+#         i = -1
+#         deps = record["depends"]
+#         with suppress(ValueError):
+#             i = deps.index("requests >=2.9.1")
+#         if i >= 0:
+#             deps[i] = "requests >=2.20.0"
+if:
+  name: anaconda-client
+  version: "1.11.0"
+then:
+  - replace_depends:
+      old: "requests >=2.9.1"
+      new: "requests >=2.20.0"
+---
+#     if record.get("timestamp", 0) <= 1684878992896:  # 2023-05-23
+#         # https://github.com/conda-forge/conda-forge-ci-setup-feedstock/issues/242
+#         # https://github.com/conda-forge/anaconda-client-feedstock/issues/40
+#         if any("urllib3" in dep for dep in record["depends"]):
+#             _replace_pin(
+#                 "urllib3 >=1.26.4",
+#                 "urllib3 >=1.26.4,<2.0.0a0",
+#                 record["depends"],
+#                 record,
+#             )
+#         else:
+#             # old versions depended on urllib3 via requests;
+#             # requests 2.30+ allows urllib3 2.x
+#             for lower_bound in (">=2.9.1", ">=2.0", ">=2.20.0"):
+#                 _replace_pin(
+#                     f"requests {lower_bound}",
+#                     f"requests {lower_bound},<2.30.0a0",
+#                     record["depends"],
+#                     record,
+#                 )
+if:
+  name: anaconda-client
+  timestamp_le: 1684878992896  # 2023-05-23
+  has_depends: "urllib3?( *)"
+then:
+  - tighten_depends:
+      name: urllib3
+      upper_bound: "2.0.0a0"
+---
+if:
+  name: anaconda-client
+  timestamp_le: 1684878992896  # 2023-05-23
+  not_has_depends: "urllib3?( *)"
+then:
+  - tighten_depends:
+      name: requests
+      upper_bound: "2.30.0a0"
+---
+#     # https://github.com/conda-forge/anaconda-client-feedstock/pull/44
+#     # https://github.com/Anaconda-Platform/anaconda-client/issues/678
+#     if (
+#         parse_version(record["version"])
+#         == parse_version("1.12.0")
+#     ) and record["build_number"] == 0:
+#         # Guard python-dateutil dependency with trailing space in "python "
+#         python_pinning = [x for x in record["depends"] if x.startswith("python ")]
+#         for pinning in python_pinning:
+#             _replace_pin(pinning, "python >=3.8", record["depends"], record)
+if:
+  name: anaconda-client
+  version: "1.12.0"
+  build_number: 0
+then:
+  - replace_depends:
+      old: "python *"
+      new: "python >=3.8"

--- a/recipe/patch_yaml/boa.yaml
+++ b/recipe/patch_yaml/boa.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=../patch_yaml_model.json
+# if record_name == "boa" and record.get("timestamp", 0) <= 1619005998286:
+#     depends = record.get("depends", [])
+#     for i, dep in enumerate(depends):
+#         if dep.startswith("mamba") and "<" not in dep and ".*" not in dep:
+#             _dep_parts = dep.split(" ")
+#             _dep_parts[1] = _dep_parts[1] + ",<0.15a0"
+#             depends[i] = " ".join(_dep_parts)
+#     record["depends"] = depends
+if:
+  name: boa
+  timestamp_le: 1619005998286
+then:
+  - tighten_depends:
+      name: mamba
+      upper_bound: "0.15a0"

--- a/recipe/patch_yaml/conda-build.yaml
+++ b/recipe/patch_yaml/conda-build.yaml
@@ -1,0 +1,50 @@
+# yaml-language-server: $schema=../patch_yaml_model.json
+# if record_name == "conda-build":
+#     # Code removed in conda 4.13.0 broke older conda-build releases;
+#     # x-ref issue: conda/conda-build#4481
+#     if (
+#         parse_version(record["version"]) <=
+#         parse_version("3.21.7") or
+#         # backported fix in 3.21.8, build 1
+#         # (PR: conda-forge/conda-build-feedstock#176)
+#         record["version"] == "3.21.8" and record["build_number"] == 0
+#     ):
+#         for i, dep in enumerate(record["depends"]):
+#             dep_name, *dep_other = dep.split()
+#             if dep_name == "conda" and ",<" not in dep:
+#                 record["depends"][i] = "{} {}<4.13.0".format(
+#                     dep_name, dep_other[0] + "," if dep_other else ""
+#                 )
+if:
+  name: conda-build
+  version_le: "3.21.7"
+then:
+  - tighten_depends:
+      name: conda
+      upper_bound: "4.13.0"
+---
+if:
+  name: conda-build
+  version: "3.21.8"
+  build_number: 0
+then:
+  - tighten_depends:
+      name: conda
+      upper_bound: "4.13.0"
+---
+#     # pin setuptools to <66 to avoid `parse_version` issues
+#     # see https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/3973
+#     if record.get("timestamp", 0) <= 1674131439051:  # 2023-01-19
+#         for i, dep in enumerate(record["depends"]):
+#             dep_name, *dep_other = dep.split()
+#             if dep_name == "setuptools" and ",<" not in dep:
+#                 record["depends"][i] = "{} {}<66.0.0a0".format(
+#                     dep_name, dep_other[0] + "," if dep_other else ""
+#                 )
+if:
+  name: conda-build
+  timestamp_le: 1674131439051  # 2023-01-19
+then:
+  - tighten_depends:
+      name: setuptools
+      upper_bound: "66.0.0a0"

--- a/recipe/patch_yaml/conda-forge-ci-setup.yaml
+++ b/recipe/patch_yaml/conda-forge-ci-setup.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=../patch_yaml_model.json
+# if record_name == "conda-forge-ci-setup" and record.get('timestamp', 0) < 1638899810000:
+#     constrains = record.get("constrains", [])
+#     found = any(c.startswith("boa") for c in constrains)
+#     if not found:
+#         constrains.append("boa >=0.8,<0.9")
+#     record["constrains"] = constrains
+if:
+  name: conda-forge-ci-setup
+  timestamp_lt: 1638899810000
+  not_has_constrains: "boa?( *)"
+then:
+  - add_constrains: "boa >=0.8,<0.9"

--- a/recipe/patch_yaml/conda-libmamba-solver.yaml
+++ b/recipe/patch_yaml/conda-libmamba-solver.yaml
@@ -1,0 +1,47 @@
+# yaml-language-server: $schema=../patch_yaml_model.json
+# # conda-libmamba-solver uses calver YY.MM.micro
+# if record_name == "conda-libmamba-solver":
+#     if record.get("timestamp", 0) <= 1669391735453:  # 2022-11-25
+#         # libmamba 0.23 introduces API breaking changes, pin to v0.22
+#         _replace_pin("libmambapy >=0.22", "libmambapy 0.22.*", record["depends"], record)
+#         # conda 22.11 introduces the plugin system, which needs a new release
+#         _replace_pin("conda >=4.12", "conda >=4.12,<22.11.0a", record["depends"], record)
+#         _replace_pin("conda >=4.13", "conda >=4.13,<22.11.0a", record["depends"], record)
+if:
+  name: conda-libmamba-solver
+  timestamp_le: 1669391735453  # 2022-11-25
+then:
+  - replace_depends:
+      old: "libmambapy >=0.22"
+      new: "libmambapy 0.22.*"
+  - replace_depends:
+      old: "conda >=4.12"
+      new: "conda >=4.12,<22.11.0a"
+  - replace_depends: 
+      old: "conda >=4.13"
+      new: "conda >=4.13,<22.11.0a"
+---
+# if record_name == "conda-libmamba-solver":
+#     if record.get("timestamp", 0) <= 1674230331000:  # 2023-01-20
+#         # conda 23.1 changed an internal SubdirData API needed with S3/FTP channels
+#         _replace_pin("conda >=22.11.0", "conda >=22.11.0,<23.1.0a", record["depends"], record)
+if:
+  name: conda-libmamba-solver
+  timestamp_le: 1674230331000  # 2023-01-20
+then:
+  - replace_depends:
+      old: "conda >=22.11.0"
+      new: "conda >=22.11.0,<23.1.0a"
+---
+# if record_name == "conda-libmamba-solver":
+#     if record.get("timestamp", 0) <= 1678721528000: # 2023-03-13:
+#         # conda 23.3 changed an internal SubdirData API needed with S3/FTP channels
+#         # conda deprecated Boltons leading to a breakage in the solver api interface
+#         _replace_pin("conda >=22.11.0", "conda >=22.11.0,<23.2.0a", record["depends"], record)
+if:
+  name: conda-libmamba-solver
+  timestamp_le: 1678721528000  # 2023-03-13
+then:
+  - replace_depends:
+      old: "conda >=22.11.0"
+      new: "conda >=22.11.0,<23.2.0a"

--- a/recipe/patch_yaml/conda-lock.yaml
+++ b/recipe/patch_yaml/conda-lock.yaml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=../patch_yaml_model.json
+# if record_name == "conda-lock" and record.get("timestamp", 0) < 1685186303000:
+#     assert "constrains" not in record
+#     record["constrains"] = ["urllib3 <2"]
+if:
+  name: conda-lock
+  timestamp_le: 1685186303000
+  not_has_constrains: "urllib3 <2"
+then:
+  - add_constrains: "urllib3 <2"

--- a/recipe/patch_yaml/conda-smithy.yaml
+++ b/recipe/patch_yaml/conda-smithy.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=../patch_yaml_model.json
+# # conda moved to calvar from semver and this broke old versions of
+# # conda smithy that do on-the-fly version checks
+# if (
+#     record_name == "conda-smithy"
+#     and (
+#         parse_version(record["version"]) <=
+#         parse_version("3.21.1")
+#     )
+# ):
+#     for i in range(len(record["depends"])):
+#         parts = record["depends"][i].split(" ")
+#         if parts[0] == "conda":
+#             if len(parts) == 1:
+#                 parts.append("<5a0")
+#             elif len(parts) == 2 and "<" not in parts[1]:
+#                 parts[1] = parts[1] + ",<5a0"
+#             record["depends"][i] = " ".join(parts)
+if:
+  name: conda-smithy
+  version_le: "3.21.1"
+then:
+  - tighten_depends: 
+      name: conda
+      upper_bound: 5.0a0

--- a/recipe/patch_yaml/conda.yaml
+++ b/recipe/patch_yaml/conda.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=../patch_yaml_model.json
+# if (record_name == "conda" and
+#     record["version"] == "22.11.1" and
+#     record["build_number"] == 0):
+#     for i, dep in enumerate(record["constrains"]):
+#         dep_name, *dep_other = dep.split()
+#         if dep_name.startswith("conda-libmamba-solver"):
+#             record["constrains"][i] = "conda-libmamba-solver >=22.12.0"
+if:
+  name: conda
+  version: "22.11.1"
+  build_number: 0
+then:
+  - replace_constrains:
+      old: "conda-libmamba-solver?( *)"
+      new: "conda-libmamba-solver >=22.12.0"

--- a/recipe/patch_yaml/constructor.yaml
+++ b/recipe/patch_yaml/constructor.yaml
@@ -1,0 +1,40 @@
+# yaml-language-server: $schema=../patch_yaml_model.json
+# if record_name == "constructor":
+#     # constructor 2.x incompatible with conda 4.6+
+#     # see https://github.com/jaimergp/anaconda-repodata-hotfixes/blob/229c10f6/main.py#L834
+#     if int(record["version"].split(".")[0]) < 3:
+#         _replace_pin("conda", "conda <4.6.0a0", record["depends"], record)
+if:
+  name: constructor
+  version_ge: 2.0.0a0
+  version_lt: 3.0.0a0
+then:
+  - replace_depends:
+      old: conda
+      new: conda <4.6.0a0
+# if record_name == "constructor":
+#     # Pin NSIS on constructor
+#     # https://github.com/conda/constructor/issues/526
+#     if record.get("timestamp", 0) <= 1658913358571:
+#         _replace_pin("nsis >=3.01", "nsis 3.01", record["depends"], record)
+---
+if:
+  name: constructor
+  timestamp_le: 1658913358571
+then:
+  - replace_depends:
+      old: nsis >=3.01
+      new: nsis 3.01
+---
+# if record_name == "constructor":
+#     # conda 23.1 broke constructor
+#     # https://github.com/conda/constructor/pull/627
+#     if record.get("timestamp", 0) <= 1674637311000:
+#         _replace_pin("conda >=4.6", "conda >=4.6,<23.1.0a0", record["depends"], record)
+if:
+  name: constructor
+  timestamp_le: 1674637311000
+then:
+  - replace_depends:
+      old: conda >=4.6
+      new: conda >=4.6,<23.1.0a0

--- a/recipe/patch_yaml/libmamba.yaml
+++ b/recipe/patch_yaml/libmamba.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=../patch_yaml_model.json
+# if subdir in ["linux-64", "linux-aarch64", "linux-ppc64le"] and \
+#     record_name in {"libmamba", "libmambapy"} \
+#     and record.get("version", 0) == "0.23.3":
+#     _replace_pin("libstdcxx-ng >=10.3.0", "libstdcxx-ng >=12.1.0", record["depends"], record)
+#     _replace_pin("libgcc-ng >=10.3.0", "libgcc-ng >=12.1.0", record["depends"], record)
+if:
+  name_in: [libmamba, libmambapy]
+  subdir_in: ["linux-64", "linux-aarch64", "linux-ppc64le"]
+  version: "0.23.3"
+then:
+  - replace_depends:
+      old: libstdcxx-ng >=10.3.0
+      new: libstdcxx-ng >=12.1.0  
+  - replace_depends:
+      old: libgcc-ng >=10.3.0
+      new: libgcc-ng >=12.1.0
+    
+    

--- a/recipe/patch_yaml/mamba.yaml
+++ b/recipe/patch_yaml/mamba.yaml
@@ -1,0 +1,65 @@
+# yaml-language-server: $schema=../patch_yaml_model.json
+# if (
+#     record_name == "mamba" and (
+#       parse_version(record["version"]) < parse_version("0.24.0") 
+#       or (
+#          parse_version(record["version"]) < parse_version("0.24.0")) 
+#          and record["build_number"] == 0
+#       )
+# ):
+#     for i, dep in enumerate(record["depends"]):
+#         dep_name, *dep_other = dep.split()
+#         if dep_name == "conda" and ",<" not in dep:
+#             record["depends"][i] = "{} {}<4.13.0".format(
+#                 dep_name, dep_other[0] + "," if dep_other else ""
+#                 )
+if:
+  name: mamba
+  version_lt: "0.24.0"
+then:
+  - tighten_depends:
+      name: conda
+      upper_bound: "4.13.0"
+---
+if:
+  name: mamba
+  version: "0.24.0"  # jaimergp: I think the code above is buggy and really meant == not <
+  build_number: 0
+then:
+  - tighten_depends:
+      name: conda
+      upper_bound: "4.13.0"
+---
+# if record_name == "mamba" and (
+#     parse_version(record["version"]) ==
+#     parse_version("0.24.0")) and (
+#         record["build_number"] == 1):
+#     for i, dep in enumerate(record["depends"]):
+#         dep_name, *dep_other = dep.split()
+#         if dep_name == "conda":
+#             record["depends"][i] = "conda >=4.8"
+if:
+  name: mamba
+  version: "0.24.0"
+  build_number: 1
+then:
+  - replace_depends:
+      old: "conda?( *)"
+      new: "conda >=4.8"  # don't we want to add <5 here too?
+---
+# if record_name == "mamba" and (
+#     parse_version(record["version"]) ==
+#     parse_version("0.25.0")):
+#     for i, dep in enumerate(record["depends"]):
+#         dep_name, *dep_other = dep.split()
+#         if dep_name == "conda":
+#             record["depends"][i] = "conda >=4.8,<5"
+# @jaimergp: Looks like the intent here was to
+# avoid breakage with conda switching to calver
+if:
+  name: mamba
+  version: "0.25.0"
+then:
+  - replace_depends:
+      old: "conda?( *)"
+      new: "conda >=4.8,<5"


### PR DESCRIPTION
Checklist

* [X] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/patch_yaml/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here --!>

@beckermr - as discussed in the call, these are the patches I worked on during the flight. I am not sure if we want to keep them in the Python module now though, so let me know what to do with this. At any rate, at least the work is there, worst case we just close.