### PR TITLE
Fix prompt-toolkit for ipython 8.18

### DIFF
--- a/recipe/patch_yaml/ipython.yaml
+++ b/recipe/patch_yaml/ipython.yaml
@@ -9,3 +9,16 @@ if:
   has_depends: "jedi?( *)"
 then:
   - add_depends: "jedi <0.18"
+---
+if:
+  name: ipython
+  version_ge: 8.18.0
+  version_le: 8.18.1
+  timestamp_lt: 1701703017000
+then:
+  - replace_depends:
+      old: prompt-toolkit >=3.0.30,<3.1.0,!=3.0.37
+      new: prompt-toolkit >=3.0.41,<3.1.0
+  - replace_depends:
+      old: prompt_toolkit >=3.0.30,<3.1.0,!=3.0.37
+      new: prompt-toolkit >=3.0.41,<3.1.0


### PR DESCRIPTION
Checklist

* [X] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [X] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [X] Ran `python show_diff.py` and posted the output as part of the PR.
* [X] Modifications won't affect packages built in the future.



ipython 8.18.0 requires `prompt-toolkit >= 3.0.41` (https://github.com/ipython/ipython/issues/14255).
It was fixed in ipython 8.18.1 (https://github.com/ipython/ipython/pull/14257) but missed in conda-forge package.
Fixed in build 2 of the recipe: https://github.com/conda-forge/ipython-feedstock/pull/204


```bash
$ python show_diff.py --subdirs noarch
================================================================================
================================================================================
noarch
noarch::ipython-8.18.0-pyh5737063_0.conda
noarch::ipython-8.18.0-pyh31c8845_0.conda
noarch::ipython-8.18.0-pyh0d859eb_0.conda
-    "prompt_toolkit >=3.0.30,<3.1.0,!=3.0.37",
+    "prompt-toolkit >=3.0.41,<3.1.0",
noarch::ipython-8.18.1-pyh31011fe_1.conda
noarch::ipython-8.18.1-pyh5737063_1.conda
-    "prompt-toolkit >=3.0.30,<3.1.0,!=3.0.37",
+    "prompt-toolkit >=3.0.41,<3.1.0",
```