### PR TITLE
Tighten conda-build dep in boa

### DIFF
--- a/recipe/patch_yaml/boa.yaml
+++ b/recipe/patch_yaml/boa.yaml
@@ -14,3 +14,13 @@ then:
   - tighten_depends:
       name: mamba
       upper_bound: "0.15"
+---
+# https://github.com/mamba-org/boa/issues/392
+if:
+  name: boa
+  timestamp_le: 1707432932930
+  version_in: ["0.15.0", "0.15.1", "0.16.0"]
+then:
+  - tighten_depends:
+      name: conda-build
+      upper_bound: "24.1"


### PR DESCRIPTION
Checklist

* [X] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [X] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

Addresses incompatibility disclosed at https://github.com/mamba-org/boa/issues/392