### PR TITLE
Update pyspectral python lower bound to 3.10

### DIFF
--- a/recipe/patch_yaml/pyspectral.yaml
+++ b/recipe/patch_yaml/pyspectral.yaml
@@ -4,6 +4,7 @@
 # Feedstock patched here: https://github.com/conda-forge/pyspectral-feedstock/pull/36
 if:
   artifact_in: ["pyspectral-0.13.0-pyhd8ed1ab_0.conda"]
+  timestamp_lt: 1701704368000
 then:
   - replace_depends:
       old: "python >=3.7"

--- a/recipe/patch_yaml/pyspectral.yaml
+++ b/recipe/patch_yaml/pyspectral.yaml
@@ -1,0 +1,11 @@
+# Retroactively fix Python lower limit to Python 3.10
+# Upstream package dropped older versions of Python and include incompatible
+# syntax. Autobot was faster than the maintainers and it got merged.
+# Feedstock patched here: https://github.com/conda-forge/pyspectral-feedstock/pull/36
+if:
+  artifact_in: ["pyspectral-0.13.0-pyhd8ed1ab_0.conda"]
+then:
+  - replace_depends:
+      old: "python >=3.7"
+      new: "python >=3.10"
+

--- a/recipe/patch_yaml/pyspectral.yaml
+++ b/recipe/patch_yaml/pyspectral.yaml
@@ -9,4 +9,3 @@ then:
   - replace_depends:
       old: "python >=3.7"
       new: "python >=3.10"
-


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

```
$ python show_diff.py --use-cache --subdirs noarch
================================================================================
================================================================================
noarch
noarch::pyspectral-0.13.0-pyhd8ed1ab_0.conda
-    "python >=3.7",
+    "python >=3.10",
```