### PR TITLE
Fix numpy version on ethos_penalps

### DIFF
--- a/recipe/patch_yaml/ethos_penalps.yaml
+++ b/recipe/patch_yaml/ethos_penalps.yaml
@@ -3,6 +3,6 @@ if:
   name: ethos_penalps
   version_le: 1.0.0
 then:
-  - replace_depends::
+  - replace_depends:
       old: numpy <1.24.0
       new: numpy >1.23.5

--- a/recipe/patch_yaml/ethos_penalps.yaml
+++ b/recipe/patch_yaml/ethos_penalps.yaml
@@ -1,0 +1,10 @@
+# The old numpy version raises an error in the tests on windows
+if:
+  name: ethos_penalps
+  version_le: 1.0.0
+then:
+  - replace_depends::
+      old: numpy <1.24.0
+      new: numpy >1.23.5
+---
+

--- a/recipe/patch_yaml/ethos_penalps.yaml
+++ b/recipe/patch_yaml/ethos_penalps.yaml
@@ -6,5 +6,3 @@ then:
   - replace_depends::
       old: numpy <1.24.0
       new: numpy >1.23.5
----
-


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
