### PR TITLE
Tighten depends max_pin="x.x.x" for all azure-sdk-for-cpp packages

### DIFF
--- a/recipe/patch_yaml/azure-core-cpp.yaml
+++ b/recipe/patch_yaml/azure-core-cpp.yaml
@@ -1,0 +1,13 @@
+# The Azure SDK for C++ maintainers do not guarantee binary compatibility
+# between any releases
+# https://github.com/Azure/azure-sdk-for-cpp/issues/5322
+#
+# The run_exports max_pin was set to "x.x.x" in
+# https://github.com/conda-forge/azure-core-cpp-feedstock/pull/14
+if:
+  has_depends: azure-core-cpp*
+  timestamp_lt: 1709048999000
+then:
+  - tighten_depends:
+      name: azure-core-cpp
+      max_pin: x.x.x

--- a/recipe/patch_yaml/azure-identity-cpp.yaml
+++ b/recipe/patch_yaml/azure-identity-cpp.yaml
@@ -1,0 +1,13 @@
+# The Azure SDK for C++ maintainers do not guarantee binary compatibility
+# between any releases
+# https://github.com/Azure/azure-sdk-for-cpp/issues/5322
+#
+# The run_exports max_pin was set to "x.x.x" in
+# https://github.com/conda-forge/azure-identity-cpp-feedstock/pull/6
+if:
+  has_depends: azure-identity-cpp*
+  timestamp_lt: 1709048999000
+then:
+  - tighten_depends:
+      name: azure-identity-cpp
+      max_pin: x.x.x

--- a/recipe/patch_yaml/azure-storage-blobs-cpp.yaml
+++ b/recipe/patch_yaml/azure-storage-blobs-cpp.yaml
@@ -1,0 +1,13 @@
+# The Azure SDK for C++ maintainers do not guarantee binary compatibility
+# between any releases
+# https://github.com/Azure/azure-sdk-for-cpp/issues/5322
+#
+# The run_exports max_pin was set to "x.x.x" in
+# https://github.com/conda-forge/azure-storage-blobs-cpp-feedstock/pull/10
+if:
+  has_depends: azure-storage-blobs-cpp*
+  timestamp_lt: 1709048999000
+then:
+  - tighten_depends:
+      name: azure-storage-blobs-cpp
+      max_pin: x.x.x

--- a/recipe/patch_yaml/azure-storage-common-cpp.yaml
+++ b/recipe/patch_yaml/azure-storage-common-cpp.yaml
@@ -1,0 +1,13 @@
+# The Azure SDK for C++ maintainers do not guarantee binary compatibility
+# between any releases
+# https://github.com/Azure/azure-sdk-for-cpp/issues/5322
+#
+# The run_exports max_pin was set to "x.x.x" in
+# https://github.com/conda-forge/azure-storage-common-cpp-feedstock/pull/13
+if:
+  has_depends: azure-storage-common-cpp*
+  timestamp_lt: 1709048999000
+then:
+  - tighten_depends:
+      name: azure-storage-common-cpp
+      max_pin: x.x.x

--- a/recipe/patch_yaml/azure-storage-files-datalake-cpp.yaml
+++ b/recipe/patch_yaml/azure-storage-files-datalake-cpp.yaml
@@ -1,0 +1,13 @@
+# The Azure SDK for C++ maintainers do not guarantee binary compatibility
+# between any releases
+# https://github.com/Azure/azure-sdk-for-cpp/issues/5322
+#
+# The run_exports max_pin was set to "x.x.x" in
+# https://github.com/conda-forge/azure-storage-files-datalake-cpp-feedstock/pull/8
+if:
+  has_depends: azure-storage-files-datalake-cpp*
+  timestamp_lt: 1709048999000
+then:
+  - tighten_depends:
+      name: azure-storage-files-datalake-cpp
+      max_pin: x.x.x

--- a/recipe/patch_yaml/azure-storage-files-shares-cpp.yaml
+++ b/recipe/patch_yaml/azure-storage-files-shares-cpp.yaml
@@ -1,0 +1,13 @@
+# The Azure SDK for C++ maintainers do not guarantee binary compatibility
+# between any releases
+# https://github.com/Azure/azure-sdk-for-cpp/issues/5322
+#
+# The run_exports max_pin was set to "x.x.x" in
+# https://github.com/conda-forge/azure-storage-files-shares-cpp-feedstock/pull/7
+if:
+  has_depends: azure-storage-files-shares-cpp*
+  timestamp_lt: 1709048999000
+then:
+  - tighten_depends:
+      name: azure-storage-files-shares-cpp
+      max_pin: x.x.x

--- a/recipe/patch_yaml/azure-storage-queues-cpp.yaml
+++ b/recipe/patch_yaml/azure-storage-queues-cpp.yaml
@@ -1,0 +1,13 @@
+# The Azure SDK for C++ maintainers do not guarantee binary compatibility
+# between any releases
+# https://github.com/Azure/azure-sdk-for-cpp/issues/5322
+#
+# The run_exports max_pin was set to "x.x.x" in
+# https://github.com/conda-forge/azure-storage-queues-cpp-feedstock/pull/6
+if:
+  has_depends: azure-storage-queues-cpp*
+  timestamp_lt: 1709048999000
+then:
+  - tighten_depends:
+      name: azure-storage-queues-cpp
+      max_pin: x.x.x


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
---

**Timeline:**

* We originally added the azure-sdk-for-cpp libraries with a run exports max pin of `x` (https://github.com/conda-forge/staged-recipes/pull/23297)

* The azure-core-cpp 1.11.0 update broke tiledb on Linux (https://github.com/conda-forge/tiledb-feedstock/issues/228)

* We submitted minimal repodata patches to only address the issue with azure-core-cpp 1.11.0 and tiledb (#639 &#649)

* We learned from the Azure SDK for C++ maintainers that they do not guarantee binary compatibility between any releases (https://github.com/Azure/azure-sdk-for-cpp/issues/5322)

* Thus we updated all the recipes to use a run exports max pin of `x.x.x` (https://github.com/conda-forge/azure-core-cpp-feedstock/pull/14, https://github.com/conda-forge/azure-identity-cpp-feedstock/pull/6, https://github.com/conda-forge/azure-storage-blobs-cpp-feedstock/pull/10, https://github.com/conda-forge/azure-storage-common-cpp-feedstock/pull/13, https://github.com/conda-forge/azure-storage-files-datalake-cpp-feedstock/pull/8, https://github.com/conda-forge/azure-storage-files-shares-cpp-feedstock/pull/7, https://github.com/conda-forge/azure-storage-queues-cpp-feedstock/pull/6)

* This repodata patch is the final step to ensure no future problems due to insufficient pins of the azure-sdk-for-cpp libraries