### PR TITLE
Patch PyQtGraph 0.13.4 to require Python 3.9+

### DIFF
--- a/recipe/patch_yaml/pyqtgraph.yaml
+++ b/recipe/patch_yaml/pyqtgraph.yaml
@@ -20,3 +20,12 @@ then:
   - replace_depends:
       old: python >=3.7
       new: python >=3.8
+---
+if:
+  name: pyqtgraph
+  version: "0.13.4"
+  build_number: 0
+then:
+  - replace_depends:
+      old: python >=3.8
+      new: python >=3.9


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

conda-forge recipe for pyqtgraph 0.13.3 indicates it is compatible with Python 3.8+, but it requires Python 3.9+