### PR TITLE
Fix pendulum<3.0 in airflow

### DIFF
--- a/recipe/patch_yaml/airflow.yaml
+++ b/recipe/patch_yaml/airflow.yaml
@@ -1,0 +1,10 @@
+# airflow <=2.7.2 is not compatible with pendulum >=3.0.0,
+# see https://github.com/conda-forge/airflow-feedstock/issues/127
+# fixed in https://github.com/conda-forge/airflow-feedstock/pull/123
+if:
+  name: airflow
+  timestamp_lt: 1706650867000
+then:
+  - replace_depends:
+      old: pendulum >=2.0
+      new: ${old},<3.0


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

Related issue:
https://github.com/conda-forge/airflow-feedstock/issues/127
Fixed in:
https://github.com/conda-forge/airflow-feedstock/pull/123

```
$ ./show_diff.py 
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
osx-arm64::airflow-2.5.3-py39h2804cbe_0.conda
osx-arm64::airflow-2.5.1-py310ha5d4528_1.conda
osx-arm64::airflow-2.5.3-py310hbe9552e_0.conda
osx-arm64::airflow-2.7.2-py38h10201cd_0.conda
osx-arm64::airflow-2.6.1-py38h10201cd_0.conda
osx-arm64::airflow-2.6.2-py310hbe9552e_0.conda
osx-arm64::airflow-2.5.1-py39ha55b623_1.conda
osx-arm64::airflow-2.5.1-py38hb2d7053_1.conda
osx-arm64::airflow-2.7.0-py310hbe9552e_0.conda
osx-arm64::airflow-2.5.1-py310hbe9552e_2.conda
osx-arm64::airflow-2.7.2-py38h10201cd_1.conda
osx-arm64::airflow-2.5.2-py310hbe9552e_0.conda
osx-arm64::airflow-2.6.3-py39h2804cbe_0.conda
osx-arm64::airflow-2.6.0-py38h10201cd_0.conda
osx-arm64::airflow-2.6.3-py310hbe9552e_0.conda
osx-arm64::airflow-2.6.2-py38h10201cd_1.conda
osx-arm64::airflow-2.7.0-py311h267d04e_0.conda
osx-arm64::airflow-2.7.2-py312h81bd7bf_1.conda
osx-arm64::airflow-2.6.1-py39h2804cbe_0.conda
osx-arm64::airflow-2.7.2-py39h2804cbe_1.conda
osx-arm64::airflow-2.7.1-py310hbe9552e_0.conda
osx-arm64::airflow-2.7.1-py39h2804cbe_0.conda
osx-arm64::airflow-2.7.2-py310hbe9552e_0.conda
osx-arm64::airflow-2.6.0-py310hbe9552e_0.conda
osx-arm64::airflow-2.7.1-py311h267d04e_0.conda
osx-arm64::airflow-2.6.1-py310hbe9552e_0.conda
osx-arm64::airflow-2.5.3-py38h10201cd_0.conda
osx-arm64::airflow-2.7.2-py311h267d04e_1.conda
osx-arm64::airflow-2.7.1-py38h10201cd_0.conda
osx-arm64::airflow-2.6.2-py310hbe9552e_1.conda
osx-arm64::airflow-2.6.2-py311h267d04e_1.conda
osx-arm64::airflow-2.6.2-py39h2804cbe_1.conda
osx-arm64::airflow-2.6.3-py38h10201cd_0.conda
osx-arm64::airflow-2.7.2-py310hbe9552e_1.conda
osx-arm64::airflow-2.5.1-py39h2804cbe_2.conda
osx-arm64::airflow-2.7.2-py311h267d04e_0.conda
osx-arm64::airflow-2.7.0-py39h2804cbe_0.conda
osx-arm64::airflow-2.5.1-py38h10201cd_2.conda
osx-arm64::airflow-2.6.0-py39h2804cbe_0.conda
osx-arm64::airflow-2.5.2-py39h2804cbe_0.conda
osx-arm64::airflow-2.7.0-py38h10201cd_0.conda
osx-arm64::airflow-2.6.2-py39h2804cbe_0.conda
osx-arm64::airflow-2.7.2-py39h2804cbe_0.conda
osx-arm64::airflow-2.5.2-py38h10201cd_0.conda
osx-arm64::airflow-2.6.2-py38h10201cd_0.conda
osx-arm64::airflow-2.6.3-py311h267d04e_0.conda
-    "pendulum >=2.0",
+    "pendulum >=2.0,<3.0",
================================================================================
================================================================================
linux-aarch64
linux-aarch64::airflow-2.7.2-py38he3eb160_0.conda
linux-aarch64::airflow-2.7.2-py312h996f985_1.conda
linux-aarch64::airflow-2.7.1-py311hec3470c_0.conda
linux-aarch64::airflow-2.7.0-py39h4420490_0.conda
linux-aarch64::airflow-2.5.2-py39h4420490_0.conda
linux-aarch64::airflow-2.5.2-py38he3eb160_0.conda
linux-aarch64::airflow-2.6.1-py38he3eb160_0.conda
linux-aarch64::airflow-2.6.2-py310h4c7bcd0_0.conda
linux-aarch64::airflow-2.7.1-py39h4420490_0.conda
linux-aarch64::airflow-2.7.0-py38he3eb160_0.conda
linux-aarch64::airflow-2.6.0-py38he3eb160_0.conda
linux-aarch64::airflow-2.6.2-py39h4420490_0.conda
linux-aarch64::airflow-2.7.2-py38he3eb160_1.conda
linux-aarch64::airflow-2.5.1-py310h4c7bcd0_2.conda
linux-aarch64::airflow-2.7.2-py39h4420490_0.conda
linux-aarch64::airflow-2.6.3-py311hec3470c_0.conda
linux-aarch64::airflow-2.7.2-py311hec3470c_0.conda
linux-aarch64::airflow-2.6.3-py38he3eb160_0.conda
linux-aarch64::airflow-2.6.0-py39h4420490_0.conda
linux-aarch64::airflow-2.6.2-py310h4c7bcd0_1.conda
linux-aarch64::airflow-2.6.2-py38he3eb160_0.conda
linux-aarch64::airflow-2.6.2-py311hec3470c_1.conda
linux-aarch64::airflow-2.7.0-py310h4c7bcd0_0.conda
linux-aarch64::airflow-2.5.3-py38he3eb160_0.conda
linux-aarch64::airflow-2.7.1-py38he3eb160_0.conda
linux-aarch64::airflow-2.7.1-py310h4c7bcd0_0.conda
linux-aarch64::airflow-2.6.0-py310h4c7bcd0_0.conda
linux-aarch64::airflow-2.6.2-py39h4420490_1.conda
linux-aarch64::airflow-2.5.3-py310h4c7bcd0_0.conda
linux-aarch64::airflow-2.7.2-py310h4c7bcd0_1.conda
linux-aarch64::airflow-2.6.3-py39h4420490_0.conda
linux-aarch64::airflow-2.5.3-py39h4420490_0.conda
linux-aarch64::airflow-2.5.1-py39h4420490_2.conda
linux-aarch64::airflow-2.5.2-py310h4c7bcd0_0.conda
linux-aarch64::airflow-2.6.2-py38he3eb160_1.conda
linux-aarch64::airflow-2.7.0-py311hec3470c_0.conda
linux-aarch64::airflow-2.6.3-py310h4c7bcd0_0.conda
linux-aarch64::airflow-2.6.1-py39h4420490_0.conda
linux-aarch64::airflow-2.7.2-py311hec3470c_1.conda
linux-aarch64::airflow-2.6.1-py310h4c7bcd0_0.conda
linux-aarch64::airflow-2.7.2-py39h4420490_1.conda
linux-aarch64::airflow-2.7.2-py310h4c7bcd0_0.conda
linux-aarch64::airflow-2.5.1-py38he3eb160_2.conda
-    "pendulum >=2.0",
+    "pendulum >=2.0,<3.0",
================================================================================
================================================================================
linux-ppc64le
linux-ppc64le::airflow-2.7.0-py311h1af927a_0.conda
linux-ppc64le::airflow-2.7.2-py39h0b1cf3c_0.conda
linux-ppc64le::airflow-2.7.1-py38h8328f6c_0.conda
linux-ppc64le::airflow-2.6.2-py310h194a6c8_1.conda
linux-ppc64le::airflow-2.7.2-py38h8328f6c_1.conda
linux-ppc64le::airflow-2.6.2-py310h194a6c8_0.conda
linux-ppc64le::airflow-2.6.3-py38h8328f6c_0.conda
linux-ppc64le::airflow-2.6.3-py310h194a6c8_0.conda
linux-ppc64le::airflow-2.7.2-py311h1af927a_1.conda
linux-ppc64le::airflow-2.6.3-py39h0b1cf3c_0.conda
linux-ppc64le::airflow-2.5.3-py39h0b1cf3c_0.conda
linux-ppc64le::airflow-2.6.0-py310h194a6c8_0.conda
linux-ppc64le::airflow-2.7.1-py310h194a6c8_0.conda
linux-ppc64le::airflow-2.6.2-py39h0b1cf3c_0.conda
linux-ppc64le::airflow-2.7.2-py311h1af927a_0.conda
linux-ppc64le::airflow-2.6.2-py38h8328f6c_0.conda
linux-ppc64le::airflow-2.5.1-py38h8328f6c_2.conda
linux-ppc64le::airflow-2.6.0-py38h8328f6c_0.conda
linux-ppc64le::airflow-2.5.1-py39h0b1cf3c_2.conda
linux-ppc64le::airflow-2.6.1-py38h8328f6c_0.conda
linux-ppc64le::airflow-2.6.0-py39h0b1cf3c_0.conda
linux-ppc64le::airflow-2.6.2-py39h0b1cf3c_1.conda
linux-ppc64le::airflow-2.6.3-py311h1af927a_0.conda
linux-ppc64le::airflow-2.5.2-py39h0b1cf3c_0.conda
linux-ppc64le::airflow-2.5.2-py310h194a6c8_0.conda
linux-ppc64le::airflow-2.7.2-py38h8328f6c_0.conda
linux-ppc64le::airflow-2.6.1-py39h0b1cf3c_0.conda
linux-ppc64le::airflow-2.6.1-py310h194a6c8_0.conda
linux-ppc64le::airflow-2.7.2-py312h7864ebf_1.conda
linux-ppc64le::airflow-2.7.1-py39h0b1cf3c_0.conda
linux-ppc64le::airflow-2.5.1-py310h194a6c8_2.conda
linux-ppc64le::airflow-2.6.2-py311h1af927a_1.conda
linux-ppc64le::airflow-2.7.0-py310h194a6c8_0.conda
linux-ppc64le::airflow-2.7.0-py38h8328f6c_0.conda
linux-ppc64le::airflow-2.5.3-py310h194a6c8_0.conda
linux-ppc64le::airflow-2.6.2-py38h8328f6c_1.conda
linux-ppc64le::airflow-2.7.2-py310h194a6c8_0.conda
linux-ppc64le::airflow-2.5.3-py38h8328f6c_0.conda
linux-ppc64le::airflow-2.5.2-py38h8328f6c_0.conda
linux-ppc64le::airflow-2.7.0-py39h0b1cf3c_0.conda
linux-ppc64le::airflow-2.7.1-py311h1af927a_0.conda
linux-ppc64le::airflow-2.7.2-py39h0b1cf3c_1.conda
linux-ppc64le::airflow-2.7.2-py310h194a6c8_1.conda
-    "pendulum >=2.0",
+    "pendulum >=2.0,<3.0",
================================================================================
================================================================================
noarch
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
osx-64::airflow-2.3.0-py37hf471621_0.tar.bz2
osx-64::airflow-2.5.3-py310h2ec42d9_0.conda
osx-64::airflow-2.3.2-py39ha435c47_0.tar.bz2
osx-64::airflow-2.3.2-py38h52b2510_1.tar.bz2
osx-64::airflow-2.5.0-py39h412838c_0.conda
osx-64::airflow-2.5.1-py39h412838c_1.conda
osx-64::airflow-2.6.3-py39h6e9494a_0.conda
osx-64::airflow-2.7.1-py38h50d1736_0.conda
osx-64::airflow-2.4.2-py37hf471621_0.tar.bz2
osx-64::airflow-2.3.2-py38h52b2510_0.tar.bz2
osx-64::airflow-2.6.2-py38h50d1736_1.conda
osx-64::airflow-2.5.1-py310h6bde348_0.conda
osx-64::airflow-2.6.1-py310h2ec42d9_0.conda
osx-64::airflow-2.6.2-py39h6e9494a_1.conda
osx-64::airflow-2.4.2-py39h412838c_0.tar.bz2
osx-64::airflow-2.4.1-py37hf471621_1.tar.bz2
osx-64::airflow-2.5.1-py39ha435c47_0.conda
osx-64::airflow-2.5.0-py310h795411f_0.conda
osx-64::airflow-2.4.1-py38h52b2510_1.tar.bz2
osx-64::airflow-2.7.2-py39h6e9494a_1.conda
osx-64::airflow-2.7.0-py38h50d1736_0.conda
osx-64::airflow-2.7.2-py310h2ec42d9_0.conda
osx-64::airflow-2.3.3-py37hf471621_0.tar.bz2
osx-64::airflow-2.7.0-py311h6eed73b_0.conda
osx-64::airflow-2.6.3-py38h50d1736_0.conda
osx-64::airflow-2.5.3-py39h6e9494a_0.conda
osx-64::airflow-2.6.1-py39h6e9494a_0.conda
osx-64::airflow-2.4.0-py37hf471621_0.tar.bz2
osx-64::airflow-2.7.2-py311h6eed73b_1.conda
osx-64::airflow-2.4.3-py38h2cdcfb1_0.tar.bz2
osx-64::airflow-2.3.2-py310h795411f_1.tar.bz2
osx-64::airflow-2.3.4-py37hf471621_0.tar.bz2
osx-64::airflow-2.4.3-py310h795411f_0.tar.bz2
osx-64::airflow-2.4.3-py39h412838c_0.tar.bz2
osx-64::airflow-2.5.0-py38h2cdcfb1_0.conda
osx-64::airflow-2.6.2-py38h50d1736_0.conda
osx-64::airflow-2.5.1-py310h795411f_0.conda
osx-64::airflow-2.7.2-py38h50d1736_0.conda
osx-64::airflow-2.4.2-py310h6bde348_0.tar.bz2
osx-64::airflow-2.6.2-py311h6eed73b_1.conda
osx-64::airflow-2.5.1-py310h6bde348_1.conda
osx-64::airflow-2.3.4-py38h52b2510_0.tar.bz2
osx-64::airflow-2.3.1-py39ha435c47_0.tar.bz2
osx-64::airflow-2.3.3-py38h52b2510_0.tar.bz2
osx-64::airflow-2.3.3-py38h52b2510_1.tar.bz2
osx-64::airflow-2.6.3-py310h2ec42d9_0.conda
osx-64::airflow-2.4.1-py37hb8049f7_1.tar.bz2
osx-64::airflow-2.3.2-py37hf471621_0.tar.bz2
osx-64::airflow-2.4.1-py39h412838c_1.tar.bz2
osx-64::airflow-2.3.3-py39ha435c47_1.tar.bz2
osx-64::airflow-2.4.0-py39ha435c47_0.tar.bz2
osx-64::airflow-2.4.2-py310h795411f_0.tar.bz2
osx-64::airflow-2.3.0-py39ha435c47_0.tar.bz2
osx-64::airflow-2.3.4-py39ha435c47_1.tar.bz2
osx-64::airflow-2.3.4-py37hf471621_1.tar.bz2
osx-64::airflow-2.3.4-py38h52b2510_1.tar.bz2
osx-64::airflow-2.3.3-py37hf471621_1.tar.bz2
osx-64::airflow-2.5.1-py38h2cdcfb1_0.conda
osx-64::airflow-2.5.1-py39h6e9494a_2.conda
osx-64::airflow-2.5.0-py310h6bde348_0.conda
osx-64::airflow-2.7.2-py38h50d1736_1.conda
osx-64::airflow-2.3.2-py37hf471621_1.tar.bz2
osx-64::airflow-2.6.1-py38h50d1736_0.conda
osx-64::airflow-2.4.1-py39ha435c47_0.tar.bz2
osx-64::airflow-2.6.0-py39h6e9494a_0.conda
osx-64::airflow-2.5.2-py39h6e9494a_0.conda
osx-64::airflow-2.4.1-py310h795411f_0.tar.bz2
osx-64::airflow-2.7.1-py311h6eed73b_0.conda
osx-64::airflow-2.3.3-py39ha435c47_0.tar.bz2
osx-64::airflow-2.4.0-py310h795411f_0.tar.bz2
osx-64::airflow-2.7.0-py39h6e9494a_0.conda
osx-64::airflow-2.3.4-py310h795411f_1.tar.bz2
osx-64::airflow-2.3.3-py310h795411f_1.tar.bz2
osx-64::airflow-2.4.3-py38h52b2510_0.tar.bz2
osx-64::airflow-2.7.1-py39h6e9494a_0.conda
osx-64::airflow-2.4.1-py39ha435c47_1.tar.bz2
osx-64::airflow-2.5.1-py39h412838c_0.conda
osx-64::airflow-2.3.1-py38h52b2510_0.tar.bz2
osx-64::airflow-2.7.0-py310h2ec42d9_0.conda
osx-64::airflow-2.5.1-py38h50d1736_2.conda
osx-64::airflow-2.7.2-py39h6e9494a_0.conda
osx-64::airflow-2.5.3-py38h50d1736_0.conda
osx-64::airflow-2.6.0-py310h2ec42d9_0.conda
osx-64::airflow-2.5.2-py310h2ec42d9_0.conda
osx-64::airflow-2.4.0-py38h52b2510_0.tar.bz2
osx-64::airflow-2.5.1-py38h52b2510_0.conda
osx-64::airflow-2.5.0-py39ha435c47_0.conda
osx-64::airflow-2.5.2-py38h50d1736_0.conda
osx-64::airflow-2.3.3-py310h795411f_0.tar.bz2
osx-64::airflow-2.6.2-py39h6e9494a_0.conda
osx-64::airflow-2.4.1-py37hf471621_0.tar.bz2
osx-64::airflow-2.4.1-py310h795411f_1.tar.bz2
osx-64::airflow-2.7.2-py311h6eed73b_0.conda
osx-64::airflow-2.4.1-py38h52b2510_0.tar.bz2
osx-64::airflow-2.7.1-py310h2ec42d9_0.conda
osx-64::airflow-2.5.1-py38h2cdcfb1_1.conda
osx-64::airflow-2.3.4-py310h795411f_0.tar.bz2
osx-64::airflow-2.4.1-py310h6bde348_1.tar.bz2
osx-64::airflow-2.6.2-py310h2ec42d9_1.conda
osx-64::airflow-2.7.2-py312hb401068_1.conda
osx-64::airflow-2.4.2-py39ha435c47_0.tar.bz2
osx-64::airflow-2.3.4-py39ha435c47_0.tar.bz2
osx-64::airflow-2.4.2-py37hb8049f7_0.tar.bz2
osx-64::airflow-2.6.2-py310h2ec42d9_0.conda
osx-64::airflow-2.7.2-py310h2ec42d9_1.conda
osx-64::airflow-2.4.2-py38h2cdcfb1_0.tar.bz2
osx-64::airflow-2.4.3-py310h6bde348_0.tar.bz2
osx-64::airflow-2.5.0-py38h52b2510_0.conda
osx-64::airflow-2.3.1-py37hf471621_0.tar.bz2
osx-64::airflow-2.3.0-py38h52b2510_0.tar.bz2
osx-64::airflow-2.6.0-py38h50d1736_0.conda
osx-64::airflow-2.6.3-py311h6eed73b_0.conda
osx-64::airflow-2.4.3-py39ha435c47_0.tar.bz2
osx-64::airflow-2.4.2-py38h52b2510_0.tar.bz2
osx-64::airflow-2.4.1-py38h2cdcfb1_1.tar.bz2
osx-64::airflow-2.3.2-py39ha435c47_1.tar.bz2
osx-64::airflow-2.5.1-py310h2ec42d9_2.conda
-    "pendulum >=2.0",
+    "pendulum >=2.0,<3.0",
================================================================================
================================================================================
linux-64
linux-64::airflow-2.5.0-py310h51d5547_0.conda
linux-64::airflow-2.7.0-py39hf3d152e_0.conda
linux-64::airflow-2.5.1-py310hf87f941_0.conda
linux-64::airflow-2.3.2-py39hfa8f2c8_1.tar.bz2
linux-64::airflow-2.5.1-py38h578d9bd_2.conda
linux-64::airflow-2.4.1-py310h51d5547_1.tar.bz2
linux-64::airflow-2.5.0-py39hfa8f2c8_0.conda
linux-64::airflow-2.3.4-py310hf87f941_0.tar.bz2
linux-64::airflow-2.3.4-py38h1abaa86_0.tar.bz2
linux-64::airflow-2.3.2-py37h6dacc13_1.tar.bz2
linux-64::airflow-2.4.2-py37h6dacc13_0.tar.bz2
linux-64::airflow-2.5.2-py38h578d9bd_0.conda
linux-64::airflow-2.6.2-py311h38be061_1.conda
linux-64::airflow-2.3.0-py37h6dacc13_0.tar.bz2
linux-64::airflow-2.3.1-py39hfa8f2c8_0.tar.bz2
linux-64::airflow-2.5.0-py39hc5d2bb1_0.conda
linux-64::airflow-2.4.3-py310hf87f941_0.tar.bz2
linux-64::airflow-2.6.3-py39hf3d152e_0.conda
linux-64::airflow-2.5.1-py38h1abaa86_0.conda
linux-64::airflow-2.3.3-py310hf87f941_1.tar.bz2
linux-64::airflow-2.3.2-py37h6dacc13_0.tar.bz2
linux-64::airflow-2.3.4-py38h1abaa86_1.tar.bz2
linux-64::airflow-2.4.2-py39hc5d2bb1_0.tar.bz2
linux-64::airflow-2.3.3-py310hf87f941_0.tar.bz2
linux-64::airflow-2.4.2-py38h1abaa86_0.tar.bz2
linux-64::airflow-2.5.0-py310hf87f941_0.conda
linux-64::airflow-2.5.1-py310h51d5547_0.conda
linux-64::airflow-2.5.2-py310hff52083_0.conda
linux-64::airflow-2.6.2-py39hf3d152e_0.conda
linux-64::airflow-2.6.1-py39hf3d152e_0.conda
linux-64::airflow-2.4.1-py38h1abaa86_1.tar.bz2
linux-64::airflow-2.4.3-py38haad2881_0.tar.bz2
linux-64::airflow-2.4.3-py38h1abaa86_0.tar.bz2
linux-64::airflow-2.5.1-py38haad2881_0.conda
linux-64::airflow-2.6.0-py310hff52083_0.conda
linux-64::airflow-2.4.1-py38h1abaa86_0.tar.bz2
linux-64::airflow-2.7.0-py38h578d9bd_0.conda
linux-64::airflow-2.3.4-py37h6dacc13_1.tar.bz2
linux-64::airflow-2.4.2-py310h51d5547_0.tar.bz2
linux-64::airflow-2.6.0-py39hf3d152e_0.conda
linux-64::airflow-2.5.1-py39hc5d2bb1_0.conda
linux-64::airflow-2.3.3-py38h1abaa86_1.tar.bz2
linux-64::airflow-2.7.2-py39hf3d152e_0.conda
linux-64::airflow-2.3.3-py38h1abaa86_0.tar.bz2
linux-64::airflow-2.7.1-py311h38be061_0.conda
linux-64::airflow-2.7.2-py38h578d9bd_1.conda
linux-64::airflow-2.3.1-py38h1abaa86_0.tar.bz2
linux-64::airflow-2.3.4-py37h6dacc13_0.tar.bz2
linux-64::airflow-2.4.2-py310hf87f941_0.tar.bz2
linux-64::airflow-2.7.2-py38h578d9bd_0.conda
linux-64::airflow-2.4.1-py39hc5d2bb1_1.tar.bz2
linux-64::airflow-2.6.2-py38h578d9bd_0.conda
linux-64::airflow-2.3.4-py39hfa8f2c8_1.tar.bz2
linux-64::airflow-2.4.0-py310hf87f941_0.tar.bz2
linux-64::airflow-2.4.1-py39hfa8f2c8_1.tar.bz2
linux-64::airflow-2.4.1-py310hf87f941_0.tar.bz2
linux-64::airflow-2.4.2-py37hbfb17c8_0.tar.bz2
linux-64::airflow-2.3.2-py38h1abaa86_1.tar.bz2
linux-64::airflow-2.5.1-py310hff52083_2.conda
linux-64::airflow-2.4.3-py310h51d5547_0.tar.bz2
linux-64::airflow-2.6.3-py38h578d9bd_0.conda
linux-64::airflow-2.3.4-py310hf87f941_1.tar.bz2
linux-64::airflow-2.3.4-py39hfa8f2c8_0.tar.bz2
linux-64::airflow-2.6.3-py310hff52083_0.conda
linux-64::airflow-2.7.2-py39hf3d152e_1.conda
linux-64::airflow-2.7.0-py310hff52083_0.conda
linux-64::airflow-2.4.1-py37h6dacc13_0.tar.bz2
linux-64::airflow-2.5.3-py39hf3d152e_0.conda
linux-64::airflow-2.4.2-py38haad2881_0.tar.bz2
linux-64::airflow-2.5.2-py39hf3d152e_0.conda
linux-64::airflow-2.7.2-py311h38be061_0.conda
linux-64::airflow-2.7.2-py310hff52083_0.conda
linux-64::airflow-2.6.2-py310hff52083_0.conda
linux-64::airflow-2.6.3-py311h38be061_0.conda
linux-64::airflow-2.7.0-py311h38be061_0.conda
linux-64::airflow-2.6.2-py39hf3d152e_1.conda
linux-64::airflow-2.5.1-py39hfa8f2c8_0.conda
linux-64::airflow-2.6.1-py310hff52083_0.conda
linux-64::airflow-2.7.1-py310hff52083_0.conda
linux-64::airflow-2.3.1-py37h6dacc13_0.tar.bz2
linux-64::airflow-2.7.2-py310hff52083_1.conda
linux-64::airflow-2.5.3-py38h578d9bd_0.conda
linux-64::airflow-2.3.3-py37h6dacc13_1.tar.bz2
linux-64::airflow-2.4.3-py39hfa8f2c8_0.tar.bz2
linux-64::airflow-2.3.0-py38h1abaa86_0.tar.bz2
linux-64::airflow-2.5.1-py39hc5d2bb1_1.conda
linux-64::airflow-2.4.1-py39hfa8f2c8_0.tar.bz2
linux-64::airflow-2.7.2-py312h7900ff3_1.conda
linux-64::airflow-2.4.1-py38haad2881_1.tar.bz2
linux-64::airflow-2.5.1-py39hf3d152e_2.conda
linux-64::airflow-2.3.2-py310hf87f941_1.tar.bz2
linux-64::airflow-2.3.3-py37h6dacc13_0.tar.bz2
linux-64::airflow-2.3.2-py38h1abaa86_0.tar.bz2
linux-64::airflow-2.5.0-py38h1abaa86_0.conda
linux-64::airflow-2.6.0-py38h578d9bd_0.conda
linux-64::airflow-2.4.2-py39hfa8f2c8_0.tar.bz2
linux-64::airflow-2.6.1-py38h578d9bd_0.conda
linux-64::airflow-2.3.0-py39hfa8f2c8_0.tar.bz2
linux-64::airflow-2.4.1-py37hbfb17c8_1.tar.bz2
linux-64::airflow-2.3.3-py39hfa8f2c8_1.tar.bz2
linux-64::airflow-2.5.1-py38haad2881_1.conda
linux-64::airflow-2.7.2-py311h38be061_1.conda
linux-64::airflow-2.5.0-py38haad2881_0.conda
linux-64::airflow-2.4.3-py39hc5d2bb1_0.tar.bz2
linux-64::airflow-2.3.2-py39hfa8f2c8_0.tar.bz2
linux-64::airflow-2.4.1-py310hf87f941_1.tar.bz2
linux-64::airflow-2.7.1-py38h578d9bd_0.conda
linux-64::airflow-2.5.3-py310hff52083_0.conda
linux-64::airflow-2.5.1-py310h51d5547_1.conda
linux-64::airflow-2.6.2-py310hff52083_1.conda
linux-64::airflow-2.3.3-py39hfa8f2c8_0.tar.bz2
linux-64::airflow-2.4.1-py37h6dacc13_1.tar.bz2
linux-64::airflow-2.6.2-py38h578d9bd_1.conda
linux-64::airflow-2.4.0-py39hfa8f2c8_0.tar.bz2
linux-64::airflow-2.4.0-py37h6dacc13_0.tar.bz2
linux-64::airflow-2.4.0-py38h1abaa86_0.tar.bz2
linux-64::airflow-2.7.1-py39hf3d152e_0.conda
-    "pendulum >=2.0",
+    "pendulum >=2.0,<3.0",

```
