### PR TITLE
Add patch for alsa-lib loosening to x.x

### DIFF
--- a/recipe/patch_yaml/alsa_lib.yaml
+++ b/recipe/patch_yaml/alsa_lib.yaml
@@ -4,8 +4,7 @@
 # https://github.com/conda-forge/alsa-lib-feedstock/pull/18
 if:
   has_depends: alsa-lib >=1.2.10,<1.2.11.0a0
-  # python -c "import time; print(f'{time.time():.0f}000')"
-  timestamp_lt: 1708909734000
+  timestamp_lt: 1709396227000
 
 then:
   - loosen_depends:

--- a/recipe/patch_yaml/alsa_lib.yaml
+++ b/recipe/patch_yaml/alsa_lib.yaml
@@ -1,0 +1,13 @@
+# 2024/02
+# alsa_lib moved to minor level pinning
+# https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/5448#issuecomment-1963146321
+# https://github.com/conda-forge/alsa-lib-feedstock/pull/18
+if:
+  has_depends: alsa-lib >=1.2.10,<1.2.11.0a0
+  # python -c "import time; print(f'{time.time():.0f}000')"
+  timestamp_lt: 1708909734000
+
+then:
+  - loosen_depends:
+      name: alsa-lib
+      max_pin: 'x.x'


### PR DESCRIPTION
See https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/5448 
for more discussion

Merge after https://github.com/conda-forge/alsa-lib-feedstock/pull/18

Checklist

* [ ] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
