### PR TITLE
Sardana isn't compatible with Python 3.12

### DIFF
--- a/recipe/patch_yaml/sardana.yaml
+++ b/recipe/patch_yaml/sardana.yaml
@@ -15,3 +15,19 @@ then:
   - replace_depends:
       old: taurus >=4.7.0
       new: taurus >=4.7.0,<5
+---
+if:
+  name: sardana
+  version_le: 3.4.2
+then:
+  - replace_depends:
+      old: python >=3.5
+      new: python >=3.5,<3.12
+---
+if:
+  name: sardana-core
+  version_le: 3.4.2
+then:
+  - replace_depends:
+      old: python >=3.5
+      new: python >=3.5,<3.12


### PR DESCRIPTION
Checklist

* [X] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [X] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [X] Ran `python show_diff.py` and posted the output as part of the PR.
* [X] Modifications won't affect packages built in the future.

Requirements were already updated in the recipe for sardana 3.4.3.
 
Yesterday `pytango` (one of sardana requirements) 9.5.0 was released and added Python 3.12 compatibility. This is creating issues because python 3.12 is now installed by default when building and testing packages depending on sardana, which doesn't work.
Previous versions (`<=3.4.2`) need to be patched to avoid this.

Sardana was split in multiple outputs after 3.4.0. Need to patch sardana-core for those versions.

I didn't put a condition with timestamp as I set `version_le: 3.4.2` and current conda package version is 3.4.3.

```
# python show_diff.py --subdirs noarch --use-cache
================================================================================
================================================================================
noarch
noarch::sardana-3.1.3-pyhd8ed1ab_0.tar.bz2
noarch::sardana-3.2.1-pyhd8ed1ab_0.tar.bz2
noarch::sardana-3.1.3-pyhd8ed1ab_1.tar.bz2
noarch::sardana-3.1.1-pyhd8ed1ab_0.tar.bz2
noarch::sardana-3.2.0-pyhd8ed1ab_0.tar.bz2
noarch::sardana-3.0.3-pyhd8ed1ab_0.tar.bz2
noarch::sardana-3.1.0-pyhd8ed1ab_0.tar.bz2
noarch::sardana-3.3.8-pyhd8ed1ab_0.conda
noarch::sardana-3.1.2-pyhd8ed1ab_0.tar.bz2
noarch::sardana-core-3.4.2-pyhd8ed1ab_0.conda
noarch::sardana-3.3.3-pyhd8ed1ab_0.tar.bz2
noarch::sardana-3.3.6-pyhd8ed1ab_0.tar.bz2
noarch::sardana-core-3.4.0-pyhd8ed1ab_1.conda
noarch::sardana-core-3.4.0-pyhd8ed1ab_2.conda
noarch::sardana-3.3.5-pyhd8ed1ab_0.tar.bz2
noarch::sardana-core-3.4.1-pyhd8ed1ab_0.conda
noarch::sardana-3.3.4-pyhd8ed1ab_0.tar.bz2
noarch::sardana-3.3.7-pyhd8ed1ab_0.conda
-    "python >=3.5",
+    "python >=3.5,<3.12",
```
