### PR TITLE
Pin holoviz packages to param <2

### DIFF
--- a/recipe/patch_yaml/datashader.yaml
+++ b/recipe/patch_yaml/datashader.yaml
@@ -1,0 +1,13 @@
+# Pinning Param <2 before the release of Param 2
+# Timestamp 1696575733000 <=> Fri Oct 06 2023 07:02:13 GMT+0000
+
+# Datashader always depended on Param and either didn't define
+# any upper pin or used <2.0.
+if:
+  name: datashader
+  timestamp_lt: 1696575733000
+  has_depends: param*
+then:
+  - tighten_depends:
+      name: param
+      upper_bound: 2.0.0

--- a/recipe/patch_yaml/geoviews.yaml
+++ b/recipe/patch_yaml/geoviews.yaml
@@ -10,4 +10,4 @@ if:
 then:
   - tighten_depends:
       name: param
-      upper_bound: 2
+      upper_bound: "2"

--- a/recipe/patch_yaml/geoviews.yaml
+++ b/recipe/patch_yaml/geoviews.yaml
@@ -1,0 +1,13 @@
+# Pinning Param <2 before the release of Param 2
+# Timestamp 1696575733000 <=> Fri Oct 06 2023 07:02:13 GMT+0000
+
+# Geoviews always had Param as a dependency. It was either not pinning
+# it or pinning <2.
+if:
+  name: geoviews
+  timestamp_lt: 1696575733000
+  has_depends: param*
+then:
+  - tighten_depends:
+      name: param
+      upper_bound: 2

--- a/recipe/patch_yaml/holoviews.yaml
+++ b/recipe/patch_yaml/holoviews.yaml
@@ -1,0 +1,24 @@
+# Pinning Param <2 before the release of Param 2
+# Timestamp 1696575733000 <=> Fri Oct 06 2023 07:02:13 GMT+0000
+
+# To pin versions that were not pinning Param at all (e.g. 1.10.0)
+if:
+  name: holoviews
+  timestamp_lt: 1696575733000
+  has_depends: param*
+then:
+  - tighten_depends:
+      name: param
+      upper_bound: 2.0.0
+---
+# After 1.10.0 HoloViews was pinning param<2.0, however
+# starting from 1.16.0 the param<2.0 pin was moved to <3.0,
+# that was too early.
+if:
+  name: holoviews
+  timestamp_lt: 1696575733000
+  has_depends: param >=1.12.0,<3.0
+then:
+  - replace_depends:
+      old: param >=1.12.0,<3.0
+      new: param >=1.12.0,<2.0

--- a/recipe/patch_yaml/hvplot.yaml
+++ b/recipe/patch_yaml/hvplot.yaml
@@ -1,0 +1,22 @@
+# Pinning Param <2 before the release of Param 2
+# Timestamp 1696575733000 <=> Fri Oct 06 2023 07:02:13 GMT+0000
+
+# hvPlot depends directly on Param since version 0.7.3,
+# this was not always specified
+if:
+  name: hvplot
+  timestamp_lt: 1696575733000
+  version_gt: 0.7.2
+  not_has_depends: param*
+then:
+  - add_depends: param <2.0
+---
+# Versions that depended on Param didn't specify any upper pin
+if:
+  name: hvplot
+  timestamp_lt: 1696575733000
+  has_depends: param*
+then:
+  - tighten_depends:
+      name: param
+      upper_bound: 2.0.0

--- a/recipe/patch_yaml/lumen.yaml
+++ b/recipe/patch_yaml/lumen.yaml
@@ -1,0 +1,10 @@
+# Pinning Param <2 before the release of Param 2
+# Timestamp 1696575733000 <=> Fri Oct 06 2023 07:02:13 GMT+0000
+
+# Before that date Lumen wasn't defining Param 2.0 as a dependency
+# while it directly depended on it.
+if:
+  name: lumen
+  timestamp_lt: 1696575733000
+then:
+  - add_depends: param <2.0

--- a/recipe/patch_yaml/panel.yaml
+++ b/recipe/patch_yaml/panel.yaml
@@ -110,7 +110,7 @@ if:
 then:
   - tighten_depends:
       name: param
-      upper_bound: 2
+      upper_bound: "2"
 ---
 # Starting from 1.0.0 Param was pinned to <3.0 while it should have been <2.0
 if:

--- a/recipe/patch_yaml/panel.yaml
+++ b/recipe/patch_yaml/panel.yaml
@@ -98,3 +98,26 @@ then:
       old: bokeh*
       new: bokeh >=2.2,<2.3
   - add_depends: bokeh >=2.2,<2.3
+---
+# Pinning Param <2 before the release of Param 2
+# Timestamp 1696575733000 <=> Fri Oct 06 2023 07:02:13 GMT+0000
+
+# Before version 1.0.0 Panel was not upper pinning Param at all
+if:
+  name: panel
+  timestamp_lt: 1696575733000
+  has_depends: param*
+then:
+  - tighten_depends:
+      name: param
+      upper_bound: 2
+---
+# Starting from 1.0.0 Param was pinned to <3.0 while it should have been <2.0
+if:
+  name: panel
+  timestamp_lt: 1696575733000
+  has_depends: param >=1.12.0,<3
+then:
+  - replace_depends:
+      old: param >=1.12.0,<3
+      new: param >=1.12.0,<2.0


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] ~~Only wrote code directly into `generate_patch_json.py` if absolutely necessary.~~
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

[Param 2](https://github.com/holoviz/param) is going to be released in the next few days. Param is a foundational library of the [HoloViz ecosystem](https://holoviz.org) and is going through a major release, it comes with breaking changes that can result in a very bad experience if Param 2 is installed with versions not supporting it, as Param's machinery is exerted on class creation and if it fails leads to errors on import.

This PR aims to patch all the HoloViz packages depending on Param to pin them to `param <2`. Ideally, and if this PR is approved of course, it would be merged before Param 2 is released to make sure that users don't create environments with older and incompatible HoloViz packages and Param 2. The next releases of these packages will pin `param >=2,<3`.

<details>
<summary>python show_diff.py</summary>

```
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
win-32::holoviews-1.9.5-py36_0.tar.bz2
win-32::holoviews-1.8.4-py27_0.tar.bz2
win-32::holoviews-1.7.0-py35_0.tar.bz2
win-32::holoviews-1.6.2-py27_0.tar.bz2
win-32::holoviews-1.9.3-py36_0.tar.bz2
win-32::holoviews-1.8.4-py36_0.tar.bz2
win-32::holoviews-1.9.1-py27_0.tar.bz2
win-32::holoviews-1.8.3-py35_0.tar.bz2
win-32::holoviews-1.9.2-py27_0.tar.bz2
win-32::holoviews-1.8.2-py27_0.tar.bz2
win-32::holoviews-1.9.1-py36_0.tar.bz2
win-32::holoviews-1.9.0-py35_0.tar.bz2
win-32::holoviews-1.9.0-py27_0.tar.bz2
win-32::holoviews-1.9.4-py36_0.tar.bz2
win-32::holoviews-1.8.1-py27_0.tar.bz2
win-32::holoviews-1.9.3-py27_0.tar.bz2
win-32::holoviews-1.9.2-py35_0.tar.bz2
win-32::holoviews-1.6.2-py35_0.tar.bz2
win-32::holoviews-1.5.0-py34_0.tar.bz2
win-32::holoviews-1.8.1-py35_0.tar.bz2
win-32::holoviews-1.7.0-py27_0.tar.bz2
win-32::holoviews-1.8.1-py36_0.tar.bz2
win-32::holoviews-1.5.0-py27_0.tar.bz2
win-32::holoviews-1.9.3-py35_0.tar.bz2
win-32::holoviews-1.8.4-py35_0.tar.bz2
win-32::holoviews-1.8.3-py27_0.tar.bz2
win-32::holoviews-1.5.0-py35_0.tar.bz2
win-32::holoviews-1.8.2-py36_0.tar.bz2
win-32::holoviews-1.8.0-py27_0.tar.bz2
win-32::holoviews-1.9.5-py35_0.tar.bz2
win-32::holoviews-1.7.0-py36_0.tar.bz2
win-32::holoviews-1.9.5-py27_0.tar.bz2
win-32::holoviews-1.9.0-py36_0.tar.bz2
win-32::holoviews-1.8.4-py27_1.tar.bz2
win-32::holoviews-1.8.0-py35_0.tar.bz2
win-32::holoviews-1.8.4-py36_1.tar.bz2
win-32::holoviews-1.9.2-py36_0.tar.bz2
win-32::holoviews-1.6.2-py34_0.tar.bz2
win-32::holoviews-1.9.1-py35_0.tar.bz2
win-32::holoviews-1.8.0-py36_0.tar.bz2
win-32::holoviews-1.8.4-py35_1.tar.bz2
win-32::holoviews-1.9.4-py27_0.tar.bz2
win-32::holoviews-1.8.2-py35_0.tar.bz2
win-32::holoviews-1.8.3-py36_0.tar.bz2
win-32::holoviews-1.9.4-py35_0.tar.bz2
-    "param",
+    "param <2.0.0a0",
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
noarch
noarch::datashader-0.7.0-py_1.tar.bz2
noarch::datashader-0.12.1-pyh44b312d_1.tar.bz2
noarch::datashader-0.11.1-pyh9f0ad1d_0.tar.bz2
noarch::datashader-0.14.1-pyh6c4a22f_0.tar.bz2
noarch::datashader-0.6.9-py_0.tar.bz2
noarch::datashader-0.12.0-pyhd3deb0d_0.tar.bz2
noarch::datashader-0.8.0-py_0.tar.bz2
noarch::datashader-0.14.0-pyh6c4a22f_0.tar.bz2
noarch::datashader-0.12.1-pyh44b312d_0.tar.bz2
noarch::datashader-0.14.1-pyh6c4a22f_1.tar.bz2
noarch::datashader-0.14.2-pyh6c4a22f_0.tar.bz2
noarch::datashader-0.11.0-pyh9f0ad1d_0.tar.bz2
noarch::datashader-0.9.0-py_0.tar.bz2
noarch::datashader-0.6.6-0.tar.bz2
noarch::datashader-0.14.3-pyh1a96a4e_0.conda
noarch::datashader-0.10.0-py_0.tar.bz2
noarch::datashader-0.7.0-py_0.tar.bz2
noarch::datashader-0.13.0-pyh6c4a22f_0.tar.bz2
noarch::datashader-0.6.8-py_0.tar.bz2
noarch::datashader-0.14.4-pyh1a96a4e_0.conda
-    "param >=1.6.1",
+    "param >=1.6.1,<2.0.0a0",
noarch::geoviews-1.4.3-py_0.tar.bz2
-    "param >=1.5.1",
+    "param >=1.5.1,<2.0.0a0",
noarch::datashader-0.15.2-pyhd8ed1ab_0.conda
noarch::datashader-0.15.1-pyhd8ed1ab_0.conda
noarch::holoviews-1.10.0-py_1.tar.bz2
noarch::datashader-0.15.0-pyhd8ed1ab_0.conda
noarch::holoviews-1.10.0-py_0.tar.bz2
-    "param",
+    "param <2.0.0a0",
noarch::hvplot-0.7.3-pyh6c4a22f_0.tar.bz2
noarch::lumen-0.5.1-pyhd8ed1ab_0.conda
noarch::lumen-0.4.1-pyhd8ed1ab_0.tar.bz2
noarch::hvplot-0.8.1-pyhd8ed1ab_0.tar.bz2
noarch::hvplot-0.8.2-pyhd8ed1ab_0.conda
+    "param <2.0",
noarch::panel-0.13.1-pyhd8ed1ab_0.tar.bz2
noarch::panel-0.14.4-pyhd8ed1ab_0.conda
noarch::panel-0.14.1-pyhd8ed1ab_0.tar.bz2
noarch::panel-0.13.0-pyhd8ed1ab_0.tar.bz2
noarch::hvplot-0.8.0-pyh6c4a22f_0.tar.bz2
noarch::panel-0.14.0-pyhd8ed1ab_0.tar.bz2
noarch::panel-0.13.0-pyhd8ed1ab_1.tar.bz2
noarch::panel-0.14.2-pyhd8ed1ab_0.conda
noarch::panel-0.14.3-pyhd8ed1ab_0.conda
-    "param >=1.12.0",
+    "param >=1.12.0,<2.0.0a0",
noarch::panel-0.1.2-0.tar.bz2
noarch::panel-0.1.3-0.tar.bz2
noarch::panel-0.3.1-0.tar.bz2
-    "param >=1.8.1",
+    "param >=1.8.1,<2.0.0a0",
noarch::panel-0.10.0-py_0.tar.bz2
noarch::panel-0.12.0-pyhd8ed1ab_0.tar.bz2
noarch::panel-0.10.1-pyhd8ed1ab_1.tar.bz2
noarch::panel-0.10.2-pyhd8ed1ab_0.tar.bz2
noarch::panel-0.12.1-pyhd8ed1ab_0.tar.bz2
noarch::panel-0.11.0-pyhd8ed1ab_0.tar.bz2
noarch::panel-0.12.7-pyhd8ed1ab_0.tar.bz2
noarch::panel-0.12.3-pyhd8ed1ab_0.tar.bz2
noarch::panel-0.10.1-pyhd8ed1ab_0.tar.bz2
noarch::panel-0.11.2-pyhd8ed1ab_0.tar.bz2
noarch::panel-0.12.6-pyhd8ed1ab_0.tar.bz2
noarch::panel-0.12.4-pyhd8ed1ab_0.tar.bz2
noarch::panel-0.11.1-pyhd8ed1ab_0.tar.bz2
noarch::panel-0.10.3-pyhd8ed1ab_0.tar.bz2
noarch::panel-0.11.3-pyhd8ed1ab_0.tar.bz2
-    "param >=1.10.0",
+    "param >=1.10.0,<2.0.0a0",
noarch::panel-0.4.0-0.tar.bz2
noarch::panel-0.4.0-1.tar.bz2
-    "param >=1.8.2",
+    "param >=1.8.2,<2.0.0a0",
noarch::panel-0.5.1-0.tar.bz2
noarch::hvplot-0.8.3-pyhd8ed1ab_0.conda
noarch::panel-0.5.1-h39e3cac_2.tar.bz2
noarch::hvplot-0.8.4-pyhd8ed1ab_1.conda
noarch::panel-0.5.1-h24bf2e0_2.tar.bz2
noarch::panel-0.5.1-1.tar.bz2
-    "param >=1.9.0",
+    "param >=1.9.0,<2.0.0a0",
noarch::panel-0.6.2-0.tar.bz2
noarch::panel-0.6.4-0.tar.bz2
noarch::panel-0.6.0-h5ca1d4c_0.tar.bz2
noarch::panel-0.6.0-1.tar.bz2
noarch::panel-0.6.3-0.tar.bz2
-    "param >=1.9.1",
+    "param >=1.9.1,<2.0.0a0",
noarch::panel-0.9.1-py_0.tar.bz2
noarch::panel-0.8.1-pyh9f0ad1d_1.tar.bz2
noarch::panel-0.7.0-0.tar.bz2
noarch::panel-0.9.3-py_0.tar.bz2
noarch::panel-0.8.0-0.tar.bz2
noarch::panel-0.9.2-py_0.tar.bz2
-    "param >=1.9.2",
+    "param >=1.9.2,<2.0.0a0",
noarch::panel-0.9.5-py_1.tar.bz2
noarch::panel-0.9.6-py_0.tar.bz2
noarch::panel-0.9.7-py_0.tar.bz2
noarch::geoviews-1.10.0-pyhd8ed1ab_0.conda
noarch::geoviews-1.10.1-pyhd8ed1ab_0.conda
noarch::panel-0.9.5-py_0.tar.bz2
-    "param >=1.9.3",
+    "param >=1.9.3,<2.0.0a0",
noarch::holoviews-1.17.0-pyhd8ed1ab_0.conda
noarch::holoviews-1.16.0-pyhd8ed1ab_0.conda
noarch::holoviews-1.17.1-pyhd8ed1ab_0.conda
noarch::holoviews-1.16.1-pyhd8ed1ab_0.conda
noarch::holoviews-1.16.2-pyhd8ed1ab_0.conda
-    "param >=1.12.0,<3.0",
+    "param >=1.12.0,<2.0",
noarch::panel-1.2.1-pyhd8ed1ab_0.conda
noarch::panel-1.0.0-pyhd8ed1ab_0.conda
noarch::panel-1.1.0-pyhd8ed1ab_0.conda
noarch::panel-1.2.0-pyhd8ed1ab_0.conda
noarch::panel-1.1.1-pyhd8ed1ab_0.conda
noarch::panel-1.0.1-pyhd8ed1ab_0.conda
noarch::panel-1.0.2-pyhd8ed1ab_0.conda
noarch::panel-1.2.2-pyhd8ed1ab_0.conda
noarch::panel-1.0.4-pyhd8ed1ab_0.conda
noarch::panel-1.1.0-pyhd8ed1ab_2.conda
noarch::panel-1.0.3-pyhd8ed1ab_0.conda
noarch::panel-1.2.3-pyhd8ed1ab_0.conda
-    "param >=1.12.0,<3",
+    "param >=1.12.0,<2.0",
================================================================================
================================================================================
win-64
win-64::holoviews-1.9.3-py35_0.tar.bz2
win-64::holoviews-1.8.0-py27_0.tar.bz2
win-64::holoviews-1.8.2-py27_0.tar.bz2
win-64::holoviews-1.9.1-py27_0.tar.bz2
win-64::holoviews-1.9.1-py36_0.tar.bz2
win-64::holoviews-1.9.5-py35_0.tar.bz2
win-64::holoviews-1.5.0-py35_0.tar.bz2
win-64::holoviews-1.8.4-py27_1.tar.bz2
win-64::holoviews-1.8.0-py36_0.tar.bz2
win-64::holoviews-1.6.2-py27_0.tar.bz2
win-64::holoviews-1.8.0-py35_0.tar.bz2
win-64::holoviews-1.9.2-py35_0.tar.bz2
win-64::holoviews-1.8.4-py36_0.tar.bz2
win-64::holoviews-1.5.0-py34_0.tar.bz2
win-64::holoviews-1.6.2-py35_0.tar.bz2
win-64::holoviews-1.9.5-py36_0.tar.bz2
win-64::holoviews-1.8.4-py35_0.tar.bz2
win-64::holoviews-1.9.5-py27_0.tar.bz2
win-64::holoviews-1.8.3-py36_0.tar.bz2
win-64::holoviews-1.8.3-py27_0.tar.bz2
win-64::holoviews-1.9.4-py27_0.tar.bz2
win-64::holoviews-1.8.4-py35_1.tar.bz2
win-64::holoviews-1.7.0-py36_0.tar.bz2
win-64::holoviews-1.5.0-py27_0.tar.bz2
win-64::holoviews-1.8.1-py36_0.tar.bz2
win-64::holoviews-1.8.2-py36_0.tar.bz2
win-64::holoviews-1.9.4-py35_0.tar.bz2
win-64::holoviews-1.9.0-py36_0.tar.bz2
win-64::holoviews-1.8.1-py27_0.tar.bz2
win-64::holoviews-1.9.3-py27_0.tar.bz2
win-64::holoviews-1.7.0-py35_0.tar.bz2
win-64::holoviews-1.8.4-py36_1.tar.bz2
win-64::holoviews-1.9.2-py27_0.tar.bz2
win-64::holoviews-1.9.1-py35_0.tar.bz2
win-64::holoviews-1.9.2-py36_0.tar.bz2
win-64::holoviews-1.8.3-py35_0.tar.bz2
win-64::holoviews-1.9.0-py35_0.tar.bz2
win-64::holoviews-1.6.2-py34_0.tar.bz2
win-64::holoviews-1.9.4-py36_0.tar.bz2
win-64::holoviews-1.8.4-py27_0.tar.bz2
win-64::holoviews-1.7.0-py27_0.tar.bz2
win-64::holoviews-1.9.3-py36_0.tar.bz2
win-64::holoviews-1.8.2-py35_0.tar.bz2
win-64::holoviews-1.8.1-py35_0.tar.bz2
win-64::holoviews-1.9.0-py27_0.tar.bz2
-    "param",
+    "param <2.0.0a0",
================================================================================
================================================================================
osx-64
osx-64::holoviews-1.8.2-py27_0.tar.bz2
osx-64::holoviews-1.8.1-py36_0.tar.bz2
osx-64::holoviews-1.9.2-py36_0.tar.bz2
osx-64::holoviews-1.9.1-py36_0.tar.bz2
osx-64::holoviews-1.8.3-py36_0.tar.bz2
osx-64::holoviews-1.8.1-py27_0.tar.bz2
osx-64::holoviews-1.8.4-py35_0.tar.bz2
osx-64::holoviews-1.9.5-py36_0.tar.bz2
osx-64::holoviews-1.8.4-py36_0.tar.bz2
osx-64::holoviews-1.8.3-py27_0.tar.bz2
osx-64::holoviews-1.9.4-py35_0.tar.bz2
osx-64::holoviews-1.8.2-py35_0.tar.bz2
osx-64::holoviews-1.9.1-py35_0.tar.bz2
osx-64::holoviews-1.8.4-py36_1.tar.bz2
osx-64::holoviews-1.8.3-py35_0.tar.bz2
osx-64::holoviews-1.9.3-py36_0.tar.bz2
osx-64::holoviews-1.9.4-py36_0.tar.bz2
osx-64::holoviews-1.9.3-py27_0.tar.bz2
osx-64::holoviews-1.9.4-py27_0.tar.bz2
osx-64::holoviews-1.9.0-py27_0.tar.bz2
osx-64::holoviews-1.9.2-py35_0.tar.bz2
osx-64::holoviews-1.8.1-py35_0.tar.bz2
osx-64::holoviews-1.9.1-py27_0.tar.bz2
osx-64::holoviews-1.9.0-py35_0.tar.bz2
osx-64::holoviews-1.9.5-py35_0.tar.bz2
osx-64::holoviews-1.9.2-py27_0.tar.bz2
osx-64::holoviews-1.8.0-py27_0.tar.bz2
osx-64::holoviews-1.9.0-py36_0.tar.bz2
osx-64::holoviews-1.8.4-py35_1.tar.bz2
osx-64::holoviews-1.8.4-py27_1.tar.bz2
osx-64::holoviews-1.8.4-py27_0.tar.bz2
osx-64::holoviews-1.9.5-py27_0.tar.bz2
osx-64::holoviews-1.8.2-py36_0.tar.bz2
osx-64::holoviews-1.9.3-py35_0.tar.bz2
osx-64::holoviews-1.8.0-py35_0.tar.bz2
osx-64::holoviews-1.8.0-py36_0.tar.bz2
-    "param",
+    "param <2.0.0a0",
================================================================================
================================================================================
linux-64
linux-64::holoviews-1.8.4-py27_0.tar.bz2
linux-64::holoviews-1.9.5-py35_0.tar.bz2
linux-64::holoviews-1.8.2-py27_0.tar.bz2
linux-64::holoviews-1.7.0-py36_0.tar.bz2
linux-64::holoviews-1.8.0-py27_0.tar.bz2
linux-64::holoviews-1.9.4-py27_0.tar.bz2
linux-64::holoviews-1.6.2-py27_0.tar.bz2
linux-64::holoviews-1.8.1-py27_0.tar.bz2
linux-64::holoviews-1.8.4-py36_0.tar.bz2
linux-64::holoviews-1.8.1-py35_0.tar.bz2
linux-64::holoviews-1.9.1-py36_0.tar.bz2
linux-64::holoviews-1.8.0-py35_0.tar.bz2
linux-64::holoviews-1.8.4-py35_1.tar.bz2
linux-64::holoviews-1.8.1-py36_0.tar.bz2
linux-64::holoviews-1.7.0-py27_0.tar.bz2
linux-64::holoviews-1.6.2-py34_0.tar.bz2
linux-64::holoviews-1.5.0-py35_0.tar.bz2
linux-64::holoviews-1.8.3-py27_0.tar.bz2
linux-64::holoviews-1.9.5-py27_0.tar.bz2
linux-64::holoviews-1.9.4-py36_0.tar.bz2
linux-64::holoviews-1.8.3-py36_0.tar.bz2
linux-64::holoviews-1.9.1-py27_0.tar.bz2
linux-64::holoviews-1.9.5-py36_0.tar.bz2
linux-64::holoviews-1.7.0-py35_0.tar.bz2
linux-64::holoviews-1.8.4-py27_1.tar.bz2
linux-64::holoviews-1.9.1-py35_0.tar.bz2
linux-64::holoviews-1.8.4-py35_0.tar.bz2
linux-64::holoviews-1.9.3-py36_0.tar.bz2
linux-64::holoviews-1.9.2-py35_0.tar.bz2
linux-64::holoviews-1.9.2-py36_0.tar.bz2
linux-64::holoviews-1.8.3-py35_0.tar.bz2
linux-64::holoviews-1.8.2-py36_0.tar.bz2
linux-64::holoviews-1.9.3-py27_0.tar.bz2
linux-64::holoviews-1.5.0-py34_0.tar.bz2
linux-64::holoviews-1.8.4-py36_1.tar.bz2
linux-64::holoviews-1.8.0-py36_0.tar.bz2
linux-64::holoviews-1.8.2-py35_0.tar.bz2
linux-64::holoviews-1.6.2-py35_0.tar.bz2
linux-64::holoviews-1.9.4-py35_0.tar.bz2
linux-64::holoviews-1.9.0-py27_0.tar.bz2
linux-64::holoviews-1.9.0-py35_0.tar.bz2
linux-64::holoviews-1.9.2-py27_0.tar.bz2
linux-64::holoviews-1.9.0-py36_0.tar.bz2
linux-64::holoviews-1.5.0-py27_0.tar.bz2
linux-64::holoviews-1.9.3-py35_0.tar.bz2
-    "param",
+    "param <2.0.0a0",
```

</details>

<!-- Put any other comments or information here --!>
