### PR TITLE
Relax old `cuda-nvcc`'s `gcc`/`gxx` constraints

### DIFF
--- a/recipe/patch_yaml/cuda-nvcc-gcc-linux-64.yaml
+++ b/recipe/patch_yaml/cuda-nvcc-gcc-linux-64.yaml
@@ -1,0 +1,11 @@
+if:
+  name: cuda-nvcc
+  timestamp_lt: 1704441600000
+  subdir_in: linux-64
+then:
+  - replace_depends:
+      old: gcc_linux-64 12.*
+      new: gcc_linux-64
+  - replace_depends:
+      old: gxx_linux-64 12.*
+      new: gxx_linux-64

--- a/recipe/patch_yaml/cuda-nvcc-gcc-linux-aarch64.yaml
+++ b/recipe/patch_yaml/cuda-nvcc-gcc-linux-aarch64.yaml
@@ -1,0 +1,11 @@
+if:
+  name: cuda-nvcc
+  timestamp_lt: 1704441600000
+  subdir_in: linux-aarch64
+then:
+  - replace_depends:
+      old: gcc_linux-aarch64 12.*
+      new: gcc_linux-aarch64
+  - replace_depends:
+      old: gxx_linux-aarch64 12.*
+      new: gxx_linux-aarch64

--- a/recipe/patch_yaml/cuda-nvcc-gcc-linux-ppc64le.yaml
+++ b/recipe/patch_yaml/cuda-nvcc-gcc-linux-ppc64le.yaml
@@ -1,0 +1,11 @@
+if:
+  name: cuda-nvcc
+  timestamp_lt: 1704441600000
+  subdir_in: linux-ppc64le
+then:
+  - replace_depends:
+      old: gcc_linux-ppc64le 12.*
+      new: gcc_linux-ppc64le
+  - replace_depends:
+      old: gxx_linux-ppc64le 12.*
+      new: gxx_linux-ppc64le


### PR DESCRIPTION
The GCC dependencies are added to `cuda-nvcc`'s Linux packages to ensure there is a working C & C++ compiler available alongside NVCC. However the way they were being added before resulted in the compiler constraints conda-forge uses for builds leaking into the package and constraining the GCC dependencies unintentionally.

However we already constrain GCC versions used with NVCC ourselves. Also we want to maintain flexibility on these GCC dependencies so users can make that choice for themselves. This has been fixed starting with the latest CUDA 12.1 packages. Though older packages still have this issue. So this applies a repodata patch to those older packages to drop this unneeded constraint.

xref: https://github.com/conda-forge/cuda-nvcc-feedstock/pull/34
xref: https://github.com/conda-forge/cuda-nvcc-feedstock/pull/21#discussion_r1244460063

<hr>

Checklist

* [ ] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
