### PR TITLE
vtk is not compatible with libexpat 2.6

### DIFF
--- a/recipe/patch_yaml/vtk-expat-26.yaml
+++ b/recipe/patch_yaml/vtk-expat-26.yaml
@@ -1,0 +1,8 @@
+if:
+  name: vtk-base
+  timestamp_lt: 1710405220000
+  has_depends: libexpat*
+then:
+  - tighten_depends:
+      name: libexpat
+      max_pin: x.x


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

PR to fix future builds: https://github.com/conda-forge/vtk-feedstock/pull/321
upstream issue: https://gitlab.kitware.com/vtk/vtk/-/issues/19258

<details>
<summary>show_diff.py</summary>

```
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
osx-arm64::vtk-base-9.2.6-qt_py311h1234567_220.conda
osx-arm64::vtk-base-9.2.6-qt_py311h1234567_209.conda
osx-arm64::vtk-base-9.2.6-qt_py38h1234567_213.conda
osx-arm64::vtk-base-9.2.6-qt_py310h1234567_209.conda
osx-arm64::vtk-base-9.2.6-qt_py311h1234567_214.conda
osx-arm64::vtk-base-9.2.6-qt_py310h1234567_215.conda
osx-arm64::vtk-base-9.2.6-qt_py39h1234567_210.conda
osx-arm64::vtk-base-9.2.6-qt_py311h1234567_208.conda
osx-arm64::vtk-base-9.2.6-qt_py38h1234567_214.conda
osx-arm64::vtk-base-9.2.6-qt_py311h1234567_206.conda
osx-arm64::vtk-base-9.2.6-qt_py38h1234567_204.conda
osx-arm64::vtk-base-9.2.6-qt_py311h1234567_211.conda
osx-arm64::vtk-base-9.2.6-qt_py38h1234567_205.conda
osx-arm64::vtk-base-9.2.6-qt_py310h1234567_214.conda
osx-arm64::vtk-base-9.2.6-qt_py39h1234567_214.conda
osx-arm64::vtk-base-9.2.6-qt_py310h1234567_216.conda
osx-arm64::vtk-base-9.2.6-qt_py310h1234567_219.conda
osx-arm64::vtk-base-9.2.6-qt_py310h1234567_205.conda
osx-arm64::vtk-base-9.2.6-qt_py39h1234567_218.conda
osx-arm64::vtk-base-9.2.6-qt_py311h1234567_212.conda
osx-arm64::vtk-base-9.2.6-qt_py311h1234567_203.conda
osx-arm64::vtk-base-9.2.6-qt_py39h1234567_203.conda
osx-arm64::vtk-base-9.2.6-qt_py38h1234567_203.conda
osx-arm64::vtk-base-9.2.6-qt_py39h1234567_211.conda
osx-arm64::vtk-base-9.2.6-qt_py310h1234567_210.conda
osx-arm64::vtk-base-9.2.6-qt_py310h1234567_218.conda
osx-arm64::vtk-base-9.2.6-qt_py39h1234567_216.conda
osx-arm64::vtk-base-9.2.6-qt_py312h1234567_220.conda
osx-arm64::vtk-base-9.2.6-qt_py38h1234567_207.conda
osx-arm64::vtk-base-9.2.6-qt_py311h1234567_204.conda
osx-arm64::vtk-base-9.2.6-qt_py39h1234567_207.conda
osx-arm64::vtk-base-9.2.6-qt_py38h1234567_206.conda
osx-arm64::vtk-base-9.2.6-qt_py310h1234567_217.conda
osx-arm64::vtk-base-9.2.6-qt_py38h1234567_215.conda
osx-arm64::vtk-base-9.2.6-qt_py38h1234567_218.conda
osx-arm64::vtk-base-9.2.6-qt_py310h1234567_206.conda
osx-arm64::vtk-base-9.2.6-qt_py310h1234567_207.conda
osx-arm64::vtk-base-9.2.6-qt_py38h1234567_210.conda
osx-arm64::vtk-base-9.2.6-qt_py38h1234567_209.conda
osx-arm64::vtk-base-9.2.6-qt_py310h1234567_211.conda
osx-arm64::vtk-base-9.2.6-qt_py310h1234567_220.conda
osx-arm64::vtk-base-9.2.6-qt_py38h1234567_208.conda
osx-arm64::vtk-base-9.2.6-qt_py310h1234567_208.conda
osx-arm64::vtk-base-9.2.6-qt_py39h1234567_205.conda
osx-arm64::vtk-base-9.2.6-qt_py39h1234567_206.conda
osx-arm64::vtk-base-9.2.6-qt_py38h1234567_211.conda
osx-arm64::vtk-base-9.2.6-qt_py38h1234567_216.conda
osx-arm64::vtk-base-9.2.6-qt_py39h1234567_217.conda
osx-arm64::vtk-base-9.2.6-qt_py311h1234567_219.conda
osx-arm64::vtk-base-9.2.6-qt_py38h1234567_212.conda
osx-arm64::vtk-base-9.2.6-qt_py311h1234567_213.conda
osx-arm64::vtk-base-9.2.6-qt_py310h1234567_203.conda
osx-arm64::vtk-base-9.2.6-qt_py39h1234567_212.conda
osx-arm64::vtk-base-9.2.6-qt_py311h1234567_205.conda
osx-arm64::vtk-base-9.2.6-qt_py312h1234567_219.conda
osx-arm64::vtk-base-9.2.6-qt_py310h1234567_213.conda
osx-arm64::vtk-base-9.2.6-qt_py39h1234567_219.conda
osx-arm64::vtk-base-9.2.6-qt_py310h1234567_204.conda
osx-arm64::vtk-base-9.2.6-qt_py311h1234567_218.conda
osx-arm64::vtk-base-9.2.6-qt_py311h1234567_217.conda
osx-arm64::vtk-base-9.2.6-qt_py39h1234567_220.conda
osx-arm64::vtk-base-9.2.6-qt_py39h1234567_213.conda
osx-arm64::vtk-base-9.2.6-qt_py39h1234567_204.conda
osx-arm64::vtk-base-9.2.6-qt_py311h1234567_215.conda
osx-arm64::vtk-base-9.2.6-qt_py39h1234567_215.conda
osx-arm64::vtk-base-9.2.6-qt_py311h1234567_210.conda
osx-arm64::vtk-base-9.2.6-qt_py311h1234567_216.conda
osx-arm64::vtk-base-9.2.6-qt_py38h1234567_217.conda
osx-arm64::vtk-base-9.2.6-qt_py312h1234567_218.conda
osx-arm64::vtk-base-9.2.6-qt_py311h1234567_207.conda
osx-arm64::vtk-base-9.2.6-qt_py39h1234567_209.conda
osx-arm64::vtk-base-9.2.6-qt_py39h1234567_208.conda
osx-arm64::vtk-base-9.2.6-qt_py310h1234567_212.conda
osx-arm64::vtk-base-9.2.6-qt_py38h1234567_219.conda
osx-arm64::vtk-base-9.2.6-qt_py38h1234567_220.conda
-    "libexpat >=2.5.0,<3.0a0",
+    "libexpat >=2.5.0,<2.6.0a0",
================================================================================
================================================================================
linux-ppc64le
linux-ppc64le::vtk-base-9.2.6-qt_py38h1234567_214.conda
linux-ppc64le::vtk-base-9.2.6-qt_py39h1234567_215.conda
linux-ppc64le::vtk-base-9.2.6-qt_py310h1234567_204.conda
linux-ppc64le::vtk-base-9.2.6-qt_py39h1234567_203.conda
linux-ppc64le::vtk-base-9.2.6-qt_py38h1234567_209.conda
linux-ppc64le::vtk-base-9.2.6-qt_py39h1234567_204.conda
linux-ppc64le::vtk-base-9.2.6-qt_py311h1234567_203.conda
linux-ppc64le::vtk-base-9.2.6-qt_py310h1234567_215.conda
linux-ppc64le::vtk-base-9.2.6-qt_py311h1234567_204.conda
linux-ppc64le::vtk-base-9.2.6-qt_py38h1234567_207.conda
linux-ppc64le::vtk-base-9.2.6-qt_py311h1234567_211.conda
linux-ppc64le::vtk-base-9.2.6-qt_py310h1234567_216.conda
linux-ppc64le::vtk-base-9.2.6-qt_py38h1234567_204.conda
linux-ppc64le::vtk-base-9.2.6-qt_py311h1234567_208.conda
linux-ppc64le::vtk-base-9.2.6-qt_py311h1234567_214.conda
linux-ppc64le::vtk-base-9.2.6-qt_py310h1234567_205.conda
linux-ppc64le::vtk-base-9.2.6-qt_py310h1234567_208.conda
linux-ppc64le::vtk-base-9.2.6-qt_py38h1234567_219.conda
linux-ppc64le::vtk-base-9.2.6-qt_py39h1234567_211.conda
linux-ppc64le::vtk-base-9.2.6-qt_py39h1234567_208.conda
linux-ppc64le::vtk-base-9.2.6-qt_py311h1234567_219.conda
linux-ppc64le::vtk-base-9.2.6-qt_py310h1234567_214.conda
linux-ppc64le::vtk-base-9.2.6-qt_py310h1234567_203.conda
linux-ppc64le::vtk-base-9.2.6-qt_py311h1234567_216.conda
linux-ppc64le::vtk-base-9.2.6-qt_py38h1234567_211.conda
linux-ppc64le::vtk-base-9.2.6-qt_py311h1234567_212.conda
linux-ppc64le::vtk-base-9.2.6-qt_py310h1234567_211.conda
linux-ppc64le::vtk-base-9.2.6-qt_py38h1234567_220.conda
linux-ppc64le::vtk-base-9.2.6-qt_py310h1234567_220.conda
linux-ppc64le::vtk-base-9.2.6-qt_py312h1234567_220.conda
linux-ppc64le::vtk-base-9.2.6-qt_py39h1234567_219.conda
linux-ppc64le::vtk-base-9.2.6-qt_py311h1234567_213.conda
linux-ppc64le::vtk-base-9.2.6-qt_py39h1234567_210.conda
linux-ppc64le::vtk-base-9.2.6-qt_py310h1234567_217.conda
linux-ppc64le::vtk-base-9.2.6-qt_py38h1234567_210.conda
linux-ppc64le::vtk-base-9.2.6-qt_py310h1234567_213.conda
linux-ppc64le::vtk-base-9.2.6-qt_py310h1234567_218.conda
linux-ppc64le::vtk-base-9.2.6-qt_py310h1234567_209.conda
linux-ppc64le::vtk-base-9.2.6-qt_py38h1234567_218.conda
linux-ppc64le::vtk-base-9.2.6-qt_py38h1234567_213.conda
linux-ppc64le::vtk-base-9.2.6-qt_py38h1234567_208.conda
linux-ppc64le::vtk-base-9.2.6-qt_py38h1234567_203.conda
linux-ppc64le::vtk-base-9.2.6-qt_py39h1234567_218.conda
linux-ppc64le::vtk-base-9.2.6-qt_py311h1234567_207.conda
linux-ppc64le::vtk-base-9.2.6-qt_py310h1234567_212.conda
linux-ppc64le::vtk-base-9.2.6-qt_py39h1234567_213.conda
linux-ppc64le::vtk-base-9.2.6-qt_py39h1234567_216.conda
linux-ppc64le::vtk-base-9.2.6-qt_py311h1234567_206.conda
linux-ppc64le::vtk-base-9.2.6-qt_py38h1234567_215.conda
linux-ppc64le::vtk-base-9.2.6-qt_py311h1234567_218.conda
linux-ppc64le::vtk-base-9.2.6-qt_py311h1234567_210.conda
linux-ppc64le::vtk-base-9.2.6-qt_py38h1234567_216.conda
linux-ppc64le::vtk-base-9.2.6-qt_py38h1234567_217.conda
linux-ppc64le::vtk-base-9.2.6-qt_py39h1234567_217.conda
linux-ppc64le::vtk-base-9.2.6-qt_py38h1234567_212.conda
linux-ppc64le::vtk-base-9.2.6-qt_py39h1234567_209.conda
linux-ppc64le::vtk-base-9.2.6-qt_py38h1234567_205.conda
linux-ppc64le::vtk-base-9.2.6-qt_py39h1234567_220.conda
linux-ppc64le::vtk-base-9.2.6-qt_py310h1234567_219.conda
linux-ppc64le::vtk-base-9.2.6-qt_py311h1234567_217.conda
linux-ppc64le::vtk-base-9.2.6-qt_py310h1234567_206.conda
linux-ppc64le::vtk-base-9.2.6-qt_py39h1234567_207.conda
linux-ppc64le::vtk-base-9.2.6-qt_py311h1234567_205.conda
linux-ppc64le::vtk-base-9.2.6-qt_py39h1234567_206.conda
linux-ppc64le::vtk-base-9.2.6-qt_py311h1234567_215.conda
linux-ppc64le::vtk-base-9.2.6-qt_py310h1234567_207.conda
linux-ppc64le::vtk-base-9.2.6-qt_py311h1234567_220.conda
linux-ppc64le::vtk-base-9.2.6-qt_py38h1234567_206.conda
linux-ppc64le::vtk-base-9.2.6-qt_py311h1234567_209.conda
linux-ppc64le::vtk-base-9.2.6-qt_py39h1234567_212.conda
linux-ppc64le::vtk-base-9.2.6-qt_py312h1234567_218.conda
linux-ppc64le::vtk-base-9.2.6-qt_py39h1234567_205.conda
linux-ppc64le::vtk-base-9.2.6-qt_py310h1234567_210.conda
linux-ppc64le::vtk-base-9.2.6-qt_py312h1234567_219.conda
linux-ppc64le::vtk-base-9.2.6-qt_py39h1234567_214.conda
-    "libexpat >=2.5.0,<3.0a0",
+    "libexpat >=2.5.0,<2.6.0a0",
================================================================================
================================================================================
linux-aarch64
linux-aarch64::vtk-base-9.2.6-qt_py310h1234567_207.conda
linux-aarch64::vtk-base-9.2.6-qt_py311h1234567_207.conda
linux-aarch64::vtk-base-9.2.6-qt_py39h1234567_213.conda
linux-aarch64::vtk-base-9.2.6-qt_py39h1234567_205.conda
linux-aarch64::vtk-base-9.2.6-qt_py38h1234567_206.conda
linux-aarch64::vtk-base-9.2.6-qt_py39h1234567_217.conda
linux-aarch64::vtk-base-9.2.6-qt_py311h1234567_205.conda
linux-aarch64::vtk-base-9.2.6-qt_py38h1234567_219.conda
linux-aarch64::vtk-base-9.2.6-qt_py39h1234567_207.conda
linux-aarch64::vtk-base-9.2.6-qt_py38h1234567_207.conda
linux-aarch64::vtk-base-9.2.6-qt_py39h1234567_215.conda
linux-aarch64::vtk-base-9.2.6-qt_py39h1234567_206.conda
linux-aarch64::vtk-base-9.2.6-qt_py311h1234567_204.conda
linux-aarch64::vtk-base-9.2.6-qt_py310h1234567_205.conda
linux-aarch64::vtk-base-9.2.6-qt_py310h1234567_218.conda
linux-aarch64::vtk-base-9.2.6-qt_py312h1234567_219.conda
linux-aarch64::vtk-base-9.2.6-qt_py39h1234567_219.conda
linux-aarch64::vtk-base-9.2.6-qt_py38h1234567_216.conda
linux-aarch64::vtk-base-9.2.6-qt_py310h1234567_204.conda
linux-aarch64::vtk-base-9.2.6-qt_py311h1234567_203.conda
linux-aarch64::vtk-base-9.2.6-qt_py310h1234567_206.conda
linux-aarch64::vtk-base-9.2.6-qt_py39h1234567_214.conda
linux-aarch64::vtk-base-9.2.6-qt_py39h1234567_203.conda
linux-aarch64::vtk-base-9.2.6-qt_py310h1234567_209.conda
linux-aarch64::vtk-base-9.2.6-qt_py311h1234567_218.conda
linux-aarch64::vtk-base-9.2.6-qt_py312h1234567_220.conda
linux-aarch64::vtk-base-9.2.6-qt_py310h1234567_220.conda
linux-aarch64::vtk-base-9.2.6-qt_py38h1234567_208.conda
linux-aarch64::vtk-base-9.2.6-qt_py311h1234567_217.conda
linux-aarch64::vtk-base-9.2.6-qt_py311h1234567_220.conda
linux-aarch64::vtk-base-9.2.6-qt_py311h1234567_213.conda
linux-aarch64::vtk-base-9.2.6-qt_py38h1234567_205.conda
linux-aarch64::vtk-base-9.2.6-qt_py312h1234567_218.conda
linux-aarch64::vtk-base-9.2.6-qt_py311h1234567_212.conda
linux-aarch64::vtk-base-9.2.6-qt_py38h1234567_218.conda
linux-aarch64::vtk-base-9.2.6-qt_py38h1234567_209.conda
linux-aarch64::vtk-base-9.2.6-qt_py310h1234567_203.conda
linux-aarch64::vtk-base-9.2.6-qt_py39h1234567_218.conda
linux-aarch64::vtk-base-9.2.6-qt_py38h1234567_212.conda
linux-aarch64::vtk-base-9.2.6-qt_py38h1234567_204.conda
linux-aarch64::vtk-base-9.2.6-qt_py311h1234567_214.conda
linux-aarch64::vtk-base-9.2.6-qt_py39h1234567_210.conda
linux-aarch64::vtk-base-9.2.6-qt_py310h1234567_216.conda
linux-aarch64::vtk-base-9.2.6-qt_py310h1234567_217.conda
linux-aarch64::vtk-base-9.2.6-qt_py311h1234567_211.conda
linux-aarch64::vtk-base-9.2.6-qt_py310h1234567_213.conda
linux-aarch64::vtk-base-9.2.6-qt_py39h1234567_204.conda
linux-aarch64::vtk-base-9.2.6-qt_py38h1234567_217.conda
linux-aarch64::vtk-base-9.2.6-qt_py310h1234567_208.conda
linux-aarch64::vtk-base-9.2.6-qt_py311h1234567_219.conda
linux-aarch64::vtk-base-9.2.6-qt_py38h1234567_213.conda
linux-aarch64::vtk-base-9.2.6-qt_py38h1234567_220.conda
linux-aarch64::vtk-base-9.2.6-qt_py38h1234567_214.conda
linux-aarch64::vtk-base-9.2.6-qt_py38h1234567_203.conda
linux-aarch64::vtk-base-9.2.6-qt_py310h1234567_214.conda
linux-aarch64::vtk-base-9.2.6-qt_py39h1234567_212.conda
linux-aarch64::vtk-base-9.2.6-qt_py311h1234567_206.conda
linux-aarch64::vtk-base-9.2.6-qt_py39h1234567_208.conda
linux-aarch64::vtk-base-9.2.6-qt_py39h1234567_211.conda
linux-aarch64::vtk-base-9.2.6-qt_py310h1234567_215.conda
linux-aarch64::vtk-base-9.2.6-qt_py311h1234567_210.conda
linux-aarch64::vtk-base-9.2.6-qt_py38h1234567_211.conda
linux-aarch64::vtk-base-9.2.6-qt_py310h1234567_211.conda
linux-aarch64::vtk-base-9.2.6-qt_py311h1234567_209.conda
linux-aarch64::vtk-base-9.2.6-qt_py39h1234567_216.conda
linux-aarch64::vtk-base-9.2.6-qt_py38h1234567_215.conda
linux-aarch64::vtk-base-9.2.6-qt_py310h1234567_212.conda
linux-aarch64::vtk-base-9.2.6-qt_py39h1234567_209.conda
linux-aarch64::vtk-base-9.2.6-qt_py38h1234567_210.conda
linux-aarch64::vtk-base-9.2.6-qt_py39h1234567_220.conda
linux-aarch64::vtk-base-9.2.6-qt_py310h1234567_210.conda
linux-aarch64::vtk-base-9.2.6-qt_py311h1234567_215.conda
linux-aarch64::vtk-base-9.2.6-qt_py311h1234567_216.conda
linux-aarch64::vtk-base-9.2.6-qt_py310h1234567_219.conda
linux-aarch64::vtk-base-9.2.6-qt_py311h1234567_208.conda
-    "libexpat >=2.5.0,<3.0a0",
+    "libexpat >=2.5.0,<2.6.0a0",
================================================================================
================================================================================
noarch
================================================================================
================================================================================
win-64
win-64::vtk-base-9.2.6-qt_py38h1234567_214.conda
win-64::vtk-base-9.2.6-qt_py38h1234567_208.conda
win-64::vtk-base-9.2.6-qt_py311h1234567_207.conda
win-64::vtk-base-9.2.6-qt_py39h1234567_206.conda
win-64::vtk-base-9.2.6-qt_py310h1234567_220.conda
win-64::vtk-base-9.2.6-qt_py311h1234567_205.conda
win-64::vtk-base-9.2.6-qt_py311h1234567_218.conda
win-64::vtk-base-9.2.6-qt_py310h1234567_208.conda
win-64::vtk-base-9.2.6-qt_py310h1234567_207.conda
win-64::vtk-base-9.2.6-qt_py310h1234567_213.conda
win-64::vtk-base-9.2.6-qt_py311h1234567_214.conda
win-64::vtk-base-9.2.6-qt_py311h1234567_209.conda
win-64::vtk-base-9.2.6-qt_py310h1234567_214.conda
win-64::vtk-base-9.2.6-qt_py311h1234567_217.conda
win-64::vtk-base-9.2.6-qt_py38h1234567_210.conda
win-64::vtk-base-9.2.6-qt_py311h1234567_219.conda
win-64::vtk-base-9.2.6-qt_py38h1234567_207.conda
win-64::vtk-base-9.2.6-qt_py38h1234567_216.conda
win-64::vtk-base-9.2.6-qt_py312h1234567_218.conda
win-64::vtk-base-9.2.6-qt_py311h1234567_212.conda
win-64::vtk-base-9.2.6-qt_py38h1234567_209.conda
win-64::vtk-base-9.2.6-qt_py312h1234567_220.conda
win-64::vtk-base-9.2.6-qt_py39h1234567_205.conda
win-64::vtk-base-9.2.6-qt_py311h1234567_210.conda
win-64::vtk-base-9.2.6-qt_py38h1234567_204.conda
win-64::vtk-base-9.2.6-qt_py311h1234567_203.conda
win-64::vtk-base-9.2.6-qt_py39h1234567_207.conda
win-64::vtk-base-9.2.6-qt_py38h1234567_219.conda
win-64::vtk-base-9.2.6-qt_py310h1234567_210.conda
win-64::vtk-base-9.2.6-qt_py310h1234567_203.conda
win-64::vtk-base-9.2.6-qt_py39h1234567_209.conda
win-64::vtk-base-9.2.6-qt_py39h1234567_219.conda
win-64::vtk-base-9.2.6-qt_py39h1234567_217.conda
win-64::vtk-base-9.2.6-qt_py38h1234567_203.conda
win-64::vtk-base-9.2.6-qt_py39h1234567_215.conda
win-64::vtk-base-9.2.6-qt_py39h1234567_218.conda
win-64::vtk-base-9.2.6-qt_py311h1234567_216.conda
win-64::vtk-base-9.2.6-qt_py39h1234567_214.conda
win-64::vtk-base-9.2.6-qt_py38h1234567_215.conda
win-64::vtk-base-9.2.6-qt_py310h1234567_205.conda
win-64::vtk-base-9.2.6-qt_py311h1234567_213.conda
win-64::vtk-base-9.2.6-qt_py311h1234567_208.conda
win-64::vtk-base-9.2.6-qt_py38h1234567_212.conda
win-64::vtk-base-9.2.6-qt_py310h1234567_204.conda
win-64::vtk-base-9.2.6-qt_py39h1234567_212.conda
win-64::vtk-base-9.2.6-qt_py39h1234567_203.conda
win-64::vtk-base-9.2.6-qt_py38h1234567_206.conda
win-64::vtk-base-9.2.6-qt_py311h1234567_215.conda
win-64::vtk-base-9.2.6-qt_py310h1234567_217.conda
win-64::vtk-base-9.2.6-qt_py310h1234567_216.conda
win-64::vtk-base-9.2.6-qt_py310h1234567_215.conda
win-64::vtk-base-9.2.6-qt_py310h1234567_219.conda
win-64::vtk-base-9.2.6-qt_py39h1234567_213.conda
win-64::vtk-base-9.2.6-qt_py39h1234567_210.conda
win-64::vtk-base-9.2.6-qt_py310h1234567_209.conda
win-64::vtk-base-9.2.6-qt_py311h1234567_204.conda
win-64::vtk-base-9.2.6-qt_py39h1234567_216.conda
win-64::vtk-base-9.2.6-qt_py311h1234567_220.conda
win-64::vtk-base-9.2.6-qt_py38h1234567_217.conda
win-64::vtk-base-9.2.6-qt_py39h1234567_220.conda
win-64::vtk-base-9.2.6-qt_py310h1234567_212.conda
win-64::vtk-base-9.2.6-qt_py39h1234567_204.conda
win-64::vtk-base-9.2.6-qt_py38h1234567_213.conda
win-64::vtk-base-9.2.6-qt_py38h1234567_220.conda
win-64::vtk-base-9.2.6-qt_py310h1234567_206.conda
win-64::vtk-base-9.2.6-qt_py38h1234567_218.conda
win-64::vtk-base-9.2.6-qt_py38h1234567_205.conda
win-64::vtk-base-9.2.6-qt_py311h1234567_206.conda
win-64::vtk-base-9.2.6-qt_py39h1234567_208.conda
win-64::vtk-base-9.2.6-qt_py310h1234567_218.conda
win-64::vtk-base-9.2.6-qt_py312h1234567_219.conda
-    "libexpat >=2.5.0,<3.0a0",
+    "libexpat >=2.5.0,<2.6.0a0",
================================================================================
================================================================================
osx-64
osx-64::vtk-base-9.2.6-qt_py39h1234567_204.conda
osx-64::vtk-base-9.2.6-qt_py310h1234567_204.conda
osx-64::vtk-base-9.2.6-qt_py312h1234567_218.conda
osx-64::vtk-base-9.2.6-qt_py39h1234567_210.conda
osx-64::vtk-base-9.2.6-qt_py311h1234567_220.conda
osx-64::vtk-base-9.2.6-qt_py310h1234567_205.conda
osx-64::vtk-base-9.2.6-qt_py310h1234567_219.conda
osx-64::vtk-base-9.2.6-qt_py311h1234567_217.conda
osx-64::vtk-base-9.2.6-qt_py311h1234567_219.conda
osx-64::vtk-base-9.2.6-qt_py38h1234567_212.conda
osx-64::vtk-base-9.2.6-qt_py39h1234567_216.conda
osx-64::vtk-base-9.2.6-qt_py38h1234567_210.conda
osx-64::vtk-base-9.2.6-qt_py311h1234567_204.conda
osx-64::vtk-base-9.2.6-qt_py39h1234567_208.conda
osx-64::vtk-base-9.2.6-qt_py39h1234567_203.conda
osx-64::vtk-base-9.2.6-qt_py311h1234567_203.conda
osx-64::vtk-base-9.2.6-qt_py39h1234567_218.conda
osx-64::vtk-base-9.2.6-qt_py38h1234567_213.conda
osx-64::vtk-base-9.2.6-qt_py312h1234567_220.conda
osx-64::vtk-base-9.2.6-qt_py310h1234567_215.conda
osx-64::vtk-base-9.2.6-qt_py39h1234567_212.conda
osx-64::vtk-base-9.2.6-qt_py311h1234567_210.conda
osx-64::vtk-base-9.2.6-qt_py38h1234567_218.conda
osx-64::vtk-base-9.2.6-qt_py38h1234567_209.conda
osx-64::vtk-base-9.2.6-qt_py39h1234567_217.conda
osx-64::vtk-base-9.2.6-qt_py311h1234567_213.conda
osx-64::vtk-base-9.2.6-qt_py39h1234567_219.conda
osx-64::vtk-base-9.2.6-qt_py38h1234567_216.conda
osx-64::vtk-base-9.2.6-qt_py310h1234567_208.conda
osx-64::vtk-base-9.2.6-qt_py38h1234567_219.conda
osx-64::vtk-base-9.2.6-qt_py38h1234567_207.conda
osx-64::vtk-base-9.2.6-qt_py310h1234567_217.conda
osx-64::vtk-base-9.2.6-qt_py38h1234567_208.conda
osx-64::vtk-base-9.2.6-qt_py311h1234567_216.conda
osx-64::vtk-base-9.2.6-qt_py311h1234567_214.conda
osx-64::vtk-base-9.2.6-qt_py39h1234567_213.conda
osx-64::vtk-base-9.2.6-qt_py311h1234567_206.conda
osx-64::vtk-base-9.2.6-qt_py39h1234567_209.conda
osx-64::vtk-base-9.2.6-qt_py311h1234567_207.conda
osx-64::vtk-base-9.2.6-qt_py38h1234567_211.conda
osx-64::vtk-base-9.2.6-qt_py311h1234567_205.conda
osx-64::vtk-base-9.2.6-qt_py38h1234567_217.conda
osx-64::vtk-base-9.2.6-qt_py38h1234567_204.conda
osx-64::vtk-base-9.2.6-qt_py310h1234567_216.conda
osx-64::vtk-base-9.2.6-qt_py310h1234567_203.conda
osx-64::vtk-base-9.2.6-qt_py38h1234567_214.conda
osx-64::vtk-base-9.2.6-qt_py310h1234567_218.conda
osx-64::vtk-base-9.2.6-qt_py38h1234567_215.conda
osx-64::vtk-base-9.2.6-qt_py310h1234567_207.conda
osx-64::vtk-base-9.2.6-qt_py39h1234567_214.conda
osx-64::vtk-base-9.2.6-qt_py38h1234567_205.conda
osx-64::vtk-base-9.2.6-qt_py39h1234567_206.conda
osx-64::vtk-base-9.2.6-qt_py311h1234567_218.conda
osx-64::vtk-base-9.2.6-qt_py38h1234567_220.conda
osx-64::vtk-base-9.2.6-qt_py310h1234567_214.conda
osx-64::vtk-base-9.2.6-qt_py312h1234567_219.conda
osx-64::vtk-base-9.2.6-qt_py38h1234567_203.conda
osx-64::vtk-base-9.2.6-qt_py39h1234567_215.conda
osx-64::vtk-base-9.2.6-qt_py39h1234567_220.conda
osx-64::vtk-base-9.2.6-qt_py310h1234567_212.conda
osx-64::vtk-base-9.2.6-qt_py311h1234567_212.conda
osx-64::vtk-base-9.2.6-qt_py39h1234567_211.conda
osx-64::vtk-base-9.2.6-qt_py310h1234567_211.conda
osx-64::vtk-base-9.2.6-qt_py310h1234567_213.conda
osx-64::vtk-base-9.2.6-qt_py39h1234567_205.conda
osx-64::vtk-base-9.2.6-qt_py39h1234567_207.conda
osx-64::vtk-base-9.2.6-qt_py38h1234567_206.conda
osx-64::vtk-base-9.2.6-qt_py310h1234567_210.conda
osx-64::vtk-base-9.2.6-qt_py311h1234567_215.conda
osx-64::vtk-base-9.2.6-qt_py311h1234567_208.conda
osx-64::vtk-base-9.2.6-qt_py310h1234567_220.conda
osx-64::vtk-base-9.2.6-qt_py310h1234567_206.conda
osx-64::vtk-base-9.2.6-qt_py311h1234567_209.conda
osx-64::vtk-base-9.2.6-qt_py310h1234567_209.conda
-    "libexpat >=2.5.0,<3.0a0",
+    "libexpat >=2.5.0,<2.6.0a0",
================================================================================
================================================================================
linux-64
linux-64::vtk-base-9.2.6-osmesa_py310h1234567_113.conda
linux-64::vtk-base-9.2.6-osmesa_py38h1234567_113.conda
linux-64::vtk-base-9.2.6-egl_py38h1234567_3.conda
linux-64::vtk-base-9.2.6-qt_py38h1234567_218.conda
linux-64::vtk-base-9.2.6-qt_py310h1234567_210.conda
linux-64::vtk-base-9.2.6-qt_py310h1234567_209.conda
linux-64::vtk-base-9.2.6-osmesa_py39h1234567_115.conda
linux-64::vtk-base-9.2.6-egl_py312h1234567_19.conda
linux-64::vtk-base-9.2.6-osmesa_py312h1234567_120.conda
linux-64::vtk-base-9.2.6-egl_py312h1234567_20.conda
linux-64::vtk-base-9.2.6-qt_py312h1234567_218.conda
linux-64::vtk-base-9.2.6-osmesa_py311h1234567_116.conda
linux-64::vtk-base-9.2.6-egl_py38h1234567_17.conda
linux-64::vtk-base-9.2.6-egl_py38h1234567_4.conda
linux-64::vtk-base-9.2.6-qt_py38h1234567_213.conda
linux-64::vtk-base-9.2.6-osmesa_py39h1234567_106.conda
linux-64::vtk-base-9.2.6-egl_py38h1234567_13.conda
linux-64::vtk-base-9.2.6-egl_py39h1234567_11.conda
linux-64::vtk-base-9.2.6-egl_py38h1234567_7.conda
linux-64::vtk-base-9.2.6-osmesa_py39h1234567_108.conda
linux-64::vtk-base-9.2.6-egl_py310h1234567_14.conda
linux-64::vtk-base-9.2.6-qt_py310h1234567_207.conda
linux-64::vtk-base-9.2.6-qt_py39h1234567_205.conda
linux-64::vtk-base-9.2.6-qt_py38h1234567_210.conda
linux-64::vtk-base-9.2.6-osmesa_py311h1234567_110.conda
linux-64::vtk-base-9.2.6-osmesa_py310h1234567_108.conda
linux-64::vtk-base-9.2.6-osmesa_py311h1234567_119.conda
linux-64::vtk-base-9.2.6-qt_py310h1234567_214.conda
linux-64::vtk-base-9.2.6-qt_py310h1234567_211.conda
linux-64::vtk-base-9.2.6-osmesa_py39h1234567_107.conda
linux-64::vtk-base-9.2.6-qt_py39h1234567_212.conda
linux-64::vtk-base-9.2.6-egl_py38h1234567_19.conda
linux-64::vtk-base-9.2.6-qt_py39h1234567_211.conda
linux-64::vtk-base-9.2.6-egl_py39h1234567_17.conda
linux-64::vtk-base-9.2.6-egl_py312h1234567_18.conda
linux-64::vtk-base-9.2.6-osmesa_py310h1234567_112.conda
linux-64::vtk-base-9.2.6-qt_py39h1234567_209.conda
linux-64::vtk-base-9.2.6-qt_py311h1234567_215.conda
linux-64::vtk-base-9.2.6-osmesa_py38h1234567_110.conda
linux-64::vtk-base-9.2.6-qt_py39h1234567_214.conda
linux-64::vtk-base-9.2.6-osmesa_py39h1234567_117.conda
linux-64::vtk-base-9.2.6-osmesa_py310h1234567_110.conda
linux-64::vtk-base-9.2.6-egl_py311h1234567_16.conda
linux-64::vtk-base-9.2.6-qt_py38h1234567_214.conda
linux-64::vtk-base-9.2.6-osmesa_py38h1234567_103.conda
linux-64::vtk-base-9.2.6-osmesa_py311h1234567_117.conda
linux-64::vtk-base-9.2.6-qt_py39h1234567_210.conda
linux-64::vtk-base-9.2.6-egl_py38h1234567_10.conda
linux-64::vtk-base-9.2.6-egl_py38h1234567_20.conda
linux-64::vtk-base-9.2.6-osmesa_py38h1234567_115.conda
linux-64::vtk-base-9.2.6-osmesa_py38h1234567_105.conda
linux-64::vtk-base-9.2.6-qt_py310h1234567_215.conda
linux-64::vtk-base-9.2.6-osmesa_py310h1234567_107.conda
linux-64::vtk-base-9.2.6-qt_py39h1234567_206.conda
linux-64::vtk-base-9.2.6-osmesa_py39h1234567_116.conda
linux-64::vtk-base-9.2.6-egl_py311h1234567_19.conda
linux-64::vtk-base-9.2.6-osmesa_py39h1234567_104.conda
linux-64::vtk-base-9.2.6-qt_py311h1234567_212.conda
linux-64::vtk-base-9.2.6-qt_py310h1234567_204.conda
linux-64::vtk-base-9.2.6-qt_py310h1234567_206.conda
linux-64::vtk-base-9.2.6-qt_py38h1234567_216.conda
linux-64::vtk-base-9.2.6-osmesa_py311h1234567_105.conda
linux-64::vtk-base-9.2.6-osmesa_py310h1234567_120.conda
linux-64::vtk-base-9.2.6-egl_py311h1234567_13.conda
linux-64::vtk-base-9.2.6-egl_py311h1234567_10.conda
linux-64::vtk-base-9.2.6-qt_py38h1234567_211.conda
linux-64::vtk-base-9.2.6-egl_py38h1234567_18.conda
linux-64::vtk-base-9.2.6-osmesa_py38h1234567_117.conda
linux-64::vtk-base-9.2.6-osmesa_py311h1234567_113.conda
linux-64::vtk-base-9.2.6-qt_py311h1234567_204.conda
linux-64::vtk-base-9.2.6-egl_py38h1234567_11.conda
linux-64::vtk-base-9.2.6-qt_py310h1234567_217.conda
linux-64::vtk-base-9.2.6-osmesa_py310h1234567_104.conda
linux-64::vtk-base-9.2.6-egl_py39h1234567_15.conda
linux-64::vtk-base-9.2.6-egl_py39h1234567_5.conda
linux-64::vtk-base-9.2.6-egl_py310h1234567_6.conda
linux-64::vtk-base-9.2.6-qt_py38h1234567_206.conda
linux-64::vtk-base-9.2.6-osmesa_py310h1234567_117.conda
linux-64::vtk-base-9.2.6-qt_py311h1234567_213.conda
linux-64::vtk-base-9.2.6-qt_py38h1234567_215.conda
linux-64::vtk-base-9.2.6-egl_py39h1234567_13.conda
linux-64::vtk-base-9.2.6-egl_py311h1234567_14.conda
linux-64::vtk-base-9.2.6-qt_py311h1234567_211.conda
linux-64::vtk-base-9.2.6-qt_py311h1234567_208.conda
linux-64::vtk-base-9.2.6-osmesa_py310h1234567_105.conda
linux-64::vtk-base-9.2.6-egl_py311h1234567_18.conda
linux-64::vtk-base-9.2.6-egl_py311h1234567_9.conda
linux-64::vtk-base-9.2.6-qt_py39h1234567_208.conda
linux-64::vtk-base-9.2.6-osmesa_py311h1234567_108.conda
linux-64::vtk-base-9.2.6-qt_py39h1234567_203.conda
linux-64::vtk-base-9.2.6-qt_py39h1234567_204.conda
linux-64::vtk-base-9.2.6-egl_py310h1234567_18.conda
linux-64::vtk-base-9.2.6-osmesa_py38h1234567_116.conda
linux-64::vtk-base-9.2.6-egl_py39h1234567_4.conda
linux-64::vtk-base-9.2.6-egl_py311h1234567_8.conda
linux-64::vtk-base-9.2.6-egl_py310h1234567_15.conda
linux-64::vtk-base-9.2.6-qt_py311h1234567_219.conda
linux-64::vtk-base-9.2.6-osmesa_py311h1234567_103.conda
linux-64::vtk-base-9.2.6-egl_py39h1234567_12.conda
linux-64::vtk-base-9.2.6-osmesa_py39h1234567_118.conda
linux-64::vtk-base-9.2.6-qt_py311h1234567_209.conda
linux-64::vtk-base-9.2.6-egl_py310h1234567_7.conda
linux-64::vtk-base-9.2.6-qt_py38h1234567_204.conda
linux-64::vtk-base-9.2.6-egl_py310h1234567_5.conda
linux-64::vtk-base-9.2.6-osmesa_py39h1234567_105.conda
linux-64::vtk-base-9.2.6-osmesa_py311h1234567_114.conda
linux-64::vtk-base-9.2.6-osmesa_py311h1234567_104.conda
linux-64::vtk-base-9.2.6-osmesa_py39h1234567_120.conda
linux-64::vtk-base-9.2.6-qt_py311h1234567_210.conda
linux-64::vtk-base-9.2.6-qt_py311h1234567_218.conda
linux-64::vtk-base-9.2.6-egl_py39h1234567_9.conda
linux-64::vtk-base-9.2.6-egl_py38h1234567_5.conda
linux-64::vtk-base-9.2.6-osmesa_py311h1234567_115.conda
linux-64::vtk-base-9.2.6-qt_py311h1234567_214.conda
linux-64::vtk-base-9.2.6-osmesa_py38h1234567_119.conda
linux-64::vtk-base-9.2.6-osmesa_py310h1234567_106.conda
linux-64::vtk-base-9.2.6-qt_py38h1234567_220.conda
linux-64::vtk-base-9.2.6-osmesa_py311h1234567_109.conda
linux-64::vtk-base-9.2.6-qt_py310h1234567_208.conda
linux-64::vtk-base-9.2.6-osmesa_py38h1234567_109.conda
linux-64::vtk-base-9.2.6-egl_py311h1234567_11.conda
linux-64::vtk-base-9.2.6-osmesa_py311h1234567_106.conda
linux-64::vtk-base-9.2.6-egl_py38h1234567_15.conda
linux-64::vtk-base-9.2.6-osmesa_py39h1234567_103.conda
linux-64::vtk-base-9.2.6-egl_py310h1234567_3.conda
linux-64::vtk-base-9.2.6-egl_py39h1234567_20.conda
linux-64::vtk-base-9.2.6-osmesa_py310h1234567_111.conda
linux-64::vtk-base-9.2.6-egl_py311h1234567_20.conda
linux-64::vtk-base-9.2.6-egl_py39h1234567_8.conda
linux-64::vtk-base-9.2.6-egl_py38h1234567_6.conda
linux-64::vtk-base-9.2.6-qt_py311h1234567_206.conda
linux-64::vtk-base-9.2.6-qt_py39h1234567_218.conda
linux-64::vtk-base-9.2.6-egl_py310h1234567_8.conda
linux-64::vtk-base-9.2.6-egl_py311h1234567_12.conda
linux-64::vtk-base-9.2.6-osmesa_py312h1234567_118.conda
linux-64::vtk-base-9.2.6-qt_py38h1234567_205.conda
linux-64::vtk-base-9.2.6-egl_py310h1234567_17.conda
linux-64::vtk-base-9.2.6-osmesa_py39h1234567_110.conda
linux-64::vtk-base-9.2.6-qt_py38h1234567_209.conda
linux-64::vtk-base-9.2.6-osmesa_py38h1234567_112.conda
linux-64::vtk-base-9.2.6-osmesa_py39h1234567_119.conda
linux-64::vtk-base-9.2.6-osmesa_py38h1234567_120.conda
linux-64::vtk-base-9.2.6-egl_py38h1234567_9.conda
linux-64::vtk-base-9.2.6-osmesa_py38h1234567_108.conda
linux-64::vtk-base-9.2.6-osmesa_py310h1234567_114.conda
linux-64::vtk-base-9.2.6-egl_py39h1234567_16.conda
linux-64::vtk-base-9.2.6-osmesa_py38h1234567_114.conda
linux-64::vtk-base-9.2.6-qt_py310h1234567_218.conda
linux-64::vtk-base-9.2.6-qt_py38h1234567_219.conda
linux-64::vtk-base-9.2.6-osmesa_py39h1234567_114.conda
linux-64::vtk-base-9.2.6-egl_py38h1234567_8.conda
linux-64::vtk-base-9.2.6-qt_py39h1234567_207.conda
linux-64::vtk-base-9.2.6-osmesa_py310h1234567_103.conda
linux-64::vtk-base-9.2.6-egl_py38h1234567_16.conda
linux-64::vtk-base-9.2.6-egl_py39h1234567_14.conda
linux-64::vtk-base-9.2.6-osmesa_py310h1234567_115.conda
linux-64::vtk-base-9.2.6-egl_py310h1234567_20.conda
linux-64::vtk-base-9.2.6-egl_py311h1234567_3.conda
linux-64::vtk-base-9.2.6-qt_py311h1234567_207.conda
linux-64::vtk-base-9.2.6-qt_py310h1234567_212.conda
linux-64::vtk-base-9.2.6-osmesa_py38h1234567_111.conda
linux-64::vtk-base-9.2.6-egl_py39h1234567_3.conda
linux-64::vtk-base-9.2.6-osmesa_py310h1234567_118.conda
linux-64::vtk-base-9.2.6-qt_py38h1234567_217.conda
linux-64::vtk-base-9.2.6-qt_py310h1234567_205.conda
linux-64::vtk-base-9.2.6-osmesa_py39h1234567_109.conda
linux-64::vtk-base-9.2.6-egl_py311h1234567_6.conda
linux-64::vtk-base-9.2.6-osmesa_py311h1234567_120.conda
linux-64::vtk-base-9.2.6-egl_py311h1234567_7.conda
linux-64::vtk-base-9.2.6-osmesa_py39h1234567_113.conda
linux-64::vtk-base-9.2.6-qt_py39h1234567_219.conda
linux-64::vtk-base-9.2.6-qt_py312h1234567_220.conda
linux-64::vtk-base-9.2.6-qt_py312h1234567_219.conda
linux-64::vtk-base-9.2.6-egl_py39h1234567_7.conda
linux-64::vtk-base-9.2.6-osmesa_py311h1234567_107.conda
linux-64::vtk-base-9.2.6-egl_py39h1234567_10.conda
linux-64::vtk-base-9.2.6-egl_py39h1234567_19.conda
linux-64::vtk-base-9.2.6-qt_py39h1234567_213.conda
linux-64::vtk-base-9.2.6-qt_py310h1234567_203.conda
linux-64::vtk-base-9.2.6-qt_py310h1234567_213.conda
linux-64::vtk-base-9.2.6-qt_py38h1234567_212.conda
linux-64::vtk-base-9.2.6-egl_py38h1234567_12.conda
linux-64::vtk-base-9.2.6-qt_py38h1234567_207.conda
linux-64::vtk-base-9.2.6-egl_py311h1234567_15.conda
linux-64::vtk-base-9.2.6-osmesa_py310h1234567_109.conda
linux-64::vtk-base-9.2.6-qt_py310h1234567_220.conda
linux-64::vtk-base-9.2.6-qt_py311h1234567_216.conda
linux-64::vtk-base-9.2.6-osmesa_py38h1234567_107.conda
linux-64::vtk-base-9.2.6-egl_py311h1234567_5.conda
linux-64::vtk-base-9.2.6-egl_py38h1234567_14.conda
linux-64::vtk-base-9.2.6-egl_py310h1234567_16.conda
linux-64::vtk-base-9.2.6-egl_py310h1234567_19.conda
linux-64::vtk-base-9.2.6-egl_py310h1234567_12.conda
linux-64::vtk-base-9.2.6-qt_py311h1234567_205.conda
linux-64::vtk-base-9.2.6-qt_py39h1234567_217.conda
linux-64::vtk-base-9.2.6-osmesa_py38h1234567_106.conda
linux-64::vtk-base-9.2.6-qt_py38h1234567_203.conda
linux-64::vtk-base-9.2.6-qt_py39h1234567_220.conda
linux-64::vtk-base-9.2.6-qt_py39h1234567_216.conda
linux-64::vtk-base-9.2.6-osmesa_py312h1234567_119.conda
linux-64::vtk-base-9.2.6-qt_py310h1234567_216.conda
linux-64::vtk-base-9.2.6-egl_py39h1234567_6.conda
linux-64::vtk-base-9.2.6-osmesa_py39h1234567_112.conda
linux-64::vtk-base-9.2.6-egl_py310h1234567_13.conda
linux-64::vtk-base-9.2.6-osmesa_py311h1234567_111.conda
linux-64::vtk-base-9.2.6-egl_py310h1234567_11.conda
linux-64::vtk-base-9.2.6-qt_py311h1234567_220.conda
linux-64::vtk-base-9.2.6-egl_py311h1234567_4.conda
linux-64::vtk-base-9.2.6-osmesa_py310h1234567_116.conda
linux-64::vtk-base-9.2.6-osmesa_py310h1234567_119.conda
linux-64::vtk-base-9.2.6-egl_py39h1234567_18.conda
linux-64::vtk-base-9.2.6-osmesa_py38h1234567_118.conda
linux-64::vtk-base-9.2.6-egl_py311h1234567_17.conda
linux-64::vtk-base-9.2.6-osmesa_py39h1234567_111.conda
linux-64::vtk-base-9.2.6-osmesa_py38h1234567_104.conda
linux-64::vtk-base-9.2.6-egl_py310h1234567_10.conda
linux-64::vtk-base-9.2.6-qt_py311h1234567_203.conda
linux-64::vtk-base-9.2.6-egl_py310h1234567_9.conda
linux-64::vtk-base-9.2.6-qt_py310h1234567_219.conda
linux-64::vtk-base-9.2.6-qt_py39h1234567_215.conda
linux-64::vtk-base-9.2.6-osmesa_py311h1234567_112.conda
linux-64::vtk-base-9.2.6-osmesa_py311h1234567_118.conda
linux-64::vtk-base-9.2.6-qt_py311h1234567_217.conda
linux-64::vtk-base-9.2.6-egl_py310h1234567_4.conda
-    "libexpat >=2.5.0,<3.0a0",
+    "libexpat >=2.5.0,<2.6.0a0",
```

</details>