### PR TITLE
Add patch to disallow coinstallation of libtorch that clobbers pybind11

### DIFF
--- a/recipe/patch_yaml/pytorch.yaml
+++ b/recipe/patch_yaml/pytorch.yaml
@@ -150,10 +150,13 @@ then:
   - add_depends: pytorch 1.6
 
 ---
+# The first build of libtorch clobbered other headers such as
+# those from pybind11
+# https://github.com/conda-forge/pytorch-cpu-feedstock/issues/212
 if:
   name: libtorch
   version: 2.1.0
-  build_number_in: [2, 102, 202]
+  build_number_in: [2, 102, 302]
 
 then:
   - add_constrains: pybind11 <0.0.0a0

--- a/recipe/patch_yaml/pytorch.yaml
+++ b/recipe/patch_yaml/pytorch.yaml
@@ -148,3 +148,12 @@ if:
   not_has_depends: pytorch?( *)
 then:
   - add_depends: pytorch 1.6
+
+---
+if:
+  name: libtorch
+  version: 2.1.0
+  build_number: 2
+
+then:
+  - add_constrains: pybind11 <0.0.0a0

--- a/recipe/patch_yaml/pytorch.yaml
+++ b/recipe/patch_yaml/pytorch.yaml
@@ -153,7 +153,7 @@ then:
 if:
   name: libtorch
   version: 2.1.0
-  build_number: 2
+  build_number_in: [2, 102, 202]
 
 then:
   - add_constrains: pybind11 <0.0.0a0


### PR DESCRIPTION
closes https://github.com/conda-forge/pytorch-cpu-feedstock/issues/212

cc: @erykoff 

Checklist

* [ ] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
