### PR TITLE
Add conda environment and tips for testing patches locally

### DIFF
--- a/recipe/README.md
+++ b/recipe/README.md
@@ -158,7 +158,17 @@ then:
   ...
 ```
 
+> [!WARNING]
+> The condition `timestamp_lt` is required to prevent your patch from modifying
+> any packages built in the future. Don't forget to calculate it with `python -c
+> "import time; print(f'{time.time():.0f}000')"` and include it in the `if:`
+> section of your patch
+
 ## Testing New Patches using `show_diff.py`
+
+> [!TIP]
+> You can install a development environment for testing your repodata patch
+> using the environment file `dev-env-for-patches.yaml`
 
 The `show_diff.py` script in this directory can be used to test out
 modifications to `gen_patch_json.py`.  This scripts shows the difference
@@ -187,6 +197,13 @@ path specified by the `CACHE_DIR` environment variable.
 Typically, `show_diff.py` is run without any argument to download the
 necessary repodata followed by repeated calls to `show_diff.py --use-cache`
 to test out changes to the `gen_patch_json.py` script.
+
+> [!TIP]
+> If you're having trouble running `show_diff.py` locally, don't despair. You
+> should still submit your patch. The Azure job also returns this information.
+> Search the build log for `patching repodata:` and copy-paste the output for
+> all the architectures to your Pull Request. Stop copying once you've reached
+> `patching repodata: 100%`
 
 ## Patch JSON Format for `anaconda.org`
 

--- a/recipe/dev-env-for-patches.yaml
+++ b/recipe/dev-env-for-patches.yaml
@@ -1,0 +1,28 @@
+# Dev environment for preparing repodata patches. Enables you to run `python
+# show_diff.py` and `pre-commit run -a`
+#
+# usage:
+#   cd recipe/
+#   mamba env create --file dev-env-for-patches.yaml
+#   mamba activate repodata-patches
+#   pre-commit run -a
+#   # Check the patch for a few architectures
+#   python show_diff.py --subdirs noarch linux-64
+#   # Check the patch for all architectures
+#   python show_diff.py
+#   # Use the cache for quicker feedback
+#   python show_diff.py --use-cache
+#
+# NOTE: If these requirements are out-of-date, please open an Issue or send a PR
+# to update them
+name: repodata-patches
+channels:
+  - conda-forge
+  - nodefaults
+dependencies:
+  - annotated-types
+  - conda-build
+  - license-expression
+  - pre-commit
+  - pydantic
+  - python


### PR DESCRIPTION
Checklist

* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.

---

I added a conda environment that includes all the dependencies required to run `pre-commit` and `show_diff.py` (and no more, since it's not needed to run `gen_patch_json.py` locally). I also added some tips to the README that I would have found helpful when preparing repodata patches in the past.

Closes #493 
