### PR TITLE
Tighten pinning on S2geometry for Pys2index

### DIFF
--- a/recipe/patch_yaml/pys2index.yaml
+++ b/recipe/patch_yaml/pys2index.yaml
@@ -1,0 +1,8 @@
+if:
+  name: pys2index
+  version_in: ["0.1.3", "0.1.4"]
+  timestamp_lt: 1700148986000
+then:
+  - replace_depends:
+      old: s2geometry
+      new: s2geometry >=0.10.0

--- a/recipe/patch_yaml/pys2index.yaml
+++ b/recipe/patch_yaml/pys2index.yaml
@@ -1,7 +1,7 @@
 if:
   name: pys2index
   version_in: ["0.1.3", "0.1.4"]
-  timestamp_lt: 1700148986000
+  timestamp_lt: 1700488387000
 then:
   - replace_depends:
       old: s2geometry


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] ~Only wrote code directly into `generate_patch_json.py` if absolutely necessary.~
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future.

This fixes a build incompatibility described in conda-forge/pys2index-feedstock#17 and resolved in conda-forge/pys2index-feedstock#18.

Basically, `s2geometry` changed from only providing `libs2.so` in versions up to 0.9.0, to the more standard `libs2.so.0.10.0`, `libs2.so.0`, `libs2.so` triple in 0.10.0. The loose pinning in `pys2index` meant that versions of `pys2index` built with the newer `s2geometry` versions and hence linking against `libs2.so.0` could be installed alongside older `s2geometry` versions without that file.

Output from `python show_diff.py`:

```
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
osx-arm64::pys2index-0.1.3-py38he0a633c_2.tar.bz2
osx-arm64::pys2index-0.1.3-py310ha6127ee_0.tar.bz2
osx-arm64::pys2index-0.1.4-py312h260253b_0.conda
osx-arm64::pys2index-0.1.3-py38he0a633c_1.tar.bz2
osx-arm64::pys2index-0.1.3-py311h5c64717_2.tar.bz2
osx-arm64::pys2index-0.1.4-py39h819cc4c_0.conda
osx-arm64::pys2index-0.1.4-py311hddbb800_0.conda
osx-arm64::pys2index-0.1.3-py39h99de9ae_2.tar.bz2
osx-arm64::pys2index-0.1.3-py39h99de9ae_1.tar.bz2
osx-arm64::pys2index-0.1.3-py310h629746b_2.tar.bz2
osx-arm64::pys2index-0.1.3-py39hc86685f_0.tar.bz2
osx-arm64::pys2index-0.1.3-py38h7fa088a_0.tar.bz2
osx-arm64::pys2index-0.1.3-py310h629746b_1.tar.bz2
osx-arm64::pys2index-0.1.4-py310he53c7d2_0.conda
-    "s2geometry"
+    "s2geometry >=0.10.0"
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
noarch
================================================================================
================================================================================
win-64
win-64::pys2index-0.1.3-py38h137dd97_2.tar.bz2
win-64::pys2index-0.1.3-py310hc781a3c_0.tar.bz2
win-64::pys2index-0.1.3-py37h2cdfcc5_0.tar.bz2
win-64::pys2index-0.1.3-py39hefe7e4c_0.tar.bz2
win-64::pys2index-0.1.3-py310h220cb41_2.tar.bz2
win-64::pys2index-0.1.3-py38h137dd97_1.tar.bz2
win-64::pys2index-0.1.3-py310h220cb41_1.tar.bz2
win-64::pys2index-0.1.3-py39hbd792c9_2.tar.bz2
win-64::pys2index-0.1.4-py39h5c3ab46_0.conda
win-64::pys2index-0.1.4-py312h4f1204c_0.conda
win-64::pys2index-0.1.3-py311h12feb9d_2.tar.bz2
win-64::pys2index-0.1.3-py38h9e3ed74_0.tar.bz2
win-64::pys2index-0.1.4-py311h12feb9d_0.conda
win-64::pys2index-0.1.4-py310h4856b71_0.conda
win-64::pys2index-0.1.3-py39hbd792c9_1.tar.bz2
-    "s2geometry",
+    "s2geometry >=0.10.0",
================================================================================
================================================================================
osx-64
osx-64::pys2index-0.1.3-py38he49a349_1.tar.bz2
osx-64::pys2index-0.1.3-py39h6dc771e_2.tar.bz2
osx-64::pys2index-0.1.4-py39h577a1a9_0.conda
osx-64::pys2index-0.1.4-py312h3d0a563_0.conda
osx-64::pys2index-0.1.3-py37hc08ad63_0.tar.bz2
osx-64::pys2index-0.1.3-py310h5f0db6a_0.tar.bz2
osx-64::pys2index-0.1.4-py310h28179fc_0.conda
osx-64::pys2index-0.1.3-py310h3e792ce_1.tar.bz2
osx-64::pys2index-0.1.3-py39hdd8ae6b_0.tar.bz2
osx-64::pys2index-0.1.3-py38h63108dd_0.tar.bz2
osx-64::pys2index-0.1.3-py311h349b758_2.tar.bz2
osx-64::pys2index-0.1.3-py38he49a349_2.tar.bz2
osx-64::pys2index-0.1.3-py39h6dc771e_1.tar.bz2
osx-64::pys2index-0.1.3-py310h3e792ce_2.tar.bz2
osx-64::pys2index-0.1.4-py311hba0c30a_0.conda
-    "s2geometry"
+    "s2geometry >=0.10.0"
================================================================================
================================================================================
linux-64
linux-64::pys2index-0.1.3-py311h59ea3da_2.tar.bz2
linux-64::pys2index-0.1.3-py37h48bf904_0.tar.bz2
linux-64::pys2index-0.1.4-py310hcb52e73_0.conda
linux-64::pys2index-0.1.3-py310hc4a4660_1.tar.bz2
linux-64::pys2index-0.1.3-py39hac2352c_0.tar.bz2
linux-64::pys2index-0.1.3-py39h7c9e3ff_2.tar.bz2
linux-64::pys2index-0.1.4-py311h92ebd52_0.conda
linux-64::pys2index-0.1.3-py38h4e30db6_1.tar.bz2
linux-64::pys2index-0.1.4-py39hda80f44_0.conda
linux-64::pys2index-0.1.3-py38h514daf8_0.tar.bz2
linux-64::pys2index-0.1.4-py312hfb10629_0.conda
linux-64::pys2index-0.1.3-py38h4e30db6_2.tar.bz2
linux-64::pys2index-0.1.3-py39h7c9e3ff_1.tar.bz2
linux-64::pys2index-0.1.3-py310hc4a4660_2.tar.bz2
linux-64::pys2index-0.1.3-py310hc4a4660_0.tar.bz2
-    "s2geometry"
+    "s2geometry >=0.10.0"
```