### PR TITLE
ENH add upper bound of mamba2 for conda-forge-feedstock-check-solvable

### DIFF
--- a/recipe/patch_yaml/conda-forge-feedstock-check-solvable.yaml
+++ b/recipe/patch_yaml/conda-forge-feedstock-check-solvable.yaml
@@ -12,5 +12,5 @@ if:
   version_le: 0.5.2
 then:
   - tighten_depends:
-    name: mamba
-    upper_bound: 2.0a0
+      name: mamba
+      upper_bound: 2.0a0

--- a/recipe/patch_yaml/conda-forge-feedstock-check-solvable.yaml
+++ b/recipe/patch_yaml/conda-forge-feedstock-check-solvable.yaml
@@ -13,4 +13,4 @@ if:
 then:
   - tighten_depends:
       name: mamba
-      upper_bound: 2.0a0
+      upper_bound: "2"

--- a/recipe/patch_yaml/conda-forge-feedstock-check-solvable.yaml
+++ b/recipe/patch_yaml/conda-forge-feedstock-check-solvable.yaml
@@ -6,3 +6,11 @@ then:
   - tighten_depends:
       name: conda-build
       upper_bound: 24.5.0
+---
+if:
+  name: conda-forge-feedstock-check-solvable
+  version_le: 0.5.2
+then:
+  - tighten_depends:
+    name: mamba
+    upper_bound: 2.0a0


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
