### PR TITLE
pin jupyterlab 4.2.0 vs jupyterlab_server >=2.27.1

### DIFF
--- a/recipe/patch_yaml/jupyterlab.yaml
+++ b/recipe/patch_yaml/jupyterlab.yaml
@@ -1,7 +1,7 @@
 if:
   name: jupyterlab
   timestamp_lt: 1715435708000
-  version_eq: 4.20.0
+  version_eq: 4.2.0
 then:
   - replace_depends:
       old: jupyterlab_server >=2.19.0,<3

--- a/recipe/patch_yaml/jupyterlab.yaml
+++ b/recipe/patch_yaml/jupyterlab.yaml
@@ -3,6 +3,6 @@ if:
   timestamp_lt: 1715435708000
   version_eq: 4.20.0
 then:
-  - tighten_depends:
-      name: jupyterlab_server
-      lower_bound: 2.27.1
+  - replace_depends:
+      old: jupyterlab_server >=2.19.0,<3
+      new: jupyterlab_server >=2.27.1,<3

--- a/recipe/patch_yaml/jupyterlab.yaml
+++ b/recipe/patch_yaml/jupyterlab.yaml
@@ -1,0 +1,8 @@
+if:
+  name: jupyterlab
+  timestamp_lt: 1715435708000
+  version_eq: 4.20.0
+then:
+  - tighten_depends:
+      name: jupyterlab_server
+      lower_bound: 2.27.1


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

References:
- noted on https://github.com/conda-forge/jupyterlab-feedstock/issues/433
  - fixed on `_1`: https://github.com/conda-forge/jupyterlab-feedstock/pull/434

Diff:
```diff
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
noarch
noarch::jupyterlab-4.2.0-pyhd8ed1ab_0.conda
-    "jupyterlab_server >=2.19.0,<3",
+    "jupyterlab_server >=2.27.1,<3",
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
================================================================================
================================================================================
linux-64
```