### PR TITLE
Add patch yaml for cuda-cccl-impl to constrain cccl.

### DIFF
--- a/recipe/patch_yaml/cuda-cccl-impl.yaml
+++ b/recipe/patch_yaml/cuda-cccl-impl.yaml
@@ -1,0 +1,8 @@
+# The cccl package replaces cuda-cccl-impl. This patch prevents simultaneous installation.
+if:
+  name: cuda-cccl-impl
+  version: 2.0.1
+  build_number: 0
+then:
+  # Prevent clobbering with cccl
+  - add_constrains: cccl <0.0.0a0


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/patch_yaml/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future.
  * (The patch is only applied to a single build number of a single version of a package that will be sunset and archived.)

Context: `cuda-cccl-impl` is being renamed to `cccl`. This patch prevents simultaneous installation of the conflicting packages.

Previous discussion:
- https://github.com/conda-forge/cuda-cccl-impl-feedstock/pull/3
- https://github.com/conda-forge/cuda-cccl-impl-feedstock/issues/2#issuecomment-1684385614

Side note: The new YAML syntax for repodata patches is really great!

`python show_diff.py` output:

```
================================================================================
================================================================================
noarch
================================================================================
linux-64
linux-64::cuda-cccl-impl-2.0.1-ha770c72_0.conda
+  "constrains": [
+    "cccl <0.0.0a0"
+  ],
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
linux-aarch64
linux-aarch64::cuda-cccl-impl-2.0.1-h8af1aa0_0.conda
+  "constrains": [
+    "cccl <0.0.0a0"
+  ],
================================================================================
================================================================================
linux-ppc64le
linux-ppc64le::cuda-cccl-impl-2.0.1-ha3edaa6_0.conda
+  "constrains": [
+    "cccl <0.0.0a0"
+  ],
================================================================================
================================================================================
osx-64
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
win-32
================================================================================
================================================================================
win-64
win-64::cuda-cccl-impl-2.0.1-h57928b3_0.conda
+  "constrains": [
+    "cccl <0.0.0a0"
+  ],
```