### PR TITLE
Add py-lief<0.14 bound for conda-build<24.3.0

### DIFF
--- a/recipe/patch_yaml/conda-build.yaml
+++ b/recipe/patch_yaml/conda-build.yaml
@@ -91,3 +91,13 @@ then:
   - tighten_depends:
       name: conda
       upper_bound: 24.3.0
+---
+# https://github.com/conda/conda-build/issues/5227
+if:
+  name: conda-build
+  version_lt: 24.3.0
+  timestamp_le: 1711365884254  # 2024-03-25
+then:
+  - tighten_depends:
+      name: py-lief
+      upper_bound: "0.14"


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
ref:
- https://github.com/conda/conda-build/issues/5227