### PR TITLE
capture build string variations in hdf5 1.14.3 patch

### DIFF
--- a/recipe/patch_yaml/hdf5.yaml
+++ b/recipe/patch_yaml/hdf5.yaml
@@ -2,8 +2,8 @@
 # hdf5 1.14.2 and 1.14.3 have the same ABI
 # https://gamma.hdfgroup.org/ftp/pub/outgoing/hdf5/prelim_reports/hdf5-1.14.2-vs-hdf5-1.14.3-1-interface_compatibility_report.html
 if:
-  has_depends: hdf5 >=1.14.2,<1.14.3.0a0
-  timestamp_lt: 1701868616000
+  has_depends: hdf5 >=1.14.2,<1.14.3.0a0?( *)
+  timestamp_lt: 1702066879000
 
 then:
   - loosen_depends:


### PR DESCRIPTION
Update rule in #611 to capture dependencies with build string pinning, which would be anything that build against hdf5 with mpi, e.g. petsc.

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

[showdiff output](https://gist.github.com/minrk/9d0e77781155d14bb5b9095734bfabb3)