### PR TITLE
Should be not 2.18.0

### DIFF
--- a/recipe/patch_yaml/parcels.yaml
+++ b/recipe/patch_yaml/parcels.yaml
@@ -1,10 +1,10 @@
-# https://github.com/conda-forge/parcels-feedstock/pull/104
+# https://github.com/conda-forge/parcels-feedstock/pull/107
 if:
   name: parcels
   timestamp_le: 1715955583000  # 2024-05-17
   version: 3.0.2
-  build_number_in: [0]
+  build_number_in: [0, 1]
 then:
   - replace_depends:
       old: zarr >=2.11.0
-      new: zarr >=2.11.0,<2.18.0
+      new: zarr >=2.11.0,!=2.18.0


### PR DESCRIPTION
Checklist

* [X] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [X] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [X] Ran `python show_diff.py` and posted the output as part of the PR.
* [X] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

```
$ python show_diff.py 
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
noarch
noarch::parcels-3.0.2-pyh779afd3_0.conda
noarch::parcels-3.0.2-pyhea20964_0.conda
noarch::parcels-3.0.2-pyh4c7d964_0.conda
-    "zarr >=2.11.0,<2.18.0"
+    "zarr >=2.11.0,!=2.18.0"
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
================================================================================
================================================================================
linux-64
```