### PR TITLE
patch invoke<2.0.0 to require python<3.11

### DIFF
--- a/recipe/patch_yaml/invoke.yaml
+++ b/recipe/patch_yaml/invoke.yaml
@@ -1,0 +1,16 @@
+# Versions of invoke from before version 2.0.0 are not compatible with
+# Python 3.11 because of inspect.getargspec being removed.
+if:
+  name: invoke
+  version_lt: 2.0.0
+  timestamp_lt: 1686854880000  # 2023/06/15 18:48Z
+then:
+  - replace_depends:
+      old: python
+      new: python <= 3.11.0a0
+  - replace_depends:
+      old: python 2.7|>=3.4
+      new: python 2.7|>=3.4,<3.11.0a0
+  - tighten_depends:
+      name: python
+      upper_bound: 3.11.0a0


### PR DESCRIPTION
pyinvoke (conda package `invoke`) did not support Python 3.11 until version 2.0.0. Patch the repodata to prevent this invalid scenario.

`invoke` versions older than 1.3.0 are not affected as their recipes target very narrow versions of Python. Regardless, I added a `tighten_depends` just to make it crystal clear that everything is covered.
```
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
noarch
noarch::invoke-1.4.0-py_0.tar.bz2
noarch::invoke-1.4.1-py_0.tar.bz2
noarch::invoke-1.3.0-py_1.tar.bz2
noarch::invoke-1.5.0-pyhd3deb0d_0.tar.bz2
-    "python"
+    "python <= 3.11.0a0"
noarch::invoke-1.6.0-pyhd8ed1ab_0.tar.bz2
noarch::invoke-1.7.0-pyhd8ed1ab_0.tar.bz2
noarch::invoke-1.7.1-pyhd8ed1ab_0.tar.bz2
noarch::invoke-1.7.3-pyhd8ed1ab_0.tar.bz2
-    "python 2.7|>=3.4"
+    "python 2.7|>=3.4,<3.11.0a0"
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
================================================================================
================================================================================
linux-64
```

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here --!>
