### PR TITLE
Add patch for j2cli to be incompatible with python 3.12

### DIFF
--- a/recipe/patch_yaml/j2cli.yaml
+++ b/recipe/patch_yaml/j2cli.yaml
@@ -1,3 +1,6 @@
+# j2cli versions 0.3.10 and older used imp
+# which was removed from python 3.12
+# https://github.com/conda-forge/j2cli-feedstock/pull/2
 if:
   name: j2cli
   timestamp_lt: 1711413151000

--- a/recipe/patch_yaml/j2cli.yaml
+++ b/recipe/patch_yaml/j2cli.yaml
@@ -5,4 +5,4 @@ if:
 then:
   - tighten_depends:
       name: python
-      upper_bound: 3.11
+      upper_bound: 3.12

--- a/recipe/patch_yaml/j2cli.yaml
+++ b/recipe/patch_yaml/j2cli.yaml
@@ -1,0 +1,9 @@
+if:
+  name: j2cli
+  timestamp_lt: 1711413151000
+
+then:
+  - tighten_depends:
+      name: python
+      upper_bound: 3.12
+

--- a/recipe/patch_yaml/j2cli.yaml
+++ b/recipe/patch_yaml/j2cli.yaml
@@ -5,4 +5,4 @@ if:
 then:
   - tighten_depends:
       name: python
-      upper_bound: 3.12
+      upper_bound: '3.12'

--- a/recipe/patch_yaml/j2cli.yaml
+++ b/recipe/patch_yaml/j2cli.yaml
@@ -5,5 +5,4 @@ if:
 then:
   - tighten_depends:
       name: python
-      upper_bound: 3.12
-
+      upper_bound: 3.11


### PR DESCRIPTION
Checklist

* [ ] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
