### PR TITLE
Patch openff-bespokefit packages for QCPortal<0.49 following API change

### DIFF
--- a/recipe/patch_yaml/openff-bespokefit-patch.yaml
+++ b/recipe/patch_yaml/openff-bespokefit-patch.yaml
@@ -20,4 +20,4 @@ if:
 then:
   - tighten_depends:
       name: qcportal
-      upper_bound: 0.49
+      upper_bound: "0.49"

--- a/recipe/patch_yaml/openff-bespokefit-patch.yaml
+++ b/recipe/patch_yaml/openff-bespokefit-patch.yaml
@@ -8,3 +8,16 @@ if:
   timestamp_lt: 1694139596000
 then:
   - add_constrains: "anyio <4.0.0a0"
+
+---
+
+# Bespokefit directly calls the QCPortal API, however this API changed in QCPortal 0.50
+if:
+  subdir_in: noarch
+  name: openff-bespokefit
+  timestamp_lt: 1707768684000
+  has_depends: qcportal*
+then:
+  - tighten_depends:
+      name: qcportal
+      upper_bound: 0.49

--- a/recipe/patch_yaml/openff-bespokefit-patch.yaml
+++ b/recipe/patch_yaml/openff-bespokefit-patch.yaml
@@ -20,4 +20,4 @@ if:
 then:
   - tighten_depends:
       name: qcportal
-      upper_bound: "0.49"
+      upper_bound: "0.50"


### PR DESCRIPTION
ref https://github.com/conda-forge/openff-bespokefit-feedstock/issues/19

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

Output of running `python show_diff.py`
```diff
(conda-forge-patching) jw@mba$ python show_diff.py --use-cache             
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
noarch
noarch::openff-bespokefit-0.1.3-pyhd8ed1ab_2.conda
noarch::openff-bespokefit-0.2.2-pyhd8ed1ab_5.conda
noarch::openff-bespokefit-0.1.3-pyhd8ed1ab_0.conda
noarch::openff-bespokefit-0.2.1-pyhd8ed1ab_0.conda
noarch::openff-bespokefit-0.1.1-pyhd8ed1ab_0.tar.bz2
noarch::openff-bespokefit-0.2.2-pyhd8ed1ab_0.conda
noarch::openff-bespokefit-0.1.0-pyhd8ed1ab_0.tar.bz2
noarch::openff-bespokefit-0.1.2-pyhd8ed1ab_1.tar.bz2
noarch::openff-bespokefit-0.1.2-pyhd8ed1ab_0.tar.bz2
noarch::openff-bespokefit-0.2.2-pyhd8ed1ab_1.conda
noarch::openff-bespokefit-0.1.3-pyhd8ed1ab_3.conda
-    "qcportal >=0.15.6",
+    "qcportal >=0.15.6,<0.49.0a0",
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
================================================================================
================================================================================
linux-64
```
