### PR TITLE
Patch ffmpeg 6.0.0 and 6.0.1 for stricter pinning

### DIFF
--- a/recipe/patch_yaml/ffmpeg.yaml
+++ b/recipe/patch_yaml/ffmpeg.yaml
@@ -12,3 +12,13 @@ then:
   - tighten_depends:
       name: ffmpeg
       max_pin: x.x
+
+---
+
+if:
+  has_depends: ffmpeg >=6.0.[0-1],<7.0a0
+  timestamp_lt: 1699713363000
+then:
+  - tighten_depends:
+      name: ffmpeg
+      max_pin: x.x


### PR DESCRIPTION
It seems like the SO name changed
https://github.com/conda-forge/ffmpeg-feedstock/pull/216
Checklist

* [ ] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here --!>
