### PR TITLE
patch kartograf to set min version of `gufe`

### DIFF
--- a/recipe/patch_yaml/kartograf.yaml
+++ b/recipe/patch_yaml/kartograf.yaml
@@ -1,0 +1,12 @@
+# kartograph requires newer versions of gufe to work
+# https://github.com/conda-forge/kartograf-feedstock/issues/10
+if:
+  subdir_in: noarch
+  name: kartograf
+  timestamp_lt: 1703125261000
+then:
+  - replace_depends:
+      # str of thing to be replaced
+      old: gufe
+      # thing to replace `old` with
+      new: gufe>=0.9.5


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

See https://github.com/conda-forge/kartograf-feedstock/issues/10
tl;dr we didn't have a min pin so really old packages of gufe could get pulled down 