### PR TITLE
Revert traittypes vs traitlets 5.10 patch

### DIFF
--- a/recipe/patch_yaml/traittypes.yaml
+++ b/recipe/patch_yaml/traittypes.yaml
@@ -4,4 +4,4 @@ if:
 then:
   - replace_depends:
       old: traitlets?( *)
-      new: traitlets >=4.2.2,<5.10.0
+      new: traitlets >=4.2.2


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

References:
- reverts #553

Notes:

- _super_ sorry to flip-flop :crying_cat_face: 
  - there _is_ a change, but it's due to a traitlets change in error reporting an overzealous `DeprecationWarning` that has no formal timeline for hard deprecation
  - this only appears under certain test conditions

```diff
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
win-32::traittypes-0.0.6-py36_0.tar.bz2
win-32::traittypes-0.0.5-py34_0.tar.bz2
win-32::traittypes-0.0.6-py35_0.tar.bz2
win-32::traittypes-0.0.5-py35_0.tar.bz2
win-32::traittypes-0.0.6-py27_0.tar.bz2
win-32::traittypes-0.0.6-py34_0.tar.bz2
win-32::traittypes-0.0.5-py27_0.tar.bz2
-    "traitlets >=4.2.2,<5.10.0"
+    "traitlets >=4.2.2"
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
noarch
noarch::traittypes-0.2.1-py_1.tar.bz2
noarch::traittypes-0.2.1-pyh9f0ad1d_2.tar.bz2
-    "traitlets >=4.2.2,<5.10.0"
+    "traitlets >=4.2.2"
================================================================================
================================================================================
win-64
win-64::traittypes-0.1.0-py36_1.tar.bz2
win-64::traittypes-0.0.6-py27_0.tar.bz2
win-64::traittypes-0.1.0-py36_0.tar.bz2
win-64::traittypes-0.2.0-py35_0.tar.bz2
win-64::traittypes-0.2.1-py35_0.tar.bz2
win-64::traittypes-0.0.6-py35_0.tar.bz2
win-64::traittypes-0.1.0-py35_1.tar.bz2
win-64::traittypes-0.2.0-py27_0.tar.bz2
win-64::traittypes-0.0.6-py34_0.tar.bz2
win-64::traittypes-0.1.0-py27_1.tar.bz2
win-64::traittypes-0.2.0-py36_0.tar.bz2
win-64::traittypes-0.2.1-py36_0.tar.bz2
win-64::traittypes-0.0.5-py34_0.tar.bz2
win-64::traittypes-0.0.5-py35_0.tar.bz2
win-64::traittypes-0.1.0-py35_0.tar.bz2
win-64::traittypes-0.2.1-py27_0.tar.bz2
win-64::traittypes-0.0.6-py36_0.tar.bz2
win-64::traittypes-0.0.5-py27_0.tar.bz2
win-64::traittypes-0.1.0-py27_0.tar.bz2
-    "traitlets >=4.2.2,<5.10.0"
+    "traitlets >=4.2.2"
================================================================================
================================================================================
osx-64
osx-64::traittypes-0.0.6-py27_0.tar.bz2
osx-64::traittypes-0.1.0-py27_1.tar.bz2
osx-64::traittypes-0.2.0-py36_0.tar.bz2
osx-64::traittypes-0.0.5-py27_0.tar.bz2
osx-64::traittypes-0.2.0-py35_0.tar.bz2
osx-64::traittypes-0.2.1-py36_0.tar.bz2
osx-64::traittypes-0.0.6-py35_0.tar.bz2
osx-64::traittypes-0.2.1-py27_0.tar.bz2
osx-64::traittypes-0.2.0-py27_0.tar.bz2
osx-64::traittypes-0.0.5-py35_0.tar.bz2
osx-64::traittypes-0.1.0-py35_0.tar.bz2
osx-64::traittypes-0.0.6-py34_0.tar.bz2
osx-64::traittypes-0.2.1-py35_0.tar.bz2
osx-64::traittypes-0.1.0-py27_0.tar.bz2
osx-64::traittypes-0.1.0-py36_0.tar.bz2
osx-64::traittypes-0.0.6-py36_0.tar.bz2
osx-64::traittypes-0.1.0-py36_1.tar.bz2
osx-64::traittypes-0.0.5-py34_0.tar.bz2
osx-64::traittypes-0.1.0-py35_1.tar.bz2
-    "traitlets >=4.2.2,<5.10.0"
+    "traitlets >=4.2.2"
================================================================================
================================================================================
linux-64
linux-64::traittypes-0.1.0-py35_0.tar.bz2
linux-64::traittypes-0.0.5-py27_0.tar.bz2
linux-64::traittypes-0.0.6-py35_0.tar.bz2
linux-64::traittypes-0.1.0-py35_1.tar.bz2
linux-64::traittypes-0.2.0-py27_0.tar.bz2
linux-64::traittypes-0.1.0-py36_1.tar.bz2
linux-64::traittypes-0.1.0-py27_0.tar.bz2
linux-64::traittypes-0.0.6-py27_0.tar.bz2
linux-64::traittypes-0.0.6-py34_0.tar.bz2
linux-64::traittypes-0.2.1-py35_0.tar.bz2
linux-64::traittypes-0.2.1-py36_0.tar.bz2
linux-64::traittypes-0.1.0-py27_1.tar.bz2
linux-64::traittypes-0.2.0-py36_0.tar.bz2
linux-64::traittypes-0.0.6-py36_0.tar.bz2
linux-64::traittypes-0.2.0-py35_0.tar.bz2
linux-64::traittypes-0.0.5-py34_0.tar.bz2
linux-64::traittypes-0.0.5-py35_0.tar.bz2
linux-64::traittypes-0.1.0-py36_0.tar.bz2
linux-64::traittypes-0.2.1-py27_0.tar.bz2
-    "traitlets >=4.2.2,<5.10.0"
+    "traitlets >=4.2.2"

```