### PR TITLE
Pin PySide 6.6.0 to the exact version of qt6-main we need

### DIFF
--- a/recipe/patch_yaml/pyside6.yaml
+++ b/recipe/patch_yaml/pyside6.yaml
@@ -1,0 +1,12 @@
+if:
+  name: pyside6
+  timestamp_lt: 1701832611000
+  version_in:
+    - 6.6.0
+then:
+  - replace_depends:
+      old: qt6-main >=6.6.0,<6.7.0a0
+      new: qt6-main >=6.6.0,<6.6.1a0
+
+
+

--- a/recipe/patch_yaml/pyside6.yaml
+++ b/recipe/patch_yaml/pyside6.yaml
@@ -7,6 +7,3 @@ then:
   - replace_depends:
       old: qt6-main >=6.6.0,<6.7.0a0
       new: qt6-main >=6.6.0,<6.6.1a0
-
-
-


### PR DESCRIPTION
https://github.com/conda-forge/pyside2-feedstock/pull/210
trying to release 6.6.1 as we speak
Checklist

* [ ] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
