### PR TITLE
DOC: Add explanation of repodata patch

### DIFF
--- a/recipe/README.md
+++ b/recipe/README.md
@@ -1,5 +1,12 @@
 # `conda-forge` Repodata Patching
 
+## What is a repodata patch?
+
+Sometimes, already published conda packages contain metadata errors (which can be repaired without needing to rebuild
+the packages). Most commonly, package dependencies are incorrect, but the package artifacts themselves
+are fine. A repodata patch specifies which packages are contain errors and how the package
+should be modified to fix the error.
+
 The best way to make a new patch is to use the patch YAML specification below. Custom patches
 in python can be put into the `gen_patch_json.py` file.
 


### PR DESCRIPTION
Part of the NumPy 2 migration annoucement directs package maintainers to this repository. Adding a bit more context to the README, might make their landing here softer.

Checklist

* [ ] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
