### PR TITLE
Patch NetworkX 3.2 build 0 with correct min python version

### DIFF
--- a/recipe/patch_yaml/networkx.yaml
+++ b/recipe/patch_yaml/networkx.yaml
@@ -36,3 +36,12 @@ then:
   - replace_depends:
       old: pandas >=1.1
       new: pandas >=1.3
+---
+if:
+  name: networkx
+  version: "3.2"
+  build_number: 0
+then:
+  - replace_depends:
+      old: python >=3.8
+      new: python >=3.9


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

This fixes https://github.com/networkx/networkx/issues/7039 

Output from `show_diff.py`:

```
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
noarch
noarch::networkx-3.2-pyhd8ed1ab_0.conda
-    "python >=3.8"
+    "python >=3.9"
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
================================================================================
================================================================================
linux-64
```
