### PR TITLE
pin traitlets <5.10 for notebook <6.5.6

### DIFF
--- a/recipe/patch_yaml/notebook.yaml
+++ b/recipe/patch_yaml/notebook.yaml
@@ -1,0 +1,8 @@
+if:
+  name: notebook
+  version_lt: 6.5.6
+  timestamp_lt: 1695942954000
+then:
+  - tighten_depends:
+      name: traitlets
+      upper_bound: 5.10.0


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->


references:

- https://github.com/jupyter/notebook/issues/7048
- https://github.com/conda-forge/notebook-feedstock/issues/132

diff:

```diff
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
win-32::notebook-4.2.1-py27_0.tar.bz2
win-32::notebook-4.4.1-py36_0.tar.bz2
win-32::notebook-4.2.0-py27_0.tar.bz2
win-32::notebook-4.1.0-py34_0.tar.bz2
win-32::notebook-4.4.1-py27_0.tar.bz2
win-32::notebook-4.2.2-py35_0.tar.bz2
win-32::notebook-4.2.3-py27_0.tar.bz2
win-32::notebook-4.2.2-py27_0.tar.bz2
win-32::notebook-4.2.1-py34_0.tar.bz2
win-32::notebook-4.4.1-py35_0.tar.bz2
win-32::notebook-4.1.0-py27_0.tar.bz2
win-32::notebook-4.2.0-py35_0.tar.bz2
win-32::notebook-4.3.1-py34_0.tar.bz2
win-32::notebook-4.3.1-py27_0.tar.bz2
win-32::notebook-4.3.2-py35_0.tar.bz2
win-32::notebook-4.3.2-py27_0.tar.bz2
win-32::notebook-4.3.2-py36_0.tar.bz2
win-32::notebook-4.1.0-py35_0.tar.bz2
win-32::notebook-4.2.3-py34_0.tar.bz2
win-32::notebook-4.2.0-py34_0.tar.bz2
win-32::notebook-4.2.2-py34_0.tar.bz2
win-32::notebook-4.3.1-py35_0.tar.bz2
win-32::notebook-4.2.3-py35_0.tar.bz2
win-32::notebook-4.2.1-py35_0.tar.bz2
-    "traitlets"
+    "traitlets <5.10.0a0"
win-32::notebook-5.2.2-py27_1.tar.bz2
win-32::notebook-5.0.0-py36_0.tar.bz2
win-32::notebook-5.3.1-py27_0.tar.bz2
win-32::notebook-5.2.0-py35_0.tar.bz2
win-32::notebook-5.3.1-py36_0.tar.bz2
win-32::notebook-5.2.0-py27_0.tar.bz2
win-32::notebook-5.2.1-py27_2.tar.bz2
win-32::notebook-5.2.2-py36_1.tar.bz2
win-32::notebook-5.2.0-py27_1.tar.bz2
win-32::notebook-5.0.0-py27_0.tar.bz2
win-32::notebook-5.2.2-py35_1.tar.bz2
win-32::notebook-5.3.1-py35_0.tar.bz2
win-32::notebook-5.1.0-py36_0.tar.bz2
win-32::notebook-5.2.2-py36_0.tar.bz2
win-32::notebook-5.2.0-py35_1.tar.bz2
win-32::notebook-5.2.1-py35_2.tar.bz2
win-32::notebook-5.2.1-py36_2.tar.bz2
win-32::notebook-5.1.0-py35_0.tar.bz2
win-32::notebook-5.2.0-py36_1.tar.bz2
win-32::notebook-5.0.0-py35_0.tar.bz2
win-32::notebook-5.2.2-py35_0.tar.bz2
win-32::notebook-5.2.0-py36_0.tar.bz2
win-32::notebook-5.2.2-py27_0.tar.bz2
win-32::notebook-5.1.0-py27_0.tar.bz2
-    "traitlets >=4.3"
+    "traitlets >=4.3,<5.10.0a0"
win-32::notebook-5.3.1-py35_1.tar.bz2
win-32::notebook-5.3.1-py27_2.tar.bz2
win-32::notebook-5.3.1-py36_1.tar.bz2
win-32::notebook-5.4.1-py27_0.tar.bz2
win-32::notebook-5.3.1-py35_2.tar.bz2
win-32::notebook-5.4.0-py36_0.tar.bz2
win-32::notebook-5.3.1-py27_1.tar.bz2
win-32::notebook-5.4.0-py35_0.tar.bz2
win-32::notebook-5.4.0-py27_0.tar.bz2
win-32::notebook-5.4.1-py35_0.tar.bz2
win-32::notebook-5.3.1-py36_2.tar.bz2
win-32::notebook-5.4.1-py36_0.tar.bz2
-    "traitlets >=4.2.1"
+    "traitlets >=4.2.1,<5.10.0a0"
================================================================================
================================================================================
osx-arm64
osx-arm64::notebook-6.3.0-py38h10201cd_0.tar.bz2
osx-arm64::notebook-6.1.5-py38h10201cd_0.tar.bz2
osx-arm64::notebook-6.1.6-py38h10201cd_0.tar.bz2
osx-arm64::notebook-6.3.0-py39h2804cbe_0.tar.bz2
osx-arm64::notebook-6.1.5-py39h2804cbe_0.tar.bz2
osx-arm64::notebook-6.2.0-py39h2804cbe_0.tar.bz2
osx-arm64::notebook-6.1.6-py39h2804cbe_0.tar.bz2
osx-arm64::notebook-6.2.0-py38h10201cd_0.tar.bz2
-    "traitlets >=4.2.1"
+    "traitlets >=4.2.1,<5.10.0a0"
================================================================================
================================================================================
linux-ppc64le
linux-ppc64le::notebook-6.3.0-py37h35e4cab_0.tar.bz2
linux-ppc64le::notebook-6.0.2-py36_0.tar.bz2
linux-ppc64le::notebook-6.3.0-py36he7cccf2_0.tar.bz2
linux-ppc64le::notebook-6.2.0-py39hc1b9086_0.tar.bz2
linux-ppc64le::notebook-6.1.5-py36he7cccf2_0.tar.bz2
linux-ppc64le::notebook-6.0.1-py37_0.tar.bz2
linux-ppc64le::notebook-6.2.0-py37hadc05a3_0.tar.bz2
linux-ppc64le::notebook-6.1.4-py36h9f0ad1d_0.tar.bz2
linux-ppc64le::notebook-6.1.0-py36hc560c46_0.tar.bz2
linux-ppc64le::notebook-6.1.5-py39hc1b9086_0.tar.bz2
linux-ppc64le::notebook-6.1.4-py36hc560c46_0.tar.bz2
linux-ppc64le::notebook-6.1.3-py36h9f0ad1d_0.tar.bz2
linux-ppc64le::notebook-6.1.6-py36h270354c_0.tar.bz2
linux-ppc64le::notebook-6.2.0-py37h35e4cab_0.tar.bz2
linux-ppc64le::notebook-6.1.1-py36hc560c46_0.tar.bz2
linux-ppc64le::notebook-6.3.0-py36h270354c_0.tar.bz2
linux-ppc64le::notebook-6.1.6-py36he7cccf2_0.tar.bz2
linux-ppc64le::notebook-6.0.3-py36_0.tar.bz2
linux-ppc64le::notebook-6.1.4-py38h32f6830_0.tar.bz2
linux-ppc64le::notebook-6.1.4-py37hc8dfbb8_0.tar.bz2
linux-ppc64le::notebook-6.1.3-py38h32f6830_0.tar.bz2
linux-ppc64le::notebook-6.0.3-py37hc8dfbb8_1.tar.bz2
linux-ppc64le::notebook-6.1.6-py39hc1b9086_0.tar.bz2
linux-ppc64le::notebook-6.1.0-py37hc8dfbb8_0.tar.bz2
linux-ppc64le::notebook-6.0.1-py38_0.tar.bz2
linux-ppc64le::notebook-6.0.3-py37hc8dfbb8_0.tar.bz2
linux-ppc64le::notebook-6.1.5-py37h35e4cab_0.tar.bz2
linux-ppc64le::notebook-6.1.6-py37h35e4cab_0.tar.bz2
linux-ppc64le::notebook-6.2.0-py36h270354c_0.tar.bz2
linux-ppc64le::notebook-6.0.2-py37_0.tar.bz2
linux-ppc64le::notebook-6.3.0-py37hadc05a3_0.tar.bz2
linux-ppc64le::notebook-6.2.0-py36he7cccf2_0.tar.bz2
linux-ppc64le::notebook-6.0.2-py38_0.tar.bz2
linux-ppc64le::notebook-6.1.5-py38hf8b3453_0.tar.bz2
linux-ppc64le::notebook-6.1.6-py38hf8b3453_0.tar.bz2
linux-ppc64le::notebook-6.0.3-py36hc560c46_1.tar.bz2
linux-ppc64le::notebook-6.2.0-py38hf8b3453_0.tar.bz2
linux-ppc64le::notebook-6.3.0-py38hf8b3453_0.tar.bz2
linux-ppc64le::notebook-6.1.2-py38h32f6830_0.tar.bz2
linux-ppc64le::notebook-6.1.4-py36hc560c46_1.tar.bz2
linux-ppc64le::notebook-6.1.0-py36h9f0ad1d_0.tar.bz2
linux-ppc64le::notebook-6.0.1-py36_0.tar.bz2
linux-ppc64le::notebook-6.1.4-py39hde42818_1.tar.bz2
linux-ppc64le::notebook-6.0.3-py36h9f0ad1d_1.tar.bz2
linux-ppc64le::notebook-6.1.1-py38h32f6830_0.tar.bz2
linux-ppc64le::notebook-6.1.5-py36h270354c_0.tar.bz2
linux-ppc64le::notebook-6.0.3-py37_0.tar.bz2
linux-ppc64le::notebook-6.1.0-py38h32f6830_0.tar.bz2
linux-ppc64le::notebook-6.1.2-py37hc8dfbb8_0.tar.bz2
linux-ppc64le::notebook-6.1.3-py37hc8dfbb8_0.tar.bz2
linux-ppc64le::notebook-6.1.1-py37hc8dfbb8_0.tar.bz2
linux-ppc64le::notebook-6.1.1-py36h9f0ad1d_0.tar.bz2
linux-ppc64le::notebook-6.0.3-py36h9f0ad1d_0.tar.bz2
linux-ppc64le::notebook-6.0.3-py38h32f6830_0.tar.bz2
linux-ppc64le::notebook-6.0.3-py38h32f6830_1.tar.bz2
linux-ppc64le::notebook-6.0.3-py38_0.tar.bz2
linux-ppc64le::notebook-6.1.2-py36hc560c46_0.tar.bz2
linux-ppc64le::notebook-6.1.3-py36hc560c46_0.tar.bz2
linux-ppc64le::notebook-6.1.4-py36h9f0ad1d_1.tar.bz2
linux-ppc64le::notebook-6.1.4-py38h32f6830_1.tar.bz2
linux-ppc64le::notebook-6.3.0-py39hc1b9086_0.tar.bz2
linux-ppc64le::notebook-6.1.4-py37hc8dfbb8_1.tar.bz2
linux-ppc64le::notebook-6.1.2-py36h9f0ad1d_0.tar.bz2
-    "traitlets >=4.2.1"
+    "traitlets >=4.2.1,<5.10.0a0"
================================================================================
================================================================================
linux-aarch64
linux-aarch64::notebook-6.2.0-py37hd9ded2f_0.tar.bz2
linux-aarch64::notebook-6.1.2-py37hc8dfbb8_0.tar.bz2
linux-aarch64::notebook-6.0.3-py38h32f6830_1.tar.bz2
linux-aarch64::notebook-6.1.6-py39ha65689a_0.tar.bz2
linux-aarch64::notebook-6.1.6-py36h2e20a7f_0.tar.bz2
linux-aarch64::notebook-6.1.5-py37hd9ded2f_0.tar.bz2
linux-aarch64::notebook-6.2.0-py38h2063c64_0.tar.bz2
linux-aarch64::notebook-6.0.3-py38_0.tar.bz2
linux-aarch64::notebook-6.1.5-py36h704843e_0.tar.bz2
linux-aarch64::notebook-6.1.6-py38h2063c64_0.tar.bz2
linux-aarch64::notebook-6.1.1-py37hc8dfbb8_0.tar.bz2
linux-aarch64::notebook-6.0.2-py38_0.tar.bz2
linux-aarch64::notebook-6.0.3-py36h9f0ad1d_0.tar.bz2
linux-aarch64::notebook-6.0.3-py36h9f0ad1d_1.tar.bz2
linux-aarch64::notebook-6.1.0-py38h32f6830_0.tar.bz2
linux-aarch64::notebook-6.1.1-py36hc560c46_0.tar.bz2
linux-aarch64::notebook-6.3.0-py36h2e20a7f_0.tar.bz2
linux-aarch64::notebook-6.1.0-py36hc560c46_0.tar.bz2
linux-aarch64::notebook-6.1.0-py36h9f0ad1d_0.tar.bz2
linux-aarch64::notebook-6.1.3-py36h9f0ad1d_0.tar.bz2
linux-aarch64::notebook-6.1.4-py36hc560c46_1.tar.bz2
linux-aarch64::notebook-6.1.0-py37hc8dfbb8_0.tar.bz2
linux-aarch64::notebook-6.0.3-py36hc560c46_1.tar.bz2
linux-aarch64::notebook-6.1.5-py38h2063c64_0.tar.bz2
linux-aarch64::notebook-6.3.0-py37hd9ded2f_0.tar.bz2
linux-aarch64::notebook-6.0.2-py36_0.tar.bz2
linux-aarch64::notebook-6.0.3-py38h32f6830_0.tar.bz2
linux-aarch64::notebook-6.1.4-py39hde42818_1.tar.bz2
linux-aarch64::notebook-6.0.1-py38_0.tar.bz2
linux-aarch64::notebook-6.1.4-py37hc8dfbb8_0.tar.bz2
linux-aarch64::notebook-6.1.3-py36hc560c46_0.tar.bz2
linux-aarch64::notebook-6.0.3-py37_0.tar.bz2
linux-aarch64::notebook-6.1.3-py38h32f6830_0.tar.bz2
linux-aarch64::notebook-6.1.4-py38h32f6830_1.tar.bz2
linux-aarch64::notebook-6.1.6-py37hd9ded2f_0.tar.bz2
linux-aarch64::notebook-6.1.4-py36h9f0ad1d_0.tar.bz2
linux-aarch64::notebook-6.1.5-py39ha65689a_0.tar.bz2
linux-aarch64::notebook-6.0.1-py36_0.tar.bz2
linux-aarch64::notebook-6.2.0-py36h2e20a7f_0.tar.bz2
linux-aarch64::notebook-6.2.0-py39ha65689a_0.tar.bz2
linux-aarch64::notebook-6.3.0-py39ha65689a_0.tar.bz2
linux-aarch64::notebook-6.0.3-py37hc8dfbb8_1.tar.bz2
linux-aarch64::notebook-6.1.5-py36h2e20a7f_0.tar.bz2
linux-aarch64::notebook-6.1.6-py36h704843e_0.tar.bz2
linux-aarch64::notebook-6.3.0-py36h704843e_0.tar.bz2
linux-aarch64::notebook-6.0.3-py36_0.tar.bz2
linux-aarch64::notebook-6.3.0-py37h4bcbb9b_0.tar.bz2
linux-aarch64::notebook-6.0.2-py37_0.tar.bz2
linux-aarch64::notebook-6.0.3-py37hc8dfbb8_0.tar.bz2
linux-aarch64::notebook-6.1.4-py36hc560c46_0.tar.bz2
linux-aarch64::notebook-6.1.1-py38h32f6830_0.tar.bz2
linux-aarch64::notebook-6.1.1-py36h9f0ad1d_0.tar.bz2
linux-aarch64::notebook-6.2.0-py36h704843e_0.tar.bz2
linux-aarch64::notebook-6.1.2-py38h32f6830_0.tar.bz2
linux-aarch64::notebook-6.2.0-py37h4bcbb9b_0.tar.bz2
linux-aarch64::notebook-6.1.3-py37hc8dfbb8_0.tar.bz2
linux-aarch64::notebook-6.1.4-py36h9f0ad1d_1.tar.bz2
linux-aarch64::notebook-6.3.0-py38h2063c64_0.tar.bz2
linux-aarch64::notebook-6.1.4-py38h32f6830_0.tar.bz2
linux-aarch64::notebook-6.1.2-py36h9f0ad1d_0.tar.bz2
linux-aarch64::notebook-6.0.1-py37_0.tar.bz2
linux-aarch64::notebook-6.1.2-py36hc560c46_0.tar.bz2
linux-aarch64::notebook-6.1.4-py37hc8dfbb8_1.tar.bz2
-    "traitlets >=4.2.1"
+    "traitlets >=4.2.1,<5.10.0a0"
================================================================================
================================================================================
noarch
noarch::notebook-6.4.0-pyha770c72_0.tar.bz2
noarch::notebook-6.5.5-pyha770c72_0.conda
noarch::notebook-6.4.1-pyha770c72_0.tar.bz2
noarch::notebook-6.5.2-pyha770c72_0.tar.bz2
noarch::notebook-6.4.12-pyha770c72_0.tar.bz2
noarch::notebook-6.4.5-pyha770c72_0.tar.bz2
noarch::notebook-6.4.4-pyha770c72_0.tar.bz2
noarch::notebook-6.5.2-pyha770c72_1.tar.bz2
noarch::notebook-6.4.3-pyha770c72_0.tar.bz2
noarch::notebook-6.4.2-pyha770c72_0.tar.bz2
noarch::notebook-6.3.0-pyha770c72_1.tar.bz2
noarch::notebook-6.5.1-pyha770c72_0.tar.bz2
noarch::notebook-6.4.6-pyha770c72_0.tar.bz2
noarch::notebook-6.4.11-pyha770c72_0.tar.bz2
noarch::notebook-6.4.8-pyha770c72_0.tar.bz2
noarch::notebook-6.4.10-pyha770c72_0.tar.bz2
noarch::notebook-6.4.7-pyha770c72_0.tar.bz2
noarch::notebook-6.5.4-pyha770c72_0.conda
noarch::notebook-6.4.9-pyha770c72_0.tar.bz2
noarch::notebook-6.5.3-pyha770c72_0.conda
-    "traitlets >=4.2.1"
+    "traitlets >=4.2.1,<5.10.0a0"
================================================================================
================================================================================
win-64
win-64::notebook-4.1.0-py27_0.tar.bz2
win-64::notebook-4.2.3-py35_0.tar.bz2
win-64::notebook-4.3.2-py36_0.tar.bz2
win-64::notebook-4.2.1-py34_0.tar.bz2
win-64::notebook-4.3.2-py27_0.tar.bz2
win-64::notebook-4.2.0-py34_0.tar.bz2
win-64::notebook-4.2.1-py27_0.tar.bz2
win-64::notebook-4.2.2-py34_0.tar.bz2
win-64::notebook-4.2.0-py35_0.tar.bz2
win-64::notebook-4.2.3-py34_0.tar.bz2
win-64::notebook-4.2.2-py35_0.tar.bz2
win-64::notebook-4.3.2-py35_0.tar.bz2
win-64::notebook-4.2.0-py27_0.tar.bz2
win-64::notebook-4.3.1-py34_0.tar.bz2
win-64::notebook-4.2.2-py27_0.tar.bz2
win-64::notebook-4.1.0-py34_0.tar.bz2
win-64::notebook-4.3.1-py27_0.tar.bz2
win-64::notebook-4.3.1-py35_0.tar.bz2
win-64::notebook-4.4.1-py35_0.tar.bz2
win-64::notebook-4.4.1-py27_0.tar.bz2
win-64::notebook-4.4.1-py36_0.tar.bz2
win-64::notebook-4.1.0-py35_0.tar.bz2
win-64::notebook-4.2.3-py27_0.tar.bz2
win-64::notebook-4.2.1-py35_0.tar.bz2
-    "traitlets"
+    "traitlets <5.10.0a0"
win-64::notebook-5.2.0-py36_1.tar.bz2
win-64::notebook-5.1.0-py27_0.tar.bz2
win-64::notebook-5.2.1-py35_2.tar.bz2
win-64::notebook-5.3.1-py35_0.tar.bz2
win-64::notebook-5.2.2-py35_1.tar.bz2
win-64::notebook-5.0.0-py27_0.tar.bz2
win-64::notebook-5.1.0-py36_0.tar.bz2
win-64::notebook-5.2.0-py27_1.tar.bz2
win-64::notebook-5.2.1-py27_2.tar.bz2
win-64::notebook-5.3.1-py36_0.tar.bz2
win-64::notebook-5.1.0-py35_0.tar.bz2
win-64::notebook-5.0.0-py36_0.tar.bz2
win-64::notebook-5.2.2-py36_0.tar.bz2
win-64::notebook-5.2.0-py35_1.tar.bz2
win-64::notebook-5.2.0-py27_0.tar.bz2
win-64::notebook-5.2.0-py36_0.tar.bz2
win-64::notebook-5.2.2-py36_1.tar.bz2
win-64::notebook-5.3.1-py27_0.tar.bz2
win-64::notebook-5.2.1-py36_2.tar.bz2
win-64::notebook-5.2.2-py27_0.tar.bz2
win-64::notebook-5.2.2-py27_1.tar.bz2
win-64::notebook-5.2.0-py35_0.tar.bz2
win-64::notebook-5.2.2-py35_0.tar.bz2
win-64::notebook-5.0.0-py35_0.tar.bz2
-    "traitlets >=4.3"
+    "traitlets >=4.3,<5.10.0a0"
win-64::notebook-5.7.6-py36_0.tar.bz2
win-64::notebook-6.0.0-py36_0.tar.bz2
win-64::notebook-5.6.0-py36_0.tar.bz2
win-64::notebook-5.7.1-py36_1000.tar.bz2
win-64::notebook-5.7.10-py37hc8dfbb8_0.tar.bz2
win-64::notebook-6.1.4-py39hde42818_1.tar.bz2
win-64::notebook-6.0.2-py37_0.tar.bz2
win-64::notebook-5.7.8-py36_0.tar.bz2
win-64::notebook-5.3.1-py27_2.tar.bz2
win-64::notebook-6.1.5-py38haa244fe_0.tar.bz2
win-64::notebook-5.6.0-py27_0.tar.bz2
win-64::notebook-5.4.0-py36_0.tar.bz2
win-64::notebook-6.2.0-py39hcbf5309_0.tar.bz2
win-64::notebook-6.1.2-py37hc8dfbb8_0.tar.bz2
win-64::notebook-5.6.0-py35_1.tar.bz2
win-64::notebook-6.2.0-py36ha15d459_0.tar.bz2
win-64::notebook-5.7.2-py37_1000.tar.bz2
win-64::notebook-5.7.5-py37_0.tar.bz2
win-64::notebook-5.7.1-py27_1000.tar.bz2
win-64::notebook-6.1.5-py39hcbf5309_0.tar.bz2
win-64::notebook-6.0.3-py38_0.tar.bz2
win-64::notebook-6.0.2-py36_0.tar.bz2
win-64::notebook-6.0.1-py36_0.tar.bz2
win-64::notebook-5.6.0-py37_1.tar.bz2
win-64::notebook-6.1.1-py36h9f0ad1d_0.tar.bz2
win-64::notebook-6.1.4-py38h32f6830_0.tar.bz2
win-64::notebook-5.7.7-py37_0.tar.bz2
win-64::notebook-6.3.0-py38haa244fe_0.tar.bz2
win-64::notebook-5.7.8-py37_0.tar.bz2
win-64::notebook-5.4.1-py36_0.tar.bz2
win-64::notebook-5.3.1-py35_1.tar.bz2
win-64::notebook-6.2.0-py38haa244fe_0.tar.bz2
win-64::notebook-5.6.0-py27_1.tar.bz2
win-64::notebook-6.1.4-py36h9f0ad1d_0.tar.bz2
win-64::notebook-5.7.7-py27_0.tar.bz2
win-64::notebook-5.7.9-py36h9f0ad1d_0.tar.bz2
win-64::notebook-5.7.0-py27_0.tar.bz2
win-64::notebook-6.1.6-py38haa244fe_0.tar.bz2
win-64::notebook-6.2.0-py37h03978a9_0.tar.bz2
win-64::notebook-6.0.3-py36_0.tar.bz2
win-64::notebook-6.1.0-py36h9f0ad1d_0.tar.bz2
win-64::notebook-5.7.9-py37hc8dfbb8_0.tar.bz2
win-64::notebook-5.7.4-py36_1.tar.bz2
win-64::notebook-6.1.0-py38h32f6830_0.tar.bz2
win-64::notebook-6.1.3-py36h9f0ad1d_0.tar.bz2
win-64::notebook-5.4.0-py27_0.tar.bz2
win-64::notebook-6.1.4-py37hc8dfbb8_1.tar.bz2
win-64::notebook-6.0.3-py37hc8dfbb8_0.tar.bz2
win-64::notebook-6.1.5-py37h03978a9_0.tar.bz2
win-64::notebook-5.7.7-py36_0.tar.bz2
win-64::notebook-5.3.1-py27_1.tar.bz2
win-64::notebook-6.0.3-py38h32f6830_1.tar.bz2
win-64::notebook-5.7.8-py36_1.tar.bz2
win-64::notebook-5.7.11-py36ha15d459_0.tar.bz2
win-64::notebook-6.1.4-py36h9f0ad1d_1.tar.bz2
win-64::notebook-6.1.4-py38h32f6830_1.tar.bz2
win-64::notebook-6.3.0-py39hcbf5309_0.tar.bz2
win-64::notebook-5.7.0-py35_0.tar.bz2
win-64::notebook-6.1.1-py37hc8dfbb8_0.tar.bz2
win-64::notebook-6.1.2-py36h9f0ad1d_0.tar.bz2
win-64::notebook-5.5.0-py36_0.tar.bz2
win-64::notebook-6.1.6-py37h03978a9_0.tar.bz2
win-64::notebook-5.7.10-py36h9f0ad1d_0.tar.bz2
win-64::notebook-5.6.0-py36_1.tar.bz2
win-64::notebook-5.7.8-py27_0.tar.bz2
win-64::notebook-5.7.11-py37h03978a9_0.tar.bz2
win-64::notebook-5.7.6-py37_0.tar.bz2
win-64::notebook-5.3.1-py36_2.tar.bz2
win-64::notebook-6.3.0-py36ha15d459_0.tar.bz2
win-64::notebook-6.1.4-py37hc8dfbb8_0.tar.bz2
win-64::notebook-6.1.5-py36ha15d459_0.tar.bz2
win-64::notebook-5.5.0-py27_0.tar.bz2
win-64::notebook-6.1.1-py38h32f6830_0.tar.bz2
win-64::notebook-5.4.1-py27_0.tar.bz2
win-64::notebook-5.7.0-py36_0.tar.bz2
win-64::notebook-5.3.1-py36_1.tar.bz2
win-64::notebook-6.1.3-py37hc8dfbb8_0.tar.bz2
win-64::notebook-6.1.6-py39hcbf5309_0.tar.bz2
win-64::notebook-6.0.3-py36h9f0ad1d_0.tar.bz2
win-64::notebook-5.7.5-py36_0.tar.bz2
win-64::notebook-6.0.2-py38_0.tar.bz2
win-64::notebook-5.7.2-py27_1000.tar.bz2
win-64::notebook-5.7.4-py37_1.tar.bz2
win-64::notebook-6.1.2-py38h32f6830_0.tar.bz2
win-64::notebook-6.1.3-py38h32f6830_0.tar.bz2
win-64::notebook-5.4.0-py35_0.tar.bz2
win-64::notebook-6.0.1-py38_0.tar.bz2
win-64::notebook-5.3.1-py35_2.tar.bz2
win-64::notebook-6.0.3-py38h32f6830_0.tar.bz2
win-64::notebook-5.7.1-py37_1000.tar.bz2
win-64::notebook-6.1.0-py37hc8dfbb8_0.tar.bz2
win-64::notebook-5.7.8-py27_1.tar.bz2
win-64::notebook-5.4.1-py35_0.tar.bz2
win-64::notebook-5.7.0-py27_1000.tar.bz2
win-64::notebook-5.7.8-py37_1.tar.bz2
win-64::notebook-5.7.11-py39hcbf5309_0.tar.bz2
win-64::notebook-6.0.3-py36h9f0ad1d_1.tar.bz2
win-64::notebook-6.3.0-py37h03978a9_0.tar.bz2
win-64::notebook-5.7.4-py27_1.tar.bz2
win-64::notebook-6.0.3-py37_0.tar.bz2
win-64::notebook-5.7.6-py27_0.tar.bz2
win-64::notebook-5.7.2-py36_1000.tar.bz2
win-64::notebook-5.5.0-py35_0.tar.bz2
win-64::notebook-5.7.0-py37_1000.tar.bz2
win-64::notebook-6.1.6-py36ha15d459_0.tar.bz2
win-64::notebook-5.7.0-py36_1000.tar.bz2
win-64::notebook-5.6.0-py35_0.tar.bz2
win-64::notebook-6.0.3-py37hc8dfbb8_1.tar.bz2
win-64::notebook-5.7.11-py38haa244fe_0.tar.bz2
win-64::notebook-6.0.1-py37_0.tar.bz2
win-64::notebook-6.0.0-py37_0.tar.bz2
-    "traitlets >=4.2.1"
+    "traitlets >=4.2.1,<5.10.0a0"
================================================================================
================================================================================
osx-64
osx-64::notebook-4.2.2-py35_0.tar.bz2
osx-64::notebook-4.3.1-py35_0.tar.bz2
osx-64::notebook-4.2.3-py34_0.tar.bz2
osx-64::notebook-4.2.2-py34_0.tar.bz2
osx-64::notebook-4.2.1-py34_0.tar.bz2
osx-64::notebook-4.4.1-py36_0.tar.bz2
osx-64::notebook-4.2.2-py27_0.tar.bz2
osx-64::notebook-4.4.1-py35_0.tar.bz2
osx-64::notebook-4.2.0-py34_0.tar.bz2
osx-64::notebook-4.2.0-py27_0.tar.bz2
osx-64::notebook-4.3.2-py36_0.tar.bz2
osx-64::notebook-4.1.0-py35_0.tar.bz2
osx-64::notebook-4.3.2-py35_0.tar.bz2
osx-64::notebook-4.2.0-py35_0.tar.bz2
osx-64::notebook-4.1.0-py34_0.tar.bz2
osx-64::notebook-4.3.2-py27_0.tar.bz2
osx-64::notebook-4.2.1-py27_0.tar.bz2
osx-64::notebook-4.3.1-py34_0.tar.bz2
osx-64::notebook-4.2.1-py35_0.tar.bz2
osx-64::notebook-4.2.3-py35_0.tar.bz2
osx-64::notebook-4.4.1-py27_0.tar.bz2
osx-64::notebook-4.2.3-py27_0.tar.bz2
osx-64::notebook-4.1.0-py27_0.tar.bz2
osx-64::notebook-4.3.1-py27_0.tar.bz2
-    "traitlets"
+    "traitlets <5.10.0a0"
osx-64::notebook-5.2.0-py35_0.tar.bz2
osx-64::notebook-5.2.0-py35_1.tar.bz2
osx-64::notebook-5.2.2-py35_0.tar.bz2
osx-64::notebook-5.0.0-py36_0.tar.bz2
osx-64::notebook-5.2.2-py27_0.tar.bz2
osx-64::notebook-5.2.0-py36_1.tar.bz2
osx-64::notebook-5.2.2-py36_0.tar.bz2
osx-64::notebook-5.2.2-py27_1.tar.bz2
osx-64::notebook-5.2.2-py36_1.tar.bz2
osx-64::notebook-5.0.0-py35_0.tar.bz2
osx-64::notebook-5.2.1-py35_2.tar.bz2
osx-64::notebook-5.2.2-py35_1.tar.bz2
osx-64::notebook-5.2.0-py36_0.tar.bz2
osx-64::notebook-5.2.1-py36_2.tar.bz2
osx-64::notebook-5.1.0-py36_0.tar.bz2
osx-64::notebook-5.2.1-py27_2.tar.bz2
osx-64::notebook-5.1.0-py27_0.tar.bz2
osx-64::notebook-5.2.0-py27_1.tar.bz2
osx-64::notebook-5.0.0-py27_0.tar.bz2
osx-64::notebook-5.1.0-py35_0.tar.bz2
osx-64::notebook-5.2.0-py27_0.tar.bz2
-    "traitlets >=4.3"
+    "traitlets >=4.3,<5.10.0a0"
osx-64::notebook-6.0.3-py37_0.tar.bz2
osx-64::notebook-5.7.5-py27_0.tar.bz2
osx-64::notebook-6.0.3-py36_0.tar.bz2
osx-64::notebook-6.3.0-py36h5dafb3c_0.tar.bz2
osx-64::notebook-5.4.1-py35_0.tar.bz2
osx-64::notebook-6.0.0-py36_0.tar.bz2
osx-64::notebook-6.2.0-py39h6e9494a_0.tar.bz2
osx-64::notebook-5.4.0-py36_0.tar.bz2
osx-64::notebook-5.7.0-py35_0.tar.bz2
osx-64::notebook-6.3.0-py39h6e9494a_0.tar.bz2
osx-64::notebook-5.7.11-py39h6e9494a_0.tar.bz2
osx-64::notebook-6.1.3-py36h9f0ad1d_0.tar.bz2
osx-64::notebook-6.1.6-py39h6e9494a_0.tar.bz2
osx-64::notebook-6.1.4-py36hc560c46_0.tar.bz2
osx-64::notebook-6.0.0-py37_0.tar.bz2
osx-64::notebook-5.6.0-py36_1.tar.bz2
osx-64::notebook-5.7.11-py36h79c6626_0.tar.bz2
osx-64::notebook-5.7.6-py37_0.tar.bz2
osx-64::notebook-6.2.0-py38h50d1736_0.tar.bz2
osx-64::notebook-5.4.1-py36_0.tar.bz2
osx-64::notebook-5.7.5-py36_0.tar.bz2
osx-64::notebook-6.3.0-py36h79c6626_0.tar.bz2
osx-64::notebook-5.7.6-py27_0.tar.bz2
osx-64::notebook-6.1.4-py38h32f6830_1.tar.bz2
osx-64::notebook-6.1.2-py36hc560c46_0.tar.bz2
osx-64::notebook-5.7.8-py37_0.tar.bz2
osx-64::notebook-6.0.2-py38_0.tar.bz2
osx-64::notebook-6.0.1-py36_0.tar.bz2
osx-64::notebook-5.7.5-py37_0.tar.bz2
osx-64::notebook-6.1.0-py38h32f6830_0.tar.bz2
osx-64::notebook-5.7.0-py36_1000.tar.bz2
osx-64::notebook-5.7.8-py27_0.tar.bz2
osx-64::notebook-6.1.0-py37hc8dfbb8_0.tar.bz2
osx-64::notebook-6.1.6-py38h50d1736_0.tar.bz2
osx-64::notebook-5.7.8-py27_1.tar.bz2
osx-64::notebook-5.7.9-py36h9f0ad1d_0.tar.bz2
osx-64::notebook-5.7.1-py36_1000.tar.bz2
osx-64::notebook-5.6.0-py35_0.tar.bz2
osx-64::notebook-6.1.2-py37hc8dfbb8_0.tar.bz2
osx-64::notebook-6.0.3-py36h9f0ad1d_1.tar.bz2
osx-64::notebook-6.0.3-py37hc8dfbb8_0.tar.bz2
osx-64::notebook-6.1.3-py38h32f6830_0.tar.bz2
osx-64::notebook-6.1.5-py38h50d1736_0.tar.bz2
osx-64::notebook-5.4.0-py27_0.tar.bz2
osx-64::notebook-5.4.1-py27_0.tar.bz2
osx-64::notebook-5.5.0-py35_0.tar.bz2
osx-64::notebook-6.1.4-py38h32f6830_0.tar.bz2
osx-64::notebook-5.5.0-py36_0.tar.bz2
osx-64::notebook-6.1.5-py39h6e9494a_0.tar.bz2
osx-64::notebook-5.7.10-py36h9f0ad1d_0.tar.bz2
osx-64::notebook-5.7.8-py36_1.tar.bz2
osx-64::notebook-5.7.2-py27_1000.tar.bz2
osx-64::notebook-6.1.6-py36h79c6626_0.tar.bz2
osx-64::notebook-6.1.1-py36h9f0ad1d_0.tar.bz2
osx-64::notebook-5.3.1-py36_1.tar.bz2
osx-64::notebook-6.0.3-py37hc8dfbb8_1.tar.bz2
osx-64::notebook-5.7.8-py36_0.tar.bz2
osx-64::notebook-5.7.9-py37hc8dfbb8_0.tar.bz2
osx-64::notebook-5.7.0-py27_1000.tar.bz2
osx-64::notebook-5.7.7-py27_0.tar.bz2
osx-64::notebook-6.0.3-py36h9f0ad1d_0.tar.bz2
osx-64::notebook-5.7.2-py37_1000.tar.bz2
osx-64::notebook-5.7.4-py37_1.tar.bz2
osx-64::notebook-6.0.2-py37_0.tar.bz2
osx-64::notebook-5.7.2-py36_1000.tar.bz2
osx-64::notebook-6.3.0-py38h50d1736_0.tar.bz2
osx-64::notebook-6.0.2-py36_0.tar.bz2
osx-64::notebook-6.1.4-py37hc8dfbb8_0.tar.bz2
osx-64::notebook-5.3.1-py35_1.tar.bz2
osx-64::notebook-5.6.0-py27_0.tar.bz2
osx-64::notebook-5.7.4-py27_1.tar.bz2
osx-64::notebook-5.7.10-py37hc8dfbb8_0.tar.bz2
osx-64::notebook-6.1.4-py36h9f0ad1d_0.tar.bz2
osx-64::notebook-5.7.7-py37_0.tar.bz2
osx-64::notebook-6.1.4-py36hc560c46_1.tar.bz2
osx-64::notebook-5.7.8-py37_1.tar.bz2
osx-64::notebook-5.6.0-py37_1.tar.bz2
osx-64::notebook-6.0.3-py38h32f6830_1.tar.bz2
osx-64::notebook-5.4.0-py35_0.tar.bz2
osx-64::notebook-6.0.3-py36hc560c46_1.tar.bz2
osx-64::notebook-6.2.0-py36h5dafb3c_0.tar.bz2
osx-64::notebook-6.1.3-py36hc560c46_0.tar.bz2
osx-64::notebook-6.1.4-py36h9f0ad1d_1.tar.bz2
osx-64::notebook-6.1.1-py38h32f6830_0.tar.bz2
osx-64::notebook-5.6.0-py36_0.tar.bz2
osx-64::notebook-5.7.11-py38h50d1736_0.tar.bz2
osx-64::notebook-6.1.2-py38h32f6830_0.tar.bz2
osx-64::notebook-5.6.0-py35_1.tar.bz2
osx-64::notebook-6.1.1-py37hc8dfbb8_0.tar.bz2
osx-64::notebook-6.1.2-py36h9f0ad1d_0.tar.bz2
osx-64::notebook-6.0.3-py38h32f6830_0.tar.bz2
osx-64::notebook-5.7.11-py37hf985489_0.tar.bz2
osx-64::notebook-5.7.0-py27_0.tar.bz2
osx-64::notebook-5.7.0-py36_0.tar.bz2
osx-64::notebook-5.7.1-py27_1000.tar.bz2
osx-64::notebook-5.7.6-py36_0.tar.bz2
osx-64::notebook-6.2.0-py37hf985489_0.tar.bz2
osx-64::notebook-5.5.0-py27_0.tar.bz2
osx-64::notebook-6.1.5-py36h79c6626_0.tar.bz2
osx-64::notebook-6.1.1-py36hc560c46_0.tar.bz2
osx-64::notebook-6.1.4-py37hc8dfbb8_1.tar.bz2
osx-64::notebook-5.6.0-py27_1.tar.bz2
osx-64::notebook-6.1.4-py39hde42818_1.tar.bz2
osx-64::notebook-6.2.0-py36h79c6626_0.tar.bz2
osx-64::notebook-5.7.4-py36_1.tar.bz2
osx-64::notebook-6.1.5-py36h5dafb3c_0.tar.bz2
osx-64::notebook-6.1.0-py36hc560c46_0.tar.bz2
osx-64::notebook-6.0.3-py38_0.tar.bz2
osx-64::notebook-6.2.0-py37h5186d4c_0.tar.bz2
osx-64::notebook-5.7.7-py36_0.tar.bz2
osx-64::notebook-5.3.1-py27_1.tar.bz2
osx-64::notebook-6.0.1-py37_0.tar.bz2
osx-64::notebook-6.1.3-py37hc8dfbb8_0.tar.bz2
osx-64::notebook-6.0.1-py38_0.tar.bz2
osx-64::notebook-6.1.5-py37hf985489_0.tar.bz2
osx-64::notebook-5.7.1-py37_1000.tar.bz2
osx-64::notebook-6.1.0-py36h9f0ad1d_0.tar.bz2
osx-64::notebook-5.7.0-py37_1000.tar.bz2
osx-64::notebook-6.1.6-py36h5dafb3c_0.tar.bz2
osx-64::notebook-6.3.0-py37h5186d4c_0.tar.bz2
osx-64::notebook-6.1.6-py37hf985489_0.tar.bz2
osx-64::notebook-6.3.0-py37hf985489_0.tar.bz2
-    "traitlets >=4.2.1"
+    "traitlets >=4.2.1,<5.10.0a0"
================================================================================
================================================================================
linux-64
linux-64::notebook-4.4.1-py36_0.tar.bz2
linux-64::notebook-4.2.1-py34_0.tar.bz2
linux-64::notebook-4.3.2-py35_0.tar.bz2
linux-64::notebook-4.2.0-py34_0.tar.bz2
linux-64::notebook-4.3.1-py34_0.tar.bz2
linux-64::notebook-4.3.1-py35_0.tar.bz2
linux-64::notebook-4.1.0-py34_0.tar.bz2
linux-64::notebook-4.2.3-py27_0.tar.bz2
linux-64::notebook-4.2.2-py35_0.tar.bz2
linux-64::notebook-4.2.0-py35_0.tar.bz2
linux-64::notebook-4.2.2-py34_0.tar.bz2
linux-64::notebook-4.2.1-py27_0.tar.bz2
linux-64::notebook-4.3.2-py27_0.tar.bz2
linux-64::notebook-4.2.2-py27_0.tar.bz2
linux-64::notebook-4.1.0-py27_0.tar.bz2
linux-64::notebook-4.2.1-py35_0.tar.bz2
linux-64::notebook-4.1.0-py35_0.tar.bz2
linux-64::notebook-4.4.1-py35_0.tar.bz2
linux-64::notebook-4.2.3-py35_0.tar.bz2
linux-64::notebook-4.2.3-py34_0.tar.bz2
linux-64::notebook-4.4.1-py27_0.tar.bz2
linux-64::notebook-4.3.1-py27_0.tar.bz2
linux-64::notebook-4.2.0-py27_0.tar.bz2
linux-64::notebook-4.3.2-py36_0.tar.bz2
-    "traitlets"
+    "traitlets <5.10.0a0"
linux-64::notebook-5.2.0-py35_1.tar.bz2
linux-64::notebook-5.2.1-py35_2.tar.bz2
linux-64::notebook-5.2.2-py36_0.tar.bz2
linux-64::notebook-5.3.1-py36_0.tar.bz2
linux-64::notebook-5.2.0-py35_0.tar.bz2
linux-64::notebook-5.0.0-py35_0.tar.bz2
linux-64::notebook-5.2.2-py27_0.tar.bz2
linux-64::notebook-5.1.0-py35_0.tar.bz2
linux-64::notebook-5.2.0-py36_1.tar.bz2
linux-64::notebook-5.2.2-py27_1.tar.bz2
linux-64::notebook-5.2.1-py27_2.tar.bz2
linux-64::notebook-5.0.0-py27_0.tar.bz2
linux-64::notebook-5.0.0-py36_0.tar.bz2
linux-64::notebook-5.2.1-py36_2.tar.bz2
linux-64::notebook-5.2.0-py27_0.tar.bz2
linux-64::notebook-5.2.2-py35_1.tar.bz2
linux-64::notebook-5.2.0-py27_1.tar.bz2
linux-64::notebook-5.3.1-py35_0.tar.bz2
linux-64::notebook-5.2.0-py36_0.tar.bz2
linux-64::notebook-5.1.0-py36_0.tar.bz2
linux-64::notebook-5.2.2-py36_1.tar.bz2
linux-64::notebook-5.2.2-py35_0.tar.bz2
linux-64::notebook-5.3.1-py27_0.tar.bz2
linux-64::notebook-5.1.0-py27_0.tar.bz2
-    "traitlets >=4.3"
+    "traitlets >=4.3,<5.10.0a0"
linux-64::notebook-5.7.0-py35_0.tar.bz2
linux-64::notebook-5.7.11-py39hf3d152e_0.tar.bz2
linux-64::notebook-5.7.1-py27_1000.tar.bz2
linux-64::notebook-5.3.1-py36_2.tar.bz2
linux-64::notebook-6.0.2-py37_0.tar.bz2
linux-64::notebook-6.1.0-py37hc8dfbb8_0.tar.bz2
linux-64::notebook-5.7.5-py37_0.tar.bz2
linux-64::notebook-6.1.4-py36hc560c46_0.tar.bz2
linux-64::notebook-6.0.3-py36h9f0ad1d_0.tar.bz2
linux-64::notebook-5.3.1-py27_1.tar.bz2
linux-64::notebook-5.7.8-py37_1.tar.bz2
linux-64::notebook-6.1.2-py36hc560c46_0.tar.bz2
linux-64::notebook-6.2.0-py39hf3d152e_0.tar.bz2
linux-64::notebook-6.1.0-py36hc560c46_0.tar.bz2
linux-64::notebook-6.2.0-py37h9c2f6ca_0.tar.bz2
linux-64::notebook-5.4.0-py35_0.tar.bz2
linux-64::notebook-5.7.2-py27_1000.tar.bz2
linux-64::notebook-5.4.1-py36_0.tar.bz2
linux-64::notebook-5.7.8-py37_0.tar.bz2
linux-64::notebook-5.7.2-py37_1000.tar.bz2
linux-64::notebook-5.3.1-py35_2.tar.bz2
linux-64::notebook-5.7.1-py36_1000.tar.bz2
linux-64::notebook-5.6.0-py36_0.tar.bz2
linux-64::notebook-6.1.1-py37hc8dfbb8_0.tar.bz2
linux-64::notebook-5.4.0-py36_0.tar.bz2
linux-64::notebook-6.0.3-py38h32f6830_0.tar.bz2
linux-64::notebook-5.4.1-py35_0.tar.bz2
linux-64::notebook-6.1.4-py37hc8dfbb8_0.tar.bz2
linux-64::notebook-5.7.0-py27_0.tar.bz2
linux-64::notebook-5.7.8-py36_0.tar.bz2
linux-64::notebook-6.1.4-py36hc560c46_1.tar.bz2
linux-64::notebook-5.7.1-py37_1000.tar.bz2
linux-64::notebook-5.7.10-py36h9f0ad1d_0.tar.bz2
linux-64::notebook-6.1.4-py38h32f6830_1.tar.bz2
linux-64::notebook-6.1.6-py38h578d9bd_0.tar.bz2
linux-64::notebook-6.1.4-py37hc8dfbb8_1.tar.bz2
linux-64::notebook-5.7.7-py37_0.tar.bz2
linux-64::notebook-5.3.1-py35_1.tar.bz2
linux-64::notebook-6.0.2-py38_0.tar.bz2
linux-64::notebook-6.2.0-py37h89c1867_0.tar.bz2
linux-64::notebook-6.0.3-py36_0.tar.bz2
linux-64::notebook-6.1.2-py36h9f0ad1d_0.tar.bz2
linux-64::notebook-6.1.5-py36hd000896_0.tar.bz2
linux-64::notebook-6.3.0-py37h89c1867_0.tar.bz2
linux-64::notebook-5.7.4-py27_1.tar.bz2
linux-64::notebook-6.2.0-py38h578d9bd_0.tar.bz2
linux-64::notebook-5.7.7-py27_0.tar.bz2
linux-64::notebook-5.7.0-py36_1000.tar.bz2
linux-64::notebook-6.0.3-py36h9f0ad1d_1.tar.bz2
linux-64::notebook-5.7.11-py37h89c1867_0.tar.bz2
linux-64::notebook-5.7.6-py36_0.tar.bz2
linux-64::notebook-6.0.3-py36hc560c46_1.tar.bz2
linux-64::notebook-6.1.2-py37hc8dfbb8_0.tar.bz2
linux-64::notebook-5.7.9-py37hc8dfbb8_0.tar.bz2
linux-64::notebook-5.7.11-py36h5fab9bb_0.tar.bz2
linux-64::notebook-6.3.0-py39hf3d152e_0.tar.bz2
linux-64::notebook-5.6.0-py27_1.tar.bz2
linux-64::notebook-5.7.5-py36_0.tar.bz2
linux-64::notebook-6.1.3-py36h9f0ad1d_0.tar.bz2
linux-64::notebook-6.0.2-py36_0.tar.bz2
linux-64::notebook-5.3.1-py27_2.tar.bz2
linux-64::notebook-6.1.3-py37hc8dfbb8_0.tar.bz2
linux-64::notebook-5.7.8-py27_0.tar.bz2
linux-64::notebook-6.0.0-py36_0.tar.bz2
linux-64::notebook-6.1.6-py36h5fab9bb_0.tar.bz2
linux-64::notebook-6.1.0-py36h9f0ad1d_0.tar.bz2
linux-64::notebook-5.7.2-py36_1000.tar.bz2
linux-64::notebook-5.7.0-py27_1000.tar.bz2
linux-64::notebook-5.7.0-py37_1000.tar.bz2
linux-64::notebook-5.6.0-py27_0.tar.bz2
linux-64::notebook-6.0.3-py38_0.tar.bz2
linux-64::notebook-5.7.6-py37_0.tar.bz2
linux-64::notebook-6.1.3-py38h32f6830_0.tar.bz2
linux-64::notebook-6.1.5-py38h578d9bd_0.tar.bz2
linux-64::notebook-5.6.0-py35_0.tar.bz2
linux-64::notebook-6.0.3-py38h32f6830_1.tar.bz2
linux-64::notebook-6.1.0-py38h32f6830_0.tar.bz2
linux-64::notebook-5.6.0-py36_1.tar.bz2
linux-64::notebook-6.1.2-py38h32f6830_0.tar.bz2
linux-64::notebook-5.7.8-py27_1.tar.bz2
linux-64::notebook-5.5.0-py27_0.tar.bz2
linux-64::notebook-6.0.3-py37hc8dfbb8_1.tar.bz2
linux-64::notebook-5.3.1-py36_1.tar.bz2
linux-64::notebook-6.1.1-py38h32f6830_0.tar.bz2
linux-64::notebook-6.1.3-py36hc560c46_0.tar.bz2
linux-64::notebook-6.0.1-py36_0.tar.bz2
linux-64::notebook-6.3.0-py36h5fab9bb_0.tar.bz2
linux-64::notebook-5.4.1-py27_0.tar.bz2
linux-64::notebook-5.7.4-py36_1.tar.bz2
linux-64::notebook-6.1.6-py37h89c1867_0.tar.bz2
linux-64::notebook-5.7.7-py36_0.tar.bz2
linux-64::notebook-6.1.1-py36h9f0ad1d_0.tar.bz2
linux-64::notebook-6.1.4-py36h9f0ad1d_1.tar.bz2
linux-64::notebook-5.7.6-py27_0.tar.bz2
linux-64::notebook-6.3.0-py36hd000896_0.tar.bz2
linux-64::notebook-5.7.9-py36h9f0ad1d_0.tar.bz2
linux-64::notebook-6.3.0-py38h578d9bd_0.tar.bz2
linux-64::notebook-6.1.5-py39hf3d152e_0.tar.bz2
linux-64::notebook-6.1.4-py38h32f6830_0.tar.bz2
linux-64::notebook-5.7.10-py37hc8dfbb8_0.tar.bz2
linux-64::notebook-6.1.1-py36hc560c46_0.tar.bz2
linux-64::notebook-6.3.0-py37h9c2f6ca_0.tar.bz2
linux-64::notebook-6.0.0-py37_0.tar.bz2
linux-64::notebook-6.0.1-py37_0.tar.bz2
linux-64::notebook-6.0.3-py37_0.tar.bz2
linux-64::notebook-5.7.8-py36_1.tar.bz2
linux-64::notebook-6.0.3-py37hc8dfbb8_0.tar.bz2
linux-64::notebook-5.7.4-py37_1.tar.bz2
linux-64::notebook-6.1.6-py39hf3d152e_0.tar.bz2
linux-64::notebook-5.4.0-py27_0.tar.bz2
linux-64::notebook-5.5.0-py35_0.tar.bz2
linux-64::notebook-6.2.0-py36h5fab9bb_0.tar.bz2
linux-64::notebook-5.6.0-py35_1.tar.bz2
linux-64::notebook-6.1.5-py37h89c1867_0.tar.bz2
linux-64::notebook-6.1.5-py36h5fab9bb_0.tar.bz2
linux-64::notebook-5.7.11-py38h578d9bd_0.tar.bz2
linux-64::notebook-6.0.1-py38_0.tar.bz2
linux-64::notebook-6.1.6-py36hd000896_0.tar.bz2
linux-64::notebook-6.2.0-py36hd000896_0.tar.bz2
linux-64::notebook-5.7.0-py36_0.tar.bz2
linux-64::notebook-5.6.0-py37_1.tar.bz2
linux-64::notebook-6.1.4-py39hde42818_1.tar.bz2
linux-64::notebook-6.1.4-py36h9f0ad1d_0.tar.bz2
linux-64::notebook-5.7.5-py27_0.tar.bz2
linux-64::notebook-5.5.0-py36_0.tar.bz2
-    "traitlets >=4.2.1"
+    "traitlets >=4.2.1,<5.10.0a0"

```