### PR TITLE
Patch `cuda-python` to use CUDA Enhanced Compatibility

### DIFF
--- a/recipe/patch_yaml/cuda-python.yaml
+++ b/recipe/patch_yaml/cuda-python.yaml
@@ -1,0 +1,13 @@
+if:
+  name: cuda-python
+  version_ge: 12.0.0
+  version_lt: 13.0.0
+  timestamp_lt: 1706947200000
+then:
+  - remove_depends:
+      - cuda-cudart*
+  - add_constrains:
+      - cuda-cudart >=12,<13.0a0
+  - replace_depends:
+      old: cuda-nvrtc*
+      new: cuda-nvrtc >=12,<13.0a0


### PR DESCRIPTION
Applies the changes from PR ( https://github.com/conda-forge/cuda-python-feedstock/pull/67 ) and PR ( https://github.com/conda-forge/cuda-python-feedstock/pull/68 ) to earlier `cuda-python`  packages starting with `12.0.0`+ when the new CUDA Toolkit packages are used

Namely this:

* Relaxes version constraints of CUDA Toolkit dependencies to `12.*`
* Moves `cuda-cudart` to an optional dependency

<hr>

Checklist

* [ ] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
