### PR TITLE
Patch `nb_conda` to require `notebook<7`

### DIFF
--- a/recipe/patch_yaml/nb_conda.yaml
+++ b/recipe/patch_yaml/nb_conda.yaml
@@ -1,0 +1,13 @@
+# nb_conda is not compatible with notebook >=7.0.0, see
+# https://github.com/conda-forge/nb_conda-feedstock/issues/21
+# https://github.com/conda-forge/nb_conda-feedstock/pull/22
+if:
+  name: nb_conda
+  timestamp_lt: 1704206086000
+then:
+  - replace_depends:
+      old: notebook >=4.2.0
+      new: ${old},<7.0.0
+  - replace_depends:
+      old: notebook >=4.3.1
+      new: ${old},<7.0.0


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
Related issues:
https://github.com/conda-forge/nb_conda-feedstock/pull/22
https://github.com/conda-forge/nb_conda-feedstock/issues/21

```
$ ./show_diff.py 
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
win-32::nb_conda-2.0.0-py35_0.tar.bz2
win-32::nb_conda-2.0.0-py34_0.tar.bz2
win-32::nb_conda-2.0.0-py27_0.tar.bz2
win-32::nb_conda-2.1.0-py36_0.tar.bz2
win-32::nb_conda-2.1.0-py27_0.tar.bz2
win-32::nb_conda-2.1.0-py35_0.tar.bz2
-    "notebook >=4.2.0",
+    "notebook >=4.2.0,<7.0.0",
win-32::nb_conda-2.2.1-py27_0.tar.bz2
win-32::nb_conda-2.2.0-py27_0.tar.bz2
win-32::nb_conda-2.2.0-py36_0.tar.bz2
win-32::nb_conda-2.2.1-py36_0.tar.bz2
win-32::nb_conda-2.2.0-py35_0.tar.bz2
win-32::nb_conda-2.2.1-py35_0.tar.bz2
-    "notebook >=4.3.1",
+    "notebook >=4.3.1,<7.0.0",
================================================================================
================================================================================
osx-arm64
osx-arm64::nb_conda-2.2.1-py38h10201cd_4.tar.bz2
osx-arm64::nb_conda-2.2.1-py39h2804cbe_4.tar.bz2
-    "notebook >=4.3.1",
+    "notebook >=4.3.1,<7.0.0",
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
noarch
noarch::nb_conda-2.2.1-unix_6.tar.bz2
noarch::nb_conda-2.2.1-win_6.tar.bz2
-    "notebook >=4.3.1",
+    "notebook >=4.3.1,<7.0.0",
================================================================================
================================================================================
win-64
win-64::nb_conda-2.0.0-py34_0.tar.bz2
win-64::nb_conda-2.1.0-py35_0.tar.bz2
win-64::nb_conda-2.0.0-py27_0.tar.bz2
win-64::nb_conda-2.1.0-py27_0.tar.bz2
win-64::nb_conda-2.0.0-py35_0.tar.bz2
win-64::nb_conda-2.1.0-py36_0.tar.bz2
-    "notebook >=4.2.0",
+    "notebook >=4.2.0,<7.0.0",
win-64::nb_conda-2.2.1-py27_1.tar.bz2
win-64::nb_conda-2.2.1-py37h03978a9_5.tar.bz2
win-64::nb_conda-2.2.1-py36ha15d459_4.tar.bz2
win-64::nb_conda-2.2.1-py310h5588dad_5.tar.bz2
win-64::nb_conda-2.2.1-py38haa244fe_4.tar.bz2
win-64::nb_conda-2.2.1-py36h9f0ad1d_3.tar.bz2
win-64::nb_conda-2.2.1-py38haa244fe_5.tar.bz2
win-64::nb_conda-2.2.1-py37hc8dfbb8_3.tar.bz2
win-64::nb_conda-2.2.1-py38h32f6830_4.tar.bz2
win-64::nb_conda-2.2.1-py36_1.tar.bz2
win-64::nb_conda-2.2.0-py27_0.tar.bz2
win-64::nb_conda-2.2.1-py37hc8dfbb8_4.tar.bz2
win-64::nb_conda-2.2.1-py36_0.tar.bz2
win-64::nb_conda-2.2.1-py37_1.tar.bz2
win-64::nb_conda-2.2.1-py39hcbf5309_4.tar.bz2
win-64::nb_conda-2.2.1-py39hde42818_4.tar.bz2
win-64::nb_conda-2.2.1-py39hde42818_3.tar.bz2
win-64::nb_conda-2.2.1-py36h9f0ad1d_4.tar.bz2
win-64::nb_conda-2.2.1-py27_2.tar.bz2
win-64::nb_conda-2.2.1-py38h32f6830_3.tar.bz2
win-64::nb_conda-2.2.1-py39hcbf5309_5.tar.bz2
win-64::nb_conda-2.2.1-py38_2.tar.bz2
win-64::nb_conda-2.2.1-py35_0.tar.bz2
win-64::nb_conda-2.2.1-py27_0.tar.bz2
win-64::nb_conda-2.2.1-py36_2.tar.bz2
win-64::nb_conda-2.2.1-py37_2.tar.bz2
win-64::nb_conda-2.2.0-py36_0.tar.bz2
win-64::nb_conda-2.2.0-py35_0.tar.bz2
win-64::nb_conda-2.2.1-py37h03978a9_4.tar.bz2
-    "notebook >=4.3.1",
+    "notebook >=4.3.1,<7.0.0",
================================================================================
================================================================================
osx-64
osx-64::nb_conda-2.1.0-py35_0.tar.bz2
osx-64::nb_conda-2.0.0-py36_0.tar.bz2
osx-64::nb_conda-2.0.0-py27_0.tar.bz2
osx-64::nb_conda-2.0.0-py35_0.tar.bz2
osx-64::nb_conda-2.1.0-py36_0.tar.bz2
osx-64::nb_conda-2.1.0-py27_0.tar.bz2
osx-64::nb_conda-2.0.0-py34_0.tar.bz2
-    "notebook >=4.2.0",
+    "notebook >=4.2.0,<7.0.0",
osx-64::nb_conda-2.2.1-py37_2.tar.bz2
osx-64::nb_conda-2.2.1-py37_1.tar.bz2
osx-64::nb_conda-2.2.1-py37h5186d4c_5.tar.bz2
osx-64::nb_conda-2.2.1-py38h50d1736_5.tar.bz2
osx-64::nb_conda-2.2.1-py36_1.tar.bz2
osx-64::nb_conda-2.2.1-py35_0.tar.bz2
osx-64::nb_conda-2.2.1-py38h50d1736_4.tar.bz2
osx-64::nb_conda-2.2.1-py37hf985489_4.tar.bz2
osx-64::nb_conda-2.2.1-py38h32f6830_3.tar.bz2
osx-64::nb_conda-2.2.1-py37h5186d4c_4.tar.bz2
osx-64::nb_conda-2.2.1-py37hf985489_5.tar.bz2
osx-64::nb_conda-2.2.1-py39h6e9494a_5.tar.bz2
osx-64::nb_conda-2.2.1-py36hc560c46_4.tar.bz2
osx-64::nb_conda-2.2.1-py38_2.tar.bz2
osx-64::nb_conda-2.2.1-py37hc8dfbb8_4.tar.bz2
osx-64::nb_conda-2.2.1-py36h9f0ad1d_4.tar.bz2
osx-64::nb_conda-2.2.1-py36h79c6626_4.tar.bz2
osx-64::nb_conda-2.2.1-py37hc8dfbb8_3.tar.bz2
osx-64::nb_conda-2.2.1-py39h6e9494a_4.tar.bz2
osx-64::nb_conda-2.2.1-py310h2ec42d9_5.tar.bz2
osx-64::nb_conda-2.2.1-py36h5dafb3c_4.tar.bz2
osx-64::nb_conda-2.2.1-py39hde42818_3.tar.bz2
osx-64::nb_conda-2.2.1-py36_2.tar.bz2
osx-64::nb_conda-2.2.1-py27_2.tar.bz2
osx-64::nb_conda-2.2.1-py27_0.tar.bz2
osx-64::nb_conda-2.2.1-py39hde42818_4.tar.bz2
osx-64::nb_conda-2.2.1-py36h9f0ad1d_3.tar.bz2
osx-64::nb_conda-2.2.1-py27_1.tar.bz2
osx-64::nb_conda-2.2.0-py27_0.tar.bz2
osx-64::nb_conda-2.2.0-py36_0.tar.bz2
osx-64::nb_conda-2.2.0-py35_0.tar.bz2
osx-64::nb_conda-2.2.1-py36_0.tar.bz2
osx-64::nb_conda-2.2.1-py38h32f6830_4.tar.bz2
-    "notebook >=4.3.1",
+    "notebook >=4.3.1,<7.0.0",
================================================================================
================================================================================
linux-64
linux-64::nb_conda-2.0.0-py35_0.tar.bz2
linux-64::nb_conda-2.1.0-py27_0.tar.bz2
linux-64::nb_conda-2.0.0-py34_0.tar.bz2
linux-64::nb_conda-2.1.0-py35_0.tar.bz2
linux-64::nb_conda-2.0.0-py27_0.tar.bz2
linux-64::nb_conda-2.1.0-py36_0.tar.bz2
-    "notebook >=4.2.0",
+    "notebook >=4.2.0,<7.0.0",
linux-64::nb_conda-2.2.1-py36h5fab9bb_4.tar.bz2
linux-64::nb_conda-2.2.1-py37h89c1867_4.tar.bz2
linux-64::nb_conda-2.2.1-py37h89c1867_5.tar.bz2
linux-64::nb_conda-2.2.1-py38h32f6830_3.tar.bz2
linux-64::nb_conda-2.2.1-py36h9f0ad1d_4.tar.bz2
linux-64::nb_conda-2.2.0-py27_0.tar.bz2
linux-64::nb_conda-2.2.1-py36_0.tar.bz2
linux-64::nb_conda-2.2.1-py37hc8dfbb8_3.tar.bz2
linux-64::nb_conda-2.2.1-py37h9c2f6ca_5.tar.bz2
linux-64::nb_conda-2.2.1-py36_2.tar.bz2
linux-64::nb_conda-2.2.1-py27_0.tar.bz2
linux-64::nb_conda-2.2.1-py39hde42818_4.tar.bz2
linux-64::nb_conda-2.2.1-py39hde42818_3.tar.bz2
linux-64::nb_conda-2.2.1-py36hc560c46_4.tar.bz2
linux-64::nb_conda-2.2.0-py36_0.tar.bz2
linux-64::nb_conda-2.2.1-py37h9c2f6ca_4.tar.bz2
linux-64::nb_conda-2.2.1-py310hff52083_5.tar.bz2
linux-64::nb_conda-2.2.1-py39hf3d152e_5.tar.bz2
linux-64::nb_conda-2.2.1-py38h578d9bd_5.tar.bz2
linux-64::nb_conda-2.2.0-py35_0.tar.bz2
linux-64::nb_conda-2.2.1-py38h32f6830_4.tar.bz2
linux-64::nb_conda-2.2.1-py36hd000896_4.tar.bz2
linux-64::nb_conda-2.2.1-py35_0.tar.bz2
linux-64::nb_conda-2.2.1-py38h578d9bd_4.tar.bz2
linux-64::nb_conda-2.2.1-py38_2.tar.bz2
linux-64::nb_conda-2.2.1-py39hf3d152e_4.tar.bz2
linux-64::nb_conda-2.2.1-py36h9f0ad1d_3.tar.bz2
linux-64::nb_conda-2.2.1-py37hc8dfbb8_4.tar.bz2
linux-64::nb_conda-2.2.1-py37_2.tar.bz2
linux-64::nb_conda-2.2.1-py27_2.tar.bz2
-    "notebook >=4.3.1",
+    "notebook >=4.3.1,<7.0.0",
```