### PR TITLE
loosen zlib-pin to major level (5/N; January 2024)

### DIFF
--- a/recipe/patch_yaml/zlib.yaml
+++ b/recipe/patch_yaml/zlib.yaml
@@ -34,3 +34,12 @@ then:
   - loosen_depends:
       name: libzlib
       upper_bound: "2"
+---
+if:
+  has_depends: libzlib >=1.2*
+  timestamp_lt: 1706745600000  # 2024-02-01 00:00 UTC
+  timestamp_ge: 1704067200000  # 2024-01-01 00:00 UTC
+then:
+  - loosen_depends:
+      name: libzlib
+      upper_bound: "2"


### PR DESCRIPTION
Follow-up to https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/739, about 2500 artefacts affected.

### Result of `python show_diff.py`

<details>

```diff
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
osx-arm64::libarrow-14.0.2-h4646434_1_cpu.conda
osx-arm64::folly-2024.01.01.00-he914830_0_jemalloc.conda
osx-arm64::libgoogle-cloud-storage-2.17.0-h8a76758_2.conda
osx-arm64::lammps-2023.11.21-cpu_py38_h455d21a_nompi_2.conda
osx-arm64::libarrow-15.0.0-h4ce3932_1_cpu.conda
osx-arm64::lfortran-0.33.1-hbeb2e11_0.conda
osx-arm64::lammps-2023.08.02-cpu_py310_h4786252_mpi_mpich_8.conda
osx-arm64::lammps-2023.11.21-cpu_py310_h4786252_mpi_mpich_0.conda
osx-arm64::lxml-5.1.0-py311h85df328_0.conda
osx-arm64::libarrow-11.0.0-h7c288cf_58_cpu.conda
osx-arm64::sagelib-10.2-py311he74d834_3.conda
osx-arm64::libmed-4.1.1-py312hbafaa6b_8.conda
osx-arm64::folly-2024.01.08.00-ha98ecff_0.conda
osx-arm64::folly-2024.01.15.00-ha8c0bfd_0.conda
osx-arm64::r-base-4.2.3-h53b85ff_12.conda
osx-arm64::ffmpeg-6.1.1-gpl_hd6ebea7_103.conda
osx-arm64::libopencv-4.9.0-py39h4373015_7.conda
osx-arm64::libopencv-4.9.0-py311hdccf81a_7.conda
osx-arm64::omniorb-4.3.2-py310h11eb220_1.conda
osx-arm64::grpcio-1.60.0-py39h047a24b_0.conda
osx-arm64::lammps-2023.11.21-cpu_py39_hb8cc403_mpi_mpich_1.conda
osx-arm64::libopencv-4.9.0-py310h01bd9cd_5.conda
osx-arm64::lammps-2023.11.21-cpu_py38_hb5f05e6_mpi_mpich_3.conda
osx-arm64::gst-plugins-bad-1.22.9-h61ae955_0.conda
osx-arm64::lxml-4.9.4-py39h14dd1eb_0.conda
osx-arm64::protozfits-2.3.0-py39ha647ab8_5.conda
osx-arm64::libxmlsec1-1.3.3-h07c84ac_0.conda
osx-arm64::lammps-2023.11.21-cpu_py39_hb8cc403_mpi_mpich_0.conda
osx-arm64::protozfits-2.3.0-py311h324a6dd_5.conda
osx-arm64::tensorflow-base-2.15.0-cpu_py311he034567_2.conda
osx-arm64::folly-2024.01.22.00-he914830_0_jemalloc.conda
osx-arm64::omniorb-4.3.2-py312h239287f_0.conda
osx-arm64::wxpython-4.2.1-py311hddcafca_2.conda
osx-arm64::lxml-5.0.1-py312h9bf3b9e_0.conda
osx-arm64::libmed-4.1.1-py310h40ed080_9.conda
osx-arm64::libarrow-14.0.2-h4ce3932_3_cpu.conda
osx-arm64::paraview-5.11.2-py39h1af8d96_102_qt.conda
osx-arm64::lfortran-0.31.0-hbeb2e11_0.conda
osx-arm64::qt6-main-6.6.1-hd6da969_8.conda
osx-arm64::netcdf-cxx4-4.3.1-mpi_mpich_hce4a381_8.conda
osx-arm64::mysql-connector-python-8.0.33-py311hacb2530_0.conda
osx-arm64::imagemagick-7.1.1_26-pl5321h04f3966_0.conda
osx-arm64::lxml-4.9.4-py38h9bc2e36_0.conda
osx-arm64::libmed-4.1.1-py39h960564c_10.conda
osx-arm64::nceplibs-g2c-1.8.0-h4bcab58_6.conda
osx-arm64::lammps-2023.11.21-cpu_py311_h0890928_mpi_mpich_1.conda
osx-arm64::lammps-2023.11.21-cpu_py38_h74d7d60_mpi_openmpi_0.conda
osx-arm64::lammps-2023.08.02-cpu_py38_hb5f05e6_mpi_mpich_8.conda
osx-arm64::lammps-2023.11.21-cpu_py39_h829d90f_mpi_openmpi_0.conda
osx-arm64::tesseract-5.3.4-he632f33_0.conda
osx-arm64::libmed-4.1.1-py38h5f8896b_9.conda
osx-arm64::lammps-2023.11.21-cpu_py39_h5afc6b9_nompi_3.conda
osx-arm64::gfortran_impl_osx-64-12.3.0-he08d67f_2.conda
osx-arm64::libarrow-11.0.0-h2f53e1b_60_cpu.conda
osx-arm64::folly-2024.01.29.00-hcdc1028_0_jemalloc.conda
osx-arm64::libarrow-13.0.0-hbd460ae_24_cpu.conda
osx-arm64::qt6-main-6.6.1-hd6da969_6.conda
osx-arm64::ffmpeg-6.1.1-lgpl_hffcf56e_1.conda
osx-arm64::grpcio-1.60.0-py312h17030e7_0.conda
osx-arm64::vigra-1.11.2-py312h3a7e92f_4.conda
osx-arm64::lammps-2023.08.02-cpu_py311_h1b1bd21_mpi_openmpi_7.conda
osx-arm64::imagemagick-7.1.1_27-pl5321hecdf51d_0.conda
osx-arm64::fish-3.7.0-he0ab8cb_0.conda
osx-arm64::libmed-4.1.1-py312hd61c751_9.conda
osx-arm64::sagelib-10.2-py310h8c42f95_3.conda
osx-arm64::grpcio-1.60.0-py38hbed3d3f_1.conda
osx-arm64::gct-6.2.1629922860-h23cd978_3.conda
osx-arm64::paraview-5.11.2-py312hf636bab_102_qt.conda
osx-arm64::ffmpeg-6.1.1-gpl_ha63e52a_101.conda
osx-arm64::sagelib-10.2-py311he74d834_2.conda
osx-arm64::nest-simulator-3.6-py38h8074ab1_3.conda
osx-arm64::postgresql-plpython-15.4-py39ha7448c8_5.conda
osx-arm64::libopencv-4.9.0-py38h14197a0_6.conda
osx-arm64::libmed-4.1.1-py310h40ed080_10.conda
osx-arm64::wxpython-4.2.1-py38h443c9a1_2.conda
osx-arm64::libopencv-4.9.0-py39hfd8dbc5_5.conda
osx-arm64::pyinstaller-6.3.0-py310h742d9d8_1.conda
osx-arm64::librdkafka-2.3.0-hb5b8459_0.conda
osx-arm64::photochem-0.4.5-py38hfbbbcb3_0.conda
osx-arm64::lammps-2023.08.02-cpu_py310_h1b23ab0_nompi_7.conda
osx-arm64::nss-3.97-h5ce2875_0.conda
osx-arm64::lammps-2023.08.02-cpu_py38_hb5f05e6_mpi_mpich_7.conda
osx-arm64::protozfits-2.3.0-py310h1ef5ab9_5.conda
osx-arm64::postgresql-15.4-h1d0603d_5.conda
osx-arm64::lammps-2023.11.21-cpu_py39_h829d90f_mpi_openmpi_3.conda
osx-arm64::lammps-2023.08.02-cpu_py39_h829d90f_mpi_openmpi_7.conda
osx-arm64::xrootd-5.6.6-py38h7b12acb_0.conda
osx-arm64::lammps-2023.08.02-cpu_py39_h5afc6b9_nompi_7.conda
osx-arm64::cppyy-cling-6.30.0-py38h9908e9a_1.conda
osx-arm64::folly-2024.01.08.00-h584d98d_0_jemalloc.conda
osx-arm64::libarrow-14.0.2-h906e67b_5_cpu.conda
osx-arm64::lxml-5.0.1-py311h85df328_0.conda
osx-arm64::folly-2024.01.29.00-ha98ecff_0.conda
osx-arm64::sasktran2-2023.12.0-py312hb67a6f4_2.conda
osx-arm64::lammps-2023.11.21-cpu_py38_hb5f05e6_mpi_mpich_1.conda
osx-arm64::gdstk-0.9.49-py39hb07f281_0.conda
osx-arm64::lammps-2023.08.02-cpu_py311_h0890928_mpi_mpich_8.conda
osx-arm64::lammps-2023.11.21-cpu_py39_h5afc6b9_nompi_1.conda
osx-arm64::aws-sdk-cpp-1.11.210-he35fd53_7.conda
osx-arm64::tiledb-2.19.1-h7f70256_0.conda
osx-arm64::sasktran2-2023.12.0-py310hd995aef_2.conda
osx-arm64::lammps-2023.08.02-cpu_py310_h49200cc_mpi_openmpi_7.conda
osx-arm64::postgresql-plpython-15.4-py311h1e905d0_5.conda
osx-arm64::lammps-2023.08.02-cpu_py310_h49200cc_mpi_openmpi_8.conda
osx-arm64::pocl-core-5.0-h620ccdb_0.conda
osx-arm64::lammps-2023.11.21-cpu_py310_h49200cc_mpi_openmpi_1.conda
osx-arm64::netcdf-cxx4-4.3.1-mpi_openmpi_h6859d3b_8.conda
osx-arm64::gmsh-4.12.1-h8a9da21_0.conda
osx-arm64::libmed-4.1.1-py311h358ef09_10.conda
osx-arm64::libmed-4.1.1-py311h358ef09_9.conda
osx-arm64::postgresql-plpython-15.5-py312h7ba0638_0.conda
osx-arm64::lammps-2023.11.21-cpu_py38_h74d7d60_mpi_openmpi_1.conda
osx-arm64::lldb-17.0.6-py38hf2ee67f_1.conda
osx-arm64::ffmpeg-6.1.1-lgpl_h654f599_2.conda
osx-arm64::protozfits-2.3.0-py312ha1b11ba_5.conda
osx-arm64::lammps-2023.08.02-cpu_py311_h3159b45_nompi_8.conda
osx-arm64::mysql-connector-python-8.0.33-py39h271af4c_0.conda
osx-arm64::libopencv-4.9.0-py310hcdc77dd_6.conda
osx-arm64::lld-17.0.6-hae11360_1.conda
osx-arm64::lxml-5.0.1-py310hd9ecdb4_0.conda
osx-arm64::lxml-5.0.1-py38h9bc2e36_0.conda
osx-arm64::folly-2024.01.15.00-hcdc1028_0_jemalloc.conda
osx-arm64::lammps-2023.11.21-cpu_py310_h1b23ab0_nompi_1.conda
osx-arm64::folly-2024.01.15.00-he914830_0_jemalloc.conda
osx-arm64::lammps-2023.08.02-cpu_py39_h829d90f_mpi_openmpi_8.conda
osx-arm64::hugin-base-2022.0.0-pl5321h810fd0b_10.conda
osx-arm64::lammps-2023.11.21-cpu_py311_h1b1bd21_mpi_openmpi_2.conda
osx-arm64::lammps-2023.08.02-cpu_py38_h74d7d60_mpi_openmpi_8.conda
osx-arm64::lxml-5.1.0-py38h9bc2e36_0.conda
osx-arm64::wgrib2-3.1.3-h35d0573_3.conda
osx-arm64::grpcio-1.60.0-py310hf7687f1_1.conda
osx-arm64::lammps-2023.11.21-cpu_py310_h49200cc_mpi_openmpi_3.conda
osx-arm64::libgdal-arrow-parquet-3.8.3-h3690797_0.conda
osx-arm64::tiledb-2.18.4-h49d9ff7_0.conda
osx-arm64::lammps-2023.11.21-cpu_py311_h0890928_mpi_mpich_2.conda
osx-arm64::cppyy-cling-6.30.0-py311h4ca21db_2.conda
osx-arm64::libarrow-13.0.0-h2f53e1b_25_cpu.conda
osx-arm64::postgresql-15.5-hf829917_0.conda
osx-arm64::libmed-4.1.1-py311hd7ceecb_8.conda
osx-arm64::gst-plugins-good-1.22.8-h96640bf_1.conda
osx-arm64::correctionlib-2.3.3-py38ha1a7c66_2.conda
osx-arm64::libmed-4.1.1-py38h5f8896b_10.conda
osx-arm64::gmsh-4.12.1-hd427cfb_0.conda
osx-arm64::r-data.table-1.14.10-r42h513102a_1.conda
osx-arm64::lammps-2023.08.02-cpu_py311_h1b1bd21_mpi_openmpi_8.conda
osx-arm64::aws-sdk-cpp-1.11.210-h29e235c_9.conda
osx-arm64::lldb-17.0.6-py311heaf9aba_1.conda
osx-arm64::omniorb-4.3.2-py311h9e0c5cf_0.conda
osx-arm64::lammps-2023.11.21-cpu_py310_h1b23ab0_nompi_2.conda
osx-arm64::lammps-2023.11.21-cpu_py39_h829d90f_mpi_openmpi_2.conda
osx-arm64::wxpython-4.2.1-py310hde93f36_2.conda
osx-arm64::lammps-2023.08.02-cpu_py311_h0890928_mpi_mpich_7.conda
osx-arm64::libpulsar-3.4.2-hd722eec_1.conda
osx-arm64::lammps-2023.11.21-cpu_py38_h455d21a_nompi_1.conda
osx-arm64::lammps-2023.11.21-cpu_py311_h1b1bd21_mpi_openmpi_3.conda
osx-arm64::gmsh-4.12.2-h8a9da21_0.conda
osx-arm64::vigra-1.11.2-py310hc6bc4a2_4.conda
osx-arm64::tensorflow-base-2.15.0-cpu_py39ha39414a_2.conda
osx-arm64::gdstk-0.9.49-py312h8ae92b5_0.conda
osx-arm64::paraview-5.11.2-py39h888847b_102_qt.conda
osx-arm64::openmpi-5.0.1-h1b401ff_102.conda
osx-arm64::uwsgi-2.0.23-py38h605dbba_0.conda
osx-arm64::pyinstaller-6.3.0-py38he974862_1.conda
osx-arm64::pillow-10.2.0-py39h755f0b7_0.conda
osx-arm64::grpcio-1.60.0-py38hbed3d3f_0.conda
osx-arm64::gfortran_impl_osx-arm64-13.2.0-h252ada1_2.conda
osx-arm64::lammps-2023.11.21-cpu_py310_h49200cc_mpi_openmpi_0.conda
osx-arm64::aws-sdk-cpp-1.11.242-h26e3666_0.conda
osx-arm64::grpcio-1.60.0-py39h047a24b_1.conda
osx-arm64::lammps-2023.11.21-cpu_py39_h5afc6b9_nompi_0.conda
osx-arm64::folly-2024.01.15.00-ha98ecff_0.conda
osx-arm64::sasktran2-2024.01.1-py311h6676678_0.conda
osx-arm64::libopencv-4.9.0-py38h04c74ea_5.conda
osx-arm64::libtensorflow_cc-2.15.0-cpu_h1998a8a_2.conda
osx-arm64::nest-simulator-3.6-py39h23e55c4_3.conda
osx-arm64::pillow-10.2.0-py311hb9c5795_0.conda
osx-arm64::gst-plugins-good-1.22.9-h0e592f3_0.conda
osx-arm64::postgresql-plpython-15.5-py38hb78573b_0.conda
osx-arm64::libmed-4.1.1-py310h469dcd4_8.conda
osx-arm64::mysql-connector-python-8.0.33-py38hc6cab92_0.conda
osx-arm64::lammps-2023.08.02-cpu_py38_h74d7d60_mpi_openmpi_7.conda
osx-arm64::gdstk-0.9.49-py310hd84021c_0.conda
osx-arm64::uwsgi-2.0.23-py310h6bcb23f_0.conda
osx-arm64::graphicsmagick-1.3.42-h4abbdc0_0.conda
osx-arm64::libmed-4.1.1-py38h5041526_8.conda
osx-arm64::verilator-5.020-h0de0349_0.conda
osx-arm64::lammps-2023.11.21-cpu_py38_h74d7d60_mpi_openmpi_3.conda
osx-arm64::cppyy-cling-6.30.0-py311h4ca21db_1.conda
osx-arm64::libarrow-13.0.0-h8b1ecf9_22_cpu.conda
osx-arm64::lammps-2023.11.21-cpu_py311_h3159b45_nompi_1.conda
osx-arm64::libvips-8.15.1-h1c4d816_1.conda
osx-arm64::paraview-5.11.2-py38h5f1cce6_102_qt.conda
osx-arm64::vigra-1.11.2-py39hd1e948a_4.conda
osx-arm64::cppyy-cling-6.30.0-py312hee8bc9d_1.conda
osx-arm64::lammps-2023.11.21-cpu_py39_hb8cc403_mpi_mpich_2.conda
osx-arm64::sasktran2-2024.01.0-py310hd995aef_0.conda
osx-arm64::wxpython-4.2.1-py310h6ab1d85_1.conda
osx-arm64::aws-sdk-cpp-1.11.210-he93ac2d_10.conda
osx-arm64::mc-4.8.31-h07369bd_0.conda
osx-arm64::omniorb-4.3.2-py39h73f87db_1.conda
osx-arm64::lammps-2023.11.21-cpu_py311_h0890928_mpi_mpich_0.conda
osx-arm64::uwsgi-2.0.23-py312hc4c5c4e_0.conda
osx-arm64::lammps-2023.11.21-cpu_py39_h5afc6b9_nompi_2.conda
osx-arm64::gmt-6.5.0-haf49670_0.conda
osx-arm64::cmake-3.28.2-h50fd54c_0.conda
osx-arm64::lammps-2023.11.21-cpu_py310_h4786252_mpi_mpich_2.conda
osx-arm64::libopencv-4.9.0-py312h6cabc61_5.conda
osx-arm64::libmed-4.1.1-py39h960564c_9.conda
osx-arm64::libgdal-arrow-parquet-3.8.3-h864bd25_0.conda
osx-arm64::folly-2024.01.01.00-hcdc1028_0_jemalloc.conda
osx-arm64::folly-2024.01.22.00-h584d98d_0_jemalloc.conda
osx-arm64::aws-sdk-cpp-1.11.210-h26e3666_11.conda
osx-arm64::lammps-2023.08.02-cpu_py310_h4786252_mpi_mpich_7.conda
osx-arm64::omniorb-libs-4.3.2-h634ed13_0.conda
osx-arm64::bytewax-0.18.1-py38h21546c9_0.conda
osx-arm64::sasktran2-2024.01.0-py312hb67a6f4_0.conda
osx-arm64::postgresql-plpython-15.5-py39h01d0bc9_0.conda
osx-arm64::libpq-15.4-h9aca644_5.conda
osx-arm64::r-data.table-1.14.10-r43h513102a_1.conda
osx-arm64::libarrow-12.0.1-h2f53e1b_36_cpu.conda
osx-arm64::paraview-5.11.2-py310h77878d4_102_qt.conda
osx-arm64::folly-2024.01.01.00-ha8c0bfd_0.conda
osx-arm64::grpcio-1.60.0-py312h17030e7_1.conda
osx-arm64::libopencv-4.9.0-py310hb0696bf_7.conda
osx-arm64::gmsh-4.12.2-hd427cfb_0.conda
osx-arm64::folly-2024.01.15.00-h75b8fe2_0.conda
osx-arm64::libarrow-15.0.0-h906e67b_2_cpu.conda
osx-arm64::lammps-2023.11.21-cpu_py310_h1b23ab0_nompi_0.conda
osx-arm64::folly-2024.01.22.00-hcdc1028_0_jemalloc.conda
osx-arm64::wxpython-4.2.1-py39h552b74b_1.conda
osx-arm64::libgdal-arrow-parquet-3.8.3-h2460107_0.conda
osx-arm64::lfortran-0.33.0-hbeb2e11_0.conda
osx-arm64::lammps-2023.08.02-cpu_py38_h455d21a_nompi_8.conda
osx-arm64::libgdal-3.8.3-h7e86f1f_0.conda
osx-arm64::photochem-0.4.5-py310he5eae8e_0.conda
osx-arm64::lammps-2023.08.02-cpu_py39_hb8cc403_mpi_mpich_8.conda
osx-arm64::openmpi-5.0.1-h58cf721_101.conda
osx-arm64::sasktran2-2024.01.1-py310hd995aef_0.conda
osx-arm64::postgresql-plpython-15.4-py310h44d1ce9_5.conda
osx-arm64::libopencv-4.9.0-py39h0ce0e69_6.conda
osx-arm64::omniorb-4.3.2-py312h239287f_1.conda
osx-arm64::lxml-4.9.4-py310hd9ecdb4_0.conda
osx-arm64::orc-1.9.2-hb41d57e_1.conda
osx-arm64::mpv-0.36.0-h794dbbe_1.conda
osx-arm64::libxml2-2.12.4-h0d0cfa8_1.conda
osx-arm64::cppyy-cling-6.30.0-py310h59dd246_2.conda
osx-arm64::soplex-6.0.4-he057f58_7.conda
osx-arm64::tensorflow-base-2.15.0-cpu_py310hb663c03_2.conda
osx-arm64::mysql-connector-python-8.0.33-py310hb0e67d6_0.conda
osx-arm64::lxml-5.1.0-py310hd9ecdb4_0.conda
osx-arm64::libopencv-4.9.0-py312h5dd5d65_7.conda
osx-arm64::folly-2024.01.01.00-ha98ecff_0.conda
osx-arm64::correctionlib-2.3.3-py310hfbac5d6_2.conda
osx-arm64::libarrow-12.0.1-h8b1ecf9_33_cpu.conda
osx-arm64::sasktran2-2024.01.1-py312hb67a6f4_0.conda
osx-arm64::photochem-0.4.5-py39h513b0d9_0.conda
osx-arm64::folly-2024.01.29.00-he914830_0_jemalloc.conda
osx-arm64::lammps-2023.11.21-cpu_py311_h3159b45_nompi_0.conda
osx-arm64::libarrow-11.0.0-hbd460ae_59_cpu.conda
osx-arm64::lammps-2023.11.21-cpu_py38_h455d21a_nompi_3.conda
osx-arm64::omniorb-4.3.2-py38hb5cc829_0.conda
osx-arm64::bytewax-0.18.1-py311h59c2206_0.conda
osx-arm64::folly-2024.01.29.00-ha8c0bfd_0.conda
osx-arm64::lammps-2023.11.21-cpu_py311_h3159b45_nompi_3.conda
osx-arm64::tiledb-2.18.4-h39064d6_0.conda
osx-arm64::libtensorflow-2.15.0-cpu_h9d8c315_2.conda
osx-arm64::postgresql-plpython-15.5-py310h574c79e_0.conda
osx-arm64::tiledb-2.18.4-h7f70256_0.conda
osx-arm64::cppyy-cling-6.30.0-py39hd308395_2.conda
osx-arm64::libarrow-11.0.0-h8b1ecf9_57_cpu.conda
osx-arm64::librdkafka-2.3.0-h6b23af2_0.conda
osx-arm64::tiledb-2.19.1-h49d9ff7_0.conda
osx-arm64::lammps-2023.08.02-cpu_py39_hb8cc403_mpi_mpich_7.conda
osx-arm64::lxml-4.9.4-py312h9bf3b9e_0.conda
osx-arm64::qtwebkit-5.212-ha51050e_16.conda
osx-arm64::pillow-10.2.0-py312hac22aec_0.conda
osx-arm64::lammps-2023.11.21-cpu_py39_h829d90f_mpi_openmpi_1.conda
osx-arm64::tiledb-2.19.1-h39064d6_0.conda
osx-arm64::bytewax-0.18.1-py310ha04cfa0_0.conda
osx-arm64::r-base-4.3.2-h53b85ff_2.conda
osx-arm64::protozfits-2.3.0-py38hc8c5f20_5.conda
osx-arm64::cpp-opentelemetry-sdk-1.13.0-h9a7c8d0_1.conda
osx-arm64::libmed-4.1.1-py39h636d4c1_8.conda
osx-arm64::gazebo-11.14.0-h9ba9e67_6.conda
osx-arm64::folly-2024.01.15.00-h584d98d_0_jemalloc.conda
osx-arm64::cppyy-cling-6.30.0-py312hee8bc9d_2.conda
osx-arm64::omniorb-libs-4.3.2-h634ed13_1.conda
osx-arm64::folly-2024.01.29.00-h584d98d_0_jemalloc.conda
osx-arm64::libarrow-15.0.0-h4ce3932_0_cpu.conda
osx-arm64::sagelib-10.2-py310h8c42f95_2.conda
osx-arm64::uwsgi-2.0.23-py311hb98bba9_0.conda
osx-arm64::paraview-5.11.2-py311he6a7cba_102_qt.conda
osx-arm64::libgrpc-1.60.0-hfc68871_1.conda
osx-arm64::lxml-5.1.0-py39h14dd1eb_0.conda
osx-arm64::gfortran_impl_osx-64-13.2.0-hc385ae8_2.conda
osx-arm64::gfortran_impl_osx-arm64-12.3.0-h53ed385_2.conda
osx-arm64::postgresql-plpython-15.5-py311hcdc9149_0.conda
osx-arm64::folly-2024.01.08.00-he914830_0_jemalloc.conda
osx-arm64::lammps-2023.11.21-cpu_py38_hb5f05e6_mpi_mpich_0.conda
osx-arm64::folly-2024.01.22.00-h75b8fe2_0.conda
osx-arm64::lxml-4.9.4-py311h85df328_0.conda
osx-arm64::ffmpeg-6.1.1-lgpl_hf829831_3.conda
osx-arm64::cppyy-cling-6.30.0-py39hd308395_1.conda
osx-arm64::pdal-2.6.2-h717e6b2_3.conda
osx-arm64::scip-8.1.0-h14b7587_7.conda
osx-arm64::cppyy-cling-6.30.0-py38h9908e9a_2.conda
osx-arm64::bytewax-0.18.1-py312h083d4f6_0.conda
osx-arm64::folly-2024.01.08.00-ha8c0bfd_0.conda
osx-arm64::lammps-2023.11.21-cpu_py39_hb8cc403_mpi_mpich_3.conda
osx-arm64::lammps-2023.11.21-cpu_py38_hb5f05e6_mpi_mpich_2.conda
osx-arm64::lldb-17.0.6-py310h76ad05f_1.conda
osx-arm64::libopencv-4.9.0-py311h1181ac7_6.conda
osx-arm64::pocl-core-5.0-h9ab2a98_1.conda
osx-arm64::libarrow-14.0.2-h4ce3932_4_cpu.conda
osx-arm64::gazebo-11.14.0-h6e57f4f_5.conda
osx-arm64::pyinstaller-6.3.0-py312ha17c255_1.conda
osx-arm64::libarrow-13.0.0-h7c288cf_23_cpu.conda
osx-arm64::libopencv-4.9.0-py38hebc4038_7.conda
osx-arm64::folly-2024.01.08.00-h75b8fe2_0.conda
osx-arm64::omniorb-4.3.2-py311h9e0c5cf_1.conda
osx-arm64::nceplibs-g2c-1.8.0-h4bcab58_5.conda
osx-arm64::lammps-2023.11.21-cpu_py311_h0890928_mpi_mpich_3.conda
osx-arm64::grpcio-1.60.0-py310hf7687f1_0.conda
osx-arm64::libopencv-4.9.0-py311h22734c1_5.conda
osx-arm64::sasktran2-2023.12.0-py311h6676678_2.conda
osx-arm64::grpcio-1.60.0-py311hf5d242d_0.conda
osx-arm64::sasktran2-2024.01.0-py311h6676678_0.conda
osx-arm64::libarrow-12.0.1-h7c288cf_34_cpu.conda
osx-arm64::libyarp-3.9.0-hff4382b_1.conda
osx-arm64::lfortran-0.30.0-hbeb2e11_0.conda
osx-arm64::xrootd-5.6.6-py311hcfa93de_0.conda
osx-arm64::emacs-29.1-h61057f5_0.conda
osx-arm64::postgresql-plpython-15.4-py312hac41b93_5.conda
osx-arm64::lfortran-0.32.0-hbeb2e11_0.conda
osx-arm64::sagelib-10.2-py39h95a1fc1_2.conda
osx-arm64::photochem-0.4.5-py311ha6a61bc_0.conda
osx-arm64::folly-2024.01.01.00-h584d98d_0_jemalloc.conda
osx-arm64::lammps-2023.08.02-cpu_py310_h1b23ab0_nompi_8.conda
osx-arm64::lammps-2023.11.21-cpu_py38_h74d7d60_mpi_openmpi_2.conda
osx-arm64::papilo-2.1.4-h24bcf1f_7.conda
osx-arm64::pillow-10.2.0-py310hfae7ebd_0.conda
osx-arm64::libopentelemetry-cpp-1.13.0-h9a7c8d0_1.conda
osx-arm64::lammps-2023.08.02-cpu_py38_h455d21a_nompi_7.conda
osx-arm64::grpcio-1.60.0-py311hf5d242d_1.conda
osx-arm64::wxpython-4.2.1-py38hf10a615_1.conda
osx-arm64::xrootd-5.6.6-py39h31dc897_0.conda
osx-arm64::pyinstaller-6.3.0-py311h4045465_1.conda
osx-arm64::gdstk-0.9.49-py38h0fa6a1b_0.conda
osx-arm64::nest-simulator-3.6-py311h4b2d909_3.conda
osx-arm64::sagelib-10.2-py39h95a1fc1_3.conda
osx-arm64::libarrow-12.0.1-hbd460ae_35_cpu.conda
osx-arm64::libpq-15.5-hdf44ceb_0.conda
osx-arm64::mesalib-23.3.4-h3f84dcd_0.conda
osx-arm64::folly-2024.01.22.00-ha98ecff_0.conda
osx-arm64::cppyy-cling-6.30.0-py310h59dd246_1.conda
osx-arm64::vigra-1.11.2-py311hb7482d5_4.conda
osx-arm64::qt6-main-6.6.1-hd6da969_7.conda
osx-arm64::omniorb-4.3.2-py39h73f87db_0.conda
osx-arm64::libgdal-arrow-parquet-3.8.3-h82b47f8_0.conda
osx-arm64::libgsf-1.14.51-h2621522_1.conda
osx-arm64::lammps-2023.11.21-cpu_py310_h4786252_mpi_mpich_3.conda
osx-arm64::libmed-4.1.1-py312hd61c751_10.conda
osx-arm64::wxpython-4.2.1-py39h8cf1816_2.conda
osx-arm64::folly-2024.01.22.00-ha8c0bfd_0.conda
osx-arm64::folly-2024.01.08.00-hcdc1028_0_jemalloc.conda
osx-arm64::lammps-2023.08.02-cpu_py39_h5afc6b9_nompi_8.conda
osx-arm64::correctionlib-2.3.3-py39h3003546_2.conda
osx-arm64::lxml-5.0.1-py39h14dd1eb_0.conda
osx-arm64::lammps-2023.08.02-cpu_py311_h3159b45_nompi_7.conda
osx-arm64::aws-sdk-cpp-1.11.210-ha042220_8.conda
osx-arm64::libgrpc-1.60.0-hfc68871_0.conda
osx-arm64::lammps-2023.11.21-cpu_py310_h49200cc_mpi_openmpi_2.conda
osx-arm64::omniorb-4.3.2-py38hb5cc829_1.conda
osx-arm64::pyinstaller-6.3.0-py39h8643609_1.conda
osx-arm64::ffmpeg-6.1.1-gpl_h73646d7_102.conda
osx-arm64::lammps-2023.11.21-cpu_py311_h1b1bd21_mpi_openmpi_0.conda
osx-arm64::lammps-2023.11.21-cpu_py310_h1b23ab0_nompi_3.conda
osx-arm64::lammps-2023.11.21-cpu_py311_h1b1bd21_mpi_openmpi_1.conda
osx-arm64::mosh-1.4.0-pl5321h8a4d794_6.conda
osx-arm64::bytewax-0.18.1-py39h7809d69_0.conda
osx-arm64::libarrow-14.0.2-h4ce3932_2_cpu.conda
osx-arm64::correctionlib-2.3.3-py311h746b990_2.conda
osx-arm64::folly-2024.01.01.00-h75b8fe2_0.conda
osx-arm64::poppler-24.01.0-h896e6cb_0.conda
osx-arm64::ovito-3.10.0-h9de8c3e_0.conda
osx-arm64::pillow-10.2.0-py38h06aea99_0.conda
osx-arm64::libopencv-4.9.0-py312h2f19533_6.conda
osx-arm64::lammps-2023.11.21-cpu_py310_h4786252_mpi_mpich_1.conda
osx-arm64::lammps-2023.11.21-cpu_py38_h455d21a_nompi_0.conda
osx-arm64::omniorb-4.3.2-py310h11eb220_0.conda
osx-arm64::folly-2024.01.29.00-h75b8fe2_0.conda
osx-arm64::xrootd-5.6.6-py312hbeacd42_0.conda
osx-arm64::postgresql-plpython-15.4-py38h0b167b4_5.conda
osx-arm64::ovito-3.10.1-haf2e8d7_0.conda
osx-arm64::emacs-29.2-h2344b7e_0.conda
osx-arm64::nest-simulator-3.6-py310h2df337d_3.conda
osx-arm64::lxml-5.1.0-py312h9bf3b9e_0.conda
osx-arm64::gdstk-0.9.49-py311h4ecd0fe_0.conda
osx-arm64::libxml2-2.12.4-h0d0cfa8_0.conda
osx-arm64::uwsgi-2.0.23-py39hbfc7551_0.conda
osx-arm64::vigra-1.11.2-py38h978b72b_4.conda
osx-arm64::xrootd-5.6.6-py310h55a7978_0.conda
osx-arm64::lldb-17.0.6-py39h2b94c37_1.conda
osx-arm64::lammps-2023.11.21-cpu_py311_h3159b45_nompi_2.conda
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
osx-arm64::libuwebsockets-20.56.0-h1059232_0.conda
osx-arm64::openjdk-11.0.22-h3fcba2d_0.conda
osx-arm64::netcdf-cxx4-4.3.1-nompi_h5a57d91_108.conda
osx-arm64::libprotobuf-static-4.25.1-h810fc01_0.conda
osx-arm64::openjdk-21.0.2-hbeb2e11_0.conda
osx-arm64::libprotobuf-4.24.4-h810fc01_0.conda
osx-arm64::imath-3.1.10-h1059232_0.conda
osx-arm64::openjdk-17.0.10-h3fcba2d_0.conda
osx-arm64::libprotobuf-4.25.1-h810fc01_0.conda
osx-arm64::gst-plugins-base-1.22.8-h09b4b5e_1.conda
osx-arm64::libsoup-3.4.4-hda4a01a_2.conda
osx-arm64::gst-plugins-base-1.22.9-h09b4b5e_0.conda
osx-arm64::libuwebsockets-20.57.0-h1059232_0.conda
osx-arm64::zimpl-3.5.3-h2185600_7.conda
osx-arm64::libprotobuf-static-4.24.4-h810fc01_0.conda
osx-arm64::openexr-3.2.1-h73dd21e_1.conda
osx-arm64::libuwebsockets-20.58.0-h1059232_0.conda
-    "libzlib >=1.2.13,<1.3.0a0"
+    "libzlib >=1.2.13,<2.0.0a0"
================================================================================
================================================================================
linux-ppc64le
linux-ppc64le::postgresql-plpython-15.4-py38h3356496_5.conda
linux-ppc64le::folly-2024.01.22.00-ha2e2e2a_0.conda
linux-ppc64le::libmed-4.1.1-py38hf533497_10.conda
linux-ppc64le::correctionlib-2.3.3-py38hbab3742_2.conda
linux-ppc64le::libarrow-12.0.1-h66aaead_36_cpu.conda
linux-ppc64le::pillow-10.2.0-py311hc7c2d70_0.conda
linux-ppc64le::folly-2024.01.01.00-ha2e2e2a_0.conda
linux-ppc64le::libmed-4.1.1-py311h87d0c13_9.conda
linux-ppc64le::lxml-4.9.4-py38h728a521_0.conda
linux-ppc64le::libarrow-14.0.2-hd7a58ba_5_cpu.conda
linux-ppc64le::elfutils-0.190-h8ac0f3d_0.conda
linux-ppc64le::tiledb-2.18.4-ha7f9dc6_0.conda
linux-ppc64le::libopencv-4.9.0-py310he676b13_5.conda
linux-ppc64le::libarrow-14.0.2-h37e139e_2_cuda.conda
linux-ppc64le::libarrow-12.0.1-he7c9020_34_cuda.conda
linux-ppc64le::mysql-connector-python-8.0.33-py39hceab3dc_0.conda
linux-ppc64le::librdkafka-2.3.0-h8da8c2a_0.conda
linux-ppc64le::gmsh-4.12.1-h01679bf_0.conda
linux-ppc64le::libopencv-4.9.0-py38ha09f83c_5.conda
linux-ppc64le::mysql-connector-python-8.0.33-py310hacfde7c_0.conda
linux-ppc64le::qtwebkit-5.212-hb836a3e_16.conda
linux-ppc64le::gmsh-4.12.2-had2a3fc_0.conda
linux-ppc64le::mc-4.8.31-h03feef7_0.conda
linux-ppc64le::libmed-4.1.1-py39h2f1e416_9.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.3-h5bb32b2_0.conda
linux-ppc64le::libarrow-12.0.1-h422db0a_33_cuda.conda
linux-ppc64le::folly-2024.01.22.00-hd3a0175_0_jemalloc.conda
linux-ppc64le::lxml-5.1.0-py312h6977c88_0.conda
linux-ppc64le::aws-sdk-cpp-1.11.210-hf0a9481_8.conda
linux-ppc64le::omniorb-4.3.2-py38h7db1d0b_0.conda
linux-ppc64le::xrootd-5.6.6-py311hb704b0a_0.conda
linux-ppc64le::libarrow-11.0.0-h422db0a_57_cuda.conda
linux-ppc64le::r-data.table-1.14.10-r43hb163d15_1.conda
linux-ppc64le::cppyy-cling-6.30.0-py38h817fbe0_1.conda
linux-ppc64le::uwsgi-2.0.23-py312hc368ea4_0.conda
linux-ppc64le::openmpi-5.0.1-hc2f713b_101.conda
linux-ppc64le::libgsf-1.14.51-hf36db77_1.conda
linux-ppc64le::nss-3.97-h4237796_0.conda
linux-ppc64le::xrootd-5.6.6-py38hddce2ab_0.conda
linux-ppc64le::libmed-4.1.1-py38hf533497_9.conda
linux-ppc64le::omniorb-4.3.2-py39ha8da32a_1.conda
linux-ppc64le::folly-2024.01.15.00-hd3a0175_0_jemalloc.conda
linux-ppc64le::libarrow-14.0.2-h37e139e_4_cuda.conda
linux-ppc64le::gmsh-4.12.1-had2a3fc_0.conda
linux-ppc64le::openjdk-21.0.2-h88f1eab_0.conda
linux-ppc64le::gst-plugins-good-1.22.8-h6d5530f_1.conda
linux-ppc64le::libopencv-4.9.0-py38h16b05bc_6.conda
linux-ppc64le::xrootd-5.6.6-py312h7627752_0.conda
linux-ppc64le::lxml-5.1.0-py311h38abc29_0.conda
linux-ppc64le::libarrow-15.0.0-h37e139e_0_cuda.conda
linux-ppc64le::libmed-4.1.1-py310h89dff34_10.conda
linux-ppc64le::lxml-4.9.4-py311h38abc29_0.conda
linux-ppc64le::vigra-1.11.2-py38h9bb7e48_4.conda
linux-ppc64le::libopencv-4.9.0-py312h30328af_5.conda
linux-ppc64le::cppyy-cling-6.30.0-py39h90088aa_2.conda
linux-ppc64le::libspral-2023.09.07-h10b1de6_2.conda
linux-ppc64le::libarrow-14.0.2-h8b74409_1_cpu.conda
linux-ppc64le::postgresql-plpython-15.4-py311hcd20d66_5.conda
linux-ppc64le::libopencv-4.9.0-py39h43dba3e_5.conda
linux-ppc64le::libarrow-15.0.0-h3250d24_1_cpu.conda
linux-ppc64le::cppyy-cling-6.30.0-py311h82048e5_1.conda
linux-ppc64le::libarrow-13.0.0-he7c9020_23_cuda.conda
linux-ppc64le::vigra-1.11.2-py39h5e20da0_4.conda
linux-ppc64le::vigra-1.11.2-py311h2c8b6e1_4.conda
linux-ppc64le::omniorb-4.3.2-py312h0bb3dca_0.conda
linux-ppc64le::lxml-5.1.0-py39hb49e68d_0.conda
linux-ppc64le::lxml-5.1.0-py39h858273d_0.conda
linux-ppc64le::ffmpeg-6.1.1-gpl_h3d1d12b_102.conda
linux-ppc64le::uwsgi-2.0.23-py310hdba7c70_0.conda
linux-ppc64le::grpcio-1.60.0-py39h278787b_1.conda
linux-ppc64le::libopencv-4.9.0-py38h16b05bc_7.conda
linux-ppc64le::folly-2024.01.29.00-h7cedaab_0.conda
linux-ppc64le::lxml-5.0.1-py39hb49e68d_0.conda
linux-ppc64le::lxml-5.0.1-py310h7e86e89_0.conda
linux-ppc64le::magic-8.3.460-h7eb73fb_0.conda
linux-ppc64le::libopencv-4.9.0-py39hbf8100b_6.conda
linux-ppc64le::cppyy-cling-6.30.0-py312ha130f81_2.conda
linux-ppc64le::libarrow-14.0.2-h3250d24_4_cpu.conda
linux-ppc64le::xrootd-5.6.6-py310h9c09684_0.conda
linux-ppc64le::openjdk-11.0.22-h88a5b0c_0.conda
linux-ppc64le::vigra-1.11.2-py312hc0c182e_4.conda
linux-ppc64le::libspral-2023.09.07-h6ff642d_1.conda
linux-ppc64le::aws-sdk-cpp-1.11.242-h8d9d826_0.conda
linux-ppc64le::postgresql-plpython-15.4-py312hfdea0cd_5.conda
linux-ppc64le::cppyy-cling-6.30.0-py312ha130f81_1.conda
linux-ppc64le::pyinstaller-6.3.0-py311h5a86d3c_1.conda
linux-ppc64le::grpcio-1.60.0-py38hc2aed35_1.conda
linux-ppc64le::pillow-10.2.0-py310hf64def1_0.conda
linux-ppc64le::ffmpeg-6.1.1-gpl_hd3c6fab_103.conda
linux-ppc64le::pyinstaller-6.3.0-py310h0719273_1.conda
linux-ppc64le::aws-sdk-cpp-1.11.210-h557885c_10.conda
linux-ppc64le::libarrow-14.0.2-h44dfd70_5_cuda.conda
linux-ppc64le::folly-2024.01.08.00-hfba947f_0.conda
linux-ppc64le::tiledb-2.18.4-h595b711_0.conda
linux-ppc64le::folly-2024.01.08.00-ha2e2e2a_0.conda
linux-ppc64le::libarrow-11.0.0-hb64f901_60_cuda.conda
linux-ppc64le::libarrow-13.0.0-h4872323_22_cpu.conda
linux-ppc64le::omniorb-4.3.2-py310h94f889b_1.conda
linux-ppc64le::gst-plugins-bad-1.22.9-h3dbc169_0.conda
linux-ppc64le::omniorb-libs-4.3.2-h64e73a3_0.conda
linux-ppc64le::libarrow-13.0.0-hb64f901_25_cuda.conda
linux-ppc64le::ffmpeg-6.1.1-gpl_h3d1d12b_101.conda
linux-ppc64le::libarrow-15.0.0-hd7a58ba_2_cpu.conda
linux-ppc64le::libarrow-12.0.1-he1575e8_35_cuda.conda
linux-ppc64le::grpcio-1.60.0-py312h930df82_1.conda
linux-ppc64le::uwsgi-2.0.23-py39h8b684bb_0.conda
linux-ppc64le::libxml2-2.12.4-h0545f4b_1.conda
linux-ppc64le::tiledb-2.18.4-h7b0036b_0.conda
linux-ppc64le::sdl2_ttf-2.22.0-hd31ca0a_0.conda
linux-ppc64le::gct-6.2.1629922860-hdfb349c_3.conda
linux-ppc64le::libmed-4.1.1-py312h2d9ea72_10.conda
linux-ppc64le::pyinstaller-6.3.0-py38h36029d9_1.conda
linux-ppc64le::libmed-4.1.1-py311h7510574_8.conda
linux-ppc64le::libarrow-12.0.1-hb64f901_36_cuda.conda
linux-ppc64le::libarrow-11.0.0-he1575e8_59_cuda.conda
linux-ppc64le::postgresql-plpython-15.4-py310hcb289b5_5.conda
linux-ppc64le::postgresql-15.4-h33705f9_5.conda
linux-ppc64le::mysql-connector-python-8.0.33-py38hd5a0080_0.conda
linux-ppc64le::libopencv-4.9.0-py310h2540226_7.conda
linux-ppc64le::imagemagick-7.1.1_26-pl5321hb955cb3_0.conda
linux-ppc64le::graphicsmagick-1.3.42-h49f435f_0.conda
linux-ppc64le::omniorb-4.3.2-py311h7d8a50b_1.conda
linux-ppc64le::libmed-4.1.1-py38h7cb2e9a_8.conda
linux-ppc64le::libarrow-13.0.0-h422db0a_22_cuda.conda
linux-ppc64le::cmake-3.28.2-h1403f77_0.conda
linux-ppc64le::cpp-opentelemetry-sdk-1.13.0-h8183353_1.conda
linux-ppc64le::libpulsar-3.4.2-h117c625_1.conda
linux-ppc64le::libopencv-4.9.0-py311h7c72235_6.conda
linux-ppc64le::postgresql-plpython-15.4-py39h55f503e_5.conda
linux-ppc64le::aws-sdk-cpp-1.11.210-h8d9d826_11.conda
linux-ppc64le::folly-2024.01.15.00-h4b663bd_0_jemalloc.conda
linux-ppc64le::libarrow-12.0.1-hebeb5a6_34_cpu.conda
linux-ppc64le::mysql-connector-python-8.0.33-py311h30da4cc_0.conda
linux-ppc64le::aws-sdk-cpp-1.11.210-h33606f4_9.conda
linux-ppc64le::libopencv-4.9.0-py311h7c72235_7.conda
linux-ppc64le::folly-2024.01.29.00-hd3a0175_0_jemalloc.conda
linux-ppc64le::omniorb-4.3.2-py312h0bb3dca_1.conda
linux-ppc64le::xrootd-5.6.6-py39he887900_0.conda
linux-ppc64le::pillow-10.2.0-py39h0427823_0.conda
linux-ppc64le::mosh-1.4.0-pl5321hb868005_6.conda
linux-ppc64le::folly-2024.01.08.00-hcb6a8eb_0_jemalloc.conda
linux-ppc64le::libmed-4.1.1-py310h869392b_8.conda
linux-ppc64le::lxml-5.0.1-py311h38abc29_0.conda
linux-ppc64le::lxml-5.0.1-py38h728a521_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.3-h7fc0403_0.conda
linux-ppc64le::gst-plugins-base-1.22.8-he115d4a_1.conda
linux-ppc64le::folly-2024.01.29.00-h4b663bd_0_jemalloc.conda
linux-ppc64le::postgresql-plpython-15.5-py310h8b10ea4_0.conda
linux-ppc64le::postgresql-plpython-15.5-py312h7263721_0.conda
linux-ppc64le::postgresql-plpython-15.5-py39h63fa360_0.conda
linux-ppc64le::libarrow-11.0.0-h66aaead_60_cpu.conda
linux-ppc64le::folly-2024.01.22.00-hcb6a8eb_0_jemalloc.conda
linux-ppc64le::pillow-10.2.0-py312hb55979e_0.conda
linux-ppc64le::libarrow-14.0.2-h3250d24_2_cpu.conda
linux-ppc64le::libopencv-4.9.0-py39hd9661d7_6.conda
linux-ppc64le::nsight-compute-2023.3.1.1-h7069fa7_0.conda
linux-ppc64le::rust-1.75.0-hb12b0c0_0.conda
linux-ppc64le::correctionlib-2.3.3-py39h5e0a701_2.conda
linux-ppc64le::uwsgi-2.0.23-py311h00e0bd1_0.conda
linux-ppc64le::libarrow-14.0.2-h3250d24_3_cpu.conda
linux-ppc64le::libmed-4.1.1-py312hf85caf3_8.conda
linux-ppc64le::lxml-4.9.4-py39h858273d_0.conda
linux-ppc64le::libvips-8.15.1-h7f39556_1.conda
linux-ppc64le::pyinstaller-6.3.0-py39hf0cda86_1.conda
linux-ppc64le::openmpi-5.0.1-h45ed331_102.conda
linux-ppc64le::omniorb-4.3.2-py39ha8da32a_0.conda
linux-ppc64le::omniorb-4.3.2-py310h94f889b_0.conda
linux-ppc64le::folly-2024.01.29.00-ha2e2e2a_0.conda
linux-ppc64le::libmed-4.1.1-py311h87d0c13_10.conda
linux-ppc64le::ffmpeg-6.1.1-lgpl_h6140296_1.conda
linux-ppc64le::tesseract-5.3.4-ha2bda83_0.conda
linux-ppc64le::pyinstaller-6.3.0-py312h4032086_1.conda
linux-ppc64le::cppyy-cling-6.30.0-py310hedd2d5c_1.conda
linux-ppc64le::libarrow-14.0.2-h37e139e_3_cuda.conda
linux-ppc64le::libopencv-4.9.0-py312h0e58758_6.conda
linux-ppc64le::cppyy-cling-6.30.0-py39h90088aa_1.conda
linux-ppc64le::nceplibs-g2c-1.8.0-h5aced58_6.conda
linux-ppc64le::libarrow-14.0.2-hd83ba7d_1_cuda.conda
linux-ppc64le::libgdal-3.8.3-h06a2fa7_0.conda
linux-ppc64le::folly-2024.01.22.00-hfba947f_0.conda
linux-ppc64le::lxml-4.9.4-py310h7e86e89_0.conda
linux-ppc64le::postgresql-plpython-15.5-py38hce4d2e1_0.conda
linux-ppc64le::libarrow-15.0.0-h37e139e_1_cuda.conda
linux-ppc64le::libopencv-4.9.0-py310h2540226_6.conda
linux-ppc64le::folly-2024.01.01.00-hcb6a8eb_0_jemalloc.conda
linux-ppc64le::r-base-4.2.3-heb61927_12.conda
linux-ppc64le::libarrow-11.0.0-he7c9020_58_cuda.conda
linux-ppc64le::libxmlsec1-1.3.3-h9f8f588_0.conda
linux-ppc64le::libarrow-15.0.0-h44dfd70_2_cuda.conda
linux-ppc64le::omniorb-4.3.2-py38h7db1d0b_1.conda
linux-ppc64le::aws-sdk-cpp-1.11.210-h6b6baf1_7.conda
linux-ppc64le::folly-2024.01.22.00-h4b663bd_0_jemalloc.conda
linux-ppc64le::folly-2024.01.01.00-h4b663bd_0_jemalloc.conda
linux-ppc64le::grpcio-1.60.0-py310h8eb8f48_1.conda
linux-ppc64le::libarrow-11.0.0-h4872323_57_cpu.conda
linux-ppc64le::imagemagick-7.1.1_27-pl5321h79d4ed6_0.conda
linux-ppc64le::pillow-10.2.0-py39hed4bbec_0.conda
linux-ppc64le::libarrow-12.0.1-h70db75b_35_cpu.conda
linux-ppc64le::libarrow-13.0.0-hebeb5a6_23_cpu.conda
linux-ppc64le::libmed-4.1.1-py39h2f1e416_10.conda
linux-ppc64le::libgoogle-cloud-storage-2.17.0-h39cc67c_2.conda
linux-ppc64le::grpcio-1.60.0-py39h27cb1e9_1.conda
linux-ppc64le::correctionlib-2.3.3-py310h02f1291_2.conda
linux-ppc64le::libopencv-4.9.0-py39h76fbe1b_5.conda
linux-ppc64le::mesalib-23.3.4-h1857240_0.conda
linux-ppc64le::libarrow-13.0.0-h70db75b_24_cpu.conda
linux-ppc64le::cppyy-cling-6.30.0-py310hedd2d5c_2.conda
linux-ppc64le::folly-2024.01.29.00-hcb6a8eb_0_jemalloc.conda
linux-ppc64le::folly-2024.01.01.00-h7cedaab_0.conda
linux-ppc64le::tiledb-2.19.1-h7b0036b_0.conda
linux-ppc64le::omniorb-libs-4.3.2-h64e73a3_1.conda
linux-ppc64le::grpcio-1.60.0-py311h3997ded_1.conda
linux-ppc64le::libarrow-13.0.0-h66aaead_25_cpu.conda
linux-ppc64le::r-base-4.3.2-h142f484_2.conda
linux-ppc64le::libarrow-15.0.0-h3250d24_0_cpu.conda
linux-ppc64le::libmed-4.1.1-py310h89dff34_9.conda
linux-ppc64le::postgresql-15.5-hcd4fc10_0.conda
linux-ppc64le::lld-17.0.6-h37013bd_1.conda
linux-ppc64le::folly-2024.01.01.00-hfba947f_0.conda
linux-ppc64le::pdal-2.6.2-h6724036_3.conda
linux-ppc64le::libopencv-4.9.0-py312h0e58758_7.conda
linux-ppc64le::libarrow-11.0.0-h70db75b_59_cpu.conda
linux-ppc64le::cppyy-cling-6.30.0-py311h82048e5_2.conda
linux-ppc64le::folly-2024.01.08.00-h4b663bd_0_jemalloc.conda
linux-ppc64le::libpq-15.5-h458bc76_0.conda
linux-ppc64le::gmt-6.5.0-h35fd5c7_0.conda
linux-ppc64le::libopencv-4.9.0-py311h9c0c7e8_5.conda
linux-ppc64le::libarrow-12.0.1-h4872323_33_cpu.conda
linux-ppc64le::poppler-24.01.0-h433edb4_0.conda
linux-ppc64le::vigra-1.11.2-py310hab72e55_4.conda
linux-ppc64le::magic-8.3.455-h7eb73fb_0.conda
linux-ppc64le::fish-3.7.0-hc9248e7_0.conda
linux-ppc64le::libxml2-2.12.4-h0545f4b_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.3-hce6b20d_0.conda
linux-ppc64le::libyarp-3.9.0-h0c15918_1.conda
linux-ppc64le::lxml-4.9.4-py312h6977c88_0.conda
linux-ppc64le::pypy3.9-7.3.15-h4020351_0.tar.bz2
linux-ppc64le::lxml-5.0.1-py39h858273d_0.conda
linux-ppc64le::folly-2024.01.15.00-h7cedaab_0.conda
linux-ppc64le::libmed-4.1.1-py312h2d9ea72_9.conda
linux-ppc64le::libmed-4.1.1-py39hcc27481_8.conda
linux-ppc64le::libgrpc-1.60.0-h14a4736_0.conda
linux-ppc64le::magic-8.3.456-h7eb73fb_0.conda
linux-ppc64le::folly-2024.01.15.00-ha2e2e2a_0.conda
linux-ppc64le::folly-2024.01.22.00-h7cedaab_0.conda
linux-ppc64le::folly-2024.01.01.00-hd3a0175_0_jemalloc.conda
linux-ppc64le::mysql-connector-python-8.0.33-py39h91b38d1_0.conda
linux-ppc64le::uwsgi-2.0.23-py38hcea13af_0.conda
linux-ppc64le::gmsh-4.12.2-h01679bf_0.conda
linux-ppc64le::lxml-5.0.1-py312h6977c88_0.conda
linux-ppc64le::r-data.table-1.14.10-r42hb163d15_1.conda
linux-ppc64le::libopencv-4.9.0-py39hd9661d7_7.conda
linux-ppc64le::cppyy-cling-6.30.0-py39ha2c232c_2.conda
linux-ppc64le::cppyy-cling-6.30.0-py38h817fbe0_2.conda
linux-ppc64le::omniorb-4.3.2-py311h7d8a50b_0.conda
linux-ppc64le::pillow-10.2.0-py38h60861ec_0.conda
linux-ppc64le::libgrpc-1.60.0-h14a4736_1.conda
linux-ppc64le::libarrow-11.0.0-hebeb5a6_58_cpu.conda
linux-ppc64le::tiledb-2.19.1-h595b711_0.conda
linux-ppc64le::correctionlib-2.3.3-py311hc2b5b1e_2.conda
linux-ppc64le::ffmpeg-6.1.1-lgpl_h6140296_2.conda
linux-ppc64le::postgresql-plpython-15.5-py311hd1eda33_0.conda
linux-ppc64le::lxml-5.1.0-py38h728a521_0.conda
linux-ppc64le::libpq-15.4-h29a043a_5.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.3-hd4ce4ff_0.conda
linux-ppc64le::libopentelemetry-cpp-1.13.0-h8183353_1.conda
linux-ppc64le::libopencv-4.9.0-py39hbf8100b_7.conda
linux-ppc64le::nceplibs-g2c-1.8.0-h5aced58_5.conda
linux-ppc64le::gst-plugins-good-1.22.9-hbd4f694_0.conda
linux-ppc64le::orc-1.9.2-ha016051_1.conda
linux-ppc64le::folly-2024.01.08.00-hd3a0175_0_jemalloc.conda
linux-ppc64le::folly-2024.01.08.00-h7cedaab_0.conda
linux-ppc64le::tiledb-2.19.1-ha7f9dc6_0.conda
linux-ppc64le::folly-2024.01.15.00-hfba947f_0.conda
linux-ppc64le::libarrow-13.0.0-he1575e8_24_cuda.conda
linux-ppc64le::lxml-5.1.0-py310h7e86e89_0.conda
linux-ppc64le::folly-2024.01.15.00-hcb6a8eb_0_jemalloc.conda
linux-ppc64le::folly-2024.01.29.00-hfba947f_0.conda
linux-ppc64le::ffmpeg-6.1.1-lgpl_h0043c9b_3.conda
linux-ppc64le::xrootd-5.6.6-py39h22b532c_0.conda
linux-ppc64le::openjdk-17.0.10-h88a5b0c_0.conda
linux-ppc64le::cppyy-cling-6.30.0-py39ha2c232c_1.conda
linux-ppc64le::gst-plugins-base-1.22.9-he115d4a_0.conda
linux-ppc64le::vigra-1.11.2-py39hb1cba2f_4.conda
linux-ppc64le::lxml-4.9.4-py39hb49e68d_0.conda
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
linux-ppc64le::openexr-3.2.1-h8c13fd7_1.conda
linux-ppc64le::libprotobuf-4.25.1-h9ce2175_0.conda
linux-ppc64le::gst-libav-1.22.9-h95e5f97_0.conda
linux-ppc64le::libprotobuf-static-4.25.1-h9ce2175_0.conda
linux-ppc64le::imath-3.1.10-hff1ad0c_0.conda
linux-ppc64le::libsoup-3.4.4-hf18c1f8_2.conda
-    "libzlib >=1.2.13,<1.3.0a0"
+    "libzlib >=1.2.13,<2.0.0a0"
================================================================================
================================================================================
linux-aarch64
linux-aarch64::uwsgi-2.0.23-py311h875fe98_0.conda
linux-aarch64::grpcio-1.60.0-py310h20b6881_1.conda
linux-aarch64::mesalib-23.3.4-h28786aa_0.conda
linux-aarch64::uwsgi-2.0.23-py310h24a9888_0.conda
linux-aarch64::uwsgi-2.0.23-py312h16153d7_0.conda
linux-aarch64::folly-2024.01.22.00-h8dd4a7f_0_jemalloc.conda
linux-aarch64::libxml2-2.12.4-h3091e33_1.conda
linux-aarch64::libarrow-14.0.2-hecd0440_3_cuda.conda
linux-aarch64::libpq-15.5-h1a766d2_0.conda
linux-aarch64::gst-plugins-good-1.22.8-hde0fa69_1.conda
linux-aarch64::libarrow-11.0.0-hd531514_57_cuda.conda
linux-aarch64::xrootd-5.6.6-py312had43f97_0.conda
linux-aarch64::lxml-5.1.0-py38h447d444_0.conda
linux-aarch64::pillow-10.2.0-py312h1e2a6dd_0.conda
linux-aarch64::magic-8.3.456-h4e13689_0.conda
linux-aarch64::libarrow-14.0.2-hecd0440_4_cuda.conda
linux-aarch64::vigra-1.11.2-py312hb0d3b70_4.conda
linux-aarch64::postgresql-plpython-15.4-py39hadb01dc_5.conda
linux-aarch64::libarrow-12.0.1-hfde2404_36_cpu.conda
linux-aarch64::vigra-1.11.2-py39h3130f5b_4.conda
linux-aarch64::libopencv-4.9.0-py311h5435783_7.conda
linux-aarch64::postgresql-plpython-15.5-py39h430b2eb_0.conda
linux-aarch64::folly-2024.01.29.00-hcdf9fb0_0.conda
linux-aarch64::folly-2024.01.01.00-hb8ddcfe_0_jemalloc.conda
linux-aarch64::libgdal-3.8.3-h2da9cb4_0.conda
linux-aarch64::lxml-5.0.1-py310ha3d0d4e_0.conda
linux-aarch64::libarrow-15.0.0-he4a0828_0_cpu.conda
linux-aarch64::pillow-10.2.0-py310h0ae3e2b_0.conda
linux-aarch64::lxml-4.9.4-py311h30c7647_0.conda
linux-aarch64::pypy3.9-7.3.15-h63376dd_0.tar.bz2
linux-aarch64::libopencv-4.9.0-py39hb9b4604_7.conda
linux-aarch64::folly-2024.01.08.00-h8a1e4c1_0_jemalloc.conda
linux-aarch64::cppyy-cling-6.30.0-py311he5a59f2_2.conda
linux-aarch64::folly-2024.01.15.00-h8dd4a7f_0_jemalloc.conda
linux-aarch64::postgresql-plpython-15.4-py312hc43be6c_5.conda
linux-aarch64::grpcio-1.60.0-py39h483cef1_1.conda
linux-aarch64::ffmpeg-6.1.1-lgpl_h8cf9aed_1.conda
linux-aarch64::gst-plugins-base-1.22.9-h6d82d15_0.conda
linux-aarch64::libarrow-11.0.0-hfde2404_60_cpu.conda
linux-aarch64::gmsh-4.12.2-ha60554b_0.conda
linux-aarch64::postgresql-plpython-15.4-py38hc50c26b_5.conda
linux-aarch64::libspral-2023.09.07-h584411f_1.conda
linux-aarch64::lxml-4.9.4-py38h447d444_0.conda
linux-aarch64::aws-sdk-cpp-1.11.210-hf4e9681_10.conda
linux-aarch64::postgresql-plpython-15.5-py310hd4fca6a_0.conda
linux-aarch64::tiledb-2.18.4-hf61e980_0.conda
linux-aarch64::libpq-15.4-h8d0093b_5.conda
linux-aarch64::libgrpc-1.60.0-heeb7df3_1.conda
linux-aarch64::folly-2024.01.15.00-hcdf9fb0_0.conda
linux-aarch64::libmed-4.1.1-py310h9a32397_8.conda
linux-aarch64::omniorb-libs-4.3.2-h48ed410_1.conda
linux-aarch64::libarrow-15.0.0-hecd0440_1_cuda.conda
linux-aarch64::r-base-4.2.3-h2f93d7e_12.conda
linux-aarch64::imagemagick-7.1.1_27-pl5321h1c444f2_0.conda
linux-aarch64::libmed-4.1.1-py311hbe12d10_9.conda
linux-aarch64::libopencv-4.9.0-py39h9edfbce_6.conda
linux-aarch64::folly-2024.01.22.00-hb8ddcfe_0_jemalloc.conda
linux-aarch64::vigra-1.11.2-py311h3ad6769_4.conda
linux-aarch64::libarrow-12.0.1-h7c3d548_35_cpu.conda
linux-aarch64::ffmpeg-6.1.1-gpl_hed0588d_101.conda
linux-aarch64::folly-2024.01.22.00-hcbc1ef6_0.conda
linux-aarch64::folly-2024.01.01.00-hcdf9fb0_0.conda
linux-aarch64::cppyy-cling-6.30.0-py311he5a59f2_1.conda
linux-aarch64::folly-2024.01.22.00-h8a1e4c1_0_jemalloc.conda
linux-aarch64::sagelib-10.2-py311h5df1c82_3.conda
linux-aarch64::tiledb-2.19.1-h6acf51b_0.conda
linux-aarch64::folly-2024.01.29.00-h8dd4a7f_0_jemalloc.conda
linux-aarch64::lxml-5.1.0-py312h04464de_0.conda
linux-aarch64::nceplibs-g2c-1.8.0-h3f93fe6_6.conda
linux-aarch64::aws-sdk-cpp-1.11.210-hf01a265_11.conda
linux-aarch64::tiledb-2.18.4-h6acf51b_0.conda
linux-aarch64::libmed-4.1.1-py38h3d8b374_10.conda
linux-aarch64::libarrow-12.0.1-h5977c1f_34_cuda.conda
linux-aarch64::lld-17.0.6-h4742870_1.conda
linux-aarch64::correctionlib-2.3.3-py311hfd6ae59_2.conda
linux-aarch64::folly-2024.01.01.00-hf875f9a_0.conda
linux-aarch64::libgdal-arrow-parquet-3.8.3-h24ea3e1_0.conda
linux-aarch64::libarrow-15.0.0-h94a09b9_2_cpu.conda
linux-aarch64::gst-plugins-bad-1.22.9-haa4ddd8_0.conda
linux-aarch64::sagelib-10.2-py310ha9e3067_3.conda
linux-aarch64::lxml-5.0.1-py39h97aa90e_0.conda
linux-aarch64::omniorb-libs-4.3.2-h48ed410_0.conda
linux-aarch64::omniorb-4.3.2-py39h86dfdcc_0.conda
linux-aarch64::postgresql-plpython-15.4-py311h765025c_5.conda
linux-aarch64::lxml-5.1.0-py39h97aa90e_0.conda
linux-aarch64::vigra-1.11.2-py38h0f5c556_4.conda
linux-aarch64::r-data.table-1.14.10-r43hb4ebc13_1.conda
linux-aarch64::folly-2024.01.01.00-h8a1e4c1_0_jemalloc.conda
linux-aarch64::libopencv-4.9.0-py38hf4f92be_6.conda
linux-aarch64::pdal-2.6.2-h52efa3f_3.conda
linux-aarch64::mosh-1.4.0-pl5321h97d052a_6.conda
linux-aarch64::tiledb-2.19.1-hf61e980_0.conda
linux-aarch64::gst-plugins-good-1.22.9-h16f724d_0.conda
linux-aarch64::libmed-4.1.1-py39h8560892_9.conda
linux-aarch64::cppyy-cling-6.30.0-py312h7bd74d4_1.conda
linux-aarch64::libspral-2023.09.07-h98a5362_2.conda
linux-aarch64::folly-2024.01.08.00-hcdf9fb0_0.conda
linux-aarch64::correctionlib-2.3.3-py38h68f7483_2.conda
linux-aarch64::libarrow-14.0.2-he4a0828_2_cpu.conda
linux-aarch64::gmsh-4.12.1-ha60554b_0.conda
linux-aarch64::libopencv-4.9.0-py39h9ea21a4_7.conda
linux-aarch64::lldb-17.0.6-py311h18aa7b8_1.conda
linux-aarch64::pillow-10.2.0-py39h8ce38d7_0.conda
linux-aarch64::lxml-5.0.1-py39hdc9d7a7_0.conda
linux-aarch64::libarrow-11.0.0-hee917c9_57_cpu.conda
linux-aarch64::pyinstaller-6.3.0-py312h16ba8cc_1.conda
linux-aarch64::libgoogle-cloud-storage-2.17.0-hdb39181_2.conda
linux-aarch64::nsight-compute-2023.3.1.1-h26df83c_0.conda
linux-aarch64::folly-2024.01.01.00-hcbc1ef6_0.conda
linux-aarch64::libarrow-12.0.1-hee917c9_33_cpu.conda
linux-aarch64::folly-2024.01.01.00-h8dd4a7f_0_jemalloc.conda
linux-aarch64::libpulsar-3.4.2-h6a8f2f8_1.conda
linux-aarch64::folly-2024.01.08.00-hf875f9a_0.conda
linux-aarch64::tesseract-5.3.4-h038deca_0.conda
linux-aarch64::libarrow-14.0.2-h026d3b8_1_cuda.conda
linux-aarch64::postgresql-15.5-h841b8aa_0.conda
linux-aarch64::postgresql-plpython-15.5-py38h19c6b48_0.conda
linux-aarch64::lxml-5.0.1-py311h30c7647_0.conda
linux-aarch64::mysql-connector-python-8.0.33-py38h8354cbf_0.conda
linux-aarch64::qt6-main-6.6.1-he744713_7.conda
linux-aarch64::libopencv-4.9.0-py38h025d7d0_5.conda
linux-aarch64::folly-2024.01.29.00-hcbc1ef6_0.conda
linux-aarch64::omniorb-4.3.2-py310hae03fa7_0.conda
linux-aarch64::openmpi-5.0.1-hfb79068_101.conda
linux-aarch64::libarrow-13.0.0-h2b72ae0_24_cuda.conda
linux-aarch64::folly-2024.01.08.00-hb8ddcfe_0_jemalloc.conda
linux-aarch64::libarrow-14.0.2-hd8ea61b_5_cuda.conda
linux-aarch64::libopencv-4.9.0-py312ha1656aa_6.conda
linux-aarch64::sagelib-10.2-py39h0db02ac_2.conda
linux-aarch64::lxml-5.0.1-py38h447d444_0.conda
linux-aarch64::xrootd-5.6.6-py38h1a5399f_0.conda
linux-aarch64::libarrow-13.0.0-h5977c1f_23_cuda.conda
linux-aarch64::omniorb-4.3.2-py311h9b119e1_0.conda
linux-aarch64::omniorb-4.3.2-py311h9b119e1_1.conda
linux-aarch64::libarrow-14.0.2-h6cc1dc9_1_cpu.conda
linux-aarch64::cmake-3.28.2-hef020d8_0.conda
linux-aarch64::libarrow-13.0.0-hd531514_22_cuda.conda
linux-aarch64::libopencv-4.9.0-py311hcc23ee9_6.conda
linux-aarch64::sagelib-10.2-py311h5df1c82_2.conda
linux-aarch64::qtwebkit-5.212-h1b3b7ad_16.conda
linux-aarch64::libopencv-4.9.0-py39h73e2d38_6.conda
linux-aarch64::cppyy-cling-6.30.0-py312h7bd74d4_2.conda
linux-aarch64::folly-2024.01.29.00-hb8ddcfe_0_jemalloc.conda
linux-aarch64::libmed-4.1.1-py310hbaddfd8_9.conda
linux-aarch64::libarrow-13.0.0-hfde2404_25_cpu.conda
linux-aarch64::magic-8.3.460-h4e13689_0.conda
linux-aarch64::imagemagick-7.1.1_26-pl5321h64d673c_0.conda
linux-aarch64::fish-3.7.0-hc0a5165_0.conda
linux-aarch64::postgresql-plpython-15.5-py312ha9bbecc_0.conda
linux-aarch64::cppyy-cling-6.30.0-py310h10cdd87_1.conda
linux-aarch64::cpp-opentelemetry-sdk-1.13.0-he75d388_1.conda
linux-aarch64::libmed-4.1.1-py38h3d8b374_9.conda
linux-aarch64::pyinstaller-6.3.0-py38h37f3631_1.conda
linux-aarch64::elfutils-0.190-h682c91b_0.conda
linux-aarch64::aws-sdk-cpp-1.11.210-h49cfcca_7.conda
linux-aarch64::libarrow-11.0.0-h7c3d548_59_cpu.conda
linux-aarch64::libvips-8.15.1-h15f3967_1.conda
linux-aarch64::libgdal-arrow-parquet-3.8.3-h4b7346d_0.conda
linux-aarch64::grpcio-1.60.0-py39h2ec6326_1.conda
linux-aarch64::openjdk-11.0.22-hac580f4_0.conda
linux-aarch64::libarrow-13.0.0-hff1e9c3_23_cpu.conda
linux-aarch64::omniorb-4.3.2-py39h86dfdcc_1.conda
linux-aarch64::magic-8.3.455-h4e13689_0.conda
linux-aarch64::ffmpeg-6.1.1-gpl_hd7a8714_103.conda
linux-aarch64::folly-2024.01.08.00-hcbc1ef6_0.conda
linux-aarch64::libmed-4.1.1-py312hea0ff8b_8.conda
linux-aarch64::pillow-10.2.0-py38hf904494_0.conda
linux-aarch64::libarrow-11.0.0-h2b72ae0_59_cuda.conda
linux-aarch64::orc-1.9.2-h5960ff3_1.conda
linux-aarch64::libopencv-4.9.0-py311h07a21fa_5.conda
linux-aarch64::pyinstaller-6.3.0-py311h0dd4530_1.conda
linux-aarch64::folly-2024.01.22.00-hf875f9a_0.conda
linux-aarch64::libopencv-4.9.0-py312he77525e_7.conda
linux-aarch64::libarrow-13.0.0-h7c3d548_24_cpu.conda
linux-aarch64::tiledb-2.19.1-h2d7fb0a_0.conda
linux-aarch64::libarrow-11.0.0-h3424d97_60_cuda.conda
linux-aarch64::rust-1.75.0-h9d3d833_0.conda
linux-aarch64::vigra-1.11.2-py39hba6120e_4.conda
linux-aarch64::libopencv-4.9.0-py39he6a447f_5.conda
linux-aarch64::libmed-4.1.1-py311h4bd975c_8.conda
linux-aarch64::libarrow-14.0.2-he4a0828_4_cpu.conda
linux-aarch64::libarrow-15.0.0-hd8ea61b_2_cuda.conda
linux-aarch64::uwsgi-2.0.23-py38h58e2faa_0.conda
linux-aarch64::qt6-main-6.6.1-he744713_8.conda
linux-aarch64::cppyy-cling-6.30.0-py310h10cdd87_2.conda
linux-aarch64::ffmpeg-6.1.1-gpl_h658a72a_102.conda
linux-aarch64::grpcio-1.60.0-py311h1a7908d_1.conda
linux-aarch64::libarrow-13.0.0-h3424d97_25_cuda.conda
linux-aarch64::lxml-5.0.1-py312h04464de_0.conda
linux-aarch64::folly-2024.01.15.00-hb8ddcfe_0_jemalloc.conda
linux-aarch64::libmed-4.1.1-py311hbe12d10_10.conda
linux-aarch64::libarrow-13.0.0-hee917c9_22_cpu.conda
linux-aarch64::postgresql-plpython-15.5-py311h1448d06_0.conda
linux-aarch64::r-base-4.3.2-h7dc8e12_2.conda
linux-aarch64::libmed-4.1.1-py312h43ecaab_10.conda
linux-aarch64::lldb-17.0.6-py38h57c4c1a_1.conda
linux-aarch64::libgdal-arrow-parquet-3.8.3-he53a0e1_0.conda
linux-aarch64::aws-sdk-cpp-1.11.210-h01d4e1e_8.conda
linux-aarch64::libarrow-14.0.2-hecd0440_2_cuda.conda
linux-aarch64::sdl2_ttf-2.22.0-h2d2b936_0.conda
linux-aarch64::openjdk-21.0.2-hf79f348_0.conda
linux-aarch64::cppyy-cling-6.30.0-py38hff2f627_2.conda
linux-aarch64::lxml-5.1.0-py310ha3d0d4e_0.conda
linux-aarch64::libopencv-4.9.0-py39h420bf2d_5.conda
linux-aarch64::tiledb-2.18.4-h2d7fb0a_0.conda
linux-aarch64::lxml-5.1.0-py39hdc9d7a7_0.conda
linux-aarch64::gmsh-4.12.2-h925e419_0.conda
linux-aarch64::lxml-4.9.4-py310ha3d0d4e_0.conda
linux-aarch64::sagelib-10.2-py310ha9e3067_2.conda
linux-aarch64::nss-3.97-hc5a5cc2_0.conda
linux-aarch64::librdkafka-2.3.0-hb18e517_0.conda
linux-aarch64::xrootd-5.6.6-py39h800dff5_0.conda
linux-aarch64::mc-4.8.31-h3618a31_0.conda
linux-aarch64::omniorb-4.3.2-py310hae03fa7_1.conda
linux-aarch64::folly-2024.01.29.00-h8a1e4c1_0_jemalloc.conda
linux-aarch64::graphicsmagick-1.3.42-h18bc9f7_0.conda
linux-aarch64::mpv-0.36.0-he3dc898_1.conda
linux-aarch64::lldb-17.0.6-py39hdad441a_1.conda
linux-aarch64::gmt-6.5.0-h7192605_0.conda
linux-aarch64::libxml2-2.12.4-h3091e33_0.conda
linux-aarch64::libgdal-arrow-parquet-3.8.3-hd39519c_0.conda
linux-aarch64::correctionlib-2.3.3-py39h23417e7_2.conda
linux-aarch64::omniorb-4.3.2-py38hc9c3f1f_0.conda
linux-aarch64::libmed-4.1.1-py312h43ecaab_9.conda
linux-aarch64::correctionlib-2.3.3-py310h88818a3_2.conda
linux-aarch64::libgrpc-1.60.0-heeb7df3_0.conda
linux-aarch64::aws-sdk-cpp-1.11.242-hf01a265_0.conda
linux-aarch64::lxml-4.9.4-py39hdc9d7a7_0.conda
linux-aarch64::ffmpeg-6.1.1-lgpl_h67e268b_3.conda
linux-aarch64::libopencv-4.9.0-py310h4751fa4_5.conda
linux-aarch64::libmed-4.1.1-py39h78b4e95_8.conda
linux-aarch64::xrootd-5.6.6-py310hbd93bf4_0.conda
linux-aarch64::xrootd-5.6.6-py311h4f4f7a9_0.conda
linux-aarch64::pillow-10.2.0-py39hf04c2c8_0.conda
linux-aarch64::vigra-1.11.2-py310h38c8dce_4.conda
linux-aarch64::postgresql-plpython-15.4-py310h5ecf261_5.conda
linux-aarch64::lxml-5.1.0-py311h30c7647_0.conda
linux-aarch64::libarrow-14.0.2-h94a09b9_5_cpu.conda
linux-aarch64::postgresql-15.4-he703394_5.conda
linux-aarch64::poppler-24.01.0-h3cd87ed_0.conda
linux-aarch64::openjdk-17.0.10-hac580f4_0.conda
linux-aarch64::pyinstaller-6.3.0-py39hb91f966_1.conda
linux-aarch64::aws-sdk-cpp-1.11.210-h7330e9a_9.conda
linux-aarch64::mysql-connector-python-8.0.33-py310h8b564ae_0.conda
linux-aarch64::pillow-10.2.0-py311hbcc2232_0.conda
linux-aarch64::grpcio-1.60.0-py38h95a9722_1.conda
linux-aarch64::folly-2024.01.22.00-hcdf9fb0_0.conda
linux-aarch64::libarrow-12.0.1-hd531514_33_cuda.conda
linux-aarch64::qt6-main-6.6.1-he744713_6.conda
linux-aarch64::mysql-connector-python-8.0.33-py311h7b38523_0.conda
linux-aarch64::folly-2024.01.08.00-h8dd4a7f_0_jemalloc.conda
linux-aarch64::libarrow-12.0.1-h2b72ae0_35_cuda.conda
linux-aarch64::cppyy-cling-6.30.0-py38hff2f627_1.conda
linux-aarch64::lldb-17.0.6-py310hafd98b1_1.conda
linux-aarch64::folly-2024.01.29.00-hf875f9a_0.conda
linux-aarch64::folly-2024.01.15.00-h8a1e4c1_0_jemalloc.conda
linux-aarch64::grpcio-1.60.0-py312hd96c8c9_1.conda
linux-aarch64::lxml-4.9.4-py312h04464de_0.conda
linux-aarch64::libarrow-12.0.1-h3424d97_36_cuda.conda
linux-aarch64::gct-6.2.1629922860-h8015430_3.conda
linux-aarch64::libarrow-15.0.0-he4a0828_1_cpu.conda
linux-aarch64::sagelib-10.2-py39h0db02ac_3.conda
linux-aarch64::ffmpeg-6.1.1-lgpl_h42e2ab2_2.conda
linux-aarch64::lxml-4.9.4-py39h97aa90e_0.conda
linux-aarch64::libarrow-12.0.1-hff1e9c3_34_cpu.conda
linux-aarch64::gmsh-4.12.1-h925e419_0.conda
linux-aarch64::omniorb-4.3.2-py38hc9c3f1f_1.conda
linux-aarch64::libarrow-15.0.0-hecd0440_0_cuda.conda
linux-aarch64::libmed-4.1.1-py39h8560892_10.conda
linux-aarch64::cppyy-cling-6.30.0-py39h1191062_2.conda
linux-aarch64::libopencv-4.9.0-py310hd45c6b0_6.conda
linux-aarch64::libmed-4.1.1-py38h169e1fb_8.conda
linux-aarch64::folly-2024.01.15.00-hf875f9a_0.conda
linux-aarch64::uwsgi-2.0.23-py39h06114da_0.conda
linux-aarch64::libyarp-3.9.0-h6d2be9b_1.conda
linux-aarch64::libarrow-11.0.0-hff1e9c3_58_cpu.conda
linux-aarch64::cppyy-cling-6.30.0-py39h20fac6d_1.conda
linux-aarch64::folly-2024.01.15.00-hcbc1ef6_0.conda
linux-aarch64::openmpi-5.0.1-h9ca730b_102.conda
linux-aarch64::libarrow-11.0.0-h5977c1f_58_cuda.conda
linux-aarch64::gst-plugins-base-1.22.8-h6d82d15_1.conda
linux-aarch64::cppyy-cling-6.30.0-py39h1191062_1.conda
linux-aarch64::libxmlsec1-1.3.3-h048dbf2_0.conda
linux-aarch64::omniorb-4.3.2-py312h89a05d2_0.conda
linux-aarch64::r-data.table-1.14.10-r42hb4ebc13_1.conda
linux-aarch64::xrootd-5.6.6-py39h8731d2c_0.conda
linux-aarch64::libarrow-14.0.2-he4a0828_3_cpu.conda
linux-aarch64::mysql-connector-python-8.0.33-py39hb32bc82_0.conda
linux-aarch64::libopencv-4.9.0-py38h74f9df4_7.conda
linux-aarch64::libopencv-4.9.0-py312he3a38e9_5.conda
linux-aarch64::libopencv-4.9.0-py310h9ecd0da_7.conda
linux-aarch64::libmed-4.1.1-py310hbaddfd8_10.conda
linux-aarch64::nceplibs-g2c-1.8.0-h3f93fe6_5.conda
linux-aarch64::libgsf-1.14.51-h7ffafe2_1.conda
linux-aarch64::mysql-connector-python-8.0.33-py39hd74382b_0.conda
linux-aarch64::libopentelemetry-cpp-1.13.0-he75d388_1.conda
linux-aarch64::cppyy-cling-6.30.0-py39h20fac6d_2.conda
linux-aarch64::omniorb-4.3.2-py312h89a05d2_1.conda
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
linux-aarch64::libprotobuf-static-4.25.1-h87e877f_0.conda
linux-aarch64::imath-3.1.10-hd84c7bf_0.conda
linux-aarch64::libprotobuf-4.25.1-h87e877f_0.conda
linux-aarch64::gst-libav-1.22.9-hc4a16bf_0.conda
linux-aarch64::openexr-3.2.1-h294c868_1.conda
linux-aarch64::libsoup-3.4.4-hb0eb4cf_2.conda
-    "libzlib >=1.2.13,<1.3.0a0"
+    "libzlib >=1.2.13,<2.0.0a0"
================================================================================
================================================================================
noarch
================================================================================
================================================================================
win-64
win-64::aws-sdk-cpp-1.11.210-h6cc9002_7.conda
win-64::correctionlib-2.3.3-py311hd32ce59_2.conda
win-64::pillow-10.2.0-py311h4dd8a23_0.conda
win-64::nceplibs-g2c-1.8.0-h83564c8_5.conda
win-64::gst-plugins-bad-1.22.9-hf741e74_0.conda
win-64::gdstk-0.9.49-py310h7dcdc39_0.conda
win-64::libarrow-14.0.2-he5f67d5_3_cpu.conda
win-64::lfortran-0.33.1-h12be248_0.conda
win-64::libarrow-15.0.0-h881831c_2_cuda.conda
win-64::libarrow-11.0.0-hbe4048c_59_cuda.conda
win-64::paraview-5.11.2-py310h1ac93a0_102_qt.conda
win-64::libarrow-11.0.0-h97b458a_59_cpu.conda
win-64::libarrow-gandiva-15.0.0-hb2eaab1_2_cpu.conda
win-64::omniorb-4.3.2-py38h8a9cac7_1.conda
win-64::libmed-4.1.1-py310h239f96b_9.conda
win-64::gmt-6.5.0-h3145845_0.conda
win-64::libarrow-12.0.1-h2d8668f_35_cpu.conda
win-64::libmed-4.1.1-py311h0794cdf_8.conda
win-64::libarrow-14.0.2-hd70cea2_3_cuda.conda
win-64::pillow-10.2.0-py39hf7d859a_0.conda
win-64::sasktran2-2024.01.1-py310haaf695d_0.conda
win-64::libarrow-12.0.1-h3b5eb60_36_cpu.conda
win-64::libopencv-4.9.0-py312h4c6a54c_6.conda
win-64::libgrpc-1.60.0-h0bf0bfa_1.conda
win-64::lxml-5.0.1-py312hd086842_0.conda
win-64::mysql-connector-python-8.0.33-py38hee1428b_0.conda
win-64::pillow-10.2.0-py39h368b509_0.conda
win-64::libclang-16.0.6-default_hde6756a_4.conda
win-64::libpq-15.5-h94c9ec1_0.conda
win-64::libopentelemetry-cpp-1.13.0-h567fb77_1.conda
win-64::aws-sdk-cpp-1.11.210-hf72cfbd_11.conda
win-64::libmed-4.1.1-py39hd1ea1e6_9.conda
win-64::libmed-4.1.1-py310h239f96b_10.conda
win-64::lxml-5.1.0-py312hd086842_0.conda
win-64::libarrow-13.0.0-h3b5eb60_25_cpu.conda
win-64::folly-2024.01.15.00-hd2f1b6b_0.conda
win-64::mysql-connector-python-8.0.33-py311hd40f987_0.conda
win-64::lxml-5.0.1-py38h5e68c31_0.conda
win-64::tesseract-5.3.4-h8c4da6d_0.conda
win-64::libarrow-gandiva-14.0.2-hb2eaab1_5_cpu.conda
win-64::grpcio-1.60.0-py311h5bc0dda_1.conda
win-64::lfortran-0.32.0-h12be248_0.conda
win-64::gst-plugins-bad-1.22.9-h9897aaa_0.conda
win-64::postgresql-plpython-15.4-py38h4aa54d8_5.conda
win-64::libarrow-12.0.1-h7104c8f_34_cpu.conda
win-64::sasktran2-2023.12.0-py310hde57285_0.conda
win-64::libarrow-11.0.0-h3ebc5eb_60_cpu.conda
win-64::sasktran2-2023.12.0-py310haaf695d_2.conda
win-64::omniorb-4.3.2-py39hd2c3553_1.conda
win-64::tiledb-2.18.4-hf67ed3d_0.conda
win-64::hugin-base-2022.0.0-pl5321hf4b0093_10.conda
win-64::gst-plugins-base-1.22.8-h001b923_1.conda
win-64::aws-sdk-cpp-1.11.210-h752ccfa_9.conda
win-64::libopencv-4.9.0-py311h599b68e_6.conda
win-64::lfortran-0.31.0-h12be248_0.conda
win-64::libmed-4.1.1-py38hb5908cc_9.conda
win-64::vigra-1.11.2-py312h032ba52_4.conda
win-64::omniorb-4.3.2-py312h3946ced_1.conda
win-64::qt6-main-6.6.1-h1c9f5e3_7.conda
win-64::paraview-5.11.2-py312h5686ce5_102_qt.conda
win-64::libarrow-13.0.0-h2d8668f_24_cpu.conda
win-64::gst-plugins-bad-1.22.9-h2895b6a_0.conda
win-64::libclang-cpp-17.0.6-default_hde6756a_2.conda
win-64::libxml2-2.12.4-hc3477c8_1.conda
win-64::libarrow-gandiva-15.0.0-hb2eaab1_1_cpu.conda
win-64::libmed-4.1.1-py311hce06eeb_10.conda
win-64::libarrow-15.0.0-h33d03ac_2_cpu.conda
win-64::libmed-4.1.1-py311hce06eeb_9.conda
win-64::aws-sdk-cpp-1.11.210-h20b5662_10.conda
win-64::sasktran2-2023.12.0-py311h93b9cd8_1.conda
win-64::libyarp-3.9.0-ha0ae21b_1.conda
win-64::libuwebsockets-20.57.0-h12be248_0.conda
win-64::lxml-5.0.1-py310hba208d0_0.conda
win-64::libarrow-gandiva-15.0.0-hb2eaab1_1_cuda.conda
win-64::lxml-5.0.1-py39h215536c_0.conda
win-64::libuwebsockets-20.56.0-h12be248_0.conda
win-64::libarrow-13.0.0-he50c52c_24_cuda.conda
win-64::libopencv-4.9.0-py39h157c242_5.conda
win-64::libopencv-4.9.0-py39h335ff2e_6.conda
win-64::omniorb-4.3.2-py312h3946ced_0.conda
win-64::libopencv-4.9.0-py311h63bf2ce_5.conda
win-64::gst-plugins-good-1.22.8-hb244fbb_1.conda
win-64::mysql-connector-python-8.0.33-py39h6904d88_0.conda
win-64::clang-17.0.6-ha177bd6_2.conda
win-64::libmed-4.1.1-py38hb5908cc_10.conda
win-64::postgresql-plpython-15.4-py311h7015055_5.conda
win-64::sasktran2-2024.01.0-py310haaf695d_0.conda
win-64::paraview-5.11.2-py38hd4761b0_102_qt.conda
win-64::libmed-4.1.1-py312h66fc33d_9.conda
win-64::libclang13-17.0.6-default_h85b4d89_2.conda
win-64::libmed-4.1.1-py39h1e6475e_8.conda
win-64::postgresql-plpython-15.5-py38h2c11c51_0.conda
win-64::libarrow-gandiva-14.0.2-hb2eaab1_3_cpu.conda
win-64::libmed-4.1.1-py38h5d6c5ff_8.conda
win-64::libopencv-4.9.0-py38hd2b4e0d_5.conda
win-64::libsoup-3.4.4-hde36b1d_2.conda
win-64::libopencv-4.9.0-py310hc896871_6.conda
win-64::clangdev-17.0.6-default_hde6756a_2.conda
win-64::libarrow-13.0.0-hd9a6b2a_23_cuda.conda
win-64::ffmpeg-6.1.1-lgpl_ha48b832_1.conda
win-64::ffmpeg-6.1.1-lgpl_ha48b832_2.conda
win-64::vigra-1.11.2-py39he6840ac_4.conda
win-64::qt6-main-6.6.1-h1c9f5e3_6.conda
win-64::lfortran-0.30.0-h12be248_0.conda
win-64::cmake-3.28.2-hf0feee3_0.conda
win-64::correctionlib-2.3.3-py310h9a75aa7_2.conda
win-64::libgdal-arrow-parquet-3.8.3-h5f241bf_0.conda
win-64::bytewax-0.18.1-py310pl5321h65afd28_0.conda
win-64::libopencv-4.9.0-py312hb707317_5.conda
win-64::sasktran2-2023.12.0-py311hd237099_2.conda
win-64::bytewax-0.18.1-py38pl5321hcc47c24_0.conda
win-64::lxml-5.0.1-py311h064e5ff_0.conda
win-64::libignition-fuel-tools7-7.1.0-hf747aff_8.conda
win-64::postgresql-plpython-15.5-py312hfeb81f1_0.conda
win-64::libignition-fuel-tools4-4.6.0-he14a2b9_6.conda
win-64::libopencv-4.9.0-py39h730eb50_7.conda
win-64::omniorb-libs-4.3.2-ha7d20b1_0.conda
win-64::postgresql-15.5-h94c9ec1_0.conda
win-64::lxml-5.1.0-py38h5e68c31_0.conda
win-64::lxml-5.0.1-py39h4d3bb3d_0.conda
win-64::sasktran2-2024.01.0-py312hf2b062a_0.conda
win-64::sasktran2-2024.01.1-py312hf2b062a_0.conda
win-64::folly-2024.01.01.00-h04b96d7_0.conda
win-64::libarrow-gandiva-14.0.2-hb2eaab1_2_cpu.conda
win-64::bytewax-0.18.1-py312pl5321h70577bd_0.conda
win-64::ffmpeg-6.1.1-gpl_hadb5375_101.conda
win-64::tiledb-2.18.4-h2657894_0.conda
win-64::clang-17-17.0.6-default_hde6756a_2.conda
win-64::libuwebsockets-20.58.0-h12be248_0.conda
win-64::libarrow-gandiva-14.0.2-hb2eaab1_4_cuda.conda
win-64::postgresql-plpython-15.5-py311h35d69d3_0.conda
win-64::clangdev-16.0.6-default_hde6756a_4.conda
win-64::gst-plugins-bad-1.22.9-h78e97af_0.conda
win-64::postgresql-plpython-15.4-py312he74e6b0_5.conda
win-64::pyinstaller-6.3.0-py38ha959d8a_1.conda
win-64::sasktran2-2024.01.1-py311hd237099_0.conda
win-64::libmed-4.1.1-py312hade77ae_8.conda
win-64::sasktran2-2024.01.0-py311hd237099_0.conda
win-64::bytewax-0.18.1-py39pl5321h5b14c5f_0.conda
win-64::clang-16-16.0.6-default_hde6756a_4.conda
win-64::soplex-6.0.4-h949ae46_7.conda
win-64::qtwebkit-5.212-h4d8ddc9_16.conda
win-64::lxml-4.9.4-py311h064e5ff_0.conda
win-64::mysql-connector-python-8.0.33-py310h6a47d84_0.conda
win-64::libopencv-4.9.0-py39h959e499_6.conda
win-64::vigra-1.11.2-py38hd9a0a9e_4.conda
win-64::ffmpeg-6.1.1-gpl_h40d57b7_103.conda
win-64::folly-2024.01.22.00-h43676e7_0.conda
win-64::pypy3.9-7.3.15-h994e1e7_0.conda
win-64::libarrow-gandiva-15.0.0-hb2eaab1_0_cuda.conda
win-64::grpcio-1.60.0-py310hb84602e_1.conda
win-64::clang-16.0.6-ha177bd6_4.conda
win-64::mysql-connector-python-8.0.33-py39h725d275_0.conda
win-64::omniorb-4.3.2-py310h2b448b3_1.conda
win-64::lld-17.0.6-haf3a982_1.conda
win-64::lldb-17.0.6-py310h7b8b68d_1.conda
win-64::lxml-5.1.0-py311h064e5ff_0.conda
win-64::libarrow-13.0.0-h970f319_25_cuda.conda
win-64::libmed-4.1.1-py312h66fc33d_10.conda
win-64::ovito-3.10.1-h8ea1a09_0.conda
win-64::pillow-10.2.0-py310h1e6a543_0.conda
win-64::postgresql-plpython-15.5-py39h25219b3_0.conda
win-64::lldb-17.0.6-py311h19fab70_1.conda
win-64::libarrow-gandiva-15.0.0-hb2eaab1_0_cpu.conda
win-64::folly-2024.01.08.00-h43676e7_0.conda
win-64::cpp-opentelemetry-sdk-1.13.0-h567fb77_1.conda
win-64::postgresql-15.4-h1beaf6b_5.conda
win-64::libarrow-15.0.0-hd70cea2_0_cuda.conda
win-64::folly-2024.01.08.00-h04b96d7_0.conda
win-64::gmsh-4.12.2-hcc95203_0.conda
win-64::libarrow-gandiva-14.0.2-hb2eaab1_2_cuda.conda
win-64::omniorb-4.3.2-py38h8a9cac7_0.conda
win-64::tiledb-2.19.1-hf67ed3d_0.conda
win-64::libarrow-15.0.0-hd70cea2_1_cuda.conda
win-64::bytewax-0.18.1-py311pl5321hd4437ae_0.conda
win-64::pyinstaller-6.3.0-py39h84a0465_1.conda
win-64::lxml-4.9.4-py312hd086842_0.conda
win-64::libpulsar-3.4.2-h4230263_1.conda
win-64::hugin-2022.0.0-pl5321h0d50380_10.conda
win-64::libopencv-4.9.0-py39hcc6aee2_7.conda
win-64::gdstk-0.9.49-py311hc50246e_0.conda
win-64::clangxx-17.0.6-default_hde6756a_2.conda
win-64::clangxx-16.0.6-default_hde6756a_4.conda
win-64::libclang-cpp-16.0.6-default_hde6756a_4.conda
win-64::libarrow-14.0.2-hd70cea2_2_cuda.conda
win-64::libxml2-2.12.4-hc3477c8_0.conda
win-64::sasktran2-2023.12.0-py312h0eb6a43_1.conda
win-64::libclang13-16.0.6-default_h85b4d89_4.conda
win-64::pdal-2.6.2-h9245793_3.conda
win-64::lxml-5.1.0-py310hba208d0_0.conda
win-64::folly-2024.01.01.00-hd2f1b6b_0.conda
win-64::libmed-4.1.1-py310hc8c821f_8.conda
win-64::gst-libav-1.22.9-hec9340f_0.conda
win-64::pyinstaller-6.3.0-py312h3bd2d22_1.conda
win-64::aws-sdk-cpp-1.11.242-hf72cfbd_0.conda
win-64::tiledb-2.19.1-hf016803_0.conda
win-64::libopencv-4.9.0-py312h766d233_7.conda
win-64::gmsh-4.12.1-hcc95203_0.conda
win-64::pillow-10.2.0-py312he768995_0.conda
win-64::gst-plugins-good-1.22.9-h62ce35e_0.conda
win-64::postgresql-plpython-15.5-py310h01700aa_0.conda
win-64::folly-2024.01.29.00-h04b96d7_0.conda
win-64::qt6-main-6.6.1-h1c9f5e3_8.conda
win-64::libarrow-11.0.0-hfc35614_58_cuda.conda
win-64::grpcio-1.60.0-py38h19421c1_1.conda
win-64::gdstk-0.9.49-py312h1b3467e_0.conda
win-64::folly-2024.01.01.00-h43676e7_0.conda
win-64::lxml-4.9.4-py39h215536c_0.conda
win-64::poppler-24.01.0-hc2f3c52_0.conda
win-64::libarrow-11.0.0-h7c23f1a_60_cuda.conda
win-64::lxml-4.9.4-py39h4d3bb3d_0.conda
win-64::correctionlib-2.3.3-py38h98a829e_2.conda
win-64::lxml-4.9.4-py38h5e68c31_0.conda
win-64::libarrow-14.0.2-h33d03ac_5_cpu.conda
win-64::libopencv-4.9.0-py310h9aad72a_7.conda
win-64::gdstk-0.9.49-py38h8a2f752_0.conda
win-64::lxml-5.1.0-py39h4d3bb3d_0.conda
win-64::tiledb-2.19.1-h2657894_0.conda
win-64::pyinstaller-6.3.0-py310h35269f2_1.conda
win-64::libmed-4.1.1-py39hd1ea1e6_10.conda
win-64::folly-2024.01.22.00-hd2f1b6b_0.conda
win-64::sasktran2-2023.12.0-py311h93b9cd8_0.conda
win-64::vigra-1.11.2-py310hadda689_4.conda
win-64::imath-3.1.10-h12be248_0.conda
win-64::postgresql-plpython-15.4-py39hf83d731_5.conda
win-64::libprotobuf-4.25.1-hb8276f3_0.conda
win-64::pillow-10.2.0-py38hc375fad_0.conda
win-64::vigra-1.11.2-py39h3f28a1e_4.conda
win-64::libgdal-arrow-parquet-3.8.3-h65542e6_0.conda
win-64::libignition-fuel-tools7-7.1.0-he14a2b9_7.conda
win-64::folly-2024.01.15.00-h04b96d7_0.conda
win-64::omniorb-4.3.2-py311h55b17b5_1.conda
win-64::omniorb-libs-4.3.2-ha7d20b1_1.conda
win-64::libopencv-4.9.0-py39h06b4e35_5.conda
win-64::libopencv-4.9.0-py310h2c3b87f_5.conda
win-64::scip-8.1.0-h4a72d87_7.conda
win-64::tiledb-2.18.4-hf016803_0.conda
win-64::lxml-5.1.0-py39h215536c_0.conda
win-64::sasktran2-2023.12.0-py310hde57285_1.conda
win-64::libarrow-14.0.2-h881831c_5_cuda.conda
win-64::aws-sdk-cpp-1.11.210-h79fa1a6_8.conda
win-64::nceplibs-g2c-1.8.0-h83564c8_6.conda
win-64::grpcio-1.60.0-py39h6848017_1.conda
win-64::lldb-17.0.6-py39hed22e34_1.conda
win-64::libopencv-4.9.0-py311h01b8a8d_7.conda
win-64::pyinstaller-6.3.0-py311h12e69fa_1.conda
win-64::folly-2024.01.22.00-h04b96d7_0.conda
win-64::libprotobuf-static-4.25.1-hb8276f3_0.conda
win-64::clang-tools-16.0.6-default_hde6756a_4.conda
win-64::vigra-1.11.2-py311hc166fa2_4.conda
win-64::gdstk-0.9.49-py39h32efe87_0.conda
win-64::libgrpc-1.60.0-h0bf0bfa_0.conda
win-64::paraview-5.11.2-py311h6f256a5_102_qt.conda
win-64::libarrow-gandiva-14.0.2-hb2eaab1_5_cuda.conda
win-64::gmsh-4.12.2-hf228048_0.conda
win-64::ovito-3.10.0-h8ea1a09_0.conda
win-64::libopencv-4.9.0-py38h703c4d5_7.conda
win-64::orc-1.9.2-hf6f83f4_1.conda
win-64::gst-plugins-base-1.22.9-h001b923_0.conda
win-64::libgdal-arrow-parquet-3.8.3-h8a628e4_0.conda
win-64::nsight-compute-2023.3.1.1-hbdb2b8c_0.conda
win-64::paraview-5.11.2-py310h43a54ae_102_qt.conda
win-64::grpcio-1.60.0-py312h7894644_1.conda
win-64::libgdal-arrow-parquet-3.8.3-h5cc1e32_0.conda
win-64::libarrow-gandiva-15.0.0-hb2eaab1_2_cuda.conda
win-64::libarrow-14.0.2-hd70cea2_4_cuda.conda
win-64::lfortran-0.33.0-h12be248_0.conda
win-64::omniorb-4.3.2-py39hd2c3553_0.conda
win-64::libgdal-3.8.3-h576f4c1_0.conda
win-64::libarrow-12.0.1-hd9a6b2a_34_cuda.conda
win-64::libopencv-4.9.0-py38hea0ef58_6.conda
win-64::omniorb-4.3.2-py310h2b448b3_0.conda
win-64::libarrow-12.0.1-h970f319_36_cuda.conda
win-64::libarrow-14.0.2-he5f67d5_4_cpu.conda
win-64::gmsh-4.12.1-hf228048_0.conda
win-64::libarrow-15.0.0-he5f67d5_1_cpu.conda
win-64::libgoogle-cloud-storage-2.17.0-hb581fae_2.conda
win-64::postgresql-plpython-15.4-py310h4609481_5.conda
win-64::omniorb-4.3.2-py311h55b17b5_0.conda
win-64::libpq-15.4-h1beaf6b_5.conda
win-64::libarrow-11.0.0-h1138768_58_cpu.conda
win-64::correctionlib-2.3.3-py39h82b40fd_2.conda
win-64::zimpl-3.5.3-h96a1494_7.conda
win-64::paraview-5.11.2-py39h47ff1f8_102_qt.conda
win-64::libarrow-13.0.0-h7104c8f_23_cpu.conda
win-64::gdstk-0.9.49-py39h2b303d1_0.conda
win-64::lxml-4.9.4-py310hba208d0_0.conda
win-64::openexr-3.2.1-hf79fc45_1.conda
win-64::ffmpeg-6.1.1-gpl_hadb5375_102.conda
win-64::libarrow-gandiva-14.0.2-hb2eaab1_4_cpu.conda
win-64::libarrow-14.0.2-he5f67d5_2_cpu.conda
win-64::libclang-17.0.6-default_hde6756a_2.conda
win-64::folly-2024.01.29.00-hd2f1b6b_0.conda
win-64::capnproto-1.0.2-h12be248_0.conda
win-64::libarrow-gandiva-14.0.2-hb2eaab1_3_cuda.conda
win-64::folly-2024.01.15.00-h43676e7_0.conda
win-64::libignition-fuel-tools4-4.6.0-hf747aff_6.conda
win-64::folly-2024.01.29.00-h43676e7_0.conda
win-64::sasktran2-2023.12.0-py312hf2b062a_2.conda
win-64::grpcio-1.60.0-py39hd28a505_1.conda
win-64::librdkafka-2.3.0-h78d1f3c_0.conda
win-64::clang-tools-17.0.6-default_hde6756a_2.conda
win-64::lldb-17.0.6-py38h0e99253_1.conda
win-64::libarrow-15.0.0-he5f67d5_0_cpu.conda
win-64::baumwelch-0.3.8-h1c255cb_0.conda
win-64::folly-2024.01.08.00-hd2f1b6b_0.conda
win-64::papilo-2.1.4-h45feaf2_7.conda
win-64::paraview-5.11.2-py39h94a1806_102_qt.conda
win-64::graphicsmagick-1.3.42-ha5c10ba_0.conda
win-64::libarrow-12.0.1-he50c52c_35_cuda.conda
win-64::ffmpeg-6.1.1-lgpl_h451b1fc_3.conda
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
================================================================================
================================================================================
osx-64
osx-64::postgresql-plpython-15.5-py311h0ff6264_0.conda
osx-64::lammps-2023.11.21-cpu_py39_hb2f5527_mpi_mpich_2.conda
osx-64::lammps-2023.11.21-cpu_py310_hbc8b412_mpi_openmpi_3.conda
osx-64::lammps-2023.08.02-cpu_py310_hdd5fa3c_mpi_mpich_8.conda
osx-64::panda3d-1.10.14-py312h629979e_1.conda
osx-64::libmed-4.1.1-py38he50afe5_8.conda
osx-64::mysql-connector-python-8.0.33-py310hb968087_0.conda
osx-64::qt6-main-6.6.1-h9fd3f66_7.conda
osx-64::vigra-1.11.2-py310hcf3634e_4.conda
osx-64::lammps-2023.11.21-cpu_py311_h835ce97_mpi_openmpi_1.conda
osx-64::lammps-2023.08.02-cpu_py38_ha0ef21c_nompi_8.conda
osx-64::paraview-5.11.2-py312haea9ebf_102_qt.conda
osx-64::sagelib-10.2-py311hf9b2163_3.conda
osx-64::lammps-2023.11.21-cpu_py39_h3c69d27_nompi_3.conda
osx-64::folly-2024.01.22.00-ha75df62_0.conda
osx-64::folly-2024.01.29.00-h37615a4_0_jemalloc.conda
osx-64::sagelib-10.2-py39h843bdee_3.conda
osx-64::libarrow-12.0.1-he852c9a_35_cpu.conda
osx-64::protozfits-2.3.0-py312hd2bd543_5.conda
osx-64::libarrow-14.0.2-hb34ab4f_1_cpu.conda
osx-64::emacs-29.1-h7a509e9_0.conda
osx-64::libarrow-11.0.0-he852c9a_59_cpu.conda
osx-64::libarrow-13.0.0-hd11c2ab_25_cpu.conda
osx-64::sagelib-10.2-py311hf9b2163_2.conda
osx-64::libgdal-arrow-parquet-3.8.3-hfe834e1_0.conda
osx-64::capnproto-1.0.2-hb4c5c48_0.conda
osx-64::libmed-4.1.1-py38h0d760da_9.conda
osx-64::gmsh-4.12.2-h546c69e_0.conda
osx-64::gmt-6.5.0-hde1d5ac_0.conda
osx-64::postgresql-15.4-hbd19fd8_5.conda
osx-64::omniorb-libs-4.3.2-h4514ac0_0.conda
osx-64::lammps-2023.08.02-cpu_py38_h9e2c45a_mpi_openmpi_8.conda
osx-64::nceplibs-g2c-1.8.0-ha04bf80_5.conda
osx-64::libopencv-4.9.0-py39ha69d4b6_7.conda
osx-64::lammps-2023.08.02-cpu_py38_h5baff61_mpi_mpich_8.conda
osx-64::folly-2024.01.29.00-h8225e4e_0_jemalloc.conda
osx-64::paraview-5.11.2-py310h0a3d4a7_102_qt.conda
osx-64::gazebo-11.14.0-h0790513_5.conda
osx-64::lammps-2023.11.21-cpu_py38_ha0ef21c_nompi_1.conda
osx-64::lfortran-0.33.1-h0d4612f_0.conda
osx-64::grpcio-1.60.0-py310h271164d_1.conda
osx-64::lammps-2023.11.21-cpu_py39_hb2f5527_mpi_mpich_1.conda
osx-64::lammps-2023.11.21-cpu_py38_ha0ef21c_nompi_2.conda
osx-64::r-base-4.3.2-h46d3641_2.conda
osx-64::lammps-2023.11.21-cpu_py311_h7e0894f_nompi_1.conda
osx-64::folly-2024.01.29.00-h079d3a0_0_jemalloc.conda
osx-64::lammps-2023.11.21-cpu_py38_h9e2c45a_mpi_openmpi_0.conda
osx-64::folly-2024.01.22.00-h079d3a0_0_jemalloc.conda
osx-64::bytewax-0.18.1-py310h1972b3a_0.conda
osx-64::lammps-2023.11.21-cpu_py311_h835ce97_mpi_openmpi_0.conda
osx-64::lammps-2023.11.21-cpu_py38_h9e2c45a_mpi_openmpi_2.conda
osx-64::lammps-2023.08.02-cpu_py39_h14e9caf_mpi_mpich_7.conda
osx-64::libarrow-13.0.0-h61d8a31_22_cpu.conda
osx-64::omniorb-4.3.2-py39h92c4140_1.conda
osx-64::lammps-2023.08.02-cpu_py39_hb2f5527_mpi_mpich_7.conda
osx-64::libgrpc-1.60.0-h038e8f1_1.conda
osx-64::libgdal-3.8.3-h89a805d_0.conda
osx-64::folly-2024.01.22.00-h8225e4e_0_jemalloc.conda
osx-64::vigra-1.11.2-py39h3aeeac0_4.conda
osx-64::cppyy-cling-6.30.0-py311h0102fb6_1.conda
osx-64::lxml-5.1.0-py39h919b5fb_0.conda
osx-64::lammps-2023.11.21-cpu_py39_hb2f5527_mpi_mpich_0.conda
osx-64::xeus-cpp-0.1.0-h5929788_1.conda
osx-64::libmed-4.1.1-py312h35fa8f2_10.conda
osx-64::protozfits-2.3.0-py311hc77e41d_5.conda
osx-64::aws-sdk-cpp-1.11.210-h4b9e967_7.conda
osx-64::libmed-4.1.1-py311h7ec1f07_9.conda
osx-64::pillow-10.2.0-py311hea5c87a_0.conda
osx-64::libxml2-2.12.4-hc0ae0f7_0.conda
osx-64::pillow-10.2.0-py38h0024655_0.conda
osx-64::mysql-connector-python-8.0.33-py39hb03ede6_0.conda
osx-64::cppyy-cling-6.30.0-py312hecaf9ea_2.conda
osx-64::wxpython-4.2.1-py311h91baca1_2.conda
osx-64::grpcio-1.60.0-py312hbbbd34f_0.conda
osx-64::lammps-2023.11.21-cpu_py310_hbc8b412_mpi_openmpi_1.conda
osx-64::omniorb-4.3.2-py38h5754c17_0.conda
osx-64::xrootd-5.6.6-py39hb562daa_0.conda
osx-64::tiledb-2.18.4-he01210c_0.conda
osx-64::aws-sdk-cpp-1.11.210-h2d1bcde_11.conda
osx-64::ffmpeg-6.1.1-lgpl_hcf84656_1.conda
osx-64::libgdal-arrow-parquet-3.8.3-h3cb0702_0.conda
osx-64::panda3d-1.10.14-py38hd1a0924_1.conda
osx-64::gfortran_impl_osx-64-12.3.0-hc328e78_2.conda
osx-64::nest-simulator-3.6-py310hebbbe1e_3.conda
osx-64::lammps-2023.11.21-cpu_py311_h835ce97_mpi_openmpi_2.conda
osx-64::libarrow-14.0.2-h9a9dd9d_5_cpu.conda
osx-64::libarrow-11.0.0-hd11c2ab_60_cpu.conda
osx-64::emacs-29.2-h4a6833b_0.conda
osx-64::folly-2024.01.29.00-ha75df62_0.conda
osx-64::correctionlib-2.3.3-py39h4aa070f_2.conda
osx-64::libopencv-4.9.0-py39h2eb2509_6.conda
osx-64::lammps-2023.11.21-cpu_py311_h835ce97_mpi_openmpi_3.conda
osx-64::libyarp-3.9.0-h9c0c770_1.conda
osx-64::verilator-5.020-h8e8e533_0.conda
osx-64::folly-2024.01.29.00-h8bd47b9_0.conda
osx-64::vigra-1.11.2-py39hafac23c_4.conda
osx-64::libxmlsec1-1.3.3-habd493b_0.conda
osx-64::openmpi-5.0.1-h794f02a_102.conda
osx-64::libmed-4.1.1-py39h27df004_10.conda
osx-64::libopencv-4.9.0-py312h9ba5894_7.conda
osx-64::librdkafka-2.3.0-h8b451cb_0.conda
osx-64::lammps-2023.11.21-cpu_py39_h5305340_nompi_1.conda
osx-64::sasktran2-2023.12.0-py310h39b5548_0.conda
osx-64::folly-2024.01.01.00-h8bd47b9_0.conda
osx-64::lammps-2023.08.02-cpu_py311_h3ff7cfc_mpi_mpich_8.conda
osx-64::libopencv-4.9.0-py38h32a9f3e_6.conda
osx-64::libarrow-13.0.0-he852c9a_24_cpu.conda
osx-64::lammps-2023.08.02-cpu_py311_h835ce97_mpi_openmpi_7.conda
osx-64::sagelib-10.2-py310haeb9d62_2.conda
osx-64::cppyy-cling-6.30.0-py38hbcdfe3b_1.conda
osx-64::folly-2024.01.01.00-h8225e4e_0_jemalloc.conda
osx-64::netcdf-cxx4-4.3.1-mpi_mpich_hd61abab_8.conda
osx-64::cmake-3.28.2-h7c85d92_0.conda
osx-64::lammps-2023.11.21-cpu_py39_h5305340_nompi_3.conda
osx-64::libtiledb-sql-0.27.0-h27b4547_0.conda
osx-64::gdstk-0.9.49-py310h83e167c_0.conda
osx-64::libarrow-13.0.0-hdae7707_23_cpu.conda
osx-64::folly-2024.01.08.00-h8bd47b9_0.conda
osx-64::lammps-2023.11.21-cpu_py39_h3c69d27_nompi_0.conda
osx-64::lammps-2023.11.21-cpu_py38_ha0ef21c_nompi_0.conda
osx-64::uwsgi-2.0.23-py311hf3eb510_0.conda
osx-64::pillow-10.2.0-py39h00e0f14_0.conda
osx-64::aws-sdk-cpp-1.11.242-h2d1bcde_0.conda
osx-64::lldb-17.0.6-py39hec5033c_1.conda
osx-64::sasktran2-2024.01.0-py311hf64b1d5_0.conda
osx-64::sasktran2-2024.01.1-py312hfd4ef4c_0.conda
osx-64::sasktran2-2023.12.0-py311hf64b1d5_2.conda
osx-64::gdstk-0.9.49-py38hbe7c026_0.conda
osx-64::sasktran2-2023.12.0-py312hcaf6f18_1.conda
osx-64::lammps-2023.08.02-cpu_py311_h7e0894f_nompi_7.conda
osx-64::gfortran_impl_osx-64-13.2.0-h2bc304d_2.conda
osx-64::libmed-4.1.1-py39h88f3b83_8.conda
osx-64::sasktran2-2023.12.0-py312hfd4ef4c_2.conda
osx-64::lammps-2023.08.02-cpu_py39_h3c69d27_nompi_8.conda
osx-64::bytewax-0.18.1-py311hf8f184a_0.conda
osx-64::lammps-2023.08.02-cpu_py310_hbc8b412_mpi_openmpi_8.conda
osx-64::tiledb-2.18.4-hee4a7ef_0.conda
osx-64::gdstk-0.9.49-py312hf3e4e0a_0.conda
osx-64::lammps-2023.08.02-cpu_py39_h7885287_mpi_openmpi_8.conda
osx-64::wxpython-4.2.1-py39h2de30b3_1.conda
osx-64::pillow-10.2.0-py39hdd30358_0.conda
osx-64::postgresql-plpython-15.5-py38h47ab5f7_0.conda
osx-64::graphicsmagick-1.3.42-h6ae7f0c_0.conda
osx-64::xrootd-5.6.6-py39h29a673c_0.conda
osx-64::folly-2024.01.29.00-h7815ab9_0.conda
osx-64::libmed-4.1.1-py310h81495ce_8.conda
osx-64::tiledb-2.19.1-hee4a7ef_0.conda
osx-64::lxml-5.1.0-py312h799ce31_0.conda
osx-64::libpq-15.5-h268af18_0.conda
osx-64::lammps-2023.11.21-cpu_py39_h7885287_mpi_openmpi_1.conda
osx-64::correctionlib-2.3.3-py311h94bc237_2.conda
osx-64::aws-sdk-cpp-1.11.210-hf51409f_10.conda
osx-64::lxml-4.9.4-py311h033124e_0.conda
osx-64::libpulsar-3.4.2-h12206b1_1.conda
osx-64::panda3d-1.10.14-py311he30b6e2_0.conda
osx-64::nest-simulator-3.6-py38hb86306f_3.conda
osx-64::lammps-2023.08.02-cpu_py310_hdd5fa3c_mpi_mpich_7.conda
osx-64::postgresql-plpython-15.5-py312h8db37ca_0.conda
osx-64::uwsgi-2.0.23-py310h5292c53_0.conda
osx-64::omniorb-4.3.2-py310hc61f13b_1.conda
osx-64::mysql-connector-python-8.0.33-py39hee6c470_0.conda
osx-64::libopencv-4.9.0-py311h9eef215_6.conda
osx-64::qtwebkit-5.212-h3b777d0_16.conda
osx-64::sasktran2-2024.01.0-py312hfd4ef4c_0.conda
osx-64::sasktran2-2023.12.0-py310hfc2ebfe_2.conda
osx-64::libarrow-12.0.1-hdae7707_34_cpu.conda
osx-64::uwsgi-2.0.23-py312h02a55a3_0.conda
osx-64::lammps-2023.11.21-cpu_py310_hdd5fa3c_mpi_mpich_0.conda
osx-64::lammps-2023.11.21-cpu_py38_h9e2c45a_mpi_openmpi_1.conda
osx-64::aws-sdk-cpp-1.11.210-heeba50e_8.conda
osx-64::lammps-2023.11.21-cpu_py311_h7e0894f_nompi_3.conda
osx-64::gdstk-0.9.49-py39h6e703ae_0.conda
osx-64::lxml-5.0.1-py39h9b7d3cf_0.conda
osx-64::imagemagick-7.1.1_26-pl5321h629a661_0.conda
osx-64::xeus-cpp-0.2.0-h5929788_0.conda
osx-64::lammps-2023.08.02-cpu_py311_h3ff7cfc_mpi_mpich_7.conda
osx-64::libmed-4.1.1-py312h36b7fe7_8.conda
osx-64::folly-2024.01.08.00-ha75df62_0.conda
osx-64::wxpython-4.2.1-py38hba267d8_2.conda
osx-64::folly-2024.01.08.00-h8225e4e_0_jemalloc.conda
osx-64::lxml-5.0.1-py312h799ce31_0.conda
osx-64::postgresql-15.5-h06f2bd8_0.conda
osx-64::xeus-cpp-0.3.0-h5929788_0.conda
osx-64::cppyy-cling-6.30.0-py39h0bb4e67_2.conda
osx-64::gfortran_impl_osx-arm64-13.2.0-h5ec2d5a_2.conda
osx-64::lxml-5.1.0-py38h3c26883_0.conda
osx-64::lammps-2023.08.02-cpu_py38_h5baff61_mpi_mpich_7.conda
osx-64::imagemagick-7.1.1_27-pl5321h0b4f3dc_0.conda
osx-64::nss-3.97-ha05da47_0.conda
osx-64::lxml-5.1.0-py39h9b7d3cf_0.conda
osx-64::ffmpeg-6.1.1-gpl_hf701f7a_103.conda
osx-64::lxml-4.9.4-py312h799ce31_0.conda
osx-64::libpq-15.4-h74b662b_5.conda
osx-64::libopencv-4.9.0-py39h937e816_5.conda
osx-64::lld-17.0.6-h455ef5f_1.conda
osx-64::openmpi-5.0.1-hf8846d2_101.conda
osx-64::uwsgi-2.0.23-py39h5d15b58_0.conda
osx-64::lldb-17.0.6-py38hd916e80_1.conda
osx-64::lammps-2023.08.02-cpu_py39_h5305340_nompi_7.conda
osx-64::sagelib-10.2-py39h843bdee_2.conda
osx-64::lammps-2023.11.21-cpu_py39_h3c69d27_nompi_1.conda
osx-64::lammps-2023.08.02-cpu_py39_h5305340_nompi_8.conda
osx-64::photochem-0.4.5-py310h41cef8c_0.conda
osx-64::libopentelemetry-cpp-1.13.0-hcda5922_1.conda
osx-64::folly-2024.01.01.00-h079d3a0_0_jemalloc.conda
osx-64::libgoogle-cloud-storage-2.17.0-ha67e85c_2.conda
osx-64::lammps-2023.08.02-cpu_py311_h7e0894f_nompi_8.conda
osx-64::omniorb-libs-4.3.2-h4514ac0_1.conda
osx-64::grpcio-1.60.0-py38ha6b6e42_0.conda
osx-64::protozfits-2.3.0-py38hf6b11e4_5.conda
osx-64::lammps-2023.11.21-cpu_py311_h3ff7cfc_mpi_mpich_2.conda
osx-64::lammps-2023.11.21-cpu_py311_h3ff7cfc_mpi_mpich_3.conda
osx-64::paraview-5.11.2-py310h98276be_102_qt.conda
osx-64::lammps-2023.11.21-cpu_py310_hdd5fa3c_mpi_mpich_1.conda
osx-64::omniorb-4.3.2-py311hec7ddcc_1.conda
osx-64::sasktran2-2023.12.0-py310h39b5548_1.conda
osx-64::lammps-2023.11.21-cpu_py39_h9bb1a43_mpi_openmpi_2.conda
osx-64::wxpython-4.2.1-py38h28436b9_1.conda
osx-64::grpcio-1.60.0-py39h99d80ef_1.conda
osx-64::qt6-main-6.6.1-h9fd3f66_6.conda
osx-64::libopencv-4.9.0-py38h530c844_5.conda
osx-64::cppyy-cling-6.30.0-py38hbcdfe3b_2.conda
osx-64::tiledb-2.18.4-h8fd0293_0.conda
osx-64::tensorflow-base-2.15.0-cpu_py311hbca55e7_2.conda
osx-64::xrootd-5.6.6-py38he1823fe_0.conda
osx-64::folly-2024.01.08.00-h37615a4_0_jemalloc.conda
osx-64::nest-simulator-3.6-py39hf45367b_3.conda
osx-64::photochem-0.4.5-py38h08ade82_0.conda
osx-64::grpcio-1.60.0-py311h78ff076_0.conda
osx-64::panda3d-1.10.14-py310hea0f3f5_1.conda
osx-64::ovito-3.10.0-hc570ecf_0.conda
osx-64::gdstk-0.9.49-py311h7edd508_0.conda
osx-64::lammps-2023.08.02-cpu_py38_h9e2c45a_mpi_openmpi_7.conda
osx-64::photochem-0.4.5-py311hf3d5ebd_0.conda
osx-64::lxml-5.0.1-py311h033124e_0.conda
osx-64::lammps-2023.08.02-cpu_py39_h9bb1a43_mpi_openmpi_7.conda
osx-64::postgresql-plpython-15.4-py310hd344ed2_5.conda
osx-64::folly-2024.01.08.00-h7815ab9_0.conda
osx-64::ffmpeg-6.1.1-lgpl_h6bf1b14_2.conda
osx-64::libopencv-4.9.0-py38hf5bf42e_7.conda
osx-64::ffmpeg-6.1.1-gpl_haae13e6_101.conda
osx-64::lammps-2023.11.21-cpu_py311_h3ff7cfc_mpi_mpich_0.conda
osx-64::correctionlib-2.3.3-py38h7671238_2.conda
osx-64::libmed-4.1.1-py310hc45b398_10.conda
osx-64::lxml-5.0.1-py38h3c26883_0.conda
osx-64::tensorflow-base-2.15.0-cpu_py310hc0a61e3_2.conda
osx-64::pyinstaller-6.3.0-py312h67dd88c_1.conda
osx-64::paraview-5.11.2-py311hfb0eeeb_102_qt.conda
osx-64::gmsh-4.12.1-h546c69e_0.conda
osx-64::lammps-2023.08.02-cpu_py39_h3c69d27_nompi_7.conda
osx-64::libgsf-1.14.51-h9e5620e_1.conda
osx-64::aws-sdk-cpp-1.11.210-hb301dda_9.conda
osx-64::lammps-2023.11.21-cpu_py39_h7885287_mpi_openmpi_2.conda
osx-64::libtensorflow_cc-2.15.0-cpu_h55a125e_2.conda
osx-64::ovito-3.10.1-h0a3f43b_0.conda
osx-64::grpcio-1.60.0-py38ha6b6e42_1.conda
osx-64::lammps-2023.11.21-cpu_py39_h14e9caf_mpi_mpich_1.conda
osx-64::lammps-2023.11.21-cpu_py310_hbc8b412_mpi_openmpi_2.conda
osx-64::ffmpeg-6.1.1-lgpl_hc8eec68_3.conda
osx-64::lfortran-0.30.0-h0d4612f_0.conda
osx-64::libarrow-11.0.0-h61d8a31_57_cpu.conda
osx-64::panda3d-1.10.14-py38hd1a0924_0.conda
osx-64::libopencv-4.9.0-py39he81eecd_7.conda
osx-64::tesseract-5.3.4-h3ed5972_0.conda
osx-64::lammps-2023.11.21-cpu_py311_h7e0894f_nompi_0.conda
osx-64::grpcio-1.60.0-py311h78ff076_1.conda
osx-64::folly-2024.01.01.00-h37615a4_0_jemalloc.conda
osx-64::libarrow-12.0.1-h61d8a31_33_cpu.conda
osx-64::wgrib2-3.1.3-hd9b90ad_3.conda
osx-64::wxpython-4.2.1-py311hdf430ba_1.conda
osx-64::pyinstaller-6.3.0-py310h03c913b_1.conda
osx-64::folly-2024.01.15.00-h8225e4e_0_jemalloc.conda
osx-64::mesalib-23.3.4-hbd9e708_0.conda
osx-64::pocl-core-5.0-h3c65c3d_0.conda
osx-64::pillow-10.2.0-py310he65384d_0.conda
osx-64::uwsgi-2.0.23-py38h890173a_0.conda
osx-64::folly-2024.01.22.00-h37615a4_0_jemalloc.conda
osx-64::omniorb-4.3.2-py38h5754c17_1.conda
osx-64::pocl-core-5.0-h6117173_0.conda
osx-64::libopencv-4.9.0-py310hcac2143_6.conda
osx-64::grpcio-1.60.0-py39h339971c_0.conda
osx-64::sasktran2-2024.01.1-py311hf64b1d5_0.conda
osx-64::gdstk-0.9.49-py39h23d43bd_0.conda
osx-64::lfortran-0.32.0-h0d4612f_0.conda
osx-64::lfortran-0.33.0-h0d4612f_0.conda
osx-64::libopencv-4.9.0-py310hd0665ea_5.conda
osx-64::ffmpeg-6.1.1-gpl_hb2c2143_102.conda
osx-64::scip-8.1.0-h274e450_7.conda
osx-64::panda3d-1.10.14-py39hfa124e7_1.conda
osx-64::soplex-6.0.4-hd68a844_7.conda
osx-64::poppler-24.01.0-h0c752f9_0.conda
osx-64::photochem-0.4.5-py39hf91a2d3_0.conda
osx-64::grpcio-1.60.0-py310h271164d_0.conda
osx-64::postgresql-plpython-15.4-py311h33a6423_5.conda
osx-64::lxml-5.1.0-py310h843f749_0.conda
osx-64::folly-2024.01.15.00-h079d3a0_0_jemalloc.conda
osx-64::folly-2024.01.22.00-h8bd47b9_0.conda
osx-64::lammps-2023.11.21-cpu_py38_h5baff61_mpi_mpich_1.conda
osx-64::cppinterop-1.1.0-clang17_repl_h28e1cfa_0.conda
osx-64::mosh-1.4.0-pl5321ha4134c2_6.conda
osx-64::lxml-4.9.4-py310h843f749_0.conda
osx-64::r-data.table-1.14.10-r43he044350_1.conda
osx-64::paraview-5.11.2-py39h75495be_102_qt.conda
osx-64::cppyy-cling-6.30.0-py39h78a5168_2.conda
osx-64::netcdf-cxx4-4.3.1-mpi_openmpi_h0c7f68d_8.conda
osx-64::wgrib2-3.1.3-hd9b90ad_2.conda
osx-64::libarrow-15.0.0-h1aaacd4_0_cpu.conda
osx-64::postgresql-plpython-15.5-py310h112046a_0.conda
osx-64::cppyy-cling-6.30.0-py310h71e7e49_2.conda
osx-64::lammps-2023.08.02-cpu_py310_h8cbf5a9_nompi_7.conda
osx-64::lammps-2023.11.21-cpu_py39_h7885287_mpi_openmpi_0.conda
osx-64::libopencv-4.9.0-py310ha3ab171_7.conda
osx-64::panda3d-1.10.14-py39hfa124e7_0.conda
osx-64::gst-plugins-good-1.22.9-hf082ce7_0.conda
osx-64::folly-2024.01.22.00-h7815ab9_0.conda
osx-64::mpv-0.36.0-h149a428_0.conda
osx-64::pdal-2.6.2-h3115ee7_3.conda
osx-64::sagelib-10.2-py310haeb9d62_3.conda
osx-64::grpcio-1.60.0-py39h339971c_1.conda
osx-64::lxml-4.9.4-py39h919b5fb_0.conda
osx-64::mc-4.8.31-haec8e5e_0.conda
osx-64::postgresql-plpython-15.5-py39h27b00d0_0.conda
osx-64::grpcio-1.60.0-py39h99d80ef_0.conda
osx-64::libopencv-4.9.0-py311h2c8e0bd_5.conda
osx-64::pyinstaller-6.3.0-py38hf1429db_1.conda
osx-64::wxpython-4.2.1-py39h0b4529e_2.conda
osx-64::folly-2024.01.15.00-ha75df62_0.conda
osx-64::xrootd-5.6.6-py312h5ba68d2_0.conda
osx-64::lammps-2023.11.21-cpu_py310_hbc8b412_mpi_openmpi_0.conda
osx-64::xrootd-5.6.6-py311hd7faa57_0.conda
osx-64::lxml-5.0.1-py310h843f749_0.conda
osx-64::gst-plugins-good-1.22.8-hb31dba0_1.conda
osx-64::paraview-5.11.2-py38h40e25b4_102_qt.conda
osx-64::libarrow-12.0.1-hd11c2ab_36_cpu.conda
osx-64::lammps-2023.08.02-cpu_py38_ha0ef21c_nompi_7.conda
osx-64::lxml-5.1.0-py311h033124e_0.conda
osx-64::omniorb-4.3.2-py310hc61f13b_0.conda
osx-64::paraview-5.11.2-py39hfcf7b94_102_qt.conda
osx-64::pocl-core-5.0-h3c65c3d_1.conda
osx-64::lammps-2023.11.21-cpu_py38_ha0ef21c_nompi_3.conda
osx-64::postgresql-plpython-15.4-py38hf95a095_5.conda
osx-64::libarrow-14.0.2-h1aaacd4_4_cpu.conda
osx-64::lldb-17.0.6-py310h9a0518d_1.conda
osx-64::yosys-0.37-he827bab_0.conda
osx-64::folly-2024.01.15.00-h7815ab9_0.conda
osx-64::bytewax-0.18.1-py39h72a7c3e_0.conda
osx-64::cppyy-cling-6.30.0-py312hecaf9ea_1.conda
osx-64::folly-2024.01.01.00-ha75df62_0.conda
osx-64::libopencv-4.9.0-py311hec44446_7.conda
osx-64::libarrow-11.0.0-hdae7707_58_cpu.conda
osx-64::lammps-2023.11.21-cpu_py38_h9e2c45a_mpi_openmpi_3.conda
osx-64::gmsh-4.12.1-h48a2193_0.conda
osx-64::omniorb-4.3.2-py312h77e02b8_1.conda
osx-64::tensorflow-base-2.15.0-cpu_py39h1d1916d_2.conda
osx-64::libgdal-arrow-parquet-3.8.3-ha8ed71e_0.conda
osx-64::lammps-2023.08.02-cpu_py311_h835ce97_mpi_openmpi_8.conda
osx-64::lammps-2023.08.02-cpu_py310_h8cbf5a9_nompi_8.conda
osx-64::libmed-4.1.1-py312h35fa8f2_9.conda
osx-64::xrootd-5.6.6-py310h4409a33_0.conda
osx-64::libvips-8.15.1-h92bf47c_1.conda
osx-64::tiledb-2.19.1-h8fd0293_0.conda
osx-64::pyinstaller-6.3.0-py311h8c2310c_1.conda
osx-64::nceplibs-g2c-1.8.0-ha04bf80_6.conda
osx-64::folly-2024.01.15.00-h8bd47b9_0.conda
osx-64::omniorb-4.3.2-py312h77e02b8_0.conda
osx-64::lammps-2023.11.21-cpu_py39_hb2f5527_mpi_mpich_3.conda
osx-64::r-data.table-1.14.10-r42he044350_1.conda
osx-64::sasktran2-2023.12.0-py311hb46bb29_0.conda
osx-64::lammps-2023.11.21-cpu_py311_h7e0894f_nompi_2.conda
osx-64::lammps-2023.11.21-cpu_py38_h5baff61_mpi_mpich_0.conda
osx-64::vigra-1.11.2-py312h27fa4d2_4.conda
osx-64::panda3d-1.10.14-py311he30b6e2_1.conda
osx-64::lammps-2023.11.21-cpu_py311_h3ff7cfc_mpi_mpich_1.conda
osx-64::lammps-2023.11.21-cpu_py310_hdd5fa3c_mpi_mpich_2.conda
osx-64::lammps-2023.08.02-cpu_py39_h14e9caf_mpi_mpich_8.conda
osx-64::lammps-2023.11.21-cpu_py39_h5305340_nompi_2.conda
osx-64::lammps-2023.08.02-cpu_py310_hbc8b412_mpi_openmpi_7.conda
osx-64::sasktran2-2024.01.1-py310hfc2ebfe_0.conda
osx-64::libxml2-2.12.4-hc0ae0f7_1.conda
osx-64::libarrow-14.0.2-h1aaacd4_2_cpu.conda
osx-64::gazebo-11.14.0-h8dd898e_6.conda
osx-64::hugin-base-2022.0.0-pl5321h5f5eb69_10.conda
osx-64::lfortran-0.31.0-h0d4612f_0.conda
osx-64::mysql-connector-python-8.0.33-py38h460aea0_0.conda
osx-64::pocl-core-5.0-h0b65ae3_1.conda
osx-64::lammps-2023.11.21-cpu_py39_h14e9caf_mpi_mpich_3.conda
osx-64::sasktran2-2023.12.0-py311hb46bb29_1.conda
osx-64::cpp-opentelemetry-sdk-1.13.0-hcda5922_1.conda
osx-64::libmed-4.1.1-py310hc45b398_9.conda
osx-64::gfortran_impl_osx-arm64-12.3.0-h4f4d140_2.conda
osx-64::lammps-2023.11.21-cpu_py310_h8cbf5a9_nompi_0.conda
osx-64::tiledb-2.19.1-he01210c_0.conda
osx-64::gct-6.2.1629922860-h2fd0c5f_3.conda
osx-64::gmsh-4.12.2-h48a2193_0.conda
osx-64::fish-3.7.0-hbbee3ac_0.conda
osx-64::lammps-2023.11.21-cpu_py39_h14e9caf_mpi_mpich_2.conda
osx-64::wxpython-4.2.1-py310h4ae869d_2.conda
osx-64::lammps-2023.08.02-cpu_py39_hb2f5527_mpi_mpich_8.conda
osx-64::cppinterop-1.1.0-clang17_repl_h257799e_1.conda
osx-64::lammps-2023.11.21-cpu_py39_h3c69d27_nompi_2.conda
osx-64::cppyy-cling-6.30.0-py39h0bb4e67_1.conda
osx-64::paraview-5.11.2-py312hb047497_102_qt.conda
osx-64::lammps-2023.11.21-cpu_py39_h9bb1a43_mpi_openmpi_0.conda
osx-64::libgdal-arrow-parquet-3.8.3-hfb8ab86_0.conda
osx-64::gst-plugins-bad-1.22.9-hdda625c_0.conda
osx-64::omniorb-4.3.2-py39h92c4140_0.conda
osx-64::lxml-4.9.4-py38h3c26883_0.conda
osx-64::pyinstaller-6.3.0-py39h5eebb3c_1.conda
osx-64::lammps-2023.08.02-cpu_py39_h9bb1a43_mpi_openmpi_8.conda
osx-64::protozfits-2.3.0-py310h44c962e_5.conda
osx-64::orc-1.9.2-ha277160_1.conda
osx-64::mpv-0.36.0-h149a428_1.conda
osx-64::paraview-5.11.2-py38h037dd49_102_qt.conda
osx-64::pillow-10.2.0-py312h0c70c2f_0.conda
osx-64::protozfits-2.3.0-py39h701e60c_5.conda
osx-64::nest-simulator-3.6-py311h22a0843_3.conda
osx-64::bytewax-0.18.1-py312h4769f7e_0.conda
osx-64::lammps-2023.11.21-cpu_py39_h7885287_mpi_openmpi_3.conda
osx-64::lammps-2023.08.02-cpu_py39_h7885287_mpi_openmpi_7.conda
osx-64::cppyy-cling-6.30.0-py39h78a5168_1.conda
osx-64::libmed-4.1.1-py311he522f9a_8.conda
osx-64::vigra-1.11.2-py38hdb508f8_4.conda
osx-64::libopencv-4.9.0-py39hb1b9b8c_6.conda
osx-64::libmed-4.1.1-py38h0d760da_10.conda
osx-64::r-base-4.2.3-h46d3641_12.conda
osx-64::wxpython-4.2.1-py310hcc2cae4_1.conda
osx-64::lammps-2023.11.21-cpu_py39_h5305340_nompi_0.conda
osx-64::libarrow-14.0.2-h1aaacd4_3_cpu.conda
osx-64::folly-2024.01.15.00-h37615a4_0_jemalloc.conda
osx-64::lammps-2023.11.21-cpu_py39_h9bb1a43_mpi_openmpi_3.conda
osx-64::librdkafka-2.3.0-hec4bce0_0.conda
osx-64::postgresql-plpython-15.4-py39h7f9fc5f_5.conda
osx-64::cppyy-cling-6.30.0-py311h0102fb6_2.conda
osx-64::papilo-2.1.4-h4673e30_7.conda
osx-64::libtiledb-sql-0.27.0-h8bbe134_0.conda
osx-64::lammps-2023.11.21-cpu_py310_hdd5fa3c_mpi_mpich_3.conda
osx-64::lammps-2023.11.21-cpu_py38_h5baff61_mpi_mpich_2.conda
osx-64::libarrow-15.0.0-h9a9dd9d_2_cpu.conda
osx-64::mysql-connector-python-8.0.33-py311h3644f4e_0.conda
osx-64::lxml-5.0.1-py39h919b5fb_0.conda
osx-64::folly-2024.01.01.00-h7815ab9_0.conda
osx-64::lammps-2023.11.21-cpu_py310_h8cbf5a9_nompi_2.conda
osx-64::libopencv-4.9.0-py312he16659d_5.conda
osx-64::qt6-main-6.6.1-h9fd3f66_8.conda
osx-64::libmed-4.1.1-py39h27df004_9.conda
osx-64::sasktran2-2024.01.0-py310hfc2ebfe_0.conda
osx-64::libopencv-4.9.0-py312h45314a4_6.conda
osx-64::omniorb-4.3.2-py311hec7ddcc_0.conda
osx-64::lxml-4.9.4-py39h9b7d3cf_0.conda
osx-64::libtensorflow-2.15.0-cpu_h1daf16d_2.conda
osx-64::lammps-2023.11.21-cpu_py310_h8cbf5a9_nompi_3.conda
osx-64::bytewax-0.18.1-py38hcde65cd_0.conda
osx-64::grpcio-1.60.0-py312hbbbd34f_1.conda
osx-64::libgrpc-1.60.0-h038e8f1_0.conda
osx-64::correctionlib-2.3.3-py310he697753_2.conda
osx-64::lldb-17.0.6-py311h1294476_1.conda
osx-64::libmed-4.1.1-py311h7ec1f07_10.conda
osx-64::lammps-2023.11.21-cpu_py39_h9bb1a43_mpi_openmpi_1.conda
osx-64::cppyy-cling-6.30.0-py310h71e7e49_1.conda
osx-64::libopencv-4.9.0-py39h38f660e_5.conda
osx-64::vigra-1.11.2-py311h7743a20_4.conda
osx-64::postgresql-plpython-15.4-py312h01252a9_5.conda
osx-64::panda3d-1.10.14-py310hea0f3f5_0.conda
osx-64::libarrow-15.0.0-h1aaacd4_1_cpu.conda
osx-64::folly-2024.01.08.00-h079d3a0_0_jemalloc.conda
osx-64::lammps-2023.11.21-cpu_py310_h8cbf5a9_nompi_1.conda
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
osx-64::libprotobuf-4.25.1-hc4f2305_0.conda
osx-64::libprotobuf-static-4.25.1-h9dd416e_0.conda
osx-64::openexr-3.2.1-h0c5910e_1.conda
osx-64::libsoup-3.4.4-h4a60539_2.conda
osx-64::libuwebsockets-20.57.0-h2d185b6_0.conda
osx-64::gst-plugins-base-1.22.9-h3fb38fc_0.conda
osx-64::rill-0.39.0-h5510862_0.conda
osx-64::netcdf-cxx4-4.3.1-nompi_h51a77e2_108.conda
osx-64::libprotobuf-static-4.24.4-h9dd416e_0.conda
osx-64::openjdk-21.0.2-h2d185b6_0.conda
osx-64::imath-3.1.10-h2d185b6_0.conda
osx-64::openjdk-17.0.10-hea0bbce_0.conda
osx-64::gst-plugins-base-1.22.8-h3fb38fc_1.conda
osx-64::libuwebsockets-20.58.0-h2d185b6_0.conda
osx-64::openjdk-11.0.22-hea0bbce_0.conda
osx-64::zimpl-3.5.3-h6ebec85_7.conda
osx-64::libprotobuf-4.24.4-hc4f2305_0.conda
osx-64::libuwebsockets-20.56.0-h2d185b6_0.conda
osx-64::rill-0.39.1-h5510862_0.conda
-    "libzlib >=1.2.13,<1.3.0a0"
+    "libzlib >=1.2.13,<2.0.0a0"
================================================================================
================================================================================
linux-64
linux-64::libarrow-14.0.2-h7303f25_3_cuda.conda
linux-64::libarrow-13.0.0-he0ed3ba_25_cuda.conda
linux-64::yosys-0.37-h3ec9cbf_0.conda
linux-64::libopencv-4.9.0-py38h6bf8061_6.conda
linux-64::lammps-2023.11.21-cpu_py311_hdd49dfd_nompi_1.conda
linux-64::pyinstaller-6.3.0-py310h93c3562_1.conda
linux-64::vigra-1.11.2-py311heb16f19_4.conda
linux-64::folly-2024.01.15.00-h1d40f03_0.conda
linux-64::vigra-1.11.2-py312h9d1948a_4.conda
linux-64::lammps-2023.11.21-cpu_py310_h8f80a90_mpi_mpich_1.conda
linux-64::lammps-2023.08.02-cuda118_py39_hf8afb37_nompi_8.conda
linux-64::panda3d-1.10.14-py39ha0cbbee_1.conda
linux-64::libmed-4.1.1-py312h63cb803_9.conda
linux-64::wxpython-4.2.1-py310he5b683e_2.conda
linux-64::aws-sdk-cpp-1.11.210-hba3e011_10.conda
linux-64::lammps-2023.11.21-cuda118_py39_hcae4e68_mpi_mpich_0.conda
linux-64::folly-2024.01.22.00-h70f49c4_0_jemalloc.conda
linux-64::libarrow-15.0.0-h84dd17c_0_cpu.conda
linux-64::postgresql-plpython-15.5-py38hc64cd6d_0.conda
linux-64::lammps-2023.11.21-cuda118_py310_h7730a0c_nompi_2.conda
linux-64::lammps-2023.11.21-cuda118_py38_h80d1e08_mpi_mpich_2.conda
linux-64::lfortran-0.31.0-hfc55251_0.conda
linux-64::lammps-2023.08.02-cuda118_py310_h7730a0c_nompi_8.conda
linux-64::gdstk-0.9.49-py39h9bdbfdd_0.conda
linux-64::sasktran2-2024.01.0-py311h118c40b_0.conda
linux-64::folly-2024.01.01.00-h23251b7_0.conda
linux-64::libarrow-11.0.0-he0ed3ba_60_cuda.conda
linux-64::correctionlib-2.3.3-py310h3845668_2.conda
linux-64::lxml-5.1.0-py312h37b5203_0.conda
linux-64::lammps-2023.11.21-cpu_py311_hd3d4698_mpi_mpich_0.conda
linux-64::wgrib2-3.1.3-h8965f03_2.conda
linux-64::lldb-17.0.6-py38h22fd443_1.conda
linux-64::libpulsar-3.4.2-h20d2f2c_1.conda
linux-64::lammps-2023.11.21-cuda118_py39_h4a9cbaf_mpi_openmpi_1.conda
linux-64::mosh-1.4.0-pl5321h64e08ae_6.conda
linux-64::libmed-4.1.1-py310h571cfe1_10.conda
linux-64::lammps-2023.11.21-cpu_py310_h5b57e7a_nompi_1.conda
linux-64::ffmpeg-6.1.1-lgpl_h6e203a7_3.conda
linux-64::lammps-2023.08.02-cpu_py310_hcea6fc9_mpi_openmpi_8.conda
linux-64::code-aster-17.0.3-np123py311hdf3bf53_0.conda
linux-64::lxml-5.0.1-py311h9691dec_0.conda
linux-64::lammps-2023.11.21-cpu_py39_hf042188_nompi_0.conda
linux-64::lammps-2023.08.02-cpu_py310_h5b57e7a_nompi_8.conda
linux-64::libarrow-11.0.0-h2792e09_57_cuda.conda
linux-64::wgrib2-3.1.3-h8965f03_3.conda
linux-64::folly-2024.01.29.00-h70f49c4_0_jemalloc.conda
linux-64::paraview-5.11.2-py39hbfc0f56_102_qt.conda
linux-64::qt6-main-6.6.1-h0ebb57b_8.conda
linux-64::postgresql-plpython-15.4-py38hd157e84_5.conda
linux-64::folly-2024.01.15.00-h70f49c4_0_jemalloc.conda
linux-64::lammps-2023.11.21-cuda118_py39_hdd7f1a5_mpi_mpich_2.conda
linux-64::folly-2024.01.29.00-h122a45c_0_jemalloc.conda
linux-64::lammps-2023.08.02-cpu_py39_h827286f_mpi_openmpi_8.conda
linux-64::lammps-2023.11.21-cuda118_py310_h483aaed_mpi_openmpi_1.conda
linux-64::bytewax-0.18.1-py39hced4d33_0.conda
linux-64::code-aster-17.0.1-np122py38hb58a787_1.conda
linux-64::panda3d-1.10.14-py38h3402557_0.conda
linux-64::libgrpc-1.60.0-h74775cd_0.conda
linux-64::gst-plugins-base-1.22.8-h8e1006c_1.conda
linux-64::libarrow-13.0.0-h6569788_24_cpu.conda
linux-64::lammps-2023.11.21-cpu_py39_hf042188_nompi_3.conda
linux-64::tensorstore-0.1.51-py311h7585f03_1.conda
linux-64::lfortran-0.32.0-hfc55251_0.conda
linux-64::magic-8.3.460-h9abf892_0.conda
linux-64::librdkafka-2.3.0-hfe68a65_0.conda
linux-64::xrootd-5.6.6-py38ha00766d_0.conda
linux-64::libopencv-4.9.0-py310hc29bc96_7.conda
linux-64::sasktran2-2024.01.1-py310h8ff1b0f_0.conda
linux-64::sasktran2-2023.12.0-py312hc424169_1.conda
linux-64::cppyy-cling-6.30.0-py39h2ea1df6_2.conda
linux-64::libarrow-14.0.2-h7303f25_4_cuda.conda
linux-64::omniorb-4.3.2-py38h0ed79f3_1.conda
linux-64::sasktran2-2024.01.1-py312h11a4be6_0.conda
linux-64::lammps-2023.11.21-cpu_py38_hde207a7_mpi_openmpi_3.conda
linux-64::lammps-2023.08.02-cpu_py39_h7e86899_mpi_mpich_7.conda
linux-64::magic-8.3.456-h9abf892_0.conda
linux-64::lxml-4.9.4-py311h9691dec_0.conda
linux-64::folly-2024.01.08.00-h1d40f03_0.conda
linux-64::paraview-5.11.2-py310h66fe41c_2_egl.conda
linux-64::libopencv-4.9.0-py312hc800f59_6.conda
linux-64::aws-sdk-cpp-1.11.210-hab19c32_7.conda
linux-64::folly-2024.01.08.00-hb244bc4_0.conda
linux-64::pyinstaller-6.3.0-py39hb6545a3_1.conda
linux-64::lammps-2023.11.21-cuda118_py310_h38e9743_mpi_mpich_2.conda
linux-64::lammps-2023.08.02-cpu_py38_h5608ceb_nompi_7.conda
linux-64::grpcio-1.60.0-py312hb06c811_1.conda
linux-64::lammps-2023.11.21-cuda118_py311_h80f0500_nompi_0.conda
linux-64::code-aster-17.0.3-np122py38hb58a787_0.conda
linux-64::cppyy-cling-6.30.0-py310h3845668_1.conda
linux-64::tensorflow-base-2.15.0-cuda120py39hf42b710_2.conda
linux-64::folly-2024.01.29.00-hbc8c634_0_jemalloc.conda
linux-64::sasktran2-2024.01.0-py310h8ff1b0f_0.conda
linux-64::aws-sdk-cpp-1.11.210-hac0d6e5_8.conda
linux-64::netcdf-cxx4-4.3.1-mpi_mpich_ha8b49f4_8.conda
linux-64::code-aster-17.0.3-np122py39hc2960b6_0.conda
linux-64::lammps-2023.08.02-cpu_py311_hd3d4698_mpi_mpich_8.conda
linux-64::lammps-2023.11.21-cpu_py38_h5608ceb_nompi_1.conda
linux-64::aws-sdk-cpp-1.11.242-h65f022c_0.conda
linux-64::fimex-1.9.9-py311h03b8f73_0.conda
linux-64::lammps-2023.11.21-cuda118_py39_hf8afb37_nompi_1.conda
linux-64::lammps-2023.08.02-cpu_py310_hcea6fc9_mpi_openmpi_7.conda
linux-64::ffmpeg-6.1.1-gpl_hf3b701a_101.conda
linux-64::wxpython-4.2.1-py38h3f90fbe_2.conda
linux-64::lammps-2023.11.21-cpu_py39_hade46e7_mpi_openmpi_3.conda
linux-64::libarrow-11.0.0-h75ae66a_58_cpu.conda
linux-64::lammps-2023.11.21-cuda118_py38_he846794_nompi_3.conda
linux-64::libspral-2023.09.07-ha9eef1b_1.conda
linux-64::folly-2024.01.08.00-h70f49c4_0_jemalloc.conda
linux-64::xrootd-5.6.6-py310h4d51e2b_0.conda
linux-64::cppinterop-1.1.0-clang17_repl_h885ea05_0.conda
linux-64::libopencv-4.9.0-py39h43ffa6f_7.conda
linux-64::folly-2024.01.29.00-hb244bc4_0.conda
linux-64::tensorflow-base-2.15.0-cpu_py310h7e4d085_2.conda
linux-64::omniorb-libs-4.3.2-h1933689_1.conda
linux-64::lammps-2023.11.21-cuda118_py38_h80d1e08_mpi_mpich_1.conda
linux-64::libmed-4.1.1-py312h63cb803_10.conda
linux-64::postgresql-plpython-15.5-py311hff8006e_0.conda
linux-64::createrepo_c-1.0.3-py310h8f447a6_0.conda
linux-64::protozfits-2.3.0-py312hdd598aa_5.conda
linux-64::lammps-2023.11.21-cpu_py39_h827286f_mpi_openmpi_1.conda
linux-64::gct-6.2.1629922860-h9f628fe_3.conda
linux-64::lammps-2023.08.02-cuda118_py311_hdd7c1f1_mpi_mpich_8.conda
linux-64::tiledb-2.18.4-h4386cac_0.conda
linux-64::photochem-0.4.5-py38h2d2fbd7_0.conda
linux-64::lammps-2023.11.21-cpu_py39_h827286f_mpi_openmpi_0.conda
linux-64::libgrpc-1.60.0-h74775cd_1.conda
linux-64::xeus-cpp-0.2.0-h3f8c671_0.conda
linux-64::lfortran-0.33.1-hfc55251_0.conda
linux-64::libarrow-11.0.0-h2f39494_57_cpu.conda
linux-64::code-aster-17.0.1-np123py311hdf3bf53_1.conda
linux-64::paraview-5.11.2-py39h3dd2915_102_qt.conda
linux-64::lammps-2023.11.21-cpu_py38_hda8f861_mpi_mpich_2.conda
linux-64::lammps-2023.08.02-cpu_py310_h8f80a90_mpi_mpich_8.conda
linux-64::lammps-2023.11.21-cuda118_py38_h80d1e08_mpi_mpich_0.conda
linux-64::libopencv-4.9.0-py310hc569fea_6.conda
linux-64::sasktran2-2023.12.0-py311hcd50c64_0.conda
linux-64::lxml-5.0.1-py38h32ae189_0.conda
linux-64::paraview-5.11.2-py39hb82b632_2_egl.conda
linux-64::lammps-2023.08.02-cuda118_py38_h9c5a0ec_mpi_openmpi_8.conda
linux-64::lammps-2023.11.21-cuda118_py38_hc73eb01_mpi_openmpi_0.conda
linux-64::lxml-5.1.0-py311h9691dec_0.conda
linux-64::netcdf-cxx4-4.3.1-mpi_openmpi_h6724935_8.conda
linux-64::lammps-2023.11.21-cpu_py38_h5608ceb_nompi_0.conda
linux-64::pyinstaller-6.3.0-py38h502143a_1.conda
linux-64::lammps-2023.11.21-cuda118_py39_hdd7f1a5_mpi_mpich_1.conda
linux-64::lammps-2023.11.21-cpu_py39_hade46e7_mpi_openmpi_1.conda
linux-64::pillow-10.2.0-py38ha43c96d_0.conda
linux-64::protozfits-2.3.0-py38h5792304_5.conda
linux-64::lammps-2023.08.02-cuda118_py310_h38e9743_mpi_mpich_8.conda
linux-64::lammps-2023.11.21-cuda118_py310_h7730a0c_nompi_1.conda
linux-64::tensorstore-0.1.51-py310h122cdbb_1.conda
linux-64::cmake-3.28.2-hcfe8598_0.conda
linux-64::sagelib-10.2-py39h031b06c_3.conda
linux-64::lldb-17.0.6-py311h1fe0947_1.conda
linux-64::capnproto-1.0.2-hfc55251_0.conda
linux-64::fimex-1.9.9-py38h2f19903_0.conda
linux-64::omniorb-libs-4.3.2-h1933689_0.conda
linux-64::lammps-2023.11.21-cpu_py310_hcea6fc9_mpi_openmpi_3.conda
linux-64::mdsplus-7.139.61-py310pl5321hbd303f0_0.conda
linux-64::bytewax-0.18.1-py310hd3dbc5d_0.conda
linux-64::lxml-5.1.0-py39ha378d84_0.conda
linux-64::lammps-2023.11.21-cpu_py39_hefd3d5c_mpi_mpich_2.conda
linux-64::libgdal-3.8.3-hcd1fc54_0.conda
linux-64::lammps-2023.11.21-cuda118_py311_h9b6f9d6_mpi_openmpi_1.conda
linux-64::libtiledb-sql-0.27.0-h9e8d02e_0.conda
linux-64::lammps-2023.11.21-cpu_py311_hbb7bd43_mpi_openmpi_0.conda
linux-64::lxml-5.0.1-py310hcfd0673_0.conda
linux-64::lammps-2023.11.21-cpu_py310_h8f80a90_mpi_mpich_2.conda
linux-64::createrepo_c-1.0.3-py311h8dbc1c1_0.conda
linux-64::lammps-2023.08.02-cuda118_py39_hcae4e68_mpi_mpich_8.conda
linux-64::libpq-15.5-h088ca5b_0.conda
linux-64::libarrow-12.0.1-h2792e09_33_cuda.conda
linux-64::bytewax-0.18.1-py311h1844ddb_0.conda
linux-64::sasktran2-2024.01.0-py312h11a4be6_0.conda
linux-64::lammps-2023.11.21-cpu_py38_hde207a7_mpi_openmpi_0.conda
linux-64::lammps-2023.08.02-cpu_py39_h7e86899_mpi_mpich_8.conda
linux-64::lammps-2023.11.21-cuda118_py39_h1a54f2e_nompi_2.conda
linux-64::libgdal-arrow-parquet-3.8.3-h157934b_0.conda
linux-64::lammps-2023.11.21-cuda118_py311_h0edc3ef_mpi_mpich_1.conda
linux-64::r-data.table-1.14.10-r42h029312a_1.conda
linux-64::libtensorflow_cc-2.15.0-cuda120h11be487_3.conda
linux-64::verilator-5.020-h7cd9344_0.conda
linux-64::fish-3.7.0-hdab1d28_0.conda
linux-64::libarrow-14.0.2-h67bfddd_1_cpu.conda
linux-64::lammps-2023.08.02-cuda118_py311_h96326dd_nompi_8.conda
linux-64::lammps-2023.08.02-cpu_py38_h5608ceb_nompi_8.conda
linux-64::code-aster-17.0.4-np122py39hc2960b6_0.conda
linux-64::ffmpeg-6.1.1-lgpl_h115001f_1.conda
linux-64::lammps-2023.08.02-cuda118_py311_h9b6f9d6_mpi_openmpi_8.conda
linux-64::papilo-2.1.4-h8cd16de_7.conda
linux-64::libarrow-13.0.0-h2792e09_22_cuda.conda
linux-64::uwsgi-2.0.23-py311h5f05a11_0.conda
linux-64::lammps-2023.11.21-cpu_py39_h7e86899_mpi_mpich_3.conda
linux-64::lammps-2023.11.21-cuda118_py39_h14e8439_mpi_mpich_0.conda
linux-64::lammps-2023.11.21-cpu_py38_hde207a7_mpi_openmpi_1.conda
linux-64::gst-plugins-base-1.22.9-h8e1006c_0.conda
linux-64::gst-plugins-good-1.22.8-he33cf32_1.conda
linux-64::cppyy-cling-6.30.0-py310h3845668_2.conda
linux-64::lammps-2023.11.21-cpu_py39_h7e86899_mpi_mpich_0.conda
linux-64::lammps-2023.11.21-cuda118_py310_hadf4ee5_nompi_3.conda
linux-64::aws-sdk-cpp-1.11.210-h65f022c_11.conda
linux-64::lammps-2023.11.21-cuda118_py311_hdd7c1f1_mpi_mpich_3.conda
linux-64::code-aster-17.0.3-np122py310h04c1e7b_0.conda
linux-64::libtensorflow-2.15.0-cuda120h316e68c_2.conda
linux-64::libarrow-11.0.0-h8e35aab_58_cuda.conda
linux-64::cppyy-cling-6.30.0-py312h24f76d5_1.conda
linux-64::cppyy-cling-6.30.0-py311h9e0f504_2.conda
linux-64::lammps-2023.11.21-cuda118_py310_h5811056_mpi_openmpi_2.conda
linux-64::lammps-2023.11.21-cpu_py310_hcea6fc9_mpi_openmpi_1.conda
linux-64::gdstk-0.9.49-py311h75db532_0.conda
linux-64::openjdk-21.0.2-haa376d0_0.conda
linux-64::mpv-0.36.0-h1e936fa_0.conda
linux-64::bytewax-0.18.1-py38h5fd4b22_0.conda
linux-64::lammps-2023.11.21-cpu_py38_h5608ceb_nompi_2.conda
linux-64::grpcio-1.60.0-py38h94a1851_1.conda
linux-64::cppyy-cling-6.30.0-py39hc26e0ff_1.conda
linux-64::libopencv-4.9.0-py310h97f20a8_5.conda
linux-64::libtensorflow-2.15.0-cpu_h8d94747_2.conda
linux-64::lammps-2023.11.21-cuda118_py311_h9b6f9d6_mpi_openmpi_3.conda
linux-64::lld-17.0.6-hc908ec4_1.conda
linux-64::tensorflow-base-2.15.0-cpu_py311h6aa969b_2.conda
linux-64::mysql-connector-python-8.0.33-py38h4bdff42_0.conda
linux-64::vigra-1.11.2-py38he5d4874_4.conda
linux-64::paraview-5.11.2-py38hd0aff77_2_egl.conda
linux-64::correctionlib-2.3.3-py39h2ea1df6_2.conda
linux-64::libopencv-4.9.0-py39h43df6ff_6.conda
linux-64::libmed-4.1.1-py310h571cfe1_9.conda
linux-64::nceplibs-g2c-1.8.0-h4a0a8e2_6.conda
linux-64::orc-1.9.2-h7829240_1.conda
linux-64::lammps-2023.11.21-cuda118_py39_h43d3bb2_mpi_openmpi_2.conda
linux-64::lammps-2023.11.21-cpu_py310_h8f80a90_mpi_mpich_3.conda
linux-64::folly-2024.01.01.00-hb244bc4_0.conda
linux-64::code-aster-17.0.4-np122py310h04c1e7b_0.conda
linux-64::mpv-0.36.0-h1e936fa_1.conda
linux-64::omniorb-4.3.2-py311h28f970a_1.conda
linux-64::gdstk-0.9.49-py39hc35b29e_0.conda
linux-64::lammps-2023.11.21-cpu_py38_hda8f861_mpi_mpich_0.conda
linux-64::lammps-2023.11.21-cpu_py39_hefd3d5c_mpi_mpich_0.conda
linux-64::lammps-2023.08.02-cuda118_py311_h80f0500_nompi_8.conda
linux-64::sasktran2-2023.12.0-py311hcd50c64_1.conda
linux-64::lammps-2023.08.02-cpu_py310_h8f80a90_mpi_mpich_7.conda
linux-64::code-aster-17.0.4-np122py38hb58a787_0.conda
linux-64::lldb-17.0.6-py310h5be3364_1.conda
linux-64::lammps-2023.11.21-cpu_py39_h5b957dd_nompi_1.conda
linux-64::libxmlsec1-1.3.3-h77a0d5c_0.conda
linux-64::lammps-2023.11.21-cuda118_py311_hc5820a9_mpi_openmpi_0.conda
linux-64::nss-3.97-h1d7d5a4_0.conda
linux-64::lammps-2023.11.21-cpu_py310_h8f80a90_mpi_mpich_0.conda
linux-64::folly-2024.01.15.00-hbc8c634_0_jemalloc.conda
linux-64::folly-2024.01.22.00-hbc8c634_0_jemalloc.conda
linux-64::tiledb-2.18.4-hc0b898c_0.conda
linux-64::libarrow-15.0.0-h84dd17c_1_cpu.conda
linux-64::lammps-2023.11.21-cuda118_py39_h1a54f2e_nompi_0.conda
linux-64::lxml-4.9.4-py310hcfd0673_0.conda
linux-64::lammps-2023.11.21-cuda118_py311_hc5820a9_mpi_openmpi_2.conda
linux-64::libarrow-15.0.0-hbf4d7a7_2_cuda.conda
linux-64::uwsgi-2.0.23-py39hff38263_0.conda
linux-64::libarrow-14.0.2-hf101f98_1_cuda.conda
linux-64::nest-simulator-3.6-py38h203082f_3.conda
linux-64::libopencv-4.9.0-py311h1c04bc5_5.conda
linux-64::libarrow-14.0.2-he2c5238_5_cpu.conda
linux-64::lammps-2023.08.02-cpu_py39_hade46e7_mpi_openmpi_8.conda
linux-64::libtensorflow_cc-2.15.0-cpu_h2f60d71_2.conda
linux-64::paraview-5.11.2-py311h2bed9c9_2_egl.conda
linux-64::vigra-1.11.2-py39h42d1cef_4.conda
linux-64::libarrow-14.0.2-hbf4d7a7_5_cuda.conda
linux-64::folly-2024.01.08.00-hbc8c634_0_jemalloc.conda
linux-64::r-base-4.3.2-hb8ee39d_2.conda
linux-64::gst-plugins-good-1.22.9-h94a241a_0.conda
linux-64::lammps-2023.11.21-cuda118_py39_h5417483_nompi_2.conda
linux-64::libmed-4.1.1-py39h38d59c9_8.conda
linux-64::lammps-2023.11.21-cpu_py311_hdd49dfd_nompi_2.conda
linux-64::fimex-1.9.9-py39h51f8da3_0.conda
linux-64::libmed-4.1.1-py312hafb6003_8.conda
linux-64::mdsplus-7.139.61-py311pl5321h4a20be6_0.conda
linux-64::lammps-2023.11.21-cuda118_py38_he846794_nompi_0.conda
linux-64::lammps-2023.11.21-cpu_py38_hde207a7_mpi_openmpi_2.conda
linux-64::mc-4.8.31-h6a540d1_0.conda
linux-64::xrootd-5.6.6-py39he3dcec1_0.conda
linux-64::tensorflow-base-2.15.0-cuda120py311h43b5e44_3.conda
linux-64::uwsgi-2.0.23-py312h0055c11_0.conda
linux-64::lammps-2023.11.21-cuda118_py310_h483aaed_mpi_openmpi_0.conda
linux-64::sasktran2-2023.12.0-py310hefcb49c_1.conda
linux-64::panda3d-1.10.14-py310h2da8f0c_1.conda
linux-64::lxml-4.9.4-py39ha378d84_0.conda
linux-64::libarrow-13.0.0-he9c478a_24_cuda.conda
linux-64::code-aster-17.0.1-np122py310h04c1e7b_1.conda
linux-64::openmpi-5.0.1-h4970cb7_101.conda
linux-64::tensorflow-base-2.15.0-cuda120py311h43b5e44_2.conda
linux-64::photochem-0.4.5-py39heaf3ece_0.conda
linux-64::lammps-2023.11.21-cuda118_py39_h097bc08_mpi_mpich_3.conda
linux-64::libopencv-4.9.0-py39h201510f_7.conda
linux-64::libmed-4.1.1-py38h7c5a157_10.conda
linux-64::lammps-2023.11.21-cuda118_py39_hcae4e68_mpi_mpich_1.conda
linux-64::lammps-2023.08.02-cuda118_py39_h291e33b_mpi_openmpi_8.conda
linux-64::libmed-4.1.1-py39h0898053_10.conda
linux-64::code-aster-17.0.4-np123py311hdf3bf53_0.conda
linux-64::xeus-cpp-0.1.0-h3f8c671_1.conda
linux-64::panda3d-1.10.14-py311hb748066_0.conda
linux-64::soplex-6.0.4-h231b4fb_7.conda
linux-64::libtensorflow-2.15.0-cuda120h316e68c_3.conda
linux-64::lldb-17.0.6-py39hb850a82_1.conda
linux-64::libarrow-13.0.0-h8e35aab_23_cuda.conda
linux-64::tiledb-2.19.1-h4386cac_0.conda
linux-64::lammps-2023.08.02-cpu_py39_hefd3d5c_mpi_mpich_7.conda
linux-64::gmsh-4.12.2-h17d5aaa_0.conda
linux-64::panda3d-1.10.14-py39ha0cbbee_0.conda
linux-64::lammps-2023.11.21-cpu_py310_h5b57e7a_nompi_0.conda
linux-64::libarrow-15.0.0-h7303f25_1_cuda.conda
linux-64::ovito-3.10.1-h8e92c3b_0.conda
linux-64::libopencv-4.9.0-py39h167ea73_5.conda
linux-64::elfutils-0.190-h6f2b95c_0.conda
linux-64::paraview-5.11.2-py311h7020bdb_102_qt.conda
linux-64::pyinstaller-6.3.0-py311hdcc4c9d_1.conda
linux-64::wxpython-4.2.1-py310hc2a762e_1.conda
linux-64::pillow-10.2.0-py39hcf8a34e_0.conda
linux-64::tensorflow-base-2.15.0-cpu_py39he1df281_2.conda
linux-64::wxpython-4.2.1-py39he0bd1f6_1.conda
linux-64::libyarp-3.9.0-ha614a09_1.conda
linux-64::wgrib2-3.1.3-h8965f03_1.conda
linux-64::lammps-2023.08.02-cuda118_py310_h5811056_mpi_openmpi_8.conda
linux-64::mysql-connector-python-8.0.33-py39h43026c6_0.conda
linux-64::folly-2024.01.22.00-h23251b7_0.conda
linux-64::folly-2024.01.15.00-h122a45c_0_jemalloc.conda
linux-64::lammps-2023.11.21-cpu_py39_h7e86899_mpi_mpich_2.conda
linux-64::folly-2024.01.08.00-h23251b7_0.conda
linux-64::correctionlib-2.3.3-py311h9e0f504_2.conda
linux-64::libopencv-4.9.0-py38h1bdf12c_7.conda
linux-64::folly-2024.01.01.00-h1d40f03_0.conda
linux-64::libarrow-13.0.0-h75ae66a_23_cpu.conda
linux-64::bytewax-0.18.1-py312h9be44f7_0.conda
linux-64::pillow-10.2.0-py39had0adad_0.conda
linux-64::lammps-2023.11.21-cpu_py39_h827286f_mpi_openmpi_2.conda
linux-64::lammps-2023.08.02-cpu_py311_hd3d4698_mpi_mpich_7.conda
linux-64::panda3d-1.10.14-py310h2da8f0c_0.conda
linux-64::sasktran2-2023.12.0-py310h8ff1b0f_2.conda
linux-64::ffmpeg-6.1.1-lgpl_h3b95f3e_2.conda
linux-64::photochem-0.4.5-py311he186e3d_0.conda
linux-64::cppyy-cling-6.30.0-py39h2ea1df6_1.conda
linux-64::libopencv-4.9.0-py311haea74c2_7.conda
linux-64::ffmpeg-6.1.1-gpl_hf2cac9d_102.conda
linux-64::sagelib-10.2-py39h031b06c_2.conda
linux-64::qt6-main-6.6.1-h0ebb57b_6.conda
linux-64::folly-2024.01.22.00-h1d40f03_0.conda
linux-64::libgdal-arrow-parquet-3.8.3-h641b2ac_0.conda
linux-64::lammps-2023.11.21-cpu_py39_h5b957dd_nompi_3.conda
linux-64::poppler-24.01.0-h590f24d_0.conda
linux-64::lammps-2023.11.21-cuda118_py39_h097bc08_mpi_mpich_2.conda
linux-64::lammps-2023.11.21-cpu_py310_hcea6fc9_mpi_openmpi_0.conda
linux-64::tensorstore-0.1.51-py312h85edf29_1.conda
linux-64::postgresql-plpython-15.5-py39h107fd68_0.conda
linux-64::cppyy-cling-6.30.0-py311h9e0f504_1.conda
linux-64::omniorb-4.3.2-py39h53428f1_0.conda
linux-64::mdsplus-7.139.61-py39pl5321h4e21038_0.conda
linux-64::paraview-5.11.2-py312h2150bb3_2_egl.conda
linux-64::lammps-2023.11.21-cpu_py310_h5b57e7a_nompi_2.conda
linux-64::emacs-29.1-hf9754c5_0.conda
linux-64::scip-8.1.0-h41ab4b8_7.conda
linux-64::folly-2024.01.29.00-h1d40f03_0.conda
linux-64::r-base-4.2.3-hc446a09_12.conda
linux-64::tiledb-2.19.1-h584b59b_0.conda
linux-64::libmed-4.1.1-py311hf519941_8.conda
linux-64::lammps-2023.11.21-cuda118_py38_h6de3bbc_mpi_mpich_3.conda
linux-64::lammps-2023.08.02-cpu_py39_hf042188_nompi_7.conda
linux-64::lammps-2023.11.21-cuda118_py311_h80f0500_nompi_1.conda
linux-64::libopencv-4.9.0-py312ha528de8_5.conda
linux-64::libarrow-12.0.1-h2f39494_33_cpu.conda
linux-64::postgresql-plpython-15.4-py311h4204730_5.conda
linux-64::lammps-2023.08.02-cpu_py38_hde207a7_mpi_openmpi_7.conda
linux-64::lammps-2023.11.21-cpu_py39_h5b957dd_nompi_0.conda
linux-64::lammps-2023.11.21-cuda118_py38_h9c5a0ec_mpi_openmpi_3.conda
linux-64::libarrow-11.0.0-he9c478a_59_cuda.conda
linux-64::lammps-2023.11.21-cuda118_py311_h96326dd_nompi_3.conda
linux-64::lammps-2023.11.21-cuda118_py39_h291e33b_mpi_openmpi_2.conda
linux-64::lammps-2023.11.21-cuda118_py310_h077d75c_mpi_mpich_0.conda
linux-64::lammps-2023.11.21-cpu_py39_hf042188_nompi_2.conda
linux-64::lammps-2023.08.02-cpu_py39_hf042188_nompi_8.conda
linux-64::libgdal-arrow-parquet-3.8.3-h69fca0d_0.conda
linux-64::libmed-4.1.1-py38h7c5a157_9.conda
linux-64::libarrow-11.0.0-hf0f33ac_60_cpu.conda
linux-64::lammps-2023.08.02-cpu_py311_hbb7bd43_mpi_openmpi_7.conda
linux-64::wxpython-4.2.1-py38hd5fd411_1.conda
linux-64::libarrow-15.0.0-h7303f25_0_cuda.conda
linux-64::gmsh-4.12.1-h17d5aaa_0.conda
linux-64::uwsgi-2.0.23-py310h7baf403_0.conda
linux-64::cppinterop-1.1.0-clang17_repl_hfbaee85_1.conda
linux-64::lammps-2023.11.21-cpu_py39_h5b957dd_nompi_2.conda
linux-64::pillow-10.2.0-py310h01dd4db_0.conda
linux-64::vigra-1.11.2-py310ha89bf53_4.conda
linux-64::tiledb-2.19.1-hc0b898c_0.conda
linux-64::libarrow-11.0.0-h6569788_59_cpu.conda
linux-64::lammps-2023.11.21-cpu_py39_hefd3d5c_mpi_mpich_3.conda
linux-64::postgresql-plpython-15.4-py312h8532d62_5.conda
linux-64::gdstk-0.9.49-py310h1487c90_0.conda
linux-64::protozfits-2.3.0-py311h07795a0_5.conda
linux-64::lammps-2023.11.21-cpu_py39_hf042188_nompi_1.conda
linux-64::libmed-4.1.1-py38h714916e_8.conda
linux-64::mysql-connector-python-8.0.33-py39habddd97_0.conda
linux-64::libpq-15.4-hedfdc17_5.conda
linux-64::protozfits-2.3.0-py310hc041de8_5.conda
linux-64::libarrow-14.0.2-h84dd17c_3_cpu.conda
linux-64::libmed-4.1.1-py311h1f9eb04_10.conda
linux-64::sagelib-10.2-py310he210692_3.conda
linux-64::rust-1.75.0-h70c747d_0.conda
linux-64::lammps-2023.11.21-cuda118_py39_h4a9cbaf_mpi_openmpi_0.conda
linux-64::xrootd-5.6.6-py311h09aadaf_0.conda
linux-64::lammps-2023.11.21-cuda118_py38_h9c5a0ec_mpi_openmpi_2.conda
linux-64::lammps-2023.11.21-cpu_py39_hade46e7_mpi_openmpi_0.conda
linux-64::qt6-main-6.6.1-h0ebb57b_7.conda
linux-64::nest-simulator-3.6-py311h42e18a1_3.conda
linux-64::libarrow-14.0.2-h7303f25_2_cuda.conda
linux-64::lammps-2023.11.21-cpu_py311_hdd49dfd_nompi_0.conda
linux-64::libopencv-4.9.0-py312h990fce5_5.conda
linux-64::libtensorflow_cc-2.15.0-cuda120h11be487_2.conda
linux-64::lammps-2023.11.21-cpu_py39_h7e86899_mpi_mpich_1.conda
linux-64::libopencv-4.9.0-py310hb592d4d_5.conda
linux-64::paraview-5.11.2-py311h82c1b7b_102_qt.conda
linux-64::panda3d-1.10.14-py312hb46afc6_1.conda
linux-64::tensorstore-0.1.51-py39h13d674c_1.conda
linux-64::lammps-2023.08.02-cuda118_py39_h4a9cbaf_mpi_openmpi_8.conda
linux-64::graphicsmagick-1.3.42-hb545115_0.conda
linux-64::sasktran2-2023.12.0-py310hefcb49c_0.conda
linux-64::gmt-6.5.0-h6fe46e5_0.conda
linux-64::ffmpeg-6.1.1-gpl_h33edf06_103.conda
linux-64::libgdal-arrow-parquet-3.8.3-h9b05d71_0.conda
linux-64::lammps-2023.11.21-cpu_py311_hd3d4698_mpi_mpich_3.conda
linux-64::lammps-2023.11.21-cpu_py38_hda8f861_mpi_mpich_3.conda
linux-64::folly-2024.01.29.00-h23251b7_0.conda
linux-64::sagelib-10.2-py311hbe93d5b_2.conda
linux-64::lammps-2023.08.02-cuda118_py38_h6de3bbc_mpi_mpich_8.conda
linux-64::omniorb-4.3.2-py310h5d3106b_0.conda
linux-64::gfortran_impl_osx-arm64-13.2.0-h307e53f_2.conda
linux-64::uwsgi-2.0.23-py38h23773a5_0.conda
linux-64::nest-simulator-3.6-py39h736a37a_3.conda
linux-64::mysql-connector-python-8.0.33-py311h381d6c5_0.conda
linux-64::libarrow-14.0.2-h84dd17c_4_cpu.conda
linux-64::lxml-4.9.4-py312h37b5203_0.conda
linux-64::libarrow-12.0.1-hf0f33ac_36_cpu.conda
linux-64::pillow-10.2.0-py311ha6c5da5_0.conda
linux-64::libopencv-4.9.0-py38hed970c9_5.conda
linux-64::mysql-connector-python-8.0.33-py310h6eefaca_0.conda
linux-64::libarrow-15.0.0-he2c5238_2_cpu.conda
linux-64::lammps-2023.11.21-cuda118_py310_h38e9743_mpi_mpich_1.conda
linux-64::libgoogle-cloud-storage-2.17.0-hc7a4891_2.conda
linux-64::lammps-2023.08.02-cpu_py38_hda8f861_mpi_mpich_8.conda
linux-64::lammps-2023.11.21-cuda118_py39_h0d794d2_mpi_openmpi_3.conda
linux-64::imagemagick-7.1.1_26-pl5321h3fa1221_0.conda
linux-64::paraview-5.11.2-py38hb2139fa_102_qt.conda
linux-64::pyinstaller-6.3.0-py312hf0b23d7_1.conda
linux-64::libmed-4.1.1-py311h1f9eb04_9.conda
linux-64::lammps-2023.08.02-cpu_py38_hda8f861_mpi_mpich_7.conda
linux-64::gdstk-0.9.49-py312h7b2b3ac_0.conda
linux-64::lammps-2023.08.02-cuda118_py310_h077d75c_mpi_mpich_8.conda
linux-64::photochem-0.4.5-py310h8994ab7_0.conda
linux-64::sagelib-10.2-py310he210692_2.conda
linux-64::lammps-2023.11.21-cpu_py311_hdd49dfd_nompi_3.conda
linux-64::sasktran2-2023.12.0-py312h11a4be6_2.conda
linux-64::paraview-5.11.2-py310haaae0e0_102_qt.conda
linux-64::pdal-2.6.2-h7c70841_3.conda
linux-64::folly-2024.01.01.00-h70f49c4_0_jemalloc.conda
linux-64::lfortran-0.30.0-hfc55251_0.conda
linux-64::libarrow-12.0.1-h8e35aab_34_cuda.conda
linux-64::sasktran2-2023.12.0-py311h118c40b_2.conda
linux-64::grpcio-1.60.0-py310h1b8f574_1.conda
linux-64::imagemagick-7.1.1_27-pl5321hb90aeea_0.conda
linux-64::lammps-2023.11.21-cpu_py311_hd3d4698_mpi_mpich_1.conda
linux-64::libarrow-12.0.1-h6569788_35_cpu.conda
linux-64::libopencv-4.9.0-py39h76a5070_6.conda
linux-64::libopencv-4.9.0-py39h15425cf_5.conda
linux-64::lammps-2023.11.21-cpu_py310_h5b57e7a_nompi_3.conda
linux-64::correctionlib-2.3.3-py38hbb0cdd4_2.conda
linux-64::folly-2024.01.15.00-h23251b7_0.conda
linux-64::code-aster-17.0.1-np122py39hc2960b6_1.conda
linux-64::libarrow-12.0.1-h75ae66a_34_cpu.conda
linux-64::libxml2-2.12.4-h232c23b_1.conda
linux-64::lammps-2023.08.02-cuda118_py310_h483aaed_mpi_openmpi_8.conda
linux-64::sagelib-10.2-py311hbe93d5b_3.conda
linux-64::pypy3.9-7.3.15-h9557127_0.conda
linux-64::lxml-5.0.1-py39ha378d84_0.conda
linux-64::lammps-2023.11.21-cuda118_py38_he846794_nompi_2.conda
linux-64::libopentelemetry-cpp-1.13.0-ha162ae1_1.conda
linux-64::postgresql-plpython-15.5-py310h4bf71c2_0.conda
linux-64::lammps-2023.11.21-cuda118_py39_h0d794d2_mpi_openmpi_1.conda
linux-64::postgresql-15.5-h82ecc9d_0.conda
linux-64::gmsh-4.12.2-h6b98cf8_0.conda
linux-64::omniorb-4.3.2-py312h8992e14_1.conda
linux-64::lammps-2023.08.02-cpu_py39_hade46e7_mpi_openmpi_7.conda
linux-64::aws-sdk-cpp-1.11.210-h405b101_9.conda
linux-64::lammps-2023.11.21-cuda118_py39_h5417483_nompi_0.conda
linux-64::r-data.table-1.14.10-r43h029312a_1.conda
linux-64::libopencv-4.9.0-py39h0d0a14e_5.conda
linux-64::omniorb-4.3.2-py311h28f970a_0.conda
linux-64::tensorflow-base-2.15.0-cuda120py310heceb7ac_3.conda
linux-64::lammps-2023.11.21-cpu_py38_h5608ceb_nompi_3.conda
linux-64::tesseract-5.3.4-hbeb23df_0.conda
linux-64::libarrow-13.0.0-hf0f33ac_25_cpu.conda
linux-64::omniorb-4.3.2-py38h0ed79f3_0.conda
linux-64::folly-2024.01.08.00-h122a45c_0_jemalloc.conda
linux-64::postgresql-plpython-15.5-py312hd1394c4_0.conda
linux-64::lxml-5.0.1-py312h37b5203_0.conda
linux-64::sasktran2-2024.01.1-py311h118c40b_0.conda
linux-64::lxml-4.9.4-py38h32ae189_0.conda
linux-64::lammps-2023.08.02-cpu_py310_h5b57e7a_nompi_7.conda
linux-64::libopencv-4.9.0-py311hfde98a4_6.conda
linux-64::lxml-4.9.4-py39h1cc6f3e_0.conda
linux-64::gfortran_impl_osx-64-12.3.0-hec5e7d4_2.conda
linux-64::libtiledb-sql-0.27.0-h39d0c6e_0.conda
linux-64::libmed-4.1.1-py39h0898053_9.conda
linux-64::lammps-2023.11.21-cuda118_py310_h077d75c_mpi_mpich_3.conda
linux-64::postgresql-15.4-h7387d8b_5.conda
linux-64::qtwebkit-5.212-h60108c6_16.conda
linux-64::lammps-2023.08.02-cuda118_py38_h0bd2086_nompi_8.conda
linux-64::protozfits-2.3.0-py39hc60452a_5.conda
linux-64::lammps-2023.11.21-cpu_py39_hefd3d5c_mpi_mpich_1.conda
linux-64::cpp-opentelemetry-sdk-1.13.0-ha162ae1_1.conda
linux-64::wxpython-4.2.1-py39hb8fee00_2.conda
linux-64::wxpython-4.2.1-py311h5202d5f_2.conda
linux-64::lammps-2023.08.02-cpu_py39_h827286f_mpi_openmpi_7.conda
linux-64::grpcio-1.60.0-py39h7d5b425_1.conda
linux-64::xrootd-5.6.6-py39h2326971_0.conda
linux-64::lammps-2023.11.21-cuda118_py311_h0edc3ef_mpi_mpich_0.conda
linux-64::lammps-2023.11.21-cuda118_py311_h80f0500_nompi_2.conda
linux-64::cppyy-cling-6.30.0-py312h24f76d5_2.conda
linux-64::lammps-2023.11.21-cuda118_py39_h14e8439_mpi_mpich_3.conda
linux-64::xeus-cpp-0.3.0-h3f8c671_0.conda
linux-64::mdsplus-7.139.61-py38pl5321ha8a3ab3_0.conda
linux-64::sdl2_ttf-2.22.0-ha14f88b_0.conda
linux-64::nceplibs-g2c-1.8.0-h4a0a8e2_5.conda
linux-64::wxpython-4.2.1-py311h022d1f3_1.conda
linux-64::lammps-2023.11.21-cpu_py39_hade46e7_mpi_openmpi_2.conda
linux-64::libopencv-4.9.0-py311hbe74fbb_5.conda
linux-64::openjdk-17.0.10-h4260e57_0.conda
linux-64::lammps-2023.11.21-cuda118_py39_hf2cf36d_nompi_3.conda
linux-64::fimex-1.9.9-py310ha40fba2_0.conda
linux-64::lammps-2023.11.21-cpu_py311_hd3d4698_mpi_mpich_2.conda
linux-64::magic-8.3.455-h9abf892_0.conda
linux-64::hugin-2022.0.0-pl5321h4964e29_10.conda
linux-64::lammps-2023.11.21-cpu_py311_hbb7bd43_mpi_openmpi_3.conda
linux-64::lxml-5.1.0-py38h32ae189_0.conda
linux-64::libmed-4.1.1-py310h045128c_8.conda
linux-64::vigra-1.11.2-py39h51c14a2_4.conda
linux-64::lfortran-0.33.0-hfc55251_0.conda
linux-64::grpcio-1.60.0-py39h174d805_1.conda
linux-64::lammps-2023.08.02-cuda118_py39_h14e8439_mpi_mpich_8.conda
linux-64::tiledb-2.18.4-h584b59b_0.conda
linux-64::folly-2024.01.15.00-hb244bc4_0.conda
linux-64::folly-2024.01.22.00-hb244bc4_0.conda
linux-64::lammps-2023.11.21-cuda118_py39_h1a54f2e_nompi_1.conda
linux-64::lammps-2023.11.21-cuda118_py311_hdd7c1f1_mpi_mpich_2.conda
linux-64::tensorflow-base-2.15.0-cuda120py310heceb7ac_2.conda
linux-64::lxml-5.1.0-py39h1cc6f3e_0.conda
linux-64::lammps-2023.11.21-cuda118_py39_hf8afb37_nompi_3.conda
linux-64::lammps-2023.08.02-cuda118_py39_h5417483_nompi_8.conda
linux-64::lammps-2023.08.02-cuda118_py39_h1a54f2e_nompi_8.conda
linux-64::nsight-compute-2023.3.1.1-h3718151_0.conda
linux-64::folly-2024.01.01.00-h122a45c_0_jemalloc.conda
linux-64::lammps-2023.11.21-cuda118_py38_h9c5a0ec_mpi_openmpi_1.conda
linux-64::lammps-2023.11.21-cpu_py310_hcea6fc9_mpi_openmpi_2.conda
linux-64::createrepo_c-1.0.3-py39hb74ab81_0.conda
linux-64::cppyy-cling-6.30.0-py39hc26e0ff_2.conda
linux-64::cppyy-cling-6.30.0-py38hbb0cdd4_2.conda
linux-64::lammps-2023.08.02-cpu_py311_hbb7bd43_mpi_openmpi_8.conda
linux-64::libopencv-4.9.0-py312h3403727_7.conda
linux-64::lammps-2023.11.21-cpu_py311_hbb7bd43_mpi_openmpi_1.conda
linux-64::panda3d-1.10.14-py311hb748066_1.conda
linux-64::libgsf-1.14.51-haef5bb9_1.conda
linux-64::libarrow-12.0.1-he0ed3ba_36_cuda.conda
linux-64::libspral-2023.09.07-h6aa6db2_2.conda
linux-64::lammps-2023.11.21-cuda118_py310_hadf4ee5_nompi_0.conda
linux-64::pillow-10.2.0-py312hf3581a9_0.conda
linux-64::omniorb-4.3.2-py39h53428f1_1.conda
linux-64::lammps-2023.11.21-cpu_py311_hbb7bd43_mpi_openmpi_2.conda
linux-64::panda3d-1.10.14-py38h3402557_1.conda
linux-64::lammps-2023.11.21-cuda118_py39_h43d3bb2_mpi_openmpi_0.conda
linux-64::xrootd-5.6.6-py312h634209f_0.conda
linux-64::lxml-5.0.1-py39h1cc6f3e_0.conda
linux-64::gdstk-0.9.49-py38hab45c01_0.conda
linux-64::libarrow-12.0.1-he9c478a_35_cuda.conda
linux-64::cppyy-cling-6.30.0-py38hbb0cdd4_1.conda
linux-64::libopencv-4.9.0-py39h8030705_5.conda
linux-64::omniorb-4.3.2-py312h8992e14_0.conda
linux-64::createrepo_c-1.0.3-py38h569db57_0.conda
linux-64::lammps-2023.11.21-cuda118_py38_h0bd2086_nompi_1.conda
linux-64::lammps-2023.08.02-cpu_py311_hdd49dfd_nompi_8.conda
linux-64::libarrow-13.0.0-h2f39494_22_cpu.conda
linux-64::lammps-2023.11.21-cuda118_py39_h4a9cbaf_mpi_openmpi_3.conda
linux-64::lammps-2023.08.02-cpu_py39_h5b957dd_nompi_7.conda
linux-64::lammps-2023.08.02-cuda118_py39_h0d794d2_mpi_openmpi_8.conda
linux-64::tensorflow-base-2.15.0-cuda120py39hf42b710_3.conda
linux-64::libxml2-2.12.4-h232c23b_0.conda
linux-64::lxml-5.1.0-py310hcfd0673_0.conda
linux-64::gfortran_impl_osx-64-13.2.0-hf49883a_2.conda
linux-64::postgresql-plpython-15.4-py39ha00ab12_5.conda
linux-64::mesalib-23.3.4-hf257a20_0.conda
linux-64::libopencv-4.9.0-py38h6615d46_5.conda
linux-64::gst-plugins-bad-1.22.9-h3448496_0.conda
linux-64::ovito-3.10.0-h15f347a_0.conda
linux-64::folly-2024.01.22.00-h122a45c_0_jemalloc.conda
linux-64::grpcio-1.60.0-py311ha6695c7_1.conda
linux-64::lammps-2023.11.21-cpu_py38_hda8f861_mpi_mpich_1.conda
linux-64::libarrow-14.0.2-h84dd17c_2_cpu.conda
linux-64::lammps-2023.08.02-cpu_py39_h5b957dd_nompi_8.conda
linux-64::lammps-2023.08.02-cuda118_py310_hadf4ee5_nompi_8.conda
linux-64::emacs-29.2-hc93ec10_0.conda
linux-64::folly-2024.01.01.00-hbc8c634_0_jemalloc.conda
linux-64::lammps-2023.08.02-cuda118_py38_hc73eb01_mpi_openmpi_8.conda
linux-64::fimex-1.9.9-py312ha83cba0_0.conda
linux-64::lammps-2023.11.21-cuda118_py310_h483aaed_mpi_openmpi_3.conda
linux-64::lammps-2023.08.02-cpu_py38_hde207a7_mpi_openmpi_8.conda
linux-64::paraview-5.11.2-py312hf537f1f_102_qt.conda
linux-64::hugin-base-2022.0.0-pl5321hd2f8e08_10.conda
linux-64::lammps-2023.11.21-cpu_py39_h827286f_mpi_openmpi_3.conda
linux-64::nest-simulator-3.6-py310hde3b743_3.conda
linux-64::gfortran_impl_osx-arm64-12.3.0-hd18e70c_2.conda
linux-64::lammps-2023.08.02-cuda118_py38_he846794_nompi_8.conda
linux-64::libvips-8.15.1-ha3bdf62_1.conda
linux-64::lammps-2023.08.02-cpu_py311_hdd49dfd_nompi_7.conda
linux-64::openjdk-11.0.22-h4260e57_0.conda
linux-64::lammps-2023.08.02-cpu_py39_hefd3d5c_mpi_mpich_8.conda
linux-64::postgresql-plpython-15.4-py310hdd8bd8b_5.conda
linux-64::paraview-5.11.2-py312h6a8de92_102_qt.conda
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
linux-64::libuwebsockets-20.58.0-hfc55251_0.conda
linux-64::gst-libav-1.22.9-hd5f137f_0.conda
linux-64::libsoup-3.4.4-h5006749_2.conda
linux-64::rill-0.39.1-heb45ecc_0.conda
linux-64::zimpl-3.5.3-h4c00192_7.conda
linux-64::libprotobuf-static-4.25.1-hf27288f_0.conda
linux-64::imath-3.1.10-hfc55251_0.conda
linux-64::rill-0.39.0-heb45ecc_0.conda
linux-64::libuwebsockets-20.57.0-hfc55251_0.conda
linux-64::libuwebsockets-20.56.0-hfc55251_0.conda
linux-64::openexr-3.2.1-h279af06_1.conda
linux-64::libprotobuf-4.25.1-hf27288f_0.conda
linux-64::netcdf-cxx4-4.3.1-nompi_h53de069_108.conda
-    "libzlib >=1.2.13,<1.3.0a0"
+    "libzlib >=1.2.13,<2.0.0a0"
```

</details>