### PR TITLE
Parametrize the pydantic validation for better error message

### DIFF
--- a/recipe/test_patch_yaml_utils.py
+++ b/recipe/test_patch_yaml_utils.py
@@ -529,8 +529,7 @@ def test_schema_up_to_date():
     assert schema_str == schema_on_disk
 
 
-patch_yaml_files = list((Path(__file__).parent / "patch_yaml").glob("*.yaml"))
-patch_yaml_files.sort()
+patch_yaml_files = sorted((Path(__file__).parent / "patch_yaml").glob("*.yaml"))
 
 
 @pytest.mark.parametrize(

--- a/recipe/test_patch_yaml_utils.py
+++ b/recipe/test_patch_yaml_utils.py
@@ -529,14 +529,14 @@ def test_schema_up_to_date():
     assert schema_str == schema_on_disk
 
 
-def test_schema_validation():
-    passed = True
-    data = Path(__file__).parent / "patch_yaml"
-    for document in data.glob("*.yaml"):
-        for patch in yaml.safe_load_all(document.read_text()):
-            try:
-                PatchYaml(**patch)
-            except Exception as e:
-                print(f"\nSchema error in {document.name}: {e}")
-                passed = False
-    assert passed, "schema validation failed!"
+patch_yaml_files = list((Path(__file__).parent / "patch_yaml").glob("*.yaml"))
+patch_yaml_files.sort()
+
+
+@pytest.mark.parametrize(
+    "document", patch_yaml_files, ids=[f.name for f in patch_yaml_files]
+)
+def test_schema_validation(document):
+    for patch in yaml.safe_load_all(document.read_text()):
+        # Will raise an exception if pydantic validation fails
+        PatchYaml(**patch)


### PR DESCRIPTION
Checklist

* [ ] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here --!>
