### PR TITLE
ENH old smithy not compatible with new conda-build

### DIFF
--- a/recipe/patch_yaml/conda-smithy.yaml
+++ b/recipe/patch_yaml/conda-smithy.yaml
@@ -19,3 +19,11 @@ then:
   - tighten_depends:
       name: conda
       upper_bound: "5"
+if:
+  name: conda-smithy
+  version: 3.30.1
+then:
+  - replace_depends:
+    old: conda-build?( *)
+    new: conda-build<3.28.2
+    

--- a/recipe/patch_yaml/conda-smithy.yaml
+++ b/recipe/patch_yaml/conda-smithy.yaml
@@ -27,4 +27,3 @@ then:
   - tighten_depends:
     name: conda-build
     upper_bound: 3.28.2
-    

--- a/recipe/patch_yaml/conda-smithy.yaml
+++ b/recipe/patch_yaml/conda-smithy.yaml
@@ -25,5 +25,5 @@ if:
   version: 3.30.1
 then:
   - tighten_depends:
-    name: conda-build
-    upper_bound: 3.28.2
+      name: conda-build
+      upper_bound: 3.28.2

--- a/recipe/patch_yaml/conda-smithy.yaml
+++ b/recipe/patch_yaml/conda-smithy.yaml
@@ -19,11 +19,12 @@ then:
   - tighten_depends:
       name: conda
       upper_bound: "5"
+---
 if:
   name: conda-smithy
   version: 3.30.1
 then:
-  - replace_depends:
-    old: conda-build?( *)
-    new: conda-build<3.28.2
+  - tighten_depends:
+    name: conda-build
+    upper_bound: 3.28.2
     


### PR DESCRIPTION
Checklist

* [ ] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

xref: https://github.com/conda-forge/conda-smithy/pull/1816
