### PR TITLE
patch ray-default and ray-client to avoid 2.9.0 + grcpio1.58

### DIFF
--- a/recipe/patch_yaml/ray-grpcio.yaml
+++ b/recipe/patch_yaml/ray-grpcio.yaml
@@ -1,0 +1,19 @@
+# Prevent ray2.9.0 and grpcio 1.58 (https://github.com/conda-forge/ray-packages-feedstock/issues/136)
+if:
+  name: ray-default
+  version_gt: "2.8.99"
+then:
+  - replace_depends:
+      old: grpcio
+      new: grpcio !=1.58
+---
+if:
+  name: ray-client
+  version_gt: "2.8.99"
+then:
+  - replace_depends:
+      old: grpcio !=1.56.0
+      new: grpcio !=1.58,!=1.56.0
+  - replace_depends:
+      old: grpcio
+      new: grpcio !=1.58

--- a/recipe/patch_yaml/ray-grpcio.yaml
+++ b/recipe/patch_yaml/ray-grpcio.yaml
@@ -1,7 +1,7 @@
 # Prevent ray2.9.0 and grpcio 1.58 (https://github.com/conda-forge/ray-packages-feedstock/issues/136)
 if:
   name: ray-default
-  version_gt: "2.8.99"
+  version_le: "2.9.0"
 then:
   - replace_depends:
       old: grpcio
@@ -9,7 +9,7 @@ then:
 ---
 if:
   name: ray-client
-  version_gt: "2.8.99"
+  version_le: "2.9.0"
 then:
   - replace_depends:
       old: grpcio !=1.56.0


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

This is my first PR to this repo. What I want to do is prevent the use of grpcio 1.58 with ray version2.9.0 and greater. Fixes conda-forge/ray-packages-feedstock#136 and conda-forge/grpc-cpp-feedstock#343.

I am not sure why `show_diff` repeats osx64 twice. Note that ray 2.9.0 is not yet supported on win64, that will be done once I fix conda-forge/ray-packages-feedstock#137.
```
$ python recipe/show_diff.py --use-cache
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
osx-arm64::ray-client-2.9.0-py39hdf13c20_0.conda
osx-arm64::ray-client-2.9.0-py311ha1ab1f8_0.conda
osx-arm64::ray-client-2.9.0-py38h150bfb4_0.conda
osx-arm64::ray-client-2.9.0-py310hb6292c7_0.conda
-    "grpcio !=1.56.0",
+    "grpcio !=1.58,!=1.56.0",
osx-arm64::ray-default-2.9.0-py311hd6b026f_0.conda
osx-arm64::ray-default-2.9.0-py310h28793f1_0.conda
osx-arm64::ray-default-2.9.0-py311hf131290_0.conda
osx-arm64::ray-default-2.9.0-py39hbdb43d7_0.conda
osx-arm64::ray-default-2.9.0-py39h32b681b_0.conda
osx-arm64::ray-default-2.9.0-py310h0ffa552_0.conda
osx-arm64::ray-default-2.9.0-py38h406562f_0.conda
osx-arm64::ray-default-2.9.0-py38h93c57f1_0.conda
-    "grpcio",
+    "grpcio !=1.58",
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
noarch
noarch::aiohttp-jinja2-1.6-pyhd8ed1ab_0.conda
-    "aiohttp >=3.9.0",
+    "aiohttp >=3.6.3",
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
osx-64::ray-client-2.9.0-py38h50d1736_0.conda
osx-64::ray-client-2.9.0-py310h2ec42d9_0.conda
osx-64::ray-client-2.9.0-py39h6e9494a_0.conda
osx-64::ray-client-2.9.0-py311h6eed73b_0.conda
-    "grpcio !=1.56.0",
+    "grpcio !=1.58,!=1.56.0",
osx-64::ray-default-2.9.0-py310h5e29caf_0.conda
osx-64::ray-default-2.9.0-py310h3d77ae6_0.conda
osx-64::ray-default-2.9.0-py311h9c189b4_0.conda
osx-64::ray-default-2.9.0-py311hf91cc31_0.conda
osx-64::ray-default-2.9.0-py39h98b42ae_0.conda
osx-64::ray-default-2.9.0-py38h6282081_0.conda
osx-64::ray-default-2.9.0-py39h464767f_0.conda
osx-64::ray-default-2.9.0-py38h18fd85d_0.conda
-    "grpcio",
+    "grpcio !=1.58",
================================================================================
================================================================================
linux-64
linux-64::ray-default-2.9.0-py38h53c94ba_0.conda
linux-64::ray-default-2.9.0-py39h7a4ae58_0.conda
linux-64::ray-client-2.9.0-py39hf3d152e_0.conda
linux-64::ray-client-2.9.0-py38h578d9bd_0.conda
linux-64::ray-default-2.9.0-py310ha1e06c9_0.conda
linux-64::ray-default-2.9.0-py311hbd2507d_0.conda
linux-64::ray-default-2.9.0-py39h9a2ef2b_0.conda
linux-64::ray-client-2.9.0-py311h38be061_0.conda
linux-64::ray-default-2.9.0-py311h48098de_0.conda
linux-64::ray-default-2.9.0-py310h8d86c01_0.conda
linux-64::ray-default-2.9.0-py38h73d8af5_0.conda
linux-64::ray-client-2.9.0-py310hff52083_0.conda
-    "grpcio",
+    "grpcio !=1.58",

```