### PR TITLE
sagelib <10.2 is not compatible with pplpy >=0.8.9

### DIFF
--- a/recipe/patch_yaml/sagelib.yaml
+++ b/recipe/patch_yaml/sagelib.yaml
@@ -1,0 +1,6 @@
+if:
+  has_depends: pplpy >=0.8.[45678],<0.9.0a0
+then:
+  - tighten_depends:
+      name: pplpy
+      upper_bound: 0.8.9


### PR DESCRIPTION
The Python/Cython library sagelib was built against versions of pplpy 0.8.4 to 0.8.9 (a Python frontend for the geometry package PPL.) However, only sagelib 10.2 that was built against 0.8.9 actually works with 0.8.9. Other versions have some serialization problems with that version of pplpy, see https://github.com/sagemath/pplpy/issues/30.

Here, we pin old builds of sagelib against pplpy <0.8.9 to make them fully functional again.

---

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary. No code in the `.py`.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` --> This only affects packages built against pplpy <0.8.9. Newer builds do not build against old versions of pplpy anymore.

<!-- Put any other comments or information here -->

---

Output from show_diff.py:

<details>
<pre>
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
osx-arm64::sagelib-9.7-py310haef829e_0.tar.bz2
osx-arm64::sagelib-9.4-py38hfc93ce5_0.tar.bz2
osx-arm64::sagelib-9.7-py39h0f1d45d_1.tar.bz2
osx-arm64::sagelib-9.6-py310hf8141c2_1.tar.bz2
osx-arm64::sagelib-9.5-py38h07b73e2_0.tar.bz2
osx-arm64::sagelib-9.6-py39h1878682_2.tar.bz2
osx-arm64::sagelib-9.7-py38h2d75e1a_2.conda
osx-arm64::sagelib-9.5-py310h405397e_2.tar.bz2
osx-arm64::sagelib-9.6-py310h5f53620_0.tar.bz2
osx-arm64::sagelib-9.6-py39h375837f_0.tar.bz2
osx-arm64::sagelib-9.5-py39hc334225_3.tar.bz2
osx-arm64::sagelib-9.6-py310hf8141c2_2.tar.bz2
osx-arm64::sagelib-9.6-py38h2e7102d_0.tar.bz2
osx-arm64::sagelib-9.7-py39h2f84395_2.conda
osx-arm64::sagelib-9.3-py38h6e57fc7_4.tar.bz2
osx-arm64::sagelib-9.8-py310h55faf8f_2.conda
osx-arm64::sagelib-9.7-py38he55e7ee_1.tar.bz2
osx-arm64::sagelib-9.6-py310h2478b59_3.tar.bz2
osx-arm64::sagelib-9.5-py38h830c1dc_2.tar.bz2
osx-arm64::sagelib-9.6-py39h1878682_1.tar.bz2
osx-arm64::sagelib-9.5-py310h405397e_3.tar.bz2
osx-arm64::sagelib-9.3-py39hc026e0e_1.tar.bz2
osx-arm64::sagelib-9.5-py38h830c1dc_3.tar.bz2
osx-arm64::sagelib-9.5-py39h1ccef93_4.tar.bz2
osx-arm64::sagelib-9.6-py310haef829e_4.tar.bz2
osx-arm64::sagelib-9.6-py38hecbb9b4_2.tar.bz2
osx-arm64::sagelib-9.3-py38h6e57fc7_2.tar.bz2
osx-arm64::sagelib-9.8-py38h2d75e1a_1.conda
osx-arm64::sagelib-9.5-py310h58a2b93_4.tar.bz2
osx-arm64::sagelib-9.5-py39hc334225_2.tar.bz2
osx-arm64::sagelib-9.3-py38h6e57fc7_1.tar.bz2
osx-arm64::sagelib-9.8-py38h494b33e_2.conda
osx-arm64::sagelib-9.3-py38h6e57fc7_3.tar.bz2
osx-arm64::sagelib-9.5-py39h546258d_0.tar.bz2
osx-arm64::sagelib-9.7-py310haef829e_1.tar.bz2
osx-arm64::sagelib-9.5-py310h653da02_1.tar.bz2
osx-arm64::sagelib-9.3-py39hc026e0e_4.tar.bz2
osx-arm64::sagelib-9.5-py38h07b73e2_1.tar.bz2
osx-arm64::sagelib-9.8-py310h55faf8f_3.conda
osx-arm64::sagelib-9.8-py38h8f5c8e1_3.conda
osx-arm64::sagelib-9.8-py310hbea4a20_1.conda
osx-arm64::sagelib-9.6-py38h9ad5a0d_3.tar.bz2
osx-arm64::sagelib-9.7-py39h0f1d45d_0.tar.bz2
osx-arm64::sagelib-9.8-py310hbea4a20_0.conda
osx-arm64::sagelib-9.3-py39hc026e0e_3.tar.bz2
osx-arm64::sagelib-9.4-py38h07b73e2_1.tar.bz2
osx-arm64::sagelib-9.6-py39h0f1d45d_4.tar.bz2
osx-arm64::sagelib-9.3-py39hc026e0e_2.tar.bz2
osx-arm64::sagelib-9.8-py39h2f84395_1.conda
osx-arm64::sagelib-9.8-py39hf866951_2.conda
osx-arm64::sagelib-9.5-py38h7824bfe_4.tar.bz2
osx-arm64::sagelib-9.7-py38he55e7ee_0.tar.bz2
osx-arm64::sagelib-9.8-py39h2f84395_0.conda
osx-arm64::sagelib-9.6-py39hdc4234c_3.tar.bz2
osx-arm64::sagelib-9.7-py310hbea4a20_2.conda
osx-arm64::sagelib-9.4-py39h546258d_1.tar.bz2
osx-arm64::sagelib-9.4-py39hda2d183_0.tar.bz2
osx-arm64::sagelib-9.5-py310h653da02_0.tar.bz2
osx-arm64::sagelib-9.8-py39hb89197b_3.conda
osx-arm64::sagelib-9.6-py38he55e7ee_4.tar.bz2
osx-arm64::sagelib-9.8-py38h2d75e1a_0.conda
osx-arm64::sagelib-9.5-py39h546258d_1.tar.bz2
osx-arm64::sagelib-9.6-py38hecbb9b4_1.tar.bz2
-    "pplpy >=0.8.6,<0.9.0a0",
+    "pplpy >=0.8.6,<0.8.9.0a0",
osx-arm64::sagelib-10.0-py311h20e94d5_2.conda
osx-arm64::sagelib-10.0-py38h8aa816a_1.conda
osx-arm64::sagelib-9.8-py38h8aa816a_5.conda
osx-arm64::sagelib-10.0-py38h1a87593_2.conda
osx-arm64::sagelib-9.8-py39h5303beb_4.conda
osx-arm64::sagelib-10.0-py310h3aecabe_1.conda
osx-arm64::sagelib-10.1-py310h794f6da_0.conda
osx-arm64::sagelib-9.8-py311ha07c8a7_5.conda
osx-arm64::sagelib-9.8-py38h57a157c_4.conda
osx-arm64::sagelib-10.1-py311h20e94d5_0.conda
osx-arm64::sagelib-9.8-py310h15c73cb_4.conda
osx-arm64::sagelib-10.0-py311ha07c8a7_1.conda
osx-arm64::sagelib-10.0-py38h8aa816a_0.conda
osx-arm64::sagelib-10.1-py38h1a87593_0.conda
osx-arm64::sagelib-9.8-py311h287fb7b_4.conda
osx-arm64::sagelib-9.8-py310h3aecabe_5.conda
osx-arm64::sagelib-10.0-py39h177c099_1.conda
osx-arm64::sagelib-10.0-py39h177c099_0.conda
osx-arm64::sagelib-10.0-py311ha07c8a7_0.conda
osx-arm64::sagelib-10.0-py310h794f6da_2.conda
osx-arm64::sagelib-10.1-py39h7e5f403_0.conda
osx-arm64::sagelib-9.8-py39h177c099_5.conda
osx-arm64::sagelib-10.0-py39h7e5f403_2.conda
osx-arm64::sagelib-10.0-py310h3aecabe_0.conda
-    "pplpy >=0.8.7,<0.9.0a0",
+    "pplpy >=0.8.7,<0.8.9.0a0",
================================================================================
================================================================================
linux-ppc64le
linux-ppc64le::sagelib-9.2-py38hfe7575d_1.tar.bz2
linux-ppc64le::sagelib-9.2-py36h23e8ec0_1.tar.bz2
linux-ppc64le::sagelib-9.2-py37h535fc39_1.tar.bz2
linux-ppc64le::sagelib-9.2-py39hc443935_1.tar.bz2
-    "pplpy >=0.8.4,<0.9.0a0",
+    "pplpy >=0.8.4,<0.8.9.0a0",
================================================================================
================================================================================
linux-aarch64
linux-aarch64::sagelib-9.2-py37h65290cc_0.tar.bz2
linux-aarch64::sagelib-9.2-py38h43eead1_1.tar.bz2
linux-aarch64::sagelib-9.2-py39h1660898_1.tar.bz2
linux-aarch64::sagelib-9.2-py36he09f22b_1.tar.bz2
linux-aarch64::sagelib-9.2-py38h43eead1_0.tar.bz2
linux-aarch64::sagelib-9.2-py37h65290cc_1.tar.bz2
linux-aarch64::sagelib-9.2-py36he09f22b_0.tar.bz2
-    "pplpy >=0.8.4,<0.9.0a0",
+    "pplpy >=0.8.4,<0.8.9.0a0",
linux-aarch64::sagelib-9.5-py310h26f1b71_2.tar.bz2
linux-aarch64::sagelib-9.8-py39haaaba6c_3.conda
linux-aarch64::sagelib-9.6-py38hb0d89e6_1.tar.bz2
linux-aarch64::sagelib-9.5-py37h63a14cd_4.tar.bz2
linux-aarch64::sagelib-9.6-py39h82eec59_4.tar.bz2
linux-aarch64::sagelib-9.6-py38hf61f25c_3.tar.bz2
linux-aarch64::sagelib-9.5-py38h0a3289c_3.tar.bz2
linux-aarch64::sagelib-9.8-py39he29eb67_2.conda
linux-aarch64::sagelib-9.5-py310ha089417_0.tar.bz2
linux-aarch64::sagelib-9.4-py38h679a460_1.tar.bz2
linux-aarch64::sagelib-9.3-py37h6986f93_4.tar.bz2
linux-aarch64::sagelib-9.6-py310hcc22e18_2.tar.bz2
linux-aarch64::sagelib-9.7-py310h04a57a7_0.tar.bz2
linux-aarch64::sagelib-9.5-py310h26f1b71_3.tar.bz2
linux-aarch64::sagelib-9.5-py310hc770ad4_4.tar.bz2
linux-aarch64::sagelib-9.5-py37h5066cd7_0.tar.bz2
linux-aarch64::sagelib-9.3-py36hee98794_3.tar.bz2
linux-aarch64::sagelib-9.3-py37h6986f93_1.tar.bz2
linux-aarch64::sagelib-9.5-py38h679a460_0.tar.bz2
linux-aarch64::sagelib-9.6-py38h7c2cf87_4.tar.bz2
linux-aarch64::sagelib-9.8-py310h52f2371_3.conda
linux-aarch64::sagelib-9.3-py39hffb6a49_1.tar.bz2
linux-aarch64::sagelib-9.3-py37h6986f93_3.tar.bz2
linux-aarch64::sagelib-9.6-py37h6c375de_2.tar.bz2
linux-aarch64::sagelib-9.8-py39h4478bdf_1.conda
linux-aarch64::sagelib-9.8-py310had41980_1.conda
linux-aarch64::sagelib-9.3-py39hffb6a49_2.tar.bz2
linux-aarch64::sagelib-9.4-py39h1ffb4c4_0.tar.bz2
linux-aarch64::sagelib-9.3-py39hffb6a49_4.tar.bz2
linux-aarch64::sagelib-9.5-py37h12edca8_2.tar.bz2
linux-aarch64::sagelib-9.6-py310hcc22e18_0.tar.bz2
linux-aarch64::sagelib-9.6-py39h0b0774c_2.tar.bz2
linux-aarch64::sagelib-9.6-py37h6c375de_1.tar.bz2
linux-aarch64::sagelib-9.6-py310h4af1d41_3.tar.bz2
linux-aarch64::sagelib-9.5-py37h5066cd7_1.tar.bz2
linux-aarch64::sagelib-9.6-py310hcc22e18_1.tar.bz2
linux-aarch64::sagelib-9.7-py39he2f1015_2.conda
linux-aarch64::sagelib-9.3-py36hee98794_4.tar.bz2
linux-aarch64::sagelib-9.3-py36hee98794_1.tar.bz2
linux-aarch64::sagelib-9.8-py310h52f2371_2.conda
linux-aarch64::sagelib-9.8-py310had41980_0.conda
linux-aarch64::sagelib-9.3-py39hffb6a49_3.tar.bz2
linux-aarch64::sagelib-9.6-py37h8396c7f_3.tar.bz2
linux-aarch64::sagelib-9.6-py38hb0d89e6_0.tar.bz2
linux-aarch64::sagelib-9.4-py39h0c97c74_1.tar.bz2
linux-aarch64::sagelib-9.5-py38h9ad6be3_4.tar.bz2
linux-aarch64::sagelib-9.6-py310h04a57a7_4.tar.bz2
linux-aarch64::sagelib-9.3-py38hf78bb88_2.tar.bz2
linux-aarch64::sagelib-9.7-py39h82eec59_0.tar.bz2
linux-aarch64::sagelib-9.3-py37h6986f93_2.tar.bz2
linux-aarch64::sagelib-9.8-py38h552e107_1.conda
linux-aarch64::sagelib-9.7-py38h7c2cf87_0.tar.bz2
linux-aarch64::sagelib-9.4-py37hf6134ff_0.tar.bz2
linux-aarch64::sagelib-9.6-py39h30b59d6_3.tar.bz2
linux-aarch64::sagelib-9.6-py37hcc5023c_4.tar.bz2
linux-aarch64::sagelib-9.8-py38h44ef88f_2.conda
linux-aarch64::sagelib-9.5-py39h0c97c74_0.tar.bz2
linux-aarch64::sagelib-9.6-py39h0b0774c_0.tar.bz2
linux-aarch64::sagelib-9.3-py38hf78bb88_4.tar.bz2
linux-aarch64::sagelib-9.6-py37h6c375de_0.tar.bz2
linux-aarch64::sagelib-9.5-py39h5ab2d25_4.tar.bz2
linux-aarch64::sagelib-9.8-py38h552e107_0.conda
linux-aarch64::sagelib-9.3-py38hf78bb88_1.tar.bz2
linux-aarch64::sagelib-9.3-py36hee98794_2.tar.bz2
linux-aarch64::sagelib-9.6-py38hb0d89e6_2.tar.bz2
linux-aarch64::sagelib-9.7-py39h82eec59_1.tar.bz2
linux-aarch64::sagelib-9.8-py38ha9748f4_3.conda
linux-aarch64::sagelib-9.6-py39h0b0774c_1.tar.bz2
linux-aarch64::sagelib-9.5-py38h679a460_1.tar.bz2
linux-aarch64::sagelib-9.5-py38h0a3289c_2.tar.bz2
linux-aarch64::sagelib-9.4-py37h5066cd7_1.tar.bz2
linux-aarch64::sagelib-9.5-py39h1e42bcf_2.tar.bz2
linux-aarch64::sagelib-9.3-py38hf78bb88_3.tar.bz2
linux-aarch64::sagelib-9.5-py39h1e42bcf_3.tar.bz2
linux-aarch64::sagelib-9.7-py310h04a57a7_1.tar.bz2
linux-aarch64::sagelib-9.7-py38habdd34f_2.conda
linux-aarch64::sagelib-9.5-py310ha089417_1.tar.bz2
linux-aarch64::sagelib-9.7-py38h7c2cf87_1.tar.bz2
linux-aarch64::sagelib-9.5-py37h12edca8_3.tar.bz2
linux-aarch64::sagelib-9.7-py310h8c7b702_2.conda
linux-aarch64::sagelib-9.5-py39h0c97c74_1.tar.bz2
linux-aarch64::sagelib-9.8-py39h4478bdf_0.conda
linux-aarch64::sagelib-9.4-py38h8747534_0.tar.bz2
-    "pplpy >=0.8.6,<0.9.0a0",
+    "pplpy >=0.8.6,<0.8.9.0a0",
linux-aarch64::sagelib-9.8-py311he22122c_5.conda
linux-aarch64::sagelib-10.0-py39h29ad0c2_2.conda
linux-aarch64::sagelib-10.1-py38hdcb3410_0.conda
linux-aarch64::sagelib-10.1-py39h29ad0c2_0.conda
linux-aarch64::sagelib-10.1-py311h0f5560f_0.conda
linux-aarch64::sagelib-9.8-py310h055e31b_5.conda
linux-aarch64::sagelib-9.8-py39h0c97323_5.conda
linux-aarch64::sagelib-10.0-py38hdcb3410_2.conda
linux-aarch64::sagelib-10.0-py310h055e31b_1.conda
linux-aarch64::sagelib-9.8-py310ha1fcb8a_4.conda
linux-aarch64::sagelib-10.0-py311he22122c_0.conda
linux-aarch64::sagelib-9.8-py39hed3cf32_4.conda
linux-aarch64::sagelib-10.0-py39h0c97323_1.conda
linux-aarch64::sagelib-10.0-py39h0c97323_0.conda
linux-aarch64::sagelib-9.8-py311h2c0d990_4.conda
linux-aarch64::sagelib-10.0-py310h055e31b_0.conda
linux-aarch64::sagelib-10.0-py311he22122c_1.conda
linux-aarch64::sagelib-10.0-py311h0f5560f_2.conda
linux-aarch64::sagelib-10.0-py310hfbc6516_2.conda
linux-aarch64::sagelib-10.0-py38h66bba7d_0.conda
linux-aarch64::sagelib-9.8-py38h66bba7d_5.conda
linux-aarch64::sagelib-10.1-py310hfbc6516_0.conda
linux-aarch64::sagelib-10.0-py38h66bba7d_1.conda
linux-aarch64::sagelib-9.8-py38hd97a410_4.conda
-    "pplpy >=0.8.7,<0.9.0a0",
+    "pplpy >=0.8.7,<0.8.9.0a0",
================================================================================
================================================================================
noarch
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
osx-64::sagelib-9.0-py37h02a2607_1.tar.bz2
osx-64::sagelib-9.0-py36h02a2607_1.tar.bz2
osx-64::sagelib-9.2-py38h6723ccb_1.tar.bz2
osx-64::sagelib-9.1-py36h370f638_0.tar.bz2
osx-64::sagelib-9.2-py39hd32c659_1.tar.bz2
osx-64::sagelib-9.2-py37h66ef59e_2.tar.bz2
osx-64::sagelib-8.8-py27h27ae613_1.tar.bz2
osx-64::sagelib-9.0-py27h02a2607_0.tar.bz2
osx-64::sagelib-9.1-py37hffdb5c0_1.tar.bz2
osx-64::sagelib-9.2-py38h8c92a00_2.tar.bz2
osx-64::sagelib-8.8-py36h247dc56_2.tar.bz2
osx-64::sagelib-8.8-py37h27ae613_1.tar.bz2
osx-64::sagelib-8.9-py37h376306d_0.tar.bz2
osx-64::sagelib-9.2-py36h39f2bb0_2.tar.bz2
osx-64::sagelib-9.1-py37hb57b699_0.tar.bz2
osx-64::sagelib-9.0-py37h879c5eb_2.tar.bz2
osx-64::sagelib-8.8-py37h247dc56_2.tar.bz2
osx-64::sagelib-8.9-py36h376306d_0.tar.bz2
osx-64::sagelib-9.1-py36h3a7473f_1.tar.bz2
osx-64::sagelib-9.2-py36hd67a5d9_0.tar.bz2
osx-64::sagelib-9.2-py38h8b1150e_2.tar.bz2
osx-64::sagelib-9.2-py39hf3b6d89_2.tar.bz2
osx-64::sagelib-8.8-py27h247dc56_2.tar.bz2
osx-64::sagelib-8.9-py27h376306d_0.tar.bz2
osx-64::sagelib-9.0-py36h879c5eb_2.tar.bz2
osx-64::sagelib-9.2-py36h8654bfd_2.tar.bz2
osx-64::sagelib-9.2-py37h592ed44_0.tar.bz2
osx-64::sagelib-9.0-py27h02a2607_1.tar.bz2
osx-64::sagelib-9.2-py37hb520e09_2.tar.bz2
osx-64::sagelib-9.0-py37h02a2607_0.tar.bz2
osx-64::sagelib-9.2-py36hd67a5d9_1.tar.bz2
osx-64::sagelib-9.2-py37h592ed44_1.tar.bz2
osx-64::sagelib-9.2-py39h5978c99_2.tar.bz2
osx-64::sagelib-8.8-py36h27ae613_1.tar.bz2
osx-64::sagelib-9.2-py38h6723ccb_0.tar.bz2
osx-64::sagelib-9.0-py27h879c5eb_2.tar.bz2
-    "pplpy >=0.8.4,<0.9.0a0",
+    "pplpy >=0.8.4,<0.8.9.0a0",
osx-64::sagelib-9.3-py39h2a6771f_3.tar.bz2
osx-64::sagelib-9.6-py310hee03c39_2.tar.bz2
osx-64::sagelib-9.6-py38h030ff5c_4.tar.bz2
osx-64::sagelib-9.7-py310hee9812e_2.conda
osx-64::sagelib-9.5-py310hdc53c30_3.tar.bz2
osx-64::sagelib-9.3-py37h647d81b_1.tar.bz2
osx-64::sagelib-9.5-py38ha7a50e7_4.tar.bz2
osx-64::sagelib-9.3-py39h2a6771f_2.tar.bz2
osx-64::sagelib-9.8-py39ha0479fc_1.conda
osx-64::sagelib-9.8-py310hb2c901a_2.conda
osx-64::sagelib-9.5-py37hc39770f_2.tar.bz2
osx-64::sagelib-9.6-py37hb3411b0_0.tar.bz2
osx-64::sagelib-9.5-py310ha1b8b38_0.tar.bz2
osx-64::sagelib-9.7-py39hf8a2b27_0.tar.bz2
osx-64::sagelib-9.8-py310hee9812e_1.conda
osx-64::sagelib-9.8-py38h8f64b8f_2.conda
osx-64::sagelib-9.6-py39hd28857d_0.tar.bz2
osx-64::sagelib-9.6-py38h0f384a6_1.tar.bz2
osx-64::sagelib-9.6-py39h53da78b_2.tar.bz2
osx-64::sagelib-9.7-py39ha0479fc_2.conda
osx-64::sagelib-9.5-py37h527333e_4.tar.bz2
osx-64::sagelib-9.3-py37h647d81b_4.tar.bz2
osx-64::sagelib-9.5-py39h1fbcbea_3.tar.bz2
osx-64::sagelib-9.8-py310hee9812e_0.conda
osx-64::sagelib-9.7-py38hc0fad1b_2.conda
osx-64::sagelib-9.3-py39h2a6771f_4.tar.bz2
osx-64::sagelib-9.5-py38h97b3fe5_3.tar.bz2
osx-64::sagelib-9.6-py39h2b5d681_3.tar.bz2
osx-64::sagelib-9.3-py38h358c2c4_1.tar.bz2
osx-64::sagelib-9.8-py39ha0479fc_0.conda
osx-64::sagelib-9.5-py37hf093b7e_1.tar.bz2
osx-64::sagelib-9.2-py36hf4127b0_3.tar.bz2
osx-64::sagelib-9.5-py38hba57b99_1.tar.bz2
osx-64::sagelib-9.8-py39h116f317_3.conda
osx-64::sagelib-9.8-py38hc0fad1b_1.conda
osx-64::sagelib-9.5-py310hdc53c30_2.tar.bz2
osx-64::sagelib-9.6-py38h24214df_0.tar.bz2
osx-64::sagelib-9.6-py310h6c9b66d_4.tar.bz2
osx-64::sagelib-9.6-py38h0f384a6_2.tar.bz2
osx-64::sagelib-9.5-py39he794440_4.tar.bz2
osx-64::sagelib-9.2-py37h13e003a_3.tar.bz2
osx-64::sagelib-9.4-py37he617a0f_0.tar.bz2
osx-64::sagelib-9.3-py38h358c2c4_2.tar.bz2
osx-64::sagelib-9.5-py39hb5a7a70_0.tar.bz2
osx-64::sagelib-9.4-py39h9b9add2_0.tar.bz2
osx-64::sagelib-9.5-py38h97b3fe5_2.tar.bz2
osx-64::sagelib-9.7-py39hf8a2b27_1.tar.bz2
osx-64::sagelib-9.5-py37hc39770f_3.tar.bz2
osx-64::sagelib-9.4-py38h2399446_0.tar.bz2
osx-64::sagelib-9.6-py37h3bc8bf5_3.tar.bz2
osx-64::sagelib-9.3-py38h358c2c4_3.tar.bz2
osx-64::sagelib-9.3-py36hff58d0c_2.tar.bz2
osx-64::sagelib-9.6-py310hbdee453_3.tar.bz2
osx-64::sagelib-9.4-py37hf093b7e_1.tar.bz2
osx-64::sagelib-9.3-py36hff58d0c_3.tar.bz2
osx-64::sagelib-9.8-py39h5bd40fe_2.conda
osx-64::sagelib-9.5-py310h2bac986_4.tar.bz2
osx-64::sagelib-9.3-py39h2a6771f_1.tar.bz2
osx-64::sagelib-9.8-py38hc0fad1b_0.conda
osx-64::sagelib-9.6-py38hb79c7c8_3.tar.bz2
osx-64::sagelib-9.7-py38h030ff5c_0.tar.bz2
osx-64::sagelib-9.3-py37h647d81b_2.tar.bz2
osx-64::sagelib-9.6-py310h8cf5725_0.tar.bz2
osx-64::sagelib-9.8-py38h83e7100_3.conda
osx-64::sagelib-9.3-py37h647d81b_3.tar.bz2
osx-64::sagelib-9.5-py38hba57b99_0.tar.bz2
osx-64::sagelib-9.7-py310h6c9b66d_1.tar.bz2
osx-64::sagelib-9.4-py38hba57b99_1.tar.bz2
osx-64::sagelib-9.6-py310hee03c39_1.tar.bz2
osx-64::sagelib-9.6-py39hf8a2b27_4.tar.bz2
osx-64::sagelib-9.4-py39hb5a7a70_1.tar.bz2
osx-64::sagelib-9.3-py36hff58d0c_1.tar.bz2
osx-64::sagelib-9.6-py37hbe9dd0b_1.tar.bz2
osx-64::sagelib-9.5-py37hf093b7e_0.tar.bz2
osx-64::sagelib-9.6-py37h02e0cb4_4.tar.bz2
osx-64::sagelib-9.6-py39h53da78b_1.tar.bz2
osx-64::sagelib-9.3-py36hff58d0c_4.tar.bz2
osx-64::sagelib-9.7-py310h6c9b66d_0.tar.bz2
osx-64::sagelib-9.5-py310ha1b8b38_1.tar.bz2
osx-64::sagelib-9.2-py38h2fbd78b_3.tar.bz2
osx-64::sagelib-9.6-py37hbe9dd0b_2.tar.bz2
osx-64::sagelib-9.3-py38h358c2c4_4.tar.bz2
osx-64::sagelib-9.5-py39h1fbcbea_2.tar.bz2
osx-64::sagelib-9.5-py39hb5a7a70_1.tar.bz2
osx-64::sagelib-9.7-py38h030ff5c_1.tar.bz2
osx-64::sagelib-9.8-py310hb2c901a_3.conda
osx-64::sagelib-9.2-py39he058a7f_3.tar.bz2
-    "pplpy >=0.8.6,<0.9.0a0",
+    "pplpy >=0.8.6,<0.8.9.0a0",
osx-64::sagelib-10.0-py38hb8d266d_2.conda
osx-64::sagelib-10.1-py38hb8d266d_0.conda
osx-64::sagelib-9.8-py310hc208e89_5.conda
osx-64::sagelib-10.0-py310h89b1bf4_2.conda
osx-64::sagelib-10.0-py38hb144cf9_0.conda
osx-64::sagelib-10.0-py310hc208e89_1.conda
osx-64::sagelib-10.0-py39hb452f22_1.conda
osx-64::sagelib-9.8-py38hb144cf9_5.conda
osx-64::sagelib-9.8-py311h3b1e84e_5.conda
osx-64::sagelib-10.0-py39hb452f22_0.conda
osx-64::sagelib-10.0-py311h2cc7121_2.conda
osx-64::sagelib-10.1-py39hf4b7944_0.conda
osx-64::sagelib-9.8-py311hc8405f5_4.conda
osx-64::sagelib-10.1-py310h89b1bf4_0.conda
osx-64::sagelib-9.8-py38h3ca777a_4.conda
osx-64::sagelib-10.0-py311h3b1e84e_0.conda
osx-64::sagelib-10.1-py311h2cc7121_0.conda
osx-64::sagelib-9.8-py39h95df521_4.conda
osx-64::sagelib-10.0-py310hc208e89_0.conda
osx-64::sagelib-9.8-py39hb452f22_5.conda
osx-64::sagelib-9.8-py310h936b8c1_4.conda
osx-64::sagelib-10.0-py311h3b1e84e_1.conda
osx-64::sagelib-10.0-py38hb144cf9_1.conda
osx-64::sagelib-10.0-py39hf4b7944_2.conda
-    "pplpy >=0.8.7,<0.9.0a0",
+    "pplpy >=0.8.7,<0.8.9.0a0",
================================================================================
================================================================================
linux-64
linux-64::sagelib-9.2-py38h43eead1_1.tar.bz2
linux-64::sagelib-9.2-py39h7fc0350_2.tar.bz2
linux-64::sagelib-9.0-py27h9c8e189_0.tar.bz2
linux-64::sagelib-9.0-py37h9c8e189_0.tar.bz2
linux-64::sagelib-9.0-py36h360dde1_2.tar.bz2
linux-64::sagelib-9.2-py36he09f22b_0.tar.bz2
linux-64::sagelib-8.8-py37h1c8ffa1_2.tar.bz2
linux-64::sagelib-9.2-py36hf3499cc_2.tar.bz2
linux-64::sagelib-9.2-py36he09f22b_1.tar.bz2
linux-64::sagelib-9.0-py37h9c8e189_1.tar.bz2
linux-64::sagelib-8.9-py36h9c8e189_0.tar.bz2
linux-64::sagelib-9.1-py36h6c52298_0.tar.bz2
linux-64::sagelib-9.1-py36h3d102d6_1.tar.bz2
linux-64::sagelib-9.1-py37h61fa694_1.tar.bz2
linux-64::sagelib-8.9-py37h9c8e189_0.tar.bz2
linux-64::sagelib-9.2-py37h65290cc_1.tar.bz2
linux-64::sagelib-8.8-py37h21c7cb8_1.tar.bz2
linux-64::sagelib-9.2-py37h6f08177_2.tar.bz2
linux-64::sagelib-9.2-py37h8068d60_2.tar.bz2
linux-64::sagelib-9.0-py37h360dde1_2.tar.bz2
linux-64::sagelib-9.1-py37hbfcc262_0.tar.bz2
linux-64::sagelib-8.8-py27h1c8ffa1_2.tar.bz2
linux-64::sagelib-9.2-py38hc577ad3_2.tar.bz2
linux-64::sagelib-8.8-py36h1c8ffa1_2.tar.bz2
linux-64::sagelib-9.0-py36h9c8e189_0.tar.bz2
linux-64::sagelib-9.2-py39h1660898_1.tar.bz2
linux-64::sagelib-9.2-py36h903ebd1_2.tar.bz2
linux-64::sagelib-9.0-py27h9c8e189_1.tar.bz2
linux-64::sagelib-9.2-py38hdb2647e_2.tar.bz2
linux-64::sagelib-9.2-py38h43eead1_0.tar.bz2
linux-64::sagelib-9.2-py39hf3cf426_2.tar.bz2
linux-64::sagelib-8.9-py27h9c8e189_0.tar.bz2
linux-64::sagelib-8.8-py27h21c7cb8_1.tar.bz2
linux-64::sagelib-8.8-py36h21c7cb8_1.tar.bz2
linux-64::sagelib-9.2-py37h65290cc_0.tar.bz2
linux-64::sagelib-9.0-py27h360dde1_2.tar.bz2
linux-64::sagelib-9.0-py36h9c8e189_1.tar.bz2
-    "pplpy >=0.8.4,<0.9.0a0",
+    "pplpy >=0.8.4,<0.8.9.0a0",
linux-64::sagelib-9.3-py36hf83666a_1.tar.bz2
linux-64::sagelib-9.8-py38h67ebd9a_0.conda
linux-64::sagelib-9.6-py37ha49f77c_0.tar.bz2
linux-64::sagelib-9.4-py39he34bcec_1.tar.bz2
linux-64::sagelib-9.6-py37ha49f77c_1.tar.bz2
linux-64::sagelib-9.5-py310h771e0a6_3.tar.bz2
linux-64::sagelib-9.4-py38hfd38005_1.tar.bz2
linux-64::sagelib-9.3-py36hf83666a_2.tar.bz2
linux-64::sagelib-9.6-py37ha49f77c_2.tar.bz2
linux-64::sagelib-9.3-py38hbed016e_3.tar.bz2
linux-64::sagelib-9.3-py36hf83666a_3.tar.bz2
linux-64::sagelib-9.5-py37hc8fef4d_3.tar.bz2
linux-64::sagelib-9.8-py39hc575d61_3.conda
linux-64::sagelib-9.3-py37hc430d82_2.tar.bz2
linux-64::sagelib-9.6-py38h5017592_4.tar.bz2
linux-64::sagelib-9.6-py37h42061e7_4.tar.bz2
linux-64::sagelib-9.3-py37hc430d82_3.tar.bz2
linux-64::sagelib-9.5-py310h5946b9b_4.tar.bz2
linux-64::sagelib-9.6-py39hd3413e4_4.tar.bz2
linux-64::sagelib-9.3-py38hbed016e_1.tar.bz2
linux-64::sagelib-9.8-py310h50425fa_2.conda
linux-64::sagelib-9.3-py38hbed016e_4.tar.bz2
linux-64::sagelib-9.2-py37hfabf6b9_3.tar.bz2
linux-64::sagelib-9.5-py39h1c80623_2.tar.bz2
linux-64::sagelib-9.3-py37hc430d82_4.tar.bz2
linux-64::sagelib-9.6-py310h4f38093_0.tar.bz2
linux-64::sagelib-9.7-py39h4a58426_2.conda
linux-64::sagelib-9.7-py38h5017592_1.tar.bz2
linux-64::sagelib-9.3-py39h2934941_3.tar.bz2
linux-64::sagelib-9.6-py37h280181f_3.tar.bz2
linux-64::sagelib-9.5-py38hd903835_2.tar.bz2
linux-64::sagelib-9.7-py38hb1be364_2.conda
linux-64::sagelib-9.6-py38hc949e4e_3.tar.bz2
linux-64::sagelib-9.5-py310h990377c_1.tar.bz2
linux-64::sagelib-9.6-py38h718827e_1.tar.bz2
linux-64::sagelib-9.5-py39h3decf45_4.tar.bz2
linux-64::sagelib-9.6-py38h718827e_2.tar.bz2
linux-64::sagelib-9.5-py38hff34d62_4.tar.bz2
linux-64::sagelib-9.3-py39h2934941_1.tar.bz2
linux-64::sagelib-9.8-py310h50425fa_3.conda
linux-64::sagelib-9.2-py36h0d8f714_3.tar.bz2
linux-64::sagelib-9.5-py39he34bcec_1.tar.bz2
linux-64::sagelib-9.8-py38h63316f8_3.conda
linux-64::sagelib-9.7-py310h28be7dd_0.tar.bz2
linux-64::sagelib-9.3-py36hf83666a_4.tar.bz2
linux-64::sagelib-9.3-py37hc430d82_1.tar.bz2
linux-64::sagelib-9.6-py310h28be7dd_4.tar.bz2
linux-64::sagelib-9.8-py38h5e3c9ae_2.conda
linux-64::sagelib-9.3-py38hbed016e_2.tar.bz2
linux-64::sagelib-9.5-py37h0c4da78_1.tar.bz2
linux-64::sagelib-9.7-py39hd3413e4_1.tar.bz2
linux-64::sagelib-9.5-py39he34bcec_0.tar.bz2
linux-64::sagelib-9.5-py310h771e0a6_2.tar.bz2
linux-64::sagelib-9.7-py38h5017592_0.tar.bz2
linux-64::sagelib-9.8-py310hf5d4ce6_0.conda
linux-64::sagelib-9.4-py38h8e9e885_0.tar.bz2
linux-64::sagelib-9.7-py39hd3413e4_0.tar.bz2
linux-64::sagelib-9.4-py37h333c953_0.tar.bz2
linux-64::sagelib-9.5-py38hfd38005_1.tar.bz2
linux-64::sagelib-9.8-py310hf5d4ce6_1.conda
linux-64::sagelib-9.7-py310ha091118_2.conda
linux-64::sagelib-9.8-py39hce79299_0.conda
linux-64::sagelib-9.8-py38h67ebd9a_1.conda
linux-64::sagelib-9.5-py37hc8fef4d_2.tar.bz2
linux-64::sagelib-9.5-py310h990377c_0.tar.bz2
linux-64::sagelib-9.5-py37ha43dc88_4.tar.bz2
linux-64::sagelib-9.8-py39hce79299_1.conda
linux-64::sagelib-9.5-py39h1c80623_3.tar.bz2
linux-64::sagelib-9.6-py39h601c6e1_0.tar.bz2
linux-64::sagelib-9.3-py39h2934941_4.tar.bz2
linux-64::sagelib-9.6-py310h4f38093_2.tar.bz2
linux-64::sagelib-9.6-py39h42ccf77_3.tar.bz2
linux-64::sagelib-9.5-py37h0c4da78_0.tar.bz2
linux-64::sagelib-9.5-py38hfd38005_0.tar.bz2
linux-64::sagelib-9.6-py310h5b61bae_3.tar.bz2
linux-64::sagelib-9.2-py38hc0b2ac7_3.tar.bz2
linux-64::sagelib-9.7-py310h28be7dd_1.tar.bz2
linux-64::sagelib-9.6-py39h601c6e1_2.tar.bz2
linux-64::sagelib-9.6-py38h718827e_0.tar.bz2
linux-64::sagelib-9.6-py39h601c6e1_1.tar.bz2
linux-64::sagelib-9.4-py39h697c7a4_0.tar.bz2
linux-64::sagelib-9.8-py39h75c9665_2.conda
linux-64::sagelib-9.5-py38hd903835_3.tar.bz2
linux-64::sagelib-9.6-py310h4f38093_1.tar.bz2
linux-64::sagelib-9.3-py39h2934941_2.tar.bz2
linux-64::sagelib-9.2-py39h249aea4_3.tar.bz2
-    "pplpy >=0.8.6,<0.9.0a0",
+    "pplpy >=0.8.6,<0.8.9.0a0",
linux-64::sagelib-9.8-py39h995b525_5.conda
linux-64::sagelib-9.8-py39h753aaff_4.conda
linux-64::sagelib-10.0-py39h995b525_1.conda
linux-64::sagelib-10.1-py311h0af1a61_0.conda
linux-64::sagelib-10.1-py38h59ecdec_0.conda
linux-64::sagelib-10.0-py310hdae0915_2.conda
linux-64::sagelib-10.0-py39h995b525_0.conda
linux-64::sagelib-10.0-py310h551a372_1.conda
linux-64::sagelib-9.8-py310h2a14f39_4.conda
linux-64::sagelib-9.8-py38h749e0f1_5.conda
linux-64::sagelib-10.0-py311h9409a4c_0.conda
linux-64::sagelib-10.1-py310hdae0915_0.conda
linux-64::sagelib-10.0-py311h9409a4c_1.conda
linux-64::sagelib-9.8-py311h9409a4c_5.conda
linux-64::sagelib-9.8-py38h00722db_4.conda
linux-64::sagelib-10.0-py38h59ecdec_2.conda
linux-64::sagelib-10.0-py310h551a372_0.conda
linux-64::sagelib-10.0-py38h749e0f1_1.conda
linux-64::sagelib-10.1-py39h65c28db_0.conda
linux-64::sagelib-10.0-py311h0af1a61_2.conda
linux-64::sagelib-9.8-py311h9bed127_4.conda
linux-64::sagelib-9.8-py310h551a372_5.conda
linux-64::sagelib-10.0-py38h749e0f1_0.conda
linux-64::sagelib-10.0-py39h65c28db_2.conda
-    "pplpy >=0.8.7,<0.9.0a0",
+    "pplpy >=0.8.7,<0.8.9.0a0",
</pre>
</details>