### PR TITLE
Prevent Numpy v1.26 with previous PyTensor builds

### DIFF
--- a/recipe/patch_yaml/pytensor.yaml
+++ b/recipe/patch_yaml/pytensor.yaml
@@ -1,0 +1,9 @@
+if:
+  name: pytensor-base
+  version_le: 2.16.1
+  timestamp_lt: 1695061975000
+  has_depends: numpy
+then:
+  - tighten_depends:
+    name: numpy
+    max_pin: '1.26'


### PR DESCRIPTION
Checklist

* [X] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [X] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [X] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [X] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here --!>

Why am I getting no output from `show_diff.py`?