### PR TITLE
fix: patch rptools

### DIFF
--- a/recipe/patch_yaml/rptools.yaml
+++ b/recipe/patch_yaml/rptools.yaml
@@ -1,0 +1,10 @@
+# from this snippet
+# pin python min,max python versions (fixed in newer version of rptools)
+if:
+  name: rptools
+  version: 6.4.1
+  timestamp: 1700600480423
+then:
+  - replace_depends:
+      old: python <=3.11
+      new: python >=3.7,<3.11


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

Output of  `python show_diff.py`:
```
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
noarch
noarch::rptools-6.4.1-pyhd8ed1ab_0.conda
-    "python <=3.11",
+    "python >=3.7,<3.11",
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
================================================================================
================================================================================
linux-6
```

