### PR TITLE
ensure `vs20YY_{{ target }}` constrains `vs_{{ target }} 20YY`

### DIFF
--- a/recipe/patch_yaml/vs.yaml
+++ b/recipe/patch_yaml/vs.yaml
@@ -1,0 +1,23 @@
+if:
+  name: vs2017_win-64
+  timestamp_lt: 1712701412000
+then:
+  - add_constrains: vs_win-64 2017.*
+---
+if:
+  name: vs2019_win-64
+  timestamp_lt: 1712701412000
+then:
+  - add_constrains: vs_win-64 2019.*
+---
+if:
+  name: vs2022_win-64
+  timestamp_lt: 1712701412000
+then:
+  - add_constrains: vs_win-64 2022.*
+---
+if:
+  name: vs2022_win-arm64
+  timestamp_lt: 1712701412000
+then:
+  - add_constrains: vs_win-arm64 2022.*


### PR DESCRIPTION
From discussion in https://github.com/conda-forge/conda-forge.github.io/issues/2102, matches https://github.com/conda-forge/vc-feedstock/pull/75 for previous releases (minus the minor version, which is not that relevant AFAICT)