### PR TITLE
Tighten up `libxgboost` `cuda-version` constraint for CUDA 11.8

### DIFF
--- a/recipe/patch_yaml/libxgboost.yaml
+++ b/recipe/patch_yaml/libxgboost.yaml
@@ -1,0 +1,11 @@
+if:
+  name: libxgboost
+  timestamp_gt: 1697007600000
+  timestamp_lt: 1697180400000
+  version: "1.7.6"
+  build_number: 4
+  build: "cuda118*"
+then:
+  - replace_depends:
+      old: cuda-version >=11.2,<12
+      new: cuda-version >=11.8,<12


### PR DESCRIPTION
In PR ( https://github.com/conda-forge/xgboost-feedstock/pull/135 ), CUDA 11.8 builds of XGBoost (most notably the `libxgboost` package) were added. However the `cuda-version` constraint of these was too loose, which allowed installation with CUDA 11.8 libraries. This was fixed in a subsequent PR ( https://github.com/conda-forge/xgboost-feedstock/pull/136 ). However the packages built prior to the latter PR still need this version constraint. So this patch tightens up the `cuda-version` constraint for them as well.

<hr>

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here --!>
