### PR TITLE
Stricter torchvision pin for cuda compatibility with pytorch

### DIFF
--- a/recipe/patch_yaml/torchvision.yaml
+++ b/recipe/patch_yaml/torchvision.yaml
@@ -23,3 +23,18 @@ then:
   - replace_depends:
       old: "pytorch [*] cuda[*]"
       new: "pytorch 1.10.* cuda*"
+---
+# Nov 13, 2023 -- hmaarrfk
+# It seems that torchvision wants to have the same cuda build as pytorch
+if:
+  name: "torchvision"
+  build_number_in: [0, 1, 2]
+  version: "0.15.2",
+  has_depends:
+    - "cudatoolkit >=11.2,<12"
+    - "pytorch >=2.0.0,<2.1.0a0"
+
+then:
+  - replace_depends:
+      old: "pytorch >=2.0.0,<2.1.0a0"
+      new: "pytorch 2.0.* cuda112*"

--- a/recipe/patch_yaml/torchvision.yaml
+++ b/recipe/patch_yaml/torchvision.yaml
@@ -29,7 +29,8 @@ then:
 if:
   name: "torchvision"
   build_number_in: [0, 1, 2]
-  version: "0.15.2"
+  version_ge: 0.15.0
+  version_lt: 0.16.0
   has_depends:
     - "cudatoolkit >=11.2,<12"
     - "pytorch >=2.0.0,<2.1.0a0"

--- a/recipe/patch_yaml/torchvision.yaml
+++ b/recipe/patch_yaml/torchvision.yaml
@@ -29,7 +29,7 @@ then:
 if:
   name: "torchvision"
   build_number_in: [0, 1, 2]
-  version: "0.15.2",
+  version: "0.15.2"
   has_depends:
     - "cudatoolkit >=11.2,<12"
     - "pytorch >=2.0.0,<2.1.0a0"


### PR DESCRIPTION
```
2023-11-15T23:44:09.9962063Z linux-64::torchvision-0.15.2-cuda112py39h22a746e_0.conda
2023-11-15T23:44:09.9963908Z linux-64::torchvision-0.15.2-cuda112py39h22a746e_1.conda
2023-11-15T23:44:09.9965449Z linux-64::torchvision-0.15.2-cuda112py311h3f38234_2.conda
2023-11-15T23:44:09.9967297Z linux-64::torchvision-0.15.2-cuda112py310h0801bf5_0.conda
2023-11-15T23:44:09.9968824Z linux-64::torchvision-0.15.1-cuda112py39h22a746e_0.conda
2023-11-15T23:44:09.9970531Z linux-64::torchvision-0.15.2-cuda112py311hc057aef_1.conda
2023-11-15T23:44:09.9972058Z linux-64::torchvision-0.15.1-cuda112py38h1d585ce_0.conda
2023-11-15T23:44:10.0003830Z linux-64::torchvision-0.15.2-cuda112py38h1d585ce_0.conda
2023-11-15T23:44:10.0005023Z linux-64::torchvision-0.15.1-cuda112py310h0801bf5_0.conda
2023-11-15T23:44:10.0005780Z linux-64::torchvision-0.15.2-cuda112py39h3fa74f1_2.conda
2023-11-15T23:44:10.0006451Z linux-64::torchvision-0.15.2-cuda112py310h993b30e_2.conda
2023-11-15T23:44:10.0007137Z linux-64::torchvision-0.15.2-cuda112py310h0801bf5_1.conda
2023-11-15T23:44:10.0007844Z linux-64::torchvision-0.15.2-cuda112py38h1d585ce_1.conda
2023-11-15T23:44:10.0008499Z linux-64::torchvision-0.15.1-cuda112py311hc057aef_0.conda
2023-11-15T23:44:10.0009196Z linux-64::torchvision-0.15.2-cuda112py311hc057aef_0.conda
2023-11-15T23:44:10.0009846Z linux-64::torchvision-0.15.2-cuda112py38hb061c0b_2.conda
2023-11-15T23:44:10.0010435Z -    "pytorch >=2.0.0,<2.1.0a0",
2023-11-15T23:44:10.0010835Z +    "pytorch 2.0.* cuda112*",
```

Checklist

* [ ] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here --!>
