### PR TITLE
seaborn: backport run_constrained on seaborn-base

### DIFF
--- a/recipe/patch_yaml/seaborn.yaml
+++ b/recipe/patch_yaml/seaborn.yaml
@@ -1,0 +1,5 @@
+if:
+  name: seaborn-base
+  timestamp_lt: 1713986364000
+then:
+  - add_constrains: seaborn =${version}=*_${build_number}


### PR DESCRIPTION
backport: https://github.com/conda-forge/seaborn-feedstock/pull/36

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
```
================================================================================
noarch
noarch::seaborn-base-0.10.1-py_1.tar.bz2
+  "constrains": [
+    "seaborn =0.10.1=*_1"
+  ],
noarch::seaborn-base-0.11.0-py_0.tar.bz2
+  "constrains": [
+    "seaborn =0.11.0=*_0"
+  ],
noarch::seaborn-base-0.11.0-pyhd8ed1ab_1.tar.bz2
+  "constrains": [
+    "seaborn =0.11.0=*_1"
+  ],
noarch::seaborn-base-0.11.1-pyhd8ed1ab_0.tar.bz2
+  "constrains": [
+    "seaborn =0.11.1=*_0"
+  ],
noarch::seaborn-base-0.11.1-pyhd8ed1ab_1.tar.bz2
+  "constrains": [
+    "seaborn =0.11.1=*_1"
+  ],
noarch::seaborn-base-0.11.2-pyhd8ed1ab_0.tar.bz2
+  "constrains": [
+    "seaborn =0.11.2=*_0"
+  ],
noarch::seaborn-base-0.12.0-pyhd8ed1ab_0.tar.bz2
+  "constrains": [
+    "seaborn =0.12.0=*_0"
+  ],
noarch::seaborn-base-0.12.1-pyhd8ed1ab_0.tar.bz2
+  "constrains": [
+    "seaborn =0.12.1=*_0"
+  ],
noarch::seaborn-base-0.12.2-pyhd8ed1ab_0.conda
+  "constrains": [
+    "seaborn =0.12.2=*_0"
+  ],
noarch::seaborn-base-0.13.0-pyhd8ed1ab_0.conda
+  "constrains": [
+    "seaborn =0.13.0=*_0"
+  ],
noarch::seaborn-base-0.13.1-pyhd8ed1ab_0.conda
+  "constrains": [
+    "seaborn =0.13.1=*_0"
+  ],
noarch::seaborn-base-0.13.2-pyhd8ed1ab_0.conda
+  "constrains": [
+    "seaborn =0.13.2=*_0"
+  ],
```

Note: this does not patch seaborn-base-0.13.2-pyhd8ed1ab_1.conda which got added a run_constrained that is impossible to fulfil (see the discussion in https://github.com/conda-forge/seaborn-feedstock/pull/35). That is unfortunate, but should not break anything, so I would suggest to just leave it be.