### PR TITLE
loosen zlib-pin to major level (6/N; December 2023)

### DIFF
--- a/recipe/patch_yaml/zlib.yaml
+++ b/recipe/patch_yaml/zlib.yaml
@@ -43,3 +43,12 @@ then:
   - loosen_depends:
       name: libzlib
       upper_bound: "2"
+---
+if:
+  has_depends: libzlib >=1.2*
+  timestamp_lt: 1704067200000  # 2024-01-01 00:00 UTC
+  timestamp_ge: 1701388800000  # 2023-12-01 00:00 UTC
+then:
+  - loosen_depends:
+      name: libzlib
+      upper_bound: "2"


### PR DESCRIPTION
Follow-up to https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/739, about 3200 artefacts affected.

### Result of `python show_diff.py`

<details>

```diff
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
osx-arm64::dotnet-sdk-8.0.100-ha659e4c_0.conda
osx-arm64::dotnet-aspnetcore-8.0.0-ha659e4c_0.conda
osx-arm64::dotnet-runtime-8.0.0-ha659e4c_0.conda
osx-arm64::libuwebsockets-20.51.0-h1059232_0.conda
osx-arm64::zimpl-3.5.3-h2185600_4.conda
osx-arm64::libuwebsockets-20.53.0-h1059232_0.conda
osx-arm64::libsoup-3.4.4-hda4a01a_1.conda
osx-arm64::micromamba-1.5.5-0.tar.bz2
osx-arm64::dotnet-aspnetcore-6.0.25-ha659e4c_0.conda
osx-arm64::libuwebsockets-20.49.0-h9e231a4_0.conda
osx-arm64::glib-tools-2.78.2-h9e231a4_0.conda
osx-arm64::libuwebsockets-20.52.0-h1059232_0.conda
osx-arm64::glib-tools-2.78.3-h9e231a4_0.conda
osx-arm64::gst-plugins-base-1.22.8-h09b4b5e_0.conda
osx-arm64::gst-plugins-base-1.22.7-h040e9b9_1.conda
osx-arm64::dotnet-runtime-7.0.14-ha659e4c_0.conda
osx-arm64::zimpl-3.5.3-h2185600_5.conda
osx-arm64::libsoup-2.74.3-hda4a01a_2.conda
osx-arm64::libdap4-3.20.6-hbe2aee2_5.conda
osx-arm64::dotnet-aspnetcore-7.0.14-ha659e4c_0.conda
osx-arm64::libuwebsockets-20.54.0-h1059232_0.conda
osx-arm64::eccodes-2.33.0-h64f3314_0.conda
osx-arm64::dotnet-runtime-6.0.25-ha659e4c_0.conda
osx-arm64::micromamba-1.5.6-0.tar.bz2
osx-arm64::libuwebsockets-20.55.0-h1059232_0.conda
osx-arm64::dotnet-sdk-6.0.417-ha659e4c_0.conda
osx-arm64::dotnet-sdk-7.0.404-ha659e4c_0.conda
-    "libzlib >=1.2.13,<1.3.0a0"
+    "libzlib >=1.2.13,<2.0.0a0"
osx-arm64::xrootd-5.6.2-py310hbae5087_2.conda
osx-arm64::pyinstaller-6.3.0-py311h4045465_0.conda
osx-arm64::ndcctools-7.7.3-py38h78e4241_0.conda
osx-arm64::r-data.table-1.14.10-r43h513102a_0.conda
osx-arm64::libarchive-3.7.2-hcacb583_1.conda
osx-arm64::gdstk-0.9.48-py310hd84021c_0.conda
osx-arm64::postgresql-plpython-15.4-py39h93fcee7_3.conda
osx-arm64::postgresql-plpython-15.4-py39h93fcee7_4.conda
osx-arm64::tiledb-2.19.0-h567544c_0.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-h864bd25_13.conda
osx-arm64::libgdal-arrow-parquet-3.8.1-hfde57df_0.conda
osx-arm64::libarrow-13.0.0-hd4cc6db_21_cpu.conda
osx-arm64::imagecodecs-2024.1.1-py310h5cce2fa_0.conda
osx-arm64::postgresql-plpython-15.4-py310h6edaefd_4.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-hab1b9fd_12.conda
osx-arm64::imagemagick-7.1.1_23-pl5321h8b80fcd_0.conda
osx-arm64::tesseract-5.3.2-hbe6b26a_2.conda
osx-arm64::arrow-cpp-9.0.0-py39h86c59b3_50_cpu.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-h02058a6_11.conda
osx-arm64::ndcctools-7.7.3-py310h3fc91fe_0.conda
osx-arm64::cmake-3.28.0-h04763b9_0.conda
osx-arm64::gmsh-4.12.0-hd427cfb_0.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-hb870c24_12.conda
osx-arm64::pdal-2.6.2-h9ac0d82_0.conda
osx-arm64::yoda-1.9.6-py38hc1a8d24_6.conda
osx-arm64::glib-2.78.2-h9e231a4_0.conda
osx-arm64::magics-metview-batch-4.15.0-h7fea6e7_0.conda
osx-arm64::folly-2023.12.04.00-hd3f4852_0_jemalloc.conda
osx-arm64::vtk-base-9.2.6-qt_py310h1234567_220.conda
osx-arm64::libscotch-7.0.4-hf7fe8bf_1.conda
osx-arm64::ifcopenshell-v0.7.0.231127-py38_novtk_h4b42877_102.conda
osx-arm64::gemmi-0.6.4-py312h17030e7_0.conda
osx-arm64::yoda-1.9.6-py311h1bc52be_5.conda
osx-arm64::postgresql-16.1-h1d0603d_6.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-h63e9480_9.conda
osx-arm64::folly-2023.12.04.00-ha5de9cd_0_jemalloc.conda
osx-arm64::cargo-c-0.9.29-hdf7d417_0.conda
osx-arm64::libxmlsec1-1.3.2-h07c84ac_1.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-hb05425c_10.conda
osx-arm64::libtensorflow-2.15.0-cpu_h9d8c315_1.conda
osx-arm64::lxml-4.9.3-py311hdef8331_3.conda
osx-arm64::pdal-2.6.2-h55873e5_2.conda
osx-arm64::lxml-4.9.3-py312hae0b87f_2.conda
osx-arm64::vtk-base-9.2.6-qt_py311h1234567_220.conda
osx-arm64::root_base-6.28.10-py311h2a25b9c_2.conda
osx-arm64::root_base-6.28.10-py39h06fd22f_0.conda
osx-arm64::root_base-6.30.2-py39h06fd22f_0.conda
osx-arm64::texlive-core-20230313-py310hc8e8c87_9.conda
osx-arm64::python-3.9.18-hd7ebdb9_1_cpython.conda
osx-arm64::libtensorflow-2.15.0-cpu_h83790c0_0.conda
osx-arm64::libgdal-3.7.3-ha0f3e8b_10.conda
osx-arm64::arrow-cpp-9.0.0-py311h952c9e6_50_cpu.conda
osx-arm64::postgresql-15.4-hc6ab77f_4.conda
osx-arm64::imagemagick-7.1.1_21-pl5321h8b80fcd_2.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-h23f7474_11.conda
osx-arm64::arrow-cpp-9.0.0-py310h0ea2bf1_50_cpu.conda
osx-arm64::libtensorflow_cc-2.15.0-cpu_h1998a8a_1.conda
osx-arm64::python-3.10.13-h2469fbe_1_cpython.conda
osx-arm64::sagelib-10.1-py38h1a87593_0.conda
osx-arm64::root_base-6.28.10-py38h27b35fb_0.conda
osx-arm64::r-data.table-1.14.10-r42h513102a_0.conda
osx-arm64::postgresql-plpython-16.1-py39h93fcee7_7.conda
osx-arm64::sagelib-10.0-py39h7e5f403_2.conda
osx-arm64::libopentelemetry-cpp-1.13.0-hbaf25a0_0.conda
osx-arm64::folly-2023.12.25.00-ha98ecff_0.conda
osx-arm64::libgdal-arrow-parquet-3.8.2-he721d7c_0.conda
osx-arm64::root_base-6.28.10-py310h44eaee5_0.conda
osx-arm64::libgdal-arrow-parquet-3.8.1-hc27aaa3_1.conda
osx-arm64::libgdal-arrow-parquet-3.8.1-hadb931b_0.conda
osx-arm64::tiledb-2.18.2-hadb9f5a_2.conda
osx-arm64::postgresql-plpython-16.1-py310h44d1ce9_6.conda
osx-arm64::scip-8.1.0-ha659d42_5.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-h1789115_11.conda
osx-arm64::ifcopenshell-v0.7.0.231127-py312_all_h344505d_202.conda
osx-arm64::ndcctools-7.7.3-py311h3d5ec97_0.conda
osx-arm64::yoda-1.9.6-py39h1a8b915_5.conda
osx-arm64::folly-2023.12.18.00-h75b8fe2_0.conda
osx-arm64::pyreadstat-1.2.6-py39h8643609_0.conda
osx-arm64::pygplates-0.39-py38h184e59d_14.conda
osx-arm64::tensorflow-base-2.15.0-cpu_py39ha39414a_1.conda
osx-arm64::folly-2023.12.04.00-h83f57a1_0.conda
osx-arm64::libgdal-3.7.3-h43ae7c0_11.conda
osx-arm64::gemmi-0.6.4-py311hf5d242d_0.conda
osx-arm64::imagemagick-7.1.1_22-pl5321h8b80fcd_0.conda
osx-arm64::vtk-base-9.2.6-qt_py38h1234567_220.conda
osx-arm64::sagelib-10.2-py310h794f6da_0.conda
osx-arm64::lld-16.0.6-hae11360_1.conda
osx-arm64::libarrow-11.0.0-hd4cc6db_56_cpu.conda
osx-arm64::libarrow-14.0.2-hfcbd24e_0_cpu.conda
osx-arm64::yoda-1.9.6-py38h44db2e8_5.conda
osx-arm64::pdal-2.6.2-h95130b0_1.conda
osx-arm64::qt6-main-6.6.1-h9c79a27_4.conda
osx-arm64::gmsh-4.12.0-h8a9da21_0.conda
osx-arm64::xrootd-5.6.4-py38h0ccaf4f_0.conda
osx-arm64::python-igraph-0.11.3-py310h28dbf85_1.conda
osx-arm64::tensorflow-base-2.15.0-cpu_py310hb663c03_1.conda
osx-arm64::mesalib-23.3.2-h3f84dcd_0.conda
osx-arm64::cmake-3.28.1-h50fd54c_0.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-hc27aaa3_9.conda
osx-arm64::python-3.12.1-hdf0ec26_1_cpython.conda
osx-arm64::pytng-0.3.1-py312h5dd6cca_1.conda
osx-arm64::libarrow-12.0.1-hd1b09a7_31_cpu.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-h8b49c50_9.conda
osx-arm64::openssh-9.6p1-hd435d45_0.conda
osx-arm64::jaxlib-0.4.20-cpu_py39h9b38f39_0.conda
osx-arm64::sagelib-10.2-py310h636d976_1.conda
osx-arm64::imagecodecs-2024.1.1-py311h788c98d_0.conda
osx-arm64::jaxlib-0.4.23-cpu_py311hb7726a2_0.conda
osx-arm64::magics-metview-4.15.0-hec748b0_0.conda
osx-arm64::sagelib-10.0-py38h1a87593_2.conda
osx-arm64::xrootd-5.6.3-py312h6fcfba9_0.conda
osx-arm64::pyinstaller-6.3.0-py312ha17c255_0.conda
osx-arm64::util-linux-2.39.3-py39h2ad0120_0.conda
osx-arm64::postgresql-plpython-16.1-py310h6edaefd_7.conda
osx-arm64::libvips-8.15.0-h4142c04_4.conda
osx-arm64::coda-2.25.1-py310h1db3a1d_0.conda
osx-arm64::openmpi-5.0.0-h2dea082_102.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-h82b47f8_13.conda
osx-arm64::ifcopenshell-v0.7.0.231127-py39_novtk_h14ba0f6_102.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-h46ccc67_11.conda
osx-arm64::ndcctools-7.7.3-py39hcfa8d96_0.conda
osx-arm64::libarrow-14.0.1-hfcbd24e_10_cpu.conda
osx-arm64::libgdal-3.8.1-hcefe9de_0.conda
osx-arm64::pygplates-0.39-py39h50f403c_14.conda
osx-arm64::ruby-3.2.2-ha6ee62f_1.conda
osx-arm64::libpq-15.4-hd435d45_3.conda
osx-arm64::boost-cpp-1.84.0-hca5e981_0.conda
osx-arm64::sagelib-10.1-py39h7e5f403_0.conda
osx-arm64::minizip-4.0.4-hc35e051_0.conda
osx-arm64::gemmi-0.6.4-py39h047a24b_0.conda
osx-arm64::lxml-4.9.3-py38h1e4dcb8_3.conda
osx-arm64::pyreadstat-1.2.6-py312ha17c255_0.conda
osx-arm64::postgresql-plpython-16.1-py312hac41b93_5.conda
osx-arm64::tiledb-2.18.2-hcd9d348_1.conda
osx-arm64::jaxlib-0.4.23-cpu_py310h75e2498_0.conda
osx-arm64::tensorflow-base-2.15.0-cpu_py311h05dd8b3_0.conda
osx-arm64::libgdal-arrow-parquet-3.8.2-h3690797_1.conda
osx-arm64::postgresql-plpython-16.1-py38h0b167b4_5.conda
osx-arm64::postgresql-plpython-15.4-py312h9d9d237_3.conda
osx-arm64::pytables-3.9.2-py310h1846626_1.conda
osx-arm64::lxml-4.9.3-py38h1e4dcb8_2.conda
osx-arm64::xrootd-5.6.4-py310hbae5087_0.conda
osx-arm64::tiledb-2.18.2-h79dc55e_2.conda
osx-arm64::postgresql-plpython-16.1-py38h355cde2_2.conda
osx-arm64::xrootd-5.6.2-py312h6fcfba9_2.conda
osx-arm64::postgresql-plpython-15.4-py312h9d9d237_4.conda
osx-arm64::root_base-6.28.10-py310h44eaee5_2.conda
osx-arm64::qt6-main-6.6.1-h9c79a27_3.conda
osx-arm64::bytewax-0.17.2-py310ha04cfa0_0.conda
osx-arm64::cppyy-cling-6.30.0-py311h4ca21db_0.conda
osx-arm64::root_base-6.28.10-py39h06fd22f_2.conda
osx-arm64::postgresql-plpython-16.1-py38h0b167b4_7.conda
osx-arm64::postgresql-16.1-hc6ab77f_7.conda
osx-arm64::libnghttp2-static-1.58.0-h8d15234_1.conda
osx-arm64::sagelib-10.1-py311h20e94d5_0.conda
osx-arm64::gdstk-0.9.48-py310hc75bf61_1.conda
osx-arm64::python-igraph-0.11.3-py311h5293b00_1.conda
osx-arm64::libgdal-3.8.1-hac00559_1.conda
osx-arm64::gdstk-0.9.48-py310h7257faa_1.conda
osx-arm64::jaxlib-0.4.20-cpu_py312h46293e5_0.conda
osx-arm64::hdf5-1.14.3-mpi_mpich_h754b83b_0.conda
osx-arm64::openslide-4.0.0-ha5580ce_1.conda
osx-arm64::tensorflow-base-2.15.0-cpu_py310h0e84cb2_0.conda
osx-arm64::tiledb-2.18.2-h19372f8_1.conda
osx-arm64::ifcopenshell-v0.7.0.231127-py312_novtk_hbaaa22a_102.conda
osx-arm64::lxml-4.9.3-py39h0fb1a5a_3.conda
osx-arm64::ffmpeg-6.1.0-gpl_h61b7210_104.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-h84bfb32_10.conda
osx-arm64::postgresql-plpython-16.1-py312h9d9d237_2.conda
osx-arm64::libgdal-arrow-parquet-3.8.2-h8e694ec_0.conda
osx-arm64::postgresql-plpython-15.4-py38h355cde2_4.conda
osx-arm64::pytables-3.9.2-py311hce229b4_1.conda
osx-arm64::sagelib-10.2-py311h62b8dda_1.conda
osx-arm64::postgresql-plpython-16.1-py39ha7448c8_7.conda
osx-arm64::postgresql-plpython-16.1-py39ha7448c8_6.conda
osx-arm64::libgoogle-cloud-storage-2.17.0-h8a76758_0.conda
osx-arm64::python-3.12.1-hdf0ec26_0_cpython.conda
osx-arm64::gdstk-0.9.48-py310hc132470_1.conda
osx-arm64::hdf5-1.14.3-mpi_openmpi_h20f603a_0.conda
osx-arm64::xrootd-5.6.3-py39h8810cd4_0.conda
osx-arm64::cppyy-cling-6.30.0-py310h59dd246_0.conda
osx-arm64::qt-main-5.15.8-h0a21348_18.conda
osx-arm64::postgresql-plpython-16.1-py312hac41b93_6.conda
osx-arm64::coda-2.25.1-py311hea92249_0.conda
osx-arm64::libgdal-arrow-parquet-3.8.1-h02058a6_3.conda
osx-arm64::lxml-4.9.3-py39h0fb1a5a_2.conda
osx-arm64::libgdal-3.8.2-hbf6594e_0.conda
osx-arm64::pygplates-0.39-py311h6d0ab83_14.conda
osx-arm64::libssh-0.10.6-haca8764_0.conda
osx-arm64::pytng-0.3.1-py39h33914a9_1.conda
osx-arm64::r-base-4.2.3-h53b85ff_11.conda
osx-arm64::yoda-1.9.6-py311hf6cffcc_6.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-h2460107_13.conda
osx-arm64::gemmi-0.6.4-py310hf7687f1_0.conda
osx-arm64::libssh-0.10.6-hf52a3f6_1.conda
osx-arm64::xrootd-5.6.2-py39h8810cd4_2.conda
osx-arm64::jaxlib-0.4.20-cpu_py311hb7726a2_0.conda
osx-arm64::ffmpeg-6.1.1-gpl_h4d3b11e_100.conda
osx-arm64::cppyy-cling-6.30.0-py312hee8bc9d_0.conda
osx-arm64::xrootd-5.6.4-py39h8810cd4_0.conda
osx-arm64::folly-2023.12.25.00-h584d98d_0_jemalloc.conda
osx-arm64::tesseract-5.3.3-hbe6b26a_0.conda
osx-arm64::libgdal-3.8.2-h7e86f1f_1.conda
osx-arm64::ifcopenshell-v0.7.0.231127-py38_all_h63b3ec5_202.conda
osx-arm64::ffmpeg-6.1.0-lgpl_hd427870_4.conda
osx-arm64::postgresql-plpython-16.1-py311h1e905d0_7.conda
osx-arm64::folly-2023.12.25.00-h75b8fe2_0.conda
osx-arm64::poppler-23.12.0-hcdd998b_0.conda
osx-arm64::tiledb-2.18.3-hddc9837_0.conda
osx-arm64::libgdal-arrow-parquet-3.8.1-h6536839_2.conda
osx-arm64::postgresql-plpython-15.4-py310h6edaefd_3.conda
osx-arm64::util-linux-2.39.3-py38h9dc91de_1.conda
osx-arm64::xrootd-5.6.3-py38h0ccaf4f_0.conda
osx-arm64::libscotch-7.0.4-hc938e73_1.conda
osx-arm64::postgresql-plpython-15.4-py38h355cde2_3.conda
osx-arm64::libxml2-2.12.3-h0d0cfa8_0.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-h54d98e9_9.conda
osx-arm64::postgresql-plpython-16.1-py38h0b167b4_6.conda
osx-arm64::folly-2023.12.11.00-hb8f665b_0_jemalloc.conda
osx-arm64::python-igraph-0.11.3-py38h8c44bf0_1.conda
osx-arm64::postgresql-plpython-16.1-py310h6edaefd_2.conda
osx-arm64::folly-2023.12.18.00-h584d98d_0_jemalloc.conda
osx-arm64::bytewax-0.17.2-py39h7809d69_0.conda
osx-arm64::magics-4.14.2-hb7c9b79_2.conda
osx-arm64::libgdal-arrow-parquet-3.8.2-hd4e9ed7_0.conda
osx-arm64::util-linux-2.39.3-py38h52f88b7_0.conda
osx-arm64::gdstk-0.9.48-py38h0fa6a1b_0.conda
osx-arm64::libvips-8.15.1-h07153ce_0.conda
osx-arm64::libgdal-arrow-parquet-3.8.1-hb870c24_4.conda
osx-arm64::sagelib-10.2-py39h01c9c45_1.conda
osx-arm64::libyarp-3.9.0-h767f962_0.conda
osx-arm64::libarrow-12.0.1-h1bbcde0_30_cpu.conda
osx-arm64::libboost-1.84.0-h238a360_0.conda
osx-arm64::lxml-4.9.3-py310h62197bd_3.conda
osx-arm64::pytables-3.9.2-py39h717dae7_1.conda
osx-arm64::xrootd-5.6.4-py312h6fcfba9_0.conda
osx-arm64::sagelib-10.0-py311h20e94d5_2.conda
osx-arm64::gst-plugins-good-1.22.7-he164ddd_1.conda
osx-arm64::python-3.11.7-hdf0ec26_1_cpython.conda
osx-arm64::aws-sdk-cpp-1.11.210-h4729158_4.conda
osx-arm64::ffmpeg-6.1.1-lgpl_he10240c_0.conda
osx-arm64::folly-2023.12.18.00-ha8c0bfd_0.conda
osx-arm64::libnetcdf-4.9.2-nompi_h291a7c2_113.conda
osx-arm64::gdstk-0.9.48-py39hb07f281_0.conda
osx-arm64::libcurl-8.5.0-h2d989ff_0.conda
osx-arm64::postgresql-plpython-16.1-py310h44d1ce9_5.conda
osx-arm64::libgdal-arrow-parquet-3.8.1-h63e9480_1.conda
osx-arm64::ifcopenshell-v0.7.0.231127-py311_all_h60a7c55_202.conda
osx-arm64::folly-2023.12.25.00-hcdc1028_0_jemalloc.conda
osx-arm64::ffmpeg-6.1.0-gpl_hfdc440f_105.conda
osx-arm64::coda-2.25.1-py38h2af7232_0.conda
osx-arm64::libxml2-2.12.2-h0d0cfa8_0.conda
osx-arm64::pdal-2.6.1-h9ac0d82_1.conda
osx-arm64::libgdal-arrow-parquet-3.8.2-h82b47f8_1.conda
osx-arm64::postgresql-plpython-15.4-py311h1bbf4d3_3.conda
osx-arm64::util-linux-2.39.3-py310hdf428d3_0.conda
osx-arm64::magics-metview-batch-4.14.2-hb7c9b79_2.conda
osx-arm64::imagemagick-7.1.1_24-pl5321h04f3966_0.conda
osx-arm64::vtk-base-9.2.6-qt_py39h1234567_220.conda
osx-arm64::fish-3.6.4-h15587f7_0.conda
osx-arm64::libtensorflow_cc-2.15.0-cpu_h0c20d54_0.conda
osx-arm64::libarrow-13.0.0-h1bbcde0_19_cpu.conda
osx-arm64::pygplates-0.39-py312he8e058a_14.conda
osx-arm64::libspatialite-5.1.0-h69abc6b_4.conda
osx-arm64::pytng-0.3.1-py311h873492f_1.conda
osx-arm64::folly-2023.12.11.00-h2db6db1_0.conda
osx-arm64::openconnect-9.12-h37a6e70_2.conda
osx-arm64::coda-2.25.1-py39h31e696d_0.conda
osx-arm64::libgdal-arrow-parquet-3.8.1-h3c75905_4.conda
osx-arm64::libarrow-13.0.0-hd1b09a7_20_cpu.conda
osx-arm64::gst-plugins-bad-1.22.7-h79f8405_0.conda
osx-arm64::ifcopenshell-v0.7.0.231127-py311_novtk_he04c108_102.conda
osx-arm64::folly-2023.12.11.00-h83f57a1_0.conda
osx-arm64::xrootd-5.6.4-py311h4094d04_0.conda
osx-arm64::gst-plugins-good-1.22.8-h96640bf_0.conda
osx-arm64::tiledb-2.18.3-h567544c_1.conda
osx-arm64::libgdal-arrow-parquet-3.8.1-h08f35de_4.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-h4a59846_10.conda
osx-arm64::cpp-opentelemetry-sdk-1.13.0-hbaf25a0_0.conda
osx-arm64::nss-3.96-h5ce2875_0.conda
osx-arm64::folly-2023.12.04.00-h2db6db1_0.conda
osx-arm64::postgresql-16.1-h1d0603d_5.conda
osx-arm64::xrootd-5.6.2-py311h4094d04_2.conda
osx-arm64::libgdal-arrow-parquet-3.8.1-hab1b9fd_4.conda
osx-arm64::curl-8.5.0-h2d989ff_0.conda
osx-arm64::openmpi-5.0.0-h2dea082_101.conda
osx-arm64::folly-2023.12.25.00-he914830_0_jemalloc.conda
osx-arm64::root_base-6.30.2-py311h2a25b9c_0.conda
osx-arm64::python-3.11.7-hdf0ec26_0_cpython.conda
osx-arm64::magics-metview-4.14.2-hcfef836_2.conda
osx-arm64::tensorflow-base-2.15.0-cpu_py39ha6a491e_0.conda
osx-arm64::folly-2023.12.18.00-ha98ecff_0.conda
osx-arm64::aws-sdk-cpp-1.11.210-h4d8a066_6.conda
osx-arm64::root_base-6.30.2-py310h44eaee5_0.conda
osx-arm64::libgdal-arrow-parquet-3.8.1-h23f7474_3.conda
osx-arm64::libpq-16.1-h9aca644_6.conda
osx-arm64::libgdal-arrow-parquet-3.8.1-h46ccc67_3.conda
osx-arm64::tiledb-2.18.3-hddc9837_1.conda
osx-arm64::util-linux-2.39.3-py311hfacc263_0.conda
osx-arm64::jaxlib-0.4.23-cpu_py39h9b38f39_0.conda
osx-arm64::bytewax-0.17.2-py312h083d4f6_0.conda
osx-arm64::libgdal-3.7.3-he52aa40_9.conda
osx-arm64::postgresql-15.4-hc6ab77f_3.conda
osx-arm64::folly-2023.12.11.00-hd3f4852_0_jemalloc.conda
osx-arm64::tensorflow-base-2.15.0-cpu_py311he034567_1.conda
osx-arm64::ffmpeg-6.1.0-lgpl_h53f4158_5.conda
osx-arm64::fltk-1.3.9-h31b9a01_0.conda
osx-arm64::gdstk-0.9.48-py312h8ae92b5_0.conda
osx-arm64::libarrow-11.0.0-h1bbcde0_54_cpu.conda
osx-arm64::folly-2023.12.25.00-ha8c0bfd_0.conda
osx-arm64::cppyy-cling-6.30.0-py38h9908e9a_0.conda
osx-arm64::ifcopenshell-v0.7.0.231127-py310_all_h151e4b9_202.conda
osx-arm64::cppyy-cling-6.30.0-py39hd308395_0.conda
osx-arm64::libnghttp2-1.58.0-ha4dd798_1.conda
osx-arm64::libglib-2.78.3-hb438215_0.conda
osx-arm64::imagecodecs-2024.1.1-py312ha527e91_0.conda
osx-arm64::magics-4.15.0-h7fea6e7_0.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-h3690797_13.conda
osx-arm64::bytewax-0.17.2-py311h59c2206_0.conda
osx-arm64::pyreadstat-1.2.6-py38he974862_0.conda
osx-arm64::bytewax-0.17.2-py38h21546c9_0.conda
osx-arm64::libpq-16.1-h9aca644_5.conda
osx-arm64::lxml-4.9.3-py310h62197bd_2.conda
osx-arm64::libcurl-static-8.5.0-h2d989ff_0.conda
osx-arm64::aws-sdk-cpp-1.11.210-h87406ae_5.conda
osx-arm64::folly-2023.12.18.00-he914830_0_jemalloc.conda
osx-arm64::tiledb-2.19.0-hddc9837_0.conda
osx-arm64::sagelib-10.2-py311h20e94d5_0.conda
osx-arm64::util-linux-2.39.3-py312h0145e38_0.conda
osx-arm64::libarchive-minimal-static-3.7.2-hceac444_1.conda
osx-arm64::davix-0.8.4-h2aacde7_3.conda
osx-arm64::yoda-1.9.6-py310h0ae8fc6_6.conda
osx-arm64::postgresql-plpython-16.1-py311h1e905d0_5.conda
osx-arm64::tiledb-2.18.3-hd6a24a2_1.conda
osx-arm64::libgdal-arrow-parquet-3.8.2-h2512d5b_0.conda
osx-arm64::libpulsar-3.4.2-h5e7b4e0_0.conda
osx-arm64::libgdal-arrow-parquet-3.8.1-h1789115_3.conda
osx-arm64::folly-2023.12.11.00-h58b644a_0.conda
osx-arm64::yoda-1.9.6-py38h44db2e8_6.conda
osx-arm64::yoda-1.9.6-py311h1bc52be_6.conda
osx-arm64::libgoogle-cloud-storage-2.17.0-h8a76758_1.conda
osx-arm64::util-linux-2.39.3-py310ha0e7487_1.conda
osx-arm64::qt6-main-6.6.1-h9c79a27_5.conda
osx-arm64::folly-2023.12.11.00-ha5de9cd_0_jemalloc.conda
osx-arm64::pygplates-0.39-py310h6bdae8c_14.conda
osx-arm64::pytng-0.3.1-py310ha5b23ed_1.conda
osx-arm64::libarrow-14.0.1-hff95c9e_7_cpu.conda
osx-arm64::imagecodecs-2024.1.1-py39h60fbabe_0.conda
osx-arm64::openconnect-9.12-hfe36939_1.conda
osx-arm64::imagemagick-7.1.1_25-pl5321h04f3966_0.conda
osx-arm64::postgresql-plpython-16.1-py39ha7448c8_5.conda
osx-arm64::postgresql-plpython-16.1-py38h355cde2_7.conda
osx-arm64::root_base-6.28.10-py38h27b35fb_2.conda
osx-arm64::glib-2.78.3-h9e231a4_0.conda
osx-arm64::mongodb-6.0.12-h7607936_0.conda
osx-arm64::postgresql-plpython-16.1-py312hac41b93_7.conda
osx-arm64::mesalib-23.3.1-h3f84dcd_0.conda
osx-arm64::libgdal-3.7.3-ha878708_12.conda
osx-arm64::postgresql-plpython-16.1-py310h44d1ce9_7.conda
osx-arm64::yoda-1.9.6-py39h1a8b915_6.conda
osx-arm64::gemmi-0.6.4-py38hbed3d3f_0.conda
osx-arm64::libnetcdf-4.9.2-mpi_openmpi_h5534319_13.conda
osx-arm64::libgdal-arrow-parquet-3.8.1-h4a59846_2.conda
osx-arm64::postgresql-plpython-16.1-py311h1e905d0_6.conda
osx-arm64::python-3.8.18-h2469fbe_1_cpython.conda
osx-arm64::libgdal-3.7.3-h4cf78b1_13.conda
osx-arm64::gdstk-0.9.48-py311h4ecd0fe_0.conda
osx-arm64::root_base-6.30.2-py38h27b35fb_0.conda
osx-arm64::xrootd-5.6.2-py38h0ccaf4f_2.conda
osx-arm64::util-linux-2.39.3-py39h019ad03_1.conda
osx-arm64::libarrow-11.0.0-hd1b09a7_55_cpu.conda
osx-arm64::tiledb-2.18.3-hd6a24a2_0.conda
osx-arm64::pyinstaller-6.3.0-py310h742d9d8_0.conda
osx-arm64::libgdal-3.8.1-h6929f36_3.conda
osx-arm64::folly-2023.12.04.00-hb8f665b_0_jemalloc.conda
osx-arm64::libgdal-arrow-parquet-3.8.1-h84bfb32_2.conda
osx-arm64::yoda-1.9.6-py310hfd3a93c_6.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-h6536839_10.conda
osx-arm64::ifcopenshell-v0.7.0.231127-py310_novtk_h1889915_102.conda
osx-arm64::libitk-5.3.0-h5b48add_8.conda
osx-arm64::openslide-3.4.1-ha5580ce_12.conda
osx-arm64::util-linux-2.39.3-py312h71122ab_1.conda
osx-arm64::postgresql-plpython-16.1-py39h93fcee7_2.conda
osx-arm64::pyinstaller-6.3.0-py39h8643609_0.conda
osx-arm64::tiledb-2.18.2-h8237eea_2.conda
osx-arm64::libarrow-14.0.1-hff95c9e_8_cpu.conda
osx-arm64::pytables-3.9.2-py312h9aef7b8_1.conda
osx-arm64::sagelib-10.1-py310h794f6da_0.conda
osx-arm64::postgresql-plpython-16.1-py311h1bbf4d3_7.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-h08f35de_12.conda
osx-arm64::libnetcdf-4.9.2-mpi_mpich_h16ebeae_13.conda
osx-arm64::jaxlib-0.4.23-cpu_py312h46293e5_0.conda
osx-arm64::libgdal-arrow-parquet-3.8.2-h2460107_1.conda
osx-arm64::qt6-main-6.5.3-h9c79a27_1.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-h3c75905_12.conda
osx-arm64::sdl2_image-2.8.0-h5a3017b_0.conda
osx-arm64::libarrow-14.0.1-h26232d2_9_cpu.conda
osx-arm64::pyreadstat-1.2.6-py311h4045465_0.conda
osx-arm64::openssh-9.3p1-hd435d45_3.conda
osx-arm64::jaxlib-0.4.20-cpu_py310h75e2498_0.conda
osx-arm64::tesseract-5.3.2-h8ba8dcc_1.conda
osx-arm64::plplot-5.15.0-h4663e38_3.conda
osx-arm64::yoda-1.9.6-py310hfd3a93c_5.conda
osx-arm64::libgdal-arrow-parquet-3.8.2-h864bd25_1.conda
osx-arm64::libgdal-arrow-parquet-3.8.1-h112f01a_0.conda
osx-arm64::xrootd-5.6.3-py310hbae5087_0.conda
osx-arm64::openslide-4.0.0-ha5580ce_0.conda
osx-arm64::tiledb-2.18.3-h567544c_0.conda
osx-arm64::libgdal-3.8.1-h1ac08d9_2.conda
osx-arm64::pyinstaller-6.3.0-py38he974862_0.conda
osx-arm64::folly-2023.12.18.00-hcdc1028_0_jemalloc.conda
osx-arm64::xrootd-5.6.3-py311h4094d04_0.conda
osx-arm64::papilo-2.1.4-hc54c17b_5.conda
osx-arm64::arrow-cpp-9.0.0-py38had38a9a_50_cpu.conda
osx-arm64::python-igraph-0.11.3-py39h13886a3_1.conda
osx-arm64::postgresql-plpython-15.4-py311h1bbf4d3_4.conda
osx-arm64::tiledb-2.18.2-he0e1ec9_1.conda
osx-arm64::libgdal-arrow-parquet-3.8.1-h54d98e9_1.conda
osx-arm64::util-linux-2.39.3-py311h5768e45_1.conda
osx-arm64::libgdal-arrow-parquet-3.8.1-hb05425c_2.conda
osx-arm64::postgresql-plpython-16.1-py311h1bbf4d3_2.conda
osx-arm64::lxml-4.9.3-py312hae0b87f_3.conda
osx-arm64::geotiff-1.7.1-h7bcba05_15.conda
osx-arm64::libarrow-12.0.1-hd4cc6db_32_cpu.conda
osx-arm64::libgdal-3.8.1-h8e72e65_4.conda
osx-arm64::libglib-2.78.2-hb438215_0.conda
osx-arm64::libpq-15.4-h18bfe24_4.conda
osx-arm64::lxml-4.9.3-py311hdef8331_2.conda
osx-arm64::postgresql-plpython-16.1-py312h9d9d237_7.conda
osx-arm64::sagelib-10.2-py39h7e5f403_0.conda
osx-arm64::python-igraph-0.11.3-py312h01beb3e_1.conda
osx-arm64::openmpi-5.0.0-h2dea082_100.conda
osx-arm64::folly-2023.12.04.00-h58b644a_0.conda
osx-arm64::pyreadstat-1.2.6-py310h742d9d8_0.conda
osx-arm64::libgdal-arrow-parquet-3.8.1-h8b49c50_1.conda
osx-arm64::ifcopenshell-v0.7.0.231127-py39_all_h37844c9_202.conda
osx-arm64::davix-0.8.5-h2aacde7_0.conda
osx-arm64::libgdal-arrow-parquet-3.8.1-h75e746b_0.conda
osx-arm64::vtk-base-9.2.6-qt_py312h1234567_220.conda
osx-arm64::postgresql-16.1-h1d0603d_7.conda
osx-arm64::fish-3.6.3-h15587f7_0.conda
osx-arm64::root_base-6.28.10-py311h2a25b9c_0.conda
osx-arm64::yoda-1.9.6-py39hc7f36f7_6.conda
osx-arm64::hdf5-1.14.3-nompi_h5bb55e9_100.conda
osx-arm64::sagelib-10.0-py310h794f6da_2.conda
osx-arm64::soplex-6.0.4-hd9965d4_5.conda
osx-arm64::symengine-0.11.2-h7e34d76_0.conda
osx-arm64::tiledb-2.19.0-hd6a24a2_0.conda
osx-arm64::openmpi-5.0.1-h2dea082_100.conda
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
================================================================================
================================================================================
linux-ppc64le
linux-ppc64le::micromamba-1.5.6-0.tar.bz2
linux-ppc64le::clang-format-13-13.0.1-root_63002_hc7454ca_5.conda
linux-ppc64le::clang-format-13.0.1-default_he4a137d_4.conda
linux-ppc64le::clang-13-13.0.1-root_62810_ha1fe2de_4.conda
linux-ppc64le::libclang-cpp-13.0.1-root_62810_ha1fe2de_4.conda
linux-ppc64le::libsoup-3.4.4-hf18c1f8_1.conda
linux-ppc64le::clang-13-13.0.1-default_he4a137d_4.conda
linux-ppc64le::libclang-13.0.1-default_he4a137d_4.conda
linux-ppc64le::clang-13-13.0.1-default_he4a137d_5.conda
linux-ppc64le::clang-format-13.0.1-root_62810_ha1fe2de_4.conda
linux-ppc64le::libsoup-2.74.3-hf18c1f8_2.conda
linux-ppc64le::libclang-13.0.1-default_he4a137d_5.conda
linux-ppc64le::micromamba-1.5.5-0.tar.bz2
linux-ppc64le::libclang-cpp-13.0.1-default_he4a137d_4.conda
linux-ppc64le::libclang-cpp13-13.0.1-default_he4a137d_4.conda
linux-ppc64le::libclang-cpp-13.0.1-default_he4a137d_5.conda
linux-ppc64le::libclang-13.0.1-root_62810_ha1fe2de_4.conda
linux-ppc64le::libclang-13.0.1-root_63002_hc7454ca_5.conda
linux-ppc64le::clang-format-13-13.0.1-root_62810_ha1fe2de_4.conda
linux-ppc64le::libclang-cpp13-13.0.1-default_he4a137d_5.conda
linux-ppc64le::libclang-cpp13-13.0.1-root_63002_hc7454ca_5.conda
linux-ppc64le::clang-format-13.0.1-default_he4a137d_5.conda
linux-ppc64le::lld-15.0.7-he9f3fe3_2.conda
linux-ppc64le::clang-13-13.0.1-root_63002_hc7454ca_5.conda
linux-ppc64le::libclang-cpp-13.0.1-root_63002_hc7454ca_5.conda
linux-ppc64le::libclang-cpp13-13.0.1-root_62810_ha1fe2de_4.conda
linux-ppc64le::clang-format-13.0.1-root_63002_hc7454ca_5.conda
linux-ppc64le::clang-format-13-13.0.1-default_he4a137d_5.conda
linux-ppc64le::libdap4-3.20.6-h64463c2_5.conda
linux-ppc64le::glib-tools-2.78.2-hff1ad0c_0.conda
linux-ppc64le::clang-tools-13.0.1-root_63002_hc7454ca_5.conda
linux-ppc64le::clang-tools-13.0.1-default_he4a137d_4.conda
linux-ppc64le::clang-tools-13.0.1-root_62810_ha1fe2de_4.conda
linux-ppc64le::clang-format-13-13.0.1-default_he4a137d_4.conda
linux-ppc64le::glib-tools-2.78.3-hff1ad0c_0.conda
linux-ppc64le::clang-tools-13.0.1-default_he4a137d_5.conda
-    "libzlib >=1.2.13,<1.3.0a0"
+    "libzlib >=1.2.13,<2.0.0a0"
linux-ppc64le::libscotch-7.0.4-h1990940_1.conda
linux-ppc64le::postgresql-plpython-16.1-py310h33ccb9c_7.conda
linux-ppc64le::xrootd-5.6.2-py38h35a9e4e_2.conda
linux-ppc64le::python-igraph-0.11.3-py311h9543305_1.conda
linux-ppc64le::arrow-cpp-9.0.0-py39h19f4155_50_cpu.conda
linux-ppc64le::xrootd-5.6.4-py39hfc0486f_0.conda
linux-ppc64le::openmpi-5.0.0-h7b0d4e8_100.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.2-h5bb32b2_1.conda
linux-ppc64le::root_base-6.28.10-py38h281cc55_2.conda
linux-ppc64le::imagecodecs-2024.1.1-py311ha490864_0.conda
linux-ppc64le::symengine-0.11.2-h93d9feb_0.conda
linux-ppc64le::xrootd-5.6.2-py39hfc0486f_2.conda
linux-ppc64le::folly-2023.12.04.00-hd3a0175_0_jemalloc.conda
linux-ppc64le::pytables-3.9.2-py310h8713445_1.conda
linux-ppc64le::coda-2.25.1-py39hc78dc1f_0.conda
linux-ppc64le::openmpi-5.0.1-h7b0d4e8_100.conda
linux-ppc64le::imagecodecs-2024.1.1-py310h4e42f5a_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-h32ae9d8_12.conda
linux-ppc64le::postgresql-plpython-16.1-py39h55f503e_6.conda
linux-ppc64le::libspatialite-5.1.0-h24f6eda_4.conda
linux-ppc64le::cpp-opentelemetry-sdk-1.13.0-hf777975_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.2-hb59525c_0.conda
linux-ppc64le::pyinstaller-6.3.0-py39hf0cda86_0.conda
linux-ppc64le::postgresql-plpython-16.1-py312hfdea0cd_5.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-hc3ee933_10.conda
linux-ppc64le::libgdal-3.8.1-h7d56667_2.conda
linux-ppc64le::mongodb-6.0.12-h4c8811f_0.conda
linux-ppc64le::libgdal-3.8.2-h06a2fa7_1.conda
linux-ppc64le::clangdev-13.0.1-root_62810_ha1fe2de_4.conda
linux-ppc64le::postgresql-plpython-16.1-py39h55f503e_5.conda
linux-ppc64le::xrootd-5.6.3-py39hcc1fbd3_0.conda
linux-ppc64le::glib-2.78.3-hff1ad0c_0.conda
linux-ppc64le::imagemagick-7.1.1_24-pl5321hb955cb3_0.conda
linux-ppc64le::pyinstaller-6.3.0-py38h36029d9_0.conda
linux-ppc64le::pyinstaller-6.3.0-py310h0719273_0.conda
linux-ppc64le::fish-3.6.4-hc9248e7_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-h60ce854_9.conda
linux-ppc64le::pyreadstat-1.2.6-py311he2df201_0.conda
linux-ppc64le::postgresql-plpython-16.1-py38h3356496_5.conda
linux-ppc64le::gmsh-4.12.0-had2a3fc_0.conda
linux-ppc64le::postgresql-plpython-15.4-py311hba550cb_4.conda
linux-ppc64le::libnetcdf-4.9.2-mpi_openmpi_h10184b0_13.conda
linux-ppc64le::arrow-cpp-9.0.0-py38h765e93b_50_cpu.conda
linux-ppc64le::python-3.11.7-h3332dee_1_cpython.conda
linux-ppc64le::aria2-1.37.0-h86b8492_1.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-h12053a3_9.conda
linux-ppc64le::python-igraph-0.11.3-py39h9ebfad1_1.conda
linux-ppc64le::libyarp-3.9.0-h7ea2182_0.conda
linux-ppc64le::python-igraph-0.11.3-py310hd7dbb72_1.conda
linux-ppc64le::libarrow-12.0.1-h1f675cc_32_cuda.conda
linux-ppc64le::magic-8.3.454-h7eb73fb_0.conda
linux-ppc64le::lxml-4.9.3-py39h9d2759b_2.conda
linux-ppc64le::postgresql-plpython-15.4-py39h8e6b938_4.conda
linux-ppc64le::root_base-6.28.10-py311h510871e_1.conda
linux-ppc64le::root_base-6.30.2-py38h281cc55_0.conda
linux-ppc64le::pygplates-0.39-py311hb2f090a_14.conda
linux-ppc64le::libarrow-14.0.1-h1b60304_8_cpu.conda
linux-ppc64le::root_base-6.30.2-py39haeecd29_1.conda
linux-ppc64le::folly-2023.12.25.00-hfba947f_0.conda
linux-ppc64le::qt-main-5.15.8-hd75f76f_18.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.1-hbcd1924_2.conda
linux-ppc64le::ffmpeg-6.1.0-lgpl_h708cf5a_5.conda
linux-ppc64le::libssh-0.10.6-h4d32c29_1.conda
linux-ppc64le::cppyy-cling-6.30.0-py312hb8a0279_0.conda
linux-ppc64le::r-base-4.2.3-heb61927_11.conda
linux-ppc64le::postgresql-plpython-16.1-py310hcb289b5_5.conda
linux-ppc64le::cppyy-cling-6.30.0-py39h5e0a701_0.conda
linux-ppc64le::pyinstaller-6.3.0-py311h5a86d3c_0.conda
linux-ppc64le::postgresql-plpython-15.4-py312h35a7702_4.conda
linux-ppc64le::python-igraph-0.11.3-py39h8e29b4d_1.conda
linux-ppc64le::root_base-6.28.10-py311h510871e_2.conda
linux-ppc64le::postgresql-plpython-16.1-py312h35a7702_7.conda
linux-ppc64le::libarchive-minimal-static-3.7.2-h009e8c7_1.conda
linux-ppc64le::ffmpeg-6.1.0-gpl_h0dc9605_105.conda
linux-ppc64le::root_base-6.30.2-py310hf6439f8_1.conda
linux-ppc64le::lxml-4.9.3-py39hbb791fb_2.conda
linux-ppc64le::util-linux-2.39.3-py38h5193096_0.conda
linux-ppc64le::folly-2023.12.18.00-h7cedaab_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.2-h6a9dc80_0.conda
linux-ppc64le::tiledb-2.18.3-hf044f0b_0.conda
linux-ppc64le::xrootd-5.6.2-py312h9dfc072_2.conda
linux-ppc64le::tiledb-2.18.2-hf044f0b_2.conda
linux-ppc64le::python-igraph-0.11.3-py312h8100052_1.conda
linux-ppc64le::postgresql-plpython-16.1-py310hcb289b5_6.conda
linux-ppc64le::postgresql-plpython-16.1-py312hfdea0cd_7.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-hbcd1924_10.conda
linux-ppc64le::libgdal-3.8.1-h2a586a6_0.conda
linux-ppc64le::postgresql-plpython-15.4-py39h8e6b938_3.conda
linux-ppc64le::libarrow-14.0.2-hd804686_0_cuda.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.1-ha7c288f_3.conda
linux-ppc64le::libarrow-14.0.1-haf00f0e_8_cuda.conda
linux-ppc64le::postgresql-plpython-16.1-py311hcd20d66_6.conda
linux-ppc64le::vtk-base-9.2.6-qt_py310h1234567_220.conda
linux-ppc64le::openssh-9.3p1-h9d99649_3.conda
linux-ppc64le::openbabel-3.1.1-py38h7d15507_9.conda
linux-ppc64le::postgresql-15.4-h0ebe0f4_4.conda
linux-ppc64le::pyreadstat-1.2.6-py38h2b47b73_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.1-hf2c6ea0_0.conda
linux-ppc64le::pygplates-0.39-py38h292b92d_14.conda
linux-ppc64le::python-3.12.1-h3332dee_0_cpython.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-ha7c288f_11.conda
linux-ppc64le::arrow-cpp-9.0.0-py311h89a3dfd_50_cpu.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.2-h32ae9d8_0.conda
linux-ppc64le::folly-2023.12.11.00-hfba947f_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-hd9eebf9_10.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.1-h8110145_0.conda
linux-ppc64le::libarrow-14.0.1-hd804686_10_cuda.conda
linux-ppc64le::pdal-2.6.2-h4f9464a_2.conda
linux-ppc64le::folly-2023.12.25.00-hd3a0175_0_jemalloc.conda
linux-ppc64le::libarrow-11.0.0-h3c28fe6_54_cpu.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-hd4ce4ff_13.conda
linux-ppc64le::pyreadstat-1.2.6-py310h925d916_0.conda
linux-ppc64le::util-linux-2.39.3-py310h3fcec6a_0.conda
linux-ppc64le::postgresql-plpython-16.1-py311hba550cb_7.conda
linux-ppc64le::openssh-9.6p1-h9d99649_0.conda
linux-ppc64le::folly-2023.12.11.00-h4b663bd_0_jemalloc.conda
linux-ppc64le::gst-plugins-good-1.22.8-h6d5530f_0.conda
linux-ppc64le::arrow-cpp-9.0.0-py39h3b28040_50_cuda.conda
linux-ppc64le::hdf5-1.14.3-nompi_hda2ee07_100.conda
linux-ppc64le::util-linux-2.39.3-py39hb455f50_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.1-h12053a3_1.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.1-h61d915f_1.conda
linux-ppc64le::libarrow-13.0.0-h1f675cc_21_cuda.conda
linux-ppc64le::pytng-0.3.1-py39h955bb5e_1.conda
linux-ppc64le::arrow-cpp-9.0.0-py38h226b594_50_cuda.conda
linux-ppc64le::lld-16.0.6-h37013bd_1.conda
linux-ppc64le::pyinstaller-6.3.0-py312h4032086_0.conda
linux-ppc64le::tiledb-2.18.2-h21d70e8_2.conda
linux-ppc64le::cppyy-cling-6.30.0-py310h02f1291_0.conda
linux-ppc64le::lxml-4.9.3-py311h1860687_2.conda
linux-ppc64le::mesalib-23.3.2-hb6f7a19_0.conda
linux-ppc64le::xrootd-5.6.3-py310hcf74ff6_0.conda
linux-ppc64le::postgresql-plpython-16.1-py38h3356496_6.conda
linux-ppc64le::root_base-6.28.10-py310h78cd517_2.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-hb59525c_12.conda
linux-ppc64le::postgresql-15.4-h0ebe0f4_3.conda
linux-ppc64le::nsight-compute-2023.2.2.3-h7069fa7_0.conda
linux-ppc64le::mesalib-23.3.1-hb6f7a19_0.conda
linux-ppc64le::python-igraph-0.11.3-py38h78b370d_1.conda
linux-ppc64le::libarrow-12.0.1-h3c28fe6_30_cpu.conda
linux-ppc64le::libarrow-12.0.1-hd092d1c_31_cuda.conda
linux-ppc64le::xrootd-5.6.3-py311hcefe779_0.conda
linux-ppc64le::libarrow-11.0.0-hdfdf2d6_56_cpu.conda
linux-ppc64le::lxml-4.9.3-py310h0e28d95_2.conda
linux-ppc64le::lxml-4.9.3-py39h9d2759b_3.conda
linux-ppc64le::folly-2023.12.25.00-hcb6a8eb_0_jemalloc.conda
linux-ppc64le::mapserver-8.0.1-py312h7a2decc_15.conda
linux-ppc64le::root_base-6.30.2-py310h78cd517_0.conda
linux-ppc64le::mapserver-8.0.1-py310hdd1dd9c_14.conda
linux-ppc64le::python-3.8.18-h4005451_1_cpython.conda
linux-ppc64le::clangdev-13.0.1-root_63002_hc7454ca_5.conda
linux-ppc64le::libarrow-13.0.0-hdfdf2d6_21_cpu.conda
linux-ppc64le::tesseract-5.3.2-ha2bda83_2.conda
linux-ppc64le::util-linux-2.39.3-py311h0232d2a_1.conda
linux-ppc64le::r-data.table-1.14.10-r43hb163d15_0.conda
linux-ppc64le::folly-2023.12.04.00-h7cedaab_0.conda
linux-ppc64le::gst-plugins-base-1.22.7-he115d4a_1.conda
linux-ppc64le::libglib-2.78.3-h7505782_0.conda
linux-ppc64le::gmt-5.4.5-h17a2fa4_32.conda
linux-ppc64le::tiledb-2.18.3-h5663ed4_1.conda
linux-ppc64le::pytng-0.3.1-py311had4d743_1.conda
linux-ppc64le::ffmpeg-6.1.1-lgpl_h708cf5a_0.conda
linux-ppc64le::boost-cpp-1.84.0-h1102270_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-h5bb32b2_13.conda
linux-ppc64le::mapserver-8.0.1-py312h897e6ac_14.conda
linux-ppc64le::libglib-2.78.2-h7505782_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-h1411139_10.conda
linux-ppc64le::libarrow-14.0.1-h48a7f54_9_cuda.conda
linux-ppc64le::folly-2023.12.18.00-hcb6a8eb_0_jemalloc.conda
linux-ppc64le::folly-2023.12.25.00-h7cedaab_0.conda
linux-ppc64le::pygplates-0.39-py39h393623d_14.conda
linux-ppc64le::imagemagick-7.1.1_23-pl5321hb955cb3_0.conda
linux-ppc64le::pytng-0.3.1-py312hc34955e_1.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.1-hcdd52e7_3.conda
linux-ppc64le::postgresql-plpython-16.1-py39h8e6b938_7.conda
linux-ppc64le::libpq-15.4-hf8082cb_4.conda
linux-ppc64le::curl-8.5.0-ha571e8f_0.conda
linux-ppc64le::folly-2023.12.18.00-ha2e2e2a_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.1-h6a9dc80_4.conda
linux-ppc64le::pdal-2.6.2-h90c4e59_1.conda
linux-ppc64le::tiledb-2.19.0-hf044f0b_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.1-hd14b39c_1.conda
linux-ppc64le::xrootd-5.6.3-py312h9dfc072_0.conda
linux-ppc64le::folly-2023.12.18.00-hfba947f_0.conda
linux-ppc64le::imagemagick-7.1.1_22-pl5321hb955cb3_0.conda
linux-ppc64le::folly-2023.12.04.00-hfba947f_0.conda
linux-ppc64le::libarrow-14.0.1-hc61255b_10_cpu.conda
linux-ppc64le::root_base-6.30.2-py38hb0900fa_1.conda
linux-ppc64le::libnetcdf-4.9.2-nompi_h4f48a67_113.conda
linux-ppc64le::libarrow-13.0.0-h3c28fe6_19_cpu.conda
linux-ppc64le::tiledb-2.18.2-h35ba0ea_1.conda
linux-ppc64le::libgdal-3.7.3-h3d67b7f_11.conda
linux-ppc64le::libarrow-14.0.1-h1b60304_7_cpu.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.1-hc3ee933_2.conda
linux-ppc64le::pygplates-0.39-py312h861c44d_14.conda
linux-ppc64le::libarrow-14.0.2-hc61255b_0_cpu.conda
linux-ppc64le::pygplates-0.39-py310h07cc1da_14.conda
linux-ppc64le::postgresql-16.1-h33705f9_6.conda
linux-ppc64le::libarrow-11.0.0-h2353a72_54_cuda.conda
linux-ppc64le::vtk-base-9.2.6-qt_py39h1234567_220.conda
linux-ppc64le::postgresql-plpython-15.4-py38he255f0a_4.conda
linux-ppc64le::xrootd-5.6.2-py310hcf74ff6_2.conda
linux-ppc64le::tiledb-2.18.3-hf044f0b_1.conda
linux-ppc64le::folly-2023.12.04.00-hcb6a8eb_0_jemalloc.conda
linux-ppc64le::gmsh-4.12.0-h01679bf_0.conda
linux-ppc64le::folly-2023.12.18.00-hd3a0175_0_jemalloc.conda
linux-ppc64le::tesseract-5.3.3-ha2bda83_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-hc7eafb2_12.conda
linux-ppc64le::openmpi-5.0.0-h7b0d4e8_101.conda
linux-ppc64le::root_base-6.30.2-py311h510871e_0.conda
linux-ppc64le::imagecodecs-2024.1.1-py312h6d761cf_0.conda
linux-ppc64le::libarrow-12.0.1-hdfdf2d6_32_cpu.conda
linux-ppc64le::ffmpeg-6.1.1-gpl_h0dc9605_100.conda
linux-ppc64le::arrow-cpp-9.0.0-py310h3601874_50_cpu.conda
linux-ppc64le::pyreadstat-1.2.6-py39h27550c1_0.conda
linux-ppc64le::folly-2023.12.25.00-ha2e2e2a_0.conda
linux-ppc64le::tiledb-2.18.2-h4980507_1.conda
linux-ppc64le::libarrow-12.0.1-h2353a72_30_cuda.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.1-h60ce854_1.conda
linux-ppc64le::libgoogle-cloud-storage-2.17.0-h39cc67c_0.conda
linux-ppc64le::postgresql-plpython-16.1-py311hcd20d66_7.conda
linux-ppc64le::postgresql-plpython-16.1-py39h55f503e_7.conda
linux-ppc64le::openslide-4.0.0-hddfbc1c_1.conda
linux-ppc64le::postgresql-plpython-15.4-py310h33ccb9c_3.conda
linux-ppc64le::libpq-16.1-h29a043a_6.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-h61d915f_9.conda
linux-ppc64le::libcurl-static-8.5.0-ha571e8f_0.conda
linux-ppc64le::postgresql-plpython-15.4-py310h33ccb9c_4.conda
linux-ppc64le::pdal-2.6.2-hb815776_0.conda
linux-ppc64le::root_base-6.28.10-py39h5f7ea32_1.conda
linux-ppc64le::cppyy-cling-6.30.0-py311hc2b5b1e_0.conda
linux-ppc64le::gst-plugins-base-1.22.8-he115d4a_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.1-h841bb50_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-h7fc0403_13.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-hce6b20d_13.conda
linux-ppc64le::xrootd-5.6.4-py311hcefe779_0.conda
linux-ppc64le::fish-3.6.3-hc9248e7_0.conda
linux-ppc64le::postgresql-plpython-15.4-py312h35a7702_3.conda
linux-ppc64le::gst-plugins-bad-1.22.7-he7ba993_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.1-h06f0423_3.conda
linux-ppc64le::mapserver-8.0.1-py39h08935ea_15.conda
linux-ppc64le::coda-2.25.1-py38he254095_0.conda
linux-ppc64le::pdal-2.6.1-hb815776_1.conda
linux-ppc64le::root_base-6.30.2-py39h5f7ea32_0.conda
linux-ppc64le::libarrow-11.0.0-h1f675cc_56_cuda.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-h0784e75_11.conda
linux-ppc64le::cppyy-cling-6.30.0-py38hbab3742_0.conda
linux-ppc64le::postgresql-plpython-16.1-py38h3356496_7.conda
linux-ppc64le::libvips-8.15.0-h072ee83_4.conda
linux-ppc64le::libarrow-14.0.1-haf00f0e_7_cuda.conda
linux-ppc64le::python-3.12.1-h3332dee_1_cpython.conda
linux-ppc64le::libgdal-3.8.1-hf6a543e_1.conda
linux-ppc64le::qtkeychain-0.14.2-h8d0edd8_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.2-hc7eafb2_0.conda
linux-ppc64le::folly-2023.12.25.00-h4b663bd_0_jemalloc.conda
linux-ppc64le::imagemagick-7.1.1_21-pl5321hb955cb3_2.conda
linux-ppc64le::libpq-16.1-h29a043a_5.conda
linux-ppc64le::libnghttp2-1.58.0-hc4d0b0b_1.conda
linux-ppc64le::xrootd-5.6.2-py311hcefe779_2.conda
linux-ppc64le::arrow-cpp-9.0.0-py311h40ffbac_50_cuda.conda
linux-ppc64le::util-linux-2.39.3-py39hf65199f_1.conda
linux-ppc64le::coda-2.25.1-py39h7349751_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.1-hc7eafb2_4.conda
linux-ppc64le::libarrow-14.0.1-hcf6d88f_9_cpu.conda
linux-ppc64le::xrootd-5.6.3-py39hfc0486f_0.conda
linux-ppc64le::cmake-3.28.1-h1403f77_0.conda
linux-ppc64le::libgdal-3.8.1-h7716807_3.conda
linux-ppc64le::davix-0.8.4-hd468006_3.conda
linux-ppc64le::python-3.11.7-h3332dee_0_cpython.conda
linux-ppc64le::lxml-4.9.3-py312h3409d76_2.conda
linux-ppc64le::libvips-8.15.1-h072ee83_0.conda
linux-ppc64le::tiledb-2.19.0-h5663ed4_0.conda
linux-ppc64le::libgdal-3.7.3-hc024264_10.conda
linux-ppc64le::magic-8.3.453-h7eb73fb_0.conda
linux-ppc64le::openmpi-5.0.0-h7b0d4e8_102.conda
linux-ppc64le::rust-1.74.1-hb12b0c0_0.conda
linux-ppc64le::tesseract-5.3.2-he97ccac_1.conda
linux-ppc64le::texlive-core-20230313-hc3d8017_9.conda
linux-ppc64le::libgdal-3.7.3-h21583f4_9.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-h6a9dc80_12.conda
linux-ppc64le::util-linux-2.39.3-py38h5193096_1.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.1-h8a764d3_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-hd14b39c_9.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-hcdd52e7_11.conda
linux-ppc64le::libgdal-3.8.2-hd1431ef_0.conda
linux-ppc64le::postgresql-16.1-h33705f9_5.conda
linux-ppc64le::tiledb-2.18.3-h21d70e8_1.conda
linux-ppc64le::root_base-6.30.2-py311h47f76dc_1.conda
linux-ppc64le::postgresql-plpython-16.1-py311hcd20d66_5.conda
linux-ppc64le::pytables-3.9.2-py312h7d75ae7_1.conda
linux-ppc64le::gmt-6.4.0-hdfbe41d_17.conda
linux-ppc64le::pytables-3.9.2-py39h6b88dcf_1.conda
linux-ppc64le::openslide-4.0.0-hddfbc1c_0.conda
linux-ppc64le::libgdal-3.7.3-h5ce396f_13.conda
linux-ppc64le::libssh-0.10.6-h192fc5f_0.conda
linux-ppc64le::ffmpeg-6.1.0-lgpl_he921317_4.conda
linux-ppc64le::eccodes-2.33.0-hfb67fc0_0.conda
linux-ppc64le::nss-3.96-h4237796_0.conda
linux-ppc64le::lxml-4.9.3-py311h1860687_3.conda
linux-ppc64le::xrootd-5.6.2-py39hcc1fbd3_2.conda
linux-ppc64le::folly-2023.12.04.00-h4b663bd_0_jemalloc.conda
linux-ppc64le::root_base-6.28.10-py39h5f7ea32_2.conda
linux-ppc64le::folly-2023.12.11.00-hd3a0175_0_jemalloc.conda
linux-ppc64le::minizip-4.0.4-ha7cce9c_0.conda
linux-ppc64le::sdl2_image-2.8.0-h2fc395b_0.conda
linux-ppc64le::lxml-4.9.3-py38h12de51e_2.conda
linux-ppc64le::libarchive-3.7.2-h5c6de3b_1.conda
linux-ppc64le::plplot-5.15.0-h87f32d5_3.conda
linux-ppc64le::libgdal-3.7.3-hd50b4b1_12.conda
linux-ppc64le::cmake-3.28.0-h1403f77_0.conda
linux-ppc64le::postgresql-plpython-16.1-py310hcb289b5_7.conda
linux-ppc64le::pytables-3.9.2-py39h22b7ba6_1.conda
linux-ppc64le::clangdev-13.0.1-default_he4a137d_4.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.1-h0784e75_3.conda
linux-ppc64le::libarrow-11.0.0-h1572511_55_cpu.conda
linux-ppc64le::tiledb-2.18.2-h7dcfde5_1.conda
linux-ppc64le::xrootd-5.6.4-py39hcc1fbd3_0.conda
linux-ppc64le::nsight-compute-2023.1.1.4-h7069fa7_0.conda
linux-ppc64le::root_base-6.28.10-py310h78cd517_1.conda
linux-ppc64le::util-linux-2.39.3-py39hf65199f_0.conda
linux-ppc64le::arrow-cpp-9.0.0-py310h9588d4c_50_cuda.conda
linux-ppc64le::libnghttp2-static-1.58.0-had385bd_1.conda
linux-ppc64le::hdf5-1.14.3-mpi_mpich_h4d8530d_0.conda
linux-ppc64le::aws-sdk-cpp-1.11.210-h2a7e5cb_5.conda
linux-ppc64le::lxml-4.9.3-py310h0e28d95_3.conda
linux-ppc64le::imagecodecs-2024.1.1-py39h9b660ee_0.conda
linux-ppc64le::folly-2023.12.11.00-ha2e2e2a_0.conda
linux-ppc64le::folly-2023.12.11.00-hcb6a8eb_0_jemalloc.conda
linux-ppc64le::davix-0.8.5-hd468006_0.conda
linux-ppc64le::mapserver-8.0.1-py310hd847014_15.conda
linux-ppc64le::vtk-base-9.2.6-qt_py38h1234567_220.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.1-hd9eebf9_2.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.1-h32ae9d8_4.conda
linux-ppc64le::mapserver-8.0.1-py311h7d49f79_14.conda
linux-ppc64le::libarrow-13.0.0-h2353a72_19_cuda.conda
linux-ppc64le::mapserver-8.0.1-py311h80e6485_15.conda
linux-ppc64le::libarrow-13.0.0-hd092d1c_20_cuda.conda
linux-ppc64le::xrootd-5.6.4-py310hcf74ff6_0.conda
linux-ppc64le::cargo-c-0.9.29-hd6e3413_0.conda
linux-ppc64le::xrootd-5.6.3-py38h35a9e4e_0.conda
linux-ppc64le::aws-sdk-cpp-1.11.210-h2a3ae50_6.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-h06f0423_11.conda
linux-ppc64le::poppler-23.12.0-h433edb4_0.conda
linux-ppc64le::ruby-3.2.2-h9fca59a_1.conda
linux-ppc64le::tiledb-2.18.3-h5663ed4_0.conda
linux-ppc64le::libgdal-3.8.1-hd1431ef_4.conda
linux-ppc64le::lxml-4.9.3-py38h12de51e_3.conda
linux-ppc64le::gst-plugins-good-1.22.7-h6d5530f_1.conda
linux-ppc64le::libpq-15.4-h9d99649_3.conda
linux-ppc64le::python-3.10.13-h4005451_1_cpython.conda
linux-ppc64le::libarrow-13.0.0-h1572511_20_cpu.conda
linux-ppc64le::postgresql-plpython-16.1-py312hfdea0cd_6.conda
linux-ppc64le::folly-2023.12.18.00-h4b663bd_0_jemalloc.conda
linux-ppc64le::lxml-4.9.3-py312h3409d76_3.conda
linux-ppc64le::tiledb-2.19.0-h21d70e8_0.conda
linux-ppc64le::util-linux-2.39.3-py39hb455f50_1.conda
linux-ppc64le::libxml2-2.12.2-h0545f4b_0.conda
linux-ppc64le::lxml-4.9.3-py39hbb791fb_3.conda
linux-ppc64le::imagemagick-7.1.1_25-pl5321hb955cb3_0.conda
linux-ppc64le::glib-2.78.2-hff1ad0c_0.conda
linux-ppc64le::postgresql-16.1-h33705f9_7.conda
linux-ppc64le::postgresql-plpython-15.4-py311hba550cb_3.conda
linux-ppc64le::hamlib-tcl-4.5.5-hd4bbf49_3.conda
linux-ppc64le::xrootd-5.6.4-py312h9dfc072_0.conda
linux-ppc64le::clangdev-13.0.1-default_he4a137d_5.conda
linux-ppc64le::xrootd-5.6.4-py38h35a9e4e_0.conda
linux-ppc64le::openbabel-3.1.1-py311h866e524_9.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.1-h1411139_2.conda
linux-ppc64le::geotiff-1.7.1-he61559f_15.conda
linux-ppc64le::pyreadstat-1.2.6-py312ha5a3bab_0.conda
linux-ppc64le::aws-sdk-cpp-1.11.210-hfa87d10_4.conda
linux-ppc64le::libxml2-2.12.3-h0545f4b_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.1-hb59525c_4.conda
linux-ppc64le::libxmlsec1-1.3.2-h9f8f588_1.conda
linux-ppc64le::libarrow-11.0.0-hd092d1c_55_cuda.conda
linux-ppc64le::libopentelemetry-cpp-1.13.0-hf777975_0.conda
linux-ppc64le::util-linux-2.39.3-py312hbe3015e_0.conda
linux-ppc64le::mapserver-8.0.1-py38h959d206_14.conda
linux-ppc64le::util-linux-2.39.3-py311h0232d2a_0.conda
linux-ppc64le::hdf5-1.14.3-mpi_openmpi_hf8c4a79_0.conda
linux-ppc64le::util-linux-2.39.3-py312hbe3015e_1.conda
linux-ppc64le::vtk-base-9.2.6-qt_py312h1234567_220.conda
linux-ppc64le::fltk-1.3.9-h92e44d1_0.conda
linux-ppc64le::root_base-6.28.10-py38h281cc55_1.conda
linux-ppc64le::postgresql-plpython-15.4-py38he255f0a_3.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.2-h7fc0403_1.conda
linux-ppc64le::coda-2.25.1-py310hfd510e7_0.conda
linux-ppc64le::r-data.table-1.14.10-r42hb163d15_0.conda
linux-ppc64le::libarrow-12.0.1-h1572511_31_cpu.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.2-hce6b20d_1.conda
linux-ppc64le::folly-2023.12.04.00-ha2e2e2a_0.conda
linux-ppc64le::pytables-3.9.2-py311h3f57c28_1.conda
linux-ppc64le::postgresql-16.1-h0ebe0f4_7.conda
linux-ppc64le::openslide-3.4.1-hddfbc1c_12.conda
linux-ppc64le::mapserver-8.0.1-py39h9196367_14.conda
linux-ppc64le::libpulsar-3.4.2-h8c92dcd_0.conda
linux-ppc64le::folly-2023.12.11.00-h7cedaab_0.conda
linux-ppc64le::ffmpeg-6.1.0-gpl_hb4da8e3_104.conda
linux-ppc64le::postgresql-plpython-16.1-py38he255f0a_7.conda
linux-ppc64le::libcurl-8.5.0-ha571e8f_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.2-hd4ce4ff_1.conda
linux-ppc64le::vtk-base-9.2.6-qt_py311h1234567_220.conda
linux-ppc64le::python-3.9.18-h7512f2e_1_cpython.conda
linux-ppc64le::libscotch-7.0.4-hcd3a5a8_1.conda
linux-ppc64le::mapserver-8.0.1-py38hd3530ef_15.conda
linux-ppc64le::tiledb-2.18.3-h21d70e8_0.conda
linux-ppc64le::pytng-0.3.1-py310haa3ec93_1.conda
linux-ppc64le::libboost-1.84.0-hfdd0173_0.conda
linux-ppc64le::libnetcdf-4.9.2-mpi_mpich_h7bc9b9b_13.conda
linux-ppc64le::tiledb-2.18.2-h5663ed4_2.conda
linux-ppc64le::imagecodecs-2024.1.1-py39h074409c_0.conda
linux-ppc64le::util-linux-2.39.3-py310h3fcec6a_1.conda
linux-ppc64le::coda-2.25.1-py311h8a84315_0.conda
linux-ppc64le::libgoogle-cloud-storage-2.17.0-h39cc67c_1.conda
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
================================================================================
================================================================================
linux-aarch64
linux-aarch64::dotnet-sdk-7.0.404-h9e6cf05_0.conda
linux-aarch64::libclang-13.0.1-default_hdf9a116_4.conda
linux-aarch64::clang-13-13.0.1-root_62810_h5d2118a_4.conda
linux-aarch64::micromamba-1.5.6-0.tar.bz2
linux-aarch64::libclang-cpp13-13.0.1-default_hdf9a116_4.conda
linux-aarch64::clang-format-13-13.0.1-root_63002_hd3e142c_5.conda
linux-aarch64::clang-tools-13.0.1-root_62810_h5d2118a_4.conda
linux-aarch64::clang-13-13.0.1-default_hdf9a116_4.conda
linux-aarch64::clang-format-13-13.0.1-default_hdf9a116_4.conda
linux-aarch64::libclang-13.0.1-root_62810_h5d2118a_4.conda
linux-aarch64::libclang-13.0.1-default_hdf9a116_5.conda
linux-aarch64::clang-format-13-13.0.1-root_62810_h5d2118a_4.conda
linux-aarch64::libclang-cpp13-13.0.1-root_63002_hd3e142c_5.conda
linux-aarch64::dotnet-sdk-6.0.417-h9e6cf05_0.conda
linux-aarch64::libclang-cpp13-13.0.1-root_62810_h5d2118a_4.conda
linux-aarch64::clang-13-13.0.1-default_hdf9a116_5.conda
linux-aarch64::libclang-13.0.1-root_63002_hd3e142c_5.conda
linux-aarch64::clang-format-13.0.1-root_63002_hd3e142c_5.conda
linux-aarch64::libclang-cpp-13.0.1-default_hdf9a116_4.conda
linux-aarch64::clang-format-13.0.1-root_62810_h5d2118a_4.conda
linux-aarch64::dotnet-runtime-7.0.14-h9e6cf05_0.conda
linux-aarch64::libsoup-2.74.3-hb0eb4cf_2.conda
linux-aarch64::clang-format-13-13.0.1-default_hdf9a116_5.conda
linux-aarch64::dotnet-runtime-6.0.25-h9e6cf05_0.conda
linux-aarch64::libsoup-3.4.4-hb0eb4cf_1.conda
linux-aarch64::libclang-cpp13-13.0.1-default_hdf9a116_5.conda
linux-aarch64::clang-tools-13.0.1-default_hdf9a116_5.conda
linux-aarch64::micromamba-1.5.5-0.tar.bz2
linux-aarch64::dotnet-aspnetcore-6.0.25-h9e6cf05_0.conda
linux-aarch64::clang-format-13.0.1-default_hdf9a116_5.conda
linux-aarch64::dotnet-aspnetcore-7.0.14-h9e6cf05_0.conda
linux-aarch64::libclang-cpp-13.0.1-root_62810_h5d2118a_4.conda
linux-aarch64::clang-format-13.0.1-default_hdf9a116_4.conda
linux-aarch64::glib-tools-2.78.3-hd84c7bf_0.conda
linux-aarch64::libclang-cpp-13.0.1-root_63002_hd3e142c_5.conda
linux-aarch64::eccodes-2.33.0-hb180dc1_0.conda
linux-aarch64::clang-tools-13.0.1-root_63002_hd3e142c_5.conda
linux-aarch64::clang-tools-13.0.1-default_hdf9a116_4.conda
linux-aarch64::libdap4-3.20.6-h0e87e92_5.conda
linux-aarch64::clang-13-13.0.1-root_63002_hd3e142c_5.conda
linux-aarch64::glib-tools-2.78.2-hd84c7bf_0.conda
linux-aarch64::lld-15.0.7-h54a4ff4_2.conda
linux-aarch64::libclang-cpp-13.0.1-default_hdf9a116_5.conda
-    "libzlib >=1.2.13,<1.3.0a0"
+    "libzlib >=1.2.13,<2.0.0a0"
linux-aarch64::tiledb-2.19.0-h1c5dee0_0.conda
linux-aarch64::sagelib-10.0-py39h29ad0c2_2.conda
linux-aarch64::imagemagick-7.1.1_21-pl5321h64d673c_2.conda
linux-aarch64::pyreadstat-1.2.6-py310h3516908_0.conda
linux-aarch64::libgdal-arrow-parquet-3.8.2-h9e0640f_0.conda
linux-aarch64::sdl2_image-2.8.0-h4267f4e_0.conda
linux-aarch64::folly-2023.12.18.00-h8dd4a7f_0_jemalloc.conda
linux-aarch64::libarrow-14.0.1-h1da9e53_9_cuda.conda
linux-aarch64::libgdal-3.8.1-hd4c587d_2.conda
linux-aarch64::postgresql-plpython-15.4-py312h75118c5_4.conda
linux-aarch64::cppyy-cling-6.30.0-py311hfd6ae59_0.conda
linux-aarch64::util-linux-2.39.3-py312h5ae9330_1.conda
linux-aarch64::openssh-9.6p1-h04b8c23_0.conda
linux-aarch64::python-3.10.13-hbbe8eec_1_cpython.conda
linux-aarch64::yoda-1.9.6-py39h602887e_5.conda
linux-aarch64::pyreadstat-1.2.6-py39hfca9663_0.conda
linux-aarch64::nss-3.96-hc5a5cc2_0.conda
linux-aarch64::libgdal-arrow-parquet-3.8.1-hfa229ce_0.conda
linux-aarch64::folly-2023.12.04.00-hb8ddcfe_0_jemalloc.conda
linux-aarch64::util-linux-2.39.3-py38h24c6ab1_0.conda
linux-aarch64::magic-8.3.453-h4e13689_0.conda
linux-aarch64::sagelib-10.0-py38hdcb3410_2.conda
linux-aarch64::libgdal-arrow-parquet-3.8.2-h24ea3e1_1.conda
linux-aarch64::python-3.12.1-h43d1f9e_0_cpython.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-h4317b21_11.conda
linux-aarch64::folly-2023.12.04.00-hcbc1ef6_0.conda
linux-aarch64::libxml2-2.12.2-h3091e33_0.conda
linux-aarch64::libarrow-14.0.1-h9b6b63f_8_cuda.conda
linux-aarch64::minizip-4.0.4-hb75dd74_0.conda
linux-aarch64::folly-2023.12.11.00-h8dd4a7f_0_jemalloc.conda
linux-aarch64::sagelib-10.1-py311h0f5560f_0.conda
linux-aarch64::ifcopenshell-v0.7.0.231127-py311_novtk_h82ab94b_102.conda
linux-aarch64::lldb-17.0.2-py39hc7031eb_0.conda
linux-aarch64::folly-2023.12.04.00-h8a1e4c1_0_jemalloc.conda
linux-aarch64::aws-sdk-cpp-1.11.210-h72419e1_4.conda
linux-aarch64::xrootd-5.6.4-py38h41211b1_0.conda
linux-aarch64::openbabel-3.1.1-py310h79f7050_9.conda
linux-aarch64::libarrow-14.0.1-h14be87f_10_cpu.conda
linux-aarch64::ffmpeg-6.1.1-lgpl_hffc26ca_0.conda
linux-aarch64::libarrow-14.0.1-h0991cb5_7_cpu.conda
linux-aarch64::imagecodecs-2024.1.1-py310h6d6f36f_0.conda
linux-aarch64::openmpi-5.0.1-hf462296_100.conda
linux-aarch64::libnetcdf-4.9.2-mpi_mpich_h19b429f_13.conda
linux-aarch64::mapserver-8.0.1-py311h1eb6d1a_14.conda
linux-aarch64::libopentelemetry-cpp-1.13.0-h4f4f98c_0.conda
linux-aarch64::libgdal-arrow-parquet-3.8.1-h4317b21_3.conda
linux-aarch64::qt6-main-6.6.1-hb1ad137_3.conda
linux-aarch64::libarrow-13.0.0-hcd49607_19_cpu.conda
linux-aarch64::xrootd-5.6.2-py38h41211b1_2.conda
linux-aarch64::postgresql-plpython-16.1-py38hc50c26b_7.conda
linux-aarch64::tiledb-2.18.3-h08a2283_0.conda
linux-aarch64::postgresql-plpython-15.4-py38hf7f31c5_4.conda
linux-aarch64::tiledb-2.18.2-h08a2283_2.conda
linux-aarch64::root_base-6.30.2-py310he64ee90_1.conda
linux-aarch64::libglib-2.78.2-h311d5f7_0.conda
linux-aarch64::pytng-0.3.1-py310hf2d9793_1.conda
linux-aarch64::postgresql-plpython-15.4-py311hc2b6b49_4.conda
linux-aarch64::libgdal-arrow-parquet-3.8.1-h7487d97_0.conda
linux-aarch64::arrow-cpp-9.0.0-py38h909599d_50_cuda.conda
linux-aarch64::libarrow-13.0.0-h9c500e0_21_cuda.conda
linux-aarch64::coda-2.25.1-py39h252d492_0.conda
linux-aarch64::root_base-6.28.10-py39h5194cdf_2.conda
linux-aarch64::imagecodecs-2024.1.1-py312h8297c15_0.conda
linux-aarch64::ffmpeg-6.1.0-gpl_h660669b_104.conda
linux-aarch64::pyinstaller-6.3.0-py38h37f3631_0.conda
linux-aarch64::lldb-17.0.2-py38h46cc842_0.conda
linux-aarch64::postgresql-plpython-16.1-py312h75118c5_7.conda
linux-aarch64::ifcopenshell-v0.7.0.231127-py39_novtk_h9d80cc5_102.conda
linux-aarch64::aws-sdk-cpp-1.11.210-hf63831a_5.conda
linux-aarch64::libarrow-11.0.0-h8c78540_56_cpu.conda
linux-aarch64::lldb-17.0.6-py310hafd98b1_0.conda
linux-aarch64::libnetcdf-4.9.2-mpi_openmpi_h6c5cf93_13.conda
linux-aarch64::mapserver-8.0.1-py310h0d0fd0e_14.conda
linux-aarch64::libgdal-arrow-parquet-3.8.2-h6a3876c_0.conda
linux-aarch64::postgresql-plpython-16.1-py39he33817a_7.conda
linux-aarch64::root_base-6.28.10-py311hcfb60d3_1.conda
linux-aarch64::lxml-4.9.3-py312h107a964_2.conda
linux-aarch64::folly-2023.12.25.00-h8a1e4c1_0_jemalloc.conda
linux-aarch64::curl-8.5.0-h4e8248e_0.conda
linux-aarch64::tesseract-5.3.3-h038deca_0.conda
linux-aarch64::pygplates-0.39-py38hcff6026_14.conda
linux-aarch64::cmake-3.28.0-hef020d8_0.conda
linux-aarch64::libarrow-13.0.0-h66536d9_18_cpu.conda
linux-aarch64::libgdal-arrow-parquet-3.8.1-h9e0640f_4.conda
linux-aarch64::yoda-1.9.6-py38h861c9fe_5.conda
linux-aarch64::libnghttp2-static-1.58.0-heb3f89f_1.conda
linux-aarch64::postgresql-plpython-16.1-py38hf7f31c5_7.conda
linux-aarch64::libgdal-arrow-parquet-3.8.1-hd786a78_3.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-h9e0640f_12.conda
linux-aarch64::libpq-15.4-h54bb95e_4.conda
linux-aarch64::util-linux-2.39.3-py311h7022ece_1.conda
linux-aarch64::openbabel-3.1.1-py312h7d6d27c_9.conda
linux-aarch64::libscotch-7.0.4-h8312190_1.conda
linux-aarch64::sagelib-10.2-py310ha9e3067_1.conda
linux-aarch64::folly-2023.12.11.00-hcdf9fb0_0.conda
linux-aarch64::libgdal-3.8.1-hfff0ee8_3.conda
linux-aarch64::libarrow-11.0.0-h3379d91_55_cuda.conda
linux-aarch64::util-linux-2.39.3-py39h493218e_0.conda
linux-aarch64::libgdal-3.8.2-h2da9cb4_1.conda
linux-aarch64::ifcopenshell-v0.7.0.231127-py310_all_hc5c3fae_202.conda
linux-aarch64::libarrow-14.0.1-h0991cb5_8_cpu.conda
linux-aarch64::mapserver-8.0.1-py310hcb0af28_15.conda
linux-aarch64::postgresql-plpython-16.1-py311h765025c_5.conda
linux-aarch64::lxml-4.9.3-py311h40dcbb3_3.conda
linux-aarch64::postgresql-plpython-16.1-py310h5ecf261_7.conda
linux-aarch64::python-igraph-0.11.3-py39hcfa1bd1_1.conda
linux-aarch64::libnghttp2-1.58.0-hb0e430d_1.conda
linux-aarch64::libxml2-2.12.3-h3091e33_0.conda
linux-aarch64::libgdal-arrow-parquet-3.8.1-ha00dc3f_2.conda
linux-aarch64::postgresql-plpython-16.1-py39hadb01dc_6.conda
linux-aarch64::folly-2023.12.11.00-h8a1e4c1_0_jemalloc.conda
linux-aarch64::folly-2023.12.11.00-hcbc1ef6_0.conda
linux-aarch64::pytables-3.9.2-py312h23391e5_1.conda
linux-aarch64::pygplates-0.39-py310hbf78999_14.conda
linux-aarch64::libarrow-13.0.0-h3379d91_20_cuda.conda
linux-aarch64::libarrow-11.0.0-h9c500e0_56_cuda.conda
linux-aarch64::postgresql-plpython-15.4-py39he33817a_3.conda
linux-aarch64::yoda-1.9.6-py310hb987c42_5.conda
linux-aarch64::pytng-0.3.1-py312h806dff4_1.conda
linux-aarch64::libgdal-arrow-parquet-3.8.2-he53a0e1_1.conda
linux-aarch64::openslide-3.4.1-h8d5e3c6_12.conda
linux-aarch64::lxml-4.9.3-py39h4de4ef8_3.conda
linux-aarch64::postgresql-plpython-16.1-py312hc43be6c_7.conda
linux-aarch64::fish-3.6.4-hc0a5165_0.conda
linux-aarch64::xrootd-5.6.2-py39hc2520fa_2.conda
linux-aarch64::folly-2023.12.11.00-hf875f9a_0.conda
linux-aarch64::jaxlib-0.4.23-cpu_py311h86dff27_0.conda
linux-aarch64::imagecodecs-2024.1.1-py39h0c86555_0.conda
linux-aarch64::imagemagick-7.1.1_23-pl5321h64d673c_0.conda
linux-aarch64::tiledb-2.19.0-hf5e255a_0.conda
linux-aarch64::mapserver-8.0.1-py312hd0ad4ef_15.conda
linux-aarch64::libgdal-arrow-parquet-3.8.1-h211257a_3.conda
linux-aarch64::libgdal-arrow-parquet-3.8.1-h302f912_2.conda
linux-aarch64::plplot-5.15.0-hd1394c8_3.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-h211257a_11.conda
linux-aarch64::vtk-base-9.2.6-qt_py38h1234567_220.conda
linux-aarch64::clangdev-13.0.1-default_hdf9a116_5.conda
linux-aarch64::xrootd-5.6.4-py39h9f09aee_0.conda
linux-aarch64::sagelib-10.1-py39h29ad0c2_0.conda
linux-aarch64::rust-1.74.1-h9d3d833_0.conda
linux-aarch64::util-linux-2.39.3-py38h24c6ab1_1.conda
linux-aarch64::coda-2.25.1-py38hd131ec7_0.conda
linux-aarch64::postgresql-plpython-16.1-py39hadb01dc_7.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-hd39519c_13.conda
linux-aarch64::libarrow-11.0.0-h84bdd85_55_cpu.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-h345faf7_9.conda
linux-aarch64::python-3.11.7-h43d1f9e_0_cpython.conda
linux-aarch64::root_base-6.28.10-py310h4cd8249_2.conda
linux-aarch64::cppyy-cling-6.30.0-py38h68f7483_0.conda
linux-aarch64::vtk-base-9.2.6-qt_py310h1234567_220.conda
linux-aarch64::libgdal-arrow-parquet-3.8.2-hff4de9e_0.conda
linux-aarch64::gmsh-4.12.0-ha60554b_0.conda
linux-aarch64::libarrow-13.0.0-h8c78540_21_cpu.conda
linux-aarch64::xrootd-5.6.2-py39h9f09aee_2.conda
linux-aarch64::tiledb-2.18.2-h150642c_1.conda
linux-aarch64::lldb-17.0.6-py39hdad441a_0.conda
linux-aarch64::libcurl-static-8.5.0-h4e8248e_0.conda
linux-aarch64::libgdal-arrow-parquet-3.8.1-h30beca3_0.conda
linux-aarch64::libgdal-arrow-parquet-3.8.2-h4b7346d_1.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-ha00dc3f_10.conda
linux-aarch64::libgoogle-cloud-storage-2.17.0-hdb39181_0.conda
linux-aarch64::postgresql-plpython-16.1-py39hadb01dc_5.conda
linux-aarch64::pytables-3.9.2-py39h6cd1a68_1.conda
linux-aarch64::pygplates-0.39-py312h5ac1326_14.conda
linux-aarch64::sagelib-10.2-py310hfbc6516_0.conda
linux-aarch64::postgresql-16.1-he703394_5.conda
linux-aarch64::qtkeychain-0.14.2-h54d81ea_0.conda
linux-aarch64::postgresql-plpython-15.4-py39he33817a_4.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-he53a0e1_13.conda
linux-aarch64::python-igraph-0.11.3-py312h9d74a5d_1.conda
linux-aarch64::openmpi-5.0.0-hf462296_101.conda
linux-aarch64::sagelib-10.0-py310hfbc6516_2.conda
linux-aarch64::lldb-17.0.2-py311h8caf9c2_0.conda
linux-aarch64::gmt-6.4.0-h473a982_17.conda
linux-aarch64::libgdal-3.7.3-h47daa1e_10.conda
linux-aarch64::python-3.8.18-hbbe8eec_1_cpython.conda
linux-aarch64::libarrow-12.0.1-h3dfa4f1_30_cuda.conda
linux-aarch64::tiledb-2.18.3-h1c5dee0_1.conda
linux-aarch64::util-linux-2.39.3-py39hb670eeb_1.conda
linux-aarch64::lxml-4.9.3-py39h03c8186_3.conda
linux-aarch64::libgdal-arrow-parquet-3.8.1-h386d13d_0.conda
linux-aarch64::libarrow-14.0.2-h0230412_0_cuda.conda
linux-aarch64::sagelib-10.2-py311h0f5560f_0.conda
linux-aarch64::gst-plugins-base-1.22.8-h6d82d15_0.conda
linux-aarch64::libboost-1.84.0-h133f18d_0.conda
linux-aarch64::jaxlib-0.4.23-cpu_py312hf61c8ac_0.conda
linux-aarch64::root_base-6.30.2-py38hdb35db9_1.conda
linux-aarch64::postgresql-plpython-15.4-py310h840c280_3.conda
linux-aarch64::xrootd-5.6.2-py310hf69743b_2.conda
linux-aarch64::libgdal-3.8.2-hc5b8144_0.conda
linux-aarch64::libarchive-minimal-static-3.7.2-h66cf738_1.conda
linux-aarch64::postgresql-16.1-he703394_7.conda
linux-aarch64::fltk-1.3.9-h5b24465_0.conda
linux-aarch64::postgresql-plpython-15.4-py310h840c280_4.conda
linux-aarch64::postgresql-plpython-15.4-py311hc2b6b49_3.conda
linux-aarch64::libxmlsec1-1.3.2-h048dbf2_1.conda
linux-aarch64::r-base-4.2.3-h2f93d7e_11.conda
linux-aarch64::cppyy-cling-6.30.0-py312h17f8acd_0.conda
linux-aarch64::tiledb-2.18.2-h98c4c2b_1.conda
linux-aarch64::mesalib-23.3.1-h5f6ae44_0.conda
linux-aarch64::tiledb-2.18.3-hf5e255a_1.conda
linux-aarch64::arrow-cpp-9.0.0-py38hb29bc53_50_cpu.conda
linux-aarch64::tesseract-5.3.2-h038deca_2.conda
linux-aarch64::util-linux-2.39.3-py39hb670eeb_0.conda
linux-aarch64::libssh-0.10.6-h6961751_0.conda
linux-aarch64::lxml-4.9.3-py39h4de4ef8_2.conda
linux-aarch64::folly-2023.12.04.00-hcdf9fb0_0.conda
linux-aarch64::pyinstaller-6.3.0-py39hb91f966_0.conda
linux-aarch64::xrootd-5.6.2-py311ha7cb667_2.conda
linux-aarch64::davix-0.8.5-h26009ac_0.conda
linux-aarch64::libitk-5.3.0-h856cdc3_8.conda
linux-aarch64::sagelib-10.0-py311h0f5560f_2.conda
linux-aarch64::gmsh-4.12.0-h925e419_0.conda
linux-aarch64::pytables-3.9.2-py311h9a8bc71_1.conda
linux-aarch64::libarrow-12.0.1-h8c78540_32_cpu.conda
linux-aarch64::libpq-16.1-h8d0093b_6.conda
linux-aarch64::r-data.table-1.14.10-r43hb4ebc13_0.conda
linux-aarch64::sagelib-10.2-py39h0db02ac_1.conda
linux-aarch64::libpq-16.1-h8d0093b_5.conda
linux-aarch64::gst-plugins-base-1.22.7-h6d82d15_1.conda
linux-aarch64::gmt-5.4.5-hd1469a4_32.conda
linux-aarch64::clangdev-13.0.1-default_hdf9a116_4.conda
linux-aarch64::libgdal-arrow-parquet-3.8.1-h7b6990b_2.conda
linux-aarch64::xrootd-5.6.4-py39hc2520fa_0.conda
linux-aarch64::mapserver-8.0.1-py39hebd7c04_15.conda
linux-aarch64::vtk-base-9.2.6-qt_py311h1234567_220.conda
linux-aarch64::jaxlib-0.4.23-cpu_py39hea16949_0.conda
linux-aarch64::folly-2023.12.25.00-hcbc1ef6_0.conda
linux-aarch64::qt-main-5.15.8-h5992497_18.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-hf9ec03e_9.conda
linux-aarch64::libssh-0.10.6-h51df5d0_1.conda
linux-aarch64::ruby-3.2.2-hcdc5f17_1.conda
linux-aarch64::tiledb-2.18.3-hf5e255a_0.conda
linux-aarch64::postgresql-plpython-16.1-py311hc2b6b49_7.conda
linux-aarch64::libarrow-11.0.0-h3dfa4f1_54_cuda.conda
linux-aarch64::sagelib-10.2-py311h5df1c82_1.conda
linux-aarch64::hdf5-1.14.3-mpi_openmpi_hae789d2_0.conda
linux-aarch64::gst-plugins-good-1.22.8-hde0fa69_0.conda
linux-aarch64::openmpi-5.0.0-hf462296_102.conda
linux-aarch64::lxml-4.9.3-py310h4ea8894_2.conda
linux-aarch64::hdf5-1.14.3-mpi_mpich_hbf85d38_0.conda
linux-aarch64::jaxlib-0.4.20-cpu_py312hf61c8ac_0.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-hd03f34d_9.conda
linux-aarch64::libgdal-arrow-parquet-3.8.1-hf9ec03e_1.conda
linux-aarch64::imagemagick-7.1.1_24-pl5321h64d673c_0.conda
linux-aarch64::mapserver-8.0.1-py311h6ad0e14_15.conda
linux-aarch64::pdal-2.6.2-hda1ea44_1.conda
linux-aarch64::clangdev-13.0.1-root_63002_hd3e142c_5.conda
linux-aarch64::libarrow-11.0.0-hcd49607_54_cpu.conda
linux-aarch64::xrootd-5.6.4-py310hf69743b_0.conda
linux-aarch64::libgdal-3.7.3-h844db8d_12.conda
linux-aarch64::postgresql-16.1-he3d1b8e_7.conda
linux-aarch64::libarrow-12.0.1-h3379d91_31_cuda.conda
linux-aarch64::mapserver-8.0.1-py312h9c24c1c_14.conda
linux-aarch64::python-igraph-0.11.3-py311h9e38939_1.conda
linux-aarch64::pyreadstat-1.2.6-py312hd4a9921_0.conda
linux-aarch64::nsight-compute-2023.2.2.3-h26df83c_0.conda
linux-aarch64::imagecodecs-2024.1.1-py311h1ace9ac_0.conda
linux-aarch64::aria2-1.37.0-ha2f80ba_1.conda
linux-aarch64::root_base-6.28.10-py38ha08b34c_1.conda
linux-aarch64::util-linux-2.39.3-py310hbe9cfeb_0.conda
linux-aarch64::cmake-3.28.1-hef020d8_0.conda
linux-aarch64::tiledb-2.18.3-h1c5dee0_0.conda
linux-aarch64::libpulsar-3.4.2-hdbc81fc_0.conda
linux-aarch64::davix-0.8.4-h26009ac_3.conda
linux-aarch64::openslide-4.0.0-h8d5e3c6_1.conda
linux-aarch64::hdf5-1.14.3-nompi_ha486f32_100.conda
linux-aarch64::xrootd-5.6.3-py39h9f09aee_0.conda
linux-aarch64::pytables-3.9.2-py310h6e51920_1.conda
linux-aarch64::libarrow-13.0.0-h84bdd85_20_cpu.conda
linux-aarch64::ifcopenshell-v0.7.0.231127-py38_novtk_h3de9a73_102.conda
linux-aarch64::mapserver-8.0.1-py38h4e6b36d_14.conda
linux-aarch64::lld-16.0.6-h4742870_1.conda
linux-aarch64::folly-2023.12.25.00-hb8ddcfe_0_jemalloc.conda
linux-aarch64::folly-2023.12.11.00-hb8ddcfe_0_jemalloc.conda
linux-aarch64::ifcopenshell-v0.7.0.231127-py311_all_h83e0fa6_202.conda
linux-aarch64::util-linux-2.39.3-py311h7022ece_0.conda
linux-aarch64::root_base-6.28.10-py311hcfb60d3_2.conda
linux-aarch64::folly-2023.12.18.00-h8a1e4c1_0_jemalloc.conda
linux-aarch64::postgresql-plpython-15.4-py312h75118c5_3.conda
linux-aarch64::coda-2.25.1-py39h7f8485b_0.conda
linux-aarch64::arrow-cpp-9.0.0-py310hc8aae64_50_cuda.conda
linux-aarch64::mesalib-23.3.2-h5f6ae44_0.conda
linux-aarch64::qt6-main-6.6.1-h3c7da85_5.conda
linux-aarch64::libgdal-arrow-parquet-3.8.1-h6a3876c_4.conda
linux-aarch64::folly-2023.12.25.00-hcdf9fb0_0.conda
linux-aarch64::postgresql-plpython-15.4-py38hf7f31c5_3.conda
linux-aarch64::ffmpeg-6.1.1-gpl_h9c27ee1_100.conda
linux-aarch64::lxml-4.9.3-py38h38730af_3.conda
linux-aarch64::pdal-2.6.2-h89ffcd8_0.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-h24ea3e1_13.conda
linux-aarch64::coda-2.25.1-py310h96bca1b_0.conda
linux-aarch64::python-igraph-0.11.3-py39h3967fa1_1.conda
linux-aarch64::folly-2023.12.18.00-hf875f9a_0.conda
linux-aarch64::folly-2023.12.25.00-h8dd4a7f_0_jemalloc.conda
linux-aarch64::libgdal-3.7.3-haea6897_13.conda
linux-aarch64::libarrow-12.0.1-h84bdd85_31_cpu.conda
linux-aarch64::qt-webengine-5.15.8-h6291042_5.conda
linux-aarch64::pytables-3.9.2-py39hca38f38_1.conda
linux-aarch64::pyreadstat-1.2.6-py38hbecd58a_0.conda
linux-aarch64::libarrow-14.0.1-h9b6b63f_7_cuda.conda
linux-aarch64::tiledb-2.19.0-h08a2283_0.conda
linux-aarch64::openconnect-9.12-hae56807_1.conda
linux-aarch64::libarrow-14.0.1-h0230412_10_cuda.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-h8f36a38_10.conda
linux-aarch64::qt6-main-6.6.1-h3c7da85_4.conda
linux-aarch64::lxml-4.9.3-py39h03c8186_2.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-h4b7346d_13.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-hff4de9e_12.conda
linux-aarch64::libarrow-13.0.0-h3dfa4f1_19_cuda.conda
linux-aarch64::ifcopenshell-v0.7.0.231127-py312_novtk_hef409ac_102.conda
linux-aarch64::ffmpeg-6.1.0-gpl_h9c27ee1_105.conda
linux-aarch64::ifcopenshell-v0.7.0.231127-py310_novtk_h3017c31_102.conda
linux-aarch64::fish-3.6.3-hc0a5165_0.conda
linux-aarch64::sagelib-10.1-py310hfbc6516_0.conda
linux-aarch64::gst-plugins-good-1.22.7-hf6e4398_1.conda
linux-aarch64::boost-cpp-1.84.0-ha990451_0.conda
linux-aarch64::root_base-6.30.2-py39h0f9be12_1.conda
linux-aarch64::imagecodecs-2024.1.1-py39hee7ecc3_0.conda
linux-aarch64::libarchive-3.7.2-hd2f85e0_1.conda
linux-aarch64::tiledb-2.18.3-h08a2283_1.conda
linux-aarch64::vtk-base-9.2.6-qt_py39h1234567_220.conda
linux-aarch64::util-linux-2.39.3-py39h493218e_1.conda
linux-aarch64::xrootd-5.6.3-py38h41211b1_0.conda
linux-aarch64::libgdal-arrow-parquet-3.8.1-h8f36a38_2.conda
linux-aarch64::libgdal-arrow-parquet-3.8.2-h432d955_0.conda
linux-aarch64::jaxlib-0.4.20-cpu_py311h86dff27_0.conda
linux-aarch64::mapserver-8.0.1-py38h702a419_15.conda
linux-aarch64::root_base-6.30.2-py310h4cd8249_0.conda
linux-aarch64::tiledb-2.18.2-he6cbd45_1.conda
linux-aarch64::pyreadstat-1.2.6-py311hf7e8aab_0.conda
linux-aarch64::tiledb-2.18.2-hf5e255a_2.conda
linux-aarch64::ifcopenshell-v0.7.0.231127-py312_all_h9b4a87d_202.conda
linux-aarch64::postgresql-16.1-he703394_6.conda
linux-aarch64::libnetcdf-4.9.2-nompi_h33102a8_113.conda
linux-aarch64::root_base-6.30.2-py38ha08b34c_0.conda
linux-aarch64::magic-8.3.454-h4e13689_0.conda
linux-aarch64::gst-plugins-bad-1.22.7-hb045302_0.conda
linux-aarch64::cppyy-cling-6.30.0-py310h88818a3_0.conda
linux-aarch64::postgresql-plpython-16.1-py312hc43be6c_5.conda
linux-aarch64::tesseract-5.3.2-h5276795_1.conda
linux-aarch64::coda-2.25.1-py311hc8f05bd_0.conda
linux-aarch64::mapserver-8.0.1-py39h63d699e_14.conda
linux-aarch64::postgresql-plpython-16.1-py311h765025c_6.conda
linux-aarch64::geotiff-1.7.1-h3e58e51_15.conda
linux-aarch64::hamlib-tcl-4.5.5-hdf905ee_3.conda
linux-aarch64::postgresql-15.4-he3d1b8e_4.conda
linux-aarch64::jaxlib-0.4.23-cpu_py310h5e86b86_0.conda
linux-aarch64::libgdal-3.7.3-h77c4555_11.conda
linux-aarch64::ffmpeg-6.1.0-lgpl_hd1800be_4.conda
linux-aarch64::pdal-2.6.1-h89ffcd8_1.conda
linux-aarch64::cppyy-cling-6.30.0-py39h23417e7_0.conda
linux-aarch64::folly-2023.12.18.00-hcdf9fb0_0.conda
linux-aarch64::cpp-opentelemetry-sdk-1.13.0-h4f4f98c_0.conda
linux-aarch64::pyinstaller-6.3.0-py311h0dd4530_0.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-hd786a78_11.conda
linux-aarch64::libgdal-3.8.1-h18a4eec_0.conda
linux-aarch64::libscotch-7.0.4-h16908e7_1.conda
linux-aarch64::xrootd-5.6.3-py312hdbc5d34_0.conda
linux-aarch64::postgresql-15.4-he3d1b8e_3.conda
linux-aarch64::ffmpeg-6.1.0-lgpl_hffc26ca_5.conda
linux-aarch64::root_base-6.30.2-py39h5194cdf_0.conda
linux-aarch64::openssh-9.3p1-h04b8c23_3.conda
linux-aarch64::tiledb-2.18.2-h1c5dee0_2.conda
linux-aarch64::folly-2023.12.18.00-hb8ddcfe_0_jemalloc.conda
linux-aarch64::root_base-6.30.2-py311hcfb60d3_0.conda
linux-aarch64::postgresql-plpython-16.1-py310h840c280_7.conda
linux-aarch64::sagelib-10.2-py39h29ad0c2_0.conda
linux-aarch64::ifcopenshell-v0.7.0.231127-py39_all_he70b05b_202.conda
linux-aarch64::arrow-cpp-9.0.0-py39h662e237_50_cpu.conda
linux-aarch64::arrow-cpp-9.0.0-py311h12edb47_50_cuda.conda
linux-aarch64::postgresql-plpython-16.1-py310h5ecf261_5.conda
linux-aarch64::libvips-8.15.1-h700ac1c_0.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-h8250874_9.conda
linux-aarch64::postgresql-plpython-16.1-py38hc50c26b_6.conda
linux-aarch64::cargo-c-0.9.29-h6a45645_0.conda
linux-aarch64::lxml-4.9.3-py310h4ea8894_3.conda
linux-aarch64::libarrow-12.0.1-h9c500e0_32_cuda.conda
linux-aarch64::xrootd-5.6.3-py310hf69743b_0.conda
linux-aarch64::pyinstaller-6.3.0-py310h1aab166_0.conda
linux-aarch64::lldb-17.0.2-py310h7487d7a_0.conda
linux-aarch64::libarrow-14.0.1-hdd0057c_9_cpu.conda
linux-aarch64::xrootd-5.6.3-py39hc2520fa_0.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-h7b6990b_10.conda
linux-aarch64::libpq-15.4-h04b8c23_3.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-hafd59a5_11.conda
linux-aarch64::libgdal-arrow-parquet-3.8.1-h8250874_1.conda
linux-aarch64::libarrow-12.0.1-hcd49607_30_cpu.conda
linux-aarch64::root_base-6.28.10-py39h5194cdf_1.conda
linux-aarch64::root_base-6.28.10-py310h4cd8249_1.conda
linux-aarch64::python-3.12.1-h43d1f9e_1_cpython.conda
linux-aarch64::root_base-6.28.10-py38ha08b34c_2.conda
linux-aarch64::aws-sdk-cpp-1.11.210-h7fb5f50_6.conda
linux-aarch64::jaxlib-0.4.20-cpu_py310h5e86b86_0.conda
linux-aarch64::imagemagick-7.1.1_25-pl5321h64d673c_0.conda
linux-aarch64::poppler-23.12.0-h3cd87ed_0.conda
linux-aarch64::imagemagick-7.1.1_22-pl5321h64d673c_0.conda
linux-aarch64::libgdal-arrow-parquet-3.8.1-hff4de9e_4.conda
linux-aarch64::libgdal-3.8.1-h506048d_1.conda
linux-aarch64::xrootd-5.6.4-py312hdbc5d34_0.conda
linux-aarch64::libgdal-arrow-parquet-3.8.1-hd03f34d_1.conda
linux-aarch64::lxml-4.9.3-py312h107a964_3.conda
linux-aarch64::symengine-0.11.2-hee1fd3f_0.conda
linux-aarch64::pytng-0.3.1-py39hb671adb_1.conda
linux-aarch64::arrow-cpp-9.0.0-py310hcda11fa_50_cpu.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-h432d955_12.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-h6a3876c_12.conda
linux-aarch64::jaxlib-0.4.20-cpu_py39hea16949_0.conda
linux-aarch64::lldb-17.0.6-py38h57c4c1a_0.conda
linux-aarch64::lldb-17.0.6-py311h18aa7b8_0.conda
linux-aarch64::libyarp-3.9.0-hc289372_0.conda
linux-aarch64::openslide-4.0.0-h8d5e3c6_0.conda
linux-aarch64::root_base-6.30.2-py311h2c5d9cf_1.conda
linux-aarch64::sagelib-10.1-py38hdcb3410_0.conda
linux-aarch64::folly-2023.12.04.00-h8dd4a7f_0_jemalloc.conda
linux-aarch64::util-linux-2.39.3-py312h5ae9330_0.conda
linux-aarch64::clangdev-13.0.1-root_62810_h5d2118a_4.conda
linux-aarch64::lxml-4.9.3-py38h38730af_2.conda
linux-aarch64::postgresql-plpython-16.1-py311h765025c_7.conda
linux-aarch64::libgdal-3.8.1-hc5b8144_4.conda
linux-aarch64::texlive-core-20230313-h033bade_9.conda
linux-aarch64::lxml-4.9.3-py311h40dcbb3_2.conda
linux-aarch64::glib-2.78.2-hd84c7bf_0.conda
linux-aarch64::python-igraph-0.11.3-py310hf7f3b39_1.conda
linux-aarch64::glib-2.78.3-hd84c7bf_0.conda
linux-aarch64::ifcopenshell-v0.7.0.231127-py38_all_hc180e4d_202.conda
linux-aarch64::pytng-0.3.1-py311h1fb865f_1.conda
linux-aarch64::mongodb-6.0.12-ha132e33_0.conda
linux-aarch64::libgdal-arrow-parquet-3.8.1-h345faf7_1.conda
linux-aarch64::openconnect-9.12-hd595388_2.conda
linux-aarch64::python-3.9.18-h4ac3b42_1_cpython.conda
linux-aarch64::libarrow-14.0.2-h14be87f_0_cpu.conda
linux-aarch64::python-igraph-0.11.3-py38h695a73d_1.conda
linux-aarch64::qt6-main-6.5.3-hb1ad137_1.conda
linux-aarch64::folly-2023.12.18.00-hcbc1ef6_0.conda
linux-aarch64::folly-2023.12.04.00-hf875f9a_0.conda
linux-aarch64::r-data.table-1.14.10-r42hb4ebc13_0.conda
linux-aarch64::xrootd-5.6.2-py312hdbc5d34_2.conda
linux-aarch64::pytng-0.3.1-py39h19488dd_1.conda
linux-aarch64::libvips-8.15.0-h700ac1c_4.conda
linux-aarch64::postgresql-plpython-16.1-py38hc50c26b_5.conda
linux-aarch64::libgoogle-cloud-storage-2.17.0-hdb39181_1.conda
linux-aarch64::postgresql-plpython-16.1-py312hc43be6c_6.conda
linux-aarch64::libgdal-arrow-parquet-3.8.1-h432d955_4.conda
linux-aarch64::python-3.11.7-h43d1f9e_1_cpython.conda
linux-aarch64::pygplates-0.39-py39h5d62464_14.conda
linux-aarch64::openmpi-5.0.0-hf462296_100.conda
linux-aarch64::arrow-cpp-9.0.0-py39h3243d39_50_cuda.conda
linux-aarch64::libglib-2.78.3-h311d5f7_0.conda
linux-aarch64::pygplates-0.39-py311h4c183d4_14.conda
linux-aarch64::libcurl-8.5.0-h4e8248e_0.conda
linux-aarch64::libgdal-arrow-parquet-3.8.2-hd39519c_1.conda
linux-aarch64::arrow-cpp-9.0.0-py311hc84ec44_50_cpu.conda
linux-aarch64::libgdal-arrow-parquet-3.8.1-hafd59a5_3.conda
linux-aarch64::util-linux-2.39.3-py310hbe9cfeb_1.conda
linux-aarch64::vtk-base-9.2.6-qt_py312h1234567_220.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-h302f912_10.conda
linux-aarch64::yoda-1.9.6-py311ha4aa0d6_5.conda
linux-aarch64::libgdal-3.7.3-heb37a4e_9.conda
linux-aarch64::folly-2023.12.25.00-hf875f9a_0.conda
linux-aarch64::libspatialite-5.1.0-h896d346_4.conda
linux-aarch64::xrootd-5.6.4-py311ha7cb667_0.conda
linux-aarch64::postgresql-plpython-16.1-py310h5ecf261_6.conda
linux-aarch64::xrootd-5.6.3-py311ha7cb667_0.conda
linux-aarch64::nsight-compute-2023.1.1.4-h26df83c_0.conda
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
================================================================================
================================================================================
noarch
================================================================================
================================================================================
win-64
win-64::tesseract-5.3.2-h8c4da6d_2.conda
win-64::libglib-2.78.2-h16e383f_0.conda
win-64::libclang-13.0.1-default_h66ee7f4_4.conda
win-64::libarrow-11.0.0-hfc35614_56_cuda.conda
win-64::python-3.12.1-h2628c8c_1_cpython.conda
win-64::libarrow-gandiva-14.0.2-hb2eaab1_0_cuda.conda
win-64::libarrow-gandiva-14.0.1-hb2eaab1_8_cuda.conda
win-64::gemmi-0.6.4-py39hd28a505_0.conda
win-64::postgresql-15.4-hc80876b_4.conda
win-64::libarrow-13.0.0-h2b3a9c8_19_cuda.conda
win-64::postgresql-16.1-h1beaf6b_5.conda
win-64::postgresql-plpython-16.1-py311h931fdd5_7.conda
win-64::python-igraph-0.11.3-py39h14a014a_1.conda
win-64::libgdal-arrow-parquet-3.8.1-hb890294_1.conda
win-64::gemmi-0.6.4-py312h7894644_0.conda
win-64::stir-5.2.0-cuda120_py311h7ed8336_203.conda
win-64::pdal-2.6.2-hf0e614a_2.conda
win-64::pyreadstat-1.2.6-py311hd8f7e58_0.conda
win-64::nsight-compute-2023.2.2.3-hbdb2b8c_0.conda
win-64::postgresql-plpython-16.1-py38h4aa54d8_7.conda
win-64::vtk-base-9.2.6-qt_py38h1234567_220.conda
win-64::libgdal-arrow-parquet-3.8.1-h252b35f_2.conda
win-64::libgoogle-cloud-storage-2.17.0-hb581fae_1.conda
win-64::postgresql-plpython-16.1-py311h7015055_7.conda
win-64::libpq-15.4-h43585b0_3.conda
win-64::imagecodecs-2024.1.1-py310h0dcf169_0.conda
win-64::postgresql-plpython-15.4-py310hf838413_3.conda
win-64::libgdal-3.7.3-hd6fa8b0_10.conda
win-64::lxml-4.9.3-py39hbae3653_3.conda
win-64::stir-5.2.0-cpu_py310h150df81_3.conda
win-64::clang-13-13.0.1-default_h66ee7f4_4.conda
win-64::libgdal-arrow-parquet-3.8.1-h7d66c31_1.conda
win-64::symengine-0.11.2-h7610957_0.conda
win-64::libgdal-arrow-parquet-3.7.3-h5cc1e32_13.conda
win-64::postgresql-plpython-16.1-py312h6a96c9b_7.conda
win-64::libclang13-16.0.6-default_h85b4d89_3.conda
win-64::gdstk-0.9.48-py312h1b3467e_0.conda
win-64::pygplates-0.39-py311h0e6f400_14.conda
win-64::postgresql-plpython-16.1-py312he74e6b0_7.conda
win-64::folly-2023.12.04.00-h04b96d7_0.conda
win-64::cmake-3.28.0-hf0feee3_0.conda
win-64::libgdal-arrow-parquet-3.8.1-h0ec6616_0.conda
win-64::lldb-17.0.6-py39hed22e34_0.conda
win-64::aws-sdk-cpp-1.11.210-h0441c79_5.conda
win-64::minizip-4.0.4-h5bed578_0.conda
win-64::clang-15-15.0.7-default_hde6756a_4.conda
win-64::libpq-15.4-hc80876b_4.conda
win-64::gdstk-0.9.48-py311hc50246e_0.conda
win-64::cpp-opentelemetry-sdk-1.13.0-h2f34e4b_0.conda
win-64::gdstk-0.9.48-py310hf182ab0_1.conda
win-64::postgresql-plpython-16.1-py311h7015055_5.conda
win-64::libgdal-arrow-parquet-3.8.1-hebcb094_0.conda
win-64::postgresql-plpython-16.1-py310h4609481_7.conda
win-64::clang-tools-17.0.6-default_hde6756a_1.conda
win-64::tiledb-2.18.3-hf115c86_1.conda
win-64::ruby-3.2.2-h20ad4f3_1.conda
win-64::libgdal-arrow-parquet-3.7.3-hea2d56f_11.conda
win-64::folly-2023.12.04.00-hd2f1b6b_0.conda
win-64::tiledb-2.18.3-h3639678_1.conda
win-64::papilo-2.1.4-h45feaf2_6.conda
win-64::libarrow-14.0.1-h91bc311_8_cpu.conda
win-64::lxml-4.9.3-py39hb421182_3.conda
win-64::postgresql-plpython-16.1-py311h7015055_6.conda
win-64::nexus-4.4.3-h1210264_13.conda
win-64::glib-tools-2.78.3-h12be248_0.conda
win-64::lldb-17.0.2-py311hbb4bc87_0.conda
win-64::r-gaston-1.6-r41h67098fc_0.conda
win-64::gemmi-0.6.4-py38h19421c1_0.conda
win-64::stir-5.2.0-cuda118_py38h3f97100_203.conda
win-64::clang-15.0.7-ha177bd6_4.conda
win-64::pytng-0.3.1-py312h55d086e_1.conda
win-64::pytng-0.3.1-py39h7dfb729_1.conda
win-64::libgdal-arrow-parquet-3.7.3-h8994dc8_10.conda
win-64::postgresql-plpython-15.4-py312h6a96c9b_3.conda
win-64::curl-8.5.0-hd5e4a3a_0.conda
win-64::libarrow-11.0.0-h1138768_56_cpu.conda
win-64::scip-8.1.0-h6584d29_6.conda
win-64::python-3.12.1-h2628c8c_0_cpython.conda
win-64::gemmi-0.6.4-py311h5bc0dda_0.conda
win-64::libarrow-14.0.2-hc3966b7_0_cuda.conda
win-64::libgdal-arrow-parquet-3.8.1-h36c32c5_1.conda
win-64::libclang-cpp-15.0.7-default_hde6756a_4.conda
win-64::aws-sdk-cpp-1.11.210-h1698a88_6.conda
win-64::postgresql-15.4-hc80876b_3.conda
win-64::libgdal-3.8.2-h70e2fc3_0.conda
win-64::gdstk-0.9.48-py39h32efe87_0.conda
win-64::python-3.8.18-h4de0772_1_cpython.conda
win-64::tiledb-2.18.3-h3639678_0.conda
win-64::papilo-2.1.4-h45feaf2_5.conda
win-64::imagecodecs-2024.1.1-py39h9d3654e_0.conda
win-64::libarrow-13.0.0-h859dacc_21_cpu.conda
win-64::tesseract-5.3.2-hd01b344_1.conda
win-64::ffmpeg-6.1.0-gpl_h56e7eb4_105.conda
win-64::libgdal-3.7.3-h3b34650_11.conda
win-64::postgresql-plpython-15.4-py311h931fdd5_4.conda
win-64::coda-2.25.1-py39hdabd458_0.conda
win-64::libgdal-arrow-parquet-3.7.3-h1583a49_12.conda
win-64::libpulsar-3.4.2-h35ac4ea_0.conda
win-64::gst-plugins-base-1.22.8-h001b923_0.conda
win-64::postgresql-plpython-16.1-py39hf83d731_7.conda
win-64::postgresql-plpython-16.1-py39hf83d731_6.conda
win-64::libarrow-gandiva-14.0.1-hb2eaab1_8_cpu.conda
win-64::gst-plugins-base-1.22.7-h001b923_1.conda
win-64::lxml-4.9.3-py38h5a3a0f9_3.conda
win-64::paraview-5.11.2-py38hd492fb1_102_qt.conda
win-64::intel-opencl-rt-2024.0.0-hb319aac_49840.conda
win-64::pytables-3.9.2-py312h62a68b9_1.conda
win-64::libclang13-17.0.6-default_h85b4d89_1.conda
win-64::python-igraph-0.11.3-py39h1a7f048_1.conda
win-64::lldb-17.0.6-py311h19fab70_0.conda
win-64::stir-5.2.0-cpu_py39h7d132c1_3.conda
win-64::pyreadstat-1.2.6-py39h585ecb4_0.conda
win-64::libarrow-11.0.0-h940c563_45_cuda.conda
win-64::tiledb-2.18.3-hf115c86_0.conda
win-64::libcurl-8.5.0-hd5e4a3a_0.conda
win-64::libgdal-arrow-parquet-3.8.1-h8994dc8_2.conda
win-64::libgdal-arrow-parquet-3.8.2-hda1b24b_0.conda
win-64::libarrow-13.0.0-h548e6fb_20_cpu.conda
win-64::stir-5.2.0-cpu_py38h28fe462_3.conda
win-64::pdal-2.6.2-h0bc4d60_0.conda
win-64::libgdal-3.7.3-hc493920_13.conda
win-64::postgresql-plpython-16.1-py310h4609481_6.conda
win-64::libgdal-3.8.1-hf2cf311_2.conda
win-64::glib-2.78.2-h12be248_0.conda
win-64::libboost-1.84.0-h65993cd_0.conda
win-64::libxml2-2.12.2-hc3477c8_0.conda
win-64::libarrow-12.0.1-h859dacc_32_cpu.conda
win-64::postgresql-plpython-16.1-py312he74e6b0_5.conda
win-64::folly-2023.12.11.00-hd2f1b6b_0.conda
win-64::python-3.9.18-h4de0772_1_cpython.conda
win-64::zimpl-3.5.3-hbb4e24d_4.conda
win-64::lxml-4.9.3-py311h750ae06_3.conda
win-64::libarrow-14.0.1-h1048771_10_cpu.conda
win-64::libarrow-13.0.0-h355d2d4_21_cuda.conda
win-64::libgdal-arrow-parquet-3.7.3-h9f59305_9.conda
win-64::tiledb-2.18.2-ha6a2892_1.conda
win-64::libgdal-arrow-parquet-3.7.3-h8a628e4_13.conda
win-64::folly-2023.12.18.00-hd2f1b6b_0.conda
win-64::coda-2.25.1-py311h1fcffe7_0.conda
win-64::libgdal-arrow-parquet-3.8.1-hacd91dc_3.conda
win-64::pytng-0.3.1-py311hcbca1fb_1.conda
win-64::folly-2023.12.11.00-h43676e7_0.conda
win-64::pygplates-0.39-py38h386569f_14.conda
win-64::glib-2.78.3-h12be248_0.conda
win-64::pygplates-0.39-py39hd81ff86_14.conda
win-64::clangdev-13.0.1-default_h66ee7f4_5.conda
win-64::gst-plugins-good-1.22.8-hb0c0023_0.conda
win-64::libarrow-14.0.1-hc3966b7_10_cuda.conda
win-64::postgresql-plpython-16.1-py38h4aa54d8_6.conda
win-64::gmsh-4.12.0-hcc95203_0.conda
win-64::imagecodecs-2024.1.1-py39h445c58b_0.conda
win-64::postgresql-plpython-15.4-py38hc2df893_4.conda
win-64::libgdal-arrow-parquet-3.8.1-h1583a49_4.conda
win-64::imagecodecs-2024.1.1-py311h7346e2b_0.conda
win-64::gdstk-0.9.48-py39h2b303d1_0.conda
win-64::lldb-17.0.2-py38hafd1aa4_0.conda
win-64::libgdal-arrow-parquet-3.8.2-h5cc1e32_1.conda
win-64::gdstk-0.9.48-py310h1c7a339_1.conda
win-64::libsoup-2.74.3-hde36b1d_2.conda
win-64::libarrow-14.0.1-h60c4337_7_cuda.conda
win-64::libgdal-arrow-parquet-3.7.3-hb92d4b4_10.conda
win-64::libgdal-arrow-parquet-3.8.2-h3b38833_0.conda
win-64::libarrow-14.0.1-h8ab2780_9_cpu.conda
win-64::stir-5.2.0-cuda112_py39h812b358_203.conda
win-64::ffmpeg-6.1.0-gpl_hc1eaed4_104.conda
win-64::paraview-5.11.2-py311hbea6787_102_qt.conda
win-64::pdal-2.6.2-hd01e5c3_1.conda
win-64::boost-cpp-1.84.0-h6f18f0d_0.conda
win-64::libgdal-3.8.2-h576f4c1_1.conda
win-64::clang-16.0.6-ha177bd6_3.conda
win-64::folly-2023.12.04.00-h43676e7_0.conda
win-64::libclang-cpp-16.0.6-default_hde6756a_3.conda
win-64::gst-plugins-bad-1.22.7-h9dbab7f_0.conda
win-64::libgdal-arrow-parquet-3.7.3-h7f75364_11.conda
win-64::tiledb-2.18.2-h1ffc264_0.conda
win-64::postgresql-16.1-h1beaf6b_6.conda
win-64::libyarp-3.9.0-hcb6c3dd_0.conda
win-64::libgdal-arrow-parquet-3.7.3-hacd91dc_11.conda
win-64::libarrow-13.0.0-hf4271b7_19_cpu.conda
win-64::libuwebsockets-20.49.0-h12be248_0.conda
win-64::r-vcfr-1.15.0-r41h67098fc_0.conda
win-64::libgdal-arrow-parquet-3.7.3-h36c32c5_9.conda
win-64::libclang-13.0.1-default_h66ee7f4_5.conda
win-64::libgdal-arrow-parquet-3.8.1-h7f75364_3.conda
win-64::libgdal-arrow-parquet-3.7.3-hb890294_9.conda
win-64::vtk-base-9.2.6-qt_py310h1234567_220.conda
win-64::plplot-5.15.0-h43338f3_3.conda
win-64::lldb-17.0.2-py310h8d0bbdd_0.conda
win-64::libarrow-gandiva-14.0.1-hb2eaab1_10_cuda.conda
win-64::lxml-4.9.3-py311h750ae06_2.conda
win-64::stir-5.2.0-cpu_py311ha2ca3b5_3.conda
win-64::postgresql-plpython-15.4-py38hc2df893_3.conda
win-64::libgdal-arrow-parquet-3.7.3-hda1b24b_12.conda
win-64::postgresql-plpython-15.4-py310hf838413_4.conda
win-64::clang-17.0.6-ha177bd6_1.conda
win-64::libpq-16.1-h1beaf6b_6.conda
win-64::libcurl-static-8.5.0-hd5e4a3a_0.conda
win-64::libgdal-3.8.1-hf69a6b9_3.conda
win-64::python-3.10.13-h4de0772_1_cpython.conda
win-64::pygplates-0.39-py312h65d26bf_14.conda
win-64::folly-2023.12.25.00-hd2f1b6b_0.conda
win-64::postgresql-plpython-15.4-py39h7f24c7b_3.conda
win-64::libarrow-14.0.1-h06f3e5f_9_cuda.conda
win-64::postgresql-16.1-hc80876b_7.conda
win-64::soplex-6.0.4-h949ae46_5.conda
win-64::pytables-3.9.2-py39h607662a_1.conda
win-64::libarrow-12.0.1-hf4271b7_30_cpu.conda
win-64::lxml-4.9.3-py38h5a3a0f9_2.conda
win-64::python-3.11.7-h2628c8c_1_cpython.conda
win-64::libxml2-2.12.3-hc3477c8_0.conda
win-64::hdf5-1.14.3-nompi_h73e8ff5_100.conda
win-64::pyinstaller-6.3.0-py310h35269f2_0.conda
win-64::stir-5.2.0-cuda118_py311h5625561_203.conda
win-64::postgresql-plpython-16.1-py38hc2df893_7.conda
win-64::libarrow-11.0.0-hfc35614_55_cuda.conda
win-64::libuwebsockets-20.52.0-h12be248_0.conda
win-64::wasmer-4.2.5-h4dd112c_0.conda
win-64::stir-5.2.0-cuda118_py310hd0e3b8f_203.conda
win-64::libarrow-12.0.1-h2b3a9c8_30_cuda.conda
win-64::libpq-16.1-h1beaf6b_5.conda
win-64::libgdal-arrow-parquet-3.8.2-h1583a49_0.conda
win-64::libarrow-11.0.0-h1138768_54_cpu.conda
win-64::pytables-3.9.2-py39he845bde_1.conda
win-64::pyreadstat-1.2.6-py312h71c11f5_0.conda
win-64::libarrow-12.0.1-h262543f_10_cuda.conda
win-64::libgdal-arrow-parquet-3.7.3-h2490618_10.conda
win-64::clang-13-13.0.1-default_h66ee7f4_5.conda
win-64::ffmpeg-6.1.0-lgpl_h823ccd3_5.conda
win-64::bytewax-0.17.2-py38pl5321hcc47c24_0.conda
win-64::libnetcdf-4.9.2-nompi_h07c049d_113.conda
win-64::pyinstaller-6.3.0-py311h12e69fa_0.conda
win-64::intel-opencl-rt-2024.0.0-h94deba9_49840.conda
win-64::folly-2023.12.25.00-h04b96d7_0.conda
win-64::libarchive-3.7.2-h313118b_1.conda
win-64::gmsh-4.12.0-hf228048_0.conda
win-64::python-3.11.7-h2628c8c_0_cpython.conda
win-64::ffmpeg-6.1.0-lgpl_hc2bb595_4.conda
win-64::pyreadstat-1.2.6-py38h84023d3_0.conda
win-64::libclang-17.0.6-default_hde6756a_1.conda
win-64::postgresql-plpython-15.4-py312h6a96c9b_4.conda
win-64::libgdal-arrow-parquet-3.7.3-h3b38833_12.conda
win-64::postgresql-plpython-16.1-py312he74e6b0_6.conda
win-64::clangdev-16.0.6-default_hde6756a_3.conda
win-64::bytewax-0.17.2-py311pl5321hd4437ae_0.conda
win-64::tiledb-2.18.3-h8e52ccb_1.conda
win-64::libgdal-arrow-parquet-3.8.1-h2490618_2.conda
win-64::postgresql-plpython-15.4-py39h7f24c7b_4.conda
win-64::fltk-1.3.9-h01c93fd_0.conda
win-64::imagecodecs-2024.1.1-py312h4936081_0.conda
win-64::libgdal-arrow-parquet-3.7.3-h252b35f_10.conda
win-64::clang-16-16.0.6-default_hde6756a_3.conda
win-64::gemmi-0.6.4-py39h6848017_0.conda
win-64::coda-2.25.1-py39ha7d8d4b_0.conda
win-64::qt6-main-6.6.1-hc9a02c6_4.conda
win-64::tiledb-2.18.2-hc200977_1.conda
win-64::tiledb-2.19.0-hf115c86_0.conda
win-64::libgdal-arrow-parquet-3.8.1-hcc52eb0_0.conda
win-64::pytng-0.3.1-py310h617134d_1.conda
win-64::postgresql-plpython-15.4-py311h931fdd5_3.conda
win-64::folly-2023.12.18.00-h04b96d7_0.conda
win-64::libarrow-gandiva-14.0.1-hb2eaab1_9_cuda.conda
win-64::libarrow-14.0.2-h1048771_0_cpu.conda
win-64::libgdal-arrow-parquet-3.7.3-h7d66c31_9.conda
win-64::postgresql-plpython-16.1-py310h4609481_5.conda
win-64::ifcopenshell-v0.7.0.231127-py310_all_hfac4f5e_202.conda
win-64::pytng-0.3.1-py39h5e6fad6_1.conda
win-64::libuwebsockets-20.53.0-h12be248_0.conda
win-64::libarrow-gandiva-14.0.1-hb2eaab1_7_cpu.conda
win-64::geotiff-1.7.1-hbf5ca3a_15.conda
win-64::vtk-base-9.2.6-qt_py311h1234567_220.conda
win-64::pytables-3.9.2-py311heec7198_1.conda
win-64::ifcopenshell-v0.7.0.231127-py38_all_h522bb4b_202.conda
win-64::stir-5.2.0-cuda118_py39hd6f898a_203.conda
win-64::clangxx-17.0.6-default_hde6756a_1.conda
win-64::clang-17-17.0.6-default_hde6756a_1.conda
win-64::ifcopenshell-v0.7.0.231127-py311_all_h7d7a231_202.conda
win-64::gst-plugins-good-1.22.7-heb220f1_1.conda
win-64::sdl2_image-2.8.0-he19da31_0.conda
win-64::ifcopenshell-v0.7.0.231127-py39_novtk_h0d70909_102.conda
win-64::bytewax-0.17.2-py312pl5321h70577bd_0.conda
win-64::gdstk-0.9.48-py310h7dcdc39_0.conda
win-64::libgdal-arrow-parquet-3.8.1-hb92d4b4_2.conda
win-64::libgdal-arrow-parquet-3.8.2-h65542e6_1.conda
win-64::tiledb-2.18.2-h3639678_2.conda
win-64::stir-5.2.0-cuda120_py310hbb71a96_203.conda
win-64::postgresql-plpython-16.1-py39h7f24c7b_7.conda
win-64::python-igraph-0.11.3-py311h9092318_1.conda
win-64::stir-5.2.0-cuda120_py39h961f521_203.conda
win-64::clangdev-15.0.7-default_hde6756a_4.conda
win-64::vtk-base-9.2.6-qt_py312h1234567_220.conda
win-64::gdstk-0.9.48-py38h8a2f752_0.conda
win-64::lld-16.0.6-haf3a982_1.conda
win-64::scip-8.1.0-h6584d29_5.conda
win-64::libgoogle-cloud-storage-2.17.0-hb581fae_0.conda
win-64::postgresql-plpython-16.1-py38h4aa54d8_5.conda
win-64::libgdal-3.8.1-h70e2fc3_4.conda
win-64::pdal-2.6.1-h0bc4d60_1.conda
win-64::soplex-6.0.4-h949ae46_6.conda
win-64::clang-tools-13.0.1-default_h66ee7f4_5.conda
win-64::libgdal-arrow-parquet-3.7.3-h98ab263_11.conda
win-64::eccodes-2.33.0-h97caf96_0.conda
win-64::qt6-main-6.6.1-hc9a02c6_3.conda
win-64::tiledb-2.18.2-h8e52ccb_2.conda
win-64::tiledb-2.19.0-h3639678_0.conda
win-64::python-igraph-0.11.3-py310hccdcdea_1.conda
win-64::clang-tools-13.0.1-default_h66ee7f4_4.conda
win-64::lxml-4.9.3-py39hbae3653_2.conda
win-64::python-igraph-0.11.3-py312ha44f137_1.conda
win-64::cmake-3.28.1-hf0feee3_0.conda
win-64::lldb-17.0.6-py38h0e99253_0.conda
win-64::libgdal-arrow-parquet-3.8.1-ha5a541d_4.conda
win-64::pyinstaller-6.3.0-py312h3bd2d22_0.conda
win-64::libgdal-3.7.3-hb48ddc7_12.conda
win-64::libclang-16.0.6-default_hde6756a_3.conda
win-64::libuwebsockets-20.54.0-h12be248_0.conda
win-64::libclang-cpp-17.0.6-default_hde6756a_1.conda
win-64::libarrow-11.0.0-hfc35614_54_cuda.conda
win-64::libarrow-14.0.1-h60c4337_8_cuda.conda
win-64::ifcopenshell-v0.7.0.231127-py310_novtk_h1a2fa24_102.conda
win-64::libgdal-arrow-parquet-3.8.1-hda1b24b_4.conda
win-64::lxml-4.9.3-py39hb421182_2.conda
win-64::folly-2023.12.18.00-h43676e7_0.conda
win-64::libclang-15.0.7-default_hde6756a_4.conda
win-64::nsight-compute-2023.1.1.4-hbdb2b8c_0.conda
win-64::folly-2023.12.25.00-h43676e7_0.conda
win-64::pyreadstat-1.2.6-py310h51ee7fe_0.conda
win-64::ifcopenshell-v0.7.0.231127-py39_all_ha6c1fe4_202.conda
win-64::libarrow-14.0.1-h91bc311_7_cpu.conda
win-64::lldb-17.0.2-py39hf6ce347_0.conda
win-64::libopentelemetry-cpp-1.13.0-h2f34e4b_0.conda
win-64::pyinstaller-6.3.0-py38ha959d8a_0.conda
win-64::paraview-5.11.2-py312had4c764_102_qt.conda
win-64::libscotch-7.0.4-h534da82_1.conda
win-64::folly-2023.12.11.00-h04b96d7_0.conda
win-64::pygplates-0.39-py310h9a95f29_14.conda
win-64::lxml-4.9.3-py310h46d54dd_3.conda
win-64::libgdal-arrow-parquet-3.8.1-hea2d56f_3.conda
win-64::python-igraph-0.11.3-py38hc5241a2_1.conda
win-64::gdstk-0.9.48-py310h50f6f4e_1.conda
win-64::bytewax-0.17.2-py39pl5321h5b14c5f_0.conda
win-64::libgdal-arrow-parquet-3.8.2-h8a628e4_1.conda
win-64::tiledb-2.18.2-hf115c86_2.conda
win-64::clangdev-17.0.6-default_hde6756a_1.conda
win-64::stir-5.2.0-cuda112_py38he021285_203.conda
win-64::clang-tools-15.0.7-default_hde6756a_4.conda
win-64::libarrow-gandiva-14.0.1-hb2eaab1_7_cuda.conda
win-64::glib-tools-2.78.2-h12be248_0.conda
win-64::libgdal-arrow-parquet-3.8.2-ha5a541d_0.conda
win-64::coda-2.25.1-py310h5eb019b_0.conda
win-64::pytables-3.9.2-py310hde27e41_1.conda
win-64::clangdev-13.0.1-default_h66ee7f4_4.conda
win-64::libgdal-arrow-parquet-3.8.1-h98ab263_3.conda
win-64::lxml-4.9.3-py312h2f4f5e2_3.conda
win-64::stir-5.2.0-cuda120_py38he42b1f3_203.conda
win-64::stir-5.2.0-cuda112_py311h1bd1eb7_203.conda
win-64::intel-opencl-rt-2024.0.0-h4869bb9_49840.conda
win-64::libarrow-gandiva-14.0.1-hb2eaab1_9_cpu.conda
win-64::postgresql-plpython-16.1-py39hf83d731_5.conda
win-64::coda-2.25.1-py38h56b84b2_0.conda
win-64::lxml-4.9.3-py312h2f4f5e2_2.conda
win-64::gemmi-0.6.4-py310hb84602e_0.conda
win-64::stir-5.2.0-cuda112_py310h5c9ace5_203.conda
win-64::libarrow-gandiva-14.0.2-hb2eaab1_0_cpu.conda
win-64::libarrow-12.0.1-h355d2d4_32_cuda.conda
win-64::tiledb-2.18.2-h403f8a8_1.conda
win-64::ifcopenshell-v0.7.0.231127-py311_novtk_hea3fc56_102.conda
win-64::tiledb-2.19.0-h8e52ccb_0.conda
win-64::scip-8.1.0-h51e9e8b_4.conda
win-64::libarrow-13.0.0-he24e1af_20_cuda.conda
win-64::aws-sdk-cpp-1.11.210-h5f33293_4.conda
win-64::ifcopenshell-v0.7.0.231127-py312_novtk_ha599453_102.conda
win-64::ifcopenshell-v0.7.0.231127-py38_novtk_h18e8662_102.conda
win-64::ifcopenshell-v0.7.0.231127-py312_all_ha4a01b5_202.conda
win-64::postgresql-plpython-16.1-py310hf838413_7.conda
win-64::lxml-4.9.3-py310h46d54dd_2.conda
win-64::ffmpeg-6.1.1-gpl_h56e7eb4_100.conda
win-64::clang-format-13.0.1-default_h66ee7f4_4.conda
win-64::zimpl-3.5.3-h96a1494_5.conda
win-64::libuwebsockets-20.55.0-h12be248_0.conda
win-64::tiledb-2.18.3-h8e52ccb_0.conda
win-64::libgdal-arrow-parquet-3.8.2-h5f241bf_1.conda
win-64::postgresql-16.1-h1beaf6b_7.conda
win-64::vtk-base-9.2.6-qt_py39h1234567_220.conda
win-64::lldb-17.0.6-py310h7b8b68d_0.conda
win-64::libuwebsockets-20.51.0-h12be248_0.conda
win-64::dpcpp_impl_win-64-2024.0.0-hedff495_49840.conda
win-64::pyinstaller-6.3.0-py39h84a0465_0.conda
win-64::poppler-23.12.0-hc2f3c52_0.conda
win-64::ffmpeg-6.1.1-lgpl_h823ccd3_0.conda
win-64::libgdal-arrow-parquet-3.8.1-h0eef876_0.conda
win-64::libgdal-arrow-parquet-3.7.3-ha5a541d_12.conda
win-64::intel-opencl-rt-2024.0.0-hb99dfa9_49840.conda
win-64::libarrow-11.0.0-h1138768_55_cpu.conda
win-64::clang-format-13.0.1-default_h66ee7f4_5.conda
win-64::libspatialite-5.1.0-hf2f0abc_4.conda
win-64::clangxx-16.0.6-default_hde6756a_3.conda
win-64::clangxx-15.0.7-default_hde6756a_4.conda
win-64::intel-opencl-rt-2024.0.0-h6222832_49840.conda
win-64::libarrow-12.0.1-he24e1af_31_cuda.conda
win-64::bytewax-0.17.2-py310pl5321h65afd28_0.conda
win-64::libglib-2.78.3-h16e383f_0.conda
win-64::libarrow-gandiva-14.0.1-hb2eaab1_10_cpu.conda
win-64::libclang13-15.0.7-default_h85b4d89_4.conda
win-64::qt6-main-6.6.1-hc9a02c6_5.conda
win-64::libgdal-3.8.1-hbbc1416_1.conda
win-64::clang-tools-16.0.6-default_hde6756a_3.conda
win-64::libgdal-3.8.1-h0791e23_0.conda
win-64::qt-main-5.15.8-h9e85ed6_18.conda
win-64::qt6-main-6.5.3-hc9a02c6_1.conda
win-64::tesseract-5.3.3-h8c4da6d_0.conda
win-64::zimpl-3.5.3-h96a1494_6.conda
win-64::libgdal-arrow-parquet-3.8.1-h3b38833_4.conda
win-64::libarrow-12.0.1-h548e6fb_31_cpu.conda
win-64::libgdal-3.7.3-hfe9b85f_9.conda
win-64::libgdal-arrow-parquet-3.7.3-h5f241bf_13.conda
win-64::libgdal-arrow-parquet-3.7.3-h65542e6_13.conda
win-64::libgdal-arrow-parquet-3.8.1-h9f59305_1.conda
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
win-64::clangxx-13.0.1-default_h66ee7f4_4.conda
win-64::clang-13.0.1-default_h46fc674_4.conda
win-64::clangxx-13.0.1-default_h66ee7f4_5.conda
win-64::clang-13.0.1-default_h46fc674_5.conda
-    "libzlib >=1.2.13,<1.3.0a0"
+    "libzlib >=1.2.13,<2.0.0a0"
================================================================================
================================================================================
osx-64
osx-64::libuwebsockets-20.55.0-h2d185b6_0.conda
osx-64::libuwebsockets-20.53.0-h2d185b6_0.conda
osx-64::dotnet-aspnetcore-8.0.0-h4becb4f_0.conda
osx-64::libuwebsockets-20.49.0-hf4d7fad_0.conda
osx-64::dotnet-runtime-8.0.0-h4becb4f_0.conda
osx-64::dotnet-aspnetcore-6.0.25-h4becb4f_0.conda
osx-64::libsoup-3.4.4-h4a60539_1.conda
osx-64::rill-0.38.1-h5510862_0.conda
osx-64::libdap4-3.20.6-h7e512d6_5.conda
osx-64::gst-plugins-base-1.22.8-h3fb38fc_0.conda
osx-64::dotnet-aspnetcore-7.0.14-h4becb4f_0.conda
osx-64::libuwebsockets-20.51.0-h2d185b6_0.conda
osx-64::gst-plugins-base-1.22.7-hd283e88_1.conda
osx-64::libsoup-2.74.3-h4a60539_2.conda
osx-64::micromamba-1.5.6-0.tar.bz2
osx-64::eccodes-2.33.0-h40b907c_0.conda
osx-64::aria2-1.37.0-he5a3eb3_1.conda
osx-64::rill-0.38.0-h5510862_0.conda
osx-64::dotnet-runtime-7.0.14-h4becb4f_0.conda
osx-64::libuwebsockets-20.54.0-h2d185b6_0.conda
osx-64::dotnet-runtime-6.0.25-h4becb4f_0.conda
osx-64::aria2-1.37.0-hd891fde_1.conda
osx-64::zimpl-3.5.3-h6ebec85_5.conda
osx-64::micromamba-1.5.5-0.tar.bz2
osx-64::glib-tools-2.78.3-hf4d7fad_0.conda
osx-64::dotnet-sdk-6.0.417-h4becb4f_0.conda
osx-64::dotnet-sdk-8.0.100-h4becb4f_0.conda
osx-64::libuwebsockets-20.52.0-h2d185b6_0.conda
osx-64::glib-tools-2.78.2-hf4d7fad_0.conda
osx-64::rill-0.38.2-h5510862_0.conda
osx-64::dotnet-sdk-7.0.404-h4becb4f_0.conda
-    "libzlib >=1.2.13,<1.3.0a0"
+    "libzlib >=1.2.13,<2.0.0a0"
osx-64::pp-sketchlib-2.1.2-py311hdd0ee46_1.conda
osx-64::libgdal-arrow-parquet-3.8.1-h62689eb_3.conda
osx-64::pp-sketchlib-2.1.2-py39hfcab31a_1.conda
osx-64::postgresql-plpython-16.1-py311h47125a7_7.conda
osx-64::xrootd-5.6.2-py38h8da60b8_2.conda
osx-64::postgresql-plpython-15.4-py312h4a1d472_3.conda
osx-64::libgdal-arrow-parquet-3.8.1-h3ee1c30_4.conda
osx-64::soplex-6.0.4-h7383368_5.conda
osx-64::libnetcdf-4.9.2-mpi_openmpi_h00c184e_13.conda
osx-64::libgdal-arrow-parquet-3.8.1-h480ad5e_1.conda
osx-64::libpq-16.1-h74b662b_5.conda
osx-64::root_base-6.28.10-py39h4d57b5c_2.conda
osx-64::aiokafka-0.10.0-py312h67dd88c_0.conda
osx-64::libgdal-3.7.3-h91068d9_9.conda
osx-64::libtensorflow-2.15.0-cpu_hc26cd4c_0.conda
osx-64::libssh-0.10.6-hb80450b_0.conda
osx-64::mandrake-1.2.2-py39hfa2c550_6.conda
osx-64::pytables-3.9.2-py310ha2b9561_1.conda
osx-64::xrootd-5.6.4-py311h0bbdad1_0.conda
osx-64::postgresql-plpython-16.1-py310h7e3f867_7.conda
osx-64::root_base-6.30.2-py39h1168b32_1.conda
osx-64::libgdal-arrow-parquet-3.8.1-h85ec132_0.conda
osx-64::pp-sketchlib-2.1.2-py310h3deeb49_1.conda
osx-64::vtk-base-9.2.6-qt_py310h1234567_220.conda
osx-64::postgresql-plpython-16.1-py312h4a1d472_7.conda
osx-64::aiokafka-0.9.0-py310h03c913b_0.conda
osx-64::magics-metview-4.14.2-h2f8389b_2.conda
osx-64::nss-3.96-ha05da47_0.conda
osx-64::coda-2.25.1-py39h7a8ce1f_0.conda
osx-64::gemmi-0.6.4-py310h7d48a1f_0.conda
osx-64::openmpi-5.0.0-h01516ab_101.conda
osx-64::postgresql-plpython-16.1-py310hd344ed2_6.conda
osx-64::imagemagick-7.1.1_23-pl5321h51fee12_0.conda
osx-64::libtensorflow_cc-2.15.0-cpu_h55a125e_1.conda
osx-64::gdstk-0.9.48-py310h3c52f0c_1.conda
osx-64::util-linux-2.39.3-py38he49f3e3_1.conda
osx-64::r-base-4.2.3-h46d3641_11.conda
osx-64::gmsh-4.12.0-h546c69e_0.conda
osx-64::lldb-17.0.6-py311he41aa78_0.conda
osx-64::xrootd-5.6.3-py39h466852b_0.conda
osx-64::texlive-core-20230313-h3723d5a_9.conda
osx-64::root_base-6.28.10-py311hf132bd6_2.conda
osx-64::folly-2023.12.11.00-h80dc065_0.conda
osx-64::libscotch-7.0.4-h6959927_1.conda
osx-64::libgdal-arrow-parquet-3.7.3-h3ee1c30_12.conda
osx-64::pytng-0.3.1-py311h0c3a6a7_1.conda
osx-64::libgdal-arrow-parquet-3.7.3-h4efde2d_10.conda
osx-64::qt6-main-6.6.1-h729e66d_4.conda
osx-64::yoda-1.9.6-py38hfa8fc59_5.conda
osx-64::folly-2023.12.04.00-h2dd0d79_0_jemalloc.conda
osx-64::pyreadstat-1.2.6-py310h03c913b_0.conda
osx-64::minizip-4.0.4-h37d7099_0.conda
osx-64::sagelib-10.1-py310h89b1bf4_0.conda
osx-64::libgoogle-cloud-storage-2.17.0-ha67e85c_0.conda
osx-64::qt6-main-6.6.1-h729e66d_3.conda
osx-64::jaxlib-0.4.20-cpu_py311h9589f2b_0.conda
osx-64::root_base-6.28.10-py38hd53aec0_2.conda
osx-64::libarrow-11.0.0-h36c5bb6_56_cpu.conda
osx-64::tesseract-5.3.2-he6dfaf8_1.conda
osx-64::libgdal-arrow-parquet-3.8.1-he1e4a8b_4.conda
osx-64::yoda-1.9.6-py310h651453d_6.conda
osx-64::libxml2-2.12.2-hc0ae0f7_0.conda
osx-64::sagelib-10.2-py310he753c6f_1.conda
osx-64::folly-2023.12.04.00-h175799c_0.conda
osx-64::folly-2023.12.11.00-h40d39b1_0.conda
osx-64::libarrow-13.0.0-h3bd19ca_20_cpu.conda
osx-64::postgresql-plpython-16.1-py311h33a6423_6.conda
osx-64::tiledb-2.18.3-h4df5763_0.conda
osx-64::qt-main-5.15.8-h26cf8db_18.conda
osx-64::lldb-17.0.2-py311hf635c3f_0.conda
osx-64::libgdal-arrow-parquet-3.8.1-hbfb9007_3.conda
osx-64::mandrake-1.2.2-py311h56b1a56_7.conda
osx-64::arrow-cpp-9.0.0-py311h0ea927f_50_cpu.conda
osx-64::util-linux-2.39.3-py38h75b9449_0.conda
osx-64::erlang-26.2.1-pl5321h0c96147_0.conda
osx-64::libitk-5.3.0-h325faac_8.conda
osx-64::root_base-6.28.10-py310h088463a_1.conda
osx-64::xrootd-5.6.2-py312hbaeceb8_2.conda
osx-64::aiokafka-0.9.0-py312h67dd88c_1.conda
osx-64::tensorflow-base-2.15.0-cpu_py310h35b30e2_0.conda
osx-64::libgdal-arrow-parquet-3.7.3-hfe834e1_13.conda
osx-64::ffmpeg-6.1.0-lgpl_hc69a8f9_4.conda
osx-64::util-linux-2.39.3-py312h23d2c39_0.conda
osx-64::postgresql-16.1-hbd19fd8_5.conda
osx-64::libgdal-arrow-parquet-3.8.1-h1d8029f_1.conda
osx-64::folly-2023.12.11.00-h2dd0d79_0_jemalloc.conda
osx-64::xrootd-5.6.2-py39h466852b_2.conda
osx-64::tensorflow-base-2.15.0-cpu_py310hc0a61e3_1.conda
osx-64::boost-cpp-1.84.0-h07eb623_0.conda
osx-64::libarrow-14.0.2-h2ef8067_0_cpu.conda
osx-64::gdstk-0.9.48-py39h6e703ae_0.conda
osx-64::libgdal-arrow-parquet-3.7.3-hff15375_10.conda
osx-64::folly-2023.12.18.00-ha75df62_0.conda
osx-64::libgdal-arrow-parquet-3.8.2-h3cb0702_1.conda
osx-64::libgdal-arrow-parquet-3.7.3-h42a2c4f_12.conda
osx-64::libgdal-3.7.3-h44a6170_11.conda
osx-64::pytables-3.9.2-py312ha78d794_1.conda
osx-64::libgdal-arrow-parquet-3.7.3-h4c0ff41_10.conda
osx-64::libxml2-2.12.3-hc0ae0f7_0.conda
osx-64::pp-sketchlib-2.1.2-py310h3deeb49_0.conda
osx-64::imagemagick-7.1.1_25-pl5321h629a661_0.conda
osx-64::openssh-9.6p1-h6dd4ff7_0.conda
osx-64::lxml-4.9.3-py39h234843f_2.conda
osx-64::r-gaston-1.6-r42hd6ad0b9_0.conda
osx-64::lldb-17.0.6-py39hcd70430_0.conda
osx-64::coda-2.25.1-py39h3f9332a_0.conda
osx-64::aws-sdk-cpp-1.11.210-hcffc49a_5.conda
osx-64::libcurl-8.5.0-h726d00d_0.conda
osx-64::pytables-3.9.2-py39h24dbf18_1.conda
osx-64::qt6-main-6.5.3-h617ce84_0.conda
osx-64::jaxlib-0.4.20-cpu_py312h239d92d_0.conda
osx-64::libxmlsec1-1.3.2-habd493b_1.conda
osx-64::aiokafka-0.10.0-py311h8c2310c_0.conda
osx-64::postgresql-plpython-15.4-py39hf4bfa82_4.conda
osx-64::postgresql-plpython-16.1-py39h7f9fc5f_7.conda
osx-64::aws-sdk-cpp-1.11.210-h7d17a91_4.conda
osx-64::pp-sketchlib-2.1.2-py38hc372b2a_0.conda
osx-64::folly-2023.12.18.00-h8bd47b9_0.conda
osx-64::xrootd-5.6.3-py310ha9b575f_0.conda
osx-64::libgdal-arrow-parquet-3.7.3-h1f2e2c0_11.conda
osx-64::folly-2023.12.18.00-h079d3a0_0_jemalloc.conda
osx-64::libcurl-static-8.5.0-h726d00d_0.conda
osx-64::magics-metview-batch-4.15.0-hb5cd182_0.conda
osx-64::postgresql-plpython-16.1-py39hf4bfa82_7.conda
osx-64::ifcopenshell-v0.7.0.231127-py38_novtk_h6ad7897_102.conda
osx-64::gst-plugins-bad-1.22.7-hbda758a_0.conda
osx-64::pytng-0.3.1-py39hcf27c3a_1.conda
osx-64::sagelib-10.0-py311h2cc7121_2.conda
osx-64::tesseract-5.3.2-h3e3889e_2.conda
osx-64::libgdal-arrow-parquet-3.7.3-h3cb0702_13.conda
osx-64::bytewax-0.17.2-py311hf8f184a_0.conda
osx-64::ndcctools-7.7.3-py310he6a79d6_0.conda
osx-64::tensorflow-base-2.15.0-cpu_py39h8cf451b_0.conda
osx-64::python-igraph-0.11.3-py310h3a26507_1.conda
osx-64::libgdal-arrow-parquet-3.8.1-h885c818_1.conda
osx-64::libglib-2.78.2-h198397b_0.conda
osx-64::poppler-23.12.0-hdd5a5e8_0.conda
osx-64::cppyy-cling-6.30.0-py38hbcdfe3b_0.conda
osx-64::libnghttp2-static-1.58.0-hf822044_1.conda
osx-64::gemmi-0.6.4-py311hb5c2e0a_0.conda
osx-64::openmpi-5.0.1-h01516ab_100.conda
osx-64::util-linux-2.39.3-py39h2550083_0.conda
osx-64::glib-2.78.2-hf4d7fad_0.conda
osx-64::pdal-2.6.1-hcce35d3_1.conda
osx-64::lldb-17.0.2-py38hf01a2f3_0.conda
osx-64::libgdal-arrow-parquet-3.7.3-h5c540d0_11.conda
osx-64::tiledb-2.18.2-hf39d8ab_2.conda
osx-64::aws-sdk-cpp-1.11.210-ha812a5c_6.conda
osx-64::plplot-5.15.0-h8f138ff_3.conda
osx-64::tiledb-2.18.2-hd5cdfc6_2.conda
osx-64::postgresql-plpython-15.4-py311h47125a7_4.conda
osx-64::libgdal-3.8.2-hf17bf98_0.conda
osx-64::pytng-0.3.1-py310h917455f_1.conda
osx-64::imagecodecs-2024.1.1-py39h53e8177_0.conda
osx-64::python-3.11.7-h9f0c242_0_cpython.conda
osx-64::util-linux-2.39.3-py39hadb4205_1.conda
osx-64::libboost-1.84.0-h5b2dd29_0.conda
osx-64::yoda-1.9.6-py39hfe05efa_6.conda
osx-64::papilo-2.1.4-h8422892_5.conda
osx-64::folly-2023.12.18.00-h7815ab9_0.conda
osx-64::gdstk-0.9.48-py38hbe7c026_0.conda
osx-64::libpq-15.4-h6dd4ff7_3.conda
osx-64::folly-2023.12.25.00-h079d3a0_0_jemalloc.conda
osx-64::libgoogle-cloud-storage-2.17.0-ha67e85c_1.conda
osx-64::ifcopenshell-v0.7.0.231127-py311_novtk_h848e2e9_102.conda
osx-64::root_base-6.30.2-py39h4d57b5c_0.conda
osx-64::lld-16.0.6-h455ef5f_1.conda
osx-64::sagelib-10.2-py39hf4b7944_0.conda
osx-64::sagelib-10.1-py39hf4b7944_0.conda
osx-64::pp-sketchlib-2.1.2-py38hc372b2a_1.conda
osx-64::yoda-1.9.6-py311hcd44ad7_6.conda
osx-64::postgresql-plpython-16.1-py38h59056bf_7.conda
osx-64::qpdf-10.6.3-h8bcb814_2.conda
osx-64::libgdal-arrow-parquet-3.8.2-hfe834e1_1.conda
osx-64::libarrow-12.0.1-h3bd19ca_31_cpu.conda
osx-64::gdstk-0.9.48-py39h23d43bd_0.conda
osx-64::postgresql-15.4-h413614c_3.conda
osx-64::libgdal-arrow-parquet-3.8.2-hfb8ab86_1.conda
osx-64::pyinstaller-6.3.0-py39h5eebb3c_0.conda
osx-64::ifcopenshell-v0.7.0.231127-py310_all_hbce1fd5_202.conda
osx-64::ifcopenshell-v0.7.0.231127-py312_all_h17670b1_202.conda
osx-64::pp-sketchlib-2.1.2-py312hdf920f1_1.conda
osx-64::magics-metview-4.15.0-h2f8389b_0.conda
osx-64::libarrow-12.0.1-he48dc09_30_cpu.conda
osx-64::gdstk-0.9.48-py310he76db83_1.conda
osx-64::yoda-1.9.6-py38hfa8fc59_6.conda
osx-64::postgresql-plpython-16.1-py39h7f9fc5f_6.conda
osx-64::curl-8.5.0-h726d00d_0.conda
osx-64::gemmi-0.6.4-py312h534208b_0.conda
osx-64::python-igraph-0.11.3-py38hd8163cf_1.conda
osx-64::libarrow-11.0.0-hcef4fff_55_cpu.conda
osx-64::libarrow-14.0.1-h2ef8067_10_cpu.conda
osx-64::arrow-cpp-9.0.0-py38hb2e311f_50_cpu.conda
osx-64::coda-2.25.1-py310h028c02d_0.conda
osx-64::gemmi-0.6.4-py38h6008ce5_0.conda
osx-64::folly-2023.12.11.00-he8cca0d_0_jemalloc.conda
osx-64::util-linux-2.39.3-py311ha082ef5_0.conda
osx-64::libgdal-arrow-parquet-3.8.1-h94e6718_1.conda
osx-64::aiokafka-0.9.0-py311h8c2310c_1.conda
osx-64::aiokafka-0.10.0-py38hf1429db_0.conda
osx-64::python-3.11.7-h9f0c242_1_cpython.conda
osx-64::pygplates-0.39-py38h78e0221_14.conda
osx-64::libtensorflow-2.15.0-cpu_h1daf16d_1.conda
osx-64::python-3.8.18-h5ba8234_1_cpython.conda
osx-64::xrootd-5.6.2-py310ha9b575f_2.conda
osx-64::cppyy-cling-6.30.0-py39h0bb4e67_0.conda
osx-64::libarrow-14.0.1-h7e6b3eb_9_cpu.conda
osx-64::libgdal-arrow-parquet-3.7.3-h62689eb_11.conda
osx-64::xmlrpc-c-1.54.06-h7cfeffa_0.conda
osx-64::r-rmatio-0.19.0-r42hb2c329c_0.conda
osx-64::mandrake-1.2.2-py38h80f232c_6.conda
osx-64::postgresql-16.1-hbd19fd8_7.conda
osx-64::postgresql-plpython-16.1-py38hf95a095_6.conda
osx-64::xrootd-5.6.2-py311h0bbdad1_2.conda
osx-64::libgdal-arrow-parquet-3.8.2-h6dd71b9_0.conda
osx-64::lldb-17.0.6-py310h19ead05_0.conda
osx-64::pyinstaller-6.3.0-py312h67dd88c_0.conda
osx-64::libgdal-arrow-parquet-3.8.1-h5c540d0_3.conda
osx-64::aiokafka-0.10.0-py39h58a92f5_0.conda
osx-64::gst-plugins-good-1.22.7-h3e9aad4_1.conda
osx-64::libgdal-arrow-parquet-3.7.3-had38a48_12.conda
osx-64::erlang-26.2-pl5321h0c96147_0.conda
osx-64::util-linux-2.39.3-py310h68052b9_1.conda
osx-64::openslide-4.0.0-h75f8748_0.conda
osx-64::postgresql-plpython-16.1-py312h01252a9_6.conda
osx-64::folly-2023.12.25.00-h37615a4_0_jemalloc.conda
osx-64::python-3.12.1-h9f0c242_0_cpython.conda
osx-64::util-linux-2.39.3-py39ha1f00b2_0.conda
osx-64::aiokafka-0.9.0-py310h03c913b_1.conda
osx-64::pyreadstat-1.2.6-py39h5eebb3c_0.conda
osx-64::folly-2023.12.18.00-h37615a4_0_jemalloc.conda
osx-64::lxml-4.9.3-py310hca08431_2.conda
osx-64::r-vcfr-1.15.0-r43hd6ad0b9_0.conda
osx-64::postgresql-16.1-hbd19fd8_6.conda
osx-64::root_base-6.28.10-py311hf132bd6_0.conda
osx-64::imagemagick-7.1.1_21-pl5321h51fee12_2.conda
osx-64::ffmpeg-6.1.0-gpl_he3d9fea_104.conda
osx-64::xrootd-5.6.3-py311h0bbdad1_0.conda
osx-64::mandrake-1.2.2-py310h5ed2698_5.conda
osx-64::mandrake-1.2.2-py310h5ed2698_7.conda
osx-64::libgdal-arrow-parquet-3.8.1-h4c0ff41_2.conda
osx-64::libgdal-3.8.1-h5c58ba9_0.conda
osx-64::lxml-4.9.3-py38hbadceb4_2.conda
osx-64::folly-2023.12.11.00-h175799c_0.conda
osx-64::hdf5-1.14.3-nompi_h691f4bf_100.conda
osx-64::libgdal-arrow-parquet-3.7.3-he1e4a8b_12.conda
osx-64::libgdal-3.8.1-h4d894c1_3.conda
osx-64::tiledb-2.18.3-hb85ba1e_0.conda
osx-64::libgdal-arrow-parquet-3.7.3-ha8ed71e_13.conda
osx-64::xrootd-5.6.4-py310ha9b575f_0.conda
osx-64::pdal-2.6.2-hd613b54_2.conda
osx-64::nexus-4.4.3-hc67716a_13.conda
osx-64::sagelib-10.2-py311h2cc7121_0.conda
osx-64::root_base-6.28.10-py38hd53aec0_1.conda
osx-64::pytables-3.9.2-py311h3cee394_1.conda
osx-64::postgresql-plpython-15.4-py38h59056bf_4.conda
osx-64::cppyy-cling-6.30.0-py39h78a5168_0.conda
osx-64::cargo-c-0.9.29-h148f8b7_0.conda
osx-64::libtiledb-sql-0.26.0-h8bb4d41_1.conda
osx-64::root_base-6.28.10-py310h088463a_2.conda
osx-64::folly-2023.12.04.00-h40d39b1_0.conda
osx-64::pdal-2.6.2-hcce35d3_0.conda
osx-64::folly-2023.12.11.00-hdf6ac6a_0_jemalloc.conda
osx-64::openmpi-5.0.0-h01516ab_102.conda
osx-64::libgdal-arrow-parquet-3.8.1-h4c5ef9b_0.conda
osx-64::root_base-6.30.2-py311hf132bd6_0.conda
osx-64::jimtcl-0.82-ha4b2086_0.conda
osx-64::aiokafka-0.9.0-py38hf1429db_1.conda
osx-64::xrootd-5.6.4-py38h8da60b8_0.conda
osx-64::root_base-6.30.2-py310h088463a_0.conda
osx-64::libarrow-11.0.0-hd806281_54_cpu.conda
osx-64::libvips-8.15.1-ha588e58_0.conda
osx-64::mandrake-1.2.2-py38h80f232c_5.conda
osx-64::folly-2023.12.04.00-he8cca0d_0_jemalloc.conda
osx-64::pyreadstat-1.2.6-py311h8c2310c_0.conda
osx-64::cpp-opentelemetry-sdk-1.13.0-h5ad93c0_0.conda
osx-64::root_base-6.28.10-py39h4d57b5c_0.conda
osx-64::vtk-base-9.2.6-qt_py38h1234567_220.conda
osx-64::libgdal-arrow-parquet-3.8.1-h514f490_0.conda
osx-64::gdstk-0.9.48-py310h5e300f4_1.conda
osx-64::libgdal-arrow-parquet-3.8.2-ha8ed71e_1.conda
osx-64::python-igraph-0.11.3-py311hf8e9688_1.conda
osx-64::magics-4.15.0-hb5cd182_0.conda
osx-64::sagelib-10.0-py38hb8d266d_2.conda
osx-64::tiledb-2.18.2-h527f106_2.conda
osx-64::fltk-1.3.9-he73b29e_0.conda
osx-64::bytewax-0.17.2-py312h4769f7e_0.conda
osx-64::pygplates-0.39-py311h7cc1e1a_14.conda
osx-64::libtiledb-sql-0.26.0-h0e50b57_1.conda
osx-64::postgresql-plpython-15.4-py312h4a1d472_4.conda
osx-64::ffmpeg-6.1.1-gpl_h16c9623_100.conda
osx-64::gst-plugins-good-1.22.8-hb31dba0_0.conda
osx-64::libarchive-3.7.2-hd35d340_1.conda
osx-64::lldb-17.0.2-py310h9f99836_0.conda
osx-64::arrow-cpp-9.0.0-py39h024314c_50_cpu.conda
osx-64::scip-8.1.0-h54180dc_5.conda
osx-64::lxml-4.9.3-py311h719c1e2_2.conda
osx-64::pytables-3.9.2-py39h3e2a518_1.conda
osx-64::libarrow-14.0.1-hd633658_7_cpu.conda
osx-64::imagemagick-7.1.1_24-pl5321h629a661_0.conda
osx-64::mongodb-6.0.12-hfc94666_0.conda
osx-64::pygplates-0.39-py310h5ce94ea_14.conda
osx-64::libarchive-minimal-static-3.7.2-h54d3e53_1.conda
osx-64::libgdal-arrow-parquet-3.8.1-had38a48_4.conda
osx-64::libgdal-arrow-parquet-3.7.3-h1d8029f_9.conda
osx-64::jaxlib-0.4.20-cpu_py310hbe00a30_0.conda
osx-64::libarrow-13.0.0-he48dc09_19_cpu.conda
osx-64::libgdal-arrow-parquet-3.8.2-he001a8e_0.conda
osx-64::geotiff-1.7.1-h509af15_15.conda
osx-64::vtk-base-9.2.6-qt_py312h1234567_220.conda
osx-64::libgdal-arrow-parquet-3.7.3-hbfb9007_11.conda
osx-64::jaxlib-0.4.23-cpu_py39heb0bab2_0.conda
osx-64::libgdal-3.8.2-h89a805d_1.conda
osx-64::imagecodecs-2024.1.1-py39h989e670_0.conda
osx-64::yoda-1.9.6-py39h0c3dc94_6.conda
osx-64::lldb-17.0.6-py38he333130_0.conda
osx-64::magics-4.14.2-h8e71180_2.conda
osx-64::cppyy-cling-6.30.0-py311h0102fb6_0.conda
osx-64::pytng-0.3.1-py312hf33f409_1.conda
osx-64::libssh-0.10.6-h6ce7c92_1.conda
osx-64::gemmi-0.6.4-py39haa0d8d9_0.conda
osx-64::postgresql-plpython-16.1-py311h33a6423_5.conda
osx-64::folly-2023.12.25.00-h7815ab9_0.conda
osx-64::imagecodecs-2024.1.1-py310h623599c_0.conda
osx-64::libgdal-arrow-parquet-3.8.1-hb50c155_2.conda
osx-64::python-igraph-0.11.3-py312h113082e_1.conda
osx-64::yoda-1.9.6-py311hcd44ad7_5.conda
osx-64::openslide-3.4.1-h75f8748_12.conda
osx-64::postgresql-15.4-h413614c_4.conda
osx-64::libgdal-arrow-parquet-3.8.1-h4efde2d_2.conda
osx-64::fish-3.6.3-h42c0413_0.conda
osx-64::tensorflow-base-2.15.0-cpu_py39h1d1916d_1.conda
osx-64::postgresql-plpython-16.1-py311h33a6423_7.conda
osx-64::libnetcdf-4.9.2-nompi_h7760872_113.conda
osx-64::qt6-main-6.5.3-h729e66d_1.conda
osx-64::r-vcfr-1.15.0-r42hd6ad0b9_0.conda
osx-64::mandrake-1.2.2-py310h5ed2698_6.conda
osx-64::util-linux-2.39.3-py311h1452253_1.conda
osx-64::xrootd-5.6.3-py38h8da60b8_0.conda
osx-64::imagecodecs-2024.1.1-py311h5e2a27e_0.conda
osx-64::ndcctools-7.7.3-py311h3fee2e7_0.conda
osx-64::libpulsar-3.4.2-h4608f1c_0.conda
osx-64::ifcopenshell-v0.7.0.231127-py38_all_h7704388_202.conda
osx-64::libpq-15.4-h4a9f144_4.conda
osx-64::openconnect-9.12-hb7befe9_1.conda
osx-64::tesseract-5.3.3-h3e3889e_0.conda
osx-64::r-rmatio-0.19.0-r43hb2c329c_0.conda
osx-64::openssh-9.3p1-h6dd4ff7_3.conda
osx-64::jaxlib-0.4.23-cpu_py312h239d92d_0.conda
osx-64::folly-2023.12.04.00-h80dc065_0.conda
osx-64::folly-2023.12.25.00-h8225e4e_0_jemalloc.conda
osx-64::ndcctools-7.7.3-py39h910a6c2_0.conda
osx-64::root_base-6.28.10-py311hf132bd6_1.conda
osx-64::xrootd-5.6.4-py39h1868286_0.conda
osx-64::libvips-8.15.0-h82c26e3_4.conda
osx-64::pyreadstat-1.2.6-py312h67dd88c_0.conda
osx-64::ruby-3.2.2-h4b2e751_1.conda
osx-64::pyinstaller-6.3.0-py38hf1429db_0.conda
osx-64::postgresql-plpython-16.1-py310hd344ed2_7.conda
osx-64::pyreadstat-1.2.6-py38hf1429db_0.conda
osx-64::wasmer-4.2.5-hf88dd22_0.conda
osx-64::aiokafka-0.10.0-py310h03c913b_0.conda
osx-64::libgdal-3.8.1-h35eb6ba_4.conda
osx-64::pytng-0.3.1-py39h4530c4c_1.conda
osx-64::vtk-base-9.2.6-qt_py311h1234567_220.conda
osx-64::gmsh-4.12.0-h48a2193_0.conda
osx-64::python-3.10.13-h00d2728_1_cpython.conda
osx-64::sagelib-10.2-py310h89b1bf4_0.conda
osx-64::libyarp-3.9.0-h8d755ce_0.conda
osx-64::libarrow-11.0.0-he8dfed2_50_cpu.conda
osx-64::ndcctools-7.7.3-py38h9e0349e_0.conda
osx-64::root_base-6.28.10-py39h4d57b5c_1.conda
osx-64::folly-2023.12.18.00-h8225e4e_0_jemalloc.conda
osx-64::root_base-6.30.2-py310he6b9cd7_1.conda
osx-64::ffmpeg-6.1.1-lgpl_h06caae9_0.conda
osx-64::postgresql-plpython-15.4-py310h7e3f867_4.conda
osx-64::libgdal-arrow-parquet-3.7.3-hfb8ab86_13.conda
osx-64::lxml-4.9.3-py38hbadceb4_3.conda
osx-64::util-linux-2.39.3-py312h21d8fb9_1.conda
osx-64::ifcopenshell-v0.7.0.231127-py312_novtk_ha749156_102.conda
osx-64::libarrow-14.0.1-hb5e1ce9_8_cpu.conda
osx-64::python-3.12.1-h9f0c242_1_cpython.conda
osx-64::imagecodecs-2024.1.1-py312h30c1dc0_0.conda
osx-64::openconnect-9.12-hf093284_2.conda
osx-64::gdstk-0.9.48-py310h83e167c_0.conda
osx-64::yoda-1.9.6-py38h3c8a8b1_6.conda
osx-64::libtensorflow_cc-2.15.0-cpu_h407b87f_0.conda
osx-64::postgresql-16.1-h413614c_7.conda
osx-64::symengine-0.11.2-hb6b57cf_0.conda
osx-64::postgresql-plpython-15.4-py310h7e3f867_3.conda
osx-64::gdstk-0.9.48-py312hf3e4e0a_0.conda
osx-64::root_base-6.30.2-py311hff73031_1.conda
osx-64::vtk-base-9.2.6-qt_py39h1234567_220.conda
osx-64::davix-0.8.5-h3f1511c_0.conda
osx-64::folly-2023.12.25.00-h8bd47b9_0.conda
osx-64::sdl2_image-2.8.0-h02668a6_0.conda
osx-64::libspatialite-5.1.0-hebe6af1_4.conda
osx-64::fish-3.6.4-h42c0413_0.conda
osx-64::sagelib-10.2-py39h92208d3_1.conda
osx-64::aiokafka-0.9.0-py39h5eebb3c_1.conda
osx-64::sagelib-10.2-py311h3d2105c_1.conda
osx-64::libgdal-arrow-parquet-3.7.3-h94e6718_9.conda
osx-64::lxml-4.9.3-py312h86694d6_3.conda
osx-64::libgdal-arrow-parquet-3.8.1-h1f2e2c0_3.conda
osx-64::postgresql-plpython-15.4-py38h59056bf_3.conda
osx-64::libpq-16.1-h74b662b_6.conda
osx-64::libarrow-12.0.1-h36c5bb6_32_cpu.conda
osx-64::lxml-4.9.3-py39h0d9b2a9_3.conda
osx-64::tiledb-2.18.3-h03cb7d7_0.conda
osx-64::pp-sketchlib-2.1.2-py311hdd0ee46_0.conda
osx-64::magics-metview-batch-4.14.2-h8e71180_2.conda
osx-64::gdstk-0.9.48-py311h7edd508_0.conda
osx-64::postgresql-plpython-16.1-py38hf95a095_5.conda
osx-64::mandrake-1.2.2-py39hfa2c550_7.conda
osx-64::tensorflow-base-2.15.0-cpu_py311h3619e24_0.conda
osx-64::ifcopenshell-v0.7.0.231127-py39_novtk_h71a9925_102.conda
osx-64::libgdal-3.8.1-h7bb8e92_2.conda
osx-64::libgdal-3.7.3-hd7e142f_13.conda
osx-64::libgdal-arrow-parquet-3.8.2-hf38bf52_0.conda
osx-64::aiokafka-0.9.0-py38hf1429db_0.conda
osx-64::libgdal-arrow-parquet-3.8.1-hff15375_2.conda
osx-64::pp-sketchlib-2.1.2-py39hfcab31a_0.conda
osx-64::lxml-4.9.3-py311h719c1e2_3.conda
osx-64::openslide-4.0.0-h75f8748_1.conda
osx-64::glib-2.78.3-hf4d7fad_0.conda
osx-64::imagemagick-7.1.1_22-pl5321h51fee12_0.conda
osx-64::root_base-6.28.10-py38hd53aec0_0.conda
osx-64::folly-2023.12.25.00-ha75df62_0.conda
osx-64::mandrake-1.2.2-py311h56b1a56_5.conda
osx-64::aiokafka-0.9.0-py39h58a92f5_1.conda
osx-64::root_base-6.30.2-py38h7214df8_1.conda
osx-64::ifcopenshell-v0.7.0.231127-py311_all_h62be79d_202.conda
osx-64::libgdal-arrow-parquet-3.7.3-hb50c155_10.conda
osx-64::postgresql-plpython-16.1-py312h01252a9_7.conda
osx-64::libgdal-arrow-parquet-3.8.1-h42a2c4f_4.conda
osx-64::xrootd-5.6.4-py39h466852b_0.conda
osx-64::tiledb-2.18.2-h36656dc_1.conda
osx-64::libgdal-3.7.3-hf1ab713_12.conda
osx-64::ifcopenshell-v0.7.0.231127-py310_novtk_h00f3cd4_102.conda
osx-64::qt6-main-6.6.1-h729e66d_5.conda
osx-64::mandrake-1.2.2-py311h56b1a56_6.conda
osx-64::tiledb-2.18.2-h4570b63_1.conda
osx-64::lxml-4.9.3-py312h86694d6_2.conda
osx-64::postgresql-plpython-15.4-py39hf4bfa82_3.conda
osx-64::postgresql-plpython-15.4-py311h47125a7_3.conda
osx-64::mandrake-1.2.2-py312h1221fbe_7.conda
osx-64::lldb-17.0.2-py39hbad8416_0.conda
osx-64::util-linux-2.39.3-py310h7a77fba_0.conda
osx-64::libgdal-arrow-parquet-3.8.1-h38f6d11_0.conda
osx-64::mesalib-23.3.2-hbd9e708_0.conda
osx-64::sagelib-10.0-py310h89b1bf4_2.conda
osx-64::xrootd-5.6.4-py312hbaeceb8_0.conda
osx-64::ifcopenshell-v0.7.0.231127-py39_all_h25ac92d_202.conda
osx-64::sagelib-10.0-py39hf4b7944_2.conda
osx-64::ffmpeg-6.1.0-gpl_hf5fe730_105.conda
osx-64::jaxlib-0.4.23-cpu_py311h9589f2b_0.conda
osx-64::mandrake-1.2.2-py38h80f232c_7.conda
osx-64::ffmpeg-6.1.0-lgpl_h4f2f312_5.conda
osx-64::sagelib-10.1-py38hb8d266d_0.conda
osx-64::aiokafka-0.9.0-py39h58a92f5_0.conda
osx-64::davix-0.8.4-h3f1511c_3.conda
osx-64::python-igraph-0.11.3-py39h1e93c3a_1.conda
osx-64::tensorflow-base-2.15.0-cpu_py311hbca55e7_1.conda
osx-64::libscotch-7.0.4-hc2ac6e5_1.conda
osx-64::postgresql-plpython-16.1-py39h7f9fc5f_5.conda
osx-64::pygplates-0.39-py39h1d5722e_14.conda
osx-64::yosys-0.36-hbd15b7a_0.conda
osx-64::coda-2.25.1-py311hce20a6b_0.conda
osx-64::libnghttp2-1.58.0-h64cf6d3_1.conda
osx-64::pyinstaller-6.3.0-py311h8c2310c_0.conda
osx-64::python-3.9.18-h7a9c478_1_cpython.conda
osx-64::r-data.table-1.14.10-r43he044350_0.conda
osx-64::tiledb-2.18.3-hb85ba1e_1.conda
osx-64::tiledb-2.19.0-hb85ba1e_0.conda
osx-64::hdf5-1.14.3-mpi_openmpi_h85372f7_0.conda
osx-64::r-gaston-1.6-r43hd6ad0b9_0.conda
osx-64::libarrow-13.0.0-hce8e2b5_16_cpu.conda
osx-64::xrootd-5.6.3-py312hbaeceb8_0.conda
osx-64::coda-2.25.1-py38h9b9e7df_0.conda
osx-64::jaxlib-0.4.23-cpu_py310hbe00a30_0.conda
osx-64::sagelib-10.1-py311h2cc7121_0.conda
osx-64::pdal-2.6.2-h818632a_1.conda
osx-64::libgdal-arrow-parquet-3.7.3-h885c818_9.conda
osx-64::cppyy-cling-6.30.0-py312hecaf9ea_0.conda
osx-64::postgresql-plpython-16.1-py312h01252a9_5.conda
osx-64::mandrake-1.2.2-py39hfa2c550_5.conda
osx-64::pyinstaller-6.3.0-py310h03c913b_0.conda
osx-64::aiokafka-0.9.0-py311h8c2310c_0.conda
osx-64::util-linux-2.39.3-py39hf312e3d_1.conda
osx-64::openmpi-5.0.0-h01516ab_100.conda
osx-64::lxml-4.9.3-py39h0d9b2a9_2.conda
osx-64::gemmi-0.6.4-py39he5a6977_0.conda
osx-64::xrootd-5.6.2-py39h1868286_2.conda
osx-64::libgdal-arrow-parquet-3.7.3-h480ad5e_9.conda
osx-64::tiledb-2.18.3-h4df5763_1.conda
osx-64::libgdal-3.7.3-h6e2c639_10.conda
osx-64::cmake-3.28.0-hc7ee4c4_0.conda
osx-64::tiledb-2.19.0-h4df5763_0.conda
osx-64::xrootd-5.6.3-py39h1868286_0.conda
osx-64::tiledb-2.19.0-h03cb7d7_0.conda
osx-64::jaxlib-0.4.20-cpu_py39heb0bab2_0.conda
osx-64::cppyy-cling-6.30.0-py310h71e7e49_0.conda
osx-64::bytewax-0.17.2-py38hcde65cd_0.conda
osx-64::mesalib-23.3.1-hbd9e708_0.conda
osx-64::lxml-4.9.3-py310hca08431_3.conda
osx-64::libarrow-13.0.0-h36c5bb6_21_cpu.conda
osx-64::folly-2023.12.04.00-hdf6ac6a_0_jemalloc.conda
osx-64::yoda-1.9.6-py311h04a8960_6.conda
osx-64::postgresql-plpython-16.1-py310hd344ed2_5.conda
osx-64::python-igraph-0.11.3-py39h18120cc_1.conda
osx-64::yoda-1.9.6-py310h8ceb2fb_5.conda
osx-64::libgdal-arrow-parquet-3.8.2-h3965734_0.conda
osx-64::pygplates-0.39-py312h0637477_14.conda
osx-64::aiokafka-0.10.0-py39h5eebb3c_0.conda
osx-64::root_base-6.30.2-py38hd53aec0_0.conda
osx-64::r-data.table-1.14.10-r42he044350_0.conda
osx-64::bytewax-0.17.2-py39h72a7c3e_0.conda
osx-64::tiledb-2.18.2-h0e5a617_1.conda
osx-64::lxml-4.9.3-py39h234843f_3.conda
osx-64::bytewax-0.17.2-py310h1972b3a_0.conda
osx-64::libgdal-3.8.1-hb7f764b_1.conda
osx-64::yoda-1.9.6-py310h8ceb2fb_6.conda
osx-64::tiledb-2.18.3-h03cb7d7_1.conda
osx-64::cmake-3.28.1-h7c85d92_0.conda
osx-64::subversion-1.14.3-pl5321hc5d908c_0.conda
osx-64::postgresql-plpython-16.1-py38hf95a095_7.conda
osx-64::aiokafka-0.9.0-py39h5eebb3c_0.conda
osx-64::libglib-2.78.3-h198397b_0.conda
osx-64::libnetcdf-4.9.2-mpi_mpich_h5394c81_13.conda
osx-64::hdf5-1.14.3-mpi_mpich_h859952d_0.conda
osx-64::arrow-cpp-9.0.0-py310ha5ff285_50_cpu.conda
osx-64::root_base-6.28.10-py310h088463a_0.conda
osx-64::libopentelemetry-cpp-1.13.0-h5ad93c0_0.conda
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
================================================================================
================================================================================
linux-64
linux-64::rill-0.38.0-heb45ecc_0.conda
linux-64::clang-format-13.0.1-root_63002_h40c82f9_5.conda
linux-64::libsoup-3.4.4-h5006749_1.conda
linux-64::libuwebsockets-20.54.0-hfc55251_0.conda
linux-64::libclang-cpp-13.0.1-root_63002_h40c82f9_5.conda
linux-64::clang-13-13.0.1-default_h7634d5b_4.conda
linux-64::libclang-cpp13-13.0.1-root_63002_h40c82f9_5.conda
linux-64::libclang-13.0.1-root_62810_h9311a46_4.conda
linux-64::clang-format-13-13.0.1-root_63002_h40c82f9_5.conda
linux-64::eccodes-2.33.0-he84ddb8_0.conda
linux-64::glib-tools-2.78.3-hfc55251_0.conda
linux-64::zimpl-3.5.3-h4c00192_6.conda
linux-64::clang-13-13.0.1-root_62810_h9311a46_4.conda
linux-64::stress-ng-0.17.03-h2797004_0.conda
linux-64::libclang-13.0.1-default_h7634d5b_4.conda
linux-64::libclang-13.0.1-default_h7634d5b_5.conda
linux-64::libdap4-3.20.6-h4292ed5_5.conda
linux-64::rill-0.38.1-heb45ecc_0.conda
linux-64::libclang-cpp-13.0.1-default_h7634d5b_5.conda
linux-64::clang-format-13.0.1-root_62810_h9311a46_4.conda
linux-64::libclang-cpp-13.0.1-default_h7634d5b_4.conda
linux-64::clang-tools-13.0.1-root_63002_h40c82f9_5.conda
linux-64::zimpl-3.5.3-h4c00192_5.conda
linux-64::libuwebsockets-20.49.0-hfc55251_0.conda
linux-64::stress-ng-0.17.02-h2797004_0.conda
linux-64::clang-tools-13.0.1-root_62810_h9311a46_4.conda
linux-64::clang-format-13-13.0.1-default_h7634d5b_4.conda
linux-64::clang-format-13-13.0.1-root_62810_h9311a46_4.conda
linux-64::clang-tools-13.0.1-default_h7634d5b_4.conda
linux-64::clang-13-13.0.1-default_h7634d5b_5.conda
linux-64::rill-0.38.2-heb45ecc_0.conda
linux-64::clang-format-13.0.1-default_h7634d5b_5.conda
linux-64::micromamba-1.5.5-0.tar.bz2
linux-64::libclang-cpp13-13.0.1-root_62810_h9311a46_4.conda
linux-64::libclang-cpp13-13.0.1-default_h7634d5b_5.conda
linux-64::libuwebsockets-20.55.0-hfc55251_0.conda
linux-64::libclang-13.0.1-root_63002_h40c82f9_5.conda
linux-64::libsoup-2.74.3-h5006749_2.conda
linux-64::libuwebsockets-20.51.0-hfc55251_0.conda
linux-64::libuwebsockets-20.53.0-hfc55251_0.conda
linux-64::clang-format-13-13.0.1-default_h7634d5b_5.conda
linux-64::clang-tools-13.0.1-default_h7634d5b_5.conda
linux-64::glib-tools-2.78.2-hfc55251_0.conda
linux-64::libclang-cpp-13.0.1-root_62810_h9311a46_4.conda
linux-64::libuwebsockets-20.52.0-hfc55251_0.conda
linux-64::libclang-cpp13-13.0.1-default_h7634d5b_4.conda
linux-64::clang-format-13.0.1-default_h7634d5b_4.conda
linux-64::clang-13-13.0.1-root_63002_h40c82f9_5.conda
linux-64::micromamba-1.5.6-0.tar.bz2
-    "libzlib >=1.2.13,<1.3.0a0"
+    "libzlib >=1.2.13,<2.0.0a0"
linux-64::vtk-base-9.2.6-qt_py312h1234567_220.conda
linux-64::r-gaston-1.6-r43h33b523d_0.conda
linux-64::libgdal-arrow-parquet-3.7.3-h263641c_12.conda
linux-64::code-aster-16.4.17-np122py310hce3d7c1_0.conda
linux-64::lxml-4.9.3-py311h1a07684_2.conda
linux-64::mandrake-1.2.2-py310h48e65b8_6.conda
linux-64::jaxlib-0.4.23-cuda118py312h1c60a56_200.conda
linux-64::jaxlib-0.4.20-cuda118py311hf905f1e_200.conda
linux-64::gmsh-4.12.0-h17d5aaa_0.conda
linux-64::gemmi-0.6.4-py38h94a1851_0.conda
linux-64::libgdal-3.8.1-hcae7082_1.conda
linux-64::lighttpd-1.4.73-lua54hc75fa04_0.conda
linux-64::mandrake-1.2.2-py38hcef84c3_6.conda
linux-64::root_base-6.30.2-py38h08944f8_1.conda
linux-64::erlang-26.2.1-pl5321hde4a2a6_0.conda
linux-64::sagelib-10.0-py39h65c28db_2.conda
linux-64::libtensorflow_cc-2.15.0-cpu_h2f60d71_1.conda
linux-64::xrootd-5.6.2-py311hab2d546_2.conda
linux-64::pyreadstat-1.2.6-py39hb6545a3_0.conda
linux-64::aiokafka-0.10.0-py310h93c3562_0.conda
linux-64::qt6-main-6.6.1-h7d2cef6_5.conda
linux-64::libgdal-arrow-parquet-3.8.1-h206199c_0.conda
linux-64::libtiledb-sql-0.26.0-hfc67c98_1.conda
linux-64::ifcopenshell-v0.7.0.231127-py39_novtk_h1e5b5ad_102.conda
linux-64::python-igraph-0.11.3-py39h007bc96_1.conda
linux-64::libgdal-3.8.2-hed8bd54_0.conda
linux-64::libarrow-11.0.0-hcc26646_54_cpu.conda
linux-64::r-data.table-1.14.10-r43h029312a_0.conda
linux-64::erlang-26.2-pl5321hde4a2a6_0.conda
linux-64::mapserver-8.0.1-py311h3d4647d_14.conda
linux-64::ffmpeg-6.1.0-lgpl_h2f45c94_5.conda
linux-64::libgdal-arrow-parquet-3.8.2-h263641c_0.conda
linux-64::mandrake-1.2.2-py310h2b071e7_6.conda
linux-64::code-aster-16.4.19-np123py311hf6e88c2_0.conda
linux-64::code-aster-16.4.16-np122py38h5b8432c_0.conda
linux-64::createrepo_c-1.0.2-py39h0cdb266_1.conda
linux-64::yoda-1.9.6-py39h684a307_6.conda
linux-64::aiokafka-0.9.0-py310h93c3562_1.conda
linux-64::libgdal-arrow-parquet-3.7.3-h641b2ac_13.conda
linux-64::ifcopenshell-v0.7.0.231127-py310_novtk_h5370e7b_102.conda
linux-64::util-linux-2.39.3-py311h4285dfd_1.conda
linux-64::dotnet-sdk-8.0.100-hb8a3ed7_0.conda
linux-64::pygplates-0.39-py39hbc3c0ed_14.conda
linux-64::mandrake-1.2.2-py311h5048fde_6.conda
linux-64::ifcopenshell-v0.7.0.231127-py312_novtk_hcd6072a_102.conda
linux-64::pp-sketchlib-2.1.2-py38hd9b7ea8_1.conda
linux-64::sagelib-10.1-py38h59ecdec_0.conda
linux-64::util-linux-2.39.3-py39h5bc7b3b_1.conda
linux-64::pp-sketchlib-2.1.2-py310h6ee4ac0_1.conda
linux-64::bytewax-0.17.2-py312h9be44f7_0.conda
linux-64::python-3.10.13-hd12c33a_1_cpython.conda
linux-64::triton-2.0.0-cuda118py39h46dc3ef_4.conda
linux-64::python-igraph-0.11.3-py312ha213cae_1.conda
linux-64::tensorflow-base-2.15.0-cpu_py311h6aa969b_1.conda
linux-64::code-aster-16.4.17-np122py39h9914496_0.conda
linux-64::pyinstaller-6.3.0-py310h93c3562_0.conda
linux-64::paraview-5.11.2-py311h748ac29_2_egl.conda
linux-64::folly-2023.12.25.00-hbc8c634_0_jemalloc.conda
linux-64::tiledb-2.18.2-hc1131af_2.conda
linux-64::davix-0.8.4-h3299534_3.conda
linux-64::folly-2023.12.18.00-h23251b7_0.conda
linux-64::mandrake-1.2.2-py311hf37ec60_7.conda
linux-64::util-linux-2.39.3-py39h1da25c5_0.conda
linux-64::pp-sketchlib-2.1.2-py310h3429ced_1.conda
linux-64::jaxlib-0.4.23-cpu_py39h45b9b01_0.conda
linux-64::pp-sketchlib-2.1.2-py312h4a00ee0_1.conda
linux-64::xmlrpc-c-1.54.06-hb242bd5_0.conda
linux-64::libnetcdf-4.9.2-mpi_openmpi_h958ee74_13.conda
linux-64::gdstk-0.9.48-py312h7b2b3ac_0.conda
linux-64::gdstk-0.9.48-py311h75db532_0.conda
linux-64::yoda-1.9.6-py311hbcaaa19_6.conda
linux-64::xrootd-5.6.2-py312h9eb2509_2.conda
linux-64::imagecodecs-2024.1.1-py39he571368_0.conda
linux-64::aria2-1.37.0-h347180d_1.conda
linux-64::vtk-base-9.2.6-egl_py39h1234567_20.conda
linux-64::gst-plugins-base-1.22.7-h8e1006c_1.conda
linux-64::pyreadstat-1.2.6-py312hf0b23d7_0.conda
linux-64::postgresql-plpython-15.4-py312hcc5c902_3.conda
linux-64::clangdev-13.0.1-default_h7634d5b_4.conda
linux-64::libarrow-12.0.1-hea7331e_30_cuda.conda
linux-64::xrootd-5.6.3-py311hab2d546_0.conda
linux-64::postgresql-plpython-16.1-py38hd157e84_5.conda
linux-64::code-aster-16.4.18-np122py38h5b8432c_0.conda
linux-64::libgdal-arrow-parquet-3.7.3-ha732904_9.conda
linux-64::postgresql-16.1-h7387d8b_5.conda
linux-64::root_base-6.30.2-py39hb30e9c3_1.conda
linux-64::triton-2.0.0-cuda112py312h4125c2b_4.conda
linux-64::openslide-4.0.0-h58ba908_0.conda
linux-64::clangdev-13.0.1-root_63002_h40c82f9_5.conda
linux-64::root_base-6.28.10-py310hc3ad01f_0.conda
linux-64::triton-2.0.0-cuda120py38h08aee3a_4.conda
linux-64::folly-2023.12.04.00-h122a45c_0_jemalloc.conda
linux-64::libarrow-14.0.2-h8141827_0_cuda.conda
linux-64::pp-sketchlib-2.1.2-py311h1b80d0b_1.conda
linux-64::lxml-4.9.3-py312he528aba_3.conda
linux-64::libgdal-arrow-parquet-3.8.2-h157934b_1.conda
linux-64::mapserver-8.0.1-py38he7d57aa_14.conda
linux-64::folly-2023.12.11.00-h23251b7_0.conda
linux-64::postgresql-plpython-15.4-py311hf60bfc6_3.conda
linux-64::ifcopenshell-v0.7.0.231127-py312_all_h7f867fa_202.conda
linux-64::pp-sketchlib-2.1.2-py38h72b2f4c_1.conda
linux-64::cppyy-cling-6.30.0-py38hbb0cdd4_0.conda
linux-64::util-linux-2.39.3-py38heb36ba7_0.conda
linux-64::postgresql-plpython-16.1-py310hdd8bd8b_7.conda
linux-64::pp-sketchlib-2.1.2-py311h7df103e_0.conda
linux-64::libgdal-arrow-parquet-3.7.3-h69fca0d_13.conda
linux-64::cppyy-cling-6.30.0-py312h24f76d5_0.conda
linux-64::createrepo_c-1.0.2-py310h1b94a8e_1.conda
linux-64::jaxlib-0.4.20-cpu_py311h3b276bd_0.conda
linux-64::pp-sketchlib-2.1.2-py310h0502fa8_0.conda
linux-64::code-aster-16.4.16-np123py311hf6e88c2_1.conda
linux-64::code-aster-16.4.16-np122py310hce3d7c1_0.conda
linux-64::lldb-17.0.6-py311h1fe0947_0.conda
linux-64::libgdal-arrow-parquet-3.8.2-h3705a34_0.conda
linux-64::jaxlib-0.4.20-cuda118py39hb35ebbd_200.conda
linux-64::pdal-2.6.2-h1f056bd_0.conda
linux-64::python-3.9.18-h0755675_1_cpython.conda
linux-64::ffmpeg-6.1.1-lgpl_h2f45c94_0.conda
linux-64::paraview-5.11.2-py310h835d648_102_qt.conda
linux-64::libgdal-arrow-parquet-3.8.2-ha23ab30_0.conda
linux-64::dotnet-aspnetcore-6.0.25-hfbc8c6f_0.conda
linux-64::mapserver-8.0.1-py38h69e5dbd_15.conda
linux-64::mandrake-1.2.2-py310h2b071e7_5.conda
linux-64::libgdal-arrow-parquet-3.8.1-haa8e18a_3.conda
linux-64::createrepo_c-1.0.2-py311hd4d6c61_1.conda
linux-64::libgdal-3.7.3-h775a7d8_13.conda
linux-64::mandrake-1.2.2-py38h983c1cf_6.conda
linux-64::imagemagick-7.1.1_23-pl5321h3fa1221_0.conda
linux-64::libgdal-arrow-parquet-3.8.1-hb9fe22c_0.conda
linux-64::pygplates-0.39-py38h6e8470b_14.conda
linux-64::folly-2023.12.25.00-hb244bc4_0.conda
linux-64::triton-2.0.0-cuda112py311h07bde9e_4.conda
linux-64::yosys-0.36-h3ec9cbf_0.conda
linux-64::libpulsar-3.4.2-h5b2b34b_0.conda
linux-64::mandrake-1.2.2-py311h5048fde_5.conda
linux-64::cargo-c-0.9.29-h5ad674e_0.conda
linux-64::aiokafka-0.9.0-py38h502143a_1.conda
linux-64::wasmer-4.2.5-hed76520_0.conda
linux-64::postgresql-plpython-16.1-py311h4204730_7.conda
linux-64::sagelib-10.1-py39h65c28db_0.conda
linux-64::code-aster-16.5.0-np122py39h9914496_0.conda
linux-64::tiledb-2.18.3-h9d8f6ff_0.conda
linux-64::mapserver-8.0.1-py312h32e93c7_15.conda
linux-64::paraview-5.11.2-py39h5834a58_2_egl.conda
linux-64::code-aster-16.4.15-np122py310hce3d7c1_2.conda
linux-64::pytng-0.3.1-py310h7d11597_1.conda
linux-64::root_base-6.28.10-py311h2383b95_0.conda
linux-64::imagecodecs-2024.1.1-py311h089f87a_0.conda
linux-64::soplex-6.0.4-h231b4fb_6.conda
linux-64::arrow-cpp-9.0.0-py310hf9f0e5c_50_cpu.conda
linux-64::libnetcdf-4.9.2-nompi_h9612171_113.conda
linux-64::ndcctools-7.7.3-py310he2ed3e8_0.conda
linux-64::tesseract-5.3.2-h7aa9634_1.conda
linux-64::fish-3.6.3-hdab1d28_0.conda
linux-64::pp-sketchlib-2.1.2-py311hde5c1b7_1.conda
linux-64::postgresql-plpython-15.4-py311hf60bfc6_4.conda
linux-64::python-igraph-0.11.3-py39h36c0382_1.conda
linux-64::root_base-6.30.2-py39he1fd38f_0.conda
linux-64::libgdal-3.7.3-hd74445f_9.conda
linux-64::util-linux-2.39.3-py39h5bc7b3b_0.conda
linux-64::libarrow-12.0.1-hcce0278_31_cpu.conda
linux-64::folly-2023.12.18.00-hbc8c634_0_jemalloc.conda
linux-64::dotnet-sdk-6.0.417-hfbc8c6f_0.conda
linux-64::gemmi-0.6.4-py39h174d805_0.conda
linux-64::tiledb-2.18.2-h41cbbac_2.conda
linux-64::mandrake-1.2.2-py311h5048fde_7.conda
linux-64::libgdal-arrow-parquet-3.7.3-ha247c86_9.conda
linux-64::pp-sketchlib-2.1.2-py311h7df103e_1.conda
linux-64::libcurl-static-8.5.0-hca28451_0.conda
linux-64::libgdal-arrow-parquet-3.7.3-hb1cea3d_10.conda
linux-64::sagelib-10.1-py310hdae0915_0.conda
linux-64::libgdal-3.8.1-h4d9a814_0.conda
linux-64::gdstk-0.9.48-py310h70b9d7f_1.conda
linux-64::gemmi-0.6.4-py312hb06c811_0.conda
linux-64::pp-sketchlib-2.1.2-py39h0300900_1.conda
linux-64::sagelib-10.2-py311h0af1a61_0.conda
linux-64::mandrake-1.2.2-py312hbe43445_7.conda
linux-64::libgdal-arrow-parquet-3.8.2-h641b2ac_1.conda
linux-64::tensorflow-base-2.15.0-cpu_py310h7e4d085_1.conda
linux-64::pytng-0.3.1-py311hb2be122_1.conda
linux-64::ffmpeg-6.1.1-gpl_h186bccc_100.conda
linux-64::folly-2023.12.18.00-h70f49c4_0_jemalloc.conda
linux-64::intel-opencl-rt-2024.0.0-ha796c99_49819.conda
linux-64::gemmi-0.6.4-py311ha6695c7_0.conda
linux-64::mandrake-1.2.2-py38h9bd7ae0_7.conda
linux-64::vtk-base-9.2.6-qt_py310h1234567_220.conda
linux-64::mandrake-1.2.2-py311hb206e98_7.conda
linux-64::libvips-8.15.0-hf0b3042_4.conda
linux-64::mandrake-1.2.2-py39h79f6574_7.conda
linux-64::yoda-1.9.6-py39h816b0d2_6.conda
linux-64::xrootd-5.6.3-py312h9eb2509_0.conda
linux-64::python-3.11.7-hab00c5b_0_cpython.conda
linux-64::coda-2.25.1-py310h5e33110_0.conda
linux-64::r-rmatio-0.19.0-r42h57805ef_0.conda
linux-64::folly-2023.12.04.00-hbc8c634_0_jemalloc.conda
linux-64::triton-2.0.0-cuda118py310h16cf72a_4.conda
linux-64::clangdev-13.0.1-root_62810_h9311a46_4.conda
linux-64::libtensorflow_cc-2.15.0-cpu_h88ceed9_0.conda
linux-64::aiokafka-0.9.0-py39hc7d112a_0.conda
linux-64::mandrake-1.2.2-py39h79f6574_6.conda
linux-64::openslide-3.4.1-h58ba908_12.conda
linux-64::mandrake-1.2.2-py310h166317f_5.conda
linux-64::mandrake-1.2.2-py38h815f229_5.conda
linux-64::magics-4.15.0-hd93a360_0.conda
linux-64::openmpi-5.0.0-hb0ee255_101.conda
linux-64::aiokafka-0.9.0-py312hf0b23d7_1.conda
linux-64::lxml-4.9.3-py310h9b7343a_3.conda
linux-64::hdf5-1.14.3-mpi_openmpi_h327c9cf_0.conda
linux-64::tensorflow-base-2.15.0-cpu_py310h3c6a6a6_0.conda
linux-64::mandrake-1.2.2-py311hf37ec60_6.conda
linux-64::code-aster-17.0.1-np123py311hf6e88c2_0.conda
linux-64::gdstk-0.9.48-py39hc35b29e_0.conda
linux-64::mandrake-1.2.2-py311heb293ab_7.conda
linux-64::folly-2023.12.04.00-h23251b7_0.conda
linux-64::plplot-5.15.0-he4f467f_3.conda
linux-64::magic-8.3.454-h9abf892_0.conda
linux-64::mandrake-1.2.2-py312h9647f8b_7.conda
linux-64::triton-2.0.0-cuda120py312h12c1f84_4.conda
linux-64::pyreadstat-1.2.6-py311hdcc4c9d_0.conda
linux-64::mandrake-1.2.2-py38hcef84c3_5.conda
linux-64::aiokafka-0.9.0-py310h93c3562_0.conda
linux-64::code-aster-16.4.19-np122py38h5b8432c_0.conda
linux-64::yoda-1.9.6-py38hbe88c4b_6.conda
linux-64::r-vcfr-1.15.0-r42h33b523d_0.conda
linux-64::xrootd-5.6.2-py39h49ef29b_2.conda
linux-64::code-aster-16.4.18-np123py311hf6e88c2_0.conda
linux-64::libscotch-7.0.4-h0c89965_1.conda
linux-64::folly-2023.12.25.00-h122a45c_0_jemalloc.conda
linux-64::imagemagick-7.1.1_22-pl5321h3fa1221_0.conda
linux-64::code-aster-17.0.1-np122py38h5b8432c_0.conda
linux-64::pp-sketchlib-2.1.2-py310h3429ced_0.conda
linux-64::libarrow-11.0.0-h991eec8_55_cuda.conda
linux-64::gst-plugins-bad-1.22.7-h9b3fba2_0.conda
linux-64::mesalib-23.3.2-h6b56f8e_0.conda
linux-64::lldb-17.0.6-py310h5be3364_0.conda
linux-64::dpcpp_impl_linux-64-2024.0.0-h034604b_49819.conda
linux-64::xrootd-5.6.4-py39h89c929b_0.conda
linux-64::libarrow-14.0.1-hd3c8e8b_8_cuda.conda
linux-64::yoda-1.9.6-py39h816b0d2_5.conda
linux-64::ifcopenshell-v0.7.0.231127-py38_novtk_h0a76ecd_102.conda
linux-64::pp-sketchlib-2.1.2-py38hd9b7ea8_0.conda
linux-64::postgresql-plpython-15.4-py310hd093153_4.conda
linux-64::mapserver-8.0.1-py39hd9950ee_14.conda
linux-64::xrootd-5.6.3-py38h04a86c8_0.conda
linux-64::tiledb-2.18.2-h99f50a1_1.conda
linux-64::lldb-17.0.2-py39h2b3d56d_0.conda
linux-64::pp-sketchlib-2.1.2-py310h37665e0_1.conda
linux-64::pygplates-0.39-py312hccccbb4_14.conda
linux-64::code-aster-17.0.1-np122py39h9914496_0.conda
linux-64::mandrake-1.2.2-py39h60f94c8_7.conda
linux-64::postgresql-plpython-16.1-py38h0f07e32_7.conda
linux-64::scip-8.1.0-hb65f9cc_6.conda
linux-64::gst-plugins-good-1.22.7-h6ea4ad1_1.conda
linux-64::libpq-15.4-hdb747bd_4.conda
linux-64::pyreadstat-1.2.6-py38h502143a_0.conda
linux-64::dotnet-aspnetcore-8.0.0-hb8a3ed7_0.conda
linux-64::cpp-opentelemetry-sdk-1.13.0-hb0e315f_0.conda
linux-64::aiokafka-0.9.0-py311hdcc4c9d_1.conda
linux-64::postgresql-plpython-16.1-py311h4204730_6.conda
linux-64::gdstk-0.9.48-py38hab45c01_0.conda
linux-64::libgdal-arrow-parquet-3.8.1-ha247c86_1.conda
linux-64::libarrow-12.0.1-h6b1a9bd_32_cpu.conda
linux-64::qtkeychain-0.14.2-hbc31b07_0.conda
linux-64::libgdal-arrow-parquet-3.8.1-ha23ab30_4.conda
linux-64::postgresql-15.4-h8972f4a_3.conda
linux-64::arrow-cpp-9.0.0-py38h5c7582c_50_cpu.conda
linux-64::bytewax-0.17.2-py39hced4d33_0.conda
linux-64::libgdal-arrow-parquet-3.7.3-h2bb1c4f_9.conda
linux-64::libgdal-arrow-parquet-3.8.1-h1ba0233_3.conda
linux-64::xrootd-5.6.4-py38h04a86c8_0.conda
linux-64::dotnet-sdk-7.0.404-hb8a3ed7_0.conda
linux-64::mandrake-1.2.2-py311hf37ec60_5.conda
linux-64::jaxlib-0.4.23-cpu_py311h3b276bd_0.conda
linux-64::libarrow-11.0.0-h17daa2b_56_cuda.conda
linux-64::tensorstore-0.1.51-py39hfddb6fb_0.conda
linux-64::openslide-4.0.0-h58ba908_1.conda
linux-64::tiledb-2.18.3-h41cbbac_1.conda
linux-64::mandrake-1.2.2-py311heb293ab_6.conda
linux-64::jaxlib-0.4.23-cuda118py39hb35ebbd_200.conda
linux-64::libarrow-13.0.0-hcce0278_20_cpu.conda
linux-64::nsight-compute-2023.1.1.4-h3718151_0.conda
linux-64::libgdal-arrow-parquet-3.8.1-h3705a34_4.conda
linux-64::aiokafka-0.9.0-py39hb6545a3_1.conda
linux-64::libgdal-arrow-parquet-3.7.3-h1ba0233_11.conda
linux-64::sagelib-10.1-py311h0af1a61_0.conda
linux-64::libgdal-arrow-parquet-3.7.3-haa8e18a_11.conda
linux-64::jaxlib-0.4.23-cuda118py311hf905f1e_200.conda
linux-64::libgdal-arrow-parquet-3.7.3-h157934b_13.conda
linux-64::mapserver-8.0.1-py312hfe50976_14.conda
linux-64::mandrake-1.2.2-py39hef89bf2_6.conda
linux-64::code-aster-16.4.17-np123py311hf6e88c2_0.conda
linux-64::root_base-6.28.10-py310hc3ad01f_2.conda
linux-64::postgresql-plpython-15.4-py39h5ae07a4_3.conda
linux-64::root_base-6.30.2-py310hc3ad01f_0.conda
linux-64::triton-2.0.0-cuda112py38ha44ebca_4.conda
linux-64::root_base-6.28.10-py310hc3ad01f_1.conda
linux-64::mandrake-1.2.2-py310h24473af_5.conda
linux-64::libtensorflow-2.15.0-cpu_h2e87cff_0.conda
linux-64::libgdal-arrow-parquet-3.7.3-h815407a_9.conda
linux-64::davix-0.8.5-h3299534_0.conda
linux-64::netpbm-10.73.43-pl5321h6ae6222_4.conda
linux-64::folly-2023.12.04.00-hb244bc4_0.conda
linux-64::pp-sketchlib-2.1.2-py39h5cf6715_0.conda
linux-64::postgresql-plpython-16.1-py311hf60bfc6_7.conda
linux-64::arrow-cpp-9.0.0-py38ha77729c_50_cuda.conda
linux-64::pp-sketchlib-2.1.2-py311h1b80d0b_0.conda
linux-64::vtk-base-9.2.6-egl_py311h1234567_20.conda
linux-64::nsight-compute-2023.2.2.3-h3718151_0.conda
linux-64::pp-sketchlib-2.1.2-py38h72b2f4c_0.conda
linux-64::cppyy-cling-6.30.0-py311h9e0f504_0.conda
linux-64::vtk-base-9.2.6-osmesa_py310h1234567_120.conda
linux-64::poppler-23.12.0-h590f24d_0.conda
linux-64::libgdal-arrow-parquet-3.8.1-hd1c60d4_0.conda
linux-64::code-aster-16.4.18-np122py310hce3d7c1_0.conda
linux-64::imagemagick-7.1.1_21-pl5321h3fa1221_2.conda
linux-64::util-linux-2.39.3-py39h1da25c5_1.conda
linux-64::magic-8.3.453-h9abf892_0.conda
linux-64::lxml-4.9.3-py39hed45dcc_3.conda
linux-64::gdstk-0.9.48-py310h1487c90_0.conda
linux-64::code-aster-16.4.17-np122py38h5b8432c_0.conda
linux-64::libscotch-7.0.4-h91e35bf_1.conda
linux-64::xrootd-5.6.3-py39h89c929b_0.conda
linux-64::code-aster-16.4.15-np122py39h9914496_2.conda
linux-64::libvips-8.15.1-hf0b3042_0.conda
linux-64::tensorflow-base-2.15.0-cpu_py311ha0be21f_0.conda
linux-64::lxml-4.9.3-py39hed45dcc_2.conda
linux-64::openssh-9.3p1-h2d3b35a_3.conda
linux-64::tiledb-2.19.0-h41cbbac_0.conda
linux-64::util-linux-2.39.3-py38heb36ba7_1.conda
linux-64::vtk-base-9.2.6-osmesa_py311h1234567_120.conda
linux-64::code-aster-17.0.1-np122py310hce3d7c1_0.conda
linux-64::aiokafka-0.10.0-py39hc7d112a_0.conda
linux-64::aiokafka-0.9.0-py39hc7d112a_1.conda
linux-64::ffmpeg-6.1.0-gpl_h0fd9395_104.conda
linux-64::root_base-6.28.10-py38h64a494c_1.conda
linux-64::libgdal-3.8.2-hcd1fc54_1.conda
linux-64::util-linux-2.39.3-py312h77dc562_1.conda
linux-64::tiledb-2.19.0-h9d8f6ff_0.conda
linux-64::geotiff-1.7.1-h6b2125f_15.conda
linux-64::mandrake-1.2.2-py39h68ee24f_6.conda
linux-64::pp-sketchlib-2.1.2-py39h19a0009_0.conda
linux-64::boost-cpp-1.84.0-h44aadfe_0.conda
linux-64::libtensorflow-2.15.0-cpu_h8d94747_1.conda
linux-64::lldb-17.0.2-py38h3893f59_0.conda
linux-64::pytng-0.3.1-py39h0fd56e7_1.conda
linux-64::folly-2023.12.18.00-hb244bc4_0.conda
linux-64::openmpi-5.0.1-hb0ee255_100.conda
linux-64::folly-2023.12.11.00-h70f49c4_0_jemalloc.conda
linux-64::mandrake-1.2.2-py39h60f94c8_6.conda
linux-64::libgdal-arrow-parquet-3.8.1-h9341cea_2.conda
linux-64::openssh-9.6p1-h2d3b35a_0.conda
linux-64::libgdal-3.8.1-h4b8bffa_3.conda
linux-64::arrow-cpp-9.0.0-py310h9b6cc23_50_cuda.conda
linux-64::tensorflow-base-2.15.0-cpu_py39he1df281_1.conda
linux-64::mapserver-8.0.1-py311h8160572_15.conda
linux-64::ifcopenshell-v0.7.0.231127-py38_all_h2f18be5_202.conda
linux-64::libgdal-arrow-parquet-3.7.3-h2a3021f_10.conda
linux-64::openconnect-9.12-hed4ed74_1.conda
linux-64::pp-sketchlib-2.1.2-py38h384da6d_0.conda
linux-64::libpq-15.4-hfc447b1_3.conda
linux-64::pp-sketchlib-2.1.2-py310h6ee4ac0_0.conda
linux-64::ffmpeg-6.1.0-lgpl_h742f0d9_4.conda
linux-64::coda-2.25.1-py39h684542f_0.conda
linux-64::sagelib-10.2-py39h65c28db_0.conda
linux-64::libgdal-arrow-parquet-3.7.3-h6d2c5c8_11.conda
linux-64::bytewax-0.17.2-py310hd3dbc5d_0.conda
linux-64::root_base-6.28.10-py38h64a494c_0.conda
linux-64::code-aster-16.5.0-np123py311hf6e88c2_0.conda
linux-64::pytables-3.9.2-py39h783497a_1.conda
linux-64::libarrow-14.0.1-hfb4d3a9_10_cpu.conda
linux-64::qt6-main-6.5.3-h3af85ea_1.conda
linux-64::libgdal-arrow-parquet-3.7.3-h9b05d71_13.conda
linux-64::vtk-base-9.2.6-egl_py38h1234567_20.conda
linux-64::libarrow-12.0.1-h17daa2b_32_cuda.conda
linux-64::aws-sdk-cpp-1.11.210-h13098a4_6.conda
linux-64::cmake-3.28.1-hcfe8598_0.conda
linux-64::r-data.table-1.14.10-r42h029312a_0.conda
linux-64::libitk-5.3.0-h26001f5_8.conda
linux-64::tiledb-2.18.3-h9d8f6ff_1.conda
linux-64::postgresql-plpython-15.4-py310hd093153_3.conda
linux-64::folly-2023.12.25.00-h23251b7_0.conda
linux-64::bytewax-0.17.2-py38h5fd4b22_0.conda
linux-64::pp-sketchlib-2.1.2-py311hde5c1b7_0.conda
linux-64::triton-2.0.0-cuda118py311ha555834_4.conda
linux-64::libarchive-minimal-static-3.7.2-h2b6973b_1.conda
linux-64::code-aster-16.5.0-np122py310hce3d7c1_0.conda
linux-64::ifcopenshell-v0.7.0.231127-py39_all_h2bb917a_202.conda
linux-64::libgdal-arrow-parquet-3.8.1-ha732904_1.conda
linux-64::qpdf-10.6.3-h2a13503_2.conda
linux-64::tiledb-2.18.2-hdd98607_1.conda
linux-64::jaxlib-0.4.20-cpu_py39h45b9b01_0.conda
linux-64::lxml-4.9.3-py311h1a07684_3.conda
linux-64::pygplates-0.39-py311hc1f9277_14.conda
linux-64::libgdal-arrow-parquet-3.8.1-h6cca535_0.conda
linux-64::r-vcfr-1.15.0-r43h33b523d_0.conda
linux-64::libspatialite-5.1.0-h7bd4643_4.conda
linux-64::magics-metview-batch-4.15.0-hd93a360_0.conda
linux-64::magics-metview-4.15.0-he53f960_0.conda
linux-64::mandrake-1.2.2-py38hcef84c3_7.conda
linux-64::libgdal-arrow-parquet-3.7.3-ha23ab30_12.conda
linux-64::triton-2.0.0-cuda112py310hb224420_4.conda
linux-64::vtk-base-9.2.6-egl_py312h1234567_20.conda
linux-64::libgdal-3.7.3-h056894e_12.conda
linux-64::libgdal-arrow-parquet-3.7.3-h6dc26ee_11.conda
linux-64::dotnet-aspnetcore-7.0.14-hb8a3ed7_0.conda
linux-64::pdal-2.6.2-h614f5e7_1.conda
linux-64::folly-2023.12.25.00-h70f49c4_0_jemalloc.conda
linux-64::aws-sdk-cpp-1.11.210-h0853bfa_5.conda
linux-64::libxml2-2.12.3-h232c23b_0.conda
linux-64::mandrake-1.2.2-py39hef89bf2_7.conda
linux-64::code-aster-16.4.16-np122py38h5b8432c_1.conda
linux-64::libgoogle-cloud-storage-2.17.0-hc7a4891_1.conda
linux-64::yoda-1.9.6-py310h4505b80_6.conda
linux-64::sagelib-10.2-py311hbe93d5b_1.conda
linux-64::libarchive-3.7.2-h2aa1ff5_1.conda
linux-64::jimtcl-0.82-h0841786_0.conda
linux-64::root_base-6.28.10-py311h2383b95_2.conda
linux-64::pp-sketchlib-2.1.2-py310h0502fa8_1.conda
linux-64::sagelib-10.0-py310hdae0915_2.conda
linux-64::postgresql-plpython-16.1-py310hdd8bd8b_6.conda
linux-64::pp-sketchlib-2.1.2-py310h37665e0_0.conda
linux-64::folly-2023.12.04.00-h1d40f03_0.conda
linux-64::ifcopenshell-v0.7.0.231127-py311_all_h8f4786a_202.conda
linux-64::lxml-4.9.3-py38h0ef1326_2.conda
linux-64::xrootd-5.6.2-py38h04a86c8_2.conda
linux-64::qt6-main-6.6.1-h7d2cef6_4.conda
linux-64::libgdal-arrow-parquet-3.8.2-h69fca0d_1.conda
linux-64::aiokafka-0.10.0-py311hdcc4c9d_0.conda
linux-64::mapserver-8.0.1-py310h6df040e_14.conda
linux-64::hamlib-tcl-4.5.5-h7bfae61_3.conda
linux-64::triton-2.0.0-cuda118py312h495f825_4.conda
linux-64::mandrake-1.2.2-py38h815f229_7.conda
linux-64::sagelib-10.2-py39h031b06c_1.conda
linux-64::libgdal-3.8.1-hd0089ee_2.conda
linux-64::curl-8.5.0-hca28451_0.conda
linux-64::libarrow-14.0.1-h0f82fcc_9_cpu.conda
linux-64::xrootd-5.6.4-py311hab2d546_0.conda
linux-64::pytables-3.9.2-py311h10c7f7f_1.conda
linux-64::python-igraph-0.11.3-py38h886cfa5_1.conda
linux-64::aiokafka-0.10.0-py38h502143a_0.conda
linux-64::code-aster-16.4.16-np122py39h9914496_1.conda
linux-64::pp-sketchlib-2.1.2-py312h90e2102_1.conda
linux-64::gdstk-0.9.48-py310h642649d_1.conda
linux-64::paraview-5.11.2-py312hf292e8a_2_egl.conda
linux-64::paraview-5.11.2-py310h00fabf8_2_egl.conda
linux-64::pytng-0.3.1-py39h873809b_1.conda
linux-64::soplex-6.0.4-ha4ec6ac_5.conda
linux-64::libssh-0.10.6-h13d97bc_1.conda
linux-64::createrepo_c-1.0.2-py38ha11f588_1.conda
linux-64::qt-webengine-5.15.8-h7517aa4_5.conda
linux-64::aiokafka-0.9.0-py311hdcc4c9d_0.conda
linux-64::yoda-1.9.6-py311hb85a074_6.conda
linux-64::mdsplus-7.139.60-py39pl5321hd78f054_1.conda
linux-64::yoda-1.9.6-py310hd81f541_6.conda
linux-64::folly-2023.12.18.00-h1d40f03_0.conda
linux-64::imagecodecs-2024.1.1-py312ha6884dc_0.conda
linux-64::libgoogle-cloud-storage-2.17.0-hc7a4891_0.conda
linux-64::postgresql-15.4-h8972f4a_4.conda
linux-64::subversion-1.14.3-pl5321h5629222_0.conda
linux-64::libgdal-arrow-parquet-3.8.1-h2bb1c4f_1.conda
linux-64::hdf5-1.14.3-nompi_h4f84152_100.conda
linux-64::libarrow-14.0.1-h422ced8_7_cpu.conda
linux-64::mdsplus-7.139.60-py38pl5321heb4381f_1.conda
linux-64::aiokafka-0.9.0-py39hb6545a3_0.conda
linux-64::glib-2.78.2-hfc55251_0.conda
linux-64::jaxlib-0.4.20-cuda118py312h1c60a56_200.conda
linux-64::hdf5-1.14.3-mpi_mpich_ha2c2bf8_0.conda
linux-64::libnetcdf-4.9.2-mpi_mpich_h60ccfc9_13.conda
linux-64::python-3.11.7-hab00c5b_1_cpython.conda
linux-64::nexus-4.4.3-hf1dafec_13.conda
linux-64::tiledb-2.19.0-hc1131af_0.conda
linux-64::lxml-4.9.3-py38h0ef1326_3.conda
linux-64::pdal-2.6.2-h5958a67_2.conda
linux-64::libgdal-arrow-parquet-3.8.1-h2a3021f_2.conda
linux-64::mandrake-1.2.2-py38h9bd7ae0_6.conda
linux-64::aiokafka-0.10.0-py39hb6545a3_0.conda
linux-64::xrootd-5.6.2-py39h89c929b_2.conda
linux-64::mdsplus-7.139.60-py311pl5321hda57400_1.conda
linux-64::pytables-3.9.2-py312h5531bb7_1.conda
linux-64::pdal-2.6.1-h1f056bd_1.conda
linux-64::postgresql-plpython-16.1-py312hcc5c902_7.conda
linux-64::pyinstaller-6.3.0-py311hdcc4c9d_0.conda
linux-64::libgdal-arrow-parquet-3.7.3-hcd610a6_12.conda
linux-64::tesseract-5.3.2-hbeb23df_2.conda
linux-64::dotnet-runtime-8.0.0-hb8a3ed7_0.conda
linux-64::pp-sketchlib-2.1.2-py39h0300900_0.conda
linux-64::lldb-17.0.2-py311h0dad9fe_0.conda
linux-64::mandrake-1.2.2-py39hef89bf2_5.conda
linux-64::libboost-1.84.0-h6fcfa73_0.conda
linux-64::jaxlib-0.4.23-cpu_py312hb17a006_0.conda
linux-64::postgresql-plpython-16.1-py39ha00ab12_5.conda
linux-64::root_base-6.28.10-py39he1fd38f_2.conda
linux-64::mesalib-23.3.1-h6b56f8e_0.conda
linux-64::ndcctools-7.7.3-py39h4841754_0.conda
linux-64::postgresql-16.1-h7387d8b_7.conda
linux-64::tiledb-2.18.3-h41cbbac_0.conda
linux-64::folly-2023.12.18.00-h122a45c_0_jemalloc.conda
linux-64::code-aster-16.5.0-np122py38h5b8432c_0.conda
linux-64::vtk-base-9.2.6-osmesa_py38h1234567_120.conda
linux-64::libopentelemetry-cpp-1.13.0-hb0e315f_0.conda
linux-64::magics-metview-4.14.2-he53f960_2.conda
linux-64::gdstk-0.9.48-py310ha6f7434_1.conda
linux-64::mandrake-1.2.2-py310h166317f_7.conda
linux-64::arrow-cpp-9.0.0-py311hc608d72_50_cpu.conda
linux-64::gst-plugins-good-1.22.8-he33cf32_0.conda
linux-64::ifcopenshell-v0.7.0.231127-py310_all_h5747a91_202.conda
linux-64::lxml-4.9.3-py39h40bd5d0_2.conda
linux-64::postgresql-plpython-15.4-py38h0f07e32_4.conda
linux-64::postgresql-plpython-16.1-py39ha00ab12_7.conda
linux-64::root_base-6.30.2-py311he0b698f_1.conda
linux-64::vtk-base-9.2.6-qt_py39h1234567_220.conda
linux-64::folly-2023.12.25.00-h1d40f03_0.conda
linux-64::libglib-2.78.2-h783c2da_0.conda
linux-64::mandrake-1.2.2-py310h2b071e7_7.conda
linux-64::cppyy-cling-6.30.0-py310h3845668_0.conda
linux-64::sagelib-10.0-py311h0af1a61_2.conda
linux-64::fltk-1.3.9-hea138e6_0.conda
linux-64::libcurl-8.5.0-hca28451_0.conda
linux-64::ruby-3.2.2-h983345b_1.conda
linux-64::arrow-cpp-9.0.0-py311h65e8ff0_50_cuda.conda
linux-64::libarrow-13.0.0-h991eec8_20_cuda.conda
linux-64::tensorstore-0.1.51-py310ha94ca7a_0.conda
linux-64::lxml-4.9.3-py312he528aba_2.conda
linux-64::fish-3.6.4-hdab1d28_0.conda
linux-64::mapserver-8.0.1-py310hffa7269_15.conda
linux-64::gdstk-0.9.48-py39h9bdbfdd_0.conda
linux-64::ifcopenshell-v0.7.0.231127-py311_novtk_h36167de_102.conda
linux-64::dotnet-runtime-6.0.25-hfbc8c6f_0.conda
linux-64::triton-2.0.0-cuda120py310h2ad3591_4.conda
linux-64::lxml-4.9.3-py39h40bd5d0_3.conda
linux-64::python-igraph-0.11.3-py310hd766dba_1.conda
linux-64::postgresql-plpython-16.1-py312h8532d62_7.conda
linux-64::yoda-1.9.6-py310hd81f541_5.conda
linux-64::libarrow-14.0.1-hd3c8e8b_7_cuda.conda
linux-64::pp-sketchlib-2.1.2-py311h6963aab_0.conda
linux-64::glib-2.78.3-hfc55251_0.conda
linux-64::coda-2.25.1-py311h96e6511_0.conda
linux-64::libarrow-11.0.0-h6b1a9bd_56_cpu.conda
linux-64::libgdal-arrow-parquet-3.8.1-h6d2c5c8_3.conda
linux-64::libxmlsec1-1.3.2-h77a0d5c_1.conda
linux-64::jaxlib-0.4.20-cpu_py312hb17a006_0.conda
linux-64::folly-2023.12.04.00-h70f49c4_0_jemalloc.conda
linux-64::cppyy-cling-6.30.0-py39hc26e0ff_0.conda
linux-64::yoda-1.9.6-py38h3d0046c_5.conda
linux-64::openmpi-5.0.0-hb0ee255_100.conda
linux-64::pyinstaller-6.3.0-py312hf0b23d7_0.conda
linux-64::tiledb-2.18.2-h9d8f6ff_2.conda
linux-64::cmake-3.28.0-hcfe8598_0.conda
linux-64::mandrake-1.2.2-py311hb206e98_6.conda
linux-64::libgdal-arrow-parquet-3.8.2-hcd610a6_0.conda
linux-64::xrootd-5.6.2-py310h69d5ccd_2.conda
linux-64::postgresql-16.1-h7387d8b_6.conda
linux-64::magics-metview-batch-4.14.2-hd93a360_2.conda
linux-64::aws-sdk-cpp-1.11.210-h967ea9e_4.conda
linux-64::mandrake-1.2.2-py38h983c1cf_7.conda
linux-64::triton-2.0.0-cuda120py39hba637e5_4.conda
linux-64::libarrow-11.0.0-hea7331e_54_cuda.conda
linux-64::libtiledb-sql-0.26.0-h6641145_1.conda
linux-64::libarrow-14.0.1-h8141827_10_cuda.conda
linux-64::mandrake-1.2.2-py39h68ee24f_7.conda
linux-64::pytng-0.3.1-py312h0bdec57_1.conda
linux-64::libgdal-3.7.3-h2d2cbd2_10.conda
linux-64::postgresql-plpython-16.1-py310hdd8bd8b_5.conda
linux-64::tiledb-2.18.3-hc1131af_0.conda
linux-64::r-rmatio-0.19.0-r43h57805ef_0.conda
linux-64::coda-2.25.1-py38haeebca4_0.conda
linux-64::libgdal-arrow-parquet-3.7.3-h3705a34_12.conda
linux-64::coda-2.25.1-py39hdeca0b6_0.conda
linux-64::libgdal-arrow-parquet-3.8.1-h6dc26ee_3.conda
linux-64::julia-1.9.4-h764f291_0.conda
linux-64::cppyy-cling-6.30.0-py39h2ea1df6_0.conda
linux-64::arrow-cpp-9.0.0-py39h85af5f1_50_cpu.conda
linux-64::code-aster-16.4.19-np122py39h9914496_0.conda
linux-64::postgresql-plpython-16.1-py38hd157e84_6.conda
linux-64::vtk-base-9.2.6-osmesa_py39h1234567_120.conda
linux-64::root_base-6.30.2-py38h64a494c_0.conda
linux-64::util-linux-2.39.3-py310h6b057ee_0.conda
linux-64::mandrake-1.2.2-py38h815f229_6.conda
linux-64::tensorstore-0.1.51-py311h3fed34c_0.conda
linux-64::postgresql-plpython-16.1-py310hd093153_7.conda
linux-64::python-3.12.1-hab00c5b_0_cpython.conda
linux-64::triton-2.0.0-cuda112py39h6cf020c_4.conda
linux-64::aiokafka-0.10.0-py312hf0b23d7_0.conda
linux-64::postgresql-plpython-16.1-py311h4204730_5.conda
linux-64::libarrow-12.0.1-hcc26646_30_cpu.conda
linux-64::qt6-main-6.5.3-h3af85ea_0.conda
linux-64::libgdal-arrow-parquet-3.8.1-h4803a0b_2.conda
linux-64::dotnet-runtime-7.0.14-hb8a3ed7_0.conda
linux-64::minizip-4.0.4-h0ab5242_0.conda
linux-64::mandrake-1.2.2-py38h9bd7ae0_5.conda
linux-64::postgresql-plpython-16.1-py312h8532d62_5.conda
linux-64::libxml2-2.12.2-h232c23b_0.conda
linux-64::postgresql-plpython-16.1-py38hd157e84_7.conda
linux-64::libarrow-13.0.0-hcc26646_19_cpu.conda
linux-64::aiokafka-0.9.0-py38h502143a_0.conda
linux-64::libgdal-arrow-parquet-3.8.1-hb1cea3d_2.conda
linux-64::code-aster-16.4.19-np122py310hce3d7c1_0.conda
linux-64::texlive-core-20230313-h35c6a99_9.conda
linux-64::libarrow-13.0.0-h17daa2b_21_cuda.conda
linux-64::code-aster-16.4.15-np122py38h5b8432c_2.conda
linux-64::jaxlib-0.4.20-cpu_py310h9ed8a0c_0.conda
linux-64::mandrake-1.2.2-py310h166317f_6.conda
linux-64::libgdal-arrow-parquet-3.8.2-h9b05d71_1.conda
linux-64::jaxlib-0.4.23-cpu_py310h9ed8a0c_0.conda
linux-64::postgresql-plpython-15.4-py312hcc5c902_4.conda
linux-64::lldb-17.0.2-py310h602e256_0.conda
linux-64::xrootd-5.6.3-py39h49ef29b_0.conda
linux-64::imagecodecs-2024.1.1-py39hf9b8f0e_0.conda
linux-64::python-3.12.1-hab00c5b_1_cpython.conda
linux-64::libglib-2.78.3-h783c2da_0.conda
linux-64::pp-sketchlib-2.1.2-py38h384da6d_1.conda
linux-64::vtk-base-9.2.6-egl_py310h1234567_20.conda
linux-64::tiledb-2.18.2-h1f358a1_1.conda
linux-64::openconnect-9.12-h65ea1d3_2.conda
linux-64::pp-sketchlib-2.1.2-py312hb45938e_1.conda
linux-64::postgresql-plpython-16.1-py39ha00ab12_6.conda
linux-64::yoda-1.9.6-py311hbcaaa19_5.conda
linux-64::lldb-17.0.6-py38h22fd443_0.conda
linux-64::nss-3.96-h1d7d5a4_0.conda
linux-64::libarrow-13.0.0-h6b1a9bd_21_cpu.conda
linux-64::openmpi-5.0.0-hb0ee255_102.conda
linux-64::pygplates-0.39-py310hb02222c_14.conda
linux-64::pp-sketchlib-2.1.2-py39h4a3024f_1.conda
linux-64::folly-2023.12.11.00-hb244bc4_0.conda
linux-64::libyarp-3.9.0-h57bc1a5_0.conda
linux-64::symengine-0.11.2-hb29318e_0.conda
linux-64::xrootd-5.6.4-py312h9eb2509_0.conda
linux-64::arrow-cpp-9.0.0-py39h30b0357_50_cuda.conda
linux-64::pp-sketchlib-2.1.2-py311h6963aab_1.conda
linux-64::pp-sketchlib-2.1.2-py38hffd39c1_1.conda
linux-64::yoda-1.9.6-py38h3d0046c_6.conda
linux-64::sdl2_image-2.8.0-h53e0c72_0.conda
linux-64::pyinstaller-6.3.0-py38h502143a_0.conda
linux-64::root_base-6.28.10-py39he1fd38f_1.conda
linux-64::libgdal-arrow-parquet-3.8.1-h815407a_1.conda
linux-64::xrootd-5.6.4-py310h69d5ccd_0.conda
linux-64::lxml-4.9.3-py310h9b7343a_2.conda
linux-64::mandrake-1.2.2-py311hb206e98_5.conda
linux-64::imagecodecs-2024.1.1-py310h496a806_0.conda
linux-64::sagelib-10.2-py310hdae0915_0.conda
linux-64::sagelib-10.2-py310he210692_1.conda
linux-64::gmsh-4.12.0-h6b98cf8_0.conda
linux-64::pp-sketchlib-2.1.2-py39h19a0009_1.conda
linux-64::postgresql-plpython-15.4-py39h5ae07a4_4.conda
linux-64::vtk-base-9.2.6-qt_py311h1234567_220.conda
linux-64::pytables-3.9.2-py39hfbd31a7_1.conda
linux-64::tensorflow-base-2.15.0-cpu_py39h65ed569_0.conda
linux-64::ffmpeg-6.1.0-gpl_h186bccc_105.conda
linux-64::libgdal-arrow-parquet-3.7.3-h4803a0b_10.conda
linux-64::triton-2.0.0-cuda118py38hd773272_4.conda
linux-64::qt-main-5.15.8-h450f30e_18.conda
linux-64::mandrake-1.2.2-py39h60f94c8_5.conda
linux-64::gemmi-0.6.4-py39h7d5b425_0.conda
linux-64::python-igraph-0.11.3-py311h8290d24_1.conda
linux-64::root_base-6.30.2-py310h756cc32_1.conda
linux-64::folly-2023.12.11.00-h122a45c_0_jemalloc.conda
linux-64::libgdal-3.8.1-hed8bd54_4.conda
linux-64::mongodb-6.0.12-h9b5ac0e_0.conda
linux-64::pytables-3.9.2-py310h374b01c_1.conda
linux-64::libarrow-14.0.2-hfb4d3a9_0_cpu.conda
linux-64::root_base-6.28.10-py38h64a494c_2.conda
linux-64::pp-sketchlib-2.1.2-py39h5cf6715_1.conda
linux-64::util-linux-2.39.3-py310h6b057ee_1.conda
linux-64::scip-8.1.0-hb65f9cc_5.conda
linux-64::sagelib-10.0-py38h59ecdec_2.conda
linux-64::postgresql-plpython-16.1-py312h8532d62_6.conda
linux-64::mapserver-8.0.1-py39h750eadb_15.conda
linux-64::pyinstaller-6.3.0-py39hb6545a3_0.conda
linux-64::paraview-5.11.2-py38haefd8db_2_egl.conda
linux-64::rust-1.74.1-h70c747d_0.conda
linux-64::magics-4.14.2-hd93a360_2.conda
linux-64::postgresql-plpython-15.4-py38h0f07e32_3.conda
linux-64::libgdal-3.7.3-h184a269_11.conda
linux-64::pp-sketchlib-2.1.2-py38hffd39c1_0.conda
linux-64::code-aster-16.4.15-np123py311hf6e88c2_2.conda
linux-64::pp-sketchlib-2.1.2-py39h4a3024f_0.conda
linux-64::lldb-17.0.6-py39hb850a82_0.conda
linux-64::ndcctools-7.7.3-py38h514f0f6_0.conda
linux-64::gst-plugins-base-1.22.8-h8e1006c_0.conda
linux-64::mandrake-1.2.2-py312h89ef9b0_7.conda
linux-64::vtk-base-9.2.6-osmesa_py312h1234567_120.conda
linux-64::clangdev-13.0.1-default_h7634d5b_5.conda
linux-64::libarrow-14.0.1-h0c95fbd_9_cuda.conda
linux-64::ttyd-1.7.4-h78d4dd0_0.conda
linux-64::tiledb-2.18.3-hc1131af_1.conda
linux-64::r-base-4.2.3-hc446a09_11.conda
linux-64::libarrow-12.0.1-h991eec8_31_cuda.conda
linux-64::root_base-6.28.10-py311h2383b95_1.conda
linux-64::libpq-16.1-hedfdc17_6.conda
linux-64::mandrake-1.2.2-py310h24473af_7.conda
linux-64::libarrow-14.0.1-h422ced8_8_cpu.conda
linux-64::code-aster-16.4.16-np122py310hce3d7c1_1.conda
linux-64::julia-1.9.3-h764f291_1.conda
linux-64::mdsplus-7.139.60-py310pl5321h290ef49_1.conda
linux-64::lighttpd-1.4.73-lua54h118f8aa_1.conda
linux-64::libssh-0.10.6-h0498e11_0.conda
linux-64::mandrake-1.2.2-py310h48e65b8_7.conda
linux-64::pyreadstat-1.2.6-py310h93c3562_0.conda
linux-64::tesseract-5.3.3-hbeb23df_0.conda
linux-64::util-linux-2.39.3-py311h4285dfd_0.conda
linux-64::mandrake-1.2.2-py310h24473af_6.conda
linux-64::lld-16.0.6-hc908ec4_1.conda
linux-64::postgresql-16.1-h8972f4a_7.conda
linux-64::code-aster-16.4.16-np123py311hf6e88c2_0.conda
linux-64::ndcctools-7.7.3-py311h689c632_0.conda
linux-64::mandrake-1.2.2-py39h68ee24f_5.conda
linux-64::papilo-2.1.4-h8cd16de_6.conda
linux-64::paraview-5.11.2-py38h30decc7_102_qt.conda
linux-64::libgdal-arrow-parquet-3.7.3-h9341cea_10.conda
linux-64::imagemagick-7.1.1_24-pl5321h3fa1221_0.conda
linux-64::libarrow-11.0.0-hcce0278_55_cpu.conda
linux-64::libnghttp2-static-1.58.0-h6bbaf85_1.conda
linux-64::python-3.8.18-hd12c33a_1_cpython.conda
linux-64::folly-2023.12.11.00-hbc8c634_0_jemalloc.conda
linux-64::libnghttp2-1.58.0-h47da74e_1.conda
linux-64::util-linux-2.39.3-py312h77dc562_0.conda
linux-64::qt6-main-6.6.1-h3af85ea_3.conda
linux-64::vtk-base-9.2.6-qt_py38h1234567_220.conda
linux-64::xrootd-5.6.4-py39h49ef29b_0.conda
linux-64::xrootd-5.6.3-py310h69d5ccd_0.conda
linux-64::tensorstore-0.1.51-py312h3c940a5_0.conda
linux-64::imagemagick-7.1.1_25-pl5321h3fa1221_0.conda
linux-64::mandrake-1.2.2-py312h0a6742c_7.conda
linux-64::root_base-6.30.2-py311h2383b95_0.conda
linux-64::root_base-6.28.10-py39he1fd38f_0.conda
linux-64::papilo-2.1.4-h7134f8c_5.conda
linux-64::pp-sketchlib-2.1.2-py312hec4aa90_1.conda
linux-64::libarrow-13.0.0-hea7331e_19_cuda.conda
linux-64::postgresql-plpython-16.1-py39h5ae07a4_7.conda
linux-64::r-gaston-1.6-r42h33b523d_0.conda
linux-64::libgdal-arrow-parquet-3.8.1-h263641c_4.conda
linux-64::bytewax-0.17.2-py311h1844ddb_0.conda
linux-64::triton-2.0.0-cuda120py311h6fb472e_4.conda
linux-64::libgdal-arrow-parquet-3.8.1-hcd610a6_4.conda
linux-64::gemmi-0.6.4-py310h1b8f574_0.conda
linux-64::folly-2023.12.11.00-h1d40f03_0.conda
linux-64::code-aster-16.4.18-np122py39h9914496_0.conda
linux-64::code-aster-16.4.16-np122py39h9914496_0.conda
linux-64::libpq-16.1-hedfdc17_5.conda
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
```
</details>