### PR TITLE
constrain all numpy-dependent packages to numpy <2

### DIFF
--- a/recipe/patch_yaml/numpy.yaml
+++ b/recipe/patch_yaml/numpy.yaml
@@ -1,0 +1,7 @@
+if:
+  has_depends: numpy?( *)
+  timestamp_lt: 1713569710960
+then:
+  - tighten_depends:
+      name: numpy
+      upper_bound: "2.0"

--- a/recipe/patch_yaml/numpy.yaml
+++ b/recipe/patch_yaml/numpy.yaml
@@ -1,5 +1,43 @@
 if:
   has_depends: numpy?( *)
+  has_depends: python >=3.9*
+  timestamp_lt: 1713569710960
+then:
+  - tighten_depends:
+      name: numpy
+      upper_bound: "2.0"
+---
+if:
+  has_depends: numpy?( *)
+  has_depends: python >=3.10*
+  timestamp_lt: 1713569710960
+then:
+  - tighten_depends:
+      name: numpy
+      upper_bound: "2.0"
+---
+if:
+  has_depends: numpy?( *)
+  has_depends: python >=3.11*
+  timestamp_lt: 1713569710960
+then:
+  - tighten_depends:
+      name: numpy
+      upper_bound: "2.0"
+---
+if:
+  has_depends: numpy?( *)
+  has_depends: python >=3.12*
+  timestamp_lt: 1713569710960
+then:
+  - tighten_depends:
+      name: numpy
+      upper_bound: "2.0"
+
+---
+if:
+  has_depends: numpy?( *)
+  subdir_in: noarch
   timestamp_lt: 1713569710960
 then:
   - tighten_depends:

--- a/recipe/patch_yaml/numpy.yaml
+++ b/recipe/patch_yaml/numpy.yaml
@@ -1,6 +1,7 @@
 if:
-  has_depends: numpy?( *)
-  has_depends: python >=3.9*
+  has_depends:
+    - numpy?( *)
+    - python >=3.9*
   timestamp_lt: 1713569710960
 then:
   - tighten_depends:
@@ -8,8 +9,9 @@ then:
       upper_bound: "2.0"
 ---
 if:
-  has_depends: numpy?( *)
-  has_depends: python >=3.10*
+  has_depends:
+    - numpy?( *)
+    - python >=3.10*
   timestamp_lt: 1713569710960
 then:
   - tighten_depends:
@@ -17,8 +19,9 @@ then:
       upper_bound: "2.0"
 ---
 if:
-  has_depends: numpy?( *)
-  has_depends: python >=3.11*
+  has_depends:
+    - numpy?( *)
+    - python >=3.11*
   timestamp_lt: 1713569710960
 then:
   - tighten_depends:
@@ -26,8 +29,9 @@ then:
       upper_bound: "2.0"
 ---
 if:
-  has_depends: numpy?( *)
-  has_depends: python >=3.12*
+  has_depends:
+    - numpy?( *)
+    - python >=3.12*
   timestamp_lt: 1713569710960
 then:
   - tighten_depends:


### PR DESCRIPTION
This addresses #516. It creates a huge diff (~\~200k~ ~100k[^1] artefacts affected 😱), which can be viewed in this [gist](https://gist.github.com/h-vetinari/f22e20a67ed1a119fed8cb0716bcb2c0).

[^1]: after restricting to py>39 & noarch

AFAICT, this is mainly due to various feedstocks open-coding a pure run-dependency like `- numpy >=1.16`, which unsurprisingly doesn't get affected by the run-export we've had for 2 years (https://github.com/conda-forge/numpy-feedstock/commit/bca09161e46d1a986e061e4aaf6a21d8eb809a98) when building against numpy.