### PR TITLE
tighten traitlets pins for traittypes

### DIFF
--- a/recipe/patch_yaml/traittypes.yaml
+++ b/recipe/patch_yaml/traittypes.yaml
@@ -1,0 +1,7 @@
+if:
+  name: traittypes
+  timestamp_lt: 1694720296000
+then:
+  - replace_depends:
+      old: traitlets?( *)
+      new: traitlets >=4.2.2,<5.10.0


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future.

Notes:
- the older, overly-tight pins like `"traitlets >=4.2.2,<5.0"` were inaccurate


```diff
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
win-32::traittypes-0.0.6-py27_0.tar.bz2
win-32::traittypes-0.0.5-py27_0.tar.bz2
win-32::traittypes-0.0.5-py34_0.tar.bz2
win-32::traittypes-0.0.5-py35_0.tar.bz2
win-32::traittypes-0.0.6-py34_0.tar.bz2
win-32::traittypes-0.0.6-py35_0.tar.bz2
win-32::traittypes-0.0.6-py36_0.tar.bz2
-    "traitlets >=4.2.2"
+    "traitlets >=4.2.2,<5.10.0"
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
noarch
noarch::traittypes-0.2.1-py_1.tar.bz2
-    "traitlets >=4.2.2,<5.0"
+    "traitlets >=4.2.2,<5.10.0"
noarch::traittypes-0.2.1-pyh9f0ad1d_2.tar.bz2
-    "traitlets >=4.2.2,<6.0"
+    "traitlets >=4.2.2,<5.10.0"
================================================================================
================================================================================
win-64
win-64::traittypes-0.0.5-py34_0.tar.bz2
win-64::traittypes-0.0.6-py27_0.tar.bz2
win-64::traittypes-0.0.6-py36_0.tar.bz2
win-64::traittypes-0.0.5-py35_0.tar.bz2
win-64::traittypes-0.0.6-py35_0.tar.bz2
win-64::traittypes-0.0.6-py34_0.tar.bz2
win-64::traittypes-0.0.5-py27_0.tar.bz2
-    "traitlets >=4.2.2"
+    "traitlets >=4.2.2,<5.10.0"
win-64::traittypes-0.1.0-py27_1.tar.bz2
win-64::traittypes-0.1.0-py36_0.tar.bz2
win-64::traittypes-0.1.0-py27_0.tar.bz2
win-64::traittypes-0.1.0-py35_0.tar.bz2
win-64::traittypes-0.1.0-py36_1.tar.bz2
win-64::traittypes-0.1.0-py35_1.tar.bz2
-    "traitlets"
+    "traitlets >=4.2.2,<5.10.0"
win-64::traittypes-0.2.1-py36_0.tar.bz2
win-64::traittypes-0.2.0-py35_0.tar.bz2
win-64::traittypes-0.2.0-py27_0.tar.bz2
win-64::traittypes-0.2.0-py36_0.tar.bz2
win-64::traittypes-0.2.1-py35_0.tar.bz2
win-64::traittypes-0.2.1-py27_0.tar.bz2
-    "traitlets >=4.2.2,<5.0"
+    "traitlets >=4.2.2,<5.10.0"
================================================================================
================================================================================
osx-64
osx-64::traittypes-0.0.5-py34_0.tar.bz2
osx-64::traittypes-0.0.5-py35_0.tar.bz2
osx-64::traittypes-0.0.6-py36_0.tar.bz2
osx-64::traittypes-0.0.6-py27_0.tar.bz2
osx-64::traittypes-0.0.5-py27_0.tar.bz2
osx-64::traittypes-0.0.6-py34_0.tar.bz2
osx-64::traittypes-0.0.6-py35_0.tar.bz2
-    "traitlets >=4.2.2"
+    "traitlets >=4.2.2,<5.10.0"
osx-64::traittypes-0.1.0-py36_0.tar.bz2
osx-64::traittypes-0.1.0-py36_1.tar.bz2
osx-64::traittypes-0.1.0-py35_1.tar.bz2
osx-64::traittypes-0.1.0-py27_0.tar.bz2
osx-64::traittypes-0.1.0-py35_0.tar.bz2
osx-64::traittypes-0.1.0-py27_1.tar.bz2
-    "traitlets"
+    "traitlets >=4.2.2,<5.10.0"
osx-64::traittypes-0.2.0-py27_0.tar.bz2
osx-64::traittypes-0.2.1-py35_0.tar.bz2
osx-64::traittypes-0.2.1-py36_0.tar.bz2
osx-64::traittypes-0.2.1-py27_0.tar.bz2
osx-64::traittypes-0.2.0-py35_0.tar.bz2
osx-64::traittypes-0.2.0-py36_0.tar.bz2
-    "traitlets >=4.2.2,<5.0"
+    "traitlets >=4.2.2,<5.10.0"
================================================================================
================================================================================
linux-64
linux-64::traittypes-0.0.6-py35_0.tar.bz2
linux-64::traittypes-0.0.5-py34_0.tar.bz2
linux-64::traittypes-0.0.5-py27_0.tar.bz2
linux-64::traittypes-0.0.6-py27_0.tar.bz2
linux-64::traittypes-0.0.6-py36_0.tar.bz2
linux-64::traittypes-0.0.6-py34_0.tar.bz2
linux-64::traittypes-0.0.5-py35_0.tar.bz2
-    "traitlets >=4.2.2"
+    "traitlets >=4.2.2,<5.10.0"
linux-64::traittypes-0.1.0-py36_1.tar.bz2
linux-64::traittypes-0.1.0-py35_1.tar.bz2
linux-64::traittypes-0.1.0-py36_0.tar.bz2
linux-64::traittypes-0.1.0-py27_0.tar.bz2
linux-64::traittypes-0.1.0-py27_1.tar.bz2
linux-64::traittypes-0.1.0-py35_0.tar.bz2
-    "traitlets"
+    "traitlets >=4.2.2,<5.10.0"
linux-64::traittypes-0.2.0-py36_0.tar.bz2
linux-64::traittypes-0.2.1-py35_0.tar.bz2
linux-64::traittypes-0.2.1-py27_0.tar.bz2
linux-64::traittypes-0.2.1-py36_0.tar.bz2
linux-64::traittypes-0.2.0-py35_0.tar.bz2
linux-64::traittypes-0.2.0-py27_0.tar.bz2
-    "traitlets >=4.2.2,<5.0"
+    "traitlets >=4.2.2,<5.10.0"

```

:bellhop_bell: @conda-forge/traittypes 