### PR TITLE
Patch r-xfun minimum versions for r-knitr

### DIFF
--- a/recipe/patch_yaml/r-knitr.yaml
+++ b/recipe/patch_yaml/r-knitr.yaml
@@ -1,0 +1,95 @@
+# knitr often bumps its minimum required version of xfun, which we miss when the
+# update PR is automerged. This can lead to errors, eg
+# https://github.com/conda-forge/r-knitr-feedstock/issues/35
+#
+# This patch fixes the xfun requirement for all the knitr versions that
+# specified a minimum required version. The first minimum was added in knitr
+# 1.29
+# https://github.com/yihui/knitr/commit/76fef5b9c535afa244989732b53cc8dfb7ffb471
+
+# xfun (>= 0.15)
+# https://github.com/yihui/knitr/blob/v1.29/DESCRIPTION#L114
+# https://github.com/yihui/knitr/blob/v1.30/DESCRIPTION#L114
+if:
+  name: r-knitr
+  version_in: ["1.29", "1.30"]
+  timestamp_lt: 1709048999000
+then:
+  - replace_depends:
+      old: r-xfun*
+      new: r-xfun >=0.15
+---
+# xfun (>= 0.19)
+# https://github.com/yihui/knitr/blob/v1.31/DESCRIPTION#L115
+if:
+  name: r-knitr
+  version_in: ["1.31"]
+  timestamp_lt: 1709048999000
+then:
+  - replace_depends:
+      old: r-xfun*
+      new: r-xfun >=0.19
+---
+# xfun (>= 0.21)
+# https://github.com/yihui/knitr/blob/v1.32/DESCRIPTION#L117
+# https://github.com/yihui/knitr/blob/v1.33/DESCRIPTION#L118
+# https://github.com/yihui/knitr/blob/v1.34/DESCRIPTION#L117
+# https://github.com/yihui/knitr/blob/v1.35/DESCRIPTION#L117
+# https://github.com/yihui/knitr/blob/v1.36/DESCRIPTION#L117
+if:
+  name: r-knitr
+  version_in: ["1.32", "1.33", "1.34", "1.35", "1.36"]
+  timestamp_lt: 1709048999000
+then:
+  - replace_depends:
+      old: r-xfun*
+      new: r-xfun >=0.21
+---
+# xfun (>= 0.27)
+# https://github.com/yihui/knitr/blob/v1.37/DESCRIPTION#L117
+if:
+  name: r-knitr
+  version_in: ["1.37"]
+  timestamp_lt: 1709048999000
+then:
+  - replace_depends:
+      old: r-xfun*
+      new: r-xfun >=0.27
+---
+# xfun (>= 0.29)
+# https://github.com/yihui/knitr/blob/v1.38/DESCRIPTION#L118
+# https://github.com/yihui/knitr/blob/v1.39/DESCRIPTION#L118
+# https://github.com/yihui/knitr/blob/v1.40/DESCRIPTION#L122
+if:
+  name: r-knitr
+  version_in: ["1.38", "1.39", "1.40"]
+  timestamp_lt: 1709048999000
+then:
+  - replace_depends:
+      old: r-xfun*
+      new: r-xfun >=0.29
+---
+# xfun (>= 0.34)
+# https://github.com/yihui/knitr/blob/v1.41/DESCRIPTION#L123
+# https://github.com/yihui/knitr/blob/v1.42/DESCRIPTION#L122
+if:
+  name: r-knitr
+  version_in: ["1.41", "1.42"]
+  timestamp_lt: 1709048999000
+then:
+  - replace_depends:
+      old: r-xfun*
+      new: r-xfun >=0.34
+---
+# xfun (>= 0.39)
+# https://github.com/yihui/knitr/blob/v1.43/DESCRIPTION#L123
+# https://github.com/yihui/knitr/blob/v1.44/DESCRIPTION#L123
+# https://github.com/yihui/knitr/blob/v1.45/DESCRIPTION#L123
+if:
+  name: r-knitr
+  version_in: ["1.43", "1.44", "1.45"]
+  timestamp_lt: 1709048999000
+then:
+  - replace_depends:
+      old: r-xfun*
+      new: r-xfun >=0.39


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

---

Fixes the specific problem identified in https://github.com/conda-forge/r-knitr-feedstock/issues/35, and while I was at it, I patched the minimum required r-xfun versions for every r-knitr release since 1.29 (when the [first minimum version](https://github.com/yihui/knitr/commit/76fef5b9c535afa244989732b53cc8dfb7ffb471) was specified).

@mfansler @conda-forge/r-knitr please review/approve

The output of `show_diff.py` looks reasonable. It patches the specific problem with 1.31 from https://github.com/conda-forge/r-knitr-feedstock/issues/35:

```
noarch::r-knitr-1.31-r40hc72bb7e_0.tar.bz2
noarch::r-knitr-1.31-r36hc72bb7e_0.tar.bz2
-    "r-xfun >=0.15",
+    "r-xfun >=0.19",
```

It also patches the most recent version 1.45, since I just bumped the minimum version in build number 1 in https://github.com/conda-forge/r-knitr-feedstock/pull/38

```
noarch::r-knitr-1.45-r43hc72bb7e_0.conda
noarch::r-knitr-1.45-r42hc72bb7e_0.conda
-    "r-xfun >=0.34",
+    "r-xfun >=0.39",
```

<details>
<summary>Expand for the full output
</summary>

```sh
python show_diff.py --use-cache --subdirs noarch
## ================================================================================
## ================================================================================
## noarch
## noarch::r-knitr-1.29-r36h6115d3f_0.tar.bz2
## noarch::r-knitr-1.29-r40h6115d3f_0.tar.bz2
## -    "r-xfun",
## +    "r-xfun >=0.15",
## noarch::r-knitr-1.31-r40hc72bb7e_0.tar.bz2
## noarch::r-knitr-1.31-r36hc72bb7e_0.tar.bz2
## -    "r-xfun >=0.15",
## +    "r-xfun >=0.19",
## noarch::r-knitr-1.33-r36hc72bb7e_0.tar.bz2
## noarch::r-knitr-1.34-r41hc72bb7e_0.tar.bz2
## noarch::r-knitr-1.33-r40hc72bb7e_0.tar.bz2
## noarch::r-knitr-1.33-r41hc72bb7e_0.tar.bz2
## noarch::r-knitr-1.34-r40hc72bb7e_0.tar.bz2
## noarch::r-knitr-1.35-r40hc72bb7e_0.tar.bz2
## noarch::r-knitr-1.36-r40hc72bb7e_0.tar.bz2
## noarch::r-knitr-1.35-r41hc72bb7e_0.tar.bz2
## -    "r-xfun >=0.15",
## +    "r-xfun >=0.21",
## noarch::r-knitr-1.37-r40hc72bb7e_0.tar.bz2
## noarch::r-knitr-1.37-r41hc72bb7e_0.tar.bz2
## -    "r-xfun >=0.15",
## +    "r-xfun >=0.27",
## noarch::r-knitr-1.42-r42hc72bb7e_0.conda
## noarch::r-knitr-1.41-r42hc72bb7e_0.conda
## noarch::r-knitr-1.41-r41hc72bb7e_0.conda
## noarch::r-knitr-1.42-r41hc72bb7e_0.conda
## -    "r-xfun >=0.29",
## +    "r-xfun >=0.34",
## noarch::r-knitr-1.43-r42hc72bb7e_1.conda
## noarch::r-knitr-1.45-r43hc72bb7e_0.conda
## noarch::r-knitr-1.44-r42hc72bb7e_0.conda
## noarch::r-knitr-1.43-r42hc72bb7e_0.conda
## noarch::r-knitr-1.43-r41hc72bb7e_0.conda
## noarch::r-knitr-1.44-r43hc72bb7e_0.conda
## noarch::r-knitr-1.45-r42hc72bb7e_0.conda
## noarch::r-knitr-1.43-r43hc72bb7e_1.conda
## -    "r-xfun >=0.34",
## +    "r-xfun >=0.39",
```

</details>