### PR TITLE
ENH better patches

### DIFF
--- a/recipe/README.md
+++ b/recipe/README.md
@@ -78,6 +78,13 @@ then:
   # remove entries from track_features
   - remove_track_features: <list of str or str>
 
+  # reset the depends or constrains section of the repodata
+  # this function resets the depends or constrains to the specified value(s)
+  - reset_<depends or constrains>: <list of str or single str>
+  # you can use data from the record being patched like this
+  # only name, version, build_number and subdir are supported
+  - reset_depends: mypackage <=${version}
+
   # replace entries via an exact match in either the depends or constrains sections
   - replace_<depends or constrains>:
       # str of thing to be replaced

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -818,16 +818,6 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                 "conda >=4.8,<23.4", "conda >=4.14,<23.4", record["depends"], record
             )
 
-        # related to https://github.com/conda-forge/nvidia-apex-feedstock/issues/29
-        if (
-            record_name == "nvidia-apex"
-            and any(
-                "=*=cuda|=*=gpu" in constr for constr in record.get("constrains", [""])
-            )
-            and record.get("timestamp", 0) < 1678454014000
-        ):
-            record["constrains"] = ["pytorch =*=cuda*", "nvidia-apex-proc =*=cuda"]
-
         ############################################
         # Compilers, Runtimes and Related Patches
         ############################################

--- a/recipe/patch_yaml/nvidia-apex.yaml
+++ b/recipe/patch_yaml/nvidia-apex.yaml
@@ -1,0 +1,18 @@
+# from this bit of code
+# related to https://github.com/conda-forge/nvidia-apex-feedstock/issues/29
+# if (
+#     record_name == "nvidia-apex"
+#     and any(
+#         "=*=cuda|=*=gpu" in constr for constr in record.get("constrains", [""])
+#     )
+#     and record.get("timestamp", 0) < 1678454014000
+# ):
+#     record["constrains"] = ["pytorch =*=cuda*", "nvidia-apex-proc =*=cuda"]
+if:
+  name: nvidia-apex
+  timestamp_lt: 1678454014000
+  has_constrains: "*=[*]=cuda|=[*]=gpu*"
+then:
+  - reset_constrains:
+      - pytorch =*=cuda*
+      - nvidia-apex-proc =*=cuda

--- a/recipe/patch_yaml_model.json
+++ b/recipe/patch_yaml_model.json
@@ -1929,6 +1929,42 @@
           "description": "Remove constraints to matched packages",
           "title": "Remove Constrains"
         },
+        "reset_depends": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "items": {
+                "minLength": 1,
+                "type": "string"
+              },
+              "type": "array"
+            }
+          ],
+          "default": null,
+          "description": "Reset the dependencies to the specified value(s)",
+          "title": "Reset Depends"
+        },
+        "reset_constrains": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "items": {
+                "minLength": 1,
+                "type": "string"
+              },
+              "type": "array"
+            }
+          ],
+          "default": null,
+          "description": "Reset the constraints to the specified value(s)",
+          "title": "Reset Constrains"
+        },
         "remove_track_features": {
           "anyOf": [
             {

--- a/recipe/patch_yaml_model.py
+++ b/recipe/patch_yaml_model.py
@@ -150,6 +150,14 @@ class _ThenClauseItem(_ForbidExtra):
         None,
         description="Remove constraints to matched packages",
     )
+    reset_depends: _NonEmptyStr | list[_NonEmptyStr] = Field(
+        None,
+        description="Reset the dependencies to the specified value(s)",
+    )
+    reset_constrains: _NonEmptyStr | list[_NonEmptyStr] = Field(
+        None,
+        description="Reset the constraints to the specified value(s)",
+    )
     remove_track_features: _NonEmptyStr | list[_NonEmptyStr] = Field(
         None,
         description="Remove item(s) from track_features to matched packages",

--- a/recipe/patch_yaml_utils.py
+++ b/recipe/patch_yaml_utils.py
@@ -299,7 +299,7 @@ def _pin_stricter(fn, record, fix_dep, max_pin, upper_bound=None):
                         dep_parts[0], dep_parts[1], new_upper, dep_parts[2]
                     )
                 else:
-                    raise RuntimeError("Weird dep length!")
+                    raise RuntimeError(f"Weird dep length in item '{depends[dep_idx]}'")
 
                 record["depends"] = depends
 

--- a/recipe/patch_yaml_utils.py
+++ b/recipe/patch_yaml_utils.py
@@ -265,7 +265,8 @@ def _pin_stricter(fn, record, fix_dep, max_pin, upper_bound=None):
             upper_bound = ".".join(upper_bound)
 
             depends[dep_idx] = "{} <{}a0".format(
-                dep_parts[0], upper_bound,
+                dep_parts[0],
+                upper_bound,
             )
             record["depends"] = depends
             continue
@@ -399,10 +400,10 @@ def _apply_patch_yaml(patch_yaml, record, subdir, fn):
                 elif not depends and subk in record:
                     del record[subk]
 
-            elif (
-                k.startswith("reset_")
-                and k[len("reset_") :] in ["depends", "constrains"]
-            ):
+            elif k.startswith("reset_") and k[len("reset_") :] in [
+                "depends",
+                "constrains",
+            ]:
                 subk = k[len("reset_") :]
                 if not isinstance(v, list):
                     v = [v]

--- a/recipe/test_patch_yaml_utils.py
+++ b/recipe/test_patch_yaml_utils.py
@@ -351,6 +351,15 @@ def test_apply_patch_yaml_rename(pre, post):
 
 @pytest.mark.parametrize("pre", [[], ["foo"]])
 @pytest.mark.parametrize("post", [[], ["bar"]])
+def test_apply_patch_yaml_reset(pre, post):
+    patch_yaml = {"then": [{"reset_depends": "numppy 1.0"}]}
+    record = {"depends": pre + ["numpy 1.0 blah"] + post}
+    _apply_patch_yaml(patch_yaml, record, None, None)
+    assert record == {"depends": ["numppy 1.0"]}
+
+
+@pytest.mark.parametrize("pre", [[], ["foo"]])
+@pytest.mark.parametrize("post", [[], ["bar"]])
 def test_apply_patch_yaml_relax_exact(pre, post):
     patch_yaml = {"then": [{"relax_exact_depends": {"name": "numpy"}}]}
     record = {"depends": pre + ["numpy 1.0.0 blah"] + post}
@@ -370,6 +379,32 @@ def test_apply_patch_yaml_tighten(pre, post):
     record = {"depends": pre + ["numpy >=1.0.0,<2.0.0a0"] + post}
     _apply_patch_yaml(patch_yaml, record, None, None)
     assert record == {"depends": pre + ["numpy >=1.0.0,<1.1.0a0"] + post}
+
+    patch_yaml = {
+        "then": [{"tighten_depends": {"name": "numpy", "upper_bound": "1.1.2"}}]
+    }
+    record = {"depends": pre + ["numpy >=1.0.0,<2.0.0a0"] + post}
+    _apply_patch_yaml(patch_yaml, record, None, None)
+    assert record == {"depends": pre + ["numpy >=1.0.0,<1.1.2.0a0"] + post}
+
+
+@pytest.mark.parametrize("pre", [[], ["foo"]])
+@pytest.mark.parametrize("post", [[], ["bar"]])
+def test_apply_patch_yaml_tighten_upper_bound(pre, post):
+    patch_yaml = {
+        "then": [{"tighten_depends": {"name": "numpy", "upper_bound": "5.0"}}]
+    }
+    record = {"depends": pre + ["numpy >=1.0.0,<7.0.0a0"] + post}
+    _apply_patch_yaml(patch_yaml, record, None, None)
+    assert record == {"depends": pre + ["numpy >=1.0.0,<5.0.0a0"] + post}
+
+    record = {"depends": pre + ["numpy >=1.0.0"] + post}
+    _apply_patch_yaml(patch_yaml, record, None, None)
+    assert record == {"depends": pre + ["numpy >=1.0.0,<5.0.0a0"] + post}
+
+    record = {"depends": pre + ["numpy"] + post}
+    _apply_patch_yaml(patch_yaml, record, None, None)
+    assert record == {"depends": pre + ["numpy <5.0a0"] + post}
 
     patch_yaml = {
         "then": [{"tighten_depends": {"name": "numpy", "upper_bound": "1.1.2"}}]


### PR DESCRIPTION
This PR adjusts the `_pin_stricter` / `tighten_depends` function to add additional upper bounds that have been missed for previous patches. 

The old version made changes like

    `blah >=1.0.0,<2.0.0a0` -> `blah >=1.0.0,<1.1.0a0` 

for `max_pin=x.x` or `upper_bound=1.1`.

The new version handles the case above, but also makes changes like

    `blah >=1.0.0` ->  `blah >=1.0.0,<1.1.0a0` 

for `max_pin=x.x` or `upper_bound=1.1`, and changes like

    `blah` ->  `blah <1.1.0a0`

for `upper_bound=1.1`.

The diff below reflects these changes which are missed constraints.