### PR TITLE
Add missing huggingface_hub dependency to tokenizers 0.14.x

### DIFF
--- a/recipe/patch_yaml/tokenizers.yaml
+++ b/recipe/patch_yaml/tokenizers.yaml
@@ -1,0 +1,6 @@
+if:
+  name: tokenizers
+  build_number: 0
+  version_in: ["0.14.0", "0.14.1"]
+then:
+  - add_depends: "huggingface_hub >=0.16.4,<0.18"


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [xt] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here --!>
