### PR TITLE
Patch openff-toolkit-examples packages for qcportal API change

### DIFF
--- a/recipe/patch_yaml/openff-toolkit-patch.yaml
+++ b/recipe/patch_yaml/openff-toolkit-patch.yaml
@@ -1,5 +1,4 @@
 # Downpin openff-toolkit-examples packages to version of qcportal before API change
-
 if:
   subdir_in: noarch
   name: openff-toolkit-examples

--- a/recipe/patch_yaml/openff-toolkit-patch.yaml
+++ b/recipe/patch_yaml/openff-toolkit-patch.yaml
@@ -1,0 +1,14 @@
+# Downpin openff-toolkit-examples packages to version of qcportal before API change
+
+if:
+  subdir_in: noarch
+  name: openff-toolkit-examples
+  has_depends: "qcportal"
+  timestamp_lt: 1694139596000
+then:
+  - replace_depends:
+      # str of thing to be replaced
+      old: qcportal
+      # thing to replace `old` with
+      new: qcportal <0.50.0a0
+

--- a/recipe/patch_yaml/openff-toolkit-patch.yaml
+++ b/recipe/patch_yaml/openff-toolkit-patch.yaml
@@ -10,4 +10,3 @@ then:
       old: qcportal
       # thing to replace `old` with
       new: qcportal <0.50.0a0
-


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

```diff
(conda-forge-patching) jw@mba$ python show_diff.py                
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
noarch
noarch::openff-toolkit-examples-0.14.3-hd8ed1ab_0.conda
noarch::openff-toolkit-examples-0.14.0-hd8ed1ab_2.conda
noarch::openff-toolkit-examples-0.10.3-hd8ed1ab_0.tar.bz2
noarch::openff-toolkit-examples-0.14.2-hd8ed1ab_0.conda
noarch::openff-toolkit-examples-0.11.2-hd8ed1ab_2.tar.bz2
noarch::openff-toolkit-examples-0.12.1-hd8ed1ab_2.conda
noarch::openff-toolkit-examples-0.10.0-hd8ed1ab_0.tar.bz2
noarch::openff-toolkit-examples-0.10.2-hd8ed1ab_0.tar.bz2
noarch::openff-toolkit-examples-0.13.0-hd8ed1ab_0.conda
noarch::openff-toolkit-examples-0.13.1-hd8ed1ab_0.conda
noarch::openff-toolkit-examples-0.12.1-hd8ed1ab_0.conda
noarch::openff-toolkit-examples-0.14.1-hd8ed1ab_0.conda
noarch::openff-toolkit-examples-0.10.7-hd8ed1ab_0.conda
noarch::openff-toolkit-examples-0.11.4-hd8ed1ab_1.conda
noarch::openff-toolkit-examples-0.11.1-hd8ed1ab_0.tar.bz2
noarch::openff-toolkit-examples-0.10.4-hd8ed1ab_0.tar.bz2
noarch::openff-toolkit-examples-0.10.6-hd8ed1ab_0.tar.bz2
noarch::openff-toolkit-examples-0.11.2-hd8ed1ab_1.tar.bz2
noarch::openff-toolkit-examples-0.11.4-hd8ed1ab_0.tar.bz2
noarch::openff-toolkit-examples-0.14.0-hd8ed1ab_4.conda
noarch::openff-toolkit-examples-0.10.5-hd8ed1ab_0.tar.bz2
noarch::openff-toolkit-examples-0.11.3-hd8ed1ab_0.tar.bz2
noarch::openff-toolkit-examples-0.11.0-hd8ed1ab_0.tar.bz2
noarch::openff-toolkit-examples-0.14.0-hd8ed1ab_0.conda
noarch::openff-toolkit-examples-0.12.0-hd8ed1ab_0.conda
noarch::openff-toolkit-examples-0.14.0-hd8ed1ab_1.conda
noarch::openff-toolkit-examples-0.10.1-hd8ed1ab_0.tar.bz2
noarch::openff-toolkit-examples-0.11.0-hd8ed1ab_1.tar.bz2
noarch::openff-toolkit-examples-0.14.0-hd8ed1ab_3.conda
noarch::openff-toolkit-examples-0.12.1-hd8ed1ab_1.conda
noarch::openff-toolkit-examples-0.13.2-hd8ed1ab_0.conda
-    "qcportal"
+    "qcportal <0.50.0a0"
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
================================================================================
================================================================================
linux-64
```