### PR TITLE
Patch libmaga_sparse to match actual build environment

### DIFF
--- a/recipe/patch_yaml/magma.yaml
+++ b/recipe/patch_yaml/magma.yaml
@@ -4,6 +4,7 @@ if:
   version: 2.7.2
   build_number_in: [2]
   has_depends: cuda-version >=12.0,<13
+  subdir_in: [linux-aarch64, win-64, linux-64, linux-ppc64le]
 then:
   - replace_depends:
       old: cuda-cudart >=12.1.105,<13.0a0

--- a/recipe/patch_yaml/magma.yaml
+++ b/recipe/patch_yaml/magma.yaml
@@ -1,0 +1,15 @@
+if:
+  timestamp_lt: 1710258820000
+  version: 2.7.2
+  build_number_in: [2]
+  has_depends: cuda-version >=12.0,<13
+then:
+  - replace_depends:
+    old: cuda-cudart >=12.1.105,<13.0a0
+    new: cuda-cudart >=12.0.107,<13.0a0
+  - replace_depends:
+    old: libcublas >=12.1.3.1,<13.0a0
+    new: libcublas >=12.0.1.189,<13.0a0
+  - replace_depends:
+    old: libcusparse >=12.1.0.106,<13.0a0
+    new: libcusparse >=12.0.0.76,<13.0a0

--- a/recipe/patch_yaml/magma.yaml
+++ b/recipe/patch_yaml/magma.yaml
@@ -6,11 +6,11 @@ if:
   has_depends: cuda-version >=12.0,<13
 then:
   - replace_depends:
-    old: cuda-cudart >=12.1.105,<13.0a0
-    new: cuda-cudart >=12.0.107,<13.0a0
+      old: cuda-cudart >=12.1.105,<13.0a0
+      new: cuda-cudart >=12.0.107,<13.0a0
   - replace_depends:
-    old: libcublas >=12.1.3.1,<13.0a0
-    new: libcublas >=12.0.1.189,<13.0a0
+      old: libcublas >=12.1.3.1,<13.0a0
+      new: libcublas >=12.0.1.189,<13.0a0
   - replace_depends:
-    old: libcusparse >=12.1.0.106,<13.0a0
-    new: libcusparse >=12.0.0.76,<13.0a0
+      old: libcusparse >=12.1.0.106,<13.0a0
+      new: libcusparse >=12.0.0.76,<13.0a0

--- a/recipe/patch_yaml/magma.yaml
+++ b/recipe/patch_yaml/magma.yaml
@@ -1,5 +1,6 @@
 if:
   timestamp_lt: 1710258820000
+  name: libmagma_sparse
   version: 2.7.2
   build_number_in: [2]
   has_depends: cuda-version >=12.0,<13


### PR DESCRIPTION
The magma feedstock is a multi-output recipe. During the recent addition of the CUDA 12 build, the cuda-version was pinned in the host environment of the top-level recipe, but not the host environment of the outputs. Thus, while the artifacts were built with matching CUDA compiler and CUDA libraries (cusparse, etc), the output environments were not forced to match, and thus they pulled in CUDA 12.1 libraries for dependency resolution.

This causes a problem because now libmagma_sparse, although it was built with CUDA 12.0 libraries, it depends on CUDA 12.1 libraries.

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
~~[ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.~~
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

Fixes https://github.com/conda-forge/magma-feedstock/issues/41
