### PR TITLE
add historic pins for sqlglot vs sqlglotrs

### DIFF
--- a/recipe/patch_yaml/sqlglot.yaml
+++ b/recipe/patch_yaml/sqlglot.yaml
@@ -44,6 +44,7 @@ then:
       - sqlglotrs 0.1.3.*
   - remove_constrains:
       - sqlglot 0.1.3.*
+      - sqlglot 0.1.2.*
 
 ---
 if:

--- a/recipe/patch_yaml/sqlglot.yaml
+++ b/recipe/patch_yaml/sqlglot.yaml
@@ -1,0 +1,58 @@
+if:
+  name: sqlglot
+  timestamp_lt: 1712352563000
+  version_ge: 20.10.0
+  version_le: 21.0.1
+then:
+  - add_constrains:
+      - sqlglotrs 0.1.0.*
+  - remove_constrains:
+      - sqlglot 0.1.0.*
+
+---
+if:
+  name: sqlglot
+  timestamp_lt: 1712352563000
+  version_ge: 21.0.2
+  version_le: 22.0.1
+then:
+  - add_constrains:
+      - sqlglotrs 0.1.1.*
+  - remove_constrains:
+      - sqlglot 0.1.1.*
+
+---
+if:
+  name: sqlglot
+  timestamp_lt: 1712352563000
+  version_ge: 22.1.0
+  version_le: 23.0.5
+then:
+  - add_constrains:
+      - sqlglotrs 0.1.2.*
+  - remove_constrains:
+      - sqlglot 0.1.2.*
+
+---
+if:
+  name: sqlglot
+  timestamp_lt: 1712352563000
+  version_ge: 23.2.0
+  version_le: 23.3.0
+then:
+  - add_constrains:
+      - sqlglotrs 0.1.3.*
+  - remove_constrains:
+      - sqlglot 0.1.3.*
+
+---
+if:
+  name: sqlglot
+  timestamp_lt: 1712352563000
+  version_ge: 23.6.3
+  version_le: 23.7.0
+then:
+  - add_constrains:
+      - sqlglotrs 0.2.0.*
+  - remove_constrains:
+      - sqlglot 0.2.0.*


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

References:
- backport of: https://github.com/conda-forge/sqlglot-feedstock/pull/398
  - fixed on [`noarch/sqlglot-23.7.0-pyhd8ed1ab_1.conda`](https://anaconda.org/conda-forge/sqlglot/files?version=23.7.0)
- original PR that introduced the issue: https://github.com/conda-forge/sqlglot-feedstock/pull/391

:bell: @conda-forge/sqlglot @conda-forge/sqlglotrs

<details>

<summary>

`python recipe/show_diff.py`

</summary>


```diff

2024-04-06T01:27:14.5557572Z ============================== 2 passed in 2.39s ===============================
2024-04-06T01:27:15.7946966Z 
2024-04-06T01:32:08.7206251Z patching repodata:   0%|          | 0/9 [00:00<?, ?it/s]
2024-04-06T01:32:08.7301324Z patching repodata:  11%|█         | 1/9 [04:52<39:03, 292.92s/it]
2024-04-06T01:32:08.7302061Z ================================================================================
2024-04-06T01:32:08.7302690Z ================================================================================
2024-04-06T01:32:08.7302940Z noarch
2024-04-06T01:32:08.7303333Z noarch::sqlglot-20.11.0-pyhd8ed1ab_0.conda
2024-04-06T01:32:08.7303646Z noarch::sqlglot-21.0.0-pyhd8ed1ab_0.conda
2024-04-06T01:32:08.7303925Z noarch::sqlglot-21.0.1-pyhd8ed1ab_0.conda
2024-04-06T01:32:08.7304098Z +  "constrains": [
2024-04-06T01:32:08.7304272Z +    "sqlglotrs 0.1.0.*"
2024-04-06T01:32:08.7304410Z +  ],
2024-04-06T01:32:08.7304657Z noarch::sqlglot-21.1.2-pyhd8ed1ab_0.conda
2024-04-06T01:32:08.7304906Z noarch::sqlglot-21.1.1-pyhd8ed1ab_0.conda
2024-04-06T01:32:08.7305184Z noarch::sqlglot-21.2.0-pyhd8ed1ab_0.conda
2024-04-06T01:32:08.7305436Z noarch::sqlglot-21.1.0-pyhd8ed1ab_0.conda
2024-04-06T01:32:08.7305719Z noarch::sqlglot-21.2.1-pyhd8ed1ab_0.conda
2024-04-06T01:32:08.7305966Z noarch::sqlglot-22.0.1-pyhd8ed1ab_0.conda
2024-04-06T01:32:08.7306243Z noarch::sqlglot-21.0.2-pyhd8ed1ab_0.conda
2024-04-06T01:32:08.7306433Z +  "constrains": [
2024-04-06T01:32:08.7306577Z +    "sqlglotrs 0.1.1.*"
2024-04-06T01:32:08.7306742Z +  ],
2024-04-06T01:32:08.7306958Z noarch::sqlglot-22.3.1-pyhd8ed1ab_1.conda
2024-04-06T01:32:08.7307232Z noarch::sqlglot-23.0.0-pyhd8ed1ab_0.conda
2024-04-06T01:32:08.7307480Z noarch::sqlglot-23.0.4-pyhd8ed1ab_0.conda
2024-04-06T01:32:08.7307755Z noarch::sqlglot-22.1.1-pyhd8ed1ab_0.conda
2024-04-06T01:32:08.7308004Z noarch::sqlglot-23.0.5-pyhd8ed1ab_0.conda
2024-04-06T01:32:08.7308281Z noarch::sqlglot-22.2.1-pyhd8ed1ab_0.conda
2024-04-06T01:32:08.7308708Z noarch::sqlglot-23.0.2-pyhd8ed1ab_0.conda
2024-04-06T01:32:08.7308990Z noarch::sqlglot-22.3.1-pyhd8ed1ab_2.conda
2024-04-06T01:32:08.7309245Z noarch::sqlglot-23.0.1-pyhd8ed1ab_0.conda
2024-04-06T01:32:08.7309523Z noarch::sqlglot-22.3.0-pyhd8ed1ab_0.conda
2024-04-06T01:32:08.7309809Z noarch::sqlglot-22.4.0-pyhd8ed1ab_0.conda
2024-04-06T01:32:08.7310066Z noarch::sqlglot-22.2.0-pyhd8ed1ab_0.conda
2024-04-06T01:32:08.7310347Z noarch::sqlglot-22.5.0-pyhd8ed1ab_0.conda
2024-04-06T01:32:08.7310601Z noarch::sqlglot-22.3.1-pyhd8ed1ab_0.conda
2024-04-06T01:32:08.7311282Z noarch::sqlglot-22.1.0-pyhd8ed1ab_0.conda
2024-04-06T01:32:08.7311546Z noarch::sqlglot-23.0.3-pyhd8ed1ab_0.conda
2024-04-06T01:32:08.7311745Z +  "constrains": [
2024-04-06T01:32:08.7311894Z +    "sqlglotrs 0.1.2.*"
2024-04-06T01:32:08.7312052Z +  ],
2024-04-06T01:32:08.7312609Z noarch::sqlglot-23.0.5-pyhd8ed1ab_1.conda
2024-04-06T01:32:08.7312898Z -    "sqlglot 0.1.2.*"
2024-04-06T01:32:08.7313132Z +    "sqlglotrs 0.1.2.*"
2024-04-06T01:32:08.7313379Z noarch::sqlglot-23.2.0-pyhd8ed1ab_0.conda
2024-04-06T01:32:08.7313667Z -    "sqlglot 0.1.2.*"
2024-04-06T01:32:08.7313834Z +    "sqlglotrs 0.1.3.*"
2024-04-06T01:32:08.7314136Z noarch::sqlglot-23.2.0-pyhd8ed1ab_1.conda
2024-04-06T01:32:08.7314406Z noarch::sqlglot-23.3.0-pyhd8ed1ab_0.conda
2024-04-06T01:32:08.7314925Z -    "sqlglot 0.1.3.*"
2024-04-06T01:32:08.7315080Z +    "sqlglotrs 0.1.3.*"
2024-04-06T01:32:08.7315382Z noarch::sqlglot-23.6.4-pyhd8ed1ab_0.conda
2024-04-06T01:32:08.7315635Z noarch::sqlglot-23.6.3-pyhd8ed1ab_0.conda
2024-04-06T01:32:08.7315962Z noarch::sqlglot-23.7.0-pyhd8ed1ab_0.conda
2024-04-06T01:32:08.7316347Z -    "sqlglot 0.2.0.*"
2024-04-06T01:32:08.7316536Z +    "sqlglotrs 0.2.0.*"
2024-04-06T01:32:08.7316622Z 
2024-04-06T01:32:09.6761432Z 
2024-04-06T01:32:09.6771506Z patching repodata:  22%|██▏       | 2/9 [04:53<14:08, 121.18s/it]
2024-04-06T01:32:09.6778732Z ================================================================================
2024-04-06T01:32:09.6785183Z ================================================================================
2024-04-06T01:32:09.6797538Z linux-armv7l
2024-04-06T01:32:09.6799557Z 
2024-04-06T01:36:05.5757444Z 
2024-04-06T01:36:05.5769216Z patching repodata:  33%|███▎      | 3/9 [08:49<17:21, 173.56s/it]
2024-04-06T01:36:05.5816940Z ================================================================================
2024-04-06T01:36:05.5817562Z ================================================================================
2024-04-06T01:36:05.5817944Z linux-aarch64
2024-04-06T01:36:05.5818101Z 
2024-04-06T01:39:37.4202871Z 
2024-04-06T01:39:37.4206498Z patching repodata:  44%|████▍     | 4/9 [12:21<15:43, 188.68s/it]
2024-04-06T01:39:37.4207247Z ================================================================================
2024-04-06T01:39:37.4207820Z ================================================================================
2024-04-06T01:39:37.4232028Z linux-ppc64le
2024-04-06T01:39:37.4232494Z 
2024-04-06T01:39:53.4350384Z 
2024-04-06T01:39:53.4376802Z patching repodata:  56%|█████▌    | 5/9 [12:37<08:25, 126.41s/it]
2024-04-06T01:39:53.4377949Z ================================================================================
2024-04-06T01:39:53.4458218Z ================================================================================
2024-04-06T01:39:53.4459079Z linux-64
2024-04-06T01:39:53.4459203Z 
2024-04-06T01:43:05.4296933Z 
2024-04-06T01:43:05.4337390Z ================================================================================
2024-04-06T01:43:05.4338844Z ================================================================================
2024-04-06T01:43:05.4340148Z osx-arm64
2024-04-06T01:43:05.4340545Z 
2024-04-06T01:43:05.4340695Z 
2024-04-06T01:43:43.6829592Z patching repodata:  67%|██████▋   | 6/9 [15:49<07:26, 148.71s/it]
2024-04-06T01:43:43.6831404Z patching repodata:  78%|███████▊  | 7/9 [16:27<03:45, 112.60s/it]
2024-04-06T01:43:43.6831934Z ================================================================================
2024-04-06T01:43:43.6832447Z ================================================================================
2024-04-06T01:43:43.6833099Z win-32
2024-04-06T01:43:43.6833386Z 
2024-04-06T01:50:52.2256533Z 
2024-04-06T01:50:52.2350742Z patching repodata:  89%|████████▉ | 8/9 [23:36<03:33, 213.18s/it]
2024-04-06T01:50:52.2356446Z ================================================================================
2024-04-06T01:50:52.2357409Z ================================================================================
2024-04-06T01:50:52.2418025Z osx-64
2024-04-06T01:50:52.2418449Z 
2024-04-06T01:51:53.7902795Z 
2024-04-06T01:51:53.7904104Z ================================================================================
2024-04-06T01:51:53.7904691Z ================================================================================
2024-04-06T01:51:53.7904985Z win-64
2024-04-06T01:51:53.7905116Z 
2024-04-06T01:51:53.7905230Z 
2024-04-06T01:51:53.7905903Z patching repodata: 100%|██████████| 9/9 [24:37<00:00, 165.78s/it]
2024-04-06T01:51:53.7912437Z patching repodata: 100%|██████████| 9/9 [24:37<00:00, 164.22s/it]
2024-04-06T01:51:54.9286646Z 
2024-04-06T01:51:54.9288720Z Resource usage statistics from building conda-forge-repodata-patches:
2024-04-06T01:51:54.9333975Z    Process count: 5
2024-04-06T01:51:54.9334516Z    CPU time: Sys=0:00:12.5, User=0:45:51.1
2024-04-06T01:51:54.9335968Z    Memory: 3.5G
2024-04-06T01:51:54.9336271Z    Disk usage: 1.7K
2024-04-06T01:51:54.9339708Z    Time elapsed: 0:24:45.5
```

</details>

notes:
- maybe `conda-forge recipe-lint` should catch self-depends :sweat_smile: 