### PR TITLE
Soften `cuda-nvcc_{{ target_platform }}`'s `sysroot` pin

### DIFF
--- a/recipe/patch_yaml/cuda-nvcc.yaml
+++ b/recipe/patch_yaml/cuda-nvcc.yaml
@@ -35,3 +35,31 @@ then:
   - replace_depends:
       old: gxx_linux-ppc64le 12.*
       new: gxx_linux-ppc64le
+---
+
+
+# Relax `sysroot` pins of `cuda-nvcc_{{ target_platform }}`
+# Done by arch to handle package name differences
+if:
+  name: cuda-nvcc_linux-64
+  timestamp_lt: 1707120000000
+then:
+  - loosen_depends:
+      name: sysroot_linux-64
+      max_pin: x
+---
+if:
+  name: cuda-nvcc_linux-aarch64
+  timestamp_lt: 1707120000000
+then:
+  - loosen_depends:
+      name: sysroot_linux-aarch64
+      max_pin: x
+---
+if:
+  name: cuda-nvcc_linux-ppc64le
+  timestamp_lt: 1707120000000
+then:
+  - loosen_depends:
+      name: sysroot_linux-ppc64le
+      max_pin: x


### PR DESCRIPTION
Soften `cuda-nvcc_{{ target_platform }}`'s `sysroot` upper bound to allow anything that matches the same major version.

xref: https://github.com/conda-forge/cuda-nvcc-feedstock/pull/36

<hr>

Checklist

* [ ] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
