### PR TITLE
tighten run-exported libarrow 16 constraints to minor level

### DIFF
--- a/recipe/patch_yaml/libarrow.yaml
+++ b/recipe/patch_yaml/libarrow.yaml
@@ -1,0 +1,8 @@
+# need to tighten run-export from major to minor, see
+# https://github.com/conda-forge/arrow-cpp-feedstock/pull/1409
+if:
+  has_depends: libarrow >=16.0.0,<17.0a0
+then:
+  - tighten_depends:
+      name: libarrow
+      upper_bound: "16.1"


### PR DESCRIPTION
see https://github.com/conda-forge/arrow-cpp-feedstock/pull/1409

### output of `python show_diff.py`

```diff
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
osx-arm64::librerun-sdk-0.15.1-h37dcc22_1.conda
osx-arm64::pyarrow-tests-16.0.0-py310h072bfae_0.conda
osx-arm64::turbodbc-4.12.0-py310ha7a4bcf_1.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-h870dc84_24.conda
osx-arm64::libgdal-arrow-parquet-3.8.5-h496fde9_5.conda
osx-arm64::libgdal-arrow-parquet-3.8.5-h870dc84_4.conda
osx-arm64::pyarrow-tests-16.0.0-py311h7762100_0.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-h496fde9_25.conda
osx-arm64::libgdal-arrow-parquet-3.9.0-h870dc84_1.conda
osx-arm64::libgdal-arrow-parquet-3.9.0-h496fde9_2.conda
osx-arm64::pyarrow-tests-16.0.0-py312hc5e3ef6_0.conda
osx-arm64::turbodbc-4.12.0-py312h4edb63c_1.conda
osx-arm64::pyarrow-tests-16.0.0-py38hf3f6391_0.conda
osx-arm64::turbodbc-4.12.0-py311h663a3eb_1.conda
osx-arm64::pyarrow-tests-16.0.0-py39h9d97825_0.conda
-    "libarrow >=16.0.0,<17.0a0",
+    "libarrow >=16.0.0,<16.1.0a0",
================================================================================
================================================================================
linux-ppc64le
linux-ppc64le::pyarrow-tests-16.0.0-py38h4d0c9b9_0.conda
linux-ppc64le::pyarrow-tests-16.0.0-py310hb7dbd2e_0.conda
linux-ppc64le::pyarrow-tests-16.0.0-py311h6e1e640_0.conda
linux-ppc64le::pyarrow-tests-16.0.0-py312h87797d5_0.conda
linux-ppc64le::pyarrow-tests-16.0.0-py39h9b0ccd3_0.conda
linux-ppc64le::librerun-sdk-0.15.1-h580c8bb_1.conda
-    "libarrow >=16.0.0,<17.0a0",
+    "libarrow >=16.0.0,<16.1.0a0",
================================================================================
================================================================================
linux-aarch64
linux-aarch64::libgdal-arrow-parquet-3.9.0-h23849c3_2.conda
linux-aarch64::pyarrow-tests-16.0.0-py310h70ca0e3_0.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-h23849c3_25.conda
linux-aarch64::libgdal-arrow-parquet-3.9.0-h13dbb8b_1.conda
linux-aarch64::librerun-sdk-0.15.1-hb10aa79_1.conda
linux-aarch64::libgdal-arrow-parquet-3.8.5-h13dbb8b_4.conda
linux-aarch64::pyarrow-tests-16.0.0-py39h59ea48c_0.conda
linux-aarch64::pyarrow-tests-16.0.0-py312hfd4cb0c_0.conda
linux-aarch64::libgdal-arrow-parquet-3.8.5-h23849c3_5.conda
linux-aarch64::pyarrow-tests-16.0.0-py311hfc23d97_0.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-h13dbb8b_24.conda
linux-aarch64::pyarrow-tests-16.0.0-py38hc6bfc80_0.conda
-    "libarrow >=16.0.0,<17.0a0",
+    "libarrow >=16.0.0,<16.1.0a0",
================================================================================
================================================================================
noarch
================================================================================
================================================================================
win-64
win-64::pymongoarrow-1.3.0-py311hcba1cf7_1.conda
win-64::nyxus-0.7.5-py310h21c6c61_2.conda
win-64::nyxus-0.7.5-py38h1380443_2.conda
win-64::pyarrow-tests-16.0.0-py312h4af9903_0.conda
win-64::nyxus-0.7.5-py38ha0e0d49_2.conda
win-64::pymongoarrow-1.3.0-py39h00bc6e0_1.conda
win-64::libgdal-arrow-parquet-3.9.0-haac80e4_1.conda
win-64::turbodbc-4.12.0-py311h498e7aa_1.conda
win-64::libgdal-arrow-parquet-3.8.5-h6da87a5_5.conda
win-64::pymongoarrow-1.3.0-py38h7015101_1.conda
win-64::nyxus-0.7.5-py311hd0feb74_2.conda
win-64::nyxus-0.7.5-py39he4b14a7_2.conda
win-64::libgdal-arrow-parquet-3.9.0-h6da87a5_2.conda
win-64::pyarrow-tests-16.0.0-py39h338ae66_0.conda
win-64::nyxus-0.7.5-py39h152cd1d_2.conda
win-64::pyarrow-tests-16.0.0-py310h6bd4de8_0.conda
win-64::turbodbc-4.12.0-py310h322be88_1.conda
win-64::libgdal-arrow-parquet-3.7.3-h6da87a5_25.conda
win-64::nyxus-0.7.5-py38hafa1348_2.conda
win-64::pymongoarrow-1.3.0-py310h885cd5d_1.conda
win-64::tip-3.0.3-h9146937_4.conda
win-64::nyxus-0.7.5-py311hb323b13_2.conda
win-64::turbodbc-4.12.0-py312h4c53b8e_1.conda
win-64::nyxus-0.7.5-py39hdd66d57_2.conda
win-64::libgdal-arrow-parquet-3.8.5-haac80e4_4.conda
win-64::libgdal-arrow-parquet-3.7.3-haac80e4_24.conda
win-64::nyxus-0.7.5-py310h5ae78d9_2.conda
win-64::pyarrow-tests-16.0.0-py38h1a60bc1_0.conda
win-64::pyarrow-tests-16.0.0-py311h6d3785f_0.conda
win-64::pymongoarrow-1.3.0-py312h00dac36_1.conda
win-64::nyxus-0.7.5-py310h2aa3716_2.conda
win-64::nyxus-0.7.5-py311hd895272_2.conda
-    "libarrow >=16.0.0,<17.0a0",
+    "libarrow >=16.0.0,<16.1.0a0",
================================================================================
================================================================================
osx-64
osx-64::nyxus-0.7.5-py39h3f93271_2.conda
osx-64::libgdal-arrow-parquet-3.9.0-h569be30_2.conda
osx-64::pymongoarrow-1.3.0-py39h135324b_1.conda
osx-64::turbodbc-4.12.0-py310hdbbc7dc_1.conda
osx-64::pymongoarrow-1.3.0-py310h99d711d_1.conda
osx-64::librerun-sdk-0.15.1-he67afd4_1.conda
osx-64::libgdal-arrow-parquet-3.8.5-ha9b2d09_4.conda
osx-64::pyarrow-tests-16.0.0-py38hba6ee1e_0.conda
osx-64::turbodbc-4.12.0-py311h728538e_1.conda
osx-64::pyarrow-tests-16.0.0-py312hde6b23b_0.conda
osx-64::turbodbc-4.12.0-py312h44b61b1_1.conda
osx-64::pyarrow-tests-16.0.0-py311hf169777_0.conda
osx-64::pymongoarrow-1.3.0-py38hda995f0_1.conda
osx-64::pymongoarrow-1.3.0-py311hd7a42a3_1.conda
osx-64::libgdal-arrow-parquet-3.7.3-ha9b2d09_24.conda
osx-64::nyxus-0.7.5-py38h4d38b44_2.conda
osx-64::river-ingester-1.0.11-hcbe1388_2.conda
osx-64::libgdal-arrow-parquet-3.9.0-ha9b2d09_1.conda
osx-64::nyxus-0.7.5-py311hf8bacd6_2.conda
osx-64::pyarrow-tests-16.0.0-py39h7aa4791_0.conda
osx-64::pymongoarrow-1.3.0-py312h9c61d65_1.conda
osx-64::nyxus-0.7.5-py310ha0cceca_2.conda
osx-64::libgdal-arrow-parquet-3.8.5-h569be30_5.conda
osx-64::pyarrow-tests-16.0.0-py310h8999d80_0.conda
osx-64::arrow-c-glib-16.0.0-h5428c58_0.conda
osx-64::libgdal-arrow-parquet-3.7.3-h569be30_25.conda
-    "libarrow >=16.0.0,<17.0a0",
+    "libarrow >=16.0.0,<16.1.0a0",
================================================================================
================================================================================
linux-64
linux-64::pymongoarrow-1.3.0-py39h8f04da6_1.conda
linux-64::arrow-c-glib-16.0.0-h04ea711_0.conda
linux-64::librerun-sdk-0.15.1-ha93e086_1.conda
linux-64::pymongoarrow-1.3.0-py38hc9c4ff8_1.conda
linux-64::nyxus-0.7.5-py38hc985d48_2.conda
linux-64::pymongoarrow-1.3.0-py310hf92a623_1.conda
linux-64::pymongoarrow-1.3.0-py312h1afcdd5_1.conda
linux-64::turbodbc-4.12.0-py310h994b10c_1.conda
linux-64::pymongoarrow-1.3.0-py311h8a581e7_1.conda
linux-64::libgdal-arrow-parquet-3.9.0-h8d1bc82_1.conda
linux-64::pyarrow-tests-16.0.0-py311hd5e4297_0.conda
linux-64::nyxus-0.7.5-py311h6641c2c_2.conda
linux-64::libgdal-arrow-parquet-3.7.3-h484e903_25.conda
linux-64::pyarrow-tests-16.0.0-py310hd207890_0.conda
linux-64::pyarrow-tests-16.0.0-py39h38d04b8_0.conda
linux-64::turbodbc-4.12.0-py311hc8b2a83_1.conda
linux-64::libgdal-arrow-parquet-3.8.5-h8d1bc82_4.conda
linux-64::nyxus-0.7.5-py38h56f7b43_2.conda
linux-64::nyxus-0.7.5-py310h1737e6d_2.conda
linux-64::nyxus-0.7.5-py310hbea93ef_2.conda
linux-64::nyxus-0.7.5-py311h9af264d_2.conda
linux-64::pyarrow-tests-16.0.0-py38hc396e17_0.conda
linux-64::turbodbc-4.12.0-py312h53204ba_1.conda
linux-64::nyxus-0.7.5-py38h3b78ff2_2.conda
linux-64::libgdal-arrow-parquet-3.8.5-h484e903_5.conda
linux-64::nyxus-0.7.5-py310hd177b7a_2.conda
linux-64::tip-3.0.3-h6758050_4.conda
linux-64::libgdal-arrow-parquet-3.7.3-h8d1bc82_24.conda
linux-64::river-ingester-1.0.11-hd58f0dd_2.conda
linux-64::nyxus-0.7.5-py39h2dae9cf_2.conda
linux-64::libgdal-arrow-parquet-3.9.0-h484e903_2.conda
linux-64::nyxus-0.7.5-py311h7acd7f4_2.conda
linux-64::pyarrow-tests-16.0.0-py312h3f82784_0.conda
linux-64::nyxus-0.7.5-py39ha4fdef6_2.conda
-    "libarrow >=16.0.0,<17.0a0",
+    "libarrow >=16.0.0,<16.1.0a0",
```