### PR TITLE
Fix omniorb dependency for cpptango on macOS

### DIFF
--- a/recipe/patch_yaml/cpptango.yaml
+++ b/recipe/patch_yaml/cpptango.yaml
@@ -1,0 +1,10 @@
+if:
+  name: cpptango
+  version: 9.5.0
+  has_depends: omniorb-libs >=4.3.1,<4.4.0a0
+  subdir_in: ["osx-64", "osx-arm64"]
+  timestamp_lt: 1705487016000
+then:
+  - tighten_depends:
+      name: omniorb-libs
+      max_pin: 'x.x.x'


### PR DESCRIPTION
Checklist

* [X] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [X] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [X] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [X] Ran `python show_diff.py` and posted the output as part of the PR.
* [X] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

On macOS, cpptango 9.5.0 is explicitely linked against omniorb 4.3.1. Releasing 4.3.2 currently broke 9.5 installation as run_export is set to x.x. It must be tighten to x.x.x.

```
$ otool -L libtango.9.5.0.dylib
libtango.9.5.0.dylib:
	@rpath/libtango.95.dylib (compatibility version 95.0.0, current version 9.5.0)
	@rpath/libomniORB4.3.1.dylib (compatibility version 0.0.0, current version 0.0.0)
```

This isn't the case on Linux (and Windows) where 4.3 is used:

```
$ ldd libtango.so.9.5.0
	linux-vdso.so.1 =>  (0x00007ffe189ae000)
	libdl.so.2 => /lib64/libdl.so.2 (0x00007f9beb7e6000)
	libomniORB4.so.3 => /opt/conda/envs/tango/lib/././libomniORB4.so.3 (0x00007f9bec169000)
```

Not sure why yet.
I will see if it can be fixed in cpptango. Otherwise I might have to change the run_export on omniorb.

For now, current cpptango macOS packages have to be fixed:

```
$ python show_diff.py --subdirs linux-64 osx-64 osx-arm64 --use-cache
================================================================================
================================================================================
osx-arm64
osx-arm64::cpptango-9.5.0-hf3ed413_0.conda
osx-arm64::cpptango-9.5.0-hace4bee_1.conda
-    "omniorb-libs >=4.3.1,<4.4.0a0",
+    "omniorb-libs >=4.3.1,<4.3.2.0a0",
================================================================================
================================================================================
osx-64
osx-64::cpptango-9.5.0-he842357_0.conda
osx-64::cpptango-9.5.0-haad327e_1.conda
-    "omniorb-libs >=4.3.1,<4.4.0a0",
+    "omniorb-libs >=4.3.1,<4.3.2.0a0",
================================================================================
================================================================================
linux-64
```
