### PR TITLE
Add missing libintl-devel dependency to glib

### DIFF
--- a/recipe/patch_yaml/glib.yaml
+++ b/recipe/patch_yaml/glib.yaml
@@ -1,0 +1,12 @@
+if:
+  name: glib
+  version: "2.80.0"
+  build_number: 2
+  timestamp_lt: 1712499562000
+  subdir_in:
+    - win-64
+    - osx-64
+    - osx-arm64
+then:
+  - add_depends:
+      - libintl-devel


### PR DESCRIPTION
Diff:

<details>

```
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
osx-arm64
osx-arm64::glib-2.80.0-hfc324ee_2.conda
+    "libintl-devel",
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
noarch
================================================================================
================================================================================
win-64
win-64::glib-2.80.0-h39d0aa6_2.conda
+    "libintl-devel",
================================================================================
================================================================================
linux-64
================================================================================
================================================================================
osx-64
```

Note that `osx-64` is missing from the list as repodata has not been synced for it yet (seems really slow today again).
</details>

Fixed in https://github.com/conda-forge/glib-feedstock/pull/172