### PR TITLE
pin existing universal_pathlib to python<3.12

### DIFF
--- a/recipe/patch_yaml/universal_pathlib.yaml
+++ b/recipe/patch_yaml/universal_pathlib.yaml
@@ -1,0 +1,8 @@
+if:
+  name: universal_pathlib
+  version_le: 0.1.4
+  timestamp_lt: 1701176492000
+then:
+  - tighten_depends:
+      name: python
+      upper_bound: "3.12.0"


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

references:
- fixes https://github.com/conda-forge/universal_pathlib-feedstock/issues/35
- observed in https://github.com/conda-forge/dagster-libs-feedstock/pull/13

```diff
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
noarch
noarch::universal_pathlib-0.0.21-pyh191b570_0.tar.bz2
noarch::universal_pathlib-0.0.12-pyhe74cb21_0.tar.bz2
noarch::universal_pathlib-0.0.19-pyh191b570_0.tar.bz2
noarch::universal_pathlib-0.0.23-pyh71feb2d_0.conda
noarch::universal_pathlib-0.0.9-pyhe74cb21_0.tar.bz2
noarch::universal_pathlib-0.0.15-pyh191b570_0.tar.bz2
noarch::universal_pathlib-0.0.17-pyh191b570_0.tar.bz2
noarch::universal_pathlib-0.0.2-pyhf1ccde4_0.tar.bz2
noarch::universal_pathlib-v0.0.2-pyhf1ccde4_0.tar.bz2
noarch::universal_pathlib-0.0.6-pyhe74cb21_0.tar.bz2
noarch::universal_pathlib-0.0.11-pyhe74cb21_0.tar.bz2
noarch::universal_pathlib-0.0.7-pyhe74cb21_0.tar.bz2
noarch::universal_pathlib-0.0.10-pyhe74cb21_0.tar.bz2
noarch::universal_pathlib-0.0.16-pyh191b570_0.tar.bz2
noarch::universal_pathlib-v0.0.1-pyhf1ccde4_0.tar.bz2
noarch::universal_pathlib-0.0.20-pyh191b570_0.tar.bz2
noarch::universal_pathlib-0.0.3-pyhe74cb21_0.tar.bz2
noarch::universal_pathlib-0.0.18-pyh191b570_0.tar.bz2
noarch::universal_pathlib-0.0.22-pyh71feb2d_0.conda
-    "python >=3.7"
+    "python >=3.7,<3.12.0a0"
noarch::universal_pathlib-0.1.1-pyhd8ed1ab_0.conda
noarch::universal_pathlib-0.1.0-pyhd8ed1ab_0.conda
noarch::universal_pathlib-0.1.3-pyhd8ed1ab_0.conda
noarch::universal_pathlib-0.0.24-pyhd8ed1ab_0.conda
noarch::universal_pathlib-0.1.2-pyhd8ed1ab_0.conda
-    "python >=3.8"
+    "python >=3.8,<3.12.0a0"
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
================================================================================
================================================================================
linux-64

```