### PR TITLE
more granular tightening for numpy 2.0

### DIFF
--- a/recipe/patch_yaml/numpy2_known_lower_bound.yaml
+++ b/recipe/patch_yaml/numpy2_known_lower_bound.yaml
@@ -4,6 +4,7 @@ if:
   name: astropy
   version_lt: 6.1.0
   has_depends: python >=3.9*
+  not_has_depends: numpy *,<2.0a0
 then:
   - tighten_depends:
       name: numpy
@@ -13,6 +14,7 @@ if:
   name: awkward
   version_lt: 2.6.3
   has_depends: python >=3.9*
+  not_has_depends: numpy *,<2.0a0
 then:
   - tighten_depends:
       name: numpy
@@ -22,6 +24,7 @@ if:
   name: bokeh
   version_lt: 3.4.1
   has_depends: python >=3.9*
+  not_has_depends: numpy *,<2.0a0
 then:
   - tighten_depends:
       name: numpy
@@ -32,6 +35,7 @@ if:
   name: boost
   version_lt: 1.86.0
   has_depends: python >=3.9*
+  not_has_depends: numpy *,<2.0a0
 then:
   - tighten_depends:
       name: numpy
@@ -41,6 +45,7 @@ if:
   name: cartopy
   version_lt: 0.23.0
   has_depends: python >=3.9*
+  not_has_depends: numpy *,<2.0a0
 then:
   - tighten_depends:
       name: numpy
@@ -50,6 +55,7 @@ if:
   name: contourpy
   version_lt: 1.2.1
   has_depends: python >=3.9*
+  not_has_depends: numpy *,<2.0a0
 then:
   - tighten_depends:
       name: numpy
@@ -59,6 +65,7 @@ if:
   name: cupy
   version_lt: 14.0.0
   has_depends: python >=3.9*
+  not_has_depends: numpy *,<2.0a0
 then:
   - tighten_depends:
       name: numpy
@@ -68,6 +75,7 @@ if:
   name: cython
   version_lt: 3.0.4
   has_depends: python >=3.9*
+  not_has_depends: numpy *,<2.0a0
 then:
   - tighten_depends:
       name: numpy
@@ -77,6 +85,7 @@ if:
   name: gdal
   version_lt: 3.9.0
   has_depends: python >=3.9*
+  not_has_depends: numpy *,<2.0a0
 then:
   - tighten_depends:
       name: numpy
@@ -86,6 +95,7 @@ if:
   name: geopandas
   version_lt: 0.14.4
   has_depends: python >=3.9*
+  not_has_depends: numpy *,<2.0a0
 then:
   - tighten_depends:
       name: numpy
@@ -95,6 +105,7 @@ if:
   name: h5py
   version_lt: 3.11.0
   has_depends: python >=3.9*
+  not_has_depends: numpy *,<2.0a0
 then:
   - tighten_depends:
       name: numpy
@@ -104,6 +115,7 @@ if:
   name: hypothesis
   version_lt: 6.100.2
   has_depends: python >=3.9*
+  not_has_depends: numpy *,<2.0a0
 then:
   - tighten_depends:
       name: numpy
@@ -113,6 +125,7 @@ if:
   name: jax
   version_lt: 0.4.26
   has_depends: python >=3.9*
+  not_has_depends: numpy *,<2.0a0
 then:
   - tighten_depends:
       name: numpy
@@ -123,15 +136,17 @@ if:
   name: libboost-python
   version_lt: 1.86.0
   has_depends: python >=3.9*
+  not_has_depends: numpy *,<2.0a0
 then:
   - tighten_depends:
       name: numpy
       upper_bound: "2.0"
 ---
 if:
-  name: matplotlib
+  name: matplotlib-base
   version_lt: 3.8.4
   has_depends: python >=3.9*
+  not_has_depends: numpy *,<2.0a0
 then:
   - tighten_depends:
       name: numpy
@@ -141,6 +156,7 @@ if:
   name: ml_dtypes
   version_lt: 0.4.0
   has_depends: python >=3.9*
+  not_has_depends: numpy *,<2.0a0
 then:
   - tighten_depends:
       name: numpy
@@ -150,6 +166,7 @@ if:
   name: networkx
   version_lt: 3.3.0
   has_depends: python >=3.9*
+  not_has_depends: numpy *,<2.0a0
 then:
   - tighten_depends:
       name: numpy
@@ -159,6 +176,7 @@ if:
   name: numba
   version_lt: 0.60.0
   has_depends: python >=3.9*
+  not_has_depends: numpy *,<2.0a0
 then:
   - tighten_depends:
       name: numpy
@@ -168,6 +186,7 @@ if:
   name: numcodecs
   version_lt: 0.12.1
   has_depends: python >=3.9*
+  not_has_depends: numpy *,<2.0a0
 then:
   - tighten_depends:
       name: numpy
@@ -177,6 +196,7 @@ if:
   name: numexpr
   version_lt: 2.10.0
   has_depends: python >=3.9*
+  not_has_depends: numpy *,<2.0a0
 then:
   - tighten_depends:
       name: numpy
@@ -186,6 +206,7 @@ if:
   name: pandas
   version_lt: 2.2.2
   has_depends: python >=3.9*
+  not_has_depends: numpy *,<2.0a0
 then:
   - tighten_depends:
       name: numpy
@@ -195,6 +216,7 @@ if:
   name: pyarrow
   version_lt: 16.0.0
   has_depends: python >=3.9*
+  not_has_depends: numpy *,<2.0a0
 then:
   - tighten_depends:
       name: numpy
@@ -204,6 +226,7 @@ if:
   name: pybind11
   version_lt: 2.12.0
   has_depends: python >=3.9*
+  not_has_depends: numpy *,<2.0a0
 then:
   - tighten_depends:
       name: numpy
@@ -213,6 +236,7 @@ if:
   name: pytorch
   version_lt: 2.3.0
   has_depends: python >=3.9*
+  not_has_depends: numpy *,<2.0a0
 then:
   - tighten_depends:
       name: numpy
@@ -224,6 +248,7 @@ if:
   # both enough as well as necessary to build scipy
   version_lt: 0.15.0
   has_depends: python >=3.9*
+  not_has_depends: numpy *,<2.0a0
 then:
   - tighten_depends:
       name: numpy
@@ -233,6 +258,7 @@ if:
   name: pywavelets
   version_lt: 1.6.0
   has_depends: python >=3.9*
+  not_has_depends: numpy *,<2.0a0
 then:
   - tighten_depends:
       name: numpy
@@ -242,6 +268,7 @@ if:
   name: rasterio
   version_lt: 1.3.10
   has_depends: python >=3.9*
+  not_has_depends: numpy *,<2.0a0
 then:
   - tighten_depends:
       name: numpy
@@ -251,6 +278,7 @@ if:
   name: seaborn
   version_lt: 0.13.2
   has_depends: python >=3.9*
+  not_has_depends: numpy *,<2.0a0
 then:
   - tighten_depends:
       name: numpy
@@ -260,6 +288,7 @@ if:
   name: scikit-bio
   version_lt: 0.6.1
   has_depends: python >=3.9*
+  not_has_depends: numpy *,<2.0a0
 then:
   - tighten_depends:
       name: numpy
@@ -269,6 +298,7 @@ if:
   name: scikit-image
   version_lt: 0.23.1
   has_depends: python >=3.9*
+  not_has_depends: numpy *,<2.0a0
 then:
   - tighten_depends:
       name: numpy
@@ -278,6 +308,7 @@ if:
   name: scikit-learn
   version_lt: 1.4.2
   has_depends: python >=3.9*
+  not_has_depends: numpy *,<2.0a0
 then:
   - tighten_depends:
       name: numpy
@@ -287,6 +318,7 @@ if:
   name: shapely
   version_lt: 2.0.4
   has_depends: python >=3.9*
+  not_has_depends: numpy *,<2.0a0
 then:
   - tighten_depends:
       name: numpy
@@ -296,6 +328,7 @@ if:
   name: statsmodels
   version_lt: 0.14.2
   has_depends: python >=3.9*
+  not_has_depends: numpy *,<2.0a0
 then:
   - tighten_depends:
       name: numpy
@@ -305,6 +338,7 @@ if:
   name: sympy
   version_lt: 1.12.1
   has_depends: python >=3.9*
+  not_has_depends: numpy *,<2.0a0
 then:
   - tighten_depends:
       name: numpy
@@ -314,6 +348,7 @@ if:
   name: threadpoolctl
   version_lt: 3.5.0
   has_depends: python >=3.9*
+  not_has_depends: numpy *,<2.0a0
 then:
   - tighten_depends:
       name: numpy
@@ -323,6 +358,7 @@ if:
   name: tifffile
   version_lt: 2024.4.24
   has_depends: python >=3.9*
+  not_has_depends: numpy *,<2.0a0
 then:
   - tighten_depends:
       name: numpy
@@ -332,6 +368,7 @@ if:
   name: unyt
   version_lt: 3.0.2
   has_depends: python >=3.9*
+  not_has_depends: numpy *,<2.0a0
 then:
   - tighten_depends:
       name: numpy
@@ -341,6 +378,7 @@ if:
   name: xgboost
   version_lt: 2.1.0
   has_depends: python >=3.9*
+  not_has_depends: numpy *,<2.0a0
 then:
   - tighten_depends:
       name: numpy
@@ -350,6 +388,7 @@ if:
   name: yt
   version_lt: 4.3.1
   has_depends: python >=3.9*
+  not_has_depends: numpy *,<2.0a0
 then:
   - tighten_depends:
       name: numpy
@@ -359,6 +398,7 @@ if:
   name: zarr
   version_lt: 2.18.0
   has_depends: python >=3.9*
+  not_has_depends: numpy *,<2.0a0
 then:
   - tighten_depends:
       name: numpy

--- a/recipe/patch_yaml/numpy2_known_lower_bound.yaml
+++ b/recipe/patch_yaml/numpy2_known_lower_bound.yaml
@@ -1,0 +1,365 @@
+# packages from https://github.com/numpy/numpy/issues/26191
+# where we know the lowest version that supports numpy 2.0
+if:
+  name: astropy
+  version_lt: 6.1.0
+  has_depends: python >=3.9*
+then:
+  - tighten_depends:
+      name: numpy
+      upper_bound: "2.0"
+---
+if:
+  name: awkward
+  version_lt: 2.6.3
+  has_depends: python >=3.9*
+then:
+  - tighten_depends:
+      name: numpy
+      upper_bound: "2.0"
+---
+if:
+  name: bokeh
+  version_lt: 3.4.1
+  has_depends: python >=3.9*
+then:
+  - tighten_depends:
+      name: numpy
+      upper_bound: "2.0"
+---
+if:
+  # legacy name for libboost-python
+  name: boost
+  version_lt: 1.86.0
+  has_depends: python >=3.9*
+then:
+  - tighten_depends:
+      name: numpy
+      upper_bound: "2.0"
+---
+if:
+  name: cartopy
+  version_lt: 0.23.0
+  has_depends: python >=3.9*
+then:
+  - tighten_depends:
+      name: numpy
+      upper_bound: "2.0"
+---
+if:
+  name: contourpy
+  version_lt: 1.2.1
+  has_depends: python >=3.9*
+then:
+  - tighten_depends:
+      name: numpy
+      upper_bound: "2.0"
+---
+if:
+  name: cupy
+  version_lt: 14.0.0
+  has_depends: python >=3.9*
+then:
+  - tighten_depends:
+      name: numpy
+      upper_bound: "2.0"
+---
+if:
+  name: cython
+  version_lt: 3.0.4
+  has_depends: python >=3.9*
+then:
+  - tighten_depends:
+      name: numpy
+      upper_bound: "2.0"
+---
+if:
+  name: gdal
+  version_lt: 3.9.0
+  has_depends: python >=3.9*
+then:
+  - tighten_depends:
+      name: numpy
+      upper_bound: "2.0"
+---
+if:
+  name: geopandas
+  version_lt: 0.14.4
+  has_depends: python >=3.9*
+then:
+  - tighten_depends:
+      name: numpy
+      upper_bound: "2.0"
+---
+if:
+  name: h5py
+  version_lt: 3.11.0
+  has_depends: python >=3.9*
+then:
+  - tighten_depends:
+      name: numpy
+      upper_bound: "2.0"
+---
+if:
+  name: hypothesis
+  version_lt: 6.100.2
+  has_depends: python >=3.9*
+then:
+  - tighten_depends:
+      name: numpy
+      upper_bound: "2.0"
+---
+if:
+  name: jax
+  version_lt: 0.4.26
+  has_depends: python >=3.9*
+then:
+  - tighten_depends:
+      name: numpy
+      upper_bound: "2.0"
+---
+if:
+  # no need to do -devel as well, as it depends exactly on this package
+  name: libboost-python
+  version_lt: 1.86.0
+  has_depends: python >=3.9*
+then:
+  - tighten_depends:
+      name: numpy
+      upper_bound: "2.0"
+---
+if:
+  name: matplotlib
+  version_lt: 3.8.4
+  has_depends: python >=3.9*
+then:
+  - tighten_depends:
+      name: numpy
+      upper_bound: "2.0"
+---
+if:
+  name: ml_dtypes
+  version_lt: 0.4.0
+  has_depends: python >=3.9*
+then:
+  - tighten_depends:
+      name: numpy
+      upper_bound: "2.0"
+---
+if:
+  name: networkx
+  version_lt: 3.3.0
+  has_depends: python >=3.9*
+then:
+  - tighten_depends:
+      name: numpy
+      upper_bound: "2.0"
+---
+if:
+  name: numba
+  version_lt: 0.60.0
+  has_depends: python >=3.9*
+then:
+  - tighten_depends:
+      name: numpy
+      upper_bound: "2.0"
+---
+if:
+  name: numcodecs
+  version_lt: 0.12.1
+  has_depends: python >=3.9*
+then:
+  - tighten_depends:
+      name: numpy
+      upper_bound: "2.0"
+---
+if:
+  name: numexpr
+  version_lt: 2.10.0
+  has_depends: python >=3.9*
+then:
+  - tighten_depends:
+      name: numpy
+      upper_bound: "2.0"
+---
+if:
+  name: pandas
+  version_lt: 2.2.2
+  has_depends: python >=3.9*
+then:
+  - tighten_depends:
+      name: numpy
+      upper_bound: "2.0"
+---
+if:
+  name: pyarrow
+  version_lt: 16.0.0
+  has_depends: python >=3.9*
+then:
+  - tighten_depends:
+      name: numpy
+      upper_bound: "2.0"
+---
+if:
+  name: pybind11
+  version_lt: 2.12.0
+  has_depends: python >=3.9*
+then:
+  - tighten_depends:
+      name: numpy
+      upper_bound: "2.0"
+---
+if:
+  name: pytorch
+  version_lt: 2.3.0
+  has_depends: python >=3.9*
+then:
+  - tighten_depends:
+      name: numpy
+      upper_bound: "2.0"
+---
+if:
+  name: pythran
+  # upstream only supports explicitly from 0.16.0, but 0.15.0 is
+  # both enough as well as necessary to build scipy
+  version_lt: 0.15.0
+  has_depends: python >=3.9*
+then:
+  - tighten_depends:
+      name: numpy
+      upper_bound: "2.0"
+---
+if:
+  name: pywavelets
+  version_lt: 1.6.0
+  has_depends: python >=3.9*
+then:
+  - tighten_depends:
+      name: numpy
+      upper_bound: "2.0"
+---
+if:
+  name: rasterio
+  version_lt: 1.3.10
+  has_depends: python >=3.9*
+then:
+  - tighten_depends:
+      name: numpy
+      upper_bound: "2.0"
+---
+if:
+  name: seaborn
+  version_lt: 0.13.2
+  has_depends: python >=3.9*
+then:
+  - tighten_depends:
+      name: numpy
+      upper_bound: "2.0"
+---
+if:
+  name: scikit-bio
+  version_lt: 0.6.1
+  has_depends: python >=3.9*
+then:
+  - tighten_depends:
+      name: numpy
+      upper_bound: "2.0"
+---
+if:
+  name: scikit-image
+  version_lt: 0.23.1
+  has_depends: python >=3.9*
+then:
+  - tighten_depends:
+      name: numpy
+      upper_bound: "2.0"
+---
+if:
+  name: scikit-learn
+  version_lt: 1.4.2
+  has_depends: python >=3.9*
+then:
+  - tighten_depends:
+      name: numpy
+      upper_bound: "2.0"
+---
+if:
+  name: shapely
+  version_lt: 2.0.4
+  has_depends: python >=3.9*
+then:
+  - tighten_depends:
+      name: numpy
+      upper_bound: "2.0"
+---
+if:
+  name: statsmodels
+  version_lt: 0.14.2
+  has_depends: python >=3.9*
+then:
+  - tighten_depends:
+      name: numpy
+      upper_bound: "2.0"
+---
+if:
+  name: sympy
+  version_lt: 1.12.1
+  has_depends: python >=3.9*
+then:
+  - tighten_depends:
+      name: numpy
+      upper_bound: "2.0"
+---
+if:
+  name: threadpoolctl
+  version_lt: 3.5.0
+  has_depends: python >=3.9*
+then:
+  - tighten_depends:
+      name: numpy
+      upper_bound: "2.0"
+---
+if:
+  name: tifffile
+  version_lt: 2024.4.24
+  has_depends: python >=3.9*
+then:
+  - tighten_depends:
+      name: numpy
+      upper_bound: "2.0"
+---
+if:
+  name: unyt
+  version_lt: 3.0.2
+  has_depends: python >=3.9*
+then:
+  - tighten_depends:
+      name: numpy
+      upper_bound: "2.0"
+---
+if:
+  name: xgboost
+  version_lt: 2.1.0
+  has_depends: python >=3.9*
+then:
+  - tighten_depends:
+      name: numpy
+      upper_bound: "2.0"
+---
+if:
+  name: yt
+  version_lt: 4.3.1
+  has_depends: python >=3.9*
+then:
+  - tighten_depends:
+      name: numpy
+      upper_bound: "2.0"
+---
+if:
+  name: zarr
+  version_lt: 2.18.0
+  has_depends: python >=3.9*
+then:
+  - tighten_depends:
+      name: numpy
+      upper_bound: "2.0"

--- a/recipe/patch_yaml/numpy2_unknown_lower_bound.yaml
+++ b/recipe/patch_yaml/numpy2_unknown_lower_bound.yaml
@@ -1,0 +1,149 @@
+# packages from https://github.com/numpy/numpy/issues/26191
+# where we DO NOT know the lowest version that supports numpy 2.0;
+# so patch everything using current timestamp.
+#
+# TODO: As soon as the lower bounds (for numpy 2.0 support) of these packages
+# become known, these should move to numpy2_known_lower_bound.yaml
+if:
+  name: biopython
+  has_depends: python >=3.9*
+  timestamp_lt: 1715576845035
+then:
+  - tighten_depends:
+      name: numpy
+      upper_bound: "2.0"
+---
+if:
+  name: dask
+  has_depends: python >=3.9*
+  timestamp_lt: 1715576845035
+then:
+  - tighten_depends:
+      name: numpy
+      upper_bound: "2.0"
+---
+if:
+  name: imagecodecs
+  has_depends: python >=3.9*
+  timestamp_lt: 1715576845035
+then:
+  - tighten_depends:
+      name: numpy
+      upper_bound: "2.0"
+---
+if:
+  name: imageio
+  has_depends: python >=3.9*
+  timestamp_lt: 1715576845035
+then:
+  - tighten_depends:
+      name: numpy
+      upper_bound: "2.0"
+---
+if:
+  name: keras
+  has_depends: python >=3.9*
+  timestamp_lt: 1715576845035
+then:
+  - tighten_depends:
+      name: numpy
+      upper_bound: "2.0"
+---
+if:
+  name: mdanalysis
+  has_depends: python >=3.9*
+  timestamp_lt: 1715576845035
+then:
+  - tighten_depends:
+      name: numpy
+      upper_bound: "2.0"
+---
+if:
+  name: netcdf4
+  has_depends: python >=3.9*
+  timestamp_lt: 1715576845035
+then:
+  - tighten_depends:
+      name: numpy
+      upper_bound: "2.0"
+---
+if:
+  name: py-opencv
+  has_depends: python >=3.9*
+  timestamp_lt: 1715576845035
+then:
+  - tighten_depends:
+      name: numpy
+      upper_bound: "2.0"
+---
+if:
+  name: pymc
+  has_depends: python >=3.9*
+  timestamp_lt: 1715576845035
+then:
+  - tighten_depends:
+      name: numpy
+      upper_bound: "2.0"
+---
+if:
+  name: pytables
+  has_depends: python >=3.9*
+  timestamp_lt: 1715576845035
+then:
+  - tighten_depends:
+      name: numpy
+      upper_bound: "2.0"
+---
+if:
+  name: pytensor
+  has_depends: python >=3.9*
+  timestamp_lt: 1715576845035
+then:
+  - tighten_depends:
+      name: numpy
+      upper_bound: "2.0"
+---
+if:
+  name: sparse
+  has_depends: python >=3.9*
+  timestamp_lt: 1715576845035
+then:
+  - tighten_depends:
+      name: numpy
+      upper_bound: "2.0"
+---
+if:
+  name: tensorflow
+  has_depends: python >=3.9*
+  timestamp_lt: 1715576845035
+then:
+  - tighten_depends:
+      name: numpy
+      upper_bound: "2.0"
+---
+if:
+  name: treelite
+  has_depends: python >=3.9*
+  timestamp_lt: 1715576845035
+then:
+  - tighten_depends:
+      name: numpy
+      upper_bound: "2.0"
+---
+if:
+  name: xarray
+  has_depends: python >=3.9*
+  timestamp_lt: 1715576845035
+then:
+  - tighten_depends:
+      name: numpy
+      upper_bound: "2.0"
+---
+if:
+  name: zfpy
+  has_depends: python >=3.9*
+  timestamp_lt: 1715576845035
+then:
+  - tighten_depends:
+      name: numpy
+      upper_bound: "2.0"

--- a/recipe/patch_yaml/numpy2_unknown_lower_bound.yaml
+++ b/recipe/patch_yaml/numpy2_unknown_lower_bound.yaml
@@ -8,6 +8,7 @@ if:
   name: biopython
   has_depends: python >=3.9*
   timestamp_lt: 1715576845035
+  not_has_depends: numpy *,<2.0a0
 then:
   - tighten_depends:
       name: numpy
@@ -17,6 +18,7 @@ if:
   name: dask
   has_depends: python >=3.9*
   timestamp_lt: 1715576845035
+  not_has_depends: numpy *,<2.0a0
 then:
   - tighten_depends:
       name: numpy
@@ -26,6 +28,7 @@ if:
   name: imagecodecs
   has_depends: python >=3.9*
   timestamp_lt: 1715576845035
+  not_has_depends: numpy *,<2.0a0
 then:
   - tighten_depends:
       name: numpy
@@ -35,6 +38,7 @@ if:
   name: imageio
   has_depends: python >=3.9*
   timestamp_lt: 1715576845035
+  not_has_depends: numpy *,<2.0a0
 then:
   - tighten_depends:
       name: numpy
@@ -44,6 +48,7 @@ if:
   name: keras
   has_depends: python >=3.9*
   timestamp_lt: 1715576845035
+  not_has_depends: numpy *,<2.0a0
 then:
   - tighten_depends:
       name: numpy
@@ -53,6 +58,7 @@ if:
   name: mdanalysis
   has_depends: python >=3.9*
   timestamp_lt: 1715576845035
+  not_has_depends: numpy *,<2.0a0
 then:
   - tighten_depends:
       name: numpy
@@ -62,6 +68,7 @@ if:
   name: netcdf4
   has_depends: python >=3.9*
   timestamp_lt: 1715576845035
+  not_has_depends: numpy *,<2.0a0
 then:
   - tighten_depends:
       name: numpy
@@ -71,6 +78,7 @@ if:
   name: py-opencv
   has_depends: python >=3.9*
   timestamp_lt: 1715576845035
+  not_has_depends: numpy *,<2.0a0
 then:
   - tighten_depends:
       name: numpy
@@ -80,6 +88,7 @@ if:
   name: pymc
   has_depends: python >=3.9*
   timestamp_lt: 1715576845035
+  not_has_depends: numpy *,<2.0a0
 then:
   - tighten_depends:
       name: numpy
@@ -89,6 +98,7 @@ if:
   name: pytables
   has_depends: python >=3.9*
   timestamp_lt: 1715576845035
+  not_has_depends: numpy *,<2.0a0
 then:
   - tighten_depends:
       name: numpy
@@ -98,6 +108,7 @@ if:
   name: pytensor
   has_depends: python >=3.9*
   timestamp_lt: 1715576845035
+  not_has_depends: numpy *,<2.0a0
 then:
   - tighten_depends:
       name: numpy
@@ -107,6 +118,7 @@ if:
   name: sparse
   has_depends: python >=3.9*
   timestamp_lt: 1715576845035
+  not_has_depends: numpy *,<2.0a0
 then:
   - tighten_depends:
       name: numpy
@@ -116,6 +128,7 @@ if:
   name: tensorflow
   has_depends: python >=3.9*
   timestamp_lt: 1715576845035
+  not_has_depends: numpy *,<2.0a0
 then:
   - tighten_depends:
       name: numpy
@@ -125,6 +138,7 @@ if:
   name: treelite
   has_depends: python >=3.9*
   timestamp_lt: 1715576845035
+  not_has_depends: numpy *,<2.0a0
 then:
   - tighten_depends:
       name: numpy
@@ -134,6 +148,7 @@ if:
   name: xarray
   has_depends: python >=3.9*
   timestamp_lt: 1715576845035
+  not_has_depends: numpy *,<2.0a0
 then:
   - tighten_depends:
       name: numpy
@@ -143,6 +158,7 @@ if:
   name: zfpy
   has_depends: python >=3.9*
   timestamp_lt: 1715576845035
+  not_has_depends: numpy *,<2.0a0
 then:
   - tighten_depends:
       name: numpy


### PR DESCRIPTION
Alternative to #712. Lowest numpy-2.0-compatible bounds per package taken from https://github.com/numpy/numpy/issues/26191.

A large number of packages in the patch yaml don't show up in the diff, which basically means that the run-exports were working without issue for those packages.

Mostly addresses #516
