### PR TITLE
Avoid conda 24.3.0 breaking conda-build

### DIFF
--- a/recipe/patch_yaml/conda-build.yaml
+++ b/recipe/patch_yaml/conda-build.yaml
@@ -86,6 +86,7 @@ if:
   name: conda-build
   version_gt: 3.21.8
   version_lt: 24.3.0
+  timestamp_le: 1710834612324  # 2024-03-19
 then:
   - tighten_depends:
       name: conda

--- a/recipe/patch_yaml/conda-build.yaml
+++ b/recipe/patch_yaml/conda-build.yaml
@@ -90,4 +90,4 @@ if:
 then:
   - tighten_depends:
       name: conda
-      upper_bound: 24.3.0 
+      upper_bound: 24.3.0

--- a/recipe/patch_yaml/conda-build.yaml
+++ b/recipe/patch_yaml/conda-build.yaml
@@ -79,3 +79,14 @@ then:
   - tighten_depends:
       name: conda
       upper_bound: 23.9.0
+---
+# conda.auxlib.packaging was removed in 24.3.0 but still neeeded by conda-build
+# https://github.com/conda/conda-build/pull/5221
+if:
+  name: conda-build
+  version_gt: 3.21.8
+  version_lt: 24.3.0
+then:
+  - tighten_depends:
+      name: conda
+      upper_bound: 24.3.0 


### PR DESCRIPTION
Checklist

* [X] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [X] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->


`conda` 24.3.0 deprecated some stuff that conda-build still used (see https://github.com/conda/conda-build/pull/5221).