### PR TITLE
pin pytest<8 in pytest-asyncio

### DIFF
--- a/recipe/patch_yaml/pytest-asyncio.yaml
+++ b/recipe/patch_yaml/pytest-asyncio.yaml
@@ -4,6 +4,6 @@ if:
   version_lt: 0.23.4
   timestamp_le: 1706889375000
 then:
-  - replace_depends:
-      old: pytest >=7.0.0
-      new: pytest >=7.0.0,<8
+  - tighten_depends:
+      name: pytest
+      upper_bound: '8.0.0'

--- a/recipe/patch_yaml/pytest-asyncio.yaml
+++ b/recipe/patch_yaml/pytest-asyncio.yaml
@@ -1,0 +1,9 @@
+# https://github.com/pytest-dev/pytest-asyncio/issues/737
+if:
+  name: pytest-asyncio
+  version_lt: 0.23.4
+  timestamp_le: 1706889375000
+then:
+  - replace_depends:
+      old: pytest >=7.0.0
+      new: pytest >=7.0.0,<8


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

Related:
- https://github.com/conda-forge/pytest-asyncio-feedstock/issues/41

:bell: @conda-forge/pytest-asyncio

```diff
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
win-32::pytest-asyncio-0.5.0-py36_0.tar.bz2
win-32::pytest-asyncio-0.6.0-py36_0.tar.bz2
win-32::pytest-asyncio-0.8.0-py36_0.tar.bz2
win-32::pytest-asyncio-0.6.0-py27_0.tar.bz2
win-32::pytest-asyncio-0.5.0-py27_0.tar.bz2
win-32::pytest-asyncio-0.5.0-py35_0.tar.bz2
win-32::pytest-asyncio-0.8.0-py35_0.tar.bz2
win-32::pytest-asyncio-0.6.0-py35_0.tar.bz2
-    "pytest >=3.0.2",
+    "pytest >=3.0.2,<8.0.0a0",
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-ppc64le
linux-ppc64le::pytest-asyncio-0.12.0-py36h9f0ad1d_1.tar.bz2
linux-ppc64le::pytest-asyncio-0.14.0-py39hc1b9086_0.tar.bz2
linux-ppc64le::pytest-asyncio-0.12.0-py39hde42818_2.tar.bz2
linux-ppc64le::pytest-asyncio-0.12.0-py38h32f6830_2.tar.bz2
linux-ppc64le::pytest-asyncio-0.14.0-py37h35e4cab_0.tar.bz2
linux-ppc64le::pytest-asyncio-0.14.0-py36he7cccf2_0.tar.bz2
linux-ppc64le::pytest-asyncio-0.12.0-py38h32f6830_1.tar.bz2
linux-ppc64le::pytest-asyncio-0.12.0-py36hc560c46_2.tar.bz2
linux-ppc64le::pytest-asyncio-0.12.0-py36h9f0ad1d_2.tar.bz2
linux-ppc64le::pytest-asyncio-0.12.0-py37hc8dfbb8_2.tar.bz2
linux-ppc64le::pytest-asyncio-0.12.0-py37hc8dfbb8_1.tar.bz2
linux-ppc64le::pytest-asyncio-0.12.0-py36hc560c46_1.tar.bz2
linux-ppc64le::pytest-asyncio-0.14.0-py38hf8b3453_0.tar.bz2
linux-ppc64le::pytest-asyncio-0.14.0-py36h270354c_0.tar.bz2
-    "pytest >=5.4",
+    "pytest >=5.4,<8.0.0a0",
================================================================================
================================================================================
linux-aarch64
linux-aarch64::pytest-asyncio-0.14.0-py39ha65689a_0.tar.bz2
linux-aarch64::pytest-asyncio-0.12.0-py36hc560c46_2.tar.bz2
linux-aarch64::pytest-asyncio-0.12.0-py36h9f0ad1d_2.tar.bz2
linux-aarch64::pytest-asyncio-0.12.0-py37hc8dfbb8_2.tar.bz2
linux-aarch64::pytest-asyncio-0.12.0-py39hde42818_2.tar.bz2
linux-aarch64::pytest-asyncio-0.12.0-py37hc8dfbb8_1.tar.bz2
linux-aarch64::pytest-asyncio-0.12.0-py36hc560c46_1.tar.bz2
linux-aarch64::pytest-asyncio-0.14.0-py36h2e20a7f_0.tar.bz2
linux-aarch64::pytest-asyncio-0.14.0-py38h2063c64_0.tar.bz2
linux-aarch64::pytest-asyncio-0.12.0-py36h9f0ad1d_1.tar.bz2
linux-aarch64::pytest-asyncio-0.12.0-py38h32f6830_1.tar.bz2
linux-aarch64::pytest-asyncio-0.14.0-py37hd9ded2f_0.tar.bz2
linux-aarch64::pytest-asyncio-0.12.0-py38h32f6830_2.tar.bz2
linux-aarch64::pytest-asyncio-0.14.0-py36h704843e_0.tar.bz2
-    "pytest >=5.4",
+    "pytest >=5.4,<8.0.0a0",
================================================================================
================================================================================
noarch
noarch::pytest-asyncio-0.15.1-pyhd8ed1ab_0.tar.bz2
noarch::pytest-asyncio-0.16.0-pyhd8ed1ab_0.tar.bz2
noarch::pytest-asyncio-0.14.0-pyhd8ed1ab_0.tar.bz2
-    "pytest >=5.4",
+    "pytest >=5.4,<8.0.0a0",
noarch::pytest-asyncio-0.18.0-pyhd8ed1ab_0.tar.bz2
noarch::pytest-asyncio-0.18.3-pyhd8ed1ab_0.tar.bz2
noarch::pytest-asyncio-0.17.2-pyhd8ed1ab_0.tar.bz2
noarch::pytest-asyncio-0.18.2-pyhd8ed1ab_0.tar.bz2
noarch::pytest-asyncio-0.17.0-pyhd8ed1ab_0.tar.bz2
noarch::pytest-asyncio-0.18.1-pyhd8ed1ab_0.tar.bz2
-    "pytest >=5.4.0",
+    "pytest >=5.4.0,<8.0.0a0",
noarch::pytest-asyncio-0.19.0-pyhd8ed1ab_0.tar.bz2
noarch::pytest-asyncio-0.20.1-pyhd8ed1ab_0.tar.bz2
noarch::pytest-asyncio-0.20.3-pyhd8ed1ab_0.conda
noarch::pytest-asyncio-0.20.2-pyhd8ed1ab_0.tar.bz2
-    "pytest >=6.1.0",
+    "pytest >=6.1.0,<8.0.0a0",
noarch::pytest-asyncio-0.21.1-pyhd8ed1ab_0.conda
noarch::pytest-asyncio-0.21.0-pyhd8ed1ab_0.conda
noarch::pytest-asyncio-0.23.1-pyhd8ed1ab_0.conda
noarch::pytest-asyncio-0.23.0-pyhd8ed1ab_0.conda
noarch::pytest-asyncio-0.23.3-pyhd8ed1ab_0.conda
noarch::pytest-asyncio-0.23.2-pyhd8ed1ab_0.conda
-    "pytest >=7.0.0",
+    "pytest >=7.0.0,<8.0.0a0",
================================================================================
================================================================================
win-64
win-64::pytest-asyncio-0.12.0-py37hc8dfbb8_0.tar.bz2
win-64::pytest-asyncio-0.10.0-py37_1000.tar.bz2
win-64::pytest-asyncio-0.10.0-py38_1000.tar.bz2
win-64::pytest-asyncio-0.10.0-py37hc8dfbb8_1001.tar.bz2
win-64::pytest-asyncio-0.12.0-py38h32f6830_0.tar.bz2
win-64::pytest-asyncio-0.12.0-py36h9f0ad1d_0.tar.bz2
win-64::pytest-asyncio-0.10.0-py38h32f6830_1001.tar.bz2
win-64::pytest-asyncio-0.10.0-py36_1000.tar.bz2
win-64::pytest-asyncio-0.10.0-py36h9f0ad1d_1001.tar.bz2
-    "pytest >=3.0.6",
+    "pytest >=3.0.6,<8.0.0a0",
win-64::pytest-asyncio-0.12.0-py39hde42818_2.tar.bz2
win-64::pytest-asyncio-0.12.0-py37hc8dfbb8_2.tar.bz2
win-64::pytest-asyncio-0.12.0-py36h9f0ad1d_1.tar.bz2
win-64::pytest-asyncio-0.14.0-py37h03978a9_0.tar.bz2
win-64::pytest-asyncio-0.12.0-py37hc8dfbb8_1.tar.bz2
win-64::pytest-asyncio-0.14.0-py36ha15d459_0.tar.bz2
win-64::pytest-asyncio-0.12.0-py38h32f6830_2.tar.bz2
win-64::pytest-asyncio-0.14.0-py38haa244fe_0.tar.bz2
win-64::pytest-asyncio-0.12.0-py38h32f6830_1.tar.bz2
win-64::pytest-asyncio-0.12.0-py36h9f0ad1d_2.tar.bz2
win-64::pytest-asyncio-0.14.0-py39hcbf5309_0.tar.bz2
-    "pytest >=5.4",
+    "pytest >=5.4,<8.0.0a0",
win-64::pytest-asyncio-0.9.0-py35_0.tar.bz2
win-64::pytest-asyncio-0.8.0-py35_0.tar.bz2
win-64::pytest-asyncio-0.6.0-py36_0.tar.bz2
win-64::pytest-asyncio-0.5.0-py35_0.tar.bz2
win-64::pytest-asyncio-0.6.0-py35_0.tar.bz2
win-64::pytest-asyncio-0.6.0-py27_0.tar.bz2
win-64::pytest-asyncio-0.8.0-py36_0.tar.bz2
win-64::pytest-asyncio-0.9.0-py37_1000.tar.bz2
win-64::pytest-asyncio-0.9.0-py36_1000.tar.bz2
win-64::pytest-asyncio-0.5.0-py27_0.tar.bz2
win-64::pytest-asyncio-0.9.0-py36_0.tar.bz2
win-64::pytest-asyncio-0.5.0-py36_0.tar.bz2
-    "pytest >=3.0.2",
+    "pytest >=3.0.2,<8.0.0a0",
================================================================================
================================================================================
osx-64
osx-64::pytest-asyncio-0.10.0-py37hc8dfbb8_1001.tar.bz2
osx-64::pytest-asyncio-0.12.0-py36h9f0ad1d_0.tar.bz2
osx-64::pytest-asyncio-0.10.0-py38h32f6830_1001.tar.bz2
osx-64::pytest-asyncio-0.10.0-py37_1000.tar.bz2
osx-64::pytest-asyncio-0.12.0-py36hc560c46_0.tar.bz2
osx-64::pytest-asyncio-0.10.0-py38_1000.tar.bz2
osx-64::pytest-asyncio-0.10.0-py36_1000.tar.bz2
osx-64::pytest-asyncio-0.10.0-py36h9f0ad1d_1001.tar.bz2
osx-64::pytest-asyncio-0.10.0-py36hc560c46_1001.tar.bz2
osx-64::pytest-asyncio-0.12.0-py38h32f6830_0.tar.bz2
osx-64::pytest-asyncio-0.12.0-py37hc8dfbb8_0.tar.bz2
-    "pytest >=3.0.6",
+    "pytest >=3.0.6,<8.0.0a0",
osx-64::pytest-asyncio-0.12.0-py36h9f0ad1d_1.tar.bz2
osx-64::pytest-asyncio-0.12.0-py36hc560c46_1.tar.bz2
osx-64::pytest-asyncio-0.12.0-py37hc8dfbb8_1.tar.bz2
osx-64::pytest-asyncio-0.12.0-py36h9f0ad1d_2.tar.bz2
osx-64::pytest-asyncio-0.12.0-py39hde42818_2.tar.bz2
osx-64::pytest-asyncio-0.12.0-py37hc8dfbb8_2.tar.bz2
osx-64::pytest-asyncio-0.12.0-py36hc560c46_2.tar.bz2
osx-64::pytest-asyncio-0.14.0-py36h5dafb3c_0.tar.bz2
osx-64::pytest-asyncio-0.14.0-py38h50d1736_0.tar.bz2
osx-64::pytest-asyncio-0.14.0-py36h79c6626_0.tar.bz2
osx-64::pytest-asyncio-0.12.0-py38h32f6830_2.tar.bz2
osx-64::pytest-asyncio-0.14.0-py37hf985489_0.tar.bz2
osx-64::pytest-asyncio-0.12.0-py38h32f6830_1.tar.bz2
osx-64::pytest-asyncio-0.14.0-py39h6e9494a_0.tar.bz2
-    "pytest >=5.4",
+    "pytest >=5.4,<8.0.0a0",
osx-64::pytest-asyncio-0.6.0-py36_0.tar.bz2
osx-64::pytest-asyncio-0.8.0-py35_0.tar.bz2
osx-64::pytest-asyncio-0.9.0-py36_0.tar.bz2
osx-64::pytest-asyncio-0.5.0-py36_0.tar.bz2
osx-64::pytest-asyncio-0.5.0-py27_0.tar.bz2
osx-64::pytest-asyncio-0.6.0-py35_0.tar.bz2
osx-64::pytest-asyncio-0.6.0-py27_0.tar.bz2
osx-64::pytest-asyncio-0.5.0-py35_0.tar.bz2
osx-64::pytest-asyncio-0.9.0-py37_1000.tar.bz2
osx-64::pytest-asyncio-0.9.0-py36_1000.tar.bz2
osx-64::pytest-asyncio-0.9.0-py35_0.tar.bz2
osx-64::pytest-asyncio-0.8.0-py36_0.tar.bz2
-    "pytest >=3.0.2",
+    "pytest >=3.0.2,<8.0.0a0",
================================================================================
================================================================================
linux-64
linux-64::pytest-asyncio-0.12.0-py37hc8dfbb8_0.tar.bz2
linux-64::pytest-asyncio-0.10.0-py37hc8dfbb8_1001.tar.bz2
linux-64::pytest-asyncio-0.12.0-py38h32f6830_0.tar.bz2
linux-64::pytest-asyncio-0.10.0-py38h32f6830_1001.tar.bz2
linux-64::pytest-asyncio-0.12.0-py36hc560c46_0.tar.bz2
linux-64::pytest-asyncio-0.10.0-py37_1000.tar.bz2
linux-64::pytest-asyncio-0.10.0-py36_1000.tar.bz2
linux-64::pytest-asyncio-0.10.0-py36hc560c46_1001.tar.bz2
linux-64::pytest-asyncio-0.12.0-py36h9f0ad1d_0.tar.bz2
linux-64::pytest-asyncio-0.10.0-py38_1000.tar.bz2
linux-64::pytest-asyncio-0.10.0-py36h9f0ad1d_1001.tar.bz2
-    "pytest >=3.0.6",
+    "pytest >=3.0.6,<8.0.0a0",
linux-64::pytest-asyncio-0.14.0-py36h5fab9bb_0.tar.bz2
linux-64::pytest-asyncio-0.14.0-py37h89c1867_0.tar.bz2
linux-64::pytest-asyncio-0.12.0-py38h32f6830_1.tar.bz2
linux-64::pytest-asyncio-0.12.0-py37hc8dfbb8_1.tar.bz2
linux-64::pytest-asyncio-0.12.0-py37hc8dfbb8_2.tar.bz2
linux-64::pytest-asyncio-0.12.0-py36h9f0ad1d_1.tar.bz2
linux-64::pytest-asyncio-0.14.0-py36hd000896_0.tar.bz2
linux-64::pytest-asyncio-0.12.0-py38h32f6830_2.tar.bz2
linux-64::pytest-asyncio-0.14.0-py39hf3d152e_0.tar.bz2
linux-64::pytest-asyncio-0.12.0-py36h9f0ad1d_2.tar.bz2
linux-64::pytest-asyncio-0.12.0-py36hc560c46_2.tar.bz2
linux-64::pytest-asyncio-0.14.0-py38h578d9bd_0.tar.bz2
linux-64::pytest-asyncio-0.12.0-py39hde42818_2.tar.bz2
linux-64::pytest-asyncio-0.12.0-py36hc560c46_1.tar.bz2
-    "pytest >=5.4",
+    "pytest >=5.4,<8.0.0a0",
linux-64::pytest-asyncio-0.5.0-py35_0.tar.bz2
linux-64::pytest-asyncio-0.6.0-py35_0.tar.bz2
linux-64::pytest-asyncio-0.5.0-py36_0.tar.bz2
linux-64::pytest-asyncio-0.6.0-py36_0.tar.bz2
linux-64::pytest-asyncio-0.9.0-py35_0.tar.bz2
linux-64::pytest-asyncio-0.5.0-py27_0.tar.bz2
linux-64::pytest-asyncio-0.8.0-py35_0.tar.bz2
linux-64::pytest-asyncio-0.9.0-py36_1000.tar.bz2
linux-64::pytest-asyncio-0.9.0-py37_1000.tar.bz2
linux-64::pytest-asyncio-0.8.0-py36_0.tar.bz2
linux-64::pytest-asyncio-0.9.0-py36_0.tar.bz2
linux-64::pytest-asyncio-0.6.0-py27_0.tar.bz2
-    "pytest >=3.0.2",
+    "pytest >=3.0.2,<8.0.0a0",
```