### PR TITLE
Update historic tpot pins against python, numpy

### DIFF
--- a/recipe/patch_yaml/tpot.yaml
+++ b/recipe/patch_yaml/tpot.yaml
@@ -1,0 +1,12 @@
+# uses now-removed `imp` module, see:
+# - https://github.com/conda-forge/tpot-feedstock/issues/39
+# - https://github.com/EpistasisLab/tpot/issues/1327
+if:
+  name: tpot
+  version_lt: 0.12.2
+  version_ge: 0.11.2
+  timestamp_lt: 1708983815000
+then:
+  - tighten_depends:
+      name: python
+      upper_bound: 3.12

--- a/recipe/patch_yaml/tpot.yaml
+++ b/recipe/patch_yaml/tpot.yaml
@@ -2,10 +2,30 @@
 # - https://github.com/conda-forge/tpot-feedstock/issues/39
 # - https://github.com/EpistasisLab/tpot/issues/1327
 # noarch was added on
-# - https://github.com/conda-forge/tpot-feedstock/pull/21
+# - https://github.com/conda-forge/tpot-feedstock/pull/17
 if:
   name: tpot
-  version_ge: 0.11.2
+  version_ge: 0.11.0
+  version_lt: 0.11.1
+  timestamp_lt: 1708983815000
+then:
+  - tighten_depends:
+      name: python
+      upper_bound: "3.12"
+  - tighten_depends:
+      name: numpy
+      upper_bound: "1.20"
+  - tighten_depends:
+      name: scikit-learn
+      upper_bound: "0.22"
+
+---
+
+# scikit-learn >=0.22 compatibility was fixed:
+# - https://github.com/EpistasisLab/tpot/pull/986
+if:
+  name: tpot
+  version_ge: 0.11.1
   version_lt: 0.12.0
   timestamp_lt: 1708983815000
 then:

--- a/recipe/patch_yaml/tpot.yaml
+++ b/recipe/patch_yaml/tpot.yaml
@@ -1,12 +1,31 @@
 # uses now-removed `imp` module, see:
 # - https://github.com/conda-forge/tpot-feedstock/issues/39
 # - https://github.com/EpistasisLab/tpot/issues/1327
+# noarch was added on
+# - https://github.com/conda-forge/tpot-feedstock/pull/21
 if:
   name: tpot
-  version_lt: 0.12.2
   version_ge: 0.11.2
+  version_lt: 0.12.0
   timestamp_lt: 1708983815000
 then:
   - tighten_depends:
       name: python
-      upper_bound: 3.12
+      upper_bound: "3.12"
+  - tighten_depends:
+      name: numpy
+      upper_bound: "1.20"
+
+---
+
+# numpy >=1.20 compatibility was fixed:
+# - https://github.com/EpistasisLab/tpot/pull/1280
+if:
+  name: tpot
+  version_ge: 0.12.0
+  version_lt: 0.12.2
+  timestamp_lt: 1708983815000
+then:
+  - tighten_depends:
+      name: python
+      upper_bound: "3.12"


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

References:
- fixes https://github.com/conda-forge/tpot-feedstock/issues/39

Notes:
- fixing the `python` and `numpy` pins is enough to get `import tpot` to run (and the test suite to _start_) back to `0.11.2`
  - at the far end of the `noarch: python` epoch, the tests fail, but many packages don't even _have_ test suites in conda-forge, so I'm not going to do the larger matrix sweep to pin _everything_ to get those to work

Changes:

```diff
================================================================================
================================================================================
win-32
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
noarch
noarch::tpot-0.11.6.post1-pyhd3deb0d_0.tar.bz2
noarch::tpot-0.11.5-pyh9f0ad1d_0.tar.bz2
noarch::tpot-0.11.2-pyh9f0ad1d_0.tar.bz2
noarch::tpot-0.11.6-pyh9f0ad1d_0.tar.bz2
noarch::tpot-0.11.6.post3-pyhd3deb0d_0.tar.bz2
noarch::tpot-0.11.6.post2-pyhd3deb0d_1.tar.bz2
noarch::tpot-0.11.7-pyhd8ed1ab_1.tar.bz2
noarch::tpot-0.11.3-pyh9f0ad1d_0.tar.bz2
-    "numpy >=1.16.3",
+    "numpy >=1.16.3,<1.20.0a0",
-    "python >=3.5",
+    "python >=3.5,<3.12.0a0",
noarch::tpot-0.12.0-pyhd8ed1ab_0.conda
noarch::tpot-0.12.1-pyhd8ed1ab_0.conda
-    "python >=3.5",
+    "python >=3.5,<3.12.0a0",
================================================================================
================================================================================
osx-64
================================================================================
================================================================================
linux-64
```

> `anaconda.org` then started sending `524`s), will validate against what the PR says