### PR TITLE
Constrain `openff-bespokefit` under new QCPortal

### DIFF
--- a/recipe/patch_yaml/openff-bespokefit-qcportal-patch.yaml
+++ b/recipe/patch_yaml/openff-bespokefit-qcportal-patch.yaml
@@ -1,0 +1,20 @@
+if:
+  subdir_in: noarch
+  artifact_in:
+    - noarch/openff-bespokefit-0.2.2-pyhd8ed1ab_5.conda
+    - noarch/openff-bespokefit-0.2.2-pyhd8ed1ab_1.conda
+    - noarch/openff-bespokefit-0.2.2-pyhd8ed1ab_0.conda
+    - noarch/openff-bespokefit-0.2.1-pyhd8ed1ab_0.conda
+    - noarch/openff-bespokefit-0.1.3-pyhd8ed1ab_3.conda
+    - noarch/openff-bespokefit-0.1.3-pyhd8ed1ab_2.conda
+    - noarch/openff-bespokefit-0.2.0-pyhd8ed1ab_1.conda
+    - noarch/openff-bespokefit-0.2.0-pyhd8ed1ab_0.conda
+    - noarch/openff-bespokefit-0.1.3-pyhd8ed1ab_0.conda
+    - noarch/openff-bespokefit-0.1.2-pyhd8ed1ab_1.tar.bz2
+    - noarch/openff-bespokefit-0.1.2-pyhd8ed1ab_0.tar.bz2
+    - noarch/openff-bespokefit-0.1.1-pyhd8ed1ab_0.tar.bz2
+    - noarch/openff-bespokefit-0.1.0-pyhd8ed1ab_0.tar.bz2
+then:
+  - replace_depends:
+      old: "qcportal >=0.15.6"
+      new: "qcportal >=0.15.6,<0.50"

--- a/recipe/patch_yaml/openff-bespokefit-qcportal-patch.yaml
+++ b/recipe/patch_yaml/openff-bespokefit-qcportal-patch.yaml
@@ -1,19 +1,19 @@
 if:
   subdir_in: noarch
   artifact_in:
-    - noarch/openff-bespokefit-0.2.2-pyhd8ed1ab_5.conda
-    - noarch/openff-bespokefit-0.2.2-pyhd8ed1ab_1.conda
-    - noarch/openff-bespokefit-0.2.2-pyhd8ed1ab_0.conda
-    - noarch/openff-bespokefit-0.2.1-pyhd8ed1ab_0.conda
-    - noarch/openff-bespokefit-0.1.3-pyhd8ed1ab_3.conda
-    - noarch/openff-bespokefit-0.1.3-pyhd8ed1ab_2.conda
-    - noarch/openff-bespokefit-0.2.0-pyhd8ed1ab_1.conda
-    - noarch/openff-bespokefit-0.2.0-pyhd8ed1ab_0.conda
-    - noarch/openff-bespokefit-0.1.3-pyhd8ed1ab_0.conda
-    - noarch/openff-bespokefit-0.1.2-pyhd8ed1ab_1.tar.bz2
-    - noarch/openff-bespokefit-0.1.2-pyhd8ed1ab_0.tar.bz2
-    - noarch/openff-bespokefit-0.1.1-pyhd8ed1ab_0.tar.bz2
-    - noarch/openff-bespokefit-0.1.0-pyhd8ed1ab_0.tar.bz2
+    - openff-bespokefit-0.2.2-pyhd8ed1ab_5.conda
+    - openff-bespokefit-0.2.2-pyhd8ed1ab_1.conda
+    - openff-bespokefit-0.2.2-pyhd8ed1ab_0.conda
+    - openff-bespokefit-0.2.1-pyhd8ed1ab_0.conda
+    - openff-bespokefit-0.1.3-pyhd8ed1ab_3.conda
+    - openff-bespokefit-0.1.3-pyhd8ed1ab_2.conda
+    - openff-bespokefit-0.2.0-pyhd8ed1ab_1.conda
+    - openff-bespokefit-0.2.0-pyhd8ed1ab_0.conda
+    - openff-bespokefit-0.1.3-pyhd8ed1ab_0.conda
+    - openff-bespokefit-0.1.2-pyhd8ed1ab_1.tar.bz2
+    - openff-bespokefit-0.1.2-pyhd8ed1ab_0.tar.bz2
+    - openff-bespokefit-0.1.1-pyhd8ed1ab_0.tar.bz2
+    - openff-bespokefit-0.1.0-pyhd8ed1ab_0.tar.bz2
 then:
   - replace_depends:
       old: "qcportal >=0.15.6"


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

One of our dependencies updated their API and our packages now pull in an incompatible version. I'm here because I know adding new builds with this extra constraint won't be the best solution to the problem.

It took a bit of work to install the deps to run the script (would it be useful to update `recipe/README.md` with a "here's what you need to install to run this" section?), but here it is:

```shell
$ python show_diff.py --use-cache --subdirs noarch
================================================================================
================================================================================
noarch
noarch::openff-bespokefit-0.1.0-pyhd8ed1ab_0.tar.bz2
noarch::openff-bespokefit-0.2.2-pyhd8ed1ab_1.conda
noarch::openff-bespokefit-0.2.2-pyhd8ed1ab_5.conda
noarch::openff-bespokefit-0.1.3-pyhd8ed1ab_0.conda
noarch::openff-bespokefit-0.2.1-pyhd8ed1ab_0.conda
noarch::openff-bespokefit-0.1.1-pyhd8ed1ab_0.tar.bz2
noarch::openff-bespokefit-0.1.3-pyhd8ed1ab_2.conda
noarch::openff-bespokefit-0.1.2-pyhd8ed1ab_1.tar.bz2
noarch::openff-bespokefit-0.1.2-pyhd8ed1ab_0.tar.bz2
noarch::openff-bespokefit-0.1.3-pyhd8ed1ab_3.conda
noarch::openff-bespokefit-0.2.2-pyhd8ed1ab_0.conda
-    "qcportal >=0.15.6",
+    "qcportal >=0.15.6,<0.50",
```

I was looking for a `name: openff-bespokefit` sort of field but couldn't navigate my way into one ... `  <repodata key>: openff-bespokefit` didn't seem right. I also assume `artifact_in:` wouldn't take regex within the YAML, but I didn't try.