### PR TITLE
patch prometheus_client 0.18.0 for the correct min python

### DIFF
--- a/recipe/patch_yaml/prometheus_client.yaml
+++ b/recipe/patch_yaml/prometheus_client.yaml
@@ -1,0 +1,10 @@
+# prometheus_client 0.18.0 requires Python 3.8 and does not run on older versions
+if:
+  name: prometheus_client
+  timestamp_le: 1699961588000  # 2023-11-14
+  version: 0.18.0
+  build_number_in: [0]
+then:
+  - replace_depends:
+      old: python >=3.6
+      new: python >=3.8


### PR DESCRIPTION
Checklist

* [X] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [X] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [X] Ran `python show_diff.py` and posted the output as part of the PR.
* [X] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->


PR fixing the feedstock in https://github.com/conda-forge/prometheus_client-feedstock/pull/38. Closes https://github.com/conda-forge/prometheus_client-feedstock/issues/37

```
> python show_diff.py
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
noarch
noarch::prometheus_client-0.18.0-pyhd8ed1ab_0.conda
-    "python >=3.6"
+    "python >=3.8"
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
================================================================================
================================================================================
linux-64
```