### PR TITLE
fix: setuptools 69.1 requires Python 3.8

### DIFF
--- a/recipe/patch_yaml/setuptools.yaml
+++ b/recipe/patch_yaml/setuptools.yaml
@@ -22,3 +22,13 @@ then:
       new: setuptools <60.0.0
   - add_depends:  # doesn't add duplicates
       - setuptools <60.0.0
+---
+if:
+  name: setuptools
+  version_in:
+    - "69.1.0"
+  build: pyhd8ed1ab_0
+then:
+  - replace_depends:
+      old: python >=3.7
+      new: python >=3.8


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->


See https://github.com/conda-forge/setuptools-feedstock/pull/334, https://github.com/conda-forge/setuptools-feedstock/issues/333, would fix CI issues like https://github.com/wntrblm/nox/pull/762.


```
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
noarch
noarch::setuptools-69.1.0-pyhd8ed1ab_0.conda
-    "python >=3.7"
+    "python >=3.8"
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
================================================================================
================================================================================
linux-64
```