### PR TITLE
Set upper_bound of 1.11.0 for tiledb binaries that depend on azure-core-cpp

### DIFF
--- a/recipe/patch_yaml/tiledb.yaml
+++ b/recipe/patch_yaml/tiledb.yaml
@@ -1,0 +1,15 @@
+# azure-core-cpp 1.11.0 broke tiledb
+# https://github.com/conda-forge/tiledb-feedstock/issues/228
+#
+# azure-core-cpp minor releases are documented as backwards compatible, but
+# clearly are not. Future azure-core-cpp conda binaries will have run exports
+# with max_pin="x.x" to prevent future problems
+# https://github.com/conda-forge/azure-core-cpp-feedstock/pull/11
+if:
+  name: tiledb
+  has_depends: azure-core-cpp*
+  timestamp_lt: 1705699107000
+then:
+  - tighten_depends:
+      name: azure-core-cpp
+      upper_bound: 1.11.0

--- a/recipe/patch_yaml/tiledb.yaml
+++ b/recipe/patch_yaml/tiledb.yaml
@@ -7,7 +7,7 @@
 # https://github.com/conda-forge/azure-core-cpp-feedstock/pull/11
 if:
   name: tiledb
-  has_depends: azure-core-cpp*
+  has_depends: azure-core-cpp >=1.10*
   timestamp_lt: 1705699107000
 then:
   - tighten_depends:


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

---

* azure-core-cpp 1.11.0 broke tiledb (https://github.com/conda-forge/tiledb-feedstock/issues/228)
* azure-core-cpp minor releases are documented as backwards compatible, but clearly are not. Future azure-core-cpp conda binaries will have run exports with `max_pin="x.x"` to prevent future problems (https://github.com/conda-forge/azure-core-cpp-feedstock/pull/11)
* I have already updated the tiledb recipe to include the upper bound of 1.11.0 (https://github.com/conda-forge/tiledb-feedstock/pull/229)
* More details on the plan in https://github.com/conda-forge/admin-requests/pull/911#issuecomment-1892553599

We plan to update `tiledb` upstream to be compatible with azure-core-cpp 1.11+ and remove the upper bound from the recipe. Due to the `timestamp_lt`, future releases will not be affected by this repodata patch