### PR TITLE
Patch openff-bespokefit to anyio<4

### DIFF
--- a/recipe/patch_yaml/openff-bespokefit-patch.yaml
+++ b/recipe/patch_yaml/openff-bespokefit-patch.yaml
@@ -6,5 +6,6 @@ if:
   subdir_in: noarch
   name: openff-bespokefit
   has_constrains: "starlette =0.20"
+  timestamp_lt: 1694139596000
 then:
   - add_constrains: "anyio <4.0.0a0"

--- a/recipe/patch_yaml/openff-bespokefit-patch.yaml
+++ b/recipe/patch_yaml/openff-bespokefit-patch.yaml
@@ -1,4 +1,3 @@
-
 # Down-constrain latest packages to prevent incompatible starlette+anyio combination
 # cc https://github.com/encode/starlette/issues/2262
 # cc https://github.com/openforcefield/openff-bespokefit/issues/283

--- a/recipe/patch_yaml/openff-bespokefit-patch.yaml
+++ b/recipe/patch_yaml/openff-bespokefit-patch.yaml
@@ -1,0 +1,10 @@
+
+# Down-constrain latest packages to prevent incompatible starlette+anyio combination
+# cc https://github.com/encode/starlette/issues/2262
+# cc https://github.com/openforcefield/openff-bespokefit/issues/283
+if:
+  subdir_in: noarch
+  name: openff-bespokefit
+  has_constrains: "starlette =0.20"
+then:
+  - add_constrains: "anyio <4.0.0a0"


### PR DESCRIPTION
We're constrained against an older starlette, which is not compatible with the recently-released anyio version 4.

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->


```diff
(conda-forge-patching) jw@mba$ python show_diff.py                             
================================================================================
================================================================================
noarch
noarch::openff-bespokefit-0.2.1-pyhd8ed1ab_0.conda
noarch::openff-bespokefit-0.1.3-pyhd8ed1ab_3.conda
noarch::openff-bespokefit-0.2.2-pyhd8ed1ab_5.conda
noarch::openff-bespokefit-0.1.3-pyhd8ed1ab_0.conda
noarch::openff-bespokefit-0.1.2-pyhd8ed1ab_1.tar.bz2
noarch::openff-bespokefit-0.1.3-pyhd8ed1ab_2.conda
noarch::openff-bespokefit-0.2.2-pyhd8ed1ab_0.conda
noarch::openff-bespokefit-0.2.2-pyhd8ed1ab_1.conda
+    "anyio <4.0.0a0",
================================================================================
================================================================================
linux-64
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
osx-64
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
win-32
================================================================================
================================================================================
win-64
```

<!-- Put any other comments or information here --!>
