### PR TITLE
Patch `cupy-core` to allow it to be installed in CPU-only envs

### DIFF
--- a/recipe/patch_yaml/cupy.yaml
+++ b/recipe/patch_yaml/cupy.yaml
@@ -24,3 +24,23 @@ if:
 then:
   # create conflicts with older cupy to avoid coexistence
   - add_constrains: cupy=${version}
+---
+if:
+  name: cupy-core
+  version_le: 13.1.0
+  timestamp_lt: 1713751559000
+  has_depends: cuda-version >=11.2,<12
+then:
+  # move cuda-version from run to run_constrained
+  - remove_depends: cuda-version >=11.2,<12
+  - add_constrains: cuda-version >=11.2,<12
+---
+if:
+  name: cupy-core
+  version_le: 13.1.0
+  timestamp_lt: 1713751559000
+  has_depends: cuda-version >=12.0,<13
+then:
+  # move cuda-version from run to run_constrained
+  - remove_depends: cuda-version >=12.0,<13
+  - add_constrains: cuda-version >=12.0,<13


### PR DESCRIPTION
xref: https://github.com/conda-forge/cupy-feedstock/pull/264#issuecomment-2068276984

Checklist

* [ ] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
