### PR TITLE
Patch NumPy pin on ancient PyMC versions

### DIFF
--- a/recipe/patch_yaml/pymc.yaml
+++ b/recipe/patch_yaml/pymc.yaml
@@ -1,0 +1,21 @@
+# All versions of the pymc package above 2.x have an upper-bound
+# (of 1.26) on the NumPy version. This patch introduces a (different)
+# upper bound of (1.24) for 2.x because if the solver were to receive
+# an otherwise unsolvably high version of NumPy, it would select the very
+# deprecated 2.x.
+
+# pymc v5 depends transitively on NumPy via PyTensor.
+# pymc v4 depends transitively on NumPy via Aesara.
+# pymc3 is a different package.
+# pymc v2 is the subject of this patch.
+# There is no v1 in this package.
+if:
+  name: pymc
+  version_lt: 3
+  version_ge: 2
+  timestamp_lt: 1695061975000
+  has_depends: numpy*
+then:
+  - tighten_depends:
+      name: numpy
+      upper_bound: '1.24'

--- a/recipe/patch_yaml/pymc.yaml
+++ b/recipe/patch_yaml/pymc.yaml
@@ -11,8 +11,8 @@
 # There is no v1 in this package.
 if:
   name: pymc
-  version_lt: 3
-  version_ge: 2
+  version_lt: '3'
+  version_ge: '2'
   timestamp_lt: 1695061975000
   has_depends: numpy*
 then:


### PR DESCRIPTION
All versions of the pymc package above 2.x have an upper-bound (of 1.26) on the NumPy version. This patch introduces a (different) upper bound of (1.24) for 2.x because if the solver were to receive an otherwise unsolvably high version of NumPy, it would select the very deprecated 2.x.

Checklist

* [X] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [X] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [X] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [X] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here --!>
