### PR TITLE
loosen zlib-pin to major level (8/N; October 2023)

### DIFF
--- a/recipe/patch_yaml/zlib.yaml
+++ b/recipe/patch_yaml/zlib.yaml
@@ -1,8 +1,8 @@
 # zlib was pinning to minor level, but 1.2 is compatible with 1.3
 if:
   has_depends: libzlib >=1.2*
-  timestamp_ge: 1714521600000  # 2024-05-01 00:00 UTC
   timestamp_lt: 1717200000000  # 2024-06-01 00:00 UTC
+  timestamp_ge: 1714521600000  # 2024-05-01 00:00 UTC
 then:
   - loosen_depends:
       name: libzlib
@@ -10,8 +10,8 @@ then:
 ---
 if:
   has_depends: libzlib >=1.2*
-  timestamp_ge: 1711929600000  # 2024-04-01 00:00 UTC
   timestamp_lt: 1714521600000  # 2024-05-01 00:00 UTC
+  timestamp_ge: 1711929600000  # 2024-04-01 00:00 UTC
 then:
   - loosen_depends:
       name: libzlib
@@ -19,8 +19,8 @@ then:
 ---
 if:
   has_depends: libzlib >=1.2*
-  timestamp_ge: 1709251200000  # 2024-03-01 00:00 UTC
   timestamp_lt: 1711929600000  # 2024-04-01 00:00 UTC
+  timestamp_ge: 1709251200000  # 2024-03-01 00:00 UTC
 then:
   - loosen_depends:
       name: libzlib
@@ -57,6 +57,15 @@ if:
   has_depends: libzlib >=1.2*
   timestamp_lt: 1701388800000  # 2023-12-01 00:00 UTC
   timestamp_ge: 1698796800000  # 2023-11-01 00:00 UTC
+then:
+  - loosen_depends:
+      name: libzlib
+      upper_bound: "2"
+---
+if:
+  has_depends: libzlib >=1.2*
+  timestamp_lt: 1698796800000  # 2023-11-01 00:00 UTC
+  timestamp_ge: 1696118400000  # 2023-10-01 00:00 UTC
 then:
   - loosen_depends:
       name: libzlib


### PR DESCRIPTION
Follow-up to https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/739, about 5200 artefacts affected.

### Result of `python show_diff.py`

<details>

```diff
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
linux-ppc64le
linux-ppc64le::libprotobuf-static-4.24.4-h9ce2175_0.conda
linux-ppc64le::minizip-1.2-hff1ad0c_1.conda
linux-ppc64le::libmlir17-17.0.2-hae84d68_0.conda
linux-ppc64le::libmlir17-17.0.3-hae84d68_0.conda
linux-ppc64le::micromamba-1.5.0-2.tar.bz2
linux-ppc64le::heaptrack-1.2.0-h8b59792_4.conda
linux-ppc64le::libmlir-17.0.3-hae84d68_0.conda
linux-ppc64le::libprotobuf-4.24.4-h9ce2175_0.conda
linux-ppc64le::micromamba-1.5.1-1.tar.bz2
linux-ppc64le::minizip-1.2-hff1ad0c_2.conda
linux-ppc64le::libmlir-17.0.2-hae84d68_0.conda
linux-ppc64le::minizip-1.2-hff1ad0c_0.conda
linux-ppc64le::msgpack-cxx-6.1.0-h940a808_1.conda
linux-ppc64le::libsqlite-3.43.2-hd4bbf49_0.conda
linux-ppc64le::libprotobuf-4.24.3-h9ce2175_1.conda
linux-ppc64le::libprotobuf-static-4.24.3-h9ce2175_1.conda
linux-ppc64le::pigz-2.8-hd4bbf49_0.conda
linux-ppc64le::micromamba-1.5.0-3.tar.bz2
linux-ppc64le::liblal-7.4.1-fftw_hb2f3d55_100.conda
-    "libzlib >=1.2.13,<1.3.0a0"
+    "libzlib >=1.2.13,<2.0.0a0"
linux-ppc64le::uwsgi-2.0.22-py310h54989dc_0.conda
linux-ppc64le::libadios2-2.9.1-nompi_ha8a2491_104.conda
linux-ppc64le::ogre-14.1.1-h2ec09fa_0.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-h153dd9e_41.conda
linux-ppc64le::aws-sdk-cpp-1.10.57-hd0881c2_24.conda
linux-ppc64le::r-harp-1.20-py310r43hfd510e7_1.conda
linux-ppc64le::folly-2023.09.25.00-ha2e2e2a_1.conda
linux-ppc64le::imagemagick-7.1.1_19-pl5321hea77106_0.conda
linux-ppc64le::libarrow-11.0.0-h4279b5a_43_cuda.conda
linux-ppc64le::openjdk-17.0.9-h88a5b0c_0.conda
linux-ppc64le::vtk-base-9.2.6-qt_py38h1234567_218.conda
linux-ppc64le::texlive-core-20230313-hf5ee659_6.conda
linux-ppc64le::omniorb-libs-4.3.1-h64e73a3_2.conda
linux-ppc64le::folly-2023.10.23.00-hcb6a8eb_0_jemalloc.conda
linux-ppc64le::folly-2023.09.25.00-h7cedaab_1.conda
linux-ppc64le::libarrow-11.0.0-hd911c6c_40_cpu.conda
linux-ppc64le::folly-2023.10.09.00-hfba947f_0.conda
linux-ppc64le::pyreadstat-1.2.3-py311he2df201_1.conda
linux-ppc64le::openimageio-2.4.16.0-hb327d11_0.conda
linux-ppc64le::libadios2-2.9.1-nompi_h1520396_104.conda
linux-ppc64le::vowpalwabbit-9.9.0-py311h2d91192_1.conda
linux-ppc64le::folly-2023.10.16.00-hfba947f_0.conda
linux-ppc64le::libgrpc-1.57.0-h6f946ae_2.conda
linux-ppc64le::uwsgi-2.0.22-py39hf4939ad_0.conda
linux-ppc64le::assimp-5.3.1-hd1f22cc_2.conda
linux-ppc64le::r-harp-1.20-py311r43h8a84315_1.conda
linux-ppc64le::ffmpeg-5.1.2-lgpl_h6a8ed3c_12.conda
linux-ppc64le::libopencv-4.8.1-py310hc5350b9_2.conda
linux-ppc64le::vigra-1.11.2-py38hc6dbad1_3.conda
linux-ppc64le::uwsgi-2.0.22-py312h61d3571_2.conda
linux-ppc64le::vigra-1.11.2-py39h9e8839c_1.conda
linux-ppc64le::vowpalwabbit-9.9.0-py39hcb48f23_2.conda
linux-ppc64le::harp-1.20-py311h057db71_1.conda
linux-ppc64le::libadios2-2.9.1-nompi_ha8a2491_103.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-h80010d5_38.conda
linux-ppc64le::folly-2023.10.02.00-ha2e2e2a_0.conda
linux-ppc64le::openpmd-api-0.15.2-nompi_py39hd3ca6be_102.conda
linux-ppc64le::vtk-base-9.2.6-qt_py39h1234567_218.conda
linux-ppc64le::wxwidgets-3.2.3-h78d0b3a_0.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-h1fbd0d1_39.conda
linux-ppc64le::aws-sdk-cpp-1.11.182-h2f2cd1f_2.conda
linux-ppc64le::libarrow-13.0.0-h4279b5a_9_cuda.conda
linux-ppc64le::openpmd-api-0.15.2-mpi_openmpi_py310h80afca9_2.conda
linux-ppc64le::ffmpeg-4.4.2-lgpl_h8915e98_13.conda
linux-ppc64le::uwsgi-2.0.22-py39hafd096c_2.conda
linux-ppc64le::openimageio-2.5.4.0-py38h1743087_1.conda
linux-ppc64le::rust-1.73.0-hb12b0c0_2.conda
linux-ppc64le::folly-2023.10.23.00-ha2e2e2a_0.conda
linux-ppc64le::harp-1.20.1-py39he3f3676_0.conda
linux-ppc64le::netcdf4-1.6.5-nompi_py312h7d9bdac_100.conda
linux-ppc64le::libarrow-10.0.1-ha3503e9_46_cuda.conda
linux-ppc64le::libadios2-2.9.1-mpi_mpich_h71aec2e_3.conda
linux-ppc64le::libgdal-3.6.4-hd1abc68_20.conda
linux-ppc64le::grpcio-1.58.1-py39h27cb1e9_1.conda
linux-ppc64le::libgrpc-1.59.1-h1ecfef9_0.conda
linux-ppc64le::openimageio-2.5.4.0-py39h6a8fdfd_1.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-h25bfa33_41.conda
linux-ppc64le::vigra-1.11.2-py38he7552fe_2.conda
linux-ppc64le::libopencv-4.8.1-py39h2a3f629_1.conda
linux-ppc64le::python-igraph-0.11.2-py39h2528f8b_1.conda
linux-ppc64le::pyinstaller-6.1.0-py39hf0cda86_0.conda
linux-ppc64le::vtk-base-9.2.6-qt_py38h1234567_215.conda
linux-ppc64le::libgdal-arrow-parquet-3.6.4-h8bacceb_20.conda
linux-ppc64le::harp-1.20-py38he3f3676_1.conda
linux-ppc64le::grpcio-1.57.0-py312h930df82_2.conda
linux-ppc64le::vowpalwabbit-9.9.0-py311h2d91192_2.conda
linux-ppc64le::python-3.10.13-h4005451_0_cpython.conda
linux-ppc64le::ale-py-0.8.1-py312hd0d26aa_1.conda
linux-ppc64le::grpcio-1.57.1-py310h8eb8f48_0.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-h932c2cf_40.conda
linux-ppc64le::libarrow-12.0.1-ha3503e9_17_cuda.conda
linux-ppc64le::ogre-14.1.0-h2ec09fa_2.conda
linux-ppc64le::tiledb-2.17.3-hd5af256_1.conda
linux-ppc64le::boost-cpp-1.82.0-h1102270_4.conda
linux-ppc64le::libarrow-13.0.0-h1967950_13_cuda.conda
linux-ppc64le::libarrow-13.0.0-h2c63c72_7_cpu.conda
linux-ppc64le::folly-2023.10.23.00-h7cedaab_0.conda
linux-ppc64le::libarrow-10.0.1-h2c63c72_45_cpu.conda
linux-ppc64le::mysql-libs-8.0.33-h3ac40eb_5.conda
linux-ppc64le::netcdf4-1.6.5-mpi_mpich_py38hd340d46_0.conda
linux-ppc64le::pyreadstat-1.2.3-py312ha5a3bab_1.conda
linux-ppc64le::lld-17.0.2-he12c2f4_0.conda
linux-ppc64le::python-igraph-0.11.2-py39h085bd8d_1.conda
linux-ppc64le::openpmd-api-0.15.2-mpi_mpich_py39hf5aa837_2.conda
linux-ppc64le::imagecodecs-2023.9.18-py311ha490864_1.conda
linux-ppc64le::libopentelemetry-cpp-1.11.0-hf57dd51_2.conda
linux-ppc64le::grpcio-1.57.0-py39h278787b_2.conda
linux-ppc64le::vigra-1.11.2-py39hdab3d78_1.conda
linux-ppc64le::netcdf4-1.6.5-mpi_openmpi_py39hd0890ac_0.conda
linux-ppc64le::minizip-static-1.2-hff1ad0c_2.conda
linux-ppc64le::libboost-1.82.0-hfdd0173_6.conda
linux-ppc64le::vigra-1.11.2-py310h10b0627_2.conda
linux-ppc64le::healpy-1.16.6-py39h5937c45_0.conda
linux-ppc64le::uwsgi-2.0.22-py39hafd096c_3.conda
linux-ppc64le::python-igraph-0.11.2-py310hd47e8ce_0.conda
linux-ppc64le::llvm-tools-17.0.3-h8d57982_1.conda
linux-ppc64le::leptonica-1.83.1-he9446d5_4.conda
linux-ppc64le::hamlib-tcl-4.5.5-hd4bbf49_1.conda
linux-ppc64le::libarrow-13.0.0-he90d24d_10_cuda.conda
linux-ppc64le::minizip-4.0.1-ha7cce9c_5.conda
linux-ppc64le::pygrib-2.1.4-py310hd03383d_8.conda
linux-ppc64le::tiledb-2.17.2-hd5af256_0.conda
linux-ppc64le::libadios2-2.9.1-mpi_openmpi_h788cb01_4.conda
linux-ppc64le::pytng-0.3.1-py39h955bb5e_0.conda
linux-ppc64le::libarrow-11.0.0-h1967950_46_cuda.conda
linux-ppc64le::grpcio-1.57.0-py39h278787b_3.conda
linux-ppc64le::libarrow-13.0.0-ha3503e9_8_cuda.conda
linux-ppc64le::vowpalwabbit-9.9.0-py310he0826b2_1.conda
linux-ppc64le::libbrial-1.2.12-h284c7cb_1.conda
linux-ppc64le::libopencv-4.8.1-py38h9ac54da_1.conda
linux-ppc64le::openpmd-api-0.15.2-mpi_openmpi_py38h51eaa99_2.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-h7ee3c24_40.conda
linux-ppc64le::gst-plugins-base-1.22.6-he115d4a_2.conda
linux-ppc64le::libarrow-11.0.0-h7f4e557_40_cuda.conda
linux-ppc64le::openimageio-2.4.16.0-h90c2320_0.conda
linux-ppc64le::uwsgi-2.0.22-py310h7bd0854_3.conda
linux-ppc64le::netcdf4-1.6.5-mpi_openmpi_py310hd51dc40_0.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-h270f272_41.conda
linux-ppc64le::libarrow-11.0.0-he90d24d_44_cuda.conda
linux-ppc64le::imagecodecs-2023.9.18-py39h074409c_2.conda
linux-ppc64le::libgdal-3.7.2-hcdd9db5_7.conda
linux-ppc64le::uwsgi-2.0.22-py311h8d7da3a_0.conda
linux-ppc64le::ffmpeg-4.4.2-gpl_hfe77c91_113.conda
linux-ppc64le::libarrow-10.0.1-hd23afd8_47_cpu.conda
linux-ppc64le::pyinstaller-5.13.2-py39hf0cda86_1.conda
linux-ppc64le::pillow-10.0.1-py39hed4bbec_2.conda
linux-ppc64le::libarrow-13.0.0-h1e79fd3_12_cpu.conda
linux-ppc64le::libkml-1.3.0-h11c2a8d_1016.conda
linux-ppc64le::libarrow-12.0.1-ha5789e2_16_cuda.conda
linux-ppc64le::pyreadstat-1.2.4-py312ha5a3bab_0.conda
linux-ppc64le::libarrow-13.0.0-hd911c6c_6_cpu.conda
linux-ppc64le::python-igraph-0.11.2-py39h2528f8b_0.conda
linux-ppc64le::llvm-17.0.3-h381f82a_0.conda
linux-ppc64le::pytables-3.9.1-py310h8713445_0.conda
linux-ppc64le::libadios2-2.9.1-mpi_openmpi_h2535527_4.conda
linux-ppc64le::grpcio-1.57.0-py311h3997ded_3.conda
linux-ppc64le::libadios2-2.9.1-mpi_mpich_h16fd881_3.conda
linux-ppc64le::libarrow-12.0.1-h7f4e557_15_cuda.conda
linux-ppc64le::python-igraph-0.10.8-py311h5de371b_1.conda
linux-ppc64le::grpcio-1.58.2-py311h3997ded_0.conda
linux-ppc64le::mlir-17.0.3-hae84d68_0.conda
linux-ppc64le::uwsgi-2.0.22-py38h91479bb_0.conda
linux-ppc64le::libarrow-12.0.1-h2c63c72_16_cpu.conda
linux-ppc64le::libopencv-4.8.1-py311h69df981_2.conda
linux-ppc64le::libadios2-2.9.1-mpi_openmpi_h9917a5b_3.conda
linux-ppc64le::ldas-tools-framecpp-3.0.2-h8a80fd7_3.conda
linux-ppc64le::aws-sdk-cpp-1.11.156-h25893bc_4.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-hd2e52fb_41.conda
linux-ppc64le::harp-1.20.1-py311h057db71_0.conda
linux-ppc64le::tiledb-2.17.3-hac2e0cb_1.conda
linux-ppc64le::llvm-tools-17.0.3-h8d57982_0.conda
linux-ppc64le::healpy-1.16.6-py39h05b5db2_1.conda
linux-ppc64le::mapserver-8.0.1-py311h3822a02_10.conda
linux-ppc64le::libadios2-2.9.1-mpi_mpich_he1f242b_3.conda
linux-ppc64le::libopentelemetry-cpp-1.12.0-hf57dd51_0.conda
linux-ppc64le::pytables-3.8.0-py38h97b587e_4.conda
linux-ppc64le::libcurl-static-8.4.0-ha571e8f_0.conda
linux-ppc64le::openjdk-21.0.0-h88f1eab_0.conda
linux-ppc64le::pygplates-0.39-py39hbd3f1d8_11.conda
linux-ppc64le::vtk-base-9.2.6-qt_py39h1234567_217.conda
linux-ppc64le::folly-2023.10.09.00-hcb6a8eb_0_jemalloc.conda
linux-ppc64le::grpcio-1.57.0-py39h27cb1e9_3.conda
linux-ppc64le::libarrow-12.0.1-h72e63e7_20_cuda.conda
linux-ppc64le::uwsgi-2.0.22-py38h1671ed3_3.conda
linux-ppc64le::openmpi-4.1.6-h7f051ca_101.conda
linux-ppc64le::libarrow-11.0.0-h4988e9a_46_cpu.conda
linux-ppc64le::netcdf4-1.6.5-mpi_mpich_py39h5cc4e33_0.conda
linux-ppc64le::openpmd-api-0.15.2-mpi_mpich_py39h0081349_2.conda
linux-ppc64le::imagemagick-7.1.1_19-pl5321h7ca5942_1.conda
linux-ppc64le::libadios2-2.9.1-mpi_openmpi_hcde4a47_4.conda
linux-ppc64le::pytng-0.3.1-py311had4d743_0.conda
linux-ppc64le::libarrow-10.0.1-h72e63e7_49_cuda.conda
linux-ppc64le::libvips-8.14.5-hbd25ded_3.conda
linux-ppc64le::libarrow-10.0.1-h500e1c2_48_cpu.conda
linux-ppc64le::eccodes-2.32.1-h08d12ae_0.conda
linux-ppc64le::pdal-2.6.0-h26c395a_0.conda
linux-ppc64le::libarrow-12.0.1-hd23afd8_18_cpu.conda
linux-ppc64le::libgd-2.3.3-h403d9e2_9.conda
linux-ppc64le::grpcio-1.57.1-py311h3997ded_0.conda
linux-ppc64le::libarrow-13.0.0-hd23afd8_9_cpu.conda
linux-ppc64le::grpcio-1.59.2-py38hc2aed35_0.conda
linux-ppc64le::libarrow-12.0.1-hd911c6c_15_cpu.conda
linux-ppc64le::vigra-1.11.2-py39h3127d94_3.conda
linux-ppc64le::netcdf4-1.6.5-nompi_py310h24b77d7_100.conda
linux-ppc64le::vtk-base-9.2.6-qt_py311h1234567_218.conda
linux-ppc64le::mysql-router-8.0.33-h53d5d11_5.conda
linux-ppc64le::openpmd-api-0.15.2-mpi_mpich_py310h8b3a226_2.conda
linux-ppc64le::healpy-1.16.6-py312h102d2d1_1.conda
linux-ppc64le::llvm-openmp-17.0.3-h8759ddb_0.conda
linux-ppc64le::openimageio-2.5.4.0-py311h96f7d0a_1.conda
linux-ppc64le::smesh-9.9.0.0-h95e6ad8_7.conda
linux-ppc64le::llvmlite-0.41.1-py39h27cb1e9_0.conda
linux-ppc64le::imagecodecs-2023.9.18-py39h9b660ee_2.conda
linux-ppc64le::minizip-4.0.2-ha7cce9c_0.conda
linux-ppc64le::libarrow-10.0.1-hd911c6c_44_cpu.conda
linux-ppc64le::cargo-c-0.9.26-hd6e3413_0.conda
linux-ppc64le::grpcio-1.59.1-py312h930df82_0.conda
linux-ppc64le::libarrow-10.0.1-h4988e9a_50_cpu.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.2-h392d21e_6.conda
linux-ppc64le::libarrow-11.0.0-h2c63c72_41_cpu.conda
linux-ppc64le::openpmd-api-0.15.2-mpi_openmpi_py312h8adf232_2.conda
linux-ppc64le::grpcio-1.57.1-py39h27cb1e9_0.conda
linux-ppc64le::ogre-14.1.2-h2ec09fa_0.conda
linux-ppc64le::imagemagick-7.1.1_20-pl5321h7ca5942_0.conda
linux-ppc64le::pytables-3.9.1-py312h7d75ae7_0.conda
linux-ppc64le::folly-2023.10.23.00-h4b663bd_0_jemalloc.conda
linux-ppc64le::vtk-base-9.2.6-qt_py310h1234567_216.conda
linux-ppc64le::folly-2023.10.16.00-h7cedaab_0.conda
linux-ppc64le::grpcio-1.58.1-py310h8eb8f48_2.conda
linux-ppc64le::minizip-static-1.2-hff1ad0c_1.conda
linux-ppc64le::pyinstaller-6.1.0-py311h5a86d3c_0.conda
linux-ppc64le::libadios2-2.9.1-mpi_mpich_h6737005_4.conda
linux-ppc64le::smesh-9.9.0.0-hfe52b29_9.conda
linux-ppc64le::folly-2023.10.02.00-h7cedaab_0.conda
linux-ppc64le::pyreadstat-1.2.3-py39h27550c1_1.conda
linux-ppc64le::libllvm17-17.0.3-h8d57982_1.conda
linux-ppc64le::pygplates-0.39-py311h1f6a259_10.conda
linux-ppc64le::libgrpc-1.58.2-h7c4fc85_0.conda
linux-ppc64le::r-harp-1.20.1-py38r43he254095_0.conda
linux-ppc64le::grpcio-1.58.1-py38hc2aed35_2.conda
linux-ppc64le::pillow-10.0.1-py311hc7c2d70_2.conda
linux-ppc64le::python-3.8.18-h4005451_0_cpython.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-h25bfa33_42.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-h1dbedd3_40.conda
linux-ppc64le::folly-2023.10.30.00-hfba947f_0.conda
linux-ppc64le::folly-2023.09.25.00-hfba947f_1.conda
linux-ppc64le::libarrow-13.0.0-h1e79fd3_11_cpu.conda
linux-ppc64le::grpcio-1.58.2-py312h930df82_0.conda
linux-ppc64le::libllvm17-17.0.2-h8d57982_0.conda
linux-ppc64le::libadios2-2.9.1-mpi_openmpi_h9917a5b_4.conda
linux-ppc64le::python-igraph-0.10.8-py310hd47e8ce_1.conda
linux-ppc64le::llvmdev-17.0.3-h8d57982_0.conda
linux-ppc64le::cpp-opentelemetry-sdk-1.12.0-hf57dd51_0.conda
linux-ppc64le::pytables-3.8.0-py310h8713445_4.conda
linux-ppc64le::openimageio-2.4.16.0-h48ca1d0_0.conda
linux-ppc64le::mapserver-8.0.1-py38hd967882_10.conda
linux-ppc64le::vigra-1.11.2-py310hff0043e_1.conda
linux-ppc64le::mapserver-8.0.1-py39ha3984a4_10.conda
linux-ppc64le::libarrow-13.0.0-ha5789e2_7_cuda.conda
linux-ppc64le::cargo-c-0.9.27-hd6e3413_0.conda
linux-ppc64le::libarrow-13.0.0-h7f4e557_6_cuda.conda
linux-ppc64le::pygplates-0.39-py311h1f6a259_11.conda
linux-ppc64le::nco-5.1.8-h9437046_1.conda
linux-ppc64le::poppler-23.10.0-h433edb4_0.conda
linux-ppc64le::folly-2023.10.23.00-hd3a0175_0_jemalloc.conda
linux-ppc64le::uwsgi-2.0.22-py310h7bd0854_2.conda
linux-ppc64le::ldas-tools-framecpp-2.9.2-hfc9cd27_1.conda
linux-ppc64le::pypy3.9-7.3.13-h4020351_1.tar.bz2
linux-ppc64le::libarrow-11.0.0-h72e63e7_45_cuda.conda
linux-ppc64le::imagecodecs-2023.9.18-py312h6d761cf_2.conda
linux-ppc64le::tiledb-2.17.2-hac2e0cb_0.conda
linux-ppc64le::omniorb-4.3.1-py310h94f889b_2.conda
linux-ppc64le::openimageio-2.5.4.0-py312h6dcf9d4_1.conda
linux-ppc64le::libarrow-12.0.1-h4279b5a_18_cuda.conda
linux-ppc64le::openpmd-api-0.15.2-mpi_openmpi_py39h4258fc8_2.conda
linux-ppc64le::libadios2-2.9.1-mpi_openmpi_h17025f5_3.conda
linux-ppc64le::mapserver-8.0.1-py312h05850e7_10.conda
linux-ppc64le::libadios2-2.9.1-mpi_mpich_h2376794_3.conda
linux-ppc64le::vtk-base-9.2.6-qt_py310h1234567_215.conda
linux-ppc64le::libgrpc-1.57.1-h2b58ef7_0.conda
linux-ppc64le::openpmd-api-0.15.2-mpi_mpich_py38h9212c1e_2.conda
linux-ppc64le::healpy-1.16.6-py39h05b5db2_0.conda
linux-ppc64le::mlir-17.0.2-hae84d68_0.conda
linux-ppc64le::pyinstaller-5.13.2-py311h5a86d3c_1.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-h789ac9f_38.conda
linux-ppc64le::openimageio-2.5.4.0-py311heab5d8d_2.conda
linux-ppc64le::netcdf4-1.6.5-mpi_mpich_py311hbcdc183_0.conda
linux-ppc64le::libgrpc-1.58.1-h7c4fc85_2.conda
linux-ppc64le::libopencv-4.8.1-py310hc5350b9_3.conda
linux-ppc64le::vtk-base-9.2.6-qt_py311h1234567_217.conda
linux-ppc64le::vigra-1.11.2-py39h62d90b9_3.conda
linux-ppc64le::omniorb-4.3.1-py312h0bb3dca_2.conda
linux-ppc64le::vowpalwabbit-9.9.0-py312ha4828ec_2.conda
linux-ppc64le::grpcio-1.57.0-py38hc2aed35_3.conda
linux-ppc64le::cppyy-cling-6.27.1-py312hb8a0279_1.conda
linux-ppc64le::libarrow-12.0.1-h1967950_21_cuda.conda
linux-ppc64le::grpcio-1.59.1-py38hc2aed35_0.conda
linux-ppc64le::freeimage-3.18.0-h37884e8_18.conda
linux-ppc64le::grpcio-1.57.1-py39h278787b_0.conda
linux-ppc64le::grpcio-1.57.0-py39h27cb1e9_2.conda
linux-ppc64le::llvm-17.0.3-h381f82a_1.conda
linux-ppc64le::libgrpc-1.59.2-h1ecfef9_0.conda
linux-ppc64le::libadios2-2.9.1-nompi_h825cff7_103.conda
linux-ppc64le::cairo-1.18.0-h5505270_0.conda
linux-ppc64le::cppyy-cling-6.27.1-py39h5e0a701_1.conda
linux-ppc64le::nsight-compute-2022.4.0.15-h2bdc722_1.conda
linux-ppc64le::ale-py-0.8.1-py39haede44f_1.conda
linux-ppc64le::pytables-3.9.1-py39h22b7ba6_0.conda
linux-ppc64le::pygplates-0.39-py39hbd3f1d8_10.conda
linux-ppc64le::folly-2023.10.16.00-hd3a0175_0_jemalloc.conda
linux-ppc64le::libopencv-4.8.1-py311hfb4bf84_1.conda
linux-ppc64le::texlive-core-20230313-haca2b93_7.conda
linux-ppc64le::ogre-1.10.12-h1a7ea67_15.conda
linux-ppc64le::libarrow-11.0.0-h7baa363_42_cpu.conda
linux-ppc64le::libarrow-10.0.1-h1e79fd3_49_cpu.conda
linux-ppc64le::libadios2-2.9.1-nompi_hf580554_103.conda
linux-ppc64le::pillow-10.0.1-py38h60861ec_2.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-h153dd9e_42.conda
linux-ppc64le::folly-2023.10.16.00-h4b663bd_0_jemalloc.conda
linux-ppc64le::grpcio-1.57.0-py310h8eb8f48_3.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-heed4b0a_42.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-h1fbd7b5_41.conda
linux-ppc64le::openjdk-11.0.21-h88a5b0c_0.conda
linux-ppc64le::pillow-10.1.0-py38h60861ec_0.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-h3cc2e5a_40.conda
linux-ppc64le::libarrow-11.0.0-ha3503e9_42_cuda.conda
linux-ppc64le::vigra-1.11.2-py310h99abacd_3.conda
linux-ppc64le::netcdf4-1.6.5-mpi_openmpi_py38hcf908bf_0.conda
linux-ppc64le::vigra-1.11.2-py311h7ec7fd0_1.conda
linux-ppc64le::nss-3.94-h4237796_0.conda
linux-ppc64le::magic-8.3.417-h7eb73fb_0.conda
linux-ppc64le::pyreadstat-1.2.3-py310h925d916_1.conda
linux-ppc64le::afterimage-1.21-h897aa08_1005.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-h71ea5ff_38.conda
linux-ppc64le::libgdal-arrow-parquet-3.6.4-h68ed162_21.conda
linux-ppc64le::mapserver-8.0.1-py39ha3984a4_9.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-hedcd465_42.conda
linux-ppc64le::pdal-2.5.6-h26c395a_4.conda
linux-ppc64le::omniorb-4.3.1-py311h7d8a50b_2.conda
linux-ppc64le::pyreadstat-1.2.4-py39h27550c1_0.conda
linux-ppc64le::uwsgi-2.0.22-py312h61d3571_3.conda
linux-ppc64le::libadios2-2.9.1-mpi_openmpi_h788cb01_3.conda
linux-ppc64le::grpcio-1.58.1-py39h278787b_1.conda
linux-ppc64le::pygplates-0.39-py38h19d2db2_11.conda
linux-ppc64le::r-harp-1.20-py38r43he254095_1.conda
linux-ppc64le::cpp-opentelemetry-sdk-1.11.0-hf57dd51_2.conda
linux-ppc64le::cppyy-cling-6.27.1-py38hbab3742_1.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-h71ea5ff_39.conda
linux-ppc64le::ogre-14.1.1-h03ae338_0.conda
linux-ppc64le::openpmd-api-0.15.2-mpi_openmpi_py311h76a134e_2.conda
linux-ppc64le::pillow-10.1.0-py312hb55979e_0.conda
linux-ppc64le::grpcio-1.58.2-py39h27cb1e9_0.conda
linux-ppc64le::netcdf4-1.6.5-nompi_py39hdb904ae_100.conda
linux-ppc64le::vigra-1.11.2-py39h0fec085_2.conda
linux-ppc64le::ale-py-0.8.1-py311h2d67c06_1.conda
linux-ppc64le::libarrow-12.0.1-h1e79fd3_20_cpu.conda
linux-ppc64le::grpcio-1.59.1-py311h3997ded_0.conda
linux-ppc64le::llvmlite-0.41.1-py39h278787b_0.conda
linux-ppc64le::omniorb-4.3.1-py38h7db1d0b_2.conda
linux-ppc64le::pyreadstat-1.2.3-py38h2b47b73_1.conda
linux-ppc64le::cppyy-cling-6.27.1-py311hc2b5b1e_1.conda
linux-ppc64le::mysql-client-8.0.33-hfff87ee_5.conda
linux-ppc64le::pyinstaller-6.1.0-py38h36029d9_0.conda
linux-ppc64le::freeimage-3.18.0-ha9c0d71_17.conda
linux-ppc64le::harp-1.20.1-py38he3f3676_0.conda
linux-ppc64le::python-3.12.0-h3332dee_0_cpython.conda
linux-ppc64le::r-harp-1.20-py39r43h7349751_1.conda
linux-ppc64le::sdl_image-1.2.12-hbadbcff_6.conda
linux-ppc64le::libadios2-2.9.1-nompi_h1520396_103.conda
linux-ppc64le::grpcio-1.58.1-py39h278787b_2.conda
linux-ppc64le::folly-2023.09.25.00-hd3a0175_1_jemalloc.conda
linux-ppc64le::python-igraph-0.11.2-py311h5de371b_0.conda
linux-ppc64le::libarrow-13.0.0-h72e63e7_12_cuda.conda
linux-ppc64le::healpy-1.16.6-py311h7a0c736_0.conda
linux-ppc64le::lld-17.0.3-he12c2f4_0.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-h80010d5_39.conda
linux-ppc64le::vigra-1.11.2-py311hc164628_3.conda
linux-ppc64le::aws-sdk-cpp-1.11.182-h3c9f993_1.conda
linux-ppc64le::healpy-1.16.6-py310hbef9412_1.conda
linux-ppc64le::libsoup-3.4.4-hc050987_0.conda
linux-ppc64le::python-3.11.6-h3332dee_0_cpython.conda
linux-ppc64le::boost-cpp-1.82.0-h1102270_6.conda
linux-ppc64le::folly-2023.10.16.00-hcb6a8eb_0_jemalloc.conda
linux-ppc64le::libarrow-12.0.1-h4988e9a_21_cpu.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-h53d450d_42.conda
linux-ppc64le::openimageio-2.4.16.0-h897d165_0.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-haf63fe6_39.conda
linux-ppc64le::aws-sdk-cpp-1.11.182-h6464b03_0.conda
linux-ppc64le::llvmlite-0.41.1-py310h8eb8f48_0.conda
linux-ppc64le::libarrow-13.0.0-h7baa363_8_cpu.conda
linux-ppc64le::libarrow-11.0.0-ha5789e2_41_cuda.conda
linux-ppc64le::pytables-3.8.0-py39h22b7ba6_4.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-h1cdb267_40.conda
linux-ppc64le::libadios2-2.9.1-mpi_mpich_h16fd881_4.conda
linux-ppc64le::libopencv-4.8.1-py312h815a980_3.conda
linux-ppc64le::folly-2023.10.02.00-hfba947f_0.conda
linux-ppc64le::llvmdev-17.0.3-h8d57982_1.conda
linux-ppc64le::pygplates-0.39-py312h26ee55e_12.conda
linux-ppc64le::pyinstaller-6.1.0-py312h4032086_0.conda
linux-ppc64le::pygplates-0.39-py310h925a461_12.conda
linux-ppc64le::libxmlsec1-1.3.2-h59429d2_0.conda
linux-ppc64le::grpcio-1.58.2-py39h278787b_0.conda
linux-ppc64le::openpmd-api-0.15.2-nompi_py38h0d09d59_102.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-hbcd0642_41.conda
linux-ppc64le::libgrpc-1.57.0-h2b58ef7_3.conda
linux-ppc64le::pytng-0.3.1-py310haa3ec93_0.conda
linux-ppc64le::pygrib-2.1.4-py39h639ea50_8.conda
linux-ppc64le::libopencv-4.8.1-py311h69df981_3.conda
linux-ppc64le::netcdf4-1.6.5-mpi_mpich_py310h50b4216_0.conda
linux-ppc64le::vigra-1.11.2-py312h6e05058_3.conda
linux-ppc64le::pigz-2.6-hd4bbf49_1.conda
linux-ppc64le::libarrow-11.0.0-h1e79fd3_45_cpu.conda
linux-ppc64le::libarrow-13.0.0-h72e63e7_11_cuda.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-h270f272_42.conda
linux-ppc64le::pytables-3.9.1-py311h3f57c28_0.conda
linux-ppc64le::grpcio-1.58.1-py310h8eb8f48_1.conda
linux-ppc64le::llvm-tools-17.0.2-h8d57982_0.conda
linux-ppc64le::grpcio-1.58.2-py310h8eb8f48_0.conda
linux-ppc64le::ale-py-0.8.1-py38h0fdcef1_1.conda
linux-ppc64le::curl-8.4.0-ha571e8f_0.conda
linux-ppc64le::orc-1.9.0-h6c0f13e_3.conda
linux-ppc64le::openimageio-2.5.4.0-py312h4304c11_2.conda
linux-ppc64le::mapserver-8.0.1-py38hd967882_9.conda
linux-ppc64le::pillow-10.1.0-py310hf64def1_0.conda
linux-ppc64le::pyinstaller-5.13.2-py38h36029d9_1.conda
linux-ppc64le::pytables-3.9.1-py39h6b88dcf_0.conda
linux-ppc64le::folly-2023.09.25.00-hcb6a8eb_1_jemalloc.conda
linux-ppc64le::python-igraph-0.10.8-py39h2528f8b_1.conda
linux-ppc64le::openpmd-api-0.15.2-nompi_py39hea7354c_102.conda
linux-ppc64le::libopencv-4.8.1-py38h70f9450_3.conda
linux-ppc64le::pyreadstat-1.2.4-py310h925d916_0.conda
linux-ppc64le::folly-2023.10.09.00-ha2e2e2a_0.conda
linux-ppc64le::libopencv-4.8.1-py39h10628a7_1.conda
linux-ppc64le::python-igraph-0.11.2-py312h4cf8cea_1.conda
linux-ppc64le::python-igraph-0.11.2-py311h5de371b_1.conda
linux-ppc64le::vowpalwabbit-9.9.0-py38hbe7e15d_2.conda
linux-ppc64le::vtk-base-9.2.6-qt_py38h1234567_217.conda
linux-ppc64le::libadios2-2.9.1-nompi_hf580554_104.conda
linux-ppc64le::pytng-0.3.1-py39h872a5d3_0.conda
linux-ppc64le::llvm-openmp-17.0.2-h8759ddb_0.conda
linux-ppc64le::gmsh-4.11.1-h43fa0ad_4.conda
linux-ppc64le::grpcio-1.58.1-py311h3997ded_2.conda
linux-ppc64le::pyreadstat-1.2.4-py38h2b47b73_0.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-hef555a9_39.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-h1fbd0d1_38.conda
linux-ppc64le::libboost-1.82.0-hfdd0173_5.conda
linux-ppc64le::harp-1.20-py39he3f3676_1.conda
linux-ppc64le::openimageio-2.5.4.0-py38h15921d0_2.conda
linux-ppc64le::vtk-base-9.2.6-qt_py39h1234567_215.conda
linux-ppc64le::folly-2023.10.09.00-h4b663bd_0_jemalloc.conda
linux-ppc64le::r-harp-1.20-py39r43hc78dc1f_1.conda
linux-ppc64le::harp-1.20.1-py310he3f3676_0.conda
linux-ppc64le::pygplates-0.39-py38h19d2db2_10.conda
linux-ppc64le::openpmd-api-0.15.2-mpi_mpich_py311he797d23_2.conda
linux-ppc64le::uwsgi-2.0.22-py38h1671ed3_1.conda
linux-ppc64le::openpmd-api-0.15.2-nompi_py310h8735542_102.conda
linux-ppc64le::vigra-1.11.2-py311hc3b3380_2.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-h1fbd7b5_42.conda
linux-ppc64le::libopencv-4.8.1-py310hd3ff249_1.conda
linux-ppc64le::ogre-14.1.0-h03ae338_2.conda
linux-ppc64le::libboost-1.82.0-hfdd0173_4.conda
linux-ppc64le::cppyy-cling-6.27.1-py310h02f1291_1.conda
linux-ppc64le::grpcio-1.59.2-py39h278787b_0.conda
linux-ppc64le::libnghttp2-1.55.1-hc4d0b0b_0.conda
linux-ppc64le::libadios2-2.9.1-nompi_h95651d6_104.conda
linux-ppc64le::healpy-1.16.6-py311h7a0c736_1.conda
linux-ppc64le::r-harp-1.20.1-py310r43hfd510e7_0.conda
linux-ppc64le::libopencv-4.8.1-py39hb72e928_3.conda
linux-ppc64le::mapserver-8.0.1-py311h3822a02_9.conda
linux-ppc64le::llvmlite-0.41.1-py311h3997ded_0.conda
linux-ppc64le::libadios2-2.9.1-mpi_openmpi_h2535527_3.conda
linux-ppc64le::python-igraph-0.11.2-py39h085bd8d_0.conda
linux-ppc64le::pytables-3.8.0-py311h3f57c28_4.conda
linux-ppc64le::uwsgi-2.0.22-py39hafd096c_1.conda
linux-ppc64le::pyinstaller-6.1.0-py310h0719273_0.conda
linux-ppc64le::folly-2023.10.09.00-hd3a0175_0_jemalloc.conda
linux-ppc64le::pypy3.9-7.3.13-h4020351_0.tar.bz2
linux-ppc64le::pillow-10.1.0-py311hc7c2d70_0.conda
linux-ppc64le::openimageio-2.5.4.0-py310hfc69c9e_1.conda
linux-ppc64le::mysql-server-8.0.33-h07a0d21_5.conda
linux-ppc64le::harp-1.20-py310he3f3676_1.conda
linux-ppc64le::tiledb-2.17.3-hd5af256_0.conda
linux-ppc64le::netcdf4-1.6.5-mpi_openmpi_py311h2d08ffa_0.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-haf63fe6_38.conda
linux-ppc64le::vtk-base-9.2.6-qt_py310h1234567_217.conda
linux-ppc64le::uwsgi-2.0.22-py310h7bd0854_1.conda
linux-ppc64le::libarrow-10.0.1-h1967950_50_cuda.conda
linux-ppc64le::libpulsar-3.2.0-h93b3b90_5.conda
linux-ppc64le::nodejs-16.20.2-hf6a0410_2.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-hc56b5ba_38.conda
linux-ppc64le::libadios2-2.9.1-nompi_h825cff7_104.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-hef555a9_38.conda
linux-ppc64le::libarrow-10.0.1-ha5789e2_45_cuda.conda
linux-ppc64le::grpcio-1.57.0-py310h8eb8f48_2.conda
linux-ppc64le::openpmd-api-0.15.2-nompi_py312h6b60f96_102.conda
linux-ppc64le::octave-8.3.0-h7b00d66_1.conda
linux-ppc64le::grpcio-1.59.2-py312h930df82_0.conda
linux-ppc64le::pillow-10.1.0-py39h0427823_0.conda
linux-ppc64le::netcdf4-1.6.5-mpi_openmpi_py312hfca56c5_0.conda
linux-ppc64le::yarp-cxx-3.8.1-h7ea2182_7.conda
linux-ppc64le::pygplates-0.39-py310h925a461_10.conda
linux-ppc64le::netcdf4-1.6.5-mpi_mpich_py312h03f8c67_0.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-h73e3dfd_41.conda
linux-ppc64le::libopencv-4.8.1-py38h70f9450_2.conda
linux-ppc64le::python-igraph-0.11.2-py310hd47e8ce_1.conda
linux-ppc64le::libgdal-arrow-parquet-3.6.4-he2b6be6_22.conda
linux-ppc64le::smesh-9.9.0.0-hf386b7c_8.conda
linux-ppc64le::vigra-1.11.2-py39hbdda1c3_2.conda
linux-ppc64le::pillow-10.1.0-py39hed4bbec_0.conda
linux-ppc64le::tesseract-5.3.2-ha6c3bad_1.conda
linux-ppc64le::vtk-base-9.2.6-qt_py311h1234567_216.conda
linux-ppc64le::sqlite-3.43.2-h63c7444_0.conda
linux-ppc64le::libadios2-2.9.1-mpi_openmpi_h17025f5_4.conda
linux-ppc64le::pygrib-2.1.4-py38hf8cb758_8.conda
linux-ppc64le::pillow-10.0.1-py312hb55979e_2.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-h789ac9f_39.conda
linux-ppc64le::grpcio-1.59.1-py310h8eb8f48_0.conda
linux-ppc64le::libarrow-12.0.1-h7baa363_17_cpu.conda
linux-ppc64le::vigra-1.11.2-py312h1aab40a_1.conda
linux-ppc64le::folly-2023.10.30.00-hd3a0175_0_jemalloc.conda
linux-ppc64le::ffmpeg-5.1.2-gpl_h27b0073_112.conda
linux-ppc64le::grpcio-1.57.0-py312h930df82_3.conda
linux-ppc64le::uwsgi-2.0.22-py311h35e3da6_3.conda
linux-ppc64le::python-igraph-0.11.2-py38hb26de0c_0.conda
linux-ppc64le::r-harp-1.20.1-py39r43h7349751_0.conda
linux-ppc64le::vigra-1.11.2-py38h440fec3_1.conda
linux-ppc64le::folly-2023.10.16.00-ha2e2e2a_0.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-h71c10ed_40.conda
linux-ppc64le::grpcio-1.57.0-py311h3997ded_2.conda
linux-ppc64le::libvips-8.14.5-h92ad1e0_2.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-h988fe9c_39.conda
linux-ppc64le::tiledb-2.17.3-hac2e0cb_0.conda
linux-ppc64le::libkml-1.3.0-h5aa9a33_1018.conda
linux-ppc64le::libadios2-2.9.1-mpi_openmpi_hcde4a47_3.conda
linux-ppc64le::pygrib-2.1.4-py311h8267192_8.conda
linux-ppc64le::vtk-base-9.2.6-qt_py38h1234567_216.conda
linux-ppc64le::vtk-base-9.2.6-qt_py39h1234567_216.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-h2f31fd4_40.conda
linux-ppc64le::grpcio-1.58.1-py38hc2aed35_1.conda
linux-ppc64le::qt-main-5.15.8-h06ed4ad_17.conda
linux-ppc64le::libarrow-13.0.0-h4988e9a_13_cpu.conda
linux-ppc64le::imagecodecs-2023.9.18-py311ha490864_2.conda
linux-ppc64le::libarrow-10.0.1-he90d24d_48_cuda.conda
linux-ppc64le::ldas-tools-framecpp-3.0.2-h2f38f2f_2.conda
linux-ppc64le::libadios2-2.9.1-mpi_mpich_he1f242b_4.conda
linux-ppc64le::netcdf4-1.6.5-nompi_py311hf4c972e_100.conda
linux-ppc64le::grpcio-1.59.1-py39h27cb1e9_0.conda
linux-ppc64le::vowpalwabbit-9.9.0-py39hcb48f23_1.conda
linux-ppc64le::pygplates-0.39-py312h26ee55e_11.conda
linux-ppc64le::openpmd-api-0.15.2-mpi_mpich_py312h8c9bac9_2.conda
linux-ppc64le::libgrpc-1.58.1-h68d966a_1.conda
linux-ppc64le::libopencv-4.8.1-py39h5d5037c_2.conda
linux-ppc64le::tiledb-2.17.3-h4ed4581_0.conda
linux-ppc64le::grpcio-1.58.1-py312h930df82_2.conda
linux-ppc64le::yarp-cxx-3.8.1-h7ea2182_6.conda
linux-ppc64le::vtk-base-9.2.6-qt_py310h1234567_218.conda
linux-ppc64le::libarrow-12.0.1-he90d24d_19_cuda.conda
linux-ppc64le::openjdk-21.0.1-h88f1eab_0.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-h73e3dfd_42.conda
linux-ppc64le::libgdal-3.7.2-hd5c3bb3_6.conda
linux-ppc64le::folly-2023.09.25.00-h4b663bd_1_jemalloc.conda
linux-ppc64le::pygplates-0.39-py38h19d2db2_12.conda
linux-ppc64le::imagemagick-7.1.1_21-pl5321h7ca5942_0.conda
linux-ppc64le::folly-2023.10.02.00-hd3a0175_0_jemalloc.conda
linux-ppc64le::folly-2023.10.23.00-hfba947f_0.conda
linux-ppc64le::nginx-1.25.3-hd111a0b_0.conda
linux-ppc64le::gst-plugins-good-1.22.6-hcf0ac4c_2.conda
linux-ppc64le::llvmlite-0.41.1-py38hc2aed35_0.conda
linux-ppc64le::pillow-10.0.1-py39h0427823_2.conda
linux-ppc64le::grpcio-1.58.1-py312h930df82_1.conda
linux-ppc64le::python-igraph-0.10.8-py38hb26de0c_1.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-hedcd465_41.conda
linux-ppc64le::pygrib-2.1.4-py39h8591698_8.conda
linux-ppc64le::poppler-23.08.0-h433edb4_3.conda
linux-ppc64le::llvm-17.0.2-h381f82a_0.conda
linux-ppc64le::squashfs-tools-4.6.1-h40af005_0.conda
linux-ppc64le::grpcio-1.59.2-py311h3997ded_0.conda
linux-ppc64le::ffmpeg-6.0.0-gpl_hd94cd3e_105.conda
linux-ppc64le::grpcio-1.59.2-py310h8eb8f48_0.conda
linux-ppc64le::ffmpeg-6.0.0-lgpl_h23b7ab8_5.conda
linux-ppc64le::pygrib-2.1.4-py312h2482cc6_8.conda
linux-ppc64le::folly-2023.10.09.00-h7cedaab_0.conda
linux-ppc64le::python-igraph-0.10.8-py39h085bd8d_1.conda
linux-ppc64le::pygplates-0.39-py310h925a461_11.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.2-h127584c_7.conda
linux-ppc64le::mosh-1.4.0-pl5321h86f7a29_4.conda
linux-ppc64le::libopencv-4.8.1-py39h5d5037c_3.conda
linux-ppc64le::tiledb-2.17.3-h4ed4581_1.conda
linux-ppc64le::libarrow-10.0.1-h4279b5a_47_cuda.conda
linux-ppc64le::ogre-14.1.2-h03ae338_0.conda
linux-ppc64le::imagecodecs-2023.9.18-py39h9b660ee_1.conda
linux-ppc64le::uwsgi-2.0.22-py311h35e3da6_2.conda
linux-ppc64le::libarrow-10.0.1-h7baa363_46_cpu.conda
linux-ppc64le::libkml-1.3.0-h5aa9a33_1017.conda
linux-ppc64le::healpy-1.16.6-py39h5937c45_1.conda
linux-ppc64le::openpmd-api-0.15.2-mpi_openmpi_py39ha7b6021_2.conda
linux-ppc64le::folly-2023.10.30.00-hcb6a8eb_0_jemalloc.conda
linux-ppc64le::ale-py-0.8.1-py310h5f00c0f_1.conda
linux-ppc64le::pyinstaller-5.13.2-py310h0719273_1.conda
linux-ppc64le::folly-2023.10.30.00-ha2e2e2a_0.conda
linux-ppc64le::hamlib-tcl-4.5.5-hd4bbf49_0.conda
linux-ppc64le::openimageio-2.5.4.0-py310h6b3035b_2.conda
linux-ppc64le::tiledb-2.17.2-h4ed4581_0.conda
linux-ppc64le::imagecodecs-2023.9.18-py310h4e42f5a_2.conda
linux-ppc64le::folly-2023.10.30.00-h7cedaab_0.conda
linux-ppc64le::uwsgi-2.0.22-py38h1671ed3_2.conda
linux-ppc64le::libopencv-4.8.1-py39hb72e928_2.conda
linux-ppc64le::healpy-1.16.6-py310hbef9412_0.conda
linux-ppc64le::llvmdev-17.0.2-h8d57982_0.conda
linux-ppc64le::libarrow-10.0.1-h7f4e557_44_cuda.conda
linux-ppc64le::mapserver-8.0.1-py310h52a997a_10.conda
linux-ppc64le::libadios2-2.9.1-mpi_mpich_h71aec2e_4.conda
linux-ppc64le::vtk-base-9.2.6-qt_py311h1234567_215.conda
linux-ppc64le::vowpalwabbit-9.9.0-py38hbe7e15d_1.conda
linux-ppc64le::pytables-3.8.0-py39h6b88dcf_4.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-h9015d2b_40.conda
linux-ppc64le::rust-1.73.0-hb12b0c0_0.conda
linux-ppc64le::leptonica-1.83.1-hd06ca6c_5.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-hbcd0642_42.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.2-hb18610b_5.conda
linux-ppc64le::vtk-base-9.2.6-qt_py312h1234567_218.conda
linux-ppc64le::libgdal-3.7.2-h41b821e_5.conda
linux-ppc64le::boost-cpp-1.82.0-h1102270_5.conda
linux-ppc64le::r-harp-1.20.1-py311r43h8a84315_0.conda
linux-ppc64le::rust-1.73.0-hb12b0c0_1.conda
linux-ppc64le::openimageio-2.5.4.0-py39hcf337c1_2.conda
linux-ppc64le::libgdal-3.6.4-hfe25fe2_22.conda
linux-ppc64le::r-harp-1.20.1-py39r43hc78dc1f_0.conda
linux-ppc64le::vigra-1.11.2-py312h5855c6a_2.conda
linux-ppc64le::libvips-8.14.5-hda3b86f_1.conda
linux-ppc64le::libcurl-8.4.0-ha571e8f_0.conda
linux-ppc64le::eccodes-2.32.0-h08d12ae_0.conda
linux-ppc64le::grpcio-1.57.0-py38hc2aed35_2.conda
linux-ppc64le::openmpi-4.1.6-hd9f040f_100.conda
linux-ppc64le::aws-sdk-cpp-1.11.156-h6464b03_5.conda
linux-ppc64le::libllvm17-17.0.3-h8d57982_0.conda
linux-ppc64le::pytables-3.8.0-py312h7d75ae7_4.conda
linux-ppc64le::folly-2023.10.02.00-h4b663bd_0_jemalloc.conda
linux-ppc64le::mapserver-8.0.1-py310h52a997a_9.conda
linux-ppc64le::libadios2-2.9.1-nompi_h95651d6_103.conda
linux-ppc64le::imagecodecs-2023.9.18-py310h4e42f5a_1.conda
linux-ppc64le::libarrow-13.0.0-h500e1c2_10_cpu.conda
linux-ppc64le::libmatio-1.5.24-h125b1b5_0.conda
linux-ppc64le::folly-2023.10.30.00-h4b663bd_0_jemalloc.conda
linux-ppc64le::libpulsar-3.2.0-ha754e51_4.conda
linux-ppc64le::grpcio-1.59.1-py39h278787b_0.conda
linux-ppc64le::python-igraph-0.11.2-py38hb26de0c_1.conda
linux-ppc64le::grpcio-1.58.2-py38hc2aed35_0.conda
linux-ppc64le::openimageio-2.4.16.0-h78a443b_0.conda
linux-ppc64le::grpcio-1.58.1-py39h27cb1e9_2.conda
linux-ppc64le::openpmd-api-0.15.2-nompi_py311hf45da4e_102.conda
linux-ppc64le::grpcio-1.59.2-py39h27cb1e9_0.conda
linux-ppc64le::libadios2-2.9.1-mpi_mpich_h6737005_3.conda
linux-ppc64le::libarrow-12.0.1-h500e1c2_19_cpu.conda
linux-ppc64le::folly-2023.10.02.00-hcb6a8eb_0_jemalloc.conda
linux-ppc64le::grpcio-1.57.1-py312h930df82_0.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-h988fe9c_38.conda
linux-ppc64le::pygplates-0.39-py311h1f6a259_12.conda
linux-ppc64le::pillow-10.0.1-py310hf64def1_2.conda
linux-ppc64le::libarrow-11.0.0-h500e1c2_44_cpu.conda
linux-ppc64le::uwsgi-2.0.22-py311h35e3da6_1.conda
linux-ppc64le::grpcio-1.57.1-py38hc2aed35_0.conda
linux-ppc64le::imagecodecs-2023.9.18-py39h074409c_1.conda
linux-ppc64le::libadios2-2.9.1-mpi_mpich_h2376794_4.conda
linux-ppc64le::libnghttp2-static-1.55.1-had385bd_0.conda
linux-ppc64le::ale-py-0.8.1-py39h37a20f3_1.conda
linux-ppc64le::libarrow-11.0.0-hd23afd8_43_cpu.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-hc56b5ba_39.conda
linux-ppc64le::grpcio-1.58.1-py311h3997ded_1.conda
linux-ppc64le::omniorb-4.3.1-py39ha8da32a_2.conda
linux-ppc64le::ldas-tools-framecpp-2.9.2-hb6bff72_2.conda
linux-ppc64le::libgdal-3.6.4-hc076312_21.conda
linux-ppc64le::pygplates-0.39-py39hbd3f1d8_12.conda
linux-ppc64le::pyreadstat-1.2.4-py311he2df201_0.conda
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
================================================================================
================================================================================
osx-arm64
osx-arm64::micromamba-1.5.0-2.tar.bz2
osx-arm64::libmlir17-17.0.2-h2d3518b_0.conda
osx-arm64::openjdk-17.0.9-h3fcba2d_0.conda
osx-arm64::gst-plugins-base-1.22.6-h27255cc_2.conda
osx-arm64::libprotobuf-static-4.24.4-hc9861d8_0.conda
osx-arm64::libprotobuf-4.24.4-hc9861d8_0.conda
osx-arm64::libmlir-17.0.3-hba3f82b_0.conda
osx-arm64::minizip-1.2-ha614eb4_2.conda
osx-arm64::pcre2-10.42-h26f9a81_0.conda
osx-arm64::micromamba-1.5.1-1.tar.bz2
osx-arm64::openjdk-11.0.21-hc8a6bc2_0.conda
osx-arm64::pigz-2.8-h091b4b1_0.conda
osx-arm64::ldas-tools-framecpp-2.9.2-he0fb27f_2.conda
osx-arm64::libprotobuf-static-4.24.3-hf590ac1_1.conda
osx-arm64::libpcm-1.2.3-ha82066f_8.conda
osx-arm64::minizip-1.2-ha614eb4_1.conda
osx-arm64::websocketpp-0.8.2-he63ff86_3.conda
osx-arm64::libsqlite-3.43.2-h091b4b1_0.conda
osx-arm64::micromamba-1.5.0-3.tar.bz2
osx-arm64::liblal-7.4.1-fftw_h5834690_100.conda
osx-arm64::eccodes-2.32.0-h437576b_0.conda
osx-arm64::libmlir-17.0.2-h2d3518b_0.conda
osx-arm64::minizip-1.2-ha614eb4_0.conda
osx-arm64::msgpack-cxx-6.1.0-h74fd3a8_1.conda
osx-arm64::libprotobuf-4.24.3-hf590ac1_1.conda
osx-arm64::openjdk-21.0.1-hed44d8b_0.conda
osx-arm64::libmlir17-17.0.3-hba3f82b_0.conda
osx-arm64::eccodes-2.32.1-h1dd2316_0.conda
osx-arm64::openjdk-21.0.0-hed44d8b_0.conda
-    "libzlib >=1.2.13,<1.3.0a0"
+    "libzlib >=1.2.13,<2.0.0a0"
osx-arm64::folly-2023.09.25.00-hb929855_1_jemalloc.conda
osx-arm64::pygplates-0.39-py311h97f3abb_10.conda
osx-arm64::ambertools-23.3-py311hd5bda53_5.conda
osx-arm64::libllvm17-17.0.3-hc359061_1.conda
osx-arm64::libopencv-4.8.1-py38h35d01dd_2.conda
osx-arm64::vigra-1.11.2-py39hbcd3961_2.conda
osx-arm64::pyreadr-0.5.0-py39hcac2ee9_0.conda
osx-arm64::omniorb-4.3.1-py312hf13160d_2.conda
osx-arm64::ifcopenshell-v0.7.0a10-py310h1c3345d_2.conda
osx-arm64::netcdf4-1.6.5-mpi_openmpi_py310h05ed02d_0.conda
osx-arm64::cctools_osx-64-973.0.1-h4f2729c_15.conda
osx-arm64::folly-2023.10.02.00-h539f04e_0.conda
osx-arm64::imagemagick-7.1.1_21-pl5321hc29442c_0.conda
osx-arm64::lammps-2023.08.02-cpu_py39_h77ea923_openmpi_3.conda
osx-arm64::vigra-1.11.2-py39haf254f6_1.conda
osx-arm64::lfortran-0.21.3-hbe7ddab_0.conda
osx-arm64::lammps-2023.08.02-cpu_py311_he687244_mpich_4.conda
osx-arm64::libvips-8.14.5-hce5f879_1.conda
osx-arm64::tensorflow-base-2.12.1-cpu_py311hda9fa7b_1.conda
osx-arm64::folly-2023.10.30.00-ha5de9cd_0_jemalloc.conda
osx-arm64::paraview-5.11.2-py39h84dc85d_102_qt.conda
osx-arm64::heyoka-llvm-13-2.0.0-hed95047_1.conda
osx-arm64::omniorb-4.3.1-py39h014b858_2.conda
osx-arm64::grpcio-1.59.2-py38hfeb05b4_0.conda
osx-arm64::libadios2-2.9.1-mpi_openmpi_hcb5871a_3.conda
osx-arm64::grpcio-1.58.1-py311h79dd126_2.conda
osx-arm64::ambertools-23.3-py310h2aae41f_5.conda
osx-arm64::pyreadr-0.5.0-py311h989c61b_0.conda
osx-arm64::grpcio-1.57.0-py38hfeb05b4_2.conda
osx-arm64::paraview-5.11.2-py39hb186274_102_qt.conda
osx-arm64::libarrow-11.0.0-h5325880_42_cpu.conda
osx-arm64::ffmpeg-6.0.0-lgpl_hcc92bfd_5.conda
osx-arm64::gmsh-4.11.1-hf05cd70_4.conda
osx-arm64::libgdal-3.6.4-he12048d_21.conda
osx-arm64::aws-sdk-cpp-1.11.182-h25e7660_1.conda
osx-arm64::libboost-1.82.0-h72cdd8a_4.conda
osx-arm64::qt6-main-6.5.2-h418310c_6.conda
osx-arm64::lfortran-0.25.0-hbeb2e11_0.conda
osx-arm64::triqs-3.2.0-py39h755e2d8_7.conda
osx-arm64::openimageio-2.4.16.0-py310he9cb28c_0.conda
osx-arm64::healpy-1.16.6-py311h29c129b_0.conda
osx-arm64::triqs-3.2.0-py39h3dd32c9_7.conda
osx-arm64::uwsgi-2.0.22-py312h55e8bdd_3.conda
osx-arm64::dask-sql-2023.10.1-py311hfbab5a9_0.conda
osx-arm64::grpcio-1.58.2-py310h6121c79_0.conda
osx-arm64::cctools_osx-arm64-973.0.1-h62378fb_15.conda
osx-arm64::libarrow-12.0.1-hf4fadc0_16_cpu.conda
osx-arm64::triqs-3.2.0-py311hdc400ac_7.conda
osx-arm64::libarrow-10.0.1-h36aaf85_46_cpu.conda
osx-arm64::jaxlib-0.4.18-cpu_py310h75e2498_0.conda
osx-arm64::lammps-2023.08.02-cpu_py38_h9e6eba2_openmpi_3.conda
osx-arm64::vtk-base-9.2.6-qt_py310h1234567_218.conda
osx-arm64::libgdal-arrow-parquet-3.7.2-h487009e_6.conda
osx-arm64::libadios2-2.9.1-mpi_mpich_h4bf048f_4.conda
osx-arm64::libarrow-11.0.0-h82e8550_43_cpu.conda
osx-arm64::lammps-2023.08.02-cpu_py310_hdbbd2cf_mpich_5.conda
osx-arm64::vowpalwabbit-9.9.0-py38h40b03ef_2.conda
osx-arm64::tensorflow-base-2.13.1-cpu_py310h0e84cb2_1.conda
osx-arm64::ambertools-23.3-py38h0acb9de_3.conda
osx-arm64::ifcopenshell-v0.7.0a10-py38hc36f3f8_2.conda
osx-arm64::libadios2-2.9.1-nompi_h63cf921_103.conda
osx-arm64::libadios2-2.9.1-mpi_mpich_ha7a4453_3.conda
osx-arm64::libadios2-2.9.1-mpi_mpich_h14620ef_4.conda
osx-arm64::wxwidgets-3.2.3-h3ae78ef_0.conda
osx-arm64::lammps-2023.08.02-cpu_py311_h1b396ce_openmpi_5.conda
osx-arm64::libtensorflow_cc-2.13.1-cpu_h0c20d54_1.conda
osx-arm64::pytng-0.3.1-py39h33914a9_0.conda
osx-arm64::minizip-static-1.2-ha614eb4_2.conda
osx-arm64::vtk-base-9.2.6-qt_py38h1234567_218.conda
osx-arm64::lld-17.0.2-h1753c5f_0.conda
osx-arm64::ambertools-23.3-py311hf3cd52f_4.conda
osx-arm64::llvm-tools-17.0.3-hc359061_1.conda
osx-arm64::libadios2-2.9.1-mpi_openmpi_h3fe9733_4.conda
osx-arm64::ambertools-23.3-py38h34f1375_6.conda
osx-arm64::pillow-10.0.1-py310hdfbc14a_2.conda
osx-arm64::lammps-2023.08.02-cpu_py310_h6437ca0_openmpi_7.conda
osx-arm64::ndcctools-7.7.2-py39hec72b60_0.conda
osx-arm64::jaxlib-0.4.18-cpu_py311hb7726a2_0.conda
osx-arm64::harp-1.20.1-py310h2275332_0.conda
osx-arm64::heyoka-2.0.0-h11efc27_1.conda
osx-arm64::gazebo-11.13.0-h7c12456_11.conda
osx-arm64::ambertools-23.3-py39hfb5d5ac_4.conda
osx-arm64::photochem-0.4.4-py311ha18d1a0_0.conda
osx-arm64::pytables-3.8.0-py311h5f09214_4.conda
osx-arm64::folly-2023.10.16.00-hd3f4852_0_jemalloc.conda
osx-arm64::pygrib-2.1.4-py311h9320766_8.conda
osx-arm64::pyinstaller-5.13.2-py310h742d9d8_1.conda
osx-arm64::lammps-2023.08.02-cpu_py311_he687244_mpich_5.conda
osx-arm64::grpcio-1.58.1-py38hfeb05b4_1.conda
osx-arm64::openimageio-2.5.4.0-py310h83d333c_1.conda
osx-arm64::mosh-1.4.0-pl5321ha77fba2_4.conda
osx-arm64::openimageio-2.5.4.0-py38h9702f6c_1.conda
osx-arm64::gdstk-0.9.46-py39h692b333_0.conda
osx-arm64::grpcio-1.57.1-py310h6121c79_0.conda
osx-arm64::grpcio-1.58.2-py39h52f163a_0.conda
osx-arm64::libarrow-13.0.0-h0c25ffe_6_cpu.conda
osx-arm64::netcdf4-1.6.5-mpi_mpich_py310hce3a974_0.conda
osx-arm64::folly-2023.10.16.00-h83f57a1_0.conda
osx-arm64::ffmpeg-6.0.0-gpl_h1ceb99f_105.conda
osx-arm64::ogre-14.1.2-h19e911b_0.conda
osx-arm64::harp-1.20-py38h2275332_1.conda
osx-arm64::healpy-1.16.6-py310h3a32917_1.conda
osx-arm64::openpmd-api-0.15.2-mpi_mpich_py311hf2f38fa_2.conda
osx-arm64::grpcio-1.58.1-py310h6121c79_1.conda
osx-arm64::libadios2-2.9.1-nompi_h0dd9c28_104.conda
osx-arm64::openpmd-api-0.15.2-nompi_py312hed703ef_102.conda
osx-arm64::ogre-1.10.12-h5c04fa6_15.conda
osx-arm64::minizip-4.0.2-hd5cad61_0.conda
osx-arm64::ifcopenshell-v0.7.0a10-py39he5275f1_2.conda
osx-arm64::jaxlib-0.4.14-cpu_py39he2ef314_1.conda
osx-arm64::openpmd-api-0.15.2-mpi_mpich_py312h011dce4_2.conda
osx-arm64::libarrow-13.0.0-h4164969_12_cpu.conda
osx-arm64::lammps-2023.08.02-cpu_py311_hcedb0ea_openmpi_7.conda
osx-arm64::ogre-14.1.1-h19e911b_0.conda
osx-arm64::protozfits-2.3.0-py310h2a7e794_1.conda
osx-arm64::heyoka-3.0.0-had0bed7_0.conda
osx-arm64::llvmdev-17.0.2-he79909e_0.conda
osx-arm64::healpy-1.16.6-py39h4168898_0.conda
osx-arm64::llvm-tools-17.0.2-he79909e_0.conda
osx-arm64::libgrpc-1.58.1-h5c97886_1.conda
osx-arm64::libgdal-3.7.2-h86be4ad_5.conda
osx-arm64::gdstk-0.9.46-py38hbce28a2_0.conda
osx-arm64::pygplates-0.39-py310h5c1f820_10.conda
osx-arm64::lammps-2023.08.02-cpu_py310_h44be136_openmpi_5.conda
osx-arm64::mysql-client-8.0.33-hf1148c8_5.conda
osx-arm64::lld-17.0.3-he164760_0.conda
osx-arm64::gst-plugins-good-1.22.6-h0f007b1_2.conda
osx-arm64::libitk-5.3.0-h541f4bf_7.conda
osx-arm64::libarrow-10.0.1-h837c6e2_45_cpu.conda
osx-arm64::vigra-1.11.2-py310h6875605_2.conda
osx-arm64::triqs-3.2.0-py38hf9cbd22_6.conda
osx-arm64::bytewax-0.17.1-py312h50e32b6_2.conda
osx-arm64::libarrow-13.0.0-h82e8550_9_cpu.conda
osx-arm64::folly-2023.10.09.00-hb8f665b_0_jemalloc.conda
osx-arm64::grpcio-1.58.1-py39h52f163a_1.conda
osx-arm64::heyoka-2.0.0-h5ec39c5_1.conda
osx-arm64::jaxlib-0.4.19-cpu_py310h17d2260_0.conda
osx-arm64::libopentelemetry-cpp-1.11.0-hda75a1d_2.conda
osx-arm64::libgdal-arrow-parquet-3.6.4-hb97af44_20.conda
osx-arm64::pillow-10.0.1-py38h6fd45aa_2.conda
osx-arm64::jaxlib-0.4.14-cpu_py310h17d2260_1.conda
osx-arm64::grpcio-1.58.1-py310h6121c79_2.conda
osx-arm64::ifcopenshell-v0.7.0a10-py39h1b60430_2.conda
osx-arm64::ffmpeg-4.4.2-gpl_h3f99325_113.conda
osx-arm64::lammps-2023.08.02-cpu_py310_hdbbd2cf_mpich_3.conda
osx-arm64::python-3.8.18-h2469fbe_0_cpython.conda
osx-arm64::lammps-2023.08.02-cpu_py39_h7cd824f_openmpi_6.conda
osx-arm64::cctools_osx-arm64-973.0.1-h2a25c60_15.conda
osx-arm64::netcdf4-1.6.5-mpi_mpich_py39heaa551b_0.conda
osx-arm64::libadios2-2.9.1-nompi_h986cc0a_103.conda
osx-arm64::python-igraph-0.11.2-py310h74d7e66_1.conda
osx-arm64::openimageio-2.5.4.0-py310hce50749_2.conda
osx-arm64::pygplates-0.39-py38hc53ad44_10.conda
osx-arm64::lfortran-0.21.5-hed44d8b_2.conda
osx-arm64::pyreadstat-1.2.4-py312ha17c255_0.conda
osx-arm64::netcdf4-1.6.5-nompi_py311ha6bebe6_100.conda
osx-arm64::nodejs-16.20.2-h7ed3092_2.conda
osx-arm64::folly-2023.09.25.00-h4e9558f_1_jemalloc.conda
osx-arm64::harp-1.20.1-py311hc42ed2c_0.conda
osx-arm64::grpcio-1.57.0-py311h79dd126_2.conda
osx-arm64::pyreadr-0.4.9-py39h0026de1_1.conda
osx-arm64::squashfs-tools-4.6.1-hb8b0402_0.conda
osx-arm64::openimageio-2.5.4.0-py39hcf4feee_1.conda
osx-arm64::imagecodecs-2023.9.18-py312hbe4d967_2.conda
osx-arm64::ndcctools-7.7.2-py310h7a27ce5_0.conda
osx-arm64::lldb-16.0.6-py39hc28f90a_0.conda
osx-arm64::paraview-5.11.2-py39h9186e5d_102_qt.conda
osx-arm64::folly-2023.10.16.00-ha5de9cd_0_jemalloc.conda
osx-arm64::libarrow-10.0.1-h63fb9dc_49_cpu.conda
osx-arm64::libkml-1.3.0-h4f02115_1016.conda
osx-arm64::jaxlib-0.4.19-cpu_py39he2ef314_0.conda
osx-arm64::gazebo-11.14.0-h59fe437_0.conda
osx-arm64::triqs-3.2.0-py311h3365640_7.conda
osx-arm64::libadios2-2.9.1-mpi_openmpi_h770f5e9_3.conda
osx-arm64::qt6-3d-6.5.3-h65d21c2_0.conda
osx-arm64::openpmd-api-0.15.2-mpi_mpich_py310h554ef6c_2.conda
osx-arm64::triqs-3.2.0-py311h3365640_6.conda
osx-arm64::texlive-core-20230313-py310h7fae8ea_6.conda
osx-arm64::pygplates-0.39-py312h88e6dac_12.conda
osx-arm64::libadios2-2.9.1-mpi_mpich_hb89f278_4.conda
osx-arm64::ifcopenshell-v0.7.0a10-py311h724c0c6_2.conda
osx-arm64::libadios2-2.9.1-mpi_openmpi_h2d5a834_3.conda
osx-arm64::pillow-10.1.0-py39h755f0b7_0.conda
osx-arm64::ogre-14.1.0-h30262ea_2.conda
osx-arm64::ambertools-23.3-py310h11fdf75_3.conda
osx-arm64::grpcio-1.57.1-py311h79dd126_0.conda
osx-arm64::pillow-10.1.0-py310hfae7ebd_0.conda
osx-arm64::vtk-base-9.2.6-qt_py311h1234567_216.conda
osx-arm64::openmeeg-2.5.6-py312hf3859b2_4.conda
osx-arm64::libadios2-2.9.1-mpi_mpich_ha72127e_4.conda
osx-arm64::grpcio-1.59.2-py312h780eafd_0.conda
osx-arm64::vowpalwabbit-9.9.0-py39h1e0b67c_1.conda
osx-arm64::libarrow-11.0.0-hf4fadc0_41_cpu.conda
osx-arm64::libboost-1.82.0-h72cdd8a_6.conda
osx-arm64::nco-5.1.8-h91bca93_1.conda
osx-arm64::folly-2023.10.30.00-h58b644a_0.conda
osx-arm64::paraview-5.11.2-py38h3bbeea0_102_qt.conda
osx-arm64::freeimage-3.18.0-hf3106d1_17.conda
osx-arm64::heyoka-2.0.0-h029d28e_1.conda
osx-arm64::ndcctools-7.7.2-py38h78e4241_0.conda
osx-arm64::libadios2-2.9.1-mpi_openmpi_h05051f9_3.conda
osx-arm64::libgrpc-1.57.0-h02f74b2_3.conda
osx-arm64::grpcio-1.59.1-py311h79dd126_0.conda
osx-arm64::libgdal-3.6.4-h6b465e7_22.conda
osx-arm64::gazebo-11.14.0-h84b3fa0_1.conda
osx-arm64::cppyy-cling-6.27.1-py39hd308395_1.conda
osx-arm64::minizip-4.0.1-h5a7aac7_5.conda
osx-arm64::dask-sql-2023.10.1-py310h2efcc80_0.conda
osx-arm64::grpcio-1.57.0-py312h780eafd_3.conda
osx-arm64::grpcio-1.59.1-py39h52f163a_0.conda
osx-arm64::libvips-8.14.5-h2dbb12f_2.conda
osx-arm64::paraview-5.11.2-py311ha00ec6d_102_qt.conda
osx-arm64::lammps-2023.08.02-cpu_py310_h44be136_openmpi_4.conda
osx-arm64::python-3.12.0-h47c9636_0_cpython.conda
osx-arm64::imagemagick-7.1.1_20-pl5321hf40678b_0.conda
osx-arm64::pyreadstat-1.2.4-py38he974862_0.conda
osx-arm64::pyinstaller-5.13.2-py38he974862_1.conda
osx-arm64::uwsgi-2.0.22-py311h797116b_3.conda
osx-arm64::ndcctools-7.7.0-py311hf3cef61_0.conda
osx-arm64::llvmlite-0.41.1-py310hf7687f1_0.conda
osx-arm64::vtk-base-9.2.6-qt_py38h1234567_217.conda
osx-arm64::pygrib-2.1.4-py38h261e500_8.conda
osx-arm64::libkml-1.3.0-h1eb4d9f_1018.conda
osx-arm64::harp-1.20.1-py39h2275332_0.conda
osx-arm64::libopencv-4.8.1-py311h927bda1_3.conda
osx-arm64::libadios2-2.9.1-nompi_hc6a385b_104.conda
osx-arm64::uwsgi-2.0.22-py311h797116b_2.conda
osx-arm64::vtk-base-9.2.6-qt_py311h1234567_218.conda
osx-arm64::tiledb-2.17.3-hb4613eb_0.conda
osx-arm64::grpcio-1.58.1-py312h780eafd_2.conda
osx-arm64::folly-2023.10.02.00-h97a60c1_0_jemalloc.conda
osx-arm64::cppyy-cling-6.27.1-py310h59dd246_1.conda
osx-arm64::pygplates-0.39-py310h5c1f820_11.conda
osx-arm64::vtk-base-9.2.6-qt_py39h1234567_216.conda
osx-arm64::ogre-14.1.0-h19e911b_2.conda
osx-arm64::pillow-10.0.1-py311h8dc27b9_2.conda
osx-arm64::folly-2023.10.09.00-ha5de9cd_0_jemalloc.conda
osx-arm64::pyreadr-0.4.9-py312h9afa136_1.conda
osx-arm64::netcdf4-1.6.5-nompi_py38hbde5882_100.conda
osx-arm64::grpcio-1.57.0-py39h52f163a_2.conda
osx-arm64::libgrpc-1.58.2-h19be7b0_0.conda
osx-arm64::pyinstaller-6.1.0-py39h8643609_0.conda
osx-arm64::libpulsar-3.2.0-hc0d535e_5.conda
osx-arm64::netcdf4-1.6.5-nompi_py310h3aafd6c_100.conda
osx-arm64::folly-2023.10.02.00-h4e9558f_0_jemalloc.conda
osx-arm64::vtk-base-9.2.6-qt_py38h1234567_215.conda
osx-arm64::openmeeg-2.5.6-py38h22f42f3_4.conda
osx-arm64::r-harp-1.20.1-py311hea92249_0.conda
osx-arm64::ambertools-23.3-py39h436489c_6.conda
osx-arm64::aws-sdk-cpp-1.11.156-ha282cf0_4.conda
osx-arm64::healpy-1.16.6-py312h5c1c293_1.conda
osx-arm64::cpp-opentelemetry-sdk-1.12.0-hda75a1d_0.conda
osx-arm64::protozfits-2.3.0-py39h9fe7d5a_1.conda
osx-arm64::libopencv-4.8.1-py310h9ce838d_2.conda
osx-arm64::libopencv-4.8.1-py310h3142fb2_1.conda
osx-arm64::libgdal-3.7.2-h40a65a3_6.conda
osx-arm64::triqs-3.2.0-py39h755e2d8_6.conda
osx-arm64::pygplates-0.39-py38hc53ad44_12.conda
osx-arm64::lfortran-0.21.5-hed44d8b_4.conda
osx-arm64::openpmd-api-0.15.2-mpi_openmpi_py310hee0ea13_2.conda
osx-arm64::netcdf4-1.6.5-mpi_mpich_py311h31cea76_0.conda
osx-arm64::grpcio-1.57.1-py312h780eafd_0.conda
osx-arm64::lammps-2023.08.02-cpu_py310_h13f71d6_mpich_7.conda
osx-arm64::pyreadr-0.4.9-py38hba03813_1.conda
osx-arm64::grpcio-1.59.1-py38hfeb05b4_0.conda
osx-arm64::libgrpc-1.57.0-hbf2b313_2.conda
osx-arm64::qt6-main-6.5.3-h9991a84_0.conda
osx-arm64::mold-2.3.1-h0a35e54_0.conda
osx-arm64::mlir-17.0.2-h2d3518b_0.conda
osx-arm64::heyoka-2.0.0-he25913f_1.conda
osx-arm64::openimageio-2.4.16.0-py312hd268a35_0.conda
osx-arm64::vtk-base-9.2.6-qt_py310h1234567_217.conda
osx-arm64::libarrow-12.0.1-h5325880_17_cpu.conda
osx-arm64::openimageio-2.4.16.0-py39hfb50237_0.conda
osx-arm64::libarrow-13.0.0-h5325880_8_cpu.conda
osx-arm64::lldb-16.0.6-py38h79030ad_0.conda
osx-arm64::pytables-3.9.1-py312h9aef7b8_0.conda
osx-arm64::r-harp-1.20-py38h2af7232_1.conda
osx-arm64::tesseract-5.3.2-hf994385_1.conda
osx-arm64::pillow-10.0.1-py312hb653a51_2.conda
osx-arm64::lfortran-0.21.5-hed44d8b_5.conda
osx-arm64::python-igraph-0.11.2-py39h64b2e74_1.conda
osx-arm64::imagecodecs-2023.9.18-py39ha02826a_1.conda
osx-arm64::osmium-tool-1.16.0-h50f88fa_2.conda
osx-arm64::pytables-3.8.0-py38hcf313c7_4.conda
osx-arm64::lammps-2023.08.02-cpu_py311_h23098a1_mpich_6.conda
osx-arm64::lammps-2023.08.02-cpu_py38_h0e78505_mpich_3.conda
osx-arm64::chemicalite-2022.04.1-hcb187e3_12.conda
osx-arm64::lfortran-0.21.5-hed44d8b_3.conda
osx-arm64::ifcopenshell-v0.7.0a10-py38hc21e005_1.conda
osx-arm64::pyinstaller-6.1.0-py312ha17c255_0.conda
osx-arm64::ldas-tools-framecpp-2.9.2-he8bb7c5_1.conda
osx-arm64::pytables-3.8.0-py312h2ed9014_4.conda
osx-arm64::libadios2-2.9.1-mpi_mpich_h1df5735_3.conda
osx-arm64::netcdf4-1.6.5-nompi_py39h0873ea8_100.conda
osx-arm64::pytables-3.9.1-py310h1846626_0.conda
osx-arm64::jaxlib-0.4.18-cpu_py312h46293e5_0.conda
osx-arm64::aws-sdk-cpp-1.11.182-hba14a0b_2.conda
osx-arm64::pyinstaller-6.1.0-py38he974862_0.conda
osx-arm64::ffmpeg-5.1.2-lgpl_h5eb873f_12.conda
osx-arm64::harp-1.20-py311hc42ed2c_1.conda
osx-arm64::harp-1.20-py310h2275332_1.conda
osx-arm64::openpmd-api-0.15.2-mpi_openmpi_py311hf55b99c_2.conda
osx-arm64::llvm-17.0.2-h2b67075_0.conda
osx-arm64::openimageio-2.5.4.0-py38h3fb5564_2.conda
osx-arm64::libopencv-4.8.1-py38h35d01dd_3.conda
osx-arm64::pyinstaller-6.1.0-py310h742d9d8_0.conda
osx-arm64::pytables-3.9.1-py39h717dae7_0.conda
osx-arm64::lammps-2023.08.02-cpu_py38_h0e78505_mpich_5.conda
osx-arm64::pytng-0.3.1-py311h873492f_0.conda
osx-arm64::libarrow-12.0.1-h82e8550_18_cpu.conda
osx-arm64::tiledb-2.17.2-h400cb46_0.conda
osx-arm64::nginx-1.25.3-h40919b7_0.conda
osx-arm64::lammps-2023.08.02-cpu_py311_hcedb0ea_openmpi_6.conda
osx-arm64::grpcio-1.57.1-py38hfeb05b4_0.conda
osx-arm64::gazebo-11.13.0-h59fe437_12.conda
osx-arm64::qt-main-5.15.8-h6bf1bb6_17.conda
osx-arm64::libcurl-static-8.4.0-h2d989ff_0.conda
osx-arm64::grpcio-1.58.1-py38hfeb05b4_2.conda
osx-arm64::healpy-1.16.6-py310hc9bbe2c_0.conda
osx-arm64::cppyy-cling-6.27.1-py311h4ca21db_1.conda
osx-arm64::bytewax-0.17.1-py310h90e2b35_2.conda
osx-arm64::libadios2-2.9.1-nompi_hce71c91_104.conda
osx-arm64::omniorb-4.3.1-py310hfce7497_2.conda
osx-arm64::llvmlite-0.41.1-py311hf5d242d_0.conda
osx-arm64::omniorb-libs-4.3.1-h13d9943_2.conda
osx-arm64::vowpalwabbit-9.9.0-py311ha4d11ac_2.conda
osx-arm64::libllvm17-17.0.3-hc359061_0.conda
osx-arm64::boost-cpp-1.82.0-hca5e981_5.conda
osx-arm64::vtk-base-9.2.6-qt_py310h1234567_216.conda
osx-arm64::python-igraph-0.11.2-py312h8d8ca30_1.conda
osx-arm64::libadios2-2.9.1-nompi_h2706e1b_103.conda
osx-arm64::ale-py-0.8.1-py311hd7a9565_1.conda
osx-arm64::grpcio-1.58.2-py311h79dd126_0.conda
osx-arm64::bytewax-0.17.1-py38hc465553_2.conda
osx-arm64::libkml-1.3.0-h1eb4d9f_1017.conda
osx-arm64::netcdf4-1.6.5-mpi_openmpi_py39h58962e1_0.conda
osx-arm64::paraview-5.11.2-py311h673f61a_102_qt.conda
osx-arm64::jaxlib-0.4.14-cpu_py311he8a259a_1.conda
osx-arm64::ndcctools-7.7.2-py38hf8267ce_0.conda
osx-arm64::ldas-tools-framecpp-3.0.2-h4fcec16_3.conda
osx-arm64::lammps-2023.08.02-cpu_py38_h9e6eba2_openmpi_4.conda
osx-arm64::libgdal-arrow-parquet-3.7.2-hec9bbb6_5.conda
osx-arm64::nss-3.94-hc6b9969_0.conda
osx-arm64::libmediainfo-23.10-hbb71fad_0.conda
osx-arm64::uwsgi-2.0.22-py310h8fc4ae9_1.conda
osx-arm64::nodejs-20.8.1-h0950e01_0.conda
osx-arm64::harp-1.20.1-py38h2275332_0.conda
osx-arm64::mysql-libs-8.0.33-he3dca8b_5.conda
osx-arm64::uwsgi-2.0.22-py311h8a62a3c_0.conda
osx-arm64::folly-2023.10.09.00-h58b644a_0.conda
osx-arm64::ndcctools-7.7.1-py39hcfa8d96_0.conda
osx-arm64::lammps-2023.08.02-cpu_py38_h159ea53_mpich_6.conda
osx-arm64::pillow-10.1.0-py311hb9c5795_0.conda
osx-arm64::nodejs-18.17.1-h7ed3092_1.conda
osx-arm64::llvm-tools-17.0.3-hc359061_0.conda
osx-arm64::libgrpc-1.59.1-hbcf6334_0.conda
osx-arm64::yarp-cxx-3.8.1-head0e6e_6.conda
osx-arm64::triqs-3.2.0-py312h010257e_7.conda
osx-arm64::dask-sql-2023.10.0-py310h2efcc80_0.conda
osx-arm64::libgrpc-1.58.1-h19be7b0_2.conda
osx-arm64::folly-2023.10.23.00-hcdc1028_0_jemalloc.conda
osx-arm64::lammps-2023.08.02-cpu_py39_hd590433_mpich_6.conda
osx-arm64::libtensorflow-2.12.1-cpu_h8bdb520_1.conda
osx-arm64::lammps-2023.08.02-cpu_py39_h4943416_mpich_4.conda
osx-arm64::grpcio-1.59.2-py310h6121c79_0.conda
osx-arm64::grpcio-1.57.0-py39h52f163a_3.conda
osx-arm64::grpcio-1.57.0-py310h6121c79_2.conda
osx-arm64::boost-cpp-1.82.0-hca5e981_4.conda
osx-arm64::ffmpeg-5.1.2-gpl_h9861f02_112.conda
osx-arm64::ogre-14.1.2-h30262ea_0.conda
osx-arm64::ldas-tools-framecpp-3.0.2-hd22d539_2.conda
osx-arm64::afterimage-1.21-h908a25a_1005.conda
osx-arm64::libarrow-12.0.1-h0c25ffe_15_cpu.conda
osx-arm64::hugin-base-2022.0.0-pl5321hef7cccf_8.conda
osx-arm64::cctools_osx-64-973.0.1-hfb56cc2_15.conda
osx-arm64::triqs-3.2.0-py38h5f1bdad_6.conda
osx-arm64::libadios2-2.9.1-nompi_h37b74dd_104.conda
osx-arm64::heyoka-llvm-16-2.0.0-h4a435fa_1.conda
osx-arm64::grpcio-1.59.1-py310h6121c79_0.conda
osx-arm64::dask-sql-2023.10.0-py311hfbab5a9_0.conda
osx-arm64::cairo-1.18.0-hd1e100b_0.conda
osx-arm64::lfortran-0.21.5-hed44d8b_7.conda
osx-arm64::llvmdev-17.0.3-hc359061_0.conda
osx-arm64::protozfits-2.3.0-py38h4d08397_1.conda
osx-arm64::folly-2023.10.23.00-h75b8fe2_0.conda
osx-arm64::pygplates-0.39-py311h97f3abb_12.conda
osx-arm64::libarrow-13.0.0-hf4fadc0_7_cpu.conda
osx-arm64::pcre2-static-10.42-h26f9a81_0.conda
osx-arm64::chemicalite-2022.04.1-h4c1a556_13.conda
osx-arm64::pygplates-0.39-py311h97f3abb_11.conda
osx-arm64::healpy-1.16.6-py39h3aee632_1.conda
osx-arm64::libarrow-13.0.0-h87fad27_13_cpu.conda
osx-arm64::libopentelemetry-cpp-1.12.0-hda75a1d_0.conda
osx-arm64::ambertools-23.3-py310h89a8e17_4.conda
osx-arm64::uwsgi-2.0.22-py39h81f957d_2.conda
osx-arm64::vtk-base-9.2.6-qt_py39h1234567_215.conda
osx-arm64::libadios2-2.9.1-mpi_mpich_h669b64a_3.conda
osx-arm64::tiledb-2.17.3-h555b8a3_1.conda
osx-arm64::mlir-17.0.3-hba3f82b_0.conda
osx-arm64::ale-py-0.8.1-py310h38a53a8_1.conda
osx-arm64::pyreadstat-1.2.3-py310hab90de1_1.conda
osx-arm64::libopencv-4.8.1-py311h1cc70c8_1.conda
osx-arm64::vigra-1.11.2-py39h426957a_3.conda
osx-arm64::libopencv-4.8.1-py39h483c304_1.conda
osx-arm64::r-harp-1.20.1-py310h1db3a1d_0.conda
osx-arm64::libopencv-4.8.1-py39h3005bad_3.conda
osx-arm64::llvmlite-0.41.1-py39h047a24b_0.conda
osx-arm64::vowpalwabbit-9.9.0-py38h3889012_1.conda
osx-arm64::leptonica-1.83.1-hc69d283_5.conda
osx-arm64::pygrib-2.1.4-py39h914d841_8.conda
osx-arm64::triqs-3.2.0-py310hb266d3d_7.conda
osx-arm64::cppyy-cling-6.27.1-py312hee8bc9d_1.conda
osx-arm64::tensorflow-base-2.12.1-cpu_py38h7de3861_1.conda
osx-arm64::lfortran-0.23.0-hbeb2e11_0.conda
osx-arm64::heyoka-3.0.0-he663e9d_0.conda
osx-arm64::lammps-2023.08.02-cpu_py39_h4943416_mpich_5.conda
osx-arm64::libadios2-2.9.1-mpi_openmpi_hd79087d_4.conda
osx-arm64::assimp-5.3.1-he63ff86_2.conda
osx-arm64::libllvm17-17.0.2-he79909e_0.conda
osx-arm64::healpy-1.16.6-py311h097425f_1.conda
osx-arm64::qt6-main-6.6.0-h9991a84_0.conda
osx-arm64::ndcctools-7.7.1-py310h3fc91fe_0.conda
osx-arm64::lfortran-0.27.0-hed44d8b_0.conda
osx-arm64::libopencv-4.8.1-py310h9ce838d_3.conda
osx-arm64::pdal-2.6.0-h4618ce4_0.conda
osx-arm64::heyoka-2.0.0-h88a18fb_1.conda
osx-arm64::lammps-2023.08.02-cpu_py39_h7cd824f_openmpi_7.conda
osx-arm64::triqs-3.2.0-py312h234acf8_7.conda
osx-arm64::uwsgi-2.0.22-py39h1196e1c_0.conda
osx-arm64::folly-2023.10.09.00-h83f57a1_0.conda
osx-arm64::cargo-c-0.9.27-hdf7d417_0.conda
osx-arm64::uwsgi-2.0.22-py310h8fc4ae9_3.conda
osx-arm64::vowpalwabbit-9.9.0-py310h6446520_1.conda
osx-arm64::openimageio-2.5.4.0-py312h6fe0b6f_1.conda
osx-arm64::lammps-2023.08.02-cpu_py38_h7c1f8ad_openmpi_7.conda
osx-arm64::pygrib-2.1.4-py310h3705f70_8.conda
osx-arm64::vigra-1.11.2-py311h5ee74f8_3.conda
osx-arm64::vowpalwabbit-9.9.0-py311h934da0d_1.conda
osx-arm64::vtk-base-9.2.6-qt_py311h1234567_215.conda
osx-arm64::openpmd-api-0.15.2-nompi_py38hcf396f9_102.conda
osx-arm64::tensorflow-base-2.13.1-cpu_py38h9e37100_1.conda
osx-arm64::uwsgi-2.0.22-py38h7fe962d_0.conda
osx-arm64::libnghttp2-1.55.1-h2b02ca0_0.conda
osx-arm64::heyoka-llvm-14-2.0.0-hf269ef6_1.conda
osx-arm64::ndcctools-7.7.1-py311h3d5ec97_0.conda
osx-arm64::heyoka-llvm-15-2.0.0-h3213e78_1.conda
osx-arm64::smesh-9.9.0.0-hc4060f7_8.conda
osx-arm64::imagecodecs-2023.9.18-py311h0b517cc_2.conda
osx-arm64::libarrow-11.0.0-h0c25ffe_40_cpu.conda
osx-arm64::leptonica-1.83.1-hfd1401c_4.conda
osx-arm64::dask-sql-2023.10.0-py38h2692745_1.conda
osx-arm64::mold-2.3.0-hdbeb7c9_0.conda
osx-arm64::python-igraph-0.11.2-py311h72fc80f_0.conda
osx-arm64::uwsgi-2.0.22-py38hda3d3a1_2.conda
osx-arm64::lfortran-0.21.2-hbe7ddab_0.conda
osx-arm64::python-igraph-0.10.8-py39h178e2a8_1.conda
osx-arm64::protozfits-2.3.0-py311heff9fe7_1.conda
osx-arm64::libvips-8.14.5-h0e81681_3.conda
osx-arm64::vigra-1.11.2-py312h7a46c7c_2.conda
osx-arm64::folly-2023.09.25.00-h97a60c1_1_jemalloc.conda
osx-arm64::tiledb-2.17.3-h555b8a3_0.conda
osx-arm64::pyreadstat-1.2.4-py39h8643609_0.conda
osx-arm64::bytewax-0.17.1-py39haac67bd_2.conda
osx-arm64::mysql-connector-cpp-8.0.29-h13d9943_3.conda
osx-arm64::ambertools-23.3-py311hd5bda53_6.conda
osx-arm64::gazebo-11.13.0-h7c12456_10.conda
osx-arm64::openmeeg-2.5.6-py311ha34dd9c_4.conda
osx-arm64::openpmd-api-0.15.2-nompi_py310h1893314_102.conda
osx-arm64::r-harp-1.20.1-py38h2af7232_0.conda
osx-arm64::jaxlib-0.4.19-cpu_py312h02d5aa3_0.conda
osx-arm64::folly-2023.10.16.00-h2db6db1_0.conda
osx-arm64::grpcio-1.58.1-py39h52f163a_2.conda
osx-arm64::libarrow-10.0.1-h8276777_50_cpu.conda
osx-arm64::netcdf4-1.6.5-nompi_py312h9035142_100.conda
osx-arm64::paraview-5.11.2-py310h53048f5_102_qt.conda
osx-arm64::openmeeg-2.5.6-py39hfb363a9_4.conda
osx-arm64::grpcio-1.57.0-py38hfeb05b4_3.conda
osx-arm64::uwsgi-2.0.22-py311h797116b_1.conda
osx-arm64::grpcio-1.59.2-py311h79dd126_0.conda
osx-arm64::grpcio-1.57.0-py312h780eafd_2.conda
osx-arm64::pygplates-0.39-py312h88e6dac_11.conda
osx-arm64::curl-8.4.0-h2d989ff_0.conda
osx-arm64::pygplates-0.39-py39h976a749_12.conda
osx-arm64::gazebo-11.13.0-hcc5424f_9.conda
osx-arm64::python-igraph-0.11.2-py38h8fa9ae3_1.conda
osx-arm64::pyreadstat-1.2.4-py310h742d9d8_0.conda
osx-arm64::netcdf4-1.6.5-mpi_openmpi_py311h6754c9a_0.conda
osx-arm64::grpcio-1.59.2-py39h52f163a_0.conda
osx-arm64::openmpi-4.1.6-h4971d84_100.conda
osx-arm64::vigra-1.11.2-py311h9b777ca_2.conda
osx-arm64::ndcctools-7.7.0-py39h6d2f949_0.conda
osx-arm64::pyreadr-0.4.9-py311h824b5d7_1.conda
osx-arm64::folly-2023.10.30.00-hb8f665b_0_jemalloc.conda
osx-arm64::libadios2-2.9.1-mpi_openmpi_haea5992_4.conda
osx-arm64::vigra-1.11.2-py310h90ab986_3.conda
osx-arm64::ndcctools-7.7.2-py310h3fc91fe_0.conda
osx-arm64::pdal-2.5.6-hb8312d3_4.conda
osx-arm64::triqs-3.2.0-py310h410086f_6.conda
osx-arm64::sdl_image-1.2.12-hf5c8ead_6.conda
osx-arm64::openscenegraph-3.6.5-h71ba0d9_18.conda
osx-arm64::libmatio-1.5.24-h3b23503_0.conda
osx-arm64::ogre-14.1.1-h30262ea_0.conda
osx-arm64::libadios2-2.9.1-mpi_openmpi_h01ce388_4.conda
osx-arm64::libgdal-arrow-parquet-3.6.4-h8040843_21.conda
osx-arm64::libarrow-10.0.1-h77bd43d_47_cpu.conda
osx-arm64::vtk-base-9.2.6-qt_py38h1234567_216.conda
osx-arm64::ambertools-23.3-py38h34f1375_5.conda
osx-arm64::tensorflow-base-2.12.1-cpu_py310h6202087_1.conda
osx-arm64::folly-2023.10.16.00-h58b644a_0.conda
osx-arm64::llvm-17.0.3-h2b67075_1.conda
osx-arm64::pygplates-0.39-py39h976a749_10.conda
osx-arm64::lfortran-0.21.5-hbe7ddab_1.conda
osx-arm64::folly-2023.10.02.00-hb929855_0_jemalloc.conda
osx-arm64::vowpalwabbit-9.9.0-py39haf5df7a_2.conda
osx-arm64::imagecodecs-2023.9.18-py310h646f8c5_1.conda
osx-arm64::imagecodecs-2023.9.18-py39ha02826a_2.conda
osx-arm64::qt6-3d-6.6.0-h65d21c2_0.conda
osx-arm64::ifcopenshell-v0.7.0a10-py311h5f70c33_2.conda
osx-arm64::lldb-16.0.6-py311hb7211e6_0.conda
osx-arm64::pytables-3.8.0-py310h441c2ec_4.conda
osx-arm64::folly-2023.10.23.00-ha98ecff_0.conda
osx-arm64::protozfits-2.3.0-py311h8e6d870_0.conda
osx-arm64::heyoka-llvm-14-3.0.0-hf269ef6_0.conda
osx-arm64::photochem-0.4.4-py38h0457063_0.conda
osx-arm64::libadios2-2.9.1-nompi_h6e6decc_103.conda
osx-arm64::qt6-main-6.5.2-hcd86305_5.conda
osx-arm64::libcurl-8.4.0-h2d989ff_0.conda
osx-arm64::ndcctools-7.7.1-py38h78e4241_0.conda
osx-arm64::libgdal-arrow-parquet-3.6.4-h2bb1f22_22.conda
osx-arm64::libpulsar-3.2.0-hcd83280_4.conda
osx-arm64::paraview-5.11.2-py310h3cefc14_102_qt.conda
osx-arm64::tensorflow-base-2.12.1-cpu_py39hd1a7ea3_1.conda
osx-arm64::dask-sql-2023.10.1-py39h017d637_0.conda
osx-arm64::pillow-10.0.1-py39h90af52a_2.conda
osx-arm64::grpcio-1.58.1-py311h79dd126_1.conda
osx-arm64::lammps-2023.08.02-cpu_py39_h77ea923_openmpi_4.conda
osx-arm64::libadios2-2.9.1-mpi_mpich_h1eec86a_4.conda
osx-arm64::ambertools-23.3-py310h2aae41f_6.conda
osx-arm64::orc-1.9.0-hcd02cb2_3.conda
osx-arm64::folly-2023.10.23.00-ha8c0bfd_0.conda
osx-arm64::pygplates-0.39-py39h976a749_11.conda
osx-arm64::vtk-base-9.2.6-qt_py39h1234567_218.conda
osx-arm64::folly-2023.10.30.00-h2db6db1_0.conda
osx-arm64::lammps-2023.08.02-cpu_py39_h4943416_mpich_3.conda
osx-arm64::pillow-10.1.0-py312hac22aec_0.conda
osx-arm64::folly-2023.10.02.00-hf3e1787_0.conda
osx-arm64::pyreadr-0.5.0-py312h473bb10_0.conda
osx-arm64::ale-py-0.8.1-py38h53ce561_1.conda
osx-arm64::lammps-2023.08.02-cpu_py38_h7c1f8ad_openmpi_6.conda
osx-arm64::libopencv-4.8.1-py312h494ba3b_3.conda
osx-arm64::triqs-3.2.0-py39h3dd32c9_6.conda
osx-arm64::libgdal-3.6.4-hf83647e_20.conda
osx-arm64::dask-sql-2023.10.0-py38h2692745_0.conda
osx-arm64::openpmd-api-0.15.2-mpi_openmpi_py38h85233c0_2.conda
osx-arm64::pyinstaller-5.13.2-py39h8643609_1.conda
osx-arm64::paraview-5.11.2-py38h750e622_102_qt.conda
osx-arm64::openimageio-2.4.16.0-py38hab7664e_0.conda
osx-arm64::vigra-1.11.2-py312hc610b90_1.conda
osx-arm64::pytables-3.8.0-py39h94cd330_4.conda
osx-arm64::heyoka-llvm-12-2.0.0-hcf5fcb2_1.conda
osx-arm64::libgrpc-1.57.1-h02f74b2_0.conda
osx-arm64::gdstk-0.9.46-py310h745f51c_0.conda
osx-arm64::smesh-9.9.0.0-hb6b1f3d_9.conda
osx-arm64::pytng-0.3.1-py310ha5b23ed_0.conda
osx-arm64::libarrow-12.0.1-h55e072d_19_cpu.conda
osx-arm64::libadios2-2.9.1-nompi_h6c7eb87_104.conda
osx-arm64::libarrow-12.0.1-h87fad27_21_cpu.conda
osx-arm64::openpmd-api-0.15.2-nompi_py311h6190857_102.conda
osx-arm64::cppyy-cling-6.27.1-py38h9908e9a_1.conda
osx-arm64::pyinstaller-5.13.2-py311h4045465_1.conda
osx-arm64::pyinstaller-6.1.0-py311h4045465_0.conda
osx-arm64::photochem-0.4.4-py39h47feec1_0.conda
osx-arm64::r-harp-1.20-py39h31e696d_1.conda
osx-arm64::libgdal-3.7.2-h116f65a_7.conda
osx-arm64::heyoka-llvm-16-3.0.0-h4a435fa_0.conda
osx-arm64::heyoka-llvm-11-2.0.0-hd89da14_1.conda
osx-arm64::lammps-2023.08.02-cpu_py310_h44be136_openmpi_3.conda
osx-arm64::sqlite-3.43.2-hf2abe2d_0.conda
osx-arm64::grpcio-1.57.1-py39h52f163a_0.conda
osx-arm64::lammps-2023.08.02-cpu_py38_h0e78505_mpich_4.conda
osx-arm64::triqs-3.2.0-py310h410086f_7.conda
osx-arm64::lammps-2023.08.02-cpu_py38_h159ea53_mpich_7.conda
osx-arm64::ifcopenshell-v0.7.0a10-py38hc21e005_2.conda
osx-arm64::ambertools-23.3-py38h6e2678a_4.conda
osx-arm64::folly-2023.10.09.00-hd3f4852_0_jemalloc.conda
osx-arm64::openpmd-api-0.15.2-mpi_openmpi_py312hd046e9c_2.conda
osx-arm64::cpp-opentelemetry-sdk-1.11.0-hda75a1d_2.conda
osx-arm64::folly-2023.10.30.00-hd3f4852_0_jemalloc.conda
osx-arm64::openpmd-api-0.15.2-mpi_mpich_py39h3eff245_2.conda
osx-arm64::paraview-5.11.2-py312h716c886_102_qt.conda
osx-arm64::vigra-1.11.2-py312hf485725_3.conda
osx-arm64::openmeeg-2.5.6-py310h4ae8585_4.conda
osx-arm64::aws-sdk-cpp-1.11.182-hff1bf15_0.conda
osx-arm64::pyreadr-0.5.0-py38hbf71bf5_0.conda
osx-arm64::python-igraph-0.11.2-py39h64b2e74_0.conda
osx-arm64::netcdf4-1.6.5-mpi_openmpi_py38hdee5289_0.conda
osx-arm64::grpcio-1.57.0-py311h79dd126_3.conda
osx-arm64::jaxlib-0.4.19-cpu_py311he8a259a_0.conda
osx-arm64::libarrow-13.0.0-h17e2c58_11_cpu.conda
osx-arm64::libopencv-4.8.1-py311h927bda1_2.conda
osx-arm64::libtensorflow-2.13.1-cpu_h83790c0_1.conda
osx-arm64::vtk-base-9.2.6-qt_py311h1234567_217.conda
osx-arm64::libadios2-2.9.1-mpi_mpich_h881ba8b_3.conda
osx-arm64::lfortran-0.21.3-hbe7ddab_1.conda
osx-arm64::libgdal-arrow-parquet-3.7.2-h141375c_7.conda
osx-arm64::qt6-main-6.5.2-h9991a84_6.conda
osx-arm64::lammps-2023.08.02-cpu_py310_h6437ca0_openmpi_6.conda
osx-arm64::grpcio-1.58.1-py312h780eafd_1.conda
osx-arm64::cctools_osx-64-973.0.1-hf0ce4cb_15.conda
osx-arm64::lammps-2023.08.02-cpu_py39_hd590433_mpich_7.conda
osx-arm64::dask-sql-2023.10.0-py39h017d637_0.conda
osx-arm64::openimageio-2.5.4.0-py312h72cd4a4_2.conda
osx-arm64::ambertools-23.3-py39hdc8aaf7_3.conda
osx-arm64::photochem-0.4.4-py310h8ed26e2_0.conda
osx-arm64::lfortran-0.22.0-hed44d8b_0.conda
osx-arm64::aws-sdk-cpp-1.11.156-hff1bf15_5.conda
osx-arm64::vtk-base-9.2.6-qt_py312h1234567_218.conda
osx-arm64::ndcctools-7.7.2-py311h3d5ec97_0.conda
osx-arm64::libadios2-2.9.1-nompi_h4702e56_103.conda
osx-arm64::vowpalwabbit-9.9.0-py310h9feb4ac_2.conda
osx-arm64::tiledb-2.17.3-he462678_1.conda
osx-arm64::libarrow-12.0.1-h17e2c58_20_cpu.conda
osx-arm64::libarrow-11.0.0-h87fad27_46_cpu.conda
osx-arm64::libgrpc-1.59.2-hbcf6334_0.conda
osx-arm64::python-igraph-0.11.2-py310h74d7e66_0.conda
osx-arm64::llvmlite-0.41.1-py38hbed3d3f_0.conda
osx-arm64::lammps-2023.08.02-cpu_py310_h13f71d6_mpich_6.conda
osx-arm64::libopencv-4.8.1-py38h5dc10ea_1.conda
osx-arm64::libopencv-4.8.1-py39h3005bad_2.conda
osx-arm64::lammps-2023.08.02-cpu_py38_h9e6eba2_openmpi_5.conda
osx-arm64::libbrial-1.2.12-ha7f5006_1.conda
osx-arm64::netcdf4-1.6.5-mpi_mpich_py38h4041e12_0.conda
osx-arm64::pyreadstat-1.2.3-py311h79498d2_1.conda
osx-arm64::ifcopenshell-v0.7.0a10-py311h724c0c6_1.conda
osx-arm64::collada-dom-2.5.0-h458611f_7.conda
osx-arm64::openimageio-2.5.4.0-py311h1cdafb0_2.conda
osx-arm64::lammps-2023.08.02-cpu_py39_h77ea923_openmpi_5.conda
osx-arm64::folly-2023.09.25.00-h8c8b5cc_1.conda
osx-arm64::tiledb-2.17.2-h7fe5213_0.conda
osx-arm64::texlive-core-20230313-py310hf3d225c_7.conda
osx-arm64::folly-2023.09.25.00-hf3e1787_1.conda
osx-arm64::uwsgi-2.0.22-py39h81f957d_1.conda
osx-arm64::imagecodecs-2023.9.18-py310h646f8c5_2.conda
osx-arm64::heyoka-2.0.0-hbf6992f_1.conda
osx-arm64::python-igraph-0.10.8-py310h857be79_1.conda
osx-arm64::imagemagick-7.1.1_19-pl5321hec8f2ed_0.conda
osx-arm64::r-harp-1.20.1-py39h31e696d_0.conda
osx-arm64::libadios2-2.9.1-mpi_mpich_ha31068b_3.conda
osx-arm64::poppler-23.10.0-hcdd998b_0.conda
osx-arm64::vtk-base-9.2.6-qt_py310h1234567_215.conda
osx-arm64::pillow-10.1.0-py38h06aea99_0.conda
osx-arm64::freeimage-3.18.0-hb30a9ca_18.conda
osx-arm64::protozfits-2.3.0-py39hd5335c6_0.conda
osx-arm64::libadios2-2.9.1-mpi_openmpi_h9d59845_4.conda
osx-arm64::folly-2023.10.23.00-h584d98d_0_jemalloc.conda
osx-arm64::gdstk-0.9.46-py312h5f5ee38_0.conda
osx-arm64::folly-2023.10.02.00-h8c8b5cc_0.conda
osx-arm64::openimageio-2.5.4.0-py311h940057b_1.conda
osx-arm64::triqs-3.2.0-py38hf9cbd22_7.conda
osx-arm64::libxmlsec1-1.3.2-h8a598cd_0.conda
osx-arm64::paraview-5.11.2-py38h7053a62_102_qt.conda
osx-arm64::ndcctools-7.7.2-py39hcfa8d96_0.conda
osx-arm64::libarrow-11.0.0-h55e072d_44_cpu.conda
osx-arm64::lammps-2023.08.02-cpu_py311_h1b396ce_openmpi_4.conda
osx-arm64::folly-2023.10.23.00-he914830_0_jemalloc.conda
osx-arm64::tiledb-2.17.2-h28ea8ba_0.conda
osx-arm64::lfortran-0.29.0-hed44d8b_0.conda
osx-arm64::uwsgi-2.0.22-py310hc197ab2_0.conda
osx-arm64::openpmd-api-0.15.2-mpi_mpich_py38h203be7b_2.conda
osx-arm64::poppler-23.08.0-hcdd998b_3.conda
osx-arm64::gdstk-0.9.46-py311h52bd988_0.conda
osx-arm64::tiledb-2.17.3-hb4613eb_1.conda
osx-arm64::lfortran-0.28.0-hed44d8b_0.conda
osx-arm64::ifcopenshell-v0.7.0a10-py39he5275f1_1.conda
osx-arm64::dask-sql-2023.10.0-py311hfbab5a9_1.conda
osx-arm64::openscenegraph-3.6.5-hbf6730c_17.conda
osx-arm64::grpcio-1.57.0-py310h6121c79_3.conda
osx-arm64::imagemagick-7.1.1_19-pl5321h75e221c_1.conda
osx-arm64::libboost-1.82.0-h72cdd8a_5.conda
osx-arm64::tiledb-2.17.3-he462678_0.conda
osx-arm64::bytewax-0.17.1-py311h03d9925_2.conda
osx-arm64::pygplates-0.39-py38hc53ad44_11.conda
osx-arm64::paraview-5.11.2-py311h4bcc4b4_102_qt.conda
osx-arm64::ifcopenshell-v0.7.0a10-py311h5f70c33_1.conda
osx-arm64::ambertools-23.3-py312h2d94d45_6.conda
osx-arm64::ifcopenshell-v0.7.0a10-py310h60c11ec_1.conda
osx-arm64::python-igraph-0.11.2-py38h8fa9ae3_0.conda
osx-arm64::vtk-base-9.2.6-qt_py39h1234567_217.conda
osx-arm64::aws-sdk-cpp-1.10.57-hd972c10_24.conda
osx-arm64::mysql-server-8.0.33-h46a5c71_5.conda
osx-arm64::folly-2023.10.09.00-h2db6db1_0.conda
osx-arm64::pyreadstat-1.2.4-py311h4045465_0.conda
osx-arm64::lammps-2023.08.02-cpu_py311_he687244_mpich_3.conda
osx-arm64::r-harp-1.20-py311hea92249_1.conda
osx-arm64::lammps-2023.08.02-cpu_py311_h1b396ce_openmpi_3.conda
osx-arm64::triqs-3.2.0-py310hb266d3d_6.conda
osx-arm64::ifcopenshell-v0.7.0a10-py310h1c3345d_1.conda
osx-arm64::pyreadstat-1.2.3-py38he9a9ba6_1.conda
osx-arm64::protozfits-2.3.0-py38h10b3b7c_0.conda
osx-arm64::openpmd-api-0.15.2-nompi_py39h4bb3461_102.conda
osx-arm64::lfortran-0.24.0-hbeb2e11_0.conda
osx-arm64::grpcio-1.59.1-py312h780eafd_0.conda
osx-arm64::ale-py-0.8.1-py39hca40b88_1.conda
osx-arm64::omniorb-4.3.1-py311h8617d33_2.conda
osx-arm64::folly-2023.10.16.00-hb8f665b_0_jemalloc.conda
osx-arm64::triqs-3.2.0-py311hdc400ac_6.conda
osx-arm64::omniorb-4.3.1-py38h8c06ffa_2.conda
osx-arm64::ndcctools-7.7.0-py38h3b9d5fa_0.conda
osx-arm64::rocksdb-8.5.3-h9a28685_0.conda
osx-arm64::vigra-1.11.2-py38hb2b9eab_3.conda
osx-arm64::lammps-2023.08.02-cpu_py311_h23098a1_mpich_7.conda
osx-arm64::python-igraph-0.11.2-py311h72fc80f_1.conda
osx-arm64::vigra-1.11.2-py311h8d5b71e_1.conda
osx-arm64::llvmdev-17.0.3-hc359061_1.conda
osx-arm64::triqs-3.2.0-py38h5f1bdad_7.conda
osx-arm64::ambertools-23.3-py39h436489c_5.conda
osx-arm64::python-3.11.6-h47c9636_0_cpython.conda
osx-arm64::pygplates-0.39-py310h5c1f820_12.conda
osx-arm64::lfortran-0.26.0-hed44d8b_0.conda
osx-arm64::grpcio-1.58.2-py38hfeb05b4_0.conda
osx-arm64::heyoka-llvm-13-3.0.0-hed95047_0.conda
osx-arm64::vigra-1.11.2-py38h9733853_2.conda
osx-arm64::lfortran-0.21.5-hbe7ddab_0.conda
osx-arm64::r-harp-1.20-py310h1db3a1d_1.conda
osx-arm64::llvm-17.0.3-h2b67075_0.conda
osx-arm64::heyoka-3.0.0-h9e77e2b_0.conda
osx-arm64::ifcopenshell-v0.7.0a10-py310h60c11ec_2.conda
osx-arm64::heyoka-llvm-15-3.0.0-h3213e78_0.conda
osx-arm64::openpmd-api-0.15.2-mpi_openmpi_py39h79022b1_2.conda
osx-arm64::ffmpeg-4.4.2-lgpl_h5ca3fce_13.conda
osx-arm64::imagecodecs-2023.9.18-py311h0b517cc_1.conda
osx-arm64::libarrow-11.0.0-h17e2c58_45_cpu.conda
osx-arm64::rocksdb-8.1.1-h9a28685_0.conda
osx-arm64::dask-sql-2023.10.0-py39h017d637_1.conda
osx-arm64::smesh-9.9.0.0-h5af7d45_7.conda
osx-arm64::yarp-cxx-3.8.1-head0e6e_7.conda
osx-arm64::netcdf4-1.6.5-mpi_openmpi_py312h8a92b93_0.conda
osx-arm64::cargo-c-0.9.26-hdf7d417_0.conda
osx-arm64::protozfits-2.3.0-py310h8284565_0.conda
osx-arm64::pyreadstat-1.2.3-py39ha52a465_1.conda
osx-arm64::heyoka-3.0.0-h31f32e4_0.conda
osx-arm64::libgd-2.3.3-hfdf3952_9.conda
osx-arm64::pyreadstat-1.2.3-py312h1609c5e_1.conda
osx-arm64::python-igraph-0.10.8-py38hcfe92ae_1.conda
osx-arm64::boost-cpp-1.82.0-hca5e981_6.conda
osx-arm64::ale-py-0.8.1-py312h735ab6f_1.conda
osx-arm64::uwsgi-2.0.22-py312h55e8bdd_2.conda
osx-arm64::paraview-5.11.2-py310h7e72bf8_102_qt.conda
osx-arm64::libadios2-2.9.1-mpi_openmpi_ha7668c6_3.conda
osx-arm64::tensorflow-base-2.13.1-cpu_py39ha6a491e_1.conda
osx-arm64::uwsgi-2.0.22-py39h81f957d_3.conda
osx-arm64::tensorflow-base-2.13.1-cpu_py311h05dd8b3_1.conda
osx-arm64::dask-sql-2023.10.0-py310h2efcc80_1.conda
osx-arm64::libnghttp2-static-1.55.1-h1395956_0.conda
osx-arm64::libsoup-3.4.4-h436d2c9_0.conda
osx-arm64::dask-sql-2023.10.1-py38h2692745_0.conda
osx-arm64::python-3.10.13-h2469fbe_0_cpython.conda
osx-arm64::libtensorflow_cc-2.12.1-cpu_hd34dfa9_1.conda
osx-arm64::libarrow-13.0.0-h55e072d_10_cpu.conda
osx-arm64::ifcopenshell-v0.7.0a10-py38hc36f3f8_1.conda
osx-arm64::jaxlib-0.4.18-cpu_py39h9b38f39_0.conda
osx-arm64::ambertools-23.3-py311hb55c4a1_3.conda
osx-arm64::pyreadr-0.5.0-py310ha993a9b_0.conda
osx-arm64::openmpi-4.1.6-h526c993_101.conda
osx-arm64::lammps-2023.08.02-cpu_py310_hdbbd2cf_mpich_4.conda
osx-arm64::openimageio-2.4.16.0-py311h461ca67_0.conda
osx-arm64::uwsgi-2.0.22-py38hda3d3a1_3.conda
osx-arm64::pyreadr-0.4.9-py310h2b8a472_1.conda
osx-arm64::libarrow-10.0.1-h3b9e1da_48_cpu.conda
osx-arm64::openimageio-2.5.4.0-py39hf1d333c_2.conda
osx-arm64::grpcio-1.58.2-py312h780eafd_0.conda
osx-arm64::uwsgi-2.0.22-py310h8fc4ae9_2.conda
osx-arm64::folly-2023.10.30.00-h83f57a1_0.conda
osx-arm64::folly-2023.09.25.00-h539f04e_1.conda
osx-arm64::libarrow-10.0.1-he713f65_44_cpu.conda
osx-arm64::harp-1.20-py39h2275332_1.conda
osx-arm64::pytables-3.9.1-py311hce229b4_0.conda
osx-arm64::ndcctools-7.7.0-py310h4b37b16_0.conda
osx-arm64::vowpalwabbit-9.9.0-py312h8db9b2a_2.conda
osx-arm64::vigra-1.11.2-py310h4844aed_1.conda
osx-arm64::vigra-1.11.2-py38hb96fff7_1.conda
osx-arm64::ifcopenshell-v0.7.0a10-py39h1b60430_1.conda
osx-arm64::lldb-16.0.6-py310h2ec6184_0.conda
osx-arm64::netcdf4-1.6.5-mpi_mpich_py312h9fe0e39_0.conda
osx-arm64::minizip-static-1.2-ha614eb4_1.conda
osx-arm64::uwsgi-2.0.22-py38hda3d3a1_1.conda
osx-arm64::pygrib-2.1.4-py312h2eac005_8.conda
osx-arm64::python-igraph-0.10.8-py311h29c06c0_1.conda
osx-arm64::cctools_osx-arm64-973.0.1-h998149b_15.conda
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
================================================================================
================================================================================
noarch
================================================================================
================================================================================
win-64
win-64::grpcio-1.57.1-py310hb84602e_0.conda
win-64::ifcopenshell-v0.7.0a10-py310h274c5cd_1.conda
win-64::qt6-main-6.5.2-hc9a02c6_6.conda
win-64::pyinstaller-6.1.0-py39h84a0465_0.conda
win-64::grpcio-1.57.0-py39hd28a505_2.conda
win-64::topologytoolkit-1.2.0-with_paraview_py310h3a18124_0.conda
win-64::libmediainfo-23.10-h8ec2201_0.conda
win-64::ifcopenshell-v0.7.0a10-py39hefd8b2d_2.conda
win-64::vigra-1.11.2-py39ha8c69a6_2.conda
win-64::topologytoolkit-1.2.0-with_paraview_py311hce8889c_0.conda
win-64::ogre-1.10.12-ha04c5d8_15.conda
win-64::imagecodecs-2023.9.18-py311h7346e2b_1.conda
win-64::grpcio-1.58.1-py310hb84602e_2.conda
win-64::clang-17.0.3-h3dc180e_0.conda
win-64::grpcio-1.57.0-py312h7894644_3.conda
win-64::harp-1.20-py310h084e8c7_1.conda
win-64::pyhdk-0.9.0-py311h1234567_2_cpu.conda
win-64::pytables-3.8.0-py38h4c0c689_4.conda
win-64::pyhdk-0.9.0-py39h1234567_2_cpu.conda
win-64::bytewax-0.17.1-py311pl5321hd4437ae_2.conda
win-64::mysql-client-8.0.33-hed9f4ee_5.conda
win-64::dask-sql-2023.10.1-py39h98e7215_0.conda
win-64::pyreadstat-1.2.3-py312h71c11f5_1.conda
win-64::libgdal-arrow-parquet-3.6.4-h1080fac_22.conda
win-64::folly-2023.09.25.00-h04b96d7_1.conda
win-64::libkml-1.3.0-hd45a9bc_1017.conda
win-64::minizip-1.2-h12be248_1.conda
win-64::gdstk-0.9.46-py310h7dcdc39_0.conda
win-64::minizip-1.2-h12be248_2.conda
win-64::grpcio-1.57.1-py39hd28a505_0.conda
win-64::libprotobuf-static-4.24.4-hb8276f3_0.conda
win-64::gst-plugins-good-1.22.6-hdc28085_2.conda
win-64::llvmlite-0.41.1-py39h6848017_0.conda
win-64::topologytoolkit-1.2.0-no_paraview_py311hec88788_100.conda
win-64::libgdal-3.7.2-hfca678f_6.conda
win-64::libarrow-13.0.0-h21b21d9_13_cuda.conda
win-64::cairo-1.18.0-h1fef639_0.conda
win-64::heyoka-llvm-14-2.0.0-h4273656_1.conda
win-64::grpcio-1.57.0-py311h5bc0dda_2.conda
win-64::libignition-fuel-tools7-7.1.0-hadaf4a5_5.conda
win-64::openvdb-10.0.1-py310h7989b67_7.conda
win-64::libcurl-static-8.4.0-hd5e4a3a_0.conda
win-64::harp-1.20.1-py39h51f3108_0.conda
win-64::libmlir-17.0.3-he744812_0.conda
win-64::tiledb-2.17.2-hec1fcaa_0.conda
win-64::libgd-2.3.3-h312136b_9.conda
win-64::libgrpc-1.58.1-h43eea02_1.conda
win-64::grpcio-1.57.1-py312h7894644_0.conda
win-64::grpcio-1.58.1-py310hb84602e_1.conda
win-64::libclang-cpp-17.0.2-default_heb8d277_0.conda
win-64::pyreadr-0.4.9-py39h39b8732_1.conda
win-64::yarp-cxx-3.8.1-hcb6c3dd_7.conda
win-64::paraview-5.11.2-py39h6dda895_102_qt.conda
win-64::libprotobuf-4.24.3-hb8276f3_1.conda
win-64::stir-5.2.0-cuda112_py310h5c9ace5_201.conda
win-64::pygrib-2.1.4-py310hc449e4a_8.conda
win-64::minizip-4.0.1-h5bed578_5.conda
win-64::pillow-10.0.1-py311h4dd8a23_2.conda
win-64::stir-5.2.0-cuda112_py310hd4c8a74_200.conda
win-64::libopencv-4.8.1-py39h4d8ec3f_2.conda
win-64::libgdal-3.6.4-h395bf9d_20.conda
win-64::grpcio-1.58.1-py312h7894644_2.conda
win-64::libgdal-3.6.4-h8c6448d_22.conda
win-64::grpcio-1.57.0-py310hb84602e_3.conda
win-64::stir-5.2.0-cuda118_py38h3f97100_201.conda
win-64::paraview-5.11.2-py312had65f79_102_qt.conda
win-64::vigra-1.11.2-py312h291e2b4_1.conda
win-64::vigra-1.11.2-py39h2f10253_3.conda
win-64::vigra-1.11.2-py38ha7a9b53_2.conda
win-64::cpp-opentelemetry-sdk-1.11.0-hd5c52a9_2.conda
win-64::assimp-5.3.1-h81f0834_2.conda
win-64::grpcio-1.57.0-py39h6848017_3.conda
win-64::netcdf4-1.6.5-nompi_py39h9a3bb69_100.conda
win-64::pygrib-2.1.4-py312h9a02840_8.conda
win-64::gdstk-0.9.46-py38h8a2f752_0.conda
win-64::libarrow-11.0.0-h9f5ee77_41_cuda.conda
win-64::openvdb-10.0.1-py311h9297afd_8.conda
win-64::llvmdev-17.0.3-h1ab654d_0.conda
win-64::websocketpp-0.8.2-h81f0834_3.conda
win-64::pyreadstat-1.2.4-py310h51ee7fe_0.conda
win-64::libarrow-13.0.0-hdb90ae5_6_cuda.conda
win-64::qt6-main-6.5.2-h1088b08_5.conda
win-64::heyoka-llvm-14-3.0.0-h4273656_0.conda
win-64::harp-1.20-py38h14973db_1.conda
win-64::r-harp-1.20-r41h5eb019b_1.conda
win-64::lfortran-0.21.5-h12be248_1.conda
win-64::libopencv-4.8.1-py38h8009d80_3.conda
win-64::heyoka-2.0.0-h2333ef2_1.conda
win-64::folly-2023.10.30.00-h43676e7_0.conda
win-64::stir-5.2.0-cuda112_py311h5e56a69_200.conda
win-64::stir-5.2.0-cpu_py38h28fe462_1.conda
win-64::osmium-tool-1.16.0-hb7794c7_2.conda
win-64::poppler-23.10.0-hc2f3c52_0.conda
win-64::lfortran-0.29.0-h12be248_0.conda
win-64::ecell4_base-2.1.0-py310h2480f55_7.conda
win-64::ffmpeg-5.1.2-lgpl_hb417bf4_12.conda
win-64::pillow-10.1.0-py39h368b509_0.conda
win-64::topologytoolkit-1.2.0-with_paraview_py39ha8c59e8_1.conda
win-64::ecell4_base-2.1.0-py310h2480f55_6.conda
win-64::stir-5.2.0-cpu_py311ha2ca3b5_1.conda
win-64::folly-2023.10.02.00-h04b96d7_0.conda
win-64::ogre-14.1.1-h330a6e2_0.conda
win-64::tiledb-2.17.3-hec1fcaa_1.conda
win-64::tiledb-2.17.3-h1ffc264_0.conda
win-64::heyoka-llvm-13-3.0.0-h8387fb0_0.conda
win-64::gmsh-4.11.1-hea07939_4.conda
win-64::libgrpc-1.57.1-hec45c60_0.conda
win-64::stir-5.2.0-cuda112_py39h456d3e6_200.conda
win-64::vigra-1.11.2-py38h497697a_3.conda
win-64::pygplates-0.39-py38h3578e79_10.conda
win-64::llvmdev-17.0.3-h1ab654d_1.conda
win-64::pytng-0.3.1-py311hcbca1fb_0.conda
win-64::libpulsar-3.2.0-h20228c9_5.conda
win-64::grpcio-1.58.2-py39hd28a505_0.conda
win-64::heyoka-2.0.0-h08b8c6c_1.conda
win-64::libgrpc-1.58.1-h2a9c87f_2.conda
win-64::ale-py-0.8.1-py39hc6c698a_1.conda
win-64::r-harp-1.20.1-r41h5eb019b_0.conda
win-64::vigra-1.11.2-py312hcdd8a35_2.conda
win-64::libboost-1.82.0-h65993cd_6.conda
win-64::libgdal-3.6.4-h4a87d68_21.conda
win-64::libarrow-12.0.1-h824ab2f_17_cpu.conda
win-64::lldb-16.0.6-py310h8d0bbdd_0.conda
win-64::libarrow-13.0.0-hc7845e2_13_cpu.conda
win-64::lfortran-0.21.5-h12be248_3.conda
win-64::openpmd-api-0.15.2-nompi_py39hacf97e5_102.conda
win-64::libarrow-11.0.0-h30f8788_42_cuda.conda
win-64::vigra-1.11.2-py39h1a08ff2_1.conda
win-64::pygrib-2.1.4-py39h150c3fc_8.conda
win-64::sdl_image-1.2.12-h4156d39_6.conda
win-64::imread-0.7.4-py311h0767c5d_6.conda
win-64::ffmpeg-6.0.0-lgpl_h02abe2f_5.conda
win-64::pyreadstat-1.2.4-py311hd8f7e58_0.conda
win-64::topologytoolkit-1.2.0-no_paraview_py311hec88788_101.conda
win-64::llvm-tools-17.0.3-h1ab654d_0.conda
win-64::libarrow-10.0.1-h30f8788_46_cuda.conda
win-64::grpcio-1.57.0-py38h19421c1_3.conda
win-64::libboost-1.82.0-h65993cd_5.conda
win-64::omniorb-libs-4.3.1-ha7d20b1_2.conda
win-64::r-harp-1.20-r41h56b84b2_1.conda
win-64::clangdev-17.0.3-default_heb8d277_0.conda
win-64::python-3.12.0-h2628c8c_0_cpython.conda
win-64::libadios2-2.9.1-nompi_h1d0fc58_104.conda
win-64::pypy3.9-7.3.13-h994e1e7_1.conda
win-64::lldb-16.0.6-py311hbb4bc87_0.conda
win-64::r-harp-1.20.1-r41h56b84b2_0.conda
win-64::flang-17.0.3-h12be248_0.conda
win-64::libgdal-3.7.2-hc5c2e26_5.conda
win-64::pytables-3.8.0-py39he845bde_4.conda
win-64::libopencv-4.8.1-py311h9530f43_1.conda
win-64::paraview-5.11.2-py310h18e0b7d_102_qt.conda
win-64::imagecodecs-2023.9.18-py311h7346e2b_2.conda
win-64::nco-5.1.8-hf994ca5_1.conda
win-64::rocksdb-8.5.3-hf81f564_0.conda
win-64::dask-sql-2023.10.0-py38h0062393_1.conda
win-64::python-3.10.13-h4de0772_0_cpython.conda
win-64::mysql-server-8.0.33-hb7c0f37_5.conda
win-64::ifcopenshell-v0.7.0a10-py311h1bbf5e4_2.conda
win-64::pillow-10.1.0-py310h1e6a543_0.conda
win-64::bytewax-0.17.1-py39pl5321h5b14c5f_2.conda
win-64::qt-main-5.15.8-h9e85ed6_17.conda
win-64::pyreadstat-1.2.4-py312h71c11f5_0.conda
win-64::openvdb-10.0.1-py39h7612c97_8.conda
win-64::libarrow-13.0.0-h5e87f9a_8_cuda.conda
win-64::harp-1.20.1-py39hed691a2_0.conda
win-64::dask-sql-2023.10.0-py311h3ef6736_0.conda
win-64::topologytoolkit-1.2.0-no_paraview_py38hb99b627_100.conda
win-64::libgdal-arrow-parquet-3.7.2-ha9bf930_5.conda
win-64::vtk-base-9.2.6-qt_py39h1234567_218.conda
win-64::libopencv-4.8.1-py312h55e7661_3.conda
win-64::pygplates-0.39-py39hc740846_10.conda
win-64::netcdf4-1.6.5-nompi_py311he019f65_100.conda
win-64::llvmlite-0.41.1-py311h5bc0dda_0.conda
win-64::libarrow-13.0.0-hf069bef_7_cpu.conda
win-64::ifcopenshell-v0.7.0a10-py311he6a91dd_1.conda
win-64::libllvm-c17-17.0.3-h1ab654d_0.conda
win-64::python-3.8.18-h4de0772_0_cpython.conda
win-64::llvm-17.0.3-h3dc180e_1.conda
win-64::folly-2023.10.16.00-h43676e7_0.conda
win-64::python-igraph-0.11.2-py39he170af6_0.conda
win-64::pytables-3.9.1-py311heec7198_0.conda
win-64::ffmpeg-4.4.2-lgpl_hf152e9b_13.conda
win-64::libadios2-2.9.1-nompi_h530d7cd_103.conda
win-64::pillow-10.1.0-py311h4dd8a23_0.conda
win-64::pyreadstat-1.2.3-py39h585ecb4_1.conda
win-64::paraview-5.11.2-py311h56e6bdc_102_qt.conda
win-64::paraview-5.11.2-py38hb02ff3a_102_qt.conda
win-64::vigra-1.11.2-py39hae94f55_3.conda
win-64::pillow-10.1.0-py38hc375fad_0.conda
win-64::pcre2-10.42-h17e33f8_0.conda
win-64::hugin-base-2022.0.0-pl5321hf814aea_8.conda
win-64::vigra-1.11.2-py311h054fd1b_1.conda
win-64::libarrow-11.0.0-hd2d01ff_46_cpu.conda
win-64::pyhdk-0.9.0-py38h1234567_2_cpu.conda
win-64::vigra-1.11.2-py39h53c46f3_2.conda
win-64::qt6-main-6.5.3-hc9a02c6_0.conda
win-64::openmeeg-2.5.6-py38hb8cb45c_4.conda
win-64::openvdb-10.0.1-py39h7612c97_7.conda
win-64::folly-2023.10.23.00-h43676e7_0.conda
win-64::grpcio-1.57.1-py38h19421c1_0.conda
win-64::ifcopenshell-v0.7.0a10-py39h4df3226_2.conda
win-64::stir-5.2.0-cpu_py39h1deee1a_0.conda
win-64::paraview-5.11.2-py39h428627d_102_qt.conda
win-64::grpcio-1.59.1-py310hb84602e_0.conda
win-64::heyoka-llvm-16-3.0.0-h931b0a2_0.conda
win-64::pytng-0.3.1-py310h617134d_0.conda
win-64::ecell4_base-2.1.0-py38hf90c960_6.conda
win-64::freeimage-3.18.0-h609497f_18.conda
win-64::libarrow-13.0.0-h824ab2f_8_cpu.conda
win-64::tiledb-2.17.2-h1ffc264_0.conda
win-64::curl-8.4.0-hd5e4a3a_0.conda
win-64::libopencv-4.8.1-py310ha4a9f80_1.conda
win-64::grpcio-1.59.2-py310hb84602e_0.conda
win-64::dask-sql-2023.10.0-py38h0062393_0.conda
win-64::folly-2023.10.09.00-h04b96d7_0.conda
win-64::folly-2023.09.25.00-h43676e7_1.conda
win-64::pyreadr-0.5.0-py312h56036e7_0.conda
win-64::grpcio-1.59.2-py39h6848017_0.conda
win-64::libignition-fuel-tools4-4.6.0-hadaf4a5_4.conda
win-64::libclang-17.0.3-default_heb8d277_0.conda
win-64::topologytoolkit-1.2.0-with_paraview_py311hce8889c_1.conda
win-64::python-igraph-0.10.8-py311h1e46476_1.conda
win-64::gdstk-0.9.46-py39h32efe87_0.conda
win-64::pyinstaller-5.13.2-py39h84a0465_1.conda
win-64::folly-2023.10.30.00-h04b96d7_0.conda
win-64::qt6-main-6.6.0-hc9a02c6_0.conda
win-64::openvdb-10.0.1-py39h83b1a0d_8.conda
win-64::vtk-base-9.2.6-qt_py311h1234567_218.conda
win-64::ogre-14.1.2-h2ded32d_0.conda
win-64::folly-2023.10.23.00-h04b96d7_0.conda
win-64::folly-2023.10.16.00-hd2f1b6b_0.conda
win-64::topologytoolkit-1.2.0-no_paraview_py39h057ce71_101.conda
win-64::gdstk-0.9.46-py311hc50246e_0.conda
win-64::libgrpc-1.59.2-h5bbd4a7_0.conda
win-64::ffmpeg-4.4.2-gpl_hf960ced_113.conda
win-64::lfortran-0.25.0-h12be248_0.conda
win-64::pcre2-static-10.42-h17e33f8_0.conda
win-64::libgdal-arrow-parquet-3.7.2-h7eebffa_7.conda
win-64::pyreadr-0.5.0-py311ha5690a0_0.conda
win-64::grpcio-1.58.1-py39h6848017_1.conda
win-64::libclang13-17.0.2-default_hc80b9e7_0.conda
win-64::libarrow-10.0.1-h28c6d42_47_cpu.conda
win-64::ogre-14.1.0-h2ded32d_2.conda
win-64::qt6-3d-6.6.0-h294d793_0.conda
win-64::libarrow-12.0.1-hf069bef_16_cpu.conda
win-64::libpulsar-3.2.0-h8e9a35a_4.conda
win-64::dask-sql-2023.10.1-py38h0062393_0.conda
win-64::pillow-10.0.1-py312he768995_2.conda
win-64::grpcio-1.59.2-py38h19421c1_0.conda
win-64::topologytoolkit-1.2.0-with_paraview_py38h57c3c6e_1.conda
win-64::lfortran-0.21.5-h12be248_2.conda
win-64::pytng-0.3.1-py39h5e6fad6_0.conda
win-64::libllvm-c17-17.0.2-h1ab654d_0.conda
win-64::omniorb-4.3.1-py311h55b17b5_2.conda
win-64::libcurl-8.4.0-hd5e4a3a_0.conda
win-64::grpcio-1.59.2-py39hd28a505_0.conda
win-64::ale-py-0.8.1-py39h130f6a1_1.conda
win-64::tiledb-2.17.3-hbf04793_1.conda
win-64::llvm-17.0.2-h3dc180e_0.conda
win-64::libarrow-10.0.1-hd2d01ff_49_cpu.conda
win-64::libclang-17.0.2-default_heb8d277_0.conda
win-64::libopencv-4.8.1-py39h4d8ec3f_3.conda
win-64::pyinstaller-6.1.0-py310h35269f2_0.conda
win-64::poppler-23.08.0-habf82aa_3.conda
win-64::r-harp-1.20.1-r41h1fcffe7_0.conda
win-64::python-igraph-0.11.2-py311h1e46476_0.conda
win-64::libllvm17-17.0.2-h1ab654d_0.conda
win-64::libarrow-13.0.0-h004feb1_9_cuda.conda
win-64::ifcopenshell-v0.7.0a10-py310h7cfe178_2.conda
win-64::ffmpeg-6.0.0-gpl_h1627b0f_105.conda
win-64::topologytoolkit-1.2.0-with_paraview_py39ha8c59e8_0.conda
win-64::flang-17.0.2-h12be248_0.conda
win-64::openmeeg-2.5.6-py312h0cc4730_4.conda
win-64::libmatio-1.5.24-h8f40fab_0.conda
win-64::grpcio-1.58.1-py311h5bc0dda_1.conda
win-64::vtk-base-9.2.6-qt_py38h1234567_216.conda
win-64::libarrow-10.0.1-h28c6d42_48_cpu.conda
win-64::pyreadr-0.5.0-py38hda8ff42_0.conda
win-64::topologytoolkit-1.2.0-no_paraview_py310h57875ad_100.conda
win-64::yarp-cxx-3.8.1-hcb6c3dd_6.conda
win-64::pyhdk-0.8.0-py311h1234567_2_cpu.conda
win-64::dask-sql-2023.10.1-py310hb5dc9fe_0.conda
win-64::vigra-1.11.2-py38h3a38352_1.conda
win-64::vtk-base-9.2.6-qt_py310h1234567_217.conda
win-64::grpcio-1.57.1-py311h5bc0dda_0.conda
win-64::clang-tools-17.0.2-default_heb8d277_0.conda
win-64::libarrow-12.0.1-hdbedc8d_20_cpu.conda
win-64::leptonica-1.83.1-h65bf234_4.conda
win-64::libarrow-11.0.0-h28c6d42_43_cpu.conda
win-64::libprotobuf-4.24.4-hb8276f3_0.conda
win-64::hugin-2022.0.0-pl5321h9f4a025_8.conda
win-64::lfortran-0.21.5-h12be248_5.conda
win-64::pygplates-0.39-py39hc740846_12.conda
win-64::grpcio-1.58.2-py311h5bc0dda_0.conda
win-64::msgpack-cxx-6.1.0-h6475f74_1.conda
win-64::libarrow-10.0.1-h9f5ee77_45_cuda.conda
win-64::stir-5.2.0-cuda112_py38h3f84f4e_200.conda
win-64::pygplates-0.39-py39hc740846_11.conda
win-64::libpcm-1.2.3-h62350a0_8.conda
win-64::imagecodecs-2023.9.18-py39h9d3654e_2.conda
win-64::grpcio-1.57.0-py38h19421c1_2.conda
win-64::libarrow-13.0.0-h64a251c_10_cpu.conda
win-64::libopencv-4.8.1-py311h6be31c5_3.conda
win-64::libllvm17-17.0.3-h1ab654d_0.conda
win-64::dask-sql-2023.10.0-py310hb5dc9fe_0.conda
win-64::heyoka-llvm-13-2.0.0-h8387fb0_1.conda
win-64::libgdal-arrow-parquet-3.6.4-h0a7561c_20.conda
win-64::libarrow-12.0.1-h5e87f9a_17_cuda.conda
win-64::ale-py-0.8.1-py311haa5eaab_1.conda
win-64::libopencv-4.8.1-py39h2b60c14_1.conda
win-64::vigra-1.11.2-py311h4f64184_2.conda
win-64::aws-sdk-cpp-1.11.182-hef92bd4_1.conda
win-64::libarrow-13.0.0-hbe1a61e_7_cuda.conda
win-64::llvmlite-0.41.1-py39hd28a505_0.conda
win-64::ogre-14.1.1-h2ded32d_0.conda
win-64::heyoka-llvm-15-2.0.0-h8ad36fd_1.conda
win-64::pillow-10.0.1-py38hc375fad_2.conda
win-64::ifcopenshell-v0.7.0a10-py38haa0d8ba_2.conda
win-64::libarrow-12.0.1-hdb90ae5_15_cuda.conda
win-64::aws-sdk-cpp-1.11.182-hc1d519e_0.conda
win-64::openscenegraph-3.6.5-h9ee3662_17.conda
win-64::stir-5.2.0-cuda118_py311h5625561_201.conda
win-64::pytables-3.9.1-py310hde27e41_0.conda
win-64::stir-5.2.0-cuda118_py310h36d4a96_200.conda
win-64::ifcopenshell-v0.7.0a10-py38haa0d8ba_1.conda
win-64::libarrow-12.0.1-h2267a67_19_cuda.conda
win-64::grpcio-1.58.1-py39hd28a505_1.conda
win-64::pygplates-0.39-py311h2fa41f2_11.conda
win-64::rocksdb-8.1.1-hf81f564_0.conda
win-64::libarrow-11.0.0-h28c6d42_44_cpu.conda
win-64::ecell4_base-2.1.0-py39hd10ee7f_6.conda
win-64::mlir-17.0.2-he744812_0.conda
win-64::libopentelemetry-cpp-1.12.0-hd5c52a9_0.conda
win-64::pytables-3.9.1-py39h607662a_0.conda
win-64::pytables-3.9.1-py312h62a68b9_0.conda
win-64::heyoka-3.0.0-h08b8c6c_0.conda
win-64::qt6-main-6.5.2-h1088b08_6.conda
win-64::imagecodecs-2023.9.18-py39h445c58b_2.conda
win-64::pyreadr-0.5.0-py39h39b8732_0.conda
win-64::freeimage-3.18.0-hec7e4a7_17.conda
win-64::topologytoolkit-1.2.0-no_paraview_py310h57875ad_101.conda
win-64::minizip-static-1.2-h12be248_2.conda
win-64::libarrow-11.0.0-h9f5ee77_40_cuda.conda
win-64::topologytoolkit-1.2.0-with_paraview_py310h3a18124_1.conda
win-64::llvmlite-0.41.1-py38h19421c1_0.conda
win-64::ifcopenshell-v0.7.0a10-py310h7cfe178_1.conda
win-64::lld-17.0.3-h21f6fed_0.conda
win-64::clangxx-17.0.2-default_heb8d277_0.conda
win-64::mysql-router-8.0.33-h9f3c685_5.conda
win-64::libarrow-12.0.1-hc7845e2_21_cpu.conda
win-64::imagecodecs-2023.9.18-py310h0dcf169_2.conda
win-64::lld-17.0.2-h21f6fed_0.conda
win-64::openvdb-10.0.1-py310h7989b67_8.conda
win-64::r-harp-1.20.1-r41ha7d8d4b_0.conda
win-64::pytables-3.9.1-py39he845bde_0.conda
win-64::libarrow-13.0.0-h6204054_12_cuda.conda
win-64::grpcio-1.57.0-py310hb84602e_2.conda
win-64::pyinstaller-6.1.0-py312h3bd2d22_0.conda
win-64::pyhdk-0.8.0-py38h1234567_2_cpu.conda
win-64::dask-sql-2023.10.0-py39h98e7215_1.conda
win-64::grpcio-1.59.1-py39h6848017_0.conda
win-64::topologytoolkit-1.2.0-no_paraview_py39h057ce71_100.conda
win-64::libarrow-10.0.1-hdd83e72_46_cpu.conda
win-64::imagecodecs-2023.9.18-py39h9d3654e_1.conda
win-64::grpcio-1.58.2-py38h19421c1_0.conda
win-64::openvdb-10.0.1-py38h7ecc502_8.conda
win-64::libarrow-12.0.1-h004feb1_18_cuda.conda
win-64::libgrpc-1.57.0-h550f6bd_2.conda
win-64::tiledb-2.17.3-hbf04793_0.conda
win-64::pillow-10.1.0-py312he768995_0.conda
win-64::openpmd-api-0.15.2-nompi_py311h988fdc3_102.conda
win-64::nsight-compute-2022.4.0.15-hbdb2b8c_1.conda
win-64::aws-sdk-cpp-1.10.57-h45a597c_24.conda
win-64::ifcopenshell-v0.7.0a10-py310h274c5cd_2.conda
win-64::grpcio-1.59.1-py312h7894644_0.conda
win-64::openscenegraph-3.6.5-h2596158_18.conda
win-64::mlir-17.0.3-he744812_0.conda
win-64::mysql-connector-cpp-8.0.29-h33a2287_3.conda
win-64::pytables-3.8.0-py311heec7198_4.conda
win-64::pytables-3.8.0-py312h62a68b9_4.conda
win-64::llvmdev-17.0.2-h1ab654d_0.conda
win-64::tiledb-2.17.3-h1ffc264_1.conda
win-64::openvdb-10.0.1-py312h28e84d2_8.conda
win-64::pyhdk-0.8.0-py310h1234567_2_cpu.conda
win-64::grpcio-1.57.0-py39h6848017_2.conda
win-64::heyoka-2.0.0-h1bb38bf_1.conda
win-64::pyreadr-0.4.9-py310hfdea923_1.conda
win-64::libarrow-10.0.1-h58a770d_44_cpu.conda
win-64::grpcio-1.57.1-py39h6848017_0.conda
win-64::vigra-1.11.2-py310h8cf53b4_2.conda
win-64::imread-0.7.4-py39hee5c089_6.conda
win-64::eccodes-2.32.1-habb35d2_0.conda
win-64::omniorb-4.3.1-py312h3946ced_2.conda
win-64::pyreadr-0.4.9-py312h56036e7_1.conda
win-64::libadios2-2.9.1-nompi_h52f8237_103.conda
win-64::topologytoolkit-1.2.0-with_paraview_py312hf4fb59d_1.conda
win-64::paraview-5.11.2-py310h3bf304d_102_qt.conda
win-64::harp-1.20.1-py310h084e8c7_0.conda
win-64::openmeeg-2.5.6-py39h82a7e75_4.conda
win-64::libgrpc-1.58.2-h2a9c87f_0.conda
win-64::pygplates-0.39-py311h2fa41f2_10.conda
win-64::imread-0.7.4-py39hdeef8c4_6.conda
win-64::stir-5.2.0-cpu_py39h7d132c1_1.conda
win-64::openmeeg-2.5.6-py311h7a86d16_4.conda
win-64::stir-5.2.0-cuda118_py38h3e33db5_200.conda
win-64::stir-5.2.0-cpu_py310h05295b1_0.conda
win-64::topologytoolkit-1.2.0-no_paraview_py38hb99b627_101.conda
win-64::bytewax-0.17.1-py312pl5321h70577bd_2.conda
win-64::libarrow-13.0.0-hdbedc8d_12_cpu.conda
win-64::libarrow-12.0.1-hbe1a61e_16_cuda.conda
win-64::minizip-static-1.2-h12be248_1.conda
win-64::smesh-9.9.0.0-hb7cdee2_9.conda
win-64::openvdb-10.0.1-py38h7ecc502_7.conda
win-64::wxwidgets-3.2.3-h63ad7f6_0.conda
win-64::grpcio-1.58.2-py312h7894644_0.conda
win-64::vtk-base-9.2.6-qt_py312h1234567_218.conda
win-64::clang-17-17.0.2-default_heb8d277_0.conda
win-64::heyoka-llvm-15-3.0.0-h8ad36fd_0.conda
win-64::ogre-14.1.0-h330a6e2_2.conda
win-64::minizip-1.2-h4dfd0cc_0.conda
win-64::stir-5.2.0-cuda112_py39h812b358_201.conda
win-64::harp-1.20.1-py38h14973db_0.conda
win-64::grpcio-1.57.0-py39hd28a505_3.conda
win-64::lldb-16.0.6-py38hafd1aa4_0.conda
win-64::pytables-3.8.0-py310hde27e41_4.conda
win-64::paraview-5.11.2-py38h1c698c5_102_qt.conda
win-64::python-igraph-0.10.8-py310hc9e38e4_1.conda
win-64::pyreadr-0.4.9-py311ha5690a0_1.conda
win-64::lfortran-0.21.5-h12be248_0.conda
win-64::heyoka-llvm-16-2.0.0-h931b0a2_1.conda
win-64::grpcio-1.59.1-py38h19421c1_0.conda
win-64::vtk-base-9.2.6-qt_py311h1234567_216.conda
win-64::paraview-5.11.2-py38h42108bf_102_qt.conda
win-64::harp-1.20-py39hed691a2_1.conda
win-64::heyoka-3.0.0-h1bb38bf_0.conda
win-64::vtk-base-9.2.6-qt_py39h1234567_215.conda
win-64::bytewax-0.17.1-py310pl5321h65afd28_2.conda
win-64::python-igraph-0.10.8-py39hbc72104_1.conda
win-64::python-igraph-0.11.2-py39hbc72104_0.conda
win-64::libclang-cpp-17.0.3-default_heb8d277_0.conda
win-64::libadios2-2.9.1-nompi_hcfb9f8b_103.conda
win-64::grpcio-1.58.1-py38h19421c1_1.conda
win-64::netcdf4-1.6.5-nompi_py310h6477780_100.conda
win-64::vtk-base-9.2.6-qt_py38h1234567_217.conda
win-64::libarrow-13.0.0-hdbedc8d_11_cpu.conda
win-64::stir-5.2.0-cuda118_py311hfbe46ba_200.conda
win-64::eccodes-2.32.0-habb35d2_0.conda
win-64::llvm-tools-17.0.3-h1ab654d_1.conda
win-64::lfortran-0.21.3-h12be248_1.conda
win-64::vigra-1.11.2-py39h99f675e_1.conda
win-64::ifcopenshell-v0.7.0a10-py39h4df3226_1.conda
win-64::dask-sql-2023.10.0-py39h98e7215_0.conda
win-64::libopencv-4.8.1-py39h94859e0_1.conda
win-64::python-igraph-0.11.2-py311h1e46476_1.conda
win-64::pygplates-0.39-py311h2fa41f2_12.conda
win-64::topologytoolkit-1.2.0-no_paraview_py312hcc0305c_101.conda
win-64::paraview-5.11.2-py311habe2941_102_qt.conda
win-64::r-harp-1.20-r41hdabd458_1.conda
win-64::pyinstaller-6.1.0-py311h12e69fa_0.conda
win-64::orc-1.9.0-hd95f75e_3.conda
win-64::libarrow-10.0.1-h0385748_47_cuda.conda
win-64::vigra-1.11.2-py310h490fd1e_3.conda
win-64::libopencv-4.8.1-py38hf4ff69e_1.conda
win-64::clang-17.0.2-h3dc180e_0.conda
win-64::libarrow-11.0.0-h58a770d_41_cpu.conda
win-64::heyoka-2.0.0-h34149e3_1.conda
win-64::omniorb-4.3.1-py38h8a9cac7_2.conda
win-64::grpcio-1.59.2-py312h7894644_0.conda
win-64::leptonica-1.83.1-he4e1813_5.conda
win-64::python-igraph-0.11.2-py312h8a18d57_1.conda
win-64::paraview-5.11.2-py311hc07011c_102_qt.conda
win-64::folly-2023.10.02.00-h43676e7_0.conda
win-64::dask-sql-2023.10.1-py311h3ef6736_0.conda
win-64::collada-dom-2.5.0-h583ae1e_7.conda
win-64::libarrow-13.0.0-he7bc412_9_cpu.conda
win-64::libgdal-arrow-parquet-3.7.2-ha1df3d4_6.conda
win-64::libgrpc-1.57.0-hec45c60_3.conda
win-64::libarrow-11.0.0-h0385748_44_cuda.conda
win-64::python-igraph-0.11.2-py39hbc72104_1.conda
win-64::grpcio-1.58.2-py39h6848017_0.conda
win-64::dask-sql-2023.10.0-py311h3ef6736_1.conda
win-64::r-harp-1.20-r41ha7d8d4b_1.conda
win-64::libarrow-10.0.1-hd2d01ff_50_cpu.conda
win-64::clangdev-17.0.2-default_heb8d277_0.conda
win-64::lldb-16.0.6-py39hf6ce347_0.conda
win-64::libarrow-13.0.0-h2267a67_10_cuda.conda
win-64::harp-1.20-py311h1dae2b4_1.conda
win-64::libarrow-11.0.0-hd2d01ff_45_cpu.conda
win-64::libopencv-4.8.1-py310h3e0f747_2.conda
win-64::vtk-base-9.2.6-qt_py39h1234567_217.conda
win-64::libarrow-11.0.0-h0385748_43_cuda.conda
win-64::python-igraph-0.11.2-py310hc9e38e4_1.conda
win-64::aws-sdk-cpp-1.11.156-hc1d519e_5.conda
win-64::vtk-base-9.2.6-qt_py311h1234567_217.conda
win-64::pyinstaller-6.1.0-py38ha959d8a_0.conda
win-64::pygplates-0.39-py38h3578e79_12.conda
win-64::stir-5.2.0-cuda112_py311h1bd1eb7_201.conda
win-64::pigz-2.6-h4b92bb4_1.conda
win-64::folly-2023.10.23.00-hd2f1b6b_0.conda
win-64::grpcio-1.57.0-py311h5bc0dda_3.conda
win-64::libmlir-17.0.2-he744812_0.conda
win-64::harp-1.20-py39h51f3108_1.conda
win-64::folly-2023.09.25.00-hd2f1b6b_1.conda
win-64::ale-py-0.8.1-py310h2021ac3_1.conda
win-64::omniorb-4.3.1-py39hd2c3553_2.conda
win-64::libllvm-c17-17.0.3-h1ab654d_1.conda
win-64::lfortran-0.22.0-h12be248_0.conda
win-64::python-igraph-0.11.2-py310hc9e38e4_0.conda
win-64::ecell4_base-2.1.0-py311ha580b43_7.conda
win-64::python-3.11.6-h2628c8c_0_cpython.conda
win-64::libarrow-12.0.1-h1e3473c_15_cpu.conda
win-64::grpcio-1.58.1-py311h5bc0dda_2.conda
win-64::pyreadstat-1.2.3-py311hd8f7e58_1.conda
win-64::libadios2-2.9.1-nompi_h530d7cd_104.conda
win-64::folly-2023.10.09.00-hd2f1b6b_0.conda
win-64::ifcopenshell-v0.7.0a10-py38h729798d_2.conda
win-64::r-harp-1.20.1-r41hdabd458_0.conda
win-64::grpcio-1.58.1-py312h7894644_1.conda
win-64::libarrow-11.0.0-hdd83e72_42_cpu.conda
win-64::stir-5.2.0-cuda118_py39h21226eb_200.conda
win-64::ifcopenshell-v0.7.0a10-py38h729798d_1.conda
win-64::lfortran-0.21.5-h12be248_4.conda
win-64::vigra-1.11.2-py311h3596d3b_3.conda
win-64::lfortran-0.21.5-h12be248_7.conda
win-64::libarrow-11.0.0-h940c563_46_cuda.conda
win-64::vtk-base-9.2.6-qt_py310h1234567_215.conda
win-64::libopencv-4.8.1-py310h3e0f747_3.conda
win-64::grpcio-1.59.2-py311h5bc0dda_0.conda
win-64::lfortran-0.27.0-h12be248_0.conda
win-64::ffmpeg-5.1.2-gpl_h8bb4bc8_112.conda
win-64::boost-cpp-1.82.0-h6f18f0d_5.conda
win-64::heyoka-llvm-12-2.0.0-h660613d_1.conda
win-64::libgdal-3.7.2-h3217549_7.conda
win-64::pygplates-0.39-py310hf17f16a_10.conda
win-64::llvm-17.0.3-h3dc180e_0.conda
win-64::grpcio-1.57.0-py312h7894644_2.conda
win-64::libarrow-10.0.1-h0385748_48_cuda.conda
win-64::heyoka-2.0.0-hec4426d_1.conda
win-64::stir-5.2.0-cpu_py311hf7a2716_0.conda
win-64::ecell4_base-2.1.0-py38hf90c960_7.conda
win-64::openmeeg-2.5.6-py39h4e44c7e_4.conda
win-64::ecell4_base-2.1.0-py311ha580b43_6.conda
win-64::ale-py-0.8.1-py38h246ea8d_1.conda
win-64::pillow-10.0.1-py310h1e6a543_2.conda
win-64::pytng-0.3.1-py39h7dfb729_0.conda
win-64::ale-py-0.8.1-py312h9e46860_1.conda
win-64::libprotobuf-static-4.24.3-hb8276f3_1.conda
win-64::libarrow-11.0.0-h58a770d_40_cpu.conda
win-64::imread-0.7.4-py312h01c683d_6.conda
win-64::vtk-base-9.2.6-qt_py310h1234567_216.conda
win-64::boost-cpp-1.82.0-h6f18f0d_4.conda
win-64::gdstk-0.9.46-py39h2b303d1_0.conda
win-64::libadios2-2.9.1-nompi_h72362e8_103.conda
win-64::mysql-libs-8.0.33-h8b0d2c3_5.conda
win-64::python-igraph-0.11.2-py39he170af6_1.conda
win-64::libarrow-10.0.1-h940c563_50_cuda.conda
win-64::ifcopenshell-v0.7.0a10-py311h1bbf5e4_1.conda
win-64::pyinstaller-5.13.2-py310h35269f2_1.conda
win-64::stir-5.2.0-cuda118_py310hd0e3b8f_201.conda
win-64::libopencv-4.8.1-py39he2c65a9_2.conda
win-64::libopencv-4.8.1-py311h6be31c5_2.conda
win-64::imagecodecs-2023.9.18-py312h4936081_2.conda
win-64::netcdf4-1.6.5-nompi_py38h46ce47e_100.conda
win-64::openvdb-10.0.1-py311h9297afd_7.conda
win-64::openpmd-api-0.15.2-nompi_py312h166936a_102.conda
win-64::clangxx-17.0.3-default_heb8d277_0.conda
win-64::libadios2-2.9.1-nompi_h1d0fc58_103.conda
win-64::libopencv-4.8.1-py38h8009d80_2.conda
win-64::lfortran-0.23.0-h12be248_0.conda
win-64::vigra-1.11.2-py312hd114928_3.conda
win-64::folly-2023.10.09.00-h43676e7_0.conda
win-64::stir-5.2.0-cpu_py310h150df81_1.conda
win-64::pillow-10.0.1-py39h368b509_2.conda
win-64::grpcio-1.58.2-py310hb84602e_0.conda
win-64::paraview-5.11.2-py310hf693273_102_qt.conda
win-64::pyinstaller-5.13.2-py311h12e69fa_1.conda
win-64::llvmlite-0.41.1-py310hb84602e_0.conda
win-64::libadios2-2.9.1-nompi_hcfb9f8b_104.conda
win-64::boost-cpp-1.82.0-h6f18f0d_6.conda
win-64::pyreadr-0.4.9-py38hda8ff42_1.conda
win-64::vtk-base-9.2.6-qt_py38h1234567_215.conda
win-64::cpp-opentelemetry-sdk-1.12.0-hd5c52a9_0.conda
win-64::vtk-base-9.2.6-qt_py310h1234567_218.conda
win-64::imread-0.7.4-py310h0bb040c_6.conda
win-64::llvm-tools-17.0.2-h1ab654d_0.conda
win-64::lfortran-0.28.0-h12be248_0.conda
win-64::imagecodecs-2023.9.18-py39h445c58b_1.conda
win-64::grpcio-1.58.1-py38h19421c1_2.conda
win-64::python-igraph-0.11.2-py38h5697605_1.conda
win-64::folly-2023.10.16.00-h04b96d7_0.conda
win-64::libarrow-13.0.0-h1e3473c_6_cpu.conda
win-64::libkml-1.3.0-haf3e7a6_1018.conda
win-64::pygplates-0.39-py310hf17f16a_12.conda
win-64::openpmd-api-0.15.2-nompi_py310h60a9cca_102.conda
win-64::tiledb-2.17.3-hec1fcaa_0.conda
win-64::ecell4_base-2.1.0-py39hd10ee7f_7.conda
win-64::libclang13-17.0.3-default_hc80b9e7_0.conda
win-64::libkml-1.3.0-hd45a9bc_1016.conda
win-64::pyhdk-0.9.0-py310h1234567_2_cpu.conda
win-64::pygrib-2.1.4-py38hb12060b_8.conda
win-64::aws-sdk-cpp-1.11.182-h9479ca2_2.conda
win-64::pyinstaller-5.13.2-py38ha959d8a_1.conda
win-64::libarrow-10.0.1-h58a770d_45_cpu.conda
win-64::pygplates-0.39-py312h4fad4f6_11.conda
win-64::pyreadr-0.5.0-py310hfdea923_0.conda
win-64::pigz-2.8-h4b92bb4_0.conda
win-64::pygrib-2.1.4-py39h11138c0_8.conda
win-64::pyhdk-0.8.0-py39h1234567_2_cpu.conda
win-64::stir-5.2.0-cuda118_py39hd6f898a_201.conda
win-64::vigra-1.11.2-py310h9eb0d7a_1.conda
win-64::imagecodecs-2023.9.18-py310h0dcf169_1.conda
win-64::pytables-3.8.0-py39h607662a_4.conda
win-64::libarrow-10.0.1-h940c563_49_cuda.conda
win-64::libgdal-arrow-parquet-3.6.4-h44ec5f3_21.conda
win-64::tesseract-5.3.2-hb328096_1.conda
win-64::vtk-base-9.2.6-qt_py311h1234567_215.conda
win-64::grpcio-1.58.1-py39h6848017_2.conda
win-64::pyreadstat-1.2.3-py38h84023d3_1.conda
win-64::ecell4_base-2.1.0-py312h23365d4_7.conda
win-64::pygplates-0.39-py312h4fad4f6_12.conda
win-64::libadios2-2.9.1-nompi_h52f8237_104.conda
win-64::pygplates-0.39-py38h3578e79_11.conda
win-64::lfortran-0.26.0-h12be248_0.conda
win-64::stir-5.2.0-cpu_py38h5c36b7e_0.conda
win-64::ifcopenshell-v0.7.0a10-py311he6a91dd_2.conda
win-64::gst-plugins-base-1.22.6-h001b923_2.conda
win-64::heyoka-3.0.0-h34149e3_0.conda
win-64::grpcio-1.59.1-py39hd28a505_0.conda
win-64::ogre-14.1.2-h330a6e2_0.conda
win-64::bytewax-0.17.1-py38pl5321hcc47c24_2.conda
win-64::libllvm17-17.0.3-h1ab654d_1.conda
win-64::python-igraph-0.11.2-py38h5697605_0.conda
win-64::clang-17-17.0.3-default_heb8d277_0.conda
win-64::openpmd-api-0.15.2-nompi_py39hfef24c1_102.conda
win-64::python-igraph-0.10.8-py39he170af6_1.conda
win-64::dask-sql-2023.10.0-py310hb5dc9fe_1.conda
win-64::lfortran-0.21.2-h12be248_0.conda
win-64::vtk-base-9.2.6-qt_py38h1234567_218.conda
win-64::lfortran-0.24.0-h12be248_0.conda
win-64::imread-0.7.4-py38hfc48e8c_6.conda
win-64::pyreadstat-1.2.4-py38h84023d3_0.conda
win-64::qt6-3d-6.5.3-h294d793_0.conda
win-64::pillow-10.1.0-py39hf7d859a_0.conda
win-64::libopencv-4.8.1-py39he2c65a9_3.conda
win-64::folly-2023.10.30.00-hd2f1b6b_0.conda
win-64::tiledb-2.17.2-hbf04793_0.conda
win-64::ifcopenshell-v0.7.0a10-py39hefd8b2d_1.conda
win-64::pygplates-0.39-py310hf17f16a_11.conda
win-64::clang-tools-17.0.3-default_heb8d277_0.conda
win-64::smesh-9.9.0.0-h27babe3_8.conda
win-64::stir-5.2.0-cuda112_py38he021285_201.conda
win-64::libarrow-12.0.1-h21b21d9_21_cuda.conda
win-64::libarrow-13.0.0-h6204054_11_cuda.conda
win-64::r-harp-1.20-r41h1fcffe7_1.conda
win-64::libadios2-2.9.1-nompi_h72362e8_104.conda
win-64::libarrow-12.0.1-h6204054_20_cuda.conda
win-64::libarrow-12.0.1-h64a251c_19_cpu.conda
win-64::libboost-1.82.0-h65993cd_4.conda
win-64::harp-1.20.1-py311h1dae2b4_0.conda
win-64::openmeeg-2.5.6-py310h8cb444f_4.conda
win-64::folly-2023.10.02.00-hd2f1b6b_0.conda
win-64::topologytoolkit-1.2.0-with_paraview_py38h57c3c6e_0.conda
win-64::libgrpc-1.59.1-h5bbd4a7_0.conda
win-64::aws-sdk-cpp-1.11.156-h660de7d_4.conda
win-64::minizip-4.0.2-h5bed578_0.conda
win-64::pdal-2.6.0-ha3658a6_0.conda
win-64::gdstk-0.9.46-py312h1b3467e_0.conda
win-64::heyoka-3.0.0-h2333ef2_0.conda
win-64::pyreadstat-1.2.3-py310h51ee7fe_1.conda
win-64::grpcio-1.58.1-py39hd28a505_2.conda
win-64::lfortran-0.21.3-h12be248_0.conda
win-64::pygrib-2.1.4-py311hb25bc96_8.conda
win-64::grpcio-1.59.1-py311h5bc0dda_0.conda
win-64::vtk-base-9.2.6-qt_py39h1234567_216.conda
win-64::pdal-2.5.6-ha3658a6_4.conda
win-64::libarrow-10.0.1-h9f5ee77_44_cuda.conda
win-64::pyreadstat-1.2.4-py39h585ecb4_0.conda
win-64::libopentelemetry-cpp-1.11.0-hd5c52a9_2.conda
win-64::libarrow-12.0.1-he7bc412_18_cpu.conda
win-64::paraview-5.11.2-py39heb84223_102_qt.conda
win-64::openvdb-10.0.1-py39h83b1a0d_7.conda
win-64::omniorb-4.3.1-py310h2b448b3_2.conda
win-64::openpmd-api-0.15.2-nompi_py38h4154134_102.conda
win-64::smesh-9.9.0.0-h8cb9368_7.conda
win-64::netcdf4-1.6.5-nompi_py312he4da9c3_100.conda
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
================================================================================
================================================================================
linux-aarch64
linux-aarch64::websocketpp-0.8.2-h28f1edd_3.conda
linux-aarch64::libprotobuf-4.24.3-h87e877f_1.conda
linux-aarch64::liblal-7.4.1-fftw_h22fc402_100.conda
linux-aarch64::libmlir-17.0.3-h6acfec4_0.conda
linux-aarch64::libmlir17-17.0.3-h6acfec4_0.conda
linux-aarch64::minizip-1.2-hd84c7bf_0.conda
linux-aarch64::libprotobuf-static-4.24.4-h87e877f_0.conda
linux-aarch64::libprotobuf-static-4.24.3-h87e877f_1.conda
linux-aarch64::msgpack-cxx-6.1.0-he84f5c7_1.conda
linux-aarch64::micromamba-1.5.0-2.tar.bz2
linux-aarch64::libmlir-17.0.2-h6acfec4_0.conda
linux-aarch64::pigz-2.8-h194ca79_0.conda
linux-aarch64::libsqlite-3.43.2-h194ca79_0.conda
linux-aarch64::minizip-1.2-hd84c7bf_1.conda
linux-aarch64::micromamba-1.5.0-3.tar.bz2
linux-aarch64::eccodes-2.32.1-h638bc8f_0.conda
linux-aarch64::libprotobuf-4.24.4-h87e877f_0.conda
linux-aarch64::eccodes-2.32.0-h638bc8f_0.conda
linux-aarch64::pcre2-10.42-hd0f9c67_0.conda
linux-aarch64::heaptrack-1.2.0-h6d5d897_4.conda
linux-aarch64::micromamba-1.5.1-1.tar.bz2
linux-aarch64::minizip-1.2-hd84c7bf_2.conda
linux-aarch64::libmlir17-17.0.2-h6acfec4_0.conda
-    "libzlib >=1.2.13,<1.3.0a0"
+    "libzlib >=1.2.13,<2.0.0a0"
linux-aarch64::libarrow-12.0.1-hd8c837b_21_cpu.conda
linux-aarch64::llvmdev-17.0.3-h70e38ee_1.conda
linux-aarch64::fenics-libdolfin-2019.1.0-he5c876f_38.conda
linux-aarch64::grpcio-1.59.2-py310h20b6881_0.conda
linux-aarch64::libadios2-2.9.1-mpi_mpich_h798f37a_4.conda
linux-aarch64::openimageio-2.4.16.0-ha16a733_0.conda
linux-aarch64::pygrib-2.1.4-py39h0b06bf4_8.conda
linux-aarch64::libadios2-2.9.1-mpi_mpich_hfbe1fc2_4.conda
linux-aarch64::fenics-libdolfin-2019.1.0-h716b0b4_42.conda
linux-aarch64::libnghttp2-1.55.1-hb0e430d_0.conda
linux-aarch64::pillow-10.0.1-py312h1e2a6dd_2.conda
linux-aarch64::netcdf4-1.6.5-nompi_py311hcd50196_100.conda
linux-aarch64::cppyy-cling-6.27.1-py311hfd6ae59_1.conda
linux-aarch64::folly-2023.09.25.00-hf875f9a_1.conda
linux-aarch64::heyoka-llvm-14-3.0.0-h63e26b0_0.conda
linux-aarch64::openimageio-2.4.15.0-h151a90d_1.conda
linux-aarch64::hamlib-tcl-4.5.5-hdf905ee_0.conda
linux-aarch64::libboost-1.82.0-h133f18d_6.conda
linux-aarch64::folly-2023.10.23.00-h8dd4a7f_0_jemalloc.conda
linux-aarch64::nodejs-16.20.2-hc1f8a26_2.conda
linux-aarch64::vowpalwabbit-9.9.0-py311hfa3b387_1.conda
linux-aarch64::jaxlib-0.4.19-cpu_py310h5e86b86_0.conda
linux-aarch64::fenics-libdolfin-2019.1.0-h799ccea_42.conda
linux-aarch64::python-igraph-0.11.2-py311h1a6d65a_1.conda
linux-aarch64::smesh-9.9.0.0-hc752b2f_7.conda
linux-aarch64::dask-sql-2023.10.0-py38h2a08342_1.conda
linux-aarch64::pygplates-0.39-py38hef996c5_12.conda
linux-aarch64::jaxlib-0.4.19-cpu_py312hf61c8ac_0.conda
linux-aarch64::netcdf4-1.6.5-mpi_mpich_py310h84864ae_0.conda
linux-aarch64::folly-2023.10.09.00-hcdf9fb0_0.conda
linux-aarch64::openimageio-2.4.16.0-h151a90d_0.conda
linux-aarch64::lld-17.0.2-h8ef0f76_0.conda
linux-aarch64::pytables-3.9.1-py312h23391e5_0.conda
linux-aarch64::vtk-base-9.2.6-qt_py311h1234567_215.conda
linux-aarch64::libgdal-3.7.2-h52108d7_5.conda
linux-aarch64::fenics-libdolfin-2019.1.0-h2b44da5_39.conda
linux-aarch64::pillow-10.0.1-py311hbcc2232_2.conda
linux-aarch64::harp-1.20-py39h5702257_1.conda
linux-aarch64::heyoka-3.0.0-hd32b3df_0.conda
linux-aarch64::libadios2-2.9.1-mpi_openmpi_h70cb021_4.conda
linux-aarch64::openimageio-2.5.4.0-py312hda6ec94_2.conda
linux-aarch64::uwsgi-2.0.22-py311hbd9d994_0.conda
linux-aarch64::python-igraph-0.11.2-py39h240255e_1.conda
linux-aarch64::openpmd-api-0.15.2-mpi_openmpi_py39h7472676_2.conda
linux-aarch64::libadios2-2.9.1-mpi_mpich_hf9996c7_4.conda
linux-aarch64::grpcio-1.58.2-py312hd96c8c9_0.conda
linux-aarch64::pygrib-2.1.4-py38hd82fde1_8.conda
linux-aarch64::pytables-3.9.1-py39hca38f38_0.conda
linux-aarch64::uwsgi-2.0.22-py38h20a68f3_2.conda
linux-aarch64::uwsgi-2.0.22-py311hdfcdb29_3.conda
linux-aarch64::vigra-1.11.2-py39hb25b0c9_2.conda
linux-aarch64::python-3.12.0-h43d1f9e_0_cpython.conda
linux-aarch64::grpcio-1.57.1-py311h1a7908d_0.conda
linux-aarch64::libkml-1.3.0-h7d16752_1018.conda
linux-aarch64::libarrow-10.0.1-hfbc0944_46_cpu.conda
linux-aarch64::lldb-16.0.6-py39hc7031eb_0.conda
linux-aarch64::healpy-1.16.6-py310h1b8455a_1.conda
linux-aarch64::freeimage-3.18.0-h5e0f794_18.conda
linux-aarch64::libarrow-10.0.1-h7a85b91_46_cuda.conda
linux-aarch64::pypy3.9-7.3.13-h63376dd_1.tar.bz2
linux-aarch64::grpcio-1.57.1-py39h483cef1_0.conda
linux-aarch64::uwsgi-2.0.22-py38h20a68f3_1.conda
linux-aarch64::pytables-3.8.0-py312h23391e5_4.conda
linux-aarch64::libarrow-11.0.0-h2b36d5a_46_cuda.conda
linux-aarch64::python-igraph-0.11.2-py39h97b983d_0.conda
linux-aarch64::grpcio-1.57.0-py39h483cef1_2.conda
linux-aarch64::heyoka-3.0.0-h5d02d9c_0.conda
linux-aarch64::llvmlite-0.41.1-py38h95a9722_0.conda
linux-aarch64::fenics-libdolfin-2019.1.0-h2b44da5_38.conda
linux-aarch64::libvips-8.14.5-hf1bd917_2.conda
linux-aarch64::fenics-libdolfin-2019.1.0-he31ffb1_40.conda
linux-aarch64::libllvm17-17.0.2-h70e38ee_0.conda
linux-aarch64::texlive-core-20230313-h69276c6_7.conda
linux-aarch64::fenics-libdolfin-2019.1.0-ha0ef2c6_38.conda
linux-aarch64::dask-sql-2023.10.0-py39h030f67e_0.conda
linux-aarch64::pyreadstat-1.2.4-py38hbecd58a_0.conda
linux-aarch64::fenics-libdolfin-2019.1.0-h2803a63_40.conda
linux-aarch64::grpcio-1.59.1-py311h1a7908d_0.conda
linux-aarch64::aws-sdk-cpp-1.11.182-hbdc7a1d_1.conda
linux-aarch64::uwsgi-2.0.22-py310h76a2826_0.conda
linux-aarch64::vowpalwabbit-9.9.0-py311hfa3b387_2.conda
linux-aarch64::fenics-libdolfin-2019.1.0-hc7d1891_41.conda
linux-aarch64::libarrow-11.0.0-hd8c837b_46_cpu.conda
linux-aarch64::libopencv-4.8.1-py39h95b090a_1.conda
linux-aarch64::harp-1.20-py38h5702257_1.conda
linux-aarch64::llvm-openmp-17.0.3-h8b0cb96_0.conda
linux-aarch64::boost-cpp-1.82.0-ha990451_6.conda
linux-aarch64::uwsgi-2.0.22-py39h6f34d88_3.conda
linux-aarch64::pillow-10.0.1-py38hf904494_2.conda
linux-aarch64::dask-sql-2023.10.0-py39h030f67e_1.conda
linux-aarch64::ale-py-0.8.1-py311h2685f18_1.conda
linux-aarch64::imagecodecs-2023.9.18-py39hee7ecc3_2.conda
linux-aarch64::r-harp-1.20-py311r43hc8f05bd_1.conda
linux-aarch64::lldb-16.0.6-py310h7487d7a_0.conda
linux-aarch64::mapserver-8.0.1-py310hd7b7184_10.conda
linux-aarch64::grpcio-1.58.1-py38h95a9722_1.conda
linux-aarch64::vigra-1.11.2-py39h806c46c_1.conda
linux-aarch64::heyoka-3.0.0-h5bd34f8_0.conda
linux-aarch64::libkml-1.3.0-h7d16752_1017.conda
linux-aarch64::r-harp-1.20.1-py38r43hd131ec7_0.conda
linux-aarch64::python-igraph-0.10.8-py311h1a6d65a_1.conda
linux-aarch64::healpy-1.16.6-py310h1b8455a_0.conda
linux-aarch64::r-harp-1.20.1-py39r43h252d492_0.conda
linux-aarch64::grpcio-1.59.2-py39h2ec6326_0.conda
linux-aarch64::openpmd-api-0.15.2-mpi_mpich_py312h03c6d3c_2.conda
linux-aarch64::fenics-libdolfin-2019.1.0-h4b1f341_40.conda
linux-aarch64::libopencv-4.8.1-py311h664a2b8_3.conda
linux-aarch64::llvm-17.0.3-h5271726_1.conda
linux-aarch64::mysql-server-8.0.33-h6a16c3d_5.conda
linux-aarch64::qt6-main-6.5.3-ha16346e_0.conda
linux-aarch64::curl-8.4.0-h4e8248e_0.conda
linux-aarch64::vtk-base-9.2.6-qt_py39h1234567_216.conda
linux-aarch64::heyoka-2.0.0-h5bd34f8_1.conda
linux-aarch64::python-igraph-0.11.2-py310h9e80044_1.conda
linux-aarch64::pyreadstat-1.2.3-py312hd4a9921_1.conda
linux-aarch64::imagemagick-7.1.1_20-pl5321h1233903_0.conda
linux-aarch64::pyinstaller-6.1.0-py38h37f3631_0.conda
linux-aarch64::libopentelemetry-cpp-1.11.0-hd2f1292_2.conda
linux-aarch64::llvm-tools-17.0.3-h70e38ee_0.conda
linux-aarch64::mapserver-8.0.1-py38h74c20f3_10.conda
linux-aarch64::healpy-1.16.6-py39hdd5fb1c_0.conda
linux-aarch64::libarrow-10.0.1-h399ce64_45_cpu.conda
linux-aarch64::minizip-static-1.2-hd84c7bf_2.conda
linux-aarch64::libopencv-4.8.1-py311h664a2b8_2.conda
linux-aarch64::mapserver-8.0.1-py39h9c801f7_9.conda
linux-aarch64::pytables-3.8.0-py38h8b086c5_4.conda
linux-aarch64::folly-2023.10.30.00-hb8ddcfe_0_jemalloc.conda
linux-aarch64::vigra-1.11.2-py310h4945953_2.conda
linux-aarch64::libkml-1.3.0-h995c52a_1016.conda
linux-aarch64::libpulsar-3.2.0-h43ea208_5.conda
linux-aarch64::libadios2-2.9.1-nompi_hecd7c66_104.conda
linux-aarch64::pdal-2.5.6-h54a7a2a_4.conda
linux-aarch64::mold-2.3.0-h2d6341c_0.conda
linux-aarch64::libopencv-4.8.1-py39h82dced3_3.conda
linux-aarch64::vtk-base-9.2.6-qt_py310h1234567_216.conda
linux-aarch64::netcdf4-1.6.5-mpi_mpich_py311h26533c6_0.conda
linux-aarch64::libarrow-10.0.1-h359ceba_45_cuda.conda
linux-aarch64::libgrpc-1.58.1-hb1224e5_1.conda
linux-aarch64::libarrow-11.0.0-hf5ee1fb_44_cuda.conda
linux-aarch64::pyreadstat-1.2.4-py39hfca9663_0.conda
linux-aarch64::pyreadstat-1.2.4-py312hd4a9921_0.conda
linux-aarch64::pyreadstat-1.2.3-py39hfca9663_1.conda
linux-aarch64::tiledb-2.17.3-h2dfc8ae_1.conda
linux-aarch64::libllvm17-17.0.3-h70e38ee_1.conda
linux-aarch64::vtk-base-9.2.6-qt_py311h1234567_217.conda
linux-aarch64::qt6-main-6.6.0-ha16346e_0.conda
linux-aarch64::mapserver-8.0.1-py38h74c20f3_9.conda
linux-aarch64::openimageio-2.5.4.0-py39h5d78193_1.conda
linux-aarch64::libarrow-13.0.0-hff56712_6_cuda.conda
linux-aarch64::libarrow-11.0.0-h359ceba_41_cuda.conda
linux-aarch64::openjdk-21.0.1-hf79f348_0.conda
linux-aarch64::libarrow-11.0.0-h1a8754d_43_cpu.conda
linux-aarch64::imagecodecs-2023.9.18-py39h0c86555_1.conda
linux-aarch64::fenics-libdolfin-2019.1.0-h2477b5d_41.conda
linux-aarch64::pygplates-0.39-py39hb8a4201_10.conda
linux-aarch64::openpmd-api-0.15.2-nompi_py39h7fa5be0_102.conda
linux-aarch64::boost-cpp-1.82.0-ha990451_5.conda
linux-aarch64::harp-1.20-py311h180e050_1.conda
linux-aarch64::uwsgi-2.0.22-py38hc87ea82_0.conda
linux-aarch64::vtk-base-9.2.6-qt_py310h1234567_215.conda
linux-aarch64::libarrow-13.0.0-hf5ee1fb_10_cuda.conda
linux-aarch64::pyreadstat-1.2.4-py310h3516908_0.conda
linux-aarch64::openimageio-2.4.15.0-h7148cd2_1.conda
linux-aarch64::libarrow-11.0.0-h6c2fda7_43_cuda.conda
linux-aarch64::grpcio-1.58.1-py39h2ec6326_1.conda
linux-aarch64::libarrow-12.0.1-hf5ee1fb_19_cuda.conda
linux-aarch64::imagecodecs-2023.9.18-py310h6d6f36f_2.conda
linux-aarch64::leptonica-1.83.1-h0ae7791_5.conda
linux-aarch64::grpcio-1.57.0-py310h20b6881_2.conda
linux-aarch64::dask-sql-2023.10.1-py39h030f67e_0.conda
linux-aarch64::libadios2-2.9.1-mpi_openmpi_h9c94c55_3.conda
linux-aarch64::openimageio-2.4.16.0-hdeceb33_0.conda
linux-aarch64::r-harp-1.20-py39r43h7f8485b_1.conda
linux-aarch64::mysql-router-8.0.33-h7b6bbdb_5.conda
linux-aarch64::smesh-9.9.0.0-h1fb3108_8.conda
linux-aarch64::libcurl-8.4.0-h4e8248e_0.conda
linux-aarch64::libadios2-2.9.1-nompi_h0e897e0_104.conda
linux-aarch64::pyinstaller-6.1.0-py311h0dd4530_0.conda
linux-aarch64::dask-sql-2023.10.0-py311h0ba7c2e_1.conda
linux-aarch64::boost-cpp-1.82.0-ha990451_4.conda
linux-aarch64::tiledb-2.17.3-hdb54b9b_1.conda
linux-aarch64::rust-1.73.0-h9d3d833_0.conda
linux-aarch64::pyinstaller-6.1.0-py39hb91f966_0.conda
linux-aarch64::folly-2023.10.30.00-hf875f9a_0.conda
linux-aarch64::harp-1.20.1-py38h5702257_0.conda
linux-aarch64::netcdf4-1.6.5-nompi_py39h5d0e02b_100.conda
linux-aarch64::libopencv-4.8.1-py312h7cad72c_3.conda
linux-aarch64::pillow-10.0.1-py39hf04c2c8_2.conda
linux-aarch64::harp-1.20.1-py311h180e050_0.conda
linux-aarch64::openpmd-api-0.15.2-nompi_py310hd14842b_102.conda
linux-aarch64::lldb-16.0.6-py311h8caf9c2_0.conda
linux-aarch64::pytables-3.8.0-py39h6cd1a68_4.conda
linux-aarch64::tiledb-2.17.2-hdb54b9b_0.conda
linux-aarch64::openimageio-2.4.16.0-h7148cd2_0.conda
linux-aarch64::grpcio-1.58.1-py38h95a9722_2.conda
linux-aarch64::folly-2023.10.30.00-hcdf9fb0_0.conda
linux-aarch64::pygrib-2.1.4-py312hfc4e102_8.conda
linux-aarch64::pytables-3.8.0-py311h9a8bc71_4.conda
linux-aarch64::omniorb-4.3.1-py38hc9c3f1f_2.conda
linux-aarch64::libarrow-11.0.0-h097f756_40_cpu.conda
linux-aarch64::heyoka-llvm-12-2.0.0-h0f5c0ee_1.conda
linux-aarch64::r-harp-1.20.1-py310r43h96bca1b_0.conda
linux-aarch64::openmpi-4.1.6-h06852b5_100.conda
linux-aarch64::grpcio-1.57.0-py38h95a9722_2.conda
linux-aarch64::libopencv-4.8.1-py38h8cebfec_1.conda
linux-aarch64::pyinstaller-6.1.0-py310h1aab166_0.conda
linux-aarch64::libgdal-3.6.4-hbc56290_21.conda
linux-aarch64::heyoka-llvm-13-3.0.0-h4c37d1a_0.conda
linux-aarch64::grpcio-1.59.1-py39h483cef1_0.conda
linux-aarch64::tiledb-2.17.3-h3e6b69a_1.conda
linux-aarch64::folly-2023.09.25.00-hcbc1ef6_1.conda
linux-aarch64::vtk-base-9.2.6-qt_py310h1234567_217.conda
linux-aarch64::llvmdev-17.0.2-h70e38ee_0.conda
linux-aarch64::uwsgi-2.0.22-py311hdfcdb29_1.conda
linux-aarch64::libarrow-12.0.1-h359ceba_16_cuda.conda
linux-aarch64::llvmlite-0.41.1-py310h20b6881_0.conda
linux-aarch64::fenics-libdolfin-2019.1.0-hf540da4_39.conda
linux-aarch64::imagemagick-7.1.1_19-pl5321h3dc99c5_0.conda
linux-aarch64::grpcio-1.57.1-py39h2ec6326_0.conda
linux-aarch64::fenics-libdolfin-2019.1.0-hdf384fb_38.conda
linux-aarch64::libadios2-2.9.1-mpi_openmpi_h550ea5c_3.conda
linux-aarch64::folly-2023.10.09.00-hf875f9a_0.conda
linux-aarch64::grpcio-1.58.2-py39h483cef1_0.conda
linux-aarch64::grpcio-1.58.1-py312hd96c8c9_2.conda
linux-aarch64::libarrow-11.0.0-hff56712_40_cuda.conda
linux-aarch64::harp-1.20-py310h5702257_1.conda
linux-aarch64::mlir-17.0.3-h6acfec4_0.conda
linux-aarch64::grpcio-1.59.2-py38h95a9722_0.conda
linux-aarch64::fenics-libdolfin-2019.1.0-haf7120c_41.conda
linux-aarch64::python-igraph-0.11.2-py311h1a6d65a_0.conda
linux-aarch64::omniorb-4.3.1-py312h89a05d2_2.conda
linux-aarch64::aws-sdk-cpp-1.11.156-hdea27d8_4.conda
linux-aarch64::pygplates-0.39-py311h38e62c5_10.conda
linux-aarch64::cppyy-cling-6.27.1-py310h88818a3_1.conda
linux-aarch64::libarrow-10.0.1-h097f756_44_cpu.conda
linux-aarch64::imagecodecs-2023.9.18-py39h0c86555_2.conda
linux-aarch64::openmpi-4.1.6-h1f4154d_101.conda
linux-aarch64::folly-2023.10.23.00-hcdf9fb0_0.conda
linux-aarch64::sdl_image-1.2.12-h4987065_6.conda
linux-aarch64::uwsgi-2.0.22-py310h0437cc5_2.conda
linux-aarch64::openimageio-2.5.4.0-py38h1c887ff_1.conda
linux-aarch64::vigra-1.11.2-py39he333f03_3.conda
linux-aarch64::squashfs-tools-4.6.1-h24ece89_0.conda
linux-aarch64::qt6-main-6.5.2-h97a3909_5.conda
linux-aarch64::grpcio-1.58.1-py39h2ec6326_2.conda
linux-aarch64::libopencv-4.8.1-py311h8b942fa_1.conda
linux-aarch64::afterimage-1.21-h6ecfecd_1005.conda
linux-aarch64::libbrial-1.2.12-h17533bf_1.conda
linux-aarch64::orc-1.9.0-h5828fcf_3.conda
linux-aarch64::uwsgi-2.0.22-py38h20a68f3_3.conda
linux-aarch64::ogre-14.1.2-hb5b1993_0.conda
linux-aarch64::octave-8.3.0-hcc7940c_1.conda
linux-aarch64::libgdal-3.6.4-hc73c54a_20.conda
linux-aarch64::openpmd-api-0.15.2-mpi_openmpi_py311ha822e1d_2.conda
linux-aarch64::libarrow-13.0.0-h1a8754d_9_cpu.conda
linux-aarch64::gmsh-4.11.1-h879f771_4.conda
linux-aarch64::libgdal-arrow-parquet-3.7.2-h37aa2f1_7.conda
linux-aarch64::cpp-opentelemetry-sdk-1.12.0-hd2f1292_0.conda
linux-aarch64::libarrow-10.0.1-hd8c837b_50_cpu.conda
linux-aarch64::fenics-libdolfin-2019.1.0-h4c35517_38.conda
linux-aarch64::dask-sql-2023.10.0-py310h7f85ab7_1.conda
linux-aarch64::pyinstaller-6.1.0-py312h16ba8cc_0.conda
linux-aarch64::jaxlib-0.4.18-cpu_py312hf61c8ac_0.conda
linux-aarch64::libtiledb-sql-0.25.1-h886d7b1_0.conda
linux-aarch64::vowpalwabbit-9.9.0-py312hc6d66ea_2.conda
linux-aarch64::pygplates-0.39-py310h21874ea_12.conda
linux-aarch64::r-harp-1.20.1-py39r43h7f8485b_0.conda
linux-aarch64::libadios2-2.9.1-nompi_hb3655a9_103.conda
linux-aarch64::libadios2-2.9.1-nompi_h0e897e0_103.conda
linux-aarch64::ffmpeg-4.4.2-gpl_h773c8b4_113.conda
linux-aarch64::libgrpc-1.59.1-h877c88e_0.conda
linux-aarch64::dask-sql-2023.10.1-py38h2a08342_0.conda
linux-aarch64::pytables-3.9.1-py39h6cd1a68_0.conda
linux-aarch64::dask-sql-2023.10.1-py310h7f85ab7_0.conda
linux-aarch64::vowpalwabbit-9.9.0-py310h2724568_1.conda
linux-aarch64::vtk-base-9.2.6-qt_py312h1234567_218.conda
linux-aarch64::uwsgi-2.0.22-py310h0437cc5_1.conda
linux-aarch64::pygplates-0.39-py311h38e62c5_11.conda
linux-aarch64::pytables-3.9.1-py310h6e51920_0.conda
linux-aarch64::pillow-10.1.0-py312h1e2a6dd_0.conda
linux-aarch64::libarrow-13.0.0-h03fb76e_10_cpu.conda
linux-aarch64::openpmd-api-0.15.2-mpi_mpich_py39h02ac68f_2.conda
linux-aarch64::fenics-libdolfin-2019.1.0-h6d2774e_42.conda
linux-aarch64::grpcio-1.59.2-py312hd96c8c9_0.conda
linux-aarch64::fenics-libdolfin-2019.1.0-he5c876f_39.conda
linux-aarch64::fenics-libdolfin-2019.1.0-h799ccea_41.conda
linux-aarch64::python-igraph-0.10.8-py39h240255e_1.conda
linux-aarch64::libarrow-10.0.1-h03fb76e_48_cpu.conda
linux-aarch64::python-3.11.6-h43d1f9e_0_cpython.conda
linux-aarch64::r-harp-1.20-py39r43h252d492_1.conda
linux-aarch64::libadios2-2.9.1-mpi_mpich_h996dc08_4.conda
linux-aarch64::texlive-core-20230313-hd647d2e_6.conda
linux-aarch64::cpp-opentelemetry-sdk-1.11.0-hd2f1292_2.conda
linux-aarch64::libllvm17-17.0.3-h70e38ee_0.conda
linux-aarch64::llvmlite-0.41.1-py39h2ec6326_0.conda
linux-aarch64::ogre-14.1.1-hb5b1993_0.conda
linux-aarch64::uwsgi-2.0.22-py311hdfcdb29_2.conda
linux-aarch64::folly-2023.10.09.00-hcbc1ef6_0.conda
linux-aarch64::mysql-client-8.0.33-h88b4a5d_5.conda
linux-aarch64::pillow-10.0.1-py310h0ae3e2b_2.conda
linux-aarch64::python-igraph-0.11.2-py312he6f5f83_1.conda
linux-aarch64::folly-2023.10.16.00-hf875f9a_0.conda
linux-aarch64::netcdf4-1.6.5-mpi_openmpi_py312h3ac0e53_0.conda
linux-aarch64::libopencv-4.8.1-py39h397868c_2.conda
linux-aarch64::qt6-3d-6.6.0-h06f141b_0.conda
linux-aarch64::pillow-10.1.0-py38hf904494_0.conda
linux-aarch64::jaxlib-0.4.18-cpu_py310h5e86b86_0.conda
linux-aarch64::yarp-cxx-3.8.1-hc289372_6.conda
linux-aarch64::tiledb-2.17.3-h3e6b69a_0.conda
linux-aarch64::libgdal-3.7.2-hc84c8eb_6.conda
linux-aarch64::libvips-8.14.5-haa71913_3.conda
linux-aarch64::libarrow-13.0.0-h399ce64_7_cpu.conda
linux-aarch64::cppyy-cling-6.27.1-py38h68f7483_1.conda
linux-aarch64::libvips-8.14.5-ha45944c_1.conda
linux-aarch64::folly-2023.09.25.00-h8a1e4c1_1_jemalloc.conda
linux-aarch64::netcdf4-1.6.5-mpi_mpich_py38h52e48cf_0.conda
linux-aarch64::fenics-libdolfin-2019.1.0-hf540da4_38.conda
linux-aarch64::netcdf4-1.6.5-nompi_py310h77e224f_100.conda
linux-aarch64::pygrib-2.1.4-py39h1f7d879_8.conda
linux-aarch64::python-igraph-0.11.2-py39h240255e_0.conda
linux-aarch64::libadios2-2.9.1-nompi_hf39fb1f_103.conda
linux-aarch64::libpulsar-3.2.0-hb2aa8fa_4.conda
linux-aarch64::vigra-1.11.2-py311h911bf46_3.conda
linux-aarch64::imagecodecs-2023.9.18-py312h8297c15_2.conda
linux-aarch64::libarrow-11.0.0-h399ce64_41_cpu.conda
linux-aarch64::imagemagick-7.1.1_21-pl5321h1233903_0.conda
linux-aarch64::nco-5.1.8-h218977e_1.conda
linux-aarch64::vtk-base-9.2.6-qt_py38h1234567_217.conda
linux-aarch64::dask-sql-2023.10.0-py310h7f85ab7_0.conda
linux-aarch64::nsight-compute-2022.4.0.15-hf82c7b2_1.conda
linux-aarch64::minizip-4.0.1-hb75dd74_5.conda
linux-aarch64::dask-sql-2023.10.1-py311h0ba7c2e_0.conda
linux-aarch64::libarrow-13.0.0-h359ceba_7_cuda.conda
linux-aarch64::netcdf4-1.6.5-mpi_openmpi_py310h7bc6f4b_0.conda
linux-aarch64::libarrow-12.0.1-hff56712_15_cuda.conda
linux-aarch64::vowpalwabbit-9.9.0-py38h757c6bb_1.conda
linux-aarch64::libarrow-12.0.1-h2b36d5a_21_cuda.conda
linux-aarch64::fenics-libdolfin-2019.1.0-h805460f_38.conda
linux-aarch64::ffmpeg-5.1.2-gpl_had025a3_112.conda
linux-aarch64::libarrow-12.0.1-h7a85b91_17_cuda.conda
linux-aarch64::libadios2-2.9.1-nompi_hf07bb53_103.conda
linux-aarch64::r-harp-1.20.1-py311r43hc8f05bd_0.conda
linux-aarch64::libarrow-12.0.1-hfbc0944_17_cpu.conda
linux-aarch64::healpy-1.16.6-py311ha51fd1d_0.conda
linux-aarch64::openpmd-api-0.15.2-mpi_openmpi_py310h2ee61f2_2.conda
linux-aarch64::pygplates-0.39-py310h21874ea_11.conda
linux-aarch64::ogre-1.10.12-hb1a949d_15.conda
linux-aarch64::netcdf4-1.6.5-mpi_openmpi_py39h61f5a0f_0.conda
linux-aarch64::pygplates-0.39-py312hf18a4a8_11.conda
linux-aarch64::fenics-libdolfin-2019.1.0-hd7fc1fa_42.conda
linux-aarch64::fenics-libdolfin-2019.1.0-h2d9ea5b_41.conda
linux-aarch64::fenics-libdolfin-2019.1.0-hc7d1891_42.conda
linux-aarch64::pygplates-0.39-py38hef996c5_10.conda
linux-aarch64::pytng-0.3.1-py39hb671adb_0.conda
linux-aarch64::folly-2023.09.25.00-hb8ddcfe_1_jemalloc.conda
linux-aarch64::libitk-5.3.0-hb48eaf8_7.conda
linux-aarch64::omniorb-4.3.1-py310hae03fa7_2.conda
linux-aarch64::folly-2023.10.23.00-h8a1e4c1_0_jemalloc.conda
linux-aarch64::netcdf4-1.6.5-mpi_mpich_py39hfd381cf_0.conda
linux-aarch64::nodejs-20.8.1-hc1f8a26_0.conda
linux-aarch64::mosh-1.4.0-pl5321h8e49138_4.conda
linux-aarch64::jaxlib-0.4.19-cpu_py39hea16949_0.conda
linux-aarch64::pygrib-2.1.4-py310h4dcf694_8.conda
linux-aarch64::libadios2-2.9.1-mpi_mpich_hfbe1fc2_3.conda
linux-aarch64::libgrpc-1.57.0-h048544f_2.conda
linux-aarch64::ffmpeg-6.0.0-gpl_h76c8505_105.conda
linux-aarch64::openjdk-21.0.0-hf79f348_0.conda
linux-aarch64::pigz-2.6-h194ca79_1.conda
linux-aarch64::vtk-base-9.2.6-qt_py38h1234567_218.conda
linux-aarch64::folly-2023.10.02.00-hf875f9a_0.conda
linux-aarch64::r-harp-1.20-py38r43hd131ec7_1.conda
linux-aarch64::ffmpeg-5.1.2-lgpl_hdc83834_12.conda
linux-aarch64::openimageio-2.4.16.0-h6b97b4e_0.conda
linux-aarch64::libadios2-2.9.1-mpi_openmpi_hdeab2ad_4.conda
linux-aarch64::libsoup-3.4.4-h7b0f9e5_0.conda
linux-aarch64::fenics-libdolfin-2019.1.0-h83c0b5d_40.conda
linux-aarch64::openimageio-2.4.16.0-h09ff249_0.conda
linux-aarch64::imagecodecs-2023.9.18-py310h6d6f36f_1.conda
linux-aarch64::tesseract-5.3.2-h96c1a18_1.conda
linux-aarch64::libarrow-12.0.1-h31a590f_20_cpu.conda
linux-aarch64::libgdal-arrow-parquet-3.7.2-h7f838be_5.conda
linux-aarch64::libgdal-3.6.4-h691daf4_22.conda
linux-aarch64::libadios2-2.9.1-mpi_mpich_h996dc08_3.conda
linux-aarch64::mapserver-8.0.1-py311h12c5543_10.conda
linux-aarch64::mlir-17.0.2-h6acfec4_0.conda
linux-aarch64::folly-2023.10.02.00-hb8ddcfe_0_jemalloc.conda
linux-aarch64::ale-py-0.8.1-py310h3f830e4_1.conda
linux-aarch64::openimageio-2.4.16.0-haafd841_0.conda
linux-aarch64::pyinstaller-5.13.2-py38h37f3631_1.conda
linux-aarch64::fenics-libdolfin-2019.1.0-hf3ed601_41.conda
linux-aarch64::grpcio-1.58.2-py38h95a9722_0.conda
linux-aarch64::python-igraph-0.10.8-py39h97b983d_1.conda
linux-aarch64::jaxlib-0.4.19-cpu_py311h86dff27_0.conda
linux-aarch64::omniorb-4.3.1-py39h86dfdcc_2.conda
linux-aarch64::imagecodecs-2023.9.18-py311h1ace9ac_2.conda
linux-aarch64::libgrpc-1.59.2-h877c88e_0.conda
linux-aarch64::gst-plugins-good-1.22.6-hf2f9846_2.conda
linux-aarch64::grpcio-1.58.1-py310h20b6881_1.conda
linux-aarch64::libmatio-1.5.24-hd3396f4_0.conda
linux-aarch64::fenics-libdolfin-2019.1.0-he333d15_40.conda
linux-aarch64::libnghttp2-static-1.55.1-heb3f89f_0.conda
linux-aarch64::pygplates-0.39-py312hf18a4a8_12.conda
linux-aarch64::folly-2023.10.16.00-h8a1e4c1_0_jemalloc.conda
linux-aarch64::openimageio-2.5.4.0-py310h3325f89_1.conda
linux-aarch64::llvm-17.0.2-h5271726_0.conda
linux-aarch64::freeimage-3.18.0-h437902f_17.conda
linux-aarch64::aws-sdk-cpp-1.10.57-h891f815_24.conda
linux-aarch64::vigra-1.11.2-py39he99c9d4_2.conda
linux-aarch64::qt6-3d-6.5.3-h06f141b_0.conda
linux-aarch64::rust-1.73.0-h9d3d833_2.conda
linux-aarch64::heyoka-llvm-11-2.0.0-hf0cbf0a_1.conda
linux-aarch64::grpcio-1.57.1-py38h95a9722_0.conda
linux-aarch64::uwsgi-2.0.22-py310h0437cc5_3.conda
linux-aarch64::pytables-3.8.0-py310h6e51920_4.conda
linux-aarch64::heyoka-llvm-14-2.0.0-h63e26b0_1.conda
linux-aarch64::libarrow-12.0.1-h097f756_15_cpu.conda
linux-aarch64::openimageio-2.5.4.0-py38ha0b67d0_2.conda
linux-aarch64::python-igraph-0.11.2-py38h8451dc0_1.conda
linux-aarch64::folly-2023.10.16.00-hcdf9fb0_0.conda
linux-aarch64::ogre-14.1.2-h32c6b7a_0.conda
linux-aarch64::fenics-libdolfin-2019.1.0-hc649106_40.conda
linux-aarch64::libarrow-12.0.1-h03fb76e_19_cpu.conda
linux-aarch64::vigra-1.11.2-py39h62747cc_3.conda
linux-aarch64::python-igraph-0.10.8-py38h8451dc0_1.conda
linux-aarch64::openpmd-api-0.15.2-nompi_py311h818263b_102.conda
linux-aarch64::pygplates-0.39-py39hb8a4201_11.conda
linux-aarch64::libarrow-13.0.0-h6c2fda7_9_cuda.conda
linux-aarch64::qt-main-5.15.8-hc564a22_17.conda
linux-aarch64::libarrow-10.0.1-hff56712_44_cuda.conda
linux-aarch64::vtk-base-9.2.6-qt_py311h1234567_216.conda
linux-aarch64::pytng-0.3.1-py310hf2d9793_0.conda
linux-aarch64::leptonica-1.83.1-h91ba0ff_4.conda
linux-aarch64::vigra-1.11.2-py38h272aa3d_3.conda
linux-aarch64::folly-2023.10.16.00-hcbc1ef6_0.conda
linux-aarch64::poppler-23.08.0-hbb0fca6_3.conda
linux-aarch64::vigra-1.11.2-py310he597914_3.conda
linux-aarch64::openimageio-2.4.16.0-hf340f44_0.conda
linux-aarch64::grpcio-1.59.1-py38h95a9722_0.conda
linux-aarch64::pyinstaller-5.13.2-py310h1aab166_1.conda
linux-aarch64::pytng-0.3.1-py311h1fb865f_0.conda
linux-aarch64::pdal-2.6.0-h54a7a2a_0.conda
linux-aarch64::libopencv-4.8.1-py39h397868c_3.conda
linux-aarch64::pygplates-0.39-py38hef996c5_11.conda
linux-aarch64::imagecodecs-2023.9.18-py311h1ace9ac_1.conda
linux-aarch64::pypy3.9-7.3.13-h63376dd_0.tar.bz2
linux-aarch64::qt6-main-6.5.2-h97a3909_6.conda
linux-aarch64::folly-2023.10.23.00-hb8ddcfe_0_jemalloc.conda
linux-aarch64::jaxlib-0.4.14-cpu_py39hea16949_1.conda
linux-aarch64::harp-1.20.1-py310h5702257_0.conda
linux-aarch64::libgrpc-1.58.1-hc6fdb64_2.conda
linux-aarch64::lldb-16.0.6-py38h46cc842_0.conda
linux-aarch64::fenics-libdolfin-2019.1.0-haf7120c_42.conda
linux-aarch64::vigra-1.11.2-py38hf1167f3_2.conda
linux-aarch64::grpcio-1.58.1-py311h1a7908d_1.conda
linux-aarch64::libarrow-12.0.1-hb77284e_20_cuda.conda
linux-aarch64::libboost-1.82.0-h133f18d_4.conda
linux-aarch64::folly-2023.10.30.00-h8a1e4c1_0_jemalloc.conda
linux-aarch64::ale-py-0.8.1-py312ha5f9cab_1.conda
linux-aarch64::vowpalwabbit-9.9.0-py39h6fef2a7_1.conda
linux-aarch64::grpcio-1.59.2-py311h1a7908d_0.conda
linux-aarch64::libgrpc-1.58.2-hc6fdb64_0.conda
linux-aarch64::grpcio-1.58.2-py310h20b6881_0.conda
linux-aarch64::pygplates-0.39-py311h38e62c5_12.conda
linux-aarch64::tiledb-2.17.2-h2dfc8ae_0.conda
linux-aarch64::vowpalwabbit-9.9.0-py38h757c6bb_2.conda
linux-aarch64::heyoka-llvm-15-3.0.0-hba6061c_0.conda
linux-aarch64::pillow-10.1.0-py310h0ae3e2b_0.conda
linux-aarch64::heyoka-2.0.0-hafcf619_1.conda
linux-aarch64::ldas-tools-framecpp-2.9.2-h2906c2a_2.conda
linux-aarch64::libxmlsec1-1.3.2-h45794a5_0.conda
linux-aarch64::grpcio-1.57.0-py312hd96c8c9_2.conda
linux-aarch64::openimageio-2.5.4.0-py310hc02df3e_2.conda
linux-aarch64::healpy-1.16.6-py312h1da9b9c_1.conda
linux-aarch64::fenics-libdolfin-2019.1.0-ha0ef2c6_39.conda
linux-aarch64::llvm-17.0.3-h5271726_0.conda
linux-aarch64::libarrow-13.0.0-hb77284e_11_cuda.conda
linux-aarch64::pillow-10.1.0-py311hbcc2232_0.conda
linux-aarch64::libgdal-arrow-parquet-3.6.4-h3ee9319_21.conda
linux-aarch64::uwsgi-2.0.22-py312h1875e38_2.conda
linux-aarch64::openpmd-api-0.15.2-nompi_py39h8acd475_102.conda
linux-aarch64::folly-2023.10.23.00-hcbc1ef6_0.conda
linux-aarch64::fenics-libdolfin-2019.1.0-hd7fc1fa_41.conda
linux-aarch64::python-igraph-0.11.2-py38h8451dc0_0.conda
linux-aarch64::llvm-tools-17.0.2-h70e38ee_0.conda
linux-aarch64::llvm-tools-17.0.3-h70e38ee_1.conda
linux-aarch64::imagecodecs-2023.9.18-py39hee7ecc3_1.conda
linux-aarch64::r-harp-1.20-py310r43h96bca1b_1.conda
linux-aarch64::grpcio-1.57.0-py38h95a9722_3.conda
linux-aarch64::openpmd-api-0.15.2-mpi_openmpi_py38h3e7efc2_2.conda
linux-aarch64::uwsgi-2.0.22-py39h13923b4_0.conda
linux-aarch64::grpcio-1.57.0-py312hd96c8c9_3.conda
linux-aarch64::heyoka-2.0.0-h7e24eb7_1.conda
linux-aarch64::libopencv-4.8.1-py38he8f0970_3.conda
linux-aarch64::libarrow-10.0.1-hf5ee1fb_48_cuda.conda
linux-aarch64::libadios2-2.9.1-mpi_openmpi_h550ea5c_4.conda
linux-aarch64::nss-3.94-hc5a5cc2_0.conda
linux-aarch64::openpmd-api-0.15.2-mpi_openmpi_py39h7246c96_2.conda
linux-aarch64::netcdf4-1.6.5-mpi_openmpi_py311h65ba2fa_0.conda
linux-aarch64::cppyy-cling-6.27.1-py312h17f8acd_1.conda
linux-aarch64::uwsgi-2.0.22-py39h6f34d88_2.conda
linux-aarch64::openpmd-api-0.15.2-mpi_mpich_py39hd6556c9_2.conda
linux-aarch64::ale-py-0.8.1-py39h8961c1f_1.conda
linux-aarch64::heyoka-3.0.0-hc5e576e_0.conda
linux-aarch64::libadios2-2.9.1-mpi_openmpi_h70cb021_3.conda
linux-aarch64::netcdf4-1.6.5-mpi_openmpi_py38h7813e94_0.conda
linux-aarch64::libboost-1.82.0-h133f18d_5.conda
linux-aarch64::vtk-base-9.2.6-qt_py311h1234567_218.conda
linux-aarch64::openimageio-2.4.16.0-hd5ee62a_0.conda
linux-aarch64::libopencv-4.8.1-py38he8f0970_2.conda
linux-aarch64::aws-sdk-cpp-1.11.156-h5e82cfa_5.conda
linux-aarch64::tiledb-2.17.3-h2dfc8ae_0.conda
linux-aarch64::poppler-23.10.0-h3cd87ed_0.conda
linux-aarch64::dask-sql-2023.10.0-py311h0ba7c2e_0.conda
linux-aarch64::grpcio-1.59.1-py310h20b6881_0.conda
linux-aarch64::libadios2-2.9.1-mpi_mpich_h5eedc61_3.conda
linux-aarch64::mysql-libs-8.0.33-hf629957_5.conda
linux-aarch64::tiledb-2.17.3-hdb54b9b_0.conda
linux-aarch64::vowpalwabbit-9.9.0-py39h6fef2a7_2.conda
linux-aarch64::folly-2023.10.16.00-hb8ddcfe_0_jemalloc.conda
linux-aarch64::libopencv-4.8.1-py310h38630c7_3.conda
linux-aarch64::vigra-1.11.2-py312h5773ee8_3.conda
linux-aarch64::folly-2023.10.09.00-h8dd4a7f_0_jemalloc.conda
linux-aarch64::folly-2023.10.09.00-hb8ddcfe_0_jemalloc.conda
linux-aarch64::python-igraph-0.11.2-py39h97b983d_1.conda
linux-aarch64::pyreadstat-1.2.3-py310h3516908_1.conda
linux-aarch64::pyinstaller-5.13.2-py311h0dd4530_1.conda
linux-aarch64::grpcio-1.57.0-py311h1a7908d_3.conda
linux-aarch64::pygrib-2.1.4-py311he1d05c2_8.conda
linux-aarch64::llvmdev-17.0.3-h70e38ee_0.conda
linux-aarch64::libarrow-12.0.1-h1a8754d_18_cpu.conda
linux-aarch64::vtk-base-9.2.6-qt_py39h1234567_215.conda
linux-aarch64::heyoka-llvm-16-2.0.0-h707f7fb_1.conda
linux-aarch64::openimageio-2.5.4.0-py311h315b53b_2.conda
linux-aarch64::healpy-1.16.6-py311ha51fd1d_1.conda
linux-aarch64::grpcio-1.57.0-py39h2ec6326_2.conda
linux-aarch64::openjdk-11.0.21-hac580f4_0.conda
linux-aarch64::libarrow-13.0.0-hfbc0944_8_cpu.conda
linux-aarch64::libtiledb-sql-0.25.1-h556e676_0.conda
linux-aarch64::pillow-10.1.0-py39hf04c2c8_0.conda
linux-aarch64::libadios2-2.9.1-nompi_hf07bb53_104.conda
linux-aarch64::healpy-1.16.6-py39hfd335d8_0.conda
linux-aarch64::hamlib-tcl-4.5.5-hdf905ee_1.conda
linux-aarch64::jaxlib-0.4.18-cpu_py39hea16949_0.conda
linux-aarch64::libarrow-13.0.0-hd8c837b_13_cpu.conda
linux-aarch64::uwsgi-2.0.22-py312h1875e38_3.conda
linux-aarch64::vigra-1.11.2-py312h02539a3_1.conda
linux-aarch64::libadios2-2.9.1-mpi_openmpi_hb0a4856_3.conda
linux-aarch64::libgrpc-1.57.1-h91e51c7_0.conda
linux-aarch64::vtk-base-9.2.6-qt_py39h1234567_218.conda
linux-aarch64::grpcio-1.57.0-py310h20b6881_3.conda
linux-aarch64::libarrow-10.0.1-h1a8754d_47_cpu.conda
linux-aarch64::ogre-14.1.0-h32c6b7a_2.conda
linux-aarch64::libgrpc-1.57.0-h91e51c7_3.conda
linux-aarch64::python-igraph-0.11.2-py310h9e80044_0.conda
linux-aarch64::tiledb-2.17.2-h3e6b69a_0.conda
linux-aarch64::openpmd-api-0.15.2-nompi_py38hff2ea3c_102.conda
linux-aarch64::vowpalwabbit-9.9.0-py310h2724568_2.conda
linux-aarch64::heyoka-llvm-15-2.0.0-hba6061c_1.conda
linux-aarch64::pygplates-0.39-py39hb8a4201_12.conda
linux-aarch64::folly-2023.09.25.00-hcdf9fb0_1.conda
linux-aarch64::libgdal-arrow-parquet-3.6.4-h9b33096_20.conda
linux-aarch64::libarrow-11.0.0-hb77284e_45_cuda.conda
linux-aarch64::vigra-1.11.2-py311h3bbcec0_2.conda
linux-aarch64::fenics-libdolfin-2019.1.0-hc1f0f74_38.conda
linux-aarch64::fenics-libdolfin-2019.1.0-h2477b5d_42.conda
linux-aarch64::grpcio-1.58.1-py310h20b6881_2.conda
linux-aarch64::uwsgi-2.0.22-py39h6f34d88_1.conda
linux-aarch64::libadios2-2.9.1-nompi_hf39fb1f_104.conda
linux-aarch64::folly-2023.09.25.00-h8dd4a7f_1_jemalloc.conda
linux-aarch64::heyoka-llvm-16-3.0.0-h707f7fb_0.conda
linux-aarch64::omniorb-4.3.1-py311h9b119e1_2.conda
linux-aarch64::healpy-1.16.6-py39hdd5fb1c_1.conda
linux-aarch64::vigra-1.11.2-py39hd6e7c08_1.conda
linux-aarch64::grpcio-1.59.2-py39h483cef1_0.conda
linux-aarch64::libgdal-arrow-parquet-3.7.2-hd5c5ac7_6.conda
linux-aarch64::fenics-libdolfin-2019.1.0-h4c35517_39.conda
linux-aarch64::libarrow-10.0.1-hb77284e_49_cuda.conda
linux-aarch64::heyoka-2.0.0-hd32b3df_1.conda
linux-aarch64::pytng-0.3.1-py39h19488dd_0.conda
linux-aarch64::libadios2-2.9.1-nompi_hb3655a9_104.conda
linux-aarch64::libopencv-4.8.1-py310h38630c7_2.conda
linux-aarch64::vtk-base-9.2.6-qt_py310h1234567_218.conda
linux-aarch64::openimageio-2.4.15.0-ha16a733_1.conda
linux-aarch64::magic-8.3.417-h4e13689_0.conda
linux-aarch64::grpcio-1.58.1-py39h483cef1_2.conda
linux-aarch64::pytables-3.9.1-py311h9a8bc71_0.conda
linux-aarch64::libarrow-13.0.0-h097f756_6_cpu.conda
linux-aarch64::openimageio-2.5.4.0-py39h82e6be3_2.conda
linux-aarch64::libarrow-10.0.1-h2b36d5a_50_cuda.conda
linux-aarch64::libgd-2.3.3-hcd22fd5_9.conda
linux-aarch64::heyoka-2.0.0-h5d02d9c_1.conda
linux-aarch64::heyoka-llvm-13-2.0.0-h4c37d1a_1.conda
linux-aarch64::fenics-libdolfin-2019.1.0-h805460f_39.conda
linux-aarch64::ogre-14.1.1-h32c6b7a_0.conda
linux-aarch64::vigra-1.11.2-py38hba6fa90_1.conda
linux-aarch64::assimp-5.3.1-h28f1edd_2.conda
linux-aarch64::cargo-c-0.9.26-h6a45645_0.conda
linux-aarch64::grpcio-1.58.1-py312hd96c8c9_1.conda
linux-aarch64::netcdf4-1.6.5-nompi_py312h7a984fc_100.conda
linux-aarch64::ffmpeg-6.0.0-lgpl_haa40f77_5.conda
linux-aarch64::libgdal-3.7.2-hade022d_7.conda
linux-aarch64::libadios2-2.9.1-mpi_mpich_hf9996c7_3.conda
linux-aarch64::heyoka-2.0.0-hc5e576e_1.conda
linux-aarch64::folly-2023.10.02.00-hcbc1ef6_0.conda
linux-aarch64::folly-2023.10.23.00-hf875f9a_0.conda
linux-aarch64::imagemagick-7.1.1_19-pl5321h1233903_1.conda
linux-aarch64::libopencv-4.8.1-py39h12acc05_1.conda
linux-aarch64::libadios2-2.9.1-mpi_mpich_h798f37a_3.conda
linux-aarch64::folly-2023.10.02.00-hcdf9fb0_0.conda
linux-aarch64::openpmd-api-0.15.2-mpi_mpich_py311h81d8e69_2.conda
linux-aarch64::llvmlite-0.41.1-py311h1a7908d_0.conda
linux-aarch64::lld-17.0.3-h8ef0f76_0.conda
linux-aarch64::grpcio-1.59.1-py312hd96c8c9_0.conda
linux-aarch64::pyinstaller-5.13.2-py39hb91f966_1.conda
linux-aarch64::grpcio-1.59.1-py39h2ec6326_0.conda
linux-aarch64::pygplates-0.39-py310h21874ea_10.conda
linux-aarch64::openpmd-api-0.15.2-nompi_py312he67cd28_102.conda
linux-aarch64::fenics-libdolfin-2019.1.0-h2d9ea5b_42.conda
linux-aarch64::openpmd-api-0.15.2-mpi_openmpi_py312he9a8ce0_2.conda
linux-aarch64::llvm-openmp-17.0.2-h8b0cb96_0.conda
linux-aarch64::mapserver-8.0.1-py312h9e03824_10.conda
linux-aarch64::jaxlib-0.4.18-cpu_py311h86dff27_0.conda
linux-aarch64::mold-2.3.1-h2d6341c_0.conda
linux-aarch64::openjdk-17.0.9-hac580f4_0.conda
linux-aarch64::grpcio-1.57.0-py311h1a7908d_2.conda
linux-aarch64::vtk-base-9.2.6-qt_py39h1234567_217.conda
linux-aarch64::fenics-libdolfin-2019.1.0-hc0e1031_40.conda
linux-aarch64::nginx-1.25.3-h4005cde_0.conda
linux-aarch64::healpy-1.16.6-py39hfd335d8_1.conda
linux-aarch64::mapserver-8.0.1-py39h9c801f7_10.conda
linux-aarch64::grpcio-1.58.2-py39h2ec6326_0.conda
linux-aarch64::grpcio-1.58.1-py311h1a7908d_2.conda
linux-aarch64::vtk-base-9.2.6-qt_py38h1234567_215.conda
linux-aarch64::libopencv-4.8.1-py39h82dced3_2.conda
linux-aarch64::libadios2-2.9.1-mpi_mpich_h5eedc61_4.conda
linux-aarch64::folly-2023.10.02.00-h8a1e4c1_0_jemalloc.conda
linux-aarch64::fenics-libdolfin-2019.1.0-hfba04bd_40.conda
linux-aarch64::vigra-1.11.2-py310hff2cf2b_1.conda
linux-aarch64::qt6-main-6.5.2-ha16346e_6.conda
linux-aarch64::aws-sdk-cpp-1.11.182-h5e82cfa_0.conda
linux-aarch64::libarrow-11.0.0-h7a85b91_42_cuda.conda
linux-aarch64::folly-2023.10.30.00-hcbc1ef6_0.conda
linux-aarch64::python-3.10.13-hbbe8eec_0_cpython.conda
linux-aarch64::libopencv-4.8.1-py310h03392f9_1.conda
linux-aarch64::libarrow-13.0.0-h31a590f_11_cpu.conda
linux-aarch64::openimageio-2.5.4.0-py312hd1436a3_1.conda
linux-aarch64::mapserver-8.0.1-py311h12c5543_9.conda
linux-aarch64::pcre2-static-10.42-hd0f9c67_0.conda
linux-aarch64::libarrow-13.0.0-h31a590f_12_cpu.conda
linux-aarch64::libopentelemetry-cpp-1.12.0-hd2f1292_0.conda
linux-aarch64::llvmlite-0.41.1-py39h483cef1_0.conda
linux-aarch64::python-igraph-0.10.8-py310h9e80044_1.conda
linux-aarch64::harp-1.20.1-py39h5702257_0.conda
linux-aarch64::libarrow-12.0.1-h6c2fda7_18_cuda.conda
linux-aarch64::libadios2-2.9.1-nompi_hecd7c66_103.conda
linux-aarch64::openimageio-2.5.4.0-py311hf3ef9f3_1.conda
linux-aarch64::libarrow-11.0.0-h03fb76e_44_cpu.conda
linux-aarch64::netcdf4-1.6.5-nompi_py38hfe05524_100.conda
linux-aarch64::netcdf4-1.6.5-mpi_mpich_py312hea60785_0.conda
linux-aarch64::cppyy-cling-6.27.1-py39h23417e7_1.conda
linux-aarch64::mapserver-8.0.1-py310hd7b7184_9.conda
linux-aarch64::pillow-10.1.0-py39h8ce38d7_0.conda
linux-aarch64::fenics-libdolfin-2019.1.0-hdf384fb_39.conda
linux-aarch64::pyreadstat-1.2.3-py38hbecd58a_1.conda
linux-aarch64::openpmd-api-0.15.2-mpi_mpich_py38he568268_2.conda
linux-aarch64::pyreadstat-1.2.3-py311hf7e8aab_1.conda
linux-aarch64::vtk-base-9.2.6-qt_py38h1234567_216.conda
linux-aarch64::minizip-static-1.2-hd84c7bf_1.conda
linux-aarch64::pyreadstat-1.2.4-py311hf7e8aab_0.conda
linux-aarch64::cairo-1.18.0-ha13f110_0.conda
linux-aarch64::libarrow-13.0.0-h7a85b91_8_cuda.conda
linux-aarch64::libcurl-static-8.4.0-h4e8248e_0.conda
linux-aarch64::gst-plugins-base-1.22.6-h6d82d15_2.conda
linux-aarch64::ldas-tools-framecpp-3.0.2-he06774a_3.conda
linux-aarch64::minizip-4.0.2-hb75dd74_0.conda
linux-aarch64::omniorb-libs-4.3.1-h48ed410_2.conda
linux-aarch64::pytables-3.8.0-py39hca38f38_4.conda
linux-aarch64::fenics-libdolfin-2019.1.0-hc1f0f74_39.conda
linux-aarch64::libgdal-arrow-parquet-3.6.4-he6ee4da_22.conda
linux-aarch64::libarrow-13.0.0-h2b36d5a_13_cuda.conda
linux-aarch64::grpcio-1.57.1-py312hd96c8c9_0.conda
linux-aarch64::libarrow-10.0.1-h6c2fda7_47_cuda.conda
linux-aarch64::ogre-14.1.0-hb5b1993_2.conda
linux-aarch64::ffmpeg-4.4.2-lgpl_hb8e50a8_13.conda
linux-aarch64::grpcio-1.58.2-py311h1a7908d_0.conda
linux-aarch64::cargo-c-0.9.27-h6a45645_0.conda
linux-aarch64::folly-2023.10.09.00-h8a1e4c1_0_jemalloc.conda
linux-aarch64::folly-2023.10.02.00-h8dd4a7f_0_jemalloc.conda
linux-aarch64::libadios2-2.9.1-mpi_openmpi_h9c94c55_4.conda
linux-aarch64::grpcio-1.57.1-py310h20b6881_0.conda
linux-aarch64::openimageio-2.4.16.0-h0db837e_0.conda
linux-aarch64::vigra-1.11.2-py312ha44b425_2.conda
linux-aarch64::wxwidgets-3.2.3-h6541cd0_0.conda
linux-aarch64::sqlite-3.43.2-h3b3482f_0.conda
linux-aarch64::grpcio-1.57.0-py39h483cef1_3.conda
linux-aarch64::folly-2023.10.16.00-h8dd4a7f_0_jemalloc.conda
linux-aarch64::libarrow-11.0.0-h31a590f_45_cpu.conda
linux-aarch64::vigra-1.11.2-py311hdbc613f_1.conda
linux-aarch64::libadios2-2.9.1-mpi_openmpi_hb0a4856_4.conda
linux-aarch64::libarrow-13.0.0-hb77284e_12_cuda.conda
linux-aarch64::pillow-10.0.1-py39h8ce38d7_2.conda
linux-aarch64::dask-sql-2023.10.0-py38h2a08342_0.conda
linux-aarch64::libarrow-11.0.0-hfbc0944_42_cpu.conda
linux-aarch64::folly-2023.10.30.00-h8dd4a7f_0_jemalloc.conda
linux-aarch64::grpcio-1.57.0-py39h2ec6326_3.conda
linux-aarch64::yarp-cxx-3.8.1-hc289372_7.conda
linux-aarch64::ale-py-0.8.1-py39h8a077f8_1.conda
linux-aarch64::rust-1.73.0-h9d3d833_1.conda
linux-aarch64::libarrow-10.0.1-h31a590f_49_cpu.conda
linux-aarch64::libarrow-12.0.1-h399ce64_16_cpu.conda
linux-aarch64::python-3.8.18-hbbe8eec_0_cpython.conda
linux-aarch64::fenics-libdolfin-2019.1.0-h6d2774e_41.conda
linux-aarch64::openpmd-api-0.15.2-mpi_mpich_py310h64c8497_2.conda
linux-aarch64::libadios2-2.9.1-mpi_openmpi_hdeab2ad_3.conda
linux-aarch64::grpcio-1.58.1-py39h483cef1_1.conda
linux-aarch64::openimageio-2.4.15.0-hf340f44_1.conda
linux-aarch64::ale-py-0.8.1-py38heae203d_1.conda
linux-aarch64::aws-sdk-cpp-1.11.182-h6525491_2.conda
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
```

</details>