### PR TITLE
Pin ansiwrap python

### DIFF
--- a/recipe/patch_yaml/ansiwrap.yaml
+++ b/recipe/patch_yaml/ansiwrap.yaml
@@ -7,4 +7,4 @@ if:
 then:
   - tighten_depends:
       name: python
-      upper_bound: 3.12.0a0
+      upper_bound: 3.12.0

--- a/recipe/patch_yaml/ansiwrap.yaml
+++ b/recipe/patch_yaml/ansiwrap.yaml
@@ -1,0 +1,10 @@
+# Versions of ansiwrap from before version 2.4.0 are not compatible with
+# Python 3.12 because of `ModuleNotFoundError: No module named 'imp'``
+if:
+  name: ansiwrap
+  version_lt: 0.8.5
+  timestamp_lt: 1698066670000
+then:
+  - tighten_depends:
+      name: python
+      upper_bound: 3.12.0a0


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->


References:
- https://github.com/conda-forge/dagster-feedstock/issues/297
- https://github.com/conda-forge/ansiwrap-feedstock/pull/3

```diff
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
noarch
noarch::ansiwrap-0.8.4-py_0.tar.bz2
noarch::ansiwrap-0.8.3-py_0.tar.bz2
-    "python",
+    "python <3.12.0a0",
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
================================================================================
================================================================================
linux-64

```