### PR TITLE
mamba's CLI is broken with conda=23.11.0

### DIFF
--- a/recipe/patch_yaml/mamba.yaml
+++ b/recipe/patch_yaml/mamba.yaml
@@ -129,3 +129,14 @@ then:
   - tighten_depends:
       name: conda
       upper_bound: "23.9.0"
+---
+# conda=23.11.0 broke mamba's cli
+# https://github.com/conda/conda/issues/13400
+if:
+  name: mamba
+  version_le: 1.5.3
+  timestamp_lt: 1701773340000
+then:
+  - tighten_depends:
+      name: conda
+      upper_bound: 23.11.0

--- a/recipe/patch_yaml/mamba.yaml
+++ b/recipe/patch_yaml/mamba.yaml
@@ -134,9 +134,10 @@ then:
 # https://github.com/conda/conda/issues/13400
 if:
   name: mamba
+  version_ge: 1.5.2
   version_le: 1.5.3
   timestamp_lt: 1701773340000
 then:
-  - tighten_depends:
-      name: conda
-      upper_bound: 23.11.0
+  - replace_depends:
+      old: conda >=23.9,<24
+      new: conda >=23.9,<23.11.0


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

```sh
mamba install --yes --quiet 'conda-forge-ci-setup=3.*' 'conda-smithy>=3.7.1,<4.0.0a0' conda-forge-pinning 'conda-build>=3.16' 'gitpython>=3.0.8,<3.1.20' requests ruamel.yaml 'pygithub>=2.1.1'
Currently, only install, create, list, search, run, info, clean, remove, update, repoquery, activate and deactivate are supported through mamba.
```

refs:
- https://github.com/conda-forge/staged-recipes/pull/24670
- https://github.com/conda/conda/issues/13400
- https://github.com/mamba-org/mamba/issues/3033

```diff
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
osx-arm64::mamba-1.5.2-py311hb045da1_1.conda
osx-arm64::mamba-1.5.3-py310ha5d4528_1.conda
osx-arm64::mamba-1.5.3-py312h14bc7db_2.conda
osx-arm64::mamba-1.5.3-py311hb045da1_2.conda
osx-arm64::mamba-1.5.2-py38hb2d7053_1.conda
osx-arm64::mamba-1.5.3-py38hb2d7053_2.conda
osx-arm64::mamba-1.5.3-py311hb045da1_1.conda
osx-arm64::mamba-1.5.3-py39ha55b623_2.conda
osx-arm64::mamba-1.5.2-py312h14bc7db_1.conda
osx-arm64::mamba-1.5.3-py310ha5d4528_2.conda
osx-arm64::mamba-1.5.3-py39ha55b623_1.conda
osx-arm64::mamba-1.5.3-py38hb2d7053_1.conda
osx-arm64::mamba-1.5.3-py312h14bc7db_1.conda
osx-arm64::mamba-1.5.2-py38hb2d7053_0.conda
osx-arm64::mamba-1.5.2-py39ha55b623_0.conda
osx-arm64::mamba-1.5.2-py39ha55b623_1.conda
osx-arm64::mamba-1.5.2-py311hb045da1_0.conda
osx-arm64::mamba-1.5.2-py310ha5d4528_0.conda
osx-arm64::mamba-1.5.2-py310ha5d4528_1.conda
-    "conda >=23.9,<24",
+    "conda >=23.9,<23.11.0",
================================================================================
================================================================================
linux-ppc64le
linux-ppc64le::mamba-1.5.2-py310h400a96e_1.conda
linux-ppc64le::mamba-1.5.2-py312hff23a77_1.conda
linux-ppc64le::mamba-1.5.2-py38h8e2b860_0.conda
linux-ppc64le::mamba-1.5.3-py310h400a96e_2.conda
linux-ppc64le::mamba-1.5.3-py39h82e2c57_1.conda
linux-ppc64le::mamba-1.5.2-py38h8e2b860_1.conda
linux-ppc64le::mamba-1.5.2-py311haa85789_0.conda
linux-ppc64le::mamba-1.5.2-py311haa85789_1.conda
linux-ppc64le::mamba-1.5.3-py39ha24e7b4_2.conda
linux-ppc64le::mamba-1.5.2-py310h400a96e_0.conda
linux-ppc64le::mamba-1.5.2-py39ha24e7b4_1.conda
linux-ppc64le::mamba-1.5.3-py38h8e2b860_2.conda
linux-ppc64le::mamba-1.5.2-py39h82e2c57_1.conda
linux-ppc64le::mamba-1.5.3-py311haa85789_2.conda
linux-ppc64le::mamba-1.5.3-py39h82e2c57_2.conda
linux-ppc64le::mamba-1.5.3-py312hff23a77_2.conda
linux-ppc64le::mamba-1.5.3-py39ha24e7b4_1.conda
linux-ppc64le::mamba-1.5.3-py311haa85789_1.conda
linux-ppc64le::mamba-1.5.2-py39ha24e7b4_0.conda
linux-ppc64le::mamba-1.5.2-py39h82e2c57_0.conda
linux-ppc64le::mamba-1.5.3-py310h400a96e_1.conda
linux-ppc64le::mamba-1.5.3-py38h8e2b860_1.conda
linux-ppc64le::mamba-1.5.3-py312hff23a77_1.conda
-    "conda >=23.9,<24",
+    "conda >=23.9,<23.11.0",
================================================================================
================================================================================
linux-aarch64
linux-aarch64::mamba-1.5.2-py39h927961e_0.conda
linux-aarch64::mamba-1.5.2-py39h927961e_1.conda
linux-aarch64::mamba-1.5.2-py310hcbdc16a_1.conda
linux-aarch64::mamba-1.5.2-py39h83cf0c7_1.conda
linux-aarch64::mamba-1.5.3-py310hcbdc16a_1.conda
linux-aarch64::mamba-1.5.3-py312hd80a4d2_2.conda
linux-aarch64::mamba-1.5.2-py312hd80a4d2_1.conda
linux-aarch64::mamba-1.5.3-py311hb6c5aa6_2.conda
linux-aarch64::mamba-1.5.3-py311hb6c5aa6_1.conda
linux-aarch64::mamba-1.5.3-py312hd80a4d2_1.conda
linux-aarch64::mamba-1.5.3-py38hf92fa3f_2.conda
linux-aarch64::mamba-1.5.3-py39h927961e_2.conda
linux-aarch64::mamba-1.5.3-py39h927961e_1.conda
linux-aarch64::mamba-1.5.2-py311hb6c5aa6_0.conda
linux-aarch64::mamba-1.5.2-py311hb6c5aa6_1.conda
linux-aarch64::mamba-1.5.3-py39h83cf0c7_1.conda
linux-aarch64::mamba-1.5.3-py39h83cf0c7_2.conda
linux-aarch64::mamba-1.5.3-py38hf92fa3f_1.conda
linux-aarch64::mamba-1.5.3-py310hcbdc16a_2.conda
linux-aarch64::mamba-1.5.2-py38hf92fa3f_0.conda
linux-aarch64::mamba-1.5.2-py39h83cf0c7_0.conda
linux-aarch64::mamba-1.5.2-py310hcbdc16a_0.conda
linux-aarch64::mamba-1.5.2-py38hf92fa3f_1.conda
-    "conda >=23.9,<24",
+    "conda >=23.9,<23.11.0",
================================================================================
================================================================================
noarch
================================================================================
================================================================================
win-64
win-64::mamba-1.5.3-py311h8cb466b_2.conda
win-64::mamba-1.5.2-py39hca8391b_1.conda
win-64::mamba-1.5.3-py39h749ce95_1.conda
win-64::mamba-1.5.2-py311h8cb466b_1.conda
win-64::mamba-1.5.2-py38hc9c81c8_0.conda
win-64::mamba-1.5.3-py39hca8391b_2.conda
win-64::mamba-1.5.3-py311h8cb466b_1.conda
win-64::mamba-1.5.3-py312h5494d5c_2.conda
win-64::mamba-1.5.2-py311h8cb466b_0.conda
win-64::mamba-1.5.2-py38hc9c81c8_1.conda
win-64::mamba-1.5.2-py39h749ce95_0.conda
win-64::mamba-1.5.2-py39h749ce95_1.conda
win-64::mamba-1.5.2-py310hd9d798f_0.conda
win-64::mamba-1.5.2-py312h5494d5c_1.conda
win-64::mamba-1.5.2-py310hd9d798f_1.conda
win-64::mamba-1.5.3-py310hd9d798f_2.conda
win-64::mamba-1.5.3-py39hca8391b_1.conda
win-64::mamba-1.5.3-py38hc9c81c8_1.conda
win-64::mamba-1.5.2-py39hca8391b_0.conda
win-64::mamba-1.5.3-py39h749ce95_2.conda
win-64::mamba-1.5.3-py312h5494d5c_1.conda
win-64::mamba-1.5.3-py38hc9c81c8_2.conda
win-64::mamba-1.5.3-py310hd9d798f_1.conda
-    "conda >=23.9,<24",
+    "conda >=23.9,<23.11.0",
================================================================================
================================================================================
osx-64
osx-64::mamba-1.5.3-py39h412838c_2.conda
osx-64::mamba-1.5.2-py311h8082e30_0.conda
osx-64::mamba-1.5.3-py39h053c3d7_1.conda
osx-64::mamba-1.5.3-py39h412838c_1.conda
osx-64::mamba-1.5.2-py38h2cdcfb1_1.conda
osx-64::mamba-1.5.3-py312ha12221d_2.conda
osx-64::mamba-1.5.3-py38h2cdcfb1_1.conda
osx-64::mamba-1.5.2-py38h2cdcfb1_0.conda
osx-64::mamba-1.5.3-py311h8082e30_1.conda
osx-64::mamba-1.5.2-py310h6bde348_1.conda
osx-64::mamba-1.5.3-py310h6bde348_1.conda
osx-64::mamba-1.5.3-py310h6bde348_2.conda
osx-64::mamba-1.5.2-py311h8082e30_1.conda
osx-64::mamba-1.5.2-py39h412838c_0.conda
osx-64::mamba-1.5.2-py39h412838c_1.conda
osx-64::mamba-1.5.3-py311h8082e30_2.conda
osx-64::mamba-1.5.3-py312ha12221d_1.conda
osx-64::mamba-1.5.2-py312ha12221d_1.conda
osx-64::mamba-1.5.2-py39h053c3d7_0.conda
osx-64::mamba-1.5.2-py39h053c3d7_1.conda
osx-64::mamba-1.5.3-py38h2cdcfb1_2.conda
osx-64::mamba-1.5.2-py310h6bde348_0.conda
osx-64::mamba-1.5.3-py39h053c3d7_2.conda
-    "conda >=23.9,<24",
+    "conda >=23.9,<23.11.0",
================================================================================
================================================================================
linux-64
linux-64::mamba-1.5.3-py312h9460a1c_1.conda
linux-64::mamba-1.5.3-py39hc5d2bb1_1.conda
linux-64::mamba-1.5.2-py311h3072747_0.conda
linux-64::mamba-1.5.3-py38haad2881_2.conda
linux-64::mamba-1.5.3-py39hcbb6966_1.conda
linux-64::mamba-1.5.2-py311h3072747_1.conda
linux-64::mamba-1.5.2-py39hcbb6966_0.conda
linux-64::mamba-1.5.3-py310h51d5547_1.conda
linux-64::mamba-1.5.3-py311h3072747_1.conda
linux-64::mamba-1.5.3-py311h3072747_2.conda
linux-64::mamba-1.5.2-py39hc5d2bb1_0.conda
linux-64::mamba-1.5.3-py38haad2881_1.conda
linux-64::mamba-1.5.2-py310h51d5547_0.conda
linux-64::mamba-1.5.3-py39hc5d2bb1_2.conda
linux-64::mamba-1.5.3-py312h9460a1c_2.conda
linux-64::mamba-1.5.2-py39hc5d2bb1_1.conda
linux-64::mamba-1.5.2-py39hcbb6966_1.conda
linux-64::mamba-1.5.2-py38haad2881_1.conda
linux-64::mamba-1.5.3-py310h51d5547_2.conda
linux-64::mamba-1.5.3-py39hcbb6966_2.conda
linux-64::mamba-1.5.2-py310h51d5547_1.conda
linux-64::mamba-1.5.2-py312h9460a1c_1.conda
linux-64::mamba-1.5.2-py38haad2881_0.conda
-    "conda >=23.9,<24",
+    "conda >=23.9,<23.11.0",
```