### PR TITLE
Add new dependency for openslide 4.0.0 on libdicom

### DIFF
--- a/recipe/patch_yaml/openslide.yaml
+++ b/recipe/patch_yaml/openslide.yaml
@@ -1,0 +1,7 @@
+if:
+  name: openslide
+  version: 4.0.0
+  build_number: 0
+
+then:
+  - add_depends: libdicom >=1.0.5,<1.1.0a0


### PR DESCRIPTION
xref: https://github.com/conda-forge/openslide-feedstock/pull/25

cc: @kaczmarj

Checklist

* [ ] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
