### PR TITLE
pin ruff in python-lsp-ruff

### DIFF
--- a/recipe/patch_yaml/python-lsp-ruff.yaml
+++ b/recipe/patch_yaml/python-lsp-ruff.yaml
@@ -1,0 +1,8 @@
+if:
+  name: python-lsp-ruff
+  version_lt: 1.5.3
+  timestamp_lt: 1697634626000
+then:
+  - tighten_depends:
+      name: ruff
+      upper_bound: 0.1.0


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

References:
- finishes https://github.com/conda-forge/python-lsp-ruff-feedstock/pull/10

```diff
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-ppc64le
linux-ppc64le::llvm-17.0.3-h381f82a_0.conda
+    "clang 17.0.3.*",
+    "clang-tools 17.0.3.*",
+    "llvm-tools 17.0.3.*",
linux-ppc64le::llvm-tools-17.0.3-h8d57982_0.conda
+    "clang 17.0.3.*",
+    "clang-tools 17.0.3.*",
+    "llvm 17.0.3.*",
linux-ppc64le::llvmdev-17.0.3-h8d57982_0.conda
+  "constrains": [
+    "clang 17.0.3.*",
+    "clang-tools 17.0.3.*",
+    "llvm 17.0.3.*",
+    "llvm-tools 17.0.3.*"
+  ],
================================================================================
================================================================================
linux-aarch64
linux-aarch64::llvm-17.0.3-h5271726_0.conda
+    "clang 17.0.3.*",
+    "clang-tools 17.0.3.*",
+    "llvm-tools 17.0.3.*",
linux-aarch64::llvm-tools-17.0.3-h70e38ee_0.conda
+    "clang 17.0.3.*",
+    "clang-tools 17.0.3.*",
+    "llvm 17.0.3.*",
linux-aarch64::llvmdev-17.0.3-h70e38ee_0.conda
+  "constrains": [
+    "clang 17.0.3.*",
+    "clang-tools 17.0.3.*",
+    "llvm 17.0.3.*",
+    "llvm-tools 17.0.3.*"
+  ],
================================================================================
================================================================================
noarch
noarch::python-lsp-ruff-1.2.0-pyhd8ed1ab_0.conda
-    "ruff >=0.0.192"
+    "ruff >=0.0.192,<0.1.0a0"
noarch::python-lsp-ruff-1.3.0-pyhd8ed1ab_0.conda
-    "ruff >=0.0.260"
+    "ruff >=0.0.260,<0.1.0a0"
noarch::python-lsp-ruff-1.4.0-pyhd8ed1ab_1.conda
noarch::python-lsp-ruff-1.4.0-pyhd8ed1ab_0.conda
noarch::python-lsp-ruff-1.5.0-pyhd8ed1ab_0.conda
-    "ruff >=0.0.260",
+    "ruff >=0.0.260,<0.1.0a0",
noarch::python-lsp-ruff-1.5.1-pyhd8ed1ab_0.conda
noarch::python-lsp-ruff-1.5.2-pyhd8ed1ab_0.conda
-    "ruff >=0.0.267",
+    "ruff >=0.0.267,<0.1.0a0",
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
================================================================================
================================================================================
linux-64

```