### PR TITLE
Use conda_index.index._apply_instructions

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -16,7 +16,7 @@ import requests
 from packaging.version import parse as parse_version
 from concurrent.futures import ProcessPoolExecutor, as_completed
 
-from conda_build.index import _apply_instructions
+from conda_index.index import _apply_instructions
 from show_diff import show_record_diffs
 from get_license_family import get_license_family
 from patch_yaml_utils import (

--- a/recipe/show_diff.py
+++ b/recipe/show_diff.py
@@ -7,7 +7,7 @@ import os
 import urllib
 from concurrent.futures import ProcessPoolExecutor, as_completed
 
-from conda_build.index import _apply_instructions
+from conda_index.index import _apply_instructions
 
 CACHE_DIR = os.environ.get(
     "CACHE_DIR", os.path.join(os.path.dirname(os.path.abspath(__file__)), "cache")


### PR DESCRIPTION
conda_build.index._apply_instructions is marked for deprecation.
refs:
- https://github.com/conda/conda-build/pull/5152#discussion_r1468079893
- https://github.com/conda/conda-build/pull/5226

Checklist

* [ ] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
