### PR TITLE
Replace cuda-cccl-impl dependencies with cccl

### DIFF
--- a/recipe/patch_yaml/cuda-cccl-impl.yaml
+++ b/recipe/patch_yaml/cuda-cccl-impl.yaml
@@ -33,8 +33,8 @@ if:
   build_number: 0
 then:
   - replace_depends:
-      old: cuda-cccl-impl ==2.0.1
-      new: cccl ==2.2.0
+      old: cuda-cccl-impl 2.0.1
+      new: cccl 2.2.0
 ---
 # The cccl package replaces cuda-cccl-impl. This patch fixes previous cuda-cccl dependencies
 if:
@@ -43,5 +43,5 @@ if:
   build_number: 0
 then:
   - replace_depends:
-      old: cuda-cccl-impl ==2.0.1
-      new: cccl ==2.1.0
+      old: cuda-cccl-impl 2.0.1
+      new: cccl 2.1.0

--- a/recipe/patch_yaml/cuda-cccl-impl.yaml
+++ b/recipe/patch_yaml/cuda-cccl-impl.yaml
@@ -25,3 +25,23 @@ if:
 then:
   # Prevent clobbering with cccl
   - add_constrains: cccl <0.0.0a0
+---
+# The cccl package replaces cuda-cccl-impl. This patch fixes previous cuda-cccl dependencies
+if:
+  name: cuda-cccl
+  version: 12.3.101
+  build_number: 0
+then:
+  - replace_depends:
+      old: cuda-cccl-impl ==2.0.1
+      new: cccl ==2.2.0
+---
+# The cccl package replaces cuda-cccl-impl. This patch fixes previous cuda-cccl dependencies
+if:
+  name: cuda-cccl
+  version: 12.2.140
+  build_number: 0
+then:
+  - replace_depends:
+      old: cuda-cccl-impl ==2.0.1
+      new: cccl ==2.1.0


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
The `cuda-cccl-impl` package was replaced by `cccl`. We did not update `cuda-cccl` accordingly. This patch is to fix dependencies in `cuda-cccl` versions from the CUDA 12.3 and 12.2 releases. 

The latest 12.4 `cuda-cccl` have already been fixed in https://github.com/conda-forge/cuda-cccl-feedstock/pull/7
Versions from the 12.1 and 12.0 releases do not need to move from `cuda-cccl-impl` as the 2.0.1 version is what they shipped with.