### PR TITLE
Restrict LAMMPS dependence on mlip to version 1.0

### DIFF
--- a/recipe/patch_yaml/lammps.yaml
+++ b/recipe/patch_yaml/lammps.yaml
@@ -1,0 +1,9 @@
+if:
+  name: lammps
+  version_le: 2023.08.03
+  has_depends: mlip*
+  timestamp_lt: 1694705144
+then:
+  - replace_depends:
+      old: mlip
+      new: mlip =1.0

--- a/recipe/patch_yaml/lammps.yaml
+++ b/recipe/patch_yaml/lammps.yaml
@@ -1,8 +1,9 @@
 if:
   name: lammps
-  version_le: 2023.08.03
-  has_depends: mlip*
-  timestamp_lt: 1694705144
+  subdir_in: linux-64
+  version_le: 2023.08.02
+  has_depends: mlip
+  timestamp_lt: 1694757696000
 then:
   - replace_depends:
       old: mlip


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here --!>
