### PR TITLE
loosen zlib-pin to major level (4/N; February 2024)

### DIFF
--- a/recipe/patch_yaml/zlib.yaml
+++ b/recipe/patch_yaml/zlib.yaml
@@ -25,3 +25,12 @@ then:
   - loosen_depends:
       name: libzlib
       upper_bound: "2"
+---
+if:
+  has_depends: libzlib >=1.2*
+  timestamp_lt: 1709251200000  # 2024-03-01 00:00 UTC
+  timestamp_ge: 1706745600000  # 2024-02-01 00:00 UTC
+then:
+  - loosen_depends:
+      name: libzlib
+      upper_bound: "2"


### PR DESCRIPTION
Follow-up to https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/739, about 2800 artefacts affected.

### Result of `python show_diff.py`

<details>

```diff
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
linux-ppc64le
linux-ppc64le::pyinstaller-6.4.0-py38h36029d9_0.conda
linux-ppc64le::mysql-connector-python-8.3.0-py39h27cb1e9_0.conda
linux-ppc64le::gdb-14.1-py311h24db8f9_1.conda
linux-ppc64le::mysql-connector-python-8.2.0-py39h6ab4ff6_3.conda
linux-ppc64le::correctionlib-2.5.0-py310h02f1291_1.conda
linux-ppc64le::grpcio-1.61.0-py38hc2aed35_0.conda
linux-ppc64le::postgresql-plpython-16.2-py311hba550cb_0.conda
linux-ppc64le::pyinstaller-6.4.0-py311h5a86d3c_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.3-hdfa7800_2.conda
linux-ppc64le::libgdal-3.8.4-h3b82920_0.conda
linux-ppc64le::ldas-tools-framecpp-2.9.3-hb6bff72_0.conda
linux-ppc64le::root_base-6.30.4-py311ha62296e_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-h51ba7d5_16.conda
linux-ppc64le::mysql-connector-odbc-8.2.0-hff1ad0c_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.3-h2b88b31_2.conda
linux-ppc64le::libarrow-13.0.0-hffd44c3_27_cpu.conda
linux-ppc64le::grpcio-1.61.0-py311h3997ded_0.conda
linux-ppc64le::mysql-connector-python-8.2.0-py311h525ad2a_2.conda
linux-ppc64le::mysql-connector-python-8.2.0-py39hfb68d66_0.conda
linux-ppc64le::pdal-2.6.3-ha5c445d_1.conda
linux-ppc64le::libspral-2024.01.18-h10b1de6_0.conda
linux-ppc64le::git-2.44.0-pl5321ha2d6717_0.conda
linux-ppc64le::libarrow-12.0.1-h2e7a05a_40_cuda.conda
linux-ppc64le::grpcio-1.61.0-py312h930df82_0.conda
linux-ppc64le::eccodes-2.34.0-hfb67fc0_0.conda
linux-ppc64le::mysql-connector-python-8.2.0-py310h0073785_4.conda
linux-ppc64le::llvmlite-0.42.0-py39h278787b_0.conda
linux-ppc64le::libarrow-14.0.2-h7a6a30a_6_cpu.conda
linux-ppc64le::mysql-libs-8.3.0-hc9dddf0_2.conda
linux-ppc64le::libgrpc-1.60.1-h14a4736_0.conda
linux-ppc64le::grpcio-1.60.1-py39h27cb1e9_0.conda
linux-ppc64le::libopencv-4.9.0-py312h1a56779_8.conda
linux-ppc64le::postgresql-plpython-16.2-py312h35a7702_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.3-h51ba7d5_3.conda
linux-ppc64le::libgit2-1.7.2-hb5ae12b_1.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.3-hd1c468f_3.conda
linux-ppc64le::correctionlib-2.4.0-py312hb8a0279_1.conda
linux-ppc64le::glib-2.78.4-hff1ad0c_0.conda
linux-ppc64le::boost-cpp-1.84.0-h1102270_1.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.4-hd5c359a_0.conda
linux-ppc64le::postgresql-plpython-15.6-py312h7263721_0.conda
linux-ppc64le::postgresql-plpython-16.2-py38h3356496_0.conda
linux-ppc64le::magic-8.3.462-h7eb73fb_0.conda
linux-ppc64le::libarrow-15.0.0-hdd8f72f_5_cuda.conda
linux-ppc64le::mysql-connector-python-8.2.0-py39h8bcd33c_4.conda
linux-ppc64le::correctionlib-2.4.0-py39h5e0a701_0.conda
linux-ppc64le::grpcio-1.61.1-py311h3997ded_1.conda
linux-ppc64le::mysql-connector-python-8.2.0-py310h25df70f_2.conda
linux-ppc64le::root_base-6.28.12-py310ha789440_0.conda
linux-ppc64le::folly-2024.02.19.00-h7cedaab_0.conda
linux-ppc64le::grpcio-1.61.0-py39h278787b_0.conda
linux-ppc64le::folly-2024.02.05.00-hcb6a8eb_0_jemalloc.conda
linux-ppc64le::python-igraph-0.11.4-py39h7ec3726_0.conda
linux-ppc64le::mysql-client-8.3.0-hb59264c_2.conda
linux-ppc64le::rust-1.76.0-hb12b0c0_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.3-h3197adc_1.conda
linux-ppc64le::correctionlib-2.4.0-py311hc2b5b1e_1.conda
linux-ppc64le::libarrow-15.0.0-h4204d7d_6_cpu.conda
linux-ppc64le::postgresql-plpython-16.2-py310h33ccb9c_0.conda
linux-ppc64le::python-3.11.8-h3332dee_0_cpython.conda
linux-ppc64le::libarrow-12.0.1-h8357d1b_37_cuda.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-h0d6f61e_16.conda
linux-ppc64le::libarrow-12.0.1-h07bc205_40_cpu.conda
linux-ppc64le::mysql-router-8.3.0-hdbc54a6_1.conda
linux-ppc64le::folly-2024.02.12.00-hcb6a8eb_0_jemalloc.conda
linux-ppc64le::postgresql-plpython-16.2-py310hcb289b5_0.conda
linux-ppc64le::libgdal-3.7.3-h225c741_15.conda
linux-ppc64le::mysql-connector-python-8.2.0-py39h44bd956_4.conda
linux-ppc64le::mysql-connector-python-8.2.0-py38he1cbe02_1.conda
linux-ppc64le::correctionlib-2.4.0-py310h02f1291_0.conda
linux-ppc64le::folly-2024.02.12.00-hfba947f_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-h2b88b31_14.conda
linux-ppc64le::libarrow-13.0.0-h8357d1b_26_cuda.conda
linux-ppc64le::libgdal-3.8.3-h1f67e0e_2.conda
linux-ppc64le::correctionlib-2.5.0-py38hbab3742_1.conda
linux-ppc64le::ffmpeg-6.1.1-gpl_h6b347f3_104.conda
linux-ppc64le::mysql-router-8.2.0-h2199598_0.conda
linux-ppc64le::grpcio-1.61.1-py38hc2aed35_0.conda
linux-ppc64le::postgresql-plpython-16.2-py39h55f503e_0.conda
linux-ppc64le::correctionlib-2.4.0-py39h5e0a701_1.conda
linux-ppc64le::postgresql-16.2-h33705f9_0.conda
linux-ppc64le::libgdal-3.8.3-h3b82920_3.conda
linux-ppc64le::tectonic-0.15.0-hdb07515_0.conda
linux-ppc64le::grpcio-1.61.1-py39h278787b_0.conda
linux-ppc64le::libarrow-14.0.2-h4204d7d_9_cpu.conda
linux-ppc64le::mysql-connector-python-8.3.0-py39h278787b_0.conda
linux-ppc64le::libarrow-12.0.1-h952d1ae_38_cuda.conda
linux-ppc64le::tiledb-2.20.0-he665fa0_0.conda
linux-ppc64le::postgresql-plpython-15.6-py311hd1eda33_0.conda
linux-ppc64le::mysql-connector-python-8.3.0-py310h8eb8f48_0.conda
linux-ppc64le::mysql-libs-8.2.0-hc9dddf0_1.conda
linux-ppc64le::libxml2-2.12.5-h0545f4b_0.conda
linux-ppc64le::correctionlib-2.4.0-py311hc2b5b1e_0.conda
linux-ppc64le::gdb-14.1-py311h31981db_0.conda
linux-ppc64le::root_base-6.28.12-py39h23a9725_0.conda
linux-ppc64le::tiledb-2.20.0-he665fa0_1.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-h51ba7d5_15.conda
linux-ppc64le::grpcio-1.61.1-py39h27cb1e9_1.conda
linux-ppc64le::poppler-24.02.0-h433edb4_0.conda
linux-ppc64le::gdb-14.1-py312h013b4cb_1.conda
linux-ppc64le::libglib-2.78.4-h7505782_0.conda
linux-ppc64le::mysql-connector-python-8.2.0-py310h25df70f_1.conda
linux-ppc64le::libarrow-14.0.2-h51ad07c_8_cpu.conda
linux-ppc64le::mysql-connector-python-8.2.0-py38he1cbe02_3.conda
linux-ppc64le::libarrow-13.0.0-ha0799b4_28_cuda.conda
linux-ppc64le::postgresql-plpython-16.2-py39h8e6b938_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.3-hd83fe9a_2.conda
linux-ppc64le::mysql-connector-python-8.2.0-py39h668e91c_3.conda
linux-ppc64le::mysql-client-8.2.0-hb59264c_1.conda
linux-ppc64le::mysql-connector-python-8.2.0-py312hd4897f9_3.conda
linux-ppc64le::valgrind-3.22.0-hf7e7dc2_1.conda
linux-ppc64le::cpp-opentelemetry-sdk-1.14.1-h724142c_1.conda
linux-ppc64le::mysql-connector-python-8.2.0-py311h0cecea3_4.conda
linux-ppc64le::elfutils-0.190-h8166f02_1.conda
linux-ppc64le::mysql-connector-python-8.3.0-py38hc2aed35_0.conda
linux-ppc64le::postgresql-plpython-16.2-py311hcd20d66_0.conda
linux-ppc64le::postgresql-16.2-h0ebe0f4_0.conda
linux-ppc64le::folly-2024.02.05.00-ha2e2e2a_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.3-h0d6f61e_3.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.4-h51ba7d5_0.conda
linux-ppc64le::llvmlite-0.42.0-py311h3997ded_0.conda
linux-ppc64le::nss-3.98-h4237796_0.conda
linux-ppc64le::clangdev-13.0.1-default_he4a137d_6.conda
linux-ppc64le::postgresql-plpython-15.6-py39h63fa360_0.conda
linux-ppc64le::correctionlib-2.5.0-py312hb8a0279_1.conda
linux-ppc64le::libarrow-15.0.0-h6065bf7_4_cuda.conda
linux-ppc64le::fish-3.7.0-h0f16736_1.conda
linux-ppc64le::sqlite-3.45.1-h63c7444_0.conda
linux-ppc64le::grpcio-1.60.1-py38hc2aed35_0.conda
linux-ppc64le::libopentelemetry-cpp-1.14.1-h8183353_0.conda
linux-ppc64le::tiledb-2.20.0-h7b0036b_0.conda
linux-ppc64le::folly-2024.02.19.00-h4b663bd_0_jemalloc.conda
linux-ppc64le::postgresql-plpython-16.2-py38he255f0a_0.conda
linux-ppc64le::ffmpeg-6.1.1-lgpl_h68add63_4.conda
linux-ppc64le::postgresql-15.6-hcd4fc10_0.conda
linux-ppc64le::root_base-6.30.4-py38hec8aaec_0.conda
linux-ppc64le::mysql-connector-python-8.2.0-py38hae5bee0_4.conda
linux-ppc64le::folly-2024.02.12.00-hd3a0175_0_jemalloc.conda
linux-ppc64le::openimageio-2.5.5.0-py311h0f0c752_1.conda
linux-ppc64le::grpcio-1.60.1-py39h278787b_0.conda
linux-ppc64le::folly-2024.02.05.00-h7cedaab_0.conda
linux-ppc64le::grpcio-1.61.1-py39h278787b_1.conda
linux-ppc64le::pyinstaller-6.4.0-py39hf0cda86_0.conda
linux-ppc64le::grpcio-1.61.1-py312h930df82_0.conda
linux-ppc64le::mysql-connector-python-8.2.0-py38he1cbe02_2.conda
linux-ppc64le::mysql-server-8.2.0-h0e1e9db_1.conda
linux-ppc64le::pdal-2.6.3-ha5c445d_2.conda
linux-ppc64le::ogre-14.2.0-hebe49f4_0.conda
linux-ppc64le::folly-2024.02.19.00-hfba947f_0.conda
linux-ppc64le::mysql-server-8.3.0-h0e1e9db_1.conda
linux-ppc64le::pyinstaller-6.4.0-py312h4032086_0.conda
linux-ppc64le::folly-2024.02.19.00-hd3a0175_0_jemalloc.conda
linux-ppc64le::cpp-opentelemetry-sdk-1.14.2-h724142c_0.conda
linux-ppc64le::folly-2024.02.05.00-hd3a0175_0_jemalloc.conda
linux-ppc64le::grpcio-1.61.1-py39h27cb1e9_0.conda
linux-ppc64le::libopencv-4.9.0-py39h159720b_8.conda
linux-ppc64le::libarrow-15.0.0-h7a6a30a_4_cpu.conda
linux-ppc64le::python-3.12.2-h3332dee_0_cpython.conda
linux-ppc64le::mysql-libs-8.2.0-hc9dddf0_0.conda
linux-ppc64le::mysql-libs-8.3.0-hc9dddf0_1.conda
linux-ppc64le::cpp-opentelemetry-sdk-1.14.0-h8183353_0.conda
linux-ppc64le::glibmm-2.68-2.78.1-h8df1eea_0.conda
linux-ppc64le::correctionlib-2.4.0-py310h02f1291_1.conda
linux-ppc64le::libarrow-12.0.1-h333c2e4_39_cpu.conda
linux-ppc64le::pdal-2.6.3-h24cb560_0.conda
linux-ppc64le::sdl_image-1.2.12-hbadbcff_7.conda
linux-ppc64le::mysql-connector-python-8.3.0-py312h930df82_0.conda
linux-ppc64le::libgrpc-1.61.0-hd114dec_0.conda
linux-ppc64le::folly-2024.02.05.00-h4b663bd_0_jemalloc.conda
linux-ppc64le::libarrow-13.0.0-h333c2e4_28_cpu.conda
linux-ppc64le::tiledb-2.20.0-h595b711_0.conda
linux-ppc64le::libgrpc-1.61.1-h77dda89_1.conda
linux-ppc64le::r-base-4.3.3-h142f484_0.conda
linux-ppc64le::libarrow-15.0.0-h976f814_6_cuda.conda
linux-ppc64le::libarrow-14.0.2-h7a6a30a_7_cpu.conda
linux-ppc64le::libarrow-14.0.2-he4b4deb_10_cpu.conda
linux-ppc64le::mesalib-24.0.1-h77ffee0_0.conda
linux-ppc64le::clangdev-13.0.1-root_63004_h83775d6_6.conda
linux-ppc64le::mysql-server-8.2.0-h7e611a5_0.conda
linux-ppc64le::libopentelemetry-cpp-1.14.2-h724142c_0.conda
linux-ppc64le::libpq-15.6-h458bc76_0.conda
linux-ppc64le::openimageio-2.5.5.0-py38h53b6dcf_1.conda
linux-ppc64le::grpcio-1.61.0-py39h27cb1e9_0.conda
linux-ppc64le::gdb-14.1-py38h4b9f071_0.conda
linux-ppc64le::libarrow-12.0.1-h1a9dde0_37_cpu.conda
linux-ppc64le::libgoogle-cloud-storage-2.21.0-h39cc67c_1.conda
linux-ppc64le::mysql-connector-python-8.2.0-py39h668e91c_1.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-hd1c468f_15.conda
linux-ppc64le::gdb-14.1-py310h2d728ed_0.conda
linux-ppc64le::mysql-connector-python-8.3.0-py311h3997ded_0.conda
linux-ppc64le::libopencv-4.9.0-py310hb6858ef_8.conda
linux-ppc64le::grpcio-1.61.0-py310h8eb8f48_0.conda
linux-ppc64le::postgresql-plpython-15.6-py310h8b10ea4_0.conda
linux-ppc64le::libopentelemetry-cpp-1.14.0-h8183353_0.conda
linux-ppc64le::mysql-client-8.2.0-hb59264c_0.conda
linux-ppc64le::libarrow-14.0.2-hdd8f72f_8_cuda.conda
linux-ppc64le::llvmlite-0.42.0-py310h8eb8f48_1.conda
linux-ppc64le::grpcio-1.60.1-py311h3997ded_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-hd1c468f_16.conda
linux-ppc64le::python-igraph-0.11.4-py310h2268931_0.conda
linux-ppc64le::libopencv-4.9.0-py311ha695111_8.conda
linux-ppc64le::mysql-server-8.3.0-h94846b4_2.conda
linux-ppc64le::libarrow-13.0.0-h2e7a05a_29_cuda.conda
linux-ppc64le::grpcio-1.61.1-py311h3997ded_0.conda
linux-ppc64le::mysql-router-8.2.0-hdbc54a6_1.conda
linux-ppc64le::libboost-1.84.0-hac66d7f_1.conda
linux-ppc64le::mysql-connector-python-8.2.0-py39h6ab4ff6_1.conda
linux-ppc64le::python-igraph-0.11.4-py39h5811586_0.conda
linux-ppc64le::ldas-tools-framecpp-3.0.3-h858635c_0.conda
linux-ppc64le::imagemagick-7.1.1_28-pl5321h79d4ed6_0.conda
linux-ppc64le::gdb-14.1-py39h1bf2b07_0.conda
linux-ppc64le::aws-sdk-cpp-1.11.242-h9876045_2.conda
linux-ppc64le::root_base-6.30.4-py310ha789440_0.conda
linux-ppc64le::gst-plugins-base-1.23.1-he115d4a_0.conda
linux-ppc64le::mysql-connector-odbc-8.3.0-hff1ad0c_0.conda
linux-ppc64le::mysql-connector-python-8.2.0-py310h25df70f_3.conda
linux-ppc64le::llvmlite-0.42.0-py311h3997ded_1.conda
linux-ppc64le::correctionlib-2.4.0-py38hbab3742_0.conda
linux-ppc64le::libarrow-14.0.2-h6065bf7_7_cuda.conda
linux-ppc64le::cmake-3.28.3-h1403f77_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-hd5c359a_16.conda
linux-ppc64le::cpp-opentelemetry-sdk-1.14.1-h8183353_0.conda
linux-ppc64le::libarrow-12.0.1-ha0799b4_39_cuda.conda
linux-ppc64le::libarrow-15.0.0-hdb7c3e0_3_cuda.conda
linux-ppc64le::postgresql-plpython-15.6-py38hce4d2e1_0.conda
linux-ppc64le::libarrow-15.0.0-h1869b8e_3_cpu.conda
linux-ppc64le::tiledb-2.20.0-ha7f9dc6_0.conda
linux-ppc64le::aws-sdk-cpp-1.11.267-h5f0e86c_1.conda
linux-ppc64le::libgit2-1.7.2-hb5ae12b_2.conda
linux-ppc64le::libarrow-13.0.0-h07bc205_29_cpu.conda
linux-ppc64le::nco-5.2.0-hd97f16e_0.conda
linux-ppc64le::prometheus-cpp-1.2.3-hb56e5db_0.conda
linux-ppc64le::correctionlib-2.4.0-py38hbab3742_1.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.4-h0d6f61e_0.conda
linux-ppc64le::postgresql-plpython-16.2-py312hfdea0cd_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.3-he60b8ef_1.conda
linux-ppc64le::root_base-6.28.12-py311ha62296e_0.conda
linux-ppc64le::python-igraph-0.11.4-py38hb812dcf_0.conda
linux-ppc64le::libgit2-1.7.2-hf0aa560_0.conda
linux-ppc64le::mysql-connector-python-8.2.0-py38h72572ad_0.conda
linux-ppc64le::libarrow-13.0.0-h952d1ae_27_cuda.conda
linux-ppc64le::libarrow-14.0.2-h976f814_9_cuda.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.3-h1a00e85_1.conda
linux-ppc64le::folly-2024.02.26.00-hd483122_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-h10ce74c_14.conda
linux-ppc64le::gst-plugins-good-1.23.1-hbd4f694_0.conda
linux-ppc64le::python-igraph-0.11.4-py312ha28a094_0.conda
linux-ppc64le::ldas-tools-framecpp-2.9.3-hb6bff72_1.conda
linux-ppc64le::tiledb-2.20.0-ha7f9dc6_1.conda
linux-ppc64le::texlive-core-20230313-h64f6741_10.conda
linux-ppc64le::openimageio-2.5.5.0-py312h2a3d727_1.conda
linux-ppc64le::pdal-2.6.2-h24cb560_4.conda
linux-ppc64le::libarrow-12.0.1-hffd44c3_38_cpu.conda
linux-ppc64le::folly-2024.02.12.00-ha2e2e2a_0.conda
linux-ppc64le::folly-2024.02.12.00-h7cedaab_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-h14f989f_14.conda
linux-ppc64le::folly-2024.02.19.00-ha2e2e2a_0.conda
linux-ppc64le::libgdal-3.7.3-h314c1d2_14.conda
linux-ppc64le::magic-8.3.463-h7eb73fb_0.conda
linux-ppc64le::grpcio-1.61.1-py312h930df82_1.conda
linux-ppc64le::python-igraph-0.11.4-py311h06ed5b6_0.conda
linux-ppc64le::orc-1.9.2-hf0e23c8_2.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-hd83fe9a_14.conda
linux-ppc64le::libarrow-15.0.0-h379c18b_7_cuda.conda
linux-ppc64le::git-2.43.0-pl5321ha2d6717_1.conda
linux-ppc64le::folly-2024.02.19.00-hf679787_2_jemalloc.conda
linux-ppc64le::mysql-connector-python-8.2.0-py312h015ed96_4.conda
linux-ppc64le::aws-sdk-cpp-1.11.242-h21dbc46_1.conda
linux-ppc64le::libgoogle-cloud-storage-2.21.0-h39cc67c_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.3-hd5c359a_3.conda
linux-ppc64le::mesalib-24.0.2-h77ffee0_0.conda
linux-ppc64le::mysql-client-8.3.0-hb59264c_1.conda
linux-ppc64le::libgdal-3.7.3-h225c741_16.conda
linux-ppc64le::libopencv-4.9.0-py39h9564b8b_8.conda
linux-ppc64le::mysql-connector-odbc-8.0.33-hff1ad0c_0.conda
linux-ppc64le::root_base-6.30.4-py39h23a9725_0.conda
linux-ppc64le::llvmlite-0.42.0-py310h8eb8f48_0.conda
linux-ppc64le::mysql-connector-python-8.2.0-py39h668e91c_2.conda
linux-ppc64le::folly-2024.02.26.00-hf679787_0_jemalloc.conda
linux-ppc64le::pcre2-static-10.43-h3bd5b6e_0.conda
linux-ppc64le::grpcio-1.61.1-py38hc2aed35_1.conda
linux-ppc64le::llvmlite-0.42.0-py39h27cb1e9_1.conda
linux-ppc64le::folly-2024.02.19.00-h4b663bd_1_jemalloc.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.4-hd1c468f_0.conda
linux-ppc64le::mysql-connector-python-8.2.0-py310h702dca7_0.conda
linux-ppc64le::mysql-connector-python-8.2.0-py311h525ad2a_1.conda
linux-ppc64le::libgrpc-1.61.1-hd114dec_0.conda
linux-ppc64le::cargo-c-0.9.30-hd6e3413_0.conda
linux-ppc64le::libgdal-3.8.3-h3b836db_1.conda
linux-ppc64le::libpulsar-3.4.2-h540a46f_2.conda
linux-ppc64le::ogre-14.2.0-haab7b0d_0.conda
linux-ppc64le::libarrow-13.0.0-h1a9dde0_26_cpu.conda
linux-ppc64le::libvips-8.15.1-h809683a_2.conda
linux-ppc64le::correctionlib-2.5.0-py39h5e0a701_1.conda
linux-ppc64le::grpcio-1.60.1-py310h8eb8f48_0.conda
linux-ppc64le::folly-2024.02.19.00-ha2e2e2a_1.conda
linux-ppc64le::libgoogle-cloud-storage-2.21.0-h39cc67c_2.conda
linux-ppc64le::tiledb-2.20.1-he665fa0_1.conda
linux-ppc64le::grpcio-1.60.1-py312h930df82_0.conda
linux-ppc64le::tiledb-2.20.1-hf5aa9c4_1.conda
linux-ppc64le::pyinstaller-6.4.0-py310h0719273_0.conda
linux-ppc64le::freeimage-3.18.0-h5e9a449_19.conda
linux-ppc64le::llvmlite-0.42.0-py312h930df82_1.conda
linux-ppc64le::aws-sdk-cpp-1.11.267-h9876045_0.conda
linux-ppc64le::eccodes-2.34.1-hfb67fc0_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.3-h10ce74c_2.conda
linux-ppc64le::imagemagick-7.1.1_29-pl5321h79d4ed6_0.conda
linux-ppc64le::mosh-1.4.0-pl5321hac0b02d_7.conda
linux-ppc64le::folly-2024.02.19.00-hd483122_2.conda
linux-ppc64le::squashfuse-0.5.2-h40af005_0.conda
linux-ppc64le::correctionlib-2.5.0-py311hc2b5b1e_1.conda
linux-ppc64le::openimageio-2.5.5.0-py39hc51cb0a_1.conda
linux-ppc64le::grpcio-1.61.1-py310h8eb8f48_0.conda
linux-ppc64le::root_base-6.28.12-py38hec8aaec_0.conda
linux-ppc64le::libarrow-15.0.0-h51ad07c_5_cpu.conda
linux-ppc64le::folly-2024.02.12.00-h4b663bd_0_jemalloc.conda
linux-ppc64le::prometheus-cpp-1.2.2-hb56e5db_0.conda
linux-ppc64le::mesalib-24.0.0-h77ffee0_0.conda
linux-ppc64le::mysql-connector-python-8.2.0-py311h525ad2a_3.conda
linux-ppc64le::llvmlite-0.42.0-py39h27cb1e9_0.conda
linux-ppc64le::llvmlite-0.42.0-py39h278787b_1.conda
linux-ppc64le::libopencv-4.9.0-py38h2347515_8.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-h15fa69a_15.conda
linux-ppc64le::libarrow-15.0.0-he4b4deb_7_cpu.conda
linux-ppc64le::mysql-connector-python-8.2.0-py39h598b36e_0.conda
linux-ppc64le::mysql-connector-python-8.2.0-py311he52b4ac_0.conda
linux-ppc64le::folly-2024.02.19.00-hcb6a8eb_0_jemalloc.conda
linux-ppc64le::tiledb-2.20.1-ha7f9dc6_1.conda
linux-ppc64le::nco-5.2.1-hd97f16e_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-h0d6f61e_15.conda
linux-ppc64le::grpcio-1.61.1-py310h8eb8f48_1.conda
linux-ppc64le::mysql-router-8.3.0-h24a4ef9_2.conda
linux-ppc64le::folly-2024.02.05.00-hfba947f_0.conda
linux-ppc64le::libopentelemetry-cpp-1.14.1-h724142c_1.conda
linux-ppc64le::openimageio-2.5.5.0-py310h74bdb46_1.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.3-h6ad8f72_1.conda
linux-ppc64le::libarrow-14.0.2-h6065bf7_6_cuda.conda
linux-ppc64le::libarrow-14.0.2-h379c18b_10_cuda.conda
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
linux-ppc64le::imath-3.1.11-hff1ad0c_0.conda
linux-ppc64le::libprotobuf-4.25.1-h9ce2175_2.conda
linux-ppc64le::libprotobuf-static-4.25.2-hffb1566_0.conda
linux-ppc64le::pcre2-10.43-h3bd5b6e_0.conda
linux-ppc64le::libsolv-static-0.7.28-hff1ad0c_0.conda
linux-ppc64le::libclang-13.0.1-root_63004_h83775d6_6.conda
linux-ppc64le::clang-tools-13.0.1-root_63004_h83775d6_6.conda
linux-ppc64le::openjpeg-2.5.2-h1c3486c_0.conda
linux-ppc64le::libclang-cpp-13.0.1-default_he4a137d_6.conda
linux-ppc64le::clang-format-13.0.1-default_he4a137d_6.conda
linux-ppc64le::libclang-cpp13-13.0.1-default_he4a137d_6.conda
linux-ppc64le::openexr-3.2.2-h8c13fd7_0.conda
linux-ppc64le::libprotobuf-4.25.2-hffb1566_0.conda
linux-ppc64le::libsqlite-3.45.1-hd4bbf49_0.conda
linux-ppc64le::clang-13-13.0.1-default_he4a137d_6.conda
linux-ppc64le::libclang-cpp13-13.0.1-root_63004_h83775d6_6.conda
linux-ppc64le::libclang-cpp-13.0.1-root_63004_h83775d6_6.conda
linux-ppc64le::libprotobuf-static-4.25.1-h9ce2175_1.conda
linux-ppc64le::clang-format-13-13.0.1-root_63004_h83775d6_6.conda
linux-ppc64le::libprotobuf-static-4.25.1-h9ce2175_2.conda
linux-ppc64le::glib-tools-2.78.4-hff1ad0c_0.conda
linux-ppc64le::clang-tools-13.0.1-default_he4a137d_6.conda
linux-ppc64le::libpng-1.6.43-hd4bbf49_0.conda
linux-ppc64le::libprotobuf-static-4.25.2-hffb1566_1.conda
linux-ppc64le::libprotobuf-4.25.2-hffb1566_1.conda
linux-ppc64le::openjpeg-2.5.1-h1c3486c_0.conda
linux-ppc64le::git-cliff-2.0.3-h6565b52_0.conda
linux-ppc64le::exiv2-0.28.2-h7e15c4a_0.conda
linux-ppc64le::libclang-13.0.1-default_he4a137d_6.conda
linux-ppc64le::clang-13-13.0.1-root_63004_h83775d6_6.conda
linux-ppc64le::libsolv-0.7.28-hff1ad0c_0.conda
linux-ppc64le::gcab-1.6-h1dc1efa_0.conda
linux-ppc64le::libpng-1.6.42-hd4bbf49_0.conda
linux-ppc64le::libprotobuf-4.25.1-h9ce2175_1.conda
linux-ppc64le::git-cliff-2.0.4-h6565b52_0.conda
linux-ppc64le::clang-format-13.0.1-root_63004_h83775d6_6.conda
linux-ppc64le::clang-format-13-13.0.1-default_he4a137d_6.conda
-    "libzlib >=1.2.13,<1.3.0a0"
+    "libzlib >=1.2.13,<2.0.0a0"
================================================================================
================================================================================
osx-arm64
osx-arm64::libmediainfo-24.01-hea7cd4b_0.conda
osx-arm64::wxpython-4.2.1-py312hd5f1910_3.conda
osx-arm64::lammps-2023.11.21-cpu_py39_h5afc6b9_nompi_4.conda
osx-arm64::mesalib-24.0.0-hd5bafc3_0.conda
osx-arm64::libpulsar-3.4.2-h0931c4d_2.conda
osx-arm64::ndcctools-7.8.0-py311ha2834e1_0.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-h88be5e4_16.conda
osx-arm64::libgdal-3.8.3-ha86f356_3.conda
osx-arm64::grpcio-1.60.1-py39h047a24b_0.conda
osx-arm64::paraview-5.11.2-py312h13170fa_102_qt.conda
osx-arm64::photochem-0.4.5-py310he5eae8e_1.conda
osx-arm64::paraview-5.11.2-py311h9148e6d_102_qt.conda
osx-arm64::correctionlib-2.4.0-py312h903fe9b_1.conda
osx-arm64::llvmlite-0.42.0-py311hf5d242d_1.conda
osx-arm64::mysql-connector-python-8.2.0-py38h628b379_3.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-h54f588f_14.conda
osx-arm64::jaxlib-0.4.23-cpu_py39ha42a457_0.conda
osx-arm64::mysql-server-8.3.0-h7154028_1.conda
osx-arm64::protozfits-2.4.0-py38hc8c5f20_0.conda
osx-arm64::mysql-libs-8.3.0-hf036fc4_1.conda
osx-arm64::gdstk-0.9.50-py310hd84021c_0.conda
osx-arm64::grpcio-1.61.0-py311hf5d242d_0.conda
osx-arm64::libgdal-arrow-parquet-3.8.4-h88be5e4_0.conda
osx-arm64::correctionlib-2.5.0-py312h903fe9b_1.conda
osx-arm64::folly-2024.02.12.00-h75b8fe2_0.conda
osx-arm64::grpcio-1.61.1-py311hf5d242d_1.conda
osx-arm64::libvips-8.15.1-hc1cfc8e_2.conda
osx-arm64::python-igraph-0.11.4-py311h633d148_0.conda
osx-arm64::mysql-connector-odbc-8.2.0-hbeb2e11_0.conda
osx-arm64::ogre-14.2.0-hedcb8d7_0.conda
osx-arm64::kaldi-5.5.112-cpu_h012d200_0.conda
osx-arm64::ndcctools-7.7.3-py310h7a27ce5_1.conda
osx-arm64::wxpython-4.2.1-py39h8cf1816_3.conda
osx-arm64::postgresql-plpython-16.2-py311h1e905d0_0.conda
osx-arm64::papilo-2.2.0-ha5580d7_0.conda
osx-arm64::pdal-2.6.3-h3c564ca_2.conda
osx-arm64::grpcio-1.61.1-py39h047a24b_1.conda
osx-arm64::r-base-4.3.3-h53b85ff_0.conda
osx-arm64::libgit2-1.7.2-h9878266_0.conda
osx-arm64::libgdal-arrow-parquet-3.8.3-h54f588f_2.conda
osx-arm64::libgdal-arrow-parquet-3.8.3-h6d0569a_2.conda
osx-arm64::lammps-2023.11.21-cpu_py39_hb8cc403_mpi_mpich_4.conda
osx-arm64::libgdal-arrow-parquet-3.8.3-h88be5e4_3.conda
osx-arm64::libarrow-14.0.2-hce17ec8_9_cpu.conda
osx-arm64::grpcio-1.61.1-py38hbed3d3f_0.conda
osx-arm64::folly-2024.02.05.00-he914830_0_jemalloc.conda
osx-arm64::nest-simulator-3.6-py310h2df337d_4.conda
osx-arm64::libgdal-3.7.3-h249e391_15.conda
osx-arm64::mysql-connector-odbc-8.3.0-hbeb2e11_0.conda
osx-arm64::sqlite-3.45.1-hf2abe2d_0.conda
osx-arm64::gfortran_impl_osx-arm64-12.3.0-h53ed385_3.conda
osx-arm64::libgdal-arrow-parquet-3.8.3-hb2b4c7c_1.conda
osx-arm64::protozfits-2.4.0-py312h6806c9a_1.conda
osx-arm64::imagemagick-7.1.1_28-pl5321hecdf51d_0.conda
osx-arm64::grpcio-1.60.1-py310hf7687f1_0.conda
osx-arm64::folly-2024.02.05.00-hcdc1028_0_jemalloc.conda
osx-arm64::tiledb-2.20.1-h7f70256_1.conda
osx-arm64::libtiledb-sql-0.27.1-ha40b254_0.conda
osx-arm64::libgoogle-cloud-storage-2.21.0-h8a76758_1.conda
osx-arm64::postgresql-16.2-h1d0603d_0.conda
osx-arm64::python-igraph-0.11.4-py310hae504d7_0.conda
osx-arm64::photochem-0.4.5-py39h513b0d9_1.conda
osx-arm64::photochem-0.4.5-py38hfbbbcb3_1.conda
osx-arm64::jaxlib-0.4.23-cpu_py311hfb01863_0.conda
osx-arm64::prometheus-cpp-1.2.2-hd5cc21f_0.conda
osx-arm64::nest-simulator-3.6-py39h23e55c4_4.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-h5211192_16.conda
osx-arm64::mysql-connector-python-8.2.0-py310h0e9b4e3_4.conda
osx-arm64::python-3.12.2-hdf0ec26_0_cpython.conda
osx-arm64::sagelib-10.2-py311he74d834_4.conda
osx-arm64::cmake-3.28.3-h50fd54c_0.conda
osx-arm64::photochem-0.4.5-py311ha6a61bc_1.conda
osx-arm64::protozfits-2.4.0-py39ha647ab8_0.conda
osx-arm64::folly-2024.02.19.00-h59a6c36_2_jemalloc.conda
osx-arm64::correctionlib-2.4.0-py310hfbac5d6_1.conda
osx-arm64::libarrow-15.0.0-hd462d9b_7_cpu.conda
osx-arm64::postgresql-plpython-16.2-py312h9d9d237_0.conda
osx-arm64::gfortran_impl_osx-64-13.2.0-hc385ae8_3.conda
osx-arm64::libtiledb-sql-0.27.0-hf4080d3_1.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-h813bb4d_15.conda
osx-arm64::pdal-2.6.3-h06576fe_0.conda
osx-arm64::jaxlib-0.4.23-cpu_py311h95f3fdf_0.conda
osx-arm64::libboost-1.84.0-h8e0f962_1.conda
osx-arm64::mysql-server-8.2.0-h7154028_1.conda
osx-arm64::mysql-connector-python-8.2.0-py311hf9d5505_4.conda
osx-arm64::pdal-2.6.2-h06576fe_4.conda
osx-arm64::root_base-6.30.4-py38h24ac074_0.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-h475c03a_15.conda
osx-arm64::lammps-2023.11.21-cpu_py38_h455d21a_nompi_4.conda
osx-arm64::jaxlib-0.4.23-cpu_py310h08fc835_0.conda
osx-arm64::chemicalite-2024.02.1-h038ee98_0.conda
osx-arm64::libgoogle-cloud-storage-2.21.0-h8a76758_0.conda
osx-arm64::folly-2024.02.12.00-he914830_0_jemalloc.conda
osx-arm64::libglib-2.78.4-h1635a5e_0.conda
osx-arm64::mysql-connector-python-8.2.0-py38h628b379_1.conda
osx-arm64::ndcctools-7.8.0-py38hf8267ce_0.conda
osx-arm64::mysql-libs-8.3.0-hf036fc4_2.conda
osx-arm64::libgrpc-1.61.1-hf54c306_0.conda
osx-arm64::libtiledb-sql-0.27.0-ha40b254_1.conda
osx-arm64::jaxlib-0.4.23-cpu_py310h134d535_0.conda
osx-arm64::folly-2024.02.05.00-ha98ecff_0.conda
osx-arm64::folly-2024.02.05.00-h75b8fe2_0.conda
osx-arm64::libgdal-arrow-parquet-3.8.3-h3ba49ef_2.conda
osx-arm64::protozfits-2.4.0-py311h324a6dd_0.conda
osx-arm64::folly-2024.02.19.00-h611ff2f_2.conda
osx-arm64::grpcio-1.59.3-py38hbed3d3f_0.conda
osx-arm64::libtiledb-sql-0.27.1-ha3e379b_1.conda
osx-arm64::libgdal-arrow-parquet-3.8.4-h475c03a_0.conda
osx-arm64::mysql-server-8.2.0-ha98ed9d_0.conda
osx-arm64::jaxlib-0.4.23-cpu_py312hd7baab4_0.conda
osx-arm64::protozfits-2.4.0-py39h0a0d377_1.conda
osx-arm64::correctionlib-2.5.0-py311h746b990_1.conda
osx-arm64::postgresql-plpython-16.2-py38h0b167b4_0.conda
osx-arm64::libgdal-arrow-parquet-3.8.3-h5211192_3.conda
osx-arm64::folly-2024.02.12.00-hcdc1028_0_jemalloc.conda
osx-arm64::mysql-connector-python-8.2.0-py38h628b379_2.conda
osx-arm64::folly-2024.02.19.00-ha8c0bfd_0.conda
osx-arm64::root_base-6.28.12-py310h498b7c9_0.conda
osx-arm64::grpcio-1.61.1-py312h17030e7_0.conda
osx-arm64::postgresql-plpython-16.2-py310h44d1ce9_0.conda
osx-arm64::postgresql-16.2-hc6ab77f_0.conda
osx-arm64::postgresql-plpython-15.6-py310h574c79e_0.conda
osx-arm64::glib-2.78.4-h1059232_0.conda
osx-arm64::postgresql-plpython-16.2-py312hac41b93_0.conda
osx-arm64::cpp-opentelemetry-sdk-1.14.1-h845e006_1.conda
osx-arm64::wxpython-4.2.1-py38h443c9a1_3.conda
osx-arm64::folly-2024.02.19.00-hcdc1028_0_jemalloc.conda
osx-arm64::correctionlib-2.4.0-py311h746b990_0.conda
osx-arm64::yoda-1.9.6-py311h051c466_7.conda
osx-arm64::sdl_image-1.2.12-hf6ccccd_7.conda
osx-arm64::yoda-1.9.6-py311h2efded2_7.conda
osx-arm64::paraview-5.11.2-py38h57ffa2f_102_qt.conda
osx-arm64::lammps-2023.11.21-cpu_py38_hb5f05e6_mpi_mpich_4.conda
osx-arm64::libpq-15.6-hdf44ceb_0.conda
osx-arm64::postgresql-plpython-16.2-py311h1bbf4d3_0.conda
osx-arm64::openimageio-2.5.5.0-py39h980a1b3_1.conda
osx-arm64::ndcctools-7.7.3-py39hec72b60_1.conda
osx-arm64::root_base-6.30.4-py310h498b7c9_0.conda
osx-arm64::tectonic-0.15.0-he52c5f7_0.conda
osx-arm64::libgrpc-1.61.1-h9c2137f_1.conda
osx-arm64::mesalib-24.0.1-hd5bafc3_0.conda
osx-arm64::libgdal-3.7.3-h249e391_16.conda
osx-arm64::nodejs-18.19.0-h5f47a4d_0.conda
osx-arm64::prometheus-cpp-1.2.3-hd5cc21f_0.conda
osx-arm64::libarrow-12.0.1-h0be8b36_38_cpu.conda
osx-arm64::cctools_osx-arm64-973.0.1-h998149b_16.conda
osx-arm64::libarrow-15.0.0-hc29b0e1_3_cpu.conda
osx-arm64::postgresql-plpython-16.2-py310h6edaefd_0.conda
osx-arm64::ldas-tools-framecpp-3.0.3-hc098058_0.conda
osx-arm64::jaxlib-0.4.23-cpu_py312h2f7f50b_0.conda
osx-arm64::mysql-libs-8.2.0-hf036fc4_1.conda
osx-arm64::correctionlib-2.4.0-py39h3003546_1.conda
osx-arm64::grpcio-1.59.3-py311hf5d242d_0.conda
osx-arm64::pyinstaller-6.4.0-py310h742d9d8_0.conda
osx-arm64::llvmlite-0.42.0-py312h17030e7_1.conda
osx-arm64::freeimage-3.18.0-h703098a_19.conda
osx-arm64::libgdal-arrow-parquet-3.8.3-he22b21c_1.conda
osx-arm64::pyinstaller-6.4.0-py39h8643609_0.conda
osx-arm64::grpcio-1.61.1-py310hf7687f1_1.conda
osx-arm64::mysql-connector-python-8.2.0-py312h19c814c_4.conda
osx-arm64::soplex-8.0.0-h20b30fb_0.conda
osx-arm64::grpcio-1.59.3-py310hf7687f1_0.conda
osx-arm64::lammps-2023.11.21-cpu_py311_h1b1bd21_mpi_openmpi_4.conda
osx-arm64::llvmlite-0.42.0-py310hf7687f1_1.conda
osx-arm64::wxpython-4.2.1-py311hddcafca_3.conda
osx-arm64::sagelib-10.2-py310h8c42f95_4.conda
osx-arm64::mysql-libs-8.2.0-hf036fc4_0.conda
osx-arm64::libgdal-arrow-parquet-3.8.3-h7546cc7_3.conda
osx-arm64::openimageio-2.5.5.0-py38h38dd809_1.conda
osx-arm64::root_base-6.28.12-py39h5968530_0.conda
osx-arm64::libopentelemetry-cpp-1.14.0-h9a7c8d0_0.conda
osx-arm64::ovito-3.10.3-haf2e8d7_0.conda
osx-arm64::mysql-server-8.3.0-ha815ee0_2.conda
osx-arm64::grpcio-1.61.1-py312h17030e7_1.conda
osx-arm64::libopencv-4.9.0-py311hc2e992b_8.conda
osx-arm64::grpcio-1.61.1-py310hf7687f1_0.conda
osx-arm64::lammps-2023.11.21-cpu_py311_h0890928_mpi_mpich_4.conda
osx-arm64::libarrow-14.0.2-h4c2354f_10_cpu.conda
osx-arm64::cpp-opentelemetry-sdk-1.14.0-h9a7c8d0_0.conda
osx-arm64::libarrow-12.0.1-h0e0d12a_37_cpu.conda
osx-arm64::ffmpeg-6.1.1-lgpl_ha73f736_4.conda
osx-arm64::ndcctools-7.7.3-py38hf8267ce_1.conda
osx-arm64::folly-2024.02.19.00-ha98ecff_1.conda
osx-arm64::qt6-main-6.6.2-h321c56d_3.conda
osx-arm64::jaxlib-0.4.23-cpu_py39h4651e46_0.conda
osx-arm64::libgrpc-1.59.3-h9560976_0.conda
osx-arm64::tiledb-2.20.0-h49d9ff7_0.conda
osx-arm64::cpp-opentelemetry-sdk-1.14.2-h845e006_0.conda
osx-arm64::cctools_osx-arm64-973.0.1-h62378fb_16.conda
osx-arm64::tiledb-2.20.1-heca79f6_1.conda
osx-arm64::correctionlib-2.5.0-py310hfbac5d6_1.conda
osx-arm64::correctionlib-2.5.0-py39h3003546_1.conda
osx-arm64::libtiledb-sql-0.27.1-hb9f5928_1.conda
osx-arm64::mysql-connector-python-8.2.0-py39h89480e0_2.conda
osx-arm64::python-igraph-0.11.4-py39h4c42df0_0.conda
osx-arm64::libopentelemetry-cpp-1.14.1-h845e006_1.conda
osx-arm64::correctionlib-2.4.0-py39h3003546_0.conda
osx-arm64::lammps-2023.11.21-cpu_py39_h829d90f_mpi_openmpi_4.conda
osx-arm64::sasktran2-2024.02.2-py311h6676678_0.conda
osx-arm64::folly-2024.02.12.00-ha98ecff_0.conda
osx-arm64::scip-9.0.0-he65f4b3_0.conda
osx-arm64::ndcctools-7.7.3-py311ha2834e1_0.conda
osx-arm64::mysql-connector-python-8.2.0-py310haf7edca_2.conda
osx-arm64::libarrow-13.0.0-hdb63349_29_cpu.conda
osx-arm64::ndcctools-7.8.0-py39hec72b60_0.conda
osx-arm64::tiledb-2.20.0-h39064d6_0.conda
osx-arm64::root_base-6.28.12-py311hca8578e_0.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-h3ba49ef_14.conda
osx-arm64::python-igraph-0.11.4-py312h39a0190_0.conda
osx-arm64::gdstk-0.9.50-py38h0fa6a1b_0.conda
osx-arm64::paraview-5.11.2-py39h73d86f4_102_qt.conda
osx-arm64::mysql-connector-python-8.2.0-py310haf7edca_3.conda
osx-arm64::imagemagick-7.1.1_29-pl5321hecdf51d_0.conda
osx-arm64::libarrow-12.0.1-hcb41b44_39_cpu.conda
osx-arm64::tiledb-2.20.0-h7f70256_0.conda
osx-arm64::folly-2024.02.19.00-h584d98d_1_jemalloc.conda
osx-arm64::python-igraph-0.11.4-py38h092055f_0.conda
osx-arm64::grpcio-1.59.3-py312h17030e7_0.conda
osx-arm64::freecad-0.21.2-py39hd081c59_1.conda
osx-arm64::folly-2024.02.26.00-h611ff2f_0.conda
osx-arm64::grpcio-1.60.1-py38hbed3d3f_0.conda
osx-arm64::libgdal-arrow-parquet-3.8.3-h7d4097a_2.conda
osx-arm64::ndcctools-7.8.0-py311ha2834e1_1.conda
osx-arm64::libarrow-13.0.0-h0e0d12a_26_cpu.conda
osx-arm64::ndcctools-7.8.0-py310h7a27ce5_0.conda
osx-arm64::pcre2-static-10.43-h26f9a81_0.conda
osx-arm64::poppler-24.02.0-h896e6cb_0.conda
osx-arm64::gazebo-11.14.0-h816cae4_7.conda
osx-arm64::root_base-6.30.4-py311hca8578e_0.conda
osx-arm64::yoda-1.9.6-py39h655a27a_7.conda
osx-arm64::folly-2024.02.12.00-h584d98d_0_jemalloc.conda
osx-arm64::libgdal-3.8.3-hb4bbca3_2.conda
osx-arm64::openimageio-2.5.5.0-py310h4fc12f9_1.conda
osx-arm64::llvmlite-0.42.0-py311hf5d242d_0.conda
osx-arm64::postgresql-15.6-hf829917_0.conda
osx-arm64::python-3.11.8-hdf0ec26_0_cpython.conda
osx-arm64::folly-2024.02.19.00-h584d98d_0_jemalloc.conda
osx-arm64::orc-1.9.2-h798d188_2.conda
osx-arm64::ndcctools-7.7.3-py311ha2834e1_1.conda
osx-arm64::mysql-connector-python-8.2.0-py310haf7edca_1.conda
osx-arm64::grpcio-1.61.1-py311hf5d242d_0.conda
osx-arm64::correctionlib-2.4.0-py38ha1a7c66_1.conda
osx-arm64::gdstk-0.9.50-py39hb07f281_0.conda
osx-arm64::grpcio-1.61.0-py312h17030e7_0.conda
osx-arm64::magics-metview-batch-4.15.3-h7fea6e7_0.conda
osx-arm64::libarrow-13.0.0-hcb41b44_28_cpu.conda
osx-arm64::mysql-connector-python-8.2.0-py39hc7acf85_0.conda
osx-arm64::aws-sdk-cpp-1.11.242-h022b410_1.conda
osx-arm64::tiledb-2.20.0-h1456d97_0.conda
osx-arm64::libgrpc-1.61.0-hf54c306_0.conda
osx-arm64::grpcio-1.60.1-py312h17030e7_0.conda
osx-arm64::postgresql-plpython-15.6-py311hcdc9149_0.conda
osx-arm64::qt6-main-6.6.2-hd6da969_2.conda
osx-arm64::gdstk-0.9.50-py311h4ecd0fe_0.conda
osx-arm64::pocl-core-5.0-h9ab2a98_2.conda
osx-arm64::pdal-2.6.3-h3c564ca_1.conda
osx-arm64::protozfits-2.4.0-py310h1ef5ab9_0.conda
osx-arm64::tiledb-2.20.1-h1456d97_1.conda
osx-arm64::git-2.44.0-pl5321h015987d_0.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-h5211192_15.conda
osx-arm64::libtiledb-sql-0.27.1-h0353341_1.conda
osx-arm64::libtiledb-sql-0.27.0-hec35b05_1.conda
osx-arm64::wxpython-4.2.1-py310hde93f36_3.conda
osx-arm64::yoda-1.9.6-py39ha08121d_7.conda
osx-arm64::ndcctools-7.7.3-py39hec72b60_0.conda
osx-arm64::zimpl-3.5.4-h1e65763_0.conda
osx-arm64::mysql-connector-python-8.2.0-py311h54fd69b_1.conda
osx-arm64::postgresql-plpython-15.6-py39h01d0bc9_0.conda
osx-arm64::lammps-2023.11.21-cpu_py310_h4786252_mpi_mpich_4.conda
osx-arm64::folly-2024.02.19.00-he914830_0_jemalloc.conda
osx-arm64::libgit2-1.7.2-hfa83a07_1.conda
osx-arm64::libopencv-4.9.0-py39h8b10f08_8.conda
osx-arm64::correctionlib-2.4.0-py310hfbac5d6_0.conda
osx-arm64::gdstk-0.9.50-py312h8ae92b5_0.conda
osx-arm64::qt6-3d-6.6.2-h779fb94_0.conda
osx-arm64::libarrow-12.0.1-hdb63349_40_cpu.conda
osx-arm64::ovito-3.10.2-haf2e8d7_0.conda
osx-arm64::jaxlib-0.4.23-cpu_py310h28d0f57_0.conda
osx-arm64::cargo-c-0.9.30-hdf7d417_0.conda
osx-arm64::mysql-client-8.3.0-hf908a46_2.conda
osx-arm64::libgdal-3.7.3-h635eb66_14.conda
osx-arm64::paraview-5.11.2-py310hc624b27_102_qt.conda
osx-arm64::folly-2024.02.05.00-ha8c0bfd_0.conda
osx-arm64::protozfits-2.4.0-py311hfe4dcd0_1.conda
osx-arm64::postgresql-plpython-15.6-py38hb78573b_0.conda
osx-arm64::hugin-base-2023.0.0-pl5321he3a8293_0.conda
osx-arm64::postgresql-plpython-16.2-py39ha7448c8_0.conda
osx-arm64::libopencv-4.9.0-py312h182e171_8.conda
osx-arm64::libgdal-arrow-parquet-3.8.3-he2e2c97_1.conda
osx-arm64::folly-2024.02.12.00-ha8c0bfd_0.conda
osx-arm64::grpcio-1.61.0-py310hf7687f1_0.conda
osx-arm64::protozfits-2.4.0-py310he9c4a9d_1.conda
osx-arm64::grpcio-1.61.1-py38hbed3d3f_1.conda
osx-arm64::folly-2024.02.05.00-h584d98d_0_jemalloc.conda
osx-arm64::pyinstaller-6.4.0-py311h4045465_0.conda
osx-arm64::libarrow-14.0.2-hf5e4c59_7_cpu.conda
osx-arm64::gfortran_impl_osx-arm64-13.2.0-h252ada1_3.conda
osx-arm64::openimageio-2.5.5.0-py311h6bce30c_1.conda
osx-arm64::mesalib-24.0.2-hd5bafc3_0.conda
osx-arm64::libopentelemetry-cpp-1.14.1-h9a7c8d0_0.conda
osx-arm64::libgrpc-1.60.1-hfc68871_0.conda
osx-arm64::mysql-client-8.2.0-hf908a46_1.conda
osx-arm64::git-2.43.0-pl5321h015987d_1.conda
osx-arm64::libgoogle-cloud-storage-2.21.0-h8a76758_2.conda
osx-arm64::magics-metview-4.15.2-hec748b0_0.conda
osx-arm64::nco-5.2.1-hf4d03cd_0.conda
osx-arm64::mysql-connector-python-8.2.0-py311h54fd69b_3.conda
osx-arm64::lammps-2023.11.21-cpu_py38_h74d7d60_mpi_openmpi_4.conda
osx-arm64::folly-2024.02.26.00-h59a6c36_0_jemalloc.conda
osx-arm64::qt6-main-6.6.2-hd6da969_1.conda
osx-arm64::magics-metview-4.15.3-hec748b0_0.conda
osx-arm64::freecad-0.21.2-py38h52acecf_1.conda
osx-arm64::cctools_osx-64-973.0.1-hfb56cc2_16.conda
osx-arm64::ndcctools-7.8.0-py39hec72b60_1.conda
osx-arm64::ndcctools-7.8.0-py38hf8267ce_1.conda
osx-arm64::grpcio-1.61.0-py39h047a24b_0.conda
osx-arm64::mysql-connector-odbc-8.0.33-hbeb2e11_0.conda
osx-arm64::tiledb-2.20.0-h7f70256_1.conda
osx-arm64::aws-sdk-cpp-1.11.242-hd5252b3_2.conda
osx-arm64::llvmlite-0.42.0-py39h047a24b_0.conda
osx-arm64::libopencv-4.9.0-py310h63e2394_8.conda
osx-arm64::grpcio-1.61.1-py39h047a24b_0.conda
osx-arm64::cctools_osx-64-973.0.1-h4f2729c_16.conda
osx-arm64::ndcctools-7.8.0-py310h7a27ce5_1.conda
osx-arm64::lammps-2023.11.21-cpu_py310_h49200cc_mpi_openmpi_4.conda
osx-arm64::correctionlib-2.4.0-py311h746b990_1.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-h7546cc7_16.conda
osx-arm64::libopentelemetry-cpp-1.14.2-h845e006_0.conda
osx-arm64::grpcio-1.59.3-py39h047a24b_0.conda
osx-arm64::aws-sdk-cpp-1.11.267-hd5252b3_0.conda
osx-arm64::pyinstaller-6.4.0-py312ha17c255_0.conda
osx-arm64::freecad-0.21.2-py310hcbabef8_1.conda
osx-arm64::qt6-main-6.6.2-hd6da969_0.conda
osx-arm64::libgdal-3.8.4-ha86f356_0.conda
osx-arm64::ndcctools-7.7.3-py310h7a27ce5_0.conda
osx-arm64::openimageio-2.5.5.0-py312hb8813bf_1.conda
osx-arm64::libarrow-15.0.0-hf5e4c59_4_cpu.conda
osx-arm64::gfortran_impl_osx-64-12.3.0-he08d67f_3.conda
osx-arm64::grpcio-1.60.1-py311hf5d242d_0.conda
osx-arm64::libarrow-15.0.0-hd4bdf93_5_cpu.conda
osx-arm64::yoda-1.9.6-py310h1e6aeb2_7.conda
osx-arm64::folly-2024.02.19.00-h75b8fe2_0.conda
osx-arm64::qt-main-5.15.8-h6bf1bb6_19.conda
osx-arm64::lammps-2023.11.21-cpu_py311_h3159b45_nompi_4.conda
osx-arm64::folly-2024.02.19.00-ha98ecff_0.conda
osx-arm64::freecad-0.21.2-py311h703f406_1.conda
osx-arm64::libgit2-1.7.2-hfa83a07_2.conda
osx-arm64::mosh-1.4.0-pl5321ha63e738_7.conda
osx-arm64::ffmpeg-6.1.1-gpl_h31ea89b_104.conda
osx-arm64::protozfits-2.4.0-py312ha1b11ba_0.conda
osx-arm64::postgresql-plpython-16.2-py38h355cde2_0.conda
osx-arm64::pyinstaller-6.4.0-py38he974862_0.conda
osx-arm64::grpcio-1.61.0-py38hbed3d3f_0.conda
osx-arm64::photochem-0.4.5-py312h968895c_1.conda
osx-arm64::root_base-6.28.12-py38h24ac074_0.conda
osx-arm64::ndcctools-7.7.3-py38hf8267ce_0.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-h475c03a_16.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-h6d0569a_14.conda
osx-arm64::mysql-connector-python-8.2.0-py310hf3b822e_0.conda
osx-arm64::mysql-connector-python-8.2.0-py312hdc847c7_3.conda
osx-arm64::libarrow-14.0.2-hf5e4c59_6_cpu.conda
osx-arm64::cpp-opentelemetry-sdk-1.14.1-h9a7c8d0_0.conda
osx-arm64::mysql-connector-python-8.2.0-py39h3c61e11_4.conda
osx-arm64::verilator-5.022-h0de0349_0.conda
osx-arm64::mysql-client-8.3.0-hf908a46_1.conda
osx-arm64::nest-simulator-3.6-py38h8074ab1_4.conda
osx-arm64::jaxlib-0.4.23-cpu_py311h6cc994a_0.conda
osx-arm64::libtiledb-sql-0.27.1-hec35b05_0.conda
osx-arm64::glibmm-2.68-2.78.1-hf0590b4_0.conda
osx-arm64::jaxlib-0.4.23-cpu_py312h920971a_0.conda
osx-arm64::correctionlib-2.5.0-py38ha1a7c66_1.conda
osx-arm64::mysql-connector-python-8.2.0-py38h9a65889_4.conda
osx-arm64::mysql-connector-python-8.2.0-py38h85e7f9a_0.conda
osx-arm64::libopencv-4.9.0-py38h1205745_8.conda
osx-arm64::magics-4.15.2-h7fea6e7_0.conda
osx-arm64::sasktran2-2024.02.2-py310hd995aef_0.conda
osx-arm64::nss-3.98-h5ce2875_0.conda
osx-arm64::libxml2-2.12.5-h0d0cfa8_0.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-h10cadd5_14.conda
osx-arm64::llvmlite-0.42.0-py39h047a24b_1.conda
osx-arm64::mysql-client-8.2.0-hf908a46_0.conda
osx-arm64::fish-3.7.0-haafb362_1.conda
osx-arm64::qt6-3d-6.6.2-h779fb94_1.conda
osx-arm64::jaxlib-0.4.23-cpu_py39hcdc4e9d_0.conda
osx-arm64::magics-4.15.3-h7fea6e7_0.conda
osx-arm64::boost-cpp-1.84.0-hca5e981_1.conda
osx-arm64::sasktran2-2024.02.2-py312hb67a6f4_0.conda
osx-arm64::tiledb-2.20.0-h1456d97_1.conda
osx-arm64::libgdal-arrow-parquet-3.8.4-h7546cc7_0.conda
osx-arm64::nco-5.2.0-hf4d03cd_0.conda
osx-arm64::mysql-connector-python-8.2.0-py311h54fd69b_2.conda
osx-arm64::texlive-core-20230313-py310hd70578c_10.conda
osx-arm64::mysql-connector-python-8.2.0-py39h89480e0_3.conda
osx-arm64::mysql-connector-python-8.2.0-py311h6b2e718_0.conda
osx-arm64::yoda-1.9.6-py38h55b04b2_7.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-h7546cc7_15.conda
osx-arm64::postgresql-plpython-15.6-py312h7ba0638_0.conda
osx-arm64::mysql-connector-python-8.2.0-py39h89480e0_1.conda
osx-arm64::libarrow-13.0.0-h0be8b36_27_cpu.conda
osx-arm64::yoda-1.9.6-py38h14519ec_7.conda
osx-arm64::libgdal-arrow-parquet-3.8.3-hb858efb_1.conda
osx-arm64::libgdal-arrow-parquet-3.8.4-h5211192_0.conda
osx-arm64::nest-simulator-3.6-py311h4b2d909_4.conda
osx-arm64::correctionlib-2.4.0-py38ha1a7c66_0.conda
osx-arm64::sagelib-10.2-py39h95a1fc1_4.conda
osx-arm64::llvmlite-0.42.0-py310hf7687f1_0.conda
osx-arm64::yoda-1.9.6-py310ha40e558_7.conda
osx-arm64::ogre-14.2.0-h2297113_0.conda
osx-arm64::root_base-6.30.4-py39h5968530_0.conda
osx-arm64::libgdal-arrow-parquet-3.8.3-h475c03a_3.conda
osx-arm64::postgresql-plpython-16.2-py39h93fcee7_0.conda
osx-arm64::libtiledb-sql-0.27.1-hf4080d3_0.conda
osx-arm64::gst-plugins-good-1.23.1-h0e592f3_0.conda
osx-arm64::lammps-2023.11.21-cpu_py310_h1b23ab0_nompi_4.conda
osx-arm64::libarrow-15.0.0-h4f70cd7_6_cpu.conda
osx-arm64::kaldi-5.5.1112-cpu_h012d200_0.conda
osx-arm64::protozfits-2.4.0-py38hf691a6a_1.conda
osx-arm64::libarrow-14.0.2-h75e90f8_8_cpu.conda
osx-arm64::aws-sdk-cpp-1.11.267-h73c0887_1.conda
osx-arm64::libgdal-3.8.3-h76853cb_1.conda
osx-arm64::magics-metview-batch-4.15.2-h7fea6e7_0.conda
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
osx-arm64::libprotobuf-4.25.1-h810fc01_2.conda
osx-arm64::libsolv-0.7.28-h1059232_0.conda
osx-arm64::exiv2-0.28.2-h193c0af_0.conda
osx-arm64::libuwebsockets-20.59.0-h1059232_0.conda
osx-arm64::ldas-tools-framecpp-2.9.3-haf1138d_1.conda
osx-arm64::libpng-1.6.43-h091b4b1_0.conda
osx-arm64::pcre2-10.43-h26f9a81_0.conda
osx-arm64::libprotobuf-4.25.2-hbfab5d5_1.conda
osx-arm64::openexr-3.2.2-h73dd21e_0.conda
osx-arm64::openjpeg-2.5.2-h9f1df11_0.conda
osx-arm64::git-cliff-2.0.4-h46549a6_0.conda
osx-arm64::eccodes-2.34.0-h64f3314_0.conda
osx-arm64::eccodes-2.34.1-h64f3314_0.conda
osx-arm64::libuwebsockets-20.60.0-h1059232_0.conda
osx-arm64::glib-tools-2.78.4-h1059232_0.conda
osx-arm64::libprotobuf-static-4.25.1-h810fc01_2.conda
osx-arm64::git-cliff-2.0.3-h46549a6_0.conda
osx-arm64::libprotobuf-static-4.25.2-hbfab5d5_1.conda
osx-arm64::imath-3.1.11-h1059232_0.conda
osx-arm64::libsqlite-3.45.1-h091b4b1_0.conda
osx-arm64::cfitsio-4.4.0-h808cd33_0.conda
osx-arm64::gst-plugins-base-1.23.1-h09b4b5e_0.conda
osx-arm64::openjpeg-2.5.1-h9f1df11_0.conda
osx-arm64::gcab-1.6-ha625eb9_0.conda
osx-arm64::libprotobuf-static-4.25.1-h810fc01_1.conda
osx-arm64::libsolv-static-0.7.28-h1059232_0.conda
osx-arm64::libprotobuf-4.25.1-h810fc01_1.conda
osx-arm64::libprotobuf-static-4.25.2-hbfab5d5_0.conda
osx-arm64::ldas-tools-framecpp-2.9.3-haf1138d_0.conda
osx-arm64::libprotobuf-4.25.2-hbfab5d5_0.conda
osx-arm64::libpng-1.6.42-h091b4b1_0.conda
-    "libzlib >=1.2.13,<1.3.0a0"
+    "libzlib >=1.2.13,<2.0.0a0"
================================================================================
================================================================================
linux-aarch64
linux-aarch64::yoda-1.9.6-py310h14d4aea_7.conda
linux-aarch64::libarrow-15.0.0-h1ea4120_3_cpu.conda
linux-aarch64::qt6-main-6.6.2-hee6f1d7_0.conda
linux-aarch64::libarrow-14.0.2-h5281d86_8_cuda.conda
linux-aarch64::postgresql-plpython-16.2-py310h5ecf261_0.conda
linux-aarch64::grpcio-1.61.1-py312hd96c8c9_0.conda
linux-aarch64::mysql-connector-python-8.3.0-py312hd96c8c9_0.conda
linux-aarch64::mysql-connector-python-8.2.0-py38h64bd98a_2.conda
linux-aarch64::qt6-main-6.6.2-hee6f1d7_1.conda
linux-aarch64::mysql-router-8.3.0-h863eda9_2.conda
linux-aarch64::gdb-14.1-py38h2b3f54b_1.conda
linux-aarch64::grpcio-1.61.1-py39h2ec6326_0.conda
linux-aarch64::cpp-opentelemetry-sdk-1.14.0-he75d388_0.conda
linux-aarch64::mysql-server-8.2.0-h5ebf288_0.conda
linux-aarch64::llvmlite-0.42.0-py311h1a7908d_1.conda
linux-aarch64::folly-2024.02.19.00-h8dd4a7f_0_jemalloc.conda
linux-aarch64::libgdal-3.7.3-h64d5f55_15.conda
linux-aarch64::poppler-24.02.0-h3cd87ed_0.conda
linux-aarch64::mysql-server-8.2.0-h184738f_1.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-h7de54d5_14.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-he39ecf7_14.conda
linux-aarch64::libgdal-3.8.4-h79c3f81_0.conda
linux-aarch64::prometheus-cpp-1.2.3-hba22eae_0.conda
linux-aarch64::yoda-1.9.6-py38hb838e32_7.conda
linux-aarch64::mysql-connector-python-8.3.0-py311h1a7908d_0.conda
linux-aarch64::grpcio-1.61.0-py39h483cef1_0.conda
linux-aarch64::libarrow-14.0.2-h25d962f_10_cuda.conda
linux-aarch64::python-igraph-0.11.4-py311h704f91b_0.conda
linux-aarch64::elfutils-0.190-h48015c3_1.conda
linux-aarch64::libgoogle-cloud-storage-2.21.0-hdb39181_2.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-heb82e3f_16.conda
linux-aarch64::cpp-opentelemetry-sdk-1.14.1-he2cb375_1.conda
linux-aarch64::yoda-1.9.6-py38h0ab97ab_7.conda
linux-aarch64::mosh-1.4.0-pl5321h39f48f8_7.conda
linux-aarch64::openimageio-2.5.5.0-py310h3be1484_1.conda
linux-aarch64::grpcio-1.61.0-py39h2ec6326_0.conda
linux-aarch64::libarrow-12.0.1-h15be74b_39_cpu.conda
linux-aarch64::gdb-14.1-py310hd9843ee_0.conda
linux-aarch64::libspral-2024.01.18-h98a5362_0.conda
linux-aarch64::boost-cpp-1.84.0-ha990451_1.conda
linux-aarch64::cpp-opentelemetry-sdk-1.14.1-he75d388_0.conda
linux-aarch64::qt6-main-6.6.2-hee6f1d7_2.conda
linux-aarch64::libgit2-1.7.2-h0e3f3ab_0.conda
linux-aarch64::gdb-14.1-py39h7517b90_1.conda
linux-aarch64::libgdal-arrow-parquet-3.8.3-h0ee8fc8_3.conda
linux-aarch64::libgdal-3.8.3-h4c8926b_2.conda
linux-aarch64::jaxlib-0.4.23-cpu_py310h3e4fee0_0.conda
linux-aarch64::pdal-2.6.3-h0e3fb3b_1.conda
linux-aarch64::libgdal-arrow-parquet-3.8.4-h1096846_0.conda
linux-aarch64::libarrow-12.0.1-hfbd3bf7_38_cpu.conda
linux-aarch64::cmake-3.28.3-hef020d8_0.conda
linux-aarch64::libopencv-4.9.0-py38h64fa409_8.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-h4321476_14.conda
linux-aarch64::python-3.11.8-h43d1f9e_0_cpython.conda
linux-aarch64::grpcio-1.61.0-py38h95a9722_0.conda
linux-aarch64::llvmlite-0.42.0-py39h2ec6326_0.conda
linux-aarch64::libopentelemetry-cpp-1.14.1-he75d388_0.conda
linux-aarch64::mysql-connector-python-8.2.0-py310hfaf3312_3.conda
linux-aarch64::libarrow-15.0.0-h606a0d5_4_cpu.conda
linux-aarch64::texlive-core-20230313-h53b60a4_10.conda
linux-aarch64::mesalib-24.0.0-h9a8754c_0.conda
linux-aarch64::folly-2024.02.19.00-h8a1e4c1_0_jemalloc.conda
linux-aarch64::python-igraph-0.11.4-py38hbb79c39_0.conda
linux-aarch64::qt6-3d-6.6.2-h9d35714_1.conda
linux-aarch64::sagelib-10.2-py39h0db02ac_4.conda
linux-aarch64::folly-2024.02.19.00-hcdf9fb0_1.conda
linux-aarch64::libgrpc-1.60.1-heeb7df3_0.conda
linux-aarch64::grpcio-1.61.0-py311h1a7908d_0.conda
linux-aarch64::jaxlib-0.4.23-cpu_py311hccaee7e_0.conda
linux-aarch64::libarrow-14.0.2-hdc5933b_10_cpu.conda
linux-aarch64::folly-2024.02.26.00-hcba86c1_0_jemalloc.conda
linux-aarch64::freecad-0.21.2-py39h474977f_1.conda
linux-aarch64::mysql-connector-python-8.2.0-py39h8e05081_1.conda
linux-aarch64::libarrow-13.0.0-h48579e3_29_cuda.conda
linux-aarch64::libarrow-14.0.2-h7f502e5_6_cuda.conda
linux-aarch64::squashfuse-0.5.2-h24ece89_0.conda
linux-aarch64::yoda-1.9.6-py310hae8538c_7.conda
linux-aarch64::grpcio-1.61.1-py312hd96c8c9_1.conda
linux-aarch64::ogre-14.2.0-he860dd8_0.conda
linux-aarch64::libgdal-arrow-parquet-3.8.3-haece04f_2.conda
linux-aarch64::libopencv-4.9.0-py311he71d442_8.conda
linux-aarch64::r-base-4.3.3-h7dc8e12_0.conda
linux-aarch64::git-2.44.0-pl5321he5f4d6e_0.conda
linux-aarch64::mysql-connector-python-8.2.0-py38h64bd98a_1.conda
linux-aarch64::mysql-connector-python-8.2.0-py39h53392d3_4.conda
linux-aarch64::aws-sdk-cpp-1.11.242-he17354f_2.conda
linux-aarch64::pdal-2.6.3-h0e3fb3b_2.conda
linux-aarch64::llvmlite-0.42.0-py310h20b6881_1.conda
linux-aarch64::libgdal-arrow-parquet-3.8.4-h0b51c4b_0.conda
linux-aarch64::folly-2024.02.12.00-hcbc1ef6_0.conda
linux-aarch64::root_base-6.28.12-py310h805b46d_0.conda
linux-aarch64::postgresql-plpython-16.2-py39hadb01dc_0.conda
linux-aarch64::mysql-connector-python-8.2.0-py311hd75a881_3.conda
linux-aarch64::grpcio-1.60.1-py38h95a9722_0.conda
linux-aarch64::libxml2-2.12.5-h3091e33_0.conda
linux-aarch64::postgresql-plpython-16.2-py311hc2b6b49_0.conda
linux-aarch64::pdal-2.6.2-h92b2622_4.conda
linux-aarch64::correctionlib-2.5.0-py312h17f8acd_1.conda
linux-aarch64::qt6-wayland-6.6.2-hb5dcbe4_1.conda
linux-aarch64::mysql-libs-8.2.0-hf629957_0.conda
linux-aarch64::tiledb-2.20.0-h5d659e3_1.conda
linux-aarch64::folly-2024.02.19.00-hcbc1ef6_0.conda
linux-aarch64::clangdev-13.0.1-root_63004_hc2ea517_6.conda
linux-aarch64::tiledb-2.20.1-h5d659e3_1.conda
linux-aarch64::llvmlite-0.42.0-py311h1a7908d_0.conda
linux-aarch64::python-igraph-0.11.4-py39h71eae25_0.conda
linux-aarch64::libarrow-12.0.1-h48579e3_40_cuda.conda
linux-aarch64::tiledb-2.20.0-hf61e980_0.conda
linux-aarch64::mysql-connector-python-8.2.0-py311h723c9f8_4.conda
linux-aarch64::ldas-tools-framecpp-2.9.3-h2906c2a_0.conda
linux-aarch64::folly-2024.02.05.00-h8dd4a7f_0_jemalloc.conda
linux-aarch64::qt6-3d-6.6.2-h9d35714_0.conda
linux-aarch64::correctionlib-2.4.0-py38h68f7483_1.conda
linux-aarch64::libgdal-arrow-parquet-3.8.3-h801b28d_1.conda
linux-aarch64::libgrpc-1.61.1-h69280e2_0.conda
linux-aarch64::libgdal-3.7.3-h54adebc_14.conda
linux-aarch64::libgdal-arrow-parquet-3.8.3-h0b51c4b_3.conda
linux-aarch64::llvmlite-0.42.0-py39h483cef1_0.conda
linux-aarch64::freecad-0.21.2-py311h112c160_1.conda
linux-aarch64::yoda-1.9.6-py39h5e4b2ea_7.conda
linux-aarch64::jaxlib-0.4.23-cpu_py39h428b8f9_0.conda
linux-aarch64::postgresql-plpython-16.2-py312hc43be6c_0.conda
linux-aarch64::jaxlib-0.4.23-cpu_py311h26ea12b_0.conda
linux-aarch64::mesalib-24.0.2-h9a8754c_0.conda
linux-aarch64::libgdal-arrow-parquet-3.8.4-h0ee8fc8_0.conda
linux-aarch64::nco-5.2.1-h1cece5e_0.conda
linux-aarch64::root_base-6.30.4-py39hef8aca2_0.conda
linux-aarch64::gdb-14.1-py311h4fa0569_0.conda
linux-aarch64::correctionlib-2.5.0-py39h23417e7_1.conda
linux-aarch64::pyinstaller-6.4.0-py39hb91f966_0.conda
linux-aarch64::tiledb-2.20.0-h6acf51b_0.conda
linux-aarch64::tiledb-2.20.0-h2d7fb0a_1.conda
linux-aarch64::mysql-connector-python-8.2.0-py38h25be17d_4.conda
linux-aarch64::postgresql-plpython-15.6-py310hd4fca6a_0.conda
linux-aarch64::libarrow-14.0.2-hca0e038_9_cpu.conda
linux-aarch64::libarrow-15.0.0-hdc5933b_7_cpu.conda
linux-aarch64::libgoogle-cloud-storage-2.21.0-hdb39181_0.conda
linux-aarch64::folly-2024.02.12.00-h8a1e4c1_0_jemalloc.conda
linux-aarch64::libopentelemetry-cpp-1.14.1-he2cb375_1.conda
linux-aarch64::aws-sdk-cpp-1.11.242-haa9e8f5_1.conda
linux-aarch64::postgresql-plpython-15.6-py311h1448d06_0.conda
linux-aarch64::grpcio-1.61.1-py39h2ec6326_1.conda
linux-aarch64::mysql-connector-python-8.3.0-py39h2ec6326_0.conda
linux-aarch64::correctionlib-2.5.0-py310h88818a3_1.conda
linux-aarch64::correctionlib-2.4.0-py310h88818a3_1.conda
linux-aarch64::folly-2024.02.19.00-hcba86c1_2_jemalloc.conda
linux-aarch64::correctionlib-2.4.0-py39h23417e7_0.conda
linux-aarch64::grpcio-1.61.1-py310h20b6881_1.conda
linux-aarch64::folly-2024.02.19.00-hb8ddcfe_0_jemalloc.conda
linux-aarch64::mysql-connector-python-8.2.0-py39h2a1d91c_3.conda
linux-aarch64::libpq-15.6-h1a766d2_0.conda
linux-aarch64::freeimage-3.18.0-h237be09_19.conda
linux-aarch64::libgdal-3.8.3-hbec6d97_1.conda
linux-aarch64::libarrow-13.0.0-hcc06fae_29_cpu.conda
linux-aarch64::mysql-connector-python-8.2.0-py311h74a6fea_0.conda
linux-aarch64::libtiledb-sql-0.27.0-h00e3d98_1.conda
linux-aarch64::mysql-server-8.3.0-h184738f_1.conda
linux-aarch64::tiledb-2.20.0-h5d659e3_0.conda
linux-aarch64::cargo-c-0.9.30-h6a45645_0.conda
linux-aarch64::mysql-connector-python-8.2.0-py312h4e0aa4d_3.conda
linux-aarch64::libgdal-arrow-parquet-3.8.3-heb82e3f_3.conda
linux-aarch64::yoda-1.9.6-py39hd58b29f_7.conda
linux-aarch64::postgresql-plpython-15.6-py39h430b2eb_0.conda
linux-aarch64::grpcio-1.60.1-py312hd96c8c9_0.conda
linux-aarch64::correctionlib-2.4.0-py38h68f7483_0.conda
linux-aarch64::pyinstaller-6.4.0-py312h16ba8cc_0.conda
linux-aarch64::postgresql-15.6-h841b8aa_0.conda
linux-aarch64::grpcio-1.61.0-py310h20b6881_0.conda
linux-aarch64::libarrow-15.0.0-hae59cde_6_cuda.conda
linux-aarch64::libarrow-12.0.1-h03b846e_39_cuda.conda
linux-aarch64::mysql-connector-odbc-8.0.33-hd84c7bf_0.conda
linux-aarch64::llvmlite-0.42.0-py312hd96c8c9_1.conda
linux-aarch64::nss-3.98-hc5a5cc2_0.conda
linux-aarch64::libarrow-13.0.0-hddbbd58_27_cuda.conda
linux-aarch64::python-3.12.2-h43d1f9e_0_cpython.conda
linux-aarch64::mysql-connector-python-8.2.0-py39h2a1d91c_2.conda
linux-aarch64::mysql-client-8.2.0-h88b4a5d_1.conda
linux-aarch64::mysql-connector-python-8.2.0-py39hd8adca8_4.conda
linux-aarch64::grpcio-1.61.1-py311h1a7908d_1.conda
linux-aarch64::postgresql-16.2-he3d1b8e_0.conda
linux-aarch64::mysql-libs-8.3.0-hf629957_1.conda
linux-aarch64::git-2.43.0-pl5321he5f4d6e_1.conda
linux-aarch64::folly-2024.02.12.00-h8dd4a7f_0_jemalloc.conda
linux-aarch64::mysql-connector-python-8.3.0-py38h95a9722_0.conda
linux-aarch64::libgdal-arrow-parquet-3.8.3-h40982f3_1.conda
linux-aarch64::sagelib-10.2-py310ha9e3067_4.conda
linux-aarch64::mysql-client-8.3.0-h88b4a5d_1.conda
linux-aarch64::libgdal-arrow-parquet-3.8.4-heb82e3f_0.conda
linux-aarch64::yoda-1.9.6-py311hf0f485a_7.conda
linux-aarch64::jaxlib-0.4.23-cpu_py39hcb6b853_0.conda
linux-aarch64::gdb-14.1-py311ha6c8fc5_1.conda
linux-aarch64::libarrow-13.0.0-ha7524ee_26_cpu.conda
linux-aarch64::libopentelemetry-cpp-1.14.2-he2cb375_0.conda
linux-aarch64::ldas-tools-framecpp-3.0.3-hab2f7a7_0.conda
linux-aarch64::libarrow-13.0.0-he46a8e9_26_cuda.conda
linux-aarch64::libgdal-arrow-parquet-3.8.3-hb715082_1.conda
linux-aarch64::libgdal-arrow-parquet-3.8.3-h1096846_3.conda
linux-aarch64::postgresql-plpython-16.2-py310h840c280_0.conda
linux-aarch64::jaxlib-0.4.23-cpu_py312h3386078_0.conda
linux-aarch64::libboost-1.84.0-h1fed05a_1.conda
linux-aarch64::mysql-connector-odbc-8.3.0-hd84c7bf_0.conda
linux-aarch64::libvips-8.15.1-hb7a52a8_2.conda
linux-aarch64::yoda-1.9.6-py311h0b8019c_7.conda
linux-aarch64::postgresql-plpython-15.6-py312ha9bbecc_0.conda
linux-aarch64::mysql-connector-python-8.3.0-py310h20b6881_0.conda
linux-aarch64::grpcio-1.61.1-py39h483cef1_0.conda
linux-aarch64::libopentelemetry-cpp-1.14.0-he75d388_0.conda
linux-aarch64::libarrow-12.0.1-hddbbd58_38_cuda.conda
linux-aarch64::mysql-connector-python-8.2.0-py39h8e05081_3.conda
linux-aarch64::libarrow-12.0.1-he46a8e9_37_cuda.conda
linux-aarch64::gdb-14.1-py310h30ec16e_1.conda
linux-aarch64::libgit2-1.7.2-h7abf3dc_1.conda
linux-aarch64::mysql-client-8.3.0-h88b4a5d_2.conda
linux-aarch64::libarrow-15.0.0-h5281d86_5_cuda.conda
linux-aarch64::llvmlite-0.42.0-py310h20b6881_0.conda
linux-aarch64::libarrow-12.0.1-ha7524ee_37_cpu.conda
linux-aarch64::folly-2024.02.05.00-hcbc1ef6_0.conda
linux-aarch64::grpcio-1.60.1-py311h1a7908d_0.conda
linux-aarch64::jaxlib-0.4.23-cpu_py310hc9ab186_0.conda
linux-aarch64::magic-8.3.462-h4e13689_0.conda
linux-aarch64::mysql-connector-python-8.2.0-py39h3af1173_0.conda
linux-aarch64::folly-2024.02.05.00-hb8ddcfe_0_jemalloc.conda
linux-aarch64::pyinstaller-6.4.0-py38h37f3631_0.conda
linux-aarch64::libgrpc-1.61.1-hf163b96_1.conda
linux-aarch64::folly-2024.02.12.00-hf875f9a_0.conda
linux-aarch64::folly-2024.02.12.00-hb8ddcfe_0_jemalloc.conda
linux-aarch64::root_base-6.30.4-py310h805b46d_0.conda
linux-aarch64::grpcio-1.61.1-py310h20b6881_0.conda
linux-aarch64::mesalib-24.0.1-h9a8754c_0.conda
linux-aarch64::libarrow-14.0.2-h606a0d5_6_cpu.conda
linux-aarch64::python-igraph-0.11.4-py310h9c02e51_0.conda
linux-aarch64::openimageio-2.5.5.0-py38h863afa6_1.conda
linux-aarch64::correctionlib-2.4.0-py311hfd6ae59_1.conda
linux-aarch64::prometheus-cpp-1.2.2-hba22eae_0.conda
linux-aarch64::tiledb-2.20.1-h13462af_1.conda
linux-aarch64::pdal-2.6.3-h92b2622_0.conda
linux-aarch64::mysql-connector-python-8.2.0-py39hdace5af_0.conda
linux-aarch64::libarrow-15.0.0-h7600164_3_cuda.conda
linux-aarch64::folly-2024.02.19.00-hcdf9fb0_0.conda
linux-aarch64::libgit2-1.7.2-h7abf3dc_2.conda
linux-aarch64::rust-1.76.0-h9d3d833_0.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-h1096846_16.conda
linux-aarch64::orc-1.9.2-h0b612ef_2.conda
linux-aarch64::libgdal-3.8.3-h79c3f81_3.conda
linux-aarch64::postgresql-plpython-16.2-py311h765025c_0.conda
linux-aarch64::mysql-router-8.3.0-hc287d43_1.conda
linux-aarch64::grpcio-1.61.1-py38h95a9722_0.conda
linux-aarch64::folly-2024.02.19.00-h8dd4a7f_1_jemalloc.conda
linux-aarch64::grpcio-1.61.1-py39h483cef1_1.conda
linux-aarch64::mysql-connector-python-8.2.0-py311hd75a881_1.conda
linux-aarch64::grpcio-1.60.1-py39h2ec6326_0.conda
linux-aarch64::mysql-libs-8.2.0-hf629957_1.conda
linux-aarch64::llvmlite-0.42.0-py39h483cef1_1.conda
linux-aarch64::libarrow-14.0.2-h7f502e5_7_cuda.conda
linux-aarch64::mysql-libs-8.3.0-hf629957_2.conda
linux-aarch64::mysql-connector-odbc-8.2.0-hd84c7bf_0.conda
linux-aarch64::correctionlib-2.5.0-py311hfd6ae59_1.conda
linux-aarch64::mysql-connector-python-8.2.0-py38h074e3a4_0.conda
linux-aarch64::mysql-connector-python-8.2.0-py310h49cef61_0.conda
linux-aarch64::libtiledb-sql-0.27.0-hd3e7fb2_1.conda
linux-aarch64::gst-plugins-base-1.23.1-h6d82d15_0.conda
linux-aarch64::cpp-opentelemetry-sdk-1.14.2-he2cb375_0.conda
linux-aarch64::libarrow-13.0.0-h03b846e_28_cuda.conda
linux-aarch64::correctionlib-2.5.0-py38h68f7483_1.conda
linux-aarch64::folly-2024.02.05.00-hf875f9a_0.conda
linux-aarch64::freecad-0.21.2-py38h7278bdd_1.conda
linux-aarch64::libarrow-13.0.0-hfbd3bf7_27_cpu.conda
linux-aarch64::correctionlib-2.4.0-py312h17f8acd_1.conda
linux-aarch64::gdb-14.1-py38h4d214e7_0.conda
linux-aarch64::gst-plugins-good-1.23.1-h16f724d_0.conda
linux-aarch64::libopencv-4.9.0-py312h3fb0399_8.conda
linux-aarch64::folly-2024.02.12.00-hcdf9fb0_0.conda
linux-aarch64::postgresql-16.2-he703394_0.conda
linux-aarch64::pyinstaller-6.4.0-py310h1aab166_0.conda
linux-aarch64::nodejs-18.19.0-hc1f8a26_0.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-heb82e3f_15.conda
linux-aarch64::folly-2024.02.19.00-h9f1c85f_2.conda
linux-aarch64::mysql-router-8.2.0-hc287d43_1.conda
linux-aarch64::glib-2.78.4-hd84c7bf_0.conda
linux-aarch64::libarrow-13.0.0-h15be74b_28_cpu.conda
linux-aarch64::mysql-connector-python-8.2.0-py38h64bd98a_3.conda
linux-aarch64::libarrow-15.0.0-hca0e038_6_cpu.conda
linux-aarch64::qt6-wayland-6.6.2-hb5dcbe4_0.conda
linux-aarch64::correctionlib-2.4.0-py311hfd6ae59_0.conda
linux-aarch64::libgoogle-cloud-storage-2.21.0-hdb39181_1.conda
linux-aarch64::mysql-connector-python-8.2.0-py312h36d963c_4.conda
linux-aarch64::gdb-14.1-py312ha8ef5a0_1.conda
linux-aarch64::folly-2024.02.05.00-hcdf9fb0_0.conda
linux-aarch64::postgresql-plpython-15.6-py38h19c6b48_0.conda
linux-aarch64::jaxlib-0.4.23-cpu_py312h5344b68_0.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-h0b51c4b_16.conda
linux-aarch64::libtiledb-sql-0.27.0-h2f8fe2f_1.conda
linux-aarch64::ldas-tools-framecpp-2.9.3-h2906c2a_1.conda
linux-aarch64::libopencv-4.9.0-py39he9983ff_8.conda
linux-aarch64::postgresql-plpython-16.2-py39he33817a_0.conda
linux-aarch64::libopencv-4.9.0-py310h38a5948_8.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-h0ee8fc8_15.conda
linux-aarch64::libgdal-3.7.3-h64d5f55_16.conda
linux-aarch64::python-igraph-0.11.4-py39h3ba7c66_0.conda
linux-aarch64::mysql-client-8.2.0-h88b4a5d_0.conda
linux-aarch64::sqlite-3.45.1-h3b3482f_0.conda
linux-aarch64::libgdal-arrow-parquet-3.8.3-he39ecf7_2.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-h7ec424c_14.conda
linux-aarch64::ogre-14.2.0-ha44472d_0.conda
linux-aarch64::grpcio-1.61.1-py311h1a7908d_0.conda
linux-aarch64::libglib-2.78.4-h311d5f7_0.conda
linux-aarch64::libarrow-14.0.2-h606a0d5_7_cpu.conda
linux-aarch64::jaxlib-0.4.23-cpu_py311h03b349b_0.conda
linux-aarch64::libarrow-14.0.2-hae59cde_9_cuda.conda
linux-aarch64::correctionlib-2.4.0-py39h23417e7_1.conda
linux-aarch64::openimageio-2.5.5.0-py311h9db3b34_1.conda
linux-aarch64::sdl_image-1.2.12-h4987065_7.conda
linux-aarch64::imagemagick-7.1.1_29-pl5321h1c444f2_0.conda
linux-aarch64::clangdev-13.0.1-default_hdf9a116_6.conda
linux-aarch64::postgresql-plpython-16.2-py38hf7f31c5_0.conda
linux-aarch64::tiledb-2.20.0-h2d7fb0a_0.conda
linux-aarch64::tectonic-0.15.0-h79ba523_0.conda
linux-aarch64::jaxlib-0.4.23-cpu_py39hbaee456_0.conda
linux-aarch64::libgdal-arrow-parquet-3.8.3-h7de54d5_2.conda
linux-aarch64::aws-sdk-cpp-1.11.267-he17354f_0.conda
linux-aarch64::libarrow-15.0.0-h9feaf6d_5_cpu.conda
linux-aarch64::ffmpeg-6.1.1-lgpl_h498cb94_4.conda
linux-aarch64::freecad-0.21.2-py310he4739b2_1.conda
linux-aarch64::imagemagick-7.1.1_28-pl5321h1c444f2_0.conda
linux-aarch64::grpcio-1.60.1-py39h483cef1_0.conda
linux-aarch64::qt6-main-6.6.2-hee6f1d7_3.conda
linux-aarch64::grpcio-1.61.0-py312hd96c8c9_0.conda
linux-aarch64::root_base-6.28.12-py311h8158f40_0.conda
linux-aarch64::gdb-14.1-py39hf7f8583_0.conda
linux-aarch64::folly-2024.02.05.00-h8a1e4c1_0_jemalloc.conda
linux-aarch64::jaxlib-0.4.23-cpu_py310hb30cb30_0.conda
linux-aarch64::qt6-wayland-6.6.2-h06b39ba_0.conda
linux-aarch64::pcre2-static-10.43-hd0f9c67_0.conda
linux-aarch64::libopencv-4.9.0-py39h17f4bbb_8.conda
linux-aarch64::libarrow-15.0.0-h7f502e5_4_cuda.conda
linux-aarch64::grpcio-1.61.1-py38h95a9722_1.conda
linux-aarch64::mysql-connector-python-8.2.0-py39h2a1d91c_1.conda
linux-aarch64::aws-sdk-cpp-1.11.267-hfce6cab_1.conda
linux-aarch64::folly-2024.02.19.00-hf875f9a_0.conda
linux-aarch64::libarrow-14.0.2-h9feaf6d_8_cpu.conda
linux-aarch64::grpcio-1.60.1-py310h20b6881_0.conda
linux-aarch64::mysql-server-8.3.0-hac5c46b_2.conda
linux-aarch64::valgrind-3.22.0-h966f666_1.conda
linux-aarch64::libarrow-12.0.1-hcc06fae_40_cpu.conda
linux-aarch64::python-igraph-0.11.4-py312ha886c06_0.conda
linux-aarch64::root_base-6.28.12-py38hc352f86_0.conda
linux-aarch64::libgrpc-1.61.0-h69280e2_0.conda
linux-aarch64::openimageio-2.5.5.0-py39ha94bd05_1.conda
linux-aarch64::folly-2024.02.26.00-h9f1c85f_0.conda
linux-aarch64::mysql-router-8.2.0-hfa5de57_0.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-haf9e9b0_15.conda
linux-aarch64::openimageio-2.5.5.0-py312hfaf23d4_1.conda
linux-aarch64::postgresql-plpython-16.2-py38hc50c26b_0.conda
linux-aarch64::libpulsar-3.4.2-h13e5eec_2.conda
linux-aarch64::magic-8.3.463-h4e13689_0.conda
linux-aarch64::ffmpeg-6.1.1-gpl_hd8c5532_104.conda
linux-aarch64::mysql-connector-python-8.2.0-py310hd791ce2_4.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-h0ee8fc8_16.conda
linux-aarch64::nco-5.2.0-h1cece5e_0.conda
linux-aarch64::fish-3.7.0-ha2d8f12_1.conda
linux-aarch64::libarrow-15.0.0-h25d962f_7_cuda.conda
linux-aarch64::llvmlite-0.42.0-py39h2ec6326_1.conda
linux-aarch64::correctionlib-2.4.0-py310h88818a3_0.conda
linux-aarch64::libgdal-arrow-parquet-3.8.3-h1f4d587_1.conda
linux-aarch64::root_base-6.30.4-py38hc352f86_0.conda
linux-aarch64::root_base-6.30.4-py311h8158f40_0.conda
linux-aarch64::libgdal-arrow-parquet-3.8.3-h4321476_2.conda
linux-aarch64::mysql-connector-python-8.2.0-py310hfaf3312_1.conda
linux-aarch64::jaxlib-0.4.23-cpu_py312h19cc8db_0.conda
linux-aarch64::tiledb-2.20.1-h2d7fb0a_1.conda
linux-aarch64::mysql-connector-python-8.3.0-py39h483cef1_0.conda
linux-aarch64::root_base-6.28.12-py39hef8aca2_0.conda
linux-aarch64::pyinstaller-6.4.0-py311h0dd4530_0.conda
linux-aarch64::glibmm-2.68-2.78.1-h6dbd646_0.conda
linux-aarch64::sagelib-10.2-py311h5df1c82_4.conda
linux-aarch64::postgresql-plpython-16.2-py312h75118c5_0.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-h0b51c4b_15.conda
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
linux-aarch64::libclang-cpp13-13.0.1-root_63004_hc2ea517_6.conda
linux-aarch64::libsqlite-3.45.1-h194ca79_0.conda
linux-aarch64::libprotobuf-static-4.25.2-h648ac29_1.conda
linux-aarch64::gcab-1.6-hcf730d6_0.conda
linux-aarch64::libprotobuf-static-4.25.1-h87e877f_1.conda
linux-aarch64::libclang-cpp-13.0.1-root_63004_hc2ea517_6.conda
linux-aarch64::libclang-13.0.1-root_63004_hc2ea517_6.conda
linux-aarch64::cfitsio-4.4.0-hf28c5f1_0.conda
linux-aarch64::git-cliff-2.0.3-h4daaf6c_0.conda
linux-aarch64::libsolv-static-0.7.28-hd84c7bf_0.conda
linux-aarch64::libpng-1.6.42-h194ca79_0.conda
linux-aarch64::openexr-3.2.2-h294c868_0.conda
linux-aarch64::clang-format-13-13.0.1-root_63004_hc2ea517_6.conda
linux-aarch64::pcre2-10.43-hd0f9c67_0.conda
linux-aarch64::libpng-1.6.43-h194ca79_0.conda
linux-aarch64::libprotobuf-static-4.25.1-h87e877f_2.conda
linux-aarch64::eccodes-2.34.0-hb180dc1_0.conda
linux-aarch64::clang-format-13.0.1-root_63004_hc2ea517_6.conda
linux-aarch64::libclang-cpp13-13.0.1-default_hdf9a116_6.conda
linux-aarch64::clang-format-13.0.1-default_hdf9a116_6.conda
linux-aarch64::clang-tools-13.0.1-root_63004_hc2ea517_6.conda
linux-aarch64::clang-format-13-13.0.1-default_hdf9a116_6.conda
linux-aarch64::clang-tools-13.0.1-default_hdf9a116_6.conda
linux-aarch64::libprotobuf-4.25.2-h648ac29_0.conda
linux-aarch64::git-cliff-2.0.4-h4daaf6c_0.conda
linux-aarch64::openjpeg-2.5.2-h0d9d63b_0.conda
linux-aarch64::glib-tools-2.78.4-hd84c7bf_0.conda
linux-aarch64::clang-13-13.0.1-root_63004_hc2ea517_6.conda
linux-aarch64::openjpeg-2.5.1-h0d9d63b_0.conda
linux-aarch64::libprotobuf-static-4.25.2-h648ac29_0.conda
linux-aarch64::eccodes-2.34.1-hb180dc1_0.conda
linux-aarch64::imath-3.1.11-hd84c7bf_0.conda
linux-aarch64::libprotobuf-4.25.1-h87e877f_1.conda
linux-aarch64::clang-13-13.0.1-default_hdf9a116_6.conda
linux-aarch64::exiv2-0.28.2-h02033e9_0.conda
linux-aarch64::libprotobuf-4.25.2-h648ac29_1.conda
linux-aarch64::libclang-cpp-13.0.1-default_hdf9a116_6.conda
linux-aarch64::libsolv-0.7.28-hd84c7bf_0.conda
linux-aarch64::libclang-13.0.1-default_hdf9a116_6.conda
linux-aarch64::libprotobuf-4.25.1-h87e877f_2.conda
-    "libzlib >=1.2.13,<1.3.0a0"
+    "libzlib >=1.2.13,<2.0.0a0"
================================================================================
================================================================================
noarch
================================================================================
================================================================================
win-64
win-64::postgresql-plpython-16.2-py38h4aa54d8_0.conda
win-64::libgdal-arrow-parquet-3.8.3-h49fa16d_2.conda
win-64::freecad-0.21.2-py310hcbc28db_1.conda
win-64::correctionlib-2.4.0-py38h98a829e_0.conda
win-64::mysql-connector-python-8.2.0-py39hda5e05d_0.conda
win-64::mysql-server-8.3.0-h81ad02e_1.conda
win-64::pdal-2.6.3-h42184c4_0.conda
win-64::mysql-connector-python-8.2.0-py39h563d2cf_3.conda
win-64::libarrow-gandiva-14.0.2-h2bad095_8_cuda.conda
win-64::ffmpeg-6.1.1-lgpl_h919ce7c_4.conda
win-64::libgdal-arrow-parquet-3.8.3-h845fcc4_2.conda
win-64::sasktran2-2024.02.2-py311hd237099_0.conda
win-64::stir-6.0.0-cuda112_py311h1bd1eb7_200.conda
win-64::grpcio-1.60.1-py310hb84602e_0.conda
win-64::baumwelch-0.3.8-h1c255cb_1.conda
win-64::libclang-cpp-16.0.6-default_h3a3e6c3_5.conda
win-64::libgdal-arrow-parquet-3.8.3-h60c25c2_1.conda
win-64::correctionlib-2.5.0-py311hd32ce59_1.conda
win-64::postgresql-plpython-16.2-py310h4609481_0.conda
win-64::libarrow-gandiva-14.0.2-h2bad095_9_cpu.conda
win-64::libignition-fuel-tools4-4.6.0-hf747aff_7.conda
win-64::openjpeg-2.5.1-h3d672ee_0.conda
win-64::mysql-connector-python-8.2.0-py39hf08970b_4.conda
win-64::grpcio-1.60.1-py39hd28a505_0.conda
win-64::grpcio-1.61.1-py38h19421c1_1.conda
win-64::kaldi-5.5.1112-cuda112h2069925_0.conda
win-64::libopentelemetry-cpp-1.14.1-h567fb77_0.conda
win-64::libxml2-2.12.5-hc3477c8_0.conda
win-64::libclang-16.0.6-default_h3a3e6c3_5.conda
win-64::gdstk-0.9.50-py39h2b303d1_0.conda
win-64::grpcio-1.60.1-py312h7894644_0.conda
win-64::libarrow-gandiva-14.0.2-h6d0e577_10_cpu.conda
win-64::mysql-connector-python-8.2.0-py39h50d83c6_1.conda
win-64::libgdal-3.8.3-hb5c751e_1.conda
win-64::python-3.11.8-h2628c8c_0_cpython.conda
win-64::libgrpc-1.61.1-h864d0f4_1.conda
win-64::correctionlib-2.4.0-py39h82b40fd_0.conda
win-64::aws-sdk-cpp-1.11.267-hf843ccd_0.conda
win-64::libarrow-13.0.0-h14a3b3b_28_cuda.conda
win-64::freecad-0.21.2-py311h185e270_1.conda
win-64::folly-2024.02.05.00-h04b96d7_0.conda
win-64::mysql-connector-python-8.2.0-py39h991b227_4.conda
win-64::mysql-connector-python-8.2.0-py311h37cd1cf_4.conda
win-64::libarrow-14.0.2-h6ac46d8_9_cuda.conda
win-64::mysql-connector-python-8.2.0-py38h56cbec2_1.conda
win-64::mysql-connector-python-8.2.0-py311h82abddb_2.conda
win-64::mysql-connector-python-8.2.0-py38hec51b86_4.conda
win-64::ovito-3.10.2-h8ea1a09_0.conda
win-64::libgdal-arrow-parquet-3.7.3-h49fa16d_14.conda
win-64::postgresql-plpython-16.2-py39hf83d731_0.conda
win-64::libarrow-14.0.2-hd787b2a_10_cuda.conda
win-64::grpcio-1.60.1-py38h19421c1_0.conda
win-64::grpcio-1.61.1-py39hd28a505_0.conda
win-64::libgdal-3.7.3-hf28eecd_14.conda
win-64::folly-2024.02.19.00-h43676e7_0.conda
win-64::mysql-connector-python-8.2.0-py310h8d33f92_1.conda
win-64::openjpeg-2.5.2-h3d672ee_0.conda
win-64::correctionlib-2.4.0-py310h9a75aa7_0.conda
win-64::eccodes-2.34.1-h97caf96_0.conda
win-64::qt6-main-6.6.2-h1c9f5e3_0.conda
win-64::libsolv-0.7.28-h12be248_0.conda
win-64::gdstk-0.9.50-py312h1b3467e_0.conda
win-64::pcre2-10.43-h17e33f8_0.conda
win-64::libpulsar-3.4.2-hbebb60c_2.conda
win-64::clangxx-16.0.6-default_h3a3e6c3_5.conda
win-64::libgoogle-cloud-storage-2.21.0-hb581fae_2.conda
win-64::libgdal-arrow-parquet-3.8.3-h04505bc_2.conda
win-64::libarrow-14.0.2-h94e56f8_7_cuda.conda
win-64::libarrow-15.0.0-hf1f0c47_3_cpu.conda
win-64::stir-6.0.0-cuda112_py38he021285_200.conda
win-64::paraview-5.11.2-py312h238983a_102_qt.conda
win-64::correctionlib-2.4.0-py311hd32ce59_0.conda
win-64::libgdal-arrow-parquet-3.7.3-hd1afe5b_16.conda
win-64::qt6-3d-6.6.2-h294d793_1.conda
win-64::freecad-0.21.2-py38heb5c132_1.conda
win-64::conduit-0.9.1-py311h2110639_0.conda
win-64::libopencv-4.9.0-py38h4505b37_8.conda
win-64::python-igraph-0.11.4-py39h0deea09_0.conda
win-64::libarrow-gandiva-14.0.2-h2bad095_6_cpu.conda
win-64::libprotobuf-static-4.25.2-h503648d_1.conda
win-64::cpp-opentelemetry-sdk-1.14.0-h567fb77_0.conda
win-64::postgresql-plpython-15.6-py312hfeb81f1_0.conda
win-64::nco-5.2.1-h871a938_0.conda
win-64::llvmlite-0.42.0-py310hb84602e_0.conda
win-64::aws-sdk-cpp-1.11.267-h93f5800_1.conda
win-64::postgresql-plpython-16.2-py311h7015055_0.conda
win-64::karilang-kernel-0.1.0-h891cef7_0.conda
win-64::mysql-client-8.3.0-hed9f4ee_1.conda
win-64::libgdal-arrow-parquet-3.8.3-h6aedb6f_3.conda
win-64::pdal-2.6.3-h572f625_2.conda
win-64::libarrow-12.0.1-hc834cb5_39_cpu.conda
win-64::stir-6.0.0-cpu_py39h7d132c1_0.conda
win-64::correctionlib-2.5.0-py39h82b40fd_1.conda
win-64::libgit2-1.7.2-hc6d37dd_2.conda
win-64::libarrow-14.0.2-heb6a4d3_7_cpu.conda
win-64::zimpl-3.5.4-h1b7cc75_0.conda
win-64::stir-6.0.0-cuda120_py310hbb71a96_200.conda
win-64::tiledb-2.20.0-h898bb53_1.conda
win-64::libgdal-3.8.3-h0f7007b_2.conda
win-64::libopencv-4.9.0-py39h75d48ce_8.conda
win-64::pyinstaller-6.4.0-py312h3bd2d22_0.conda
win-64::postgresql-plpython-15.6-py311h35d69d3_0.conda
win-64::llvmlite-0.42.0-py39hd28a505_1.conda
win-64::libarrow-gandiva-14.0.2-h2bad095_9_cuda.conda
win-64::libgdal-arrow-parquet-3.7.3-h6aedb6f_16.conda
win-64::grpcio-1.61.1-py312h7894644_0.conda
win-64::libclang13-16.0.6-default_hf64faad_5.conda
win-64::pyinstaller-6.4.0-py39h84a0465_0.conda
win-64::python-igraph-0.11.4-py311h8ea321e_0.conda
win-64::stir-6.0.0-cuda120_py39h961f521_200.conda
win-64::correctionlib-2.5.0-py312h48fe75a_1.conda
win-64::mysql-client-8.2.0-hed9f4ee_1.conda
win-64::folly-2024.02.12.00-hd2f1b6b_0.conda
win-64::correctionlib-2.5.0-py38h98a829e_1.conda
win-64::conduit-0.9.1-py38hef6e68c_0.conda
win-64::pyinstaller-6.4.0-py38ha959d8a_0.conda
win-64::libgoogle-cloud-storage-2.21.0-hb581fae_0.conda
win-64::ffmpeg-6.1.1-gpl_hb766fab_104.conda
win-64::libgoogle-cloud-storage-2.21.0-hb581fae_1.conda
win-64::prometheus-cpp-1.2.3-h6d55216_0.conda
win-64::freeimage-3.18.0-ha010600_19.conda
win-64::libarrow-12.0.1-h4939f27_37_cpu.conda
win-64::gst-plugins-base-1.23.1-h001b923_0.conda
win-64::folly-2024.02.05.00-h43676e7_0.conda
win-64::llvmlite-0.42.0-py310hb84602e_1.conda
win-64::mysql-connector-python-8.2.0-py310h8d33f92_3.conda
win-64::tiledb-2.20.0-he030554_1.conda
win-64::libsolv-static-0.7.28-h12be248_0.conda
win-64::libgdal-arrow-parquet-3.7.3-h60fb7f5_15.conda
win-64::grpcio-1.61.0-py39hd28a505_0.conda
win-64::postgresql-plpython-16.2-py311h931fdd5_0.conda
win-64::clang-format-13.0.1-default_h66ee7f4_6.conda
win-64::freecad-0.21.2-py39hd60bf24_1.conda
win-64::r-seqminer-9.4-r41h5bfd6cc_0.conda
win-64::libarrow-gandiva-14.0.2-h2bad095_7_cuda.conda
win-64::cpp-opentelemetry-sdk-1.14.1-h3b54c5a_1.conda
win-64::pdal-2.6.3-h572f625_1.conda
win-64::libgrpc-1.61.1-h943f600_0.conda
win-64::libarrow-15.0.0-hd787b2a_7_cuda.conda
win-64::correctionlib-2.4.0-py312h48fe75a_1.conda
win-64::glib-2.78.4-h12be248_0.conda
win-64::grpcio-1.61.1-py39h6848017_1.conda
win-64::libgdal-arrow-parquet-3.8.3-h0d5c0e5_1.conda
win-64::libgdal-arrow-parquet-3.8.3-hd1afe5b_3.conda
win-64::libarrow-gandiva-15.0.0-h41a35cd_5_cpu.conda
win-64::mysql-router-8.3.0-h190823e_2.conda
win-64::libgdal-3.7.3-h8e5d517_16.conda
win-64::mysql-connector-python-8.2.0-py39h563d2cf_2.conda
win-64::libopentelemetry-cpp-1.14.2-h3b54c5a_0.conda
win-64::mysql-connector-python-8.2.0-py311h82abddb_3.conda
win-64::libarrow-15.0.0-hd01637b_7_cpu.conda
win-64::stir-6.0.0-cuda118_py38h3f97100_200.conda
win-64::clang-16.0.6-hb9829f2_5.conda
win-64::libgdal-3.7.3-h8e5d517_15.conda
win-64::libclang-13.0.1-default_h66ee7f4_6.conda
win-64::folly-2024.02.19.00-h04b96d7_0.conda
win-64::hugin-base-2023.0.0-pl5321ha458e25_0.conda
win-64::mysql-router-8.2.0-h1dfa4b2_1.conda
win-64::poppler-24.02.0-hc2f3c52_0.conda
win-64::llvmlite-0.42.0-py39hd28a505_0.conda
win-64::clang-tools-16.0.6-default_h3a3e6c3_5.conda
win-64::libgrpc-1.61.0-h943f600_0.conda
win-64::grpcio-1.61.0-py39h6848017_0.conda
win-64::qt6-main-6.6.2-h1c9f5e3_3.conda
win-64::libopencv-4.9.0-py310haab42c9_8.conda
win-64::scip-9.0.0-h0d0ae4c_0.conda
win-64::qt-main-5.15.8-h9e85ed6_19.conda
win-64::grpcio-1.61.1-py39h6848017_0.conda
win-64::grpcio-1.61.0-py310hb84602e_0.conda
win-64::mysql-connector-python-8.2.0-py39h50d83c6_2.conda
win-64::folly-2024.02.19.00-hd2f1b6b_0.conda
win-64::libgdal-arrow-parquet-3.7.3-h04505bc_14.conda
win-64::libgdal-arrow-parquet-3.8.4-h3f7f693_0.conda
win-64::pyinstaller-6.4.0-py311h12e69fa_0.conda
win-64::exiv2-0.28.2-hadc2d18_0.conda
win-64::libpng-1.6.42-h19919ed_0.conda
win-64::grpcio-1.61.1-py310hb84602e_1.conda
win-64::eccodes-2.34.0-h97caf96_0.conda
win-64::sdl_image-1.2.12-h9ea3bf0_7.conda
win-64::correctionlib-2.4.0-py311hd32ce59_1.conda
win-64::libarrow-13.0.0-hbf6b392_27_cuda.conda
win-64::qt6-3d-6.6.2-h294d793_0.conda
win-64::libgdal-arrow-parquet-3.8.4-hd1afe5b_0.conda
win-64::libopencv-4.9.0-py39hf5dcb13_8.conda
win-64::llvmlite-0.42.0-py312h7894644_1.conda
win-64::cmake-3.28.3-hf0feee3_0.conda
win-64::postgresql-plpython-16.2-py312he74e6b0_0.conda
win-64::postgresql-plpython-16.2-py312h6a96c9b_0.conda
win-64::libgdal-arrow-parquet-3.7.3-h6aedb6f_15.conda
win-64::hugin-2023.0.0-pl5321hbdb762e_0.conda
win-64::python-igraph-0.11.4-py38he88c658_0.conda
win-64::libarrow-12.0.1-h613457a_40_cpu.conda
win-64::python-igraph-0.11.4-py312hd474c18_0.conda
win-64::libarrow-15.0.0-h6ac46d8_6_cuda.conda
win-64::libgdal-3.8.4-h7c2897a_0.conda
win-64::prometheus-cpp-1.2.2-h6d55216_0.conda
win-64::libprotobuf-static-4.25.2-h503648d_0.conda
win-64::folly-2024.02.12.00-h43676e7_0.conda
win-64::mysql-connector-python-8.2.0-py38h580763a_0.conda
win-64::conduit-0.9.1-py310haa2df91_0.conda
win-64::libarrow-13.0.0-h4939f27_26_cpu.conda
win-64::postgresql-plpython-15.6-py39h25219b3_0.conda
win-64::libgdal-arrow-parquet-3.8.3-hc873f47_1.conda
win-64::libarrow-15.0.0-h0ac756b_5_cuda.conda
win-64::grpcio-1.60.1-py39h6848017_0.conda
win-64::libarrow-gandiva-14.0.2-h2bad095_6_cuda.conda
win-64::libgdal-arrow-parquet-3.8.4-h6aedb6f_0.conda
win-64::postgresql-plpython-15.6-py38h2c11c51_0.conda
win-64::correctionlib-2.4.0-py310h9a75aa7_1.conda
win-64::git-cliff-2.0.4-hcb6e01d_0.conda
win-64::boost-cpp-1.84.0-h6f18f0d_1.conda
win-64::kaldi-5.5.112-cpu_he6cc000_0.conda
win-64::libarrow-gandiva-15.0.0-h41a35cd_6_cpu.conda
win-64::libgdal-arrow-parquet-3.7.3-hd1afe5b_15.conda
win-64::postgresql-plpython-16.2-py39h7f24c7b_0.conda
win-64::stir-6.0.0-cuda118_py311h5625561_200.conda
win-64::mysql-connector-python-8.2.0-py310h856dec3_4.conda
win-64::cfitsio-4.4.0-h9b0cee5_0.conda
win-64::libuwebsockets-20.59.0-h12be248_0.conda
win-64::openexr-3.2.2-hf79fc45_0.conda
win-64::libgdal-arrow-parquet-3.7.3-h3f7f693_16.conda
win-64::paraview-5.11.2-py39hc16c544_102_qt.conda
win-64::folly-2024.02.19.00-h70b2ba9_2.conda
win-64::postgresql-plpython-15.6-py310h01700aa_0.conda
win-64::mysql-connector-python-8.2.0-py312h62aed12_4.conda
win-64::grpcio-1.61.1-py311h5bc0dda_1.conda
win-64::libarrow-gandiva-14.0.2-h2bad095_7_cpu.conda
win-64::correctionlib-2.4.0-py38h98a829e_1.conda
win-64::libopencv-4.9.0-py312h9dd2360_8.conda
win-64::libgdal-arrow-parquet-3.8.4-h49126f6_0.conda
win-64::folly-2024.02.26.00-h70b2ba9_0.conda
win-64::libarrow-13.0.0-h2d3fa70_29_cuda.conda
win-64::mysql-connector-python-8.2.0-py311h82abddb_1.conda
win-64::libarrow-gandiva-15.0.0-hc896d4e_7_cuda.conda
win-64::postgresql-15.6-h94c9ec1_0.conda
win-64::libprotobuf-4.25.1-hb8276f3_1.conda
win-64::mysql-client-8.2.0-hed9f4ee_0.conda
win-64::libglib-2.78.4-h16e383f_0.conda
win-64::libgrpc-1.60.1-h0bf0bfa_0.conda
win-64::libarrow-15.0.0-heb6a4d3_4_cpu.conda
win-64::paraview-5.11.2-py38h7c61273_102_qt.conda
win-64::folly-2024.02.05.00-hd2f1b6b_0.conda
win-64::ovito-3.10.3-h8ea1a09_0.conda
win-64::libprotobuf-4.25.2-h503648d_1.conda
win-64::grpcio-1.61.1-py311h5bc0dda_0.conda
win-64::stir-6.0.0-cuda112_py310h5c9ace5_200.conda
win-64::tiledb-2.20.0-hf016803_0.conda
win-64::mysql-connector-python-8.2.0-py38h56cbec2_3.conda
win-64::aws-sdk-cpp-1.11.242-hf843ccd_2.conda
win-64::stir-6.0.0-cpu_py310h150df81_0.conda
win-64::libarrow-15.0.0-ha3e3d60_3_cuda.conda
win-64::tectonic-0.15.0-h1cbdeb6_0.conda
win-64::tiledb-2.20.1-he030554_1.conda
win-64::grpcio-1.61.0-py311h5bc0dda_0.conda
win-64::kaldi-5.5.1112-cpu_he6cc000_0.conda
win-64::libgit2-1.7.2-hc6d37dd_1.conda
win-64::libgdal-arrow-parquet-3.7.3-h49126f6_16.conda
win-64::nco-5.2.0-h871a938_0.conda
win-64::stir-6.0.0-cpu_py38h28fe462_0.conda
win-64::tiledb-2.20.1-h898bb53_1.conda
win-64::tiledb-2.20.1-hde99414_1.conda
win-64::stir-6.0.0-cuda120_py311h7ed8336_200.conda
win-64::cpp-opentelemetry-sdk-1.14.2-h3b54c5a_0.conda
win-64::postgresql-plpython-16.2-py310hf838413_0.conda
win-64::mysql-connector-python-8.2.0-py39h563d2cf_1.conda
win-64::mysql-server-8.2.0-h9bdc1ac_0.conda
win-64::libboost-1.84.0-hcc118f5_1.conda
win-64::tiledb-2.20.0-h2657894_0.conda
win-64::libgdal-arrow-parquet-3.8.3-h3f7f693_3.conda
win-64::mysql-connector-python-8.2.0-py39h50d83c6_3.conda
win-64::mysql-connector-python-8.2.0-py310h8d33f92_2.conda
win-64::mysql-router-8.3.0-h1dfa4b2_1.conda
win-64::libarrow-14.0.2-h12634d7_8_cpu.conda
win-64::git-cliff-2.0.3-hcb6e01d_0.conda
win-64::libignition-fuel-tools7-7.1.0-h80edc6a_9.conda
win-64::glibmm-2.68-2.78.1-hb2f1372_0.conda
win-64::paraview-5.11.2-py310h461edbe_102_qt.conda
win-64::libarrow-13.0.0-h7600769_26_cuda.conda
win-64::mysql-connector-python-8.2.0-py39h2fdb7f6_0.conda
win-64::libarrow-gandiva-15.0.0-h2bad095_3_cuda.conda
win-64::sasktran2-2024.02.2-py312hf2b062a_0.conda
win-64::clang-16-16.0.6-default_h3a3e6c3_5.conda
win-64::libprotobuf-static-4.25.1-hb8276f3_2.conda
win-64::libopencv-4.9.0-py311hf93d0e6_8.conda
win-64::libgdal-arrow-parquet-3.8.3-hed6f11a_1.conda
win-64::pyinstaller-6.4.0-py310h35269f2_0.conda
win-64::mysql-libs-8.3.0-h8b0d2c3_2.conda
win-64::clangdev-16.0.6-default_h3a3e6c3_5.conda
win-64::stir-6.0.0-cuda112_py39h812b358_200.conda
win-64::libgdal-arrow-parquet-3.8.3-hae6d7e4_2.conda
win-64::qt6-main-6.6.2-h1c9f5e3_2.conda
win-64::postgresql-16.2-hc80876b_0.conda
win-64::llvmlite-0.42.0-py311h5bc0dda_1.conda
win-64::mysql-connector-python-8.2.0-py311h2979cf9_0.conda
win-64::libarrow-14.0.2-h94e56f8_6_cuda.conda
win-64::libpq-15.6-h94c9ec1_0.conda
win-64::llvmlite-0.42.0-py39h6848017_0.conda
win-64::qt6-main-6.6.2-h1c9f5e3_1.conda
win-64::libarrow-14.0.2-h1401081_9_cpu.conda
win-64::libarrow-gandiva-15.0.0-h41a35cd_5_cuda.conda
win-64::libarrow-13.0.0-hc834cb5_28_cpu.conda
win-64::grpcio-1.61.1-py312h7894644_1.conda
win-64::grpcio-1.61.1-py39hd28a505_1.conda
win-64::mysql-server-8.2.0-h81ad02e_1.conda
win-64::mysql-server-8.3.0-hf076638_2.conda
win-64::mysql-libs-8.2.0-h8b0d2c3_0.conda
win-64::tiledb-2.20.0-h898bb53_0.conda
win-64::sasktran2-2024.02.2-py310haaf695d_0.conda
win-64::libgdal-arrow-parquet-3.7.3-h9e0f2ba_14.conda
win-64::libarrow-14.0.2-heb6a4d3_6_cpu.conda
win-64::orc-1.9.2-h2702c50_2.conda
win-64::cpp-opentelemetry-sdk-1.14.1-h567fb77_0.conda
win-64::libarrow-12.0.1-hbf6b392_38_cuda.conda
win-64::libpng-1.6.43-h19919ed_0.conda
win-64::libuwebsockets-20.60.0-h12be248_0.conda
win-64::libarrow-gandiva-15.0.0-h41a35cd_6_cuda.conda
win-64::libarrow-gandiva-15.0.0-h2bad095_4_cuda.conda
win-64::stir-6.0.0-cuda120_py38he42b1f3_200.conda
win-64::paraview-5.11.2-py311h3e05f83_102_qt.conda
win-64::kaldi-5.5.112-cuda112h2069925_0.conda
win-64::grpcio-1.61.0-py38h19421c1_0.conda
win-64::mysql-connector-python-8.2.0-py310h5657699_0.conda
win-64::libarrow-15.0.0-h94e56f8_4_cuda.conda
win-64::libprotobuf-4.25.2-h503648d_0.conda
win-64::libarrow-gandiva-15.0.0-hc896d4e_7_cpu.conda
win-64::aws-sdk-cpp-1.11.242-h43af401_1.conda
win-64::libarrow-12.0.1-h7600769_37_cuda.conda
win-64::libprotobuf-static-4.25.1-hb8276f3_1.conda
win-64::libgdal-arrow-parquet-3.7.3-h3f7f693_15.conda
win-64::correctionlib-2.4.0-py39h82b40fd_1.conda
win-64::libgit2-1.7.2-hc6d37dd_0.conda
win-64::clang-tools-13.0.1-default_h66ee7f4_6.conda
win-64::mysql-libs-8.3.0-h8b0d2c3_1.conda
win-64::python-igraph-0.11.4-py310h12da152_0.conda
win-64::gdstk-0.9.50-py39h32efe87_0.conda
win-64::libarrow-15.0.0-h1401081_6_cpu.conda
win-64::libarrow-gandiva-15.0.0-h2bad095_3_cpu.conda
win-64::libarrow-15.0.0-h04ba218_5_cpu.conda
win-64::pdal-2.6.2-h42184c4_4.conda
win-64::libmediainfo-24.01-hc600624_0.conda
win-64::mysql-connector-python-8.2.0-py312ha1afc8e_3.conda
win-64::libprotobuf-4.25.1-hb8276f3_2.conda
win-64::libarrow-gandiva-14.0.2-h2bad095_8_cpu.conda
win-64::mysql-client-8.3.0-hed9f4ee_2.conda
win-64::stir-6.0.0-cpu_py311ha2ca3b5_0.conda
win-64::grpcio-1.60.1-py311h5bc0dda_0.conda
win-64::libgdal-arrow-parquet-3.8.3-h49126f6_3.conda
win-64::python-igraph-0.11.4-py39hb7077b8_0.conda
win-64::postgresql-plpython-16.2-py38hc2df893_0.conda
win-64::mysql-libs-8.2.0-h8b0d2c3_1.conda
win-64::folly-2024.02.12.00-h04b96d7_0.conda
win-64::libarrow-13.0.0-h4be152c_27_cpu.conda
win-64::glib-tools-2.78.4-h12be248_0.conda
win-64::python-3.12.2-h2628c8c_0_cpython.conda
win-64::papilo-2.2.0-h7877cb0_0.conda
win-64::libarrow-14.0.2-hd01637b_10_cpu.conda
win-64::mysql-router-8.2.0-h7628ff7_0.conda
win-64::libarrow-gandiva-14.0.2-h6d0e577_10_cuda.conda
win-64::libarrow-12.0.1-h4be152c_38_cpu.conda
win-64::folly-2024.02.19.00-h04b96d7_1.conda
win-64::grpcio-1.61.0-py312h7894644_0.conda
win-64::gdstk-0.9.50-py38h8a2f752_0.conda
win-64::libopentelemetry-cpp-1.14.1-h3b54c5a_1.conda
win-64::stir-6.0.0-cuda118_py310hd0e3b8f_200.conda
win-64::libopentelemetry-cpp-1.14.0-h567fb77_0.conda
win-64::clang-13-13.0.1-default_h66ee7f4_6.conda
win-64::libgdal-3.8.3-h7c2897a_3.conda
win-64::soplex-8.0.0-hb545602_0.conda
win-64::imath-3.1.11-h12be248_0.conda
win-64::tiledb-2.20.0-hf67ed3d_0.conda
win-64::gst-plugins-good-1.23.1-h62ce35e_0.conda
win-64::libgdal-arrow-parquet-3.7.3-h845fcc4_14.conda
win-64::libarrow-14.0.2-h8b13df6_8_cuda.conda
win-64::clangdev-13.0.1-default_h66ee7f4_6.conda
win-64::correctionlib-2.5.0-py310h9a75aa7_1.conda
win-64::libarrow-12.0.1-h2d3fa70_40_cuda.conda
win-64::gdstk-0.9.50-py311hc50246e_0.conda
win-64::libarrow-gandiva-15.0.0-h2bad095_4_cpu.conda
win-64::tiledb-2.20.0-he030554_0.conda
win-64::grpcio-1.61.1-py310hb84602e_0.conda
win-64::ogre-14.2.0-h5d47b67_0.conda
win-64::libarrow-12.0.1-h14a3b3b_39_cuda.conda
win-64::gdstk-0.9.50-py310h7dcdc39_0.conda
win-64::conduit-0.9.1-py39hbc30dbd_0.conda
win-64::libarrow-13.0.0-h613457a_29_cpu.conda
win-64::postgresql-16.2-h1beaf6b_0.conda
win-64::pcre2-static-10.43-h17e33f8_0.conda
win-64::llvmlite-0.42.0-py39h6848017_1.conda
win-64::llvmlite-0.42.0-py311h5bc0dda_0.conda
win-64::ogre-14.2.0-h87d0416_0.conda
win-64::stir-6.0.0-cuda118_py39hd6f898a_200.conda
win-64::grpcio-1.61.1-py38h19421c1_0.conda
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
win-64::clangxx-13.0.1-default_h66ee7f4_6.conda
win-64::clang-13.0.1-default_h46fc674_6.conda
-    "libzlib >=1.2.13,<1.3.0a0"
+    "libzlib >=1.2.13,<2.0.0a0"
================================================================================
================================================================================
osx-64
osx-64::correctionlib-2.4.0-py310he697753_1.conda
osx-64::photochem-0.4.5-py38h08ade82_1.conda
osx-64::aws-sdk-cpp-1.11.267-hf59c3df_0.conda
osx-64::llvmlite-0.42.0-py39he5a6977_0.conda
osx-64::libgdal-arrow-parquet-3.8.4-ha895dd2_0.conda
osx-64::folly-2024.02.12.00-h37615a4_0_jemalloc.conda
osx-64::ndcctools-7.8.0-py39h677b332_0.conda
osx-64::ndcctools-7.8.0-py311hc4bdf42_1.conda
osx-64::folly-2024.02.19.00-h7815ab9_0.conda
osx-64::mysql-client-8.3.0-hbece87f_1.conda
osx-64::folly-2024.02.12.00-ha75df62_0.conda
osx-64::glibmm-2.68-2.78.1-h112a47c_0.conda
osx-64::llvmlite-0.42.0-py39he5a6977_1.conda
osx-64::postgresql-plpython-15.6-py39h27b00d0_0.conda
osx-64::libboost-1.84.0-h4bb364b_1.conda
osx-64::qt6-main-6.6.2-h10ce37f_3.conda
osx-64::ffmpeg-6.1.1-gpl_h73cf981_104.conda
osx-64::mysql-connector-python-8.2.0-py311hf1ae53e_3.conda
osx-64::grpcio-1.59.3-py310h271164d_0.conda
osx-64::ndcctools-7.7.3-py310h3f3ca68_0.conda
osx-64::photochem-0.4.5-py39hf91a2d3_1.conda
osx-64::mesalib-24.0.0-hbd9e708_0.conda
osx-64::root_base-6.30.4-py38h340b97f_0.conda
osx-64::prometheus-cpp-1.2.3-h56c0b21_0.conda
osx-64::paraview-5.11.2-py311h3889fb4_102_qt.conda
osx-64::libopencv-4.9.0-py38h09f996b_8.conda
osx-64::sasktran2-2024.02.2-py310hfc2ebfe_0.conda
osx-64::r-seqminer-9.4-r42hc6f5d9b_0.conda
osx-64::gdstk-0.9.50-py312hf3e4e0a_0.conda
osx-64::ovito-3.10.2-h0a3f43b_0.conda
osx-64::correctionlib-2.4.0-py39h4aa070f_1.conda
osx-64::jaxlib-0.4.23-cpu_py312h498d6f8_0.conda
osx-64::soplex-8.0.0-h4eed031_0.conda
osx-64::jaxlib-0.4.23-cpu_py311h2c77ff9_0.conda
osx-64::correctionlib-2.5.0-py39h4aa070f_1.conda
osx-64::libgdal-3.8.4-h46636ed_0.conda
osx-64::mysql-connector-python-8.2.0-py38h4190047_1.conda
osx-64::ndcctools-7.8.0-py38hd480228_1.conda
osx-64::wxpython-4.2.1-py311h91baca1_3.conda
osx-64::mysql-connector-python-8.2.0-py39h9131017_0.conda
osx-64::photochem-0.4.5-py310h41cef8c_1.conda
osx-64::libgdal-arrow-parquet-3.7.3-hace69e5_15.conda
osx-64::libglib-2.78.4-hab64008_0.conda
osx-64::jaxlib-0.4.23-cpu_py312h53a6dab_0.conda
osx-64::nco-5.2.0-hfcf1594_0.conda
osx-64::qt6-main-6.6.2-h9fd3f66_2.conda
osx-64::gazebo-11.14.0-h26deb8f_7.conda
osx-64::karilang-kernel-0.1.0-h1717a11_0.conda
osx-64::jaxlib-0.4.23-cpu_py311he344bf5_0.conda
osx-64::libarrow-14.0.2-h20c95d7_6_cpu.conda
osx-64::libgdal-arrow-parquet-3.7.3-h48e125e_14.conda
osx-64::conduit-0.9.1-py39h32270e5_0.conda
osx-64::protozfits-2.4.0-py312hd2bd543_0.conda
osx-64::llvmlite-0.42.0-py310h7d48a1f_1.conda
osx-64::pocl-core-5.0-h3c65c3d_2.conda
osx-64::gfortran_impl_osx-arm64-13.2.0-h5ec2d5a_3.conda
osx-64::folly-2024.02.26.00-hdf78ba7_0_jemalloc.conda
osx-64::jaxlib-0.4.23-cpu_py39h124a94f_0.conda
osx-64::libgdal-3.8.3-h2bd90a6_1.conda
osx-64::ndcctools-7.7.3-py311hc4bdf42_0.conda
osx-64::grpcio-1.61.1-py39h99d80ef_1.conda
osx-64::conduit-0.9.1-py310h0bb9a09_0.conda
osx-64::folly-2024.02.12.00-h8225e4e_0_jemalloc.conda
osx-64::pdal-2.6.3-hd2646b2_1.conda
osx-64::grpcio-1.59.3-py39h339971c_0.conda
osx-64::verilator-5.022-h8e8e533_0.conda
osx-64::mysql-connector-python-8.2.0-py312h6f46682_4.conda
osx-64::root_base-6.30.4-py310hec7f349_0.conda
osx-64::libgdal-arrow-parquet-3.8.3-h265e6be_1.conda
osx-64::git-2.43.0-pl5321h8687b19_1.conda
osx-64::libarrow-12.0.1-h620627f_38_cpu.conda
osx-64::correctionlib-2.4.0-py311h94bc237_1.conda
osx-64::mysql-client-8.3.0-hbece87f_2.conda
osx-64::libarrow-15.0.0-h7fd388d_6_cpu.conda
osx-64::mysql-connector-python-8.2.0-py39h99f93b6_1.conda
osx-64::lammps-2023.11.21-cpu_py311_h835ce97_mpi_openmpi_4.conda
osx-64::libgdal-arrow-parquet-3.7.3-ha895dd2_16.conda
osx-64::sagelib-10.2-py311hf9b2163_4.conda
osx-64::sqlite-3.45.1-h7461747_0.conda
osx-64::gdstk-0.9.50-py39h23d43bd_0.conda
osx-64::correctionlib-2.4.0-py312hf41e57d_1.conda
osx-64::libarrow-12.0.1-hd9b807b_40_cpu.conda
osx-64::libmediainfo-24.01-hfe259de_0.conda
osx-64::loos-4.1.0-py312hf335720_0.conda
osx-64::folly-2024.02.19.00-hdf78ba7_2_jemalloc.conda
osx-64::jaxlib-0.4.23-cpu_py312hc517bdf_0.conda
osx-64::libgdal-arrow-parquet-3.8.3-hfe2b1a0_3.conda
osx-64::mysql-connector-python-8.2.0-py311hf1ae53e_2.conda
osx-64::libopencv-4.9.0-py310hbcd118e_8.conda
osx-64::julia-1.10.1-h1943a53_0.conda
osx-64::libtiledb-sql-0.27.0-hf123d00_1.conda
osx-64::libopencv-4.9.0-py312h5065d0e_8.conda
osx-64::cmake-3.28.3-h7c85d92_0.conda
osx-64::libgit2-1.7.2-h33a806c_0.conda
osx-64::dwarfdump-0.9.0-h27ecd69_0.conda
osx-64::folly-2024.02.19.00-ha75df62_0.conda
osx-64::mysql-connector-python-8.2.0-py39h1a323f9_4.conda
osx-64::julia-1.10.0-h1943a53_0.conda
osx-64::photochem-0.4.5-py311hf3d5ebd_1.conda
osx-64::libvips-8.15.1-h7248a31_2.conda
osx-64::mysql-connector-python-8.2.0-py39h21f0dbf_1.conda
osx-64::libgdal-3.7.3-hb00e93c_14.conda
osx-64::lammps-2023.11.21-cpu_py310_hdd5fa3c_mpi_mpich_4.conda
osx-64::lammps-2023.11.21-cpu_py38_h5baff61_mpi_mpich_4.conda
osx-64::libgdal-arrow-parquet-3.7.3-heeac95c_16.conda
osx-64::python-igraph-0.11.4-py310h554570a_0.conda
osx-64::libgrpc-1.61.1-h32bdf18_1.conda
osx-64::mysql-connector-python-8.2.0-py38h120e042_2.conda
osx-64::jaxlib-0.4.23-cpu_py310h589cea4_0.conda
osx-64::grpcio-1.60.1-py311h78ff076_0.conda
osx-64::mysql-connector-python-8.2.0-py39h0e8d113_4.conda
osx-64::imagemagick-7.1.1_28-pl5321h0b4f3dc_0.conda
osx-64::fish-3.7.0-ha70b2fa_1.conda
osx-64::libarrow-13.0.0-hd9b807b_29_cpu.conda
osx-64::gdb-14.1-py39hb11c474_1.conda
osx-64::lammps-2023.11.21-cpu_py311_h7e0894f_nompi_4.conda
osx-64::protozfits-2.4.0-py39h4c27f90_1.conda
osx-64::libgdal-arrow-parquet-3.7.3-hdc8e218_14.conda
osx-64::libgit2-1.7.2-h40db0df_1.conda
osx-64::tiledb-2.20.0-hee4a7ef_0.conda
osx-64::tensorstore-0.1.54-py310h64f779d_1.conda
osx-64::conduit-0.9.1-py38hcb62128_0.conda
osx-64::conduit-0.9.1-py311heed906f_0.conda
osx-64::gdb-14.1-py311h7722b1f_0.conda
osx-64::grpcio-1.61.1-py310h271164d_0.conda
osx-64::libarrow-14.0.2-hd2c9378_10_cpu.conda
osx-64::mysql-connector-python-8.2.0-py39h804c80b_0.conda
osx-64::ndcctools-7.8.0-py310h3f3ca68_0.conda
osx-64::python-igraph-0.11.4-py312hc869fd5_0.conda
osx-64::folly-2024.02.26.00-hf0236fa_0.conda
osx-64::qt-main-5.15.8-h4385fff_19.conda
osx-64::yoda-1.9.6-py310h485fde1_7.conda
osx-64::libgdal-arrow-parquet-3.8.3-ha895dd2_3.conda
osx-64::mysql-connector-python-8.2.0-py39h0fa98f0_3.conda
osx-64::conduit-0.9.1-py310he45b8d4_0.conda
osx-64::grpcio-1.60.1-py312hbbbd34f_0.conda
osx-64::mysql-connector-python-8.2.0-py312h6d6cdfd_3.conda
osx-64::cpp-opentelemetry-sdk-1.14.1-h6552d82_1.conda
osx-64::folly-2024.02.05.00-h37615a4_0_jemalloc.conda
osx-64::tiledb-2.20.0-hc714e58_1.conda
osx-64::tensorstore-0.1.54-py39h76e517c_1.conda
osx-64::cpp-opentelemetry-sdk-1.14.1-hcda5922_0.conda
osx-64::postgresql-plpython-16.2-py310h7e3f867_0.conda
osx-64::gdstk-0.9.50-py38hbe7c026_0.conda
osx-64::correctionlib-2.4.0-py39h4aa070f_0.conda
osx-64::paraview-5.11.2-py39h41772ec_102_qt.conda
osx-64::folly-2024.02.19.00-h37615a4_1_jemalloc.conda
osx-64::libtiledb-sql-0.27.1-h76635fd_0.conda
osx-64::gfortran_impl_osx-64-12.3.0-hc328e78_3.conda
osx-64::cctools_osx-64-973.0.1-h031c385_16.conda
osx-64::aws-sdk-cpp-1.11.267-h4da54b2_1.conda
osx-64::libdwarf-testing-meta-0.9.0-h27ecd69_0.conda
osx-64::libgdal-arrow-parquet-3.7.3-h9b91149_14.conda
osx-64::ffmpeg-6.1.1-lgpl_h25bbcf7_4.conda
osx-64::tiledb-2.20.1-hc714e58_1.conda
osx-64::erlang-26.2.2-pl5321h0c96147_0.conda
osx-64::loos-4.1.0-py311h11e5fa7_0.conda
osx-64::kaldi-5.5.1112-cpu_h0f3c836_0.conda
osx-64::paraview-5.11.2-py38h9fb4076_102_qt.conda
osx-64::freecad-0.21.2-py311hb9bc545_1.conda
osx-64::lammps-2023.11.21-cpu_py38_ha0ef21c_nompi_4.conda
osx-64::conduit-0.9.1-py38h852bba6_0.conda
osx-64::libgdal-arrow-parquet-3.7.3-hace69e5_16.conda
osx-64::magics-4.15.2-hb5cd182_0.conda
osx-64::yoda-1.9.6-py39hd103029_7.conda
osx-64::python-3.12.2-h9f0c242_0_cpython.conda
osx-64::protozfits-2.4.0-py38hcd3839c_1.conda
osx-64::libgoogle-cloud-storage-2.21.0-ha67e85c_0.conda
osx-64::grpcio-1.61.0-py310h271164d_0.conda
osx-64::imagemagick-7.1.1_29-pl5321h0b4f3dc_0.conda
osx-64::mysql-server-8.3.0-h7e12b8d_1.conda
osx-64::postgresql-plpython-15.6-py312h8db37ca_0.conda
osx-64::grpcio-1.61.1-py312hbbbd34f_1.conda
osx-64::root_base-6.30.4-py39h5399eaa_0.conda
osx-64::python-igraph-0.11.4-py39h1cfa49b_0.conda
osx-64::libgdal-3.8.3-h46636ed_3.conda
osx-64::mysql-connector-python-8.2.0-py38hcd46198_0.conda
osx-64::hugin-base-2023.0.0-pl5321h356f363_0.conda
osx-64::libxml2-2.12.5-hc0ae0f7_0.conda
osx-64::postgresql-plpython-16.2-py38hf95a095_0.conda
osx-64::nss-3.98-ha05da47_0.conda
osx-64::libarrow-14.0.2-h70cdda4_8_cpu.conda
osx-64::lammps-2023.11.21-cpu_py39_h5305340_nompi_4.conda
osx-64::libdwarf-0.9.1-h27ecd69_0.conda
osx-64::libopentelemetry-cpp-1.14.1-h6552d82_1.conda
osx-64::mysql-client-8.2.0-hbece87f_0.conda
osx-64::paraview-5.11.2-py312h85cce60_102_qt.conda
osx-64::grpcio-1.60.1-py310h271164d_0.conda
osx-64::paraview-5.11.2-py310h4f82dc4_102_qt.conda
osx-64::prometheus-cpp-1.2.2-h56c0b21_0.conda
osx-64::jaxlib-0.4.23-cpu_py39hcc7f3aa_0.conda
osx-64::root_base-6.28.12-py311h0aa6aca_0.conda
osx-64::libtiledb-sql-0.27.0-h6f15af7_1.conda
osx-64::llvmlite-0.42.0-py312h534208b_1.conda
osx-64::correctionlib-2.5.0-py311h94bc237_1.conda
osx-64::tiledb-2.20.1-he01210c_1.conda
osx-64::folly-2024.02.19.00-h8bd47b9_1.conda
osx-64::mysql-connector-python-8.2.0-py39h1bc6601_3.conda
osx-64::folly-2024.02.19.00-h8225e4e_0_jemalloc.conda
osx-64::correctionlib-2.5.0-py38h7671238_1.conda
osx-64::python-igraph-0.11.4-py38h73d9d12_0.conda
osx-64::poppler-24.02.0-h0c752f9_0.conda
osx-64::julia-1.9.4-he430073_0.conda
osx-64::libtiledb-sql-0.27.0-h711a700_1.conda
osx-64::mysql-connector-python-8.2.0-py311h3960ec0_0.conda
osx-64::magics-4.15.3-hb5cd182_0.conda
osx-64::python-3.11.8-h9f0c242_0_cpython.conda
osx-64::folly-2024.02.12.00-h079d3a0_0_jemalloc.conda
osx-64::grpcio-1.61.1-py311h78ff076_1.conda
osx-64::nco-5.2.1-hfcf1594_0.conda
osx-64::libtiledb-sql-0.27.0-h76635fd_1.conda
osx-64::libarrow-14.0.2-h1d3a63f_9_cpu.conda
osx-64::folly-2024.02.05.00-ha75df62_0.conda
osx-64::postgresql-15.6-h06f2bd8_0.conda
osx-64::libdwarf-dev-0.9.0-h27ecd69_0.conda
osx-64::tiledb-2.20.0-h8fd0293_0.conda
osx-64::postgresql-plpython-16.2-py312h01252a9_0.conda
osx-64::conduit-0.9.1-py38ha5be9e6_0.conda
osx-64::chemicalite-2024.02.1-hc323757_0.conda
osx-64::folly-2024.02.05.00-h7815ab9_0.conda
osx-64::lammps-2023.11.21-cpu_py39_h14e9caf_mpi_mpich_4.conda
osx-64::nest-simulator-3.6-py310hebbbe1e_4.conda
osx-64::glib-2.78.4-h2d185b6_0.conda
osx-64::pyinstaller-6.4.0-py312h67dd88c_0.conda
osx-64::lammps-2023.11.21-cpu_py38_h9e2c45a_mpi_openmpi_4.conda
osx-64::grpcio-1.61.0-py311h78ff076_0.conda
osx-64::conduit-0.9.1-py311h4aafcd8_0.conda
osx-64::qt6-main-6.6.2-h9fd3f66_0.conda
osx-64::postgresql-plpython-16.2-py312h4a1d472_0.conda
osx-64::libtiledb-sql-0.27.1-hf123d00_0.conda
osx-64::libgdal-arrow-parquet-3.8.4-hace69e5_0.conda
osx-64::r-seqminer-9.4-r43hc6f5d9b_0.conda
osx-64::photochem-0.4.5-py312h4e4cf99_1.conda
osx-64::loos-4.1.0-py310h99df6af_0.conda
osx-64::freeimage-3.18.0-h796174d_19.conda
osx-64::llvmlite-0.42.0-py39haa0d8d9_0.conda
osx-64::libgdal-arrow-parquet-3.8.3-hdc8e218_2.conda
osx-64::libgdal-arrow-parquet-3.7.3-heeac95c_15.conda
osx-64::gdstk-0.9.50-py39h6e703ae_0.conda
osx-64::jaxlib-0.4.23-cpu_py310he573ce2_0.conda
osx-64::gfortran_impl_osx-64-13.2.0-h2bc304d_3.conda
osx-64::libdwarf-testing-meta-0.9.1-h27ecd69_0.conda
osx-64::sagelib-10.2-py310haeb9d62_4.conda
osx-64::dwarfdump-0.9.1-h27ecd69_0.conda
osx-64::qt6-3d-6.6.2-hba7393b_0.conda
osx-64::yoda-1.9.6-py310hc623c3f_7.conda
osx-64::grpcio-1.61.1-py38ha6b6e42_1.conda
osx-64::yoda-1.9.6-py38hdcff933_7.conda
osx-64::mysql-connector-python-8.2.0-py310haecc576_0.conda
osx-64::llvmlite-0.42.0-py39haa0d8d9_1.conda
osx-64::folly-2024.02.19.00-h37615a4_0_jemalloc.conda
osx-64::pyinstaller-6.4.0-py310h03c913b_0.conda
osx-64::ndcctools-7.7.3-py311hc4bdf42_1.conda
osx-64::grpcio-1.59.3-py311h78ff076_0.conda
osx-64::magics-metview-4.15.3-h2f8389b_0.conda
osx-64::libgoogle-cloud-storage-2.21.0-ha67e85c_1.conda
osx-64::yoda-1.9.6-py38ha84742d_7.conda
osx-64::protozfits-2.4.0-py311hc77e41d_0.conda
osx-64::sasktran2-2024.02.2-py312hfd4ef4c_0.conda
osx-64::grpcio-1.61.0-py39h99d80ef_0.conda
osx-64::libtiledb-sql-0.27.1-h1d9990a_1.conda
osx-64::pocl-core-5.0-h0b65ae3_2.conda
osx-64::grpcio-1.59.3-py38ha6b6e42_0.conda
osx-64::protozfits-2.4.0-py311h7bda159_1.conda
osx-64::libopentelemetry-cpp-1.14.0-hcda5922_0.conda
osx-64::libarrow-15.0.0-h20c95d7_4_cpu.conda
osx-64::ndcctools-7.7.3-py38hd480228_1.conda
osx-64::libarrow-12.0.1-hc069ab1_37_cpu.conda
osx-64::folly-2024.02.05.00-h079d3a0_0_jemalloc.conda
osx-64::grpcio-1.61.1-py310h271164d_1.conda
osx-64::correctionlib-2.4.0-py38h7671238_1.conda
osx-64::mysql-connector-odbc-8.3.0-h2d185b6_0.conda
osx-64::libtiledb-sql-0.27.1-h6f15af7_0.conda
osx-64::postgresql-plpython-16.2-py38h59056bf_0.conda
osx-64::libgdal-3.7.3-h9922bd6_16.conda
osx-64::qt6-main-6.6.2-h9fd3f66_1.conda
osx-64::boost-cpp-1.84.0-h07eb623_1.conda
osx-64::tiledb-2.20.0-he01210c_0.conda
osx-64::grpcio-1.61.0-py39h339971c_0.conda
osx-64::mysql-libs-8.2.0-ha9146f8_0.conda
osx-64::grpcio-1.61.0-py38ha6b6e42_0.conda
osx-64::mysql-server-8.3.0-hae7dd02_2.conda
osx-64::tensorstore-0.1.54-py311h0b93a2a_1.conda
osx-64::openimageio-2.5.5.0-h33a5fa7_1.conda
osx-64::pcre2-static-10.43-h0ad2156_0.conda
osx-64::tiledb-2.20.0-he01210c_1.conda
osx-64::ogre-14.2.0-h8414a5c_0.conda
osx-64::libarrow-15.0.0-h331b9b1_7_cpu.conda
osx-64::mysql-connector-python-8.2.0-py39h1bc6601_2.conda
osx-64::zimpl-3.5.4-hdb88abb_0.conda
osx-64::mysql-libs-8.3.0-ha9146f8_1.conda
osx-64::mysql-connector-python-8.2.0-py310h22c505b_1.conda
osx-64::protozfits-2.4.0-py312h4a2c1c8_1.conda
osx-64::magics-metview-4.15.2-h2f8389b_0.conda
osx-64::libtiledb-sql-0.27.1-hc16dca8_1.conda
osx-64::postgresql-plpython-16.2-py311h33a6423_0.conda
osx-64::nodejs-18.19.0-h119ffd7_0.conda
osx-64::libgdal-arrow-parquet-3.8.3-hace69e5_3.conda
osx-64::ndcctools-7.8.0-py38hd480228_0.conda
osx-64::libdwarf-0.9.0-h27ecd69_0.conda
osx-64::llvmlite-0.42.0-py311hb5c2e0a_0.conda
osx-64::cpp-opentelemetry-sdk-1.14.0-hcda5922_0.conda
osx-64::gdb-14.1-py38h8a98f55_0.conda
osx-64::papilo-2.2.0-h69457ee_0.conda
osx-64::libgrpc-1.61.0-h83379a4_0.conda
osx-64::libgdal-arrow-parquet-3.8.3-h9b91149_2.conda
osx-64::postgresql-16.2-hbd19fd8_0.conda
osx-64::tiledb-2.20.1-he6a79cd_1.conda
osx-64::aws-sdk-cpp-1.11.242-hf59c3df_2.conda
osx-64::grpcio-1.61.1-py39h339971c_1.conda
osx-64::nest-simulator-3.6-py39hf45367b_4.conda
osx-64::gdb-14.1-py38he8b00f4_1.conda
osx-64::libopentelemetry-cpp-1.14.2-h6552d82_0.conda
osx-64::libopencv-4.9.0-py39h6efa6ab_8.conda
osx-64::folly-2024.02.19.00-h8bd47b9_0.conda
osx-64::correctionlib-2.4.0-py311h94bc237_0.conda
osx-64::mysql-connector-python-8.2.0-py311had8ac61_4.conda
osx-64::grpcio-1.59.3-py312hbbbd34f_0.conda
osx-64::ovito-3.10.3-h0a3f43b_0.conda
osx-64::grpcio-1.61.1-py39h99d80ef_0.conda
osx-64::pyinstaller-6.4.0-py311h8c2310c_0.conda
osx-64::libtiledb-sql-0.27.0-h8bbe134_1.conda
osx-64::openimageio-2.5.5.0-hb1b453f_1.conda
osx-64::grpcio-1.61.0-py312hbbbd34f_0.conda
osx-64::ndcctools-7.8.0-py39h677b332_1.conda
osx-64::libpulsar-3.4.2-hc535e07_2.conda
osx-64::libtiledb-sql-0.27.1-h1528a6e_1.conda
osx-64::texlive-core-20230313-haa2e6a7_10.conda
osx-64::protozfits-2.4.0-py39h701e60c_0.conda
osx-64::mysql-connector-python-8.2.0-py38hd92117c_4.conda
osx-64::mysql-server-8.2.0-h7e12b8d_1.conda
osx-64::folly-2024.02.19.00-hf0236fa_2.conda
osx-64::mysql-client-8.2.0-hbece87f_1.conda
osx-64::libarrow-13.0.0-hc069ab1_26_cpu.conda
osx-64::libpq-15.6-h268af18_0.conda
osx-64::libarrow-15.0.0-h86e6b74_5_cpu.conda
osx-64::libarrow-12.0.1-hd1a66e8_39_cpu.conda
osx-64::postgresql-plpython-16.2-py39hf4bfa82_0.conda
osx-64::folly-2024.02.19.00-h079d3a0_0_jemalloc.conda
osx-64::ndcctools-7.8.0-py310h3f3ca68_1.conda
osx-64::postgresql-plpython-16.2-py310hd344ed2_0.conda
osx-64::mysql-connector-odbc-8.2.0-h2d185b6_0.conda
osx-64::jaxlib-0.4.23-cpu_py311h7977596_0.conda
osx-64::folly-2024.02.05.00-h8225e4e_0_jemalloc.conda
osx-64::postgresql-plpython-15.6-py311h0ff6264_0.conda
osx-64::python-igraph-0.11.4-py39h6cb1d1c_0.conda
osx-64::gfortran_impl_osx-arm64-12.3.0-h4f4d140_3.conda
osx-64::libgdal-arrow-parquet-3.8.4-heeac95c_0.conda
osx-64::grpcio-1.60.1-py38ha6b6e42_0.conda
osx-64::yoda-1.9.6-py311h4768b96_7.conda
osx-64::libgrpc-1.60.1-h038e8f1_0.conda
osx-64::libgdal-arrow-parquet-3.8.3-heeac95c_3.conda
osx-64::cargo-c-0.9.30-ha7549e5_0.conda
osx-64::wxpython-4.2.1-py39h0b4529e_3.conda
osx-64::yosys-0.38-he827bab_0.conda
osx-64::grpcio-1.61.1-py311h78ff076_0.conda
osx-64::libarrow-15.0.0-h9a3ee76_3_cpu.conda
osx-64::libgdal-arrow-parquet-3.8.3-hb63b4fd_1.conda
osx-64::git-2.44.0-pl5321h8687b19_0.conda
osx-64::openimageio-2.5.5.0-h91697fc_1.conda
osx-64::nest-simulator-3.6-py38hb86306f_4.conda
osx-64::libtiledb-sql-0.27.0-h27b4547_1.conda
osx-64::pdal-2.6.3-hd2646b2_2.conda
osx-64::gdb-14.1-py312h18f103a_1.conda
osx-64::root_base-6.30.4-py311h0aa6aca_0.conda
osx-64::libgdal-arrow-parquet-3.7.3-hf401ec8_14.conda
osx-64::lammps-2023.11.21-cpu_py39_hb2f5527_mpi_mpich_4.conda
osx-64::libgdal-arrow-parquet-3.7.3-h8f4eb83_15.conda
osx-64::pdal-2.6.3-h82f9e37_0.conda
osx-64::libgdal-arrow-parquet-3.8.4-hfe2b1a0_0.conda
osx-64::conduit-0.9.1-py310h70abc4e_0.conda
osx-64::root_base-6.28.12-py310hec7f349_0.conda
osx-64::gdb-14.1-py39hee52e7a_0.conda
osx-64::conduit-0.9.1-py39hc591e1e_0.conda
osx-64::postgresql-plpython-15.6-py38h47ab5f7_0.conda
osx-64::gdb-14.1-py310h22f9da6_1.conda
osx-64::gdb-14.1-py311h11e876c_1.conda
osx-64::correctionlib-2.5.0-py312hf41e57d_1.conda
osx-64::ogre-14.2.0-h5c474ad_0.conda
osx-64::loos-4.1.0-py39h9a28c73_0.conda
osx-64::gst-plugins-good-1.23.1-h3337715_0.conda
osx-64::llvmlite-0.42.0-py310h7d48a1f_0.conda
osx-64::libgdal-arrow-parquet-3.8.3-h48e125e_2.conda
osx-64::lammps-2023.11.21-cpu_py39_h3c69d27_nompi_4.conda
osx-64::conduit-0.9.1-py39hb0e2882_0.conda
osx-64::libarrow-14.0.2-h20c95d7_7_cpu.conda
osx-64::grpcio-1.61.1-py312hbbbd34f_0.conda
osx-64::lammps-2023.11.21-cpu_py311_h3ff7cfc_mpi_mpich_4.conda
osx-64::lammps-2023.11.21-cpu_py310_hbc8b412_mpi_openmpi_4.conda
osx-64::jaxlib-0.4.23-cpu_py39h33b98f6_0.conda
osx-64::mysql-connector-python-8.2.0-py310h4eecb6e_3.conda
osx-64::scip-9.0.0-h47bf6e7_0.conda
osx-64::grpcio-1.59.3-py39h99d80ef_0.conda
osx-64::libopencv-4.9.0-py311h8fa4719_8.conda
osx-64::protozfits-2.4.0-py310h44c962e_0.conda
osx-64::libgdal-arrow-parquet-3.7.3-ha895dd2_15.conda
osx-64::mysql-connector-python-8.2.0-py310h4eecb6e_2.conda
osx-64::libgdal-arrow-parquet-3.8.3-h96f4127_1.conda
osx-64::folly-2024.02.05.00-h8bd47b9_0.conda
osx-64::libarrow-13.0.0-hd1a66e8_28_cpu.conda
osx-64::libgrpc-1.61.1-h83379a4_0.conda
osx-64::libdwarf-dev-0.9.1-h27ecd69_0.conda
osx-64::python-igraph-0.11.4-py311h090a316_0.conda
osx-64::folly-2024.02.12.00-h8bd47b9_0.conda
osx-64::kaldi-5.5.112-cpu_h0f3c836_0.conda
osx-64::gdb-14.1-py310h9fedbc6_0.conda
osx-64::sasktran2-2024.02.2-py311hf64b1d5_0.conda
osx-64::cpp-opentelemetry-sdk-1.14.2-h6552d82_0.conda
osx-64::mysql-libs-8.2.0-ha9146f8_1.conda
osx-64::tectonic-0.15.0-h1754a03_0.conda
osx-64::libopentelemetry-cpp-1.14.1-hcda5922_0.conda
osx-64::wxpython-4.2.1-py38hba267d8_3.conda
osx-64::r-base-4.3.3-hbe75827_0.conda
osx-64::sagelib-10.2-py39h843bdee_4.conda
osx-64::freecad-0.21.2-py38h0a83025_1.conda
osx-64::libgdal-arrow-parquet-3.7.3-hfe2b1a0_16.conda
osx-64::postgresql-plpython-16.2-py311h47125a7_0.conda
osx-64::correctionlib-2.4.0-py38h7671238_0.conda
osx-64::nest-simulator-3.6-py311h22a0843_4.conda
osx-64::conduit-0.9.1-py311hcefa724_0.conda
osx-64::magics-metview-batch-4.15.3-hb5cd182_0.conda
osx-64::cctools_osx-64-973.0.1-ha1c5b94_16.conda
osx-64::gdstk-0.9.50-py310h83e167c_0.conda
osx-64::mysql-connector-python-8.2.0-py311h0bd93ab_1.conda
osx-64::libgit2-1.7.2-h40db0df_2.conda
osx-64::cctools_osx-arm64-973.0.1-h8d715a0_16.conda
osx-64::qt6-3d-6.6.2-hba7393b_1.conda
osx-64::ndcctools-7.7.3-py310h3f3ca68_1.conda
osx-64::libgdal-3.7.3-h9922bd6_15.conda
osx-64::mysql-connector-odbc-8.0.33-h2d185b6_0.conda
osx-64::folly-2024.02.12.00-h7815ab9_0.conda
osx-64::ldas-tools-framecpp-3.0.3-hdf332f8_0.conda
osx-64::correctionlib-2.4.0-py310he697753_0.conda
osx-64::yoda-1.9.6-py39heeff07a_7.conda
osx-64::tiledb-2.20.0-hc714e58_0.conda
osx-64::libgdal-3.8.3-hf248df1_2.conda
osx-64::libarrow-13.0.0-h620627f_27_cpu.conda
osx-64::mysql-libs-8.3.0-ha9146f8_2.conda
osx-64::pdal-2.6.2-h82f9e37_4.conda
osx-64::orc-1.9.2-h3758fe2_2.conda
osx-64::magics-metview-batch-4.15.2-hb5cd182_0.conda
osx-64::pypy3.9-7.3.15-hae43b7a_0.conda
osx-64::mesalib-24.0.1-hbd9e708_0.conda
osx-64::postgresql-plpython-16.2-py39h7f9fc5f_0.conda
osx-64::mysql-connector-python-8.2.0-py39h0fa98f0_2.conda
osx-64::postgresql-plpython-15.6-py310h112046a_0.conda
osx-64::sdl_image-1.2.12-h2043787_7.conda
osx-64::ndcctools-7.7.3-py38hd480228_0.conda
osx-64::cctools_osx-arm64-973.0.1-h7bb7a8e_16.conda
osx-64::freecad-0.21.2-py39h062ef08_1.conda
osx-64::lammps-2023.11.21-cpu_py39_h7885287_mpi_openmpi_4.conda
osx-64::ndcctools-7.8.0-py311hc4bdf42_0.conda
osx-64::openimageio-2.5.5.0-hb0c076a_1.conda
osx-64::jaxlib-0.4.23-cpu_py310hd883831_0.conda
osx-64::ndcctools-7.7.3-py39h677b332_0.conda
osx-64::mosh-1.4.0-pl5321h14cb5a3_7.conda
osx-64::wxpython-4.2.1-py312h2bde87c_3.conda
osx-64::wxpython-4.2.1-py310h4ae869d_3.conda
osx-64::tensorstore-0.1.54-py312h3584885_1.conda
osx-64::llvmlite-0.42.0-py311hb5c2e0a_1.conda
osx-64::libgdal-arrow-parquet-3.8.3-hb0860dd_1.conda
osx-64::root_base-6.28.12-py39h5399eaa_0.conda
osx-64::grpcio-1.60.1-py39h99d80ef_0.conda
osx-64::protozfits-2.4.0-py310hefbe1a0_1.conda
osx-64::mesalib-24.0.2-hbd9e708_0.conda
osx-64::lammps-2023.11.21-cpu_py39_h9bb1a43_mpi_openmpi_4.conda
osx-64::root_base-6.28.12-py38h340b97f_0.conda
osx-64::lammps-2023.11.21-cpu_py310_h8cbf5a9_nompi_4.conda
osx-64::libgdal-arrow-parquet-3.8.3-hc78a71b_2.conda
osx-64::postgresql-16.2-h413614c_0.conda
osx-64::correctionlib-2.5.0-py310he697753_1.conda
osx-64::grpcio-1.61.1-py38ha6b6e42_0.conda
osx-64::ndcctools-7.7.3-py39h677b332_1.conda
osx-64::gdstk-0.9.50-py311h7edd508_0.conda
osx-64::mysql-connector-python-8.2.0-py310h66af2ad_4.conda
osx-64::grpcio-1.60.1-py39h339971c_0.conda
osx-64::libopencv-4.9.0-py39hbb10068_8.conda
osx-64::mysql-connector-python-8.2.0-py38h120e042_3.conda
osx-64::mysql-server-8.2.0-h6d730d4_0.conda
osx-64::libgoogle-cloud-storage-2.21.0-ha67e85c_2.conda
osx-64::pyinstaller-6.4.0-py38hf1429db_0.conda
osx-64::grpcio-1.61.1-py39h339971c_0.conda
osx-64::loos-4.1.0-py38hd60aa96_0.conda
osx-64::freecad-0.21.2-py310h6f4b145_1.conda
osx-64::aws-sdk-cpp-1.11.242-hcd1352c_1.conda
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
osx-64::libprotobuf-static-4.25.2-ha3fb9cb_0.conda
osx-64::openexr-3.2.2-h0c5910e_0.conda
osx-64::gcab-1.6-hbca7060_0.conda
osx-64::ldas-tools-framecpp-2.9.3-hb626621_0.conda
osx-64::eccodes-2.34.0-h40b907c_0.conda
osx-64::libsolv-static-0.7.28-h2d185b6_0.conda
osx-64::libprotobuf-4.25.2-h4e4d658_1.conda
osx-64::git-cliff-2.0.3-hc76a939_0.conda
osx-64::openjpeg-2.5.2-h7310d3a_0.conda
osx-64::imath-3.1.11-h2d185b6_0.conda
osx-64::gst-plugins-base-1.23.1-h12dd0d4_0.conda
osx-64::git-cliff-2.0.4-hc76a939_0.conda
osx-64::openjpeg-2.5.1-h7310d3a_0.conda
osx-64::libprotobuf-4.25.1-hc4f2305_1.conda
osx-64::ldas-tools-framecpp-2.9.3-hb626621_1.conda
osx-64::exiv2-0.28.2-h239cba9_0.conda
osx-64::libsqlite-3.45.1-h92b6c6a_0.conda
osx-64::glib-tools-2.78.4-h2d185b6_0.conda
osx-64::libprotobuf-4.25.2-h4e4d658_0.conda
osx-64::libprotobuf-4.25.1-hc4f2305_2.conda
osx-64::libpng-1.6.42-h92b6c6a_0.conda
osx-64::libprotobuf-static-4.25.2-ha3fb9cb_1.conda
osx-64::libsolv-0.7.28-h2d185b6_0.conda
osx-64::cfitsio-4.4.0-h60fb419_0.conda
osx-64::eccodes-2.34.1-h40b907c_0.conda
osx-64::libprotobuf-static-4.25.1-h9dd416e_2.conda
osx-64::libpng-1.6.43-h92b6c6a_0.conda
osx-64::libprotobuf-static-4.25.1-h9dd416e_1.conda
osx-64::libuwebsockets-20.59.0-h2d185b6_0.conda
osx-64::pcre2-10.43-h0ad2156_0.conda
osx-64::libuwebsockets-20.60.0-h2d185b6_0.conda
-    "libzlib >=1.2.13,<1.3.0a0"
+    "libzlib >=1.2.13,<2.0.0a0"
================================================================================
================================================================================
linux-64
linux-64::pdal-2.6.3-h312035a_1.conda
linux-64::libgdal-arrow-parquet-3.7.3-hbf5f116_15.conda
linux-64::libarrow-14.0.2-hbbf05ad_10_cuda.conda
linux-64::libarrow-12.0.1-h3be7598_38_cuda.conda
linux-64::lammps-2023.11.21-cpu_py39_hf042188_nompi_4.conda
linux-64::poppler-24.02.0-h590f24d_0.conda
linux-64::tiledb-2.20.0-hc0b898c_0.conda
linux-64::postgresql-plpython-15.6-py310h4bf71c2_0.conda
linux-64::folly-2024.02.05.00-h122a45c_0_jemalloc.conda
linux-64::grpcio-1.60.1-py38h94a1851_0.conda
linux-64::openimageio-2.5.5.0-h6411561_1.conda
linux-64::lammps-2023.11.21-cpu_py310_hcea6fc9_mpi_openmpi_4.conda
linux-64::mysql-connector-python-8.2.0-py310h9a4a04d_3.conda
linux-64::libgdal-arrow-parquet-3.8.4-h0f68c7b_0.conda
linux-64::mysql-server-8.2.0-h434d1e9_1.conda
linux-64::magic-8.3.463-h9abf892_0.conda
linux-64::mysql-router-8.2.0-h7d6b259_1.conda
linux-64::libgdal-3.8.3-ha28fdbc_1.conda
linux-64::postgresql-plpython-16.2-py39ha00ab12_0.conda
linux-64::wxpython-4.2.1-py312hcd885e0_3.conda
linux-64::libgdal-arrow-parquet-3.8.3-h173fbbb_1.conda
linux-64::robotraconteur-1.0.0-py311ha1b276c_1.conda
linux-64::mdsplus-7.139.64-py38pl5321ha8a3ab3_0.conda
linux-64::julia-1.10.1-h764f291_0.conda
linux-64::mysql-client-8.3.0-h545f5f4_2.conda
linux-64::folly-2024.02.12.00-h23251b7_0.conda
linux-64::mysql-connector-python-8.2.0-py39h519aa44_2.conda
linux-64::libarrow-13.0.0-hc8ada47_29_cuda.conda
linux-64::code-aster-17.0.5-np122py310h04c1e7b_0.conda
linux-64::grpcio-1.61.0-py312hb06c811_0.conda
linux-64::photochem-0.4.5-py38h2d2fbd7_1.conda
linux-64::folly-2024.02.19.00-h23251b7_0.conda
linux-64::libgrpc-1.60.1-h74775cd_0.conda
linux-64::gdstk-0.9.50-py39h9bdbfdd_0.conda
linux-64::protozfits-2.4.0-py39h376b3e8_1.conda
linux-64::correctionlib-2.4.0-py311h9e0f504_1.conda
linux-64::loos-4.1.0-py38hfc2a9ad_0.conda
linux-64::pdal-2.6.3-h312035a_2.conda
linux-64::mosh-1.4.0-pl5321h092b9fe_7.conda
linux-64::libgit2-1.7.2-h65212e3_1.conda
linux-64::robotraconteur-0.18.0-py311ha1b276c_0.conda
linux-64::qt6-main-6.6.2-hb9293b2_2.conda
linux-64::kaldi-5.5.1112-cpu_h31769b2_0.conda
linux-64::tensorstore-0.1.54-py310h76b92c1_1.conda
linux-64::gdstk-0.9.50-py311h75db532_0.conda
linux-64::mysql-router-8.2.0-h1922fb2_0.conda
linux-64::photochem-0.4.5-py310h8994ab7_1.conda
linux-64::protozfits-2.4.0-py312hdd598aa_0.conda
linux-64::qt6-wayland-6.6.2-h35d8138_0.conda
linux-64::cpp-opentelemetry-sdk-1.14.1-ha162ae1_0.conda
linux-64::mdsplus-7.139.62-py311pl5321h4a20be6_0.conda
linux-64::libgoogle-cloud-storage-2.21.0-hc7a4891_1.conda
linux-64::tiledb-2.20.0-hd75ad12_1.conda
linux-64::postgresql-plpython-16.2-py311hf60bfc6_0.conda
linux-64::tiledb-2.20.1-hf82822d_1.conda
linux-64::lammps-2023.11.21-cuda118_py310_h483aaed_mpi_openmpi_4.conda
linux-64::folly-2024.02.19.00-h70f49c4_1_jemalloc.conda
linux-64::nodejs-18.19.0-hb753e55_0.conda
linux-64::folly-2024.02.19.00-h72ab1f5_2_jemalloc.conda
linux-64::python-igraph-0.11.4-py39hc8c42eb_0.conda
linux-64::mdsplus-7.139.64-py310pl5321hbd303f0_0.conda
linux-64::postgresql-plpython-15.6-py312hd1394c4_0.conda
linux-64::mysql-connector-odbc-8.0.33-hfc55251_0.conda
linux-64::gdb-14.1-py39hf942bb9_0.conda
linux-64::photochem-0.4.5-py311he186e3d_1.conda
linux-64::correctionlib-2.5.0-py311h9e0f504_1.conda
linux-64::valgrind-3.22.0-hcd5def8_1.conda
linux-64::createrepo_c-1.0.4-py311h8dbc1c1_0.conda
linux-64::texlive-core-20230313-h1c0206c_10.conda
linux-64::root_base-6.30.4-py310hc6cfe62_0.conda
linux-64::tiledb-2.20.0-h4386cac_0.conda
linux-64::nest-simulator-3.6-py38h203082f_4.conda
linux-64::folly-2024.02.19.00-h122a45c_0_jemalloc.conda
linux-64::cctools_osx-64-973.0.1-h36c9c07_16.conda
linux-64::mysql-libs-8.3.0-hca2cd23_2.conda
linux-64::libarrow-14.0.2-h9634e4e_9_cuda.conda
linux-64::paraview-5.11.2-py38h434e1c3_2_egl.conda
linux-64::postgresql-plpython-16.2-py311h4204730_0.conda
linux-64::lammps-2023.11.21-cpu_py311_hd3d4698_mpi_mpich_4.conda
linux-64::lammps-2023.11.21-cuda118_py39_h0d794d2_mpi_openmpi_4.conda
linux-64::libgdal-arrow-parquet-3.8.3-h554decd_2.conda
linux-64::gfortran_impl_osx-arm64-13.2.0-h307e53f_3.conda
linux-64::sagelib-10.2-py311hbe93d5b_4.conda
linux-64::prometheus-cpp-1.2.2-h90a924e_0.conda
linux-64::lammps-2023.11.21-cpu_py38_h5608ceb_nompi_4.conda
linux-64::mysql-connector-python-8.2.0-py38h5a2ef47_2.conda
linux-64::mysql-server-8.3.0-h11eb426_2.conda
linux-64::lammps-2023.11.21-cuda118_py39_hdd7f1a5_mpi_mpich_4.conda
linux-64::r-seqminer-9.4-r43ha661321_0.conda
linux-64::libgdal-arrow-parquet-3.8.3-h0f68c7b_3.conda
linux-64::sagelib-10.2-py39h031b06c_4.conda
linux-64::rust-1.76.0-h70c747d_0.conda
linux-64::postgresql-plpython-16.2-py312hcc5c902_0.conda
linux-64::lammps-2023.11.21-cuda118_py39_hf2cf36d_nompi_4.conda
linux-64::cctools_osx-arm64-973.0.1-h05ba045_16.conda
linux-64::magics-4.15.2-hd93a360_0.conda
linux-64::robotraconteur-1.0.0-py310h4f694cf_1.conda
linux-64::lammps-2023.11.21-cuda118_py38_he846794_nompi_4.conda
linux-64::conduit-0.9.1-py311hbb7570c_0.conda
linux-64::yoda-1.9.6-py39h3dfa4de_7.conda
linux-64::cargo-c-0.9.30-h5ad674e_0.conda
linux-64::paraview-5.11.2-py312hd7a169c_102_qt.conda
linux-64::tiledb-2.20.0-h584b59b_1.conda
linux-64::imagemagick-7.1.1_29-pl5321hb90aeea_0.conda
linux-64::jaxlib-0.4.23-cuda118py311hceab81f_200.conda
linux-64::postgresql-plpython-15.6-py39h107fd68_0.conda
linux-64::actions-runner-2.311.0-hcd5def8_0.conda
linux-64::jaxlib-0.4.23-cpu_py312h1743843_0.conda
linux-64::clangdev-13.0.1-root_63004_hcf29762_6.conda
linux-64::libpulsar-3.4.2-h5b25a9d_2.conda
linux-64::python-igraph-0.11.4-py310hd7113ba_0.conda
linux-64::yoda-1.9.6-py310h5454746_7.conda
linux-64::conduit-0.9.1-py39h7b17fe3_0.conda
linux-64::robotraconteur-0.18.0-py38h83dc16b_0.conda
linux-64::fish-3.7.0-h3dcaff5_1.conda
linux-64::gfortran_impl_osx-64-13.2.0-hf49883a_3.conda
linux-64::libgit2-1.7.2-h76de150_0.conda
linux-64::libarrow-12.0.1-hf3a83aa_39_cuda.conda
linux-64::libgdal-arrow-parquet-3.8.3-hcd7ded7_2.conda
linux-64::code-aster-17.0.7-np122py39hc2960b6_0.conda
linux-64::nco-5.2.0-he646072_0.conda
linux-64::lammps-2023.11.21-cpu_py310_h8f80a90_mpi_mpich_4.conda
linux-64::libgdal-arrow-parquet-3.8.3-h435aaf2_3.conda
linux-64::lammps-2023.11.21-cuda118_py39_h4a9cbaf_mpi_openmpi_4.conda
linux-64::correctionlib-2.4.0-py38hbb0cdd4_0.conda
linux-64::code-aster-17.0.6-np123py311hdf3bf53_0.conda
linux-64::grpcio-1.61.1-py39h7d5b425_1.conda
linux-64::llvmlite-0.42.0-py310h1b8f574_1.conda
linux-64::libtiledb-sql-0.27.1-h203c794_1.conda
linux-64::julia-1.10.1-h5490d3b_1.conda
linux-64::llvmlite-0.42.0-py39h7d5b425_0.conda
linux-64::folly-2024.02.19.00-ha956c68_2.conda
linux-64::magic-8.3.462-h9abf892_0.conda
linux-64::lammps-2023.11.21-cuda118_py311_h80f0500_nompi_4.conda
linux-64::libarrow-15.0.0-h0809cb0_3_cpu.conda
linux-64::conduit-0.9.1-py39ha295988_0.conda
linux-64::magics-metview-4.15.3-he53f960_0.conda
linux-64::r-seqminer-9.4-r42ha661321_0.conda
linux-64::libgdal-arrow-parquet-3.7.3-h435aaf2_16.conda
linux-64::conduit-0.9.1-py310h5cd70fc_0.conda
linux-64::mesalib-24.0.0-hf257a20_0.conda
linux-64::pyinstaller-6.4.0-py38h502143a_0.conda
linux-64::qt6-main-6.6.2-hb9293b2_0.conda
linux-64::libarrow-15.0.0-h061b4f0_3_cuda.conda
linux-64::cpp-opentelemetry-sdk-1.14.0-ha162ae1_0.conda
linux-64::folly-2024.02.19.00-h1d40f03_0.conda
linux-64::git-2.44.0-pl5321h709897a_0.conda
linux-64::libgrpc-1.61.1-h42401df_1.conda
linux-64::ldas-tools-framecpp-2.9.3-h4f0fbb0_1.conda
linux-64::paraview-5.11.2-py38h5e594a3_102_qt.conda
linux-64::libarrow-15.0.0-hbbf05ad_7_cuda.conda
linux-64::aws-sdk-cpp-1.11.242-h0bb408c_2.conda
linux-64::folly-2024.02.05.00-hb244bc4_0.conda
linux-64::grpcio-1.61.0-py38h94a1851_0.conda
linux-64::jaxlib-0.4.23-cuda118py310h8c47008_200.conda
linux-64::ndcctools-7.8.0-py311h689c632_0.conda
linux-64::mysql-connector-python-8.2.0-py38h5a2ef47_1.conda
linux-64::conduit-0.9.1-py310h7c0bdf8_0.conda
linux-64::tensorstore-0.1.51-py39h2f588e0_2.conda
linux-64::robotraconteur-1.0.0-py312h33ef3a6_1.conda
linux-64::postgresql-plpython-15.6-py311hff8006e_0.conda
linux-64::mysql-connector-python-8.2.0-py39hb5de971_1.conda
linux-64::libgdal-3.7.3-h19bedfc_15.conda
linux-64::libarrow-12.0.1-h5a9302f_38_cpu.conda
linux-64::kaldi-5.5.112-cuda112h971fcfb_0.conda
linux-64::qt6-wayland-6.6.2-h6af8810_1.conda
linux-64::folly-2024.02.05.00-h1d40f03_0.conda
linux-64::mdsplus-7.139.63-py311pl5321h4a20be6_0.conda
linux-64::lammps-2023.11.21-cpu_py38_hda8f861_mpi_mpich_4.conda
linux-64::libopencv-4.9.0-py310h0e49cd2_8.conda
linux-64::ndcctools-7.8.0-py38h514f0f6_0.conda
linux-64::root_base-6.28.12-py38h4feed2d_0.conda
linux-64::clangdev-13.0.1-default_h7634d5b_6.conda
linux-64::llvmlite-0.42.0-py39h174d805_1.conda
linux-64::protozfits-2.4.0-py311hf1c902a_1.conda
linux-64::conduit-0.9.1-py39h7af37c2_0.conda
linux-64::libtiledb-sql-0.27.1-h9e8d02e_0.conda
linux-64::robotraconteur-1.0.0-py311ha1b276c_0.conda
linux-64::folly-2024.02.19.00-h70f49c4_0_jemalloc.conda
linux-64::libtiledb-sql-0.27.1-h230ed91_0.conda
linux-64::dwarfdump-0.9.0-hecc041a_0.conda
linux-64::libarrow-15.0.0-hdbe5c44_5_cpu.conda
linux-64::libgdal-arrow-parquet-3.7.3-h48313cc_14.conda
linux-64::postgresql-15.6-h82ecc9d_0.conda
linux-64::aws-sdk-cpp-1.11.242-h8ff76d7_1.conda
linux-64::libarrow-13.0.0-h3be7598_27_cuda.conda
linux-64::libtiledb-sql-0.27.1-hbf6a0d6_1.conda
linux-64::libgdal-arrow-parquet-3.7.3-h0f68c7b_16.conda
linux-64::jaxlib-0.4.23-cpu_py311hc0fb0b9_0.conda
linux-64::conduit-0.9.1-py38hd6c014b_0.conda
linux-64::git-2.43.0-pl5321h709897a_1.conda
linux-64::dwarfdump-0.9.1-hecc041a_0.conda
linux-64::jaxlib-0.4.23-cuda118py312h82c1838_200.conda
linux-64::photochem-0.4.5-py39heaf3ece_1.conda
linux-64::qt6-3d-6.6.2-hf2d569e_0.conda
linux-64::pyinstaller-6.4.0-py310h93c3562_0.conda
linux-64::libopentelemetry-cpp-1.14.0-ha162ae1_0.conda
linux-64::mysql-connector-python-8.2.0-py311he22a6d4_4.conda
linux-64::grpcio-1.60.1-py312hb06c811_0.conda
linux-64::python-3.12.2-hab00c5b_0_cpython.conda
linux-64::libgdal-3.7.3-h4f45c9d_14.conda
linux-64::postgresql-plpython-16.2-py312h8532d62_0.conda
linux-64::gst-plugins-base-1.23.1-h8e1006c_0.conda
linux-64::gst-plugins-good-1.23.1-h94a241a_0.conda
linux-64::grpcio-1.61.1-py311ha6695c7_1.conda
linux-64::libarrow-14.0.2-h49c8883_6_cpu.conda
linux-64::libopencv-4.9.0-py311hd7d28c8_8.conda
linux-64::jaxlib-0.4.23-cuda118py312ha7cc576_200.conda
linux-64::grpcio-1.61.1-py311ha6695c7_0.conda
linux-64::root_base-6.28.12-py310hc6cfe62_0.conda
linux-64::loos-4.1.0-py312h2a5e245_0.conda
linux-64::freecad-0.21.2-py311h94c7332_1.conda
linux-64::libgdal-arrow-parquet-3.8.3-hbf5f116_3.conda
linux-64::magics-4.15.3-hd93a360_0.conda
linux-64::qt-main-5.15.8-h5810be5_19.conda
linux-64::root_base-6.30.4-py39h479b7f5_0.conda
linux-64::createrepo_c-1.0.4-py310h8f447a6_0.conda
linux-64::libopencv-4.9.0-py312h3e73a0f_8.conda
linux-64::mysql-connector-python-8.2.0-py39hac733e2_4.conda
linux-64::libgdal-arrow-parquet-3.8.4-h2af65d3_0.conda
linux-64::kaldi-5.5.1112-cuda120h41cae9c_0.conda
linux-64::mdsplus-7.139.65-py39pl5321h4e21038_0.conda
linux-64::code-aster-17.0.7-np122py38hb58a787_0.conda
linux-64::grpcio-1.61.1-py39h7d5b425_0.conda
linux-64::mdsplus-7.139.62-py310pl5321hbd303f0_0.conda
linux-64::nco-5.2.1-he646072_0.conda
linux-64::tensorstore-0.1.54-py311hbfb5fdc_0.conda
linux-64::mysql-connector-python-8.2.0-py39h357227b_0.conda
linux-64::ndcctools-7.7.3-py39h4841754_1.conda
linux-64::correctionlib-2.4.0-py312h24f76d5_1.conda
linux-64::openimageio-2.5.5.0-h3f1ea95_1.conda
linux-64::robotraconteur-1.0.0-py39h6f21934_0.conda
linux-64::libglib-2.78.4-h783c2da_0.conda
linux-64::lammps-2023.11.21-cuda118_py310_hadf4ee5_nompi_4.conda
linux-64::tiledb-2.20.0-hd75ad12_0.conda
linux-64::tensorstore-0.1.54-py310h76b92c1_0.conda
linux-64::gfortran_impl_osx-arm64-12.3.0-hd18e70c_3.conda
linux-64::ndcctools-7.8.0-py310he2ed3e8_0.conda
linux-64::mdsplus-7.139.65-py38pl5321ha8a3ab3_0.conda
linux-64::imagemagick-7.1.1_28-pl5321hb90aeea_0.conda
linux-64::libgoogle-cloud-storage-2.21.0-hc7a4891_0.conda
linux-64::protozfits-2.4.0-py310hc041de8_0.conda
linux-64::lammps-2023.11.21-cpu_py311_hbb7bd43_mpi_openmpi_4.conda
linux-64::gdb-14.1-py311h33463bb_0.conda
linux-64::protozfits-2.4.0-py310h766c928_1.conda
linux-64::mysql-connector-python-8.2.0-py310h74e39b9_0.conda
linux-64::sdl_image-1.2.12-h7bc34b5_7.conda
linux-64::libgdal-3.8.3-h9323651_3.conda
linux-64::libarrow-13.0.0-hdf9a9d5_29_cpu.conda
linux-64::libgit2-1.7.2-h65212e3_2.conda
linux-64::magics-metview-batch-4.15.2-hd93a360_0.conda
linux-64::yoda-1.9.6-py39ha980afe_7.conda
linux-64::freecad-0.21.2-py310h3bfde82_1.conda
linux-64::python-igraph-0.11.4-py312h7e4364d_0.conda
linux-64::libgdal-3.8.3-h80d7d79_2.conda
linux-64::grpcio-1.61.0-py310h1b8f574_0.conda
linux-64::correctionlib-2.4.0-py39h2ea1df6_0.conda
linux-64::libarrow-14.0.2-hdbe5c44_8_cpu.conda
linux-64::correctionlib-2.4.0-py310h3845668_1.conda
linux-64::protozfits-2.4.0-py39hc60452a_0.conda
linux-64::root_base-6.28.12-py311h1329b8c_0.conda
linux-64::robotraconteur-0.18.0-py310h4f694cf_0.conda
linux-64::libgdal-arrow-parquet-3.7.3-h435aaf2_15.conda
linux-64::folly-2024.02.19.00-hb244bc4_0.conda
linux-64::libspral-2024.01.18-h6aa6db2_0.conda
linux-64::lammps-2023.11.21-cpu_py39_hefd3d5c_mpi_mpich_4.conda
linux-64::libgdal-arrow-parquet-3.8.4-hbf5f116_0.conda
linux-64::python-igraph-0.11.4-py311hce45d13_0.conda
linux-64::jaxlib-0.4.23-cpu_py310he792417_0.conda
linux-64::libgdal-arrow-parquet-3.7.3-h554decd_14.conda
linux-64::jaxlib-0.4.23-cpu_py39h46a095e_0.conda
linux-64::hugin-base-2023.0.0-pl5321hfb9f980_0.conda
linux-64::sqlite-3.45.1-h2c6b66d_0.conda
linux-64::ogre-14.2.0-h1ab86f5_0.conda
linux-64::tiledb-2.20.1-h584b59b_1.conda
linux-64::libtiledb-sql-0.27.0-h9e8d02e_1.conda
linux-64::mdsplus-7.139.65-py311pl5321h4a20be6_0.conda
linux-64::mysql-client-8.2.0-h545f5f4_1.conda
linux-64::postgresql-plpython-15.6-py38hc64cd6d_0.conda
linux-64::lammps-2023.11.21-cuda118_py39_hcae4e68_mpi_mpich_4.conda
linux-64::createrepo_c-1.0.4-py38h569db57_0.conda
linux-64::lammps-2023.11.21-cpu_py311_hdd49dfd_nompi_4.conda
linux-64::postgresql-plpython-16.2-py310hd093153_0.conda
linux-64::kaldi-5.5.112-cpu_h31769b2_0.conda
linux-64::libgoogle-cloud-storage-2.21.0-hc7a4891_2.conda
linux-64::libdwarf-dev-0.9.1-hecc041a_0.conda
linux-64::folly-2024.02.12.00-h1d40f03_0.conda
linux-64::gdb-14.1-py38hc0042fb_0.conda
linux-64::libarrow-15.0.0-h17fe1ab_6_cpu.conda
linux-64::soplex-8.0.0-hb8295c1_0.conda
linux-64::freecad-0.21.2-py38h4a931db_1.conda
linux-64::gdb-14.1-py311he970d7a_1.conda
linux-64::libopencv-4.9.0-py39hc62deea_8.conda
linux-64::libgdal-arrow-parquet-3.8.3-h16e9503_2.conda
linux-64::conduit-0.9.1-py38hc658cf2_0.conda
linux-64::code-aster-17.0.5-np123py311hdf3bf53_0.conda
linux-64::cmake-3.28.3-hcfe8598_0.conda
linux-64::karilang-kernel-0.1.0-hbfa4dcf_0.conda
linux-64::libgdal-arrow-parquet-3.8.3-h7b844d3_1.conda
linux-64::hugin-2023.0.0-pl5321hfca3cae_0.conda
linux-64::grpcio-1.61.1-py38h94a1851_1.conda
linux-64::root_base-6.28.12-py39h479b7f5_0.conda
linux-64::ogre-14.2.0-h71d15da_0.conda
linux-64::mysql-connector-python-8.2.0-py311h6ca8dce_3.conda
linux-64::code-aster-17.0.5-np122py39hc2960b6_0.conda
linux-64::libgrpc-1.61.0-hccd595a_0.conda
linux-64::glib-2.78.4-hfc55251_0.conda
linux-64::protozfits-2.4.0-py38h56c7270_1.conda
linux-64::libgrpc-1.61.1-hccd595a_0.conda
linux-64::mysql-connector-python-8.2.0-py38h4afd844_4.conda
linux-64::ffmpeg-6.1.1-gpl_h8007c5b_104.conda
linux-64::photochem-0.4.5-py312he956743_1.conda
linux-64::ndcctools-7.8.0-py310he2ed3e8_1.conda
linux-64::erlang-26.2.2-pl5321hde4a2a6_0.conda
linux-64::folly-2024.02.19.00-hbc8c634_0_jemalloc.conda
linux-64::jaxlib-0.4.23-cuda118py310h22361d4_200.conda
linux-64::ovito-3.10.3-h8e92c3b_0.conda
linux-64::mysql-libs-8.3.0-hca2cd23_1.conda
linux-64::mysql-connector-python-8.2.0-py38h5a2ef47_3.conda
linux-64::lammps-2023.11.21-cuda118_py38_h80d1e08_mpi_mpich_4.conda
linux-64::sagelib-10.2-py310he210692_4.conda
linux-64::jaxlib-0.4.23-cpu_py311hfd936b8_0.conda
linux-64::paraview-5.11.2-py311he43584d_2_egl.conda
linux-64::mysql-client-8.3.0-h545f5f4_1.conda
linux-64::wxpython-4.2.1-py38h3f90fbe_3.conda
linux-64::gdstk-0.9.50-py312h7b2b3ac_0.conda
linux-64::mysql-server-8.3.0-h434d1e9_1.conda
linux-64::lammps-2023.11.21-cuda118_py38_hc73eb01_mpi_openmpi_4.conda
linux-64::libarrow-15.0.0-h5001e6d_7_cpu.conda
linux-64::correctionlib-2.5.0-py39h2ea1df6_1.conda
linux-64::libarrow-12.0.1-hdf9a9d5_40_cpu.conda
linux-64::kaldi-5.5.112-cuda120h41cae9c_0.conda
linux-64::jaxlib-0.4.23-cpu_py39hbe6c8ad_0.conda
linux-64::ndcctools-7.7.3-py310he2ed3e8_1.conda
linux-64::libgdal-arrow-parquet-3.8.3-hf1f22dc_1.conda
linux-64::folly-2024.02.19.00-h23251b7_1.conda
linux-64::mysql-connector-odbc-8.2.0-hfc55251_0.conda
linux-64::mysql-router-8.3.0-h6f722d6_2.conda
linux-64::libopentelemetry-cpp-1.14.2-h83bf46b_0.conda
linux-64::correctionlib-2.4.0-py311h9e0f504_0.conda
linux-64::pyinstaller-6.4.0-py312hf0b23d7_0.conda
linux-64::paraview-5.11.2-py39h5361cb4_2_egl.conda
linux-64::julia-1.10.0-h764f291_0.conda
linux-64::lammps-2023.11.21-cuda118_py39_hf8afb37_nompi_4.conda
linux-64::mysql-connector-python-8.2.0-py39h1d06a94_0.conda
linux-64::freecad-0.21.2-py39he0a02f4_1.conda
linux-64::gdb-14.1-py310h7e17b58_0.conda
linux-64::libdwarf-dev-0.9.0-hecc041a_0.conda
linux-64::libopencv-4.9.0-py38h3618cbe_8.conda
linux-64::ldas-tools-framecpp-2.9.3-h4f0fbb0_0.conda
linux-64::libdwarf-testing-meta-0.9.1-hecc041a_0.conda
linux-64::protozfits-2.4.0-py311h07795a0_0.conda
linux-64::mysql-connector-python-8.2.0-py38hf5004fd_0.conda
linux-64::mysql-libs-8.2.0-hca2cd23_1.conda
linux-64::ldas-tools-framecpp-3.0.3-h59d2ec3_0.conda
linux-64::glibmm-2.68-2.78.1-h2f54ecc_0.conda
linux-64::folly-2024.02.12.00-hbc8c634_0_jemalloc.conda
linux-64::code-aster-17.0.7-np123py311hdf3bf53_0.conda
linux-64::libarrow-15.0.0-h917be6d_4_cuda.conda
linux-64::paraview-5.11.2-py310h4559d26_2_egl.conda
linux-64::lammps-2023.11.21-cpu_py39_h5b957dd_nompi_4.conda
linux-64::yoda-1.9.6-py38h3e03392_7.conda
linux-64::loos-4.1.0-py311h7f15919_0.conda
linux-64::ndcctools-7.7.3-py311h689c632_1.conda
linux-64::code-aster-17.0.5-np122py38hb58a787_0.conda
linux-64::mysql-connector-python-8.2.0-py310hb7afee8_4.conda
linux-64::grpcio-1.60.1-py311ha6695c7_0.conda
linux-64::robotraconteur-1.0.0-py38h83dc16b_0.conda
linux-64::llvmlite-0.42.0-py311ha6695c7_1.conda
linux-64::libarrow-13.0.0-h02f7050_28_cpu.conda
linux-64::mdsplus-7.139.63-py310pl5321hbd303f0_0.conda
linux-64::mysql-connector-python-8.2.0-py39h47610e7_4.conda
linux-64::robotraconteur-0.18.0-py39h6f21934_0.conda
linux-64::lammps-2023.11.21-cpu_py310_h5b57e7a_nompi_4.conda
linux-64::qt6-main-6.6.2-hb9293b2_1.conda
linux-64::mdsplus-7.139.62-py38pl5321ha8a3ab3_0.conda
linux-64::qt6-3d-6.6.2-hf2d569e_1.conda
linux-64::cctools_osx-arm64-973.0.1-h26e29f1_16.conda
linux-64::postgresql-plpython-16.2-py38h0f07e32_0.conda
linux-64::libarrow-14.0.2-hd8c18fe_8_cuda.conda
linux-64::mdsplus-7.139.63-py38pl5321ha8a3ab3_0.conda
linux-64::python-3.11.8-hab00c5b_0_cpython.conda
linux-64::ndcctools-7.8.0-py38h514f0f6_1.conda
linux-64::lammps-2023.11.21-cpu_py39_hade46e7_mpi_openmpi_4.conda
linux-64::pyinstaller-6.4.0-py311hdcc4c9d_0.conda
linux-64::paraview-5.11.2-py312hd3aac20_2_egl.conda
linux-64::mysql-connector-python-8.2.0-py311h6ca8dce_2.conda
linux-64::folly-2024.02.12.00-h122a45c_0_jemalloc.conda
linux-64::libarrow-12.0.1-h7c592b7_37_cuda.conda
linux-64::yoda-1.9.6-py38hc96b135_7.conda
linux-64::jaxlib-0.4.23-cpu_py39hcbc6598_0.conda
linux-64::kaldi-5.5.1112-cuda112h971fcfb_0.conda
linux-64::libboost-1.84.0-h8013b2b_1.conda
linux-64::gdb-14.1-py38hea0fc72_1.conda
linux-64::ndcctools-7.7.3-py38h514f0f6_1.conda
linux-64::yosys-0.38-h3ec9cbf_0.conda
linux-64::libarrow-12.0.1-hc8ada47_40_cuda.conda
linux-64::libgdal-arrow-parquet-3.7.3-h2af65d3_16.conda
linux-64::openimageio-2.5.5.0-he96b5ba_1.conda
linux-64::correctionlib-2.5.0-py310h3845668_1.conda
linux-64::code-aster-17.0.6-np122py38hb58a787_0.conda
linux-64::yoda-1.9.6-py310h925d3af_7.conda
linux-64::paraview-5.11.2-py311h671db93_102_qt.conda
linux-64::sasktran2-2024.02.2-py310h8ff1b0f_0.conda
linux-64::mysql-connector-python-8.3.0-py310h1b8f574_0.conda
linux-64::nest-simulator-3.6-py311h42e18a1_4.conda
linux-64::mysql-connector-python-8.2.0-py312hb7aa08c_3.conda
linux-64::cpp-opentelemetry-sdk-1.14.2-h83bf46b_0.conda
linux-64::jaxlib-0.4.23-cpu_py312h1065e9f_0.conda
linux-64::postgresql-plpython-16.2-py39h5ae07a4_0.conda
linux-64::gdstk-0.9.50-py39hc35b29e_0.conda
linux-64::mysql-router-8.3.0-h7d6b259_1.conda
linux-64::mysql-connector-python-8.3.0-py38h94a1851_0.conda
linux-64::postgresql-16.2-h8972f4a_0.conda
linux-64::chemicalite-2024.02.1-h781c27e_0.conda
linux-64::llvmlite-0.42.0-py310h1b8f574_0.conda
linux-64::verilator-5.022-h7cd9344_0.conda
linux-64::magics-metview-batch-4.15.3-hd93a360_0.conda
linux-64::folly-2024.02.12.00-h70f49c4_0_jemalloc.conda
linux-64::libdwarf-0.9.1-hecc041a_0.conda
linux-64::grpcio-1.61.1-py39h174d805_0.conda
linux-64::libgdal-arrow-parquet-3.7.3-h8d757da_15.conda
linux-64::folly-2024.02.12.00-hb244bc4_0.conda
linux-64::jaxlib-0.4.23-cpu_py312hc2644f4_0.conda
linux-64::libarrow-13.0.0-h7c592b7_26_cuda.conda
linux-64::orc-1.9.2-h00e871a_2.conda
linux-64::freeimage-3.18.0-h173641a_19.conda
linux-64::jaxlib-0.4.23-cuda118py39he398bb5_200.conda
linux-64::mysql-connector-python-8.2.0-py39h519aa44_3.conda
linux-64::aws-sdk-cpp-1.11.267-h0bb408c_0.conda
linux-64::lammps-2023.11.21-cpu_py39_h827286f_mpi_openmpi_4.conda
linux-64::mdsplus-7.139.65-py310pl5321hbd303f0_0.conda
linux-64::libarrow-15.0.0-h9634e4e_6_cuda.conda
linux-64::tectonic-0.15.0-hffe7e2f_0.conda
linux-64::tensorstore-0.1.51-py312h663d25f_2.conda
linux-64::libgdal-arrow-parquet-3.7.3-h2af65d3_15.conda
linux-64::pdal-2.6.2-h42c966b_4.conda
linux-64::jaxlib-0.4.23-cuda118py311he1bf99d_200.conda
linux-64::llvmlite-0.42.0-py311ha6695c7_0.conda
linux-64::mesalib-24.0.2-hf257a20_0.conda
linux-64::libgdal-3.7.3-h19bedfc_16.conda
linux-64::libvips-8.15.1-hebc2340_2.conda
linux-64::protozfits-2.4.0-py312h5192d77_1.conda
linux-64::fimex-1.10.1-py38hbe82734_0.conda
linux-64::boost-cpp-1.84.0-h44aadfe_1.conda
linux-64::robotraconteur-1.0.0-py39h6f21934_1.conda
linux-64::ndcctools-7.8.0-py39h4841754_0.conda
linux-64::python-igraph-0.11.4-py39h996dcd9_0.conda
linux-64::llvmlite-0.42.0-py39h7d5b425_1.conda
linux-64::tiledb-2.20.1-hd75ad12_1.conda
linux-64::tensorstore-0.1.51-py310h76b92c1_2.conda
linux-64::libarrow-13.0.0-h5534346_26_cpu.conda
linux-64::libtiledb-sql-0.27.0-h39d0c6e_1.conda
linux-64::ndcctools-7.8.0-py311h689c632_1.conda
linux-64::mysql-connector-python-8.3.0-py312hb06c811_0.conda
linux-64::lammps-2023.11.21-cuda118_py310_h38e9743_mpi_mpich_4.conda
linux-64::fimex-1.10.1-py311h3e54437_0.conda
linux-64::postgresql-plpython-16.2-py38hd157e84_0.conda
linux-64::nest-simulator-3.6-py39h736a37a_4.conda
linux-64::mdsplus-7.139.64-py39pl5321h4e21038_0.conda
linux-64::gdb-14.1-py39h1a87753_1.conda
linux-64::aws-sdk-cpp-1.11.267-h5606698_1.conda
linux-64::robotraconteur-1.0.0-py310h4f694cf_0.conda
linux-64::conduit-0.9.1-py38h0cf86ba_0.conda
linux-64::mysql-connector-python-8.3.0-py39h174d805_0.conda
linux-64::ovito-3.10.2-h8e92c3b_0.conda
linux-64::tensorstore-0.1.54-py312h663d25f_1.conda
linux-64::yoda-1.9.6-py311h4edfbc2_7.conda
linux-64::segalign-0.1.2-h8fba7ec_0.conda
linux-64::libdwarf-testing-meta-0.9.0-hecc041a_0.conda
linux-64::mysql-connector-odbc-8.3.0-hfc55251_0.conda
linux-64::grpcio-1.61.0-py311ha6695c7_0.conda
linux-64::lammps-2023.11.21-cpu_py39_h7e86899_mpi_mpich_4.conda
linux-64::jaxlib-0.4.23-cpu_py310h8d585fe_0.conda
linux-64::nest-simulator-3.6-py310hde3b743_4.conda
linux-64::libpq-15.6-h088ca5b_0.conda
linux-64::mysql-connector-python-8.2.0-py310h9a4a04d_1.conda
linux-64::wxpython-4.2.1-py39hb8fee00_3.conda
linux-64::ffmpeg-6.1.1-lgpl_h30e776b_4.conda
linux-64::grpcio-1.61.1-py312hb06c811_1.conda
linux-64::llvmlite-0.42.0-py39h174d805_0.conda
linux-64::libarrow-13.0.0-h5a9302f_27_cpu.conda
linux-64::libarrow-12.0.1-h5534346_37_cpu.conda
linux-64::libgdal-arrow-parquet-3.8.3-h2af65d3_3.conda
linux-64::jaxlib-0.4.23-cpu_py311ha400362_0.conda
linux-64::correctionlib-2.4.0-py39h2ea1df6_1.conda
linux-64::jaxlib-0.4.23-cuda118py312h5dcafd1_200.conda
linux-64::mdsplus-7.139.63-py39pl5321h4e21038_0.conda
linux-64::elfutils-0.190-h924a536_1.conda
linux-64::folly-2024.02.26.00-ha956c68_0.conda
linux-64::pyinstaller-6.4.0-py39hb6545a3_0.conda
linux-64::libarrow-15.0.0-hd8c18fe_5_cuda.conda
linux-64::code-aster-17.0.7-np122py310h04c1e7b_0.conda
linux-64::sasktran2-2024.02.2-py311h118c40b_0.conda
linux-64::mysql-client-8.2.0-h545f5f4_0.conda
linux-64::tiledb-2.20.0-h584b59b_0.conda
linux-64::tensorstore-0.1.54-py312h663d25f_0.conda
linux-64::fimex-1.10.1-py312he5fabbb_0.conda
linux-64::postgresql-plpython-16.2-py310hdd8bd8b_0.conda
linux-64::libarrow-14.0.2-h5001e6d_10_cpu.conda
linux-64::code-aster-17.0.6-np122py39hc2960b6_0.conda
linux-64::mysql-connector-python-8.2.0-py311h6ca8dce_1.conda
linux-64::root_base-6.30.4-py38h4feed2d_0.conda
linux-64::grpcio-1.61.1-py312hb06c811_0.conda
linux-64::cpp-opentelemetry-sdk-1.14.1-h83bf46b_1.conda
linux-64::grpcio-1.60.1-py310h1b8f574_0.conda
linux-64::grpcio-1.61.0-py39h7d5b425_0.conda
linux-64::libgdal-arrow-parquet-3.8.3-hee511c9_1.conda
linux-64::yoda-1.9.6-py311hd4f50a2_7.conda
linux-64::zimpl-3.5.4-h4a59bd9_0.conda
linux-64::gdstk-0.9.50-py38hab45c01_0.conda
linux-64::fimex-1.10.1-py39h36f8898_0.conda
linux-64::openimageio-2.5.5.0-h36589a0_1.conda
linux-64::libarrow-14.0.2-h49c8883_7_cpu.conda
linux-64::libgdal-arrow-parquet-3.7.3-hbf5f116_16.conda
linux-64::cctools_osx-64-973.0.1-h9f43cba_16.conda
linux-64::root_base-6.30.4-py311h1329b8c_0.conda
linux-64::tensorstore-0.1.54-py39h2f588e0_0.conda
linux-64::folly-2024.02.26.00-h72ab1f5_0_jemalloc.conda
linux-64::mysql-connector-python-8.2.0-py312hab3d6ff_4.conda
linux-64::wxpython-4.2.1-py311h5202d5f_3.conda
linux-64::gdstk-0.9.50-py310h1487c90_0.conda
linux-64::segalign-0.1.2-h76155d9_0.conda
linux-64::libarrow-15.0.0-h49c8883_4_cpu.conda
linux-64::grpcio-1.61.1-py310h1b8f574_1.conda
linux-64::correctionlib-2.5.0-py38hbb0cdd4_1.conda
linux-64::squashfuse-0.5.2-hdfefc0d_0.conda
linux-64::libgdal-arrow-parquet-3.7.3-hcd7ded7_14.conda
linux-64::libarrow-13.0.0-hf3a83aa_28_cuda.conda
linux-64::libopentelemetry-cpp-1.14.1-h83bf46b_1.conda
linux-64::mysql-connector-python-8.3.0-py39h7d5b425_0.conda
linux-64::protozfits-2.4.0-py38h5792304_0.conda
linux-64::libarrow-14.0.2-h17fe1ab_9_cpu.conda
linux-64::ndcctools-7.8.0-py39h4841754_1.conda
linux-64::lammps-2023.11.21-cpu_py38_hde207a7_mpi_openmpi_4.conda
linux-64::libopentelemetry-cpp-1.14.1-ha162ae1_0.conda
linux-64::jaxlib-0.4.23-cpu_py310h98810a9_0.conda
linux-64::libarrow-14.0.2-h917be6d_6_cuda.conda
linux-64::qt6-wayland-6.6.2-h6af8810_0.conda
linux-64::libgdal-arrow-parquet-3.8.3-h48313cc_2.conda
linux-64::libtiledb-sql-0.27.1-h09ee14b_1.conda
linux-64::wxpython-4.2.1-py310he5b683e_3.conda
linux-64::mdsplus-7.139.64-py311pl5321h4a20be6_0.conda
linux-64::grpcio-1.61.1-py310h1b8f574_0.conda
linux-64::loos-4.1.0-py39he563e60_0.conda
linux-64::correctionlib-2.4.0-py38hbb0cdd4_1.conda
linux-64::lammps-2023.11.21-cuda118_py311_hc5820a9_mpi_openmpi_4.conda
linux-64::libdwarf-0.9.0-hecc041a_0.conda
linux-64::pcre2-static-10.43-hcad00b1_0.conda
linux-64::mysql-libs-8.2.0-hca2cd23_0.conda
linux-64::mysql-server-8.2.0-he45e2b4_0.conda
linux-64::libarrow-12.0.1-h02f7050_39_cpu.conda
linux-64::libopencv-4.9.0-py39h195e0e5_8.conda
linux-64::prometheus-cpp-1.2.3-h90a924e_0.conda
linux-64::mesalib-24.0.1-hf257a20_0.conda
linux-64::conduit-0.9.1-py310h5b7d257_0.conda
linux-64::correctionlib-2.4.0-py310h3845668_0.conda
linux-64::jaxlib-0.4.23-cuda118py39h531a5cb_200.conda
linux-64::conduit-0.9.1-py311h97458bf_0.conda
linux-64::postgresql-16.2-h7387d8b_0.conda
linux-64::grpcio-1.61.1-py38h94a1851_0.conda
linux-64::tensorstore-0.1.54-py39h2f588e0_1.conda
linux-64::papilo-2.2.0-hf8fb4ea_0.conda
linux-64::gdb-14.1-py312heaf2220_1.conda
linux-64::libxml2-2.12.5-h232c23b_0.conda
linux-64::libtiledb-sql-0.27.1-h39d0c6e_0.conda
linux-64::mysql-connector-python-8.2.0-py39hb5de971_2.conda
linux-64::robotraconteur-1.0.0-py38h83dc16b_1.conda
linux-64::fimex-1.10.1-py310h1a1e9cd_0.conda
linux-64::lammps-2023.11.21-cuda118_py311_h0edc3ef_mpi_mpich_4.conda
linux-64::loos-4.1.0-py310hbb4369c_0.conda
linux-64::libtiledb-sql-0.27.0-h230ed91_1.conda
linux-64::gdb-14.1-py310h6006605_1.conda
linux-64::magics-metview-4.15.2-he53f960_0.conda
linux-64::grpcio-1.60.1-py39h174d805_0.conda
linux-64::mysql-connector-python-8.3.0-py311ha6695c7_0.conda
linux-64::qt6-main-6.6.2-hb9293b2_3.conda
linux-64::grpcio-1.61.1-py39h174d805_1.conda
linux-64::scip-9.0.0-h0857b24_0.conda
linux-64::tensorstore-0.1.51-py311hbfb5fdc_2.conda
linux-64::folly-2024.02.05.00-h70f49c4_0_jemalloc.conda
linux-64::mysql-connector-python-8.2.0-py310h9a4a04d_2.conda
linux-64::libmediainfo-24.01-h291fda7_0.conda
linux-64::sasktran2-2024.02.2-py312h11a4be6_0.conda
linux-64::paraview-5.11.2-py310h6465788_102_qt.conda
linux-64::libgdal-arrow-parquet-3.8.4-h435aaf2_0.conda
linux-64::grpcio-1.61.0-py39h174d805_0.conda
linux-64::folly-2024.02.05.00-h23251b7_0.conda
linux-64::tensorstore-0.1.54-py311hbfb5fdc_1.conda
linux-64::mysql-connector-python-8.2.0-py311h004d086_0.conda
linux-64::createrepo_c-1.0.4-py39hb74ab81_0.conda
linux-64::correctionlib-2.5.0-py312h24f76d5_1.conda
linux-64::gfortran_impl_osx-64-12.3.0-hec5e7d4_3.conda
linux-64::conduit-0.9.1-py311h0bfab9f_0.conda
linux-64::mysql-connector-python-8.2.0-py39hb5de971_3.conda
linux-64::pdal-2.6.3-h42c966b_0.conda
linux-64::folly-2024.02.05.00-hbc8c634_0_jemalloc.conda
linux-64::libgdal-arrow-parquet-3.7.3-hbc7e741_14.conda
linux-64::mdsplus-7.139.62-py39pl5321h4e21038_0.conda
linux-64::libarrow-14.0.2-h917be6d_7_cuda.conda
linux-64::paraview-5.11.2-py39h7a34761_102_qt.conda
linux-64::r-base-4.3.3-hb8ee39d_0.conda
linux-64::llvmlite-0.42.0-py312hb06c811_1.conda
linux-64::grpcio-1.60.1-py39h7d5b425_0.conda
linux-64::python-igraph-0.11.4-py38h9d99ad5_0.conda
linux-64::libgdal-3.8.4-h9323651_0.conda
linux-64::openimageio-2.5.5.0-hb45bdfe_1.conda
linux-64::mysql-connector-python-8.2.0-py39h519aa44_1.conda
linux-64::nss-3.98-h1d7d5a4_0.conda
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
linux-64::clang-format-13-13.0.1-root_63004_hcf29762_6.conda
linux-64::glib-tools-2.78.4-hfc55251_0.conda
linux-64::libsqlite-3.45.1-h2797004_0.conda
linux-64::openjpeg-2.5.1-h488ebb8_0.conda
linux-64::libclang-cpp13-13.0.1-root_63004_hcf29762_6.conda
linux-64::clang-13-13.0.1-default_h7634d5b_6.conda
linux-64::libprotobuf-4.25.1-hf27288f_2.conda
linux-64::clang-tools-13.0.1-default_h7634d5b_6.conda
linux-64::eccodes-2.34.1-he84ddb8_0.conda
linux-64::libprotobuf-static-4.25.2-h08a7969_0.conda
linux-64::libpng-1.6.43-h2797004_0.conda
linux-64::imath-3.1.11-hfc55251_0.conda
linux-64::libclang-cpp-13.0.1-root_63004_hcf29762_6.conda
linux-64::seasocks-1.4.6-hcd5def8_0.conda
linux-64::libprotobuf-4.25.1-hf27288f_1.conda
linux-64::libpng-1.6.42-h2797004_0.conda
linux-64::cfitsio-4.4.0-hbdc6101_0.conda
linux-64::clang-format-13.0.1-default_h7634d5b_6.conda
linux-64::eccodes-2.34.0-he84ddb8_0.conda
linux-64::clang-format-13-13.0.1-default_h7634d5b_6.conda
linux-64::clang-format-13.0.1-root_63004_hcf29762_6.conda
linux-64::libuwebsockets-20.60.0-hfc55251_0.conda
linux-64::openjpeg-2.5.2-h488ebb8_0.conda
linux-64::seasocks-1.4.5-hcd5def8_0.conda
linux-64::clang-tools-13.0.1-root_63004_hcf29762_6.conda
linux-64::libsolv-0.7.28-hfc55251_0.conda
linux-64::libprotobuf-static-4.25.1-hf27288f_1.conda
linux-64::pcre2-10.43-hcad00b1_0.conda
linux-64::exiv2-0.28.2-h3cdc00d_0.conda
linux-64::libclang-cpp13-13.0.1-default_h7634d5b_6.conda
linux-64::libprotobuf-static-4.25.2-h08a7969_1.conda
linux-64::gcab-1.6-h6ee01cb_0.conda
linux-64::libsolv-static-0.7.28-hfc55251_0.conda
linux-64::libclang-13.0.1-root_63004_hcf29762_6.conda
linux-64::libprotobuf-4.25.2-h08a7969_0.conda
linux-64::clang-13-13.0.1-root_63004_hcf29762_6.conda
linux-64::openexr-3.2.2-h279af06_0.conda
linux-64::libclang-13.0.1-default_h7634d5b_6.conda
linux-64::git-cliff-2.0.4-he0a03d5_0.conda
linux-64::libclang-cpp-13.0.1-default_h7634d5b_6.conda
linux-64::libuwebsockets-20.59.0-hfc55251_0.conda
linux-64::git-cliff-2.0.3-he0a03d5_0.conda
linux-64::libprotobuf-static-4.25.1-hf27288f_2.conda
linux-64::libprotobuf-4.25.2-h08a7969_1.conda
-    "libzlib >=1.2.13,<1.3.0a0"
+    "libzlib >=1.2.13,<2.0.0a0"
```

</details>