### PR TITLE
Add missing dependency on cuda-cupti for CUDA 12 jaxlib builds

### DIFF
--- a/recipe/patch_yaml/jaxlib.yaml
+++ b/recipe/patch_yaml/jaxlib.yaml
@@ -17,3 +17,15 @@ if:
 then:
   - add_depends:
       - abseil-cpp ==20220623.0
+---
+# To fix https://github.com/conda-forge/cuda-cupti-feedstock/issues/9
+# Some CUDA 12 builds used a cuda-cupti-dev with a missing run_exports
+if:
+  name: jaxlib
+  version: 0.4.23
+  build_number_in: [200, 201]
+  has_depends: cuda-version >=12.0,<13
+  subdir_in: [linux-64]
+then:
+  - add_depends:
+      - "cuda-cupti >=12.0.90,<13.0a0"


### PR DESCRIPTION
Fix for:
* https://github.com/conda-forge/cuda-cupti-feedstock/issues/14
* https://github.com/conda-forge/cuda-cupti-feedstock/issues/9


Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
