### PR TITLE
Prevent NumPy 1.26 with previous versions of DeePMD-kit

### DIFF
--- a/recipe/patch_yaml/deepmd-kit.yaml
+++ b/recipe/patch_yaml/deepmd-kit.yaml
@@ -6,4 +6,4 @@ if:
 then:
   - tighten_depends:
       name: numpy
-      upper_bound: 1.26
+      upper_bound: "1.26"

--- a/recipe/patch_yaml/deepmd-kit.yaml
+++ b/recipe/patch_yaml/deepmd-kit.yaml
@@ -1,0 +1,9 @@
+# https://github.com/conda-forge/deepmd-kit-feedstock/issues/56
+if:
+  name: deepmd-kit
+  version_le: "2.2.4"
+  timestamp_lt: 1695668542000
+then:
+  - tighten_depends:
+      name: numpy
+      upper_bound: 1.26


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

Fix https://github.com/conda-forge/deepmd-kit-feedstock/issues/56.

xref: https://github.com/deepmodeling/deepmd-kit/pull/2853


Outputs:
<details>

```
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
osx-arm64::deepmd-kit-2.1.5-cpu_py39he76cc3d_0.tar.bz2
osx-arm64::deepmd-kit-2.2.1-cpu_py39h616bdeb_0.conda
osx-arm64::deepmd-kit-2.2.4-cpu_py310ha402ce5_0.conda
osx-arm64::deepmd-kit-2.2.3-cpu_py311h33c3522_2.conda
osx-arm64::deepmd-kit-2.2.1-cpu_py39h9342233_1.conda
osx-arm64::deepmd-kit-2.1.5-cpu_py38h14e4837_1.conda
osx-arm64::deepmd-kit-2.2.1-cpu_py39h9342233_0.conda
osx-arm64::deepmd-kit-2.1.5-cpu_py310h9bcf5e8_2.conda
osx-arm64::deepmd-kit-2.1.5-cpu_py310ha92d729_1.conda
osx-arm64::deepmd-kit-2.2.2-cpu_py38h9ca7f48_0.conda
osx-arm64::deepmd-kit-2.2.1-cpu_py38hac706cf_0.conda
osx-arm64::deepmd-kit-2.2.2-cpu_py39h3d4fa4d_0.conda
osx-arm64::deepmd-kit-2.1.5-cpu_py39h616bdeb_2.conda
osx-arm64::deepmd-kit-2.2.2-cpu_py39h9f7d82e_0.conda
osx-arm64::deepmd-kit-2.2.3-cpu_py38h9ca7f48_0.conda
osx-arm64::deepmd-kit-2.2.1-cpu_py310h1ffebac_0.conda
osx-arm64::deepmd-kit-2.2.1-cpu_py310h1ffebac_1.conda
osx-arm64::deepmd-kit-2.2.3-cpu_py38hf59b50b_1.conda
osx-arm64::deepmd-kit-2.2.3-cpu_py39h7e948ea_1.conda
osx-arm64::deepmd-kit-2.2.3-cpu_py39h7e948ea_2.conda
osx-arm64::deepmd-kit-2.2.4-cpu_py311h6c163a1_0.conda
osx-arm64::deepmd-kit-2.2.2-cpu_py310he42e9b7_0.conda
osx-arm64::deepmd-kit-2.2.1-cpu_py38hac706cf_1.conda
osx-arm64::deepmd-kit-2.2.2-cpu_py310h78c4e1c_0.conda
osx-arm64::deepmd-kit-2.2.3-cpu_py311h6c163a1_1.conda
osx-arm64::deepmd-kit-2.2.3-cpu_py310ha402ce5_2.conda
osx-arm64::deepmd-kit-2.2.3-cpu_py38hf59b50b_2.conda
osx-arm64::deepmd-kit-2.2.4-cpu_py39h8cb6fdd_0.conda
osx-arm64::deepmd-kit-2.1.5-cpu_py38h14e4837_0.tar.bz2
osx-arm64::deepmd-kit-2.2.2-cpu_py38he67906d_0.conda
osx-arm64::deepmd-kit-2.1.5-cpu_py39h3423c9d_1.conda
osx-arm64::deepmd-kit-2.2.4-cpu_py310h71af2c8_0.conda
osx-arm64::deepmd-kit-2.2.3-cpu_py39h9f7d82e_0.conda
osx-arm64::deepmd-kit-2.1.5-cpu_py310h080bbea_0.tar.bz2
osx-arm64::deepmd-kit-2.2.1-cpu_py38h3ba8a0d_0.conda
osx-arm64::deepmd-kit-2.2.3-cpu_py310ha402ce5_1.conda
osx-arm64::deepmd-kit-2.1.5-cpu_py38h2c6c9a7_1.conda
osx-arm64::deepmd-kit-2.2.4-cpu_py39h7e948ea_0.conda
osx-arm64::deepmd-kit-2.1.5-cpu_py38h3ba8a0d_2.conda
osx-arm64::deepmd-kit-2.1.5-cpu_py310ha92d729_0.tar.bz2
osx-arm64::deepmd-kit-2.1.5-cpu_py38hac706cf_2.conda
osx-arm64::deepmd-kit-2.2.3-cpu_py310h71af2c8_2.conda
osx-arm64::deepmd-kit-2.1.5-cpu_py39h3423c9d_0.tar.bz2
osx-arm64::deepmd-kit-2.2.3-cpu_py38h44499e1_1.conda
osx-arm64::deepmd-kit-2.1.5-cpu_py39h9342233_2.conda
osx-arm64::deepmd-kit-2.2.3-cpu_py38h44499e1_2.conda
osx-arm64::deepmd-kit-2.2.1-cpu_py38h3ba8a0d_1.conda
osx-arm64::deepmd-kit-2.2.4-cpu_py311h33c3522_0.conda
osx-arm64::deepmd-kit-2.2.4-cpu_py38h44499e1_0.conda
osx-arm64::deepmd-kit-2.2.1-cpu_py39h616bdeb_1.conda
osx-arm64::deepmd-kit-2.2.4-cpu_py38hf59b50b_0.conda
osx-arm64::deepmd-kit-2.1.5-cpu_py39he76cc3d_1.conda
osx-arm64::deepmd-kit-2.2.3-cpu_py310he42e9b7_0.conda
osx-arm64::deepmd-kit-2.2.3-cpu_py311h33c3522_1.conda
osx-arm64::deepmd-kit-2.2.1-cpu_py310h9bcf5e8_0.conda
osx-arm64::deepmd-kit-2.1.5-cpu_py310h080bbea_1.conda
osx-arm64::deepmd-kit-2.2.3-cpu_py38he67906d_0.conda
osx-arm64::deepmd-kit-2.2.3-cpu_py310h71af2c8_1.conda
osx-arm64::deepmd-kit-2.2.3-cpu_py39h3d4fa4d_0.conda
osx-arm64::deepmd-kit-2.2.3-cpu_py311h6c163a1_2.conda
osx-arm64::deepmd-kit-2.2.1-cpu_py310h9bcf5e8_1.conda
osx-arm64::deepmd-kit-2.2.3-cpu_py310h78c4e1c_0.conda
osx-arm64::deepmd-kit-2.2.3-cpu_py39h8cb6fdd_1.conda
osx-arm64::deepmd-kit-2.1.5-cpu_py38h2c6c9a7_0.tar.bz2
osx-arm64::deepmd-kit-2.2.3-cpu_py39h8cb6fdd_2.conda
osx-arm64::deepmd-kit-2.1.5-cpu_py310h1ffebac_2.conda
-    "numpy",
+    "numpy <1.26.0a0",
osx-arm64::llvm-17.0.1-h2b67075_0.conda
+    "clang 17.0.1.*",
+    "clang-tools 17.0.1.*",
+    "llvm-tools 17.0.1.*",
osx-arm64::llvm-tools-17.0.1-he79909e_0.conda
+    "clang 17.0.1.*",
+    "clang-tools 17.0.1.*",
+    "llvm 17.0.1.*",
osx-arm64::llvmdev-17.0.1-he79909e_0.conda
+  "constrains": [
+    "clang 17.0.1.*",
+    "clang-tools 17.0.1.*",
+    "llvm 17.0.1.*",
+    "llvm-tools 17.0.1.*"
+  ],
================================================================================
================================================================================
linux-ppc64le
linux-ppc64le::llvm-17.0.1-h381f82a_0.conda
+    "clang 17.0.1.*",
+    "clang-tools 17.0.1.*",
+    "llvm-tools 17.0.1.*",
linux-ppc64le::llvm-tools-17.0.1-h8d57982_0.conda
+    "clang 17.0.1.*",
+    "clang-tools 17.0.1.*",
+    "llvm 17.0.1.*",
linux-ppc64le::llvmdev-17.0.1-h8d57982_0.conda
+  "constrains": [
+    "clang 17.0.1.*",
+    "clang-tools 17.0.1.*",
+    "llvm 17.0.1.*",
+    "llvm-tools 17.0.1.*"
+  ],
================================================================================
================================================================================
linux-aarch64
linux-aarch64::llvm-17.0.1-h5271726_0.conda
+    "clang 17.0.1.*",
+    "clang-tools 17.0.1.*",
+    "llvm-tools 17.0.1.*",
linux-aarch64::llvm-tools-17.0.1-h70e38ee_0.conda
+    "clang 17.0.1.*",
+    "clang-tools 17.0.1.*",
+    "llvm 17.0.1.*",
linux-aarch64::llvmdev-17.0.1-h70e38ee_0.conda
+  "constrains": [
+    "clang 17.0.1.*",
+    "clang-tools 17.0.1.*",
+    "llvm 17.0.1.*",
+    "llvm-tools 17.0.1.*"
+  ],
================================================================================
================================================================================
noarch
================================================================================
================================================================================
win-64
win-64::llvm-17.0.1-h3dc180e_0.conda
+  "constrains": [
+    "clang 17.0.1.*",
+    "clang-tools 17.0.1.*",
+    "llvm-tools 17.0.1.*",
+    "llvmdev 17.0.1.*"
+  ],
win-64::llvm-tools-17.0.1-h1ab654d_0.conda
+    "clang 17.0.1.*",
+    "clang-tools 17.0.1.*",
+    "llvm 17.0.1.*",
win-64::llvmdev-17.0.1-h1ab654d_0.conda
+  "constrains": [
+    "clang 17.0.1.*",
+    "clang-tools 17.0.1.*",
+    "llvm 17.0.1.*",
+    "llvm-tools 17.0.1.*"
+  ],
================================================================================
================================================================================
osx-64
osx-64::deepmd-kit-2.2.3-cpu_py39h166a853_0.conda
osx-64::deepmd-kit-2.1.5-cpu_py39hbe12200_0.tar.bz2
osx-64::deepmd-kit-2.1.5-cpu_py39hc79f68b_0.tar.bz2
osx-64::deepmd-kit-2.2.3-cpu_py38h0cafa61_1.conda
osx-64::deepmd-kit-2.1.5-cpu_py310h176287a_2.conda
osx-64::deepmd-kit-2.1.5-cpu_py37h5a5b9e2_0.tar.bz2
osx-64::deepmd-kit-2.0.1-py39h0e41a89_0.tar.bz2
osx-64::deepmd-kit-2.2.3-cpu_py311hfcc7d15_2.conda
osx-64::deepmd-kit-2.2.3-cpu_py310haa643af_1.conda
osx-64::deepmd-kit-2.2.2-cpu_py38h006a0d2_0.conda
osx-64::deepmd-kit-2.1.5-cpu_py310h21f73b4_1.conda
osx-64::deepmd-kit-2.2.3-cpu_py38h006a0d2_0.conda
osx-64::deepmd-kit-2.1.5-cpu_py39hc79f68b_1.conda
osx-64::deepmd-kit-2.2.1-cpu_py38h67296f8_1.conda
osx-64::deepmd-kit-2.1.5-cpu_py37h0963357_0.tar.bz2
osx-64::deepmd-kit-2.2.4-cpu_py310hc19038a_0.conda
osx-64::deepmd-kit-2.1.5-cpu_py310h4fd926e_0.tar.bz2
osx-64::deepmd-kit-2.2.3-cpu_py38haad08bb_1.conda
osx-64::deepmd-kit-1.2.4-py36h68e38f6_0.tar.bz2
osx-64::deepmd-kit-2.2.4-cpu_py39h7971fdf_0.conda
osx-64::deepmd-kit-2.2.2-cpu_py310h10154f5_0.conda
osx-64::deepmd-kit-2.0.1-py38hd31830b_0.tar.bz2
osx-64::deepmd-kit-2.2.3-cpu_py39h7971fdf_2.conda
osx-64::deepmd-kit-1.1.2-py36h2af55cb_0.tar.bz2
osx-64::deepmd-kit-2.2.2-cpu_py38hfad9891_0.conda
osx-64::deepmd-kit-2.0.1-py36h25cd0f7_0.tar.bz2
osx-64::deepmd-kit-2.2.4-cpu_py39hcf8b111_0.conda
osx-64::deepmd-kit-2.1.5-cpu_py310h0422278_2.conda
osx-64::deepmd-kit-1.3.3-py39h0e41a89_1.tar.bz2
osx-64::deepmd-kit-2.2.1-cpu_py310h0422278_1.conda
osx-64::deepmd-kit-2.2.3-cpu_py39hcf8b111_1.conda
osx-64::deepmd-kit-2.2.3-cpu_py39hcf8b111_2.conda
osx-64::deepmd-kit-1.2.4-py37h3f09065_0.tar.bz2
osx-64::deepmd-kit-2.2.3-cpu_py311hfcc7d15_1.conda
osx-64::deepmd-kit-2.0.0-py37h2ac4d38_0.tar.bz2
osx-64::deepmd-kit-1.1.3-py37h2af55cb_1.tar.bz2
osx-64::deepmd-kit-2.0.0-py36h25cd0f7_0.tar.bz2
osx-64::deepmd-kit-2.1.5-cpu_py39h6d91de0_2.conda
osx-64::deepmd-kit-2.2.4-cpu_py311hfcc7d15_0.conda
osx-64::deepmd-kit-1.0.1-py37h2af55cb_1.tar.bz2
osx-64::deepmd-kit-2.2.3-cpu_py39h7971fdf_1.conda
osx-64::deepmd-kit-2.2.1-cpu_py39hafb6426_0.conda
osx-64::deepmd-kit-2.2.3-cpu_py38haad08bb_2.conda
osx-64::deepmd-kit-1.1.4-py38hd9721c0_1.tar.bz2
osx-64::deepmd-kit-2.2.3-cpu_py310hc19038a_1.conda
osx-64::deepmd-kit-2.2.4-cpu_py310haa643af_0.conda
osx-64::deepmd-kit-2.2.3-cpu_py38h0cafa61_2.conda
osx-64::deepmd-kit-2.1.5-cpu_py38h67296f8_2.conda
osx-64::deepmd-kit-1.1.4-py36h2af55cb_0.tar.bz2
osx-64::deepmd-kit-1.1.3-py36h2af55cb_1.tar.bz2
osx-64::deepmd-kit-2.0.1-py37h2ac4d38_0.tar.bz2
osx-64::deepmd-kit-2.2.1-cpu_py39h6d91de0_0.conda
osx-64::deepmd-kit-2.2.1-cpu_py38h3bd5415_1.conda
osx-64::deepmd-kit-1.1.4-py36h68e38f6_1.tar.bz2
osx-64::deepmd-kit-2.0.0-py39h0e41a89_0.tar.bz2
osx-64::deepmd-kit-2.1.5-cpu_py38h2ace0ec_1.conda
osx-64::deepmd-kit-2.1.5-cpu_py39hbe12200_1.conda
osx-64::deepmd-kit-2.1.5-cpu_py38h722fb1d_1.conda
osx-64::deepmd-kit-1.0.1-py37h2af55cb_2.tar.bz2
osx-64::deepmd-kit-1.3.3-py36h68e38f6_0.tar.bz2
osx-64::deepmd-kit-2.2.4-cpu_py38haad08bb_0.conda
osx-64::deepmd-kit-1.2.4-py38hd9721c0_0.tar.bz2
osx-64::deepmd-kit-2.2.3-cpu_py310hc19038a_2.conda
osx-64::deepmd-kit-2.2.3-cpu_py310ha9775e6_0.conda
osx-64::deepmd-kit-2.2.2-cpu_py310ha9775e6_0.conda
osx-64::deepmd-kit-2.1.5-cpu_py38h2ace0ec_0.tar.bz2
osx-64::deepmd-kit-2.2.3-cpu_py38hfad9891_0.conda
osx-64::deepmd-kit-2.1.5-cpu_py310h21f73b4_0.tar.bz2
osx-64::deepmd-kit-2.2.1-cpu_py310h0422278_0.conda
osx-64::deepmd-kit-2.1.5-cpu_py39hafb6426_2.conda
osx-64::deepmd-kit-1.3.3-py38hd9721c0_1.tar.bz2
osx-64::deepmd-kit-2.1.5-cpu_py310h4fd926e_1.conda
osx-64::deepmd-kit-1.1.4-py37h2af55cb_0.tar.bz2
osx-64::deepmd-kit-2.2.1-cpu_py310h176287a_0.conda
osx-64::deepmd-kit-1.1.3-py36h2af55cb_0.tar.bz2
osx-64::deepmd-kit-2.0.0-py38hd31830b_0.tar.bz2
osx-64::deepmd-kit-1.1.3-py37h2af55cb_0.tar.bz2
osx-64::deepmd-kit-2.2.1-cpu_py38h3bd5415_0.conda
osx-64::deepmd-kit-2.2.4-cpu_py38h0cafa61_0.conda
osx-64::deepmd-kit-1.3.3-py37h3f09065_1.tar.bz2
osx-64::deepmd-kit-1.1.0-py37h2af55cb_0.tar.bz2
osx-64::deepmd-kit-1.3.3-py38hd9721c0_0.tar.bz2
osx-64::deepmd-kit-2.2.3-cpu_py310haa643af_2.conda
osx-64::deepmd-kit-1.1.4-py37h3f09065_1.tar.bz2
osx-64::deepmd-kit-2.1.5-cpu_py38h3bd5415_2.conda
osx-64::deepmd-kit-1.3.3-py37h3f09065_0.tar.bz2
osx-64::deepmd-kit-1.1.1-py37h2af55cb_0.tar.bz2
osx-64::deepmd-kit-2.2.2-cpu_py39h166a853_0.conda
osx-64::deepmd-kit-2.2.1-cpu_py39hafb6426_1.conda
osx-64::deepmd-kit-2.2.3-cpu_py311hca95592_2.conda
osx-64::deepmd-kit-2.2.3-cpu_py311hca95592_1.conda
osx-64::deepmd-kit-2.2.3-cpu_py39h04a4144_0.conda
osx-64::deepmd-kit-1.1.2-py37h2af55cb_0.tar.bz2
osx-64::deepmd-kit-2.2.3-cpu_py310h10154f5_0.conda
osx-64::deepmd-kit-2.2.4-cpu_py311hca95592_0.conda
osx-64::deepmd-kit-2.2.2-cpu_py39h04a4144_0.conda
osx-64::deepmd-kit-2.1.5-cpu_py38h722fb1d_0.tar.bz2
osx-64::deepmd-kit-2.2.1-cpu_py38h67296f8_0.conda
osx-64::deepmd-kit-2.2.1-cpu_py39h6d91de0_1.conda
osx-64::deepmd-kit-1.3.3-py36h68e38f6_1.tar.bz2
osx-64::deepmd-kit-2.2.1-cpu_py310h176287a_1.conda
-    "numpy",
+    "numpy <1.26.0a0",
osx-64::deepmd-kit-2.1.4-cpu_py310h23b1c27_1.tar.bz2
osx-64::deepmd-kit-2.1.1-cpu_py310hca2c24a_2.tar.bz2
osx-64::deepmd-kit-2.1.2-cpu_py310hca2c24a_0.tar.bz2
osx-64::deepmd-kit-2.1.3-cpu_py310hca2c24a_0.tar.bz2
osx-64::deepmd-kit-2.1.0-cpu_py310hb59dc0c_2.tar.bz2
osx-64::deepmd-kit-2.1.4-cpu_py310h23b1c27_0.tar.bz2
osx-64::deepmd-kit-2.1.1-cpu_py310h9978a18_1.tar.bz2
osx-64::deepmd-kit-2.1.1-cpu_py310h9978a18_0.tar.bz2
-    "numpy >=1.21.6,<2.0a0",
+    "numpy >=1.21.6,<1.26.0a0",
osx-64::deepmd-kit-2.1.1-cpu_py38h273a204_1.tar.bz2
osx-64::deepmd-kit-2.1.0-cpu_py39h81a97c9_2.tar.bz2
osx-64::deepmd-kit-2.1.1-cpu_py37h25223b4_0.tar.bz2
osx-64::deepmd-kit-2.1.0-cpu_py37h51344ab_2.tar.bz2
osx-64::deepmd-kit-2.1.1-cpu_py37h25223b4_1.tar.bz2
osx-64::deepmd-kit-2.1.0-cpu_py38hf1267d8_2.tar.bz2
osx-64::deepmd-kit-2.1.1-cpu_py38h273a204_0.tar.bz2
osx-64::deepmd-kit-2.1.1-cpu_py39he904bf9_1.tar.bz2
-    "numpy >=1.19.5,<2.0a0",
+    "numpy >=1.19.5,<1.26.0a0",
osx-64::deepmd-kit-2.1.4-cpu_py39h4ac4959_0.tar.bz2
osx-64::deepmd-kit-2.1.1-cpu_py37h492d7e2_2.tar.bz2
osx-64::deepmd-kit-2.1.1-cpu_py39h495a075_2.tar.bz2
osx-64::deepmd-kit-2.1.4-cpu_py38h7bccc44_1.tar.bz2
osx-64::deepmd-kit-2.1.3-cpu_py39h495a075_0.tar.bz2
osx-64::deepmd-kit-2.1.4-cpu_py37h77a073e_0.tar.bz2
osx-64::deepmd-kit-2.1.2-cpu_py39h495a075_0.tar.bz2
osx-64::deepmd-kit-2.1.4-cpu_py38h7bccc44_0.tar.bz2
osx-64::deepmd-kit-2.1.3-cpu_py37h492d7e2_0.tar.bz2
osx-64::deepmd-kit-2.1.4-cpu_py39h4ac4959_1.tar.bz2
osx-64::deepmd-kit-2.1.4-cpu_py37h77a073e_1.tar.bz2
osx-64::deepmd-kit-2.1.1-cpu_py38h7d4b06c_2.tar.bz2
osx-64::deepmd-kit-2.1.3-cpu_py38h7d4b06c_0.tar.bz2
osx-64::deepmd-kit-2.1.2-cpu_py38h7d4b06c_0.tar.bz2
osx-64::deepmd-kit-2.1.2-cpu_py37h492d7e2_0.tar.bz2
-    "numpy >=1.20.3,<2.0a0",
+    "numpy >=1.20.3,<1.26.0a0",
osx-64::llvm-17.0.1-h9c2cb20_0.conda
+    "clang 17.0.1.*",
+    "clang-tools 17.0.1.*",
+    "llvm-tools 17.0.1.*",
osx-64::llvm-tools-17.0.1-he4b1e75_0.conda
+    "clang 17.0.1.*",
+    "clang-tools 17.0.1.*",
+    "llvm 17.0.1.*",
osx-64::llvmdev-17.0.1-he4b1e75_0.conda
+  "constrains": [
+    "clang 17.0.1.*",
+    "clang-tools 17.0.1.*",
+    "llvm 17.0.1.*",
+    "llvm-tools 17.0.1.*"
+  ],
================================================================================
================================================================================
linux-64
linux-64::deepmd-kit-2.1.5-cpu_py38hac1f573_1.conda
linux-64::deepmd-kit-2.2.1-cuda112py39hff1f28f_0.conda
linux-64::deepmd-kit-2.2.1-cuda112py39hc25b61a_1.conda
linux-64::deepmd-kit-2.2.1-cuda112py310hc7f9661_0.conda
linux-64::deepmd-kit-2.2.1-cpu_py39h5da6643_1.conda
linux-64::deepmd-kit-2.2.3-cpu_py38hac568ea_1.conda
linux-64::deepmd-kit-1.2.4-py36hd0f40e7_0.tar.bz2
linux-64::deepmd-kit-1.3.3-py36hd0f40e7_1.tar.bz2
linux-64::deepmd-kit-2.2.3-cuda112py311hab8cd01_2.conda
linux-64::deepmd-kit-2.2.4-cuda112py311hd8739ab_0.conda
linux-64::deepmd-kit-2.2.3-cuda112py39h7739e1a_0.conda
linux-64::deepmd-kit-2.2.2-cuda112py39hff1f28f_0.conda
linux-64::deepmd-kit-2.1.5-cuda112py310hc7f9661_2.conda
linux-64::deepmd-kit-2.2.3-cpu_py311hd3373b2_1.conda
linux-64::deepmd-kit-2.1.5-cpu_py39h5da6643_2.conda
linux-64::deepmd-kit-2.1.5-cuda112py38h14b3170_2.conda
linux-64::deepmd-kit-2.2.4-cpu_py39hb3b2118_0.conda
linux-64::deepmd-kit-2.1.5-cuda112py39hc25b61a_2.conda
linux-64::deepmd-kit-2.2.4-cuda112py39h1c5b1a1_0.conda
linux-64::deepmd-kit-2.2.1-cuda112py310h83992c3_1.conda
linux-64::deepmd-kit-2.1.5-cpu_py310h6b39082_0.tar.bz2
linux-64::deepmd-kit-2.2.1-cpu_py310hf5c7989_1.conda
linux-64::deepmd-kit-2.2.3-cpu_py310h05aa237_0.conda
linux-64::deepmd-kit-2.1.5-cuda112py38hdc93e6d_0.tar.bz2
linux-64::deepmd-kit-1.1.3-py36h7b493b7_1.tar.bz2
linux-64::deepmd-kit-2.1.5-cuda112py39hbe123ec_1.conda
linux-64::deepmd-kit-2.2.3-cpu_py39hb3b2118_1.conda
linux-64::deepmd-kit-1.3.3-py38hd484797_1.tar.bz2
linux-64::deepmd-kit-2.2.1-cpu_py310hf5c7989_0.conda
linux-64::deepmd-kit-2.2.2-cpu_py39ha84a261_0.conda
linux-64::deepmd-kit-2.2.3-cpu_py39ha84a261_0.conda
linux-64::deepmd-kit-2.2.2-cpu_py38hd31cb8c_0.conda
linux-64::deepmd-kit-2.2.3-cpu_py39h4a825ef_2.conda
linux-64::deepmd-kit-1.0.1-py37h2666dde_1.tar.bz2
linux-64::deepmd-kit-2.2.3-cuda112py310h7e691f3_2.conda
linux-64::deepmd-kit-1.1.3-py37h7b493b7_1.tar.bz2
linux-64::deepmd-kit-2.2.1-cpu_py38hbe94b23_1.conda
linux-64::deepmd-kit-2.1.5-cuda112py38h59bfc4e_2.conda
linux-64::deepmd-kit-2.0.0-py38h75ac216_0.tar.bz2
linux-64::deepmd-kit-2.2.3-cuda112py39h6dea384_1.conda
linux-64::deepmd-kit-1.1.2-py37h7b493b7_0.tar.bz2
linux-64::deepmd-kit-1.1.4-py36hd0f40e7_1.tar.bz2
linux-64::deepmd-kit-2.2.4-cuda112py38hb56d304_0.conda
linux-64::deepmd-kit-2.2.4-cpu_py311hd3373b2_0.conda
linux-64::deepmd-kit-2.2.4-cuda112py311hab8cd01_0.conda
linux-64::deepmd-kit-2.0.1-py39h3807357_0.tar.bz2
linux-64::deepmd-kit-2.2.1-cpu_py38ha024a07_1.conda
linux-64::deepmd-kit-1.1.0-py37h7b493b7_0.tar.bz2
linux-64::deepmd-kit-2.2.3-cpu_py39h80b3f99_0.conda
linux-64::deepmd-kit-1.2.4-py37h8c9b708_0.tar.bz2
linux-64::deepmd-kit-1.0.0-py37h2666dde_0.tar.bz2
linux-64::deepmd-kit-2.1.5-cpu_py39had91cea_1.conda
linux-64::deepmd-kit-1.2.4-py38hd484797_0.tar.bz2
linux-64::deepmd-kit-2.2.1-cuda112py310hc7f9661_1.conda
linux-64::deepmd-kit-2.1.5-cpu_py38h62ec7cc_0.tar.bz2
linux-64::deepmd-kit-2.2.2-cuda112py39hc25b61a_0.conda
linux-64::deepmd-kit-2.2.4-cpu_py38h32d0d73_0.conda
linux-64::deepmd-kit-1.3.3-py38hd484797_0.tar.bz2
linux-64::deepmd-kit-2.2.3-cuda112py38hb253b35_1.conda
linux-64::deepmd-kit-1.0.1-py37h7b493b7_2.tar.bz2
linux-64::deepmd-kit-2.2.3-cuda112py311hab8cd01_1.conda
linux-64::deepmd-kit-2.1.5-cuda112py39hbe123ec_0.tar.bz2
linux-64::deepmd-kit-2.1.5-cpu_py39h31c43e6_1.conda
linux-64::deepmd-kit-2.2.4-cpu_py38hac568ea_0.conda
linux-64::deepmd-kit-1.1.3-py37h7b493b7_0.tar.bz2
linux-64::deepmd-kit-2.0.1-py37ha73233c_0.tar.bz2
linux-64::deepmd-kit-2.2.3-cpu_py310h4723fd4_1.conda
linux-64::deepmd-kit-2.1.5-cpu_py37h6eac3ac_0.tar.bz2
linux-64::deepmd-kit-1.1.4-py37h7b493b7_0.tar.bz2
linux-64::deepmd-kit-2.2.2-cuda112py310hc7f9661_0.conda
linux-64::deepmd-kit-2.2.2-cuda112py38h59bfc4e_0.conda
linux-64::deepmd-kit-2.2.3-cuda112py310h686a75d_0.conda
linux-64::deepmd-kit-2.2.3-cuda112py310h7d5e500_2.conda
linux-64::deepmd-kit-2.1.5-cpu_py39he0e077c_2.conda
linux-64::deepmd-kit-2.2.2-cpu_py310h05aa237_0.conda
linux-64::deepmd-kit-2.2.3-cuda112py38hb56d304_1.conda
linux-64::deepmd-kit-2.2.3-cpu_py311h9bf1473_1.conda
linux-64::deepmd-kit-1.1.3-py36h7b493b7_0.tar.bz2
linux-64::deepmd-kit-1.1.4-py36h7b493b7_0.tar.bz2
linux-64::deepmd-kit-2.2.3-cuda112py39h6d82d3a_0.conda
linux-64::deepmd-kit-2.1.5-cpu_py310hb42d931_2.conda
linux-64::deepmd-kit-2.2.4-cuda112py310h7d5e500_0.conda
linux-64::deepmd-kit-2.2.3-cpu_py310h17caf13_0.conda
linux-64::deepmd-kit-2.2.1-cuda112py38h14b3170_0.conda
linux-64::deepmd-kit-2.1.5-cuda112py39hb860074_1.conda
linux-64::deepmd-kit-2.1.5-cpu_py39hb03a7eb_0.tar.bz2
linux-64::deepmd-kit-2.1.5-cpu_py310h926c96e_1.conda
linux-64::deepmd-kit-2.2.3-cpu_py310h64c2733_2.conda
linux-64::deepmd-kit-2.2.2-cpu_py39h80b3f99_0.conda
linux-64::deepmd-kit-2.2.1-cuda112py38h59bfc4e_0.conda
linux-64::deepmd-kit-2.2.3-cpu_py38h32d0d73_2.conda
linux-64::deepmd-kit-2.2.3-cuda112py310h7d5e500_1.conda
linux-64::deepmd-kit-2.1.5-cpu_py38hbe94b23_2.conda
linux-64::deepmd-kit-2.2.1-cuda112py38h14b3170_1.conda
linux-64::deepmd-kit-2.1.5-cpu_py310h0fb45c8_0.tar.bz2
linux-64::deepmd-kit-2.1.5-cuda112py38hdc93e6d_1.conda
linux-64::deepmd-kit-2.2.3-cuda112py39h1c5b1a1_1.conda
linux-64::deepmd-kit-2.2.1-cpu_py39he0e077c_0.conda
linux-64::deepmd-kit-2.1.5-cpu_py38hb458029_1.conda
linux-64::deepmd-kit-2.2.4-cpu_py311h9bf1473_0.conda
linux-64::deepmd-kit-1.3.3-py36hd0f40e7_0.tar.bz2
linux-64::deepmd-kit-2.2.4-cpu_py310h4723fd4_0.conda
linux-64::deepmd-kit-2.2.1-cuda112py39hff1f28f_1.conda
linux-64::deepmd-kit-1.1.2-py36h7b493b7_0.tar.bz2
linux-64::deepmd-kit-2.1.5-cpu_py310hf5c7989_2.conda
linux-64::deepmd-kit-2.1.5-cuda112py39hb860074_0.tar.bz2
linux-64::deepmd-kit-2.1.5-cpu_py310hbc40a29_1.conda
linux-64::deepmd-kit-1.3.3-py37h8c9b708_1.tar.bz2
linux-64::deepmd-kit-2.1.5-cuda112py310h3cedfcd_1.conda
linux-64::deepmd-kit-2.0.1-py36he56bb99_0.tar.bz2
linux-64::deepmd-kit-2.2.3-cpu_py310h4723fd4_2.conda
linux-64::deepmd-kit-2.2.3-cuda112py39h1c5b1a1_2.conda
linux-64::deepmd-kit-2.0.0-py39h3807357_0.tar.bz2
linux-64::deepmd-kit-2.2.4-cpu_py310h64c2733_0.conda
linux-64::deepmd-kit-2.2.3-cuda112py310h7e691f3_1.conda
linux-64::deepmd-kit-2.2.3-cpu_py38h32d0d73_1.conda
linux-64::deepmd-kit-2.2.1-cpu_py38hbe94b23_0.conda
linux-64::deepmd-kit-2.2.3-cpu_py39h4a825ef_1.conda
linux-64::deepmd-kit-2.2.4-cuda112py39h6dea384_0.conda
linux-64::deepmd-kit-2.2.1-cuda112py310h83992c3_0.conda
linux-64::deepmd-kit-2.2.3-cuda112py38hb56d304_2.conda
linux-64::deepmd-kit-1.1.4-py38hd484797_1.tar.bz2
linux-64::deepmd-kit-2.1.5-cpu_py37h0da8480_0.tar.bz2
linux-64::deepmd-kit-2.1.5-cuda112py310h83992c3_2.conda
linux-64::deepmd-kit-2.2.1-cuda112py38h59bfc4e_1.conda
linux-64::deepmd-kit-2.2.2-cuda112py38h14b3170_0.conda
linux-64::deepmd-kit-2.2.3-cpu_py311hd3373b2_2.conda
linux-64::deepmd-kit-1.1.4-py37h8c9b708_1.tar.bz2
linux-64::deepmd-kit-2.2.4-cpu_py39h4a825ef_0.conda
linux-64::deepmd-kit-2.1.5-cuda112py39hff1f28f_2.conda
linux-64::deepmd-kit-1.0.1-py37h2666dde_0.tar.bz2
linux-64::deepmd-kit-2.2.3-cpu_py311h9bf1473_2.conda
linux-64::deepmd-kit-2.2.3-cpu_py39hb3b2118_2.conda
linux-64::deepmd-kit-2.2.1-cpu_py39h5da6643_0.conda
linux-64::deepmd-kit-2.2.2-cpu_py38h84be3f0_0.conda
linux-64::deepmd-kit-1.1.1-py37h7b493b7_0.tar.bz2
linux-64::deepmd-kit-2.2.1-cpu_py38ha024a07_0.conda
linux-64::deepmd-kit-2.2.1-cuda112py39hc25b61a_0.conda
linux-64::deepmd-kit-2.2.3-cuda112py38hd8b2f09_0.conda
linux-64::deepmd-kit-2.2.3-cuda112py311hd8739ab_1.conda
linux-64::deepmd-kit-1.3.3-py37h8c9b708_0.tar.bz2
linux-64::deepmd-kit-2.1.5-cuda112py37h7baefd2_0.tar.bz2
linux-64::deepmd-kit-2.1.5-cuda112py38hf6e0080_1.conda
linux-64::deepmd-kit-2.0.1-py38h75ac216_0.tar.bz2
linux-64::deepmd-kit-2.2.3-cpu_py310h64c2733_1.conda
linux-64::deepmd-kit-2.2.3-cuda112py311hd8739ab_2.conda
linux-64::deepmd-kit-2.0.0-py36he56bb99_0.tar.bz2
linux-64::deepmd-kit-2.2.1-cpu_py310hb42d931_1.conda
linux-64::deepmd-kit-2.1.5-cuda112py310h978c1a5_0.tar.bz2
linux-64::deepmd-kit-2.2.4-cuda112py310h7e691f3_0.conda
linux-64::deepmd-kit-2.2.3-cpu_py38hd31cb8c_0.conda
linux-64::deepmd-kit-2.2.3-cuda112py38hb253b35_2.conda
linux-64::deepmd-kit-2.1.5-cpu_py38h4134a04_0.tar.bz2
linux-64::deepmd-kit-2.1.5-cuda112py37hf1b0982_0.tar.bz2
linux-64::deepmd-kit-2.2.1-cpu_py39he0e077c_1.conda
linux-64::deepmd-kit-2.1.5-cuda112py310h978c1a5_1.conda
linux-64::deepmd-kit-2.0.0-py37ha73233c_0.tar.bz2
linux-64::deepmd-kit-2.1.5-cpu_py38ha024a07_2.conda
linux-64::deepmd-kit-2.2.4-cuda112py38hb253b35_0.conda
linux-64::deepmd-kit-1.3.3-py39h3807357_1.tar.bz2
linux-64::deepmd-kit-2.2.2-cpu_py310h17caf13_0.conda
linux-64::deepmd-kit-2.2.1-cpu_py310hb42d931_0.conda
linux-64::deepmd-kit-2.2.3-cuda112py38hff3e940_0.conda
linux-64::deepmd-kit-2.2.3-cuda112py310h5b7cfd1_0.conda
linux-64::deepmd-kit-2.1.5-cpu_py39h4914717_0.tar.bz2
linux-64::deepmd-kit-2.1.5-cuda112py310h3cedfcd_0.tar.bz2
linux-64::deepmd-kit-2.2.3-cuda112py39h6dea384_2.conda
linux-64::deepmd-kit-2.1.5-cuda112py38hf6e0080_0.tar.bz2
linux-64::deepmd-kit-2.2.3-cpu_py38hac568ea_2.conda
linux-64::deepmd-kit-2.2.3-cpu_py38h84be3f0_0.conda
linux-64::deepmd-kit-2.2.2-cuda112py310h83992c3_0.conda
-    "numpy",
+    "numpy <1.26.0a0",
linux-64::deepmd-kit-2.1.3-cuda110py310hd24fe8b_0.tar.bz2
linux-64::deepmd-kit-2.1.4-cpu_py310hff795e8_0.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda110py310h79cbef8_1.tar.bz2
linux-64::deepmd-kit-2.1.2-cuda112py310ha4a373e_0.tar.bz2
linux-64::deepmd-kit-2.1.4-cuda112py310h2ffce05_1.tar.bz2
linux-64::deepmd-kit-2.1.3-cuda102py310h0bcd3bd_0.tar.bz2
linux-64::deepmd-kit-2.1.3-cuda112py310h2ffce05_0.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda111py310h9d1b763_1.tar.bz2
linux-64::deepmd-kit-2.1.1-cpu_py310hfbd252d_1.tar.bz2
linux-64::deepmd-kit-2.1.4-cuda102py310h0bcd3bd_1.tar.bz2
linux-64::deepmd-kit-2.1.4-cuda110py310ha19c859_0.tar.bz2
linux-64::deepmd-kit-2.1.2-cuda102py310h0bcd3bd_0.tar.bz2
linux-64::deepmd-kit-2.1.0-cuda111py310h3e46cc4_2.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda102py310h55b80cb_2.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda110py310ha18b0f3_1.tar.bz2
linux-64::deepmd-kit-2.1.4-cpu_py310hff795e8_1.tar.bz2
linux-64::deepmd-kit-2.1.4-cuda111py310h2ac52a0_0.tar.bz2
linux-64::deepmd-kit-2.1.3-cuda111py310h2ac52a0_0.tar.bz2
linux-64::deepmd-kit-2.1.2-cuda102py310h55b80cb_0.tar.bz2
linux-64::deepmd-kit-2.1.4-cuda110py310hd24fe8b_1.tar.bz2
linux-64::deepmd-kit-2.1.4-cuda111py310h1253da4_1.tar.bz2
linux-64::deepmd-kit-2.1.3-cuda111py310h1253da4_0.tar.bz2
linux-64::deepmd-kit-2.1.1-cpu_py310h73222b0_2.tar.bz2
linux-64::deepmd-kit-2.1.4-cuda102py310h0bcd3bd_0.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda112py310hab208e9_0.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda112py310hc52a2ec_1.tar.bz2
linux-64::deepmd-kit-2.1.1-cpu_py310h8a86196_1.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda112py310ha4a373e_2.tar.bz2
linux-64::deepmd-kit-2.1.2-cuda111py310h1253da4_0.tar.bz2
linux-64::deepmd-kit-2.1.0-cuda111py310hcec2b2d_2.tar.bz2
linux-64::deepmd-kit-2.1.3-cuda112py310ha4a373e_0.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda112py310h88e12e6_1.tar.bz2
linux-64::deepmd-kit-2.1.4-cuda111py310h2ac52a0_1.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda102py310h4939f5f_1.tar.bz2
linux-64::deepmd-kit-2.1.2-cuda112py310h2ffce05_0.tar.bz2
linux-64::deepmd-kit-2.1.0-cuda110py310hde9cef4_2.tar.bz2
linux-64::deepmd-kit-2.1.4-cuda112py310ha4a373e_1.tar.bz2
linux-64::deepmd-kit-2.1.0-cpu_py310h7720ea0_2.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda110py310h39a25ec_0.tar.bz2
linux-64::deepmd-kit-2.1.1-cpu_py310hff795e8_2.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda111py310h1253da4_2.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda112py310h2ffce05_2.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda102py310h0bcd3bd_2.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda111py310h3e46cc4_0.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda110py310hd24fe8b_2.tar.bz2
linux-64::deepmd-kit-2.1.4-cuda110py310hd24fe8b_0.tar.bz2
linux-64::deepmd-kit-2.1.0-cpu_py310he9c5d42_2.tar.bz2
linux-64::deepmd-kit-2.1.1-cpu_py310he9c5d42_0.tar.bz2
linux-64::deepmd-kit-2.1.2-cuda111py310h2ac52a0_0.tar.bz2
linux-64::deepmd-kit-2.1.1-cpu_py310h7720ea0_0.tar.bz2
linux-64::deepmd-kit-2.1.0-cuda102py310h6610ee7_2.tar.bz2
linux-64::deepmd-kit-2.1.2-cuda110py310ha19c859_0.tar.bz2
linux-64::deepmd-kit-2.1.4-cpu_py310h73222b0_1.tar.bz2
linux-64::deepmd-kit-2.1.0-cuda102py310h4939f5f_2.tar.bz2
linux-64::deepmd-kit-2.1.3-cpu_py310h73222b0_0.tar.bz2
linux-64::deepmd-kit-2.1.4-cuda112py310ha4a373e_0.tar.bz2
linux-64::deepmd-kit-2.1.4-cuda110py310ha19c859_1.tar.bz2
linux-64::deepmd-kit-2.1.4-cuda102py310h55b80cb_1.tar.bz2
linux-64::deepmd-kit-2.1.4-cpu_py310h73222b0_0.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda111py310hcec2b2d_0.tar.bz2
linux-64::deepmd-kit-2.1.2-cpu_py310hff795e8_0.tar.bz2
linux-64::deepmd-kit-2.1.3-cpu_py310hff795e8_0.tar.bz2
linux-64::deepmd-kit-2.1.4-cuda112py310h2ffce05_0.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda102py310h4939f5f_0.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda110py310hde9cef4_0.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda102py310h6610ee7_0.tar.bz2
linux-64::deepmd-kit-2.1.2-cpu_py310h73222b0_0.tar.bz2
linux-64::deepmd-kit-2.1.3-cuda102py310h55b80cb_0.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda111py310h2ac52a0_2.tar.bz2
linux-64::deepmd-kit-2.1.0-cuda112py310hab208e9_2.tar.bz2
linux-64::deepmd-kit-2.1.3-cuda110py310ha19c859_0.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda110py310ha19c859_2.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda111py310h744eec9_1.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda112py310hc2b352c_0.tar.bz2
linux-64::deepmd-kit-2.1.0-cuda112py310hc2b352c_2.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda102py310h6610ee7_1.tar.bz2
linux-64::deepmd-kit-2.1.4-cuda102py310h55b80cb_0.tar.bz2
linux-64::deepmd-kit-2.1.0-cuda110py310h39a25ec_2.tar.bz2
linux-64::deepmd-kit-2.1.4-cuda111py310h1253da4_0.tar.bz2
-    "numpy >=1.21.6,<2.0a0",
+    "numpy >=1.21.6,<1.26.0a0",
linux-64::deepmd-kit-2.1.0-cuda110py37h8c56a88_2.tar.bz2
linux-64::deepmd-kit-2.1.0-cuda112py37h563aa2e_2.tar.bz2
linux-64::deepmd-kit-2.1.1-cpu_py37h7c099b2_1.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda112py37h563aa2e_0.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda112py38ha333da4_0.tar.bz2
linux-64::deepmd-kit-2.1.0-cuda112py38hfed40ba_2.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda102py38hbf4e9aa_0.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda111py38he1cf02b_0.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda110py37h8c56a88_0.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda102py38hbf4e9aa_1.tar.bz2
linux-64::deepmd-kit-2.1.0-cuda111py37hfb20bc8_2.tar.bz2
linux-64::deepmd-kit-2.1.1-cpu_py39hfe69fae_1.tar.bz2
linux-64::deepmd-kit-2.1.0-cuda112py37h69bbc10_2.tar.bz2
linux-64::deepmd-kit-2.1.0-cuda102py39hdef969f_2.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda111py39hff05581_0.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda102py39h585ac91_0.tar.bz2
linux-64::deepmd-kit-2.1.0-cpu_py38hff3f523_2.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda112py38haa557ab_1.tar.bz2
linux-64::deepmd-kit-2.1.1-cpu_py39h09986e6_0.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda102py39h585ac91_1.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda110py38hf313c49_1.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda102py38hd189ee7_0.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda110py37h2e7fe6a_0.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda111py38h9504bd0_1.tar.bz2
linux-64::deepmd-kit-2.1.0-cuda112py39hb3b2c89_2.tar.bz2
linux-64::deepmd-kit-2.1.0-cuda112py38ha333da4_2.tar.bz2
linux-64::deepmd-kit-2.1.0-cuda102py38hbf4e9aa_2.tar.bz2
linux-64::deepmd-kit-2.1.0-cuda110py38h05e9f3b_2.tar.bz2
linux-64::deepmd-kit-2.1.0-cuda102py38hd189ee7_2.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda112py37h6af7b28_1.tar.bz2
linux-64::deepmd-kit-2.1.1-cpu_py39h492eaff_1.tar.bz2
linux-64::deepmd-kit-2.1.0-cuda110py38h5df001a_2.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda111py38h3ad7b74_1.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda112py39hb3b2c89_0.tar.bz2
linux-64::deepmd-kit-2.1.0-cuda110py39h57571d7_2.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda110py39h52a0fcd_1.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda111py39hfa80b01_1.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda111py39h427c5e1_0.tar.bz2
linux-64::deepmd-kit-2.1.0-cuda111py38he1cf02b_2.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda102py37hffa29ac_1.tar.bz2
linux-64::deepmd-kit-2.1.1-cpu_py38hf75e09b_1.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda110py38ha64eeb3_1.tar.bz2
linux-64::deepmd-kit-2.1.0-cuda111py38hc530c23_2.tar.bz2
linux-64::deepmd-kit-2.1.1-cpu_py37hf8f8815_0.tar.bz2
linux-64::deepmd-kit-2.1.0-cuda112py39h464d01d_2.tar.bz2
linux-64::deepmd-kit-2.1.0-cuda111py39h427c5e1_2.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda102py39hdef969f_0.tar.bz2
linux-64::deepmd-kit-2.1.0-cuda111py39hff05581_2.tar.bz2
linux-64::deepmd-kit-2.1.1-cpu_py37he6d818a_1.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda111py37hf9310a6_0.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda102py37hffa29ac_0.tar.bz2
linux-64::deepmd-kit-2.1.0-cuda102py37hf00d0fa_2.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda110py38h5df001a_0.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda102py37hf00d0fa_1.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda111py37hfb20bc8_0.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda102py39hdef969f_1.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda112py39h464d01d_0.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda110py39h812f1c7_0.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda102py37hf00d0fa_0.tar.bz2
linux-64::deepmd-kit-2.1.1-cpu_py38hff3f523_0.tar.bz2
linux-64::deepmd-kit-2.1.1-cpu_py39h8f15d6c_0.tar.bz2
linux-64::deepmd-kit-2.1.0-cpu_py37h56151c6_2.tar.bz2
linux-64::deepmd-kit-2.1.1-cpu_py38ha3ba308_0.tar.bz2
linux-64::deepmd-kit-2.1.0-cpu_py38ha3ba308_2.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda112py38hfed40ba_0.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda111py37hc817ec7_1.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda110py37hbde8f90_1.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda112py37h634ffc6_1.tar.bz2
linux-64::deepmd-kit-2.1.0-cpu_py39h09986e6_2.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda102py38hd189ee7_1.tar.bz2
linux-64::deepmd-kit-2.1.0-cuda111py37hf9310a6_2.tar.bz2
linux-64::deepmd-kit-2.1.1-cpu_py38hf67c2f2_1.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda111py39h62a5e91_1.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda110py37he70b675_1.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda110py38h05e9f3b_0.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda111py38hc530c23_0.tar.bz2
linux-64::deepmd-kit-2.1.0-cuda110py37h2e7fe6a_2.tar.bz2
linux-64::deepmd-kit-2.1.0-cuda102py37hffa29ac_2.tar.bz2
linux-64::deepmd-kit-2.1.1-cpu_py37h56151c6_0.tar.bz2
linux-64::deepmd-kit-2.1.0-cpu_py39h8f15d6c_2.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda111py37h7968835_1.tar.bz2
linux-64::deepmd-kit-2.1.0-cuda102py39h585ac91_2.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda112py39h88cb5df_1.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda112py39h855e5d1_1.tar.bz2
linux-64::deepmd-kit-2.1.0-cpu_py37hf8f8815_2.tar.bz2
linux-64::deepmd-kit-2.1.0-cuda110py39h812f1c7_2.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda112py37h69bbc10_0.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda112py38h5fc9f33_1.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda110py39h609c9d2_1.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda110py39h57571d7_0.tar.bz2
-    "numpy >=1.19.5,<2.0a0",
+    "numpy >=1.19.5,<1.26.0a0",
linux-64::deepmd-kit-2.1.3-cpu_py38h3ea1c15_0.tar.bz2
linux-64::deepmd-kit-2.1.4-cuda112py39h64a9307_0.tar.bz2
linux-64::deepmd-kit-2.1.3-cuda102py39he496b81_0.tar.bz2
linux-64::deepmd-kit-2.1.4-cuda102py37hb2ab762_1.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda102py38h2bb2d1d_2.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda112py37ha05564c_2.tar.bz2
linux-64::deepmd-kit-2.1.3-cuda111py39hb9594c1_0.tar.bz2
linux-64::deepmd-kit-2.1.1-cpu_py38h3ea1c15_2.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda111py39h0fe8309_2.tar.bz2
linux-64::deepmd-kit-2.1.3-cpu_py38h33970f9_0.tar.bz2
linux-64::deepmd-kit-2.1.3-cuda111py38hbbab967_0.tar.bz2
linux-64::deepmd-kit-2.1.3-cpu_py37hd676f73_0.tar.bz2
linux-64::deepmd-kit-2.1.2-cuda110py38h358e49c_0.tar.bz2
linux-64::deepmd-kit-2.1.2-cuda110py39hb2f420d_0.tar.bz2
linux-64::deepmd-kit-2.1.4-cuda102py38h11715f9_0.tar.bz2
linux-64::deepmd-kit-2.1.2-cpu_py38h33970f9_0.tar.bz2
linux-64::deepmd-kit-2.1.3-cuda110py37hc8e10ac_0.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda110py38he3cc57b_2.tar.bz2
linux-64::deepmd-kit-2.1.4-cpu_py38h33970f9_0.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda110py39h8b6b782_2.tar.bz2
linux-64::deepmd-kit-2.1.3-cuda102py38h2bb2d1d_0.tar.bz2
linux-64::deepmd-kit-2.1.4-cpu_py39h27ce753_0.tar.bz2
linux-64::deepmd-kit-2.1.1-cpu_py37hd676f73_2.tar.bz2
linux-64::deepmd-kit-2.1.3-cpu_py39h27ce753_0.tar.bz2
linux-64::deepmd-kit-2.1.2-cuda110py39h8b6b782_0.tar.bz2
linux-64::deepmd-kit-2.1.4-cuda111py37hd92c339_1.tar.bz2
linux-64::deepmd-kit-2.1.4-cuda110py39hb2f420d_0.tar.bz2
linux-64::deepmd-kit-2.1.4-cuda110py39h8b6b782_1.tar.bz2
linux-64::deepmd-kit-2.1.3-cuda110py38h358e49c_0.tar.bz2
linux-64::deepmd-kit-2.1.3-cuda110py39hb2f420d_0.tar.bz2
linux-64::deepmd-kit-2.1.4-cuda112py38h09aea2c_0.tar.bz2
linux-64::deepmd-kit-2.1.4-cuda112py39h64a9307_1.tar.bz2
linux-64::deepmd-kit-2.1.4-cuda112py37ha05564c_0.tar.bz2
linux-64::deepmd-kit-2.1.3-cuda112py39h64a9307_0.tar.bz2
linux-64::deepmd-kit-2.1.4-cuda111py38hbbab967_1.tar.bz2
linux-64::deepmd-kit-2.1.4-cpu_py38h3ea1c15_1.tar.bz2
linux-64::deepmd-kit-2.1.4-cpu_py39h27ce753_1.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda110py38h358e49c_2.tar.bz2
linux-64::deepmd-kit-2.1.4-cuda112py38hc235f9a_0.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda110py39hb2f420d_2.tar.bz2
linux-64::deepmd-kit-2.1.4-cpu_py39h5febcf3_0.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda112py38hc235f9a_2.tar.bz2
linux-64::deepmd-kit-2.1.4-cpu_py38h33970f9_1.tar.bz2
linux-64::deepmd-kit-2.1.3-cuda110py39h8b6b782_0.tar.bz2
linux-64::deepmd-kit-2.1.4-cuda110py38he3cc57b_1.tar.bz2
linux-64::deepmd-kit-2.1.4-cuda111py37h834de96_1.tar.bz2
linux-64::deepmd-kit-2.1.4-cuda112py37h308490f_1.tar.bz2
linux-64::deepmd-kit-2.1.2-cuda112py38hc235f9a_0.tar.bz2
linux-64::deepmd-kit-2.1.4-cuda112py39hd74434a_1.tar.bz2
linux-64::deepmd-kit-2.1.2-cuda110py37hd7ad9fb_0.tar.bz2
linux-64::deepmd-kit-2.1.4-cuda111py38hdb9bee1_0.tar.bz2
linux-64::deepmd-kit-2.1.2-cuda102py38h2bb2d1d_0.tar.bz2
linux-64::deepmd-kit-2.1.4-cuda111py37h834de96_0.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda110py37hc8e10ac_2.tar.bz2
linux-64::deepmd-kit-2.1.2-cuda112py38h09aea2c_0.tar.bz2
linux-64::deepmd-kit-2.1.4-cuda111py39h0fe8309_1.tar.bz2
linux-64::deepmd-kit-2.1.1-cpu_py37hf7f1ea7_2.tar.bz2
linux-64::deepmd-kit-2.1.4-cuda102py39hc68d516_1.tar.bz2
linux-64::deepmd-kit-2.1.4-cpu_py37hd676f73_1.tar.bz2
linux-64::deepmd-kit-2.1.4-cpu_py37hd676f73_0.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda102py39he496b81_2.tar.bz2
linux-64::deepmd-kit-2.1.3-cuda112py37h308490f_0.tar.bz2
linux-64::deepmd-kit-2.1.4-cpu_py38h3ea1c15_0.tar.bz2
linux-64::deepmd-kit-2.1.4-cuda111py39hb9594c1_0.tar.bz2
linux-64::deepmd-kit-2.1.3-cuda112py39hd74434a_0.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda110py37hd7ad9fb_2.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda102py37hddb8397_2.tar.bz2
linux-64::deepmd-kit-2.1.4-cuda110py37hd7ad9fb_0.tar.bz2
linux-64::deepmd-kit-2.1.4-cuda102py38h2bb2d1d_1.tar.bz2
linux-64::deepmd-kit-2.1.2-cpu_py39h27ce753_0.tar.bz2
linux-64::deepmd-kit-2.1.4-cuda112py37ha05564c_1.tar.bz2
linux-64::deepmd-kit-2.1.4-cuda111py39hb9594c1_1.tar.bz2
linux-64::deepmd-kit-2.1.4-cpu_py37hf7f1ea7_0.tar.bz2
linux-64::deepmd-kit-2.1.3-cpu_py37hf7f1ea7_0.tar.bz2
linux-64::deepmd-kit-2.1.4-cuda112py38h09aea2c_1.tar.bz2
linux-64::deepmd-kit-2.1.4-cuda102py39he496b81_1.tar.bz2
linux-64::deepmd-kit-2.1.3-cuda112py38hc235f9a_0.tar.bz2
linux-64::deepmd-kit-2.1.2-cuda111py37hd92c339_0.tar.bz2
linux-64::deepmd-kit-2.1.2-cpu_py38h3ea1c15_0.tar.bz2
linux-64::deepmd-kit-2.1.3-cuda102py38h11715f9_0.tar.bz2
linux-64::deepmd-kit-2.1.4-cuda110py39h8b6b782_0.tar.bz2
linux-64::deepmd-kit-2.1.2-cuda111py39hb9594c1_0.tar.bz2
linux-64::deepmd-kit-2.1.2-cuda102py39hc68d516_0.tar.bz2
linux-64::deepmd-kit-2.1.2-cuda102py38h11715f9_0.tar.bz2
linux-64::deepmd-kit-2.1.4-cuda111py39h0fe8309_0.tar.bz2
linux-64::deepmd-kit-2.1.3-cuda110py37hd7ad9fb_0.tar.bz2
linux-64::deepmd-kit-2.1.1-cpu_py38h33970f9_2.tar.bz2
linux-64::deepmd-kit-2.1.4-cuda102py37hddb8397_0.tar.bz2
linux-64::deepmd-kit-2.1.4-cuda110py38he3cc57b_0.tar.bz2
linux-64::deepmd-kit-2.1.3-cuda102py39hc68d516_0.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda102py38h11715f9_2.tar.bz2
linux-64::deepmd-kit-2.1.4-cpu_py37hf7f1ea7_1.tar.bz2
linux-64::deepmd-kit-2.1.4-cuda112py39hd74434a_0.tar.bz2
linux-64::deepmd-kit-2.1.2-cuda112py39h64a9307_0.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda112py39h64a9307_2.tar.bz2
linux-64::deepmd-kit-2.1.3-cuda102py37hddb8397_0.tar.bz2
linux-64::deepmd-kit-2.1.3-cuda112py37ha05564c_0.tar.bz2
linux-64::deepmd-kit-2.1.4-cuda102py39he496b81_0.tar.bz2
linux-64::deepmd-kit-2.1.4-cpu_py39h5febcf3_1.tar.bz2
linux-64::deepmd-kit-2.1.4-cuda111py37hd92c339_0.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda111py37hd92c339_2.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda112py39hd74434a_2.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda102py39hc68d516_2.tar.bz2
linux-64::deepmd-kit-2.1.4-cuda110py37hd7ad9fb_1.tar.bz2
linux-64::deepmd-kit-2.1.4-cuda111py38hdb9bee1_1.tar.bz2
linux-64::deepmd-kit-2.1.2-cuda102py39he496b81_0.tar.bz2
linux-64::deepmd-kit-2.1.3-cuda111py38hdb9bee1_0.tar.bz2
linux-64::deepmd-kit-2.1.4-cuda102py37hb2ab762_0.tar.bz2
linux-64::deepmd-kit-2.1.2-cpu_py39h5febcf3_0.tar.bz2
linux-64::deepmd-kit-2.1.2-cuda112py37h308490f_0.tar.bz2
linux-64::deepmd-kit-2.1.3-cuda102py37hb2ab762_0.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda112py37h308490f_2.tar.bz2
linux-64::deepmd-kit-2.1.4-cuda110py39hb2f420d_1.tar.bz2
linux-64::deepmd-kit-2.1.3-cpu_py39h5febcf3_0.tar.bz2
linux-64::deepmd-kit-2.1.4-cuda110py37hc8e10ac_1.tar.bz2
linux-64::deepmd-kit-2.1.2-cpu_py37hd676f73_0.tar.bz2
linux-64::deepmd-kit-2.1.2-cuda110py38he3cc57b_0.tar.bz2
linux-64::deepmd-kit-2.1.4-cuda112py38hc235f9a_1.tar.bz2
linux-64::deepmd-kit-2.1.2-cuda110py37hc8e10ac_0.tar.bz2
linux-64::deepmd-kit-2.1.4-cuda102py39hc68d516_0.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda111py38hbbab967_2.tar.bz2
linux-64::deepmd-kit-2.1.2-cuda112py37ha05564c_0.tar.bz2
linux-64::deepmd-kit-2.1.1-cpu_py39h27ce753_2.tar.bz2
linux-64::deepmd-kit-2.1.2-cuda112py39hd74434a_0.tar.bz2
linux-64::deepmd-kit-2.1.2-cuda111py37h834de96_0.tar.bz2
linux-64::deepmd-kit-2.1.2-cpu_py37hf7f1ea7_0.tar.bz2
linux-64::deepmd-kit-2.1.2-cuda111py38hbbab967_0.tar.bz2
linux-64::deepmd-kit-2.1.4-cuda110py37hc8e10ac_0.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda111py38hdb9bee1_2.tar.bz2
linux-64::deepmd-kit-2.1.4-cuda112py37h308490f_0.tar.bz2
linux-64::deepmd-kit-2.1.4-cuda110py38h358e49c_1.tar.bz2
linux-64::deepmd-kit-2.1.2-cuda111py39h0fe8309_0.tar.bz2
linux-64::deepmd-kit-2.1.3-cuda111py37hd92c339_0.tar.bz2
linux-64::deepmd-kit-2.1.4-cuda102py38h2bb2d1d_0.tar.bz2
linux-64::deepmd-kit-2.1.4-cuda111py38hbbab967_0.tar.bz2
linux-64::deepmd-kit-2.1.2-cuda111py38hdb9bee1_0.tar.bz2
linux-64::deepmd-kit-2.1.3-cuda112py38h09aea2c_0.tar.bz2
linux-64::deepmd-kit-2.1.2-cuda102py37hb2ab762_0.tar.bz2
linux-64::deepmd-kit-2.1.1-cpu_py39h5febcf3_2.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda111py39hb9594c1_2.tar.bz2
linux-64::deepmd-kit-2.1.4-cuda110py38h358e49c_0.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda112py38h09aea2c_2.tar.bz2
linux-64::deepmd-kit-2.1.2-cuda102py37hddb8397_0.tar.bz2
linux-64::deepmd-kit-2.1.3-cuda110py38he3cc57b_0.tar.bz2
linux-64::deepmd-kit-2.1.4-cuda102py37hddb8397_1.tar.bz2
linux-64::deepmd-kit-2.1.4-cuda102py38h11715f9_1.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda111py37h834de96_2.tar.bz2
linux-64::deepmd-kit-2.1.3-cuda111py39h0fe8309_0.tar.bz2
linux-64::deepmd-kit-2.1.1-cuda102py37hb2ab762_2.tar.bz2
linux-64::deepmd-kit-2.1.3-cuda111py37h834de96_0.tar.bz2
-    "numpy >=1.20.3,<2.0a0",
+    "numpy >=1.20.3,<1.26.0a0",
linux-64::llvm-17.0.1-ha0738ec_0.conda
+    "clang 17.0.1.*",
+    "clang-tools 17.0.1.*",
+    "llvm-tools 17.0.1.*",
linux-64::llvm-tools-17.0.1-h5cf9203_0.conda
+    "clang 17.0.1.*",
+    "clang-tools 17.0.1.*",
+    "llvm 17.0.1.*",
linux-64::llvmdev-17.0.1-h5cf9203_0.conda
+  "constrains": [
+    "clang 17.0.1.*",
+    "clang-tools 17.0.1.*",
+    "llvm 17.0.1.*",
+    "llvm-tools 17.0.1.*"
+  ],
```

</details>

I don't know why llvm is in the outputs?