### PR TITLE
pin typeguard >=4.0.1's typing_extensions to 4.7.0

### DIFF
--- a/recipe/patch_yaml/typeguard.yaml
+++ b/recipe/patch_yaml/typeguard.yaml
@@ -1,0 +1,8 @@
+if:
+  name: typeguard
+  version_ge: 4.1.5
+  timestamp_lt: 1702067733000
+then:
+  - replace_depends:
+      old: typing_extensions >=4.4.0
+      new: typing_extensions >=4.7.0

--- a/recipe/patch_yaml/typeguard.yaml
+++ b/recipe/patch_yaml/typeguard.yaml
@@ -1,6 +1,7 @@
 if:
   name: typeguard
-  version_ge: 4.1.5
+  # https://github.com/agronholm/typeguard/blob/4.0.1/pyproject.toml#L30C27-L30C32
+  version_ge: 4.0.1
   timestamp_lt: 1702067733000
 then:
   - replace_depends:


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

References:
- https://github.com/conda-forge/typeguard-feedstock/pull/41
- https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=839948&view=logs&j=656edd35-690f-5c53-9ba3-09c10d0bea97&s=96ac2280-8cb4-5df5-99de-dd2da759617d&t=986b1512-c876-5f92-0d81-ba851554a0a3&l=11439
  ```
  import: 'dagster_pandera'
  + pip check
  typeguard 4.1.5 has requirement typing-extensions>=4.7.0; python_version < "3.12", but you have typing-extensions 4.6.3.
  ```
Changes:

```
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
noarch
noarch::typeguard-4.1.1-pyhd8ed1ab_0.conda
noarch::typeguard-4.1.0-pyhd8ed1ab_0.conda
noarch::typeguard-4.1.3-pyhd8ed1ab_1.conda
noarch::typeguard-4.1.4-pyhd8ed1ab_0.conda
noarch::typeguard-4.1.3-pyhd8ed1ab_0.conda
noarch::typeguard-4.1.5-pyhd8ed1ab_0.conda
noarch::typeguard-4.0.1-pyhd8ed1ab_0.conda
noarch::typeguard-4.1.2-pyhd8ed1ab_0.conda
-    "typing_extensions >=4.4.0"
+    "typing_extensions >=4.7.0"
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
================================================================================
================================================================================
linux-64

```

<details>
<summary>initially, was</summary>

```diff
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
noarch
noarch::joseki-2.2.0-pyhd8ed1ab_0.conda
-{
-  "build": "pyhd8ed1ab_0",
-  "build_number": 0,
-  "depends": [
-    "attrs >=22.2.0",
-    "click >=8.1.3",
-    "importlib-resources >=5.10.2",
-    "netcdf4 >=1.6.2",
-    "numpy >=1.22.0",
-    "pandas >=1.5.2",
-    "pint >=0.20.1",
-    "python >=3.8",
-    "scipy >=1.9.3",
-    "ussa1976 >=0.3.4",
-    "xarray >=2022.12.0"
-  ],
-  "license": "MIT",
-  "md5": "4c752308f6659dde7207e0be0dde9dec",
-  "name": "joseki",
-  "noarch": "python",
-  "sha256": "30ff7c41c6c600fce246d0913c237ae902797446d246ee4a829fb149f3f12efd",
-  "size": 84028,
-  "subdir": "noarch",
-  "timestamp": 1689670820578,
-  "version": "2.2.0"
-}
+{}
noarch::joseki-2.3.0-pyhd8ed1ab_0.conda
-{
-  "build": "pyhd8ed1ab_0",
-  "build_number": 0,
-  "depends": [
-    "attrs >=22.2.0",
-    "click >=8.1.3",
-    "importlib-resources >=5.10.2",
-    "netcdf4 >=1.6.2",
-    "numpy >=1.22.0",
-    "pandas >=1.5.2",
-    "pint >=0.20.1",
-    "python >=3.8",
-    "scipy >=1.9.3",
-    "ussa1976 >=0.3.4",
-    "xarray >=2022.12.0"
-  ],
-  "license": "MIT",
-  "md5": "f448ee458795eb74d8863d0f45344432",
-  "name": "joseki",
-  "noarch": "python",
-  "sha256": "92b9c7af9d7f08904c22641a37e091dae87ea8972598de7a4d80ff72c4ec2477",
-  "size": 85596,
-  "subdir": "noarch",
-  "timestamp": 1689863350112,
-  "version": "2.3.0"
-}
+{}
noarch::typeguard-4.1.5-pyhd8ed1ab_0.conda
-    "typing_extensions >=4.4.0"
+    "typing_extensions >=4.7.0"
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
================================================================================
================================================================================
linux-64

```
</summary>