### PR TITLE
add patch (enforce numpy<=1.19) for sigpy_0.1.25_1 build

### DIFF
--- a/recipe/patch_yaml/sigpy.yaml
+++ b/recipe/patch_yaml/sigpy.yaml
@@ -1,0 +1,6 @@
+if:
+  artifact_in: sigpy-0.1.25-pyha21a80b_1.conda
+then:
+  - replace_depends:
+      old: numpy
+      new: numpy <=1.19


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here --!>
