### PR TITLE
Create npe2.yaml to patch (remove) pydantic pin

### DIFF
--- a/recipe/patch_yaml/npe2.yaml
+++ b/recipe/patch_yaml/npe2.yaml
@@ -1,8 +1,8 @@
 if:
   name: npe2
   version_in: ["0.7.3", "0.7.4"]
-  timestamp_lt: 1710016095000 # 2024-03-09
+  timestamp_lt: 1710016095000  # 2024-03-09
 then:
   - replace_depends:
-      old: pydantic <2.0a0 
+      old: pydantic <2.0a0
       new: pydantic

--- a/recipe/patch_yaml/npe2.yaml
+++ b/recipe/patch_yaml/npe2.yaml
@@ -1,0 +1,8 @@
+if:
+  name: npe2
+  version_in: ["0.7.3", "0.7.4"]
+  timestamp_lt: 1710016095000 # 2024-03-09
+then:
+  - replace_depends:
+      old: pydantic <2.0a0 
+      new: pydantic


### PR DESCRIPTION
In https://github.com/napari/npe2/pull/321 the pydantic < 2 pin was dropped from npe2 but it was missed here, so the conda-forge package still requires pydantic 1.
0.7.3 and 0.7.4 shouldn't have pydantic upper bound.

See also: https://github.com/conda-forge/npe2-feedstock/pull/20
closes: https://github.com/napari/npe2/issues/343

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
