### PR TITLE
Fix sktime constraint on pycatch22

### DIFF
--- a/recipe/patch_yaml/sktime.yaml
+++ b/recipe/patch_yaml/sktime.yaml
@@ -1,0 +1,8 @@
+if:
+  name: sktime
+  timestamp_lt: 1713265776000
+  version_in: "0.28.0"
+then:
+  - replace_constrains:
+      old: pycatch22 >=0.4,<0.4.4,
+      new: pycatch22 >=0.4,<0.4.4


### PR DESCRIPTION
The `pycatch22` constraint of `sktime` has a redundant comma at the end which breaks conda installations.

Relates to these:
* https://github.com/sktime/sktime/issues/6304
* https://github.com/conda/conda/issues/13802
* https://github.com/conda-forge/sktime-feedstock/pull/118


Output of the `show_diff.py` script I ran locally:

```
$ python show_diff.py 
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
osx-arm64::sktime-0.28.0-py38h10201cd_0.conda
osx-arm64::sktime-0.28.0-py310hbe9552e_0.conda
osx-arm64::sktime-0.28.0-py39h2804cbe_0.conda
osx-arm64::sktime-0.28.0-py311h267d04e_0.conda
-    "pycatch22 >=0.4,<0.4.4,",
+    "pycatch22 >=0.4,<0.4.4",
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
linux-aarch64
linux-aarch64::sktime-0.28.0-py310h4c7bcd0_0.conda
linux-aarch64::sktime-0.28.0-py38he3eb160_0.conda
linux-aarch64::sktime-0.28.0-py39h4420490_0.conda
linux-aarch64::sktime-0.28.0-py311hec3470c_0.conda
-    "pycatch22 >=0.4,<0.4.4,",
+    "pycatch22 >=0.4,<0.4.4",
================================================================================
================================================================================
noarch
================================================================================
================================================================================
win-64
win-64::sktime-0.28.0-py39hcbf5309_0.conda
win-64::sktime-0.28.0-py311h1ea47a8_0.conda
win-64::sktime-0.28.0-py310h5588dad_0.conda
win-64::sktime-0.28.0-py38haa244fe_0.conda
-    "pycatch22 >=0.4,<0.4.4,",
+    "pycatch22 >=0.4,<0.4.4",
================================================================================
================================================================================
osx-64
osx-64::sktime-0.28.0-py39h6e9494a_0.conda
osx-64::sktime-0.28.0-py311h6eed73b_0.conda
osx-64::sktime-0.28.0-py38h50d1736_0.conda
osx-64::sktime-0.28.0-py310h2ec42d9_0.conda
-    "pycatch22 >=0.4,<0.4.4,",
+    "pycatch22 >=0.4,<0.4.4",
================================================================================
================================================================================
linux-64
linux-64::sktime-0.28.0-py39hf3d152e_0.conda
linux-64::sktime-0.28.0-py38h578d9bd_0.conda
linux-64::sktime-0.28.0-py311h38be061_0.conda
linux-64::sktime-0.28.0-py310hff52083_0.conda
-    "pycatch22 >=0.4,<0.4.4,",
+    "pycatch22 >=0.4,<0.4.4",
```