### PR TITLE
loosen zlib-pin to major level (1/N)

### DIFF
--- a/recipe/patch_yaml/zlib.yaml
+++ b/recipe/patch_yaml/zlib.yaml
@@ -6,4 +6,4 @@ if:
 then:
   - loosen_depends:
       name: libzlib
-      upper_bound: "1.4"
+      upper_bound: "2"

--- a/recipe/patch_yaml/zlib.yaml
+++ b/recipe/patch_yaml/zlib.yaml
@@ -1,6 +1,8 @@
 # zlib was pinning to minor level, but 1.2 is compatible with 1.3
 if:
   has_depends: libzlib >=1.2*
+  timestamp_gt: 1714521600000  # 2024-05-01 00:00 UTC
+  timestamp_lt: 1717200000000  # 2024-06-01 00:00 UTC
 then:
   - loosen_depends:
       name: libzlib

--- a/recipe/patch_yaml/zlib.yaml
+++ b/recipe/patch_yaml/zlib.yaml
@@ -1,0 +1,7 @@
+# zlib was pinning to minor level, but 1.2 is compatible with 1.3
+if:
+  has_depends: libzlib >=1.2*
+then:
+  - loosen_depends:
+      name: libzlib
+      upper_bound: "1.4"


### PR DESCRIPTION
Restricted to monthly cadence after discussion in https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/5959

Previously:
> This is a draft because it impacts a large number of packages, almost 100k 😑
> 
> That's even though we're "only" patching 2.5 years worth of packages, since [conda-forge/zlib-feedstock@a97f1e6](https://github.com/conda-forge/zlib-feedstock/commit/a97f1e6e3b2288f1b225f9976b2d40cf7231ddaa) changed the run-export to `libzlib`.
> 
> Here's a [gist](https://gist.github.com/h-vetinari/dc5e9d3aa76408ad10cb493dd5b28a6a) with the affected packages.

