### PR TITLE
fix postgres vs. openssl 3.2

### DIFF
--- a/recipe/patch_yaml/libpq.yaml
+++ b/recipe/patch_yaml/libpq.yaml
@@ -1,0 +1,8 @@
+# see https://github.com/conda-forge/postgresql-feedstock/issues/178
+if:
+  name: libpq
+  timestamp_lt: 1701138897977
+then:
+  - tighten_depends:
+      name: openssl
+      upper_bound: "3.2"


### PR DESCRIPTION
See https://github.com/conda-forge/postgresql-feedstock/issues/178 for more details.

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->



```diff
>python show_diff.py
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
osx-arm64::libpq-14.2-h2f670be_0.tar.bz2
osx-arm64::libpq-13.5-h2f670be_1.tar.bz2
osx-arm64::libpq-14.1-h2f670be_1.tar.bz2
-    "openssl >=3.0.0,<4.0a0",
+    "openssl >=3.0.0,<3.2.0a0",
osx-arm64::libpq-14.5-h2af30dc_1.tar.bz2
osx-arm64::libpq-14.5-hd90caff_0.tar.bz2
osx-arm64::libpq-13.8-h2af30dc_0.tar.bz2
-    "openssl >=3.0.5,<4.0a0",
+    "openssl >=3.0.5,<3.2.0a0",
osx-arm64::libpq-14.4-hd0d3353_0.tar.bz2
osx-arm64::libpq-14.3-hd0d3353_0.tar.bz2
-    "openssl >=3.0.3,<4.0a0",
+    "openssl >=3.0.3,<3.2.0a0",
osx-arm64::libpq-15.1-h998ac43_1.conda
osx-arm64::libpq-14.5-h998ac43_2.conda
osx-arm64::libpq-14.5-h1a28acd_4.conda
osx-arm64::libpq-14.5-h1a28acd_5.conda
osx-arm64::libpq-15.1-h1a28acd_2.conda
osx-arm64::libpq-14.5-h998ac43_3.conda
osx-arm64::libpq-15.1-h1a28acd_3.conda
-    "openssl >=3.0.7,<4.0a0"
+    "openssl >=3.0.7,<3.2.0a0"
osx-arm64::libpq-15.3-h7126958_0.conda
osx-arm64::libpq-15.3-h7126958_1.conda
osx-arm64::libpq-14.5-h7126958_6.conda
-    "openssl >=3.1.0,<4.0a0"
+    "openssl >=3.1.0,<3.2.0a0"
osx-arm64::libpq-15.3-hcea71ed_2.conda
osx-arm64::libpq-14.5-hcea71ed_7.conda
-    "openssl >=3.1.1,<4.0a0"
+    "openssl >=3.1.1,<3.2.0a0"
osx-arm64::libpq-15.0-h2af30dc_1.conda
osx-arm64::libpq-15.1-h2af30dc_0.conda
-    "openssl >=3.0.7,<4.0a0",
+    "openssl >=3.0.7,<3.2.0a0",
osx-arm64::libpq-15.2-h1a28acd_0.conda
-    "openssl >=3.0.8,<4.0a0"
+    "openssl >=3.0.8,<3.2.0a0"
osx-arm64::libpq-15.4-hcea71ed_0.conda
-    "openssl >=3.1.2,<4.0a0"
+    "openssl >=3.1.2,<3.2.0a0"
osx-arm64::libpq-15.4-hcea71ed_2.conda
osx-arm64::libpq-16.0-hcea71ed_0.conda
osx-arm64::libpq-15.4-hcea71ed_1.conda
osx-arm64::libpq-16.0-hcea71ed_1.conda
-    "openssl >=3.1.3,<4.0a0"
+    "openssl >=3.1.3,<3.2.0a0"
osx-arm64::libpq-16.1-hd435d45_0.conda
-    "openssl >=3.1.4,<4.0a0"
+    "openssl >=3.1.4,<3.2.0a0"
================================================================================
================================================================================
linux-ppc64le
linux-ppc64le::libpq-13.5-h3e31190_1.tar.bz2
linux-ppc64le::libpq-14.1-h3e31190_1.tar.bz2
linux-ppc64le::libpq-14.2-h3e31190_0.tar.bz2
-    "openssl >=3.0.0,<4.0a0",
+    "openssl >=3.0.0,<3.2.0a0",
linux-ppc64le::libpq-14.5-h8203483_0.tar.bz2
linux-ppc64le::libpq-14.5-h8203483_1.tar.bz2
linux-ppc64le::libpq-13.8-h8203483_0.tar.bz2
-    "openssl >=3.0.5,<4.0a0",
+    "openssl >=3.0.5,<3.2.0a0",
linux-ppc64le::libpq-14.4-h8203483_0.tar.bz2
linux-ppc64le::libpq-14.3-h8203483_0.tar.bz2
-    "openssl >=3.0.3,<4.0a0",
+    "openssl >=3.0.3,<3.2.0a0",
linux-ppc64le::libpq-15.1-h41524dc_1.conda
linux-ppc64le::libpq-15.1-h38393a0_2.conda
linux-ppc64le::libpq-14.5-h38393a0_5.conda
linux-ppc64le::libpq-15.1-h38393a0_3.conda
linux-ppc64le::libpq-14.5-h38393a0_4.conda
linux-ppc64le::libpq-14.5-h41524dc_2.conda
linux-ppc64le::libpq-14.5-haac5f4d_3.conda
-    "openssl >=3.0.7,<4.0a0"
+    "openssl >=3.0.7,<3.2.0a0"
linux-ppc64le::libpq-15.3-h7442559_0.conda
linux-ppc64le::libpq-15.3-h7442559_1.conda
linux-ppc64le::libpq-14.5-h7442559_6.conda
-    "openssl >=3.1.0,<4.0a0"
+    "openssl >=3.1.0,<3.2.0a0"
linux-ppc64le::libpq-15.3-h9d99649_2.conda
linux-ppc64le::libpq-14.5-h9d99649_7.conda
-    "openssl >=3.1.1,<4.0a0"
+    "openssl >=3.1.1,<3.2.0a0"
linux-ppc64le::libpq-15.1-h8203483_0.conda
linux-ppc64le::libpq-15.0-h8203483_1.conda
-    "openssl >=3.0.7,<4.0a0",
+    "openssl >=3.0.7,<3.2.0a0",
linux-ppc64le::libpq-15.2-h38393a0_0.conda
-    "openssl >=3.0.8,<4.0a0"
+    "openssl >=3.0.8,<3.2.0a0"
linux-ppc64le::libpq-15.4-h9d99649_0.conda
-    "openssl >=3.1.2,<4.0a0"
+    "openssl >=3.1.2,<3.2.0a0"
linux-ppc64le::libpq-16.0-h9d99649_1.conda
linux-ppc64le::libpq-15.4-h9d99649_1.conda
linux-ppc64le::libpq-16.0-h9d99649_0.conda
linux-ppc64le::libpq-15.4-h9d99649_2.conda
-    "openssl >=3.1.3,<4.0a0"
+    "openssl >=3.1.3,<3.2.0a0"
linux-ppc64le::libpq-16.1-h9d99649_0.conda
-    "openssl >=3.1.4,<4.0a0"
+    "openssl >=3.1.4,<3.2.0a0"
================================================================================
================================================================================
linux-aarch64
linux-aarch64::libpq-14.1-he5b4f81_1.tar.bz2
linux-aarch64::libpq-14.2-he5b4f81_0.tar.bz2
linux-aarch64::libpq-13.5-he5b4f81_1.tar.bz2
-    "openssl >=3.0.0,<4.0a0",
+    "openssl >=3.0.0,<3.2.0a0",
linux-aarch64::libpq-14.5-h2856e3f_1.tar.bz2
linux-aarch64::libpq-14.5-h2856e3f_0.tar.bz2
linux-aarch64::libpq-13.8-h2856e3f_0.tar.bz2
-    "openssl >=3.0.5,<4.0a0",
+    "openssl >=3.0.5,<3.2.0a0",
linux-aarch64::libpq-14.4-h2856e3f_0.tar.bz2
linux-aarch64::libpq-14.3-h2856e3f_0.tar.bz2
-    "openssl >=3.0.3,<4.0a0",
+    "openssl >=3.0.3,<3.2.0a0",
linux-aarch64::libpq-15.3-h04b8c23_2.conda
linux-aarch64::libpq-14.5-h04b8c23_7.conda
-    "openssl >=3.1.1,<4.0a0"
+    "openssl >=3.1.1,<3.2.0a0"
linux-aarch64::libpq-15.1-hd21d9e6_2.conda
linux-aarch64::libpq-15.1-hd21d9e6_3.conda
linux-aarch64::libpq-14.5-hd21d9e6_5.conda
linux-aarch64::libpq-15.1-h68e116c_1.conda
linux-aarch64::libpq-14.5-hd21d9e6_4.conda
linux-aarch64::libpq-14.5-h68e116c_2.conda
linux-aarch64::libpq-14.5-h9991ba5_3.conda
-    "openssl >=3.0.7,<4.0a0"
+    "openssl >=3.0.7,<3.2.0a0"
linux-aarch64::libpq-14.5-hf616e62_6.conda
linux-aarch64::libpq-15.3-hf616e62_0.conda
linux-aarch64::libpq-15.3-hf616e62_1.conda
-    "openssl >=3.1.0,<4.0a0"
+    "openssl >=3.1.0,<3.2.0a0"
linux-aarch64::libpq-15.1-h2856e3f_0.conda
linux-aarch64::libpq-15.0-h2856e3f_1.conda
-    "openssl >=3.0.7,<4.0a0",
+    "openssl >=3.0.7,<3.2.0a0",
linux-aarch64::libpq-15.2-hd21d9e6_0.conda
-    "openssl >=3.0.8,<4.0a0"
+    "openssl >=3.0.8,<3.2.0a0"
linux-aarch64::libpq-15.4-h04b8c23_0.conda
-    "openssl >=3.1.2,<4.0a0"
+    "openssl >=3.1.2,<3.2.0a0"
linux-aarch64::libpq-16.0-h04b8c23_0.conda
linux-aarch64::libpq-15.4-h04b8c23_2.conda
linux-aarch64::libpq-16.0-h04b8c23_1.conda
linux-aarch64::libpq-15.4-h04b8c23_1.conda
-    "openssl >=3.1.3,<4.0a0"
+    "openssl >=3.1.3,<3.2.0a0"
linux-aarch64::libpq-16.1-h04b8c23_0.conda
-    "openssl >=3.1.4,<4.0a0"
+    "openssl >=3.1.4,<3.2.0a0"
================================================================================
================================================================================
noarch
================================================================================
================================================================================
win-64
win-64::libpq-14.2-h1ea2d34_0.tar.bz2
win-64::libpq-13.5-h1ea2d34_1.tar.bz2
win-64::libpq-14.1-h1ea2d34_1.tar.bz2
-    "openssl >=3.0.0,<4.0a0",
+    "openssl >=3.0.0,<3.2.0a0",
win-64::libpq-14.5-h1ea2d34_0.tar.bz2
win-64::libpq-14.5-hf15792c_1.tar.bz2
win-64::libpq-13.8-hf15792c_0.tar.bz2
-    "openssl >=3.0.5,<4.0a0",
+    "openssl >=3.0.5,<3.2.0a0",
win-64::libpq-14.4-h1ea2d34_0.tar.bz2
win-64::libpq-14.3-h1ea2d34_0.tar.bz2
-    "openssl >=3.0.3,<4.0a0",
+    "openssl >=3.0.3,<3.2.0a0",
win-64::libpq-14.5-h43585b0_7.conda
win-64::libpq-15.3-h43585b0_2.conda
-    "openssl >=3.1.1,<4.0a0",
+    "openssl >=3.1.1,<3.2.0a0",
win-64::libpq-15.1-hf15792c_1.conda
win-64::libpq-14.5-ha9684e8_5.conda
win-64::libpq-14.5-ha9684e8_4.conda
win-64::libpq-14.5-hf15792c_3.conda
win-64::libpq-15.1-hf15792c_0.conda
win-64::libpq-15.1-ha9684e8_3.conda
win-64::libpq-14.5-hf15792c_2.conda
win-64::libpq-15.1-ha9684e8_2.conda
win-64::libpq-15.0-hf15792c_1.conda
-    "openssl >=3.0.7,<4.0a0",
+    "openssl >=3.0.7,<3.2.0a0",
win-64::libpq-14.5-ha9684e8_6.conda
win-64::libpq-15.3-ha9684e8_1.conda
win-64::libpq-15.3-ha9684e8_0.conda
-    "openssl >=3.1.0,<4.0a0",
+    "openssl >=3.1.0,<3.2.0a0",
win-64::libpq-15.2-ha9684e8_0.conda
-    "openssl >=3.0.8,<4.0a0",
+    "openssl >=3.0.8,<3.2.0a0",
win-64::libpq-15.4-h43585b0_0.conda
-    "openssl >=3.1.2,<4.0a0",
+    "openssl >=3.1.2,<3.2.0a0",
win-64::libpq-16.0-h43585b0_0.conda
win-64::libpq-15.4-h43585b0_1.conda
win-64::libpq-16.0-h43585b0_1.conda
win-64::libpq-15.4-h43585b0_2.conda
-    "openssl >=3.1.3,<4.0a0",
+    "openssl >=3.1.3,<3.2.0a0",
win-64::libpq-16.1-h43585b0_0.conda
-    "openssl >=3.1.4,<4.0a0",
+    "openssl >=3.1.4,<3.2.0a0",
================================================================================
================================================================================
osx-64
osx-64::libpq-14.2-h8ce7ee7_0.tar.bz2
osx-64::libpq-14.1-h8ce7ee7_1.tar.bz2
osx-64::libpq-13.5-h8ce7ee7_1.tar.bz2
-    "openssl >=3.0.0,<4.0a0",
+    "openssl >=3.0.0,<3.2.0a0",
osx-64::libpq-14.5-hd79e848_1.tar.bz2
osx-64::libpq-14.5-h2ca9b15_0.tar.bz2
osx-64::libpq-13.8-hd79e848_0.tar.bz2
-    "openssl >=3.0.5,<4.0a0",
+    "openssl >=3.0.5,<3.2.0a0",
osx-64::libpq-14.3-h2b7167c_0.tar.bz2
osx-64::libpq-14.4-h2b7167c_0.tar.bz2
-    "openssl >=3.0.3,<4.0a0",
+    "openssl >=3.0.3,<3.2.0a0",
osx-64::libpq-15.1-hb1ae2b1_1.conda
osx-64::libpq-15.1-h3640bf0_3.conda
osx-64::libpq-15.1-h3640bf0_2.conda
osx-64::libpq-14.5-h3640bf0_5.conda
osx-64::libpq-14.5-hb1ae2b1_2.conda
osx-64::libpq-14.5-h3640bf0_4.conda
osx-64::libpq-14.5-hb1ae2b1_3.conda
-    "openssl >=3.0.7,<4.0a0"
+    "openssl >=3.0.7,<3.2.0a0"
osx-64::libpq-14.5-h3df487d_7.conda
osx-64::libpq-15.3-h3df487d_2.conda
-    "openssl >=3.1.1,<4.0a0"
+    "openssl >=3.1.1,<3.2.0a0"
osx-64::libpq-15.3-h9dc22bb_1.conda
osx-64::libpq-15.3-h9dc22bb_0.conda
osx-64::libpq-14.5-h9dc22bb_6.conda
-    "openssl >=3.1.0,<4.0a0"
+    "openssl >=3.1.0,<3.2.0a0"
osx-64::libpq-15.0-hd79e848_1.conda
osx-64::libpq-15.1-hd79e848_0.conda
-    "openssl >=3.0.7,<4.0a0",
+    "openssl >=3.0.7,<3.2.0a0",
osx-64::libpq-15.2-h3640bf0_0.conda
-    "openssl >=3.0.8,<4.0a0"
+    "openssl >=3.0.8,<3.2.0a0"
osx-64::libpq-15.4-h3df487d_0.conda
-    "openssl >=3.1.2,<4.0a0"
+    "openssl >=3.1.2,<3.2.0a0"
osx-64::libpq-16.0-h3df487d_1.conda
osx-64::libpq-16.0-h3df487d_0.conda
osx-64::libpq-15.4-h3df487d_1.conda
osx-64::libpq-15.4-h3df487d_2.conda
-    "openssl >=3.1.3,<4.0a0"
+    "openssl >=3.1.3,<3.2.0a0"
osx-64::libpq-16.1-h6dd4ff7_0.conda
-    "openssl >=3.1.4,<4.0a0"
+    "openssl >=3.1.4,<3.2.0a0"
================================================================================
================================================================================
linux-64
linux-64::libpq-14.1-h676c864_1.tar.bz2
linux-64::libpq-13.5-h676c864_1.tar.bz2
linux-64::libpq-14.2-h676c864_0.tar.bz2
-    "openssl >=3.0.0,<4.0a0",
+    "openssl >=3.0.0,<3.2.0a0",
linux-64::libpq-14.5-he2d8382_0.tar.bz2
linux-64::libpq-13.8-he2d8382_0.tar.bz2
linux-64::libpq-14.5-he2d8382_1.tar.bz2
-    "openssl >=3.0.5,<4.0a0",
+    "openssl >=3.0.5,<3.2.0a0",
linux-64::libpq-14.3-he2d8382_0.tar.bz2
linux-64::libpq-14.4-he2d8382_0.tar.bz2
-    "openssl >=3.0.3,<4.0a0",
+    "openssl >=3.0.3,<3.2.0a0",
linux-64::libpq-15.1-h67c24c5_1.conda
linux-64::libpq-15.1-hb675445_3.conda
linux-64::libpq-14.5-h52d0468_3.conda
linux-64::libpq-14.5-hb675445_5.conda
linux-64::libpq-14.5-hb675445_4.conda
linux-64::libpq-14.5-h67c24c5_2.conda
linux-64::libpq-15.1-hb675445_2.conda
-    "openssl >=3.0.7,<4.0a0"
+    "openssl >=3.0.7,<3.2.0a0"
linux-64::libpq-14.5-hbcd7760_6.conda
linux-64::libpq-15.3-hbcd7760_1.conda
linux-64::libpq-15.3-hbcd7760_0.conda
-    "openssl >=3.1.0,<4.0a0"
+    "openssl >=3.1.0,<3.2.0a0"
linux-64::libpq-14.5-hfc447b1_7.conda
linux-64::libpq-15.3-hfc447b1_2.conda
-    "openssl >=3.1.1,<4.0a0"
+    "openssl >=3.1.1,<3.2.0a0"
linux-64::libpq-15.1-he2d8382_0.conda
linux-64::libpq-15.0-he2d8382_1.conda
-    "openssl >=3.0.7,<4.0a0",
+    "openssl >=3.0.7,<3.2.0a0",
linux-64::libpq-15.2-hb675445_0.conda
-    "openssl >=3.0.8,<4.0a0"
+    "openssl >=3.0.8,<3.2.0a0"
linux-64::libpq-15.4-hfc447b1_0.conda
-    "openssl >=3.1.2,<4.0a0"
+    "openssl >=3.1.2,<3.2.0a0"
linux-64::libpq-15.4-hfc447b1_2.conda
linux-64::libpq-16.0-hfc447b1_1.conda
linux-64::libpq-16.0-hfc447b1_0.conda
linux-64::libpq-15.4-hfc447b1_1.conda
-    "openssl >=3.1.3,<4.0a0"
+    "openssl >=3.1.3,<3.2.0a0"
linux-64::libpq-16.1-hfc447b1_0.conda
-    "openssl >=3.1.4,<4.0a0"
+    "openssl >=3.1.4,<3.2.0a0"
```
