### PR TITLE
loosen zlib-pin to major level (7/N; November 2023)

### DIFF
--- a/recipe/patch_yaml/zlib.yaml
+++ b/recipe/patch_yaml/zlib.yaml
@@ -52,3 +52,12 @@ then:
   - loosen_depends:
       name: libzlib
       upper_bound: "2"
+---
+if:
+  has_depends: libzlib >=1.2*
+  timestamp_lt: 1701388800000  # 2023-12-01 00:00 UTC
+  timestamp_ge: 1698796800000  # 2023-11-01 00:00 UTC
+then:
+  - loosen_depends:
+      name: libzlib
+      upper_bound: "2"


### PR DESCRIPTION
Follow-up to https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/739, about 3900 artefacts affected.

### Result of `python show_diff.py`

<details>

```diff
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
osx-arm64::libsqlite-3.44.0-h091b4b1_0.conda
osx-arm64::llvm-15.0.7-h4a7a88c_4.conda
osx-arm64::libmlir-17.0.5-hba3f82b_0.conda
osx-arm64::libsqlite-3.44.2-h091b4b1_0.conda
osx-arm64::gst-plugins-base-1.22.7-h040e9b9_0.conda
osx-arm64::libsolv-static-0.7.27-h9e231a4_0.conda
osx-arm64::libsolv-static-0.7.26-h9e231a4_0.conda
osx-arm64::dotnet-runtime-7.0.10-hba4e794_0.conda
osx-arm64::llvm-tools-15.0.7-h2621b3d_4.conda
osx-arm64::dotnet-sdk-7.0.400-hba4e794_0.conda
osx-arm64::micromamba-1.5.2-0.tar.bz2
osx-arm64::msgpack-c-6.0.0-h9e231a4_1.conda
osx-arm64::tk-8.6.13-h5083fa2_1.conda
osx-arm64::libmlir-17.0.6-hba3f82b_0.conda
osx-arm64::libsolv-0.7.26-h9e231a4_0.conda
osx-arm64::micromamba-1.5.1-2.tar.bz2
osx-arm64::glib-tools-2.78.1-h9e231a4_1.conda
osx-arm64::libllvm15-15.0.7-h2621b3d_4.conda
osx-arm64::cargo-bundle-licenses-1.3.0-h46549a6_0.conda
osx-arm64::libmlir17-17.0.4-hba3f82b_0.conda
osx-arm64::libmlir17-17.0.5-hba3f82b_0.conda
osx-arm64::libsolv-0.7.27-h9e231a4_0.conda
osx-arm64::liblal-7.4.1-fftw_h5834690_101.conda
osx-arm64::libuwebsockets-20.48.0-h9e231a4_0.conda
osx-arm64::glib-tools-2.78.1-h9e231a4_0.conda
osx-arm64::micromamba-1.5.3-0.tar.bz2
osx-arm64::dotnet-aspnetcore-7.0.10-hba4e794_0.conda
osx-arm64::cfitsio-4.3.1-h808cd33_0.conda
osx-arm64::libmlir-17.0.4-hba3f82b_0.conda
osx-arm64::libmlir17-17.0.6-hba3f82b_0.conda
osx-arm64::libsqlite-3.44.1-h091b4b1_0.conda
osx-arm64::lld-15.0.7-h6fc9e18_2.conda
-    "libzlib >=1.2.13,<1.3.0a0"
+    "libzlib >=1.2.13,<2.0.0a0"
osx-arm64::libgdal-arrow-parquet-3.7.3-hc01baa0_5.conda
osx-arm64::postgresql-16.1-hc6ab77f_0.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-hc01baa0_6.conda
osx-arm64::freecad-0.21.2-py310hce723d0_0.conda
osx-arm64::freecad-0.21.2-py311he87bcf8_0.conda
osx-arm64::libarrow-14.0.1-h8dffd16_3_cpu.conda
osx-arm64::pytables-3.9.2-py39h717dae7_0.conda
osx-arm64::llvmdev-17.0.4-hc359061_0.conda
osx-arm64::healpy-1.16.6-py312h2ef2e51_2.conda
osx-arm64::libgdal-arrow-parquet-3.8.0-h1634d40_5.conda
osx-arm64::libopencv-4.8.1-py38h48daea7_5.conda
osx-arm64::pygrib-2.1.5-py39h914d841_0.conda
osx-arm64::ffmpeg-6.1.0-lgpl_hd18ffc0_1.conda
osx-arm64::pygplates-0.39-py38h448790b_13.conda
osx-arm64::r-git2r-0.33.0-r42h0db8b51_0.conda
osx-arm64::libadios2-2.9.2-mpi_mpich_h12c0010_1.conda
osx-arm64::pytables-3.9.2-py310h1846626_0.conda
osx-arm64::mosh-1.4.0-pl5321h76d248e_5.conda
osx-arm64::paraview-5.11.2-py311h0b95a05_102_qt.conda
osx-arm64::libpulsar-3.4.1-h25ec3c2_0.conda
osx-arm64::sqlite-3.44.0-hf2abe2d_0.conda
osx-arm64::cpp-opentelemetry-sdk-1.12.0-hbaf25a0_1.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-hd1c4004_6.conda
osx-arm64::grpcio-1.60.0-py310h6121c79_0.conda
osx-arm64::heyoka-3.2.0-hdea24a2_0.conda
osx-arm64::lld-17.0.4-he164760_0.conda
osx-arm64::llvm-tools-17.0.6-haab561b_1.conda
osx-arm64::nceplibs-g2c-1.8.0-h5c49d8b_4.conda
osx-arm64::libopencv-4.8.1-py312h494ba3b_4.conda
osx-arm64::folly-2023.11.27.00-ha5de9cd_0_jemalloc.conda
osx-arm64::grpcio-1.60.0-py38hfeb05b4_0.conda
osx-arm64::paraview-5.11.2-py38h2be843e_102_qt.conda
osx-arm64::fltk-1.3.8-h31b9a01_4.conda
osx-arm64::libarrow-13.0.0-he278929_18_cpu.conda
osx-arm64::postgresql-plpython-16.1-py312h9d9d237_0.conda
osx-arm64::libarrow-14.0.1-ha4caa07_2_cpu.conda
osx-arm64::heyoka-3.1.0-he663e9d_0.conda
osx-arm64::gemmi-0.6.3-py39h29ec2fe_0.conda
osx-arm64::folly-2023.11.06.00-h2db6db1_0.conda
osx-arm64::libvips-8.15.0-hd347eac_2.conda
osx-arm64::libmed-4.1.1-py38h68d1944_6.conda
osx-arm64::grpcio-1.60.0-py311h79dd126_0.conda
osx-arm64::ifcopenshell-v0.7.0.231127-py311_novtk_ha535539_101.conda
osx-arm64::libadios2-2.9.2-mpi_openmpi_hc4c21e9_0.conda
osx-arm64::cppyy-cling-6.28.0-py310h4461d00_1.conda
osx-arm64::libmed-4.1.1-py310hdcb7978_7.conda
osx-arm64::ogre-14.1.2-h1691b42_1.conda
osx-arm64::libadios2-2.9.2-mpi_openmpi_h32c2fb0_1.conda
osx-arm64::lld-17.0.5-he164760_0.conda
osx-arm64::gazebo-11.14.0-h2148378_4.conda
osx-arm64::protozfits-2.3.0-py311h2986e75_4.conda
osx-arm64::gdstk-0.9.47-py39h692b333_0.conda
osx-arm64::mlir-17.0.6-hba3f82b_0.conda
osx-arm64::mysql-connector-python-8.0.32-py311hd82e36e_1.conda
osx-arm64::llvmdev-15.0.7-h2621b3d_4.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-h545ce25_3.conda
osx-arm64::r-harp-1.20.2-py39h31e696d_0.conda
osx-arm64::mysql-connector-python-8.0.32-py39h6075a83_1.conda
osx-arm64::libgdal-arrow-parquet-3.8.0-h75e746b_7.conda
osx-arm64::pyhdf-0.11.3-py39h21d1337_2.conda
osx-arm64::pyhdf-0.11.3-py312h4bc3512_2.conda
osx-arm64::libarrow-11.0.0-h0451105_48_cpu.conda
osx-arm64::freecad-0.21.2-py39h400c673_0.conda
osx-arm64::aws-sdk-cpp-1.11.182-h7c7ece8_3.conda
osx-arm64::vtk-base-9.2.6-qt_py312h1234567_219.conda
osx-arm64::harp-1.20.2-py310h2275332_0.conda
osx-arm64::pygrib-2.1.5-py311h9320766_0.conda
osx-arm64::libgdal-3.7.3-h71081f8_8.conda
osx-arm64::libgdal-3.8.0-heef1736_0.conda
osx-arm64::heyoka-3.2.0-h9e77e2b_0.conda
osx-arm64::libgdal-3.7.3-h48cc1a0_5.conda
osx-arm64::tiledb-2.17.4-hb4613eb_0.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-h079d9d4_2.conda
osx-arm64::protozfits-2.3.0-py310h7a35917_4.conda
osx-arm64::cppyy-cling-6.28.0-py310h59dd246_2.conda
osx-arm64::pyinstaller-6.2.0-py39h8643609_0.conda
osx-arm64::heyoka-3.1.0-h31f32e4_0.conda
osx-arm64::vtk-base-9.2.6-qt_py310h1234567_219.conda
osx-arm64::ifcopenshell-v0.7.0.231127-py39_all_hbd7c877_201.conda
osx-arm64::protozfits-2.3.0-py38h8866f21_2.conda
osx-arm64::pyreadstat-1.2.5-py39h8643609_0.conda
osx-arm64::libllvm17-17.0.4-hc359061_0.conda
osx-arm64::libgdal-arrow-parquet-3.8.0-hbca91e2_2.conda
osx-arm64::libadios2-2.9.2-mpi_mpich_h12c0010_0.conda
osx-arm64::heyoka-llvm-14-3.1.0-hf269ef6_0.conda
osx-arm64::libarrow-10.0.1-h5f21a3a_54_cpu.conda
osx-arm64::openbabel-3.1.1-py312h2eeb2e4_9.conda
osx-arm64::postgresql-plpython-16.1-py311h1bbf4d3_0.conda
osx-arm64::libmed-4.1.1-py310hdcb7978_0.conda
osx-arm64::pdal-2.6.0-hc5a8e0f_1.conda
osx-arm64::git-2.42.0-pl5321h6e320eb_1.conda
osx-arm64::pygrib-2.1.5-py310h3705f70_0.conda
osx-arm64::libgdal-3.8.0-hcefe9de_7.conda
osx-arm64::libadios2-2.9.2-nompi_h4d0f312_100.conda
osx-arm64::libadios2-2.9.2-mpi_openmpi_h6324500_1.conda
osx-arm64::fish-3.6.1-h15587f7_1.conda
osx-arm64::mold-2.3.2-hdbeb7c9_0.conda
osx-arm64::libarrow-13.0.0-h6df756b_17_cpu.conda
osx-arm64::tiledb-2.18.1-he462678_0.conda
osx-arm64::heyoka-llvm-15-3.1.0-h3213e78_0.conda
osx-arm64::mold-2.3.3-hdbeb7c9_0.conda
osx-arm64::paraview-5.11.2-py312hfea8ab8_102_qt.conda
osx-arm64::libarrow-10.0.1-h9be0040_57_cpu.conda
osx-arm64::indexed_gzip-1.8.7-py311h873492f_0.conda
osx-arm64::orc-1.9.0-h7c018df_4.conda
osx-arm64::libadios2-2.9.2-mpi_mpich_h84be5a8_0.conda
osx-arm64::freecad-0.21.2-py310hf5a454c_1.conda
osx-arm64::libadios2-2.9.2-nompi_hcaa6dfb_100.conda
osx-arm64::ovito-3.9.4-h45f7d94_0.conda
osx-arm64::ifcopenshell-v0.7.0.231127-py311_all_haad7bbc_201.conda
osx-arm64::libmed-4.1.1-py312h73365c5_6.conda
osx-arm64::folly-2023.11.27.00-h2db6db1_0.conda
osx-arm64::smesh-9.9.0.0-hb6b1f3d_10.conda
osx-arm64::poppler-23.11.0-hcdd998b_0.conda
osx-arm64::libgdal-arrow-parquet-3.8.0-hbca91e2_1.conda
osx-arm64::ffmpeg-6.0.1-lgpl_h280b91c_0.conda
osx-arm64::libmed-4.1.1-py310hdcb7978_6.conda
osx-arm64::heyoka-llvm-16-3.1.0-h4a435fa_0.conda
osx-arm64::libpano13-2.9.20rc2-pl5321h555d7a1_7.conda
osx-arm64::glib-2.78.1-h9e231a4_0.conda
osx-arm64::glib-2.78.1-h9e231a4_1.conda
osx-arm64::folly-2023.11.13.00-h2db6db1_0.conda
osx-arm64::folly-2023.11.27.00-hb8f665b_0_jemalloc.conda
osx-arm64::vtk-base-9.2.6-qt_py38h1234567_219.conda
osx-arm64::libarrow-13.0.0-h9e6bbaf_14_cpu.conda
osx-arm64::libmed-4.1.1-py312h73365c5_7.conda
osx-arm64::papilo-2.1.4-hc54c17b_4.conda
osx-arm64::folly-2023.11.13.00-h58b644a_0.conda
osx-arm64::folly-2023.11.06.00-hb8f665b_0_jemalloc.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-hd616f00_7.conda
osx-arm64::libgdal-arrow-parquet-3.8.0-he74f11c_0.conda
osx-arm64::r-base-4.3.2-h9389748_1.conda
osx-arm64::python-igraph-0.11.3-py311h72fc80f_0.conda
osx-arm64::openimageio-2.5.5.0-py312h72cd4a4_0.conda
osx-arm64::gemmi-0.6.3-py39h52f163a_1.conda
osx-arm64::r-harp-1.20.2-py38h2af7232_0.conda
osx-arm64::libgdal-3.7.3-h116f65a_3.conda
osx-arm64::libgdal-arrow-parquet-3.8.0-h4f999d0_2.conda
osx-arm64::libmed-4.1.1-py39h111c72b_7.conda
osx-arm64::postgresql-plpython-16.1-py39h93fcee7_0.conda
osx-arm64::mlir-17.0.4-hba3f82b_0.conda
osx-arm64::qt6-main-6.6.1-h9c79a27_0.conda
osx-arm64::libarrow-14.0.0-h3e40753_0_cpu.conda
osx-arm64::pytables-3.9.2-py311hce229b4_0.conda
osx-arm64::heyoka-llvm-14-3.2.0-hf269ef6_0.conda
osx-arm64::libgit2-1.7.1-h6a3654e_1.conda
osx-arm64::llvm-17.0.4-h2b67075_0.conda
osx-arm64::ifcopenshell-v0.7.0.231127-py312_novtk_h1ac61a4_101.conda
osx-arm64::gdstk-0.9.47-py311h52bd988_1.conda
osx-arm64::protozfits-2.3.0-py311h3b93d33_2.conda
osx-arm64::libadios2-2.9.2-nompi_h4d0f312_101.conda
osx-arm64::libmediainfo-23.11-h1d736b4_0.conda
osx-arm64::libarrow-12.0.1-h6df756b_28_cpu.conda
osx-arm64::orc-1.9.2-h7c018df_0.conda
osx-arm64::postgresql-plpython-16.1-py38h355cde2_0.conda
osx-arm64::libpq-16.1-hd435d45_0.conda
osx-arm64::libadios2-2.9.2-mpi_openmpi_h4f82210_0.conda
osx-arm64::grpcio-1.60.0-py39h52f163a_0.conda
osx-arm64::libgdal-arrow-parquet-3.8.0-ha211958_2.conda
osx-arm64::gmsh-4.11.1-ha37f9cc_6.conda
osx-arm64::freecad-0.21.2-py311h213c538_1.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-h1634d40_6.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-hd1c4004_5.conda
osx-arm64::tiledb-2.17.4-h555b8a3_0.conda
osx-arm64::libarrow-12.0.1-h0451105_24_cpu.conda
osx-arm64::libgdal-arrow-parquet-3.8.0-hc01baa0_5.conda
osx-arm64::libarrow-13.0.0-h9d7c978_15_cpu.conda
osx-arm64::libgdal-arrow-parquet-3.8.0-h1634d40_4.conda
osx-arm64::pyinstaller-6.2.0-py310h742d9d8_0.conda
osx-arm64::mlir-17.0.5-hba3f82b_0.conda
osx-arm64::libxml2-2.12.1-h0d0cfa8_0.conda
osx-arm64::protozfits-2.3.0-py38h182cc28_4.conda
osx-arm64::libopencv-4.8.1-py311h927bda1_4.conda
osx-arm64::r-base-4.3.2-haf9be62_0.conda
osx-arm64::libarrow-10.0.1-ha0d3add_53_cpu.conda
osx-arm64::soplex-6.0.4-hd9965d4_4.conda
osx-arm64::openmeeg-2.5.7-py311hd2b692a_0.conda
osx-arm64::libgdal-arrow-parquet-3.8.0-h6ae7663_0.conda
osx-arm64::pygrib-2.1.5-py39h30a3160_1.conda
osx-arm64::libllvm17-17.0.5-hc359061_0.conda
osx-arm64::imagemagick-7.1.1_21-pl5321h93169cd_1.conda
osx-arm64::qt-webengine-5.15.8-h850e111_4.conda
osx-arm64::indexed_gzip-1.8.7-py39h33914a9_0.conda
osx-arm64::paraview-5.11.2-py310hf6d9b59_102_qt.conda
osx-arm64::heyoka-3.1.0-had0bed7_0.conda
osx-arm64::libadios2-2.9.2-mpi_mpich_h687b67b_0.conda
osx-arm64::gemmi-0.6.3-py311h79dd126_1.conda
osx-arm64::libopencv-4.8.1-py39hec79f96_5.conda
osx-arm64::folly-2023.11.27.00-h58b644a_0.conda
osx-arm64::libarrow-14.0.1-h63c4d5d_4_cpu.conda
osx-arm64::libarrow-10.0.1-hb8c9fa5_51_cpu.conda
osx-arm64::libarrow-11.0.0-h6df756b_52_cpu.conda
osx-arm64::folly-2023.11.20.00-h2db6db1_0.conda
osx-arm64::libmed-4.1.1-py38h68d1944_0.conda
osx-arm64::libadios2-2.9.2-nompi_h3e55d5e_101.conda
osx-arm64::libmed-4.1.1-py39h111c72b_0.conda
osx-arm64::ifcopenshell-v0.7.0.231127-py39_novtk_h22deb30_100.conda
osx-arm64::libgdal-arrow-parquet-3.8.0-ha211958_1.conda
osx-arm64::folly-2023.11.20.00-h58b644a_0.conda
osx-arm64::gemmi-0.6.3-py38hfeb05b4_1.conda
osx-arm64::libglib-2.78.1-hb438215_1.conda
osx-arm64::libadios2-2.9.2-mpi_mpich_ha498bb1_0.conda
osx-arm64::libgdal-arrow-parquet-3.8.0-h0ca5329_2.conda
osx-arm64::geant4-11.1.3-py310h41ea9e7_0.conda
osx-arm64::grpcio-1.60.0-py312h780eafd_0.conda
osx-arm64::verilator-5.018-hc32b3af_0.conda
osx-arm64::libgdal-arrow-parquet-3.8.0-h30a05d2_6.conda
osx-arm64::libmatio-1.5.26-h3b23503_0.conda
osx-arm64::gemmi-0.6.3-py38hf5a1827_0.conda
osx-arm64::libgdal-arrow-parquet-3.8.0-h73b7f96_6.conda
osx-arm64::ifcopenshell-v0.7.0.231127-py311_novtk_ha535539_100.conda
osx-arm64::libvips-8.15.0-hbf2047f_1.conda
osx-arm64::folly-2023.11.13.00-ha5de9cd_0_jemalloc.conda
osx-arm64::vtk-base-9.2.6-qt_py311h1234567_219.conda
osx-arm64::libllvm17-17.0.6-hc359061_0.conda
osx-arm64::libopentelemetry-cpp-1.12.0-hbaf25a0_1.conda
osx-arm64::libgdal-arrow-parquet-3.8.0-h112f01a_7.conda
osx-arm64::cppyy-cling-6.28.0-py39hd308395_2.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-hd1c4004_4.conda
osx-arm64::gdstk-0.9.47-py38hbce28a2_1.conda
osx-arm64::tensorflow-base-2.14.0-cpu_py310h0e84cb2_0.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-h6ae7663_2.conda
osx-arm64::folly-2023.11.06.00-h58b644a_0.conda
osx-arm64::libmed-4.1.1-py312h73365c5_0.conda
osx-arm64::libarrow-11.0.0-h9e6bbaf_47_cpu.conda
osx-arm64::cppyy-cling-6.28.0-py38h9908e9a_2.conda
osx-arm64::openimageio-2.5.5.0-py38h3fb5564_0.conda
osx-arm64::libadios2-2.9.2-mpi_mpich_h07a8d79_0.conda
osx-arm64::boost-cpp-1.83.0-hca5e981_0.conda
osx-arm64::libgdal-arrow-parquet-3.8.0-hc4f5c7f_5.conda
osx-arm64::folly-2023.11.20.00-hb8f665b_0_jemalloc.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-hc6e45ce_4.conda
osx-arm64::libgdal-3.7.3-h27415a3_7.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-h545ce25_2.conda
osx-arm64::libspatialite-5.1.0-h66af7d6_2.conda
osx-arm64::papilo-2.1.4-hc54c17b_0.conda
osx-arm64::qt6-main-6.6.1-h1aa5e93_2.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-h079d9d4_1.conda
osx-arm64::ffmpeg-6.1.0-lgpl_h83752d4_2.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-h73c12cd_7.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-ha211958_4.conda
osx-arm64::pygrib-2.1.5-py312h2eac005_0.conda
osx-arm64::libgdal-3.7.3-h116f65a_2.conda
osx-arm64::libarrow-11.0.0-h9d7c978_49_cpu.conda
osx-arm64::protozfits-2.3.0-py39ha79343b_4.conda
osx-arm64::pygplates-0.39-py39h494e673_13.conda
osx-arm64::libgdal-arrow-parquet-3.8.0-hd616f00_6.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-h545ce25_1.conda
osx-arm64::protozfits-2.3.0-py310hdbc695e_2.conda
osx-arm64::python-igraph-0.11.3-py38h8fa9ae3_0.conda
osx-arm64::tiledb-2.18.2-h555b8a3_0.conda
osx-arm64::libglib-2.78.1-hd9b11f9_0.conda
osx-arm64::freecad-0.21.2-py38h4dbf7e3_0.conda
osx-arm64::libarrow-12.0.1-he278929_29_cpu.conda
osx-arm64::python-igraph-0.11.3-py310h74d7e66_0.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-h6ae7663_1.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-hbc64026_4.conda
osx-arm64::tensorflow-base-2.14.0-cpu_py311h05dd8b3_0.conda
osx-arm64::python-igraph-0.11.3-py312h8d8ca30_0.conda
osx-arm64::libarrow-11.0.0-he278929_53_cpu.conda
osx-arm64::libarrow-12.0.1-h9d7c978_25_cpu.conda
osx-arm64::cmake-3.27.9-h04763b9_0.conda
osx-arm64::libfido2-1.14.0-h8d15234_0.conda
osx-arm64::qtwebkit-5.212-hbfdfb58_15.conda
osx-arm64::pyhdf-0.11.3-py311hecf5fa5_2.conda
osx-arm64::pyreadstat-1.2.5-py312ha17c255_0.conda
osx-arm64::scip-8.1.0-h4a2b32c_0.conda
osx-arm64::papilo-2.1.4-hc54c17b_3.conda
osx-arm64::folly-2023.11.06.00-hd3f4852_0_jemalloc.conda
osx-arm64::folly-2023.11.13.00-hd3f4852_0_jemalloc.conda
osx-arm64::pygrib-2.1.5-py310h5eaf5bd_1.conda
osx-arm64::fltk-1.3.8-h31b9a01_5.conda
osx-arm64::mysql-connector-python-8.0.32-py310h5952ffa_1.conda
osx-arm64::libgdal-arrow-parquet-3.8.0-hc01baa0_3.conda
osx-arm64::sqlite-3.44.1-hf2abe2d_0.conda
osx-arm64::sqlite-3.44.2-hf2abe2d_0.conda
osx-arm64::indexed_gzip-1.8.7-py312h5dd6cca_0.conda
osx-arm64::openbabel-3.1.1-py39h7b5bc7f_9.conda
osx-arm64::ffmpeg-6.1.0-gpl_h032c140_102.conda
osx-arm64::libarrow-12.0.1-h81cb639_26_cpu.conda
osx-arm64::libadios2-2.9.2-nompi_hcaa6dfb_101.conda
osx-arm64::cppyy-cling-6.28.0-py311h4ca21db_2.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-h73b7f96_7.conda
osx-arm64::git-2.43.0-pl5321h6e320eb_0.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-h1634d40_4.conda
osx-arm64::ffmpeg-6.0.1-gpl_h85ac7dd_100.conda
osx-arm64::libgdal-3.7.3-h116f65a_0.conda
osx-arm64::pygrib-2.1.5-py311h7ab0296_1.conda
osx-arm64::libxml2-2.12.0-h0d0cfa8_0.conda
osx-arm64::ffmpeg-6.1.0-lgpl_h280b91c_0.conda
osx-arm64::mysql-connector-python-8.0.32-py38h2d2b0d9_1.conda
osx-arm64::pyreadstat-1.2.5-py310h742d9d8_0.conda
osx-arm64::paraview-5.11.2-py311h221c25a_102_qt.conda
osx-arm64::gemmi-0.6.3-py312h780eafd_1.conda
osx-arm64::protozfits-2.3.0-py39ha79343b_3.conda
osx-arm64::libopencv-4.8.1-py312hc03029b_5.conda
osx-arm64::wxwidgets-3.2.4-h3ae78ef_0.conda
osx-arm64::libarrow-14.0.1-h3e40753_0_cpu.conda
osx-arm64::freecad-0.21.2-py39h0478a5b_1.conda
osx-arm64::cppyy-cling-6.28.0-py38h2a82688_1.conda
osx-arm64::nodejs-18.18.2-h7ed3092_1.conda
osx-arm64::openimageio-2.5.5.0-py310hce50749_0.conda
osx-arm64::texlive-core-20230313-py310hd6d4bb7_8.conda
osx-arm64::libadios2-2.9.2-nompi_h9fdb4fb_101.conda
osx-arm64::libmed-4.1.1-py39h111c72b_6.conda
osx-arm64::libmed-4.1.1-py311h16a4e6a_0.conda
osx-arm64::libgdal-arrow-parquet-3.8.0-hc4f5c7f_3.conda
osx-arm64::openbabel-3.1.1-py311h292ccdb_9.conda
osx-arm64::openmeeg-2.5.6-py39h80c8f73_5.conda
osx-arm64::folly-2023.11.27.00-hd3f4852_0_jemalloc.conda
osx-arm64::libarrow-12.0.1-h0928616_27_cpu.conda
osx-arm64::libgdal-arrow-parquet-3.8.0-hadb931b_7.conda
osx-arm64::libopencv-4.8.1-py39h3005bad_4.conda
osx-arm64::openmeeg-2.5.7-py312hcffd864_0.conda
osx-arm64::gst-plugins-good-1.22.7-hf27f88a_0.conda
osx-arm64::libgdal-arrow-parquet-3.8.0-hd1c4004_5.conda
osx-arm64::heyoka-3.2.0-he663e9d_0.conda
osx-arm64::gazebo-11.14.0-hd4deebb_3.conda
osx-arm64::pygrib-2.1.5-py38hb1ab132_1.conda
osx-arm64::libgdal-arrow-parquet-3.8.0-hc4f5c7f_4.conda
osx-arm64::cppyy-cling-6.28.0-py311hb41d40b_1.conda
osx-arm64::healpy-1.16.6-py311he24cacd_2.conda
osx-arm64::freecad-0.21.2-py38h02e872d_1.conda
osx-arm64::grpcio-1.59.3-py38hfeb05b4_0.conda
osx-arm64::libadios2-2.9.2-mpi_openmpi_h32c2fb0_0.conda
osx-arm64::grpcio-1.59.3-py39h52f163a_0.conda
osx-arm64::libgdal-arrow-parquet-3.8.0-h0ca5329_1.conda
osx-arm64::libarrow-14.0.1-h7bb5718_1_cpu.conda
osx-arm64::libarrow-12.0.1-h9e6bbaf_23_cpu.conda
osx-arm64::pygrib-2.1.5-py38h261e500_0.conda
osx-arm64::r-harp-1.20.2-py311hea92249_0.conda
osx-arm64::libadios2-2.9.2-mpi_mpich_h07a8d79_1.conda
osx-arm64::graphviz-9.0.0-h4785655_0.conda
osx-arm64::llvm-tools-17.0.5-hc359061_0.conda
osx-arm64::nss-3.95-h6cf673f_0.conda
osx-arm64::libvips-8.15.0-h0e81681_0.conda
osx-arm64::llvm-tools-17.0.4-hc359061_0.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-h6ae7663_3.conda
osx-arm64::harp-1.20.2-py38h2275332_0.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-he74f11c_3.conda
osx-arm64::libgdal-arrow-parquet-3.8.0-h079d9d4_0.conda
osx-arm64::scip-8.1.0-ha659d42_4.conda
osx-arm64::aws-sdk-cpp-1.11.210-h31542fa_0.conda
osx-arm64::gdstk-0.9.47-py312h5f5ee38_0.conda
osx-arm64::heyoka-llvm-17-3.2.0-h5a0310b_0.conda
osx-arm64::libgdal-3.8.0-h751e6a0_5.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-h1634d40_5.conda
osx-arm64::libspatialite-5.1.0-h5b80306_1.conda
osx-arm64::libpulsar-3.2.0-h25ec3c2_6.conda
osx-arm64::tiledb-2.18.1-hb4613eb_0.conda
osx-arm64::octave-8.4.0-hd242ab5_0.conda
osx-arm64::libgdal-arrow-parquet-3.8.0-h545ce25_0.conda
osx-arm64::libadios2-2.9.2-mpi_openmpi_h4f82210_1.conda
osx-arm64::libgdal-3.8.0-h751e6a0_4.conda
osx-arm64::llvm-17.0.5-h2b67075_0.conda
osx-arm64::libllvm16-16.0.6-haab561b_3.conda
osx-arm64::ifcopenshell-v0.7.0.231127-py38_novtk_hbb8923f_101.conda
osx-arm64::soplex-6.0.4-hd9965d4_3.conda
osx-arm64::libadios2-2.9.2-nompi_h22d4965_100.conda
osx-arm64::geant4-11.1.3-py38h915767a_0.conda
osx-arm64::mysql-libs-8.0.33-he3dca8b_6.conda
osx-arm64::heyoka-llvm-15-3.2.0-h3213e78_0.conda
osx-arm64::gdstk-0.9.47-py310h745f51c_0.conda
osx-arm64::libadios2-2.9.2-mpi_mpich_h84be5a8_1.conda
osx-arm64::heyoka-llvm-16-3.2.0-h4a435fa_0.conda
osx-arm64::protozfits-2.3.0-py311h2986e75_3.conda
osx-arm64::cppyy-cling-6.28.0-py312hd4cd381_1.conda
osx-arm64::folly-2023.11.06.00-ha5de9cd_0_jemalloc.conda
osx-arm64::aws-sdk-cpp-1.11.182-h31542fa_7.conda
osx-arm64::indexed_gzip-1.8.7-py38h72f328c_0.conda
osx-arm64::hugin-base-2022.0.0-pl5321hd611669_9.conda
osx-arm64::z5py-2.0.17-py38hdfe9cbe_0.conda
osx-arm64::pygrib-2.1.5-py312h527bf2b_1.conda
osx-arm64::heyoka-3.1.0-hdea24a2_0.conda
osx-arm64::pyinstaller-6.2.0-py311h4045465_0.conda
osx-arm64::nco-5.1.9-h91bca93_0.conda
osx-arm64::libgdal-3.8.0-h751e6a0_3.conda
osx-arm64::paraview-5.11.2-py312hfb1a1c1_102_qt.conda
osx-arm64::llvmdev-17.0.6-haab561b_1.conda
osx-arm64::ifcopenshell-v0.7.0.231127-py39_novtk_h22deb30_101.conda
osx-arm64::gemmi-0.6.3-py311h6963251_0.conda
osx-arm64::heyoka-llvm-17-3.1.0-h5a0310b_0.conda
osx-arm64::paraview-5.11.2-py310hc9a5a8a_102_qt.conda
osx-arm64::aws-sdk-cpp-1.11.210-he1c5c81_1.conda
osx-arm64::libarrow-10.0.1-h77cac08_55_cpu.conda
osx-arm64::libmed-4.1.1-py311h16a4e6a_7.conda
osx-arm64::aws-sdk-cpp-1.11.210-hbd89ff5_3.conda
osx-arm64::r-harp-1.20.2-py310h1db3a1d_0.conda
osx-arm64::ifcopenshell-v0.7.0.231127-py38_novtk_hbb8923f_100.conda
osx-arm64::protozfits-2.3.0-py38h182cc28_3.conda
osx-arm64::libgsf-1.14.51-hf1ee52a_0.conda
osx-arm64::tensorflow-base-2.14.0-cpu_py39ha6a491e_0.conda
osx-arm64::heyoka-3.2.0-h31f32e4_0.conda
osx-arm64::libgdal-3.7.3-h48cc1a0_4.conda
osx-arm64::llvmdev-17.0.5-hc359061_0.conda
osx-arm64::harp-1.20.2-py39h2275332_0.conda
osx-arm64::pyhdf-0.11.3-py38h4e8fd5b_2.conda
osx-arm64::libtensorflow-2.14.0-cpu_h83790c0_0.conda
osx-arm64::libarrow-14.0.1-ha6ab924_6_cpu.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-hfde57df_8.conda
osx-arm64::paraview-5.11.2-py39ha3e5c09_102_qt.conda
osx-arm64::folly-2023.11.27.00-h83f57a1_0.conda
osx-arm64::qt6-3d-6.6.1-h336cabd_0.conda
osx-arm64::folly-2023.11.20.00-h83f57a1_0.conda
osx-arm64::z5py-2.0.17-py310hfd1a8ab_0.conda
osx-arm64::tiledb-2.18.1-h555b8a3_0.conda
osx-arm64::protozfits-2.3.0-py312hf0650c7_4.conda
osx-arm64::mysql-client-8.0.33-hf1148c8_6.conda
osx-arm64::ffmpeg-6.1.0-gpl_hb51155c_103.conda
osx-arm64::heyoka-3.2.0-had0bed7_0.conda
osx-arm64::libarrow-11.0.0-h0928616_51_cpu.conda
osx-arm64::folly-2023.11.13.00-h83f57a1_0.conda
osx-arm64::openmeeg-2.5.7-py38hc7ba4f1_0.conda
osx-arm64::folly-2023.11.06.00-h83f57a1_0.conda
osx-arm64::nodejs-20.9.0-h0950e01_0.conda
osx-arm64::ffmpeg-6.1.0-lgpl_h2f500b9_3.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-he74f11c_2.conda
osx-arm64::llvm-tools-17.0.6-hc359061_0.conda
osx-arm64::libgdal-3.7.3-h116f65a_1.conda
osx-arm64::libboost-1.83.0-h96b934a_0.conda
osx-arm64::healpy-1.16.6-py310h5973d9e_2.conda
osx-arm64::pyhdf-0.11.3-py310h9003946_2.conda
osx-arm64::gdstk-0.9.47-py311h52bd988_0.conda
osx-arm64::openmeeg-2.5.6-py310h6e75584_5.conda
osx-arm64::libadios2-2.9.2-nompi_h22d4965_101.conda
osx-arm64::libadios2-2.9.2-mpi_openmpi_h4e6bb67_0.conda
osx-arm64::libgdal-arrow-parquet-3.8.0-hc01baa0_4.conda
osx-arm64::folly-2023.11.20.00-hd3f4852_0_jemalloc.conda
osx-arm64::libarrow-10.0.1-hf59942b_56_cpu.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-he74f11c_1.conda
osx-arm64::libadios2-2.9.2-mpi_mpich_ha498bb1_1.conda
osx-arm64::gazebo-11.14.0-h4956103_2.conda
osx-arm64::libopencv-4.8.1-py311hc7436fc_5.conda
osx-arm64::cppyy-cling-6.28.0-py39ha519537_1.conda
osx-arm64::gdstk-0.9.47-py310h745f51c_1.conda
osx-arm64::tiledb-2.17.4-he462678_0.conda
osx-arm64::openbabel-3.1.1-py310h1c83318_9.conda
osx-arm64::pdal-2.6.1-hc5a8e0f_0.conda
osx-arm64::cppyy-cling-6.28.0-py312hee8bc9d_2.conda
osx-arm64::ifcopenshell-v0.7.0.231127-py311_all_haad7bbc_200.conda
osx-arm64::paraview-5.11.2-py39h719dc58_102_qt.conda
osx-arm64::llvmdev-17.0.6-hc359061_0.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-h30a05d2_7.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-hadb931b_8.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-h75e746b_8.conda
osx-arm64::ffmpeg-6.1.0-gpl_h85ac7dd_100.conda
osx-arm64::libnghttp2-1.58.0-ha4dd798_0.conda
osx-arm64::graphviz-9.0.0-h3face73_1.conda
osx-arm64::openmeeg-2.5.6-py312hcffd864_5.conda
osx-arm64::libopencv-4.8.1-py38h35d01dd_4.conda
osx-arm64::heyoka-3.1.0-h9e77e2b_0.conda
osx-arm64::wxwidgets-3.2.4-h9a2488b_1.conda
osx-arm64::soplex-6.0.4-hd9965d4_0.conda
osx-arm64::nginx-1.25.3-h6a17b9a_1.conda
osx-arm64::indexed_gzip-1.8.7-py310ha5b23ed_0.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-h0ca5329_4.conda
osx-arm64::aws-sdk-cpp-1.11.182-hb9aa301_6.conda
osx-arm64::harp-1.20.2-py311hc42ed2c_0.conda
osx-arm64::gmt-6.4.0-h47b96f7_16.conda
osx-arm64::minizip-4.0.3-hd5cad61_0.conda
osx-arm64::libgdal-arrow-parquet-3.8.0-hfde57df_7.conda
osx-arm64::libspatialite-5.1.0-hbcbf9a1_3.conda
osx-arm64::openimageio-2.5.5.0-py39hf1d333c_0.conda
osx-arm64::folly-2023.11.20.00-ha5de9cd_0_jemalloc.conda
osx-arm64::grpcio-1.59.3-py310h6121c79_0.conda
osx-arm64::chemicalite-2022.04.1-hb0f8f8a_14.conda
osx-arm64::tiledb-2.18.2-he462678_0.conda
osx-arm64::r-git2r-0.33.0-r43h0db8b51_0.conda
osx-arm64::healpy-1.16.6-py39h98e5b06_2.conda
osx-arm64::gdstk-0.9.47-py39h692b333_1.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-h079d9d4_3.conda
osx-arm64::ifcopenshell-v0.7.0.231127-py38_all_h5090900_201.conda
osx-arm64::ogre-1.10.12-h72c3531_16.conda
osx-arm64::libarrow-13.0.0-h0928616_16_cpu.conda
osx-arm64::libopencv-4.8.1-py310he8a427e_5.conda
osx-arm64::libadios2-2.9.2-nompi_h3e55d5e_100.conda
osx-arm64::z5py-2.0.17-py39h965e610_0.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-hc4f5c7f_4.conda
osx-arm64::cargo-c-0.9.28-hdf7d417_0.conda
osx-arm64::cmake-3.27.8-h04763b9_0.conda
osx-arm64::libboost-1.82.0-h489e689_6.conda
osx-arm64::mold-2.4.0-hdbeb7c9_0.conda
osx-arm64::libadios2-2.9.2-mpi_openmpi_h4e6bb67_1.conda
osx-arm64::ifcopenshell-v0.7.0.231127-py310_all_hdc40ddc_200.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-hc4f5c7f_6.conda
osx-arm64::tiledb-2.18.2-hb4613eb_0.conda
osx-arm64::grpcio-1.59.3-py312h780eafd_0.conda
osx-arm64::folly-2023.11.13.00-hb8f665b_0_jemalloc.conda
osx-arm64::gemmi-0.6.3-py310h6121c79_1.conda
osx-arm64::openbabel-3.1.1-py38h09ee0da_9.conda
osx-arm64::lld-17.0.6-he164760_0.conda
osx-arm64::geant4-11.1.3-py311hbae21b8_0.conda
osx-arm64::ogre-14.1.2-hb6b4d46_1.conda
osx-arm64::ifcopenshell-v0.7.0.231127-py312_all_h26cde7d_201.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-hbca91e2_4.conda
osx-arm64::gdstk-0.9.47-py38hbce28a2_0.conda
osx-arm64::pygplates-0.39-py312h472c75b_13.conda
osx-arm64::aws-sdk-cpp-1.11.182-h2baef6e_5.conda
osx-arm64::libgdal-3.8.0-h76f3012_6.conda
osx-arm64::ifcopenshell-v0.7.0.231127-py310_all_hdc40ddc_201.conda
osx-arm64::libtensorflow_cc-2.14.0-cpu_h0c20d54_0.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-h141375c_0.conda
osx-arm64::mysql-server-8.0.33-h0e37e67_6.conda
osx-arm64::pyinstaller-6.2.0-py38he974862_0.conda
osx-arm64::python-igraph-0.11.3-py39h64b2e74_0.conda
osx-arm64::geant4-11.1.3-py39haa97ef7_0.conda
osx-arm64::grpcio-1.59.3-py311h79dd126_0.conda
osx-arm64::libarrow-12.0.1-h87fad27_22_cpu.conda
osx-arm64::gmt-6.4.0-h3f3960f_17.conda
osx-arm64::ifcopenshell-v0.7.0.231127-py310_novtk_h19c0c48_100.conda
osx-arm64::libadios2-2.9.2-mpi_openmpi_h6324500_0.conda
osx-arm64::libadios2-2.9.2-mpi_mpich_h687b67b_1.conda
osx-arm64::protozfits-2.3.0-py39hd6257dd_2.conda
osx-arm64::libgdal-arrow-parquet-3.8.0-h1634d40_3.conda
osx-arm64::libxml2-2.11.6-h0d0cfa8_0.conda
osx-arm64::pygplates-0.39-py311h5a9e508_13.conda
osx-arm64::llvmdev-16.0.6-haab561b_3.conda
osx-arm64::heyoka-llvm-13-3.1.0-hed95047_0.conda
osx-arm64::libgrpc-1.59.3-hbcf6334_0.conda
osx-arm64::heyoka-llvm-13-3.2.0-hed95047_0.conda
osx-arm64::vtk-base-9.2.6-qt_py39h1234567_219.conda
osx-arm64::aws-sdk-cpp-1.11.210-hff40170_2.conda
osx-arm64::gmsh-4.11.1-h465cbce_6.conda
osx-arm64::llvm-17.0.6-hb5598a0_1.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-h112f01a_8.conda
osx-arm64::libvips-8.15.0-h4a36919_3.conda
osx-arm64::libgdal-3.7.3-h48cc1a0_6.conda
osx-arm64::paraview-5.11.2-py38hef74f8d_102_qt.conda
osx-arm64::ffmpeg-6.1.0-gpl_hb975139_101.conda
osx-arm64::openmeeg-2.5.6-py38hc7ba4f1_5.conda
osx-arm64::openmeeg-2.5.7-py39h80c8f73_0.conda
osx-arm64::gdstk-0.9.47-py312h5f5ee38_1.conda
osx-arm64::aws-sdk-cpp-1.11.182-h0c1a885_4.conda
osx-arm64::gmsh-4.11.1-hbd664d1_5.conda
osx-arm64::libarrow-14.0.1-ha9356e4_5_cpu.conda
osx-arm64::libgdal-arrow-parquet-3.8.0-h73c12cd_6.conda
osx-arm64::ifcopenshell-v0.7.0.231127-py39_all_hbd7c877_200.conda
osx-arm64::pytables-3.9.2-py312h9aef7b8_0.conda
osx-arm64::libarrow-11.0.0-h81cb639_50_cpu.conda
osx-arm64::gemmi-0.6.3-py310h5a194dc_0.conda
osx-arm64::libgdal-arrow-parquet-3.8.0-hbc64026_1.conda
osx-arm64::libgdal-arrow-parquet-3.8.0-hd1c4004_3.conda
osx-arm64::libmed-4.1.1-py38h68d1944_7.conda
osx-arm64::pygplates-0.39-py310h162b722_13.conda
osx-arm64::postgresql-plpython-16.1-py310h6edaefd_0.conda
osx-arm64::pyreadstat-1.2.5-py311h4045465_0.conda
osx-arm64::llvm-17.0.6-h2b67075_0.conda
osx-arm64::pyinstaller-6.2.0-py312ha17c255_0.conda
osx-arm64::llvm-tools-16.0.6-haab561b_3.conda
osx-arm64::libadios2-2.9.2-nompi_h9fdb4fb_100.conda
osx-arm64::libgdal-3.7.3-h1e75ee6_4.conda
osx-arm64::libgdal-arrow-parquet-3.8.0-hd1c4004_4.conda
osx-arm64::openmeeg-2.5.6-py311hd2b692a_5.conda
osx-arm64::gmsh-4.11.1-h1cf715d_5.conda
osx-arm64::libgdal-3.8.0-h4a48ae4_2.conda
osx-arm64::ifcopenshell-v0.7.0.231127-py310_novtk_h19c0c48_101.conda
osx-arm64::scip-8.1.0-ha659d42_3.conda
osx-arm64::ifcopenshell-v0.7.0.231127-py38_all_h5090900_200.conda
osx-arm64::libarrow-10.0.1-ha1e1ccc_52_cpu.conda
osx-arm64::pyreadstat-1.2.5-py38he974862_0.conda
osx-arm64::libmed-4.1.1-py311h16a4e6a_6.conda
osx-arm64::libgdal-3.8.0-h4a48ae4_1.conda
osx-arm64::libadios2-2.9.2-mpi_openmpi_hc4c21e9_1.conda
osx-arm64::llvm-16.0.6-hb5598a0_3.conda
osx-arm64::libopencv-4.8.1-py310h9ce838d_4.conda
osx-arm64::libgdal-arrow-parquet-3.7.3-hc4f5c7f_5.conda
osx-arm64::libnghttp2-static-1.58.0-h8d15234_0.conda
osx-arm64::ovito-3.9.3-h45f7d94_0.conda
osx-arm64::z5py-2.0.17-py311h4b05729_0.conda
osx-arm64::libllvm17-17.0.6-haab561b_1.conda
osx-arm64::libgrpc-1.60.0-hbcf6334_0.conda
osx-arm64::protozfits-2.3.0-py310h7a35917_3.conda
osx-arm64::openimageio-2.5.5.0-py311h1cdafb0_0.conda
osx-arm64::openmeeg-2.5.7-py310h6e75584_0.conda
osx-arm64::r-base-4.2.3-h8456b53_10.conda
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
================================================================================
================================================================================
linux-ppc64le
linux-ppc64le::healpix_cxx-3.81-haf2a544_2.conda
linux-ppc64le::llvm-15.0.7-h191d999_4.conda
linux-ppc64le::cudnn-8.8.0.121-h734afba_4.conda
linux-ppc64le::micromamba-1.5.3-0.tar.bz2
linux-ppc64le::micromamba-1.5.1-2.tar.bz2
linux-ppc64le::libmlir-17.0.4-hae84d68_0.conda
linux-ppc64le::libllvm15-15.0.7-h150ca27_4.conda
linux-ppc64le::cudnn-8.8.0.121-h30cf0ba_4.conda
linux-ppc64le::libmlir-17.0.6-hae84d68_0.conda
linux-ppc64le::libmlir17-17.0.5-hae84d68_0.conda
linux-ppc64le::libsqlite-3.44.0-hd4bbf49_0.conda
linux-ppc64le::libmlir-17.0.5-hae84d68_0.conda
linux-ppc64le::pcre2-10.42-h3bd5b6e_0.conda
linux-ppc64le::libmlir17-17.0.4-hae84d68_0.conda
linux-ppc64le::libsolv-0.7.27-hff1ad0c_0.conda
linux-ppc64le::libmlir17-17.0.6-hae84d68_0.conda
linux-ppc64le::libsolv-static-0.7.27-hff1ad0c_0.conda
linux-ppc64le::libsqlite-3.44.2-hd4bbf49_0.conda
linux-ppc64le::llvm-tools-15.0.7-h150ca27_4.conda
linux-ppc64le::glib-tools-2.78.1-hff1ad0c_0.conda
linux-ppc64le::micromamba-1.5.2-0.tar.bz2
linux-ppc64le::glib-tools-2.78.1-hff1ad0c_1.conda
linux-ppc64le::cudnn-8.8.0.121-h6252efc_4.conda
linux-ppc64le::cfitsio-4.3.1-hde815af_0.conda
linux-ppc64le::msgpack-c-6.0.0-hff1ad0c_1.conda
linux-ppc64le::libsqlite-3.44.1-hd4bbf49_0.conda
linux-ppc64le::healpix_cxx-3.81-h464b49a_3.conda
linux-ppc64le::liblal-7.4.1-fftw_hb2f3d55_101.conda
-    "libzlib >=1.2.13,<1.3.0a0"
+    "libzlib >=1.2.13,<2.0.0a0"
linux-ppc64le::libvips-8.15.0-h9acfa09_3.conda
linux-ppc64le::rust-1.74.0-hb12b0c0_0.conda
linux-ppc64le::llvm-openmp-17.0.6-h8759ddb_0.conda
linux-ppc64le::r-base-4.3.2-h33316b5_0.conda
linux-ppc64le::libmed-4.1.1-py311h7510574_7.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.0-h2f249b4_5.conda
linux-ppc64le::healpy-1.16.6-py310haf5d98e_2.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.0-he5ca048_6.conda
linux-ppc64le::pygrib-2.1.5-py38hf8cb758_1.conda
linux-ppc64le::aws-sdk-cpp-1.11.210-hab79af5_2.conda
linux-ppc64le::folly-2023.11.27.00-hfba947f_0.conda
linux-ppc64le::ffmpeg-6.0.1-lgpl_h23b7ab8_0.conda
linux-ppc64le::cppyy-cling-6.28.0-py311h4a6bb18_1.conda
linux-ppc64le::libadios2-2.9.2-nompi_ha8a2491_101.conda
linux-ppc64le::tiledb-2.18.1-hd5af256_0.conda
linux-ppc64le::libarrow-11.0.0-h7736392_48_cuda.conda
linux-ppc64le::mysql-connector-python-8.0.32-py39h91b38d1_1.conda
linux-ppc64le::folly-2023.11.06.00-hcb6a8eb_0_jemalloc.conda
linux-ppc64le::libarrow-14.0.1-ha4b404e_5_cpu.conda
linux-ppc64le::glib-2.78.1-hff1ad0c_0.conda
linux-ppc64le::libarrow-11.0.0-h8b23970_49_cuda.conda
linux-ppc64le::libpq-16.1-h9d99649_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-hce0db44_3.conda
linux-ppc64le::libgdal-3.7.3-hcdd9db5_3.conda
linux-ppc64le::libgdal-3.7.3-hc5aab41_4.conda
linux-ppc64le::pygrib-2.1.5-py311h8267192_1.conda
linux-ppc64le::libopencv-4.8.1-py39h2698ffd_5.conda
linux-ppc64le::boost-cpp-1.83.0-h1102270_0.conda
linux-ppc64le::gmsh-4.11.1-he211b9d_5.conda
linux-ppc64le::mysql-libs-8.0.33-h3ac40eb_6.conda
linux-ppc64le::pdal-2.6.0-h02ecd2a_1.conda
linux-ppc64le::libgdal-3.7.3-hcdd9db5_1.conda
linux-ppc64le::pygrib-2.1.5-py312h2482cc6_1.conda
linux-ppc64le::libspatialite-5.1.0-h24ed1b7_3.conda
linux-ppc64le::vtk-base-9.2.6-qt_py311h1234567_219.conda
linux-ppc64le::fltk-1.3.8-h92e44d1_4.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.0-h8583400_2.conda
linux-ppc64le::mysql-router-8.0.33-h0dc9ae2_6.conda
linux-ppc64le::lld-17.0.6-he12c2f4_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.0-h14f8107_5.conda
linux-ppc64le::libarrow-11.0.0-he939490_52_cpu.conda
linux-ppc64le::tiledb-2.18.2-hac2e0cb_0.conda
linux-ppc64le::r-harp-1.20.2-py311r43h8a84315_0.conda
linux-ppc64le::libmed-4.1.1-py310h869392b_7.conda
linux-ppc64le::libxml2-2.12.1-h0545f4b_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-h6543b56_3.conda
linux-ppc64le::libgdal-3.8.0-hcc5fb90_4.conda
linux-ppc64le::pcre2-static-10.42-h3bd5b6e_0.conda
linux-ppc64le::harp-1.20.2-py39he3f3676_0.conda
linux-ppc64le::nceplibs-g2c-1.8.0-he9906eb_4.conda
linux-ppc64le::libmed-4.1.1-py38h7cb2e9a_7.conda
linux-ppc64le::aws-sdk-cpp-1.11.210-h4170f8b_0.conda
linux-ppc64le::cppyy-cling-6.28.0-py39h8f9faf0_1.conda
linux-ppc64le::git-2.43.0-pl5321hd936a80_0.conda
linux-ppc64le::openimageio-2.5.5.0-py312h4304c11_0.conda
linux-ppc64le::libspatialite-5.1.0-h4b91802_1.conda
linux-ppc64le::libopencv-4.8.1-py39h4559d42_5.conda
linux-ppc64le::libarrow-11.0.0-ha52f67a_50_cpu.conda
linux-ppc64le::python-igraph-0.11.3-py39h2528f8b_0.conda
linux-ppc64le::postgresql-plpython-16.1-py39h8e6b938_0.conda
linux-ppc64le::libboost-1.83.0-hfdd0173_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-h2f249b4_6.conda
linux-ppc64le::pygplates-0.39-py312heda58c1_13.conda
linux-ppc64le::libllvm17-17.0.6-he7d67b2_1.conda
linux-ppc64le::mapserver-8.0.1-py38h912a50f_11.conda
linux-ppc64le::r-git2r-0.33.0-r43h47fe75f_0.conda
linux-ppc64le::cppyy-cling-6.28.0-py38hbab3742_2.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-hcfca475_4.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-h9ccea84_6.conda
linux-ppc64le::folly-2023.11.13.00-h4b663bd_0_jemalloc.conda
linux-ppc64le::libgdal-3.7.3-h642151c_8.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-hb9115a8_4.conda
linux-ppc64le::minizip-4.0.3-ha7cce9c_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-h14f8107_5.conda
linux-ppc64le::libllvm17-17.0.5-h8d57982_0.conda
linux-ppc64le::folly-2023.11.27.00-hcb6a8eb_0_jemalloc.conda
linux-ppc64le::libadios2-2.9.2-mpi_openmpi_hcde4a47_0.conda
linux-ppc64le::libarrow-13.0.0-h0376c6f_18_cpu.conda
linux-ppc64le::llvm-17.0.5-h381f82a_0.conda
linux-ppc64le::folly-2023.11.13.00-ha2e2e2a_0.conda
linux-ppc64le::graphviz-9.0.0-h3732cb2_0.conda
linux-ppc64le::libarrow-14.0.1-h8af6676_1_cuda.conda
linux-ppc64le::libarrow-12.0.1-h1967950_22_cuda.conda
linux-ppc64le::libllvm17-17.0.4-h8d57982_0.conda
linux-ppc64le::sqlite-3.44.1-h63c7444_0.conda
linux-ppc64le::libadios2-2.9.2-mpi_mpich_h6737005_1.conda
linux-ppc64le::libgdal-3.7.3-hcdd9db5_2.conda
linux-ppc64le::grpcio-1.59.3-py311h3997ded_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-h2f249b4_5.conda
linux-ppc64le::folly-2023.11.13.00-hfba947f_0.conda
linux-ppc64le::libarrow-12.0.1-hb5dbd2c_26_cuda.conda
linux-ppc64le::libarrow-12.0.1-h0a1cce7_23_cpu.conda
linux-ppc64le::libarrow-12.0.1-hfd23f2c_24_cpu.conda
linux-ppc64le::libmed-4.1.1-py310h869392b_6.conda
linux-ppc64le::gst-plugins-base-1.22.7-he115d4a_0.conda
linux-ppc64le::postgresql-plpython-16.1-py38he255f0a_0.conda
linux-ppc64le::libpulsar-3.4.1-h8c92dcd_0.conda
linux-ppc64le::aws-sdk-cpp-1.11.210-hf745ddc_3.conda
linux-ppc64le::mlir-17.0.4-hae84d68_0.conda
linux-ppc64le::llvm-tools-17.0.6-h8d57982_0.conda
linux-ppc64le::vtk-base-9.2.6-qt_py310h1234567_219.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.0-h59f606c_2.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.0-h8110145_7.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.0-h6543b56_0.conda
linux-ppc64le::ogre-14.1.2-hebe49f4_1.conda
linux-ppc64le::llvm-16.0.6-h240a7ce_3.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-h14f8107_4.conda
linux-ppc64le::openimageio-2.5.5.0-py39hcf337c1_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-h6543b56_1.conda
linux-ppc64le::pygplates-0.39-py38h6307d01_13.conda
linux-ppc64le::libadios2-2.9.2-mpi_mpich_h6737005_0.conda
linux-ppc64le::libopencv-4.8.1-py312h4c0d4eb_5.conda
linux-ppc64le::pyinstaller-6.2.0-py311h5a86d3c_0.conda
linux-ppc64le::mysql-connector-python-8.0.32-py39hceab3dc_1.conda
linux-ppc64le::libarrow-11.0.0-h0376c6f_53_cpu.conda
linux-ppc64le::libadios2-2.9.2-mpi_mpich_h2376794_1.conda
linux-ppc64le::harp-1.20.2-py310he3f3676_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-hce0db44_1.conda
linux-ppc64le::openbabel-3.1.1-py39h982a739_9.conda
linux-ppc64le::libarrow-14.0.1-he3b2c5c_0_cuda.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-h9ccea84_5.conda
linux-ppc64le::ffmpeg-6.1.0-gpl_hde42ef3_102.conda
linux-ppc64le::texlive-core-20230313-hf167c61_8.conda
linux-ppc64le::mapserver-8.0.1-py311hb40583e_13.conda
linux-ppc64le::openbabel-3.1.1-py310ha901665_9.conda
linux-ppc64le::libarrow-12.0.1-hf42ab94_27_cpu.conda
linux-ppc64le::libmed-4.1.1-py39hcc27481_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-h7cdd219_1.conda
linux-ppc64le::libarrow-14.0.1-h78492cc_2_cuda.conda
linux-ppc64le::pygrib-2.1.5-py312h2482cc6_0.conda
linux-ppc64le::libadios2-2.9.2-mpi_openmpi_h2535527_0.conda
linux-ppc64le::libarrow-14.0.0-hbd9a721_0_cpu.conda
linux-ppc64le::mapserver-8.0.1-py39h2e0adf0_13.conda
linux-ppc64le::libmed-4.1.1-py312hf85caf3_0.conda
linux-ppc64le::gst-plugins-good-1.22.7-he8d93ae_0.conda
linux-ppc64le::nginx-1.25.3-h0f00270_1.conda
linux-ppc64le::pyhdf-0.11.3-py311h68f7c1f_2.conda
linux-ppc64le::llvmdev-16.0.6-he7d67b2_3.conda
linux-ppc64le::llvm-17.0.6-h381f82a_0.conda
linux-ppc64le::libarrow-13.0.0-h0a1cce7_14_cpu.conda
linux-ppc64le::tiledb-2.18.2-h4ed4581_0.conda
linux-ppc64le::libarrow-11.0.0-h0a1cce7_47_cpu.conda
linux-ppc64le::healpy-1.16.6-py39hc8fcb18_2.conda
linux-ppc64le::libopentelemetry-cpp-1.12.0-hf777975_1.conda
linux-ppc64le::grpcio-1.59.3-py310h8eb8f48_0.conda
linux-ppc64le::libadios2-2.9.2-mpi_mpich_h71aec2e_1.conda
linux-ppc64le::pyinstaller-6.2.0-py312h4032086_0.conda
linux-ppc64le::libarrow-12.0.1-ha66ce24_23_cuda.conda
linux-ppc64le::libarrow-14.0.1-h95d35b3_4_cpu.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.0-h9ccea84_5.conda
linux-ppc64le::cpp-opentelemetry-sdk-1.12.0-hf777975_1.conda
linux-ppc64le::libspatialite-5.1.0-h7f40494_2.conda
linux-ppc64le::pyhdf-0.11.3-py38h58fc349_2.conda
linux-ppc64le::libmed-4.1.1-py311h7510574_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.0-h7cdd219_0.conda
linux-ppc64le::libadios2-2.9.2-nompi_h825cff7_100.conda
linux-ppc64le::mysql-client-8.0.33-hfff87ee_6.conda
linux-ppc64le::llvmdev-17.0.6-he7d67b2_1.conda
linux-ppc64le::libarrow-11.0.0-hb5dbd2c_50_cuda.conda
linux-ppc64le::folly-2023.11.13.00-hcb6a8eb_0_jemalloc.conda
linux-ppc64le::libadios2-2.9.2-mpi_openmpi_h2535527_1.conda
linux-ppc64le::folly-2023.11.27.00-h4b663bd_0_jemalloc.conda
linux-ppc64le::libvips-8.15.0-h3f75652_1.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-h841bb50_8.conda
linux-ppc64le::libarrow-12.0.1-h8b23970_25_cuda.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.0-hcd15798_6.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-h81fba5f_7.conda
linux-ppc64le::llvm-17.0.6-h240a7ce_1.conda
linux-ppc64le::gmsh-4.11.1-h43fa0ad_5.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.0-h2f249b4_4.conda
linux-ppc64le::tiledb-2.18.1-h4ed4581_0.conda
linux-ppc64le::pygplates-0.39-py311h8a03bae_13.conda
linux-ppc64le::pyinstaller-6.2.0-py39hf0cda86_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.0-h8a764d3_7.conda
linux-ppc64le::libarrow-14.0.1-hd2c88ea_6_cuda.conda
linux-ppc64le::aws-sdk-cpp-1.11.182-h619bab4_4.conda
linux-ppc64le::libgdal-3.7.3-hc5aab41_5.conda
linux-ppc64le::mapserver-8.0.1-py310h411da4d_12.conda
linux-ppc64le::nco-5.1.9-h9437046_0.conda
linux-ppc64le::libarrow-11.0.0-ha66ce24_47_cuda.conda
linux-ppc64le::ffmpeg-6.1.0-lgpl_h23b7ab8_0.conda
linux-ppc64le::libmed-4.1.1-py38h7cb2e9a_6.conda
linux-ppc64le::libpulsar-3.2.0-h8c92dcd_6.conda
linux-ppc64le::libarrow-11.0.0-hfd23f2c_48_cpu.conda
linux-ppc64le::libarrow-11.0.0-hab85658_53_cuda.conda
linux-ppc64le::magic-8.3.451-h7eb73fb_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.0-hb0c6cc7_1.conda
linux-ppc64le::libgdal-3.8.0-h2a586a6_7.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-h59f606c_4.conda
linux-ppc64le::cppyy-cling-6.28.0-py312hb8a0279_2.conda
linux-ppc64le::cargo-c-0.9.28-hd6e3413_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-h14f8107_6.conda
linux-ppc64le::libarrow-10.0.1-hab85658_57_cuda.conda
linux-ppc64le::mapserver-8.0.1-py39hbaa11ed_12.conda
linux-ppc64le::libgdal-3.8.0-h16a7b21_6.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-hcd15798_7.conda
linux-ppc64le::libarrow-10.0.1-h7736392_52_cuda.conda
linux-ppc64le::libgdal-3.8.0-hd2e269d_2.conda
linux-ppc64le::libllvm17-17.0.6-h8d57982_0.conda
linux-ppc64le::ffmpeg-6.0.1-gpl_hd94cd3e_100.conda
linux-ppc64le::pytables-3.9.2-py312h7d75ae7_0.conda
linux-ppc64le::pygrib-2.1.5-py310hd03383d_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.0-h59f606c_1.conda
linux-ppc64le::llvmdev-15.0.7-h150ca27_4.conda
linux-ppc64le::mapserver-8.0.1-py311h40b8a51_11.conda
linux-ppc64le::qtwebkit-5.212-h866722a_15.conda
linux-ppc64le::magic-8.3.440-h7eb73fb_0.conda
linux-ppc64le::pygplates-0.39-py310h4d12fd0_13.conda
linux-ppc64le::openimageio-2.5.5.0-py38h15921d0_0.conda
linux-ppc64le::libarrow-11.0.0-h161c01b_51_cuda.conda
linux-ppc64le::mapserver-8.0.1-py311h40b8a51_12.conda
linux-ppc64le::python-igraph-0.11.3-py310hd47e8ce_0.conda
linux-ppc64le::libarrow-10.0.1-h8b23970_53_cuda.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-hcdc0ab7_3.conda
linux-ppc64le::mysql-connector-python-8.0.32-py311h30da4cc_1.conda
linux-ppc64le::lld-17.0.5-he12c2f4_0.conda
linux-ppc64le::pyhdf-0.11.3-py39he3a5649_2.conda
linux-ppc64le::grpcio-1.59.3-py312h930df82_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-he5ca048_7.conda
linux-ppc64le::folly-2023.11.06.00-h7cedaab_0.conda
linux-ppc64le::glib-2.78.1-hff1ad0c_1.conda
linux-ppc64le::libarrow-11.0.0-h75cb34d_52_cuda.conda
linux-ppc64le::pytables-3.9.2-py311h3f57c28_0.conda
linux-ppc64le::libarrow-10.0.1-h0376c6f_57_cpu.conda
linux-ppc64le::magic-8.3.450-h7eb73fb_0.conda
linux-ppc64le::folly-2023.11.20.00-hcb6a8eb_0_jemalloc.conda
linux-ppc64le::healpy-1.16.6-py39hd998934_2.conda
linux-ppc64le::llvmdev-17.0.4-h8d57982_0.conda
linux-ppc64le::folly-2023.11.13.00-hd3a0175_0_jemalloc.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-h7cdd219_2.conda
linux-ppc64le::libarrow-12.0.1-ha52f67a_26_cpu.conda
linux-ppc64le::fish-3.6.1-hc9248e7_1.conda
linux-ppc64le::libopencv-4.8.1-py39hb72e928_4.conda
linux-ppc64le::pygrib-2.1.5-py38hf8cb758_0.conda
linux-ppc64le::libarrow-14.0.1-h9273170_5_cuda.conda
linux-ppc64le::pygplates-0.39-py39h952cdd2_13.conda
linux-ppc64le::git-2.42.0-pl5321hd936a80_1.conda
linux-ppc64le::pygrib-2.1.5-py39h8591698_0.conda
linux-ppc64le::libopencv-4.8.1-py311h69df981_4.conda
linux-ppc64le::magic-8.3.452-h7eb73fb_0.conda
linux-ppc64le::pytables-3.9.2-py310h8713445_0.conda
linux-ppc64le::cmake-3.27.9-h1403f77_0.conda
linux-ppc64le::llvm-tools-17.0.5-h8d57982_0.conda
linux-ppc64le::pyreadstat-1.2.5-py312ha5a3bab_0.conda
linux-ppc64le::mapserver-8.0.1-py312heafad12_12.conda
linux-ppc64le::libarrow-13.0.0-h75cb34d_17_cuda.conda
linux-ppc64le::libadios2-2.9.2-mpi_mpich_h2376794_0.conda
linux-ppc64le::libarrow-11.0.0-hf42ab94_51_cpu.conda
linux-ppc64le::libglib-2.78.1-h7505782_1.conda
linux-ppc64le::cmake-3.27.8-h1403f77_0.conda
linux-ppc64le::graphviz-9.0.0-h0c0c1c9_1.conda
linux-ppc64le::wxwidgets-3.2.4-h78d0b3a_0.conda
linux-ppc64le::vtk-base-9.2.6-qt_py38h1234567_219.conda
linux-ppc64le::libxml2-2.11.6-h0545f4b_0.conda
linux-ppc64le::cppyy-cling-6.28.0-py310h02f1291_2.conda
linux-ppc64le::libadios2-2.9.2-mpi_openmpi_h9917a5b_1.conda
linux-ppc64le::libopencv-4.8.1-py310hc5350b9_4.conda
linux-ppc64le::gmsh-4.11.1-h01679bf_6.conda
linux-ppc64le::mapserver-8.0.1-py310h411da4d_11.conda
linux-ppc64le::libgdal-3.8.0-hcc5fb90_5.conda
linux-ppc64le::postgresql-plpython-16.1-py310h33ccb9c_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.0-hb9115a8_4.conda
linux-ppc64le::libarrow-11.0.0-h00f7cf2_49_cpu.conda
linux-ppc64le::libadios2-2.9.2-mpi_mpich_h16fd881_0.conda
linux-ppc64le::cppyy-cling-6.28.0-py311hc2b5b1e_2.conda
linux-ppc64le::libarrow-12.0.1-hab85658_29_cuda.conda
linux-ppc64le::r-harp-1.20.2-py39r43h7349751_0.conda
linux-ppc64le::libarrow-14.0.1-h17b56de_1_cpu.conda
linux-ppc64le::libarrow-13.0.0-h8b23970_15_cuda.conda
linux-ppc64le::wxwidgets-3.2.4-hc4bc87e_1.conda
linux-ppc64le::vtk-base-9.2.6-qt_py39h1234567_219.conda
linux-ppc64le::libgsf-1.14.51-ha4aa3fc_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.0-hb9115a8_5.conda
linux-ppc64le::llvmdev-17.0.5-h8d57982_0.conda
linux-ppc64le::libvips-8.15.0-h98efc3b_2.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.0-h5207dfc_1.conda
linux-ppc64le::pytables-3.9.2-py39h22b7ba6_0.conda
linux-ppc64le::llvm-tools-17.0.6-he7d67b2_1.conda
linux-ppc64le::pytables-3.9.2-py39h6b88dcf_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-h5207dfc_4.conda
linux-ppc64le::ogre-14.1.2-haab7b0d_1.conda
linux-ppc64le::libadios2-2.9.2-mpi_openmpi_h788cb01_1.conda
linux-ppc64le::libarrow-12.0.1-h75cb34d_28_cuda.conda
linux-ppc64le::pdal-2.6.1-h02ecd2a_0.conda
linux-ppc64le::libopencv-4.8.1-py311h2fc6634_5.conda
linux-ppc64le::libadios2-2.9.2-nompi_h825cff7_101.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-hb0c6cc7_4.conda
linux-ppc64le::grpcio-1.59.3-py39h27cb1e9_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-hb9115a8_6.conda
linux-ppc64le::postgresql-plpython-16.1-py311hba550cb_0.conda
linux-ppc64le::pyinstaller-6.2.0-py310h0719273_0.conda
linux-ppc64le::cppyy-cling-6.28.0-py39h5e0a701_2.conda
linux-ppc64le::libarrow-10.0.1-hfd23f2c_52_cpu.conda
linux-ppc64le::libarrow-13.0.0-h00f7cf2_15_cpu.conda
linux-ppc64le::libmed-4.1.1-py39hcc27481_6.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.0-h81fba5f_6.conda
linux-ppc64le::libarrow-12.0.1-he939490_28_cpu.conda
linux-ppc64le::folly-2023.11.13.00-h7cedaab_0.conda
linux-ppc64le::orc-1.9.2-hb60026b_0.conda
linux-ppc64le::cppyy-cling-6.28.0-py310h1211872_1.conda
linux-ppc64le::aws-sdk-cpp-1.11.182-hf2fe211_3.conda
linux-ppc64le::libadios2-2.9.2-nompi_h95651d6_101.conda
linux-ppc64le::libadios2-2.9.2-mpi_mpich_he1f242b_1.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.0-h14f8107_3.conda
linux-ppc64le::grpcio-1.60.0-py310h8eb8f48_0.conda
linux-ppc64le::libopencv-4.8.1-py39h5d5037c_4.conda
linux-ppc64le::python-igraph-0.11.3-py39h085bd8d_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-hf2c6ea0_8.conda
linux-ppc64le::folly-2023.11.06.00-hd3a0175_0_jemalloc.conda
linux-ppc64le::libadios2-2.9.2-mpi_mpich_h16fd881_1.conda
linux-ppc64le::libarrow-13.0.0-ha66ce24_14_cuda.conda
linux-ppc64le::libadios2-2.9.2-mpi_openmpi_h17025f5_1.conda
linux-ppc64le::libgdal-3.8.0-hd2e269d_1.conda
linux-ppc64le::tiledb-2.18.2-hd5af256_0.conda
linux-ppc64le::tiledb-2.17.4-hac2e0cb_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-h9ccea84_4.conda
linux-ppc64le::orc-1.9.0-hb60026b_4.conda
linux-ppc64le::pyhdf-0.11.3-py310h8c28756_2.conda
linux-ppc64le::mysql-server-8.0.33-h46c8d89_6.conda
linux-ppc64le::libarrow-13.0.0-hf42ab94_16_cpu.conda
linux-ppc64le::libarrow-14.0.1-h7bdb23a_4_cuda.conda
linux-ppc64le::r-harp-1.20.2-py38r43he254095_0.conda
linux-ppc64le::fltk-1.3.8-h92e44d1_5.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.0-hf2c6ea0_7.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.0-h14f8107_4.conda
linux-ppc64le::lld-17.0.4-he12c2f4_0.conda
linux-ppc64le::grpcio-1.60.0-py39h27cb1e9_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.0-h2f249b4_3.conda
linux-ppc64le::libopencv-4.8.1-py38h70f9450_4.conda
linux-ppc64le::libmed-4.1.1-py311h7510574_6.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-h6543b56_2.conda
linux-ppc64le::libmed-4.1.1-py310h869392b_0.conda
linux-ppc64le::grpcio-1.59.3-py39h278787b_0.conda
linux-ppc64le::mapserver-8.0.1-py38he1bdf43_13.conda
linux-ppc64le::mlir-17.0.5-hae84d68_0.conda
linux-ppc64le::libopencv-4.8.1-py38h3af3606_5.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-hb9115a8_5.conda
linux-ppc64le::cppyy-cling-6.28.0-py312h79b5ab1_1.conda
linux-ppc64le::r-base-4.2.3-h2be2338_10.conda
linux-ppc64le::folly-2023.11.06.00-h4b663bd_0_jemalloc.conda
linux-ppc64le::libarrow-10.0.1-ha52f67a_54_cpu.conda
linux-ppc64le::pyhdf-0.11.3-py39h3e46586_2.conda
linux-ppc64le::pyreadstat-1.2.5-py310h925d916_0.conda
linux-ppc64le::openbabel-3.1.1-py312h138ba7c_9.conda
linux-ppc64le::folly-2023.11.20.00-h4b663bd_0_jemalloc.conda
linux-ppc64le::healpy-1.16.6-py312hd1ac6f3_2.conda
linux-ppc64le::vtk-base-9.2.6-qt_py312h1234567_219.conda
linux-ppc64le::cppyy-cling-6.28.0-py38hcd5ca52_1.conda
linux-ppc64le::python-igraph-0.11.3-py38hb26de0c_0.conda
linux-ppc64le::mapserver-8.0.1-py312h5dfa4ca_13.conda
linux-ppc64le::folly-2023.11.27.00-ha2e2e2a_0.conda
linux-ppc64le::harp-1.20.2-py311h057db71_0.conda
linux-ppc64le::pyreadstat-1.2.5-py39h27550c1_0.conda
linux-ppc64le::pyreadstat-1.2.5-py38h2b47b73_0.conda
linux-ppc64le::mapserver-8.0.1-py310h424b161_13.conda
linux-ppc64le::libarrow-12.0.1-h0376c6f_29_cpu.conda
linux-ppc64le::libarrow-14.0.1-hbd9a721_0_cpu.conda
linux-ppc64le::tiledb-2.17.4-h4ed4581_0.conda
linux-ppc64le::libarrow-10.0.1-hb5dbd2c_54_cuda.conda
linux-ppc64le::grpcio-1.60.0-py311h3997ded_0.conda
linux-ppc64le::gmsh-4.11.1-had2a3fc_6.conda
linux-ppc64le::libgdal-3.8.0-hcc5fb90_3.conda
linux-ppc64le::libadios2-2.9.2-mpi_mpich_he1f242b_0.conda
linux-ppc64le::tiledb-2.17.4-hd5af256_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.0-hb9115a8_3.conda
linux-ppc64le::libgdal-3.7.3-hc5aab41_6.conda
linux-ppc64le::python-igraph-0.11.3-py311h5de371b_0.conda
linux-ppc64le::libglib-2.78.1-hd7af32a_0.conda
linux-ppc64le::pygrib-2.1.5-py39h639ea50_1.conda
linux-ppc64le::folly-2023.11.06.00-hfba947f_0.conda
linux-ppc64le::llvm-tools-16.0.6-he7d67b2_3.conda
linux-ppc64le::nss-3.95-h4237796_0.conda
linux-ppc64le::libadios2-2.9.2-nompi_h1520396_100.conda
linux-ppc64le::pygrib-2.1.5-py39h8591698_1.conda
linux-ppc64le::libxml2-2.12.0-h0545f4b_0.conda
linux-ppc64le::mapserver-8.0.1-py312heafad12_11.conda
linux-ppc64le::libadios2-2.9.2-mpi_openmpi_hcde4a47_1.conda
linux-ppc64le::pygrib-2.1.5-py39h639ea50_0.conda
linux-ppc64le::hamlib-tcl-4.5.5-hd4bbf49_2.conda
linux-ppc64le::aws-sdk-cpp-1.11.182-h7cc3fa2_6.conda
linux-ppc64le::libarrow-13.0.0-hab85658_18_cuda.conda
linux-ppc64le::libarrow-10.0.1-h75cb34d_56_cuda.conda
linux-ppc64le::folly-2023.11.20.00-hfba947f_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-hce0db44_2.conda
linux-ppc64le::libarrow-10.0.1-he939490_56_cpu.conda
linux-ppc64le::libfido2-1.14.0-had385bd_0.conda
linux-ppc64le::openimageio-2.5.5.0-py311heab5d8d_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.0-h3a104d3_6.conda
linux-ppc64le::pygrib-2.1.5-py310hd03383d_1.conda
linux-ppc64le::libarrow-14.0.1-h68c7127_3_cuda.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.0-hce0db44_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-h127584c_0.conda
linux-ppc64le::ffmpeg-6.1.0-gpl_hd94cd3e_100.conda
linux-ppc64le::libarrow-14.0.1-hc3a9d9e_3_cpu.conda
linux-ppc64le::libmed-4.1.1-py39hcc27481_7.conda
linux-ppc64le::pyreadstat-1.2.5-py311he2df201_0.conda
linux-ppc64le::ogre-1.10.12-h4c48191_16.conda
linux-ppc64le::llvm-tools-17.0.4-h8d57982_0.conda
linux-ppc64le::folly-2023.11.20.00-h7cedaab_0.conda
linux-ppc64le::mapserver-8.0.1-py39hbaa11ed_11.conda
linux-ppc64le::folly-2023.11.20.00-ha2e2e2a_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.0-hb0c6cc7_2.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-h8a764d3_8.conda
linux-ppc64le::llvm-17.0.4-h381f82a_0.conda
linux-ppc64le::openimageio-2.5.5.0-py310h6b3035b_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-h3a104d3_7.conda
linux-ppc64le::pyinstaller-6.2.0-py38h36029d9_0.conda
linux-ppc64le::postgresql-16.1-h0ebe0f4_0.conda
linux-ppc64le::mysql-connector-python-8.0.32-py38hd5a0080_1.conda
linux-ppc64le::r-git2r-0.33.0-r42h47fe75f_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.0-h841bb50_7.conda
linux-ppc64le::libmed-4.1.1-py312hf85caf3_6.conda
linux-ppc64le::grpcio-1.60.0-py38hc2aed35_0.conda
linux-ppc64le::libgrpc-1.59.3-h1ecfef9_0.conda
linux-ppc64le::libarrow-13.0.0-h161c01b_16_cuda.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.0-hcfca475_1.conda
linux-ppc64le::libgit2-1.7.1-hf0aa560_1.conda
linux-ppc64le::ffmpeg-6.1.0-lgpl_h5e7638c_1.conda
linux-ppc64le::libspral-2023.09.07-haa7499b_0.conda
linux-ppc64le::libarrow-10.0.1-h161c01b_55_cuda.conda
linux-ppc64le::postgresql-plpython-16.1-py312h35a7702_0.conda
linux-ppc64le::libgrpc-1.60.0-h1ecfef9_0.conda
linux-ppc64le::grpcio-1.59.3-py38hc2aed35_0.conda
linux-ppc64le::folly-2023.11.27.00-h7cedaab_0.conda
linux-ppc64le::magic-8.3.449-h7eb73fb_0.conda
linux-ppc64le::grpcio-1.60.0-py312h930df82_0.conda
linux-ppc64le::libmed-4.1.1-py312hf85caf3_7.conda
linux-ppc64le::mapserver-8.0.1-py38h912a50f_12.conda
linux-ppc64le::libadios2-2.9.2-nompi_h1520396_101.conda
linux-ppc64le::folly-2023.11.06.00-ha2e2e2a_0.conda
linux-ppc64le::libgdal-3.7.3-hcdd9db5_0.conda
linux-ppc64le::libmed-4.1.1-py38h7cb2e9a_0.conda
linux-ppc64le::libgdal-3.8.0-hd30b8ff_0.conda
linux-ppc64le::r-harp-1.20.2-py310r43hfd510e7_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.0-hcdc0ab7_0.conda
linux-ppc64le::poppler-23.11.0-h433edb4_0.conda
linux-ppc64le::libopencv-4.8.1-py312h815a980_4.conda
linux-ppc64le::ffmpeg-6.1.0-lgpl_h16b8b48_3.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-h7cdd219_3.conda
linux-ppc64le::aws-sdk-cpp-1.11.210-h682e0b3_1.conda
linux-ppc64le::ffmpeg-6.1.0-lgpl_h139ac60_2.conda
linux-ppc64le::libarrow-12.0.1-h4988e9a_22_cpu.conda
linux-ppc64le::python-igraph-0.11.3-py312h4cf8cea_0.conda
linux-ppc64le::libadios2-2.9.2-mpi_openmpi_h788cb01_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-hcdc0ab7_1.conda
linux-ppc64le::libgdal-3.7.3-h0e95c21_4.conda
linux-ppc64le::octave-8.4.0-h7935f5f_0.conda
linux-ppc64le::libllvm16-16.0.6-he7d67b2_3.conda
linux-ppc64le::libarrow-10.0.1-h0a1cce7_51_cpu.conda
linux-ppc64le::libarrow-14.0.1-h341366e_6_cpu.conda
linux-ppc64le::sqlite-3.44.2-h63c7444_0.conda
linux-ppc64le::aws-sdk-cpp-1.11.182-h4170f8b_7.conda
linux-ppc64le::healpy-1.16.6-py311h03b18ea_2.conda
linux-ppc64le::harp-1.20.2-py38he3f3676_0.conda
linux-ppc64le::imagemagick-7.1.1_21-pl5321hadc2bbb_1.conda
linux-ppc64le::libarrow-10.0.1-ha66ce24_51_cuda.conda
linux-ppc64le::libnghttp2-1.58.0-hc4d0b0b_0.conda
linux-ppc64le::llvm-openmp-17.0.4-h8759ddb_0.conda
linux-ppc64le::folly-2023.11.20.00-hd3a0175_0_jemalloc.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-hcdc0ab7_2.conda
linux-ppc64le::libarrow-14.0.1-h1510803_2_cpu.conda
linux-ppc64le::libadios2-2.9.2-nompi_h95651d6_100.conda
linux-ppc64le::ffmpeg-6.1.0-gpl_ha056839_101.conda
linux-ppc64le::libopencv-4.8.1-py310ha71f803_5.conda
linux-ppc64le::sqlite-3.44.0-h63c7444_0.conda
linux-ppc64le::libarrow-13.0.0-he939490_17_cpu.conda
linux-ppc64le::magic-8.3.430-h7eb73fb_0.conda
linux-ppc64le::ffmpeg-6.1.0-gpl_h23dd224_103.conda
linux-ppc64le::libarrow-12.0.1-h00f7cf2_25_cpu.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-h8110145_8.conda
linux-ppc64le::llvmdev-17.0.6-h8d57982_0.conda
linux-ppc64le::libadios2-2.9.2-nompi_hf580554_101.conda
linux-ppc64le::r-harp-1.20.2-py39r43hc78dc1f_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.0-h5207dfc_2.conda
linux-ppc64le::libarrow-12.0.1-h7736392_24_cuda.conda
linux-ppc64le::aws-sdk-cpp-1.11.182-hbeda0f9_5.conda
linux-ppc64le::grpcio-1.60.0-py39h278787b_0.conda
linux-ppc64le::pygrib-2.1.5-py311h8267192_0.conda
linux-ppc64le::libarrow-12.0.1-h161c01b_27_cuda.conda
linux-ppc64le::libarrow-14.0.0-he3b2c5c_0_cuda.conda
linux-ppc64le::pyhdf-0.11.3-py312hb7dc6c4_2.conda
linux-ppc64le::tiledb-2.18.1-hac2e0cb_0.conda
linux-ppc64le::llvm-openmp-17.0.5-h8759ddb_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.0-h9ccea84_3.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.3-h6ac4788_4.conda
linux-ppc64le::libarrow-10.0.1-h00f7cf2_53_cpu.conda
linux-ppc64le::libnghttp2-static-1.58.0-had385bd_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.8.0-h9ccea84_4.conda
linux-ppc64le::mysql-connector-python-8.0.32-py310hacfde7c_1.conda
linux-ppc64le::libgdal-3.7.3-hd97cc84_7.conda
linux-ppc64le::mlir-17.0.6-hae84d68_0.conda
linux-ppc64le::libmatio-1.5.26-h125b1b5_0.conda
linux-ppc64le::mosh-1.4.0-pl5321h411aebb_5.conda
linux-ppc64le::libadios2-2.9.2-mpi_openmpi_h17025f5_0.conda
linux-ppc64le::r-base-4.3.2-h142f484_1.conda
linux-ppc64le::smesh-9.9.0.0-hfe52b29_10.conda
linux-ppc64le::folly-2023.11.27.00-hd3a0175_0_jemalloc.conda
linux-ppc64le::libarrow-10.0.1-hf42ab94_55_cpu.conda
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
================================================================================
================================================================================
linux-aarch64
linux-aarch64::cfitsio-4.3.1-hf28c5f1_0.conda
linux-aarch64::libmlir17-17.0.6-h6acfec4_0.conda
linux-aarch64::cudnn-8.8.0.121-hc0e3c58_4.conda
linux-aarch64::cudnn-8.8.0.121-h9670b63_4.conda
linux-aarch64::libmlir-17.0.5-h6acfec4_0.conda
linux-aarch64::libsolv-0.7.27-hd84c7bf_0.conda
linux-aarch64::micromamba-1.5.2-0.tar.bz2
linux-aarch64::liblal-7.4.1-fftw_h22fc402_101.conda
linux-aarch64::libsqlite-3.44.0-h194ca79_0.conda
linux-aarch64::msgpack-c-6.0.0-hd84c7bf_1.conda
linux-aarch64::libmlir-17.0.4-h6acfec4_0.conda
linux-aarch64::llvm-tools-15.0.7-hb4f23b0_4.conda
linux-aarch64::libmlir-17.0.6-h6acfec4_0.conda
linux-aarch64::glib-tools-2.78.1-hd84c7bf_0.conda
linux-aarch64::libsqlite-3.44.2-h194ca79_0.conda
linux-aarch64::libllvm15-15.0.7-hb4f23b0_4.conda
linux-aarch64::cudnn-8.8.0.121-h1f32b72_4.conda
linux-aarch64::libmlir17-17.0.4-h6acfec4_0.conda
linux-aarch64::libsolv-static-0.7.27-hd84c7bf_0.conda
linux-aarch64::libmlir17-17.0.5-h6acfec4_0.conda
linux-aarch64::healpix_cxx-3.81-hf7894ff_3.conda
linux-aarch64::llvm-15.0.7-h0466fd2_4.conda
linux-aarch64::glib-tools-2.78.1-hd84c7bf_1.conda
linux-aarch64::healpix_cxx-3.81-h8d5b841_2.conda
linux-aarch64::micromamba-1.5.3-0.tar.bz2
linux-aarch64::libsqlite-3.44.1-h194ca79_0.conda
linux-aarch64::micromamba-1.5.1-2.tar.bz2
-    "libzlib >=1.2.13,<1.3.0a0"
+    "libzlib >=1.2.13,<2.0.0a0"
linux-aarch64::heyoka-3.2.0-h5bd34f8_0.conda
linux-aarch64::grpcio-1.60.0-py310h20b6881_0.conda
linux-aarch64::pytables-3.9.2-py311h9a8bc71_0.conda
linux-aarch64::libadios2-2.9.2-mpi_mpich_h5eedc61_1.conda
linux-aarch64::pdal-2.6.0-hef25a86_1.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-h1ce90ac_6.conda
linux-aarch64::libarrow-12.0.1-h921de59_28_cuda.conda
linux-aarch64::cppyy-cling-6.28.0-py312h67e780f_1.conda
linux-aarch64::libadios2-2.9.2-nompi_h0e897e0_101.conda
linux-aarch64::pyhdf-0.11.3-py312h96846e4_2.conda
linux-aarch64::libarrow-13.0.0-hf4eb8d8_14_cpu.conda
linux-aarch64::sqlite-3.44.2-h3b3482f_0.conda
linux-aarch64::folly-2023.11.06.00-hcdf9fb0_0.conda
linux-aarch64::qt6-main-6.6.1-hd9c75f7_2.conda
linux-aarch64::libgdal-3.7.3-hdb1e3be_7.conda
linux-aarch64::openbabel-3.1.1-py38he2e8253_9.conda
linux-aarch64::mapserver-8.0.1-py38hb1260a8_11.conda
linux-aarch64::folly-2023.11.27.00-hf875f9a_0.conda
linux-aarch64::heyoka-llvm-13-3.2.0-h4c37d1a_0.conda
linux-aarch64::libmed-4.1.1-py38h169e1fb_0.conda
linux-aarch64::libarrow-13.0.0-h9b863c7_14_cuda.conda
linux-aarch64::libarrow-12.0.1-hfd85296_26_cuda.conda
linux-aarch64::libgdal-arrow-parquet-3.8.0-h386d13d_7.conda
linux-aarch64::libarrow-12.0.1-ha90daa3_27_cuda.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-hf85a21e_6.conda
linux-aarch64::folly-2023.11.13.00-hf875f9a_0.conda
linux-aarch64::postgresql-plpython-16.1-py39he33817a_0.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-h1ce90ac_5.conda
linux-aarch64::mold-2.4.0-h2d6341c_0.conda
linux-aarch64::heyoka-llvm-17-3.2.0-hd17d45b_0.conda
linux-aarch64::python-igraph-0.11.3-py310h9e80044_0.conda
linux-aarch64::pyinstaller-6.2.0-py39hb91f966_0.conda
linux-aarch64::libarrow-11.0.0-h56ed9ee_50_cpu.conda
linux-aarch64::libarrow-13.0.0-h921de59_17_cuda.conda
linux-aarch64::libmed-4.1.1-py39h78b4e95_0.conda
linux-aarch64::libadios2-2.9.2-mpi_openmpi_hb0a4856_0.conda
linux-aarch64::libgdal-arrow-parquet-3.8.0-h7487d97_7.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-h2370eb2_6.conda
linux-aarch64::rust-1.74.0-h9d3d833_0.conda
linux-aarch64::heyoka-3.2.0-hdde0490_0.conda
linux-aarch64::libgdal-3.8.0-h79eee4c_5.conda
linux-aarch64::libadios2-2.9.2-nompi_h0e897e0_100.conda
linux-aarch64::heyoka-llvm-14-3.2.0-h63e26b0_0.conda
linux-aarch64::libgdal-3.7.3-hade022d_2.conda
linux-aarch64::libarrow-11.0.0-h9b863c7_47_cuda.conda
linux-aarch64::ffmpeg-6.1.0-lgpl_he948236_1.conda
linux-aarch64::mlir-17.0.4-h6acfec4_0.conda
linux-aarch64::libgdal-3.8.0-h79eee4c_4.conda
linux-aarch64::libtiledb-sql-0.25.3-h82ef8a1_1.conda
linux-aarch64::heyoka-3.2.0-hd32b3df_0.conda
linux-aarch64::mysql-router-8.0.33-hfa5de57_6.conda
linux-aarch64::folly-2023.11.13.00-hb8ddcfe_0_jemalloc.conda
linux-aarch64::lld-17.0.4-h8ef0f76_0.conda
linux-aarch64::libmed-4.1.1-py312hea0ff8b_6.conda
linux-aarch64::r-git2r-0.33.0-r42h7c3d48d_0.conda
linux-aarch64::mapserver-8.0.1-py310hcaa8260_12.conda
linux-aarch64::mapserver-8.0.1-py39h254dbd1_12.conda
linux-aarch64::octave-8.4.0-hab87be2_0.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-h7916788_1.conda
linux-aarch64::libtiledb-sql-0.25.3-h886d7b1_0.conda
linux-aarch64::fltk-1.3.8-h5b24465_5.conda
linux-aarch64::mapserver-8.0.1-py39h094aedf_13.conda
linux-aarch64::vtk-base-9.2.6-qt_py311h1234567_219.conda
linux-aarch64::libopencv-4.8.1-py39h111c63c_5.conda
linux-aarch64::aws-sdk-cpp-1.11.210-hb3d6992_2.conda
linux-aarch64::freecad-0.21.2-py38h0b068e4_1.conda
linux-aarch64::r-base-4.2.3-haf36131_10.conda
linux-aarch64::libadios2-2.9.2-nompi_hf39fb1f_101.conda
linux-aarch64::pygrib-2.1.5-py39h0b06bf4_1.conda
linux-aarch64::libgdal-arrow-parquet-3.8.0-h1e8d288_0.conda
linux-aarch64::libarrow-12.0.1-hd8c837b_22_cpu.conda
linux-aarch64::libadios2-2.9.2-nompi_hf39fb1f_100.conda
linux-aarch64::freecad-0.21.2-py310he110416_1.conda
linux-aarch64::libnghttp2-1.58.0-hb0e430d_0.conda
linux-aarch64::libarrow-12.0.1-h44762d4_28_cpu.conda
linux-aarch64::libgdal-arrow-parquet-3.8.0-h2370eb2_5.conda
linux-aarch64::gmsh-4.11.1-h822ba6c_5.conda
linux-aarch64::fish-3.6.1-hc0a5165_1.conda
linux-aarch64::folly-2023.11.06.00-h8a1e4c1_0_jemalloc.conda
linux-aarch64::nco-5.1.9-h218977e_0.conda
linux-aarch64::libadios2-2.9.2-mpi_mpich_hf9996c7_0.conda
linux-aarch64::grpcio-1.60.0-py311h1a7908d_0.conda
linux-aarch64::vtk-base-9.2.6-qt_py310h1234567_219.conda
linux-aarch64::ffmpeg-6.1.0-gpl_h89d2186_103.conda
linux-aarch64::libarrow-11.0.0-h66536d9_53_cpu.conda
linux-aarch64::libxml2-2.12.0-h3091e33_0.conda
linux-aarch64::libopencv-4.8.1-py39h397868c_4.conda
linux-aarch64::libarrow-13.0.0-h2585930_15_cpu.conda
linux-aarch64::pygplates-0.39-py310had7b4d2_13.conda
linux-aarch64::libarrow-14.0.1-h0a5bb7e_1_cpu.conda
linux-aarch64::tiledb-2.18.2-hdb54b9b_0.conda
linux-aarch64::libgdal-arrow-parquet-3.8.0-h7916788_0.conda
linux-aarch64::hamlib-tcl-4.5.5-hdf905ee_2.conda
linux-aarch64::postgresql-plpython-16.1-py310h840c280_0.conda
linux-aarch64::grpcio-1.59.3-py311h1a7908d_0.conda
linux-aarch64::libarrow-11.0.0-haeabbad_49_cuda.conda
linux-aarch64::r-harp-1.20.2-py310r43h96bca1b_0.conda
linux-aarch64::heyoka-llvm-15-3.2.0-hba6061c_0.conda
linux-aarch64::libboost-1.83.0-h133f18d_0.conda
linux-aarch64::libmatio-1.5.26-hd3396f4_0.conda
linux-aarch64::openbabel-3.1.1-py39ha28ab6a_9.conda
linux-aarch64::folly-2023.11.06.00-h8dd4a7f_0_jemalloc.conda
linux-aarch64::pytables-3.9.2-py310h6e51920_0.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-h2370eb2_5.conda
linux-aarch64::libopencv-4.8.1-py38he8f0970_4.conda
linux-aarch64::libmed-4.1.1-py312hea0ff8b_0.conda
linux-aarch64::libarrow-10.0.1-hea04715_52_cuda.conda
linux-aarch64::libgdal-arrow-parquet-3.8.0-h1ce90ac_5.conda
linux-aarch64::libgdal-arrow-parquet-3.8.0-h019a8e0_1.conda
linux-aarch64::libadios2-2.9.2-mpi_mpich_h798f37a_1.conda
linux-aarch64::llvmdev-17.0.5-h70e38ee_0.conda
linux-aarch64::llvm-17.0.6-h3718a53_1.conda
linux-aarch64::libadios2-2.9.2-nompi_hecd7c66_100.conda
linux-aarch64::llvmdev-17.0.6-h70e38ee_0.conda
linux-aarch64::pygrib-2.1.5-py39h0b06bf4_0.conda
linux-aarch64::mapserver-8.0.1-py38hb1260a8_12.conda
linux-aarch64::libadios2-2.9.2-mpi_openmpi_hdeab2ad_0.conda
linux-aarch64::mapserver-8.0.1-py39h254dbd1_11.conda
linux-aarch64::llvmdev-17.0.6-h0b931ab_1.conda
linux-aarch64::vtk-base-9.2.6-qt_py312h1234567_219.conda
linux-aarch64::openimageio-2.5.5.0-py38ha0b67d0_0.conda
linux-aarch64::libgdal-arrow-parquet-3.8.0-h1ce90ac_3.conda
linux-aarch64::libgdal-arrow-parquet-3.8.0-hf80a06e_4.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-h019a8e0_4.conda
linux-aarch64::r-harp-1.20.2-py39r43h252d492_0.conda
linux-aarch64::libadios2-2.9.2-nompi_hf07bb53_101.conda
linux-aarch64::vtk-base-9.2.6-qt_py39h1234567_219.conda
linux-aarch64::cppyy-cling-6.28.0-py39h23417e7_2.conda
linux-aarch64::libgdal-arrow-parquet-3.8.0-h4374522_2.conda
linux-aarch64::harp-1.20.2-py311h180e050_0.conda
linux-aarch64::r-harp-1.20.2-py39r43h7f8485b_0.conda
linux-aarch64::magic-8.3.430-h4e13689_0.conda
linux-aarch64::r-harp-1.20.2-py38r43hd131ec7_0.conda
linux-aarch64::cppyy-cling-6.28.0-py311hfd6ae59_2.conda
linux-aarch64::libarrow-12.0.1-h0b41522_24_cpu.conda
linux-aarch64::libarrow-10.0.1-h56ed9ee_54_cpu.conda
linux-aarch64::folly-2023.11.06.00-hf875f9a_0.conda
linux-aarch64::llvm-17.0.6-h5271726_0.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-h37aa2f1_0.conda
linux-aarch64::llvm-tools-17.0.6-h0b931ab_1.conda
linux-aarch64::libgdal-3.7.3-h3215297_6.conda
linux-aarch64::postgresql-plpython-16.1-py311hc2b6b49_0.conda
linux-aarch64::libgdal-3.7.3-h0ea5625_8.conda
linux-aarch64::libpulsar-3.2.0-hdbc81fc_6.conda
linux-aarch64::libadios2-2.9.2-mpi_openmpi_h70cb021_1.conda
linux-aarch64::r-base-4.3.2-h7dc8e12_1.conda
linux-aarch64::nodejs-18.18.2-hc1f8a26_1.conda
linux-aarch64::libpq-16.1-h04b8c23_0.conda
linux-aarch64::mapserver-8.0.1-py312he0c83cc_11.conda
linux-aarch64::libmed-4.1.1-py38h169e1fb_7.conda
linux-aarch64::libglib-2.78.1-h0464669_0.conda
linux-aarch64::folly-2023.11.20.00-h8a1e4c1_0_jemalloc.conda
linux-aarch64::pyinstaller-6.2.0-py38h37f3631_0.conda
linux-aarch64::libarrow-10.0.1-hf4eb8d8_51_cpu.conda
linux-aarch64::libgdal-arrow-parquet-3.8.0-hf7b85e9_6.conda
linux-aarch64::nodejs-20.9.0-hc1f8a26_0.conda
linux-aarch64::libmed-4.1.1-py310h9a32397_7.conda
linux-aarch64::cppyy-cling-6.28.0-py38h68f7483_2.conda
linux-aarch64::libnghttp2-static-1.58.0-heb3f89f_0.conda
linux-aarch64::libtiledb-sql-0.26.0-h82ef8a1_0.conda
linux-aarch64::mysql-connector-python-8.0.32-py39hd74382b_1.conda
linux-aarch64::pyhdf-0.11.3-py39h3ee3c2a_2.conda
linux-aarch64::libgdal-3.8.0-h18a4eec_7.conda
linux-aarch64::cppyy-cling-6.28.0-py311haf98386_1.conda
linux-aarch64::pygplates-0.39-py312h083ebee_13.conda
linux-aarch64::folly-2023.11.20.00-hcdf9fb0_0.conda
linux-aarch64::ogre-14.1.2-ha44472d_1.conda
linux-aarch64::mysql-server-8.0.33-h5ebf288_6.conda
linux-aarch64::pytables-3.9.2-py39hca38f38_0.conda
linux-aarch64::heyoka-llvm-13-3.1.0-h4c37d1a_0.conda
linux-aarch64::cmake-3.27.9-hef020d8_0.conda
linux-aarch64::libopencv-4.8.1-py312h7cad72c_4.conda
linux-aarch64::harp-1.20.2-py310h5702257_0.conda
linux-aarch64::qt-webengine-5.15.8-hb6addb8_4.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-h2370eb2_4.conda
linux-aarch64::libarrow-14.0.1-h733b303_1_cuda.conda
linux-aarch64::libgdal-arrow-parquet-3.8.0-h04756a3_6.conda
linux-aarch64::openimageio-2.5.5.0-py310hc02df3e_0.conda
linux-aarch64::libspatialite-5.1.0-h761fefd_1.conda
linux-aarch64::libadios2-2.9.2-mpi_mpich_h996dc08_1.conda
linux-aarch64::libgdal-arrow-parquet-3.8.0-h2370eb2_3.conda
linux-aarch64::libarrow-10.0.1-h9b863c7_51_cuda.conda
linux-aarch64::pygrib-2.1.5-py38hd82fde1_0.conda
linux-aarch64::libadios2-2.9.2-nompi_hb3655a9_100.conda
linux-aarch64::heyoka-3.2.0-hc5e576e_0.conda
linux-aarch64::openimageio-2.5.5.0-py311h315b53b_0.conda
linux-aarch64::libgdal-arrow-parquet-3.8.0-hbceec08_0.conda
linux-aarch64::libllvm17-17.0.6-h70e38ee_0.conda
linux-aarch64::libopencv-4.8.1-py311h664a2b8_4.conda
linux-aarch64::mlir-17.0.5-h6acfec4_0.conda
linux-aarch64::libadios2-2.9.2-mpi_openmpi_hb0a4856_1.conda
linux-aarch64::freecad-0.21.2-py39heb714cc_0.conda
linux-aarch64::libarrow-14.0.1-hc7032e4_4_cpu.conda
linux-aarch64::libadios2-2.9.2-mpi_openmpi_h550ea5c_0.conda
linux-aarch64::magic-8.3.452-h4e13689_0.conda
linux-aarch64::pyinstaller-6.2.0-py311h0dd4530_0.conda
linux-aarch64::pygplates-0.39-py39h9d70819_13.conda
linux-aarch64::glib-2.78.1-hd84c7bf_0.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-hf02963a_3.conda
linux-aarch64::folly-2023.11.20.00-hb8ddcfe_0_jemalloc.conda
linux-aarch64::libxml2-2.12.1-h3091e33_0.conda
linux-aarch64::magic-8.3.449-h4e13689_0.conda
linux-aarch64::libarrow-12.0.1-h659e372_29_cuda.conda
linux-aarch64::folly-2023.11.13.00-h8a1e4c1_0_jemalloc.conda
linux-aarch64::mysql-client-8.0.33-h88b4a5d_6.conda
linux-aarch64::libarrow-12.0.1-h66536d9_29_cpu.conda
linux-aarch64::libgdal-arrow-parquet-3.8.0-hf80a06e_3.conda
linux-aarch64::libgdal-3.7.3-hade022d_1.conda
linux-aarch64::llvm-tools-17.0.6-h70e38ee_0.conda
linux-aarch64::python-igraph-0.11.3-py39h97b983d_0.conda
linux-aarch64::libarrow-14.0.1-h007172e_0_cpu.conda
linux-aarch64::libadios2-2.9.2-mpi_mpich_h996dc08_0.conda
linux-aarch64::libspral-2023.09.07-h7876b6f_0.conda
linux-aarch64::cppyy-cling-6.28.0-py310h709f82d_1.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-hf80a06e_4.conda
linux-aarch64::vtk-base-9.2.6-qt_py38h1234567_219.conda
linux-aarch64::libopencv-4.8.1-py312hdc4b82e_5.conda
linux-aarch64::folly-2023.11.13.00-hcbc1ef6_0.conda
linux-aarch64::libadios2-2.9.2-mpi_mpich_h5eedc61_0.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-hf02963a_2.conda
linux-aarch64::pygrib-2.1.5-py39h1f7d879_1.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-hbceec08_3.conda
linux-aarch64::healpy-1.16.6-py312hf8a0fec_2.conda
linux-aarch64::libarrow-11.0.0-h0b41522_48_cpu.conda
linux-aarch64::pyhdf-0.11.3-py310h196913e_2.conda
linux-aarch64::libopencv-4.8.1-py310h4a2c686_5.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-hab69875_7.conda
linux-aarch64::ffmpeg-6.1.0-lgpl_h9dc3a40_3.conda
linux-aarch64::libgdal-arrow-parquet-3.8.0-h019a8e0_2.conda
linux-aarch64::folly-2023.11.06.00-hb8ddcfe_0_jemalloc.conda
linux-aarch64::smesh-9.9.0.0-ha8b8cbd_10.conda
linux-aarch64::openimageio-2.5.5.0-py312hda6ec94_0.conda
linux-aarch64::libgdal-3.7.3-hdd972f8_4.conda
linux-aarch64::libgdal-arrow-parquet-3.8.0-h74be130_2.conda
linux-aarch64::libarrow-12.0.1-haeabbad_25_cuda.conda
linux-aarch64::pyreadstat-1.2.5-py311hf7e8aab_0.conda
linux-aarch64::aws-sdk-cpp-1.11.210-h496e8e8_1.conda
linux-aarch64::freecad-0.21.2-py311he79a59d_1.conda
linux-aarch64::libgit2-1.7.1-h0e3f3ab_1.conda
linux-aarch64::libmed-4.1.1-py312hea0ff8b_7.conda
linux-aarch64::libarrow-13.0.0-h659e372_18_cuda.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-hf85a21e_4.conda
linux-aarch64::heyoka-llvm-14-3.1.0-h63e26b0_0.conda
linux-aarch64::libarrow-10.0.1-h66536d9_57_cpu.conda
linux-aarch64::tiledb-2.18.1-h3e6b69a_0.conda
linux-aarch64::libgdal-3.8.0-h79eee4c_3.conda
linux-aarch64::heyoka-llvm-15-3.1.0-hba6061c_0.conda
linux-aarch64::libadios2-2.9.2-nompi_hb3655a9_101.conda
linux-aarch64::tiledb-2.18.1-hdb54b9b_0.conda
linux-aarch64::libarrow-12.0.1-hea04715_24_cuda.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-h7916788_3.conda
linux-aarch64::mapserver-8.0.1-py310hcaa8260_11.conda
linux-aarch64::libvips-8.15.0-h50c3125_2.conda
linux-aarch64::libtiledb-sql-0.25.3-h8dc64c1_1.conda
linux-aarch64::python-igraph-0.11.3-py312he6f5f83_0.conda
linux-aarch64::heyoka-3.2.0-h5d02d9c_0.conda
linux-aarch64::libarrow-13.0.0-ha90daa3_16_cuda.conda
linux-aarch64::healpy-1.16.6-py39h5a4fe56_2.conda
linux-aarch64::libarrow-11.0.0-h921de59_52_cuda.conda
linux-aarch64::libarrow-12.0.1-h56ed9ee_26_cpu.conda
linux-aarch64::folly-2023.11.27.00-hcbc1ef6_0.conda
linux-aarch64::libarrow-13.0.0-h5eadc21_16_cpu.conda
linux-aarch64::r-harp-1.20.2-py311r43hc8f05bd_0.conda
linux-aarch64::libmed-4.1.1-py38h169e1fb_6.conda
linux-aarch64::libopentelemetry-cpp-1.12.0-h4f4f98c_1.conda
linux-aarch64::libarrow-11.0.0-h44762d4_52_cpu.conda
linux-aarch64::libtiledb-sql-0.25.3-h556e676_0.conda
linux-aarch64::pygrib-2.1.5-py310h4dcf694_1.conda
linux-aarch64::aws-sdk-cpp-1.11.210-h0393473_0.conda
linux-aarch64::harp-1.20.2-py39h5702257_0.conda
linux-aarch64::healpy-1.16.6-py310hd71e85f_2.conda
linux-aarch64::grpcio-1.59.3-py38h95a9722_0.conda
linux-aarch64::mapserver-8.0.1-py38h073515d_13.conda
linux-aarch64::libarrow-13.0.0-haeabbad_15_cuda.conda
linux-aarch64::cmake-3.27.8-hef020d8_0.conda
linux-aarch64::pygrib-2.1.5-py311he1d05c2_1.conda
linux-aarch64::minizip-4.0.3-hb75dd74_0.conda
linux-aarch64::folly-2023.11.27.00-hcdf9fb0_0.conda
linux-aarch64::healpy-1.16.6-py311h401c86f_2.conda
linux-aarch64::ffmpeg-6.0.1-lgpl_haa40f77_0.conda
linux-aarch64::magic-8.3.451-h4e13689_0.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-h386d13d_8.conda
linux-aarch64::tiledb-2.18.2-h3e6b69a_0.conda
linux-aarch64::mysql-connector-python-8.0.32-py310h8b564ae_1.conda
linux-aarch64::libarrow-10.0.1-h659e372_57_cuda.conda
linux-aarch64::libadios2-2.9.2-mpi_openmpi_h9c94c55_1.conda
linux-aarch64::libgdal-arrow-parquet-3.8.0-hf85a21e_4.conda
linux-aarch64::grpcio-1.59.3-py310h20b6881_0.conda
linux-aarch64::r-git2r-0.33.0-r43h7c3d48d_0.conda
linux-aarch64::libgdal-arrow-parquet-3.8.0-hf02963a_0.conda
linux-aarch64::libopencv-4.8.1-py39h82dced3_4.conda
linux-aarch64::cppyy-cling-6.28.0-py38had76cbd_1.conda
linux-aarch64::libarrow-10.0.1-hfd85296_54_cuda.conda
linux-aarch64::openbabel-3.1.1-py311ha56b990_9.conda
linux-aarch64::libarrow-11.0.0-hfd85296_50_cuda.conda
linux-aarch64::libarrow-11.0.0-hea04715_48_cuda.conda
linux-aarch64::wxwidgets-3.2.4-h6541cd0_0.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-hbceec08_2.conda
linux-aarch64::ffmpeg-6.1.0-lgpl_haa40f77_0.conda
linux-aarch64::libllvm17-17.0.5-h70e38ee_0.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-hc1fd19b_4.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-ha30fd73_4.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-hf7b85e9_7.conda
linux-aarch64::wxwidgets-3.2.4-h000d3c6_1.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-h9861d1e_7.conda
linux-aarch64::mapserver-8.0.1-py310h8aaf537_13.conda
linux-aarch64::nceplibs-g2c-1.8.0-h889722f_4.conda
linux-aarch64::libgdal-3.8.0-h0c311dc_1.conda
linux-aarch64::libarrow-10.0.1-ha90daa3_55_cuda.conda
linux-aarch64::aws-sdk-cpp-1.11.182-hdd9bb2e_4.conda
linux-aarch64::qt6-wayland-6.6.0-h06b39ba_0.conda
linux-aarch64::mysql-connector-python-8.0.32-py311h7b38523_1.conda
linux-aarch64::libglib-2.78.1-h311d5f7_1.conda
linux-aarch64::texlive-core-20230313-hc704561_8.conda
linux-aarch64::libopencv-4.8.1-py39hd2a6bb6_5.conda
linux-aarch64::libarrow-14.0.1-hb441215_4_cuda.conda
linux-aarch64::libadios2-2.9.2-mpi_mpich_h798f37a_0.conda
linux-aarch64::folly-2023.11.13.00-hcdf9fb0_0.conda
linux-aarch64::libarrow-12.0.1-h2585930_25_cpu.conda
linux-aarch64::libadios2-2.9.2-mpi_mpich_hfbe1fc2_1.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-h1e8d288_2.conda
linux-aarch64::libgdal-arrow-parquet-3.8.0-hf80a06e_5.conda
linux-aarch64::libgrpc-1.60.0-h877c88e_0.conda
linux-aarch64::pygrib-2.1.5-py310h4dcf694_0.conda
linux-aarch64::mysql-connector-python-8.0.32-py38h8354cbf_1.conda
linux-aarch64::magic-8.3.450-h4e13689_0.conda
linux-aarch64::tiledb-2.18.1-h2dfc8ae_0.conda
linux-aarch64::libarrow-14.0.1-h38604f6_2_cpu.conda
linux-aarch64::tiledb-2.17.4-h3e6b69a_0.conda
linux-aarch64::freecad-0.21.2-py39ha0d004a_1.conda
linux-aarch64::llvmdev-15.0.7-hb4f23b0_4.conda
linux-aarch64::libgdal-arrow-parquet-3.8.0-h9861d1e_6.conda
linux-aarch64::libadios2-2.9.2-mpi_mpich_hfbe1fc2_0.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-h30beca3_8.conda
linux-aarch64::libvips-8.15.0-h2a7589d_3.conda
linux-aarch64::libadios2-2.9.2-mpi_openmpi_hdeab2ad_1.conda
linux-aarch64::gst-plugins-base-1.22.7-h6d82d15_0.conda
linux-aarch64::libarrow-11.0.0-h659e372_53_cuda.conda
linux-aarch64::pygrib-2.1.5-py312hfc4e102_0.conda
linux-aarch64::libgdal-arrow-parquet-3.8.0-h30beca3_7.conda
linux-aarch64::magic-8.3.440-h4e13689_0.conda
linux-aarch64::heyoka-llvm-16-3.1.0-h707f7fb_0.conda
linux-aarch64::ffmpeg-6.1.0-gpl_h76c8505_100.conda
linux-aarch64::pyreadstat-1.2.5-py312hd4a9921_0.conda
linux-aarch64::ffmpeg-6.0.1-gpl_h76c8505_100.conda
linux-aarch64::libopencv-4.8.1-py38h809d15d_5.conda
linux-aarch64::freecad-0.21.2-py310h11b2f60_0.conda
linux-aarch64::heyoka-llvm-17-3.1.0-hd17d45b_0.conda
linux-aarch64::pygrib-2.1.5-py312hfc4e102_1.conda
linux-aarch64::heyoka-3.1.0-hd32b3df_0.conda
linux-aarch64::libarrow-11.0.0-ha90daa3_51_cuda.conda
linux-aarch64::gmsh-4.11.1-h879f771_5.conda
linux-aarch64::mlir-17.0.6-h6acfec4_0.conda
linux-aarch64::lld-17.0.6-h8ef0f76_0.conda
linux-aarch64::pyhdf-0.11.3-py38h29b6294_2.conda
linux-aarch64::pygrib-2.1.5-py38hd82fde1_1.conda
linux-aarch64::boost-cpp-1.83.0-ha990451_0.conda
linux-aarch64::libgdal-arrow-parquet-3.8.0-hfa229ce_7.conda
linux-aarch64::libarrow-10.0.1-haeabbad_53_cuda.conda
linux-aarch64::aws-sdk-cpp-1.11.182-h0393473_7.conda
linux-aarch64::libgdal-arrow-parquet-3.8.0-h4374522_1.conda
linux-aarch64::qt6-wayland-6.6.1-h06b39ba_0.conda
linux-aarch64::libarrow-14.0.1-h6e3241d_5_cuda.conda
linux-aarch64::llvm-17.0.4-h5271726_0.conda
linux-aarch64::libgdal-arrow-parquet-3.8.0-h5fcfb6c_1.conda
linux-aarch64::libgdal-3.7.3-hade022d_3.conda
linux-aarch64::ogre-14.1.2-he860dd8_1.conda
linux-aarch64::libmed-4.1.1-py311h4bd975c_0.conda
linux-aarch64::libmed-4.1.1-py310h9a32397_0.conda
linux-aarch64::ffmpeg-6.1.0-gpl_hf8e3664_102.conda
linux-aarch64::libllvm17-17.0.4-h70e38ee_0.conda
linux-aarch64::libarrow-14.0.1-h8f55250_3_cpu.conda
linux-aarch64::cppyy-cling-6.28.0-py310h88818a3_2.conda
linux-aarch64::graphviz-9.0.0-h65e8cce_1.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-hfa229ce_8.conda
linux-aarch64::fltk-1.3.8-h5b24465_4.conda
linux-aarch64::heyoka-llvm-16-3.2.0-h707f7fb_0.conda
linux-aarch64::gst-plugins-good-1.22.7-h76033de_0.conda
linux-aarch64::libarrow-14.0.1-he0a0def_6_cuda.conda
linux-aarch64::libarrow-11.0.0-h5eadc21_51_cpu.conda
linux-aarch64::folly-2023.11.27.00-hb8ddcfe_0_jemalloc.conda
linux-aarch64::libgdal-arrow-parquet-3.8.0-hf85a21e_5.conda
linux-aarch64::libarrow-11.0.0-hf4eb8d8_47_cpu.conda
linux-aarch64::libxml2-2.11.6-h3091e33_0.conda
linux-aarch64::qt6-3d-6.6.1-h9d35714_0.conda
linux-aarch64::llvmdev-17.0.4-h70e38ee_0.conda
linux-aarch64::qtwebkit-5.212-h079fc77_15.conda
linux-aarch64::libfido2-1.14.0-heb3f89f_0.conda
linux-aarch64::graphviz-9.0.0-h1e60024_0.conda
linux-aarch64::libarrow-14.0.1-haaf7269_0_cuda.conda
linux-aarch64::lld-17.0.5-h8ef0f76_0.conda
linux-aarch64::ogre-1.10.12-h70aca81_16.conda
linux-aarch64::mosh-1.4.0-pl5321he590726_5.conda
linux-aarch64::heyoka-3.1.0-hc5e576e_0.conda
linux-aarch64::libgdal-3.8.0-h0c311dc_2.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-hbceec08_1.conda
linux-aarch64::libarrow-14.0.1-h8104869_2_cuda.conda
linux-aarch64::libarrow-14.0.1-hdfc1338_5_cpu.conda
linux-aarch64::llvm-openmp-17.0.6-h8b0cb96_0.conda
linux-aarch64::pygplates-0.39-py38h3590543_13.conda
linux-aarch64::pyreadstat-1.2.5-py39hfca9663_0.conda
linux-aarch64::libadios2-2.9.2-mpi_mpich_hf9996c7_1.conda
linux-aarch64::folly-2023.11.13.00-h8dd4a7f_0_jemalloc.conda
linux-aarch64::llvm-openmp-17.0.5-h8b0cb96_0.conda
linux-aarch64::heyoka-3.1.0-h5bd34f8_0.conda
linux-aarch64::libarrow-12.0.1-hf4eb8d8_23_cpu.conda
linux-aarch64::libgdal-arrow-parquet-3.8.0-h2370eb2_4.conda
linux-aarch64::pygrib-2.1.5-py39h1f7d879_0.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-h1e8d288_3.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-h7916788_2.conda
linux-aarch64::python-igraph-0.11.3-py39h240255e_0.conda
linux-aarch64::libadios2-2.9.2-nompi_hecd7c66_101.conda
linux-aarch64::folly-2023.11.20.00-h8dd4a7f_0_jemalloc.conda
linux-aarch64::folly-2023.11.06.00-hcbc1ef6_0.conda
linux-aarch64::libllvm17-17.0.6-h0b931ab_1.conda
linux-aarch64::python-igraph-0.11.3-py311h1a6d65a_0.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-h4374522_4.conda
linux-aarch64::tiledb-2.17.4-h2dfc8ae_0.conda
linux-aarch64::libmed-4.1.1-py311h4bd975c_7.conda
linux-aarch64::libarrow-10.0.1-h921de59_56_cuda.conda
linux-aarch64::libopencv-4.8.1-py310h38630c7_4.conda
linux-aarch64::cpp-opentelemetry-sdk-1.12.0-h4f4f98c_1.conda
linux-aarch64::mapserver-8.0.1-py311h9b30abf_11.conda
linux-aarch64::qt6-main-6.6.1-hb1ad137_0.conda
linux-aarch64::grpcio-1.60.0-py39h2ec6326_0.conda
linux-aarch64::mapserver-8.0.1-py312hb463781_13.conda
linux-aarch64::libarrow-10.0.1-h2585930_53_cpu.conda
linux-aarch64::pdal-2.6.1-hef25a86_0.conda
linux-aarch64::libopencv-4.8.1-py311hb76f871_5.conda
linux-aarch64::nss-3.95-hc5a5cc2_0.conda
linux-aarch64::aws-sdk-cpp-1.11.210-h0ea5927_3.conda
linux-aarch64::libgdal-arrow-parquet-3.8.0-h1ce90ac_4.conda
linux-aarch64::aws-sdk-cpp-1.11.182-haa12d54_5.conda
linux-aarch64::libpulsar-3.4.1-hdbc81fc_0.conda
linux-aarch64::libarrow-12.0.1-h2b36d5a_22_cuda.conda
linux-aarch64::llvm-tools-17.0.4-h70e38ee_0.conda
linux-aarch64::llvm-tools-16.0.6-h0b931ab_3.conda
linux-aarch64::sqlite-3.44.0-h3b3482f_0.conda
linux-aarch64::gmsh-4.11.1-h925e419_6.conda
linux-aarch64::tiledb-2.18.2-h2dfc8ae_0.conda
linux-aarch64::libmed-4.1.1-py39h78b4e95_7.conda
linux-aarch64::r-base-4.3.2-hbff713c_0.conda
linux-aarch64::libgdal-3.7.3-h3215297_5.conda
linux-aarch64::healpy-1.16.6-py39hd3b3c0a_2.conda
linux-aarch64::openimageio-2.5.5.0-py39h82e6be3_0.conda
linux-aarch64::libspatialite-5.1.0-h5d3fd7e_2.conda
linux-aarch64::freecad-0.21.2-py311h346ceb6_0.conda
linux-aarch64::postgresql-plpython-16.1-py38hf7f31c5_0.conda
linux-aarch64::pytables-3.9.2-py312h23391e5_0.conda
linux-aarch64::git-2.43.0-pl5321h1f628b6_0.conda
linux-aarch64::aws-sdk-cpp-1.11.182-h0180861_3.conda
linux-aarch64::llvm-16.0.6-h3718a53_3.conda
linux-aarch64::gmsh-4.11.1-ha60554b_6.conda
linux-aarch64::orc-1.9.0-h7b7b289_4.conda
linux-aarch64::heyoka-3.1.0-h5d02d9c_0.conda
linux-aarch64::libarrow-14.0.0-haaf7269_0_cuda.conda
linux-aarch64::pyinstaller-6.2.0-py310h1aab166_0.conda
linux-aarch64::llvmdev-16.0.6-h0b931ab_3.conda
linux-aarch64::mold-2.3.3-h2d6341c_0.conda
linux-aarch64::pyhdf-0.11.3-py311h3c0e0ee_2.conda
linux-aarch64::llvm-tools-17.0.5-h70e38ee_0.conda
linux-aarch64::pyreadstat-1.2.5-py310h3516908_0.conda
linux-aarch64::pygrib-2.1.5-py311he1d05c2_0.conda
linux-aarch64::libmed-4.1.1-py310h9a32397_6.conda
linux-aarch64::ffmpeg-6.1.0-lgpl_hbdebcb8_2.conda
linux-aarch64::libarrow-12.0.1-h9b863c7_23_cuda.conda
linux-aarch64::cppyy-cling-6.28.0-py312h17f8acd_2.conda
linux-aarch64::libarrow-12.0.1-h5eadc21_27_cpu.conda
linux-aarch64::libgdal-arrow-parquet-3.8.0-hab69875_6.conda
linux-aarch64::libgdal-arrow-parquet-3.8.0-ha30fd73_1.conda
linux-aarch64::libgdal-arrow-parquet-3.8.0-hf85a21e_3.conda
linux-aarch64::libgdal-3.8.0-hec07126_6.conda
linux-aarch64::grpcio-1.59.3-py312hd96c8c9_0.conda
linux-aarch64::libarrow-10.0.1-h44762d4_56_cpu.conda
linux-aarch64::imagemagick-7.1.1_21-pl5321h4210f1c_1.conda
linux-aarch64::libarrow-10.0.1-h5eadc21_55_cpu.conda
linux-aarch64::tiledb-2.17.4-hdb54b9b_0.conda
linux-aarch64::libadios2-2.9.2-mpi_openmpi_h550ea5c_1.conda
linux-aarch64::heyoka-3.1.0-hdde0490_0.conda
linux-aarch64::libgsf-1.14.51-h75dfdf1_0.conda
linux-aarch64::postgresql-plpython-16.1-py312h75118c5_0.conda
linux-aarch64::libgdal-3.8.0-h0c733e1_0.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-h5fcfb6c_4.conda
linux-aarch64::python-igraph-0.11.3-py38h8451dc0_0.conda
linux-aarch64::libarrow-10.0.1-h0b41522_52_cpu.conda
linux-aarch64::libadios2-2.9.2-mpi_openmpi_h9c94c55_0.conda
linux-aarch64::squashfuse-0.5.0-h24ece89_0.conda
linux-aarch64::aws-sdk-cpp-1.11.182-he7f6286_6.conda
linux-aarch64::folly-2023.11.20.00-hcbc1ef6_0.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-h7487d97_8.conda
linux-aarch64::libarrow-13.0.0-h44762d4_17_cpu.conda
linux-aarch64::llvm-17.0.5-h5271726_0.conda
linux-aarch64::mold-2.3.2-h2d6341c_0.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-hf80a06e_5.conda
linux-aarch64::nginx-1.25.3-h03e777e_1.conda
linux-aarch64::mysql-libs-8.0.33-hf629957_6.conda
linux-aarch64::cppyy-cling-6.28.0-py39h5bca64b_1.conda
linux-aarch64::mapserver-8.0.1-py312he0c83cc_12.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-hf80a06e_6.conda
linux-aarch64::libmed-4.1.1-py39h78b4e95_6.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-hf02963a_1.conda
linux-aarch64::libtiledb-sql-0.26.0-h8dc64c1_0.conda
linux-aarch64::libadios2-2.9.2-nompi_hf07bb53_100.conda
linux-aarch64::libspatialite-5.1.0-h78899c2_3.conda
linux-aarch64::grpcio-1.60.0-py312hd96c8c9_0.conda
linux-aarch64::libgdal-3.7.3-hade022d_0.conda
linux-aarch64::folly-2023.11.20.00-hf875f9a_0.conda
linux-aarch64::mapserver-8.0.1-py311h77ea36c_13.conda
linux-aarch64::pyreadstat-1.2.5-py38hbecd58a_0.conda
linux-aarch64::llvm-openmp-17.0.4-h8b0cb96_0.conda
linux-aarch64::ffmpeg-6.1.0-gpl_h1291f7e_101.conda
linux-aarch64::libgrpc-1.59.3-h877c88e_0.conda
linux-aarch64::libmed-4.1.1-py311h4bd975c_6.conda
linux-aarch64::pygplates-0.39-py311h782e10f_13.conda
linux-aarch64::grpcio-1.60.0-py39h483cef1_0.conda
linux-aarch64::glib-2.78.1-hd84c7bf_1.conda
linux-aarch64::grpcio-1.59.3-py39h483cef1_0.conda
linux-aarch64::folly-2023.11.27.00-h8dd4a7f_0_jemalloc.conda
linux-aarch64::orc-1.9.2-h7b7b289_0.conda
linux-aarch64::libvips-8.15.0-hb716539_1.conda
linux-aarch64::libadios2-2.9.2-mpi_openmpi_h70cb021_0.conda
linux-aarch64::poppler-23.11.0-h3cd87ed_0.conda
linux-aarch64::libarrow-14.0.1-h4266d94_6_cpu.conda
linux-aarch64::folly-2023.11.27.00-h8a1e4c1_0_jemalloc.conda
linux-aarch64::git-2.42.0-pl5321h1f628b6_1.conda
linux-aarch64::cargo-c-0.9.28-h6a45645_0.conda
linux-aarch64::pyinstaller-6.2.0-py312h16ba8cc_0.conda
linux-aarch64::libarrow-11.0.0-h2585930_49_cpu.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-hf85a21e_5.conda
linux-aarch64::libllvm16-16.0.6-h0b931ab_3.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-h1e8d288_1.conda
linux-aarch64::libgdal-3.7.3-h3215297_4.conda
linux-aarch64::libarrow-14.0.1-h73ac756_3_cuda.conda
linux-aarch64::libgdal-arrow-parquet-3.8.0-h5fcfb6c_2.conda
linux-aarch64::pyhdf-0.11.3-py39h292dd60_2.conda
linux-aarch64::postgresql-16.1-he3d1b8e_0.conda
linux-aarch64::pytables-3.9.2-py39h6cd1a68_0.conda
linux-aarch64::libarrow-14.0.0-h007172e_0_cpu.conda
linux-aarch64::mapserver-8.0.1-py311h9b30abf_12.conda
linux-aarch64::libgdal-arrow-parquet-3.7.3-h04756a3_7.conda
linux-aarch64::freecad-0.21.2-py38hde1cb57_0.conda
linux-aarch64::grpcio-1.60.0-py38h95a9722_0.conda
linux-aarch64::harp-1.20.2-py38h5702257_0.conda
linux-aarch64::mysql-connector-python-8.0.32-py39hb32bc82_1.conda
linux-aarch64::grpcio-1.59.3-py39h2ec6326_0.conda
linux-aarch64::sqlite-3.44.1-h3b3482f_0.conda
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
================================================================================
================================================================================
noarch
================================================================================
================================================================================
win-64
win-64::ffmpeg-6.0.1-gpl_h1627b0f_100.conda
win-64::gdstk-0.9.47-py39h32efe87_1.conda
win-64::fltk-1.3.8-h01c93fd_5.conda
win-64::libmed-4.1.1-py312hade77ae_6.conda
win-64::libgdal-arrow-parquet-3.7.3-h54e46a5_6.conda
win-64::libarrow-14.0.1-hefe621f_0_cpu.conda
win-64::aws-sdk-cpp-1.11.182-h0652cf5_6.conda
win-64::python-igraph-0.11.3-py38h5697605_0.conda
win-64::imread-0.7.5-py312h01c683d_0.conda
win-64::libgdal-arrow-parquet-3.7.3-hfbfe830_4.conda
win-64::libarrow-14.0.0-hefe621f_0_cpu.conda
win-64::mysql-server-8.0.33-h9bdc1ac_6.conda
win-64::libgdal-3.7.3-h9f0bb61_8.conda
win-64::ffmpeg-6.1.0-gpl_h0859920_103.conda
win-64::indexed_gzip-1.8.7-py38h6a43da7_0.conda
win-64::ffmpeg-6.1.0-gpl_h1627b0f_100.conda
win-64::openmeeg-2.5.6-py39he280211_5.conda
win-64::folly-2023.11.27.00-h04b96d7_0.conda
win-64::libgrpc-1.59.3-h5bbd4a7_0.conda
win-64::libglib-2.78.1-h16e383f_1.conda
win-64::libgdal-arrow-parquet-3.7.3-h1b7da06_4.conda
win-64::pytables-3.9.2-py39h607662a_0.conda
win-64::libgdal-arrow-parquet-3.8.0-hcc52eb0_7.conda
win-64::openvdb-11.0.0-py310h290b482_1.conda
win-64::intel-opencl-rt-2024.0.0-hb43f91c_49840.conda
win-64::heyoka-llvm-15-3.2.0-h8ad36fd_0.conda
win-64::libarrow-13.0.0-h22fc9d6_17_cpu.conda
win-64::heyoka-3.1.0-h34149e3_0.conda
win-64::libgdal-arrow-parquet-3.7.3-he33d123_7.conda
win-64::libpano13-2.9.20rc2-pl5321h2ea5558_7.conda
win-64::clang-16-16.0.6-default_heb8d277_2.conda
win-64::ifcopenshell-v0.7.0.231127-py311_novtk_hb615de6_101.conda
win-64::libopencv-4.8.1-py38h78f74c7_5.conda
win-64::libgrpc-1.60.0-h5bbd4a7_0.conda
win-64::libgdal-3.7.3-h3217549_3.conda
win-64::pygplates-0.39-py311hdbfeb2b_13.conda
win-64::libadios2-2.9.2-nompi_hcfb9f8b_100.conda
win-64::ovito-3.9.3-hf6a3252_0.conda
win-64::tiledb-2.18.1-h1ffc264_0.conda
win-64::libgdal-arrow-parquet-3.8.0-h8a15392_2.conda
win-64::libmed-4.1.1-py311h0794cdf_6.conda
win-64::libarrow-13.0.0-h24c1d6e_14_cuda.conda
win-64::harp-1.20.2-py39h51f3108_0.conda
win-64::vtk-base-9.2.6-qt_py311h1234567_219.conda
win-64::ifcopenshell-v0.7.0.231127-py38_all_h43c6b8c_201.conda
win-64::libopencv-4.8.1-py311h5f7164f_5.conda
win-64::libarrow-14.0.1-h1ab082e_5_cpu.conda
win-64::libsolv-0.7.27-h12be248_0.conda
win-64::clang-17.0.5-h3dc180e_0.conda
win-64::libgdal-arrow-parquet-3.7.3-hebcb094_8.conda
win-64::llvm-15.0.7-ha177bd6_4.conda
win-64::intel-opencl-rt-2024.0.0-h1112a0d_49840.conda
win-64::libadios2-2.9.2-nompi_h52f8237_100.conda
win-64::llvm-tools-15.0.7-hf26bfb3_4.conda
win-64::katago-1.13.2-cpu_hd6aaa18_0.conda
win-64::pyreadstat-1.2.5-py39h585ecb4_0.conda
win-64::libgdal-arrow-parquet-3.7.3-he3522cd_7.conda
win-64::lld-17.0.5-h21f6fed_0.conda
win-64::fossil-2.23-h00fea9b_0.conda
win-64::postgresql-16.1-hc80876b_0.conda
win-64::freecad-0.21.2-py38h90b4d10_0.conda
win-64::heyoka-3.2.0-h1bb38bf_0.conda
win-64::heyoka-llvm-16-3.2.0-h931b0a2_0.conda
win-64::stir-5.2.0-cuda118_py311h5625561_202.conda
win-64::libarrow-11.0.0-h1138768_52_cpu.conda
win-64::libmed-4.1.1-py39h1e6475e_6.conda
win-64::pyhdf-0.11.3-py39h4deeca2_2.conda
win-64::libarrow-12.0.1-hde5c32a_26_cpu.conda
win-64::llvm-tools-17.0.5-h1ab654d_0.conda
win-64::libgdal-arrow-parquet-3.7.3-h543b871_2.conda
win-64::libarrow-gandiva-14.0.1-hb2eaab1_0_cuda.conda
win-64::stir-5.2.0-cuda120_py38he42b1f3_202.conda
win-64::libarrow-12.0.1-hc7845e2_22_cpu.conda
win-64::llvmdev-17.0.4-h1ab654d_0.conda
win-64::freecad-0.21.2-py39h3ed4756_1.conda
win-64::tiledb-2.18.2-hec1fcaa_0.conda
win-64::clangxx-17.0.4-default_heb8d277_1.conda
win-64::libllvm-c17-17.0.4-h1ab654d_0.conda
win-64::grpcio-1.60.0-py39h6848017_0.conda
win-64::ifcopenshell-v0.7.0.231127-py38_novtk_h8d8bcd2_100.conda
win-64::z5py-2.0.17-py311h7bb1f51_0.conda
win-64::stir-5.2.0-cpu_py311ha2ca3b5_2.conda
win-64::imread-0.7.5-py39hdeef8c4_0.conda
win-64::llvm-17.0.5-h3dc180e_0.conda
win-64::intel-opencl-rt-2024.0.0-h930cf84_49840.conda
win-64::vtk-base-9.2.6-qt_py38h1234567_219.conda
win-64::nco-5.1.9-hf994ca5_0.conda
win-64::libgdal-arrow-parquet-3.8.0-hfdfb921_0.conda
win-64::stir-5.2.0-cuda118_py39hd6f898a_202.conda
win-64::libarrow-12.0.1-h21b21d9_22_cuda.conda
win-64::cargo-bundle-licenses-1.3.0-h59061f0_0.conda
win-64::clang-17-17.0.4-default_heb8d277_0.conda
win-64::ifcopenshell-v0.7.0.231127-py39_all_hf563ec1_200.conda
win-64::cmake-3.27.9-hf0feee3_0.conda
win-64::heyoka-3.2.0-h08b8c6c_0.conda
win-64::libarrow-10.0.1-hfc35614_56_cuda.conda
win-64::libgdal-arrow-parquet-3.8.0-h54e46a5_3.conda
win-64::libmatio-1.5.26-h8f40fab_0.conda
win-64::libarrow-10.0.1-h43e3dd5_52_cuda.conda
win-64::libarrow-10.0.1-h5032e3e_51_cpu.conda
win-64::stir-5.2.0-cpu_py310h150df81_2.conda
win-64::libarrow-gandiva-14.0.1-hb2eaab1_5_cpu.conda
win-64::libarrow-11.0.0-h1138768_53_cpu.conda
win-64::libarrow-gandiva-14.0.1-hb2eaab1_1_cuda.conda
win-64::aws-sdk-cpp-1.11.210-hbe53a2f_3.conda
win-64::imread-0.7.5-py39hee5c089_0.conda
win-64::glib-2.78.1-h12be248_0.conda
win-64::harp-1.20.2-py38h14973db_0.conda
win-64::libgdal-arrow-parquet-3.8.0-h86b5c8e_5.conda
win-64::libarrow-gandiva-14.0.1-hb2eaab1_0_cpu.conda
win-64::heyoka-3.1.0-h2333ef2_0.conda
win-64::folly-2023.11.27.00-h43676e7_0.conda
win-64::heyoka-3.2.0-h2333ef2_0.conda
win-64::heyoka-llvm-16-3.1.0-h931b0a2_0.conda
win-64::ffmpeg-6.0.1-lgpl_h02abe2f_0.conda
win-64::mysql-connector-python-8.0.32-py311hd40f987_1.conda
win-64::openmeeg-2.5.7-py310hd6f8e59_0.conda
win-64::freecad-0.21.2-py310h90fa2ea_1.conda
win-64::cpp-opentelemetry-sdk-1.12.0-h2f34e4b_1.conda
win-64::glib-2.78.1-h12be248_1.conda
win-64::paraview-5.11.2-py311hf3a0c6a_102_qt.conda
win-64::libgdal-arrow-parquet-3.8.0-h0eef876_7.conda
win-64::libllvm16-16.0.6-hf26bfb3_3.conda
win-64::libclang13-17.0.5-default_hc80b9e7_0.conda
win-64::pyhdk-0.9.0-py39h1234567_3_cpu.conda
win-64::heyoka-3.1.0-h08b8c6c_0.conda
win-64::libgdal-arrow-parquet-3.8.0-h54e46a5_4.conda
win-64::openmeeg-2.5.6-py38h7b48de1_5.conda
win-64::libarrow-gandiva-14.0.1-hb2eaab1_3_cpu.conda
win-64::libgdal-arrow-parquet-3.8.0-h66703b8_0.conda
win-64::heyoka-llvm-17-3.2.0-h7af5b08_0.conda
win-64::postgresql-plpython-16.1-py310hf838413_0.conda
win-64::topologytoolkit-1.2.0-with_paraview_py38h57c3c6e_2.conda
win-64::libadios2-2.9.2-nompi_h72362e8_101.conda
win-64::orc-1.9.2-hf0b6bd4_0.conda
win-64::libgdal-arrow-parquet-3.7.3-h54e46a5_5.conda
win-64::clang-17.0.4-h3dc180e_1.conda
win-64::pytables-3.9.2-py312h62a68b9_0.conda
win-64::gemmi-0.6.3-py310hb84602e_1.conda
win-64::libgdal-arrow-parquet-3.8.0-h7cf7422_2.conda
win-64::libopencv-4.8.1-py310h83ca8e6_5.conda
win-64::llvmdev-17.0.6-h1ab654d_0.conda
win-64::pytables-3.9.2-py310hde27e41_0.conda
win-64::tiledb-2.17.4-hec1fcaa_0.conda
win-64::stir-5.2.0-cuda112_py311h1bd1eb7_202.conda
win-64::pyreadstat-1.2.5-py311hd8f7e58_0.conda
win-64::paraview-5.11.2-py38h072c700_102_qt.conda
win-64::openmeeg-2.5.7-py38h7b48de1_0.conda
win-64::topologytoolkit-1.2.0-no_paraview_py310h57875ad_102.conda
win-64::libarrow-14.0.1-h7aee523_5_cuda.conda
win-64::ifcopenshell-v0.7.0.231127-py39_novtk_hf2c3ac6_101.conda
win-64::libgdal-3.8.0-h803bde4_1.conda
win-64::r-bigsnpr-1.12.2-r41h78deb2a_0.conda
win-64::libarrow-14.0.0-hba55846_0_cuda.conda
win-64::openvdb-11.0.0-py312h875a7f6_0.conda
win-64::libarrow-13.0.0-h5eddcea_16_cuda.conda
win-64::wxwidgets-3.2.4-hc148960_1.conda
win-64::clang-17.0.4-h3dc180e_0.conda
win-64::clangdev-16.0.6-default_heb8d277_2.conda
win-64::libspatialite-5.1.0-h9175a46_2.conda
win-64::gdstk-0.9.47-py310h7dcdc39_1.conda
win-64::libmed-4.1.1-py311h0794cdf_7.conda
win-64::aws-sdk-cpp-1.11.182-h6286c09_3.conda
win-64::llvmdev-17.0.5-h1ab654d_0.conda
win-64::clangxx-17.0.4-default_heb8d277_0.conda
win-64::clangxx-17.0.6-default_heb8d277_0.conda
win-64::gdstk-0.9.47-py311hc50246e_1.conda
win-64::gmsh-4.11.1-hf228048_6.conda
win-64::libarrow-12.0.1-he36d4cf_24_cuda.conda
win-64::aws-sdk-cpp-1.11.210-h57ee34b_2.conda
win-64::grpcio-1.59.3-py312h7894644_0.conda
win-64::heyoka-llvm-14-3.2.0-h4273656_0.conda
win-64::libopencv-4.8.1-py39h83a9175_5.conda
win-64::mdtraj-1.9.9-py39hc83516f_1.conda
win-64::libllvm-c16-16.0.6-hf26bfb3_3.conda
win-64::libgdal-arrow-parquet-3.7.3-h1bcbce1_4.conda
win-64::ffmpeg-6.1.0-lgpl_h81c54b6_3.conda
win-64::libspatialite-5.1.0-h7bd4b97_3.conda
win-64::libgdal-3.7.3-h3f0de01_4.conda
win-64::ovito-3.9.4-hf6a3252_0.conda
win-64::aws-sdk-cpp-1.11.182-hf4894ff_4.conda
win-64::glib-tools-2.78.1-h12be248_1.conda
win-64::libarrow-14.0.1-h9c55e4a_6_cuda.conda
win-64::openbabel-3.1.1-py310he48ad53_9.conda
win-64::vtk-base-9.2.6-qt_py39h1234567_219.conda
win-64::libllvm15-15.0.7-hf26bfb3_4.conda
win-64::openmeeg-2.5.6-py39h1d0f4d5_5.conda
win-64::stir-5.2.0-cpu_py39h7d132c1_2.conda
win-64::ifcopenshell-v0.7.0.231127-py39_all_hf563ec1_201.conda
win-64::gemmi-0.6.3-py311h5bc0dda_0.conda
win-64::libarrow-10.0.1-h43e3dd5_51_cuda.conda
win-64::gmt-6.4.0-hec5bbaa_17.conda
win-64::folly-2023.11.13.00-hd2f1b6b_0.conda
win-64::openvdb-11.0.0-py311ha9768a2_1.conda
win-64::libllvm17-17.0.6-h1ab654d_0.conda
win-64::clangdev-17.0.4-default_heb8d277_0.conda
win-64::libgdal-arrow-parquet-3.8.0-h543b871_0.conda
win-64::clangdev-17.0.5-default_heb8d277_0.conda
win-64::libgdal-arrow-parquet-3.8.0-h68d50aa_0.conda
win-64::heyoka-3.1.0-hf463285_0.conda
win-64::ifcopenshell-v0.7.0.231127-py310_novtk_hc317d0c_101.conda
win-64::clang-16.0.6-h3dc180e_2.conda
win-64::libgdal-arrow-parquet-3.7.3-h86b5c8e_5.conda
win-64::openbabel-3.1.1-py39h6bddc37_9.conda
win-64::pygrib-2.1.5-py310hc449e4a_0.conda
win-64::libllvm17-17.0.5-h1ab654d_0.conda
win-64::libgdal-arrow-parquet-3.7.3-h48653f4_4.conda
win-64::pygplates-0.39-py38h3440a8b_13.conda
win-64::gdstk-0.9.47-py39h32efe87_0.conda
win-64::libgdal-3.8.0-h41773de_4.conda
win-64::libarrow-11.0.0-h43e3dd5_47_cuda.conda
win-64::topologytoolkit-1.2.0-no_paraview_py39h057ce71_102.conda
win-64::gemmi-0.6.3-py38h19421c1_0.conda
win-64::topologytoolkit-1.2.0-no_paraview_py38hb99b627_102.conda
win-64::openvdb-11.0.0-py39hf0036c5_0.conda
win-64::pygrib-2.1.5-py39h11138c0_0.conda
win-64::libarrow-13.0.0-h8747f53_15_cuda.conda
win-64::libgdal-arrow-parquet-3.8.0-hfbfe830_1.conda
win-64::grpcio-1.59.3-py39hd28a505_0.conda
win-64::ogre-14.1.2-h5d47b67_1.conda
win-64::stir-5.2.0-cuda118_py38h3f97100_202.conda
win-64::libarrow-13.0.0-h257e501_16_cpu.conda
win-64::openvdb-11.0.0-py311ha9768a2_0.conda
win-64::ifcopenshell-v0.7.0.231127-py38_novtk_h8d8bcd2_101.conda
win-64::llvmdev-17.0.6-hf26bfb3_1.conda
win-64::libarrow-13.0.0-hb9186dd_18_cuda.conda
win-64::poppler-23.11.0-hc2f3c52_0.conda
win-64::libarrow-12.0.1-hb9186dd_29_cuda.conda
win-64::libgdal-arrow-parquet-3.7.3-h68d50aa_1.conda
win-64::topologytoolkit-1.2.0-no_paraview_py311hec88788_102.conda
win-64::mlir-17.0.4-he744812_0.conda
win-64::lld-17.0.4-h21f6fed_0.conda
win-64::libclang13-17.0.4-default_hc80b9e7_0.conda
win-64::libgdal-arrow-parquet-3.7.3-h86b5c8e_4.conda
win-64::libmlir-17.0.5-he744812_0.conda
win-64::glib-tools-2.78.1-h12be248_0.conda
win-64::intel-opencl-rt-2024.0.0-he96b08c_49840.conda
win-64::qt-webengine-5.15.8-h4bf5c4e_4.tar.bz2
win-64::flang-17.0.5-h12be248_0.conda
win-64::mdtraj-1.9.9-py310h63e6b18_1.conda
win-64::folly-2023.11.06.00-h43676e7_0.conda
win-64::libmed-4.1.1-py312hade77ae_0.conda
win-64::topologytoolkit-1.2.0-with_paraview_py39ha8c59e8_2.conda
win-64::libopencv-4.8.1-py39he2c65a9_4.conda
win-64::libarrow-14.0.1-h1d4e43e_2_cuda.conda
win-64::libclang-17.0.6-default_heb8d277_0.conda
win-64::pdal-2.6.1-h33341dc_0.conda
win-64::llvmdev-16.0.6-hf26bfb3_3.conda
win-64::llvm-tools-17.0.6-hf26bfb3_1.conda
win-64::gmt-5.4.5-hf8251d8_32.conda
win-64::gemmi-0.6.3-py310hb84602e_0.conda
win-64::libarrow-14.0.1-h58589b8_3_cpu.conda
win-64::paraview-5.11.2-py311h890c873_102_qt.conda
win-64::libclang-cpp-17.0.4-default_heb8d277_0.conda
win-64::llvm-tools-17.0.6-h1ab654d_0.conda
win-64::folly-2023.11.20.00-h04b96d7_0.conda
win-64::gmsh-4.11.1-h5df2bc3_5.conda
win-64::grpcio-1.59.3-py310hb84602e_0.conda
win-64::libgdal-arrow-parquet-3.8.0-h48653f4_3.conda
win-64::freecad-0.21.2-py311h2e41ac0_0.conda
win-64::folly-2023.11.20.00-hd2f1b6b_0.conda
win-64::grpcio-1.60.0-py310hb84602e_0.conda
win-64::indexed_gzip-1.8.7-py310h617134d_0.conda
win-64::clang-tools-17.0.4-default_heb8d277_0.conda
win-64::stir-5.2.0-cuda120_py310hbb71a96_202.conda
win-64::libgdal-arrow-parquet-3.8.0-h1172ef0_6.conda
win-64::paraview-5.11.2-py312hade64a9_102_qt.conda
win-64::r-harp-1.20.2-r41h56b84b2_0.conda
win-64::libgdal-arrow-parquet-3.8.0-hebcb094_7.conda
win-64::libgdal-arrow-parquet-3.7.3-hfdfb921_1.conda
win-64::clangdev-17.0.6-default_heb8d277_0.conda
win-64::libadios2-2.9.2-nompi_h530d7cd_100.conda
win-64::libgdal-arrow-parquet-3.7.3-h0d1f4a9_7.conda
win-64::libgdal-arrow-parquet-3.8.0-h0d1f4a9_6.conda
win-64::katago-1.11.0-cpu_hd6aaa18_2.conda
win-64::tiledb-2.18.1-hbf04793_0.conda
win-64::libmed-4.1.1-py310hc8c821f_6.conda
win-64::pygrib-2.1.5-py311hb25bc96_1.conda
win-64::ffmpeg-6.1.0-lgpl_h155a670_2.conda
win-64::topologytoolkit-1.2.0-with_paraview_py311hce8889c_2.conda
win-64::libarrow-gandiva-14.0.0-hb2eaab1_0_cpu.conda
win-64::libarrow-gandiva-14.0.1-hb2eaab1_2_cuda.conda
win-64::libgdal-arrow-parquet-3.8.0-h1bcbce1_1.conda
win-64::clang-tools-16.0.6-default_heb8d277_2.conda
win-64::libarrow-10.0.1-h43e3dd5_53_cuda.conda
win-64::libmed-4.1.1-py38h5d6c5ff_7.conda
win-64::harp-1.20.2-py310h084e8c7_0.conda
win-64::libgdal-arrow-parquet-3.7.3-h48653f4_5.conda
win-64::vtk-base-9.2.6-qt_py312h1234567_219.conda
win-64::pyhdk-0.9.0-py38h1234567_3_cpu.conda
win-64::paraview-5.11.2-py312h9196a2e_102_qt.conda
win-64::libarrow-gandiva-14.0.1-hb2eaab1_4_cuda.conda
win-64::stir-5.2.0-cuda112_py310h5c9ace5_202.conda
win-64::harp-1.20.2-py39hed691a2_0.conda
win-64::ifcopenshell-v0.7.0.231127-py311_all_hc62016b_200.conda
win-64::openmeeg-2.5.7-py311hb22ee39_0.conda
win-64::libgdal-arrow-parquet-3.7.3-hcc52eb0_8.conda
win-64::qt6-main-6.6.1-hcfaa65b_2.conda
win-64::postgresql-plpython-16.1-py39h7f24c7b_0.conda
win-64::libarrow-12.0.1-h44a494c_25_cpu.conda
win-64::pyhdk-0.9.0-py310h1234567_3_cpu.conda
win-64::libarrow-12.0.1-h8747f53_25_cuda.conda
win-64::libarrow-14.0.1-h9e3c6ea_4_cpu.conda
win-64::soplex-6.0.4-h949ae46_4.conda
win-64::ifcopenshell-v0.7.0.231127-py312_novtk_h6beba1a_101.conda
win-64::ogre-14.1.2-h87d0416_1.conda
win-64::libgdal-arrow-parquet-3.7.3-h24302cf_6.conda
win-64::paraview-5.11.2-py310h638c5aa_102_qt.conda
win-64::libopentelemetry-cpp-1.12.0-h2f34e4b_1.conda
win-64::libadios2-2.9.2-nompi_h1d0fc58_100.conda
win-64::libgdal-arrow-parquet-3.7.3-h48653f4_6.conda
win-64::pyhdf-0.11.3-py38hfb26d6e_2.conda
win-64::libarrow-gandiva-14.0.0-hb2eaab1_0_cuda.conda
win-64::libarrow-14.0.1-hba55846_0_cuda.conda
win-64::libarrow-13.0.0-hc2aa571_18_cpu.conda
win-64::llvm-tools-17.0.4-h1ab654d_0.conda
win-64::paraview-5.11.2-py39h786a0f8_102_qt.conda
win-64::mdtraj-1.9.9-py38h6ce0b3b_1.conda
win-64::gdstk-0.9.47-py312h1b3467e_1.conda
win-64::clangxx-16.0.6-default_heb8d277_2.conda
win-64::libclang-cpp-17.0.5-default_heb8d277_0.conda
win-64::ogre-1.10.12-hc646683_16.conda
win-64::indexed_gzip-1.8.7-py311hcbca1fb_0.conda
win-64::libgdal-arrow-parquet-3.8.0-h48653f4_5.conda
win-64::wxwidgets-3.2.4-h63ad7f6_0.conda
win-64::libgdal-3.8.0-h803bde4_2.conda
win-64::intel-cmplr-lib-rt-2024.0.0-h12be248_49840.conda
win-64::clang-17.0.6-h3dc180e_0.conda
win-64::mdtraj-1.9.9-py311h3f4f50a_1.conda
win-64::libadios2-2.9.2-nompi_hcfb9f8b_101.conda
win-64::imread-0.7.5-py310h0bb040c_0.conda
win-64::libgdal-arrow-parquet-3.8.0-h7cf7422_1.conda
win-64::libarrow-12.0.1-h925df35_23_cpu.conda
win-64::libclang-17.0.5-default_heb8d277_0.conda
win-64::libarrow-11.0.0-hfc35614_53_cuda.conda
win-64::libarrow-13.0.0-h925df35_14_cpu.conda
win-64::pygrib-2.1.5-py312h9a02840_0.conda
win-64::r-harp-1.20.2-r41h1fcffe7_0.conda
win-64::folly-2023.11.06.00-h04b96d7_0.conda
win-64::freecad-0.21.2-py311hcd49359_1.conda
win-64::libgdal-arrow-parquet-3.8.0-h24302cf_4.conda
win-64::libarrow-10.0.1-h1138768_56_cpu.conda
win-64::ffmpeg-6.1.0-gpl_h8ec0088_102.conda
win-64::stir-5.2.0-cuda112_py39h812b358_202.conda
win-64::grpcio-1.60.0-py38h19421c1_0.conda
win-64::pyhdf-0.11.3-py312h1b238a0_2.conda
win-64::libclang-cpp-16.0.6-default_heb8d277_2.conda
win-64::libsolv-0.7.26-h12be248_0.conda
win-64::libarrow-11.0.0-h256070e_51_cuda.conda
win-64::libarrow-gandiva-14.0.1-hb2eaab1_3_cuda.conda
win-64::clang-17-17.0.6-default_heb8d277_0.conda
win-64::libarrow-10.0.1-h1138768_57_cpu.conda
win-64::heyoka-3.2.0-h34149e3_0.conda
win-64::libclang-cpp-17.0.6-default_heb8d277_0.conda
win-64::openmeeg-2.5.7-py312h90b1b24_0.conda
win-64::libopencv-4.8.1-py312h55e7661_4.conda
win-64::libmlir-17.0.6-he744812_0.conda
win-64::libclang-17.0.4-default_heb8d277_0.conda
win-64::ifcopenshell-v0.7.0.231127-py310_all_h20b7ea3_200.conda
win-64::libboost-1.83.0-h65993cd_0.conda
win-64::libopencv-4.8.1-py38h8009d80_4.conda
win-64::libarrow-gandiva-14.0.1-hb2eaab1_5_cuda.conda
win-64::libarrow-11.0.0-h5032e3e_49_cpu.conda
win-64::gdstk-0.9.47-py310h7dcdc39_0.conda
win-64::papilo-2.1.4-h45feaf2_3.conda
win-64::libgdal-arrow-parquet-3.8.0-he33d123_6.conda
win-64::mysql-connector-python-8.0.32-py39h6904d88_1.conda
win-64::python-igraph-0.11.3-py311h1e46476_0.conda
win-64::libarrow-10.0.1-h702c93e_55_cpu.conda
win-64::openvdb-11.0.0-py39h48436df_0.conda
win-64::libarrow-11.0.0-h702c93e_51_cpu.conda
win-64::gdstk-0.9.47-py312h1b3467e_0.conda
win-64::heyoka-llvm-14-3.1.0-h4273656_0.conda
win-64::python-igraph-0.11.3-py39hbc72104_0.conda
win-64::libgdal-3.7.3-h3f0de01_5.conda
win-64::pygrib-2.1.5-py39h150c3fc_0.conda
win-64::pyinstaller-6.2.0-py38ha959d8a_0.conda
win-64::gemmi-0.6.3-py311h5bc0dda_1.conda
win-64::libarrow-gandiva-14.0.1-hb2eaab1_4_cpu.conda
win-64::libgdal-arrow-parquet-3.8.0-h86b5c8e_3.conda
win-64::libmediainfo-23.11-h8ec2201_0.conda
win-64::libarrow-12.0.1-h7fe4498_26_cuda.conda
win-64::mysql-libs-8.0.33-h8b0d2c3_6.conda
win-64::gemmi-0.6.3-py39hd28a505_0.conda
win-64::pyinstaller-6.2.0-py39h84a0465_0.conda
win-64::freecad-0.21.2-py310h8a2c48b_0.conda
win-64::grpcio-1.59.3-py39h6848017_0.conda
win-64::libgdal-arrow-parquet-3.7.3-h68d50aa_3.conda
win-64::openvdb-11.0.0-py39h48436df_1.conda
win-64::libopencv-4.8.1-py39h4d8ec3f_4.conda
win-64::openmeeg-2.5.6-py312h90b1b24_5.conda
win-64::libadios2-2.9.2-nompi_h72362e8_100.conda
win-64::pygplates-0.39-py39he3699cd_13.conda
win-64::pygrib-2.1.5-py38hb12060b_0.conda
win-64::topologytoolkit-1.2.0-with_paraview_py310h3a18124_2.conda
win-64::heyoka-3.2.0-hf463285_0.conda
win-64::clangdev-17.0.4-default_heb8d277_1.conda
win-64::vtk-base-9.2.6-qt_py310h1234567_219.conda
win-64::libarrow-12.0.1-heb67cb5_28_cuda.conda
win-64::qtwebkit-5.212-h83416c9_15.conda
win-64::pyreadstat-1.2.5-py310h51ee7fe_0.conda
win-64::pygplates-0.39-py312h15fb7ea_13.conda
win-64::clangxx-17.0.5-default_heb8d277_0.conda
win-64::tiledb-2.18.1-hec1fcaa_0.conda
win-64::mysql-connector-python-8.0.32-py38hee1428b_1.conda
win-64::openmeeg-2.5.6-py310hd6f8e59_5.conda
win-64::topologytoolkit-1.2.0-with_paraview_py312hf4fb59d_2.conda
win-64::libllvm17-17.0.6-hf26bfb3_1.conda
win-64::libarrow-14.0.1-h0850d3a_2_cpu.conda
win-64::folly-2023.11.13.00-h04b96d7_0.conda
win-64::libopencv-4.8.1-py39hd028261_5.conda
win-64::clang-17-17.0.5-default_heb8d277_0.conda
win-64::freecad-0.21.2-py38hfc0be3f_1.conda
win-64::indexed_gzip-1.8.7-py39h7dfb729_0.conda
win-64::gemmi-0.6.3-py39h6848017_0.conda
win-64::libpq-16.1-h43585b0_0.conda
win-64::smesh-9.9.0.0-hb7cdee2_10.conda
win-64::libarrow-gandiva-14.0.1-hb2eaab1_6_cpu.conda
win-64::paraview-5.11.2-py39h3166464_102_qt.conda
win-64::libmed-4.1.1-py39h1e6475e_0.conda
win-64::msgpack-c-6.0.0-h12be248_1.conda
win-64::postgresql-plpython-16.1-py38hc2df893_0.conda
win-64::libarrow-11.0.0-h5032e3e_48_cpu.conda
win-64::pygrib-2.1.5-py39h11138c0_1.conda
win-64::libgdal-arrow-parquet-3.7.3-h66703b8_2.conda
win-64::pytables-3.9.2-py39he845bde_0.conda
win-64::stir-5.2.0-cuda112_py38he021285_202.conda
win-64::openbabel-3.1.1-py312hebe574a_9.conda
win-64::mysql-connector-python-8.0.32-py39h725d275_1.conda
win-64::aws-sdk-cpp-1.11.182-hdff5e81_7.conda
win-64::gst-plugins-good-1.22.7-hdc28085_0.conda
win-64::gemmi-0.6.3-py39hd28a505_1.conda
win-64::stir-5.2.0-cuda120_py39h961f521_202.conda
win-64::tiledb-2.18.2-hbf04793_0.conda
win-64::libgdal-arrow-parquet-3.8.0-h48653f4_4.conda
win-64::mdtraj-1.9.9-py312hf733d30_1.conda
win-64::indexed_gzip-1.8.7-py312h55d086e_0.conda
win-64::papilo-2.1.4-h45feaf2_4.conda
win-64::harp-1.20.2-py311h1dae2b4_0.conda
win-64::libgdal-arrow-parquet-3.7.3-h7eebffa_0.conda
win-64::libllvm-c17-17.0.6-h1ab654d_0.conda
win-64::mlir-17.0.5-he744812_0.conda
win-64::libgdal-arrow-parquet-3.7.3-h24302cf_4.conda
win-64::libgdal-3.7.3-h3217549_2.conda
win-64::libpulsar-3.4.1-h35ac4ea_0.conda
win-64::libgdal-3.7.3-h3217549_0.conda
win-64::libgdal-3.7.3-h3217549_1.conda
win-64::postgresql-plpython-16.1-py312h6a96c9b_0.conda
win-64::libarrow-10.0.1-h5032e3e_52_cpu.conda
win-64::libarrow-10.0.1-hfc35614_57_cuda.conda
win-64::grpcio-1.59.3-py38h19421c1_0.conda
win-64::libmed-4.1.1-py311h0794cdf_0.conda
win-64::clang-tools-17.0.4-default_heb8d277_1.conda
win-64::libmed-4.1.1-py312hade77ae_7.conda
win-64::libarrow-14.0.1-h85f1704_1_cpu.conda
win-64::libgdal-arrow-parquet-3.7.3-h66703b8_3.conda
win-64::gmsh-4.11.1-hcc95203_6.conda
win-64::libclang-16.0.6-default_heb8d277_2.conda
win-64::libadios2-2.9.2-nompi_h1d0fc58_101.conda
win-64::libarrow-11.0.0-h43e3dd5_50_cuda.conda
win-64::pygrib-2.1.5-py310hc449e4a_1.conda
win-64::gmsh-4.11.1-hea07939_5.conda
win-64::gdstk-0.9.47-py311hc50246e_0.conda
win-64::libgdal-3.8.0-hdd54a17_0.conda
win-64::soplex-6.0.4-h949ae46_3.conda
win-64::pyhdf-0.11.3-py39hdfd9647_2.conda
win-64::libarrow-11.0.0-h5032e3e_50_cpu.conda
win-64::openmeeg-2.5.6-py311hb22ee39_5.conda
win-64::libarrow-13.0.0-h44a494c_15_cpu.conda
win-64::pygrib-2.1.5-py311hb25bc96_0.conda
win-64::libarrow-14.0.1-h679b521_6_cpu.conda
win-64::topologytoolkit-1.2.0-no_paraview_py312hcc0305c_102.conda
win-64::pygplates-0.39-py310h1d4ea62_13.conda
win-64::z5py-2.0.17-py310h6549c5b_0.conda
win-64::scip-8.1.0-h350fa5e_4.conda
win-64::libgdal-arrow-parquet-3.8.0-h54e46a5_5.conda
win-64::libopencv-4.8.1-py311h6be31c5_4.conda
win-64::libgdal-arrow-parquet-3.8.0-he3522cd_6.conda
win-64::libignition-fuel-tools4-4.6.0-hacc15eb_5.conda
win-64::ifcopenshell-v0.7.0.231127-py38_all_h43c6b8c_200.conda
win-64::libgdal-arrow-parquet-3.7.3-h7cf7422_4.conda
win-64::r-seqminer-9.3-r41h5bfd6cc_0.conda
win-64::libarrow-11.0.0-h43e3dd5_48_cuda.conda
win-64::llvm-tools-16.0.6-hf26bfb3_3.conda
win-64::llvm-16.0.6-ha177bd6_3.conda
win-64::libarrow-10.0.1-h5032e3e_54_cpu.conda
win-64::aws-sdk-cpp-1.11.182-hb23311d_5.conda
win-64::scip-8.1.0-h350fa5e_3.conda
win-64::r-harp-1.20.2-r41hdabd458_0.conda
win-64::pyreadstat-1.2.5-py312h71c11f5_0.conda
win-64::libopencv-4.8.1-py310h3e0f747_4.conda
win-64::folly-2023.11.13.00-h43676e7_0.conda
win-64::libarrow-12.0.1-hc2aa571_29_cpu.conda
win-64::libarrow-10.0.1-h5032e3e_53_cpu.conda
win-64::libclang13-16.0.6-default_hc80b9e7_2.conda
win-64::libgdal-arrow-parquet-3.7.3-h543b871_1.conda
win-64::libgdal-arrow-parquet-3.8.0-h1bcbce1_2.conda
win-64::libarrow-11.0.0-hfc35614_52_cuda.conda
win-64::libmlir-17.0.4-he744812_0.conda
win-64::folly-2023.11.20.00-h43676e7_0.conda
win-64::gdstk-0.9.47-py39h2b303d1_0.conda
win-64::ifcopenshell-v0.7.0.231127-py311_novtk_hb615de6_100.conda
win-64::tiledb-2.17.4-h1ffc264_0.conda
win-64::cfitsio-4.3.1-h9b0cee5_0.conda
win-64::heyoka-3.1.0-h1bb38bf_0.conda
win-64::ffmpeg-6.1.0-lgpl_h02abe2f_0.conda
win-64::fltk-1.3.8-h01c93fd_4.conda
win-64::lld-15.0.7-h89fd471_2.conda
win-64::libadios2-2.9.2-nompi_h530d7cd_101.conda
win-64::libgdal-arrow-parquet-3.7.3-hfdfb921_2.conda
win-64::llvm-17.0.6-ha177bd6_1.conda
win-64::libgdal-arrow-parquet-3.7.3-h0eef876_8.conda
win-64::openmeeg-2.5.7-py39he280211_0.conda
win-64::libarrow-gandiva-14.0.1-hb2eaab1_1_cpu.conda
win-64::aws-sdk-cpp-1.11.210-hdff5e81_0.conda
win-64::stir-5.2.0-cpu_py38h28fe462_2.conda
win-64::libgdal-3.8.0-h7aac5c8_6.conda
win-64::libxml2-2.12.1-hc3477c8_0.conda
win-64::libmed-4.1.1-py310hc8c821f_7.conda
win-64::ffmpeg-6.1.0-lgpl_ha82106c_1.conda
win-64::libgdal-arrow-parquet-3.8.0-h0ec6616_7.conda
win-64::gemmi-0.6.3-py312h7894644_1.conda
win-64::imread-0.7.5-py38hfc48e8c_0.conda
win-64::libgdal-arrow-parquet-3.8.0-h86b5c8e_4.conda
win-64::libignition-fuel-tools7-7.1.0-hacc15eb_6.conda
win-64::flang-17.0.6-h12be248_0.conda
win-64::pdal-2.6.0-h33341dc_1.conda
win-64::libgdal-arrow-parquet-3.7.3-h0ec6616_8.conda
win-64::libxml2-2.12.0-hc3477c8_0.conda
win-64::libgdal-arrow-parquet-3.7.3-h1172ef0_7.conda
win-64::capnproto-1.0.1.1-h12be248_0.conda
win-64::libgdal-3.8.0-h41773de_5.conda
win-64::ifcopenshell-v0.7.0.231127-py312_all_h1e2aebb_201.conda
win-64::libarrow-14.0.1-hded65f7_1_cuda.conda
win-64::libgdal-arrow-parquet-3.8.0-h24302cf_5.conda
win-64::stir-5.2.0-cuda118_py310hd0e3b8f_202.conda
win-64::libclang-cpp-17.0.4-default_heb8d277_1.conda
win-64::pyinstaller-6.2.0-py310h35269f2_0.conda
win-64::libclang13-17.0.6-default_hc80b9e7_0.conda
win-64::gmt-5.4.5-hf8251d8_31.conda
win-64::lld-17.0.6-h21f6fed_0.conda
win-64::imread-0.7.5-py311h0767c5d_0.conda
win-64::pygrib-2.1.5-py39h150c3fc_1.conda
win-64::libgdal-arrow-parquet-3.8.0-h24302cf_3.conda
win-64::python-igraph-0.11.3-py39he170af6_0.conda
win-64::libarrow-11.0.0-h43e3dd5_49_cuda.conda
win-64::libclang13-17.0.4-default_hc80b9e7_1.conda
win-64::openvdb-11.0.0-py312h875a7f6_1.conda
win-64::openbabel-3.1.1-py38h74d9a06_9.conda
win-64::openvdb-11.0.0-py39hf0036c5_1.conda
win-64::hugin-2022.0.0-pl5321h411d35b_9.conda
win-64::grpcio-1.60.0-py311h5bc0dda_0.conda
win-64::pyhdf-0.11.3-py310hc90ae1c_2.conda
win-64::libarrow-12.0.1-h24c1d6e_23_cuda.conda
win-64::ifcopenshell-v0.7.0.231127-py311_all_hc62016b_201.conda
win-64::z5py-2.0.17-py38h6d4fb60_0.conda
win-64::clang-tools-17.0.5-default_heb8d277_0.conda
win-64::libarrow-12.0.1-h22fc9d6_28_cpu.conda
win-64::gdstk-0.9.47-py38h8a2f752_0.conda
win-64::postgresql-plpython-16.1-py311h931fdd5_0.conda
win-64::llvm-17.0.6-h3dc180e_0.conda
win-64::mysql-client-8.0.33-hed9f4ee_6.conda
win-64::libuwebsockets-20.48.0-h12be248_0.conda
win-64::pygrib-2.1.5-py38hb12060b_1.conda
win-64::libgdal-arrow-parquet-3.7.3-h86b5c8e_6.conda
win-64::libllvm-c17-17.0.6-hf26bfb3_1.conda
win-64::ifcopenshell-v0.7.0.231127-py310_novtk_hc317d0c_100.conda
win-64::ifcopenshell-v0.7.0.231127-py39_novtk_hf2c3ac6_100.conda
win-64::libarrow-12.0.1-h5eddcea_27_cuda.conda
win-64::stir-5.2.0-cuda120_py311h7ed8336_202.conda
win-64::libarrow-10.0.1-h256070e_55_cuda.conda
win-64::openbabel-3.1.1-py311h6f56430_9.conda
win-64::qt6-3d-6.6.1-h294d793_0.conda
win-64::cmake-3.27.8-hf0feee3_0.conda
win-64::libgdal-arrow-parquet-3.7.3-h543b871_3.conda
win-64::clang-tools-17.0.6-default_heb8d277_0.conda
win-64::libarrow-gandiva-14.0.1-hb2eaab1_2_cpu.conda
win-64::libarrow-10.0.1-h43e3dd5_54_cuda.conda
win-64::orc-1.9.0-hf0b6bd4_4.conda
win-64::libclang-17.0.4-default_heb8d277_1.conda
win-64::python-igraph-0.11.3-py310hc9e38e4_0.conda
win-64::heyoka-llvm-13-3.1.0-h8387fb0_0.conda
win-64::libgdal-3.8.0-h0791e23_7.conda
win-64::pyinstaller-6.2.0-py311h12e69fa_0.conda
win-64::papilo-2.1.4-h45feaf2_0.conda
win-64::grpcio-1.60.0-py312h7894644_0.conda
win-64::libmed-4.1.1-py38h5d6c5ff_0.conda
win-64::libarrow-11.0.0-h5032e3e_47_cpu.conda
win-64::paraview-5.11.2-py310h8a4670e_102_qt.conda
win-64::libarrow-13.0.0-heb67cb5_17_cuda.conda
win-64::libgdal-arrow-parquet-3.8.0-hfbfe830_2.conda
win-64::r-harp-1.20.2-r41h5eb019b_0.conda
win-64::libarrow-14.0.1-ha686902_3_cuda.conda
win-64::ifcopenshell-v0.7.0.231127-py310_all_h20b7ea3_201.conda
win-64::gmt-6.4.0-h1027b5f_16.conda
win-64::llvmdev-15.0.7-hf26bfb3_4.conda
win-64::freecad-0.21.2-py39hf152376_0.conda
win-64::libgdal-arrow-parquet-3.8.0-h1b7da06_1.conda
win-64::flang-17.0.4-h12be248_0.conda
win-64::scip-8.1.0-hc7fd266_0.conda
win-64::pyreadstat-1.2.5-py38h84023d3_0.conda
win-64::gemmi-0.6.3-py39h6848017_1.conda
win-64::paraview-5.11.2-py38ha67f714_102_qt.conda
win-64::libmed-4.1.1-py39h1e6475e_7.conda
win-64::mysql-connector-python-8.0.32-py310h6a47d84_1.conda
win-64::libllvm17-17.0.4-h1ab654d_0.conda
win-64::libgdal-3.8.0-h41773de_3.conda
win-64::libgdal-3.7.3-h7a92ca3_4.conda
win-64::libarrow-gandiva-14.0.1-hb2eaab1_6_cuda.conda
win-64::mlir-17.0.6-he744812_0.conda
win-64::aws-sdk-cpp-1.11.210-h56400ea_1.conda
win-64::libopencv-4.8.1-py312h601028a_5.conda
win-64::python-igraph-0.11.3-py312h8a18d57_0.conda
win-64::gdstk-0.9.47-py38h8a2f752_1.conda
win-64::gdstk-0.9.47-py39h2b303d1_1.conda
win-64::heyoka-llvm-13-3.2.0-h8387fb0_0.conda
win-64::boost-cpp-1.83.0-h6f18f0d_0.conda
win-64::heyoka-llvm-17-3.1.0-h7af5b08_0.conda
win-64::libgdal-arrow-parquet-3.7.3-h24302cf_5.conda
win-64::pytables-3.9.2-py311heec7198_0.conda
win-64::openvdb-11.0.0-py310h290b482_0.conda
win-64::libgdal-arrow-parquet-3.7.3-hfdfb921_3.conda
win-64::folly-2023.11.06.00-hd2f1b6b_0.conda
win-64::gemmi-0.6.3-py38h19421c1_1.conda
win-64::pyhdf-0.11.3-py311h702c2b7_2.conda
win-64::libarrow-12.0.1-h257e501_27_cpu.conda
win-64::libgdal-arrow-parquet-3.7.3-h68d50aa_2.conda
win-64::libxml2-2.11.6-hc3477c8_0.conda
win-64::clang-17-17.0.4-default_heb8d277_1.conda
win-64::qt6-main-6.6.1-hcfaa65b_0.conda
win-64::libglib-2.78.1-he8f3873_0.conda
win-64::pygrib-2.1.5-py312h9a02840_1.conda
win-64::libsolv-static-0.7.27-h12be248_0.conda
win-64::libsolv-static-0.7.26-h12be248_0.conda
win-64::gst-plugins-base-1.22.7-h001b923_0.conda
win-64::libpulsar-3.2.0-h35ac4ea_6.conda
win-64::libgdal-arrow-parquet-3.7.3-h27a1db3_4.conda
win-64::dpcpp_impl_win-64-2024.0.0-h3055adc_49840.conda
win-64::pyhdk-0.9.0-py311h1234567_3_cpu.conda
win-64::libarrow-14.0.1-h261ff46_4_cuda.conda
win-64::openmeeg-2.5.7-py39h1d0f4d5_0.conda
win-64::hugin-base-2022.0.0-pl5321hb4e3486_9.conda
win-64::heyoka-llvm-15-3.1.0-h8ad36fd_0.conda
win-64::libgit2-1.7.1-hc6d37dd_1.conda
win-64::grpcio-1.60.0-py39hd28a505_0.conda
win-64::tiledb-2.17.4-hbf04793_0.conda
win-64::libmed-4.1.1-py38h5d6c5ff_6.conda
win-64::libgdal-3.7.3-hd42b5dc_7.conda
win-64::libmed-4.1.1-py310hc8c821f_0.conda
win-64::mysql-router-8.0.33-h7628ff7_6.conda
win-64::libspatialite-5.1.0-hbf340bc_1.conda
win-64::llvm-17.0.4-h3dc180e_0.conda
win-64::pyinstaller-6.2.0-py312h3bd2d22_0.conda
win-64::libgdal-arrow-parquet-3.7.3-h66703b8_1.conda
win-64::z5py-2.0.17-py39h11a86fd_0.conda
win-64::libadios2-2.9.2-nompi_h52f8237_101.conda
win-64::libllvm-c17-17.0.5-h1ab654d_0.conda
win-64::libarrow-12.0.1-h8e69dea_24_cpu.conda
win-64::ffmpeg-6.1.0-gpl_h2616e31_101.conda
win-64::libgdal-3.7.3-h3f0de01_6.conda
win-64::r-harp-1.20.2-r41ha7d8d4b_0.conda
win-64::folly-2023.11.27.00-hd2f1b6b_0.conda
win-64::grpcio-1.59.3-py311h5bc0dda_0.conda
win-64::minizip-4.0.3-h5bed578_0.conda
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
================================================================================
================================================================================
osx-64
osx-64::micromamba-1.5.3-0.tar.bz2
osx-64::glib-tools-2.78.1-hf4d7fad_0.conda
osx-64::libsolv-static-0.7.26-hf4d7fad_0.conda
osx-64::libsqlite-3.44.0-h92b6c6a_0.conda
osx-64::libsqlite-3.44.1-h92b6c6a_0.conda
osx-64::liblal-7.4.1-fftw_h41ec1e9_101.conda
osx-64::libsqlite-3.44.2-h92b6c6a_0.conda
osx-64::libsolv-0.7.27-hf4d7fad_0.conda
osx-64::libuwebsockets-20.48.0-hf4d7fad_0.conda
osx-64::libmlir17-17.0.6-he9cb26f_0.conda
osx-64::xapian-core-1.4.24-he9cb26f_0.conda
osx-64::libsolv-static-0.7.27-hf4d7fad_0.conda
osx-64::libmlir17-17.0.5-he9cb26f_0.conda
osx-64::dotnet-aspnetcore-7.0.10-h038dc8a_0.conda
osx-64::zimpl-3.5.3-h6ebec85_0.conda
osx-64::msgpack-c-6.0.0-hf4d7fad_1.conda
osx-64::libmlir-17.0.4-he9cb26f_0.conda
osx-64::libmlir-17.0.6-he9cb26f_0.conda
osx-64::libsolv-0.7.26-hf4d7fad_0.conda
osx-64::zimpl-3.5.3-h6ebec85_4.conda
osx-64::micromamba-1.5.1-2.tar.bz2
osx-64::aria2-1.37.0-h48f368d_0.conda
osx-64::gst-plugins-base-1.22.7-hd283e88_0.conda
osx-64::glib-tools-2.78.1-hf4d7fad_1.conda
osx-64::micromamba-1.5.2-0.tar.bz2
osx-64::zimpl-3.5.3-h6ebec85_3.conda
osx-64::dotnet-runtime-7.0.10-h038dc8a_0.conda
osx-64::cfitsio-4.3.1-h60fb419_0.conda
osx-64::cargo-bundle-licenses-1.3.0-h6ffb035_0.conda
osx-64::tk-8.6.13-h1abcd95_1.conda
osx-64::dotnet-sdk-7.0.400-h038dc8a_0.conda
osx-64::libmlir17-17.0.4-he9cb26f_0.conda
osx-64::libmlir-17.0.5-he9cb26f_0.conda
osx-64::lld-15.0.7-hc20ea95_2.conda
-    "libzlib >=1.2.13,<1.3.0a0"
+    "libzlib >=1.2.13,<2.0.0a0"
osx-64::paraview-5.11.2-py312h3be595e_102_qt.conda
osx-64::libgdal-arrow-parquet-3.8.0-h1d72150_2.conda
osx-64::protozfits-2.3.0-py39h2a85383_3.conda
osx-64::libgdal-arrow-parquet-3.8.0-h1d46ce0_2.conda
osx-64::cppyy-cling-6.28.0-py310h4fcba6c_1.conda
osx-64::r-harp-1.20.2-r43h028c02d_0.conda
osx-64::openbabel-3.1.1-py310hbd043fc_9.conda
osx-64::graphviz-9.0.0-hee74176_1.conda
osx-64::libgdal-arrow-parquet-3.8.0-h7546dae_0.conda
osx-64::libgdal-arrow-parquet-3.8.0-h4c5ef9b_7.conda
osx-64::folly-2023.11.13.00-h40d39b1_0.conda
osx-64::llvm-tools-16.0.6-hbedff68_3.conda
osx-64::r-git2r-0.33.0-r43h632f720_0.conda
osx-64::tiledb-2.17.4-he7df483_0.conda
osx-64::z5py-2.0.17-py39h036bdd2_0.conda
osx-64::heyoka-3.2.0-h8c23967_0.conda
osx-64::libgdal-arrow-parquet-3.7.3-h2452a0a_4.conda
osx-64::libvips-8.15.0-h353e255_1.conda
osx-64::libarrow-14.0.1-hd201b0c_3_cpu.conda
osx-64::gmt-5.4.5-h8758b3d_31.conda
osx-64::libmed-4.1.1-py38h9c6b2d9_0.conda
osx-64::liblal-7.4.1-mkl_h3fc1c70_1.conda
osx-64::grpcio-1.60.0-py311hfd95bfa_0.conda
osx-64::llvmdev-17.0.4-h0a7b4ec_0.conda
osx-64::libgdal-arrow-parquet-3.8.0-h2554460_1.conda
osx-64::libtiledb-sql-0.25.3-ha69349d_1.conda
osx-64::heyoka-llvm-16-3.2.0-hec63cc5_0.conda
osx-64::soplex-6.0.4-h7383368_3.conda
osx-64::topologytoolkit-1.2.0-no_paraview_py39h5aeddb5_102.conda
osx-64::libadios2-2.9.2-mpi_mpich_h430b6c2_1.conda
osx-64::libmed-4.1.1-py310hbe2b9c3_6.conda
osx-64::verilator-5.018-hd05f8a7_0.conda
osx-64::ifcopenshell-v0.7.0.231127-py311_all_h505f237_200.conda
osx-64::llvm-17.0.6-hed0f868_1.conda
osx-64::harp-1.20.2-py311hfb9f676_0.conda
osx-64::libgdal-arrow-parquet-3.7.3-h4c5ef9b_8.conda
osx-64::harp-1.20.2-py39ha4a4c7e_0.conda
osx-64::katago-1.13.2-cpu_h4be398b_0.conda
osx-64::libgdal-3.8.0-h1c9f6b2_3.conda
osx-64::ffmpeg-6.1.0-gpl_h9a4e613_101.conda
osx-64::libtiledb-sql-0.25.3-h6fa0f17_0.conda
osx-64::libgdal-3.7.3-h2f0f026_4.conda
osx-64::libgdal-arrow-parquet-3.8.0-he5d6092_4.conda
osx-64::cmake-3.27.9-hc7ee4c4_0.conda
osx-64::openimageio-2.5.5.0-hedc2f49_0.conda
osx-64::grpcio-1.59.3-py311hfd95bfa_0.conda
osx-64::freecad-0.21.2-py311h87bb13c_0.conda
osx-64::protozfits-2.3.0-py310h2bcdec4_4.conda
osx-64::ffmpeg-6.1.0-lgpl_hcf413b0_1.conda
osx-64::gdstk-0.9.47-py312hf50b061_1.conda
osx-64::boost-cpp-1.83.0-h07eb623_0.conda
osx-64::openvdb-11.0.0-py310hc3a9529_1.conda
osx-64::libgsf-1.14.51-hfc4e93c_0.conda
osx-64::aws-sdk-cpp-1.11.182-h8a7c8da_4.conda
osx-64::healpy-1.16.6-py312h608d928_2.conda
osx-64::pyhdf-0.11.3-py310h6c4ca6f_2.conda
osx-64::paraview-5.11.2-py38hfd1d91c_102_qt.conda
osx-64::r-base-4.2.3-hee43a56_10.conda
osx-64::gmt-6.4.0-h6374924_17.conda
osx-64::root_base-6.28.4-py310hc0bc7b0_2.conda
osx-64::folly-2023.11.06.00-he8cca0d_0_jemalloc.conda
osx-64::lld-17.0.6-h0572a5a_0.conda
osx-64::protozfits-2.3.0-py312hce1344a_4.conda
osx-64::papilo-2.1.4-hbfab450_3.conda
osx-64::libgdal-arrow-parquet-3.7.3-h30b2ddb_5.conda
osx-64::topologytoolkit-1.2.0-no_paraview_py312h2e7bf46_102.conda
osx-64::gdstk-0.9.47-py312hf50b061_0.conda
osx-64::cppyy-cling-6.28.0-py39h22d348d_1.conda
osx-64::r-seqminer-9.3-r42h2988cf7_0.conda
osx-64::libgrpc-1.59.3-ha7f534c_0.conda
osx-64::libgdal-arrow-parquet-3.8.0-ha5e34e4_4.conda
osx-64::qt-webengine-5.15.8-h5f65913_4.conda
osx-64::nodejs-20.9.0-h9adec40_0.conda
osx-64::heyoka-llvm-15-3.1.0-ha5278b2_0.conda
osx-64::libadios2-2.9.2-mpi_mpich_h4ca1c25_1.conda
osx-64::aws-sdk-cpp-1.11.182-h8f92232_5.conda
osx-64::libgdal-arrow-parquet-3.7.3-hf4286a8_1.conda
osx-64::libarrow-12.0.1-h67825a0_23_cpu.conda
osx-64::libmed-4.1.1-py39ha149e06_7.conda
osx-64::healpy-1.16.6-py311h0fd7d4f_2.conda
osx-64::mlir-17.0.6-he9cb26f_0.conda
osx-64::libgrpc-1.60.0-h14a66da_0.conda
osx-64::protozfits-2.3.0-py39h2a85383_4.conda
osx-64::libgdal-3.7.3-hc1e8e0e_7.conda
osx-64::libllvm16-16.0.6-hbedff68_3.conda
osx-64::mysql-client-8.0.33-he819ae3_6.conda
osx-64::llvm-17.0.5-h9c2cb20_0.conda
osx-64::libgdal-arrow-parquet-3.8.0-ha5e34e4_3.conda
osx-64::lld-17.0.4-h0572a5a_0.conda
osx-64::gemmi-0.6.3-py39h2fa21df_1.conda
osx-64::gemmi-0.6.3-py310h2ae4ed4_0.conda
osx-64::ifcopenshell-v0.7.0.231127-py310_novtk_h3b858eb_101.conda
osx-64::cpp-opentelemetry-sdk-1.12.0-h5ad93c0_1.conda
osx-64::libarrow-10.0.1-h161d478_54_cpu.conda
osx-64::libopencv-4.8.1-py39h3b3ba6f_4.conda
osx-64::libgdal-arrow-parquet-3.7.3-h7546dae_1.conda
osx-64::libtiledb-sql-0.25.3-h0e8045e_0.conda
osx-64::folly-2023.11.20.00-h40d39b1_0.conda
osx-64::healpy-1.16.6-py39hd2325f8_2.conda
osx-64::heyoka-llvm-14-3.2.0-hcc54ee1_0.conda
osx-64::libadios2-2.9.2-nompi_h6988d94_101.conda
osx-64::pytables-3.9.2-py39h3e2a518_0.conda
osx-64::ifcopenshell-v0.7.0.231127-py38_novtk_h63767d6_100.conda
osx-64::lld-17.0.5-h0572a5a_0.conda
osx-64::gdstk-0.9.47-py38hb48097f_0.conda
osx-64::pyinstaller-6.2.0-py39h5eebb3c_0.conda
osx-64::pytables-3.9.2-py312ha78d794_0.conda
osx-64::libarrow-14.0.1-hc794484_6_cpu.conda
osx-64::paraview-5.11.2-py311h932a114_102_qt.conda
osx-64::libadios2-2.9.2-mpi_openmpi_hd11d390_1.conda
osx-64::folly-2023.11.06.00-hdf6ac6a_0_jemalloc.conda
osx-64::mold-2.3.2-hfccc6aa_0.conda
osx-64::libspatialite-5.1.0-h4a59d8e_1.conda
osx-64::papilo-2.1.4-hbfab450_4.conda
osx-64::mysql-libs-8.0.33-hed35180_6.conda
osx-64::aws-sdk-cpp-1.11.182-h6be1521_3.conda
osx-64::cargo-c-0.9.28-h148f8b7_0.conda
osx-64::pygrib-2.1.5-py39h16104f0_1.conda
osx-64::libtensorflow_cc-2.14.0-cpu_hf250fc6_0.conda
osx-64::libtiledb-sql-0.25.4-h7142884_0.conda
osx-64::libadios2-2.9.2-nompi_hfd2c3a3_101.conda
osx-64::geant4-11.1.3-py38hbc51930_0.conda
osx-64::pygrib-2.1.5-py310hd4a3b15_0.conda
osx-64::libarrow-13.0.0-hf510195_15_cpu.conda
osx-64::mysql-connector-python-8.0.32-py39h3420cfb_1.conda
osx-64::paraview-5.11.2-py311h938bd8b_102_qt.conda
osx-64::tensorflow-base-2.14.0-cpu_py39h8cf451b_0.conda
osx-64::python-igraph-0.11.3-py39h42173bc_0.conda
osx-64::libgdal-arrow-parquet-3.8.0-h85ec132_7.conda
osx-64::openmeeg-2.5.6-py310h1308d8f_5.conda
osx-64::paraview-5.11.2-py310hf7c047e_102_qt.conda
osx-64::geant4-11.1.3-py310hac373c6_0.conda
osx-64::llvmdev-15.0.7-hbedff68_4.conda
osx-64::heyoka-3.2.0-h144e566_0.conda
osx-64::aws-sdk-cpp-1.11.210-h54a1f87_3.conda
osx-64::openmeeg-2.5.6-py38hd03ceaf_5.conda
osx-64::libpq-16.1-h6dd4ff7_0.conda
osx-64::libgdal-arrow-parquet-3.8.0-h777ae90_5.conda
osx-64::scip-8.1.0-h74f5098_0.conda
osx-64::chemicalite-2022.04.1-h257dc07_14.conda
osx-64::mold-2.3.3-hfccc6aa_0.conda
osx-64::grpcio-1.60.0-py39h89aae94_0.conda
osx-64::ifcopenshell-v0.7.0.231127-py312_all_h648c240_201.conda
osx-64::cppyy-cling-6.28.0-py39h78a5168_2.conda
osx-64::llvm-tools-17.0.6-h0a7b4ec_0.conda
osx-64::r-bigsnpr-1.12.2-r43h6e7f656_0.conda
osx-64::tiledb-2.18.1-he7df483_0.conda
osx-64::freecad-0.21.2-py39h5c84dab_1.conda
osx-64::pyinstaller-6.2.0-py310h03c913b_0.conda
osx-64::scip-8.1.0-h54180dc_3.conda
osx-64::openmeeg-2.5.6-py311h6be8875_5.conda
osx-64::libgdal-arrow-parquet-3.8.0-h2452a0a_2.conda
osx-64::geant4-11.1.3-py311hfca217c_0.conda
osx-64::libopencv-4.8.1-py38h2b5fbc5_4.conda
osx-64::nginx-1.25.3-hfb9d62d_1.conda
osx-64::pygrib-2.1.5-py311hfed0b70_0.conda
osx-64::libmed-4.1.1-py311h506998e_7.conda
osx-64::gdstk-0.9.47-py39he59f6ab_1.conda
osx-64::folly-2023.11.06.00-h80dc065_0.conda
osx-64::libgdal-arrow-parquet-3.7.3-h20f9de9_4.conda
osx-64::libtiledb-sql-0.25.4-ha69349d_0.conda
osx-64::libadios2-2.9.2-mpi_openmpi_h952c9e1_0.conda
osx-64::ifcopenshell-v0.7.0.231127-py39_novtk_h5818cb4_101.conda
osx-64::gemmi-0.6.3-py38hdf9820e_1.conda
osx-64::folly-2023.11.20.00-h2dd0d79_0_jemalloc.conda
osx-64::astrometry-0.94-py38h99d554f_5.conda
osx-64::libgdal-arrow-parquet-3.7.3-he5d6092_6.conda
osx-64::pytables-3.9.2-py39h24dbf18_0.conda
osx-64::pygrib-2.1.5-py312h7204f5f_0.conda
osx-64::llvmdev-17.0.6-hbedff68_1.conda
osx-64::llvm-tools-17.0.5-h0a7b4ec_0.conda
osx-64::cppyy-cling-6.28.0-py311h1f1617f_1.conda
osx-64::r-bigsnpr-1.12.2-r42h6e7f656_0.conda
osx-64::libgdal-arrow-parquet-3.7.3-h10a006a_1.conda
osx-64::scip-8.1.0-h54180dc_4.conda
osx-64::tensorflow-base-2.14.0-cpu_py311h3619e24_0.conda
osx-64::libgdal-3.8.0-h0ef8398_2.conda
osx-64::imagemagick-7.1.1_21-pl5321heb596e0_1.conda
osx-64::libadios2-2.9.2-mpi_mpich_hb120f67_1.conda
osx-64::nco-5.1.9-h36ae7ab_0.conda
osx-64::libarrow-10.0.1-h53b974d_56_cpu.conda
osx-64::openmeeg-2.5.7-py310h1308d8f_0.conda
osx-64::gemmi-0.6.3-py39h4f0f57b_1.conda
osx-64::qtwebkit-5.212-hdff7491_15.conda
osx-64::libboost-1.83.0-hf44e908_0.conda
osx-64::libgdal-3.7.3-h926149b_1.conda
osx-64::llvmdev-16.0.6-hbedff68_3.conda
osx-64::sqlite-3.44.1-h7461747_0.conda
osx-64::libarrow-10.0.1-hc368fdd_57_cpu.conda
osx-64::folly-2023.11.13.00-h2dd0d79_0_jemalloc.conda
osx-64::libgdal-arrow-parquet-3.7.3-h1d72150_4.conda
osx-64::libllvm17-17.0.6-hbedff68_1.conda
osx-64::libgdal-arrow-parquet-3.8.0-h30b2ddb_4.conda
osx-64::libadios2-2.9.2-nompi_h8da47c4_101.conda
osx-64::gdstk-0.9.47-py39hf544904_1.conda
osx-64::libmed-4.1.1-py311h506998e_0.conda
osx-64::libgdal-arrow-parquet-3.7.3-h10a006a_2.conda
osx-64::gdstk-0.9.47-py38hb48097f_1.conda
osx-64::cmake-3.27.8-hc7ee4c4_0.conda
osx-64::texlive-core-20230313-h9ccb147_8.conda
osx-64::qt6-3d-6.6.1-haccfb53_0.conda
osx-64::libgdal-arrow-parquet-3.8.0-h20f9de9_1.conda
osx-64::vtk-base-9.2.6-qt_py39h1234567_219.conda
osx-64::gdstk-0.9.47-py39hf544904_0.conda
osx-64::libgdal-arrow-parquet-3.8.0-h30b2ddb_3.conda
osx-64::grpcio-1.59.3-py39h512e3ab_0.conda
osx-64::gdstk-0.9.47-py311hac03db6_0.conda
osx-64::indexed_gzip-1.8.7-py312hf33f409_0.conda
osx-64::folly-2023.11.13.00-h80dc065_0.conda
osx-64::harp-1.20.2-py38h6d6fcf4_0.conda
osx-64::pygrib-2.1.5-py311h8d3d721_1.conda
osx-64::ifcopenshell-v0.7.0.231127-py310_all_h1743013_200.conda
osx-64::openvdb-11.0.0-py311h082c491_1.conda
osx-64::indexed_gzip-1.8.7-py311h0c3a6a7_0.conda
osx-64::libgdal-arrow-parquet-3.8.0-hf4286a8_0.conda
osx-64::protozfits-2.3.0-py310h2bcdec4_3.conda
osx-64::libadios2-2.9.2-nompi_hfd2c3a3_100.conda
osx-64::gemmi-0.6.3-py38hdd78f75_0.conda
osx-64::openbabel-3.1.1-py39h2b06bde_9.conda
osx-64::folly-2023.11.20.00-he8cca0d_0_jemalloc.conda
osx-64::wxwidgets-3.2.4-h5e6ad94_1.conda
osx-64::libgdal-3.8.0-h1c9f6b2_5.conda
osx-64::libgdal-arrow-parquet-3.7.3-h30b2ddb_4.conda
osx-64::libtiledb-sql-0.26.0-h7142884_0.conda
osx-64::libadios2-2.9.2-mpi_mpich_hef859a5_1.conda
osx-64::openbabel-3.1.1-py38h4fdbfb7_9.conda
osx-64::libgdal-arrow-parquet-3.8.0-h38f6d11_7.conda
osx-64::libgdal-3.7.3-h926149b_3.conda
osx-64::heyoka-3.1.0-h144e566_0.conda
osx-64::harp-1.20.2-py310h740aea4_0.conda
osx-64::z5py-2.0.17-py311h5fa4459_0.conda
osx-64::libgdal-arrow-parquet-3.8.0-h777ae90_3.conda
osx-64::tiledb-2.17.4-h9fe0a6a_0.conda
osx-64::aws-sdk-cpp-1.11.182-h28d282b_7.conda
osx-64::gdstk-0.9.47-py310hee09dbd_1.conda
osx-64::libpulsar-3.2.0-h4608f1c_6.conda
osx-64::cppyy-cling-6.28.0-py311h0102fb6_2.conda
osx-64::pygrib-2.1.5-py39hce8d9d2_1.conda
osx-64::soplex-6.0.4-h7383368_4.conda
osx-64::ffmpeg-6.1.0-lgpl_h7a8fd81_0.conda
osx-64::libvips-8.15.0-hf8764c4_3.conda
osx-64::pygrib-2.1.5-py38h7170891_1.conda
osx-64::libvips-8.15.0-hbed0ce0_0.conda
osx-64::libadios2-2.9.2-mpi_openmpi_h4fcbc1e_1.conda
osx-64::fish-3.6.1-h42c0413_1.conda
osx-64::libmed-4.1.1-py38h9c6b2d9_6.conda
osx-64::openimageio-2.5.5.0-h09110be_0.conda
osx-64::gemmi-0.6.3-py310hc218492_1.conda
osx-64::grpcio-1.60.0-py310h52cc26f_0.conda
osx-64::pyinstaller-6.2.0-py311h8c2310c_0.conda
osx-64::libadios2-2.9.2-nompi_h8da47c4_100.conda
osx-64::pyhdf-0.11.3-py311h0efa85d_2.conda
osx-64::minizip-4.0.3-h23f18a7_0.conda
osx-64::protozfits-2.3.0-py38h44ead01_3.conda
osx-64::graphviz-9.0.0-h17d42e5_0.conda
osx-64::libmed-4.1.1-py39ha149e06_6.conda
osx-64::topologytoolkit-1.2.0-no_paraview_py38hebcc1c8_102.conda
osx-64::heyoka-3.1.0-h58cd08d_0.conda
osx-64::pyhdf-0.11.3-py312h00aa5f1_2.conda
osx-64::heyoka-llvm-17-3.1.0-h165d30d_0.conda
osx-64::postgresql-plpython-16.1-py38h59056bf_0.conda
osx-64::libvips-8.15.0-h844c836_2.conda
osx-64::libgdal-arrow-parquet-3.8.0-ha5e34e4_5.conda
osx-64::gdstk-0.9.47-py39he59f6ab_0.conda
osx-64::libgdal-arrow-parquet-3.7.3-h768cd43_7.conda
osx-64::tiledb-2.18.1-h217f39e_0.conda
osx-64::libtiledb-sql-0.25.3-h7142884_1.conda
osx-64::gazebo-11.14.0-hbfe39c7_3.conda
osx-64::nceplibs-g2c-1.8.0-h016f3c3_4.conda
osx-64::freecad-0.21.2-py310h7f847b2_1.conda
osx-64::mlir-17.0.5-he9cb26f_0.conda
osx-64::libgdal-arrow-parquet-3.8.0-h514f490_7.conda
osx-64::libarrow-11.0.0-h7738530_48_cpu.conda
osx-64::postgresql-plpython-16.1-py312h4a1d472_0.conda
osx-64::ifcopenshell-v0.7.0.231127-py38_all_h354f88a_200.conda
osx-64::libgdal-arrow-parquet-3.7.3-h7546dae_3.conda
osx-64::gazebo-11.14.0-h21935b2_4.conda
osx-64::libgdal-arrow-parquet-3.7.3-h219e4d6_1.conda
osx-64::pyhdf-0.11.3-py38h1ba073c_2.conda
osx-64::pyreadstat-1.2.5-py310h03c913b_0.conda
osx-64::ogre-14.1.2-h06fbdbb_1.conda
osx-64::glib-2.78.1-hf4d7fad_0.conda
osx-64::libgdal-3.8.0-hdcb9b1b_0.conda
osx-64::libnghttp2-static-1.58.0-hf822044_0.conda
osx-64::folly-2023.11.06.00-h40d39b1_0.conda
osx-64::paraview-5.11.2-py39heb99220_102_qt.conda
osx-64::topologytoolkit-1.2.0-no_paraview_py310h4b30c82_102.conda
osx-64::mysql-server-8.0.33-h03692dd_6.conda
osx-64::llvm-tools-15.0.7-hbedff68_4.conda
osx-64::topologytoolkit-1.2.0-no_paraview_py311h44b89e6_102.conda
osx-64::folly-2023.11.06.00-h2dd0d79_0_jemalloc.conda
osx-64::protozfits-2.3.0-py310h2bf7cdf_2.conda
osx-64::openimageio-2.5.5.0-h94006fb_0.conda
osx-64::ifcopenshell-v0.7.0.231127-py311_novtk_hd8049e5_101.conda
osx-64::libopencv-4.8.1-py312h086e99c_4.conda
osx-64::r-harp-1.20.2-r43h7a8ce1f_0.conda
osx-64::openmeeg-2.5.7-py312he074522_0.conda
osx-64::pyhdf-0.11.3-py39h7f5a0cc_2.conda
osx-64::astrometry-0.94-py311h38d3ad1_5.conda
osx-64::ifcopenshell-v0.7.0.231127-py39_novtk_h5818cb4_100.conda
osx-64::postgresql-plpython-16.1-py39hf4bfa82_0.conda
osx-64::astrometry-0.94-py310h443aafb_5.conda
osx-64::indexed_gzip-1.8.7-py39hcf27c3a_0.conda
osx-64::protozfits-2.3.0-py311h57f9d79_2.conda
osx-64::gmsh-4.11.1-h92d8eba_5.conda
osx-64::libgdal-arrow-parquet-3.7.3-h219e4d6_3.conda
osx-64::r-qpdf-1.3.2-r42hb14e8f9_4.conda
osx-64::libgdal-arrow-parquet-3.7.3-hf8052ea_7.conda
osx-64::gazebo-11.14.0-h98d0159_2.conda
osx-64::libarrow-14.0.1-he18ce0b_5_cpu.conda
osx-64::libarrow-14.0.1-heee2434_0_cpu.conda
osx-64::gemmi-0.6.3-py312hf1aaa0c_1.conda
osx-64::libllvm17-17.0.5-h0a7b4ec_0.conda
osx-64::libgdal-arrow-parquet-3.7.3-h8951493_7.conda
osx-64::indexed_gzip-1.8.7-py310h917455f_0.conda
osx-64::poppler-23.11.0-hdd5a5e8_0.conda
osx-64::python-igraph-0.11.3-py38h678a7d2_0.conda
osx-64::libarrow-10.0.1-h4e52473_51_cpu.conda
osx-64::root_base-6.28.4-py38h412cb2a_2.conda
osx-64::libopencv-4.8.1-py39hb0fc921_5.conda
osx-64::libxml2-2.11.6-hc0ae0f7_0.conda
osx-64::r-seqminer-9.3-r43h2988cf7_0.conda
osx-64::libgdal-arrow-parquet-3.7.3-hf4286a8_2.conda
osx-64::paraview-5.11.2-py39hfc3ccf1_102_qt.conda
osx-64::libopentelemetry-cpp-1.12.0-h5ad93c0_1.conda
osx-64::libadios2-2.9.2-nompi_h64c4afe_100.conda
osx-64::pdal-2.6.1-h3e4393c_0.conda
osx-64::libgdal-arrow-parquet-3.7.3-hf4286a8_3.conda
osx-64::protozfits-2.3.0-py311h52cb0a2_4.conda
osx-64::cppyy-cling-6.28.0-py39h0bb4e67_2.conda
osx-64::glib-2.78.1-hf4d7fad_1.conda
osx-64::libopencv-4.8.1-py310hcca6821_4.conda
osx-64::libadios2-2.9.2-mpi_openmpi_hb309062_1.conda
osx-64::libgdal-arrow-parquet-3.8.0-hf8052ea_6.conda
osx-64::folly-2023.11.27.00-h175799c_0.conda
osx-64::r-base-4.3.2-hf996cbc_0.conda
osx-64::openvdb-11.0.0-py39h5b2da64_1.conda
osx-64::tiledb-2.17.4-had89b8f_0.conda
osx-64::grpcio-1.60.0-py312h5e463a0_0.conda
osx-64::pyreadstat-1.2.5-py311h8c2310c_0.conda
osx-64::libgdal-arrow-parquet-3.7.3-h514f490_8.conda
osx-64::tiledb-2.18.1-had89b8f_0.conda
osx-64::gemmi-0.6.3-py311h2f14e55_0.conda
osx-64::mysql-connector-python-8.0.32-py311h4a6c25c_1.conda
osx-64::pytables-3.9.2-py311h3cee394_0.conda
osx-64::libmatio-1.5.26-h253dbdd_0.conda
osx-64::libadios2-2.9.2-mpi_mpich_hf6be604_0.conda
osx-64::openmeeg-2.5.6-py39h0bdf745_5.conda
osx-64::libadios2-2.9.2-mpi_openmpi_h952c9e1_1.conda
osx-64::libllvm17-17.0.6-h0a7b4ec_0.conda
osx-64::libgdal-arrow-parquet-3.7.3-hda27e5f_4.conda
osx-64::libgdal-arrow-parquet-3.8.0-h9201602_6.conda
osx-64::libgdal-arrow-parquet-3.7.3-hb9029ea_0.conda
osx-64::libgdal-arrow-parquet-3.8.0-he5d6092_5.conda
osx-64::libopencv-4.8.1-py310h9624c59_5.conda
osx-64::z5py-2.0.17-py310h28fef50_0.conda
osx-64::papilo-2.1.4-h8422892_0.conda
osx-64::openimageio-2.5.5.0-hfd3dc1d_0.conda
osx-64::llvm-tools-17.0.4-h0a7b4ec_0.conda
osx-64::libgdal-arrow-parquet-3.7.3-h777ae90_6.conda
osx-64::orc-1.9.2-h9ab30d4_0.conda
osx-64::freecad-0.21.2-py38h034c499_0.conda
osx-64::hugin-base-2022.0.0-pl5321hf4cc725_9.conda
osx-64::llvmdev-17.0.6-h0a7b4ec_0.conda
osx-64::katago-1.11.0-cpu_h4be398b_2.conda
osx-64::libgdal-3.8.0-h1c9f6b2_4.conda
osx-64::vtk-base-9.2.6-qt_py38h1234567_219.conda
osx-64::libadios2-2.9.2-mpi_openmpi_h4fcbc1e_0.conda
osx-64::heyoka-3.2.0-hd20e07f_0.conda
osx-64::tiledb-2.18.2-he7df483_0.conda
osx-64::libtiledb-sql-0.26.0-ha69349d_0.conda
osx-64::libgdal-arrow-parquet-3.7.3-he5d6092_4.conda
osx-64::fltk-1.3.8-he73b29e_4.conda
osx-64::capnproto-1.0.1.1-h440efdd_0.conda
osx-64::libarrow-13.0.0-h6b0247c_14_cpu.conda
osx-64::ffmpeg-6.1.0-lgpl_h4856f40_2.conda
osx-64::libadios2-2.9.2-mpi_mpich_hb120f67_0.conda
osx-64::mysql-connector-python-8.0.32-py39heca1d08_1.conda
osx-64::grpcio-1.60.0-py38he5c74f2_0.conda
osx-64::ogre-1.10.12-h32f507b_16.conda
osx-64::libgdal-arrow-parquet-3.7.3-h2554460_4.conda
osx-64::git-2.43.0-pl5321hba7a703_0.conda
osx-64::llvm-tools-17.0.6-hbedff68_1.conda
osx-64::libgdal-arrow-parquet-3.7.3-h30b2ddb_6.conda
osx-64::libarrow-14.0.1-h660ed53_4_cpu.conda
osx-64::fossil-2.23-hf9715f5_0.conda
osx-64::libarrow-10.0.1-he67052e_55_cpu.conda
osx-64::ifcopenshell-v0.7.0.231127-py38_novtk_h63767d6_101.conda
osx-64::root_base-6.28.4-py311h01aa0cd_2.conda
osx-64::soplex-6.0.4-h7383368_0.conda
osx-64::libmed-4.1.1-py312h158710a_0.conda
osx-64::heyoka-3.1.0-h8dc0cc3_0.conda
osx-64::libmed-4.1.1-py38h9c6b2d9_7.conda
osx-64::python-igraph-0.11.3-py311h4b5d99d_0.conda
osx-64::libarrow-12.0.1-h3fdeaa9_29_cpu.conda
osx-64::folly-2023.11.13.00-hdf6ac6a_0_jemalloc.conda
osx-64::libgdal-arrow-parquet-3.7.3-ha5e34e4_6.conda
osx-64::mold-2.4.0-hfccc6aa_0.conda
osx-64::postgresql-plpython-16.1-py311h47125a7_0.conda
osx-64::libgdal-arrow-parquet-3.7.3-h777ae90_5.conda
osx-64::folly-2023.11.27.00-h2dd0d79_0_jemalloc.conda
osx-64::openmeeg-2.5.7-py39h1938461_0.conda
osx-64::libxml2-2.12.0-hc0ae0f7_0.conda
osx-64::folly-2023.11.20.00-hdf6ac6a_0_jemalloc.conda
osx-64::pyreadstat-1.2.5-py312h67dd88c_0.conda
osx-64::indexed_gzip-1.8.7-py38hc21c49e_0.conda
osx-64::python-igraph-0.11.3-py310h6a859b3_0.conda
osx-64::libmed-4.1.1-py312h158710a_6.conda
osx-64::freecad-0.21.2-py310hce16672_0.conda
osx-64::openvdb-11.0.0-py312heab6e3c_1.conda
osx-64::mysql-connector-python-8.0.32-py38h3fb4929_1.conda
osx-64::libarrow-10.0.1-h7fb87fb_52_cpu.conda
osx-64::gmt-5.4.5-h8758b3d_32.conda
osx-64::libarrow-12.0.1-h0cc9783_28_cpu.conda
osx-64::gemmi-0.6.3-py39h445be9b_0.conda
osx-64::grpcio-1.59.3-py312h5e463a0_0.conda
osx-64::libspatialite-5.1.0-hf63aa75_2.conda
osx-64::libgdal-arrow-parquet-3.8.0-h30b2ddb_5.conda
osx-64::gdstk-0.9.47-py311hac03db6_1.conda
osx-64::libadios2-2.9.2-nompi_h64c4afe_101.conda
osx-64::llvm-17.0.6-h9c2cb20_0.conda
osx-64::libarrow-11.0.0-h3fdeaa9_53_cpu.conda
osx-64::ifcopenshell-v0.7.0.231127-py310_novtk_h3b858eb_100.conda
osx-64::pyinstaller-6.2.0-py38hf1429db_0.conda
osx-64::libarrow-10.0.1-h681d9e0_53_cpu.conda
osx-64::ffmpeg-6.1.0-gpl_h81fb860_103.conda
osx-64::libopencv-4.8.1-py39h447e05a_5.conda
osx-64::libmed-4.1.1-py312h158710a_7.conda
osx-64::libpano13-2.9.20rc2-pl5321hb166da4_7.conda
osx-64::libgdal-arrow-parquet-3.7.3-h777ae90_4.conda
osx-64::libopencv-4.8.1-py311h712aba7_5.conda
osx-64::folly-2023.11.27.00-h40d39b1_0.conda
osx-64::pyreadstat-1.2.5-py38hf1429db_0.conda
osx-64::pygrib-2.1.5-py39h89a8786_0.conda
osx-64::freecad-0.21.2-py311hfaabbf5_1.conda
osx-64::pygrib-2.1.5-py310hda7b51f_1.conda
osx-64::mysql-connector-python-8.0.32-py310h0be9042_1.conda
osx-64::harp-1.20.2-py39ha1a11b5_0.conda
osx-64::z5py-2.0.17-py38hdf60bb5_0.conda
osx-64::heyoka-3.1.0-hd20e07f_0.conda
osx-64::heyoka-llvm-13-3.2.0-hee71c22_0.conda
osx-64::r-git2r-0.33.0-r42h632f720_0.conda
osx-64::libopencv-4.8.1-py311h0ef0a85_4.conda
osx-64::llvm-16.0.6-hed0f868_3.conda
osx-64::aws-sdk-cpp-1.11.210-h1fb87b4_1.conda
osx-64::libgdal-arrow-parquet-3.7.3-h38f6d11_8.conda
osx-64::ffmpeg-6.0.1-gpl_hc3e82c2_100.conda
osx-64::libgdal-3.8.0-h5b0c7d5_6.conda
osx-64::postgresql-plpython-16.1-py310h7e3f867_0.conda
osx-64::libgit2-1.7.1-hb9697d7_1.conda
osx-64::ffmpeg-6.1.0-gpl_hc3e82c2_100.conda
osx-64::libspatialite-5.1.0-haf058c1_3.conda
osx-64::libllvm17-17.0.4-h0a7b4ec_0.conda
osx-64::libmed-4.1.1-py310hbe2b9c3_7.conda
osx-64::freecad-0.21.2-py38hf9917c0_1.conda
osx-64::libtensorflow-2.14.0-cpu_h28ad5a0_0.conda
osx-64::ovito-3.9.3-h16e7d32_0.conda
osx-64::freecad-0.21.2-py39h112d278_0.conda
osx-64::protozfits-2.3.0-py311h8c93807_3.conda
osx-64::r-harp-1.20.2-r43h9b9e7df_0.conda
osx-64::python-igraph-0.11.3-py312h907717d_0.conda
osx-64::tensorflow-base-2.14.0-cpu_py310h577850d_0.conda
osx-64::ifcopenshell-v0.7.0.231127-py310_all_h1743013_201.conda
osx-64::folly-2023.11.27.00-hdf6ac6a_0_jemalloc.conda
osx-64::paraview-5.11.2-py312h53b8da2_102_qt.conda
osx-64::libxml2-2.12.1-hc0ae0f7_0.conda
osx-64::ifcopenshell-v0.7.0.231127-py38_all_h354f88a_201.conda
osx-64::libarrow-12.0.1-h61f60c6_27_cpu.conda
osx-64::folly-2023.11.27.00-he8cca0d_0_jemalloc.conda
osx-64::octave-8.4.0-hbdd2e4c_0.conda
osx-64::aws-sdk-cpp-1.11.182-h06c5342_6.conda
osx-64::folly-2023.11.27.00-h80dc065_0.conda
osx-64::pygrib-2.1.5-py38h7b2235c_0.conda
osx-64::paraview-5.11.2-py310ha63d4b9_102_qt.conda
osx-64::libarrow-14.0.1-h3b78187_2_cpu.conda
osx-64::cppyy-cling-6.28.0-py312h22143e2_1.conda
osx-64::cppyy-cling-6.28.0-py312hecaf9ea_2.conda
osx-64::libgdal-3.7.3-h926149b_0.conda
osx-64::xeus-cpp-0.0.1-h123f7b9_3.conda
osx-64::libglib-2.78.1-h6d9ecee_0.conda
osx-64::tiledb-2.18.2-had89b8f_0.conda
osx-64::heyoka-3.2.0-h58cd08d_0.conda
osx-64::r-base-4.3.2-h8eaf9e6_1.conda
osx-64::cppyy-cling-6.28.0-py38hbcdfe3b_2.conda
osx-64::python-igraph-0.11.3-py39ha7fcb8d_0.conda
osx-64::libgdal-3.8.0-h0ef8398_1.conda
osx-64::libgdal-arrow-parquet-3.8.0-h768cd43_6.conda
osx-64::qt6-main-6.6.1-h8e16aa4_2.conda
osx-64::pyhdf-0.11.3-py39h023b3bd_2.conda
osx-64::ffmpeg-6.0.1-lgpl_h7a8fd81_0.conda
osx-64::git-2.42.0-pl5321hba7a703_1.conda
osx-64::libfido2-1.14.0-h3cbcf74_0.conda
osx-64::pygrib-2.1.5-py312h8959646_1.conda
osx-64::pygrib-2.1.5-py39h5b1cf33_0.conda
osx-64::ifcopenshell-v0.7.0.231127-py311_novtk_hd8049e5_100.conda
osx-64::openbabel-3.1.1-py311he4d38a6_9.conda
osx-64::vtk-base-9.2.6-qt_py310h1234567_219.conda
osx-64::libmed-4.1.1-py311h506998e_6.conda
osx-64::libgdal-3.8.0-h5c58ba9_7.conda
osx-64::openmeeg-2.5.7-py38hd03ceaf_0.conda
osx-64::libgdal-arrow-parquet-3.8.0-h777ae90_4.conda
osx-64::libarrow-12.0.1-hcb2530e_22_cpu.conda
osx-64::folly-2023.11.20.00-h175799c_0.conda
osx-64::folly-2023.11.20.00-h80dc065_0.conda
osx-64::qt6-main-6.6.1-h729e66d_0.conda
osx-64::gmsh-4.11.1-hec6da19_6.conda
osx-64::libgdal-3.7.3-h2f0f026_5.conda
osx-64::heyoka-3.1.0-h8c23967_0.conda
osx-64::gemmi-0.6.3-py39h6d03484_0.conda
osx-64::cppyy-cling-6.28.0-py39hb460cbf_1.conda
osx-64::llvm-17.0.4-h9c2cb20_0.conda
osx-64::libmed-4.1.1-py39ha149e06_0.conda
osx-64::libpulsar-3.4.1-h4608f1c_0.conda
osx-64::ifcopenshell-v0.7.0.231127-py312_novtk_h44959ec_101.conda
osx-64::grpcio-1.59.3-py310h52cc26f_0.conda
osx-64::libgdal-arrow-parquet-3.7.3-ha5e34e4_5.conda
osx-64::folly-2023.11.13.00-h175799c_0.conda
osx-64::libmed-4.1.1-py310hbe2b9c3_0.conda
osx-64::libgdal-arrow-parquet-3.8.0-h2452a0a_1.conda
osx-64::heyoka-llvm-16-3.1.0-hec63cc5_0.conda
osx-64::openmeeg-2.5.7-py39h0bdf745_0.conda
osx-64::libnghttp2-1.58.0-h64cf6d3_0.conda
osx-64::gmsh-4.11.1-h13d1ca8_5.conda
osx-64::nodejs-18.18.2-h2713218_1.conda
osx-64::libadios2-2.9.2-mpi_mpich_h430b6c2_0.conda
osx-64::libarrow-12.0.1-hf510195_25_cpu.conda
osx-64::libmediainfo-23.11-h4c551c5_0.conda
osx-64::xeus-cpp-0.1.0-h123f7b9_0.conda
osx-64::libarrow-13.0.0-h3fdeaa9_18_cpu.conda
osx-64::libarrow-12.0.1-he8dfed2_26_cpu.conda
osx-64::libarrow-11.0.0-h703c482_49_cpu.conda
osx-64::wxwidgets-3.2.4-h553ca1f_0.conda
osx-64::libopencv-4.8.1-py38hdfd1146_5.conda
osx-64::r-qpdf-1.3.2-r43hb14e8f9_4.conda
osx-64::pdal-2.6.0-h3e4393c_1.conda
osx-64::libarrow-11.0.0-h67825a0_47_cpu.conda
osx-64::openvdb-11.0.0-py39h56ec7d3_1.conda
osx-64::libadios2-2.9.2-mpi_openmpi_hced3b01_0.conda
osx-64::libadios2-2.9.2-nompi_h6988d94_100.conda
osx-64::r-harp-1.20.2-r43h3f9332a_0.conda
osx-64::protozfits-2.3.0-py39h04ceba3_2.conda
osx-64::sqlite-3.44.2-h7461747_0.conda
osx-64::cppyy-cling-6.28.0-py310h71e7e49_2.conda
osx-64::openmeeg-2.5.6-py39h1938461_5.conda
osx-64::libgdal-arrow-parquet-3.7.3-h10a006a_3.conda
osx-64::libarrow-11.0.0-h61f60c6_51_cpu.conda
osx-64::protozfits-2.3.0-py38h8f3d9be_2.conda
osx-64::heyoka-llvm-17-3.2.0-h165d30d_0.conda
osx-64::libadios2-2.9.2-nompi_hab57b9e_100.conda
osx-64::vtk-base-9.2.6-qt_py311h1234567_219.conda
osx-64::libarrow-11.0.0-h0cc9783_52_cpu.conda
osx-64::sqlite-3.44.0-h7461747_0.conda
osx-64::folly-2023.11.13.00-he8cca0d_0_jemalloc.conda
osx-64::libgdal-3.7.3-h9b6da23_4.conda
osx-64::ovito-3.9.4-h16e7d32_0.conda
osx-64::heyoka-llvm-15-3.2.0-ha5278b2_0.conda
osx-64::libadios2-2.9.2-mpi_mpich_hf6be604_1.conda
osx-64::heyoka-llvm-14-3.1.0-hcc54ee1_0.conda
osx-64::grpcio-1.59.3-py38he5c74f2_0.conda
osx-64::libgdal-arrow-parquet-3.7.3-h85ec132_8.conda
osx-64::root_base-6.28.4-py39h0769efa_2.conda
osx-64::libgdal-3.7.3-h4ba7c2c_8.conda
osx-64::gst-plugins-good-1.22.7-h14d408c_0.conda
osx-64::ffmpeg-6.1.0-gpl_h0a522cb_102.conda
osx-64::libopencv-4.8.1-py39hdcc82d0_4.conda
osx-64::aws-sdk-cpp-1.11.210-h6469584_2.conda
osx-64::aws-sdk-cpp-1.11.210-h28d282b_0.conda
osx-64::heyoka-llvm-13-3.1.0-hee71c22_0.conda
osx-64::libgdal-arrow-parquet-3.7.3-h7546dae_2.conda
osx-64::astrometry-0.94-py39h1d2c97e_5.conda
osx-64::libadios2-2.9.2-mpi_openmpi_hd11d390_0.conda
osx-64::postgresql-16.1-h413614c_0.conda
osx-64::r-harp-1.20.2-r43hce20a6b_0.conda
osx-64::libllvm15-15.0.7-hbedff68_4.conda
osx-64::libadios2-2.9.2-mpi_openmpi_hced3b01_1.conda
osx-64::libgdal-arrow-parquet-3.8.0-h2554460_2.conda
osx-64::orc-1.9.0-hd1092d7_4.conda
osx-64::pyreadstat-1.2.5-py39h5eebb3c_0.conda
osx-64::cppyy-cling-6.28.0-py38hd500f33_1.conda
osx-64::libarrow-12.0.1-h2781eaa_24_cpu.conda
osx-64::pytables-3.9.2-py310ha2b9561_0.conda
osx-64::libopencv-4.8.1-py312h989985c_5.conda
osx-64::astrometry-0.94-py39h46eed2d_5.conda
osx-64::openimageio-2.5.5.0-hcc91bea_0.conda
osx-64::libgdal-arrow-parquet-3.8.0-he5d6092_3.conda
osx-64::healpy-1.16.6-py310hd12f66c_2.conda
osx-64::libadios2-2.9.2-mpi_openmpi_hb309062_0.conda
osx-64::libgdal-3.7.3-h926149b_2.conda
osx-64::folly-2023.11.06.00-h175799c_0.conda
osx-64::pyinstaller-6.2.0-py312h67dd88c_0.conda
osx-64::libgdal-arrow-parquet-3.8.0-h8951493_6.conda
osx-64::libgdal-arrow-parquet-3.8.0-h10a006a_0.conda
osx-64::vtk-base-9.2.6-qt_py312h1234567_219.conda
osx-64::protozfits-2.3.0-py38h44ead01_4.conda
osx-64::yosys-0.35-hbd15b7a_0.conda
osx-64::ifcopenshell-v0.7.0.231127-py311_all_h505f237_201.conda
osx-64::libadios2-2.9.2-mpi_mpich_h4ca1c25_0.conda
osx-64::libgdal-arrow-parquet-3.8.0-h219e4d6_0.conda
osx-64::openbabel-3.1.1-py312h38d6ea8_9.conda
osx-64::smesh-9.9.0.0-h5d5cab2_10.conda
osx-64::healpy-1.16.6-py39h0b62560_2.conda
osx-64::gmt-6.4.0-hae0332e_16.conda
osx-64::libgdal-arrow-parquet-3.7.3-he5d6092_5.conda
osx-64::libadios2-2.9.2-mpi_mpich_hef859a5_0.conda
osx-64::libarrow-14.0.1-hcf474e5_1_cpu.conda
osx-64::gemmi-0.6.3-py311h0c2eab9_1.conda
osx-64::ffmpeg-6.1.0-lgpl_hddc4b52_3.conda
osx-64::grpcio-1.60.0-py39h512e3ab_0.conda
osx-64::nss-3.95-hfeb00ea_0.conda
osx-64::llvm-15.0.7-hed0f868_4.conda
osx-64::openmeeg-2.5.7-py311h6be8875_0.conda
osx-64::libgdal-arrow-parquet-3.8.0-h1d72150_1.conda
osx-64::ogre-14.1.2-h5c474ad_1.conda
osx-64::fltk-1.3.8-he73b29e_5.conda
osx-64::openmeeg-2.5.6-py312he074522_5.conda
osx-64::libgdal-arrow-parquet-3.7.3-h219e4d6_2.conda
osx-64::heyoka-3.2.0-h8dc0cc3_0.conda
osx-64::libarrow-13.0.0-h0cc9783_17_cpu.conda
osx-64::libboost-1.82.0-h99d8d82_6.conda
osx-64::libadios2-2.9.2-nompi_hab57b9e_101.conda
osx-64::mosh-1.4.0-pl5321h10fd14f_5.conda
osx-64::tiledb-2.18.2-h9fe0a6a_0.conda
osx-64::libgdal-3.7.3-h2f0f026_6.conda
osx-64::libarrow-14.0.0-heee2434_0_cpu.conda
osx-64::grpcio-1.59.3-py39h89aae94_0.conda
osx-64::mlir-17.0.4-he9cb26f_0.conda
osx-64::gdstk-0.9.47-py310hee09dbd_0.conda
osx-64::libglib-2.78.1-h198397b_1.conda
osx-64::llvmdev-17.0.5-h0a7b4ec_0.conda
osx-64::geant4-11.1.3-py39hdeb0af8_0.conda
osx-64::paraview-5.11.2-py38h51b3298_102_qt.conda
osx-64::ifcopenshell-v0.7.0.231127-py39_all_h0257371_201.conda
osx-64::ifcopenshell-v0.7.0.231127-py39_all_h0257371_200.conda
osx-64::libgdal-arrow-parquet-3.7.3-h9201602_7.conda
osx-64::gmsh-4.11.1-hcd5f316_6.conda
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
================================================================================
================================================================================
linux-64
linux-64::cudnn-8.8.0.121-hcdd5f01_4.conda
linux-64::libsolv-static-0.7.26-hfc55251_0.conda
linux-64::micromamba-1.5.2-0.tar.bz2
linux-64::libmlir-17.0.6-hcd5def8_0.conda
linux-64::cargo-bundle-licenses-1.3.0-h91f3281_0.conda
linux-64::lld-15.0.7-h07fd6de_2.conda
linux-64::cudnn-8.8.0.121-h264754d_4.conda
linux-64::cudnn-8.8.0.121-hd5ab71f_4.conda
linux-64::cudnn-8.8.0.121-h838ba91_4.conda
linux-64::libsolv-0.7.27-hfc55251_0.conda
linux-64::libuwebsockets-20.48.0-hfc55251_0.conda
linux-64::zimpl-3.5.3-h4c00192_4.conda
linux-64::xapian-core-1.4.24-hcd5def8_0.conda
linux-64::libmlir17-17.0.5-hcd5def8_0.conda
linux-64::tk-8.6.13-noxft_h4845f30_101.conda
linux-64::cudnn-8.8.0.121-h56904bc_4.conda
linux-64::msgpack-c-6.0.0-hfc55251_1.conda
linux-64::libsolv-0.7.26-hfc55251_0.conda
linux-64::libmlir-17.0.5-hcd5def8_0.conda
linux-64::glib-tools-2.78.1-hfc55251_0.conda
linux-64::libsqlite-3.44.0-h2797004_0.conda
linux-64::zimpl-3.5.3-h4c00192_3.conda
linux-64::libmlir17-17.0.4-hcd5def8_0.conda
linux-64::cfitsio-4.3.1-hbdc6101_0.conda
linux-64::micromamba-1.5.1-2.tar.bz2
linux-64::libsolv-static-0.7.27-hfc55251_0.conda
linux-64::glib-tools-2.78.1-hfc55251_1.conda
linux-64::libsqlite-3.44.1-h2797004_0.conda
linux-64::libmlir17-17.0.6-hcd5def8_0.conda
linux-64::healpix_cxx-3.81-hb56f678_3.conda
linux-64::liblal-7.4.1-fftw_hcb65b59_101.conda
linux-64::libsqlite-3.44.2-h2797004_0.conda
linux-64::libmlir-17.0.4-hcd5def8_0.conda
linux-64::healpix_cxx-3.81-h9b8610f_2.conda
linux-64::tk-8.6.13-xft_h2e05e87_1.conda
linux-64::micromamba-1.5.3-0.tar.bz2
-    "libzlib >=1.2.13,<1.3.0a0"
+    "libzlib >=1.2.13,<2.0.0a0"
linux-64::cppyy-cling-6.28.0-py38hcac0450_1.conda
linux-64::pygrib-2.1.5-py311hbe899fa_1.conda
linux-64::tiledb-2.17.4-hf0b6e87_0.conda
linux-64::libgdal-arrow-parquet-3.8.0-h18440b6_6.conda
linux-64::libarrow-12.0.1-hade290a_24_cuda.conda
linux-64::tiledb-2.18.2-h6041edc_0.conda
linux-64::octave-8.4.0-h6f1e783_0.conda
linux-64::heyoka-3.1.0-h9815bed_0.conda
linux-64::mapserver-8.0.1-py38h9f822c1_11.conda
linux-64::mlir-17.0.5-hcd5def8_0.conda
linux-64::cppyy-cling-6.28.0-py311h9e0f504_2.conda
linux-64::mysql-connector-python-8.0.32-py38h4bdff42_1.conda
linux-64::libtensorflow_cc-2.14.0-cuda118h87dfefd_0.conda
linux-64::tensorstore-0.1.48-py312h3c940a5_0.conda
linux-64::mapserver-8.0.1-py39hb50a332_11.conda
linux-64::heyoka-llvm-13-3.2.0-h808c64b_0.conda
linux-64::libarrow-14.0.1-heb91f6c_5_cuda.conda
linux-64::protozfits-2.3.0-py38hd14a218_3.conda
linux-64::heyoka-3.2.0-ha2fdbe8_0.conda
linux-64::libgdal-arrow-parquet-3.7.3-h59a6a47_1.conda
linux-64::heyoka-3.2.0-h685c480_0.conda
linux-64::triton-2.0.0-cuda112py311h07bde9e_2.conda
linux-64::libgdal-arrow-parquet-3.7.3-h157f77c_5.conda
linux-64::heyoka-llvm-15-3.2.0-hf315dac_0.conda
linux-64::pygrib-2.1.5-py312h7b79ca4_0.conda
linux-64::ifcopenshell-v0.7.0.231127-py310_novtk_ha271834_101.conda
linux-64::folly-2023.11.27.00-hb244bc4_0.conda
linux-64::libarrow-14.0.1-hd159f83_2_cuda.conda
linux-64::ifcopenshell-v0.7.0.231127-py311_novtk_h53defcb_100.conda
linux-64::heyoka-3.2.0-h41b9bfe_0.conda
linux-64::qt6-main-6.6.1-h24ea32f_2.conda
linux-64::r-harp-1.20.2-r43haeebca4_0.conda
linux-64::libgdal-arrow-parquet-3.7.3-h5eff638_0.conda
linux-64::libgdal-arrow-parquet-3.7.3-h8810452_7.conda
linux-64::astrometry-0.94-py39h6324e76_5.conda
linux-64::paraview-5.11.2-py38h08adb0e_102_qt.conda
linux-64::mfront-4.1.1-py312hed16063_0.conda
linux-64::tiledb-2.18.2-h8c794c1_0.conda
linux-64::mapserver-8.0.1-py39hb50a332_12.conda
linux-64::openimageio-2.5.5.0-hd0444c6_0.conda
linux-64::libgdal-arrow-parquet-3.8.0-had43d55_5.conda
linux-64::mold-2.4.0-h76aa41c_0.conda
linux-64::libmed-4.1.1-py38h714916e_0.conda
linux-64::lld-17.0.5-hcfcaf08_0.conda
linux-64::pyhdf-0.11.3-py39h11475f6_2.conda
linux-64::libglib-2.78.1-h783c2da_1.conda
linux-64::libgdal-arrow-parquet-3.7.3-h057942d_6.conda
linux-64::ffmpeg-6.1.0-lgpl_h368fdf2_0.conda
linux-64::libarrow-11.0.0-h69b4da3_50_cuda.conda
linux-64::ffmpeg-6.1.0-lgpl_he367c51_2.conda
linux-64::mysql-connector-python-8.0.32-py310h6eefaca_1.conda
linux-64::libgdal-arrow-parquet-3.7.3-hb9fe22c_8.conda
linux-64::pyhdf-0.11.3-py310h947be00_2.conda
linux-64::qt-webengine-5.15.8-h75ea521_4.conda
linux-64::gmt-5.4.5-h8e80c7a_32.conda
linux-64::python-igraph-0.11.3-py39h692aa6f_0.conda
linux-64::llvm-tools-16.0.6-hb3ce162_3.conda
linux-64::pyreadstat-1.2.5-py311hdcc4c9d_0.conda
linux-64::libgdal-arrow-parquet-3.8.0-h157f77c_5.conda
linux-64::mdsplus-7.139.60-py39pl5321h0371e64_0.conda
linux-64::libopencv-4.8.1-py311h88b5293_5.conda
linux-64::libgdal-3.8.0-h0a992f2_1.conda
linux-64::aws-sdk-cpp-1.11.182-h2b8e6fb_4.conda
linux-64::libgdal-arrow-parquet-3.8.0-h5c7879d_1.conda
linux-64::triton-2.0.0-cuda112py310hb224420_3.conda
linux-64::libarrow-10.0.1-ha609df8_57_cuda.conda
linux-64::libopencv-4.8.1-py39h72824ba_5.conda
linux-64::libgdal-arrow-parquet-3.7.3-h18440b6_7.conda
linux-64::mdsplus-7.139.60-py38pl5321h686a8d3_0.conda
linux-64::healpy-1.16.6-py312h9252315_2.conda
linux-64::libopencv-4.8.1-py39hf605482_5.conda
linux-64::qt6-main-6.6.1-h3af85ea_0.conda
linux-64::libxml2-2.12.0-h232c23b_0.conda
linux-64::libgdal-arrow-parquet-3.8.0-h80025c2_6.conda
linux-64::protozfits-2.3.0-py39hcab481d_2.conda
linux-64::ifcopenshell-v0.7.0.231127-py39_novtk_hddb3d3d_100.conda
linux-64::libopencv-4.8.1-py311h60c0964_4.conda
linux-64::libgit2-1.7.1-h76de150_1.conda
linux-64::topologytoolkit-1.2.0-no_paraview_py38h3819e9f_102.conda
linux-64::paraview-5.11.2-py38h2c98a16_102_qt.conda
linux-64::graphviz-9.0.0-h28d9a01_0.conda
linux-64::cppyy-cling-6.28.0-py38hbb0cdd4_2.conda
linux-64::libtiledb-sql-0.26.0-hfc67c98_0.conda
linux-64::pyhdf-0.11.3-py312had763d5_2.conda
linux-64::pygrib-2.1.5-py39hd80e496_1.conda
linux-64::tensorstore-0.1.44-py311h3fed34c_4.conda
linux-64::protozfits-2.3.0-py39hac66344_4.conda
linux-64::ifcopenshell-v0.7.0.231127-py311_novtk_h53defcb_101.conda
linux-64::libarrow-14.0.1-head6c0e_5_cpu.conda
linux-64::libmed-4.1.1-py39h38d59c9_0.conda
linux-64::freecad-0.21.2-py39hedf54be_1.conda
linux-64::python-igraph-0.11.3-py310h1e3ba49_0.conda
linux-64::libgdal-3.7.3-h73cd2e6_7.conda
linux-64::libgdal-arrow-parquet-3.8.0-h157f77c_3.conda
linux-64::r-harp-1.20.2-r43h5e33110_0.conda
linux-64::libadios2-2.9.2-mpi_openmpi_h11a6eb6_0.conda
linux-64::gdstk-0.9.47-py312h7b2b3ac_1.conda
linux-64::qtwebkit-5.212-habbde2c_15.conda
linux-64::libarrow-12.0.1-h475e73a_27_cpu.conda
linux-64::pygrib-2.1.5-py310h7489141_1.conda
linux-64::molgrid-0.5.2-cuda112py38h6de4d73_3.conda
linux-64::gemmi-0.6.3-py39h7d5b425_1.conda
linux-64::vtk-base-9.2.6-osmesa_py310h1234567_119.conda
linux-64::libxml2-2.11.6-h232c23b_0.conda
linux-64::libgdal-arrow-parquet-3.8.0-ha80a243_2.conda
linux-64::vtk-base-9.2.6-osmesa_py312h1234567_119.conda
linux-64::llvmdev-17.0.6-hb3ce162_1.conda
linux-64::libvips-8.15.0-h6f7f746_1.conda
linux-64::libgdal-3.8.0-he94dabd_0.conda
linux-64::ovito-3.9.3-h4da3077_0.conda
linux-64::libtiledb-sql-0.25.3-hb82b279_0.conda
linux-64::pygrib-2.1.5-py39hdbef29a_0.conda
linux-64::llvm-15.0.7-hda56bd4_4.conda
linux-64::molgrid-0.5.2-cuda118py311he904fd0_3.conda
linux-64::libxml2-2.12.1-h232c23b_0.conda
linux-64::libnghttp2-1.58.0-h47da74e_0.conda
linux-64::libarrow-10.0.1-h3b6bca8_51_cpu.conda
linux-64::cargo-c-0.9.28-h5ad674e_0.conda
linux-64::libmed-4.1.1-py311hf519941_7.conda
linux-64::tensorstore-0.1.46-py311h3fed34c_0.conda
linux-64::aws-sdk-cpp-1.11.182-h8beafcf_7.conda
linux-64::libmed-4.1.1-py312hafb6003_0.conda
linux-64::r-seqminer-9.3-r43ha661321_0.conda
linux-64::libarrow-14.0.1-he5826ec_2_cpu.conda
linux-64::libgdal-arrow-parquet-3.8.0-h157f77c_4.conda
linux-64::libarrow-14.0.1-h7b60d4f_1_cuda.conda
linux-64::libarrow-13.0.0-h497378e_15_cpu.conda
linux-64::mdsplus-7.139.59-py310pl5321hdeeefa5_0.conda
linux-64::magic-8.3.452-h9abf892_0.conda
linux-64::libadios2-2.9.2-mpi_openmpi_h4e62573_1.conda
linux-64::code-aster-16.4.13-np122py38h50f053a_0.conda
linux-64::code-aster-16.4.13-np122py39h0a41fd1_0.conda
linux-64::libarrow-12.0.1-h69b4da3_26_cuda.conda
linux-64::pygplates-0.39-py310h029075f_13.conda
linux-64::vtk-base-9.2.6-osmesa_py311h1234567_119.conda
linux-64::libarrow-11.0.0-h3adf09d_47_cuda.conda
linux-64::libgrpc-1.60.0-hd6c4280_0.conda
linux-64::libgdal-arrow-parquet-3.7.3-h057942d_5.conda
linux-64::libarrow-10.0.1-h475e73a_55_cpu.conda
linux-64::tensorstore-0.1.48-py39hfddb6fb_0.conda
linux-64::tensorflow-base-2.14.0-cpu_py311ha0be21f_0.conda
linux-64::folly-2023.11.06.00-h122a45c_0_jemalloc.conda
linux-64::sqlite-3.44.1-h2c6b66d_0.conda
linux-64::llvm-17.0.6-ha0738ec_0.conda
linux-64::libadios2-2.9.2-nompi_h19b1890_100.conda
linux-64::ifcopenshell-v0.7.0.231127-py38_novtk_hade51a7_100.conda
linux-64::libarrow-11.0.0-hd1ba8c9_50_cpu.conda
linux-64::ifcopenshell-v0.7.0.231127-py310_all_hb22bb53_201.conda
linux-64::code-aster-16.4.15-np122py38h86d5bb0_1.conda
linux-64::triton-2.0.0-cuda118py310h16cf72a_3.conda
linux-64::topologytoolkit-1.2.0-with_paraview_py39hb71ba2f_2.conda
linux-64::mapserver-8.0.1-py310h7661141_11.conda
linux-64::triton-2.0.0-cuda118py39h46dc3ef_3.conda
linux-64::postgresql-16.1-h8972f4a_0.conda
linux-64::ogre-14.1.2-h71d15da_1.conda
linux-64::gmsh-4.11.1-ha0f7e05_5.conda
linux-64::llvm-tools-17.0.6-h5cf9203_0.conda
linux-64::libopencv-4.8.1-py38hfa56d31_4.conda
linux-64::squashfuse-0.5.0-hdfefc0d_0.conda
linux-64::folly-2023.11.13.00-h122a45c_0_jemalloc.conda
linux-64::code-aster-16.4.14-np122py39h0a41fd1_0.conda
linux-64::qt6-wayland-6.6.1-h35d8138_0.conda
linux-64::gmt-6.4.0-h81c209b_17.conda
linux-64::grpcio-1.60.0-py312hb06c811_0.conda
linux-64::freecad-0.21.2-py39hcefb63d_0.conda
linux-64::libgdal-3.8.0-h0a992f2_2.conda
linux-64::libadios2-2.9.2-nompi_h32fdd87_100.conda
linux-64::triton-2.0.0-cuda118py311ha555834_3.conda
linux-64::topologytoolkit-1.2.0-with_paraview_py38hd5f6278_2.conda
linux-64::libgdal-3.8.0-h12dd931_4.conda
linux-64::libarrow-12.0.1-hf328b5a_25_cuda.conda
linux-64::nodejs-18.18.2-hb753e55_1.conda
linux-64::libgdal-3.7.3-h6f3d308_0.conda
linux-64::z5py-2.0.17-py38h81fb8a2_0.conda
linux-64::vtk-base-9.2.6-qt_py312h1234567_219.conda
linux-64::heyoka-3.1.0-h685c480_0.conda
linux-64::z5py-2.0.17-py310h1a603b2_0.conda
linux-64::pyinstaller-6.2.0-py311hdcc4c9d_0.conda
linux-64::geant4-11.1.3-py310h493036e_0.conda
linux-64::pygplates-0.39-py311hc0096d8_13.conda
linux-64::openmeeg-2.5.6-py39hb06aecf_5.conda
linux-64::libarrow-11.0.0-h70f7bdd_52_cpu.conda
linux-64::openimageio-2.5.5.0-h08355bf_0.conda
linux-64::libarrow-14.0.1-he61f9f8_0_cpu.conda
linux-64::vtk-base-9.2.6-osmesa_py39h1234567_119.conda
linux-64::r-git2r-0.33.0-r42hbae1c7c_0.conda
linux-64::katago-1.11.0-cuda112hbdf777b_2.conda
linux-64::libgdal-arrow-parquet-3.7.3-h3b6a3d7_3.conda
linux-64::astrometry-0.94-py311hcaf8216_5.conda
linux-64::libarrow-13.0.0-h3b6bca8_14_cpu.conda
linux-64::libadios2-2.9.2-mpi_openmpi_hb779c03_0.conda
linux-64::gemmi-0.6.3-py312hb06c811_1.conda
linux-64::mdtraj-1.9.9-py38h02e2b9b_1.conda
linux-64::libgdal-arrow-parquet-3.7.3-h206199c_8.conda
linux-64::mdtraj-1.9.9-py39h67e0f1a_1.conda
linux-64::folly-2023.11.27.00-hbc8c634_0_jemalloc.conda
linux-64::libmed-4.1.1-py312hafb6003_7.conda
linux-64::code-aster-16.4.15-np122py39h374fb84_1.conda
linux-64::mapserver-8.0.1-py311hf5608e7_11.conda
linux-64::openbabel-3.1.1-py310hbff9852_9.conda
linux-64::folly-2023.11.27.00-h70f49c4_0_jemalloc.conda
linux-64::paraview-5.11.2-py312hcc78c69_2_egl.conda
linux-64::folly-2023.11.20.00-h122a45c_0_jemalloc.conda
linux-64::mdtraj-1.9.9-py310h523e8d7_1.conda
linux-64::openbabel-3.1.1-py38h8a87c98_9.conda
linux-64::triton-2.0.0-cuda118py38hd773272_3.conda
linux-64::libllvm17-17.0.5-h5cf9203_0.conda
linux-64::libmed-4.1.1-py38h714916e_6.conda
linux-64::heyoka-3.2.0-h9405d29_0.conda
linux-64::libnghttp2-static-1.58.0-h6bbaf85_0.conda
linux-64::libadios2-2.9.2-mpi_mpich_h11b1e74_1.conda
linux-64::freecad-0.21.2-py311ha41fe9f_1.conda
linux-64::protozfits-2.3.0-py311h7c7e6db_4.conda
linux-64::vtk-base-9.2.6-egl_py39h1234567_19.conda
linux-64::nodejs-20.9.0-hb753e55_0.conda
linux-64::magic-8.3.451-h9abf892_0.conda
linux-64::code-aster-16.4.14-np122py39h0a41fd1_1.conda
linux-64::code-aster-16.4.14-np123py311h72fd20c_3.conda
linux-64::libgdal-arrow-parquet-3.7.3-hbfb07db_4.conda
linux-64::ifcopenshell-v0.7.0.231127-py38_novtk_hade51a7_101.conda
linux-64::mfront-4.1.1-py311he0b7bb1_0.conda
linux-64::mapserver-8.0.1-py312he9664c8_11.conda
linux-64::libllvm16-16.0.6-hb3ce162_3.conda
linux-64::libllvm15-15.0.7-hb3ce162_4.conda
linux-64::intel-cmplr-lib-rt-2024.0.0-hfc55251_49819.conda
linux-64::libarrow-11.0.0-h3b6bca8_47_cpu.conda
linux-64::pdal-2.6.1-h28c8413_0.conda
linux-64::r-harp-1.20.2-r43h684542f_0.conda
linux-64::libgdal-arrow-parquet-3.7.3-h18e1f77_6.conda
linux-64::libarrow-12.0.1-h220006d_27_cuda.conda
linux-64::molgrid-0.5.2-cuda112py39h758fafd_3.conda
linux-64::libglib-2.78.1-hebfc3b9_0.conda
linux-64::libgdal-3.7.3-h6f3d308_3.conda
linux-64::folly-2023.11.20.00-h70f49c4_0_jemalloc.conda
linux-64::gdstk-0.9.47-py39h9bdbfdd_1.conda
linux-64::folly-2023.11.06.00-h23251b7_0.conda
linux-64::ffmpeg-6.1.0-gpl_ha330e6d_102.conda
linux-64::mold-2.3.3-h76aa41c_0.conda
linux-64::libadios2-2.9.2-nompi_h52f7759_101.conda
linux-64::llvm-tools-17.0.4-h5cf9203_0.conda
linux-64::libopencv-4.8.1-py312h317aff4_4.conda
linux-64::gdstk-0.9.47-py311h75db532_1.conda
linux-64::qt6-3d-6.6.1-hf2d569e_0.conda
linux-64::tensorstore-0.1.48-py310ha94ca7a_0.conda
linux-64::libopencv-4.8.1-py312hd874328_4.conda
linux-64::harp-1.20.2-py39hf5aaa69_0.conda
linux-64::folly-2023.11.13.00-h70f49c4_0_jemalloc.conda
linux-64::protozfits-2.3.0-py310h2b20d0d_4.conda
linux-64::grpcio-1.59.3-py310h1b8f574_0.conda
linux-64::libgdal-arrow-parquet-3.8.0-had43d55_4.conda
linux-64::protozfits-2.3.0-py38hd14a218_4.conda
linux-64::libarrow-10.0.1-h9a083b4_52_cpu.conda
linux-64::r-seqminer-9.3-r42ha661321_0.conda
linux-64::paraview-5.11.2-py311h8ea275a_102_qt.conda
linux-64::xeus-cpp-0.1.0-h7e117d8_0.conda
linux-64::mfront-4.2.0-py312hed16063_0.conda
linux-64::libarrow-12.0.1-hd1ba8c9_26_cpu.conda
linux-64::fossil-2.23-h5158675_0.conda
linux-64::libboost-1.83.0-h6fcfa73_0.conda
linux-64::topologytoolkit-1.2.0-with_paraview_py312h376f846_2.conda
linux-64::libgdal-arrow-parquet-3.8.0-hd1c60d4_7.conda
linux-64::libpulsar-3.2.0-h5b2b34b_6.conda
linux-64::openvdb-11.0.0-py311h375601d_0.conda
linux-64::libarrow-11.0.0-h38938c5_52_cuda.conda
linux-64::libgdal-arrow-parquet-3.7.3-h2e77a52_4.conda
linux-64::cmake-3.27.8-hcfe8598_0.conda
linux-64::mapserver-8.0.1-py39h4301835_13.conda
linux-64::mfront-4.1.1-py39h4c763d4_0.conda
linux-64::scip-8.1.0-hb65f9cc_3.conda
linux-64::gemmi-0.6.3-py39h174d805_0.conda
linux-64::vtk-base-9.2.6-qt_py39h1234567_219.conda
linux-64::imagemagick-7.1.1_21-pl5321hdc43972_1.conda
linux-64::code-aster-16.4.14-np122py39h374fb84_4.conda
linux-64::paraview-5.11.2-py39h59a5734_2_egl.conda
linux-64::libopentelemetry-cpp-1.12.0-hb0e315f_1.conda
linux-64::heyoka-llvm-13-3.1.0-h808c64b_0.conda
linux-64::llvm-tools-17.0.6-hb3ce162_1.conda
linux-64::indexed_gzip-1.8.7-py312h0bdec57_0.conda
linux-64::libmediainfo-23.11-had58582_0.conda
linux-64::astrometry-0.94-py38h8f6c6b8_5.conda
linux-64::pyreadstat-1.2.5-py312hf0b23d7_0.conda
linux-64::mapserver-8.0.1-py311hf5608e7_12.conda
linux-64::libvips-8.15.0-h421124b_3.conda
linux-64::libpq-16.1-hfc447b1_0.conda
linux-64::harp-1.20.2-py39hdf323c3_0.conda
linux-64::libgdal-arrow-parquet-3.8.0-hbfb07db_1.conda
linux-64::ovito-3.9.4-h4da3077_0.conda
linux-64::libarrow-10.0.1-hd1ba8c9_54_cpu.conda
linux-64::pygrib-2.1.5-py38h014c87c_1.conda
linux-64::ffmpeg-6.1.0-gpl_h334edf3_100.conda
linux-64::heyoka-llvm-16-3.1.0-h4627635_0.conda
linux-64::libgdal-arrow-parquet-3.8.0-h2e77a52_1.conda
linux-64::indexed_gzip-1.8.7-py39h0fd56e7_0.conda
linux-64::libopencv-4.8.1-py312h317aff4_5.conda
linux-64::libadios2-2.9.2-mpi_mpich_h69321e2_0.conda
linux-64::gdstk-0.9.47-py39h9bdbfdd_0.conda
linux-64::libopencv-4.8.1-py310h7a6b397_4.conda
linux-64::root_base-6.28.4-py38hd3b0eb0_2.conda
linux-64::libgdal-arrow-parquet-3.7.3-h4c5366b_2.conda
linux-64::openmeeg-2.5.7-py311h68f87e4_0.conda
linux-64::libspatialite-5.1.0-h090f1da_1.conda
linux-64::libopencv-4.8.1-py39h521b4e6_5.conda
linux-64::root_base-6.28.4-py311h6c932a2_2.conda
linux-64::mapserver-8.0.1-py310hf10d0a2_13.conda
linux-64::cppyy-cling-6.28.0-py310he4601fd_1.conda
linux-64::pytables-3.9.2-py312h5531bb7_0.conda
linux-64::r-base-4.2.3-h6f1a4fa_10.conda
linux-64::gdstk-0.9.47-py310h1487c90_0.conda
linux-64::libgdal-3.8.0-h12dd931_5.conda
linux-64::molgrid-0.5.2-cuda118py39h7277d68_3.conda
linux-64::ifcopenshell-v0.7.0.231127-py311_all_h863b9b1_201.conda
linux-64::libgdal-arrow-parquet-3.8.0-h18e1f77_3.conda
linux-64::folly-2023.11.06.00-h70f49c4_0_jemalloc.conda
linux-64::sqlite-3.44.0-h2c6b66d_0.conda
linux-64::protozfits-2.3.0-py310h836f628_2.conda
linux-64::paraview-5.11.2-py39h632554d_2_egl.conda
linux-64::mdsplus-7.139.60-py311pl5321h19eab63_0.conda
linux-64::mlir-17.0.6-hcd5def8_0.conda
linux-64::heyoka-llvm-15-3.1.0-hf315dac_0.conda
linux-64::mdtraj-1.9.9-py312hadb1fa1_1.conda
linux-64::paraview-5.11.2-py310hf56b978_2_egl.conda
linux-64::folly-2023.11.06.00-h1d40f03_0.conda
linux-64::r-bigsnpr-1.12.2-r43h08d816e_0.conda
linux-64::code-aster-16.4.14-np122py310h17eec9b_4.conda
linux-64::gemmi-0.6.3-py39h174d805_1.conda
linux-64::heyoka-llvm-16-3.2.0-h4627635_0.conda
linux-64::openimageio-2.5.5.0-h4fbd174_0.conda
linux-64::libarrow-10.0.1-h3adf09d_51_cuda.conda
linux-64::paraview-5.11.2-py39hd64348f_102_qt.conda
linux-64::cppyy-cling-6.28.0-py39he37e183_1.conda
linux-64::pygrib-2.1.5-py312h7b79ca4_1.conda
linux-64::libarrow-13.0.0-h220006d_16_cuda.conda
linux-64::pygrib-2.1.5-py39hdbef29a_1.conda
linux-64::libarrow-10.0.1-hf328b5a_53_cuda.conda
linux-64::wxwidgets-3.2.4-h3856fee_1.conda
linux-64::grpcio-1.59.3-py38h94a1851_0.conda
linux-64::openmeeg-2.5.6-py311h68f87e4_5.conda
linux-64::libgdal-arrow-parquet-3.8.0-h6cca535_7.conda
linux-64::llvm-openmp-17.0.4-h4dfa4b3_0.conda
linux-64::libarrow-14.0.1-h2b6da2a_4_cpu.conda
linux-64::protozfits-2.3.0-py311h03909e9_2.conda
linux-64::libadios2-2.9.2-nompi_h52f7759_100.conda
linux-64::code-aster-16.4.15-np123py311h72fd20c_0.conda
linux-64::liblal-7.4.1-mkl_hd48b831_1.conda
linux-64::ffmpeg-6.0.1-lgpl_h368fdf2_0.conda
linux-64::libadios2-2.9.2-nompi_h32fdd87_101.conda
linux-64::libgdal-arrow-parquet-3.8.0-h206199c_7.conda
linux-64::libgdal-arrow-parquet-3.7.3-h157f77c_4.conda
linux-64::libgdal-3.7.3-h6f3d308_2.conda
linux-64::boost-cpp-1.83.0-h44aadfe_0.conda
linux-64::code-aster-16.4.14-np122py38h86d5bb0_4.conda
linux-64::openvdb-11.0.0-py312h2ec3d3a_0.conda
linux-64::libopencv-4.8.1-py39h521b4e6_4.conda
linux-64::postgresql-plpython-16.1-py312hcc5c902_0.conda
linux-64::libadios2-2.9.2-nompi_hda08243_101.conda
linux-64::libmed-4.1.1-py38h714916e_7.conda
linux-64::gemmi-0.6.3-py310h1b8f574_0.conda
linux-64::libfido2-1.14.0-h4446dcb_0.conda
linux-64::openmeeg-2.5.7-py312h78a2e80_0.conda
linux-64::llvmdev-17.0.6-h5cf9203_0.conda
linux-64::folly-2023.11.20.00-hbc8c634_0_jemalloc.conda
linux-64::tensorstore-0.1.49-py39hfddb6fb_0.conda
linux-64::libarrow-13.0.0-h3adf09d_14_cuda.conda
linux-64::heyoka-llvm-17-3.2.0-hfdec1fc_0.conda
linux-64::tensorflow-base-2.14.0-cuda118py311h0476658_0.conda
linux-64::llvm-tools-17.0.5-h5cf9203_0.conda
linux-64::libadios2-2.9.2-mpi_mpich_h69321e2_1.conda
linux-64::libgdal-3.7.3-h5cd9125_6.conda
linux-64::libtiledb-sql-0.25.4-hfc67c98_0.conda
linux-64::libgdal-arrow-parquet-3.7.3-h80025c2_7.conda
linux-64::vtk-base-9.2.6-qt_py311h1234567_219.conda
linux-64::libarrow-10.0.1-h497378e_53_cpu.conda
linux-64::libgdal-arrow-parquet-3.8.0-h2e77a52_2.conda
linux-64::tensorstore-0.1.47-py312h3c940a5_0.conda
linux-64::postgresql-plpython-16.1-py311hf60bfc6_0.conda
linux-64::pyinstaller-6.2.0-py310h93c3562_0.conda
linux-64::ifcopenshell-v0.7.0.231127-py312_novtk_he249f1c_101.conda
linux-64::katago-1.13.2-cuda112hbdf777b_0.conda
linux-64::cppyy-cling-6.28.0-py312hcf06dec_1.conda
linux-64::libopencv-4.8.1-py312hed1d938_5.conda
linux-64::r-qpdf-1.3.2-r42h072aa9e_4.conda
linux-64::z5py-2.0.17-py311hc6f357e_0.conda
linux-64::z5py-2.0.17-py39h83c0725_0.conda
linux-64::libpulsar-3.4.1-h5b2b34b_0.conda
linux-64::tensorstore-0.1.49-py311h3fed34c_0.conda
linux-64::katago-1.13.2-cpu_hf9850b2_0.conda
linux-64::libopencv-4.8.1-py39hefd7ea3_4.conda
linux-64::pdal-2.6.0-h28c8413_1.conda
linux-64::llvm-17.0.5-ha0738ec_0.conda
linux-64::libadios2-2.9.2-mpi_mpich_h741444d_1.conda
linux-64::libmed-4.1.1-py310h045128c_6.conda
linux-64::tiledb-2.18.1-h6041edc_0.conda
linux-64::openbabel-3.1.1-py39h2d01fe1_9.conda
linux-64::protozfits-2.3.0-py311h7c7e6db_3.conda
linux-64::openvdb-11.0.0-py310h8f33680_0.conda
linux-64::libgdal-arrow-parquet-3.8.0-h127ac51_2.conda
linux-64::nginx-1.25.3-h8d34ab4_1.conda
linux-64::libarrow-11.0.0-h220006d_51_cuda.conda
linux-64::libgdal-3.7.3-h5cd9125_5.conda
linux-64::paraview-5.11.2-py38hb41e3d5_2_egl.conda
linux-64::vtk-base-9.2.6-osmesa_py38h1234567_119.conda
linux-64::pygplates-0.39-py39h1117aa3_13.conda
linux-64::libarrow-11.0.0-he8e060f_53_cpu.conda
linux-64::paraview-5.11.2-py311hf3db05a_102_qt.conda
linux-64::ffmpeg-6.1.0-lgpl_h2f0d26a_3.conda
linux-64::freecad-0.21.2-py310h4d5267d_0.conda
linux-64::openvdb-11.0.0-py312h2ec3d3a_1.conda
linux-64::openvdb-11.0.0-py39h111aba7_0.conda
linux-64::libgdal-arrow-parquet-3.8.0-hc0a9ee3_0.conda
linux-64::gst-plugins-good-1.22.7-h16e77d8_0.conda
linux-64::libopencv-4.8.1-py38h51e6e3d_4.conda
linux-64::cppyy-cling-6.28.0-py310h3845668_2.conda
linux-64::scip-8.1.0-h4a32fe0_0.conda
linux-64::libadios2-2.9.2-mpi_openmpi_hb779c03_1.conda
linux-64::vtk-base-9.2.6-egl_py311h1234567_19.conda
linux-64::ffmpeg-6.1.0-lgpl_h8721587_1.conda
linux-64::openmeeg-2.5.6-py312h78a2e80_5.conda
linux-64::freecad-0.21.2-py38h2e554b3_1.conda
linux-64::code-aster-16.4.15-np122py38h86d5bb0_0.conda
linux-64::libgrpc-1.59.3-hd6c4280_0.conda
linux-64::llvmdev-17.0.4-h5cf9203_0.conda
linux-64::openimageio-2.5.5.0-h106e79d_0.conda
linux-64::libgdal-arrow-parquet-3.8.0-h33dfb32_6.conda
linux-64::libllvm17-17.0.6-h5cf9203_0.conda
linux-64::papilo-2.1.4-h7134f8c_0.conda
linux-64::katago-1.13.2-cuda118hb213047_0.conda
linux-64::paraview-5.11.2-py312h7be1c4c_102_qt.conda
linux-64::valgrind-3.22.0-hcd5def8_0.conda
linux-64::libgdal-arrow-parquet-3.7.3-had43d55_6.conda
linux-64::vtk-base-9.2.6-qt_py310h1234567_219.conda
linux-64::libtensorflow-2.14.0-cuda118h5586705_0.conda
linux-64::tiledb-2.18.2-hf0b6e87_0.conda
linux-64::indexed_gzip-1.8.7-py38h019822b_0.conda
linux-64::tensorstore-0.1.50-py311h3fed34c_0.conda
linux-64::verilator-5.018-h4f9daa6_0.conda
linux-64::cpp-opentelemetry-sdk-1.12.0-hb0e315f_1.conda
linux-64::gmt-6.4.0-h315b372_16.conda
linux-64::code-aster-16.4.14-np122py38h50f053a_0.conda
linux-64::gemmi-0.6.3-py311ha6695c7_0.conda
linux-64::mdsplus-7.139.59-py38pl5321h686a8d3_0.conda
linux-64::tensorstore-0.1.47-py39hfddb6fb_0.conda
linux-64::sqlite-3.44.2-h2c6b66d_0.conda
linux-64::molgrid-0.5.2-cuda118py38hf4428c5_3.conda
linux-64::aria2-1.37.0-h43d1f13_0.conda
linux-64::tensorstore-0.1.46-py310ha94ca7a_0.conda
linux-64::openvdb-11.0.0-py39h111aba7_1.conda
linux-64::postgresql-plpython-16.1-py39h5ae07a4_0.conda
linux-64::libgdal-arrow-parquet-3.8.0-hf82a1f9_0.conda
linux-64::tensorflow-base-2.14.0-cpu_py39h65ed569_0.conda
linux-64::heyoka-3.1.0-ha2fdbe8_0.conda
linux-64::topologytoolkit-1.2.0-no_paraview_py311h247ee1f_102.conda
linux-64::orc-1.9.2-h4b38347_0.conda
linux-64::libmed-4.1.1-py310h045128c_7.conda
linux-64::code-aster-16.4.14-np122py38h86d5bb0_3.conda
linux-64::folly-2023.11.13.00-hbc8c634_0_jemalloc.conda
linux-64::topologytoolkit-1.2.0-with_paraview_py311h198f7f7_2.conda
linux-64::libgdal-arrow-parquet-3.7.3-he4be98e_1.conda
linux-64::libgdal-arrow-parquet-3.7.3-had43d55_5.conda
linux-64::grpcio-1.60.0-py39h174d805_0.conda
linux-64::hamlib-tcl-4.5.5-h7bfae61_2.conda
linux-64::pytables-3.9.2-py311h10c7f7f_0.conda
linux-64::heyoka-llvm-14-3.2.0-h3ff117d_0.conda
linux-64::r-base-4.3.2-hb8ee39d_1.conda
linux-64::libadios2-2.9.2-mpi_openmpi_h4e62573_0.conda
linux-64::molgrid-0.5.2-cuda112py311h233712f_3.conda
linux-64::tensorstore-0.1.46-py312h3c940a5_0.conda
linux-64::libgdal-arrow-parquet-3.8.0-h057942d_3.conda
linux-64::ffmpeg-6.1.0-gpl_h17e4e02_103.conda
linux-64::libarrow-12.0.1-h70f7bdd_28_cpu.conda
linux-64::gdstk-0.9.47-py312h7b2b3ac_0.conda
linux-64::paraview-5.11.2-py39h3b6400b_102_qt.conda
linux-64::soplex-6.0.4-ha4ec6ac_4.conda
linux-64::gdstk-0.9.47-py39hc35b29e_1.conda
linux-64::postgresql-plpython-16.1-py310hd093153_0.conda
linux-64::mapserver-8.0.1-py312hc27aeb3_13.conda
linux-64::libarrow-14.0.1-h4df1b6a_3_cpu.conda
linux-64::libarrow-12.0.1-h497378e_25_cpu.conda
linux-64::libadios2-2.9.2-mpi_mpich_h6378ecc_0.conda
linux-64::tensorstore-0.1.49-py312h3c940a5_0.conda
linux-64::tiledb-2.18.1-hf0b6e87_0.conda
linux-64::nss-3.95-h1d7d5a4_0.conda
linux-64::libarrow-14.0.0-he61f9f8_0_cpu.conda
linux-64::libtensorflow_cc-2.14.0-cpu_h88ceed9_0.conda
linux-64::paraview-5.11.2-py311h6386871_2_egl.conda
linux-64::libarrow-11.0.0-hade290a_48_cuda.conda
linux-64::folly-2023.11.20.00-h23251b7_0.conda
linux-64::folly-2023.11.13.00-h1d40f03_0.conda
linux-64::libtiledb-sql-0.25.3-hfc67c98_1.conda
linux-64::freecad-0.21.2-py38h7c2e908_0.conda
linux-64::xeus-cling-0.15.3-he80cb83_2.conda
linux-64::postgresql-plpython-16.1-py38h0f07e32_0.conda
linux-64::libarrow-10.0.1-h38938c5_56_cuda.conda
linux-64::libopencv-4.8.1-py39h72824ba_4.conda
linux-64::tensorstore-0.1.47-py311h3fed34c_0.conda
linux-64::vtk-base-9.2.6-egl_py310h1234567_19.conda
linux-64::cppyy-cling-6.28.0-py39h2ea1df6_2.conda
linux-64::grpcio-1.59.3-py39h7d5b425_0.conda
linux-64::pygrib-2.1.5-py310h7489141_0.conda
linux-64::libarrow-11.0.0-hf328b5a_49_cuda.conda
linux-64::mysql-connector-python-8.0.32-py311h381d6c5_1.conda
linux-64::tensorstore-0.1.44-py38h4ddfa59_4.conda
linux-64::fish-3.6.1-hdab1d28_1.conda
linux-64::libgdal-3.7.3-h5cd9125_4.conda
linux-64::paraview-5.11.2-py310hd192d0a_102_qt.conda
linux-64::libopencv-4.8.1-py310h0450ae1_5.conda
linux-64::folly-2023.11.20.00-hb244bc4_0.conda
linux-64::protozfits-2.3.0-py38hc5390db_2.conda
linux-64::gmsh-4.11.1-h22e7e47_5.conda
linux-64::magic-8.3.430-h9abf892_0.conda
linux-64::topologytoolkit-1.2.0-no_paraview_py310hfb85a7f_102.conda
linux-64::git-2.43.0-pl5321h7bc287a_0.conda
linux-64::libarrow-14.0.1-hc43c740_4_cuda.conda
linux-64::libgdal-arrow-parquet-3.8.0-hb9fe22c_7.conda
linux-64::mdsplus-7.139.60-py310pl5321hdeeefa5_0.conda
linux-64::aws-sdk-cpp-1.11.182-h18c0b32_3.conda
linux-64::pygplates-0.39-py312h2a406de_13.conda
linux-64::freecad-0.21.2-py310ha6085e5_1.conda
linux-64::cppyy-cling-6.28.0-py312h24f76d5_2.conda
linux-64::cppyy-cling-6.28.0-py39hc26e0ff_2.conda
linux-64::ffmpeg-6.0.1-gpl_h334edf3_100.conda
linux-64::libgdal-arrow-parquet-3.7.3-he4be98e_3.conda
linux-64::harp-1.20.2-py310hcf623fa_0.conda
linux-64::grpcio-1.60.0-py310h1b8f574_0.conda
linux-64::root_base-6.28.4-py310hc86b45a_2.conda
linux-64::libadios2-2.9.2-mpi_mpich_h11b1e74_0.conda
linux-64::libarrow-12.0.1-h3b6bca8_23_cpu.conda
linux-64::papilo-2.1.4-h7134f8c_3.conda
linux-64::libarrow-12.0.1-he8e060f_29_cpu.conda
linux-64::libopencv-4.8.1-py310h6ef52b8_4.conda
linux-64::r-base-4.3.2-h93585b2_0.conda
linux-64::r-qpdf-1.3.2-r43h072aa9e_4.conda
linux-64::code-aster-16.4.14-np122py310h17eec9b_3.conda
linux-64::libgdal-arrow-parquet-3.8.0-h898b78a_0.conda
linux-64::healpy-1.16.6-py39h62d8b71_2.conda
linux-64::grpcio-1.59.3-py311ha6695c7_0.conda
linux-64::grpcio-1.60.0-py38h94a1851_0.conda
linux-64::libgdal-arrow-parquet-3.8.0-had43d55_3.conda
linux-64::libarrow-13.0.0-he8e060f_18_cpu.conda
linux-64::paraview-5.11.2-py38h96ac4c8_2_egl.conda
linux-64::pyhdk-0.9.0-py39h1234567_3_cpu.conda
linux-64::geant4-11.1.3-py38h7b0adce_0.conda
linux-64::ifcopenshell-v0.7.0.231127-py312_all_h866fb09_201.conda
linux-64::gemmi-0.6.3-py310h1b8f574_1.conda
linux-64::code-aster-16.4.15-np123py311h72fd20c_1.conda
linux-64::libarrow-12.0.1-ha609df8_29_cuda.conda
linux-64::openvdb-11.0.0-py310h8f33680_1.conda
linux-64::aws-sdk-cpp-1.11.210-h58b5321_1.conda
linux-64::r-harp-1.20.2-r43h96e6511_0.conda
linux-64::python-igraph-0.11.3-py39h9d2ad15_0.conda
linux-64::mfront-4.1.1-py310hb8c7b27_0.conda
linux-64::indexed_gzip-1.8.7-py311hb2be122_0.conda
linux-64::libarrow-14.0.1-ha7776a4_0_cuda.conda
linux-64::triton-2.0.0-cuda112py38ha44ebca_3.conda
linux-64::tensorstore-0.1.44-py39hfddb6fb_4.conda
linux-64::triton-2.0.0-cuda112py38ha44ebca_2.conda
linux-64::pyinstaller-6.2.0-py38h502143a_0.conda
linux-64::tiledb-2.18.1-h8c794c1_0.conda
linux-64::libarrow-13.0.0-h70f7bdd_17_cpu.conda
linux-64::fltk-1.3.8-hea138e6_5.conda
linux-64::pygrib-2.1.5-py311hbe899fa_0.conda
linux-64::libadios2-2.9.2-mpi_mpich_h25b007a_1.conda
linux-64::git-2.42.0-pl5321h7bc287a_1.conda
linux-64::libgdal-arrow-parquet-3.7.3-h3b6a3d7_2.conda
linux-64::libadios2-2.9.2-mpi_mpich_h25b007a_0.conda
linux-64::heyoka-llvm-17-3.1.0-hfdec1fc_0.conda
linux-64::libarrow-10.0.1-h220006d_55_cuda.conda
linux-64::libllvm17-17.0.4-h5cf9203_0.conda
linux-64::libarrow-13.0.0-hf328b5a_15_cuda.conda
linux-64::llvmdev-16.0.6-hb3ce162_3.conda
linux-64::cmake-3.27.9-hcfe8598_0.conda
linux-64::openmeeg-2.5.7-py39hb06aecf_0.conda
linux-64::llvm-tools-15.0.7-hb3ce162_4.conda
linux-64::tensorstore-0.1.50-py310ha94ca7a_0.conda
linux-64::mysql-server-8.0.33-he45e2b4_6.conda
linux-64::tensorflow-base-2.14.0-cuda118py39hbe86951_0.conda
linux-64::grpcio-1.59.3-py39h174d805_0.conda
linux-64::tiledb-2.17.4-h8c794c1_0.conda
linux-64::libgdal-arrow-parquet-3.7.3-h33dfb32_7.conda
linux-64::libtiledb-sql-0.25.4-h6641145_0.conda
linux-64::protozfits-2.3.0-py39hac66344_3.conda
linux-64::libmed-4.1.1-py39h38d59c9_7.conda
linux-64::libtiledb-sql-0.26.0-h6641145_0.conda
linux-64::harp-1.20.2-py38h100edcd_0.conda
linux-64::gemmi-0.6.3-py38h94a1851_0.conda
linux-64::heyoka-3.1.0-h41b9bfe_0.conda
linux-64::folly-2023.11.20.00-h1d40f03_0.conda
linux-64::triton-2.0.0-cuda112py39h6cf020c_2.conda
linux-64::healpy-1.16.6-py39hfac080a_2.conda
linux-64::pygplates-0.39-py38he23d81e_13.conda
linux-64::libopencv-4.8.1-py38hfa56d31_5.conda
linux-64::gdstk-0.9.47-py311h75db532_0.conda
linux-64::triton-2.0.0-cuda112py310hb224420_2.conda
linux-64::chemicalite-2022.04.1-hfb0e8fe_14.conda
linux-64::geant4-11.1.3-py39h95bdd3d_0.conda
linux-64::llvm-17.0.6-hda56bd4_1.conda
linux-64::magic-8.3.449-h9abf892_0.conda
linux-64::libmed-4.1.1-py312hafb6003_6.conda
linux-64::libadios2-2.9.2-mpi_openmpi_hbc8a4eb_1.conda
linux-64::openmeeg-2.5.6-py38h30fb522_5.conda
linux-64::ffmpeg-6.1.0-gpl_h402741f_101.conda
linux-64::triton-2.0.0-cuda112py311h07bde9e_3.conda
linux-64::llvmdev-17.0.5-h5cf9203_0.conda
linux-64::libadios2-2.9.2-nompi_hd4a9029_101.conda
linux-64::heyoka-3.2.0-h9815bed_0.conda
linux-64::tensorstore-0.1.50-py39hfddb6fb_0.conda
linux-64::mold-2.3.2-h76aa41c_0.conda
linux-64::mysql-router-8.0.33-h1922fb2_6.conda
linux-64::code-aster-16.4.14-np122py38h50f053a_1.conda
linux-64::katago-1.11.0-cpu_hf9850b2_2.conda
linux-64::vtk-base-9.2.6-egl_py312h1234567_19.conda
linux-64::libgdal-arrow-parquet-3.8.0-h18e1f77_4.conda
linux-64::folly-2023.11.27.00-h1d40f03_0.conda
linux-64::libvips-8.15.0-h24f9523_2.conda
linux-64::gmt-5.4.5-h8e80c7a_31.conda
linux-64::pyreadstat-1.2.5-py38h502143a_0.conda
linux-64::code-aster-16.4.14-np122py39h374fb84_3.conda
linux-64::mfront-4.2.0-py39h4c763d4_0.conda
linux-64::molgrid-0.5.2-cuda118py310h44a6da7_3.conda
linux-64::libgdal-arrow-parquet-3.7.3-h057942d_4.conda
linux-64::libgdal-arrow-parquet-3.7.3-he4be98e_2.conda
linux-64::code-aster-16.4.15-np122py39h374fb84_0.conda
linux-64::lld-17.0.6-hcfcaf08_0.conda
linux-64::aws-sdk-cpp-1.11.210-ha5d3ae3_2.conda
linux-64::mapserver-8.0.1-py38hda96761_13.conda
linux-64::libgdal-arrow-parquet-3.7.3-h6cca535_8.conda
linux-64::hugin-2022.0.0-pl5321ha4af170_9.conda
linux-64::fltk-1.3.8-hea138e6_4.conda
linux-64::gdstk-0.9.47-py310h1487c90_1.conda
linux-64::libarrow-14.0.0-ha7776a4_0_cuda.conda
linux-64::gemmi-0.6.3-py38h94a1851_1.conda
linux-64::libgdal-arrow-parquet-3.7.3-h4c5366b_3.conda
linux-64::code-aster-16.4.15-np122py310h17eec9b_0.conda
linux-64::rust-1.74.0-h70c747d_0.conda
linux-64::libarrow-14.0.1-h6bac98b_6_cuda.conda
linux-64::r-harp-1.20.2-r43hdeca0b6_0.conda
linux-64::libgdal-3.7.3-h11296eb_8.conda
linux-64::pyhdf-0.11.3-py311ha36aa4f_2.conda
linux-64::glib-2.78.1-hfc55251_0.conda
linux-64::hugin-base-2022.0.0-pl5321h3186ec0_9.conda
linux-64::geant4-11.1.3-py311hfd6d702_0.conda
linux-64::libllvm17-17.0.6-hb3ce162_1.conda
linux-64::tensorstore-0.1.49-py310ha94ca7a_0.conda
linux-64::magic-8.3.440-h9abf892_0.conda
linux-64::paraview-5.11.2-py310h863c149_2_egl.conda
linux-64::pytables-3.9.2-py39hfbd31a7_0.conda
linux-64::mfront-4.2.0-py311he0b7bb1_0.conda
linux-64::tensorstore-0.1.50-py312h3c940a5_0.conda
linux-64::vtk-base-9.2.6-egl_py38h1234567_19.conda
linux-64::libmed-4.1.1-py311hf519941_0.conda
linux-64::mysql-client-8.0.33-h545f5f4_6.conda
linux-64::libopencv-4.8.1-py38hf950233_5.conda
linux-64::git-annex-10.20230626-alldep_h9c70df9_101.conda
linux-64::poppler-23.11.0-h590f24d_0.conda
linux-64::libgdal-arrow-parquet-3.7.3-h18e1f77_5.conda
linux-64::cppyy-cling-6.28.0-py39h5238f5c_1.conda
linux-64::libarrow-13.0.0-h475e73a_16_cpu.conda
linux-64::mdsplus-7.139.59-py311pl5321h19eab63_0.conda
linux-64::gst-plugins-base-1.22.7-h8e1006c_0.conda
linux-64::python-igraph-0.11.3-py311h535dc8a_0.conda
linux-64::openimageio-2.5.5.0-hd8ff6c2_0.conda
linux-64::code-aster-16.4.14-np123py311h72fd20c_4.conda
linux-64::libgdal-arrow-parquet-3.8.0-h8810452_6.conda
linux-64::libadios2-2.9.2-nompi_h19b1890_101.conda
linux-64::libopencv-4.8.1-py310h6ef52b8_5.conda
linux-64::graphviz-9.0.0-h78e8752_1.conda
linux-64::gdstk-0.9.47-py38hab45c01_0.conda
linux-64::libarrow-11.0.0-h497378e_49_cpu.conda
linux-64::pyhdk-0.9.0-py311h1234567_3_cpu.conda
linux-64::wxwidgets-3.2.4-h2791fda_0.conda
linux-64::grpcio-1.59.3-py312hb06c811_0.conda
linux-64::code-aster-16.4.9-np122py39h0a41fd1_0.conda
linux-64::capnproto-1.0.1.1-hfc55251_0.conda
linux-64::mosh-1.4.0-pl5321h2f1bd5e_5.conda
linux-64::mapserver-8.0.1-py38h9f822c1_12.conda
linux-64::smesh-9.9.0.0-hfa235d1_10.conda
linux-64::libarrow-12.0.1-h38938c5_28_cuda.conda
linux-64::folly-2023.11.06.00-hbc8c634_0_jemalloc.conda
linux-64::gemmi-0.6.3-py39h7d5b425_0.conda
linux-64::minizip-4.0.3-h0ab5242_0.conda
linux-64::tensorflow-base-2.14.0-cpu_py310h3c6a6a6_0.conda
linux-64::libadios2-2.9.2-mpi_mpich_h6378ecc_1.conda
linux-64::root_base-6.28.4-py39h6812393_2.conda
linux-64::code-aster-16.4.15-np122py310h17eec9b_1.conda
linux-64::llvm-openmp-17.0.5-h4dfa4b3_0.conda
linux-64::tensorstore-0.1.44-py312h3c940a5_4.conda
linux-64::libopencv-4.8.1-py39hd1efb47_5.conda
linux-64::libmed-4.1.1-py39h38d59c9_6.conda
linux-64::llvm-openmp-17.0.6-h4dfa4b3_0.conda
linux-64::libgdal-arrow-parquet-3.8.0-h127ac51_1.conda
linux-64::gmsh-4.11.1-h6b98cf8_6.conda
linux-64::vtk-base-9.2.6-qt_py38h1234567_219.conda
linux-64::libarrow-12.0.1-h9a083b4_24_cpu.conda
linux-64::python-igraph-0.11.3-py312h3274b17_0.conda
linux-64::tensorstore-0.1.47-py310ha94ca7a_0.conda
linux-64::libarrow-10.0.1-h69b4da3_54_cuda.conda
linux-64::pytables-3.9.2-py310h374b01c_0.conda
linux-64::llvm-17.0.4-ha0738ec_0.conda
linux-64::openmeeg-2.5.6-py310h358aeea_5.conda
linux-64::r-bigsnpr-1.12.2-r42h08d816e_0.conda
linux-64::folly-2023.11.13.00-hb244bc4_0.conda
linux-64::pytables-3.9.2-py39h783497a_0.conda
linux-64::libadios2-2.9.2-nompi_hd4a9029_100.conda
linux-64::folly-2023.11.27.00-h122a45c_0_jemalloc.conda
linux-64::openmeeg-2.5.7-py39hf085c23_0.conda
linux-64::qt6-wayland-6.6.0-h35d8138_0.conda
linux-64::libgdal-arrow-parquet-3.8.0-h057942d_4.conda
linux-64::libtiledb-sql-0.25.3-h6641145_1.conda
linux-64::aws-sdk-cpp-1.11.210-h6d06844_3.conda
linux-64::mysql-connector-python-8.0.32-py39h43026c6_1.conda
linux-64::ogre-1.10.12-hb5e08f3_16.conda
linux-64::libspral-2023.09.07-h2baf039_0.conda
linux-64::openvdb-11.0.0-py311h375601d_1.conda
linux-64::mapserver-8.0.1-py312he9664c8_12.conda
linux-64::dpcpp_impl_linux-64-2024.0.0-hd6dfaa8_49819.conda
linux-64::libgdal-arrow-parquet-3.7.3-h59a6a47_3.conda
linux-64::pyreadstat-1.2.5-py39hb6545a3_0.conda
linux-64::topologytoolkit-1.2.0-no_paraview_py312h35a6db4_102.conda
linux-64::topologytoolkit-1.2.0-no_paraview_py39haf617d6_102.conda
linux-64::healpy-1.16.6-py311h927b5fe_2.conda
linux-64::molgrid-0.5.2-cuda112py310h1e29e08_3.conda
linux-64::llvmdev-15.0.7-hb3ce162_4.conda
linux-64::libgdal-arrow-parquet-3.8.0-h057942d_5.conda
linux-64::libarrow-14.0.1-hbcb3189_3_cuda.conda
linux-64::libgdal-arrow-parquet-3.8.0-h18e1f77_5.conda
linux-64::libadios2-2.9.2-nompi_hda08243_100.conda
linux-64::intel-opencl-rt-2024.0.0-heb1d2f6_49819.conda
linux-64::libgdal-3.8.0-he7dcfe9_6.conda
linux-64::libgdal-arrow-parquet-3.7.3-hce71fa8_4.conda
linux-64::ifcopenshell-v0.7.0.231127-py38_all_h98e66d8_201.conda
linux-64::libopencv-4.8.1-py311h88b5293_4.conda
linux-64::libarrow-10.0.1-hade290a_52_cuda.conda
linux-64::mfront-4.2.0-py310hb8c7b27_0.conda
linux-64::libgdal-arrow-parquet-3.7.3-h4c5366b_1.conda
linux-64::mysql-libs-8.0.33-hca2cd23_6.conda
linux-64::libarrow-12.0.1-hecbb4c5_22_cpu.conda
linux-64::ifcopenshell-v0.7.0.231127-py39_novtk_hddb3d3d_101.conda
linux-64::tiledb-2.17.4-h6041edc_0.conda
linux-64::paraview-5.11.2-py311h0124b57_2_egl.conda
linux-64::libmatio-1.5.26-h31675a7_0.conda
linux-64::openbabel-3.1.1-py311h8b422cb_9.conda
linux-64::gemmi-0.6.3-py311ha6695c7_1.conda
linux-64::protozfits-2.3.0-py310h2b20d0d_3.conda
linux-64::libgdal-arrow-parquet-3.8.0-ha8290e9_0.conda
linux-64::openbabel-3.1.1-py312hbfe4552_9.conda
linux-64::libgdal-arrow-parquet-3.7.3-h157f77c_6.conda
linux-64::grpcio-1.60.0-py311ha6695c7_0.conda
linux-64::libadios2-2.9.2-mpi_openmpi_h4c4a84b_1.conda
linux-64::lld-17.0.4-hcfcaf08_0.conda
linux-64::tensorstore-0.1.44-py310ha94ca7a_4.conda
linux-64::libgdal-3.8.0-h12dd931_3.conda
linux-64::nco-5.1.9-h00920e0_0.conda
linux-64::libarrow-10.0.1-he8e060f_57_cpu.conda
linux-64::code-aster-16.4.9-np122py38h50f053a_0.conda
linux-64::folly-2023.11.27.00-h23251b7_0.conda
linux-64::pygrib-2.1.5-py38h014c87c_0.conda
linux-64::folly-2023.11.06.00-hb244bc4_0.conda
linux-64::folly-2023.11.13.00-h23251b7_0.conda
linux-64::mysql-connector-python-8.0.32-py39habddd97_1.conda
linux-64::libarrow-13.0.0-h38938c5_17_cuda.conda
linux-64::libadios2-2.9.2-mpi_mpich_h741444d_0.conda
linux-64::pyhdf-0.11.3-py38h3d0ad98_2.conda
linux-64::libadios2-2.9.2-mpi_openmpi_h11a6eb6_1.conda
linux-64::ifcopenshell-v0.7.0.231127-py39_all_h9e24565_201.conda
linux-64::libgsf-1.14.51-heb02ada_0.conda
linux-64::katago-1.11.0-cuda118hb213047_2.conda
linux-64::python-igraph-0.11.3-py38h39ef94c_0.conda
linux-64::texlive-core-20230313-hb36701e_8.conda
linux-64::libarrow-12.0.1-h3adf09d_23_cuda.conda
linux-64::pyhdk-0.9.0-py310h1234567_3_cpu.conda
linux-64::pyhdf-0.11.3-py39hba72f14_2.conda
linux-64::scip-8.1.0-hb65f9cc_4.conda
linux-64::libgdal-arrow-parquet-3.7.3-h5c7879d_4.conda
linux-64::libgdal-arrow-parquet-3.7.3-h59a6a47_2.conda
linux-64::libarrow-13.0.0-ha609df8_18_cuda.conda
linux-64::tensorstore-0.1.46-py39hfddb6fb_0.conda
linux-64::grpcio-1.60.0-py39h7d5b425_0.conda
linux-64::tensorflow-base-2.14.0-cuda118py310h2e5981e_0.conda
linux-64::glib-2.78.1-hfc55251_1.conda
linux-64::mfront-4.2.0-py38h42ccf06_0.conda
linux-64::libopencv-4.8.1-py311h1c4e2e0_5.conda
linux-64::libspatialite-5.1.0-h72606ae_3.conda
linux-64::paraview-5.11.2-py312h35894a9_2_egl.conda
linux-64::libarrow-11.0.0-h9a083b4_48_cpu.conda
linux-64::libmed-4.1.1-py310h045128c_0.conda
linux-64::libtensorflow-2.14.0-cpu_h2e87cff_0.conda
linux-64::libarrow-14.0.1-h0406937_1_cpu.conda
linux-64::r-git2r-0.33.0-r43hbae1c7c_0.conda
linux-64::mdsplus-7.139.59-py39pl5321h0371e64_0.conda
linux-64::libadios2-2.9.2-mpi_openmpi_h4c4a84b_0.conda
linux-64::healpy-1.16.6-py310h510b526_2.conda
linux-64::xeus-cpp-0.0.1-h7e117d8_3.conda
linux-64::mapserver-8.0.1-py311h1171653_13.conda
linux-64::libarrow-14.0.1-hcf43810_6_cpu.conda
linux-64::aws-sdk-cpp-1.11.182-h8df25a1_5.conda
linux-64::pyhdk-0.9.0-py38h1234567_3_cpu.conda
linux-64::aws-sdk-cpp-1.11.210-h8beafcf_0.conda
linux-64::magic-8.3.450-h9abf892_0.conda
linux-64::libopencv-4.8.1-py39h2bd86eb_4.conda
linux-64::openvdb-11.0.0-py39hcb02c1f_1.conda
linux-64::libvips-8.15.0-h37fe420_0.conda
linux-64::aws-sdk-cpp-1.11.182-h771f7cb_6.conda
linux-64::mlir-17.0.4-hcd5def8_0.conda
linux-64::libspatialite-5.1.0-h7385560_2.conda
linux-64::libarrow-11.0.0-h475e73a_51_cpu.conda
linux-64::libgdal-arrow-parquet-3.7.3-h3b6a3d7_1.conda
linux-64::openmeeg-2.5.7-py310h358aeea_0.conda
linux-64::paraview-5.11.2-py312h3d7dba6_102_qt.conda
linux-64::libarrow-10.0.1-h70f7bdd_56_cpu.conda
linux-64::libgdal-arrow-parquet-3.7.3-hd1c60d4_8.conda
linux-64::harp-1.20.2-py311h3638109_0.conda
linux-64::llvm-16.0.6-hda56bd4_3.conda
linux-64::orc-1.9.0-h4b38347_4.conda
linux-64::pyreadstat-1.2.5-py310h93c3562_0.conda
linux-64::libgdal-arrow-parquet-3.7.3-h127ac51_4.conda
linux-64::libgdal-3.8.0-h4d9a814_7.conda
linux-64::libtiledb-sql-0.25.3-hc3826aa_0.conda
linux-64::gdstk-0.9.47-py39hc35b29e_0.conda
linux-64::tensorstore-0.1.48-py311h3fed34c_0.conda
linux-64::heyoka-3.1.0-h9405d29_0.conda
linux-64::astrometry-0.94-py310h5ea1a38_5.conda
linux-64::libgdal-arrow-parquet-3.7.3-had43d55_4.conda
linux-64::libarrow-11.0.0-ha609df8_53_cuda.conda
linux-64::freecad-0.21.2-py311hed0c1fb_0.conda
linux-64::gmsh-4.11.1-h17d5aaa_6.conda
linux-64::libpano13-2.9.20rc2-pl5321hfc037ee_7.conda
linux-64::protozfits-2.3.0-py312hf56cf3d_4.conda
linux-64::wgrib2-3.1.3-h8965f03_0.conda
linux-64::indexed_gzip-1.8.7-py310h7d11597_0.conda
linux-64::libmed-4.1.1-py311hf519941_6.conda
linux-64::mapserver-8.0.1-py310h7661141_12.conda
linux-64::nceplibs-g2c-1.8.0-h9d508b3_4.conda
linux-64::heyoka-llvm-14-3.1.0-h3ff117d_0.conda
linux-64::triton-2.0.0-cuda112py39h6cf020c_3.conda
linux-64::openvdb-11.0.0-py39hcb02c1f_0.conda
linux-64::cppyy-cling-6.28.0-py311h9cdf4a6_1.conda
linux-64::pyinstaller-6.2.0-py39hb6545a3_0.conda
linux-64::libgdal-arrow-parquet-3.8.0-h5c7879d_2.conda
linux-64::libadios2-2.9.2-mpi_openmpi_hbc8a4eb_0.conda
linux-64::astrometry-0.94-py39h33f06bc_5.conda
linux-64::gdstk-0.9.47-py38hab45c01_1.conda
linux-64::libarrow-12.0.1-h4ed642f_22_cuda.conda
linux-64::yosys-0.35-h3ec9cbf_0.conda
linux-64::libgdal-3.7.3-he5b8fdc_4.conda
linux-64::pyinstaller-6.2.0-py312hf0b23d7_0.conda
linux-64::soplex-6.0.4-ha4ec6ac_3.conda
linux-64::topologytoolkit-1.2.0-with_paraview_py310ha71f976_2.conda
linux-64::openmeeg-2.5.6-py39hf085c23_5.conda
linux-64::ifcopenshell-v0.7.0.231127-py310_novtk_ha271834_100.conda
linux-64::pygrib-2.1.5-py39hd80e496_0.conda
linux-64::mfront-4.1.1-py38h42ccf06_0.conda
linux-64::mdtraj-1.9.9-py311h90fe790_1.conda
linux-64::paraview-5.11.2-py310h542d176_102_qt.conda
linux-64::openmeeg-2.5.7-py38h30fb522_0.conda
linux-64::ogre-14.1.2-h1ab86f5_1.conda
linux-64::papilo-2.1.4-h7134f8c_4.conda
linux-64::libgdal-3.7.3-h6f3d308_1.conda
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
```

</details>