### PR TITLE
pyarrow: Constrain pandas<3 if pyarrow<15

### DIFF
--- a/recipe/patch_yaml/pyarrow.yaml
+++ b/recipe/patch_yaml/pyarrow.yaml
@@ -29,3 +29,17 @@ then:
       name: numpy
       max_pin: x
       upper_bound: "1.20"
+---
+# Prior to Pyarrow 15.0.0 the pandas_compat code made use of pandas.core.internals.DatetimeTZBlock,
+# which will no longer be exposed as of Pandas 3. This means that converting a Table to a Dataframe
+# using Pyarrow<15.0.0 and Pandas>=3 will result in an AttributeError. Therefore, we constrain the
+# Pandas version to less than 3 if the Pyarrow version is less than 15.
+# DatetimeTZBlock no longer exposed: https://github.com/pandas-dev/pandas/pull/58467/
+# Usage of DatetimeTZBlock removed: https://github.com/apache/arrow/pull/38321
+if:
+  name: pyarrow
+  timestamp_lt: 1715513055000  # Sun 12 May 2024 11:24:15 GMT
+  version_lt: 15.0.0
+  not_has_constrains: pandas?( *)
+then:
+  - add_constrains: pandas <=3.0a0


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

Pyarrow versions less than 15 result in an `AttributeError` when used with nightly builds of Pandas (>=3) due to breaking API changes in Pandas. Therefore, constrain the Pandas version to less than 3 if the Pyarrow version is less than 15.