### PR TITLE
Patch build 1 too

### DIFF
--- a/recipe/patch_yaml/pyqtgraph.yaml
+++ b/recipe/patch_yaml/pyqtgraph.yaml
@@ -24,8 +24,11 @@ then:
 if:
   name: pyqtgraph
   version: "0.13.4"
-  build_number: 0
+  build_number_in: [0, 1]
 then:
   - replace_depends:
       old: python >=3.8
       new: python >=3.9
+  - replace_depends:
+      old: numpy >=1.20
+      new: numpy >=1.22


### PR DESCRIPTION
Due to a bad PR to conda-forge/pyqtgraph-feedstock build 1 needs to be patched as well.  Also caught
the case where the numpy version specified was too old.

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` --> - I do this by specifying version and builds effected.

<!-- Put any other comments or information here -->

`show_diff.py` output

```
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
noarch
noarch::pyqtgraph-0.13.4-pyhd8ed1ab_0.conda
-    "numpy >=1.20",
+    "numpy >=1.22",
noarch::pyqtgraph-0.13.4-pyhd8ed1ab_1.conda
-    "numpy >=1.20",
-    "python >=3.8"
+    "numpy >=1.22",
+    "python >=3.9"
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
================================================================================
================================================================================
linux-64
```