### PR TITLE
Add conflict with jpeg and libjpeg-turbo for old version of freeimage with vendored jpeg

### DIFF
--- a/recipe/patch_yaml/freeimage.yaml
+++ b/recipe/patch_yaml/freeimage.yaml
@@ -22,3 +22,14 @@ then:
   - tighten_depends:
       name: libtiff
       upper_bound: 4.4.0
+---
+# To fix https://github.com/conda-forge/freeimage-feedstock/issues/43
+# Older builds had a vendored jpeg that conflicts at runtime with jpeg and libjpeg-turbo
+if:
+  name: freeimage
+  version_in: ["3.18.0", "3.17.0"]
+  build_number: 0
+then:
+  - add_constrains:
+      - "jpeg <0.0.0a"
+      - "libjpeg-turbo <0.0.0a"


### PR DESCRIPTION
Fix https://github.com/conda-forge/freeimage-feedstock/issues/43

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here --!>
