### PR TITLE
Create conflicts with older `cupy` to avoid coexistence

### DIFF
--- a/recipe/patch_yaml/cupy.yaml
+++ b/recipe/patch_yaml/cupy.yaml
@@ -15,3 +15,12 @@ then:
   - replace_constrains:
       old: libcugraph >=0.19.0,<1.0a0
       new: libcugraph >=0.19.0
+---
+if:
+  name: cupy-core
+  version: 13.0.0
+  build_number_in: [0, 1, 2, 3]
+  timestamp_lt: 1708656816000
+then:
+  # create conflicts with older cupy to avoid coexistence
+  - add_constrains: cupy<13.0a0

--- a/recipe/patch_yaml/cupy.yaml
+++ b/recipe/patch_yaml/cupy.yaml
@@ -23,4 +23,4 @@ if:
   timestamp_lt: 1708656816000
 then:
   # create conflicts with older cupy to avoid coexistence
-  - add_constrains: cupy<13.0a0
+  - add_constrains: cupy=${version}


### PR DESCRIPTION
To address https://github.com/conda-forge/cupy-feedstock/issues/256.

cc: @carterbox @conda-forge/cupy 

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

<details>
<summary>Generated diff</summary>

```
$ python recipe/show_diff.py
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-ppc64le
linux-ppc64le::cupy-core-13.0.0-py312h651137f_0.conda
linux-ppc64le::cupy-core-13.0.0-py39h47ed449_3.conda
linux-ppc64le::cupy-core-13.0.0-py312h3eebca2_1.conda
linux-ppc64le::cupy-core-13.0.0-py312h3eebca2_0.conda
linux-ppc64le::cupy-core-13.0.0-py39h0db721b_1.conda
linux-ppc64le::cupy-core-13.0.0-py39h47ed449_0.conda
linux-ppc64le::cupy-core-13.0.0-py312h651137f_3.conda
linux-ppc64le::cupy-core-13.0.0-py39h47ed449_2.conda
linux-ppc64le::cupy-core-13.0.0-py311h886aa8d_2.conda
linux-ppc64le::cupy-core-13.0.0-py312h651137f_2.conda
linux-ppc64le::cupy-core-13.0.0-py39h47ed449_1.conda
linux-ppc64le::cupy-core-13.0.0-py311hf2bd41a_1.conda
linux-ppc64le::cupy-core-13.0.0-py39h0db721b_2.conda
linux-ppc64le::cupy-core-13.0.0-py312h3eebca2_3.conda
linux-ppc64le::cupy-core-13.0.0-py39h0db721b_0.conda
linux-ppc64le::cupy-core-13.0.0-py311h886aa8d_1.conda
linux-ppc64le::cupy-core-13.0.0-py311hf2bd41a_3.conda
linux-ppc64le::cupy-core-13.0.0-py310hea0855a_1.conda
linux-ppc64le::cupy-core-13.0.0-py310h06be86b_0.conda
linux-ppc64le::cupy-core-13.0.0-py312h651137f_1.conda
linux-ppc64le::cupy-core-13.0.0-py310hea0855a_0.conda
linux-ppc64le::cupy-core-13.0.0-py311hf2bd41a_0.conda
linux-ppc64le::cupy-core-13.0.0-py310h06be86b_1.conda
linux-ppc64le::cupy-core-13.0.0-py310h06be86b_3.conda
linux-ppc64le::cupy-core-13.0.0-py39h0db721b_3.conda
linux-ppc64le::cupy-core-13.0.0-py310hea0855a_3.conda
linux-ppc64le::cupy-core-13.0.0-py310hea0855a_2.conda
linux-ppc64le::cupy-core-13.0.0-py310h06be86b_2.conda
linux-ppc64le::cupy-core-13.0.0-py312h3eebca2_2.conda
linux-ppc64le::cupy-core-13.0.0-py311h886aa8d_3.conda
linux-ppc64le::cupy-core-13.0.0-py311hf2bd41a_2.conda
linux-ppc64le::cupy-core-13.0.0-py311h886aa8d_0.conda
+    "cupy<13.0a0",
================================================================================
================================================================================
linux-aarch64
linux-aarch64::cupy-core-13.0.0-py312hfefec42_3.conda
linux-aarch64::cupy-core-13.0.0-py312hfb1faee_2.conda
linux-aarch64::cupy-core-13.0.0-py310h64edbf0_2.conda
linux-aarch64::cupy-core-13.0.0-py310h0041da6_0.conda
linux-aarch64::cupy-core-13.0.0-py311h5731f48_2.conda
linux-aarch64::cupy-core-13.0.0-py39h729f14b_0.conda
linux-aarch64::cupy-core-13.0.0-py312hfb1faee_1.conda
linux-aarch64::cupy-core-13.0.0-py310h64edbf0_1.conda
linux-aarch64::cupy-core-13.0.0-py39h56bfa97_1.conda
linux-aarch64::cupy-core-13.0.0-py310h64edbf0_3.conda
linux-aarch64::cupy-core-13.0.0-py311h51108e9_0.conda
linux-aarch64::cupy-core-13.0.0-py39h56bfa97_2.conda
linux-aarch64::cupy-core-13.0.0-py311h51108e9_1.conda
linux-aarch64::cupy-core-13.0.0-py311h5731f48_3.conda
linux-aarch64::cupy-core-13.0.0-py310h0041da6_1.conda
linux-aarch64::cupy-core-13.0.0-py311h5731f48_0.conda
linux-aarch64::cupy-core-13.0.0-py312hfefec42_2.conda
linux-aarch64::cupy-core-13.0.0-py39h729f14b_1.conda
linux-aarch64::cupy-core-13.0.0-py310h64edbf0_0.conda
linux-aarch64::cupy-core-13.0.0-py311h51108e9_2.conda
linux-aarch64::cupy-core-13.0.0-py312hfefec42_1.conda
linux-aarch64::cupy-core-13.0.0-py39h729f14b_2.conda
linux-aarch64::cupy-core-13.0.0-py311h5731f48_1.conda
linux-aarch64::cupy-core-13.0.0-py39h56bfa97_0.conda
linux-aarch64::cupy-core-13.0.0-py39h56bfa97_3.conda
linux-aarch64::cupy-core-13.0.0-py312hfb1faee_0.conda
linux-aarch64::cupy-core-13.0.0-py310h0041da6_2.conda
linux-aarch64::cupy-core-13.0.0-py311h51108e9_3.conda
linux-aarch64::cupy-core-13.0.0-py310h0041da6_3.conda
linux-aarch64::cupy-core-13.0.0-py312hfefec42_0.conda
linux-aarch64::cupy-core-13.0.0-py39h729f14b_3.conda
linux-aarch64::cupy-core-13.0.0-py312hfb1faee_3.conda
+    "cupy<13.0a0",
================================================================================
================================================================================
noarch
noarch::conda-smithy-3.31.0-pyhd8ed1ab_0.conda
-{
-  "build": "pyhd8ed1ab_0",
-  "build_number": 0,
-  "constrains": [
-    "shellcheck"
-  ],
-  "depends": [
-    "cirun >=0.30",
-    "conda >=4.2",
-    "conda-build >=24.1.0",
-    "conda-forge-pinning",
-    "conda-package-handling >=1.9.0",
-    "git",
-    "gitpython",
-    "jinja2",
-    "libarchive",
-    "license-expression",
-    "pycryptodome",
-    "pygithub >=2,<3",
-    "python >=3.6",
-    "requests",
-    "ruamel.yaml >=0.16",
-    "scrypt",
-    "setuptools",
-    "tomli >=1.0.0",
-    "toolz",
-    "vsts-python-api"
-  ],
-  "license": "BSD-3-Clause",
-  "md5": "28d90181af7388682353862bb6e05208",
-  "name": "conda-smithy",
-  "noarch": "python",
-  "sha256": "4a785ab8591eb2cc3c6dd11fd5b5ee9aeb418988194d40f97e86aeee54d00ddc",
-  "size": 91577,
-  "subdir": "noarch",
-  "timestamp": 1708643282939,
-  "version": "3.31.0"
-}
+{}
================================================================================
================================================================================
win-64
win-64::cupy-core-13.0.0-py310h40034dd_0.conda
win-64::cupy-core-13.0.0-py39h0e644fc_2.conda
win-64::cupy-core-13.0.0-py311h9e98bd7_2.conda
win-64::cupy-core-13.0.0-py311h9e98bd7_0.conda
win-64::cupy-core-13.0.0-py310h1d6915d_2.conda
win-64::cupy-core-13.0.0-py312hdf68b13_1.conda
win-64::cupy-core-13.0.0-py39h0e644fc_1.conda
win-64::cupy-core-13.0.0-py312h45abdf0_1.conda
win-64::cupy-core-13.0.0-py312h45abdf0_0.conda
win-64::cupy-core-13.0.0-py312hb3e489c_3.conda
win-64::cupy-core-13.0.0-py310h40034dd_1.conda
win-64::cupy-core-13.0.0-py310h1d6915d_0.conda
win-64::cupy-core-13.0.0-py39h5471495_3.conda
win-64::cupy-core-13.0.0-py310h1d6915d_1.conda
win-64::cupy-core-13.0.0-py311hdd6c9a0_3.conda
win-64::cupy-core-13.0.0-py39h0e644fc_0.conda
win-64::cupy-core-13.0.0-py310h786427b_3.conda
win-64::cupy-core-13.0.0-py310h9857f2f_3.conda
win-64::cupy-core-13.0.0-py311h095fc3a_0.conda
win-64::cupy-core-13.0.0-py312h45abdf0_2.conda
win-64::cupy-core-13.0.0-py311h095fc3a_1.conda
win-64::cupy-core-13.0.0-py312h0c45704_3.conda
win-64::cupy-core-13.0.0-py312hdf68b13_0.conda
win-64::cupy-core-13.0.0-py39h4772948_0.conda
win-64::cupy-core-13.0.0-py312hdf68b13_2.conda
win-64::cupy-core-13.0.0-py39h3eed867_3.conda
win-64::cupy-core-13.0.0-py311h60ac514_3.conda
win-64::cupy-core-13.0.0-py39h4772948_2.conda
win-64::cupy-core-13.0.0-py39h4772948_1.conda
win-64::cupy-core-13.0.0-py311h9e98bd7_1.conda
win-64::cupy-core-13.0.0-py311h095fc3a_2.conda
win-64::cupy-core-13.0.0-py310h40034dd_2.conda
+    "cupy<13.0a0",
================================================================================
================================================================================
osx-64
================================================================================
================================================================================
linux-64
linux-64::cupy-core-13.0.0-py310had4011e_3.conda
linux-64::cupy-core-13.0.0-py311h84cfafc_1.conda
linux-64::cupy-core-13.0.0-py311h84cfafc_0.conda
linux-64::cupy-core-13.0.0-py312h7d03b9e_2.conda
linux-64::cupy-core-13.0.0-py312h7d03b9e_3.conda
linux-64::cupy-core-13.0.0-py39h546db9d_0.conda
linux-64::cupy-core-13.0.0-py39h546db9d_2.conda
linux-64::cupy-core-13.0.0-py39h73a3b7e_2.conda
linux-64::cupy-core-13.0.0-py312hd7a312d_0.conda
linux-64::cupy-core-13.0.0-py312h7d03b9e_0.conda
linux-64::cupy-core-13.0.0-py311heecd119_1.conda
linux-64::cupy-core-13.0.0-py39h73a3b7e_3.conda
linux-64::cupy-core-13.0.0-py310h506062a_1.conda
linux-64::cupy-core-13.0.0-py310h506062a_3.conda
linux-64::cupy-core-13.0.0-py310h506062a_0.conda
linux-64::cupy-core-13.0.0-py312hd7a312d_2.conda
linux-64::cupy-core-13.0.0-py311h84cfafc_3.conda
linux-64::cupy-core-13.0.0-py311heecd119_0.conda
linux-64::cupy-core-13.0.0-py310had4011e_2.conda
linux-64::cupy-core-13.0.0-py312hd7a312d_3.conda
linux-64::cupy-core-13.0.0-py310had4011e_0.conda
linux-64::cupy-core-13.0.0-py310h506062a_2.conda
linux-64::cupy-core-13.0.0-py312h7d03b9e_1.conda
linux-64::cupy-core-13.0.0-py310had4011e_1.conda
linux-64::cupy-core-13.0.0-py311h84cfafc_2.conda
linux-64::cupy-core-13.0.0-py39h546db9d_3.conda
linux-64::cupy-core-13.0.0-py312hd7a312d_1.conda
linux-64::cupy-core-13.0.0-py39h546db9d_1.conda
linux-64::cupy-core-13.0.0-py311heecd119_3.conda
linux-64::cupy-core-13.0.0-py39h73a3b7e_0.conda
linux-64::cupy-core-13.0.0-py39h73a3b7e_1.conda
linux-64::cupy-core-13.0.0-py311heecd119_2.conda
+    "cupy<13.0a0",
```
</details>