### PR TITLE
Add a patch to pin openblas <0.3.26 for older scipy builds

### DIFF
--- a/recipe/patch_yaml/scipy.yaml
+++ b/recipe/patch_yaml/scipy.yaml
@@ -1,0 +1,26 @@
+# 2024/01 -- hmaarrfk
+# scipy version 1.12.0 build 2 was patched
+# for compatibility with libopenblas 0.3.26
+# However older version are incompatible
+# https://github.com/conda-forge/scipy-feedstock/issues/266
+if:
+  name: scipy
+  version: 1.12.0
+  build_number_lt: 2
+
+then:
+  - add_constrains: libopenblas <0.3.26
+
+---
+
+# 2024/01 -- hmaarrfk
+# scipy version 1.12.0 build 2 was patched
+# for compatibility with libopenblas 0.3.26
+# However older version are incompatible
+# https://github.com/conda-forge/scipy-feedstock/issues/266
+if:
+  name: scipy
+  version_lt: 1.12.0
+
+then:
+  - add_constrains: libopenblas <0.3.26


### PR DESCRIPTION
xref: https://github.com/conda-forge/scipy-feedstock/issues/266#issuecomment-1907148347

cc: @h-vetinari 

diff: https://gist.github.com/hmaarrfk/b69c7844166efc7cd61f98ae2a4548d5

Checklist

* [ ] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
