### PR TITLE
unmask build variable in repodata patch templating

### DIFF
--- a/recipe/patch_yaml_utils.py
+++ b/recipe/patch_yaml_utils.py
@@ -11,6 +11,7 @@ ALLOWED_TEMPLATE_KEYS = [
     "name",
     "version",
     "build_number",
+    "build",
     "subdir",
     "next_version",
     "major_version",

--- a/recipe/test_patch_yaml_utils.py
+++ b/recipe/test_patch_yaml_utils.py
@@ -217,8 +217,9 @@ def test_apply_patch_yaml_add(key):
 @pytest.mark.parametrize("key", ["depends", "constrains"])
 def test_apply_patch_yaml_add_template(key, rkey):
     patch_yaml = {"then": [{"add_" + key: f"blah ${rkey}"}]}
-    record = {"version": "10", "name": "foo", "build_number": 2}
-    _apply_patch_yaml(patch_yaml, record, "linux-64", None)
+    record = {"version": "10", "name": "foo", "build_number": 2, "build": "pyhd8_0"}
+    patched_record = record.copy()
+    _apply_patch_yaml(patch_yaml, patched_record, "linux-64", None)
     if rkey not in [
         "subdir",
         "next_version",
@@ -226,12 +227,7 @@ def test_apply_patch_yaml_add_template(key, rkey):
         "minor_version",
         "patch_version",
     ]:
-        assert record == {
-            "version": "10",
-            key: [f"blah {record[rkey]}"],
-            "name": "foo",
-            "build_number": 2,
-        }
+        assert patched_record == (record | {key: [f"blah {patched_record[rkey]}"]})
     else:
         if rkey == "subdir":
             nval = "linux-64"
@@ -244,16 +240,18 @@ def test_apply_patch_yaml_add_template(key, rkey):
         else:
             nval = "11"
 
-        assert record == {
-            "version": "10",
-            key: [f"blah {nval}"],
-            "name": "foo",
-            "build_number": 2,
-        }
+        assert patched_record == (
+            record
+            | {
+                key: [f"blah {nval}"],
+            }
+        )
 
     patch_yaml = {"then": [{"add_" + key: f"blah ${rkey}"}]}
-    record = {"version": "10", key: ["foo"], "name": "foo", "build_number": 2}
-    _apply_patch_yaml(patch_yaml, record, "linux-64", None)
+    patched_record = record | {
+        key: ["foo"],
+    }
+    _apply_patch_yaml(patch_yaml, patched_record, "linux-64", None)
     if rkey not in [
         "subdir",
         "next_version",
@@ -261,12 +259,12 @@ def test_apply_patch_yaml_add_template(key, rkey):
         "minor_version",
         "patch_version",
     ]:
-        assert record == {
-            "version": "10",
-            key: ["foo", f"blah {record[rkey]}"],
-            "name": "foo",
-            "build_number": 2,
-        }
+        assert patched_record == (
+            record
+            | {
+                key: ["foo", f"blah {patched_record[rkey]}"],
+            }
+        )
     else:
         if rkey == "subdir":
             nval = "linux-64"
@@ -279,12 +277,12 @@ def test_apply_patch_yaml_add_template(key, rkey):
         else:
             nval = "11"
 
-        assert record == {
-            "version": "10",
-            key: ["foo", f"blah {nval}"],
-            "name": "foo",
-            "build_number": 2,
-        }
+        assert patched_record == (
+            record
+            | {
+                key: ["foo", f"blah {nval}"],
+            }
+        )
 
 
 @pytest.mark.parametrize("key", ["depends", "constrains"])


### PR DESCRIPTION
Checklist

* [ ] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

xref: https://github.com/conda-forge/conda-forge.github.io/discussions/2160 
cc @jaimergp

I am still not sure whether there are guarantees that two outputs generated by the same build process will always share the same build hash (basically what exactly goes into the hash function).