### PR TITLE
BUG make sure skyproj uses mpl base >=3.6

### DIFF
--- a/recipe/patch_yaml/skyproj.yaml
+++ b/recipe/patch_yaml/skyproj.yaml
@@ -1,6 +1,6 @@
 if:
   name: skyproj
-  version_in: [1.2.3, 1.2.3]
+  version_in: [1.2.2, 1.2.3]
   timestamp_lt: 1712771759700
 then:
   - replace_depends:

--- a/recipe/patch_yaml/skyproj.yaml
+++ b/recipe/patch_yaml/skyproj.yaml
@@ -1,0 +1,8 @@
+if:
+  name: skyproj
+  version_in: [1.2.3, 1.2.3]
+  timestamp_lt: 1712771759700
+then:
+  - replace_depends:
+      old: matplotlib-base >=3.1
+      new: matplotlib-base >=3.6


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
