### PR TITLE
Fix mamba and conda-build with latest conda

### DIFF
--- a/recipe/patch_yaml/conda-build.yaml
+++ b/recipe/patch_yaml/conda-build.yaml
@@ -70,7 +70,8 @@ then:
       old: conda >=4.13
       new: conda >=23.7.3
 ---
-# conda-build <3.25.0 relied on get_prfix removed in https://github.com/conda/conda/commit/a26db05d5abd10a251128e2ce5092e7e8bb72f46
+# conda-build <3.25.0 relied on get_prfix removed in
+# https://github.com/conda/conda/commit/a26db05d5abd10a251128e2ce5092e7e8bb72f46
 if:
   name: conda-build
   version_lt: 3.25.0

--- a/recipe/patch_yaml/conda-build.yaml
+++ b/recipe/patch_yaml/conda-build.yaml
@@ -69,3 +69,12 @@ then:
   - replace_depends:
       old: conda >=4.13
       new: conda >=23.7.3
+---
+# conda-build <3.25.0 relied on get_prfix removed in https://github.com/conda/conda/commit/a26db05d5abd10a251128e2ce5092e7e8bb72f46
+if:
+  name: conda-build
+  version_lt: 3.25.0
+then:
+  - tighten_depends:
+      name: conda
+      upper_bound: 23.9.0

--- a/recipe/patch_yaml/mamba.yaml
+++ b/recipe/patch_yaml/mamba.yaml
@@ -119,3 +119,13 @@ then:
   - replace_depends:
       old: conda >=4.8,<23.4
       new: conda >=4.14,<23.4
+---
+# mamba <=1.5.1 relies on conda.cli.common.ensure_name_or_prefix
+# removed in https://github.com/conda/conda/pull/12948
+if:
+  name: mamba
+  version_le: 1.5.1
+then:
+  - tighten_depends:
+      name: conda
+      upper_bound: "23.9.0"

--- a/recipe/patch_yaml_utils.py
+++ b/recipe/patch_yaml_utils.py
@@ -349,7 +349,7 @@ def _pin_stricter(fn, record, fix_dep, max_pin, upper_bound=None):
                 new_upper = upper_bound.split(".")
             upper = pad_list(upper, len(new_upper))
             new_upper = pad_list(new_upper, len(upper))
-            if tuple(upper) > tuple(new_upper):
+            if parse_version(".".join(upper)) > parse_version(".".join(new_upper)):
                 if str(new_upper[-1]) != "0":
                     new_upper += ["0"]
                 depends[dep_idx] = "{} >={},<{}a0".format(


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<details>

```diff
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
osx-arm64::conda-build-3.21.9-py310hbe9552e_1.tar.bz2
osx-arm64::conda-build-3.21.9-py39h2804cbe_1.tar.bz2
osx-arm64::conda-build-3.22.0-py39h2804cbe_2.tar.bz2
osx-arm64::conda-build-3.22.0-py38h10201cd_0.tar.bz2
osx-arm64::conda-build-3.21.9-py38h10201cd_0.tar.bz2
osx-arm64::conda-build-3.22.0-py310hbe9552e_1.tar.bz2
osx-arm64::conda-build-3.22.0-py311h267d04e_3.tar.bz2
osx-arm64::conda-build-3.23.0-py38h10201cd_0.tar.bz2
osx-arm64::conda-build-3.23.0-py39h2804cbe_0.tar.bz2
osx-arm64::conda-build-3.22.0-py39h2804cbe_3.tar.bz2
osx-arm64::conda-build-3.22.0-py310hbe9552e_0.tar.bz2
osx-arm64::conda-build-3.21.8-py38h10201cd_1.tar.bz2
osx-arm64::conda-build-3.22.0-py38h10201cd_3.tar.bz2
osx-arm64::conda-build-3.22.0-py39h2804cbe_0.tar.bz2
osx-arm64::conda-build-3.21.9-py310hbe9552e_0.tar.bz2
osx-arm64::conda-build-3.22.0-py38h10201cd_1.tar.bz2
osx-arm64::conda-build-3.21.8-py310hbe9552e_1.tar.bz2
osx-arm64::conda-build-3.22.0-py38h10201cd_2.tar.bz2
osx-arm64::conda-build-3.23.0-py310hbe9552e_0.tar.bz2
osx-arm64::conda-build-3.22.0-py39h2804cbe_1.tar.bz2
osx-arm64::conda-build-3.21.9-py39h2804cbe_0.tar.bz2
osx-arm64::conda-build-3.21.9-py38h10201cd_1.tar.bz2
osx-arm64::conda-build-3.22.0-py310hbe9552e_3.tar.bz2
osx-arm64::conda-build-3.22.0-py310hbe9552e_2.tar.bz2
osx-arm64::conda-build-3.23.0-py311h267d04e_0.tar.bz2
osx-arm64::conda-build-3.21.8-py39h2804cbe_1.tar.bz2
-    "conda >=4.5",
+    "conda >=4.5,<23.9.0a0",
osx-arm64::conda-build-3.23.3-py310hbe9552e_0.conda
osx-arm64::conda-build-3.23.2-py38h10201cd_1.conda
osx-arm64::conda-build-3.23.0-py310hbe9552e_1.tar.bz2
osx-arm64::conda-build-3.24.0-py38h10201cd_0.conda
osx-arm64::conda-build-3.23.3-py311h267d04e_0.conda
osx-arm64::conda-build-3.23.3-py38h10201cd_1.conda
osx-arm64::conda-build-3.23.2-py311h267d04e_0.conda
osx-arm64::conda-build-3.23.0-py39h2804cbe_1.tar.bz2
osx-arm64::conda-build-3.23.2-py311h267d04e_1.conda
osx-arm64::conda-build-3.23.2-py310hbe9552e_0.conda
osx-arm64::conda-build-3.24.0-py39h2804cbe_1.conda
osx-arm64::conda-build-3.23.1-py310hbe9552e_0.conda
osx-arm64::conda-build-3.23.3-py39h2804cbe_1.conda
osx-arm64::conda-build-3.23.1-py311h267d04e_0.conda
osx-arm64::conda-build-3.24.0-py38h10201cd_1.conda
osx-arm64::conda-build-3.23.0-py38h10201cd_1.tar.bz2
osx-arm64::conda-build-3.23.1-py38h10201cd_0.conda
osx-arm64::conda-build-3.23.3-py39h2804cbe_0.conda
osx-arm64::conda-build-3.23.3-py311h267d04e_1.conda
osx-arm64::conda-build-3.24.0-py310hbe9552e_0.conda
osx-arm64::conda-build-3.23.1-py39h2804cbe_0.conda
osx-arm64::conda-build-3.23.2-py310hbe9552e_1.conda
osx-arm64::conda-build-3.23.2-py38h10201cd_0.conda
osx-arm64::conda-build-3.23.3-py310hbe9552e_1.conda
osx-arm64::conda-build-3.23.2-py39h2804cbe_1.conda
osx-arm64::conda-build-3.23.0-py311h267d04e_1.tar.bz2
osx-arm64::conda-build-3.24.0-py39h2804cbe_0.conda
osx-arm64::conda-build-3.24.0-py311h267d04e_0.conda
osx-arm64::conda-build-3.24.0-py311h267d04e_1.conda
osx-arm64::conda-build-3.24.0-py310hbe9552e_1.conda
osx-arm64::conda-build-3.23.2-py39h2804cbe_0.conda
osx-arm64::conda-build-3.23.3-py38h10201cd_0.conda
-    "conda >=4.13",
+    "conda >=4.13,<23.9.0a0",
osx-arm64::mamba-0.24.0-py310h25b57eb_1.tar.bz2
osx-arm64::mamba-0.24.0-py38h3ce6457_1.tar.bz2
osx-arm64::mamba-0.24.0-py39hde45b87_1.tar.bz2
-    "conda >=4.8",
+    "conda >=4.8,<23.9.0a0",
osx-arm64::mamba-1.5.1-py39ha55b623_0.conda
osx-arm64::mamba-1.4.4-py311hb045da1_1.conda
osx-arm64::mamba-1.5.0-py310ha5d4528_0.conda
osx-arm64::mamba-1.4.6-py310ha5d4528_0.conda
osx-arm64::mamba-1.4.5-py311hb045da1_0.conda
osx-arm64::mamba-1.4.4-py39ha55b623_1.conda
osx-arm64::mamba-1.4.6-py38hb2d7053_0.conda
osx-arm64::mamba-1.4.5-py310ha5d4528_0.conda
osx-arm64::mamba-1.4.9-py38hb2d7053_0.conda
osx-arm64::mamba-1.4.4-py310ha5d4528_1.conda
osx-arm64::mamba-1.4.7-py38hb2d7053_0.conda
osx-arm64::mamba-1.5.1-py38hb2d7053_0.conda
osx-arm64::mamba-1.5.0-py38hb2d7053_1.conda
osx-arm64::mamba-1.4.7-py311hb045da1_0.conda
osx-arm64::mamba-1.4.7-py310ha5d4528_0.conda
osx-arm64::mamba-1.5.0-py311hb045da1_0.conda
osx-arm64::mamba-1.4.6-py39ha55b623_0.conda
osx-arm64::mamba-1.4.5-py38hb2d7053_0.conda
osx-arm64::mamba-1.4.6-py311hb045da1_0.conda
osx-arm64::mamba-1.4.5-py39ha55b623_0.conda
osx-arm64::mamba-1.5.0-py39ha55b623_1.conda
osx-arm64::mamba-1.5.1-py311hb045da1_0.conda
osx-arm64::mamba-1.4.7-py39ha55b623_0.conda
osx-arm64::mamba-1.4.9-py311hb045da1_0.conda
osx-arm64::mamba-1.4.9-py39ha55b623_0.conda
osx-arm64::mamba-1.5.1-py310ha5d4528_0.conda
osx-arm64::mamba-1.5.0-py38hb2d7053_0.conda
osx-arm64::mamba-1.5.0-py310ha5d4528_1.conda
osx-arm64::mamba-1.4.9-py310ha5d4528_0.conda
osx-arm64::mamba-1.5.0-py39ha55b623_0.conda
osx-arm64::mamba-1.5.0-py311hb045da1_1.conda
osx-arm64::mamba-1.4.4-py38hb2d7053_1.conda
-    "conda >=4.14,<24.0a0",
+    "conda >=4.14,<23.9.0a0",
================================================================================
================================================================================
linux-ppc64le
linux-ppc64le::conda-build-3.23.0-py38h8328f6c_0.tar.bz2
linux-ppc64le::conda-build-3.22.0-py38h8328f6c_2.tar.bz2
linux-ppc64le::conda-build-3.22.0-py310h194a6c8_3.tar.bz2
linux-ppc64le::conda-build-3.22.0-py37h90f3e5f_0.tar.bz2
linux-ppc64le::conda-build-3.21.9-py38h8328f6c_0.tar.bz2
linux-ppc64le::conda-build-3.22.0-py310h194a6c8_2.tar.bz2
linux-ppc64le::conda-build-3.22.0-py311h1af927a_3.tar.bz2
linux-ppc64le::conda-build-3.21.9-py38h8328f6c_1.tar.bz2
linux-ppc64le::conda-build-3.22.0-py38h70b0696_2.tar.bz2
linux-ppc64le::conda-build-3.23.0-py310h194a6c8_0.tar.bz2
linux-ppc64le::conda-build-3.22.0-py39h0b1cf3c_0.tar.bz2
linux-ppc64le::conda-build-3.22.0-py37h90f3e5f_1.tar.bz2
linux-ppc64le::conda-build-3.22.0-py39h0b1cf3c_2.tar.bz2
linux-ppc64le::conda-build-3.22.0-py310h194a6c8_1.tar.bz2
linux-ppc64le::conda-build-3.22.0-py39h8d2a46d_3.tar.bz2
linux-ppc64le::conda-build-3.21.8-py38h8328f6c_1.tar.bz2
linux-ppc64le::conda-build-3.21.9-py39h0b1cf3c_0.tar.bz2
linux-ppc64le::conda-build-3.23.0-py39h8d2a46d_0.tar.bz2
linux-ppc64le::conda-build-3.22.0-py310h194a6c8_0.tar.bz2
linux-ppc64le::conda-build-3.22.0-py38h8328f6c_3.tar.bz2
linux-ppc64le::conda-build-3.23.0-py39h0b1cf3c_0.tar.bz2
linux-ppc64le::conda-build-3.21.9-py310h194a6c8_0.tar.bz2
linux-ppc64le::conda-build-3.22.0-py37h90f3e5f_2.tar.bz2
linux-ppc64le::conda-build-3.22.0-py38h8328f6c_0.tar.bz2
linux-ppc64le::conda-build-3.21.8-py37h90f3e5f_1.tar.bz2
linux-ppc64le::conda-build-3.22.0-py38h8328f6c_1.tar.bz2
linux-ppc64le::conda-build-3.21.9-py39h0b1cf3c_1.tar.bz2
linux-ppc64le::conda-build-3.21.9-py310h194a6c8_1.tar.bz2
linux-ppc64le::conda-build-3.21.9-py37h90f3e5f_1.tar.bz2
linux-ppc64le::conda-build-3.23.0-py38h70b0696_0.tar.bz2
linux-ppc64le::conda-build-3.23.0-py311h1af927a_0.tar.bz2
linux-ppc64le::conda-build-3.21.8-py39h0b1cf3c_1.tar.bz2
linux-ppc64le::conda-build-3.22.0-py39h8d2a46d_2.tar.bz2
linux-ppc64le::conda-build-3.22.0-py39h0b1cf3c_3.tar.bz2
linux-ppc64le::conda-build-3.22.0-py39h0b1cf3c_1.tar.bz2
linux-ppc64le::conda-build-3.21.9-py37h90f3e5f_0.tar.bz2
linux-ppc64le::conda-build-3.22.0-py38h70b0696_3.tar.bz2
linux-ppc64le::conda-build-3.21.8-py310h194a6c8_1.tar.bz2
-    "conda >=4.5",
+    "conda >=4.5,<23.9.0a0",
linux-ppc64le::conda-build-3.24.0-py311h1af927a_1.conda
linux-ppc64le::conda-build-3.23.3-py39h0b1cf3c_0.conda
linux-ppc64le::conda-build-3.23.2-py39h0b1cf3c_0.conda
linux-ppc64le::conda-build-3.23.3-py39h0b1cf3c_1.conda
linux-ppc64le::conda-build-3.23.3-py311h1af927a_0.conda
linux-ppc64le::conda-build-3.23.3-py310h194a6c8_1.conda
linux-ppc64le::conda-build-3.23.0-py311h1af927a_1.tar.bz2
linux-ppc64le::conda-build-3.23.0-py39h8d2a46d_1.tar.bz2
linux-ppc64le::conda-build-3.23.2-py39h8d2a46d_1.conda
linux-ppc64le::conda-build-3.23.2-py310h194a6c8_0.conda
linux-ppc64le::conda-build-3.23.1-py310h194a6c8_0.conda
linux-ppc64le::conda-build-3.23.1-py38h70b0696_0.conda
linux-ppc64le::conda-build-3.24.0-py38h70b0696_1.conda
linux-ppc64le::conda-build-3.23.3-py39h8d2a46d_1.conda
linux-ppc64le::conda-build-3.24.0-py39h8d2a46d_0.conda
linux-ppc64le::conda-build-3.23.0-py39h0b1cf3c_1.tar.bz2
linux-ppc64le::conda-build-3.24.0-py311h1af927a_0.conda
linux-ppc64le::conda-build-3.24.0-py39h0b1cf3c_0.conda
linux-ppc64le::conda-build-3.23.2-py38h8328f6c_0.conda
linux-ppc64le::conda-build-3.24.0-py39h8d2a46d_1.conda
linux-ppc64le::conda-build-3.23.2-py311h1af927a_1.conda
linux-ppc64le::conda-build-3.24.0-py38h8328f6c_0.conda
linux-ppc64le::conda-build-3.23.1-py311h1af927a_0.conda
linux-ppc64le::conda-build-3.23.1-py38h8328f6c_0.conda
linux-ppc64le::conda-build-3.23.2-py311h1af927a_0.conda
linux-ppc64le::conda-build-3.23.2-py38h70b0696_1.conda
linux-ppc64le::conda-build-3.23.2-py39h8d2a46d_0.conda
linux-ppc64le::conda-build-3.23.3-py38h70b0696_0.conda
linux-ppc64le::conda-build-3.24.0-py38h70b0696_0.conda
linux-ppc64le::conda-build-3.23.1-py39h8d2a46d_0.conda
linux-ppc64le::conda-build-3.23.3-py38h70b0696_1.conda
linux-ppc64le::conda-build-3.23.3-py38h8328f6c_0.conda
linux-ppc64le::conda-build-3.24.0-py38h8328f6c_1.conda
linux-ppc64le::conda-build-3.23.2-py38h8328f6c_1.conda
linux-ppc64le::conda-build-3.23.3-py310h194a6c8_0.conda
linux-ppc64le::conda-build-3.23.2-py310h194a6c8_1.conda
linux-ppc64le::conda-build-3.23.2-py39h0b1cf3c_1.conda
linux-ppc64le::conda-build-3.23.0-py38h8328f6c_1.tar.bz2
linux-ppc64le::conda-build-3.24.0-py310h194a6c8_1.conda
linux-ppc64le::conda-build-3.23.3-py311h1af927a_1.conda
linux-ppc64le::conda-build-3.23.3-py38h8328f6c_1.conda
linux-ppc64le::conda-build-3.23.0-py38h70b0696_1.tar.bz2
linux-ppc64le::conda-build-3.24.0-py310h194a6c8_0.conda
linux-ppc64le::conda-build-3.24.0-py39h0b1cf3c_1.conda
linux-ppc64le::conda-build-3.23.3-py39h8d2a46d_0.conda
linux-ppc64le::conda-build-3.23.2-py38h70b0696_0.conda
linux-ppc64le::conda-build-3.23.1-py39h0b1cf3c_0.conda
linux-ppc64le::conda-build-3.23.0-py310h194a6c8_1.tar.bz2
-    "conda >=4.13",
+    "conda >=4.13,<23.9.0a0",
linux-ppc64le::mamba-0.24.0-py37h7999fb9_1.tar.bz2
linux-ppc64le::mamba-0.24.0-py37h140ae9a_1.tar.bz2
linux-ppc64le::mamba-0.24.0-py310h0d84b84_1.tar.bz2
linux-ppc64le::mamba-0.24.0-py39h3651b5a_1.tar.bz2
linux-ppc64le::mamba-0.24.0-py38hbb959db_1.tar.bz2
-    "conda >=4.8",
+    "conda >=4.8,<23.9.0a0",
linux-ppc64le::mamba-1.4.9-py39ha24e7b4_0.conda
linux-ppc64le::mamba-1.5.0-py38h8e2b860_1.conda
linux-ppc64le::mamba-1.4.4-py310h400a96e_1.conda
linux-ppc64le::mamba-1.4.4-py311haa85789_1.conda
linux-ppc64le::mamba-1.4.4-py38h8e2b860_1.conda
linux-ppc64le::mamba-1.5.0-py311haa85789_1.conda
linux-ppc64le::mamba-1.4.5-py38h8e2b860_0.conda
linux-ppc64le::mamba-1.5.0-py39h82e2c57_0.conda
linux-ppc64le::mamba-1.4.6-py311haa85789_0.conda
linux-ppc64le::mamba-1.4.7-py39h82e2c57_0.conda
linux-ppc64le::mamba-1.4.6-py38h2c3d941_0.conda
linux-ppc64le::mamba-1.4.6-py38h8e2b860_0.conda
linux-ppc64le::mamba-1.5.0-py38h8e2b860_0.conda
linux-ppc64le::mamba-1.4.7-py39ha24e7b4_0.conda
linux-ppc64le::mamba-1.5.1-py38h2c3d941_0.conda
linux-ppc64le::mamba-1.4.7-py38h2c3d941_0.conda
linux-ppc64le::mamba-1.4.9-py311haa85789_0.conda
linux-ppc64le::mamba-1.5.0-py39ha24e7b4_1.conda
linux-ppc64le::mamba-1.4.7-py38h8e2b860_0.conda
linux-ppc64le::mamba-1.4.9-py39h82e2c57_0.conda
linux-ppc64le::mamba-1.4.6-py310h400a96e_0.conda
linux-ppc64le::mamba-1.4.5-py39h82e2c57_0.conda
linux-ppc64le::mamba-1.4.5-py310h400a96e_0.conda
linux-ppc64le::mamba-1.5.1-py39ha24e7b4_0.conda
linux-ppc64le::mamba-1.4.6-py39ha24e7b4_0.conda
linux-ppc64le::mamba-1.4.7-py311haa85789_0.conda
linux-ppc64le::mamba-1.5.1-py311haa85789_0.conda
linux-ppc64le::mamba-1.5.0-py38h2c3d941_1.conda
linux-ppc64le::mamba-1.4.6-py39h82e2c57_0.conda
linux-ppc64le::mamba-1.5.0-py39h82e2c57_1.conda
linux-ppc64le::mamba-1.5.0-py310h400a96e_0.conda
linux-ppc64le::mamba-1.4.4-py38h2c3d941_1.conda
linux-ppc64le::mamba-1.4.9-py310h400a96e_0.conda
linux-ppc64le::mamba-1.4.5-py39ha24e7b4_0.conda
linux-ppc64le::mamba-1.4.9-py38h8e2b860_0.conda
linux-ppc64le::mamba-1.5.0-py38h2c3d941_0.conda
linux-ppc64le::mamba-1.4.4-py39ha24e7b4_1.conda
linux-ppc64le::mamba-1.4.4-py39h82e2c57_1.conda
linux-ppc64le::mamba-1.4.9-py38h2c3d941_0.conda
linux-ppc64le::mamba-1.4.7-py310h400a96e_0.conda
linux-ppc64le::mamba-1.4.5-py38h2c3d941_0.conda
linux-ppc64le::mamba-1.5.1-py39h82e2c57_0.conda
linux-ppc64le::mamba-1.4.5-py311haa85789_0.conda
linux-ppc64le::mamba-1.5.0-py311haa85789_0.conda
linux-ppc64le::mamba-1.5.0-py39ha24e7b4_0.conda
linux-ppc64le::mamba-1.5.1-py310h400a96e_0.conda
linux-ppc64le::mamba-1.5.0-py310h400a96e_1.conda
linux-ppc64le::mamba-1.5.1-py38h8e2b860_0.conda
-    "conda >=4.14,<24.0a0",
+    "conda >=4.14,<23.9.0a0",
================================================================================
================================================================================
linux-aarch64
linux-aarch64::conda-build-3.21.9-py310h4c7bcd0_0.tar.bz2
linux-aarch64::conda-build-3.22.0-py39h387a52e_3.tar.bz2
linux-aarch64::conda-build-3.22.0-py38he3eb160_1.tar.bz2
linux-aarch64::conda-build-3.21.9-py37hfd236b0_0.tar.bz2
linux-aarch64::conda-build-3.23.0-py39h387a52e_0.tar.bz2
linux-aarch64::conda-build-3.22.0-py38h3d695ea_2.tar.bz2
linux-aarch64::conda-build-3.22.0-py38h3d695ea_3.tar.bz2
linux-aarch64::conda-build-3.23.0-py38h3d695ea_0.tar.bz2
linux-aarch64::conda-build-3.22.0-py39h4420490_1.tar.bz2
linux-aarch64::conda-build-3.22.0-py311hec3470c_3.tar.bz2
linux-aarch64::conda-build-3.23.0-py310h4c7bcd0_0.tar.bz2
linux-aarch64::conda-build-3.22.0-py39h4420490_3.tar.bz2
linux-aarch64::conda-build-3.21.9-py39h4420490_0.tar.bz2
linux-aarch64::conda-build-3.21.8-py38he3eb160_1.tar.bz2
linux-aarch64::conda-build-3.23.0-py38he3eb160_0.tar.bz2
linux-aarch64::conda-build-3.21.9-py38he3eb160_0.tar.bz2
linux-aarch64::conda-build-3.22.0-py310h4c7bcd0_1.tar.bz2
linux-aarch64::conda-build-3.21.9-py310h4c7bcd0_1.tar.bz2
linux-aarch64::conda-build-3.21.9-py39h4420490_1.tar.bz2
linux-aarch64::conda-build-3.22.0-py39h387a52e_2.tar.bz2
linux-aarch64::conda-build-3.22.0-py310h4c7bcd0_3.tar.bz2
linux-aarch64::conda-build-3.21.8-py310h4c7bcd0_1.tar.bz2
linux-aarch64::conda-build-3.22.0-py38he3eb160_0.tar.bz2
linux-aarch64::conda-build-3.22.0-py310h4c7bcd0_2.tar.bz2
linux-aarch64::conda-build-3.22.0-py37hfd236b0_1.tar.bz2
linux-aarch64::conda-build-3.22.0-py310h4c7bcd0_0.tar.bz2
linux-aarch64::conda-build-3.23.0-py311hec3470c_0.tar.bz2
linux-aarch64::conda-build-3.21.9-py37hfd236b0_1.tar.bz2
linux-aarch64::conda-build-3.22.0-py39h4420490_0.tar.bz2
linux-aarch64::conda-build-3.22.0-py37hfd236b0_2.tar.bz2
linux-aarch64::conda-build-3.22.0-py38he3eb160_3.tar.bz2
linux-aarch64::conda-build-3.22.0-py39h4420490_2.tar.bz2
linux-aarch64::conda-build-3.21.9-py38he3eb160_1.tar.bz2
linux-aarch64::conda-build-3.21.8-py37hfd236b0_1.tar.bz2
linux-aarch64::conda-build-3.21.8-py39h4420490_1.tar.bz2
linux-aarch64::conda-build-3.22.0-py37hfd236b0_0.tar.bz2
linux-aarch64::conda-build-3.23.0-py39h4420490_0.tar.bz2
linux-aarch64::conda-build-3.22.0-py38he3eb160_2.tar.bz2
-    "conda >=4.5",
+    "conda >=4.5,<23.9.0a0",
linux-aarch64::conda-build-3.23.1-py311hec3470c_0.conda
linux-aarch64::conda-build-3.23.2-py39h4420490_0.conda
linux-aarch64::conda-build-3.23.2-py38he3eb160_1.conda
linux-aarch64::conda-build-3.23.2-py39h4420490_1.conda
linux-aarch64::conda-build-3.23.0-py38h3d695ea_1.tar.bz2
linux-aarch64::conda-build-3.23.2-py38h3d695ea_0.conda
linux-aarch64::conda-build-3.24.0-py38h3d695ea_0.conda
linux-aarch64::conda-build-3.23.2-py311hec3470c_0.conda
linux-aarch64::conda-build-3.23.3-py39h4420490_0.conda
linux-aarch64::conda-build-3.23.3-py39h4420490_1.conda
linux-aarch64::conda-build-3.23.1-py38he3eb160_0.conda
linux-aarch64::conda-build-3.23.3-py311hec3470c_1.conda
linux-aarch64::conda-build-3.23.3-py39h387a52e_0.conda
linux-aarch64::conda-build-3.23.2-py38he3eb160_0.conda
linux-aarch64::conda-build-3.23.3-py38he3eb160_0.conda
linux-aarch64::conda-build-3.23.1-py38h3d695ea_0.conda
linux-aarch64::conda-build-3.23.2-py39h387a52e_1.conda
linux-aarch64::conda-build-3.23.1-py39h4420490_0.conda
linux-aarch64::conda-build-3.23.3-py38he3eb160_1.conda
linux-aarch64::conda-build-3.23.2-py310h4c7bcd0_0.conda
linux-aarch64::conda-build-3.23.0-py39h387a52e_1.tar.bz2
linux-aarch64::conda-build-3.24.0-py38h3d695ea_1.conda
linux-aarch64::conda-build-3.23.3-py39h387a52e_1.conda
linux-aarch64::conda-build-3.23.3-py38h3d695ea_0.conda
linux-aarch64::conda-build-3.24.0-py311hec3470c_1.conda
linux-aarch64::conda-build-3.23.2-py39h387a52e_0.conda
linux-aarch64::conda-build-3.23.3-py310h4c7bcd0_0.conda
linux-aarch64::conda-build-3.24.0-py311hec3470c_0.conda
linux-aarch64::conda-build-3.23.1-py310h4c7bcd0_0.conda
linux-aarch64::conda-build-3.23.0-py39h4420490_1.tar.bz2
linux-aarch64::conda-build-3.24.0-py39h4420490_0.conda
linux-aarch64::conda-build-3.24.0-py38he3eb160_0.conda
linux-aarch64::conda-build-3.23.3-py310h4c7bcd0_1.conda
linux-aarch64::conda-build-3.23.2-py311hec3470c_1.conda
linux-aarch64::conda-build-3.23.1-py39h387a52e_0.conda
linux-aarch64::conda-build-3.23.2-py38h3d695ea_1.conda
linux-aarch64::conda-build-3.23.3-py311hec3470c_0.conda
linux-aarch64::conda-build-3.23.3-py38h3d695ea_1.conda
linux-aarch64::conda-build-3.24.0-py39h387a52e_1.conda
linux-aarch64::conda-build-3.23.0-py38he3eb160_1.tar.bz2
linux-aarch64::conda-build-3.23.0-py310h4c7bcd0_1.tar.bz2
linux-aarch64::conda-build-3.24.0-py310h4c7bcd0_1.conda
linux-aarch64::conda-build-3.24.0-py39h387a52e_0.conda
linux-aarch64::conda-build-3.24.0-py39h4420490_1.conda
linux-aarch64::conda-build-3.24.0-py310h4c7bcd0_0.conda
linux-aarch64::conda-build-3.23.0-py311hec3470c_1.tar.bz2
linux-aarch64::conda-build-3.24.0-py38he3eb160_1.conda
linux-aarch64::conda-build-3.23.2-py310h4c7bcd0_1.conda
-    "conda >=4.13",
+    "conda >=4.13,<23.9.0a0",
linux-aarch64::mamba-0.24.0-py38h0280004_1.tar.bz2
linux-aarch64::mamba-0.24.0-py310hcf12e44_1.tar.bz2
linux-aarch64::mamba-0.24.0-py37h5fa458c_1.tar.bz2
linux-aarch64::mamba-0.24.0-py37h61affeb_1.tar.bz2
linux-aarch64::mamba-0.24.0-py39hc9db4b5_1.tar.bz2
-    "conda >=4.8",
+    "conda >=4.8,<23.9.0a0",
linux-aarch64::mamba-1.4.9-py39h927961e_0.conda
linux-aarch64::mamba-1.5.1-py39h83cf0c7_0.conda
linux-aarch64::mamba-1.4.9-py311hb6c5aa6_0.conda
linux-aarch64::mamba-1.4.6-py38hf92fa3f_0.conda
linux-aarch64::mamba-1.4.6-py311hb6c5aa6_0.conda
linux-aarch64::mamba-1.5.1-py311hb6c5aa6_0.conda
linux-aarch64::mamba-1.4.4-py38hf92fa3f_1.conda
linux-aarch64::mamba-1.4.6-py310hcbdc16a_0.conda
linux-aarch64::mamba-1.4.5-py310hcbdc16a_0.conda
linux-aarch64::mamba-1.4.5-py39h83cf0c7_0.conda
linux-aarch64::mamba-1.5.0-py310hcbdc16a_1.conda
linux-aarch64::mamba-1.5.0-py39h83cf0c7_1.conda
linux-aarch64::mamba-1.4.5-py38hf92fa3f_0.conda
linux-aarch64::mamba-1.5.1-py310hcbdc16a_0.conda
linux-aarch64::mamba-1.5.0-py38h837c1e7_0.conda
linux-aarch64::mamba-1.4.4-py39h927961e_1.conda
linux-aarch64::mamba-1.4.5-py39h927961e_0.conda
linux-aarch64::mamba-1.4.4-py311hb6c5aa6_1.conda
linux-aarch64::mamba-1.4.9-py310hcbdc16a_0.conda
linux-aarch64::mamba-1.4.4-py38h837c1e7_1.conda
linux-aarch64::mamba-1.4.7-py39h927961e_0.conda
linux-aarch64::mamba-1.4.9-py39h83cf0c7_0.conda
linux-aarch64::mamba-1.4.7-py310hcbdc16a_0.conda
linux-aarch64::mamba-1.5.0-py310hcbdc16a_0.conda
linux-aarch64::mamba-1.5.0-py38hf92fa3f_0.conda
linux-aarch64::mamba-1.4.5-py311hb6c5aa6_0.conda
linux-aarch64::mamba-1.5.1-py39h927961e_0.conda
linux-aarch64::mamba-1.4.7-py38hf92fa3f_0.conda
linux-aarch64::mamba-1.4.7-py311hb6c5aa6_0.conda
linux-aarch64::mamba-1.5.1-py38h837c1e7_0.conda
linux-aarch64::mamba-1.4.6-py39h83cf0c7_0.conda
linux-aarch64::mamba-1.5.1-py38hf92fa3f_0.conda
linux-aarch64::mamba-1.4.7-py38h837c1e7_0.conda
linux-aarch64::mamba-1.5.0-py311hb6c5aa6_1.conda
linux-aarch64::mamba-1.4.4-py39h83cf0c7_1.conda
linux-aarch64::mamba-1.4.9-py38h837c1e7_0.conda
linux-aarch64::mamba-1.4.6-py39h927961e_0.conda
linux-aarch64::mamba-1.5.0-py311hb6c5aa6_0.conda
linux-aarch64::mamba-1.5.0-py39h83cf0c7_0.conda
linux-aarch64::mamba-1.4.6-py38h837c1e7_0.conda
linux-aarch64::mamba-1.4.4-py310hcbdc16a_1.conda
linux-aarch64::mamba-1.4.9-py38hf92fa3f_0.conda
linux-aarch64::mamba-1.5.0-py38h837c1e7_1.conda
linux-aarch64::mamba-1.5.0-py39h927961e_0.conda
linux-aarch64::mamba-1.4.5-py38h837c1e7_0.conda
linux-aarch64::mamba-1.5.0-py39h927961e_1.conda
linux-aarch64::mamba-1.5.0-py38hf92fa3f_1.conda
linux-aarch64::mamba-1.4.7-py39h83cf0c7_0.conda
-    "conda >=4.14,<24.0a0",
+    "conda >=4.14,<23.9.0a0",
================================================================================
================================================================================
noarch
================================================================================
================================================================================
win-64
win-64::conda-build-3.21.9-py38haa244fe_0.tar.bz2
win-64::conda-build-3.22.0-py37h03978a9_1.tar.bz2
win-64::conda-build-3.22.0-py38h32ec214_2.tar.bz2
win-64::conda-build-3.23.0-py311h1ea47a8_0.tar.bz2
win-64::conda-build-3.21.9-py39hcbf5309_0.tar.bz2
win-64::conda-build-3.22.0-py38h32ec214_3.tar.bz2
win-64::conda-build-3.22.0-py39h0d475fb_3.tar.bz2
win-64::conda-build-3.21.9-py39hcbf5309_1.tar.bz2
win-64::conda-build-3.22.0-py38haa244fe_3.tar.bz2
win-64::conda-build-3.22.0-py39h0d475fb_2.tar.bz2
win-64::conda-build-3.22.0-py38haa244fe_0.tar.bz2
win-64::conda-build-3.21.9-py310h5588dad_1.tar.bz2
win-64::conda-build-3.22.0-py39hcbf5309_2.tar.bz2
win-64::conda-build-3.22.0-py310h5588dad_2.tar.bz2
win-64::conda-build-3.22.0-py39hcbf5309_1.tar.bz2
win-64::conda-build-3.21.9-py37h03978a9_0.tar.bz2
win-64::conda-build-3.22.0-py310h5588dad_1.tar.bz2
win-64::conda-build-3.23.0-py39h0d475fb_0.tar.bz2
win-64::conda-build-3.21.8-py39hcbf5309_1.tar.bz2
win-64::conda-build-3.21.9-py38haa244fe_1.tar.bz2
win-64::conda-build-3.22.0-py37h03978a9_2.tar.bz2
win-64::conda-build-3.22.0-py311h1ea47a8_3.tar.bz2
win-64::conda-build-3.23.0-py38h32ec214_0.tar.bz2
win-64::conda-build-3.21.8-py38haa244fe_1.tar.bz2
win-64::conda-build-3.22.0-py38haa244fe_1.tar.bz2
win-64::conda-build-3.22.0-py38haa244fe_2.tar.bz2
win-64::conda-build-3.23.0-py38haa244fe_0.tar.bz2
win-64::conda-build-3.21.8-py37h03978a9_1.tar.bz2
win-64::conda-build-3.21.8-py310h5588dad_1.tar.bz2
win-64::conda-build-3.21.9-py37h03978a9_1.tar.bz2
win-64::conda-build-3.23.0-py310h5588dad_0.tar.bz2
win-64::conda-build-3.22.0-py39hcbf5309_3.tar.bz2
win-64::conda-build-3.22.0-py37h03978a9_0.tar.bz2
win-64::conda-build-3.23.0-py39hcbf5309_0.tar.bz2
win-64::conda-build-3.22.0-py39hcbf5309_0.tar.bz2
win-64::conda-build-3.22.0-py310h5588dad_3.tar.bz2
win-64::conda-build-3.22.0-py310h5588dad_0.tar.bz2
win-64::conda-build-3.21.9-py310h5588dad_0.tar.bz2
-    "conda >=4.5",
+    "conda >=4.5,<23.9.0a0",
win-64::conda-build-3.24.0-py310h5588dad_0.conda
win-64::conda-build-3.23.0-py39hcbf5309_1.tar.bz2
win-64::conda-build-3.24.0-py38h32ec214_1.conda
win-64::conda-build-3.24.0-py311h1ea47a8_0.conda
win-64::conda-build-3.23.2-py310h5588dad_0.conda
win-64::conda-build-3.23.2-py39h0d475fb_0.conda
win-64::conda-build-3.24.0-py310h5588dad_1.conda
win-64::conda-build-3.23.0-py311h1ea47a8_1.tar.bz2
win-64::conda-build-3.23.2-py311h1ea47a8_1.conda
win-64::conda-build-3.23.2-py310h5588dad_1.conda
win-64::conda-build-3.23.3-py311h1ea47a8_1.conda
win-64::conda-build-3.23.3-py38h32ec214_0.conda
win-64::conda-build-3.23.3-py310h5588dad_0.conda
win-64::conda-build-3.23.3-py39hcbf5309_0.conda
win-64::conda-build-3.23.3-py38haa244fe_0.conda
win-64::conda-build-3.24.0-py39h0d475fb_0.conda
win-64::conda-build-3.23.2-py38haa244fe_0.conda
win-64::conda-build-3.23.2-py39hcbf5309_0.conda
win-64::conda-build-3.24.0-py38haa244fe_0.conda
win-64::conda-build-3.23.0-py38haa244fe_1.tar.bz2
win-64::conda-build-3.23.0-py310h5588dad_1.tar.bz2
win-64::conda-build-3.23.3-py39h0d475fb_0.conda
win-64::conda-build-3.23.1-py38h32ec214_0.conda
win-64::conda-build-3.23.2-py39hcbf5309_1.conda
win-64::conda-build-3.23.1-py311h1ea47a8_0.conda
win-64::conda-build-3.23.3-py39hcbf5309_1.conda
win-64::conda-build-3.23.2-py38h32ec214_1.conda
win-64::conda-build-3.23.1-py38haa244fe_0.conda
win-64::conda-build-3.24.0-py38h32ec214_0.conda
win-64::conda-build-3.24.0-py39hcbf5309_1.conda
win-64::conda-build-3.23.1-py39h0d475fb_0.conda
win-64::conda-build-3.23.3-py38h32ec214_1.conda
win-64::conda-build-3.24.0-py39hcbf5309_0.conda
win-64::conda-build-3.23.3-py39h0d475fb_1.conda
win-64::conda-build-3.23.2-py39h0d475fb_1.conda
win-64::conda-build-3.24.0-py39h0d475fb_1.conda
win-64::conda-build-3.23.2-py38haa244fe_1.conda
win-64::conda-build-3.24.0-py311h1ea47a8_1.conda
win-64::conda-build-3.23.1-py39hcbf5309_0.conda
win-64::conda-build-3.23.2-py311h1ea47a8_0.conda
win-64::conda-build-3.23.0-py39h0d475fb_1.tar.bz2
win-64::conda-build-3.24.0-py38haa244fe_1.conda
win-64::conda-build-3.23.0-py38h32ec214_1.tar.bz2
win-64::conda-build-3.23.3-py38haa244fe_1.conda
win-64::conda-build-3.23.2-py38h32ec214_0.conda
win-64::conda-build-3.23.3-py310h5588dad_1.conda
win-64::conda-build-3.23.1-py310h5588dad_0.conda
win-64::conda-build-3.23.3-py311h1ea47a8_0.conda
-    "conda >=4.13",
+    "conda >=4.13,<23.9.0a0",
win-64::mamba-0.24.0-py310h9376f3e_1.tar.bz2
win-64::mamba-0.24.0-py37h13f6ddf_1.tar.bz2
win-64::mamba-0.24.0-py38hecfeebb_1.tar.bz2
win-64::mamba-0.24.0-py39hb3d9227_1.tar.bz2
-    "conda >=4.8",
+    "conda >=4.8,<23.9.0a0",
win-64::mamba-1.5.1-py38hc0fdf1e_0.conda
win-64::mamba-1.4.6-py39h749ce95_0.conda
win-64::mamba-1.5.0-py39hca8391b_1.conda
win-64::mamba-1.4.4-py310hd9d798f_1.conda
win-64::mamba-1.4.4-py38hc9c81c8_1.conda
win-64::mamba-1.4.5-py39hca8391b_0.conda
win-64::mamba-1.5.0-py38hc9c81c8_0.conda
win-64::mamba-1.5.0-py39h749ce95_1.conda
win-64::mamba-1.4.6-py311h8cb466b_0.conda
win-64::mamba-1.4.9-py311h8cb466b_0.conda
win-64::mamba-1.4.9-py39hca8391b_0.conda
win-64::mamba-1.5.1-py311h8cb466b_0.conda
win-64::mamba-1.5.0-py38hc0fdf1e_0.conda
win-64::mamba-1.4.7-py38hc9c81c8_0.conda
win-64::mamba-1.5.0-py310hd9d798f_1.conda
win-64::mamba-1.4.5-py38hc9c81c8_0.conda
win-64::mamba-1.4.9-py38hc0fdf1e_0.conda
win-64::mamba-1.5.1-py38hc9c81c8_0.conda
win-64::mamba-1.5.1-py310hd9d798f_0.conda
win-64::mamba-1.4.6-py38hc0fdf1e_0.conda
win-64::mamba-1.4.7-py39h749ce95_0.conda
win-64::mamba-1.4.7-py311h8cb466b_0.conda
win-64::mamba-1.5.1-py39hca8391b_0.conda
win-64::mamba-1.5.0-py311h8cb466b_1.conda
win-64::mamba-1.4.7-py39hca8391b_0.conda
win-64::mamba-1.4.6-py39hca8391b_0.conda
win-64::mamba-1.4.4-py311h8cb466b_1.conda
win-64::mamba-1.5.0-py38hc0fdf1e_1.conda
win-64::mamba-1.4.5-py39h749ce95_0.conda
win-64::mamba-1.5.0-py39hca8391b_0.conda
win-64::mamba-1.4.9-py38hc9c81c8_0.conda
win-64::mamba-1.4.9-py39h749ce95_0.conda
win-64::mamba-1.4.7-py38hc0fdf1e_0.conda
win-64::mamba-1.4.9-py310hd9d798f_0.conda
win-64::mamba-1.4.7-py310hd9d798f_0.conda
win-64::mamba-1.4.4-py39hca8391b_1.conda
win-64::mamba-1.4.6-py38hc9c81c8_0.conda
win-64::mamba-1.4.4-py38hc0fdf1e_1.conda
win-64::mamba-1.4.5-py310hd9d798f_0.conda
win-64::mamba-1.5.1-py39h749ce95_0.conda
win-64::mamba-1.4.5-py38hc0fdf1e_0.conda
win-64::mamba-1.5.0-py311h8cb466b_0.conda
win-64::mamba-1.5.0-py38hc9c81c8_1.conda
win-64::mamba-1.5.0-py39h749ce95_0.conda
win-64::mamba-1.5.0-py310hd9d798f_0.conda
win-64::mamba-1.4.5-py311h8cb466b_0.conda
win-64::mamba-1.4.6-py310hd9d798f_0.conda
win-64::mamba-1.4.4-py39h749ce95_1.conda
-    "conda >=4.14,<24.0a0",
+    "conda >=4.14,<23.9.0a0",
================================================================================
================================================================================
osx-64
osx-64::conda-build-3.22.0-py37hf985489_0.tar.bz2
osx-64::conda-build-3.22.0-py39h6e9494a_2.tar.bz2
osx-64::conda-build-3.21.8-py38h50d1736_1.tar.bz2
osx-64::conda-build-3.23.0-py311h6eed73b_0.tar.bz2
osx-64::conda-build-3.22.0-py39h43b90dd_3.tar.bz2
osx-64::conda-build-3.22.0-py39h6e9494a_0.tar.bz2
osx-64::conda-build-3.21.9-py38h50d1736_1.tar.bz2
osx-64::conda-build-3.22.0-py310h2ec42d9_2.tar.bz2
osx-64::conda-build-3.21.9-py39h6e9494a_0.tar.bz2
osx-64::conda-build-3.22.0-py37hf985489_2.tar.bz2
osx-64::conda-build-3.23.0-py310h2ec42d9_0.tar.bz2
osx-64::conda-build-3.23.0-py39h43b90dd_0.tar.bz2
osx-64::conda-build-3.22.0-py311h6eed73b_3.tar.bz2
osx-64::conda-build-3.21.9-py310h2ec42d9_1.tar.bz2
osx-64::conda-build-3.22.0-py310h2ec42d9_1.tar.bz2
osx-64::conda-build-3.22.0-py310h2ec42d9_0.tar.bz2
osx-64::conda-build-3.22.0-py39h43b90dd_2.tar.bz2
osx-64::conda-build-3.22.0-py38h50d1736_3.tar.bz2
osx-64::conda-build-3.22.0-py39h6e9494a_1.tar.bz2
osx-64::conda-build-3.21.8-py37hf985489_1.tar.bz2
osx-64::conda-build-3.23.0-py39h6e9494a_0.tar.bz2
osx-64::conda-build-3.23.0-py38h50d1736_0.tar.bz2
osx-64::conda-build-3.22.0-py310h2ec42d9_3.tar.bz2
osx-64::conda-build-3.22.0-py38h25b0044_2.tar.bz2
osx-64::conda-build-3.22.0-py38h25b0044_3.tar.bz2
osx-64::conda-build-3.21.8-py310h2ec42d9_1.tar.bz2
osx-64::conda-build-3.22.0-py38h50d1736_0.tar.bz2
osx-64::conda-build-3.21.9-py38h50d1736_0.tar.bz2
osx-64::conda-build-3.22.0-py39h6e9494a_3.tar.bz2
osx-64::conda-build-3.21.9-py39h6e9494a_1.tar.bz2
osx-64::conda-build-3.21.9-py310h2ec42d9_0.tar.bz2
osx-64::conda-build-3.21.8-py39h6e9494a_1.tar.bz2
osx-64::conda-build-3.22.0-py38h50d1736_2.tar.bz2
osx-64::conda-build-3.21.9-py37hf985489_0.tar.bz2
osx-64::conda-build-3.21.9-py37hf985489_1.tar.bz2
osx-64::conda-build-3.23.0-py38h25b0044_0.tar.bz2
osx-64::conda-build-3.22.0-py38h50d1736_1.tar.bz2
osx-64::conda-build-3.22.0-py37hf985489_1.tar.bz2
-    "conda >=4.5",
+    "conda >=4.5,<23.9.0a0",
osx-64::conda-build-3.23.3-py39h43b90dd_1.conda
osx-64::conda-build-3.23.1-py310h2ec42d9_0.conda
osx-64::conda-build-3.24.0-py38h25b0044_0.conda
osx-64::conda-build-3.23.0-py38h50d1736_1.tar.bz2
osx-64::conda-build-3.23.3-py38h25b0044_0.conda
osx-64::conda-build-3.23.3-py38h25b0044_1.conda
osx-64::conda-build-3.23.1-py311h6eed73b_0.conda
osx-64::conda-build-3.23.3-py311h6eed73b_1.conda
osx-64::conda-build-3.23.0-py310h2ec42d9_1.tar.bz2
osx-64::conda-build-3.23.2-py38h25b0044_1.conda
osx-64::conda-build-3.23.2-py310h2ec42d9_1.conda
osx-64::conda-build-3.23.1-py38h25b0044_0.conda
osx-64::conda-build-3.23.2-py311h6eed73b_0.conda
osx-64::conda-build-3.23.2-py39h43b90dd_0.conda
osx-64::conda-build-3.23.3-py39h43b90dd_0.conda
osx-64::conda-build-3.24.0-py39h43b90dd_1.conda
osx-64::conda-build-3.23.2-py38h50d1736_0.conda
osx-64::conda-build-3.23.2-py310h2ec42d9_0.conda
osx-64::conda-build-3.23.1-py39h6e9494a_0.conda
osx-64::conda-build-3.23.3-py38h50d1736_0.conda
osx-64::conda-build-3.23.0-py311h6eed73b_1.tar.bz2
osx-64::conda-build-3.24.0-py38h50d1736_0.conda
osx-64::conda-build-3.23.1-py38h50d1736_0.conda
osx-64::conda-build-3.23.0-py39h43b90dd_1.tar.bz2
osx-64::conda-build-3.24.0-py38h50d1736_1.conda
osx-64::conda-build-3.24.0-py311h6eed73b_0.conda
osx-64::conda-build-3.24.0-py310h2ec42d9_1.conda
osx-64::conda-build-3.23.0-py39h6e9494a_1.tar.bz2
osx-64::conda-build-3.23.3-py311h6eed73b_0.conda
osx-64::conda-build-3.23.3-py39h6e9494a_0.conda
osx-64::conda-build-3.24.0-py311h6eed73b_1.conda
osx-64::conda-build-3.23.2-py39h43b90dd_1.conda
osx-64::conda-build-3.23.3-py310h2ec42d9_0.conda
osx-64::conda-build-3.24.0-py310h2ec42d9_0.conda
osx-64::conda-build-3.23.1-py39h43b90dd_0.conda
osx-64::conda-build-3.24.0-py39h43b90dd_0.conda
osx-64::conda-build-3.24.0-py38h25b0044_1.conda
osx-64::conda-build-3.24.0-py39h6e9494a_0.conda
osx-64::conda-build-3.23.3-py38h50d1736_1.conda
osx-64::conda-build-3.23.3-py39h6e9494a_1.conda
osx-64::conda-build-3.23.0-py38h25b0044_1.tar.bz2
osx-64::conda-build-3.23.2-py38h50d1736_1.conda
osx-64::conda-build-3.23.2-py39h6e9494a_0.conda
osx-64::conda-build-3.23.2-py39h6e9494a_1.conda
osx-64::conda-build-3.24.0-py39h6e9494a_1.conda
osx-64::conda-build-3.23.3-py310h2ec42d9_1.conda
osx-64::conda-build-3.23.2-py311h6eed73b_1.conda
osx-64::conda-build-3.23.2-py38h25b0044_0.conda
-    "conda >=4.13",
+    "conda >=4.13,<23.9.0a0",
osx-64::mamba-0.24.0-py37hf471621_1.tar.bz2
osx-64::mamba-0.24.0-py38h52b2510_1.tar.bz2
osx-64::mamba-0.24.0-py310h795411f_1.tar.bz2
osx-64::mamba-0.24.0-py37he52e375_1.tar.bz2
osx-64::mamba-0.24.0-py39ha435c47_1.tar.bz2
-    "conda >=4.8",
+    "conda >=4.8,<23.9.0a0",
osx-64::mamba-1.4.6-py310h6bde348_0.conda
osx-64::mamba-1.5.1-py39h053c3d7_0.conda
osx-64::mamba-1.4.4-py39h412838c_1.conda
osx-64::mamba-1.5.1-py311h8082e30_0.conda
osx-64::mamba-1.5.0-py39h412838c_1.conda
osx-64::mamba-1.4.4-py39h053c3d7_1.conda
osx-64::mamba-1.5.0-py310h6bde348_0.conda
osx-64::mamba-1.4.9-py39h053c3d7_0.conda
osx-64::mamba-1.4.5-py310h6bde348_0.conda
osx-64::mamba-1.4.4-py38h2cdcfb1_1.conda
osx-64::mamba-1.5.0-py311h8082e30_0.conda
osx-64::mamba-1.4.9-py39h412838c_0.conda
osx-64::mamba-1.4.6-py39h412838c_0.conda
osx-64::mamba-1.4.5-py38h2cdcfb1_0.conda
osx-64::mamba-1.5.1-py38h8305e0d_0.conda
osx-64::mamba-1.4.7-py310h6bde348_0.conda
osx-64::mamba-1.4.6-py39h053c3d7_0.conda
osx-64::mamba-1.4.4-py311h8082e30_1.conda
osx-64::mamba-1.4.5-py38h8305e0d_0.conda
osx-64::mamba-1.5.0-py39h412838c_0.conda
osx-64::mamba-1.4.7-py38h2cdcfb1_0.conda
osx-64::mamba-1.4.5-py39h412838c_0.conda
osx-64::mamba-1.4.9-py310h6bde348_0.conda
osx-64::mamba-1.5.0-py38h8305e0d_0.conda
osx-64::mamba-1.4.7-py38h8305e0d_0.conda
osx-64::mamba-1.5.0-py311h8082e30_1.conda
osx-64::mamba-1.4.9-py38h2cdcfb1_0.conda
osx-64::mamba-1.4.4-py310h6bde348_1.conda
osx-64::mamba-1.4.9-py311h8082e30_0.conda
osx-64::mamba-1.5.0-py39h053c3d7_0.conda
osx-64::mamba-1.5.1-py39h412838c_0.conda
osx-64::mamba-1.5.1-py38h2cdcfb1_0.conda
osx-64::mamba-1.4.6-py38h2cdcfb1_0.conda
osx-64::mamba-1.4.7-py39h053c3d7_0.conda
osx-64::mamba-1.5.0-py38h8305e0d_1.conda
osx-64::mamba-1.4.7-py39h412838c_0.conda
osx-64::mamba-1.4.5-py39h053c3d7_0.conda
osx-64::mamba-1.4.7-py311h8082e30_0.conda
osx-64::mamba-1.4.5-py311h8082e30_0.conda
osx-64::mamba-1.4.9-py38h8305e0d_0.conda
osx-64::mamba-1.5.0-py310h6bde348_1.conda
osx-64::mamba-1.4.4-py38h8305e0d_1.conda
osx-64::mamba-1.4.6-py311h8082e30_0.conda
osx-64::mamba-1.4.6-py38h8305e0d_0.conda
osx-64::mamba-1.5.0-py38h2cdcfb1_0.conda
osx-64::mamba-1.5.0-py38h2cdcfb1_1.conda
osx-64::mamba-1.5.0-py39h053c3d7_1.conda
osx-64::mamba-1.5.1-py310h6bde348_0.conda
-    "conda >=4.14,<24.0a0",
+    "conda >=4.14,<23.9.0a0",
================================================================================
================================================================================
linux-64
linux-64::conda-build-3.22.0-py38h578d9bd_3.tar.bz2
linux-64::conda-build-3.22.0-py310hff52083_1.tar.bz2
linux-64::conda-build-3.23.0-py311h38be061_0.tar.bz2
linux-64::conda-build-3.22.0-py310hff52083_2.tar.bz2
linux-64::conda-build-3.23.0-py38h578d9bd_0.tar.bz2
linux-64::conda-build-3.21.8-py39hf3d152e_1.tar.bz2
linux-64::conda-build-3.22.0-py39hf3d152e_2.tar.bz2
linux-64::conda-build-3.22.0-py38h578d9bd_0.tar.bz2
linux-64::conda-build-3.21.8-py37h89c1867_1.tar.bz2
linux-64::conda-build-3.21.8-py38h578d9bd_1.tar.bz2
linux-64::conda-build-3.22.0-py39h4162558_2.tar.bz2
linux-64::conda-build-3.22.0-py39h4162558_3.tar.bz2
linux-64::conda-build-3.21.9-py39hf3d152e_1.tar.bz2
linux-64::conda-build-3.23.0-py310hff52083_0.tar.bz2
linux-64::conda-build-3.22.0-py310hff52083_3.tar.bz2
linux-64::conda-build-3.22.0-py310hff52083_0.tar.bz2
linux-64::conda-build-3.22.0-py37h89c1867_0.tar.bz2
linux-64::conda-build-3.22.0-py38h373033e_2.tar.bz2
linux-64::conda-build-3.21.9-py37h89c1867_1.tar.bz2
linux-64::conda-build-3.22.0-py39hf3d152e_0.tar.bz2
linux-64::conda-build-3.23.0-py38h373033e_0.tar.bz2
linux-64::conda-build-3.23.0-py39h4162558_0.tar.bz2
linux-64::conda-build-3.22.0-py39hf3d152e_3.tar.bz2
linux-64::conda-build-3.22.0-py39hf3d152e_1.tar.bz2
linux-64::conda-build-3.21.9-py39hf3d152e_0.tar.bz2
linux-64::conda-build-3.23.0-py39hf3d152e_0.tar.bz2
linux-64::conda-build-3.22.0-py311h38be061_3.tar.bz2
linux-64::conda-build-3.22.0-py38h373033e_3.tar.bz2
linux-64::conda-build-3.22.0-py37h89c1867_2.tar.bz2
linux-64::conda-build-3.21.8-py310hff52083_1.tar.bz2
linux-64::conda-build-3.21.9-py38h578d9bd_1.tar.bz2
linux-64::conda-build-3.22.0-py38h578d9bd_1.tar.bz2
linux-64::conda-build-3.21.9-py38h578d9bd_0.tar.bz2
linux-64::conda-build-3.22.0-py37h89c1867_1.tar.bz2
linux-64::conda-build-3.22.0-py38h578d9bd_2.tar.bz2
linux-64::conda-build-3.21.9-py310hff52083_1.tar.bz2
linux-64::conda-build-3.21.9-py37h89c1867_0.tar.bz2
linux-64::conda-build-3.21.9-py310hff52083_0.tar.bz2
-    "conda >=4.5",
+    "conda >=4.5,<23.9.0a0",
linux-64::conda-build-3.23.2-py38h578d9bd_0.conda
linux-64::conda-build-3.24.0-py38h578d9bd_1.conda
linux-64::conda-build-3.23.1-py38h578d9bd_0.conda
linux-64::conda-build-3.23.3-py39h4162558_0.conda
linux-64::conda-build-3.23.2-py311h38be061_0.conda
linux-64::conda-build-3.23.2-py39h4162558_0.conda
linux-64::conda-build-3.23.3-py39h4162558_1.conda
linux-64::conda-build-3.23.3-py311h38be061_0.conda
linux-64::conda-build-3.24.0-py310hff52083_0.conda
linux-64::conda-build-3.24.0-py38h373033e_0.conda
linux-64::conda-build-3.23.0-py39h4162558_1.tar.bz2
linux-64::conda-build-3.23.3-py38h373033e_0.conda
linux-64::conda-build-3.24.0-py311h38be061_0.conda
linux-64::conda-build-3.24.0-py38h373033e_1.conda
linux-64::conda-build-3.24.0-py311h38be061_1.conda
linux-64::conda-build-3.24.0-py39h4162558_1.conda
linux-64::conda-build-3.23.0-py38h373033e_1.tar.bz2
linux-64::conda-build-3.23.3-py38h578d9bd_1.conda
linux-64::conda-build-3.23.2-py39hf3d152e_1.conda
linux-64::conda-build-3.23.0-py39hf3d152e_1.tar.bz2
linux-64::conda-build-3.23.2-py38h373033e_0.conda
linux-64::conda-build-3.23.2-py310hff52083_1.conda
linux-64::conda-build-3.23.3-py310hff52083_0.conda
linux-64::conda-build-3.23.2-py39hf3d152e_0.conda
linux-64::conda-build-3.24.0-py39hf3d152e_1.conda
linux-64::conda-build-3.23.0-py38h578d9bd_1.tar.bz2
linux-64::conda-build-3.23.1-py38h373033e_0.conda
linux-64::conda-build-3.23.0-py310hff52083_1.tar.bz2
linux-64::conda-build-3.23.1-py310hff52083_0.conda
linux-64::conda-build-3.23.3-py39hf3d152e_0.conda
linux-64::conda-build-3.24.0-py310hff52083_1.conda
linux-64::conda-build-3.23.3-py310hff52083_1.conda
linux-64::conda-build-3.24.0-py38h578d9bd_0.conda
linux-64::conda-build-3.23.2-py38h578d9bd_1.conda
linux-64::conda-build-3.23.2-py39h4162558_1.conda
linux-64::conda-build-3.23.1-py311h38be061_0.conda
linux-64::conda-build-3.23.1-py39h4162558_0.conda
linux-64::conda-build-3.23.3-py311h38be061_1.conda
linux-64::conda-build-3.23.3-py38h578d9bd_0.conda
linux-64::conda-build-3.23.3-py39hf3d152e_1.conda
linux-64::conda-build-3.23.2-py311h38be061_1.conda
linux-64::conda-build-3.24.0-py39hf3d152e_0.conda
linux-64::conda-build-3.23.2-py38h373033e_1.conda
linux-64::conda-build-3.23.0-py311h38be061_1.tar.bz2
linux-64::conda-build-3.23.3-py38h373033e_1.conda
linux-64::conda-build-3.23.2-py310hff52083_0.conda
linux-64::conda-build-3.24.0-py39h4162558_0.conda
linux-64::conda-build-3.23.1-py39hf3d152e_0.conda
-    "conda >=4.13",
+    "conda >=4.13,<23.9.0a0",
linux-64::mamba-0.24.0-py38h1abaa86_1.tar.bz2
linux-64::mamba-0.24.0-py37h47bf687_1.tar.bz2
linux-64::mamba-0.24.0-py39hfa8f2c8_1.tar.bz2
linux-64::mamba-0.24.0-py310hf87f941_1.tar.bz2
linux-64::mamba-0.24.0-py37h6dacc13_1.tar.bz2
-    "conda >=4.8",
+    "conda >=4.8,<23.9.0a0",
linux-64::mamba-1.5.1-py38h5b23d11_0.conda
linux-64::mamba-1.4.9-py311h3072747_0.conda
linux-64::mamba-1.4.7-py38h5b23d11_0.conda
linux-64::mamba-1.5.1-py310h51d5547_0.conda
linux-64::mamba-1.4.9-py38haad2881_0.conda
linux-64::mamba-1.5.0-py310h51d5547_1.conda
linux-64::mamba-1.4.9-py39hcbb6966_0.conda
linux-64::mamba-1.4.6-py39hcbb6966_0.conda
linux-64::mamba-1.4.9-py38h5b23d11_0.conda
linux-64::mamba-1.4.6-py311h3072747_0.conda
linux-64::mamba-1.4.5-py39hc5d2bb1_0.conda
linux-64::mamba-1.4.4-py311h3072747_1.conda
linux-64::mamba-1.4.6-py38h5b23d11_0.conda
linux-64::mamba-1.4.7-py39hcbb6966_0.conda
linux-64::mamba-1.4.5-py38haad2881_0.conda
linux-64::mamba-1.4.4-py310h51d5547_1.conda
linux-64::mamba-1.5.0-py38haad2881_0.conda
linux-64::mamba-1.4.4-py39hcbb6966_1.conda
linux-64::mamba-1.4.5-py310h51d5547_0.conda
linux-64::mamba-1.5.0-py38h5b23d11_1.conda
linux-64::mamba-1.5.1-py39hc5d2bb1_0.conda
linux-64::mamba-1.4.7-py38haad2881_0.conda
linux-64::mamba-1.4.6-py39hc5d2bb1_0.conda
linux-64::mamba-1.4.4-py38h5b23d11_1.conda
linux-64::mamba-1.5.1-py38haad2881_0.conda
linux-64::mamba-1.4.7-py310h51d5547_0.conda
linux-64::mamba-1.5.0-py311h3072747_0.conda
linux-64::mamba-1.5.0-py311h3072747_1.conda
linux-64::mamba-1.5.0-py39hcbb6966_0.conda
linux-64::mamba-1.4.5-py311h3072747_0.conda
linux-64::mamba-1.4.4-py39hc5d2bb1_1.conda
linux-64::mamba-1.4.5-py38h5b23d11_0.conda
linux-64::mamba-1.5.0-py310h51d5547_0.conda
linux-64::mamba-1.4.7-py39hc5d2bb1_0.conda
linux-64::mamba-1.5.1-py39hcbb6966_0.conda
linux-64::mamba-1.4.5-py39hcbb6966_0.conda
linux-64::mamba-1.4.7-py311h3072747_0.conda
linux-64::mamba-1.5.0-py38h5b23d11_0.conda
linux-64::mamba-1.5.0-py39hcbb6966_1.conda
linux-64::mamba-1.4.6-py310h51d5547_0.conda
linux-64::mamba-1.5.0-py39hc5d2bb1_0.conda
linux-64::mamba-1.4.9-py39hc5d2bb1_0.conda
linux-64::mamba-1.5.1-py311h3072747_0.conda
linux-64::mamba-1.4.4-py38haad2881_1.conda
linux-64::mamba-1.4.9-py310h51d5547_0.conda
linux-64::mamba-1.4.6-py38haad2881_0.conda
linux-64::mamba-1.5.0-py39hc5d2bb1_1.conda
linux-64::mamba-1.5.0-py38haad2881_1.conda
-    "conda >=4.14,<24.0a0",
+    "conda >=4.14,<23.9.0a0",
```

</details>
cc @jaimergp
