### PR TITLE
Allow 0.190 for elfutils=0.18*

### DIFF
--- a/recipe/patch_yaml/elfutils.yaml
+++ b/recipe/patch_yaml/elfutils.yaml
@@ -1,0 +1,9 @@
+---
+if:
+  timestamp_lt: 1705581898000
+  has_depends:
+    - elfutils >=0.18*
+then:
+  - loosen_depends:
+      name: elfutils
+      upper_bound: '0.191'


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
