### PR TITLE
Revert "tighten fmt in libmamba"

### DIFF
--- a/recipe/patch_yaml/mamba.yaml
+++ b/recipe/patch_yaml/mamba.yaml
@@ -1,4 +1,3 @@
-# yaml-language-server: $schema=../patch_yaml_model.json
 # from this code
 # if (
 #     subdir in ["linux-64", "linux-aarch64", "linux-ppc64le"]
@@ -142,13 +141,3 @@ then:
   - replace_depends:
       old: conda >=23.9,<24
       new: conda >=23.9,<23.11.0
----
-# fmt 10.2.0 breaks libmamba on Windows
-# https://github.com/conda-forge/fmt-feedstock/pull/39
-if:
-  name: libmamba
-  timestamp_lt: 1704218331614
-then:
-  - tighten_depends:
-      name: fmt
-      upper_bound: "10.2.0"


### PR DESCRIPTION
fmt 10.2 accidentally dropped a symbol that lead to widespread breakage on windows, including all of our windows builds (because it affected mamba itself). After #628 stopped the bleeding, @saraedum went digging and rootcaused+fixed this upstream in https://github.com/fmtlib/fmt/pull/3786, which already made it to conda-forge: https://github.com/conda-forge/fmt-feedstock/pull/42

This means we should be able to drop the pin again, as over time, more and more packages will now build with `fmt 10.2` and thus get a `fmt >=10.2,<11.0a0` run-export, that would be incompatible with the patched constraints for mamba from #628.

An alternative would be to just rebuild mamba once for 10.2, and leave the older builds constrained to 10.1, though I don't really see the need for this if the ABI is fixed.

CC @jaimergp 