### PR TITLE
add top pin for jupyter_server 1.x vs anyio

### DIFF
--- a/recipe/patch_yaml/jupyter_server.yaml
+++ b/recipe/patch_yaml/jupyter_server.yaml
@@ -3,6 +3,6 @@ if:
   version: 1.*
   timestamp_lt: 1693923438000
 then:
-  - replace_depends:
-      old: anyio >=3.1.0
-      new: anyio >=3.1.0,<4
+  - tighten_depends:
+      name: anyio
+      upper_bound: "4"

--- a/recipe/patch_yaml/jupyter_server.yaml
+++ b/recipe/patch_yaml/jupyter_server.yaml
@@ -1,5 +1,7 @@
 if:
   name: jupyter_server
+  version: 1.*
+  timestamp_lt: 1693923438000
 then:
   - replace_depends:
       old: anyio >=3.1.0

--- a/recipe/patch_yaml/jupyter_server.yaml
+++ b/recipe/patch_yaml/jupyter_server.yaml
@@ -1,0 +1,6 @@
+if:
+  name: jupyter_server
+then:
+  - replace_depends:
+      old: anyio >=3.1.0
+      new: anyio >=3.1.0,<4


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

References:
- fixed in https://github.com/conda-forge/jupyter_server-feedstock/pull/131
- noticed on https://github.com/conda-forge/nbgrader-feedstock/pull/66

:bellhop_bell: @conda-forge/jupyter_server