### PR TITLE
loosen zlib-pin to major level (2/N)

### DIFF
--- a/recipe/patch_yaml/zlib.yaml
+++ b/recipe/patch_yaml/zlib.yaml
@@ -1,8 +1,17 @@
 # zlib was pinning to minor level, but 1.2 is compatible with 1.3
 if:
   has_depends: libzlib >=1.2*
-  timestamp_gt: 1714521600000  # 2024-05-01 00:00 UTC
+  timestamp_ge: 1714521600000  # 2024-05-01 00:00 UTC
   timestamp_lt: 1717200000000  # 2024-06-01 00:00 UTC
+then:
+  - loosen_depends:
+      name: libzlib
+      upper_bound: "2"
+---
+if:
+  has_depends: libzlib >=1.2*
+  timestamp_ge: 1711929600000  # 2024-04-01 00:00 UTC
+  timestamp_lt: 1714521600000  # 2024-05-01 00:00 UTC
 then:
   - loosen_depends:
       name: libzlib


### PR DESCRIPTION
Follow-up to #739. Will run the diff once the CDN has synched after that PR.

### Result of `python show_diff.py`

<details>

```diff
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
osx-arm64::pyarrow-tests-14.0.2-py39hb31e23e_18_cpu.conda
osx-arm64::libadios2-2.9.2-mpi_mpich_h0aa738d_2.conda
osx-arm64::libarrow-14.0.2-ha642a4c_19_cpu.conda
osx-arm64::heyoka-llvm-15-4.0.3-h510fb61_2.conda
osx-arm64::ndcctools-7.9.1-py39hec72b60_0.conda
osx-arm64::libadios2-2.10.0-mpi_openmpi_h135fdc6_1.conda
osx-arm64::lxml-5.1.1-py312h867102f_0.conda
osx-arm64::grpcio-1.62.2-py39h047a24b_0.conda
osx-arm64::tiledb-2.22.0-hb090472_2.conda
osx-arm64::libadios2-2.10.0-mpi_openmpi_h2343a08_2.conda
osx-arm64::nest-simulator-3.6-py312h6157364_5.conda
osx-arm64::pyarrow-14.0.2-py312h9cc9a04_18_cpu.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-haddc5de_22.conda
osx-arm64::heyoka-4.0.3-h4dff030_2.conda
osx-arm64::lammps-2024.02.07-cpu_py38_hb5f05e6_mpi_mpich_0.conda
osx-arm64::folly-2024.04.01.00-h25af3d9_0.conda
osx-arm64::heyoka-4.0.3-h0f46c6c_0.conda
osx-arm64::util-linux-2.39.4-py311h5768e45_0.conda
osx-arm64::poppler-24.04.0-h42742f0_0.conda
osx-arm64::libadios2-2.9.2-mpi_openmpi_h6eedf57_2.conda
osx-arm64::libadios2-2.10.0-mpi_openmpi_h6eedf57_2.conda
osx-arm64::sqlite-3.45.3-hf2abe2d_0.conda
osx-arm64::gazebo-11.14.0-origname1234567_211.conda
osx-arm64::heyoka-4.0.3-he1ce634_1.conda
osx-arm64::libgdal-3.7.3-h5dd8421_22.conda
osx-arm64::lammps-2024.02.07-cpu_py310_h4786252_mpi_mpich_1.conda
osx-arm64::libadios2-2.10.0-nompi_hecf9ec3_100.conda
osx-arm64::libgrpc-1.62.2-h9c18a4f_0.conda
osx-arm64::pyarrow-tests-13.0.0-py311hab5d6ba_36_cpu.conda
osx-arm64::libadios2-2.10.0-mpi_mpich_h0aa738d_0.conda
osx-arm64::heyoka-llvm-13-4.0.3-h6af6dbe_1.conda
osx-arm64::ffmpeg-6.1.1-gpl_h4f1e072_108.conda
osx-arm64::graphviz-2.50.0-h54e2d63_4.conda
osx-arm64::libadios2-2.10.0-mpi_mpich_hcce832b_3.conda
osx-arm64::folly-2023.09.25.00-h802e812_5.conda
osx-arm64::lammps-2024.02.07-cpu_py38_h74d7d60_mpi_openmpi_0.conda
osx-arm64::llvmdev-18.1.3-h30cc82d_0.conda
osx-arm64::git-2.45.0-pl5321hf6a64d8_0.conda
osx-arm64::mdtraj-1.9.9-py39h2c5a50e_1.conda
osx-arm64::libadios2-2.10.0-mpi_mpich_hb758b07_1.conda
osx-arm64::pyarrow-tests-14.0.2-py39hb31e23e_17_cpu.conda
osx-arm64::pyarrow-15.0.2-py38h638452a_5_cpu.conda
osx-arm64::libtiledb-sql-0.30.0-h77cfbea_0.conda
osx-arm64::photochem-0.5.3-py311h11f99fc_0.conda
osx-arm64::lxml-5.1.1-py311h301c3de_0.conda
osx-arm64::pyarrow-12.0.1-py311hab5d6ba_48_cpu.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-h579c2ad_23.conda
osx-arm64::heyoka-4.0.3-hb855aca_2.conda
osx-arm64::libadios2-2.9.2-nompi_hecf9ec3_102.conda
osx-arm64::pyarrow-tests-14.0.2-py39hb31e23e_19_cpu.conda
osx-arm64::libadios2-2.10.0-nompi_hf13c0cf_102.conda
osx-arm64::libadios2-2.10.0-nompi_hecf9ec3_102.conda
osx-arm64::pyarrow-tests-14.0.2-py311hab5d6ba_17_cpu.conda
osx-arm64::openmeeg-2.5.8-py310h110b662_0.conda
osx-arm64::rocksdb-9.1.1-hb5fc20f_0.conda
osx-arm64::pyarrow-tests-13.0.0-py311hab5d6ba_37_cpu.conda
osx-arm64::openimageio-2.5.9.0-py310h6a122d7_1.conda
osx-arm64::wxwidgets-3.2.4-hbaae905_3.conda
osx-arm64::pyarrow-15.0.2-py311h5ff715f_4_cpu.conda
osx-arm64::nest-simulator-3.7-py38h8074ab1_1.conda
osx-arm64::openimageio-2.5.9.0-py39h756737d_1.conda
osx-arm64::libadios2-2.10.0-nompi_h9cdf03b_103.conda
osx-arm64::imagecodecs-2024.1.1-py312h5aa80be_6.conda
osx-arm64::rsync-3.3.0-h8fab359_0.conda
osx-arm64::soplex-8.0.0-h0770e86_3.conda
osx-arm64::libadios2-2.10.0-mpi_openmpi_h05e85f2_3.conda
osx-arm64::libarrow-13.0.0-h89068bf_34_cpu.conda
osx-arm64::libadios2-2.10.0-mpi_mpich_h90f3fbf_3.conda
osx-arm64::folly-2024.04.08.00-h56f44e6_0.conda
osx-arm64::libgdal-3.7.3-hcb06e93_23.conda
osx-arm64::pyarrow-tests-15.0.2-py39h109976f_4_cpu.conda
osx-arm64::pyarrow-14.0.2-py38hf7a7491_18_cpu.conda
osx-arm64::libarrow-13.0.0-h97c2c9d_37_cpu.conda
osx-arm64::libarrow-14.0.2-h3b19404_17_cpu.conda
osx-arm64::libgdal-3.8.5-hfb644ca_1.conda
osx-arm64::lammps-2024.02.07-cpu_py38_h455d21a_nompi_0.conda
osx-arm64::folly-2024.04.29.00-h9e5387e_0.conda
osx-arm64::openmpi-5.0.3-hbd96bf3_100.conda
osx-arm64::tiledb-2.18.5-h39064d6_0.conda
osx-arm64::imagecodecs-2024.1.1-py39hcd304f2_5.conda
osx-arm64::tiledb-2.21.2-hf0716ca_4.conda
osx-arm64::gdstk-0.9.51-py311h4ecd0fe_0.conda
osx-arm64::lammps-2024.02.07-cpu_py311_h1b1bd21_mpi_openmpi_1.conda
osx-arm64::heyoka-llvm-16-3.2.0-h4078588_1.conda
osx-arm64::cmake-3.29.1-h50fd54c_0.conda
osx-arm64::pyarrow-13.0.0-py310h5372290_37_cpu.conda
osx-arm64::imagemagick-7.1.1_31-pl5321hf5150d3_1.conda
osx-arm64::lammps-2024.02.07-cpu_py311_h3159b45_nompi_0.conda
osx-arm64::pyarrow-tests-15.0.2-py310h01a46da_6_cpu.conda
osx-arm64::photochem-0.5.3-py39h621fe12_0.conda
osx-arm64::libadios2-2.10.0-mpi_mpich_h3ff4461_1.conda
osx-arm64::papilo-2.2.0-h36f9d74_3.conda
osx-arm64::libadios2-2.10.0-mpi_openmpi_h19e7c74_3.conda
osx-arm64::libgoogle-cloud-storage-2.23.0-h8a76758_1.conda
osx-arm64::pyarrow-tests-12.0.1-py310h5372290_48_cpu.conda
osx-arm64::imagemagick-7.1.1_31-pl5321hf5150d3_0.conda
osx-arm64::libadios2-2.10.0-nompi_h4a2cfce_100.conda
osx-arm64::openmeeg-2.5.8-py312h87ab31f_0.conda
osx-arm64::libadios2-2.10.0-mpi_mpich_hc705787_0.conda
osx-arm64::pyarrow-12.0.1-py311hab5d6ba_47_cpu.conda
osx-arm64::grpcio-1.62.2-py310hf7687f1_0.conda
osx-arm64::libmed-4.1.1-nompi_h9e11b3e_112.conda
osx-arm64::libarrow-12.0.1-h97c2c9d_48_cpu.conda
osx-arm64::pillow-10.3.0-py312h8a801b1_0.conda
osx-arm64::folly-2023.09.25.00-hba3d456_5_jemalloc.conda
osx-arm64::pyarrow-tests-13.0.0-py39hb31e23e_36_cpu.conda
osx-arm64::libadios2-2.10.0-nompi_h4a2cfce_101.conda
osx-arm64::ndcctools-7.9.2-py39hec72b60_0.conda
osx-arm64::libgdal-arrow-parquet-3.8.5-h758ee9e_2.conda
osx-arm64::texlive-core-20230313-py310h2ef9581_12.conda
osx-arm64::libadios2-2.9.2-mpi_openmpi_hf375636_2.conda
osx-arm64::libadios2-2.10.0-mpi_openmpi_hf63b5ae_3.conda
osx-arm64::imagecodecs-2024.1.1-py310hb021b09_5.conda
osx-arm64::rocksdb-8.5.3-hb5fc20f_1.conda
osx-arm64::nest-simulator-3.6-py311h4b2d909_5.conda
osx-arm64::libadios2-2.10.0-mpi_openmpi_h1489629_0.conda
osx-arm64::lxml-5.2.1-py310h1aa7b38_0.conda
osx-arm64::libadios2-2.9.2-mpi_mpich_hc705787_2.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-h5eb65b0_22.conda
osx-arm64::mlir-18.1.3-hba3f82b_0.conda
osx-arm64::pyarrow-tests-15.0.2-py311h5ff715f_4_cpu.conda
osx-arm64::libmed-4.1.1-nompi_h9c425eb_112.conda
osx-arm64::zimpl-3.5.4-h5ff29b1_3.conda
osx-arm64::folly-2023.09.25.00-h41c8258_5.conda
osx-arm64::libglib-2.80.0-hfc324ee_4.conda
osx-arm64::libadios2-2.10.0-mpi_openmpi_hf375636_1.conda
osx-arm64::pyarrow-15.0.2-py39h109976f_4_cpu.conda
osx-arm64::pyarrow-13.0.0-py311hab5d6ba_36_cpu.conda
osx-arm64::pyarrow-14.0.2-py310h5372290_19_cpu.conda
osx-arm64::pyarrow-tests-15.0.2-py39h109976f_5_cpu.conda
osx-arm64::nest-simulator-3.7-py312h6157364_1.conda
osx-arm64::heyoka-llvm-17-4.0.3-h83f1c15_2.conda
osx-arm64::libadios2-2.10.0-nompi_h4599953_103.conda
osx-arm64::ndcctools-7.10.0-py310h7a27ce5_0.conda
osx-arm64::heyoka-llvm-15-3.2.0-hdf9ca16_1.conda
osx-arm64::heyoka-llvm-14-4.0.3-hcf7c104_1.conda
osx-arm64::libarrow-15.0.2-hca667bd_5_cpu.conda
osx-arm64::ndcctools-7.9.1-py38hf8267ce_0.conda
osx-arm64::gdstk-0.9.51-py310hd84021c_0.conda
osx-arm64::libadios2-2.9.2-nompi_h4a2cfce_102.conda
osx-arm64::sasktran2-2024.03.0-py311h5aa7811_1.conda
osx-arm64::gazebo-11.14.0-orignameh85a80f7_212.conda
osx-arm64::heyoka-4.0.3-hd837ada_2.conda
osx-arm64::m4rie-20150908-h22b9e9d_1002.conda
osx-arm64::openimageio-2.5.9.0-py312ha620325_1.conda
osx-arm64::pyarrow-12.0.1-py39hb31e23e_47_cpu.conda
osx-arm64::lld-18.1.4-h89cedff_0.conda
osx-arm64::ndcctools-7.9.1-py310h7a27ce5_0.conda
osx-arm64::orc-2.0.0-h4aad248_1.conda
osx-arm64::pyarrow-15.0.2-py39h109976f_6_cpu.conda
osx-arm64::libbrial-1.2.12-h56a29cd_3.conda
osx-arm64::healpy-1.16.6-py310ha565181_4.conda
osx-arm64::geant4-11.1.3-py39heaa62ca_1.conda
osx-arm64::genomekit-5.0.0-py310h1c56d45_0.conda
osx-arm64::aws-sdk-cpp-1.11.267-h134aaec_6.conda
osx-arm64::geant4-11.1.3-py310hec043da_1.conda
osx-arm64::genomekit-5.0.0-py39hb37c894_0.conda
osx-arm64::pyarrow-14.0.2-py310h5372290_18_cpu.conda
osx-arm64::xeus-cpp-0.3.0-h66a9305_2.conda
osx-arm64::lammps-2024.02.07-cpu_py311_h0890928_mpi_mpich_0.conda
osx-arm64::gazebo-11.14.0-gzcompatnameha354356_12.conda
osx-arm64::libadios2-2.9.2-nompi_hf13c0cf_102.conda
osx-arm64::pyarrow-tests-13.0.0-py310h5372290_36_cpu.conda
osx-arm64::pyarrow-15.0.2-py310h01a46da_4_cpu.conda
osx-arm64::imagecodecs-2024.1.1-py311h57d323e_4.conda
osx-arm64::pyarrow-12.0.1-py39hb31e23e_48_cpu.conda
osx-arm64::ndcctools-7.10.1-py38hf8267ce_0.conda
osx-arm64::libadios2-2.10.0-mpi_mpich_h47c5f7b_3.conda
osx-arm64::folly-2024.04.01.00-h16d3e8c_0_jemalloc.conda
osx-arm64::pyarrow-12.0.1-py38hf7a7491_47_cpu.conda
osx-arm64::pyarrow-tests-14.0.2-py38hf7a7491_17_cpu.conda
osx-arm64::papilo-2.2.0-h36f9d74_4.conda
osx-arm64::heyoka-4.0.3-h4d9e49e_1.conda
osx-arm64::tiledb-2.18.5-h49d9ff7_0.conda
osx-arm64::libarrow-14.0.2-h3fc723a_16_cpu.conda
osx-arm64::qt-main-5.15.8-hf679f28_21.conda
osx-arm64::pyarrow-12.0.1-py38hf7a7491_48_cpu.conda
osx-arm64::pyarrow-tests-13.0.0-py312h9cc9a04_36_cpu.conda
osx-arm64::libglib-2.80.0-hfc324ee_6.conda
osx-arm64::pyarrow-tests-13.0.0-py310h5372290_37_cpu.conda
osx-arm64::tiledb-2.21.2-h299f1dd_3.conda
osx-arm64::llvm-18.1.3-h7bf68d2_0.conda
osx-arm64::python-3.11.9-h932a869_0_cpython.conda
osx-arm64::pyarrow-tests-12.0.1-py39hb31e23e_48_cpu.conda
osx-arm64::ffmpeg-6.1.1-gpl_h4f1e072_107.conda
osx-arm64::imagecodecs-2024.1.1-py311hdc959f5_5.conda
osx-arm64::pyarrow-tests-14.0.2-py38hf7a7491_18_cpu.conda
osx-arm64::pdal-2.7.1-hff7fe72_2.conda
osx-arm64::pyarrow-15.0.2-py39h109976f_5_cpu.conda
osx-arm64::pyarrow-15.0.2-py312hbf1f86f_6_cpu.conda
osx-arm64::imagecodecs-2024.1.1-py39hd6ad7bc_4.conda
osx-arm64::libmed-4.1.1-nompi_h9646804_112.conda
osx-arm64::mdtraj-1.9.9-py312h03d2bcb_1.conda
osx-arm64::pyarrow-tests-14.0.2-py312h9cc9a04_19_cpu.conda
osx-arm64::lammps-2024.02.07-cpu_py311_h3159b45_nompi_1.conda
osx-arm64::tiledb-2.18.5-h7f70256_0.conda
osx-arm64::util-linux-2.39.4-py312h71122ab_0.conda
osx-arm64::heyoka-llvm-17-4.0.3-h9a6b3e1_1.conda
osx-arm64::libgdal-arrow-parquet-3.8.5-h4f3797c_2.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-h758ee9e_23.conda
osx-arm64::pyarrow-tests-15.0.2-py38h638452a_6_cpu.conda
osx-arm64::rocksdb-9.1.0-hb5fc20f_0.conda
osx-arm64::pyarrow-12.0.1-py310h5372290_47_cpu.conda
osx-arm64::libgdal-arrow-parquet-3.8.5-h57402c5_0.conda
osx-arm64::pyarrow-tests-15.0.2-py311h5ff715f_6_cpu.conda
osx-arm64::libarrow-15.0.2-hca667bd_4_cpu.conda
osx-arm64::heyoka-4.0.3-h6bf30c6_0.conda
osx-arm64::libadios2-2.10.0-mpi_openmpi_h135fdc6_2.conda
osx-arm64::photochem-0.5.3-py312hd84c823_0.conda
osx-arm64::pyarrow-tests-14.0.2-py311hab5d6ba_19_cpu.conda
osx-arm64::pyarrow-tests-12.0.1-py38hf7a7491_48_cpu.conda
osx-arm64::nest-simulator-3.7-py39h23e55c4_1.conda
osx-arm64::ndcctools-7.9.1-py311ha2834e1_0.conda
osx-arm64::heyoka-llvm-13-4.0.3-h1331c81_2.conda
osx-arm64::ndcctools-7.9.2-py38hf8267ce_0.conda
osx-arm64::lammps-2024.02.07-cpu_py39_h5afc6b9_nompi_1.conda
osx-arm64::photochem-0.5.3-py38hdc80946_0.conda
osx-arm64::folly-2024.04.29.00-hbf02c00_0_jemalloc.conda
osx-arm64::vowpalwabbit-9.9.0-py311hdcf8cef_4.conda
osx-arm64::ffmpeg-6.1.1-lgpl_h64cd017_9.conda
osx-arm64::ndcctools-7.9.2-py310h7a27ce5_0.conda
osx-arm64::pyarrow-tests-13.0.0-py38hf7a7491_37_cpu.conda
osx-arm64::libadios2-2.10.0-mpi_openmpi_h59acc38_3.conda
osx-arm64::mesalib-24.0.6-hcfd58f2_0.conda
osx-arm64::genomekit-5.0.0-py38heaacfd5_0.conda
osx-arm64::pyinstaller-6.6.0-py310h742d9d8_0.conda
osx-arm64::pyarrow-14.0.2-py312h9cc9a04_19_cpu.conda
osx-arm64::folly-2024.04.08.00-h9e5387e_1.conda
osx-arm64::genomekit-5.0.1-py38heaacfd5_0.conda
osx-arm64::lld-18.1.3-h89cedff_0.conda
osx-arm64::libgdal-arrow-parquet-3.8.5-h391a133_2.conda
osx-arm64::lammps-2024.02.07-cpu_py311_h1b1bd21_mpi_openmpi_0.conda
osx-arm64::libadios2-2.9.2-mpi_openmpi_h135fdc6_2.conda
osx-arm64::lammps-2024.02.07-cpu_py38_h455d21a_nompi_1.conda
osx-arm64::folly-2023.09.25.00-h19963fb_5_jemalloc.conda
osx-arm64::libadios2-2.10.0-mpi_mpich_ha046f88_0.conda
osx-arm64::nco-5.2.4-hf4d03cd_0.conda
osx-arm64::pyarrow-14.0.2-py39hb31e23e_17_cpu.conda
osx-arm64::libarrow-12.0.1-h3b61f1e_47_cpu.conda
osx-arm64::libadios2-2.10.0-nompi_h8c8e0e6_103.conda
osx-arm64::heyoka-3.2.0-h00532ff_1.conda
osx-arm64::libglib-2.80.0-hfc324ee_5.conda
osx-arm64::healpy-1.16.6-py311h96e1c19_4.conda
osx-arm64::wxpython-4.2.1-py310h432c6a5_5.conda
osx-arm64::libvips-8.15.2-h5ff801d_1.conda
osx-arm64::magics-4.15.4-h036cba1_0.conda
osx-arm64::folly-2024.04.15.00-hbf02c00_0_jemalloc.conda
osx-arm64::tiledb-2.22.0-h0f8cf2c_1.conda
osx-arm64::heyoka-llvm-17-4.0.3-hb6426ec_0.conda
osx-arm64::libllvm18-18.1.4-h30cc82d_0.conda
osx-arm64::imagecodecs-2024.1.1-py39h2f378ec_6.conda
osx-arm64::pyarrow-tests-13.0.0-py39hb31e23e_37_cpu.conda
osx-arm64::heyoka-4.0.3-h69544bf_1.conda
osx-arm64::ffmpeg-6.1.1-lgpl_h7ee1505_8.conda
osx-arm64::libarrow-15.0.2-h3ee1d8f_3_cpu.conda
osx-arm64::libgdal-arrow-parquet-3.8.5-hc70703e_1.conda
osx-arm64::lammps-2024.02.07-cpu_py38_hb5f05e6_mpi_mpich_1.conda
osx-arm64::nodejs-20.12.2-h3b52c9b_0.conda
osx-arm64::aws-sdk-cpp-1.11.267-h872bb71_5.conda
osx-arm64::tiledb-2.21.2-h0f8cf2c_2.conda
osx-arm64::healpy-1.16.6-py39hc404747_4.conda
osx-arm64::libadios2-2.10.0-mpi_openmpi_h1489629_1.conda
osx-arm64::lxml-5.2.1-py311h1f7f111_0.conda
osx-arm64::pyarrow-tests-15.0.2-py312hbf1f86f_6_cpu.conda
osx-arm64::ndcctools-7.9.2-py311ha2834e1_0.conda
osx-arm64::heyoka-3.2.0-h5e3a650_0.conda
osx-arm64::imagecodecs-2024.1.1-py310hd5c6020_4.conda
osx-arm64::libadios2-2.9.2-mpi_openmpi_h1489629_2.conda
osx-arm64::pyarrow-13.0.0-py312h9cc9a04_36_cpu.conda
osx-arm64::libgdal-arrow-parquet-3.8.5-heb558df_0.conda
osx-arm64::wxpython-4.2.1-py38hb77b29d_5.conda
osx-arm64::libadios2-2.10.0-mpi_mpich_hb758b07_2.conda
osx-arm64::pyarrow-tests-12.0.1-py38hf7a7491_47_cpu.conda
osx-arm64::pyinstaller-6.6.0-py39h8643609_0.conda
osx-arm64::pyinstaller-6.6.0-py311h4045465_0.conda
osx-arm64::openmeeg-2.5.8-py39h44d4a2f_0.conda
osx-arm64::libadios2-2.10.0-mpi_mpich_h0badead_3.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-h300732c_22.conda
osx-arm64::pyarrow-15.0.2-py312hbf1f86f_5_cpu.conda
osx-arm64::gdstk-0.9.51-py38h0fa6a1b_0.conda
osx-arm64::davix-0.8.6-h5c138a1_0.conda
osx-arm64::lldb-18.1.3-py311hd92d76a_0.conda
osx-arm64::libadios2-2.10.0-mpi_openmpi_h135fdc6_0.conda
osx-arm64::libadios2-2.10.0-mpi_openmpi_h2343a08_1.conda
osx-arm64::magics-4.15.3-h036cba1_1.conda
osx-arm64::libgdal-arrow-parquet-3.8.5-h300732c_1.conda
osx-arm64::heyoka-4.0.3-hfa74252_1.conda
osx-arm64::libarrow-13.0.0-hfd3cd7d_35_cpu.conda
osx-arm64::lxml-5.1.1-py38hb2c731b_0.conda
osx-arm64::grpcio-1.62.2-py312h17030e7_0.conda
osx-arm64::sasktran2-2024.03.0-py312he954a7b_1.conda
osx-arm64::openimageio-2.5.9.0-py38h97256e8_1.conda
osx-arm64::nodejs-18.20.2-had33b45_0.conda
osx-arm64::heyoka-3.2.0-hfbe7f81_1.conda
osx-arm64::qt6-main-6.7.0-hbb9f37a_1.conda
osx-arm64::pyarrow-tests-12.0.1-py39hb31e23e_47_cpu.conda
osx-arm64::nest-simulator-3.6-py38h8074ab1_5.conda
osx-arm64::libmed-4.1.1-nompi_hc11299b_112.conda
osx-arm64::lammps-2024.02.07-cpu_py39_hb8cc403_mpi_mpich_0.conda
osx-arm64::libadios2-2.9.2-mpi_openmpi_h2343a08_2.conda
osx-arm64::libglib-2.80.0-hfc324ee_3.conda
osx-arm64::vowpalwabbit-9.9.0-py39h4327ce9_4.conda
osx-arm64::pytables-3.9.2-py310h61ce8b3_2.conda
osx-arm64::lammps-2024.02.07-cpu_py312_ha4425a9_nompi_1.conda
osx-arm64::libglib-2.80.0-hfc324ee_2.conda
osx-arm64::heyoka-llvm-17-3.2.0-h17bdccd_1.conda
osx-arm64::openmpi-5.0.2-h1b401ff_101.conda
osx-arm64::libadios2-2.10.0-nompi_hb979cb6_103.conda
osx-arm64::libbrial-1.2.12-h56a29cd_2.conda
osx-arm64::libadios2-2.10.0-mpi_openmpi_h49f6863_3.conda
osx-arm64::mdtraj-1.9.9-py310h455934c_1.conda
osx-arm64::pyarrow-tests-15.0.2-py310h01a46da_4_cpu.conda
osx-arm64::rocksdb-9.0.1-hb5fc20f_0.conda
osx-arm64::pyarrow-14.0.2-py39hb31e23e_19_cpu.conda
osx-arm64::libgdal-arrow-parquet-3.8.5-hdb20b29_0.conda
osx-arm64::nushell-0.92.0-h21b44c4_0.conda
osx-arm64::ndcctools-7.10.1-py39hec72b60_0.conda
osx-arm64::heyoka-llvm-14-3.2.0-h4a9a420_1.conda
osx-arm64::pyarrow-tests-14.0.2-py312h9cc9a04_18_cpu.conda
osx-arm64::pyarrow-13.0.0-py310h5372290_36_cpu.conda
osx-arm64::qt6-main-6.7.0-h5b9691b_0.conda
osx-arm64::pyarrow-13.0.0-py38hf7a7491_37_cpu.conda
osx-arm64::pyarrow-tests-14.0.2-py310h5372290_17_cpu.conda
osx-arm64::openmeeg-2.5.8-py311h07fa19e_0.conda
osx-arm64::pyarrow-tests-14.0.2-py38hf7a7491_19_cpu.conda
osx-arm64::libpulsar-3.5.1-hbdfd045_0.conda
osx-arm64::nushell-0.92.1-h21b44c4_0.conda
osx-arm64::healpy-1.16.6-py312hae56fe4_4.conda
osx-arm64::pyinstaller-6.6.0-py312ha17c255_0.conda
osx-arm64::lxml-5.2.1-py312h8f698c5_0.conda
osx-arm64::lammps-2024.02.07-cpu_py310_h1b23ab0_nompi_1.conda
osx-arm64::folly-2024.04.15.00-h9e5387e_0.conda
osx-arm64::libmediainfo-24.04-h617c939_0.conda
osx-arm64::libadios2-2.10.0-nompi_he95833c_102.conda
osx-arm64::libadios2-2.10.0-mpi_openmpi_h6eedf57_0.conda
osx-arm64::pyarrow-tests-12.0.1-py310h5372290_47_cpu.conda
osx-arm64::heyoka-4.0.3-hf8ae6b7_2.conda
osx-arm64::vowpalwabbit-9.9.0-py38h78e3145_4.conda
osx-arm64::libadios2-2.10.0-nompi_h4a2cfce_102.conda
osx-arm64::folly-2024.04.22.00-h9e5387e_0.conda
osx-arm64::ogre-14.2.4-hedcb8d7_0.conda
osx-arm64::geant4-11.1.3-py311hc8f5fe2_1.conda
osx-arm64::ffmpeg-6.1.1-lgpl_h7ee1505_7.conda
osx-arm64::imagemagick-7.1.1_30-pl5321hecdf51d_0.conda
osx-arm64::assimp-5.4.0-h8e95e21_0.conda
osx-arm64::lldb-18.1.3-py38hb5580c0_0.conda
osx-arm64::libarrow-14.0.2-h27a2bb5_15_cpu.conda
osx-arm64::libadios2-2.9.2-nompi_hbeb0f92_102.conda
osx-arm64::libadios2-2.10.0-nompi_hf13c0cf_100.conda
osx-arm64::pillow-10.3.0-py39h3352c98_0.conda
osx-arm64::heyoka-llvm-14-4.0.3-hf4574b5_0.conda
osx-arm64::wxpython-4.2.1-py311h098b1e8_5.conda
osx-arm64::lxml-5.1.1-py39h8557d04_0.conda
osx-arm64::vowpalwabbit-9.9.0-py312hef6b7a7_4.conda
osx-arm64::soplex-8.0.0-h0770e86_4.conda
osx-arm64::pyarrow-14.0.2-py311hab5d6ba_19_cpu.conda
osx-arm64::libadios2-2.10.0-nompi_hbeb0f92_102.conda
osx-arm64::libadios2-2.9.2-mpi_mpich_ha046f88_2.conda
osx-arm64::heyoka-4.0.3-h1913680_0.conda
osx-arm64::libadios2-2.10.0-mpi_openmpi_hf375636_0.conda
osx-arm64::libgdal-arrow-parquet-3.8.5-haddc5de_1.conda
osx-arm64::geant4-11.1.3-py38h3ebe20c_1.conda
osx-arm64::nest-simulator-3.6-py310h2df337d_5.conda
osx-arm64::heyoka-llvm-16-4.0.3-he2d6665_1.conda
osx-arm64::libarrow-13.0.0-h3b61f1e_36_cpu.conda
osx-arm64::heyoka-llvm-13-3.2.0-hced0a9f_1.conda
osx-arm64::imagecodecs-2024.1.1-py312h4f00afc_4.conda
osx-arm64::python-3.12.3-h4a7b5fc_0_cpython.conda
osx-arm64::libtiledb-sql-0.30.0-h4a0ca6b_1.conda
osx-arm64::ndcctools-7.10.1-py310h7a27ce5_0.conda
osx-arm64::lxml-5.2.1-py38h4aab999_0.conda
osx-arm64::heyoka-3.2.0-h11b573f_0.conda
osx-arm64::pyarrow-tests-14.0.2-py310h5372290_18_cpu.conda
osx-arm64::libgdal-arrow-parquet-3.8.5-h579c2ad_2.conda
osx-arm64::lldb-18.1.3-py310h99ba5de_0.conda
osx-arm64::libadios2-2.10.0-mpi_openmpi_h2343a08_0.conda
osx-arm64::pyarrow-15.0.2-py38h638452a_6_cpu.conda
osx-arm64::pyarrow-13.0.0-py39hb31e23e_37_cpu.conda
osx-arm64::lammps-2024.02.07-cpu_py312_hec54ecf_mpi_openmpi_1.conda
osx-arm64::openimageio-2.5.9.0-py311hed2966a_1.conda
osx-arm64::ndcctools-7.10.1-py311ha2834e1_0.conda
osx-arm64::folly-2023.09.25.00-h920d2ac_5_jemalloc.conda
osx-arm64::libopentelemetry-cpp-1.15.0-hfbcbe91_0.conda
osx-arm64::qt6-main-6.7.0-hbb9f37a_2.conda
osx-arm64::cpp-opentelemetry-sdk-1.15.0-hfbcbe91_0.conda
osx-arm64::gst-plugins-bad-1.24.1-h61ae955_0.conda
osx-arm64::nest-simulator-3.7-py311h4b2d909_1.conda
osx-arm64::libgdal-arrow-parquet-3.8.5-h5eb65b0_1.conda
osx-arm64::pyarrow-tests-12.0.1-py311hab5d6ba_47_cpu.conda
osx-arm64::libadios2-2.10.0-mpi_mpich_hf28efb5_3.conda
osx-arm64::pyarrow-tests-15.0.2-py38h638452a_4_cpu.conda
osx-arm64::ovito-3.10.5-haf2e8d7_0.conda
osx-arm64::pyarrow-tests-15.0.2-py39h109976f_6_cpu.conda
osx-arm64::pyarrow-tests-14.0.2-py310h5372290_19_cpu.conda
osx-arm64::genomekit-5.0.1-py39hb37c894_0.conda
osx-arm64::qt6-3d-6.7.0-h779fb94_0.conda
osx-arm64::ogre-14.2.4-h2297113_0.conda
osx-arm64::pytables-3.9.2-py312hb622ae1_2.conda
osx-arm64::grpcio-1.62.2-py38hbed3d3f_0.conda
osx-arm64::openmeeg-2.5.8-py38he85526c_0.conda
osx-arm64::pyarrow-tests-15.0.2-py38h638452a_5_cpu.conda
osx-arm64::lammps-2024.02.07-cpu_py311_h0890928_mpi_mpich_1.conda
osx-arm64::lammps-2024.02.07-cpu_py38_h74d7d60_mpi_openmpi_1.conda
osx-arm64::mdtraj-1.9.9-py311h7f29720_1.conda
osx-arm64::wxpython-4.2.1-py312h4fd8812_5.conda
osx-arm64::pyarrow-14.0.2-py38hf7a7491_19_cpu.conda
osx-arm64::magics-metview-batch-4.15.4-h036cba1_0.conda
osx-arm64::util-linux-2.39.4-py310ha0e7487_0.conda
osx-arm64::libadios2-2.10.0-nompi_h989a7f2_103.conda
osx-arm64::pyarrow-13.0.0-py312h9cc9a04_37_cpu.conda
osx-arm64::libadios2-2.10.0-nompi_hecf9ec3_101.conda
osx-arm64::lxml-5.1.1-py310ha14e010_0.conda
osx-arm64::pyarrow-tests-15.0.2-py312hbf1f86f_5_cpu.conda
osx-arm64::heyoka-llvm-13-4.0.3-hd76f09e_0.conda
osx-arm64::grpcio-1.62.2-py311hf5d242d_0.conda
osx-arm64::blosc-1.21.5-h9c252e8_1.conda
osx-arm64::libadios2-2.10.0-mpi_mpich_ha046f88_2.conda
osx-arm64::libadios2-2.10.0-mpi_mpich_ha046f88_1.conda
osx-arm64::pdal-2.7.1-hfa75dc8_6.conda
osx-arm64::libtiledb-sql-0.30.0-ha3e379b_0.conda
osx-arm64::libadios2-2.10.0-mpi_mpich_h0aa738d_1.conda
osx-arm64::gap-core-4.13.0-h7d888fe_0.conda
osx-arm64::libadios2-2.9.2-mpi_mpich_h3ff4461_2.conda
osx-arm64::imagecodecs-2024.1.1-py311ha1638ae_6.conda
osx-arm64::libadios2-2.10.0-nompi_he95833c_100.conda
osx-arm64::pyarrow-tests-13.0.0-py38hf7a7491_36_cpu.conda
osx-arm64::imagecodecs-2024.1.1-py310h8137ee9_6.conda
osx-arm64::nest-simulator-3.6-py39h23e55c4_5.conda
osx-arm64::lammps-2024.02.07-cpu_py310_h49200cc_mpi_openmpi_0.conda
osx-arm64::folly-2024.04.08.00-hbf02c00_1_jemalloc.conda
osx-arm64::libadios2-2.10.0-mpi_mpich_h3ff4461_0.conda
osx-arm64::libxml2-2.12.6-h0d0cfa8_2.conda
osx-arm64::heyoka-llvm-15-4.0.3-h296fcc0_0.conda
osx-arm64::pyarrow-14.0.2-py312h9cc9a04_17_cpu.conda
osx-arm64::pyarrow-15.0.2-py38h638452a_4_cpu.conda
osx-arm64::heyoka-4.0.3-hea21ce2_0.conda
osx-arm64::libadios2-2.10.0-mpi_mpich_hc705787_2.conda
osx-arm64::lfortran-0.35.0-hbeb2e11_0.conda
osx-arm64::libadios2-2.10.0-nompi_hbeb0f92_101.conda
osx-arm64::libadios2-2.10.0-nompi_he95833c_101.conda
osx-arm64::ntbtls-0.3.2-h1059232_0.conda
osx-arm64::openmpi-5.0.2-hbd96bf3_102.conda
osx-arm64::libarrow-15.0.2-h0fcf22f_2_cpu.conda
osx-arm64::gazebo-11.14.0-gzcompatname1234567_11.conda
osx-arm64::libadios2-2.10.0-mpi_mpich_h0aa738d_2.conda
osx-arm64::llvm-tools-18.1.3-h30cc82d_0.conda
osx-arm64::pdal-2.7.1-h6fa9509_3.conda
osx-arm64::pyarrow-13.0.0-py311hab5d6ba_37_cpu.conda
osx-arm64::pyarrow-15.0.2-py310h01a46da_6_cpu.conda
osx-arm64::pdal-2.7.1-hff7fe72_5.conda
osx-arm64::pillow-10.3.0-py310h81a8c2e_0.conda
osx-arm64::llvmdev-18.1.4-h30cc82d_0.conda
osx-arm64::libpulsar-3.5.1-hde7147b_1.conda
osx-arm64::heyoka-3.2.0-hbf9ab78_1.conda
osx-arm64::zimpl-3.5.4-h5ff29b1_4.conda
osx-arm64::lammps-2024.02.07-cpu_py39_hb8cc403_mpi_mpich_1.conda
osx-arm64::scip-9.0.0-h6bc225a_4.conda
osx-arm64::folly-2024.04.08.00-h767db08_0_jemalloc.conda
osx-arm64::pyarrow-12.0.1-py310h5372290_48_cpu.conda
osx-arm64::folly-2024.04.22.00-hbf02c00_0_jemalloc.conda
osx-arm64::ttyd-1.7.7-hebbec8b_0.conda
osx-arm64::ndcctools-7.10.0-py311ha2834e1_0.conda
osx-arm64::lammps-2024.02.07-cpu_py310_h49200cc_mpi_openmpi_1.conda
osx-arm64::pyarrow-14.0.2-py311hab5d6ba_17_cpu.conda
osx-arm64::heyoka-4.0.3-h89a6e3a_0.conda
osx-arm64::lammps-2024.02.07-cpu_py39_h829d90f_mpi_openmpi_1.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-h391a133_23.conda
osx-arm64::libadios2-2.10.0-nompi_hf13c0cf_101.conda
osx-arm64::magics-metview-4.15.4-h42d4935_0.conda
osx-arm64::pytables-3.9.2-py311hf4904c8_2.conda
osx-arm64::tiledb-2.22.0-hf0716ca_3.conda
osx-arm64::libadios2-2.10.0-mpi_mpich_hb758b07_0.conda
osx-arm64::heyoka-3.2.0-hb4942df_0.conda
osx-arm64::tiledb-2.22.0-h96aa536_0.conda
osx-arm64::pyarrow-15.0.2-py310h01a46da_5_cpu.conda
osx-arm64::pyarrow-13.0.0-py38hf7a7491_36_cpu.conda
osx-arm64::llvm-tools-18.1.4-h30cc82d_0.conda
osx-arm64::pyarrow-tests-12.0.1-py311hab5d6ba_48_cpu.conda
osx-arm64::nco-5.2.3-hf4d03cd_0.conda
osx-arm64::pyarrow-14.0.2-py38hf7a7491_17_cpu.conda
osx-arm64::pyarrow-tests-15.0.2-py311h5ff715f_5_cpu.conda
osx-arm64::lammps-2024.02.07-cpu_py310_h1b23ab0_nompi_0.conda
osx-arm64::heyoka-llvm-16-4.0.3-hc2dcc4b_0.conda
osx-arm64::pdal-2.7.1-hff7fe72_4.conda
osx-arm64::cmake-3.29.2-h50fd54c_0.conda
osx-arm64::nushell-0.92.2-h21b44c4_0.conda
osx-arm64::lldb-18.1.3-py39h8c1971a_0.conda
osx-arm64::libarrow-14.0.2-h3b19404_18_cpu.conda
osx-arm64::libllvm18-18.1.3-h30cc82d_0.conda
osx-arm64::libgoogle-cloud-storage-2.23.0-h8a76758_0.conda
osx-arm64::pyarrow-tests-13.0.0-py312h9cc9a04_37_cpu.conda
osx-arm64::tiledb-2.21.2-hca4efeb_1.conda
osx-arm64::lammps-2024.02.07-cpu_py312_hdfa2c00_mpi_mpich_1.conda
osx-arm64::util-linux-2.39.4-py39h019ad03_0.conda
osx-arm64::pyarrow-15.0.2-py311h5ff715f_6_cpu.conda
osx-arm64::aws-sdk-cpp-1.11.267-h18943f6_7.conda
osx-arm64::mongodb-6.0.12-h2f5b31f_1.conda
osx-arm64::pyinstaller-6.6.0-py38he974862_0.conda
osx-arm64::r-base-4.3.3-h76d92e8_1.conda
osx-arm64::libadios2-2.10.0-mpi_openmpi_h1489629_2.conda
osx-arm64::pytables-3.9.2-py39hed064fc_2.conda
osx-arm64::xeus-cpp-0.4.0-h66a9305_0.conda
osx-arm64::heyoka-llvm-16-4.0.3-h49979dc_2.conda
osx-arm64::pyarrow-15.0.2-py312hbf1f86f_4_cpu.conda
osx-arm64::lammps-2024.02.07-cpu_py39_h829d90f_mpi_openmpi_0.conda
osx-arm64::libadios2-2.10.0-mpi_openmpi_h6eedf57_1.conda
osx-arm64::pillow-10.3.0-py38h9ef4633_0.conda
osx-arm64::pyarrow-15.0.2-py311h5ff715f_5_cpu.conda
osx-arm64::vowpalwabbit-9.9.0-py310hdf86a80_4.conda
osx-arm64::heyoka-4.0.3-h385eb72_1.conda
osx-arm64::heyoka-3.2.0-hbd28a83_0.conda
osx-arm64::util-linux-2.39.4-py38h9dc91de_0.conda
osx-arm64::heyoka-4.0.3-he82fe33_2.conda
osx-arm64::ndcctools-7.10.0-py39hec72b60_0.conda
osx-arm64::tiledb-2.20.1-hca4efeb_7.conda
osx-arm64::libmongoc-1.23.2-hba8527f_1.conda
osx-arm64::hyperion-fortran-0.9.11-h377d536_2.conda
osx-arm64::sasktran2-2024.03.0-py310h362212e_1.conda
osx-arm64::libadios2-2.9.2-nompi_he95833c_102.conda
osx-arm64::pyarrow-13.0.0-py39hb31e23e_36_cpu.conda
osx-arm64::genomekit-5.0.1-py310h1c56d45_0.conda
osx-arm64::scip-9.0.0-h684fd09_3.conda
osx-arm64::mlir-18.1.4-hba3f82b_0.conda
osx-arm64::folly-2023.09.25.00-h2207c70_5.conda
osx-arm64::photochem-0.5.3-py310h562f64c_0.conda
osx-arm64::libgdal-3.8.5-hd6f06ec_0.conda
osx-arm64::pyarrow-tests-15.0.2-py310h01a46da_5_cpu.conda
osx-arm64::libadios2-2.10.0-mpi_openmpi_hf375636_2.conda
osx-arm64::gdstk-0.9.51-py39hb07f281_0.conda
osx-arm64::libadios2-2.10.0-mpi_mpich_h3ff4461_2.conda
osx-arm64::libarrow-12.0.1-hfd3cd7d_46_cpu.conda
osx-arm64::llvm-18.1.4-h7bf68d2_0.conda
osx-arm64::collada-dom-2.5.0-h39710e1_8.conda
osx-arm64::tiledb-2.21.2-hbfef6ee_0.conda
osx-arm64::heyoka-3.2.0-h69130e2_1.conda
osx-arm64::libarrow-15.0.2-hea125af_6_cpu.conda
osx-arm64::ogre-next-2.3.3-h01a85d9_0.conda
osx-arm64::lammps-2024.02.07-cpu_py39_h5afc6b9_nompi_0.conda
osx-arm64::lammps-2024.02.07-cpu_py310_h4786252_mpi_mpich_0.conda
osx-arm64::heyoka-3.2.0-h1f0e809_1.conda
osx-arm64::pyarrow-tests-14.0.2-py312h9cc9a04_17_cpu.conda
osx-arm64::libmed-4.1.1-nompi_hf693529_112.conda
osx-arm64::libarrow-12.0.1-h89068bf_45_cpu.conda
osx-arm64::wxpython-4.2.1-py39hc8d7b8c_5.conda
osx-arm64::folly-2023.09.25.00-h86a4d98_5.conda
osx-arm64::pyarrow-tests-14.0.2-py311hab5d6ba_18_cpu.conda
osx-arm64::heyoka-3.2.0-h0b12bfd_0.conda
osx-arm64::verilator-5.022-h0de0349_1.conda
osx-arm64::heyoka-llvm-15-4.0.3-hc975720_1.conda
osx-arm64::pyarrow-14.0.2-py310h5372290_17_cpu.conda
osx-arm64::ldas-tools-framecpp-3.0.3-hf71bc1e_1.conda
osx-arm64::pyarrow-tests-15.0.2-py312hbf1f86f_4_cpu.conda
osx-arm64::libadios2-2.10.0-mpi_mpich_hc705787_1.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-hc70703e_22.conda
osx-arm64::libadios2-2.10.0-nompi_hbeb0f92_100.conda
osx-arm64::libxmlsec1-1.3.4-hfc889cb_0.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-h4f3797c_23.conda
osx-arm64::mdtraj-1.9.9-py38heb2e344_1.conda
osx-arm64::pyarrow-14.0.2-py39hb31e23e_18_cpu.conda
osx-arm64::ndcctools-7.10.0-py38hf8267ce_0.conda
osx-arm64::libgdal-3.8.5-h2f7ae65_2.conda
osx-arm64::pyarrow-14.0.2-py311hab5d6ba_18_cpu.conda
osx-arm64::heyoka-llvm-14-4.0.3-hcbf47d0_2.conda
osx-arm64::tiledb-2.21.2-h96aa536_1.conda
osx-arm64::pillow-10.3.0-py311h0b5d0a1_0.conda
osx-arm64::libgdal-arrow-parquet-3.8.5-h4fc9195_0.conda
osx-arm64::nest-simulator-3.7-py310h2df337d_1.conda
osx-arm64::libadios2-2.9.2-mpi_mpich_hb758b07_2.conda
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
osx-arm64::jbig2dec-0.18-h22b9e9d_0.conda
osx-arm64::libmlir-18.1.3-hba3f82b_0.conda
osx-arm64::libsqlite-3.45.3-h091b4b1_0.conda
osx-arm64::openjdk-17.0.11-h3fcba2d_0.conda
osx-arm64::cfitsio-4.4.0-h808cd33_1.conda
osx-arm64::openjdk-22.0.1-hbeb2e11_0.conda
osx-arm64::libmlir18-18.1.3-hba3f82b_0.conda
osx-arm64::openjdk-11.0.23-h3fcba2d_0.conda
osx-arm64::git-cliff-2.2.1-h46549a6_0.conda
osx-arm64::openjdk-21.0.2-hbeb2e11_1.conda
osx-arm64::dotnet-sdk-6.0.420-h31fc65e_0.conda
osx-arm64::libharu-2.4.4-h22b9e9d_0.conda
osx-arm64::libmlir-18.1.4-hba3f82b_0.conda
osx-arm64::coin-or-osi-0.108.10-h0dc0bf9_0.conda
osx-arm64::openjdk-17.0.10-h3fcba2d_1.conda
osx-arm64::ldas-tools-framecpp-2.9.3-hd3db944_2.conda
osx-arm64::dlib-cpp-19.24.4-h72dd2d5_0.conda
osx-arm64::dotnet-sdk-8.0.204-h31fc65e_0.conda
osx-arm64::dotnet-aspnetcore-6.0.28-h31fc65e_0.conda
osx-arm64::openjdk-21.0.3-hbeb2e11_0.conda
osx-arm64::coin-or-utils-2.11.11-h0f73d51_0.conda
osx-arm64::dotnet-aspnetcore-8.0.4-h31fc65e_0.conda
osx-arm64::libmlir18-18.1.4-hba3f82b_0.conda
osx-arm64::dotnet-runtime-8.0.4-h31fc65e_0.conda
osx-arm64::dotnet-runtime-6.0.28-h31fc65e_0.conda
osx-arm64::eccodes-2.35.0-h64f3314_0.conda
-    "libzlib >=1.2.13,<1.3.0a0"
+    "libzlib >=1.2.13,<2.0.0a0"
================================================================================
================================================================================
linux-ppc64le
linux-ppc64le::aws-sdk-cpp-1.11.267-h316317e_7.conda
linux-ppc64le::libadios2-2.10.0-mpi_openmpi_h3892546_2.conda
linux-ppc64le::libmed-4.1.1-mpi_openmpi_h1f08be8_12.conda
linux-ppc64le::libarrow-12.0.1-h84680f2_48_cuda.conda
linux-ppc64le::openmpi-5.0.2-h3390e8d_102.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.5-h2e3b446_0.conda
linux-ppc64le::openmpi-5.0.3-h3390e8d_100.conda
linux-ppc64le::pyarrow-tests-15.0.2-py312h38b2b78_4_cuda.conda
linux-ppc64le::pyarrow-14.0.2-py310hc9c6eef_19_cpu.conda
linux-ppc64le::pytables-3.9.2-py311h9000e22_2.conda
linux-ppc64le::pyarrow-13.0.0-py310hc9c6eef_36_cpu.conda
linux-ppc64le::imagecodecs-2024.1.1-py39h20e4114_5.conda
linux-ppc64le::pyarrow-14.0.2-py311h36deb01_17_cpu.conda
linux-ppc64le::pyarrow-tests-13.0.0-py39h3340269_37_cuda.conda
linux-ppc64le::pyarrow-tests-14.0.2-py39haabe73b_19_cpu.conda
linux-ppc64le::ffmpeg-6.1.1-gpl_hc49ce7d_108.conda
linux-ppc64le::pyarrow-13.0.0-py312h38b2b78_37_cuda.conda
linux-ppc64le::pyarrow-tests-13.0.0-py311h36deb01_36_cpu.conda
linux-ppc64le::pyarrow-12.0.1-py310hc9c6eef_48_cpu.conda
linux-ppc64le::libarrow-13.0.0-h53ec466_36_cuda.conda
linux-ppc64le::libmed-4.1.1-mpi_mpich_h27f6d47_12.conda
linux-ppc64le::libarrow-14.0.2-h11fe7bc_18_cuda.conda
linux-ppc64le::pyarrow-13.0.0-py310h37309b9_37_cuda.conda
linux-ppc64le::folly-2024.04.01.00-h70bcce3_0.conda
linux-ppc64le::pyarrow-tests-12.0.1-py38h3b7d3ac_47_cuda.conda
linux-ppc64le::imagecodecs-2024.1.1-py312hed450c3_4.conda
linux-ppc64le::lxml-5.1.1-py39hbbda11a_0.conda
linux-ppc64le::libadios2-2.10.0-mpi_mpich_hbf0f72b_1.conda
linux-ppc64le::libadios2-2.10.0-nompi_h9511091_100.conda
linux-ppc64le::pyarrow-12.0.1-py38h3b7d3ac_48_cuda.conda
linux-ppc64le::ogre-14.2.4-haab7b0d_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.5-h3ad368c_2.conda
linux-ppc64le::lxml-5.1.1-py38h2d7b43d_0.conda
linux-ppc64le::libadios2-2.10.0-mpi_mpich_h9ea6a2f_1.conda
linux-ppc64le::libadios2-2.10.0-mpi_openmpi_h58bf8fa_3.conda
linux-ppc64le::pyarrow-tests-15.0.2-py311h36deb01_5_cpu.conda
linux-ppc64le::libarrow-15.0.2-h11fe7bc_5_cuda.conda
linux-ppc64le::libadios2-2.10.0-nompi_h2fc1bae_100.conda
linux-ppc64le::openimageio-2.5.9.0-py312hd6eb0dd_1.conda
linux-ppc64le::imagecodecs-2024.1.1-py310h7b0c0df_4.conda
linux-ppc64le::pyarrow-tests-14.0.2-py310h37309b9_19_cuda.conda
linux-ppc64le::libadios2-2.10.0-mpi_openmpi_h89453bf_3.conda
linux-ppc64le::libadios2-2.10.0-mpi_mpich_hb5a18fc_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.5-h3e35086_2.conda
linux-ppc64le::libarrow-15.0.2-h5912946_5_cpu.conda
linux-ppc64le::pyarrow-15.0.2-py39h3340269_5_cuda.conda
linux-ppc64le::pyarrow-tests-15.0.2-py38hd9ba88f_4_cpu.conda
linux-ppc64le::pyarrow-tests-14.0.2-py38h3b7d3ac_18_cuda.conda
linux-ppc64le::libgdal-3.7.3-ha54f08b_23.conda
linux-ppc64le::qt-main-5.15.8-he1b3ad4_21.conda
linux-ppc64le::pyarrow-tests-15.0.2-py39h3340269_6_cuda.conda
linux-ppc64le::pyarrow-13.0.0-py38h3b7d3ac_37_cuda.conda
linux-ppc64le::libadios2-2.10.0-nompi_h9958039_103.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.5-ha4001c0_1.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-hb64392d_43.conda
linux-ppc64le::pyarrow-14.0.2-py312h38b2b78_18_cuda.conda
linux-ppc64le::lxml-5.2.1-py38h0dbaae3_0.conda
linux-ppc64le::pyarrow-14.0.2-py39haabe73b_17_cpu.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-hccc506e_43.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-h318a025_23.conda
linux-ppc64le::pyarrow-13.0.0-py312h5daf4ee_36_cpu.conda
linux-ppc64le::pyarrow-tests-14.0.2-py39h3340269_17_cuda.conda
linux-ppc64le::pytables-3.9.2-py39h4dfe889_2.conda
linux-ppc64le::lxml-5.2.1-py311hb98ff45_0.conda
linux-ppc64le::pyarrow-tests-14.0.2-py311h36deb01_19_cpu.conda
linux-ppc64le::ffmpeg-6.1.1-lgpl_h49fb4ed_8.conda
linux-ppc64le::util-linux-2.39.4-py39hf65199f_0.conda
linux-ppc64le::python-3.11.9-hbe116a8_0_cpython.conda
linux-ppc64le::openjdk-17.0.10-h0367033_1.conda
linux-ppc64le::ffmpeg-6.1.1-lgpl_h49fb4ed_7.conda
linux-ppc64le::pyarrow-14.0.2-py38hd9ba88f_18_cpu.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-h07ac254_22.conda
linux-ppc64le::libadios2-2.10.0-mpi_mpich_h9ea6a2f_0.conda
linux-ppc64le::pyarrow-15.0.2-py311h2bb95fe_5_cuda.conda
linux-ppc64le::libadios2-2.10.0-mpi_openmpi_hc1ef195_0.conda
linux-ppc64le::libarrow-15.0.2-h9238d13_6_cuda.conda
linux-ppc64le::pyarrow-14.0.2-py38h3b7d3ac_18_cuda.conda
linux-ppc64le::pyarrow-tests-14.0.2-py38hd9ba88f_19_cpu.conda
linux-ppc64le::libadios2-2.10.0-mpi_mpich_hf8c5bbb_1.conda
linux-ppc64le::libarrow-14.0.2-h92960fb_19_cpu.conda
linux-ppc64le::pyarrow-tests-13.0.0-py39haabe73b_36_cpu.conda
linux-ppc64le::nco-5.2.4-hd97f16e_0.conda
linux-ppc64le::folly-2024.04.08.00-h23784f2_0_jemalloc.conda
linux-ppc64le::pyarrow-tests-13.0.0-py38hd9ba88f_37_cpu.conda
linux-ppc64le::openmpi-5.0.2-h45ed331_101.conda
linux-ppc64le::libadios2-2.9.2-nompi_h3f2de0f_102.conda
linux-ppc64le::libadios2-2.10.0-mpi_openmpi_h29eb849_1.conda
linux-ppc64le::pyarrow-14.0.2-py310h37309b9_19_cuda.conda
linux-ppc64le::pillow-10.3.0-py38h2810528_0.conda
linux-ppc64le::pyarrow-15.0.2-py310hc9c6eef_4_cpu.conda
linux-ppc64le::imagemagick-7.1.1_31-pl5321h09de15a_1.conda
linux-ppc64le::pyarrow-14.0.2-py311h2bb95fe_17_cuda.conda
linux-ppc64le::libmed-4.1.1-mpi_mpich_h0d5bc5f_12.conda
linux-ppc64le::libarrow-14.0.2-h11fe7bc_17_cuda.conda
linux-ppc64le::imagecodecs-2024.1.1-py39haaf24e6_5.conda
linux-ppc64le::tiledb-2.20.1-h7d11dcd_7.conda
linux-ppc64le::healpy-1.16.6-py39hb55f659_4.conda
linux-ppc64le::util-linux-2.39.4-py310h3fcec6a_0.conda
linux-ppc64le::libadios2-2.9.2-mpi_openmpi_ha1508ea_2.conda
linux-ppc64le::libadios2-2.10.0-nompi_hf8caf3d_101.conda
linux-ppc64le::libadios2-2.10.0-mpi_mpich_hb5a18fc_1.conda
linux-ppc64le::pyarrow-12.0.1-py311h2bb95fe_48_cuda.conda
linux-ppc64le::pyarrow-14.0.2-py310hc9c6eef_17_cpu.conda
linux-ppc64le::libarrow-13.0.0-hdb36256_35_cuda.conda
linux-ppc64le::lxml-5.2.1-py312h6c321b2_0.conda
linux-ppc64le::pyarrow-tests-15.0.2-py312h5daf4ee_6_cpu.conda
linux-ppc64le::r-base-4.3.3-heb2d98c_1.conda
linux-ppc64le::pyarrow-15.0.2-py310h37309b9_5_cuda.conda
linux-ppc64le::libadios2-2.10.0-nompi_h5df613e_102.conda
linux-ppc64le::eccodes-2.35.0-hfb67fc0_0.conda
linux-ppc64le::pyarrow-15.0.2-py39h3340269_4_cuda.conda
linux-ppc64le::pyarrow-12.0.1-py310h37309b9_47_cuda.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-h0162811_43.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-h3453f98_43.conda
linux-ppc64le::tiledb-2.22.0-h63f279d_1.conda
linux-ppc64le::wxwidgets-3.2.4-h81fb9c2_3.conda
linux-ppc64le::pyarrow-15.0.2-py38h3b7d3ac_4_cuda.conda
linux-ppc64le::mlir-18.1.3-hae84d68_0.conda
linux-ppc64le::lld-18.1.3-h1cac54b_0.conda
linux-ppc64le::pyarrow-12.0.1-py310h37309b9_48_cuda.conda
linux-ppc64le::pyarrow-12.0.1-py39h3340269_47_cuda.conda
linux-ppc64le::pyarrow-14.0.2-py312h5daf4ee_17_cpu.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-he6c6327_43.conda
linux-ppc64le::pyarrow-14.0.2-py38hd9ba88f_19_cpu.conda
linux-ppc64le::imagecodecs-2024.1.1-py39h23f614c_4.conda
linux-ppc64le::pillow-10.3.0-py312hc1ea13d_0.conda
linux-ppc64le::pyarrow-tests-14.0.2-py312h5daf4ee_17_cpu.conda
linux-ppc64le::folly-2024.04.22.00-hf517173_0_jemalloc.conda
linux-ppc64le::pyarrow-tests-15.0.2-py38h3b7d3ac_5_cuda.conda
linux-ppc64le::libmed-4.1.1-mpi_openmpi_hdece28a_12.conda
linux-ppc64le::libarrow-14.0.2-h0151fdb_16_cuda.conda
linux-ppc64le::nexus-4.4.3-h0538302_13.conda
linux-ppc64le::libadios2-2.10.0-mpi_openmpi_h29eb849_0.conda
linux-ppc64le::folly-2024.04.01.00-hf5421ea_0_jemalloc.conda
linux-ppc64le::llvm-openmp-18.1.3-h8759ddb_0.conda
linux-ppc64le::grpcio-1.62.2-py310h8eb8f48_0.conda
linux-ppc64le::pyarrow-tests-14.0.2-py311h36deb01_18_cpu.conda
linux-ppc64le::pyarrow-14.0.2-py312h38b2b78_17_cuda.conda
linux-ppc64le::libadios2-2.10.0-mpi_mpich_h4bff31c_2.conda
linux-ppc64le::pyarrow-tests-12.0.1-py38hd9ba88f_47_cpu.conda
linux-ppc64le::pyarrow-tests-12.0.1-py38h3b7d3ac_48_cuda.conda
linux-ppc64le::pyarrow-tests-14.0.2-py311h2bb95fe_17_cuda.conda
linux-ppc64le::openimageio-2.5.9.0-py311h9709008_1.conda
linux-ppc64le::pytables-3.9.2-py310hbaf089a_2.conda
linux-ppc64le::libadios2-2.9.2-nompi_h2fc1bae_102.conda
linux-ppc64le::pyarrow-14.0.2-py39h3340269_17_cuda.conda
linux-ppc64le::folly-2023.09.25.00-h1b576c0_5_jemalloc.conda
linux-ppc64le::libadios2-2.9.2-mpi_mpich_hf8c5bbb_2.conda
linux-ppc64le::pyarrow-tests-13.0.0-py39h3340269_36_cuda.conda
linux-ppc64le::libarrow-12.0.1-hdb36256_46_cuda.conda
linux-ppc64le::libadios2-2.9.2-mpi_openmpi_hc1ef195_2.conda
linux-ppc64le::pyarrow-tests-13.0.0-py38h3b7d3ac_37_cuda.conda
linux-ppc64le::libadios2-2.10.0-nompi_h7b24b19_103.conda
linux-ppc64le::pyarrow-tests-15.0.2-py310h37309b9_5_cuda.conda
linux-ppc64le::pyarrow-14.0.2-py311h36deb01_19_cpu.conda
linux-ppc64le::libadios2-2.10.0-nompi_h9511091_101.conda
linux-ppc64le::lxml-5.1.1-py39hd5592de_0.conda
linux-ppc64le::libarrow-15.0.2-hbf97785_2_cuda.conda
linux-ppc64le::grpcio-1.62.2-py39h278787b_0.conda
linux-ppc64le::libadios2-2.10.0-nompi_ha92a13b_102.conda
linux-ppc64le::libadios2-2.10.0-mpi_openmpi_h060053a_2.conda
linux-ppc64le::pyarrow-14.0.2-py311h2bb95fe_19_cuda.conda
linux-ppc64le::pillow-10.3.0-py311he6692c3_0.conda
linux-ppc64le::ffmpeg-6.1.1-gpl_hc49ce7d_107.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.5-h9f995a1_2.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-h7d16859_43.conda
linux-ppc64le::pyarrow-13.0.0-py39haabe73b_36_cpu.conda
linux-ppc64le::pyarrow-13.0.0-py312h38b2b78_36_cuda.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-h92768f1_43.conda
linux-ppc64le::pyarrow-tests-15.0.2-py311h36deb01_4_cpu.conda
linux-ppc64le::lxml-5.1.1-py310h960888a_0.conda
linux-ppc64le::pyarrow-tests-15.0.2-py38hd9ba88f_6_cpu.conda
linux-ppc64le::pyarrow-15.0.2-py312h5daf4ee_4_cpu.conda
linux-ppc64le::pyarrow-12.0.1-py311h2bb95fe_47_cuda.conda
linux-ppc64le::libadios2-2.10.0-mpi_openmpi_haea787e_0.conda
linux-ppc64le::pyarrow-13.0.0-py311h36deb01_37_cpu.conda
linux-ppc64le::libadios2-2.10.0-mpi_openmpi_h02f969a_0.conda
linux-ppc64le::pyarrow-tests-15.0.2-py311h2bb95fe_6_cuda.conda
linux-ppc64le::libadios2-2.10.0-mpi_openmpi_hc1ef195_1.conda
linux-ppc64le::magic-8.3.468-h7eb73fb_0.conda
linux-ppc64le::libmed-4.1.1-mpi_openmpi_hff1d385_12.conda
linux-ppc64le::libadios2-2.10.0-nompi_hafff54f_103.conda
linux-ppc64le::pyarrow-tests-12.0.1-py311h2bb95fe_48_cuda.conda
linux-ppc64le::tiledb-2.21.2-h7d11dcd_1.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-hf66c2d1_43.conda
linux-ppc64le::libadios2-2.9.2-nompi_h9511091_102.conda
linux-ppc64le::libadios2-2.9.2-mpi_mpich_h9ea6a2f_2.conda
linux-ppc64le::pdal-2.7.1-h1b501d7_3.conda
linux-ppc64le::gst-plugins-bad-1.24.1-h3dbc169_0.conda
linux-ppc64le::pyarrow-13.0.0-py39h3340269_36_cuda.conda
linux-ppc64le::pillow-10.3.0-py39h9d42d55_0.conda
linux-ppc64le::libglib-2.80.0-h5c35f7a_5.conda
linux-ppc64le::folly-2024.04.08.00-hf976cf3_1.conda
linux-ppc64le::pyarrow-14.0.2-py39h3340269_18_cuda.conda
linux-ppc64le::pyarrow-15.0.2-py312h5daf4ee_5_cpu.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-h3179766_43.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-h90067c3_22.conda
linux-ppc64le::pyarrow-15.0.2-py38hd9ba88f_5_cpu.conda
linux-ppc64le::pyarrow-14.0.2-py38hd9ba88f_17_cpu.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-h3e35086_23.conda
linux-ppc64le::pyarrow-13.0.0-py38hd9ba88f_36_cpu.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-hfa874bd_43.conda
linux-ppc64le::nco-5.2.3-hd97f16e_0.conda
linux-ppc64le::tiledb-2.22.0-he02fcca_0.conda
linux-ppc64le::ogre-14.2.4-hebe49f4_0.conda
linux-ppc64le::poppler-24.04.0-hf26e723_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.5-h318a025_2.conda
linux-ppc64le::pyarrow-13.0.0-py311h2bb95fe_37_cuda.conda
linux-ppc64le::grpcio-1.62.2-py39h27cb1e9_0.conda
linux-ppc64le::tiledb-2.21.2-hc6edee8_0.conda
linux-ppc64le::pyarrow-14.0.2-py39h3340269_19_cuda.conda
linux-ppc64le::pyarrow-tests-13.0.0-py39haabe73b_37_cpu.conda
linux-ppc64le::tiledb-2.21.2-he02fcca_1.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.5-h828374b_0.conda
linux-ppc64le::libarrow-15.0.2-h0151fdb_3_cuda.conda
linux-ppc64le::pyarrow-15.0.2-py311h36deb01_6_cpu.conda
linux-ppc64le::pyarrow-15.0.2-py310h37309b9_4_cuda.conda
linux-ppc64le::libadios2-2.10.0-mpi_openmpi_hbe53119_3.conda
linux-ppc64le::lxml-5.1.1-py312h859690c_0.conda
linux-ppc64le::pyarrow-tests-14.0.2-py312h5daf4ee_19_cpu.conda
linux-ppc64le::libadios2-2.10.0-mpi_mpich_h8fc796d_0.conda
linux-ppc64le::libarrow-13.0.0-hd7d6725_36_cpu.conda
linux-ppc64le::nsight-compute-2024.1.1.4-h008b9a4_1.conda
linux-ppc64le::pyarrow-tests-15.0.2-py310hc9c6eef_4_cpu.conda
linux-ppc64le::ogre-next-2.3.3-hecdd2b9_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.5-hcb712b3_0.conda
linux-ppc64le::vowpalwabbit-9.9.0-py38hb69e7d1_4.conda
linux-ppc64le::imagecodecs-2024.1.1-py39ha704933_6.conda
linux-ppc64le::python-3.12.3-h3332dee_0_cpython.conda
linux-ppc64le::pyarrow-tests-13.0.0-py38hd9ba88f_36_cpu.conda
linux-ppc64le::libmed-4.1.1-nompi_hde4df01_112.conda
linux-ppc64le::imagecodecs-2024.1.1-py310h2138a3f_6.conda
linux-ppc64le::libadios2-2.10.0-mpi_mpich_h1cc2280_3.conda
linux-ppc64le::libmed-4.1.1-nompi_h29e6f2a_112.conda
linux-ppc64le::libarrow-15.0.2-h8ce50b3_3_cpu.conda
linux-ppc64le::pyarrow-tests-14.0.2-py311h2bb95fe_18_cuda.conda
linux-ppc64le::libadios2-2.10.0-nompi_hefbdf29_103.conda
linux-ppc64le::folly-2024.04.15.00-hf976cf3_0.conda
linux-ppc64le::pillow-10.3.0-py310h0afc0cc_0.conda
linux-ppc64le::nsight-compute-2024.1.1.4-h1c5c14d_1.conda
linux-ppc64le::pyarrow-15.0.2-py312h38b2b78_4_cuda.conda
linux-ppc64le::libadios2-2.9.2-mpi_openmpi_haea787e_2.conda
linux-ppc64le::pyarrow-tests-15.0.2-py38hd9ba88f_5_cpu.conda
linux-ppc64le::folly-2024.04.22.00-hf976cf3_0.conda
linux-ppc64le::libmed-4.1.1-mpi_mpich_hef82e58_12.conda
linux-ppc64le::pyarrow-12.0.1-py39h3340269_48_cuda.conda
linux-ppc64le::pyarrow-tests-12.0.1-py310h37309b9_47_cuda.conda
linux-ppc64le::libadios2-2.10.0-nompi_hbf461e9_101.conda
linux-ppc64le::pyarrow-14.0.2-py312h38b2b78_19_cuda.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-hebbd4d1_43.conda
linux-ppc64le::texlive-core-20230313-h520046b_12.conda
linux-ppc64le::pyarrow-tests-13.0.0-py311h2bb95fe_36_cuda.conda
linux-ppc64le::assimp-5.4.0-h8326af8_0.conda
linux-ppc64le::libarrow-14.0.2-h98743ac_15_cpu.conda
linux-ppc64le::gstlal-1.13.0-py310h461e14c_1.conda
linux-ppc64le::llvmdev-18.1.4-h3a33151_0.conda
linux-ppc64le::mesalib-24.0.6-hdbb2c19_0.conda
linux-ppc64le::tiledb-2.21.2-h63f279d_2.conda
linux-ppc64le::pyarrow-tests-14.0.2-py38hd9ba88f_18_cpu.conda
linux-ppc64le::llvm-18.1.4-he6f3f58_0.conda
linux-ppc64le::libadios2-2.10.0-nompi_h3f2de0f_101.conda
linux-ppc64le::libarrow-14.0.2-h5912946_17_cpu.conda
linux-ppc64le::grpcio-1.62.2-py38hc2aed35_0.conda
linux-ppc64le::imagecodecs-2024.1.1-py310h2df85ba_5.conda
linux-ppc64le::openimageio-2.5.9.0-py38h80fe4ab_1.conda
linux-ppc64le::pyarrow-tests-15.0.2-py38h3b7d3ac_4_cuda.conda
linux-ppc64le::pyarrow-tests-13.0.0-py38h3b7d3ac_36_cuda.conda
linux-ppc64le::llvm-tools-18.1.4-h3a33151_0.conda
linux-ppc64le::rust-1.77.2-hb12b0c0_0.conda
linux-ppc64le::pyarrow-tests-15.0.2-py310hc9c6eef_6_cpu.conda
linux-ppc64le::pyarrow-12.0.1-py39haabe73b_47_cpu.conda
linux-ppc64le::lxml-5.2.1-py39he5cdba2_0.conda
linux-ppc64le::pyarrow-tests-13.0.0-py312h38b2b78_37_cuda.conda
linux-ppc64le::healpy-1.16.6-py311hd65dbda_4.conda
linux-ppc64le::pyarrow-tests-14.0.2-py312h38b2b78_19_cuda.conda
linux-ppc64le::libadios2-2.10.0-nompi_h2fc1bae_101.conda
linux-ppc64le::llvm-18.1.3-he6f3f58_0.conda
linux-ppc64le::pyarrow-tests-15.0.2-py39h3340269_4_cuda.conda
linux-ppc64le::pyarrow-15.0.2-py310h37309b9_6_cuda.conda
linux-ppc64le::gstlal-1.13.0-py39h8423a0a_1.conda
linux-ppc64le::pyarrow-tests-14.0.2-py38h3b7d3ac_19_cuda.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.5-h07ac254_1.conda
linux-ppc64le::libadios2-2.10.0-nompi_ha0b8f0e_103.conda
linux-ppc64le::pyarrow-14.0.2-py311h2bb95fe_18_cuda.conda
linux-ppc64le::ldas-tools-framecpp-3.0.3-h2371519_1.conda
linux-ppc64le::libadios2-2.10.0-mpi_mpich_hf8c5bbb_0.conda
linux-ppc64le::libadios2-2.10.0-mpi_mpich_hbf0f72b_0.conda
linux-ppc64le::pyarrow-tests-15.0.2-py312h5daf4ee_4_cpu.conda
linux-ppc64le::pyarrow-13.0.0-py311h36deb01_36_cpu.conda
linux-ppc64le::pyarrow-15.0.2-py312h38b2b78_5_cuda.conda
linux-ppc64le::imagecodecs-2024.1.1-py312hbf2ce78_6.conda
linux-ppc64le::libadios2-2.10.0-nompi_hbf461e9_100.conda
linux-ppc64le::libadios2-2.10.0-mpi_mpich_h22fc427_2.conda
linux-ppc64le::pyarrow-tests-14.0.2-py310hc9c6eef_17_cpu.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-h9fa10b8_43.conda
linux-ppc64le::pyarrow-15.0.2-py311h2bb95fe_6_cuda.conda
linux-ppc64le::llvmdev-18.1.3-h3a33151_0.conda
linux-ppc64le::pyarrow-tests-13.0.0-py310hc9c6eef_36_cpu.conda
linux-ppc64le::llvm-tools-18.1.3-h3a33151_0.conda
linux-ppc64le::util-linux-2.39.4-py38h5193096_0.conda
linux-ppc64le::pyarrow-tests-14.0.2-py311h36deb01_17_cpu.conda
linux-ppc64le::pyarrow-tests-15.0.2-py39haabe73b_5_cpu.conda
linux-ppc64le::libglib-2.80.0-h5c35f7a_2.conda
linux-ppc64le::libadios2-2.10.0-mpi_mpich_h8fc796d_1.conda
linux-ppc64le::libadios2-2.10.0-mpi_mpich_hc5567cf_2.conda
linux-ppc64le::pyarrow-15.0.2-py39h3340269_6_cuda.conda
linux-ppc64le::libadios2-2.10.0-mpi_openmpi_haea787e_1.conda
linux-ppc64le::openimageio-2.5.9.0-py310h1187590_1.conda
linux-ppc64le::pyarrow-15.0.2-py39haabe73b_6_cpu.conda
linux-ppc64le::gstlal-1.13.0-py311h96b2c23_1.conda
linux-ppc64le::openimageio-2.5.9.0-py39hba0cefc_1.conda
linux-ppc64le::folly-2024.04.29.00-hf517173_0_jemalloc.conda
linux-ppc64le::pyarrow-12.0.1-py38h3b7d3ac_47_cuda.conda
linux-ppc64le::libmed-4.1.1-nompi_h6ac8aa8_112.conda
linux-ppc64le::pyarrow-14.0.2-py312h5daf4ee_19_cpu.conda
linux-ppc64le::libarrow-12.0.1-hc8703c9_48_cpu.conda
linux-ppc64le::pyarrow-15.0.2-py38h3b7d3ac_5_cuda.conda
linux-ppc64le::libarrow-13.0.0-h84680f2_37_cuda.conda
linux-ppc64le::pyarrow-tests-14.0.2-py39haabe73b_18_cpu.conda
linux-ppc64le::libadios2-2.10.0-nompi_hcb54ac4_102.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-h3e455d8_43.conda
linux-ppc64le::libglib-2.80.0-h5c35f7a_6.conda
linux-ppc64le::util-linux-2.39.4-py312hbe3015e_0.conda
linux-ppc64le::pyarrow-tests-15.0.2-py38h3b7d3ac_6_cuda.conda
linux-ppc64le::pyarrow-13.0.0-py39haabe73b_37_cpu.conda
linux-ppc64le::healpy-1.16.6-py312h49a5560_4.conda
linux-ppc64le::grpcio-1.62.2-py312h930df82_0.conda
linux-ppc64le::pyarrow-14.0.2-py38h3b7d3ac_19_cuda.conda
linux-ppc64le::libadios2-2.10.0-nompi_h3f2de0f_100.conda
linux-ppc64le::pyarrow-13.0.0-py311h2bb95fe_36_cuda.conda
linux-ppc64le::openjdk-21.0.3-h65af0e7_0.conda
linux-ppc64le::libadios2-2.10.0-mpi_openmpi_h02f969a_1.conda
linux-ppc64le::libadios2-2.10.0-mpi_mpich_h42ed9b6_2.conda
linux-ppc64le::pyarrow-15.0.2-py38hd9ba88f_4_cpu.conda
linux-ppc64le::pyarrow-tests-12.0.1-py39haabe73b_48_cpu.conda
linux-ppc64le::aws-sdk-cpp-1.11.267-h2fb4a12_5.conda
linux-ppc64le::m4rie-20150908-h5baba08_1002.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.5-h90067c3_1.conda
linux-ppc64le::vowpalwabbit-9.9.0-py39h4cbcdda_4.conda
linux-ppc64le::aws-sdk-cpp-1.11.267-h8fea381_6.conda
linux-ppc64le::pyarrow-tests-12.0.1-py39haabe73b_47_cpu.conda
linux-ppc64le::libarrow-12.0.1-h2415b15_46_cpu.conda
linux-ppc64le::pyarrow-15.0.2-py39haabe73b_5_cpu.conda
linux-ppc64le::pyarrow-13.0.0-py310h37309b9_36_cuda.conda
linux-ppc64le::pyarrow-tests-15.0.2-py39haabe73b_4_cpu.conda
linux-ppc64le::imagemagick-7.1.1_31-pl5321h09de15a_0.conda
linux-ppc64le::libadios2-2.10.0-mpi_mpich_h6c31296_3.conda
linux-ppc64le::libarrow-13.0.0-hc8703c9_37_cpu.conda
linux-ppc64le::pyarrow-12.0.1-py311h36deb01_47_cpu.conda
linux-ppc64le::libarrow-12.0.1-hd838cdb_45_cpu.conda
linux-ppc64le::libllvm18-18.1.4-h3a33151_0.conda
linux-ppc64le::pyarrow-15.0.2-py311h2bb95fe_4_cuda.conda
linux-ppc64le::libpulsar-3.5.1-h607ab79_1.conda
linux-ppc64le::libadios2-2.9.2-nompi_hf8caf3d_102.conda
linux-ppc64le::libmed-4.1.1-nompi_h0e4c4af_112.conda
linux-ppc64le::libarrow-14.0.2-h9238d13_19_cuda.conda
linux-ppc64le::openjdk-21.0.2-h589f246_1.conda
linux-ppc64le::libopentelemetry-cpp-1.15.0-h60ae368_0.conda
linux-ppc64le::cmake-3.29.2-h1403f77_0.conda
linux-ppc64le::netcdf4-1.6.5-nompi_py38hc970dc1_100.conda
linux-ppc64le::pillow-10.3.0-py39h25080d0_0.conda
linux-ppc64le::libarrow-12.0.1-hd7d6725_47_cpu.conda
linux-ppc64le::libglib-2.80.0-h5c35f7a_4.conda
linux-ppc64le::healpy-1.16.6-py39h2d3e459_4.conda
linux-ppc64le::pyarrow-tests-13.0.0-py310h37309b9_37_cuda.conda
linux-ppc64le::folly-2024.04.29.00-hf976cf3_0.conda
linux-ppc64le::pyarrow-12.0.1-py310hc9c6eef_47_cpu.conda
linux-ppc64le::lxml-5.1.1-py311hf3c4098_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-h9f995a1_23.conda
linux-ppc64le::openjdk-11.0.23-hf042435_0.conda
linux-ppc64le::vowpalwabbit-9.9.0-py310hf2714e5_4.conda
linux-ppc64le::libmed-4.1.1-nompi_hd6493f4_112.conda
linux-ppc64le::pyarrow-tests-15.0.2-py311h36deb01_6_cpu.conda
linux-ppc64le::pyarrow-tests-15.0.2-py39h3340269_5_cuda.conda
linux-ppc64le::pytables-3.9.2-py39he46a2e2_2.conda
linux-ppc64le::lld-18.1.4-h1cac54b_0.conda
linux-ppc64le::libadios2-2.10.0-mpi_openmpi_ha1508ea_1.conda
linux-ppc64le::libadios2-2.9.2-mpi_openmpi_h29eb849_2.conda
linux-ppc64le::davix-0.8.6-hb3c4249_0.conda
linux-ppc64le::folly-2023.09.25.00-hd7e7f32_5.conda
linux-ppc64le::folly-2023.09.25.00-h33cc137_5.conda
linux-ppc64le::pyarrow-tests-14.0.2-py312h5daf4ee_18_cpu.conda
linux-ppc64le::pdal-2.7.1-hc8e65b1_2.conda
linux-ppc64le::libmed-4.1.1-mpi_mpich_h3d2802a_12.conda
linux-ppc64le::pyarrow-tests-14.0.2-py39h3340269_18_cuda.conda
linux-ppc64le::folly-2024.04.08.00-hf517173_1_jemalloc.conda
linux-ppc64le::pyarrow-tests-15.0.2-py312h38b2b78_6_cuda.conda
linux-ppc64le::libadios2-2.9.2-mpi_mpich_hb5a18fc_2.conda
linux-ppc64le::tiledb-2.21.2-h622fd85_3.conda
linux-ppc64le::pyarrow-tests-14.0.2-py310hc9c6eef_19_cpu.conda
linux-ppc64le::pyarrow-tests-14.0.2-py38h3b7d3ac_17_cuda.conda
linux-ppc64le::pyarrow-14.0.2-py311h36deb01_18_cpu.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-h5023608_43.conda
linux-ppc64le::pyarrow-14.0.2-py39haabe73b_18_cpu.conda
linux-ppc64le::libarrow-15.0.2-h5912946_4_cpu.conda
linux-ppc64le::pdal-2.7.1-hb660c7b_6.conda
linux-ppc64le::libadios2-2.10.0-nompi_h28d491e_102.conda
linux-ppc64le::ldas-tools-framecpp-2.9.3-ha332f37_2.conda
linux-ppc64le::libadios2-2.10.0-mpi_openmpi_hf402e11_2.conda
linux-ppc64le::imagecodecs-2024.1.1-py39h842b7a6_6.conda
linux-ppc64le::libmed-4.1.1-mpi_openmpi_h20f62b4_12.conda
linux-ppc64le::healpy-1.16.6-py310h574d935_4.conda
linux-ppc64le::pyarrow-14.0.2-py310hc9c6eef_18_cpu.conda
linux-ppc64le::libadios2-2.10.0-nompi_hb1fffb0_102.conda
linux-ppc64le::folly-2024.04.15.00-hf517173_0_jemalloc.conda
linux-ppc64le::libglib-2.80.0-h5c35f7a_3.conda
linux-ppc64le::pyarrow-tests-15.0.2-py311h2bb95fe_4_cuda.conda
linux-ppc64le::libxmlsec1-1.3.4-h56164d1_0.conda
linux-ppc64le::libadios2-2.10.0-mpi_openmpi_h33f094b_3.conda
linux-ppc64le::gstlal-1.13.0-py38he54f31f_1.conda
linux-ppc64le::pdal-2.7.1-hc8e65b1_4.conda
linux-ppc64le::imagecodecs-2024.1.1-py39h55648de_4.conda
linux-ppc64le::cpp-opentelemetry-sdk-1.15.0-h60ae368_0.conda
linux-ppc64le::pyarrow-tests-14.0.2-py312h38b2b78_17_cuda.conda
linux-ppc64le::libarrow-15.0.2-h11fe7bc_4_cuda.conda
linux-ppc64le::pyarrow-tests-13.0.0-py312h38b2b78_36_cuda.conda
linux-ppc64le::libarrow-12.0.1-h53ec466_47_cuda.conda
linux-ppc64le::pyarrow-13.0.0-py38h3b7d3ac_36_cuda.conda
linux-ppc64le::util-linux-2.39.4-py311h0232d2a_0.conda
linux-ppc64le::pytables-3.9.2-py312h1774bd6_2.conda
linux-ppc64le::lxml-5.2.1-py39h9c00bc8_0.conda
linux-ppc64le::pyarrow-12.0.1-py38hd9ba88f_48_cpu.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-h10f2063_43.conda
linux-ppc64le::libxml2-2.12.6-h0545f4b_2.conda
linux-ppc64le::pyarrow-14.0.2-py39haabe73b_19_cpu.conda
linux-ppc64le::pyarrow-15.0.2-py311h36deb01_5_cpu.conda
linux-ppc64le::pyarrow-tests-15.0.2-py39haabe73b_6_cpu.conda
linux-ppc64le::libadios2-2.10.0-mpi_mpich_hb5b6d68_3.conda
linux-ppc64le::libmed-4.1.1-mpi_openmpi_hde2fcd3_12.conda
linux-ppc64le::libarrow-14.0.2-h5912946_18_cpu.conda
linux-ppc64le::openjdk-22.0.1-h65af0e7_0.conda
linux-ppc64le::pyarrow-tests-13.0.0-py312h5daf4ee_37_cpu.conda
linux-ppc64le::pyarrow-tests-15.0.2-py310h37309b9_6_cuda.conda
linux-ppc64le::pyinstaller-6.6.0-py310h0719273_0.conda
linux-ppc64le::nsight-compute-2024.1.1.4-h1c5c14d_0.conda
linux-ppc64le::gap-core-4.13.0-h7b12599_0.conda
linux-ppc64le::util-linux-2.39.4-py39hb455f50_0.conda
linux-ppc64le::pyarrow-tests-12.0.1-py311h36deb01_47_cpu.conda
linux-ppc64le::openjdk-17.0.11-hf042435_0.conda
linux-ppc64le::imagecodecs-2024.1.1-py312haf122af_5.conda
linux-ppc64le::tiledb-2.22.0-haaf0c58_2.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.5-h62d8867_0.conda
linux-ppc64le::pyarrow-tests-12.0.1-py39h3340269_48_cuda.conda
linux-ppc64le::pyarrow-15.0.2-py310hc9c6eef_6_cpu.conda
linux-ppc64le::pyarrow-tests-12.0.1-py310hc9c6eef_48_cpu.conda
linux-ppc64le::libllvm18-18.1.3-h3a33151_0.conda
linux-ppc64le::pyarrow-13.0.0-py39h3340269_37_cuda.conda
linux-ppc64le::pyarrow-15.0.2-py310hc9c6eef_5_cpu.conda
linux-ppc64le::pyarrow-tests-13.0.0-py310h37309b9_36_cuda.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-h84de697_22.conda
linux-ppc64le::pyarrow-14.0.2-py310h37309b9_18_cuda.conda
linux-ppc64le::lxml-5.2.1-py310hc3fa083_0.conda
linux-ppc64le::libadios2-2.10.0-mpi_openmpi_h7b67502_2.conda
linux-ppc64le::imagecodecs-2024.1.1-py311hcebba2c_6.conda
linux-ppc64le::imagemagick-7.1.1_30-pl5321h79d4ed6_0.conda
linux-ppc64le::imagecodecs-2024.1.1-py311hf1233a4_5.conda
linux-ppc64le::pdal-2.7.1-hc8e65b1_5.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-h9369108_43.conda
linux-ppc64le::pyarrow-tests-12.0.1-py310hc9c6eef_47_cpu.conda
linux-ppc64le::pyarrow-12.0.1-py39haabe73b_48_cpu.conda
linux-ppc64le::libadios2-2.10.0-mpi_mpich_h2778cd8_3.conda
linux-ppc64le::blosc-1.21.5-h5f40997_1.conda
linux-ppc64le::libgdal-3.8.5-h3def1e2_2.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-ha4001c0_22.conda
linux-ppc64le::pyarrow-tests-13.0.0-py310hc9c6eef_37_cpu.conda
linux-ppc64le::pyarrow-tests-14.0.2-py39h3340269_19_cuda.conda
linux-ppc64le::pyarrow-15.0.2-py38h3b7d3ac_6_cuda.conda
linux-ppc64le::pyarrow-14.0.2-py38h3b7d3ac_17_cuda.conda
linux-ppc64le::pyarrow-tests-14.0.2-py310h37309b9_17_cuda.conda
linux-ppc64le::libarrow-15.0.2-h98743ac_2_cpu.conda
linux-ppc64le::libarrow-13.0.0-h2415b15_35_cpu.conda
linux-ppc64le::folly-2023.09.25.00-h9cf1176_5_jemalloc.conda
linux-ppc64le::libgrpc-1.62.2-h359702e_0.conda
linux-ppc64le::pyarrow-tests-14.0.2-py39haabe73b_17_cpu.conda
linux-ppc64le::vowpalwabbit-9.9.0-py311hcbf41d7_4.conda
linux-ppc64le::orc-2.0.0-h1469529_1.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-hfbdd66c_43.conda
linux-ppc64le::libadios2-2.10.0-mpi_mpich_h7213a59_3.conda
linux-ppc64le::pyarrow-13.0.0-py312h5daf4ee_37_cpu.conda
linux-ppc64le::libpulsar-3.5.1-h3cbff40_0.conda
linux-ppc64le::pyarrow-15.0.2-py311h36deb01_4_cpu.conda
linux-ppc64le::pyarrow-tests-12.0.1-py39h3340269_47_cuda.conda
linux-ppc64le::libadios2-2.10.0-mpi_mpich_he33ab80_2.conda
linux-ppc64le::tiledb-2.21.2-hcb21e86_4.conda
linux-ppc64le::libadios2-2.10.0-nompi_hf8caf3d_100.conda
linux-ppc64le::pyarrow-12.0.1-py38hd9ba88f_47_cpu.conda
linux-ppc64le::pyarrow-tests-12.0.1-py310h37309b9_48_cuda.conda
linux-ppc64le::tiledb-2.22.0-hcb21e86_3.conda
linux-ppc64le::libgdal-3.8.5-hafc4660_1.conda
linux-ppc64le::libbrial-1.2.12-h6891418_3.conda
linux-ppc64le::pyarrow-tests-14.0.2-py310hc9c6eef_18_cpu.conda
linux-ppc64le::ffmpeg-6.1.1-lgpl_hfeef31a_9.conda
linux-ppc64le::cmake-3.29.1-h1403f77_0.conda
linux-ppc64le::pyarrow-15.0.2-py312h38b2b78_6_cuda.conda
linux-ppc64le::nsight-compute-2024.1.1.4-h008b9a4_2.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-hc508197_43.conda
linux-ppc64le::pyarrow-tests-15.0.2-py310h37309b9_4_cuda.conda
linux-ppc64le::pyarrow-15.0.2-py39haabe73b_4_cpu.conda
linux-ppc64le::libadios2-2.10.0-mpi_openmpi_h8140b57_3.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.5-h84de697_1.conda
linux-ppc64le::pyarrow-14.0.2-py310h37309b9_17_cuda.conda
linux-ppc64le::folly-2023.09.25.00-hbb20ade_5_jemalloc.conda
linux-ppc64le::pyarrow-tests-14.0.2-py310h37309b9_18_cuda.conda
linux-ppc64le::libadios2-2.9.2-mpi_mpich_hbf0f72b_2.conda
linux-ppc64le::libarrow-12.0.1-h6a4827b_45_cuda.conda
linux-ppc64le::pyarrow-tests-12.0.1-py38hd9ba88f_48_cpu.conda
linux-ppc64le::pyarrow-tests-12.0.1-py311h2bb95fe_47_cuda.conda
linux-ppc64le::pyarrow-tests-12.0.1-py311h36deb01_48_cpu.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-h3ad368c_23.conda
linux-ppc64le::git-2.45.0-pl5321h49a0eb8_0.conda
linux-ppc64le::libadios2-2.10.0-mpi_openmpi_hca594a3_2.conda
linux-ppc64le::sqlite-3.45.3-h63c7444_0.conda
linux-ppc64le::ffmpeg-6.1.1-gpl_hb0d57f3_109.conda
linux-ppc64le::libgoogle-cloud-storage-2.23.0-h39cc67c_1.conda
linux-ppc64le::libarrow-14.0.2-h8ce50b3_16_cpu.conda
linux-ppc64le::pyarrow-tests-15.0.2-py312h38b2b78_5_cuda.conda
linux-ppc64le::libmed-4.1.1-mpi_mpich_hc77c38b_12.conda
linux-ppc64le::libmongoc-1.23.2-hcd32b50_1.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-hc9d3c65_43.conda
linux-ppc64le::imagecodecs-2024.1.1-py311h76a9d72_4.conda
linux-ppc64le::pyarrow-tests-15.0.2-py312h5daf4ee_5_cpu.conda
linux-ppc64le::folly-2023.09.25.00-ha0acf69_5.conda
linux-ppc64le::libgdal-3.7.3-h72e66d7_22.conda
linux-ppc64le::mlir-18.1.4-hae84d68_0.conda
linux-ppc64le::pyarrow-15.0.2-py38hd9ba88f_6_cpu.conda
linux-ppc64le::libadios2-2.9.2-mpi_mpich_h8fc796d_2.conda
linux-ppc64le::rsync-3.3.0-hd0ad052_0.conda
linux-ppc64le::libarrow-15.0.2-h92960fb_6_cpu.conda
linux-ppc64le::libadios2-2.10.0-mpi_openmpi_ha1508ea_0.conda
linux-ppc64le::pyarrow-tests-15.0.2-py310hc9c6eef_5_cpu.conda
linux-ppc64le::pyarrow-tests-13.0.0-py312h5daf4ee_36_cpu.conda
linux-ppc64le::pyarrow-tests-15.0.2-py311h2bb95fe_5_cuda.conda
linux-ppc64le::libvips-8.15.2-h59c5f61_1.conda
linux-ppc64le::pyarrow-tests-14.0.2-py311h2bb95fe_19_cuda.conda
linux-ppc64le::grpcio-1.62.2-py311h3997ded_0.conda
linux-ppc64le::libadios2-2.9.2-nompi_hbf461e9_102.conda
linux-ppc64le::folly-2023.09.25.00-h04538ff_5.conda
linux-ppc64le::pyarrow-13.0.0-py310hc9c6eef_37_cpu.conda
linux-ppc64le::pyarrow-tests-13.0.0-py311h36deb01_37_cpu.conda
linux-ppc64le::pyarrow-15.0.2-py312h5daf4ee_6_cpu.conda
linux-ppc64le::pyarrow-14.0.2-py312h5daf4ee_18_cpu.conda
linux-ppc64le::libgdal-3.8.5-ha31c3a8_0.conda
linux-ppc64le::libgoogle-cloud-storage-2.23.0-h39cc67c_0.conda
linux-ppc64le::pyarrow-tests-14.0.2-py312h38b2b78_18_cuda.conda
linux-ppc64le::pyarrow-12.0.1-py311h36deb01_48_cpu.conda
linux-ppc64le::libbrial-1.2.12-h6891418_2.conda
linux-ppc64le::pyarrow-tests-13.0.0-py311h2bb95fe_37_cuda.conda
linux-ppc64le::folly-2024.04.08.00-h17cb809_0.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-h1acae1e_43.conda
linux-ppc64le::libarrow-14.0.2-hbf97785_15_cuda.conda
linux-ppc64le::vowpalwabbit-9.9.0-py312hc0ed15b_4.conda
linux-ppc64le::pyarrow-13.0.0-py38hd9ba88f_37_cpu.conda
linux-ppc64le::libarrow-13.0.0-hd838cdb_34_cpu.conda
linux-ppc64le::pyarrow-tests-14.0.2-py38hd9ba88f_17_cpu.conda
linux-ppc64le::libarrow-13.0.0-h6a4827b_34_cuda.conda
linux-ppc64le::folly-2023.09.25.00-ha887b78_5_jemalloc.conda
linux-ppc64le::libadios2-2.9.2-mpi_openmpi_h02f969a_2.conda
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
linux-ppc64le::libsqlite-3.45.3-hd4bbf49_0.conda
linux-ppc64le::git-cliff-2.2.1-h6565b52_0.conda
linux-ppc64le::libmlir18-18.1.3-hae84d68_0.conda
linux-ppc64le::libharu-2.4.4-h5baba08_0.conda
linux-ppc64le::libmlir-18.1.3-hae84d68_0.conda
linux-ppc64le::jbig2dec-0.18-h5baba08_0.conda
linux-ppc64le::libmlir18-18.1.4-hae84d68_0.conda
linux-ppc64le::libmlir-18.1.4-hae84d68_0.conda
linux-ppc64le::heaptrack-1.2.0-h73e8ffc_5.conda
linux-ppc64le::coin-or-osi-0.108.10-h85a6197_0.conda
linux-ppc64le::coin-or-utils-2.11.11-ha3c32cc_0.conda
linux-ppc64le::cfitsio-4.4.0-hde815af_1.conda
-    "libzlib >=1.2.13,<1.3.0a0"
+    "libzlib >=1.2.13,<2.0.0a0"
================================================================================
================================================================================
linux-aarch64
linux-aarch64::libadios2-2.10.0-nompi_h9e90768_101.conda
linux-aarch64::heyoka-llvm-17-4.0.3-h4c73c6b_2.conda
linux-aarch64::cpp-opentelemetry-sdk-1.15.0-h5cccf45_0.conda
linux-aarch64::pyarrow-14.0.2-py310h70ca0e3_18_cpu.conda
linux-aarch64::aws-sdk-cpp-1.11.267-h532d3a3_5.conda
linux-aarch64::libadios2-2.10.0-mpi_mpich_hc44bc0c_2.conda
linux-aarch64::fenics-libdolfin-2019.1.0-hefd79ac_43.conda
linux-aarch64::pyarrow-tests-14.0.2-py311hf1c3740_18_cuda.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-h86f717f_23.conda
linux-aarch64::pyarrow-15.0.2-py311hfc23d97_4_cpu.conda
linux-aarch64::pyarrow-15.0.2-py38hc6bfc80_4_cpu.conda
linux-aarch64::ogre-14.2.4-ha44472d_0.conda
linux-aarch64::heyoka-4.0.3-h99f0afa_0.conda
linux-aarch64::lldb-18.1.3-py310hf473765_0.conda
linux-aarch64::libmed-4.1.1-mpi_mpich_hcd2e5bb_12.conda
linux-aarch64::libarrow-14.0.2-h905257a_16_cuda.conda
linux-aarch64::libarrow-12.0.1-he4c5913_48_cuda.conda
linux-aarch64::texlive-core-20230313-hc896430_12.conda
linux-aarch64::pyarrow-tests-14.0.2-py39hda7dbfd_19_cuda.conda
linux-aarch64::folly-2024.04.08.00-hfbf93a7_1_jemalloc.conda
linux-aarch64::pyarrow-12.0.1-py310he892700_48_cpu.conda
linux-aarch64::imagecodecs-2024.1.1-py312h84ffe85_5.conda
linux-aarch64::aws-sdk-cpp-1.11.267-h8bf6445_7.conda
linux-aarch64::libadios2-2.9.2-mpi_openmpi_hc3bba4b_2.conda
linux-aarch64::folly-2024.04.29.00-h263637a_0.conda
linux-aarch64::pyarrow-tests-14.0.2-py312h2696e27_18_cuda.conda
linux-aarch64::pytables-3.9.2-py39hd0c79cf_2.conda
linux-aarch64::libgdal-3.8.5-h9830686_1.conda
linux-aarch64::tiledb-2.21.2-hdb39961_4.conda
linux-aarch64::libadios2-2.9.2-mpi_mpich_he568bdc_2.conda
linux-aarch64::heyoka-4.0.3-h82d5a60_2.conda
linux-aarch64::pyarrow-15.0.2-py311hfc23d97_5_cpu.conda
linux-aarch64::pyarrow-tests-15.0.2-py39h59ea48c_4_cpu.conda
linux-aarch64::graphviz-2.50.0-h65e8cce_4.conda
linux-aarch64::util-linux-2.39.4-py39hb670eeb_0.conda
linux-aarch64::ffmpeg-6.1.1-gpl_h2d8bd44_109.conda
linux-aarch64::util-linux-2.39.4-py39h493218e_0.conda
linux-aarch64::vowpalwabbit-9.9.0-py310h41866fe_4.conda
linux-aarch64::wxwidgets-3.2.4-h04735e2_3.conda
linux-aarch64::qt6-main-6.7.0-hc617877_1.conda
linux-aarch64::pyarrow-13.0.0-py310hca77690_37_cuda.conda
linux-aarch64::imagecodecs-2024.1.1-py311h6e7fc43_6.conda
linux-aarch64::libadios2-2.10.0-mpi_mpich_hbe11c07_3.conda
linux-aarch64::libarrow-14.0.2-h520d24b_16_cpu.conda
linux-aarch64::pdal-2.7.1-hb360fb6_2.conda
linux-aarch64::libadios2-2.10.0-nompi_h6380959_102.conda
linux-aarch64::heyoka-3.2.0-hb5f3ab1_1.conda
linux-aarch64::fenics-libdolfin-2019.1.0-h88d5100_43.conda
linux-aarch64::pillow-10.3.0-py39hce330b6_0.conda
linux-aarch64::folly-2024.04.15.00-h263637a_0.conda
linux-aarch64::pyarrow-14.0.2-py38h9ec0d4c_19_cuda.conda
linux-aarch64::libarrow-12.0.1-h48baae3_47_cpu.conda
linux-aarch64::libadios2-2.10.0-mpi_openmpi_h00a29b4_1.conda
linux-aarch64::xeus-cpp-0.4.0-h21677b9_0.conda
linux-aarch64::pyarrow-14.0.2-py310h70ca0e3_17_cpu.conda
linux-aarch64::util-linux-2.39.4-py310hbe9cfeb_0.conda
linux-aarch64::heyoka-4.0.3-hd76a527_1.conda
linux-aarch64::pyarrow-tests-12.0.1-py310he892700_47_cpu.conda
linux-aarch64::pyarrow-14.0.2-py312h2696e27_17_cuda.conda
linux-aarch64::robotraconteur-1.2.0-py310hcf35e14_2.conda
linux-aarch64::libadios2-2.9.2-mpi_mpich_hacceb31_2.conda
linux-aarch64::libadios2-2.10.0-nompi_h08beb9b_102.conda
linux-aarch64::pyarrow-15.0.2-py312h2696e27_6_cuda.conda
linux-aarch64::pyinstaller-6.6.0-py310h1aab166_0.conda
linux-aarch64::libmed-4.1.1-mpi_mpich_h8eac744_12.conda
linux-aarch64::libarrow-12.0.1-heb866c9_45_cuda.conda
linux-aarch64::folly-2024.04.22.00-h263637a_0.conda
linux-aarch64::imagecodecs-2024.1.1-py39hc514f2e_4.conda
linux-aarch64::libmed-4.1.1-nompi_h5d94f3f_112.conda
linux-aarch64::heyoka-3.2.0-h2606912_1.conda
linux-aarch64::fenics-libdolfin-2019.1.0-h7fb0664_43.conda
linux-aarch64::pyarrow-tests-15.0.2-py311hfc23d97_5_cpu.conda
linux-aarch64::pdal-2.7.1-hb360fb6_4.conda
linux-aarch64::libarrow-13.0.0-hf0a587b_35_cpu.conda
linux-aarch64::pyarrow-tests-14.0.2-py310hca77690_17_cuda.conda
linux-aarch64::pyarrow-12.0.1-py311h775f620_48_cpu.conda
linux-aarch64::libadios2-2.10.0-nompi_hd1764fd_100.conda
linux-aarch64::pyinstaller-6.6.0-py39hb91f966_0.conda
linux-aarch64::qt6-wayland-6.7.0-hb5dcbe4_0.conda
linux-aarch64::libgdal-arrow-parquet-3.8.5-hf8095c0_1.conda
linux-aarch64::libgdal-arrow-parquet-3.8.5-h1b69a75_1.conda
linux-aarch64::pyarrow-14.0.2-py39hda7dbfd_18_cuda.conda
linux-aarch64::pyarrow-tests-14.0.2-py38h9ec0d4c_18_cuda.conda
linux-aarch64::libxmlsec1-1.3.4-h75eb8f3_0.conda
linux-aarch64::lld-18.1.4-h9e3bf44_0.conda
linux-aarch64::libgdal-3.8.5-h5c3be40_2.conda
linux-aarch64::folly-2023.09.25.00-h56e5476_5_jemalloc.conda
linux-aarch64::libadios2-2.10.0-mpi_mpich_hba90343_2.conda
linux-aarch64::lxml-5.2.1-py39h1e169c0_0.conda
linux-aarch64::libadios2-2.10.0-mpi_mpich_hacceb31_1.conda
linux-aarch64::healpy-1.16.6-py39h44b341f_4.conda
linux-aarch64::pyarrow-14.0.2-py39hda7dbfd_19_cuda.conda
linux-aarch64::nsight-compute-2024.1.1.4-h86d3b3d_0.conda
linux-aarch64::pyarrow-tests-14.0.2-py312hfd4cb0c_17_cpu.conda
linux-aarch64::libadios2-2.9.2-mpi_openmpi_h3b2702c_2.conda
linux-aarch64::libadios2-2.10.0-nompi_hd430d99_103.conda
linux-aarch64::pyarrow-14.0.2-py38hc6bfc80_17_cpu.conda
linux-aarch64::mlir-18.1.3-h6acfec4_0.conda
linux-aarch64::nco-5.2.3-h1cece5e_0.conda
linux-aarch64::heyoka-4.0.3-hd5b15c3_2.conda
linux-aarch64::grpcio-1.62.2-py311h1a7908d_0.conda
linux-aarch64::libadios2-2.10.0-mpi_mpich_hfb4b053_0.conda
linux-aarch64::openjdk-21.0.3-h3d4cd67_0.conda
linux-aarch64::heyoka-llvm-14-4.0.3-h42c38f2_2.conda
linux-aarch64::ldas-tools-framecpp-2.9.3-he46a431_2.conda
linux-aarch64::orc-2.0.0-hd7aaf90_1.conda
linux-aarch64::libglib-2.80.0-h9d8fbc1_6.conda
linux-aarch64::pyarrow-15.0.2-py38h9ec0d4c_4_cuda.conda
linux-aarch64::pyarrow-13.0.0-py312h2696e27_37_cuda.conda
linux-aarch64::pyarrow-12.0.1-py38h932dad8_47_cpu.conda
linux-aarch64::pillow-10.3.0-py311h26f1aac_0.conda
linux-aarch64::pyarrow-13.0.0-py312h92c89dc_36_cpu.conda
linux-aarch64::qt6-main-6.7.0-hc617877_2.conda
linux-aarch64::libadios2-2.9.2-mpi_openmpi_h8126c7c_2.conda
linux-aarch64::pyarrow-12.0.1-py311hf1c3740_47_cuda.conda
linux-aarch64::ttyd-1.7.7-h950020c_0.conda
linux-aarch64::openjdk-22.0.1-h3d4cd67_0.conda
linux-aarch64::pyarrow-14.0.2-py312h2696e27_19_cuda.conda
linux-aarch64::libmongoc-1.23.2-hb3d0ef4_1.conda
linux-aarch64::gstlal-1.13.0-py38h9452d73_1.conda
linux-aarch64::pyarrow-15.0.2-py310h70ca0e3_5_cpu.conda
linux-aarch64::pyarrow-tests-15.0.2-py38h9ec0d4c_5_cuda.conda
linux-aarch64::fenics-libdolfin-2019.1.0-hdd18f1d_43.conda
linux-aarch64::libadios2-2.10.0-nompi_hf484efd_100.conda
linux-aarch64::libarrow-15.0.2-hc6620ac_5_cpu.conda
linux-aarch64::assimp-5.4.0-h0b8f51a_0.conda
linux-aarch64::pyarrow-tests-14.0.2-py39hda7dbfd_17_cuda.conda
linux-aarch64::pyarrow-tests-15.0.2-py39hda7dbfd_5_cuda.conda
linux-aarch64::imagecodecs-2024.1.1-py310h609b1a6_5.conda
linux-aarch64::pillow-10.3.0-py312h317ddc0_0.conda
linux-aarch64::pyarrow-tests-13.0.0-py311hf1c3740_37_cuda.conda
linux-aarch64::libopentelemetry-cpp-1.15.0-h5cccf45_0.conda
linux-aarch64::pyarrow-tests-12.0.1-py38h932dad8_48_cpu.conda
linux-aarch64::libarrow-15.0.2-h73981c6_4_cuda.conda
linux-aarch64::pyarrow-tests-14.0.2-py310h70ca0e3_18_cpu.conda
linux-aarch64::libadios2-2.10.0-nompi_hb93b25f_103.conda
linux-aarch64::pyarrow-tests-13.0.0-py39hda7dbfd_36_cuda.conda
linux-aarch64::tiledb-2.21.2-hd449bb5_1.conda
linux-aarch64::llvmdev-18.1.4-hbfe100b_0.conda
linux-aarch64::libgoogle-cloud-storage-2.23.0-hdb39181_0.conda
linux-aarch64::libmed-4.1.1-mpi_openmpi_he9bbc15_12.conda
linux-aarch64::pyarrow-tests-15.0.2-py310hca77690_5_cuda.conda
linux-aarch64::cmake-3.29.1-hef020d8_0.conda
linux-aarch64::pyarrow-15.0.2-py310hca77690_4_cuda.conda
linux-aarch64::libadios2-2.10.0-mpi_mpich_h468f775_2.conda
linux-aarch64::libarrow-12.0.1-hf0a587b_46_cpu.conda
linux-aarch64::pyarrow-tests-12.0.1-py310hca77690_47_cuda.conda
linux-aarch64::pyarrow-13.0.0-py310he892700_36_cpu.conda
linux-aarch64::pyarrow-13.0.0-py310he892700_37_cpu.conda
linux-aarch64::folly-2024.04.08.00-h263637a_1.conda
linux-aarch64::openimageio-2.5.9.0-py312h71790be_1.conda
linux-aarch64::ffmpeg-6.1.1-lgpl_h9a9ccc4_8.conda
linux-aarch64::llvm-18.1.4-h250cd41_0.conda
linux-aarch64::tiledb-2.21.2-hde64972_3.conda
linux-aarch64::heyoka-4.0.3-hac5675b_1.conda
linux-aarch64::fenics-libdolfin-2019.1.0-h5a9f312_43.conda
linux-aarch64::libadios2-2.10.0-mpi_mpich_h7a1d76c_3.conda
linux-aarch64::folly-2023.09.25.00-h52273b7_5.conda
linux-aarch64::libadios2-2.9.2-mpi_mpich_h2007df3_2.conda
linux-aarch64::pyarrow-tests-15.0.2-py38h9ec0d4c_6_cuda.conda
linux-aarch64::libpulsar-3.5.1-h3fba315_0.conda
linux-aarch64::folly-2023.09.25.00-h6024ccb_5.conda
linux-aarch64::libadios2-2.10.0-mpi_openmpi_h3b2702c_1.conda
linux-aarch64::libarrow-12.0.1-ha76f436_48_cpu.conda
linux-aarch64::pyarrow-12.0.1-py39h17b0f66_48_cpu.conda
linux-aarch64::ogre-next-2.3.3-h736244c_0.conda
linux-aarch64::openmpi-5.0.3-h9c6a67e_100.conda
linux-aarch64::tiledb-2.22.0-h3dfc56f_0.conda
linux-aarch64::grpcio-1.62.2-py39h2ec6326_0.conda
linux-aarch64::pyarrow-tests-14.0.2-py310h70ca0e3_17_cpu.conda
linux-aarch64::pyarrow-tests-12.0.1-py38h9ec0d4c_48_cuda.conda
linux-aarch64::rust-1.77.2-h9d3d833_0.conda
linux-aarch64::libarrow-14.0.2-h876d348_19_cuda.conda
linux-aarch64::qt6-main-6.7.0-hb745aae_0.conda
linux-aarch64::libadios2-2.10.0-mpi_openmpi_hc3bba4b_0.conda
linux-aarch64::folly-2024.04.08.00-hc6edf37_0_jemalloc.conda
linux-aarch64::vowpalwabbit-9.9.0-py312ha61e2a9_4.conda
linux-aarch64::pyarrow-15.0.2-py311hf1c3740_5_cuda.conda
linux-aarch64::folly-2023.09.25.00-h7a5f97c_5.conda
linux-aarch64::pyarrow-tests-13.0.0-py39h17b0f66_36_cpu.conda
linux-aarch64::pyarrow-13.0.0-py312h92c89dc_37_cpu.conda
linux-aarch64::libmed-4.1.1-mpi_openmpi_hc9fc2ed_12.conda
linux-aarch64::pyarrow-14.0.2-py38h9ec0d4c_18_cuda.conda
linux-aarch64::fenics-libdolfin-2019.1.0-h7aea11c_43.conda
linux-aarch64::sqlite-3.45.3-h3b3482f_0.conda
linux-aarch64::pyarrow-12.0.1-py38h9ec0d4c_48_cuda.conda
linux-aarch64::pyarrow-tests-15.0.2-py311hf1c3740_5_cuda.conda
linux-aarch64::libgdal-arrow-parquet-3.8.5-h4e6ea09_1.conda
linux-aarch64::pyarrow-tests-12.0.1-py39hda7dbfd_47_cuda.conda
linux-aarch64::libllvm18-18.1.3-hbfe100b_0.conda
linux-aarch64::pyarrow-tests-14.0.2-py39h59ea48c_17_cpu.conda
linux-aarch64::pyarrow-14.0.2-py311hfc23d97_17_cpu.conda
linux-aarch64::pyarrow-13.0.0-py311h775f620_36_cpu.conda
linux-aarch64::libarrow-14.0.2-h73981c6_18_cuda.conda
linux-aarch64::heyoka-4.0.3-hff1a8a8_0.conda
linux-aarch64::pyarrow-15.0.2-py38h9ec0d4c_6_cuda.conda
linux-aarch64::libadios2-2.10.0-mpi_mpich_h880fe8d_3.conda
linux-aarch64::libadios2-2.10.0-mpi_openmpi_hb81366b_2.conda
linux-aarch64::pyarrow-tests-15.0.2-py310hca77690_6_cuda.conda
linux-aarch64::libarrow-12.0.1-h141df2e_47_cuda.conda
linux-aarch64::pytables-3.9.2-py312haecc334_2.conda
linux-aarch64::libgdal-arrow-parquet-3.8.5-h0885be9_0.conda
linux-aarch64::pyarrow-14.0.2-py311hf1c3740_18_cuda.conda
linux-aarch64::libadios2-2.10.0-mpi_mpich_h2007df3_0.conda
linux-aarch64::heyoka-3.2.0-h11e5b17_1.conda
linux-aarch64::heyoka-llvm-13-3.2.0-hcd7efb9_1.conda
linux-aarch64::verilator-5.022-h6921256_1.conda
linux-aarch64::libarrow-15.0.2-h73981c6_5_cuda.conda
linux-aarch64::pyarrow-12.0.1-py310hca77690_47_cuda.conda
linux-aarch64::libmed-4.1.1-mpi_openmpi_h3605d43_12.conda
linux-aarch64::fenics-libdolfin-2019.1.0-h039b487_43.conda
linux-aarch64::util-linux-2.39.4-py38h24c6ab1_0.conda
linux-aarch64::libarrow-14.0.2-hc6620ac_18_cpu.conda
linux-aarch64::libadios2-2.10.0-mpi_mpich_he568bdc_0.conda
linux-aarch64::pyarrow-15.0.2-py39hda7dbfd_6_cuda.conda
linux-aarch64::fenics-libdolfin-2019.1.0-hdfa2b95_43.conda
linux-aarch64::libadios2-2.10.0-nompi_h0f8c53e_100.conda
linux-aarch64::lxml-5.2.1-py38ha061256_0.conda
linux-aarch64::libglib-2.80.0-h9d8fbc1_2.conda
linux-aarch64::libmed-4.1.1-mpi_mpich_he8d027d_12.conda
linux-aarch64::libarrow-15.0.2-h905257a_3_cuda.conda
linux-aarch64::libadios2-2.10.0-mpi_mpich_h7a034d0_1.conda
linux-aarch64::pyarrow-tests-12.0.1-py311hf1c3740_48_cuda.conda
linux-aarch64::pyarrow-tests-12.0.1-py311h775f620_48_cpu.conda
linux-aarch64::nushell-0.92.1-h0771932_0.conda
linux-aarch64::libadios2-2.10.0-nompi_h0f8c53e_101.conda
linux-aarch64::libadios2-2.10.0-nompi_h4e994de_103.conda
linux-aarch64::mesalib-24.0.6-hf00ac33_0.conda
linux-aarch64::folly-2023.09.25.00-h9a9638a_5_jemalloc.conda
linux-aarch64::healpy-1.16.6-py311h21f9ecf_4.conda
linux-aarch64::pyarrow-13.0.0-py39h17b0f66_37_cpu.conda
linux-aarch64::ldas-tools-framecpp-3.0.3-hbee1527_1.conda
linux-aarch64::libadios2-2.9.2-nompi_h1cc29aa_102.conda
linux-aarch64::pytables-3.9.2-py310h616eefd_2.conda
linux-aarch64::fenics-libdolfin-2019.1.0-h1281298_43.conda
linux-aarch64::libarrow-15.0.2-hc6620ac_4_cpu.conda
linux-aarch64::pyarrow-tests-13.0.0-py310he892700_37_cpu.conda
linux-aarch64::libadios2-2.10.0-mpi_openmpi_hec7393c_2.conda
linux-aarch64::ffmpeg-6.1.1-gpl_hbfafc94_108.conda
linux-aarch64::libarrow-12.0.1-h572430a_46_cuda.conda
linux-aarch64::gst-plugins-bad-1.24.1-haa4ddd8_0.conda
linux-aarch64::nsight-compute-2024.1.1.4-h86d3b3d_1.conda
linux-aarch64::libarrow-13.0.0-h48baae3_36_cpu.conda
linux-aarch64::libadios2-2.10.0-nompi_h1cc29aa_100.conda
linux-aarch64::libgdal-arrow-parquet-3.8.5-h78127d2_0.conda
linux-aarch64::heyoka-4.0.3-h388c640_2.conda
linux-aarch64::openimageio-2.5.9.0-py39h3ffc030_1.conda
linux-aarch64::pyarrow-tests-14.0.2-py39h59ea48c_18_cpu.conda
linux-aarch64::libarrow-13.0.0-h572430a_35_cuda.conda
linux-aarch64::pyarrow-15.0.2-py310h70ca0e3_4_cpu.conda
linux-aarch64::imagemagick-7.1.1_30-pl5321h1c444f2_0.conda
linux-aarch64::libgdal-arrow-parquet-3.8.5-hcec0193_1.conda
linux-aarch64::healpy-1.16.6-py39hb4bef55_4.conda
linux-aarch64::fenics-libdolfin-2019.1.0-h1b80c9f_43.conda
linux-aarch64::libadios2-2.10.0-mpi_openmpi_h0762ba7_2.conda
linux-aarch64::openjdk-17.0.11-h4f80945_0.conda
linux-aarch64::healpy-1.16.6-py312h6031b82_4.conda
linux-aarch64::pyarrow-15.0.2-py39h59ea48c_5_cpu.conda
linux-aarch64::pyarrow-tests-15.0.2-py39hda7dbfd_4_cuda.conda
linux-aarch64::libadios2-2.10.0-mpi_mpich_hbc262ad_3.conda
linux-aarch64::heyoka-llvm-17-4.0.3-h1548dd3_0.conda
linux-aarch64::llvm-tools-18.1.4-hbfe100b_0.conda
linux-aarch64::fenics-libdolfin-2019.1.0-h4fc7d15_43.conda
linux-aarch64::libarrow-13.0.0-h6a2b7c0_34_cpu.conda
linux-aarch64::pyarrow-tests-13.0.0-py311h775f620_36_cpu.conda
linux-aarch64::libgdal-arrow-parquet-3.8.5-h20bea24_0.conda
linux-aarch64::libgdal-3.8.5-h43eba46_0.conda
linux-aarch64::pyarrow-tests-14.0.2-py38hc6bfc80_17_cpu.conda
linux-aarch64::pyarrow-15.0.2-py311hf1c3740_6_cuda.conda
linux-aarch64::lxml-5.2.1-py310he8b16f2_0.conda
linux-aarch64::openjdk-17.0.10-h2f81f4c_1.conda
linux-aarch64::r-base-4.3.3-h14488e9_1.conda
linux-aarch64::libarrow-14.0.2-hc64e4d7_15_cpu.conda
linux-aarch64::libgoogle-cloud-storage-2.23.0-hdb39181_1.conda
linux-aarch64::pyarrow-tests-15.0.2-py312hfd4cb0c_5_cpu.conda
linux-aarch64::pyarrow-tests-12.0.1-py39hda7dbfd_48_cuda.conda
linux-aarch64::tiledb-2.21.2-hd352636_0.conda
linux-aarch64::pillow-10.3.0-py39h71661b1_0.conda
linux-aarch64::libadios2-2.10.0-mpi_mpich_h7a034d0_0.conda
linux-aarch64::ffmpeg-6.1.1-lgpl_he02c515_9.conda
linux-aarch64::magic-8.3.468-h4e13689_0.conda
linux-aarch64::pyarrow-tests-13.0.0-py310he892700_36_cpu.conda
linux-aarch64::pyarrow-tests-14.0.2-py311hfc23d97_17_cpu.conda
linux-aarch64::pyinstaller-6.6.0-py38h37f3631_0.conda
linux-aarch64::gstlal-1.13.0-py39h9f00e99_1.conda
linux-aarch64::libpulsar-3.5.1-hd642a86_1.conda
linux-aarch64::rsync-3.3.0-hc43869a_0.conda
linux-aarch64::libarrow-15.0.2-he4b40af_2_cuda.conda
linux-aarch64::libmed-4.1.1-mpi_openmpi_h6986ef6_12.conda
linux-aarch64::libarrow-14.0.2-h73981c6_17_cuda.conda
linux-aarch64::pyarrow-tests-12.0.1-py311hf1c3740_47_cuda.conda
linux-aarch64::pyarrow-tests-15.0.2-py39hda7dbfd_6_cuda.conda
linux-aarch64::libadios2-2.9.2-nompi_hf484efd_102.conda
linux-aarch64::pdal-2.7.1-hc2a9981_3.conda
linux-aarch64::heyoka-llvm-13-4.0.3-hc863e15_2.conda
linux-aarch64::pyarrow-14.0.2-py310hca77690_18_cuda.conda
linux-aarch64::libadios2-2.10.0-mpi_mpich_hfb4b053_1.conda
linux-aarch64::libadios2-2.10.0-mpi_mpich_hacceb31_0.conda
linux-aarch64::pyarrow-tests-15.0.2-py310h70ca0e3_5_cpu.conda
linux-aarch64::pyarrow-tests-13.0.0-py312h2696e27_37_cuda.conda
linux-aarch64::pyarrow-13.0.0-py311hf1c3740_37_cuda.conda
linux-aarch64::nexus-4.4.3-h2967443_13.conda
linux-aarch64::libmed-4.1.1-nompi_hab51d9d_112.conda
linux-aarch64::fenics-libdolfin-2019.1.0-h6f1cbec_43.conda
linux-aarch64::pyarrow-tests-12.0.1-py38h9ec0d4c_47_cuda.conda
linux-aarch64::pyarrow-15.0.2-py312hfd4cb0c_4_cpu.conda
linux-aarch64::pyarrow-tests-13.0.0-py311hf1c3740_36_cuda.conda
linux-aarch64::nushell-0.92.2-h0771932_0.conda
linux-aarch64::heyoka-llvm-14-4.0.3-h054fb84_0.conda
linux-aarch64::pyarrow-tests-12.0.1-py310he892700_48_cpu.conda
linux-aarch64::pyarrow-tests-15.0.2-py38hc6bfc80_4_cpu.conda
linux-aarch64::pyarrow-13.0.0-py38h9ec0d4c_36_cuda.conda
linux-aarch64::pyarrow-tests-12.0.1-py39h17b0f66_48_cpu.conda
linux-aarch64::lxml-5.1.1-py310h4b22f0c_0.conda
linux-aarch64::pyarrow-14.0.2-py39hda7dbfd_17_cuda.conda
linux-aarch64::gstlal-1.13.0-py310hc7e2d12_1.conda
linux-aarch64::fenics-libdolfin-2019.1.0-haf12972_43.conda
linux-aarch64::pyarrow-15.0.2-py312h2696e27_5_cuda.conda
linux-aarch64::pyarrow-14.0.2-py310hca77690_19_cuda.conda
linux-aarch64::folly-2024.04.22.00-hfbf93a7_0_jemalloc.conda
linux-aarch64::libarrow-14.0.2-he4b40af_15_cuda.conda
linux-aarch64::heyoka-3.2.0-hbbf0a58_1.conda
linux-aarch64::tiledb-2.20.1-hd449bb5_7.conda
linux-aarch64::pillow-10.3.0-py38h7ad23c5_0.conda
linux-aarch64::libadios2-2.10.0-nompi_h32dadc8_103.conda
linux-aarch64::pyarrow-12.0.1-py310he892700_47_cpu.conda
linux-aarch64::pyinstaller-6.6.0-py311h0dd4530_0.conda
linux-aarch64::qt6-3d-6.7.0-h9d35714_0.conda
linux-aarch64::libarrow-13.0.0-heb866c9_34_cuda.conda
linux-aarch64::pyarrow-13.0.0-py312h2696e27_36_cuda.conda
linux-aarch64::lxml-5.2.1-py312hf2f09fd_0.conda
linux-aarch64::fenics-libdolfin-2019.1.0-hbe65c83_43.conda
linux-aarch64::pytables-3.9.2-py39h5cf816e_2.conda
linux-aarch64::heyoka-4.0.3-ha4a7f3e_2.conda
linux-aarch64::pyarrow-tests-14.0.2-py310hca77690_18_cuda.conda
linux-aarch64::jaxlib-0.4.23-cpu_py39hec6e973_1.conda
linux-aarch64::libgdal-arrow-parquet-3.8.5-h14402da_2.conda
linux-aarch64::libglib-2.80.0-h9d8fbc1_3.conda
linux-aarch64::libarrow-12.0.1-h6a2b7c0_45_cpu.conda
linux-aarch64::pyarrow-tests-15.0.2-py312hfd4cb0c_4_cpu.conda
linux-aarch64::pyarrow-tests-14.0.2-py39hda7dbfd_18_cuda.conda
linux-aarch64::jaxlib-0.4.23-cpu_py312h75c7a00_1.conda
linux-aarch64::lxml-5.1.1-py39hf11b08a_0.conda
linux-aarch64::pyarrow-13.0.0-py311h775f620_37_cpu.conda
linux-aarch64::lldb-18.1.3-py311hafc2677_0.conda
linux-aarch64::pyarrow-12.0.1-py38h9ec0d4c_47_cuda.conda
linux-aarch64::poppler-24.04.0-hc4ede38_0.conda
linux-aarch64::ffmpeg-6.1.1-gpl_hbfafc94_107.conda
linux-aarch64::openimageio-2.5.9.0-py38h9608889_1.conda
linux-aarch64::pyarrow-14.0.2-py311hfc23d97_18_cpu.conda
linux-aarch64::pyarrow-15.0.2-py310hca77690_5_cuda.conda
linux-aarch64::folly-2023.09.25.00-hecdeb29_5.conda
linux-aarch64::pyarrow-tests-14.0.2-py311hf1c3740_19_cuda.conda
linux-aarch64::libgdal-arrow-parquet-3.8.5-h025d381_2.conda
linux-aarch64::pyarrow-tests-13.0.0-py312h92c89dc_37_cpu.conda
linux-aarch64::heyoka-llvm-16-4.0.3-hc35b7ae_0.conda
linux-aarch64::pyarrow-tests-12.0.1-py38h932dad8_47_cpu.conda
linux-aarch64::libadios2-2.10.0-mpi_openmpi_haa35d66_3.conda
linux-aarch64::lxml-5.1.1-py38h88ec0de_0.conda
linux-aarch64::libgdal-arrow-parquet-3.8.5-h86f717f_2.conda
linux-aarch64::pyarrow-14.0.2-py312h2696e27_18_cuda.conda
linux-aarch64::jaxlib-0.4.23-cpu_py311hfa478d0_1.conda
linux-aarch64::vowpalwabbit-9.9.0-py38hd4b9b30_4.conda
linux-aarch64::libmed-4.1.1-mpi_mpich_h0b6c529_12.conda
linux-aarch64::pyarrow-14.0.2-py38hc6bfc80_18_cpu.conda
linux-aarch64::pyarrow-tests-14.0.2-py38hc6bfc80_18_cpu.conda
linux-aarch64::pyarrow-tests-12.0.1-py311h775f620_47_cpu.conda
linux-aarch64::libadios2-2.9.2-nompi_hd1764fd_102.conda
linux-aarch64::imagemagick-7.1.1_31-pl5321h1645955_1.conda
linux-aarch64::lxml-5.1.1-py39h69a00ae_0.conda
linux-aarch64::pyarrow-12.0.1-py39h17b0f66_47_cpu.conda
linux-aarch64::imagecodecs-2024.1.1-py310h3e97ff0_6.conda
linux-aarch64::tiledb-2.21.2-h3dfc56f_1.conda
linux-aarch64::heyoka-llvm-14-4.0.3-hd1668b7_1.conda
linux-aarch64::openmpi-5.0.2-h9c6a67e_102.conda
linux-aarch64::libvips-8.15.2-h435bf5c_1.conda
linux-aarch64::pyarrow-12.0.1-py311hf1c3740_48_cuda.conda
linux-aarch64::libmed-4.1.1-nompi_h534aaa3_112.conda
linux-aarch64::folly-2023.09.25.00-h1e4f04f_5_jemalloc.conda
linux-aarch64::heyoka-llvm-15-3.2.0-hef1b9e9_1.conda
linux-aarch64::pyarrow-12.0.1-py39hda7dbfd_47_cuda.conda
linux-aarch64::pyarrow-tests-14.0.2-py312h2696e27_17_cuda.conda
linux-aarch64::pyarrow-tests-15.0.2-py312h2696e27_6_cuda.conda
linux-aarch64::pyarrow-tests-14.0.2-py311hf1c3740_17_cuda.conda
linux-aarch64::pyarrow-15.0.2-py38hc6bfc80_5_cpu.conda
linux-aarch64::ffmpeg-6.1.1-lgpl_h9a9ccc4_7.conda
linux-aarch64::pyarrow-tests-15.0.2-py311hfc23d97_4_cpu.conda
linux-aarch64::libadios2-2.10.0-mpi_openmpi_hd7186d7_2.conda
linux-aarch64::pyarrow-tests-14.0.2-py38h9ec0d4c_19_cuda.conda
linux-aarch64::pyarrow-tests-15.0.2-py312h2696e27_5_cuda.conda
linux-aarch64::imagecodecs-2024.1.1-py39hf6bbe71_6.conda
linux-aarch64::openjdk-21.0.2-h04f0a14_1.conda
linux-aarch64::heyoka-4.0.3-hdd5f348_0.conda
linux-aarch64::libadios2-2.10.0-mpi_openmpi_h00a29b4_0.conda
linux-aarch64::libadios2-2.10.0-nompi_h1b485a8_102.conda
linux-aarch64::heyoka-llvm-16-4.0.3-h6cda5ee_2.conda
linux-aarch64::heyoka-llvm-17-3.2.0-haacae90_1.conda
linux-aarch64::qt-main-5.15.8-ha53cfd4_21.conda
linux-aarch64::pyarrow-tests-15.0.2-py311hf1c3740_4_cuda.conda
linux-aarch64::libadios2-2.10.0-mpi_openmpi_hc227702_3.conda
linux-aarch64::pyarrow-tests-13.0.0-py39h17b0f66_37_cpu.conda
linux-aarch64::libadios2-2.10.0-mpi_mpich_he568bdc_1.conda
linux-aarch64::heyoka-4.0.3-h612b11c_0.conda
linux-aarch64::git-2.45.0-pl5321h08fdf5c_0.conda
linux-aarch64::heyoka-llvm-14-3.2.0-h075fc00_1.conda
linux-aarch64::libarrow-15.0.2-h520d24b_3_cpu.conda
linux-aarch64::lxml-5.1.1-py312h44bb00a_0.conda
linux-aarch64::imagecodecs-2024.1.1-py311h410c485_5.conda
linux-aarch64::libllvm18-18.1.4-hbfe100b_0.conda
linux-aarch64::fenics-libdolfin-2019.1.0-h42e516a_43.conda
linux-aarch64::folly-2023.09.25.00-hede7dbb_5_jemalloc.conda
linux-aarch64::openjdk-11.0.23-h4f80945_0.conda
linux-aarch64::heyoka-llvm-16-3.2.0-heb4bc13_1.conda
linux-aarch64::imagemagick-7.1.1_31-pl5321h1645955_0.conda
linux-aarch64::pyarrow-tests-14.0.2-py312hfd4cb0c_18_cpu.conda
linux-aarch64::pyarrow-13.0.0-py311hf1c3740_36_cuda.conda
linux-aarch64::pyarrow-14.0.2-py312hfd4cb0c_17_cpu.conda
linux-aarch64::lldb-18.1.3-py38hdedb11c_0.conda
linux-aarch64::healpy-1.16.6-py310hf27f947_4.conda
linux-aarch64::mongodb-6.0.12-h594bb5c_1.conda
linux-aarch64::openimageio-2.5.9.0-py310hcb732ad_1.conda
linux-aarch64::pyarrow-tests-13.0.0-py38h9ec0d4c_37_cuda.conda
linux-aarch64::m4rie-20150908-hf0a5ef3_1002.conda
linux-aarch64::pyarrow-tests-13.0.0-py38h932dad8_37_cpu.conda
linux-aarch64::pyarrow-tests-13.0.0-py38h9ec0d4c_36_cuda.conda
linux-aarch64::lxml-5.2.1-py311h8f0c70e_0.conda
linux-aarch64::pyarrow-15.0.2-py39hda7dbfd_4_cuda.conda
linux-aarch64::fenics-libdolfin-2019.1.0-hc9c3a49_43.conda
linux-aarch64::heyoka-4.0.3-h5f8de03_1.conda
linux-aarch64::libadios2-2.10.0-mpi_openmpi_h3b2702c_0.conda
linux-aarch64::pillow-10.3.0-py310he5cda9b_0.conda
linux-aarch64::libadios2-2.10.0-mpi_openmpi_h91ba585_3.conda
linux-aarch64::libadios2-2.10.0-mpi_mpich_h77a5f90_3.conda
linux-aarch64::pyarrow-14.0.2-py311hf1c3740_19_cuda.conda
linux-aarch64::lxml-5.1.1-py311hb16da7a_0.conda
linux-aarch64::nsight-compute-2024.1.1.4-h024db69_2.conda
linux-aarch64::nodejs-18.20.2-ha5f1e90_0.conda
linux-aarch64::pyarrow-15.0.2-py312hfd4cb0c_5_cpu.conda
linux-aarch64::lxml-5.2.1-py39hb9006e6_0.conda
linux-aarch64::pyarrow-tests-15.0.2-py310hca77690_4_cuda.conda
linux-aarch64::libadios2-2.10.0-mpi_mpich_h934b49f_2.conda
linux-aarch64::pdal-2.7.1-hb360fb6_5.conda
linux-aarch64::heyoka-4.0.3-h513471b_2.conda
linux-aarch64::pyarrow-12.0.1-py310hca77690_48_cuda.conda
linux-aarch64::heyoka-4.0.3-hd92376b_1.conda
linux-aarch64::util-linux-2.39.4-py312h5ae9330_0.conda
linux-aarch64::libarrow-13.0.0-he4c5913_37_cuda.conda
linux-aarch64::pyarrow-tests-12.0.1-py39h17b0f66_47_cpu.conda
linux-aarch64::nsight-compute-2024.1.1.4-h024db69_1.conda
linux-aarch64::tiledb-2.21.2-h6a268c0_2.conda
linux-aarch64::pyarrow-13.0.0-py310hca77690_36_cuda.conda
linux-aarch64::libglib-2.80.0-h9d8fbc1_4.conda
linux-aarch64::folly-2024.04.08.00-hf13f41a_0.conda
linux-aarch64::libadios2-2.10.0-mpi_openmpi_h8126c7c_1.conda
linux-aarch64::libadios2-2.10.0-nompi_h80bc126_103.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-h025d381_23.conda
linux-aarch64::libadios2-2.10.0-mpi_openmpi_hc3bba4b_1.conda
linux-aarch64::libbrial-1.2.12-h9429f74_2.conda
linux-aarch64::libadios2-2.10.0-mpi_mpich_h2007df3_1.conda
linux-aarch64::libarrow-13.0.0-h141df2e_36_cuda.conda
linux-aarch64::libadios2-2.10.0-mpi_openmpi_hd0f1f70_3.conda
linux-aarch64::libadios2-2.10.0-mpi_mpich_h48eb7fd_2.conda
linux-aarch64::llvm-tools-18.1.3-hbfe100b_0.conda
linux-aarch64::openimageio-2.5.9.0-py311h61aa2ad_1.conda
linux-aarch64::imagecodecs-2024.1.1-py39h953c768_5.conda
linux-aarch64::fenics-libdolfin-2019.1.0-h59aca34_43.conda
linux-aarch64::pyarrow-tests-15.0.2-py312h2696e27_4_cuda.conda
linux-aarch64::pyarrow-12.0.1-py39hda7dbfd_48_cuda.conda
linux-aarch64::vowpalwabbit-9.9.0-py311h961fb17_4.conda
linux-aarch64::libadios2-2.10.0-mpi_openmpi_h8d2ab71_1.conda
linux-aarch64::imagecodecs-2024.1.1-py312heac15d1_6.conda
linux-aarch64::libgdal-3.7.3-h5c7b00b_23.conda
linux-aarch64::pdal-2.7.1-h22709a7_6.conda
linux-aarch64::libadios2-2.10.0-nompi_h1cc29aa_101.conda
linux-aarch64::pyarrow-15.0.2-py38h9ec0d4c_5_cuda.conda
linux-aarch64::pyarrow-tests-13.0.0-py311h775f620_37_cpu.conda
linux-aarch64::imagecodecs-2024.1.1-py310hb90b9c9_4.conda
linux-aarch64::libadios2-2.10.0-mpi_openmpi_hbc11c29_2.conda
linux-aarch64::mlir-18.1.4-h6acfec4_0.conda
linux-aarch64::heyoka-4.0.3-hf1edfb8_1.conda
linux-aarch64::pyarrow-tests-13.0.0-py310hca77690_37_cuda.conda
linux-aarch64::pyarrow-tests-15.0.2-py38hc6bfc80_5_cpu.conda
linux-aarch64::pyarrow-13.0.0-py38h932dad8_37_cpu.conda
linux-aarch64::libmed-4.1.1-mpi_openmpi_h106db34_12.conda
linux-aarch64::pytables-3.9.2-py311ha81b2bb_2.conda
linux-aarch64::python-3.12.3-h43d1f9e_0_cpython.conda
linux-aarch64::pyarrow-15.0.2-py311hf1c3740_4_cuda.conda
linux-aarch64::pyarrow-tests-13.0.0-py38h932dad8_36_cpu.conda
linux-aarch64::heyoka-3.2.0-h8c9ae30_1.conda
linux-aarch64::ogre-14.2.4-he860dd8_0.conda
linux-aarch64::pyarrow-tests-15.0.2-py38h9ec0d4c_4_cuda.conda
linux-aarch64::pyarrow-15.0.2-py39h59ea48c_4_cpu.conda
linux-aarch64::pyarrow-12.0.1-py38h932dad8_48_cpu.conda
linux-aarch64::folly-2024.04.01.00-h50c9591_0_jemalloc.conda
linux-aarch64::libadios2-2.9.2-nompi_h0f8c53e_102.conda
linux-aarch64::imagecodecs-2024.1.1-py311h46f3b94_4.conda
linux-aarch64::heyoka-llvm-13-4.0.3-h5df8b53_0.conda
linux-aarch64::lldb-18.1.3-py39had3f85f_0.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-h40581f4_23.conda
linux-aarch64::davix-0.8.6-h94bde4f_0.conda
linux-aarch64::libmed-4.1.1-nompi_haf0e9f8_112.conda
linux-aarch64::pyarrow-14.0.2-py311hf1c3740_17_cuda.conda
linux-aarch64::ntbtls-0.3.2-hd84c7bf_0.conda
linux-aarch64::libadios2-2.10.0-nompi_hd1764fd_101.conda
linux-aarch64::pyarrow-tests-13.0.0-py312h92c89dc_36_cpu.conda
linux-aarch64::heyoka-llvm-17-4.0.3-h1033030_1.conda
linux-aarch64::pyarrow-14.0.2-py310hca77690_17_cuda.conda
linux-aarch64::libmed-4.1.1-mpi_mpich_h415c023_12.conda
linux-aarch64::llvm-openmp-18.1.3-h8b0cb96_0.conda
linux-aarch64::libgdal-arrow-parquet-3.8.5-h40581f4_2.conda
linux-aarch64::pyarrow-15.0.2-py312h2696e27_4_cuda.conda
linux-aarch64::grpcio-1.62.2-py310h20b6881_0.conda
linux-aarch64::heyoka-llvm-15-4.0.3-h14c4ce0_2.conda
linux-aarch64::libbrial-1.2.12-h9429f74_3.conda
linux-aarch64::pyarrow-14.0.2-py312hfd4cb0c_18_cpu.conda
linux-aarch64::robotraconteur-1.2.0-py312h7d1559b_2.conda
linux-aarch64::imagecodecs-2024.1.1-py312h0d21ec8_4.conda
linux-aarch64::pyarrow-12.0.1-py311h775f620_47_cpu.conda
linux-aarch64::pyarrow-15.0.2-py39hda7dbfd_5_cuda.conda
linux-aarch64::pyarrow-tests-13.0.0-py39hda7dbfd_37_cuda.conda
linux-aarch64::libadios2-2.9.2-mpi_mpich_hfb4b053_2.conda
linux-aarch64::python-3.11.9-hddfb980_0_cpython.conda
linux-aarch64::nodejs-20.12.2-hc1f8a26_0.conda
linux-aarch64::blosc-1.21.5-hb65639f_1.conda
linux-aarch64::libadios2-2.9.2-nompi_h9e90768_102.conda
linux-aarch64::pyarrow-15.0.2-py310hca77690_6_cuda.conda
linux-aarch64::xeus-cpp-0.3.0-h21677b9_2.conda
linux-aarch64::libadios2-2.10.0-mpi_openmpi_h8126c7c_0.conda
linux-aarch64::heyoka-llvm-15-4.0.3-hdb5b112_1.conda
linux-aarch64::tiledb-2.22.0-hdb39961_3.conda
linux-aarch64::tiledb-2.22.0-h12a777c_2.conda
linux-aarch64::libglib-2.80.0-h9d8fbc1_5.conda
linux-aarch64::libadios2-2.10.0-nompi_hf484efd_101.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-h14402da_23.conda
linux-aarch64::pyarrow-14.0.2-py39h59ea48c_17_cpu.conda
linux-aarch64::imagecodecs-2024.1.1-py39h09a5cea_6.conda
linux-aarch64::pyarrow-13.0.0-py38h9ec0d4c_37_cuda.conda
linux-aarch64::heyoka-4.0.3-hf0b32ca_0.conda
linux-aarch64::libadios2-2.10.0-nompi_hbbde0cd_102.conda
linux-aarch64::fenics-libdolfin-2019.1.0-h4a61795_43.conda
linux-aarch64::robotraconteur-1.2.0-py38h2bac0b0_2.conda
linux-aarch64::heyoka-llvm-15-4.0.3-h0955fda_0.conda
linux-aarch64::fenics-libdolfin-2019.1.0-hd21a43a_43.conda
linux-aarch64::grpcio-1.62.2-py312hd96c8c9_0.conda
linux-aarch64::grpcio-1.62.2-py39h483cef1_0.conda
linux-aarch64::libadios2-2.9.2-mpi_mpich_h7a034d0_2.conda
linux-aarch64::folly-2024.04.29.00-hfbf93a7_0_jemalloc.conda
linux-aarch64::pyarrow-14.0.2-py39h59ea48c_18_cpu.conda
linux-aarch64::imagecodecs-2024.1.1-py39hfbd7563_4.conda
linux-aarch64::util-linux-2.39.4-py311h7022ece_0.conda
linux-aarch64::libadios2-2.10.0-mpi_openmpi_h8d2ab71_0.conda
linux-aarch64::llvm-18.1.3-h250cd41_0.conda
linux-aarch64::openmpi-5.0.2-h9ca730b_101.conda
linux-aarch64::pyarrow-tests-12.0.1-py310hca77690_48_cuda.conda
linux-aarch64::libadios2-2.10.0-nompi_h9e90768_100.conda
linux-aarch64::pyarrow-tests-13.0.0-py312h2696e27_36_cuda.conda
linux-aarch64::libadios2-2.9.2-mpi_openmpi_h00a29b4_2.conda
linux-aarch64::pyarrow-tests-14.0.2-py312h2696e27_19_cuda.conda
linux-aarch64::libarrow-15.0.2-hc64e4d7_2_cpu.conda
linux-aarch64::libadios2-2.10.0-mpi_openmpi_h0ff1eac_3.conda
linux-aarch64::pyarrow-tests-14.0.2-py38h9ec0d4c_17_cuda.conda
linux-aarch64::jaxlib-0.4.23-cpu_py310h4ba55d0_1.conda
linux-aarch64::lld-18.1.3-h9e3bf44_0.conda
linux-aarch64::heyoka-llvm-16-4.0.3-h86da435_1.conda
linux-aarch64::cmake-3.29.2-hef020d8_0.conda
linux-aarch64::pyarrow-tests-15.0.2-py39h59ea48c_5_cpu.conda
linux-aarch64::pyarrow-13.0.0-py39hda7dbfd_36_cuda.conda
linux-aarch64::libxml2-2.12.6-h3091e33_2.conda
linux-aarch64::pyarrow-tests-14.0.2-py310hca77690_19_cuda.conda
linux-aarch64::llvmdev-18.1.3-hbfe100b_0.conda
linux-aarch64::nushell-0.92.0-h0771932_0.conda
linux-aarch64::gstlal-1.13.0-py311ha13c55a_1.conda
linux-aarch64::pyarrow-14.0.2-py38h9ec0d4c_17_cuda.conda
linux-aarch64::pyarrow-13.0.0-py39hda7dbfd_37_cuda.conda
linux-aarch64::pyarrow-13.0.0-py39h17b0f66_36_cpu.conda
linux-aarch64::gap-core-4.13.0-he143273_0.conda
linux-aarch64::imagecodecs-2024.1.1-py39h13a3221_5.conda
linux-aarch64::pyarrow-13.0.0-py38h932dad8_36_cpu.conda
linux-aarch64::grpcio-1.62.2-py38h95a9722_0.conda
linux-aarch64::pyarrow-tests-14.0.2-py311hfc23d97_18_cpu.conda
linux-aarch64::aws-sdk-cpp-1.11.267-hc40fc56_6.conda
linux-aarch64::libmed-4.1.1-nompi_h24ceab1_112.conda
linux-aarch64::libarrow-14.0.2-hc6620ac_17_cpu.conda
linux-aarch64::vowpalwabbit-9.9.0-py39h46f18e6_4.conda
linux-aarch64::libgrpc-1.62.2-h98a9317_0.conda
linux-aarch64::fenics-libdolfin-2019.1.0-h6f4d292_43.conda
linux-aarch64::folly-2024.04.01.00-h302560b_0.conda
linux-aarch64::pyarrow-tests-13.0.0-py310hca77690_36_cuda.conda
linux-aarch64::tiledb-2.22.0-h6a268c0_1.conda
linux-aarch64::libgdal-arrow-parquet-3.8.5-hcd417df_0.conda
linux-aarch64::heyoka-llvm-13-4.0.3-h8e60897_1.conda
linux-aarch64::pyarrow-tests-15.0.2-py311hf1c3740_6_cuda.conda
linux-aarch64::nco-5.2.4-h1cece5e_0.conda
linux-aarch64::libarrow-13.0.0-ha76f436_37_cpu.conda
linux-aarch64::pyinstaller-6.6.0-py312h16ba8cc_0.conda
linux-aarch64::folly-2024.04.15.00-hfbf93a7_0_jemalloc.conda
linux-aarch64::pyarrow-tests-15.0.2-py310h70ca0e3_4_cpu.conda
linux-aarch64::libadios2-2.9.2-mpi_openmpi_h8d2ab71_2.conda
linux-aarch64::libarrow-15.0.2-h876d348_6_cuda.conda
linux-aarch64::robotraconteur-1.2.0-py39h9179f3f_2.conda
linux-aarch64::libadios2-2.10.0-nompi_h23c59ab_102.conda
linux-aarch64::robotraconteur-1.2.0-py311hddf9d76_2.conda
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
linux-aarch64::dotnet-aspnetcore-6.0.28-h9e6cf05_0.conda
linux-aarch64::dotnet-sdk-6.0.420-h9e6cf05_0.conda
linux-aarch64::libmlir-18.1.4-h6acfec4_0.conda
linux-aarch64::libsqlite-3.45.3-h194ca79_0.conda
linux-aarch64::git-cliff-2.2.1-h4daaf6c_0.conda
linux-aarch64::coin-or-utils-2.11.11-h6f8d6ce_0.conda
linux-aarch64::cfitsio-4.4.0-hf28c5f1_1.conda
linux-aarch64::heaptrack-1.2.0-h2b44c7f_5.conda
linux-aarch64::libmlir18-18.1.3-h6acfec4_0.conda
linux-aarch64::dotnet-runtime-6.0.28-h9e6cf05_0.conda
linux-aarch64::eccodes-2.35.0-hb180dc1_0.conda
linux-aarch64::libmlir-18.1.3-h6acfec4_0.conda
linux-aarch64::libharu-2.4.4-hf0a5ef3_0.conda
linux-aarch64::libmlir18-18.1.4-h6acfec4_0.conda
linux-aarch64::jbig2dec-0.18-hf0a5ef3_0.conda
linux-aarch64::coin-or-osi-0.108.10-hb66c02a_0.conda
-    "libzlib >=1.2.13,<1.3.0a0"
+    "libzlib >=1.2.13,<2.0.0a0"
================================================================================
================================================================================
noarch
================================================================================
================================================================================
win-64
win-64::pyarrow-tests-12.0.1-py311h6d3785f_48_cpu.conda
win-64::pillow-10.3.0-py38h894f861_0.conda
win-64::nsight-compute-2024.1.1.4-hbdb2b8c_0.conda
win-64::libgdal-arrow-parquet-3.8.5-hed4f78d_0.conda
win-64::pyarrow-15.0.2-py312h41d2b33_6_cuda.conda
win-64::pyarrow-tests-14.0.2-py310h6bd4de8_17_cpu.conda
win-64::libarrow-15.0.2-ha65aa87_4_cuda.conda
win-64::pyarrow-12.0.1-py311h6d3785f_47_cpu.conda
win-64::pyarrow-tests-15.0.2-py39h822eaf3_6_cuda.conda
win-64::pyarrow-12.0.1-py39h822eaf3_47_cuda.conda
win-64::libadios2-2.10.0-nompi_h8b5fd3d_100.conda
win-64::pyarrow-13.0.0-py310h6bd4de8_37_cpu.conda
win-64::cfitsio-4.4.0-h9b0cee5_1.conda
win-64::llvm-tools-18.1.3-h81a0ecd_0.conda
win-64::heyoka-4.0.3-h176e5e0_2.conda
win-64::pyarrow-15.0.2-py38h1a60bc1_5_cpu.conda
win-64::libmediainfo-24.04-hf0fe3d4_0.conda
win-64::pyarrow-14.0.2-py310h6bd4de8_18_cpu.conda
win-64::pyarrow-tests-14.0.2-py311h6d3785f_18_cpu.conda
win-64::pyarrow-tests-15.0.2-py312h4af9903_4_cpu.conda
win-64::clangdev-18.1.3-default_h3a3e6c3_0.conda
win-64::heyoka-llvm-16-4.0.3-h5d71ec6_1.conda
win-64::libarrow-14.0.2-ha65aa87_18_cuda.conda
win-64::libadios2-2.9.2-nompi_h8b5fd3d_102.conda
win-64::clangxx-18.1.4-default_h3a3e6c3_0.conda
win-64::mlir-python-bindings-17.0.6-py39h96b901f_0.conda
win-64::nsight-compute-2024.1.1.4-h007d3c0_2.conda
win-64::tiledb-2.21.2-h25b666a_0.conda
win-64::lxml-5.1.1-py312h2e4d1dc_0.conda
win-64::pillow-10.3.0-py39h9ee4981_0.conda
win-64::collada-dom-2.5.0-hc0d5731_8.conda
win-64::openmeeg-2.5.8-py39h1bf8877_0.conda
win-64::heyoka-4.0.3-hce97297_2.conda
win-64::libarrow-12.0.1-h98f2395_46_cuda.conda
win-64::aws-sdk-cpp-1.11.267-h5d77392_6.conda
win-64::libclang-cpp-18.1.4-default_h3a3e6c3_0.conda
win-64::libarrow-gandiva-15.0.2-hd4515a1_6_cuda.conda
win-64::pyarrow-13.0.0-py39h822eaf3_37_cuda.conda
win-64::tiledb-2.22.0-h5657395_3.conda
win-64::lxml-5.2.1-py311h12967d8_0.conda
win-64::grpcio-1.62.2-py38h19421c1_0.conda
win-64::pyinstaller-6.6.0-py39h84a0465_0.conda
win-64::libglib-2.80.0-h39d0aa6_3.conda
win-64::libmed-4.1.1-nompi_heec4ef5_112.conda
win-64::pyarrow-tests-14.0.2-py310he25ef97_19_cuda.conda
win-64::pyarrow-14.0.2-py38h1a60bc1_18_cpu.conda
win-64::fossil-2.24-hd48316a_0.conda
win-64::pyarrow-tests-13.0.0-py310h6bd4de8_37_cpu.conda
win-64::pyarrow-tests-14.0.2-py312h41d2b33_19_cuda.conda
win-64::libgdal-arrow-parquet-3.7.3-h3625be8_23.conda
win-64::wasmer-4.2.8-h4dd112c_0.conda
win-64::cmake-3.29.2-hf0feee3_0.conda
win-64::pyarrow-tests-12.0.1-py38h1a60bc1_47_cpu.conda
win-64::pillow-10.3.0-py310hf5d6e66_0.conda
win-64::pyarrow-tests-15.0.2-py311h6d3785f_6_cpu.conda
win-64::folly-2024.04.29.00-h23e0033_0.conda
win-64::tiledb-2.18.5-hf67ed3d_0.conda
win-64::mlir-18.1.3-he744812_0.conda
win-64::heyoka-4.0.3-h60dbba3_0.conda
win-64::pytables-3.9.2-py311hdb33602_2.conda
win-64::pyarrow-tests-13.0.0-py39h822eaf3_36_cuda.conda
win-64::pyarrow-tests-13.0.0-py310he25ef97_37_cuda.conda
win-64::libmed-4.1.1-nompi_h1f6f142_112.conda
win-64::blosc-1.21.5-hbd69f2e_1.conda
win-64::mlir-python-bindings-16.0.6-py310h7dcdc39_0.conda
win-64::pyarrow-tests-15.0.2-py39h338ae66_5_cpu.conda
win-64::libarrow-15.0.2-he3d97d8_6_cpu.conda
win-64::libadios2-2.9.2-nompi_hc918761_102.conda
win-64::pyarrow-tests-15.0.2-py39h822eaf3_5_cuda.conda
win-64::pyarrow-15.0.2-py311h4642027_6_cuda.conda
win-64::libarrow-13.0.0-h98f2395_35_cuda.conda
win-64::lxml-5.2.1-py38h98cf29c_0.conda
win-64::pyarrow-13.0.0-py39h338ae66_37_cpu.conda
win-64::pyarrow-15.0.2-py39h822eaf3_5_cuda.conda
win-64::lfortran-0.35.0-h12be248_0.conda
win-64::pyarrow-tests-15.0.2-py311h4642027_4_cuda.conda
win-64::heyoka-llvm-15-3.2.0-h3aa310e_1.conda
win-64::heyoka-3.2.0-h11d6856_1.conda
win-64::heyoka-4.0.3-h2c984cd_2.conda
win-64::pyarrow-13.0.0-py312h41d2b33_36_cuda.conda
win-64::pyarrow-14.0.2-py310h6bd4de8_19_cpu.conda
win-64::libarrow-14.0.2-h428c574_15_cpu.conda
win-64::pyarrow-tests-13.0.0-py311h4642027_37_cuda.conda
win-64::libarrow-13.0.0-hef5c370_37_cuda.conda
win-64::libllvm18-18.1.4-h81a0ecd_0.conda
win-64::pyarrow-14.0.2-py39h338ae66_18_cpu.conda
win-64::pyarrow-14.0.2-py312h41d2b33_19_cuda.conda
win-64::heyoka-4.0.3-h80d53ed_1.conda
win-64::heyoka-llvm-17-4.0.3-h5eccc79_1.conda
win-64::heyoka-llvm-15-4.0.3-h51922dd_1.conda
win-64::papilo-2.2.0-h8eee7c9_4.conda
win-64::llvmdev-18.1.3-h81a0ecd_0.conda
win-64::pyarrow-tests-14.0.2-py311h6d3785f_17_cpu.conda
win-64::pyarrow-tests-13.0.0-py38h1a60bc1_37_cpu.conda
win-64::papilo-2.2.0-h8212e9b_3.conda
win-64::clang-tools-18.1.3-default_h3a3e6c3_0.conda
win-64::pyarrow-tests-12.0.1-py38h1a60bc1_48_cpu.conda
win-64::dpcpp_impl_win-64-2024.1.0-hc5a8ccd_964.conda
win-64::libarrow-gandiva-15.0.2-hd4515a1_5_cuda.conda
win-64::libadios2-2.10.0-nompi_h724a2c0_103.conda
win-64::libadios2-2.10.0-nompi_hc918761_100.conda
win-64::llvmdev-18.1.4-h81a0ecd_0.conda
win-64::qt6-main-6.7.0-h5dee92f_1.conda
win-64::mlir-python-bindings-18.1.3-py311h14a4280_0.conda
win-64::openmeeg-2.5.8-py312h2187710_0.conda
win-64::pyarrow-15.0.2-py312h4af9903_4_cpu.conda
win-64::nushell-0.92.2-ha06f394_0.conda
win-64::pdal-2.7.1-h382afd8_5.conda
win-64::pyarrow-14.0.2-py312h41d2b33_17_cuda.conda
win-64::jbig2dec-0.18-hdaf720e_0.conda
win-64::pyarrow-tests-14.0.2-py39h338ae66_17_cpu.conda
win-64::mlir-python-bindings-18.1.3-py38hc1458bd_0.conda
win-64::lxml-5.2.1-py39hbf02b01_0.conda
win-64::pyarrow-14.0.2-py311h6d3785f_18_cpu.conda
win-64::heyoka-llvm-17-4.0.3-h9c5c3ab_2.conda
win-64::tiledb-2.22.0-h8c3a016_0.conda
win-64::pyarrow-14.0.2-py310he25ef97_17_cuda.conda
win-64::pyinstaller-6.6.0-py38ha959d8a_0.conda
win-64::coin-or-utils-2.11.11-hff51b80_0.conda
win-64::libarrow-14.0.2-ha65aa87_17_cuda.conda
win-64::pyarrow-tests-14.0.2-py38h1a60bc1_18_cpu.conda
win-64::sasktran2-2024.03.0-py310h5e51fd8_1.conda
win-64::pyarrow-13.0.0-py39h822eaf3_36_cuda.conda
win-64::grpcio-1.62.2-py311h5bc0dda_0.conda
win-64::heyoka-3.2.0-h7523f6a_1.conda
win-64::pyarrow-14.0.2-py39h822eaf3_18_cuda.conda
win-64::pyarrow-14.0.2-py311h6d3785f_17_cpu.conda
win-64::pyarrow-12.0.1-py310he25ef97_47_cuda.conda
win-64::libarrow-13.0.0-hc4d8811_37_cpu.conda
win-64::pillow-10.3.0-py39hb49f884_0.conda
win-64::pyinstaller-6.6.0-py311h12e69fa_0.conda
win-64::pyarrow-tests-15.0.2-py311h6d3785f_4_cpu.conda
win-64::scip-9.0.0-h75b6d29_4.conda
win-64::nco-5.2.4-h871a938_0.conda
win-64::wxwidgets-3.2.4-h03c2be3_3.conda
win-64::genomekit-5.0.1-py39he337b7a_0.conda
win-64::pyarrow-15.0.2-py311h6d3785f_4_cpu.conda
win-64::rocksdb-9.1.0-h080d376_0.conda
win-64::pyarrow-tests-14.0.2-py38h1a60bc1_19_cpu.conda
win-64::libarrow-14.0.2-hf517ad9_18_cpu.conda
win-64::imagecodecs-2024.1.1-py39hae6b4d1_5.conda
win-64::heyoka-llvm-14-4.0.3-h7288b71_0.conda
win-64::heyoka-4.0.3-hb9fa263_1.conda
win-64::pyarrow-tests-15.0.2-py312h4af9903_5_cpu.conda
win-64::libgdal-arrow-parquet-3.7.3-h2c11768_23.conda
win-64::pyarrow-13.0.0-py312h4af9903_36_cpu.conda
win-64::grpcio-1.62.2-py310hb84602e_0.conda
win-64::libarrow-gandiva-15.0.2-h05de715_3_cuda.conda
win-64::pyarrow-tests-12.0.1-py310h6bd4de8_47_cpu.conda
win-64::libarrow-14.0.2-hd98a7f7_15_cuda.conda
win-64::cpp-opentelemetry-sdk-1.15.0-hf1929ed_0.conda
win-64::lxml-5.1.1-py310h95c315b_0.conda
win-64::pyarrow-tests-12.0.1-py38h85b827c_48_cuda.conda
win-64::libadios2-2.10.0-nompi_h8040cb0_103.conda
win-64::pyarrow-12.0.1-py39h822eaf3_48_cuda.conda
win-64::genomekit-5.0.0-py310h4607c91_0.conda
win-64::libgdal-3.7.3-h5890a70_23.conda
win-64::mlir-python-bindings-17.0.6-py311h14a4280_0.conda
win-64::ffmpeg-6.1.1-gpl_h66c0b5b_108.conda
win-64::gdstk-0.9.51-py311hc50246e_0.conda
win-64::libarrow-12.0.1-h36b52e9_45_cuda.conda
win-64::pyarrow-tests-14.0.2-py39h338ae66_19_cpu.conda
win-64::pyarrow-13.0.0-py38h1a60bc1_36_cpu.conda
win-64::pyarrow-13.0.0-py312h4af9903_37_cpu.conda
win-64::lldb-18.1.3-py38h92471a9_0.conda
win-64::pyarrow-tests-14.0.2-py38h1a60bc1_17_cpu.conda
win-64::zimpl-3.5.4-h56d4e8f_3.conda
win-64::nco-5.2.3-h871a938_0.conda
win-64::mlir-python-bindings-16.0.6-py39h32efe87_0.conda
win-64::libarrow-14.0.2-ha2639d9_19_cuda.conda
win-64::pyarrow-15.0.2-py311h6d3785f_5_cpu.conda
win-64::pyinstaller-6.6.0-py310h35269f2_0.conda
win-64::pyarrow-14.0.2-py312h4af9903_17_cpu.conda
win-64::imagecodecs-2024.1.1-py310hc7f5127_4.conda
win-64::pyarrow-tests-12.0.1-py311h6d3785f_47_cpu.conda
win-64::pyarrow-13.0.0-py38h85b827c_36_cuda.conda
win-64::ovito-3.10.5-h8ea1a09_0.conda
win-64::libgdal-arrow-parquet-3.8.5-h3ccf73b_0.conda
win-64::pyarrow-14.0.2-py38h85b827c_19_cuda.conda
win-64::zimpl-3.5.4-h5f048cf_4.conda
win-64::pytables-3.9.2-py312h7ab76d9_2.conda
win-64::pyarrow-tests-15.0.2-py312h4af9903_6_cpu.conda
win-64::pyarrow-tests-13.0.0-py312h41d2b33_37_cuda.conda
win-64::nushell-0.92.0-ha06f394_0.conda
win-64::pyarrow-12.0.1-py39h338ae66_48_cpu.conda
win-64::libgoogle-cloud-storage-2.23.0-hb581fae_1.conda
win-64::qt-main-5.15.8-hcef0176_21.conda
win-64::qt6-main-6.7.0-h5dee92f_0.conda
win-64::pyarrow-tests-12.0.1-py39h822eaf3_47_cuda.conda
win-64::clang-18.1.4-default_hb53fc94_0.conda
win-64::libarrow-12.0.1-hef5c370_48_cuda.conda
win-64::python-3.12.3-h2628c8c_0_cpython.conda
win-64::pyarrow-tests-14.0.2-py39h338ae66_18_cpu.conda
win-64::libarrow-14.0.2-h56068ea_16_cuda.conda
win-64::heyoka-llvm-13-4.0.3-h19081bc_2.conda
win-64::libgdal-arrow-parquet-3.8.5-h98f5757_2.conda
win-64::libarrow-gandiva-14.0.2-h4e6a3a4_16_cuda.conda
win-64::pyarrow-15.0.2-py38h85b827c_6_cuda.conda
win-64::grpcio-1.62.2-py312h7894644_0.conda
win-64::libadios2-2.10.0-nompi_hc918761_101.conda
win-64::lxml-5.1.1-py38h95ac740_0.conda
win-64::pyarrow-15.0.2-py38h1a60bc1_4_cpu.conda
win-64::pyarrow-14.0.2-py39h822eaf3_17_cuda.conda
win-64::mlir-python-bindings-18.1.3-py312hbaa67b7_0.conda
win-64::pyarrow-15.0.2-py311h6d3785f_6_cpu.conda
win-64::soplex-8.0.0-hc3e09bf_3.conda
win-64::libadios2-2.10.0-nompi_hafb0eab_103.conda
win-64::pyarrow-15.0.2-py311h4642027_5_cuda.conda
win-64::pyarrow-tests-13.0.0-py38h85b827c_37_cuda.conda
win-64::pytables-3.9.2-py310h7bf2125_2.conda
win-64::mlir-python-bindings-18.1.3-py310hc59d3a4_0.conda
win-64::imagecodecs-2024.1.1-py311hde8bdc2_6.conda
win-64::pyarrow-13.0.0-py311h6d3785f_36_cpu.conda
win-64::pyarrow-tests-13.0.0-py311h6d3785f_37_cpu.conda
win-64::folly-2024.04.22.00-h23e0033_0.conda
win-64::pyarrow-tests-15.0.2-py38h1a60bc1_6_cpu.conda
win-64::pyarrow-12.0.1-py310h6bd4de8_47_cpu.conda
win-64::pyarrow-tests-14.0.2-py39h822eaf3_17_cuda.conda
win-64::ffmpeg-6.1.1-lgpl_h9fe14be_7.conda
win-64::clang-tools-18.1.4-default_h3a3e6c3_0.conda
win-64::cmake-3.29.1-hf0feee3_0.conda
win-64::intel-cmplr-lib-rt-2024.1.0-h12be248_964.conda
win-64::pyarrow-15.0.2-py312h41d2b33_4_cuda.conda
win-64::clangxx-18.1.3-default_h3a3e6c3_0.conda
win-64::rocksdb-8.5.3-hfe94bb5_1.conda
win-64::clangdev-18.1.4-default_h3a3e6c3_0.conda
win-64::gdstk-0.9.51-py38h8a2f752_0.conda
win-64::imagecodecs-2024.1.1-py39h82727ea_6.conda
win-64::ogre-next-2.3.3-h606bb5d_0.conda
win-64::pyarrow-tests-13.0.0-py39h822eaf3_37_cuda.conda
win-64::pyarrow-13.0.0-py310he25ef97_36_cuda.conda
win-64::libarrow-15.0.2-hf517ad9_4_cpu.conda
win-64::libarrow-12.0.1-h21068e6_46_cpu.conda
win-64::libarrow-14.0.2-he3d97d8_19_cpu.conda
win-64::lxml-5.1.1-py39h7034f3b_0.conda
win-64::python-3.11.9-h631f459_0_cpython.conda
win-64::pyarrow-12.0.1-py38h1a60bc1_47_cpu.conda
win-64::pyarrow-tests-15.0.2-py38h85b827c_6_cuda.conda
win-64::pyarrow-13.0.0-py38h1a60bc1_37_cpu.conda
win-64::libllvm-c18-18.1.3-h81a0ecd_0.conda
win-64::clang-18-18.1.4-default_h3a3e6c3_0.conda
win-64::libadios2-2.10.0-nompi_hb5a00f8_100.conda
win-64::qt6-3d-6.7.0-h294d793_0.conda
win-64::ngspicesimserver-0.5-h1affa08_2.conda
win-64::libxml2-2.12.6-hc3477c8_2.conda
win-64::libadios2-2.10.0-nompi_h9bd006a_101.conda
win-64::intel-opencl-rt-2024.1.0-h586cfe6_964.conda
win-64::pyarrow-tests-12.0.1-py311h4642027_47_cuda.conda
win-64::imagecodecs-2024.1.1-py312h439985d_6.conda
win-64::libglib-2.80.0-h39d0aa6_6.conda
win-64::heyoka-llvm-16-4.0.3-h0b878c8_2.conda
win-64::lld-18.1.3-h40628bb_0.conda
win-64::mlir-python-bindings-17.0.6-py310hc59d3a4_0.conda
win-64::pyarrow-15.0.2-py312h4af9903_5_cpu.conda
win-64::pdal-2.7.1-h78909d1_6.conda
win-64::libarrow-15.0.2-h428c574_2_cpu.conda
win-64::pyarrow-15.0.2-py38h85b827c_5_cuda.conda
win-64::libgdal-arrow-parquet-3.8.5-ha912a6c_0.conda
win-64::libarrow-13.0.0-h61eb693_34_cpu.conda
win-64::lldb-18.1.3-py310h7f6bcc4_0.conda
win-64::clang-18.1.3-default_hb53fc94_0.conda
win-64::heyoka-llvm-13-4.0.3-hd068865_0.conda
win-64::pyarrow-tests-14.0.2-py312h4af9903_18_cpu.conda
win-64::pyarrow-15.0.2-py38h1a60bc1_6_cpu.conda
win-64::imagecodecs-2024.1.1-py310h6c328c2_6.conda
win-64::heyoka-4.0.3-h2660bd0_0.conda
win-64::grpcio-1.62.2-py39h6848017_0.conda
win-64::tiledb-2.21.2-hfcadb87_1.conda
win-64::libgdal-arrow-parquet-3.8.5-h3625be8_2.conda
win-64::libadios2-2.10.0-nompi_h2077877_102.conda
win-64::genomekit-5.0.1-py310h4607c91_0.conda
win-64::libarrow-gandiva-15.0.2-hd4515a1_5_cpu.conda
win-64::pyarrow-13.0.0-py39h338ae66_36_cpu.conda
win-64::ffmpeg-6.1.1-lgpl_h8221ca6_9.conda
win-64::intel-opencl-rt-2024.1.0-h17f84ac_964.conda
win-64::imagecodecs-2024.1.1-py312hb75541c_4.conda
win-64::pyarrow-15.0.2-py312h41d2b33_5_cuda.conda
win-64::libglib-2.80.0-h39d0aa6_5.conda
win-64::pyarrow-tests-12.0.1-py39h338ae66_47_cpu.conda
win-64::heyoka-3.2.0-hb2bc60d_1.conda
win-64::libmed-4.1.1-nompi_h5712609_112.conda
win-64::assimp-5.4.0-h0dbab56_0.conda
win-64::pyarrow-tests-15.0.2-py312h41d2b33_4_cuda.conda
win-64::libgdal-arrow-parquet-3.8.5-h75cf60b_1.conda
win-64::heyoka-llvm-15-4.0.3-h06afaec_2.conda
win-64::libllvm-c18-18.1.4-h81a0ecd_0.conda
win-64::heyoka-llvm-13-3.2.0-h531cf5f_1.conda
win-64::pyarrow-tests-15.0.2-py310he25ef97_5_cuda.conda
win-64::libarrow-14.0.2-h45212c0_16_cpu.conda
win-64::pyarrow-14.0.2-py39h822eaf3_19_cuda.conda
win-64::libmlir-18.1.4-he744812_0.conda
win-64::libgdal-arrow-parquet-3.8.5-h9b4d310_1.conda
win-64::orc-2.0.0-h7e885a9_1.conda
win-64::pyarrow-tests-15.0.2-py310he25ef97_6_cuda.conda
win-64::pyarrow-tests-13.0.0-py310he25ef97_36_cuda.conda
win-64::libopentelemetry-cpp-1.15.0-hf1929ed_0.conda
win-64::ffmpeg-6.1.1-lgpl_h9fe14be_8.conda
win-64::libarrow-12.0.1-hc4d8811_48_cpu.conda
win-64::aws-sdk-cpp-1.11.267-hc73a15b_5.conda
win-64::libarrow-13.0.0-h21068e6_35_cpu.conda
win-64::ogre-14.2.4-h5d47b67_0.conda
win-64::pillow-10.3.0-py311h6819b35_0.conda
win-64::folly-2024.04.08.00-hb89b1cf_0.conda
win-64::imagecodecs-2024.1.1-py39hbbfeeee_4.conda
win-64::nsight-compute-2024.1.1.4-h007d3c0_1.conda
win-64::pdal-2.7.1-h382afd8_2.conda
win-64::heyoka-llvm-17-4.0.3-hd8a7f0f_0.conda
win-64::pyarrow-tests-15.0.2-py38h85b827c_5_cuda.conda
win-64::tiledb-2.22.0-hd94df1e_1.conda
win-64::mongodb-6.0.12-h06e12ec_1.conda
win-64::pyarrow-13.0.0-py312h41d2b33_37_cuda.conda
win-64::libgdal-3.8.5-hbda495f_0.conda
win-64::pyarrow-tests-13.0.0-py310h6bd4de8_36_cpu.conda
win-64::libadios2-2.10.0-nompi_h301c490_101.conda
win-64::libpcm-1.2.3-he64ddb8_9.conda
win-64::pyarrow-15.0.2-py310he25ef97_4_cuda.conda
win-64::pyarrow-15.0.2-py310he25ef97_5_cuda.conda
win-64::pyarrow-tests-13.0.0-py312h41d2b33_36_cuda.conda
win-64::gdstk-0.9.51-py39h32efe87_0.conda
win-64::sasktran2-2024.03.0-py311h753b67f_1.conda
win-64::pyarrow-tests-15.0.2-py38h1a60bc1_5_cpu.conda
win-64::tiledb-2.18.5-h2657894_0.conda
win-64::libgoogle-cloud-storage-2.23.0-hb581fae_0.conda
win-64::tiledb-2.22.0-h31c14a9_2.conda
win-64::pyinstaller-6.6.0-py312h3bd2d22_0.conda
win-64::rocksdb-9.0.1-h080d376_0.conda
win-64::sasktran2-2024.03.0-py312hda9c2bc_1.conda
win-64::pyarrow-tests-12.0.1-py310h6bd4de8_48_cpu.conda
win-64::heyoka-3.2.0-h94d080d_1.conda
win-64::libarrow-15.0.2-hf517ad9_5_cpu.conda
win-64::pyarrow-tests-13.0.0-py38h1a60bc1_36_cpu.conda
win-64::eccodes-2.35.0-h97caf96_0.conda
win-64::heyoka-4.0.3-hab7d550_0.conda
win-64::libadios2-2.10.0-nompi_hb5a00f8_101.conda
win-64::genomekit-5.0.0-py39he337b7a_0.conda
win-64::pyarrow-15.0.2-py39h822eaf3_4_cuda.conda
win-64::libarrow-13.0.0-h36b52e9_34_cuda.conda
win-64::libarrow-gandiva-14.0.2-h4e6a3a4_16_cpu.conda
win-64::libarrow-gandiva-14.0.2-h34286b4_18_cuda.conda
win-64::pyarrow-tests-13.0.0-py312h4af9903_37_cpu.conda
win-64::tiledb-2.21.2-hf39fa12_4.conda
win-64::pyarrow-tests-14.0.2-py310h6bd4de8_18_cpu.conda
win-64::pyarrow-tests-12.0.1-py310he25ef97_48_cuda.conda
win-64::libarrow-15.0.2-ha2639d9_6_cuda.conda
win-64::mlir-python-bindings-16.0.6-py312h1b3467e_0.conda
win-64::libmed-4.1.1-nompi_ha1134f2_112.conda
win-64::clang-18-18.1.3-default_h3a3e6c3_0.conda
win-64::libgdal-arrow-parquet-3.8.5-hc4d84b9_1.conda
win-64::libarrow-gandiva-14.0.2-h34286b4_18_cpu.conda
win-64::pyarrow-tests-12.0.1-py39h822eaf3_48_cuda.conda
win-64::heyoka-4.0.3-h37f3184_2.conda
win-64::libadios2-2.10.0-nompi_h9bd006a_100.conda
win-64::libarrow-gandiva-15.0.2-h05de715_3_cpu.conda
win-64::pdal-2.7.1-hfca12c9_3.conda
win-64::libarrow-gandiva-14.0.2-h34286b4_19_cpu.conda
win-64::pyarrow-tests-14.0.2-py311h4642027_17_cuda.conda
win-64::heyoka-llvm-14-3.2.0-h1db9c27_1.conda
win-64::pyarrow-tests-14.0.2-py310he25ef97_18_cuda.conda
win-64::imagecodecs-2024.1.1-py312h4ae5d3c_5.conda
win-64::tiledb-2.21.2-h6da7456_3.conda
win-64::heyoka-4.0.3-hfa0f163_1.conda
win-64::pyarrow-15.0.2-py39h338ae66_4_cpu.conda
win-64::heyoka-llvm-17-3.2.0-hcfd26d5_1.conda
win-64::folly-2024.04.15.00-h23e0033_0.conda
win-64::libarrow-gandiva-15.0.2-hd4515a1_4_cpu.conda
win-64::pyarrow-tests-15.0.2-py310h6bd4de8_4_cpu.conda
win-64::libarrow-12.0.1-h5c45170_47_cpu.conda
win-64::libgdal-3.8.5-h4f0c4f6_1.conda
win-64::pyarrow-14.0.2-py38h1a60bc1_17_cpu.conda
win-64::lxml-5.2.1-py39h360c413_0.conda
win-64::lxml-5.1.1-py311hf937690_0.conda
win-64::pyarrow-tests-15.0.2-py310he25ef97_4_cuda.conda
win-64::folly-2024.04.08.00-h23e0033_1.conda
win-64::pyarrow-tests-14.0.2-py38h85b827c_17_cuda.conda
win-64::nushell-0.92.1-ha06f394_0.conda
win-64::grpcio-1.62.2-py39hd28a505_0.conda
win-64::qt6-main-6.7.0-h5dee92f_2.conda
win-64::heyoka-4.0.3-h14a612c_0.conda
win-64::pytables-3.9.2-py39h727adc0_2.conda
win-64::pyarrow-14.0.2-py39h338ae66_19_cpu.conda
win-64::genomekit-5.0.0-py38hac0eba8_0.conda
win-64::pyarrow-tests-14.0.2-py311h4642027_18_cuda.conda
win-64::libgdal-arrow-parquet-3.8.5-h2c11768_2.conda
win-64::pyarrow-14.0.2-py311h6d3785f_19_cpu.conda
win-64::libarrow-gandiva-15.0.2-h05de715_2_cpu.conda
win-64::pyarrow-tests-14.0.2-py38h85b827c_18_cuda.conda
win-64::llvm-tools-18.1.4-h81a0ecd_0.conda
win-64::intel-opencl-rt-2024.1.0-h870974d_964.conda
win-64::libadios2-2.10.0-nompi_h7d758a1_102.conda
win-64::libarrow-gandiva-14.0.2-h34286b4_17_cuda.conda
win-64::flang-18.1.3-h2ce125b_1.conda
win-64::lld-18.1.4-h40628bb_0.conda
win-64::libarrow-15.0.2-h56068ea_3_cuda.conda
win-64::heyoka-llvm-14-4.0.3-h8f73c2b_1.conda
win-64::imagecodecs-2024.1.1-py39hccdc85b_6.conda
win-64::pyarrow-tests-14.0.2-py312h4af9903_19_cpu.conda
win-64::libgdal-arrow-parquet-3.7.3-h8dcb0d4_23.conda
win-64::libglib-2.80.0-h39d0aa6_2.conda
win-64::pyarrow-tests-14.0.2-py312h41d2b33_17_cuda.conda
win-64::mlir-python-bindings-16.0.6-py311hc50246e_0.conda
win-64::tiledb-2.18.5-hf016803_0.conda
win-64::heyoka-4.0.3-h6d70bac_1.conda
win-64::libclang13-18.1.3-default_hf64faad_0.conda
win-64::libgdal-arrow-parquet-3.8.5-h8dcb0d4_2.conda
win-64::libmlir-18.1.3-he744812_0.conda
win-64::pyarrow-tests-12.0.1-py38h85b827c_47_cuda.conda
win-64::poppler-24.04.0-h747fd5a_0.conda
win-64::pyarrow-13.0.0-py311h4642027_37_cuda.conda
win-64::pyarrow-12.0.1-py310he25ef97_48_cuda.conda
win-64::libadios2-2.9.2-nompi_h9bd006a_102.conda
win-64::pyarrow-13.0.0-py311h4642027_36_cuda.conda
win-64::libarrow-15.0.2-h45212c0_3_cpu.conda
win-64::libllvm18-18.1.3-h81a0ecd_0.conda
win-64::pyarrow-13.0.0-py310he25ef97_37_cuda.conda
win-64::libgdal-3.8.5-hfb9f81c_2.conda
win-64::libarrow-gandiva-14.0.2-h4e6a3a4_15_cuda.conda
win-64::pyarrow-14.0.2-py312h4af9903_18_cpu.conda
win-64::pyarrow-tests-15.0.2-py310h6bd4de8_6_cpu.conda
win-64::folly-2024.04.01.00-ha28d350_0.conda
win-64::libglib-2.80.0-h39d0aa6_4.conda
win-64::libadios2-2.10.0-nompi_h9885159_103.conda
win-64::pyarrow-tests-14.0.2-py311h6d3785f_19_cpu.conda
win-64::libadios2-2.10.0-nompi_h90c1dde_102.conda
win-64::llvm-18.1.4-hb9829f2_0.conda
win-64::pyarrow-15.0.2-py310he25ef97_6_cuda.conda
win-64::pyarrow-tests-14.0.2-py39h822eaf3_19_cuda.conda
win-64::libarrow-gandiva-15.0.2-hd4515a1_6_cpu.conda
win-64::mlir-python-bindings-18.1.3-py39h96b901f_0.conda
win-64::libarrow-12.0.1-h020c536_47_cuda.conda
win-64::pyarrow-15.0.2-py39h338ae66_6_cpu.conda
win-64::libgdal-arrow-parquet-3.8.5-h3991f08_1.conda
win-64::pyarrow-tests-13.0.0-py39h338ae66_37_cpu.conda
win-64::imagecodecs-2024.1.1-py311h7b5139e_5.conda
win-64::libarrow-gandiva-14.0.2-h34286b4_19_cuda.conda
win-64::libadios2-2.10.0-nompi_h8b5fd3d_101.conda
win-64::heyoka-4.0.3-h4776d7f_2.conda
win-64::pyarrow-15.0.2-py311h4642027_4_cuda.conda
win-64::libarrow-gandiva-15.0.2-hd4515a1_4_cuda.conda
win-64::pytables-3.9.2-py39h986ddba_2.conda
win-64::pyarrow-tests-15.0.2-py311h6d3785f_5_cpu.conda
win-64::pyarrow-15.0.2-py310h6bd4de8_6_cpu.conda
win-64::pyarrow-tests-14.0.2-py38h85b827c_19_cuda.conda
win-64::pyarrow-12.0.1-py311h4642027_47_cuda.conda
win-64::pyarrow-tests-15.0.2-py39h338ae66_4_cpu.conda
win-64::pyarrow-tests-15.0.2-py310h6bd4de8_5_cpu.conda
win-64::pyarrow-tests-13.0.0-py311h4642027_36_cuda.conda
win-64::pyarrow-tests-13.0.0-py311h6d3785f_36_cpu.conda
win-64::ffmpeg-6.1.1-gpl_h66c0b5b_107.conda
win-64::libadios2-2.10.0-nompi_h4090864_102.conda
win-64::tiledb-2.21.2-h53c1088_1.conda
win-64::nsight-compute-2024.1.1.4-hbdb2b8c_1.conda
win-64::openmeeg-2.5.8-py310h3340d21_0.conda
win-64::pyarrow-tests-15.0.2-py312h41d2b33_6_cuda.conda
win-64::imagecodecs-2024.1.1-py311h5541417_4.conda
win-64::libarrow-12.0.1-h61eb693_45_cpu.conda
win-64::pyarrow-tests-13.0.0-py312h4af9903_36_cpu.conda
win-64::pyarrow-tests-14.0.2-py312h4af9903_17_cpu.conda
win-64::pyarrow-15.0.2-py310h6bd4de8_5_cpu.conda
win-64::pyarrow-tests-14.0.2-py311h4642027_19_cuda.conda
win-64::libmed-4.1.1-nompi_h230955a_112.conda
win-64::libadios2-2.10.0-nompi_h59b2cd4_102.conda
win-64::pyarrow-12.0.1-py39h338ae66_47_cpu.conda
win-64::llvm-18.1.3-hb9829f2_0.conda
win-64::openmeeg-2.5.8-py311h823dbb9_0.conda
win-64::heyoka-llvm-16-4.0.3-h38ce0ea_0.conda
win-64::pyarrow-14.0.2-py38h1a60bc1_19_cpu.conda
win-64::pyarrow-12.0.1-py38h85b827c_47_cuda.conda
win-64::openmeeg-2.5.8-py38h9aebfce_0.conda
win-64::heyoka-llvm-15-4.0.3-heeaf09b_0.conda
win-64::libarrow-15.0.2-hd98a7f7_2_cuda.conda
win-64::gdstk-0.9.51-py312h1b3467e_0.conda
win-64::libarrow-gandiva-15.0.2-h05de715_2_cuda.conda
win-64::libarrow-13.0.0-h020c536_36_cuda.conda
win-64::tiledb-2.21.2-ha92a4e1_2.conda
win-64::libgdal-arrow-parquet-3.8.5-h84dbc16_0.conda
win-64::pyarrow-14.0.2-py312h41d2b33_18_cuda.conda
win-64::pyarrow-14.0.2-py311h4642027_17_cuda.conda
win-64::libpulsar-3.5.1-h0b1f996_1.conda
win-64::mlir-18.1.4-he744812_0.conda
win-64::pyarrow-tests-15.0.2-py311h4642027_5_cuda.conda
win-64::soplex-8.0.0-hceedf09_4.conda
win-64::pyarrow-14.0.2-py38h85b827c_18_cuda.conda
win-64::lldb-18.1.3-py311hdf7c4b9_0.conda
win-64::libadios2-2.10.0-nompi_h301c490_100.conda
win-64::gdstk-0.9.51-py310h7dcdc39_0.conda
win-64::libclang-18.1.3-default_h3a3e6c3_0.conda
win-64::pyarrow-12.0.1-py311h6d3785f_48_cpu.conda
win-64::dlib-cpp-19.24.4-h2425d5f_0.conda
win-64::pyarrow-14.0.2-py310he25ef97_18_cuda.conda
win-64::gst-plugins-bad-1.24.1-h2895b6a_0.conda
win-64::pyarrow-tests-14.0.2-py39h822eaf3_18_cuda.conda
win-64::libadios2-2.9.2-nompi_hb5a00f8_102.conda
win-64::pyarrow-tests-14.0.2-py310he25ef97_17_cuda.conda
win-64::mlir-python-bindings-16.0.6-py38h8a2f752_0.conda
win-64::pyarrow-14.0.2-py311h4642027_18_cuda.conda
win-64::pyarrow-tests-14.0.2-py310h6bd4de8_19_cpu.conda
win-64::pyarrow-15.0.2-py310h6bd4de8_4_cpu.conda
win-64::pyarrow-tests-15.0.2-py39h822eaf3_4_cuda.conda
win-64::libgdal-arrow-parquet-3.7.3-h98f5757_23.conda
win-64::ogre-14.2.4-h87d0416_0.conda
win-64::pyarrow-tests-15.0.2-py312h41d2b33_5_cuda.conda
win-64::pyarrow-13.0.0-py311h6d3785f_37_cpu.conda
win-64::lxml-5.2.1-py310hdccf185_0.conda
win-64::pyarrow-15.0.2-py312h4af9903_6_cpu.conda
win-64::heyoka-4.0.3-hd5ce069_1.conda
win-64::pyarrow-12.0.1-py310h6bd4de8_48_cpu.conda
win-64::pyarrow-tests-15.0.2-py311h4642027_6_cuda.conda
win-64::imagecodecs-2024.1.1-py39hc4cac7a_5.conda
win-64::libmongoc-1.23.2-hd394d1d_1.conda
win-64::gdstk-0.9.51-py39h2b303d1_0.conda
win-64::aws-sdk-cpp-1.11.267-h3f4ca61_7.conda
win-64::libarrow-gandiva-14.0.2-h34286b4_17_cpu.conda
win-64::libgrpc-1.62.2-h5273850_0.conda
win-64::libarrow-14.0.2-hf517ad9_17_cpu.conda
win-64::intel-opencl-rt-2024.1.0-h5d91e6b_964.conda
win-64::libarrow-13.0.0-h5c45170_36_cpu.conda
win-64::pyarrow-tests-12.0.1-py310he25ef97_47_cuda.conda
win-64::heyoka-4.0.3-hdb470e1_0.conda
win-64::scip-9.0.0-h272d9c4_3.conda
win-64::pyarrow-15.0.2-py39h338ae66_5_cpu.conda
win-64::libpulsar-3.5.1-h5dbea17_0.conda
win-64::pyarrow-14.0.2-py311h4642027_19_cuda.conda
win-64::pyarrow-12.0.1-py38h1a60bc1_48_cpu.conda
win-64::libarrow-gandiva-14.0.2-h4e6a3a4_15_cpu.conda
win-64::rocksdb-9.1.1-h080d376_0.conda
win-64::mlir-python-bindings-17.0.6-py312hbaa67b7_0.conda
win-64::imagecodecs-2024.1.1-py39h3779ffd_4.conda
win-64::pyarrow-15.0.2-py38h85b827c_4_cuda.conda
win-64::pyarrow-14.0.2-py38h85b827c_17_cuda.conda
win-64::lxml-5.1.1-py39h0bf2546_0.conda
win-64::pyarrow-14.0.2-py39h338ae66_17_cpu.conda
win-64::pyarrow-14.0.2-py312h4af9903_19_cpu.conda
win-64::intel-opencl-rt-2024.1.0-h1f54710_964.conda
win-64::pyarrow-tests-14.0.2-py312h41d2b33_18_cuda.conda
win-64::pillow-10.3.0-py312h6f6a607_0.conda
win-64::pyarrow-tests-15.0.2-py38h1a60bc1_4_cpu.conda
win-64::pyarrow-tests-13.0.0-py38h85b827c_36_cuda.conda
win-64::heyoka-llvm-16-3.2.0-h080f195_1.conda
win-64::libadios2-2.9.2-nompi_h301c490_102.conda
win-64::pyarrow-13.0.0-py38h85b827c_37_cuda.conda
win-64::lxml-5.2.1-py312h56c7e3b_0.conda
win-64::git-cliff-2.2.1-hcb6e01d_0.conda
win-64::pyarrow-tests-15.0.2-py38h85b827c_4_cuda.conda
win-64::pyarrow-12.0.1-py311h4642027_48_cuda.conda
win-64::libclang-cpp-18.1.3-default_h3a3e6c3_0.conda
win-64::imagecodecs-2024.1.1-py310h533659d_5.conda
win-64::pyarrow-14.0.2-py310he25ef97_19_cuda.conda
win-64::libclang-18.1.4-default_h3a3e6c3_0.conda
win-64::mlir-python-bindings-17.0.6-py38hc1458bd_0.conda
win-64::libarrow-15.0.2-ha65aa87_5_cuda.conda
win-64::pyarrow-tests-12.0.1-py311h4642027_48_cuda.conda
win-64::heyoka-3.2.0-h03ef8d7_1.conda
win-64::pyarrow-15.0.2-py39h822eaf3_6_cuda.conda
win-64::libadios2-2.10.0-nompi_h63dc85e_103.conda
win-64::libclang13-18.1.4-default_hf64faad_0.conda
win-64::pyarrow-12.0.1-py38h85b827c_48_cuda.conda
win-64::pyarrow-tests-15.0.2-py39h338ae66_6_cpu.conda
win-64::genomekit-5.0.1-py38hac0eba8_0.conda
win-64::openmeeg-2.5.8-py39h65e40f1_0.conda
win-64::pyarrow-14.0.2-py310h6bd4de8_17_cpu.conda
win-64::tiledb-2.20.1-hc9ddcec_7.conda
win-64::pyarrow-tests-12.0.1-py39h338ae66_48_cpu.conda
win-64::pyarrow-tests-13.0.0-py39h338ae66_36_cpu.conda
win-64::heyoka-llvm-14-4.0.3-hb55abcd_2.conda
win-64::flang-18.1.3-h12be248_0.conda
win-64::heyoka-llvm-13-4.0.3-h1f8b8b3_1.conda
win-64::pdal-2.7.1-h382afd8_4.conda
win-64::lldb-18.1.3-py39h3cd603d_0.conda
win-64::pyarrow-13.0.0-py310h6bd4de8_36_cpu.conda
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
================================================================================
================================================================================
osx-64
osx-64::imagecodecs-2024.1.1-py310hf98ccbb_4.conda
osx-64::heyoka-llvm-14-4.0.3-h122d2d9_0.conda
osx-64::mlir-python-bindings-16.0.6-py39h6e703ae_0.conda
osx-64::libarrow-13.0.0-hf3b8634_35_cpu.conda
osx-64::nest-simulator-3.6-py38hb86306f_5.conda
osx-64::rocksdb-9.0.1-hcf0db61_0.conda
osx-64::pyarrow-14.0.2-py39hdbbee67_19_cpu.conda
osx-64::tiledb-2.20.1-h9fa30f9_7.conda
osx-64::libadios2-2.9.2-mpi_mpich_hda80eb8_2.conda
osx-64::heyoka-llvm-15-3.2.0-h3f6a34f_1.conda
osx-64::geant4-11.1.3-py38h999bed0_1.conda
osx-64::libllvm18-18.1.4-hbcf5fad_0.conda
osx-64::heyoka-4.0.3-h1f27543_0.conda
osx-64::libarrow-13.0.0-hb155cd9_34_cpu.conda
osx-64::pdal-2.7.1-h1ff4188_2.conda
osx-64::tiledb-2.22.0-hf5f2543_3.conda
osx-64::pyarrow-tests-14.0.2-py38h0409e80_17_cpu.conda
osx-64::mlir-python-bindings-16.0.6-py311h7edd508_0.conda
osx-64::pdal-2.7.1-h1ff4188_5.conda
osx-64::mupdf-1.24.1-py312h5244dd2_5.conda
osx-64::qt-main-5.15.8-hecaf5c3_21.conda
osx-64::libgdal-arrow-parquet-3.8.5-hd00617a_2.conda
osx-64::pyarrow-13.0.0-py310hab5bf3d_36_cpu.conda
osx-64::pyarrow-tests-15.0.2-py310hfcac963_5_cpu.conda
osx-64::heyoka-llvm-14-3.2.0-ha0bb965_1.conda
osx-64::heyoka-4.0.3-h17e631f_1.conda
osx-64::ndcctools-7.9.2-py38hd480228_0.conda
osx-64::libgdal-3.8.5-hd750f19_1.conda
osx-64::lfortran-0.35.0-h0d4612f_0.conda
osx-64::mupdf-1.24.1-h736b354_1.conda
osx-64::pyarrow-tests-15.0.2-py39h52bf62a_4_cpu.conda
osx-64::lammps-2024.02.07-cpu_py310_h8cbf5a9_nompi_1.conda
osx-64::libgdal-arrow-parquet-3.8.5-ha92cd5d_0.conda
osx-64::imagecodecs-2024.1.1-py39hcf4cbaa_6.conda
osx-64::pyarrow-tests-14.0.2-py38h0409e80_18_cpu.conda
osx-64::pyarrow-13.0.0-py38h0409e80_37_cpu.conda
osx-64::panda3d-1.10.14-py311he30b6e2_2.conda
osx-64::mupdf-1.24.1-py310h852a2d7_2.conda
osx-64::libadios2-2.10.0-mpi_mpich_h0f93c5f_1.conda
osx-64::ndcctools-7.9.2-py39h677b332_0.conda
osx-64::cryptominisat-5.8.0-py39hb10e792_3.conda
osx-64::lxml-5.1.1-py311h4429a6e_0.conda
osx-64::nest-simulator-3.7-py39hf45367b_1.conda
osx-64::graphviz-2.50.0-h8671558_4.conda
osx-64::pyarrow-14.0.2-py38h0409e80_17_cpu.conda
osx-64::openimageio-2.5.9.0-hfbc210b_1.conda
osx-64::folly-2023.09.25.00-hafaf054_5.conda
osx-64::openmeeg-2.5.8-py39h62b91fc_0.conda
osx-64::libadios2-2.10.0-mpi_mpich_h0f93c5f_0.conda
osx-64::libadios2-2.9.2-mpi_mpich_h0f93c5f_2.conda
osx-64::libadios2-2.10.0-mpi_openmpi_h76d66bf_3.conda
osx-64::fossil-2.24-h4d0655f_0.conda
osx-64::lammps-2024.02.07-cpu_py310_hdd5fa3c_mpi_mpich_0.conda
osx-64::pyarrow-tests-15.0.2-py39h52bf62a_6_cpu.conda
osx-64::libadios2-2.10.0-mpi_openmpi_h131480d_2.conda
osx-64::magics-metview-4.15.4-h6cf63bc_0.conda
osx-64::texlive-core-20230313-hb35b1a5_12.conda
osx-64::folly-2023.09.25.00-ha17a156_5.conda
osx-64::libadios2-2.10.0-mpi_openmpi_h0af81fa_2.conda
osx-64::pillow-10.3.0-py38h85abd47_0.conda
osx-64::libmed-4.1.1-nompi_he62f7a5_112.conda
osx-64::openimageio-2.5.9.0-he2d38dc_1.conda
osx-64::soplex-8.0.0-hd82fbf3_4.conda
osx-64::pyarrow-tests-12.0.1-py310hab5bf3d_47_cpu.conda
osx-64::lammps-2024.02.07-cpu_py311_h3ff7cfc_mpi_mpich_1.conda
osx-64::libarrow-15.0.2-h1b20127_4_cpu.conda
osx-64::llvm-tools-18.1.3-hbcf5fad_0.conda
osx-64::blosc-1.21.5-hafa3907_1.conda
osx-64::cpp-opentelemetry-sdk-1.15.0-h9b58172_0.conda
osx-64::mdtraj-1.9.9-py38hf6233cf_1.conda
osx-64::grpcio-1.62.2-py312hbbbd34f_0.conda
osx-64::r-base-4.3.3-hc514ba5_1.conda
osx-64::heyoka-4.0.3-h346e612_1.conda
osx-64::libglib-2.80.0-h81c1438_6.conda
osx-64::pyinstaller-6.6.0-py311h8c2310c_0.conda
osx-64::heyoka-3.2.0-h327c3a0_1.conda
osx-64::pyarrow-15.0.2-py310hfcac963_6_cpu.conda
osx-64::libadios2-2.10.0-mpi_mpich_hc18c5fb_0.conda
osx-64::pyarrow-tests-13.0.0-py312h7818618_36_cpu.conda
osx-64::scip-9.0.0-hd3f254d_3.conda
osx-64::libgdal-arrow-parquet-3.7.3-h1a577ea_22.conda
osx-64::pyinstaller-6.6.0-py38hf1429db_0.conda
osx-64::lammps-2024.02.07-cpu_py39_h14e9caf_mpi_mpich_0.conda
osx-64::heyoka-llvm-13-4.0.3-he846dff_0.conda
osx-64::ndcctools-7.10.1-py38hd480228_0.conda
osx-64::pyarrow-12.0.1-py39hdbbee67_48_cpu.conda
osx-64::pillow-10.3.0-py311h1b85569_0.conda
osx-64::papilo-2.2.0-hb65f723_4.conda
osx-64::rsync-3.3.0-h5aaac6a_0.conda
osx-64::pyarrow-14.0.2-py38h0409e80_19_cpu.conda
osx-64::fenics-libdolfin-2019.1.0-hd02cf6c_43.conda
osx-64::lxml-5.1.1-py39hd1096b7_0.conda
osx-64::pyarrow-tests-15.0.2-py38h732352c_5_cpu.conda
osx-64::libmed-4.1.1-nompi_h3d8afbc_112.conda
osx-64::lammps-2024.02.07-cpu_py312_ha3629e6_mpi_openmpi_1.conda
osx-64::lxml-5.2.1-py312ha7aaddb_0.conda
osx-64::pyarrow-14.0.2-py311h05d2ada_19_cpu.conda
osx-64::imagecodecs-2024.1.1-py39h2eb221c_5.conda
osx-64::libadios2-2.10.0-mpi_openmpi_hce0c428_1.conda
osx-64::folly-2023.09.25.00-hd213566_5_jemalloc.conda
osx-64::ndcctools-7.10.0-py310h3f3ca68_0.conda
osx-64::nest-simulator-3.6-py312h24500eb_5.conda
osx-64::libadios2-2.9.2-nompi_h6fd95ed_102.conda
osx-64::mupdf-1.24.1-py310h27a38fc_4.conda
osx-64::nest-simulator-3.7-py311h22a0843_1.conda
osx-64::heyoka-4.0.3-h340c85a_0.conda
osx-64::tiledb-2.18.5-he01210c_0.conda
osx-64::libtiledb-sql-0.30.0-h28d138e_1.conda
osx-64::libadios2-2.10.0-mpi_openmpi_hd1598ce_3.conda
osx-64::fenics-libdolfin-2019.1.0-hd2b0255_43.conda
osx-64::vowpalwabbit-9.9.0-py312h2b8bc0b_4.conda
osx-64::libadios2-2.10.0-nompi_h726fef8_101.conda
osx-64::wasmer-4.2.8-hf88dd22_0.conda
osx-64::folly-2024.04.08.00-h67ccd40_0.conda
osx-64::mdtraj-1.9.9-py312haf99ffb_1.conda
osx-64::libadios2-2.10.0-mpi_openmpi_hd499892_3.conda
osx-64::fenics-libdolfin-2019.1.0-h1033c3c_43.conda
osx-64::pytables-3.9.2-py310hea8cab2_2.conda
osx-64::pytables-3.9.2-py39h5f06305_2.conda
osx-64::libadios2-2.10.0-nompi_h72a87da_103.conda
osx-64::rocksdb-8.5.3-hcf0db61_1.conda
osx-64::heyoka-llvm-14-4.0.3-hc9666fc_2.conda
osx-64::gstlal-1.13.0-py310h636eea9_1.conda
osx-64::libadios2-2.10.0-nompi_h46e651b_103.conda
osx-64::libadios2-2.10.0-mpi_mpich_hc7e8444_3.conda
osx-64::libgdal-arrow-parquet-3.7.3-h8b533b8_22.conda
osx-64::csp-0.0.3-py311hf9119f2_0.conda
osx-64::python-3.11.9-h657bba9_0_cpython.conda
osx-64::libadios2-2.10.0-mpi_mpich_h82ee776_2.conda
osx-64::lldb-18.1.3-py39h0f51564_0.conda
osx-64::lammps-2024.02.07-cpu_py311_h3ff7cfc_mpi_mpich_0.conda
osx-64::imagecodecs-2024.1.1-py39h1ea01bd_4.conda
osx-64::lxml-5.1.1-py310hba4d2f0_0.conda
osx-64::heyoka-4.0.3-h7329a44_0.conda
osx-64::sasktran2-2024.03.0-py310h8cdae2b_1.conda
osx-64::pyarrow-14.0.2-py39hdbbee67_18_cpu.conda
osx-64::mlir-python-bindings-18.1.3-py311h8a27b7f_0.conda
osx-64::heyoka-4.0.3-hc83fb94_1.conda
osx-64::mupdf-1.24.1-h736b354_0.conda
osx-64::ldas-tools-framecpp-3.0.3-hc235760_1.conda
osx-64::fenics-libdolfin-2019.1.0-hffec760_43.conda
osx-64::imagecodecs-2024.1.1-py310h117514f_6.conda
osx-64::libvips-8.15.2-h11c5e89_1.conda
osx-64::heyoka-4.0.3-h2f56eec_1.conda
osx-64::libadios2-2.9.2-nompi_h737fe1c_102.conda
osx-64::heyoka-3.2.0-h3cbd5b6_1.conda
osx-64::heyoka-3.2.0-h413ed5c_1.conda
osx-64::nest-simulator-3.6-py311h22a0843_5.conda
osx-64::ndcctools-7.9.1-py311hc4bdf42_0.conda
osx-64::libgdal-arrow-parquet-3.8.5-h738a0e6_2.conda
osx-64::ndcctools-7.10.0-py38hd480228_0.conda
osx-64::verilator-5.022-h8e8e533_1.conda
osx-64::libadios2-2.9.2-nompi_h9395711_102.conda
osx-64::wxpython-4.2.1-py311ha82924a_5.conda
osx-64::libgdal-3.8.5-h4f2ca4b_0.conda
osx-64::pyarrow-tests-14.0.2-py39hdbbee67_18_cpu.conda
osx-64::pyarrow-tests-15.0.2-py39h52bf62a_5_cpu.conda
osx-64::pyarrow-tests-12.0.1-py39hdbbee67_47_cpu.conda
osx-64::openmeeg-2.5.8-py311hbe5bedd_0.conda
osx-64::pyarrow-tests-12.0.1-py311h05d2ada_47_cpu.conda
osx-64::pyarrow-tests-15.0.2-py311hcc74be5_6_cpu.conda
osx-64::grpcio-1.62.2-py38ha6b6e42_0.conda
osx-64::aws-sdk-cpp-1.11.267-h8dd24e3_7.conda
osx-64::ndcctools-7.10.0-py39h677b332_0.conda
osx-64::pyarrow-tests-14.0.2-py310hab5bf3d_19_cpu.conda
osx-64::cryptominisat-5.8.0-py310he18e62a_3.conda
osx-64::libadios2-2.9.2-mpi_openmpi_hce0c428_2.conda
osx-64::libgdal-arrow-parquet-3.8.5-hd1bb58d_0.conda
osx-64::lxml-5.2.1-py39h51bd67f_0.conda
osx-64::qt6-main-6.7.0-ha93d198_0.conda
osx-64::lxml-5.2.1-py38h8a571d4_0.conda
osx-64::ndcctools-7.10.1-py39h677b332_0.conda
osx-64::heyoka-4.0.3-h5c9e23b_0.conda
osx-64::libadios2-2.10.0-nompi_hb851817_100.conda
osx-64::pyarrow-15.0.2-py311hcc74be5_4_cpu.conda
osx-64::pyarrow-tests-15.0.2-py312h3db2695_5_cpu.conda
osx-64::ffmpeg-6.1.1-gpl_h55674dd_109.conda
osx-64::libarrow-12.0.1-hf3b8634_46_cpu.conda
osx-64::libadios2-2.10.0-nompi_hb851817_101.conda
osx-64::pyarrow-tests-12.0.1-py310hab5bf3d_48_cpu.conda
osx-64::csp-0.0.3-py310hfae02f7_0.conda
osx-64::libglib-2.80.0-h81c1438_2.conda
osx-64::ogre-next-2.3.3-h74574cf_0.conda
osx-64::folly-2023.09.25.00-hb472fb9_5.conda
osx-64::healpy-1.16.6-py39h8e92a4f_4.conda
osx-64::pyarrow-14.0.2-py310hab5bf3d_18_cpu.conda
osx-64::pyarrow-13.0.0-py311h05d2ada_36_cpu.conda
osx-64::libgdal-arrow-parquet-3.8.5-h8b533b8_1.conda
osx-64::gdstk-0.9.51-py39h23d43bd_0.conda
osx-64::pyarrow-15.0.2-py312h3db2695_5_cpu.conda
osx-64::pillow-10.3.0-py39h1d17011_0.conda
osx-64::fenics-libdolfin-2019.1.0-h31f0ef8_43.conda
osx-64::pdal-2.7.1-h812336a_3.conda
osx-64::gst-plugins-bad-1.24.1-hdda625c_0.conda
osx-64::panda3d-1.10.14-py310hea0f3f5_2.conda
osx-64::libadios2-2.10.0-mpi_mpich_hda80eb8_2.conda
osx-64::folly-2024.04.15.00-hf87a323_0.conda
osx-64::libadios2-2.9.2-mpi_openmpi_h131480d_2.conda
osx-64::libgdal-arrow-parquet-3.8.5-h643b0ac_2.conda
osx-64::panda3d-1.10.14-py38hd1a0924_2.conda
osx-64::libgdal-3.7.3-h6a0430f_23.conda
osx-64::libxmlsec1-1.3.4-h5526e8a_0.conda
osx-64::openmeeg-2.5.8-py312ha815679_0.conda
osx-64::libadios2-2.10.0-mpi_mpich_h7322141_1.conda
osx-64::libpulsar-3.5.1-hf8be4f9_1.conda
osx-64::libadios2-2.10.0-nompi_h9395711_100.conda
osx-64::rocksdb-9.1.1-hcf0db61_0.conda
osx-64::openmpi-5.0.3-h7cf3660_100.conda
osx-64::pyarrow-15.0.2-py38h732352c_5_cpu.conda
osx-64::lammps-2024.02.07-cpu_py312_hf614f3d_mpi_mpich_1.conda
osx-64::libarrow-15.0.2-hd49f87b_2_cpu.conda
osx-64::libadios2-2.10.0-mpi_mpich_hf0fbaed_3.conda
osx-64::libarrow-15.0.2-h965e444_3_cpu.conda
osx-64::pyarrow-tests-14.0.2-py310hab5bf3d_18_cpu.conda
osx-64::llvm-18.1.4-h7c4b0f9_0.conda
osx-64::csp-0.0.3-py39h5688ed5_0.conda
osx-64::ffmpeg-6.1.1-lgpl_hd1c3340_8.conda
osx-64::libadios2-2.10.0-nompi_hb2415ad_103.conda
osx-64::pyarrow-14.0.2-py312h7818618_17_cpu.conda
osx-64::pyarrow-14.0.2-py310hab5bf3d_19_cpu.conda
osx-64::heyoka-llvm-15-4.0.3-h2a45488_0.conda
osx-64::mlir-python-bindings-18.1.3-py39h7da9283_0.conda
osx-64::gazebo-11.14.0-orignameh42707df_212.conda
osx-64::libarrow-14.0.2-hf13115f_16_cpu.conda
osx-64::pyarrow-tests-15.0.2-py311hcc74be5_5_cpu.conda
osx-64::pyarrow-tests-13.0.0-py311h05d2ada_36_cpu.conda
osx-64::ogre-14.2.4-h5c474ad_0.conda
osx-64::erlang-26.2.4-pl5321h0c96147_0.conda
osx-64::pyarrow-tests-14.0.2-py312h7818618_17_cpu.conda
osx-64::folly-2024.04.22.00-h1dae7a0_0_jemalloc.conda
osx-64::tiledb-2.18.5-hee4a7ef_0.conda
osx-64::libadios2-2.10.0-mpi_openmpi_h30003d0_3.conda
osx-64::pyarrow-14.0.2-py312h7818618_19_cpu.conda
osx-64::heyoka-4.0.3-hb65d2f4_2.conda
osx-64::genomekit-5.0.0-py310hcfed807_0.conda
osx-64::magics-metview-batch-4.15.4-h42d7316_0.conda
osx-64::libpulsar-3.5.1-h2d82d27_0.conda
osx-64::nest-simulator-3.7-py310hebbbe1e_1.conda
osx-64::libmediainfo-24.04-h3e665c9_0.conda
osx-64::cryptominisat-5.8.0-py311hcb21608_3.conda
osx-64::libgoogle-cloud-storage-2.23.0-ha67e85c_0.conda
osx-64::libadios2-2.10.0-mpi_openmpi_ha31e0ae_1.conda
osx-64::llvmdev-18.1.3-hbcf5fad_0.conda
osx-64::mupdf-1.24.1-py38h9c20ddc_3.conda
osx-64::grpcio-1.62.2-py310h271164d_0.conda
osx-64::heyoka-4.0.3-hce1549a_2.conda
osx-64::lammps-2024.02.07-cpu_py38_h9e2c45a_mpi_openmpi_0.conda
osx-64::libtiledb-sql-0.30.0-h1d9990a_0.conda
osx-64::ndcctools-7.10.0-py311hc4bdf42_0.conda
osx-64::pyarrow-12.0.1-py38h0409e80_47_cpu.conda
osx-64::magics-4.15.4-h42d7316_0.conda
osx-64::git-2.45.0-pl5321hf33e10e_0.conda
osx-64::xeus-cpp-0.3.0-h5929788_2.conda
osx-64::assimp-5.4.0-h3e74f17_0.conda
osx-64::heyoka-llvm-17-3.2.0-ha7c5b6b_1.conda
osx-64::heyoka-llvm-16-4.0.3-h98a6219_2.conda
osx-64::lammps-2024.02.07-cpu_py311_h7e0894f_nompi_1.conda
osx-64::fenics-libdolfin-2019.1.0-hd2b3754_43.conda
osx-64::tiledb-2.22.0-hb153338_2.conda
osx-64::libarrow-14.0.2-h1d28f1a_18_cpu.conda
osx-64::lammps-2024.02.07-cpu_py39_h14e9caf_mpi_mpich_1.conda
osx-64::llvm-tools-18.1.4-hbcf5fad_0.conda
osx-64::libadios2-2.10.0-nompi_hb748dc2_103.conda
osx-64::libopentelemetry-cpp-1.15.0-h9b58172_0.conda
osx-64::libadios2-2.10.0-mpi_openmpi_hce0c428_0.conda
osx-64::lldb-18.1.3-py310heb15bc7_0.conda
osx-64::lammps-2024.02.07-cpu_py39_h7885287_mpi_openmpi_1.conda
osx-64::util-linux-2.39.4-py310h68052b9_0.conda
osx-64::pyarrow-15.0.2-py39h52bf62a_4_cpu.conda
osx-64::pyarrow-12.0.1-py310hab5bf3d_47_cpu.conda
osx-64::grpcio-1.62.2-py39h99d80ef_0.conda
osx-64::gazebo-11.14.0-origname1234567_211.conda
osx-64::heyoka-llvm-13-4.0.3-h2d551ef_2.conda
osx-64::nushell-0.92.1-h00276e2_0.conda
osx-64::tiledb-2.18.5-h8fd0293_0.conda
osx-64::wxpython-4.2.1-py310h2693ab4_5.conda
osx-64::vowpalwabbit-9.9.0-py310hb9398d2_4.conda
osx-64::pyarrow-12.0.1-py311h05d2ada_48_cpu.conda
osx-64::pytables-3.9.2-py39h2ad7703_2.conda
osx-64::folly-2024.04.08.00-hf87a323_1.conda
osx-64::libadios2-2.10.0-nompi_h9395711_102.conda
osx-64::tiledb-2.21.2-h3cc408c_1.conda
osx-64::hyperion-fortran-0.9.11-h5472e8c_1.conda
osx-64::pyarrow-tests-13.0.0-py39hdbbee67_36_cpu.conda
osx-64::libadios2-2.10.0-mpi_mpich_hd81fee9_3.conda
osx-64::heyoka-llvm-14-4.0.3-h463c6bc_1.conda
osx-64::lammps-2024.02.07-cpu_py310_h8cbf5a9_nompi_0.conda
osx-64::mupdf-1.24.1-py311heb4cf83_3.conda
osx-64::gdstk-0.9.51-py311h7edd508_0.conda
osx-64::ndcctools-7.10.1-py310h3f3ca68_0.conda
osx-64::sasktran2-2024.03.0-py312h3d667d7_1.conda
osx-64::libadios2-2.10.0-nompi_h6fd95ed_101.conda
osx-64::lammps-2024.02.07-cpu_py39_h5305340_nompi_0.conda
osx-64::photochem-0.5.3-py39ha15fc24_0.conda
osx-64::mlir-python-bindings-16.0.6-py38hbe7c026_0.conda
osx-64::photochem-0.5.3-py312hb15540d_0.conda
osx-64::fenics-libdolfin-2019.1.0-h34cbc0c_43.conda
osx-64::imagecodecs-2024.1.1-py39ha20330a_6.conda
osx-64::pyarrow-tests-14.0.2-py312h7818618_19_cpu.conda
osx-64::gdstk-0.9.51-py39h6e703ae_0.conda
osx-64::lammps-2024.02.07-cpu_py310_hbc8b412_mpi_openmpi_1.conda
osx-64::qt6-3d-6.7.0-hba7393b_0.conda
osx-64::imagecodecs-2024.1.1-py310h9338b74_5.conda
osx-64::cmake-3.29.1-h7c85d92_0.conda
osx-64::pyarrow-14.0.2-py310hab5bf3d_17_cpu.conda
osx-64::lammps-2024.02.07-cpu_py38_h5baff61_mpi_mpich_1.conda
osx-64::folly-2023.09.25.00-h809f202_5_jemalloc.conda
osx-64::ffmpeg-6.1.1-gpl_h9654dba_107.conda
osx-64::yosys-0.40-h120f7d5_0.conda
osx-64::libadios2-2.10.0-mpi_mpich_h82ee776_0.conda
osx-64::pyarrow-tests-12.0.1-py39hdbbee67_48_cpu.conda
osx-64::mlir-18.1.4-hea0bbce_0.conda
osx-64::libadios2-2.10.0-mpi_mpich_h4de8231_3.conda
osx-64::rocksdb-9.1.0-hcf0db61_0.conda
osx-64::libadios2-2.10.0-mpi_openmpi_h14705da_3.conda
osx-64::libarrow-15.0.2-h1b20127_5_cpu.conda
osx-64::pyarrow-12.0.1-py39hdbbee67_47_cpu.conda
osx-64::orc-2.0.0-hf146577_1.conda
osx-64::libgdal-arrow-parquet-3.7.3-h643b0ac_23.conda
osx-64::lxml-5.2.1-py311hfd6d4f4_0.conda
osx-64::imagecodecs-2024.1.1-py39hfb8cb73_4.conda
osx-64::libadios2-2.10.0-nompi_h0f52a84_103.conda
osx-64::genomekit-5.0.0-py38hc0ef4fa_0.conda
osx-64::nest-simulator-3.7-py38hb86306f_1.conda
osx-64::libarrow-12.0.1-hb155cd9_45_cpu.conda
osx-64::mlir-python-bindings-16.0.6-py312hf3e4e0a_0.conda
osx-64::aws-sdk-cpp-1.11.267-h01edc24_6.conda
osx-64::nodejs-20.12.2-hfc0f20e_0.conda
osx-64::photochem-0.5.3-py311hfabfaf4_0.conda
osx-64::libmongoc-1.23.2-h4d426b0_1.conda
osx-64::fenics-libdolfin-2019.1.0-hd409b60_43.conda
osx-64::openmeeg-2.5.8-py38h6b82322_0.conda
osx-64::pyarrow-14.0.2-py39hdbbee67_17_cpu.conda
osx-64::mlir-python-bindings-17.0.6-py38he37c428_0.conda
osx-64::heyoka-4.0.3-h913496c_2.conda
osx-64::libadios2-2.10.0-mpi_openmpi_h493bbf9_0.conda
osx-64::lammps-2024.02.07-cpu_py39_hb2f5527_mpi_mpich_1.conda
osx-64::libtiledb-sql-0.30.0-h2b55fc4_0.conda
osx-64::libadios2-2.10.0-nompi_h726fef8_100.conda
osx-64::libglib-2.80.0-h81c1438_5.conda
osx-64::heyoka-llvm-13-4.0.3-h50e9c9c_1.conda
osx-64::mupdf-1.24.1-py310h27a38fc_5.conda
osx-64::heyoka-llvm-16-4.0.3-h08f413d_1.conda
osx-64::mupdf-1.24.1-py38h9c20ddc_5.conda
osx-64::pillow-10.3.0-py312h0c923fa_0.conda
osx-64::libarrow-14.0.2-h1d28f1a_17_cpu.conda
osx-64::libadios2-2.10.0-nompi_h737fe1c_102.conda
osx-64::lxml-5.1.1-py38h50a1ac7_0.conda
osx-64::photochem-0.5.3-py310he41496f_0.conda
osx-64::mlir-18.1.3-hea0bbce_0.conda
osx-64::ndcctools-7.9.1-py38hd480228_0.conda
osx-64::nco-5.2.4-hfcf1594_0.conda
osx-64::libadios2-2.10.0-mpi_mpich_h7322141_2.conda
osx-64::pyarrow-12.0.1-py38h0409e80_48_cpu.conda
osx-64::libadios2-2.9.2-mpi_openmpi_h493bbf9_2.conda
osx-64::libgdal-3.7.3-h7fcbcd8_22.conda
osx-64::pyarrow-tests-12.0.1-py311h05d2ada_48_cpu.conda
osx-64::libgdal-arrow-parquet-3.7.3-h6ce0358_22.conda
osx-64::openimageio-2.5.9.0-hdd2efe8_1.conda
osx-64::imagecodecs-2024.1.1-py39h7b75b58_5.conda
osx-64::folly-2024.04.29.00-hf87a323_0.conda
osx-64::tiledb-2.21.2-h9fa30f9_1.conda
osx-64::lxml-5.1.1-py39hcfe8cff_0.conda
osx-64::ffmpeg-6.1.1-lgpl_h8972834_9.conda
osx-64::mdtraj-1.9.9-py311hbd61c5e_1.conda
osx-64::libadios2-2.9.2-mpi_mpich_h7322141_2.conda
osx-64::mlir-python-bindings-17.0.6-py312h64c540d_0.conda
osx-64::mupdf-1.24.1-py38h9c20ddc_4.conda
osx-64::panda3d-1.10.14-py312h629979e_2.conda
osx-64::openmeeg-2.5.8-py310h61f837b_0.conda
osx-64::aws-sdk-cpp-1.11.267-h874d6f0_5.conda
osx-64::lammps-2024.02.07-cpu_py38_h9e2c45a_mpi_openmpi_1.conda
osx-64::wxwidgets-3.2.4-he88646a_3.conda
osx-64::heyoka-4.0.3-h555e9f8_2.conda
osx-64::libadios2-2.10.0-nompi_h737fe1c_100.conda
osx-64::mupdf-1.24.1-py39h606c822_5.conda
osx-64::pyarrow-14.0.2-py311h05d2ada_17_cpu.conda
osx-64::mupdf-1.24.1-py312h5244dd2_3.conda
osx-64::poppler-24.04.0-h0face88_0.conda
osx-64::pyarrow-tests-14.0.2-py312h7818618_18_cpu.conda
osx-64::lammps-2024.02.07-cpu_py312_h7d83159_nompi_1.conda
osx-64::lld-18.1.4-h3c78e83_0.conda
osx-64::lammps-2024.02.07-cpu_py39_h5305340_nompi_1.conda
osx-64::libadios2-2.10.0-nompi_h726fef8_102.conda
osx-64::csp-0.0.3-py38h18d4dbe_0.conda
osx-64::nodejs-18.20.2-h096b449_0.conda
osx-64::mlir-python-bindings-17.0.6-py39h7da9283_0.conda
osx-64::pyarrow-12.0.1-py311h05d2ada_47_cpu.conda
osx-64::pyarrow-13.0.0-py312h7818618_36_cpu.conda
osx-64::zimpl-3.5.4-ha9cf984_3.conda
osx-64::pyinstaller-6.6.0-py312h67dd88c_0.conda
osx-64::libgdal-arrow-parquet-3.8.5-h1a577ea_1.conda
osx-64::libbrial-1.2.12-h81e9653_2.conda
osx-64::ndcctools-7.9.1-py39h677b332_0.conda
osx-64::libllvm18-18.1.3-hbcf5fad_0.conda
osx-64::imagecodecs-2024.1.1-py311h25b542f_6.conda
osx-64::qt6-main-6.7.0-h634ba57_2.conda
osx-64::mupdf-1.24.1-py38h2a91126_2.conda
osx-64::libgdal-arrow-parquet-3.7.3-h738a0e6_23.conda
osx-64::gazebo-11.14.0-gzcompatnameh6760714_12.conda
osx-64::hyperion-fortran-0.9.11-h5472e8c_2.conda
osx-64::libadios2-2.9.2-nompi_h726fef8_102.conda
osx-64::heyoka-llvm-17-4.0.3-h208994e_1.conda
osx-64::wxpython-4.2.1-py39h7b6c74d_5.conda
osx-64::loos-4.1.0-py38ha611bc7_1.conda
osx-64::healpy-1.16.6-py39hc8b528a_4.conda
osx-64::libgrpc-1.62.2-h384b2fc_0.conda
osx-64::fenics-libdolfin-2019.1.0-hba30375_43.conda
osx-64::mlir-python-bindings-18.1.3-py38he37c428_0.conda
osx-64::heyoka-3.2.0-h8fe2201_1.conda
osx-64::heyoka-3.2.0-h7c4ba3b_1.conda
osx-64::grpcio-1.62.2-py311h78ff076_0.conda
osx-64::fenics-libdolfin-2019.1.0-h2f023c6_43.conda
osx-64::util-linux-2.39.4-py312h21d8fb9_0.conda
osx-64::mlir-python-bindings-18.1.3-py310h7a11aa7_0.conda
osx-64::pyarrow-tests-15.0.2-py312h3db2695_6_cpu.conda
osx-64::heyoka-4.0.3-h61b3bea_0.conda
osx-64::vowpalwabbit-9.9.0-py38h3eb77a5_4.conda
osx-64::genomekit-5.0.1-py310hcfed807_0.conda
osx-64::geant4-11.1.3-py311hee81ff6_1.conda
osx-64::sasktran2-2024.03.0-py311hfc1ffe4_1.conda
osx-64::folly-2024.04.08.00-h1dae7a0_1_jemalloc.conda
osx-64::pyarrow-15.0.2-py311hcc74be5_5_cpu.conda
osx-64::libarrow-12.0.1-h54da0a0_47_cpu.conda
osx-64::mlir-python-bindings-17.0.6-py310h7a11aa7_0.conda
osx-64::mupdf-1.24.1-py39h606c822_3.conda
osx-64::pyarrow-tests-13.0.0-py38h0409e80_37_cpu.conda
osx-64::libadios2-2.10.0-mpi_openmpi_ha31e0ae_0.conda
osx-64::genomekit-5.0.1-py39h471a00b_0.conda
osx-64::pyarrow-tests-15.0.2-py311hcc74be5_4_cpu.conda
osx-64::lammps-2024.02.07-cpu_py39_h3c69d27_nompi_1.conda
osx-64::lammps-2024.02.07-cpu_py39_h7885287_mpi_openmpi_0.conda
osx-64::panda3d-1.10.14-py39hfa124e7_2.conda
osx-64::ndcctools-7.9.2-py311hc4bdf42_0.conda
osx-64::heyoka-4.0.3-h0e9d07b_2.conda
osx-64::mupdf-1.24.1-py311h033c440_2.conda
osx-64::pyarrow-tests-13.0.0-py38h0409e80_36_cpu.conda
osx-64::libmed-4.1.1-nompi_hc2357ab_112.conda
osx-64::vowpalwabbit-9.9.0-py311hcd6a77b_4.conda
osx-64::libadios2-2.10.0-mpi_mpich_h82ee776_1.conda
osx-64::pyarrow-tests-14.0.2-py311h05d2ada_18_cpu.conda
osx-64::wxpython-4.2.1-py38h1f69d7e_5.conda
osx-64::pyarrow-15.0.2-py39h52bf62a_5_cpu.conda
osx-64::libgdal-3.8.5-h7db9259_2.conda
osx-64::lammps-2024.02.07-cpu_py311_h835ce97_mpi_openmpi_0.conda
osx-64::soplex-8.0.0-hd82fbf3_3.conda
osx-64::nushell-0.92.2-h00276e2_0.conda
osx-64::libarrow-15.0.2-hfba3c4c_6_cpu.conda
osx-64::ffmpeg-6.1.1-gpl_h6b92a41_108.conda
osx-64::pyarrow-tests-15.0.2-py38h732352c_4_cpu.conda
osx-64::libadios2-2.10.0-mpi_mpich_hc18c5fb_1.conda
osx-64::libadios2-2.10.0-mpi_openmpi_hce0c428_2.conda
osx-64::libgdal-arrow-parquet-3.7.3-hb1ccceb_22.conda
osx-64::heyoka-llvm-17-4.0.3-h229d236_0.conda
osx-64::imagemagick-7.1.1_31-pl5321h3ebaa9c_0.conda
osx-64::loos-4.1.0-py39hf38d3c2_1.conda
osx-64::libadios2-2.9.2-mpi_openmpi_ha31e0ae_2.conda
osx-64::imagecodecs-2024.1.1-py312h97f30ee_5.conda
osx-64::lldb-18.1.3-py38hb774646_0.conda
osx-64::mesalib-24.0.6-h6b20dd5_0.conda
osx-64::lammps-2024.02.07-cpu_py311_h7e0894f_nompi_0.conda
osx-64::libbrial-1.2.12-h81e9653_3.conda
osx-64::libgdal-arrow-parquet-3.7.3-h84d88ca_23.conda
osx-64::loos-4.1.0-py312h1198e04_1.conda
osx-64::folly-2024.04.29.00-h1dae7a0_0_jemalloc.conda
osx-64::fenics-libdolfin-2019.1.0-ha6f2a13_43.conda
osx-64::pyarrow-tests-13.0.0-py311h05d2ada_37_cpu.conda
osx-64::photochem-0.5.3-py38haf50963_0.conda
osx-64::genomekit-5.0.1-py38hc0ef4fa_0.conda
osx-64::fenics-libdolfin-2019.1.0-h1437c18_43.conda
osx-64::openimageio-2.5.9.0-h8a5c174_1.conda
osx-64::tiledb-2.21.2-h19fb86a_2.conda
osx-64::pyarrow-15.0.2-py312h3db2695_4_cpu.conda
osx-64::pyarrow-15.0.2-py38h732352c_6_cpu.conda
osx-64::tiledb-2.21.2-he90ca55_3.conda
osx-64::pyinstaller-6.6.0-py310h03c913b_0.conda
osx-64::libmed-4.1.1-nompi_h19d1da1_112.conda
osx-64::pyarrow-14.0.2-py38h0409e80_18_cpu.conda
osx-64::nco-5.2.3-hfcf1594_0.conda
osx-64::pyarrow-15.0.2-py310hfcac963_5_cpu.conda
osx-64::libadios2-2.9.2-nompi_hb851817_102.conda
osx-64::pyarrow-14.0.2-py312h7818618_18_cpu.conda
osx-64::libadios2-2.10.0-nompi_hb851817_102.conda
osx-64::lammps-2024.02.07-cpu_py38_h5baff61_mpi_mpich_0.conda
osx-64::jaxlib-0.4.23-cpu_py39h1d8d694_1.conda
osx-64::libgdal-arrow-parquet-3.7.3-hd00617a_23.conda
osx-64::pyarrow-13.0.0-py310hab5bf3d_37_cpu.conda
osx-64::libadios2-2.10.0-mpi_openmpi_h493bbf9_1.conda
osx-64::imagecodecs-2024.1.1-py311h5f1018a_5.conda
osx-64::healpy-1.16.6-py312h243f5a9_4.conda
osx-64::libgdal-arrow-parquet-3.8.5-h6027261_0.conda
osx-64::zimpl-3.5.4-ha9cf984_4.conda
osx-64::util-linux-2.39.4-py311h1452253_0.conda
osx-64::imagecodecs-2024.1.1-py312hb18e1f5_6.conda
osx-64::gdstk-0.9.51-py38hbe7c026_0.conda
osx-64::pyarrow-tests-13.0.0-py312h7818618_37_cpu.conda
osx-64::util-linux-2.39.4-py38he49f3e3_0.conda
osx-64::pillow-10.3.0-py310h99295b8_0.conda
osx-64::libarrow-13.0.0-h54da0a0_36_cpu.conda
osx-64::lammps-2024.02.07-cpu_py311_h835ce97_mpi_openmpi_1.conda
osx-64::pyinstaller-6.6.0-py39h5eebb3c_0.conda
osx-64::tiledb-2.22.0-h19fb86a_1.conda
osx-64::pyarrow-tests-14.0.2-py39hdbbee67_19_cpu.conda
osx-64::pillow-10.3.0-py39h9dabb2a_0.conda
osx-64::libadios2-2.10.0-nompi_h6fd95ed_100.conda
osx-64::libadios2-2.10.0-mpi_openmpi_ha31e0ae_2.conda
osx-64::qt6-main-6.7.0-h634ba57_1.conda
osx-64::pyarrow-tests-14.0.2-py310hab5bf3d_17_cpu.conda
osx-64::sqlite-3.45.3-h7461747_0.conda
osx-64::heyoka-4.0.3-h27c84bd_1.conda
osx-64::libadios2-2.10.0-mpi_openmpi_h493bbf9_2.conda
osx-64::ogre-14.2.4-h8414a5c_0.conda
osx-64::davix-0.8.6-hdfeff06_0.conda
osx-64::ttyd-1.7.7-h07c7086_0.conda
osx-64::ffmpeg-6.1.1-lgpl_h41ed6eb_7.conda
osx-64::libgdal-arrow-parquet-3.8.5-h84d88ca_2.conda
osx-64::pdal-2.7.1-hacf74ca_6.conda
osx-64::geant4-11.1.3-py310h2e11d0f_1.conda
osx-64::lxml-5.2.1-py310hd994655_0.conda
osx-64::folly-2024.04.22.00-hf87a323_0.conda
osx-64::pyarrow-15.0.2-py311hcc74be5_6_cpu.conda
osx-64::openmpi-5.0.2-h7cf3660_102.conda
osx-64::fenics-libdolfin-2019.1.0-h5ddc0d0_43.conda
osx-64::jaxlib-0.4.23-cpu_py310hcf9e9e9_1.conda
osx-64::imagemagick-7.1.1_30-pl5321h0b4f3dc_0.conda
osx-64::libadios2-2.10.0-mpi_openmpi_h0af81fa_0.conda
osx-64::pytables-3.9.2-py311h6139436_2.conda
osx-64::wxpython-4.2.1-py312hba984fc_5.conda
osx-64::lxml-5.1.1-py312hd7ec574_0.conda
osx-64::lammps-2024.02.07-cpu_py310_hbc8b412_mpi_openmpi_0.conda
osx-64::libadios2-2.10.0-mpi_openmpi_h0af81fa_1.conda
osx-64::magics-4.15.3-h42d7316_1.conda
osx-64::libglib-2.80.0-h81c1438_4.conda
osx-64::libadios2-2.10.0-nompi_h737fe1c_101.conda
osx-64::pyarrow-tests-14.0.2-py311h05d2ada_19_cpu.conda
osx-64::libxml2-2.12.6-hc0ae0f7_2.conda
osx-64::folly-2024.04.01.00-hd1dc772_0_jemalloc.conda
osx-64::mupdf-1.24.1-py39h606c822_4.conda
osx-64::pyarrow-tests-12.0.1-py38h0409e80_47_cpu.conda
osx-64::fenics-libdolfin-2019.1.0-hc797277_43.conda
osx-64::ovito-3.10.5-h0a3f43b_0.conda
osx-64::heyoka-llvm-16-4.0.3-h0643251_0.conda
osx-64::heyoka-llvm-17-4.0.3-hbc323ee_2.conda
osx-64::lammps-2024.02.07-cpu_py310_hdd5fa3c_mpi_mpich_1.conda
osx-64::tiledb-2.21.2-h0d80af6_0.conda
osx-64::fenics-libdolfin-2019.1.0-h8d8e5c7_43.conda
osx-64::scip-9.0.0-h648f171_4.conda
osx-64::ndcctools-7.9.2-py310h3f3ca68_0.conda
osx-64::pyarrow-tests-13.0.0-py310hab5bf3d_37_cpu.conda
osx-64::imagecodecs-2024.1.1-py312h5c59c12_4.conda
osx-64::util-linux-2.39.4-py39hf312e3d_0.conda
osx-64::gstlal-1.13.0-py39h52830de_1.conda
osx-64::lammps-2024.02.07-cpu_py39_h3c69d27_nompi_0.conda
osx-64::heyoka-llvm-15-4.0.3-h70676df_2.conda
osx-64::libadios2-2.9.2-mpi_mpich_h82ee776_2.conda
osx-64::llvmdev-18.1.4-hbcf5fad_0.conda
osx-64::libglib-2.80.0-h81c1438_3.conda
osx-64::fenics-libdolfin-2019.1.0-hd5729c8_43.conda
osx-64::mdtraj-1.9.9-py39h11caeac_1.conda
osx-64::pyarrow-13.0.0-py39hdbbee67_37_cpu.conda
osx-64::fenics-libdolfin-2019.1.0-hbefee83_43.conda
osx-64::gdstk-0.9.51-py312hf3e4e0a_0.conda
osx-64::vowpalwabbit-9.9.0-py39he1a9de5_4.conda
osx-64::libarrow-13.0.0-h2718168_37_cpu.conda
osx-64::pyarrow-tests-15.0.2-py38h732352c_6_cpu.conda
osx-64::gstlal-1.13.0-py311ha516a7a_1.conda
osx-64::libgdal-arrow-parquet-3.8.5-h6ce0358_1.conda
osx-64::libadios2-2.10.0-nompi_h6fd95ed_102.conda
osx-64::libadios2-2.10.0-mpi_mpich_hda80eb8_1.conda
osx-64::pyarrow-tests-14.0.2-py311h05d2ada_17_cpu.conda
osx-64::mdtraj-1.9.9-py310h18b6ea6_1.conda
osx-64::tiledb-2.22.0-h3cc408c_0.conda
osx-64::mupdf-1.24.1-py311heb4cf83_5.conda
osx-64::gap-core-4.13.0-h391c3f3_0.conda
osx-64::nest-simulator-3.6-py39hf45367b_5.conda
osx-64::openmeeg-2.5.8-py39hba1bca3_0.conda
osx-64::libmed-4.1.1-nompi_h619354a_112.conda
osx-64::libarrow-12.0.1-h2718168_48_cpu.conda
osx-64::libadios2-2.10.0-mpi_mpich_h80ea392_3.conda
osx-64::xeus-cpp-0.4.0-h5929788_0.conda
osx-64::pyarrow-13.0.0-py312h7818618_37_cpu.conda
osx-64::jaxlib-0.4.23-cpu_py312h7e27765_1.conda
osx-64::libadios2-2.10.0-mpi_openmpi_h131480d_0.conda
osx-64::pyarrow-13.0.0-py38h0409e80_36_cpu.conda
osx-64::tiledb-2.21.2-hf5f2543_4.conda
osx-64::mupdf-1.24.1-py310h27a38fc_3.conda
osx-64::heyoka-llvm-13-3.2.0-h1544d49_1.conda
osx-64::pytables-3.9.2-py312hf575446_2.conda
osx-64::pyarrow-15.0.2-py310hfcac963_4_cpu.conda
osx-64::ndcctools-7.10.1-py311hc4bdf42_0.conda
osx-64::lxml-5.2.1-py39h153bb42_0.conda
osx-64::libarrow-14.0.2-h20603cd_15_cpu.conda
osx-64::folly-2023.09.25.00-h977ed93_5_jemalloc.conda
osx-64::libadios2-2.10.0-mpi_openmpi_h131480d_1.conda
osx-64::pyarrow-tests-13.0.0-py39hdbbee67_37_cpu.conda
osx-64::pyarrow-tests-15.0.2-py310hfcac963_6_cpu.conda
osx-64::pyarrow-tests-14.0.2-py38h0409e80_19_cpu.conda
osx-64::healpy-1.16.6-py311ha72f263_4.conda
osx-64::folly-2023.09.25.00-h6821a2d_5.conda
osx-64::gdstk-0.9.51-py310h83e167c_0.conda
osx-64::openimageio-2.5.9.0-h4d0dc51_1.conda
osx-64::lammps-2024.02.07-cpu_py39_hb2f5527_mpi_mpich_0.conda
osx-64::papilo-2.2.0-hb65f723_3.conda
osx-64::pyarrow-15.0.2-py38h732352c_4_cpu.conda
osx-64::lldb-18.1.3-py311hae5b5b0_0.conda
osx-64::imagemagick-7.1.1_31-pl5321h3ebaa9c_1.conda
osx-64::cryptominisat-5.8.0-py38h0f667b6_3.conda
osx-64::libadios2-2.10.0-mpi_mpich_hda80eb8_0.conda
osx-64::fenics-libdolfin-2019.1.0-hed13c58_43.conda
osx-64::libadios2-2.10.0-mpi_mpich_hc18c5fb_2.conda
osx-64::pyarrow-14.0.2-py311h05d2ada_18_cpu.conda
osx-64::libgdal-arrow-parquet-3.8.5-hb1ccceb_1.conda
osx-64::pyarrow-12.0.1-py310hab5bf3d_48_cpu.conda
osx-64::grpcio-1.62.2-py39h339971c_0.conda
osx-64::mupdf-1.24.1-py39h8b7b9b3_2.conda
osx-64::loos-4.1.0-py310h68800e2_1.conda
osx-64::openmpi-5.0.2-h794f02a_101.conda
osx-64::genomekit-5.0.0-py39h471a00b_0.conda
osx-64::heyoka-llvm-15-4.0.3-h06a9ca5_1.conda
osx-64::loos-4.1.0-py311h27c2b32_1.conda
osx-64::pdal-2.7.1-h1ff4188_4.conda
osx-64::fenics-libdolfin-2019.1.0-h1fbf077_43.conda
osx-64::libadios2-2.10.0-mpi_mpich_h7322141_0.conda
osx-64::mupdf-1.24.1-py312h5244dd2_4.conda
osx-64::libadios2-2.10.0-nompi_h9395711_101.conda
osx-64::nest-simulator-3.6-py310hebbbe1e_5.conda
osx-64::imagecodecs-2024.1.1-py311h7407010_4.conda
osx-64::healpy-1.16.6-py310h2eb64aa_4.conda
osx-64::pyarrow-tests-14.0.2-py39hdbbee67_17_cpu.conda
osx-64::ntbtls-0.3.2-h2d185b6_0.conda
osx-64::pyarrow-13.0.0-py311h05d2ada_37_cpu.conda
osx-64::folly-2024.04.15.00-h1dae7a0_0_jemalloc.conda
osx-64::util-linux-2.39.4-py39hadb4205_0.conda
osx-64::pyarrow-15.0.2-py39h52bf62a_6_cpu.conda
osx-64::nest-simulator-3.7-py312h24500eb_1.conda
osx-64::pyarrow-tests-12.0.1-py38h0409e80_48_cpu.conda
osx-64::gstlal-1.13.0-py38he3ea49f_1.conda
osx-64::libadios2-2.9.2-mpi_openmpi_h0af81fa_2.conda
osx-64::pyarrow-tests-15.0.2-py312h3db2695_4_cpu.conda
osx-64::libarrow-14.0.2-h9d16e96_19_cpu.conda
osx-64::collada-dom-2.5.0-h7f246bc_8.conda
osx-64::python-3.12.3-h1411813_0_cpython.conda
osx-64::mlir-python-bindings-18.1.3-py312h64c540d_0.conda
osx-64::pyarrow-13.0.0-py39hdbbee67_36_cpu.conda
osx-64::llvm-18.1.3-h7c4b0f9_0.conda
osx-64::mlir-python-bindings-17.0.6-py311h8a27b7f_0.conda
osx-64::cmake-3.29.2-h7c85d92_0.conda
osx-64::libgdal-arrow-parquet-3.8.5-h726cb18_0.conda
osx-64::pyarrow-tests-13.0.0-py310hab5bf3d_36_cpu.conda
osx-64::mlir-python-bindings-16.0.6-py310h83e167c_0.conda
osx-64::libadios2-2.10.0-mpi_mpich_h0f93c5f_2.conda
osx-64::pyarrow-15.0.2-py312h3db2695_6_cpu.conda
osx-64::geant4-11.1.3-py39hb6b86cd_1.conda
osx-64::lammps-2024.02.07-cpu_py39_h9bb1a43_mpi_openmpi_0.conda
osx-64::ndcctools-7.9.1-py310h3f3ca68_0.conda
osx-64::libgoogle-cloud-storage-2.23.0-ha67e85c_1.conda
osx-64::m4rie-20150908-hc616cfc_1002.conda
osx-64::libadios2-2.9.2-mpi_mpich_hc18c5fb_2.conda
osx-64::mupdf-1.24.1-py311heb4cf83_4.conda
osx-64::pyarrow-tests-15.0.2-py310hfcac963_4_cpu.conda
osx-64::gazebo-11.14.0-gzcompatname1234567_11.conda
osx-64::folly-2023.09.25.00-h1db59cf_5_jemalloc.conda
osx-64::fenics-libdolfin-2019.1.0-hecd8bc1_43.conda
osx-64::heyoka-llvm-16-3.2.0-h94abfa0_1.conda
osx-64::folly-2024.04.01.00-h0fe5285_0.conda
osx-64::lld-18.1.3-h3c78e83_0.conda
osx-64::lammps-2024.02.07-cpu_py38_ha0ef21c_nompi_0.conda
osx-64::lammps-2024.02.07-cpu_py38_ha0ef21c_nompi_1.conda
osx-64::folly-2024.04.08.00-h60c1b39_0_jemalloc.conda
osx-64::lammps-2024.02.07-cpu_py39_h9bb1a43_mpi_openmpi_1.conda
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
osx-64::eccodes-2.35.0-h40b907c_0.conda
osx-64::openjdk-11.0.23-hea0bbce_0.conda
osx-64::openjdk-22.0.1-h2d185b6_0.conda
osx-64::libmlir-18.1.3-hea0bbce_0.conda
osx-64::cpptrace-0.5.2-h2d185b6_0.conda
osx-64::dlib-cpp-19.24.4-h42d100d_0.conda
osx-64::git-cliff-2.2.1-hc76a939_0.conda
osx-64::dotnet-sdk-6.0.420-h56c0b21_0.conda
osx-64::libharu-2.4.4-hc616cfc_0.conda
osx-64::dotnet-aspnetcore-8.0.4-h56c0b21_0.conda
osx-64::libsqlite-3.45.3-h92b6c6a_0.conda
osx-64::openjdk-21.0.2-h2d185b6_1.conda
osx-64::libmlir18-18.1.3-hea0bbce_0.conda
osx-64::openjdk-17.0.11-hea0bbce_0.conda
osx-64::ldas-tools-framecpp-2.9.3-h6182ddb_2.conda
osx-64::libmlir18-18.1.4-hea0bbce_0.conda
osx-64::libmlir-18.1.4-hea0bbce_0.conda
osx-64::dotnet-aspnetcore-6.0.28-h56c0b21_0.conda
osx-64::coin-or-utils-2.11.11-h86ddba1_0.conda
osx-64::coin-or-osi-0.108.10-h13a241d_0.conda
osx-64::dotnet-sdk-8.0.204-h56c0b21_0.conda
osx-64::openjdk-21.0.3-h2d185b6_0.conda
osx-64::openjdk-17.0.10-hea0bbce_1.conda
osx-64::cfitsio-4.4.0-h60fb419_1.conda
osx-64::jbig2dec-0.18-hc616cfc_0.conda
osx-64::dotnet-runtime-6.0.28-h56c0b21_0.conda
osx-64::dotnet-runtime-8.0.4-h56c0b21_0.conda
-    "libzlib >=1.2.13,<1.3.0a0"
+    "libzlib >=1.2.13,<2.0.0a0"
================================================================================
================================================================================
linux-64
linux-64::nodejs-20.12.2-hb753e55_0.conda
linux-64::pdal-2.7.1-ha9a290f_4.conda
linux-64::pyarrow-tests-15.0.2-py310h188ebfb_5_cuda.conda
linux-64::mlir-python-bindings-18.1.3-py311hfd4b6e9_0.conda
linux-64::pyarrow-tests-12.0.1-py39h38d04b8_48_cpu.conda
linux-64::pyarrow-12.0.1-py310hd207890_48_cpu.conda
linux-64::pyarrow-13.0.0-py311hd5e4297_37_cpu.conda
linux-64::pyarrow-13.0.0-py39hf92f12d_37_cuda.conda
linux-64::ndcctools-7.10.1-py310he2ed3e8_0.conda
linux-64::pyarrow-tests-15.0.2-py312h25d8025_5_cuda.conda
linux-64::robotraconteur-1.2.0-py312h8db8e2c_2.conda
linux-64::grpcio-1.62.2-py310h1b8f574_0.conda
linux-64::pyarrow-tests-15.0.2-py39hf92f12d_4_cuda.conda
linux-64::magics-4.15.3-h3aff5e6_1.conda
linux-64::ntbtls-0.3.2-hfc55251_0.conda
linux-64::pyarrow-tests-15.0.2-py311h071ecb2_6_cuda.conda
linux-64::pyarrow-15.0.2-py39hf92f12d_6_cuda.conda
linux-64::libadios2-2.10.0-mpi_openmpi_hca57a8f_2.conda
linux-64::panda3d-1.10.14-py312hb46afc6_2.conda
linux-64::freefem-4.13-nompi_he26db76_106.conda
linux-64::libgoogle-cloud-storage-2.23.0-hc7a4891_0.conda
linux-64::pyarrow-tests-15.0.2-py38hdaf73b3_4_cuda.conda
linux-64::mupdf-1.24.1-py39hd92ed3f_4.conda
linux-64::mlir-18.1.3-hcd5def8_0.conda
linux-64::libarrow-15.0.2-h20f9d47_2_cuda.conda
linux-64::tiledb-2.21.2-h8a5282e_1.conda
linux-64::loos-4.1.0-py310hd38e77f_1.conda
linux-64::heyoka-llvm-14-4.0.3-hfa0b694_2.conda
linux-64::libllvm18-18.1.3-h2448989_0.conda
linux-64::pyarrow-14.0.2-py311h071ecb2_18_cuda.conda
linux-64::fimex-2.0.0-py310h94c42d8_0.conda
linux-64::pyarrow-tests-13.0.0-py39hf92f12d_37_cuda.conda
linux-64::openmeeg-2.5.8-py311h35ed458_0.conda
linux-64::heyoka-llvm-16-3.2.0-h4f963a8_1.conda
linux-64::pyarrow-15.0.2-py312h25d8025_4_cuda.conda
linux-64::ffmpeg-6.1.1-gpl_hee4b679_108.conda
linux-64::segalign-0.1.2.1-hdc7ec93_0.conda
linux-64::libadios2-2.10.0-mpi_openmpi_hb81d2b8_1.conda
linux-64::pyarrow-tests-15.0.2-py311hd5e4297_5_cpu.conda
linux-64::ndcctools-7.10.1-py38h514f0f6_0.conda
linux-64::lammps-2024.02.07-cpu_py311_hbb7bd43_mpi_openmpi_0.conda
linux-64::libmed-4.1.1-mpi_openmpi_h8fcc891_12.conda
linux-64::heyoka-4.0.3-h3b89245_0.conda
linux-64::libadios2-2.10.0-mpi_openmpi_hb81d2b8_2.conda
linux-64::rocksdb-8.5.3-h699acb7_1.conda
linux-64::pyarrow-15.0.2-py310hd207890_5_cpu.conda
linux-64::libgdal-arrow-parquet-3.7.3-h78b2b76_23.conda
linux-64::pyarrow-tests-14.0.2-py312h3f82784_17_cpu.conda
linux-64::libgdal-arrow-parquet-3.8.5-h85bde7e_1.conda
linux-64::llvm-tools-18.1.3-h2448989_0.conda
linux-64::mlir-python-bindings-18.1.3-py310h40dc061_0.conda
linux-64::photochem-0.5.3-py310haaf7b05_0.conda
linux-64::heyoka-llvm-13-4.0.3-h085f7cc_2.conda
linux-64::libadios2-2.10.0-nompi_hddb67e9_103.conda
linux-64::ndcctools-7.9.2-py38h514f0f6_0.conda
linux-64::pyarrow-tests-15.0.2-py311h071ecb2_5_cuda.conda
linux-64::pyarrow-14.0.2-py312h25d8025_17_cuda.conda
linux-64::folly-2023.09.25.00-h3dc3b4f_5.conda
linux-64::wxpython-4.2.1-py39he5921d3_5.conda
linux-64::openjdk-17.0.10-h26c8e23_1.conda
linux-64::graphviz-2.50.0-h78e8752_4.conda
linux-64::pyarrow-tests-15.0.2-py310h188ebfb_4_cuda.conda
linux-64::freefem-4.13-mpi_openmpi_h253a9c9_8.conda
linux-64::dotnet-runtime-6.0.28-hb8a3ed7_0.conda
linux-64::pyarrow-tests-14.0.2-py38hdaf73b3_19_cuda.conda
linux-64::pyarrow-tests-12.0.1-py39h38d04b8_47_cpu.conda
linux-64::pyarrow-tests-14.0.2-py39hf92f12d_18_cuda.conda
linux-64::libarrow-12.0.1-ha811a96_48_cpu.conda
linux-64::libarrow-14.0.2-he70291f_16_cpu.conda
linux-64::ndcctools-7.10.1-py39h4841754_0.conda
linux-64::pyarrow-13.0.0-py310h188ebfb_36_cuda.conda
linux-64::fenics-libdolfin-2019.1.0-hf87b1e8_43.conda
linux-64::lammps-2024.02.07-cpu_py39_hefd3d5c_mpi_mpich_1.conda
linux-64::imagecodecs-2024.1.1-py310h06b5df7_6.conda
linux-64::freefem-4.13-mpi_openmpi_hfb5b2ed_10.conda
linux-64::mupdf-1.24.1-py39hd92ed3f_3.conda
linux-64::pyarrow-14.0.2-py312h3f82784_19_cpu.conda
linux-64::ndcctools-7.9.2-py311h689c632_0.conda
linux-64::pyarrow-14.0.2-py310h188ebfb_18_cuda.conda
linux-64::heyoka-4.0.3-hb834d11_0.conda
linux-64::sqlite-3.45.3-h2c6b66d_0.conda
linux-64::libarrow-13.0.0-ha811a96_37_cpu.conda
linux-64::libadios2-2.9.2-mpi_mpich_h0a777c4_2.conda
linux-64::jaxlib-0.4.23-cpu_py39he9683cf_1.conda
linux-64::libgdal-arrow-parquet-3.8.5-h25ba420_0.conda
linux-64::hyperion-fortran-0.9.11-hdfd3458_1.conda
linux-64::xeus-cpp-0.4.0-h3f8c671_0.conda
linux-64::libxml2-2.12.6-h232c23b_2.conda
linux-64::lammps-2024.02.07-cuda118_py38_h6de3bbc_mpi_mpich_1.conda
linux-64::libadios2-2.10.0-nompi_hb1f6268_102.conda
linux-64::util-linux-2.39.4-py311h4285dfd_0.conda
linux-64::panda3d-1.10.14-py38h3402557_2.conda
linux-64::heyoka-4.0.3-h23ae003_1.conda
linux-64::mlir-python-bindings-17.0.6-py312h02419a9_0.conda
linux-64::pyarrow-tests-14.0.2-py311h071ecb2_18_cuda.conda
linux-64::freefem-4.13-mpi_openmpi_h5ae5f0f_11.conda
linux-64::texlive-core-20230313-h14aa9ea_12.conda
linux-64::lammps-2024.02.07-cuda118_py39_h14e8439_mpi_mpich_1.conda
linux-64::dotnet-aspnetcore-6.0.28-hb8a3ed7_0.conda
linux-64::heyoka-llvm-17-4.0.3-he4b3b48_2.conda
linux-64::lxml-5.1.1-py312h2121e9b_0.conda
linux-64::yambo-5.2.3-h6d9b495_0.conda
linux-64::ndcctools-7.9.1-py39h4841754_0.conda
linux-64::lammps-2024.02.07-cpu_py310_hcea6fc9_mpi_openmpi_0.conda
linux-64::lammps-2024.02.07-cpu_py39_h5b957dd_nompi_0.conda
linux-64::lammps-2024.02.07-cuda118_py310_h077d75c_mpi_mpich_0.conda
linux-64::vowpalwabbit-9.9.0-py312ha9060bc_4.conda
linux-64::freefem-4.13-nompi_hd610c01_111.conda
linux-64::lammps-2024.02.07-cpu_py38_hda8f861_mpi_mpich_1.conda
linux-64::libgdal-arrow-parquet-3.7.3-hdd66a18_23.conda
linux-64::pyarrow-15.0.2-py311hd5e4297_4_cpu.conda
linux-64::fenics-libdolfin-2019.1.0-h1c9dd6e_43.conda
linux-64::heyoka-llvm-15-4.0.3-h0e614fc_2.conda
linux-64::lammps-2024.02.07-cuda118_py39_hf8afb37_nompi_0.conda
linux-64::libgdal-arrow-parquet-3.8.5-h1a29c0a_1.conda
linux-64::pyarrow-14.0.2-py39hf92f12d_18_cuda.conda
linux-64::verilator-5.022-h7cd9344_1.conda
linux-64::pyarrow-14.0.2-py38hc396e17_17_cpu.conda
linux-64::freefem-4.13-mpi_mpich_h9c64db9_11.conda
linux-64::lldb-18.1.3-py39hcb0e5d4_0.conda
linux-64::lammps-2024.02.07-cuda118_py311_h9b6f9d6_mpi_openmpi_0.conda
linux-64::code-aster-17.0.13-np122py39h0e38c26_0.conda
linux-64::libarrow-15.0.2-h176673d_2_cpu.conda
linux-64::dpcpp_impl_linux-64-2024.1.0-h0e1b715_963.conda
linux-64::pyarrow-15.0.2-py310h188ebfb_4_cuda.conda
linux-64::pyarrow-tests-14.0.2-py39h38d04b8_19_cpu.conda
linux-64::libadios2-2.10.0-nompi_hb1f70c1_102.conda
linux-64::magics-4.15.4-h3aff5e6_0.conda
linux-64::lammps-2024.02.07-cuda118_py311_hdd7c1f1_mpi_mpich_1.conda
linux-64::pyarrow-12.0.1-py39h38d04b8_48_cpu.conda
linux-64::lammps-2024.02.07-cuda118_py38_he846794_nompi_0.conda
linux-64::pyarrow-tests-13.0.0-py39h38d04b8_36_cpu.conda
linux-64::lammps-2024.02.07-cuda118_py39_h43d3bb2_mpi_openmpi_0.conda
linux-64::lammps-2024.02.07-cpu_py38_h5608ceb_nompi_0.conda
linux-64::libmed-4.1.1-nompi_h4165b49_112.conda
linux-64::nco-5.2.3-he646072_0.conda
linux-64::pyarrow-13.0.0-py310h188ebfb_37_cuda.conda
linux-64::xeus-cpp-0.3.0-h3f8c671_2.conda
linux-64::pdal-2.7.1-h74df82a_3.conda
linux-64::util-linux-2.39.4-py39h1da25c5_0.conda
linux-64::molgrid-0.5.2-cuda118py39hdc35688_4.conda
linux-64::nest-simulator-3.6-py310hde3b743_5.conda
linux-64::zimpl-3.5.4-hcf47b6d_3.conda
linux-64::jaxlib-0.4.23-cuda120py310h3cc97ca_201.conda
linux-64::fenics-libdolfin-2019.1.0-ha32b64e_43.conda
linux-64::pyarrow-tests-14.0.2-py310hd207890_19_cpu.conda
linux-64::davix-0.8.6-h5f3b820_0.conda
linux-64::fenics-libdolfin-2019.1.0-h83f5d5f_43.conda
linux-64::mupdf-1.24.1-py39he61095a_2.conda
linux-64::heyoka-4.0.3-hbe2d4eb_0.conda
linux-64::openmeeg-2.5.8-py310hdcedaf2_0.conda
linux-64::lfortran-0.35.0-hfc55251_0.conda
linux-64::cryptominisat-5.8.0-py310h5aff6b2_3.conda
linux-64::grpcio-1.62.2-py39h174d805_0.conda
linux-64::libglib-2.80.0-hf2295e7_6.conda
linux-64::heyoka-4.0.3-ha060171_1.conda
linux-64::libarrow-12.0.1-h7b70231_48_cuda.conda
linux-64::imagecodecs-2024.1.1-py39hf57ff9c_4.conda
linux-64::lldb-18.1.3-py311hbdb365e_0.conda
linux-64::openmpi-5.0.2-h7fc1de5_102.conda
linux-64::ndcctools-7.10.0-py39h4841754_0.conda
linux-64::folly-2024.04.29.00-hb465b09_0_jemalloc.conda
linux-64::pyarrow-tests-13.0.0-py38hdaf73b3_37_cuda.conda
linux-64::lammps-2024.02.07-cuda118_py39_h1a54f2e_nompi_1.conda
linux-64::libadios2-2.10.0-nompi_hb328d2d_103.conda
linux-64::pyarrow-tests-14.0.2-py38hc396e17_17_cpu.conda
linux-64::mdsplus-7.139.67-py39pl5321h4e21038_0.conda
linux-64::pyarrow-15.0.2-py39hf92f12d_4_cuda.conda
linux-64::pyarrow-15.0.2-py310hd207890_6_cpu.conda
linux-64::mupdf-1.24.1-py38hf17dff3_5.conda
linux-64::libadios2-2.10.0-mpi_openmpi_hca57a8f_1.conda
linux-64::mlir-python-bindings-18.1.3-py38h88c887d_0.conda
linux-64::lammps-2024.02.07-cpu_py39_h827286f_mpi_openmpi_1.conda
linux-64::pyarrow-13.0.0-py310hd207890_36_cpu.conda
linux-64::openimageio-2.5.9.0-heefa401_1.conda
linux-64::libgdal-arrow-parquet-3.7.3-h85bde7e_22.conda
linux-64::openmeeg-2.5.8-py39h7e55f99_0.conda
linux-64::libadios2-2.10.0-nompi_h7a25b15_102.conda
linux-64::segalign-0.1.2-h232f886_2.conda
linux-64::pillow-10.3.0-py310hf73ecf8_0.conda
linux-64::openimageio-2.5.9.0-hd720949_1.conda
linux-64::pyarrow-14.0.2-py39h38d04b8_18_cpu.conda
linux-64::libvips-8.15.2-h379008d_1.conda
linux-64::sasktran2-2024.03.0-py310h3567aac_1.conda
linux-64::libarrow-14.0.2-hda1e1a0_17_cuda.conda
linux-64::pyarrow-tests-15.0.2-py39hf92f12d_5_cuda.conda
linux-64::pyarrow-12.0.1-py311h071ecb2_48_cuda.conda
linux-64::openjdk-21.0.2-h2a087ef_1.conda
linux-64::panda3d-1.10.14-py311hb748066_2.conda
linux-64::libarrow-13.0.0-h0d3d73a_36_cpu.conda
linux-64::libadios2-2.10.0-nompi_h4120c09_103.conda
linux-64::heyoka-llvm-15-4.0.3-hae948df_0.conda
linux-64::code-aster-17.0.13-np122py310hda5a0dd_0.conda
linux-64::lxml-5.2.1-py39hee1641a_0.conda
linux-64::libadios2-2.10.0-mpi_mpich_h462df65_1.conda
linux-64::ndcctools-7.9.1-py310he2ed3e8_0.conda
linux-64::geant4-11.1.3-py310hdb7d2d5_1.conda
linux-64::libgdal-arrow-parquet-3.8.5-h8979334_0.conda
linux-64::tiledb-2.18.5-hc0b898c_0.conda
linux-64::folly-2024.04.01.00-hd120b1b_0.conda
linux-64::lammps-2024.02.07-cpu_py312_h9d5194e_mpi_openmpi_1.conda
linux-64::mupdf-1.24.1-py39hd92ed3f_5.conda
linux-64::mupdf-1.24.1-he976d8a_0.conda
linux-64::wxpython-4.2.1-py311h35114c6_5.conda
linux-64::segalign-0.1.2-hdc7ec93_2.conda
linux-64::libmed-4.1.1-mpi_openmpi_hb797aa6_12.conda
linux-64::vowpalwabbit-9.9.0-py38h177e824_4.conda
linux-64::pyarrow-tests-14.0.2-py312h25d8025_17_cuda.conda
linux-64::pyarrow-tests-14.0.2-py311hd5e4297_17_cpu.conda
linux-64::tiledb-2.22.0-h8a5282e_0.conda
linux-64::util-linux-2.39.4-py38heb36ba7_0.conda
linux-64::lammps-2024.02.07-cuda118_py39_h097bc08_mpi_mpich_0.conda
linux-64::libarrow-14.0.2-ha02c9c4_19_cuda.conda
linux-64::pillow-10.3.0-py38h9e66945_0.conda
linux-64::pyarrow-tests-12.0.1-py310h188ebfb_47_cuda.conda
linux-64::libtiledb-sql-0.30.0-h73df498_0.conda
linux-64::lammps-2024.02.07-cpu_py39_hf042188_nompi_1.conda
linux-64::libadios2-2.10.0-nompi_h95d74dd_102.conda
linux-64::libarrow-13.0.0-hf406b5e_35_cpu.conda
linux-64::pyarrow-tests-15.0.2-py312h3f82784_6_cpu.conda
linux-64::fimex-2.0.0-py39hcbff474_0.conda
linux-64::pyarrow-13.0.0-py311hd5e4297_36_cpu.conda
linux-64::molgrid-0.5.2-cuda112py311hf850386_4.conda
linux-64::nushell-0.92.0-h099a793_0.conda
linux-64::pyarrow-12.0.1-py310h188ebfb_47_cuda.conda
linux-64::libarrow-12.0.1-h0d3d73a_47_cpu.conda
linux-64::code-aster-17.0.13-np122py38h0e092d0_0.conda
linux-64::libarrow-14.0.2-h07fc4ce_17_cpu.conda
linux-64::gstlal-1.13.0-py311hb526b1d_1.conda
linux-64::libglib-2.80.0-hf2295e7_5.conda
linux-64::nushell-0.92.2-h099a793_0.conda
linux-64::libtiledb-sql-0.30.0-hbf6a0d6_0.conda
linux-64::cryptominisat-5.8.0-py38h40af590_3.conda
linux-64::jaxlib-0.4.23-cpu_py312h1c22a3b_1.conda
linux-64::gdstk-0.9.51-py310h1487c90_0.conda
linux-64::libadios2-2.10.0-mpi_openmpi_hac71f51_3.conda
linux-64::pyarrow-13.0.0-py312h25d8025_37_cuda.conda
linux-64::nsight-compute-2024.1.1.4-h00cb8e3_1.conda
linux-64::cmake-3.29.1-hcfe8598_0.conda
linux-64::code-aster-17.0.12-np122py38h0e092d0_1.conda
linux-64::pyarrow-14.0.2-py38hdaf73b3_19_cuda.conda
linux-64::libadios2-2.10.0-nompi_hfc72546_103.conda
linux-64::pyarrow-15.0.2-py39hf92f12d_5_cuda.conda
linux-64::pyarrow-tests-14.0.2-py310hd207890_18_cpu.conda
linux-64::code-aster-17.0.13-np123py311hebe1895_0.conda
linux-64::loos-4.1.0-py38hdb8c354_1.conda
linux-64::lammps-2024.02.07-cuda118_py312_he99a0cd_nompi_1.conda
linux-64::libadios2-2.10.0-mpi_openmpi_hae66630_0.conda
linux-64::tiledb-2.22.0-h27f064a_3.conda
linux-64::libarrow-14.0.2-hda1e1a0_18_cuda.conda
linux-64::heyoka-llvm-13-4.0.3-h3ad1a43_0.conda
linux-64::vowpalwabbit-9.9.0-py311hc384ca8_4.conda
linux-64::code-aster-17.0.12-np122py39h0e38c26_1.conda
linux-64::libarrow-15.0.2-ha02c9c4_6_cuda.conda
linux-64::libarrow-14.0.2-hb511cb6_16_cuda.conda
linux-64::pyarrow-tests-15.0.2-py312h3f82784_4_cpu.conda
linux-64::lammps-2024.02.07-cuda118_py39_hdd7f1a5_mpi_mpich_0.conda
linux-64::libopentelemetry-cpp-1.15.0-h66972aa_0.conda
linux-64::heyoka-4.0.3-h7a6ec7e_2.conda
linux-64::pyarrow-13.0.0-py312h3f82784_37_cpu.conda
linux-64::pyarrow-tests-14.0.2-py311hd5e4297_19_cpu.conda
linux-64::pyarrow-tests-12.0.1-py311h071ecb2_48_cuda.conda
linux-64::mdsplus-7.139.67-py38pl5321ha8a3ab3_0.conda
linux-64::libadios2-2.10.0-mpi_openmpi_h2beffa2_3.conda
linux-64::pyarrow-tests-14.0.2-py38hc396e17_19_cpu.conda
linux-64::code-aster-17.0.14-np123py311hebe1895_0.conda
linux-64::poppler-24.04.0-hb6cd0d7_0.conda
linux-64::mlir-python-bindings-16.0.6-py312h7b2b3ac_0.conda
linux-64::csp-0.0.3-py310hb9ef8d8_0.conda
linux-64::heyoka-llvm-17-4.0.3-h5e9895e_1.conda
linux-64::healpy-1.16.6-py39h3d48507_4.conda
linux-64::pyarrow-12.0.1-py311hd5e4297_47_cpu.conda
linux-64::ndcctools-7.10.0-py311h689c632_0.conda
linux-64::pyarrow-13.0.0-py39hf92f12d_36_cuda.conda
linux-64::genomekit-5.0.0-py38hb339d3c_0.conda
linux-64::mlir-python-bindings-17.0.6-py39h7a9de89_0.conda
linux-64::mongodb-6.0.12-h7c7ee66_1.conda
linux-64::cryptominisat-5.8.0-py39hebe7e3d_3.conda
linux-64::nest-simulator-3.6-py312h8a0696b_5.conda
linux-64::libadios2-2.10.0-nompi_h7a25b15_100.conda
linux-64::dotnet-runtime-8.0.4-hb8a3ed7_0.conda
linux-64::libarrow-15.0.2-h07fc4ce_5_cpu.conda
linux-64::pyarrow-tests-15.0.2-py310hd207890_6_cpu.conda
linux-64::folly-2023.09.25.00-h087c275_5_jemalloc.conda
linux-64::pytables-3.9.2-py311h3e8b7c9_2.conda
linux-64::vowpalwabbit-9.9.0-py310hc4f95b4_4.conda
linux-64::pyarrow-tests-14.0.2-py38hdaf73b3_18_cuda.conda
linux-64::nodejs-18.20.2-h84e79e0_0.conda
linux-64::lammps-2024.02.07-cuda118_py39_h5417483_nompi_1.conda
linux-64::llvm-tools-18.1.4-h2448989_0.conda
linux-64::mupdf-1.24.1-he976d8a_1.conda
linux-64::mupdf-1.24.1-py311h1bc536a_2.conda
linux-64::pyarrow-tests-14.0.2-py311h071ecb2_17_cuda.conda
linux-64::libmed-4.1.1-nompi_h4951994_112.conda
linux-64::ffmpeg-6.1.1-lgpl_hb61a40e_9.conda
linux-64::molgrid-0.5.2-cuda112py310hc3bb40d_4.conda
linux-64::jaxlib-0.4.23-cuda120py312hc008a70_201.conda
linux-64::molgrid-0.5.2-cuda112py38hac05d65_4.conda
linux-64::lammps-2024.02.07-cpu_py310_h5b57e7a_nompi_0.conda
linux-64::pytables-3.9.2-py312h96d95ec_2.conda
linux-64::libadios2-2.10.0-mpi_mpich_hd095186_1.conda
linux-64::heyoka-llvm-17-4.0.3-h4c95b10_0.conda
linux-64::libmed-4.1.1-mpi_mpich_h2a35950_12.conda
linux-64::openmpi-5.0.2-h5b47a53_101.conda
linux-64::pyarrow-13.0.0-py38hc396e17_36_cpu.conda
linux-64::pyarrow-13.0.0-py39h38d04b8_37_cpu.conda
linux-64::tiledb-2.22.0-h836802f_2.conda
linux-64::libadios2-2.9.2-mpi_mpich_h462df65_2.conda
linux-64::libadios2-2.10.0-mpi_mpich_h0a777c4_0.conda
linux-64::libbrial-1.2.12-h76af697_2.conda
linux-64::util-linux-2.39.4-py312h77dc562_0.conda
linux-64::qt6-wayland-6.7.0-h6af8810_0.conda
linux-64::podofo-0.9.8-lua54h3042ad3_3.conda
linux-64::imagecodecs-2024.1.1-py39haf648d5_5.conda
linux-64::pyarrow-tests-13.0.0-py312h25d8025_36_cuda.conda
linux-64::ffmpeg-6.1.1-gpl_h5f74e41_109.conda
linux-64::ndcctools-7.9.1-py311h689c632_0.conda
linux-64::rocksdb-9.0.1-h699acb7_0.conda
linux-64::pyarrow-tests-13.0.0-py310hd207890_37_cpu.conda
linux-64::genomekit-5.0.1-py39h7363d8f_0.conda
linux-64::pyarrow-14.0.2-py38hdaf73b3_17_cuda.conda
linux-64::libglib-2.80.0-hf2295e7_3.conda
linux-64::loos-4.1.0-py311h79d6f95_1.conda
linux-64::ffmpeg-6.1.1-lgpl_h4d6f45f_8.conda
linux-64::gdstk-0.9.51-py39hc35b29e_0.conda
linux-64::intel-opencl-rt-2024.1.0-h1d408c3_963.conda
linux-64::libglib-2.80.0-hf2295e7_2.conda
linux-64::tiledb-2.20.1-hcf523ab_7.conda
linux-64::lammps-2024.02.07-cuda118_py311_h0edc3ef_mpi_mpich_0.conda
linux-64::erlang-26.2.4-pl5321hde4a2a6_0.conda
linux-64::lxml-5.1.1-py310hf050c1a_0.conda
linux-64::pyarrow-tests-15.0.2-py39h38d04b8_4_cpu.conda
linux-64::libadios2-2.10.0-mpi_mpich_h99343ea_3.conda
linux-64::libgdal-arrow-parquet-3.8.5-h3dc1c5c_2.conda
linux-64::libadios2-2.9.2-mpi_openmpi_hae66630_2.conda
linux-64::libpulsar-3.5.1-h7aad887_1.conda
linux-64::pyarrow-14.0.2-py310hd207890_18_cpu.conda
linux-64::nco-5.2.4-he646072_0.conda
linux-64::nest-simulator-3.7-py38h203082f_1.conda
linux-64::pyarrow-12.0.1-py310h188ebfb_48_cuda.conda
linux-64::heyoka-4.0.3-hf3e7229_1.conda
linux-64::pyarrow-13.0.0-py38hdaf73b3_36_cuda.conda
linux-64::libllvm18-18.1.4-h2448989_0.conda
linux-64::folly-2024.04.15.00-h24d630f_0.conda
linux-64::pyarrow-15.0.2-py310hd207890_4_cpu.conda
linux-64::pyarrow-15.0.2-py311h071ecb2_4_cuda.conda
linux-64::fimex-2.0.0-py38h038c0dc_0.conda
linux-64::pyarrow-tests-12.0.1-py38hdaf73b3_48_cuda.conda
linux-64::pyarrow-tests-12.0.1-py311h071ecb2_47_cuda.conda
linux-64::libmed-4.1.1-nompi_ha4c24a7_112.conda
linux-64::mlir-python-bindings-17.0.6-py38h88c887d_0.conda
linux-64::libtiledb-sql-0.30.0-h340d6d5_1.conda
linux-64::pytables-3.9.2-py39h7d7fcb6_2.conda
linux-64::molgrid-0.5.2-cuda118py310h1b9a9c3_4.conda
linux-64::fenics-libdolfin-2019.1.0-h1c6181d_43.conda
linux-64::pyarrow-15.0.2-py312h3f82784_5_cpu.conda
linux-64::code-aster-17.0.12-np122py310hda5a0dd_1.conda
linux-64::imagecodecs-2024.1.1-py311hc04fb91_4.conda
linux-64::ogre-14.2.4-h1ab86f5_0.conda
linux-64::pyarrow-tests-13.0.0-py310h188ebfb_36_cuda.conda
linux-64::pyarrow-14.0.2-py311hd5e4297_17_cpu.conda
linux-64::libmed-4.1.1-mpi_openmpi_h79c4543_12.conda
linux-64::folly-2023.09.25.00-hf7db282_5.conda
linux-64::pyarrow-15.0.2-py312h25d8025_6_cuda.conda
linux-64::code-aster-17.0.14-np122py310hda5a0dd_0.conda
linux-64::pyarrow-14.0.2-py38hdaf73b3_18_cuda.conda
linux-64::heyoka-llvm-13-4.0.3-he362327_1.conda
linux-64::pyarrow-tests-15.0.2-py38hdaf73b3_5_cuda.conda
linux-64::rocksdb-9.1.0-h699acb7_0.conda
linux-64::pyarrow-tests-12.0.1-py39hf92f12d_48_cuda.conda
linux-64::folly-2024.04.08.00-h9f7ad7e_0.conda
linux-64::pyarrow-tests-14.0.2-py310h188ebfb_17_cuda.conda
linux-64::lammps-2024.02.07-cpu_py311_hdd49dfd_nompi_0.conda
linux-64::cmake-3.29.2-hcfe8598_0.conda
linux-64::folly-2024.04.01.00-hda46ae2_0_jemalloc.conda
linux-64::freefem-4.13-mpi_mpich_h8ca56e3_8.conda
linux-64::fenics-libdolfin-2019.1.0-h3d4fbe5_43.conda
linux-64::heyoka-llvm-17-3.2.0-ha3b4799_1.conda
linux-64::libadios2-2.10.0-mpi_mpich_h3e60829_3.conda
linux-64::pyarrow-12.0.1-py38hc396e17_48_cpu.conda
linux-64::mupdf-1.24.1-py38h4aca153_2.conda
linux-64::pyarrow-tests-14.0.2-py312h25d8025_19_cuda.conda
linux-64::heyoka-llvm-13-3.2.0-hf29e1bc_1.conda
linux-64::pyarrow-tests-14.0.2-py312h3f82784_18_cpu.conda
linux-64::heyoka-llvm-15-4.0.3-h62877e4_1.conda
linux-64::dotnet-aspnetcore-8.0.4-hb8a3ed7_0.conda
linux-64::qt6-main-6.7.0-h10482b7_1.conda
linux-64::soplex-8.0.0-hdaec2dc_4.conda
linux-64::pyarrow-14.0.2-py312h3f82784_17_cpu.conda
linux-64::libadios2-2.10.0-mpi_mpich_h4d9cd4f_0.conda
linux-64::ndcctools-7.9.1-py38h514f0f6_0.conda
linux-64::photochem-0.5.3-py39h31cc22b_0.conda
linux-64::lld-18.1.4-hd326a66_0.conda
linux-64::pyarrow-15.0.2-py311h071ecb2_5_cuda.conda
linux-64::libglib-2.80.0-hf2295e7_4.conda
linux-64::lighttpd-1.4.73-lua54he6d00d0_3.conda
linux-64::lammps-2024.02.07-cuda118_py310_h5811056_mpi_openmpi_0.conda
linux-64::pyarrow-12.0.1-py310hd207890_47_cpu.conda
linux-64::pyarrow-12.0.1-py39h38d04b8_47_cpu.conda
linux-64::lammps-2024.02.07-cuda118_py311_h9b6f9d6_mpi_openmpi_1.conda
linux-64::libgdal-arrow-parquet-3.8.5-hbc4d037_0.conda
linux-64::pyarrow-tests-12.0.1-py310hd207890_47_cpu.conda
linux-64::pyarrow-15.0.2-py310h188ebfb_6_cuda.conda
linux-64::yambo-5.2.3-h6d9b495_1.conda
linux-64::heyoka-4.0.3-h75b028c_2.conda
linux-64::ipe-7.2.26-lua54h227836e_4.conda
linux-64::fenics-libdolfin-2019.1.0-haeb8686_43.conda
linux-64::lammps-2024.02.07-cuda118_py39_h4a9cbaf_mpi_openmpi_1.conda
linux-64::papilo-2.2.0-h35aabe7_4.conda
linux-64::libadios2-2.10.0-nompi_h95d74dd_100.conda
linux-64::pyarrow-15.0.2-py311h071ecb2_6_cuda.conda
linux-64::fimex-2.0.0-py311h4e21ecb_0.conda
linux-64::libarrow-12.0.1-hd10c0f2_45_cuda.conda
linux-64::libgdal-3.7.3-h80298fc_23.conda
linux-64::lammps-2024.02.07-cpu_py39_h7e86899_mpi_mpich_1.conda
linux-64::pyarrow-tests-15.0.2-py311h071ecb2_4_cuda.conda
linux-64::libadios2-2.9.2-mpi_mpich_h4d9cd4f_2.conda
linux-64::wxpython-4.2.1-py312h7c8d89b_5.conda
linux-64::ipe-7.2.26-lua54hf739a23_1.conda
linux-64::libmed-4.1.1-mpi_mpich_h0c1d40b_12.conda
linux-64::heyoka-4.0.3-h0e44482_1.conda
linux-64::libadios2-2.10.0-mpi_mpich_h0a777c4_2.conda
linux-64::grpcio-1.62.2-py311ha6695c7_0.conda
linux-64::fenics-libdolfin-2019.1.0-h908ce01_43.conda
linux-64::libgdal-arrow-parquet-3.7.3-h922444b_22.conda
linux-64::tiledb-2.21.2-ha9641ad_0.conda
linux-64::lammps-2024.02.07-cuda118_py312_h55cfb70_mpi_mpich_1.conda
linux-64::lammps-2024.02.07-cuda118_py39_h43d3bb2_mpi_openmpi_1.conda
linux-64::openjdk-22.0.1-hb622114_0.conda
linux-64::lammps-2024.02.07-cpu_py39_h7e86899_mpi_mpich_0.conda
linux-64::libadios2-2.9.2-mpi_openmpi_hb81d2b8_2.conda
linux-64::libadios2-2.10.0-mpi_openmpi_hca57a8f_0.conda
linux-64::folly-2023.09.25.00-h079d877_5.conda
linux-64::folly-2024.04.15.00-hb465b09_0_jemalloc.conda
linux-64::fenics-libdolfin-2019.1.0-hc532c93_43.conda
linux-64::heyoka-4.0.3-h82013f2_0.conda
linux-64::pyarrow-tests-14.0.2-py38hc396e17_18_cpu.conda
linux-64::ffmpeg-6.1.1-lgpl_h4d6f45f_7.conda
linux-64::pytables-3.9.2-py310hd76cd5d_2.conda
linux-64::freefem-4.13-mpi_openmpi_ha4610f2_6.conda
linux-64::mlir-python-bindings-17.0.6-py311hfd4b6e9_0.conda
linux-64::imagemagick-7.1.1_31-pl5321h0df52c9_0.conda
linux-64::pyarrow-15.0.2-py38hc396e17_6_cpu.conda
linux-64::libadios2-2.10.0-nompi_hb1f6268_101.conda
linux-64::fenics-libdolfin-2019.1.0-hbe19a8c_43.conda
linux-64::ndcctools-7.10.0-py310he2ed3e8_0.conda
linux-64::gstlal-1.13.0-py310h6f6463f_1.conda
linux-64::tiledb-2.21.2-h8cb5cbd_3.conda
linux-64::ogre-next-2.3.3-h1b25c05_0.conda
linux-64::pyarrow-13.0.0-py38hc396e17_37_cpu.conda
linux-64::libarrow-12.0.1-he385075_47_cuda.conda
linux-64::pyarrow-tests-15.0.2-py310hd207890_5_cpu.conda
linux-64::libgdal-arrow-parquet-3.8.5-h922444b_1.conda
linux-64::mlir-python-bindings-16.0.6-py38hab45c01_0.conda
linux-64::libgdal-3.8.5-h35436ae_0.conda
linux-64::pillow-10.3.0-py39h90c7501_0.conda
linux-64::libgdal-3.8.5-h7719672_1.conda
linux-64::pyarrow-15.0.2-py312h25d8025_5_cuda.conda
linux-64::tiledb-2.21.2-h7693966_2.conda
linux-64::jaxlib-0.4.23-cuda120py311hfb00743_201.conda
linux-64::qt6-3d-6.7.0-hf2d569e_0.conda
linux-64::magic-8.3.468-h9abf892_0.conda
linux-64::pyarrow-14.0.2-py311hd5e4297_19_cpu.conda
linux-64::llvm-openmp-18.1.3-h4dfa4b3_0.conda
linux-64::gdstk-0.9.51-py312h7b2b3ac_0.conda
linux-64::libadios2-2.9.2-nompi_h7a25b15_102.conda
linux-64::pyarrow-tests-14.0.2-py311hd5e4297_18_cpu.conda
linux-64::ffmpeg-6.1.1-gpl_hee4b679_107.conda
linux-64::heyoka-3.2.0-h6dd4625_1.conda
linux-64::loos-4.1.0-py312hf2251af_1.conda
linux-64::ndcctools-7.9.2-py310he2ed3e8_0.conda
linux-64::pyarrow-tests-13.0.0-py311hd5e4297_36_cpu.conda
linux-64::fenics-libdolfin-2019.1.0-ha52bc9e_43.conda
linux-64::mupdf-1.24.1-py310heb88e28_2.conda
linux-64::pyarrow-tests-12.0.1-py38hc396e17_48_cpu.conda
linux-64::libadios2-2.10.0-mpi_mpich_hd095186_2.conda
linux-64::wxwidgets-3.2.4-h736e084_3.conda
linux-64::pyarrow-tests-15.0.2-py38hc396e17_5_cpu.conda
linux-64::pyarrow-15.0.2-py312h3f82784_6_cpu.conda
linux-64::lammps-2024.02.07-cuda118_py38_hc73eb01_mpi_openmpi_0.conda
linux-64::python-3.11.9-hb806964_0_cpython.conda
linux-64::fossil-2.24-h8391dfe_0.conda
linux-64::code-aster-17.0.14-np122py39h0e38c26_0.conda
linux-64::libarrow-15.0.2-hda1e1a0_4_cuda.conda
linux-64::libadios2-2.10.0-mpi_mpich_hf741b70_1.conda
linux-64::mlir-python-bindings-17.0.6-py310h40dc061_0.conda
linux-64::libarrow-15.0.2-h07fc4ce_4_cpu.conda
linux-64::libgdal-arrow-parquet-3.8.5-hdd66a18_2.conda
linux-64::pyarrow-13.0.0-py312h25d8025_36_cuda.conda
linux-64::mlir-python-bindings-18.1.3-py39h7a9de89_0.conda
linux-64::lammps-2024.02.07-cuda118_py38_hc73eb01_mpi_openmpi_1.conda
linux-64::tiledb-2.21.2-hcf523ab_1.conda
linux-64::wasmer-4.2.8-hed76520_0.conda
linux-64::geant4-11.1.3-py39h80041e6_1.conda
linux-64::wxpython-4.2.1-py38hf874b0e_5.conda
linux-64::lammps-2024.02.07-cpu_py38_hda8f861_mpi_mpich_0.conda
linux-64::pyarrow-12.0.1-py311h071ecb2_47_cuda.conda
linux-64::aws-sdk-cpp-1.11.267-hddb5a97_7.conda
linux-64::imagecodecs-2024.1.1-py39h8df2417_6.conda
linux-64::libarrow-15.0.2-hefa796f_6_cpu.conda
linux-64::healpy-1.16.6-py39h9bdbed4_4.conda
linux-64::blosc-1.21.5-hc2324a3_1.conda
linux-64::mesalib-24.0.6-hfa94a56_0.conda
linux-64::pdal-2.7.1-ha9a290f_2.conda
linux-64::libgdal-arrow-parquet-3.7.3-h3dc1c5c_23.conda
linux-64::genomekit-5.0.0-py39h7363d8f_0.conda
linux-64::pyarrow-tests-15.0.2-py38hc396e17_6_cpu.conda
linux-64::pyinstaller-6.6.0-py39hb6545a3_0.conda
linux-64::libadios2-2.9.2-nompi_hb1f6268_102.conda
linux-64::heyoka-llvm-16-4.0.3-hd3131af_2.conda
linux-64::libmed-4.1.1-mpi_openmpi_hebfe0e7_12.conda
linux-64::libadios2-2.10.0-mpi_openmpi_h4d0218b_3.conda
linux-64::pyarrow-14.0.2-py38hc396e17_18_cpu.conda
linux-64::libadios2-2.10.0-mpi_mpich_h4d9cd4f_1.conda
linux-64::lammps-2024.02.07-cpu_py39_hf042188_nompi_0.conda
linux-64::jaxlib-0.4.23-cpu_py311h30db3a6_1.conda
linux-64::nest-simulator-3.6-py38h203082f_5.conda
linux-64::libadios2-2.10.0-nompi_h0740866_103.conda
linux-64::pyarrow-13.0.0-py312h3f82784_36_cpu.conda
linux-64::mdsplus-7.139.67-py310pl5321hbd303f0_0.conda
linux-64::gdstk-0.9.51-py39h9bdbfdd_0.conda
linux-64::freefem-4.13-mpi_mpich_hea71aaa_6.conda
linux-64::folly-2024.04.22.00-hb465b09_0_jemalloc.conda
linux-64::jaxlib-0.4.23-cuda118py39h3799d77_201.conda
linux-64::mupdf-1.24.1-py310hba70a52_4.conda
linux-64::pyarrow-tests-12.0.1-py38hdaf73b3_47_cuda.conda
linux-64::freefem-4.13-nompi_h20602eb_109.conda
linux-64::libarrow-13.0.0-h29cb2fa_35_cuda.conda
linux-64::folly-2024.04.08.00-h174d127_0_jemalloc.conda
linux-64::heyoka-llvm-14-3.2.0-hc0da0c5_1.conda
linux-64::lammps-2024.02.07-cpu_py39_hade46e7_mpi_openmpi_1.conda
linux-64::pyarrow-15.0.2-py311hd5e4297_5_cpu.conda
linux-64::jaxlib-0.4.23-cuda118py310h51ffd5a_201.conda
linux-64::pyarrow-14.0.2-py39h38d04b8_19_cpu.conda
linux-64::pyarrow-14.0.2-py311h071ecb2_17_cuda.conda
linux-64::libgdal-arrow-parquet-3.8.5-hed594e5_1.conda
linux-64::mupdf-1.24.1-py38hf17dff3_4.conda
linux-64::robotraconteur-1.2.0-py311h17485db_2.conda
linux-64::collada-dom-2.5.0-h7820ef8_8.conda
linux-64::imagecodecs-2024.1.1-py39hef72667_4.conda
linux-64::openmpi-5.0.3-h7fc1de5_100.conda
linux-64::qt-main-5.15.8-hc9dc06e_21.conda
linux-64::photochem-0.5.3-py38h5bf2ec1_0.conda
linux-64::folly-2024.04.08.00-h24d630f_1.conda
linux-64::pyarrow-tests-12.0.1-py311hd5e4297_47_cpu.conda
linux-64::pyarrow-14.0.2-py310hd207890_17_cpu.conda
linux-64::folly-2024.04.29.00-h24d630f_0.conda
linux-64::heyoka-4.0.3-hfc9ee76_2.conda
linux-64::genomekit-5.0.0-py310h9888954_0.conda
linux-64::pyarrow-tests-14.0.2-py312h3f82784_19_cpu.conda
linux-64::libpulsar-3.5.1-hb05de93_0.conda
linux-64::panda3d-1.10.14-py310h2da8f0c_2.conda
linux-64::openjdk-11.0.23-h24d6bf4_0.conda
linux-64::pyarrow-tests-14.0.2-py310h188ebfb_19_cuda.conda
linux-64::pyarrow-14.0.2-py312h25d8025_19_cuda.conda
linux-64::photochem-0.5.3-py312he02c6f6_0.conda
linux-64::libadios2-2.9.2-nompi_h95d74dd_102.conda
linux-64::libgoogle-cloud-storage-2.23.0-hc7a4891_1.conda
linux-64::imagecodecs-2024.1.1-py39ha98d97a_6.conda
linux-64::heyoka-4.0.3-hd7fa0d9_2.conda
linux-64::pyarrow-tests-14.0.2-py39h38d04b8_17_cpu.conda
linux-64::panda3d-1.10.14-py39ha0cbbee_2.conda
linux-64::libadios2-2.10.0-mpi_mpich_heb66213_3.conda
linux-64::libadios2-2.10.0-mpi_mpich_hf741b70_0.conda
linux-64::llvmdev-18.1.3-h2448989_0.conda
linux-64::libgdal-3.7.3-hed7d0b4_22.conda
linux-64::jaxlib-0.4.23-cuda118py312h5cced90_201.conda
linux-64::ipe-7.2.26-lua54h73ac559_3.conda
linux-64::pyarrow-tests-15.0.2-py39h38d04b8_6_cpu.conda
linux-64::pyinstaller-6.6.0-py311hdcc4c9d_0.conda
linux-64::git-2.45.0-pl5321hd39f443_0.conda
linux-64::libadios2-2.10.0-nompi_hb1f70c1_101.conda
linux-64::folly-2023.09.25.00-h171e340_5_jemalloc.conda
linux-64::molgrid-0.5.2-cuda112py39hbcc280a_4.conda
linux-64::pyarrow-12.0.1-py38hc396e17_47_cpu.conda
linux-64::lammps-2024.02.07-cuda118_py39_hf2cf36d_nompi_0.conda
linux-64::cpp-opentelemetry-sdk-1.15.0-h66972aa_0.conda
linux-64::pyarrow-tests-15.0.2-py312h25d8025_4_cuda.conda
linux-64::folly-2023.09.25.00-h881cc47_5.conda
linux-64::mupdf-1.24.1-py312hf7ff796_3.conda
linux-64::gstlal-1.13.0-py39hef60fd8_1.conda
linux-64::lammps-2024.02.07-cuda118_py39_hcae4e68_mpi_mpich_1.conda
linux-64::libadios2-2.10.0-mpi_openmpi_h68bbb10_0.conda
linux-64::tiledb-2.21.2-h27f064a_4.conda
linux-64::nest-simulator-3.6-py39h736a37a_5.conda
linux-64::rust-1.77.2-h70c747d_0.conda
linux-64::libadios2-2.10.0-nompi_h6bac8f5_101.conda
linux-64::mupdf-1.24.1-py310hba70a52_5.conda
linux-64::pyarrow-12.0.1-py38hdaf73b3_47_cuda.conda
linux-64::openmeeg-2.5.8-py39h2724a2c_0.conda
linux-64::libadios2-2.10.0-mpi_openmpi_h903ec01_1.conda
linux-64::pyarrow-14.0.2-py38hc396e17_19_cpu.conda
linux-64::lammps-2024.02.07-cuda118_py38_he846794_nompi_1.conda
linux-64::ipe-7.2.26-lua54h0e6d59e_2.conda
linux-64::pyarrow-13.0.0-py39h38d04b8_36_cpu.conda
linux-64::nsight-compute-2024.1.1.4-hf972014_0.conda
linux-64::lxml-5.1.1-py39hc0f9a0b_0.conda
linux-64::gdstk-0.9.51-py311h75db532_0.conda
linux-64::lxml-5.1.1-py38hc121132_0.conda
linux-64::pyarrow-tests-14.0.2-py310hd207890_17_cpu.conda
linux-64::pyarrow-14.0.2-py311hd5e4297_18_cpu.conda
linux-64::libadios2-2.10.0-mpi_openmpi_h652016b_3.conda
linux-64::lighttpd-1.4.73-lua54h539bc2a_2.conda
linux-64::pyarrow-tests-15.0.2-py38hdaf73b3_6_cuda.conda
linux-64::lammps-2024.02.07-cuda118_py312_h0298b05_mpi_openmpi_1.conda
linux-64::pyarrow-tests-15.0.2-py311hd5e4297_6_cpu.conda
linux-64::mlir-python-bindings-16.0.6-py310h1487c90_0.conda
linux-64::pyarrow-13.0.0-py310hd207890_37_cpu.conda
linux-64::nest-simulator-3.7-py310hde3b743_1.conda
linux-64::pyarrow-tests-13.0.0-py38hdaf73b3_36_cuda.conda
linux-64::libadios2-2.10.0-mpi_mpich_h462df65_0.conda
linux-64::heyoka-3.2.0-hb0e9e3c_1.conda
linux-64::lammps-2024.02.07-cpu_py311_hd3d4698_mpi_mpich_1.conda
linux-64::pyarrow-14.0.2-py310h188ebfb_19_cuda.conda
linux-64::scip-9.0.0-hded5f35_4.conda
linux-64::llvm-18.1.4-h39da44c_0.conda
linux-64::mdsplus-7.139.67-py311pl5321h4a20be6_0.conda
linux-64::libadios2-2.10.0-nompi_h7a25b15_101.conda
linux-64::pyarrow-14.0.2-py310h188ebfb_17_cuda.conda
linux-64::nsight-compute-2024.1.1.4-hf972014_1.conda
linux-64::freefem-4.13-mpi_openmpi_h90e8507_9.conda
linux-64::pytables-3.9.2-py39hd99417c_2.conda
linux-64::libadios2-2.9.2-mpi_mpich_hd095186_2.conda
linux-64::imagecodecs-2024.1.1-py312hb7b22c5_6.conda
linux-64::pyarrow-tests-13.0.0-py312h3f82784_36_cpu.conda
linux-64::heyoka-4.0.3-h4843edd_0.conda
linux-64::libadios2-2.10.0-mpi_openmpi_h68bbb10_2.conda
linux-64::pyarrow-tests-14.0.2-py312h25d8025_18_cuda.conda
linux-64::libarrow-15.0.2-hb511cb6_3_cuda.conda
linux-64::mupdf-1.24.1-py312hf7ff796_5.conda
linux-64::heyoka-llvm-16-4.0.3-h1956985_0.conda
linux-64::pyarrow-12.0.1-py311hd5e4297_48_cpu.conda
linux-64::imagemagick-7.1.1_30-pl5321hb90aeea_0.conda
linux-64::healpy-1.16.6-py310had64ba5_4.conda
linux-64::fenics-libdolfin-2019.1.0-h28e77e7_43.conda
linux-64::pyarrow-tests-14.0.2-py39h38d04b8_18_cpu.conda
linux-64::libbrial-1.2.12-h76af697_3.conda
linux-64::pyarrow-tests-14.0.2-py38hdaf73b3_17_cuda.conda
linux-64::libadios2-2.10.0-mpi_mpich_h4d9cd4f_2.conda
linux-64::libarrow-13.0.0-hd29dec3_34_cpu.conda
linux-64::tiledb-2.22.0-h7693966_1.conda
linux-64::pyarrow-15.0.2-py39h38d04b8_6_cpu.conda
linux-64::pyarrow-15.0.2-py311hd5e4297_6_cpu.conda
linux-64::libmed-4.1.1-nompi_hcd073cd_112.conda
linux-64::fenics-libdolfin-2019.1.0-h4f05f92_43.conda
linux-64::libadios2-2.10.0-mpi_openmpi_h68bbb10_1.conda
linux-64::pyarrow-13.0.0-py38hdaf73b3_37_cuda.conda
linux-64::ndcctools-7.10.1-py311h689c632_0.conda
linux-64::util-linux-2.39.4-py310h6b057ee_0.conda
linux-64::libgdal-arrow-parquet-3.8.5-h78b2b76_2.conda
linux-64::openmeeg-2.5.8-py312h0f244ff_0.conda
linux-64::pyarrow-tests-15.0.2-py311hd5e4297_4_cpu.conda
linux-64::nest-simulator-3.7-py39h736a37a_1.conda
linux-64::pyarrow-14.0.2-py39hf92f12d_17_cuda.conda
linux-64::qt6-main-6.7.0-h87a10bb_0.conda
linux-64::fenics-libdolfin-2019.1.0-h21ccd6b_43.conda
linux-64::pyarrow-14.0.2-py311h071ecb2_19_cuda.conda
linux-64::llvmdev-18.1.4-h2448989_0.conda
linux-64::pyarrow-12.0.1-py38hdaf73b3_48_cuda.conda
linux-64::pyarrow-13.0.0-py311h071ecb2_36_cuda.conda
linux-64::heyoka-llvm-14-4.0.3-hbcfd52c_1.conda
linux-64::pyarrow-tests-12.0.1-py38hc396e17_47_cpu.conda
linux-64::jaxlib-0.4.23-cpu_py310h8502d0d_1.conda
linux-64::aws-sdk-cpp-1.11.267-hbf3e495_6.conda
linux-64::ndcctools-7.9.2-py39h4841754_0.conda
linux-64::mupdf-1.24.1-py311h0c33687_5.conda
linux-64::folly-2023.09.25.00-h5b68320_5_jemalloc.conda
linux-64::pyarrow-tests-14.0.2-py311h071ecb2_19_cuda.conda
linux-64::lammps-2024.02.07-cpu_py310_hcea6fc9_mpi_openmpi_1.conda
linux-64::pyarrow-tests-13.0.0-py38hc396e17_36_cpu.conda
linux-64::pyarrow-15.0.2-py38hdaf73b3_5_cuda.conda
linux-64::pyarrow-15.0.2-py38hc396e17_4_cpu.conda
linux-64::mupdf-1.24.1-py311h0c33687_4.conda
linux-64::molgrid-0.5.2-cuda118py38h4f08890_4.conda
linux-64::imagecodecs-2024.1.1-py310h980a5f5_4.conda
linux-64::pillow-10.3.0-py312hdcec9eb_0.conda
linux-64::orc-2.0.0-h17fec99_1.conda
linux-64::imagecodecs-2024.1.1-py311hbe88301_6.conda
linux-64::robotraconteur-1.2.0-py38h9ab319c_2.conda
linux-64::ogre-14.2.4-h71d15da_0.conda
linux-64::pyarrow-tests-15.0.2-py312h25d8025_6_cuda.conda
linux-64::lammps-2024.02.07-cpu_py38_hde207a7_mpi_openmpi_1.conda
linux-64::libmed-4.1.1-mpi_mpich_hfa800f3_12.conda
linux-64::qt6-main-6.7.0-h10482b7_2.conda
linux-64::openjdk-17.0.11-h24d6bf4_0.conda
linux-64::geant4-11.1.3-py38h3bae467_1.conda
linux-64::jaxlib-0.4.23-cuda120py39hfad2e6e_201.conda
linux-64::pyarrow-tests-15.0.2-py310h188ebfb_6_cuda.conda
linux-64::lammps-2024.02.07-cpu_py312_h1634cf7_nompi_1.conda
linux-64::libmed-4.1.1-mpi_mpich_h7bd08a4_12.conda
linux-64::magics-metview-4.15.4-h986429f_0.conda
linux-64::mlir-python-bindings-16.0.6-py311h75db532_0.conda
linux-64::lammps-2024.02.07-cuda118_py310_h7730a0c_nompi_0.conda
linux-64::hyperion-fortran-0.9.11-hdfd3458_2.conda
linux-64::heyoka-3.2.0-h6f96d2d_1.conda
linux-64::pyarrow-12.0.1-py39hf92f12d_47_cuda.conda
linux-64::lammps-2024.02.07-cuda118_py310_h077d75c_mpi_mpich_1.conda
linux-64::ldas-tools-framecpp-2.9.3-h97420db_2.conda
linux-64::openmeeg-2.5.8-py38h65c24ca_0.conda
linux-64::csp-0.0.3-py39hcbdfff7_0.conda
linux-64::cryptominisat-5.8.0-py311h3581ac3_3.conda
linux-64::libadios2-2.10.0-mpi_mpich_h0a777c4_1.conda
linux-64::genomekit-5.0.1-py38hb339d3c_0.conda
linux-64::pyinstaller-6.6.0-py38h502143a_0.conda
linux-64::ldas-tools-framecpp-3.0.3-h5caea78_1.conda
linux-64::ttyd-1.7.7-h78d4dd0_0.conda
linux-64::libgdal-arrow-parquet-3.7.3-h1a29c0a_22.conda
linux-64::lammps-2024.02.07-cpu_py39_hade46e7_mpi_openmpi_0.conda
linux-64::assimp-5.4.0-h8343317_0.conda
linux-64::mlir-python-bindings-18.1.3-py312h02419a9_0.conda
linux-64::gstlal-1.13.0-py38hc529aad_1.conda
linux-64::fenics-libdolfin-2019.1.0-h2eb82cd_43.conda
linux-64::libadios2-2.10.0-nompi_h6bac8f5_100.conda
linux-64::soplex-8.0.0-hdaec2dc_3.conda
linux-64::loos-4.1.0-py39h7d48038_1.conda
linux-64::lammps-2024.02.07-cpu_py39_hefd3d5c_mpi_mpich_0.conda
linux-64::pyarrow-14.0.2-py312h3f82784_18_cpu.conda
linux-64::libarrow-14.0.2-h07fc4ce_18_cpu.conda
linux-64::openimageio-2.5.9.0-h5ff5cac_1.conda
linux-64::pyarrow-tests-13.0.0-py310hd207890_36_cpu.conda
linux-64::pyarrow-tests-13.0.0-py312h25d8025_37_cuda.conda
linux-64::lammps-2024.02.07-cpu_py39_h5b957dd_nompi_1.conda
linux-64::m4rie-20150908-h267a509_1002.conda
linux-64::lammps-2024.02.07-cuda118_py310_h5811056_mpi_openmpi_1.conda
linux-64::lammps-2024.02.07-cpu_py310_h5b57e7a_nompi_1.conda
linux-64::heyoka-llvm-16-4.0.3-h846b817_1.conda
linux-64::pyarrow-tests-12.0.1-py310h188ebfb_48_cuda.conda
linux-64::pyarrow-tests-15.0.2-py312h3f82784_5_cpu.conda
linux-64::libadios2-2.10.0-mpi_mpich_hf741b70_2.conda
linux-64::photochem-0.5.3-py311h4cb42f8_0.conda
linux-64::lammps-2024.02.07-cpu_py312_h765aee1_mpi_mpich_1.conda
linux-64::dotnet-sdk-8.0.204-hb8a3ed7_0.conda
linux-64::fenics-libdolfin-2019.1.0-hae8d50a_43.conda
linux-64::libarrow-13.0.0-h7b70231_37_cuda.conda
linux-64::lldb-18.1.3-py38hf2be415_0.conda
linux-64::intel-cmplr-lib-rt-2024.1.0-hfc55251_963.conda
linux-64::lammps-2024.02.07-cuda118_py311_h80f0500_nompi_1.conda
linux-64::pyarrow-tests-12.0.1-py310hd207890_48_cpu.conda
linux-64::pyarrow-tests-15.0.2-py38hc396e17_4_cpu.conda
linux-64::lammps-2024.02.07-cuda118_py310_h7730a0c_nompi_1.conda
linux-64::aws-sdk-cpp-1.11.267-h39730d7_5.conda
linux-64::lammps-2024.02.07-cpu_py311_hd3d4698_mpi_mpich_0.conda
linux-64::libadios2-2.9.2-mpi_openmpi_hca57a8f_2.conda
linux-64::pyarrow-14.0.2-py39hf92f12d_19_cuda.conda
linux-64::csp-0.0.3-py38h865c9d8_0.conda
linux-64::heyoka-4.0.3-h75065df_2.conda
linux-64::robotraconteur-1.2.0-py39h4bee610_2.conda
linux-64::sasktran2-2024.03.0-py312h1430e2c_1.conda
linux-64::libgrpc-1.62.2-h15f2491_0.conda
linux-64::nest-simulator-3.6-py311h42e18a1_5.conda
linux-64::libadios2-2.10.0-nompi_h6bac8f5_102.conda
linux-64::libarrow-15.0.2-he70291f_3_cpu.conda
linux-64::fimex-2.0.0-py312h1dba1d4_0.conda
linux-64::libgdal-arrow-parquet-3.7.3-h596c04d_23.conda
linux-64::lammps-2024.02.07-cuda118_py39_h4a9cbaf_mpi_openmpi_0.conda
linux-64::libadios2-2.10.0-mpi_openmpi_hc7ae811_3.conda
linux-64::libarrow-15.0.2-hda1e1a0_5_cuda.conda
linux-64::libxmlsec1-1.3.4-haa25aac_0.conda
linux-64::heyoka-llvm-14-4.0.3-h0a2cc97_0.conda
linux-64::freefem-4.13-nompi_ha5d34eb_110.conda
linux-64::libadios2-2.10.0-mpi_openmpi_h903ec01_2.conda
linux-64::pyinstaller-6.6.0-py310h93c3562_0.conda
linux-64::tiledb-2.18.5-h4386cac_0.conda
linux-64::pyarrow-tests-14.0.2-py39hf92f12d_17_cuda.conda
linux-64::pyarrow-12.0.1-py39hf92f12d_48_cuda.conda
linux-64::imagecodecs-2024.1.1-py312hb66cbcc_5.conda
linux-64::heyoka-3.2.0-h3d16a13_1.conda
linux-64::imagecodecs-2024.1.1-py312h7f02885_4.conda
linux-64::pyarrow-15.0.2-py312h3f82784_4_cpu.conda
linux-64::openimageio-2.5.9.0-h3220917_1.conda
linux-64::freefem-4.13-nompi_h53b8489_108.conda
linux-64::llvm-18.1.3-h39da44c_0.conda
linux-64::pyarrow-tests-15.0.2-py39h38d04b8_5_cpu.conda
linux-64::nest-simulator-3.7-py311h42e18a1_1.conda
linux-64::healpy-1.16.6-py311hf0b62b1_4.conda
linux-64::fenics-libdolfin-2019.1.0-he6f5590_43.conda
linux-64::pyinstaller-6.6.0-py312hf0b23d7_0.conda
linux-64::lld-18.1.3-hd326a66_0.conda
linux-64::pdal-2.7.1-ha9a290f_5.conda
linux-64::pyarrow-tests-13.0.0-py311hd5e4297_37_cpu.conda
linux-64::pyarrow-tests-13.0.0-py311h071ecb2_36_cuda.conda
linux-64::code-aster-17.0.12-np123py311hebe1895_1.conda
linux-64::libgdal-arrow-parquet-3.8.5-h855f076_0.conda
linux-64::sasktran2-2024.03.0-py311h9eaed7f_1.conda
linux-64::util-linux-2.39.4-py39h5bc7b3b_0.conda
linux-64::lammps-2024.02.07-cpu_py311_hbb7bd43_mpi_openmpi_1.conda
linux-64::nest-simulator-3.7-py312h8a0696b_1.conda
linux-64::libarrow-14.0.2-h20f9d47_15_cuda.conda
linux-64::pyarrow-13.0.0-py311h071ecb2_37_cuda.conda
linux-64::molgrid-0.5.2-cuda118py311h5987835_4.conda
linux-64::grpcio-1.62.2-py312hb06c811_0.conda
linux-64::pyarrow-tests-13.0.0-py38hc396e17_37_cpu.conda
linux-64::libadios2-2.9.2-nompi_h6bac8f5_102.conda
linux-64::openjdk-21.0.3-hb622114_0.conda
linux-64::libadios2-2.10.0-nompi_hb1f6268_100.conda
linux-64::rocksdb-9.1.1-h699acb7_0.conda
linux-64::libadios2-2.10.0-mpi_mpich_hd095186_0.conda
linux-64::heyoka-llvm-15-3.2.0-h790a773_1.conda
linux-64::robotraconteur-1.2.0-py310h3d5a87b_2.conda
linux-64::heyoka-4.0.3-h8b31785_1.conda
linux-64::lxml-5.1.1-py311h9005509_0.conda
linux-64::lammps-2024.02.07-cpu_py310_h8f80a90_mpi_mpich_0.conda
linux-64::fenics-libdolfin-2019.1.0-h8d78dc6_43.conda
linux-64::papilo-2.2.0-h35aabe7_3.conda
linux-64::libmed-4.1.1-nompi_h1cd9fda_112.conda
linux-64::lammps-2024.02.07-cpu_py311_hdd49dfd_nompi_1.conda
linux-64::tiledb-2.18.5-h584b59b_0.conda
linux-64::libadios2-2.10.0-mpi_openmpi_hb81d2b8_0.conda
linux-64::pyarrow-tests-15.0.2-py39hf92f12d_6_cuda.conda
linux-64::lldb-18.1.3-py310h93a787a_0.conda
linux-64::libadios2-2.10.0-mpi_mpich_h0bba950_3.conda
linux-64::nsight-compute-2024.1.1.4-h00cb8e3_2.conda
linux-64::geant4-11.1.3-py311h605c4e8_1.conda
linux-64::heyoka-3.2.0-he98065f_1.conda
linux-64::lammps-2024.02.07-cuda118_py38_h80d1e08_mpi_mpich_0.conda
linux-64::yosys-0.40-ha42962b_0.conda
linux-64::folly-2024.04.08.00-hb465b09_1_jemalloc.conda
linux-64::code-aster-17.0.14-np122py38h0e092d0_0.conda
linux-64::genomekit-5.0.1-py310h9888954_0.conda
linux-64::fenics-libdolfin-2019.1.0-ha1dc81f_43.conda
linux-64::python-3.12.3-hab00c5b_0_cpython.conda
linux-64::libgdal-arrow-parquet-3.8.5-h596c04d_2.conda
linux-64::pyarrow-15.0.2-py39h38d04b8_5_cpu.conda
linux-64::mupdf-1.24.1-py310hba70a52_3.conda
linux-64::libarrow-12.0.1-h29cb2fa_46_cuda.conda
linux-64::libadios2-2.9.2-mpi_mpich_hf741b70_2.conda
linux-64::libadios2-2.10.0-mpi_openmpi_hae66630_2.conda
linux-64::libarrow-14.0.2-h176673d_15_cpu.conda
linux-64::pyarrow-14.0.2-py312h25d8025_18_cuda.conda
linux-64::lxml-5.2.1-py39h8a3eb29_0.conda
linux-64::lammps-2024.02.07-cpu_py310_h8f80a90_mpi_mpich_1.conda
linux-64::pyarrow-tests-14.0.2-py310h188ebfb_18_cuda.conda
linux-64::scip-9.0.0-h408e105_3.conda
linux-64::pillow-10.3.0-py311h18e6fac_0.conda
linux-64::pyarrow-15.0.2-py38hdaf73b3_4_cuda.conda
linux-64::libgdal-arrow-parquet-3.7.3-hed594e5_22.conda
linux-64::libadios2-2.10.0-mpi_mpich_ha24653a_3.conda
linux-64::libarrow-13.0.0-he385075_36_cuda.conda
linux-64::pyarrow-tests-12.0.1-py311hd5e4297_48_cpu.conda
linux-64::libarrow-14.0.2-hefa796f_19_cpu.conda
linux-64::lammps-2024.02.07-cpu_py39_h827286f_mpi_openmpi_0.conda
linux-64::libadios2-2.10.0-mpi_openmpi_hae66630_1.conda
linux-64::grpcio-1.62.2-py38h94a1851_0.conda
linux-64::pyarrow-15.0.2-py38hdaf73b3_6_cuda.conda
linux-64::openimageio-2.5.9.0-h2cca261_1.conda
linux-64::libadios2-2.9.2-mpi_openmpi_h68bbb10_2.conda
linux-64::ovito-3.10.5-h8e92c3b_0.conda
linux-64::lxml-5.2.1-py310h6a33d3d_0.conda
linux-64::pyarrow-15.0.2-py38hc396e17_5_cpu.conda
linux-64::pillow-10.3.0-py39h90a76f3_0.conda
linux-64::rsync-3.3.0-he6cb5fe_0.conda
linux-64::imagecodecs-2024.1.1-py310hcfbe626_5.conda
linux-64::mupdf-1.24.1-py38hf17dff3_3.conda
linux-64::gst-plugins-bad-1.24.1-h3448496_0.conda
linux-64::imagecodecs-2024.1.1-py39h5f6d819_5.conda
linux-64::r-base-4.3.3-hf0d99cb_1.conda
linux-64::libgdal-3.8.5-hf9625ee_2.conda
linux-64::lammps-2024.02.07-cuda118_py311_h96326dd_nompi_0.conda
linux-64::pyarrow-tests-13.0.0-py310h188ebfb_37_cuda.conda
linux-64::folly-2024.04.22.00-h24d630f_0.conda
linux-64::libadios2-2.10.0-nompi_hb1f70c1_100.conda
linux-64::libarrow-12.0.1-hf406b5e_46_cpu.conda
linux-64::lxml-5.2.1-py38h81c7c4b_0.conda
linux-64::lxml-5.1.1-py39hba3cdb8_0.conda
linux-64::lxml-5.2.1-py312hb90d8a5_0.conda
linux-64::libadios2-2.10.0-nompi_h95d74dd_101.conda
linux-64::pyarrow-tests-13.0.0-py39hf92f12d_36_cuda.conda
linux-64::libmed-4.1.1-mpi_openmpi_h2c4ef5c_12.conda
linux-64::pyarrow-15.0.2-py39h38d04b8_4_cpu.conda
linux-64::healpy-1.16.6-py312h63a7e18_4.conda
linux-64::lammps-2024.02.07-cpu_py38_hde207a7_mpi_openmpi_0.conda
linux-64::libadios2-2.9.2-nompi_hb1f70c1_102.conda
linux-64::pdal-2.7.1-h86e06d4_6.conda
linux-64::pyarrow-tests-14.0.2-py39hf92f12d_19_cuda.conda
linux-64::csp-0.0.3-py311he61f6ff_0.conda
linux-64::libadios2-2.9.2-mpi_openmpi_h903ec01_2.conda
linux-64::libmongoc-1.23.2-h6a3a954_1.conda
linux-64::pyarrow-15.0.2-py310h188ebfb_5_cuda.conda
linux-64::wxpython-4.2.1-py310h8348223_5.conda
linux-64::pyarrow-tests-13.0.0-py312h3f82784_37_cpu.conda
linux-64::imagemagick-7.1.1_31-pl5321h0df52c9_1.conda
linux-64::mupdf-1.24.1-py312hf7ff796_4.conda
linux-64::libarrow-13.0.0-hd10c0f2_34_cuda.conda
linux-64::grpcio-1.62.2-py39h7d5b425_0.conda
linux-64::nushell-0.92.1-h099a793_0.conda
linux-64::lxml-5.2.1-py311hc0a218f_0.conda
linux-64::segalign-0.1.2.1-h232f886_0.conda
linux-64::pyarrow-tests-13.0.0-py311h071ecb2_37_cuda.conda
linux-64::mlir-18.1.4-hcd5def8_0.conda
linux-64::mupdf-1.24.1-py311h0c33687_3.conda
linux-64::magics-metview-batch-4.15.4-h3aff5e6_0.conda
linux-64::fenics-libdolfin-2019.1.0-h571dcef_43.conda
linux-64::libarrow-12.0.1-hd29dec3_45_cpu.conda
linux-64::freefem-4.13-mpi_mpich_h93f51ed_10.conda
linux-64::pyarrow-tests-12.0.1-py39hf92f12d_47_cuda.conda
linux-64::mlir-python-bindings-16.0.6-py39hc35b29e_0.conda
linux-64::pyarrow-14.0.2-py39h38d04b8_17_cpu.conda
linux-64::folly-2023.09.25.00-hbb00df7_5_jemalloc.conda
linux-64::libmed-4.1.1-mpi_mpich_h449f38c_12.conda
linux-64::ndcctools-7.10.0-py38h514f0f6_0.conda
linux-64::gdstk-0.9.51-py38hab45c01_0.conda
linux-64::pyarrow-tests-13.0.0-py39h38d04b8_37_cpu.conda
linux-64::jaxlib-0.4.23-cuda118py311hb60b139_201.conda
linux-64::lammps-2024.02.07-cpu_py38_h5608ceb_nompi_1.conda
linux-64::gap-core-4.13.0-h083ed3b_0.conda
linux-64::dotnet-sdk-6.0.420-hb8a3ed7_0.conda
linux-64::pyarrow-14.0.2-py310hd207890_19_cpu.conda
linux-64::libadios2-2.10.0-mpi_mpich_h462df65_2.conda
linux-64::imagecodecs-2024.1.1-py311h269dc82_5.conda
linux-64::zimpl-3.5.4-hcf47b6d_4.conda
linux-64::libadios2-2.10.0-mpi_openmpi_h903ec01_0.conda
linux-64::pyarrow-tests-15.0.2-py310hd207890_4_cpu.conda
linux-64::freefem-4.13-mpi_mpich_heacfdf8_9.conda
linux-64::libmediainfo-24.04-hb0e0bff_0.conda
linux-64::vowpalwabbit-9.9.0-py39h4366675_4.conda
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
linux-64::heaptrack-1.2.0-h78d0f09_5.conda
linux-64::libmlir-18.1.4-hcd5def8_0.conda
linux-64::dlib-cpp-19.24.4-h1f83154_0.conda
linux-64::rocm-device-libs-6.1.0-ha6fb4c9_0.conda
linux-64::eccodes-2.35.0-he84ddb8_0.conda
linux-64::coin-or-osi-0.108.10-haf5fa05_0.conda
linux-64::libmlir18-18.1.4-hcd5def8_0.conda
linux-64::coin-or-utils-2.11.11-hee58242_0.conda
linux-64::libmlir18-18.1.3-hcd5def8_0.conda
linux-64::libsqlite-3.45.3-h2797004_0.conda
linux-64::cpptrace-0.5.2-hfc55251_0.conda
linux-64::cfitsio-4.4.0-hbdc6101_1.conda
linux-64::jbig2dec-0.18-h267a509_0.conda
linux-64::libmlir-18.1.3-hcd5def8_0.conda
linux-64::git-cliff-2.2.1-he0a03d5_0.conda
linux-64::reprimand-1.5.1-h82023c1_3.conda
-    "libzlib >=1.2.13,<1.3.0a0"
+    "libzlib >=1.2.13,<2.0.0a0"
```

</details>