### PR TITLE
Prevent NumPy 1.26 with previous versions of Aesara

### DIFF
--- a/recipe/patch_yaml/aesara.yaml
+++ b/recipe/patch_yaml/aesara.yaml
@@ -76,3 +76,29 @@ if:
   version_le: 2.7.7
 then:
   - add_depends: setuptools !=65.0.*
+---
+# Numpy 1.26 breaks Aesara before v2.9.2.
+# <https://github.com/aesara-devs/aesara/pull/1512>
+if:
+  name: aesara-base
+  version_lt: 2.9.2
+  version_ge: 2.7.4
+  timestamp_lt: 1695061975000
+  has_depends: numpy*
+then:
+  - tighten_depends:
+      name: numpy
+      upper_bound: '1.26'
+---
+# The preceding clause handles the NumPy dependency until v2.7.4 build 1.
+# Before that, there was no aesara-base, and the NumPy dependency was in
+# the `aesara` package.
+if:
+  name: aesara
+  version_le: 2.7.4
+  timestamp_lt: 1695061975000
+  has_depends: numpy*
+then:
+  - tighten_depends:
+      name: numpy
+      upper_bound: '1.26'


### PR DESCRIPTION
Checklist

* [X] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [X] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [X] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [X] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here --!>
