### PR TITLE
old versions of sagelib do not work with latest maxima

### DIFF
--- a/recipe/patch_yaml/maxima.yaml
+++ b/recipe/patch_yaml/maxima.yaml
@@ -1,0 +1,12 @@
+# maxima is an optional dependency of sagelib.
+# Old versions of sagelib (9.5, 9.6, 9.7, 9.8, 10.0) cannot handle a change in
+# maxima 5.47.
+if:
+  name: maxima
+  version: "5.47.0"
+  # Newer builds include this constraint: https://github.com/conda-forge/maxima-feedstock/pull/34
+  build: "*_0"
+then:
+  - replace_constrains:
+      old: "sagelib >=9.5"
+      new: "sagelib >=10.1"


### PR DESCRIPTION
`show_diff.py` says

```
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-ppc64le
linux-ppc64le::maxima-5.47.0-h5e43d2c_0.conda
-    "sagelib >=9.5"
+    "sagelib >=10.1"
================================================================================
================================================================================
linux-aarch64
linux-aarch64::maxima-5.47.0-h6475f26_0.conda
-    "sagelib >=9.5"
+    "sagelib >=10.1"
================================================================================
================================================================================
noarch
noarch::multiprocessing-logging-0.3.4-pyhd8ed1ab_1.conda
-    "python =2.7|3.6|3.7|3.8|3.9|3.10|3.11|3.12"
+    "python ==2.7.*|3.6|3.7|3.8|3.9|3.10|3.11|3.12"
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
osx-64::maxima-5.47.0-h2b27fa8_0.conda
-    "sagelib >=9.5"
+    "sagelib >=10.1"
================================================================================
================================================================================
linux-64
linux-64::maxima-5.47.0-hed6455c_0.conda
-    "sagelib >=9.5"
+    "sagelib >=10.1"
```

For newer builds, the fix has been merged in https://github.com/conda-forge/maxima-feedstock/pull/34

---

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
