### PR TITLE
Constrain numpy < 2 for all previous releases of Pint

### DIFF
--- a/recipe/patch_yaml/pint.yaml
+++ b/recipe/patch_yaml/pint.yaml
@@ -1,0 +1,15 @@
+# Pint has not yet had a release that supports NumPy 2,
+# so we need to add a run_constrained requirement.
+if:
+  name: pint
+  version_lt: 0.23.0
+then:
+  - add_constrains: numpy <2.0.0a0
+---
+# Grab build 0 for 0.23 as well
+if:
+  name: pint
+  version: 0.23.0
+  build_number: 0
+then:
+  - add_constrains: numpy <2.0.0a0


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

`show_diff.py`:

<details><pre>
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
win-32::pint-0.8.0-py36_0.tar.bz2
win-32::pint-0.7.2-py35_1.tar.bz2
win-32::pint-0.7.2-py27_2.tar.bz2
win-32::pint-0.8.1-py35_0.tar.bz2
win-32::pint-0.6-py35_0.tar.bz2
win-32::pint-0.7.1-py27_0.tar.bz2
win-32::pint-0.7.2-py34_1.tar.bz2
win-32::pint-0.8.1-py36_0.tar.bz2
win-32::pint-0.8.0-py27_0.tar.bz2
win-32::pint-0.7.2-py34_2.tar.bz2
win-32::pint-0.7.2-py35_0.tar.bz2
win-32::pint-0.7.2-py34_0.tar.bz2
win-32::pint-0.7.1-py34_0.tar.bz2
win-32::pint-0.6-py34_0.tar.bz2
win-32::pint-0.7.2-py36_2.tar.bz2
win-32::pint-0.6-py27_0.tar.bz2
win-32::pint-0.7.2-py35_2.tar.bz2
win-32::pint-0.7.2-py27_0.tar.bz2
win-32::pint-0.8.1-py27_0.tar.bz2
win-32::pint-0.7.2-py27_1.tar.bz2
win-32::pint-0.7.1-py35_0.tar.bz2
win-32::pint-0.8.0-py35_0.tar.bz2
+    "numpy <2.0.0a0",
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
noarch
noarch::pint-0.16-py_1.tar.bz2
noarch::pint-0.11-py_0.tar.bz2
noarch::pint-0.16.1-py_0.tar.bz2
noarch::pint-0.10.1-py_0.tar.bz2
noarch::pint-0.15-py_0.tar.bz2
noarch::pint-0.20-pyhd8ed1ab_0.tar.bz2
noarch::pint-0.12-py_0.tar.bz2
noarch::pint-0.16-py_0.tar.bz2
noarch::pint-0.9-py_0.tar.bz2
noarch::pint-0.13-py_0.tar.bz2
noarch::pint-0.14-py_0.tar.bz2
noarch::pint-0.8.1-py_1.tar.bz2
noarch::pint-0.17-pyhd8ed1ab_0.tar.bz2
noarch::pint-0.19.1-pyhd8ed1ab_0.tar.bz2
noarch::pint-0.19-pyhd8ed1ab_0.tar.bz2
noarch::pint-0.19.2-pyhd8ed1ab_0.tar.bz2
noarch::pint-0.18-pyhd8ed1ab_0.tar.bz2
noarch::pint-0.23-pyhd8ed1ab_0.conda
noarch::pint-0.20.1-pyhd8ed1ab_0.tar.bz2
noarch::pint-0.22-pyhd8ed1ab_1.conda
noarch::pint-0.11-py_1.tar.bz2
noarch::pint-0.17-pyhd8ed1ab_1.tar.bz2
noarch::pint-0.10-py_1.tar.bz2
noarch::pint-0.10-py_0.tar.bz2
noarch::pint-0.21-pyhd8ed1ab_0.conda
+  "constrains": [
+    "numpy <2.0.0a0"
+  ],
================================================================================
================================================================================
win-64
win-64::pint-0.9-py36_1.tar.bz2
win-64::pint-0.7.1-py27_0.tar.bz2
win-64::pint-0.7.2-py34_1.tar.bz2
win-64::pint-0.8.1-py35_0.tar.bz2
win-64::pint-0.9-py27_2.tar.bz2
win-64::pint-0.7.2-py35_0.tar.bz2
win-64::pint-0.7.2-py34_0.tar.bz2
win-64::pint-0.8.0-py27_0.tar.bz2
win-64::pint-0.8.0-py35_0.tar.bz2
win-64::pint-0.8.1-py27_0.tar.bz2
win-64::pint-0.9-py37_1.tar.bz2
win-64::pint-0.6-py27_0.tar.bz2
win-64::pint-0.7.2-py27_2.tar.bz2
win-64::pint-0.7.1-py34_0.tar.bz2
win-64::pint-0.8.0-py36_0.tar.bz2
win-64::pint-0.6-py34_0.tar.bz2
win-64::pint-0.9-py36_2.tar.bz2
win-64::pint-0.9-py27_1.tar.bz2
win-64::pint-0.9-py38_2.tar.bz2
win-64::pint-0.7.2-py35_2.tar.bz2
win-64::pint-0.7.1-py35_0.tar.bz2
win-64::pint-0.9-py37_2.tar.bz2
win-64::pint-0.8.1-py36_0.tar.bz2
win-64::pint-0.7.2-py27_1.tar.bz2
win-64::pint-0.7.2-py34_2.tar.bz2
win-64::pint-0.7.2-py35_1.tar.bz2
win-64::pint-0.7.2-py27_0.tar.bz2
win-64::pint-0.6-py35_0.tar.bz2
win-64::pint-0.7.2-py36_2.tar.bz2
+    "numpy <2.0.0a0",
================================================================================
================================================================================
osx-64
osx-64::pint-0.7.2-py35_1.tar.bz2
osx-64::pint-0.7.2-py34_2.tar.bz2
osx-64::pint-0.7.2-py27_1.tar.bz2
osx-64::pint-0.7.1-py27_0.tar.bz2
osx-64::pint-0.8.0-py35_0.tar.bz2
osx-64::pint-0.7.2-py35_0.tar.bz2
osx-64::pint-0.7.2-py36_2.tar.bz2
osx-64::pint-0.7.2-py34_0.tar.bz2
osx-64::pint-0.6-py34_0.tar.bz2
osx-64::pint-0.9-py36_1.tar.bz2
osx-64::pint-0.7.1-py34_0.tar.bz2
osx-64::pint-0.8.1-py27_0.tar.bz2
osx-64::pint-0.8.0-py36_0.tar.bz2
osx-64::pint-0.9-py36_2.tar.bz2
osx-64::pint-0.7.2-py34_1.tar.bz2
osx-64::pint-0.6-py27_0.tar.bz2
osx-64::pint-0.7.2-py35_2.tar.bz2
osx-64::pint-0.9-py27_2.tar.bz2
osx-64::pint-0.9-py38_2.tar.bz2
osx-64::pint-0.7.1-py35_0.tar.bz2
osx-64::pint-0.7.2-py27_2.tar.bz2
osx-64::pint-0.8.1-py35_0.tar.bz2
osx-64::pint-0.7.2-py27_0.tar.bz2
osx-64::pint-0.9-py37_2.tar.bz2
osx-64::pint-0.6-py35_0.tar.bz2
osx-64::pint-0.9-py37_1.tar.bz2
osx-64::pint-0.8.0-py27_0.tar.bz2
osx-64::pint-0.9-py27_1.tar.bz2
osx-64::pint-0.8.1-py36_0.tar.bz2
+    "numpy <2.0.0a0",
================================================================================
================================================================================
linux-64
linux-64::pint-0.8.0-py35_0.tar.bz2
linux-64::pint-0.8.1-py27_0.tar.bz2
linux-64::pint-0.7.1-py34_0.tar.bz2
linux-64::pint-0.7.1-py27_0.tar.bz2
linux-64::pint-0.7.2-py34_0.tar.bz2
linux-64::pint-0.7.2-py35_1.tar.bz2
linux-64::pint-0.7.2-py34_1.tar.bz2
linux-64::pint-0.7.2-py27_2.tar.bz2
linux-64::pint-0.8.0-py27_0.tar.bz2
linux-64::pint-0.7.2-py27_1.tar.bz2
linux-64::pint-0.7.2-py35_2.tar.bz2
linux-64::pint-0.7.2-py36_2.tar.bz2
linux-64::pint-0.6-py27_0.tar.bz2
linux-64::pint-0.7.2-py27_0.tar.bz2
linux-64::pint-0.9-py37_2.tar.bz2
linux-64::pint-0.8.0-py36_0.tar.bz2
linux-64::pint-0.8.1-py36_0.tar.bz2
linux-64::pint-0.6-py34_0.tar.bz2
linux-64::pint-0.6-py35_0.tar.bz2
linux-64::pint-0.9-py36_1.tar.bz2
linux-64::pint-0.7.1-py35_0.tar.bz2
linux-64::pint-0.8.1-py35_0.tar.bz2
linux-64::pint-0.9-py37_1.tar.bz2
linux-64::pint-0.9-py38_2.tar.bz2
linux-64::pint-0.9-py27_1.tar.bz2
linux-64::pint-0.7.2-py35_0.tar.bz2
linux-64::pint-0.9-py36_2.tar.bz2
linux-64::pint-0.7.2-py34_2.tar.bz2
linux-64::pint-0.9-py27_2.tar.bz2
+    "numpy <2.0.0a0",
</pre></details>