### PR TITLE
Pin notebook 7.0.x vs jupyterlab 4.0.x

### DIFF
--- a/recipe/patch_yaml/notebook.yaml
+++ b/recipe/patch_yaml/notebook.yaml
@@ -7,12 +7,17 @@ then:
       name: traitlets
       upper_bound: 5.10.0
 ---
+# while the python-level compatibility is fine, some browser assets are broken
+# see:
+# - https://github.com/jupyter/notebook/issues/7248
+# - https://github.com/conda-forge/notebook-feedstock/pull/144
 if:
   name: notebook
-  version_lt: 7.1.0
-  version_gt: 7.0.0
   timestamp_lt: 1707513052000
 then:
-  - tighten_depends:
-      name: jupyterlab
-      upper_bound: 4.1.0
+  - replace_depends:
+      old: jupyterlab >=4.0.7,<5
+      new: jupyterlab >=4.0.7,<4.1.0a0
+  - replace_depends:
+      old: jupyterlab >=4.0.2,<5
+      new: jupyterlab >=4.0.2,<4.1.0a0

--- a/recipe/patch_yaml/notebook.yaml
+++ b/recipe/patch_yaml/notebook.yaml
@@ -6,3 +6,13 @@ then:
   - tighten_depends:
       name: traitlets
       upper_bound: 5.10.0
+---
+if:
+  name: notebook
+  version_lt: 7.1.0
+  version_gt: 7.0.0
+  timestamp_lt: 1707513052000
+then:
+  - tighten_depends:
+      name: jupyterlab
+      upper_bound: 4.1.0


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

References:
- https://github.com/jupyter/notebook/issues/7248
- https://github.com/conda-forge/notebook-feedstock/pull/144 

```
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
noarch
noarch::notebook-7.0.1-pyhd8ed1ab_0.conda
noarch::notebook-7.0.2-pyhd8ed1ab_0.conda
noarch::notebook-7.0.4-pyhd8ed1ab_0.conda
noarch::notebook-7.0.3-pyhd8ed1ab_0.conda
noarch::notebook-7.0.0-pyhd8ed1ab_0.conda
-    "jupyterlab >=4.0.2,<5",
+    "jupyterlab >=4.0.2,<4.1.0a0",
noarch::notebook-7.0.6-pyhd8ed1ab_0.conda
noarch::notebook-7.0.5-pyhd8ed1ab_0.conda
noarch::notebook-7.0.7-pyhd8ed1ab_0.conda
-    "jupyterlab >=4.0.7,<5",
+    "jupyterlab >=4.0.7,<4.1.0a0",
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
================================================================================
================================================================================
linux-64

```