### PR TITLE
fix python constraint for networkx 3.3

### DIFF
--- a/recipe/patch_yaml/networkx.yaml
+++ b/recipe/patch_yaml/networkx.yaml
@@ -45,3 +45,12 @@ then:
   - replace_depends:
       old: python >=3.8
       new: python >=3.9
+---
+if:
+  name: networkx
+  version: "3.3"
+  build_number: 0
+then:
+  - replace_depends:
+      old: python >=3.9
+      new: python >=3.10


### PR DESCRIPTION
Networkx 3.3 does not support Python 3.9 anymore, see https://github.com/conda-forge/networkx-feedstock/pull/57, resp. failures of the kind:
```
TypeError: entry_points() got an unexpected keyword argument 'group'
```

We also needed to fix this previously already, see https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/commit/68849378b451f909b2aac6ee783fa5ba4d3dffee.

CC @conda-forge/networkx 