### PR TITLE
tighten fmt in libmamba

### DIFF
--- a/recipe/patch_yaml/mamba.yaml
+++ b/recipe/patch_yaml/mamba.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../patch_yaml_model.json
 # from this code
 # if (
 #     subdir in ["linux-64", "linux-aarch64", "linux-ppc64le"]
@@ -141,3 +142,13 @@ then:
   - replace_depends:
       old: conda >=23.9,<24
       new: conda >=23.9,<23.11.0
+---
+# fmt 10.2.0 breaks libmamba on Windows
+# https://github.com/conda-forge/fmt-feedstock/pull/39
+if:
+  name: libmamba
+  timestamp_lt: 1704218331614
+then:
+  - tighten_depends:
+      name: fmt
+      upper_bound: "10.2.0"


### PR DESCRIPTION
Checklist

* [X] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [X] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

`fmt 10.2.0` breaks libmamba on Windows: https://github.com/conda-forge/fmt-feedstock/pull/39