### PR TITLE
loosen zlib-pin to major level (9/N; September 2023)

### DIFF
--- a/recipe/patch_yaml/zlib.yaml
+++ b/recipe/patch_yaml/zlib.yaml
@@ -70,3 +70,12 @@ then:
   - loosen_depends:
       name: libzlib
       upper_bound: "2"
+---
+if:
+  has_depends: libzlib >=1.2*
+  timestamp_lt: 1696118400000  # 2023-10-01 00:00 UTC
+  timestamp_ge: 1693526400000  # 2023-09-01 00:00 UTC
+then:
+  - loosen_depends:
+      name: libzlib
+      upper_bound: "2"


### PR DESCRIPTION
Follow-up to https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/739, about 4500 artefacts affected.

### Result of `python show_diff.py`

<details>

```diff
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
osx-arm64::libprotobuf-4.24.3-hf590ac1_0.conda
osx-arm64::cgns-4.4.0-hfc6d074_2.conda
osx-arm64::micromamba-1.5.1-0.tar.bz2
osx-arm64::libprotobuf-static-4.23.3-hf32f9b9_1.conda
osx-arm64::libprotobuf-4.23.3-hf32f9b9_1.conda
osx-arm64::libmlir17-17.0.1-h2d3518b_0.conda
osx-arm64::glib-tools-2.78.0-ha614eb4_0.conda
osx-arm64::gst-plugins-base-1.22.6-h27255cc_1.conda
osx-arm64::tippecanoe-2.28.1-h60ef516_0.conda
osx-arm64::openjdk-11.0.20-hbe7ddab_0.conda
osx-arm64::gdk-pixbuf-2.42.10-h15fa40c_4.conda
osx-arm64::libsolv-0.7.25-ha614eb4_0.conda
osx-arm64::openjdk-17.0.3-hbe7ddab_9.conda
osx-arm64::openjdk-11.0.20-h96b3621_3.conda
osx-arm64::libpcm-1.2.3-hb19c430_5.conda
osx-arm64::libuwebsockets-20.46.0-ha614eb4_0.conda
osx-arm64::libuwebsockets-20.47.0-ha614eb4_0.conda
osx-arm64::openexr-3.2.1-hf12bcc0_0.conda
osx-arm64::hdf4-4.2.15-h2ee6834_7.conda
osx-arm64::openjdk-20.0.2-hbe7ddab_0.conda
osx-arm64::libprotobuf-static-4.24.3-hf590ac1_0.conda
osx-arm64::openjdk-20.0.2-hbe7ddab_2.conda
osx-arm64::dlib-cpp-19.24.2-h4472759_5.conda
osx-arm64::libprotobuf-static-4.23.4-hf590ac1_6.conda
osx-arm64::openjdk-11.0.15-hbe7ddab_7.conda
osx-arm64::liblal-7.3.1-fftw_ha07d28a_102.conda
osx-arm64::openjdk-17.0.8-hbe7ddab_0.conda
osx-arm64::libraw-0.21.1-h2ee6834_2.conda
osx-arm64::openjdk-20.0.2-hbe7ddab_1.conda
osx-arm64::freetype-2.12.1-hadb7bae_2.conda
osx-arm64::gdk-pixbuf-2.42.10-he313114_3.conda
osx-arm64::libsolv-static-0.7.24-ha614eb4_4.conda
osx-arm64::openjdk-17.0.8-h96b3621_3.conda
osx-arm64::openjpeg-2.5.0-h4c1507b_3.conda
osx-arm64::openjdk-11.0.20-h96b3621_1.conda
osx-arm64::libsolv-static-0.7.25-ha614eb4_0.conda
osx-arm64::gst-plugins-base-1.22.5-h27255cc_1.conda
osx-arm64::openjdk-17.0.8-h96b3621_1.conda
osx-arm64::libprotobuf-static-4.23.4-hf590ac1_5.conda
osx-arm64::openjdk-11.0.15-hbe7ddab_5.conda
osx-arm64::openjdk-11.0.15-hbe7ddab_6.conda
osx-arm64::tippecanoe-2.31.0-h60ef516_0.conda
osx-arm64::libsolv-0.7.24-ha614eb4_4.conda
osx-arm64::openjdk-11.0.20-h96b3621_2.conda
osx-arm64::libmlir-17.0.1-h2d3518b_0.conda
osx-arm64::openjdk-20.0.0-hbe7ddab_2.conda
osx-arm64::tk-8.6.13-hb31c410_0.conda
osx-arm64::libharu-2.4.4-hadb7bae_0.conda
osx-arm64::tippecanoe-2.28.0-h60ef516_0.conda
osx-arm64::gst-plugins-base-1.22.6-h27255cc_0.conda
osx-arm64::libprotobuf-4.23.4-hf590ac1_6.conda
osx-arm64::openjdk-17.0.8-h96b3621_2.conda
osx-arm64::libprotobuf-4.23.4-hf590ac1_5.conda
-    "libzlib >=1.2.13,<1.3.0a0"
+    "libzlib >=1.2.13,<2.0.0a0"
osx-arm64::postgresql-plpython-16.0-py312h77596db_1.conda
osx-arm64::aws-sdk-cpp-1.10.57-h7859694_23.conda
osx-arm64::wxwidgets-3.2.2.1-h336aa14_4.conda
osx-arm64::openpmd-api-0.15.2-nompi_py311h99d54e9_101.conda
osx-arm64::octave-8.3.0-h2d8008e_0.conda
osx-arm64::minizip-4.0.1-h5a7aac7_4.conda
osx-arm64::vigra-1.11.2-py310h1c48c27_0.conda
osx-arm64::netcdf4-1.6.4-mpi_openmpi_py39hddcacee_3.conda
osx-arm64::pyinstaller-6.0.0-py38he9a9ba6_0.conda
osx-arm64::vigra-1.11.1-py38h4530baa_1048.conda
osx-arm64::vigra-1.11.1-py310he0093bf_1048.conda
osx-arm64::pygame-2.5.2-py311ha589028_1.conda
osx-arm64::aimrocks-0.4.0-py311hb87ac25_1.conda
osx-arm64::pygame-2.5.2-py38h58970b3_1.conda
osx-arm64::python-igraph-0.10.8-py39ha133bd5_0.conda
osx-arm64::tiledb-2.17.0-hc77a09f_0.conda
osx-arm64::postgresql-plpython-16.0-py311h885f1b6_0.conda
osx-arm64::libopencv-4.8.0-py39h53c30a2_2.conda
osx-arm64::nodejs-20.6.0-h5f47a4d_0.conda
osx-arm64::pyhdf-0.11.3-py38h0e21c57_1.conda
osx-arm64::pillow-10.0.0-py39hef383c8_1.conda
osx-arm64::omniorb-4.3.1-py310hfce7497_1.conda
osx-arm64::harp-1.20-py39hb4c5174_0.conda
osx-arm64::nest-simulator-3.6-py310haefc66e_0.conda
osx-arm64::ogre-14.0.1-h0044ca7_2.conda
osx-arm64::vtk-base-9.2.6-qt_py311h1234567_213.conda
osx-arm64::mcpl-1.6.2-py38he9a9ba6_1.conda
osx-arm64::postgresql-plpython-16.0-py38h3275ed9_1.conda
osx-arm64::nodejs-20.8.0-h5f47a4d_0.conda
osx-arm64::imagemagick-7.1.1_18-pl5321hec8f2ed_0.conda
osx-arm64::grpcio-1.58.1-py39hbad4f83_0.conda
osx-arm64::heyoka-llvm-12-2.0.0-h7dff583_0.conda
osx-arm64::llvm-tools-17.0.1-he79909e_0.conda
osx-arm64::aws-sdk-cpp-1.11.156-h0092a47_0.conda
osx-arm64::paraview-5.11.1-py39h2f60be7_102_qt.conda
osx-arm64::paraview-5.11.1-py39he4b60e0_102_qt.conda
osx-arm64::libzip-1.10.1-ha0bc3c6_3.conda
osx-arm64::bytewax-0.17.1-py310h90e2b35_1.conda
osx-arm64::gdstk-0.9.42-py310ha2cdf7a_1.conda
osx-arm64::vtk-base-9.2.6-qt_py39h1234567_213.conda
osx-arm64::netcdf4-1.6.4-mpi_mpich_py311h3ab5d76_3.conda
osx-arm64::thrift-compiler-0.19.0-ha061701_0.conda
osx-arm64::gst-plugins-bad-1.22.6-haedc527_0.conda
osx-arm64::pyinstaller-6.0.0-py310hab90de1_0.conda
osx-arm64::triqs-3.2.0-py38h20ddde0_2.conda
osx-arm64::postgresql-plpython-15.4-py38h3275ed9_1.conda
osx-arm64::folly-2023.09.11.00-h1e8fca9_0.conda
osx-arm64::folly-2023.09.25.00-h03318f1_0.conda
osx-arm64::imagecodecs-2023.9.4-py310h6800ae8_0.conda
osx-arm64::ogre-14.1.0-h7b6b3e1_1.conda
osx-arm64::heyoka-2.0.0-h1fa1327_0.conda
osx-arm64::lammps-2023.08.02-cpu_py311_hd466178_mpich_2.conda
osx-arm64::lammps-2023.08.02-cpu_py39_h382c4a1_mpich_1.conda
osx-arm64::polycap-1.2-py39h9a92469_4.conda
osx-arm64::util-linux-2.39.2-py312h0145e38_1.conda
osx-arm64::libgdal-3.6.4-h7303a4d_19.conda
osx-arm64::libboost-1.82.0-h72cdd8a_3.conda
osx-arm64::pillow-10.0.1-py311he9c13d2_0.conda
osx-arm64::grpcio-1.57.0-py312h5729958_1.conda
osx-arm64::grpcio-1.58.1-py311hea943cd_0.conda
osx-arm64::paraview-5.11.1-py39heac0134_102_qt.conda
osx-arm64::vtk-base-9.2.6-qt_py310h1234567_213.conda
osx-arm64::libspatialite-5.0.1-h32510b6_29.conda
osx-arm64::paraview-5.11.1-py311hde639f5_102_qt.conda
osx-arm64::bytewax-0.17.1-py311h03d9925_1.conda
osx-arm64::mysql-client-8.0.33-h41974c7_3.conda
osx-arm64::symengine-0.11.1-hd14cae3_0.conda
osx-arm64::python-igraph-0.10.8-py38h095d86c_0.conda
osx-arm64::imagemagick-7.1.1_16-pl5321hec8f2ed_0.conda
osx-arm64::pygame-2.5.2-py310h06173bb_1.conda
osx-arm64::blosc-1.21.5-hc338f07_0.conda
osx-arm64::imagemagick-7.1.1_15-pl5321hec8f2ed_1.conda
osx-arm64::python-igraph-0.10.6-py39ha133bd5_1.conda
osx-arm64::xrootd-5.6.2-py38h16fb1ff_1.conda
osx-arm64::libgdal-arrow-parquet-3.6.4-h5d4be45_17.conda
osx-arm64::jaxlib-0.4.14-cpu_py310h6961186_1.conda
osx-arm64::mold-2.1.0-h5d4715a_2.conda
osx-arm64::arrow-cpp-9.0.0-py39h5366f3e_47_cpu.conda
osx-arm64::libgdal-arrow-parquet-3.6.4-h064deeb_16.conda
osx-arm64::libgdal-arrow-parquet-3.6.4-h73b1666_19.conda
osx-arm64::tiledb-2.17.0-he79ed24_1.conda
osx-arm64::arrow-cpp-9.0.0-py311hddca3d5_47_cpu.conda
osx-arm64::vigra-1.11.2-py39hb8f20d0_0.conda
osx-arm64::xrootd-5.6.2-py39h8c5c091_0.conda
osx-arm64::triqs-3.2.0-py311h358a192_3.conda
osx-arm64::tiledb-2.16.3-hc77a09f_2.conda
osx-arm64::libsoup-3.4.3-h771374c_0.conda
osx-arm64::postgresql-plpython-15.4-py311h885f1b6_1.conda
osx-arm64::triqs-3.2.0-py310hc920bd7_4.conda
osx-arm64::lammps-2023.08.02-cpu_py39_hdb5a862_openmpi_1.conda
osx-arm64::util-linux-2.39.2-py38h52f88b7_0.conda
osx-arm64::gazebo-11.13.0-h4bed19e_6.conda
osx-arm64::util-linux-2.39.2-py311hfacc263_1.conda
osx-arm64::paraview-5.11.1-py311hf030f73_102_qt.conda
osx-arm64::imagecodecs-2023.9.4-py311hc277e5d_2.conda
osx-arm64::libpq-15.4-hcea71ed_2.conda
osx-arm64::openpmd-api-0.15.2-nompi_py39h18e96b0_101.conda
osx-arm64::bytewax-0.17.1-py38hc465553_1.conda
osx-arm64::pyinstaller-6.0.0-py310hab90de1_1.conda
osx-arm64::libopencv-4.8.0-py310h5fd056f_4.conda
osx-arm64::harp-1.20-py38hb4c5174_0.conda
osx-arm64::cmake-3.27.5-h1c59155_0.conda
osx-arm64::mysql-server-8.0.33-h0f2f564_3.conda
osx-arm64::heyoka-llvm-15-2.0.0-hab55ca4_0.conda
osx-arm64::libarrow-13.0.0-h0c25ffe_4_cpu.conda
osx-arm64::llvmdev-17.0.1-he79909e_0.conda
osx-arm64::sdl2_image-2.6.3-h04cbb99_2.conda
osx-arm64::folly-2023.09.18.00-hd189c9a_0_jemalloc.conda
osx-arm64::vtk-base-9.2.6-qt_py310h1234567_214.conda
osx-arm64::paraview-5.11.1-py310hdc55e3b_102_qt.conda
osx-arm64::harp-1.20-py311h0dc3549_0.conda
osx-arm64::paraview-5.11.2-py39h62f2103_102_qt.conda
osx-arm64::vigra-1.11.1-py39h45c6426_1047.conda
osx-arm64::netcdf4-1.6.4-mpi_openmpi_py312hc4d474d_3.conda
osx-arm64::grpcio-1.58.1-py38h761d82c_0.conda
osx-arm64::gst-plugins-good-1.22.5-h2008d30_1.conda
osx-arm64::libopencv-4.8.0-py310h8c12d2d_2.conda
osx-arm64::hugin-base-2022.0.0-pl5321h8c21359_6.conda
osx-arm64::r-base-4.2.3-h8ca35e0_8.conda
osx-arm64::pillow-10.0.1-py310hadb9e77_0.conda
osx-arm64::aws-sdk-cpp-1.11.156-he831950_3.conda
osx-arm64::libglib-2.78.0-h24e9cb9_0.conda
osx-arm64::netcdf4-1.6.4-mpi_mpich_py38hf64dcfa_3.conda
osx-arm64::assimp-5.3.0-he4e5961_0.conda
osx-arm64::tiledb-2.16.3-hc77a09f_3.conda
osx-arm64::grpcio-1.58.1-py310h95b248a_0.conda
osx-arm64::triqs-3.2.0-py39h35c07b5_3.conda
osx-arm64::libarrow-10.0.1-h974cd8a_40_cpu.conda
osx-arm64::lfortran-0.20.1-hbe7ddab_0.conda
osx-arm64::tiledb-2.16.3-h5345278_3.conda
osx-arm64::libarrow-12.0.1-h145d1cc_10_cpu.conda
osx-arm64::triqs-3.2.0-py38hfe7a5d8_4.conda
osx-arm64::netcdf4-1.6.4-nompi_py312h59c6c54_103.conda
osx-arm64::python-3.12.0rc3-rc3_h47c9636_1_cpython.conda
osx-arm64::xrootd-5.6.2-py38h16fb1ff_0.conda
osx-arm64::vigra-1.11.2-py311h9ffcea6_0.conda
osx-arm64::triqs-3.2.0-py39hf0d0bb3_3.conda
osx-arm64::imagecodecs-2023.9.4-py39h450eed6_2.conda
osx-arm64::r-base-4.1.3-h7fa7ea6_11.conda
osx-arm64::libgdal-3.7.2-habfc566_2.conda
osx-arm64::imagecodecs-2023.9.4-py310h346e4af_1.conda
osx-arm64::paraview-5.11.1-py39hb099f29_102_qt.conda
osx-arm64::lfortran-0.20.3-hbe7ddab_1.conda
osx-arm64::pillow-10.0.1-py39hef383c8_0.conda
osx-arm64::util-linux-2.39.2-py38h52f88b7_1.conda
osx-arm64::mosh-1.4.0-pl5321h2bd9e8a_3.conda
osx-arm64::paraview-5.11.1-py310hddc8e6e_102_qt.conda
osx-arm64::libthrift-0.19.0-ha061701_0.conda
osx-arm64::omniorb-4.3.1-py311h8617d33_1.conda
osx-arm64::lammps-2023.08.02-cpu_py310_hd4ac30c_openmpi_1.conda
osx-arm64::vtk-base-9.2.6-qt_py39h1234567_214.conda
osx-arm64::libgdal-arrow-parquet-3.7.2-hc4283fa_2.conda
osx-arm64::sdl2_image-2.6.3-h5848f73_4.conda
osx-arm64::poppler-23.08.0-h7fbffb0_2.conda
osx-arm64::libarrow-11.0.0-h0c25ffe_39_cpu.conda
osx-arm64::sdl_image-1.2.12-h44e3aef_5.conda
osx-arm64::openpmd-api-0.15.2-mpi_openmpi_py311h8627607_1.conda
osx-arm64::minizip-4.0.1-h5a7aac7_2.conda
osx-arm64::assimp-5.3.1-he4e5961_1.conda
osx-arm64::triqs-3.2.0-py311h6ca355d_3.conda
osx-arm64::magics-4.14.2-h5a25f2c_1.conda
osx-arm64::libgdal-arrow-parquet-3.7.2-h86cf875_1.conda
osx-arm64::lammps-2023.08.02-cpu_py38_ha19c33e_mpich_1.conda
osx-arm64::openpmd-api-0.15.2-mpi_openmpi_py39h4a0e9e5_1.conda
osx-arm64::openslide-3.4.1-h022909e_10.conda
osx-arm64::vigra-1.11.2-py310he0093bf_0.conda
osx-arm64::openpmd-api-0.15.2-nompi_py310h2b6d9c9_101.conda
osx-arm64::xrootd-5.6.2-py310he177ee0_1.conda
osx-arm64::vigra-1.11.1-py310h9e57bbc_1047.conda
osx-arm64::pytables-3.8.0-py39h94cd330_3.conda
osx-arm64::libopencv-4.8.0-py311h59bfeaa_4.conda
osx-arm64::paraview-5.11.2-py311hde639f5_102_qt.conda
osx-arm64::triqs-3.2.0-py39hf0d0bb3_2.conda
osx-arm64::graphicsmagick-1.3.40-he01c625_3.conda
osx-arm64::imagecodecs-2023.9.4-py39hf84e52e_1.conda
osx-arm64::openbabel-3.1.1-py311h4f068e6_8.conda
osx-arm64::util-linux-2.39.2-py39h2ad0120_0.conda
osx-arm64::lpython-0.20.0-ha614eb4_0.conda
osx-arm64::qt6-main-6.5.2-h418310c_4.conda
osx-arm64::lammps-2023.08.02-cpu_py311_hb114475_openmpi_2.conda
osx-arm64::pygame-2.5.2-py38hece1802_0.conda
osx-arm64::vigra-1.11.2-py38h2a0fd8e_0.conda
osx-arm64::pillow-10.0.1-py311he9c13d2_1.conda
osx-arm64::hdfeos2-2.20-h76103e7_1004.conda
osx-arm64::folly-2023.09.18.00-h03318f1_0.conda
osx-arm64::libcurl-8.3.0-hc52a3a8_0.conda
osx-arm64::pygame-2.5.2-py38h58970b3_2.conda
osx-arm64::tiledb-2.17.0-h5345278_0.conda
osx-arm64::omniorb-4.3.1-py38h8c06ffa_1.conda
osx-arm64::vtk-base-9.2.6-qt_py38h1234567_214.conda
osx-arm64::libopentelemetry-cpp-1.11.0-hc89833c_1.conda
osx-arm64::libopencv-4.8.0-py311hcbef0bb_3.conda
osx-arm64::libopencv-4.8.0-py38h5652bc6_2.conda
osx-arm64::gdstk-0.9.42-py39hd8f8303_1.conda
osx-arm64::postgresql-16.0-h00cd704_0.conda
osx-arm64::libopencv-4.8.1-py38hdd56bd2_0.conda
osx-arm64::gfortran_impl_osx-arm64-13.2.0-h30f4408_1.conda
osx-arm64::imagecodecs-2023.9.18-py310hfbe61c4_0.conda
osx-arm64::vigra-1.11.1-py311h9ffcea6_1048.conda
osx-arm64::postgresql-plpython-16.0-py311h885f1b6_1.conda
osx-arm64::aws-sdk-cpp-1.11.158-h0092a47_0.conda
osx-arm64::cmake-3.27.6-h1c59155_0.conda
osx-arm64::paraview-5.11.1-py310ha0bd606_102_qt.conda
osx-arm64::aimrocks-0.4.0-py310hcf5038b_1.conda
osx-arm64::aws-sdk-cpp-1.11.156-h44dad36_2.conda
osx-arm64::qtwebkit-5.212-h26a47f1_13.conda
osx-arm64::r-harp-1.20-py311h44628bf_0.conda
osx-arm64::tiledb-2.16.3-h5345278_2.conda
osx-arm64::pytables-3.8.0-py38hcf313c7_3.conda
osx-arm64::python-igraph-0.10.6-py38h095d86c_2.conda
osx-arm64::arrow-cpp-9.0.0-py39hb767fa1_49_cpu.conda
osx-arm64::aws-sdk-cpp-1.10.57-he404d52_22.conda
osx-arm64::mysql-server-8.0.33-h1a3abaa_4.conda
osx-arm64::libopencv-4.8.0-py38hdd56bd2_4.conda
osx-arm64::imagecodecs-2023.9.18-py311hc277e5d_0.conda
osx-arm64::heyoka-2.0.0-h1ae0666_0.conda
osx-arm64::mcpl-1.6.2-py311h79498d2_1.conda
osx-arm64::paraview-5.11.2-py310hdc55e3b_102_qt.conda
osx-arm64::libarrow-13.0.0-h0c25ffe_5_cpu.conda
osx-arm64::cpp-opentelemetry-sdk-1.11.0-hc89833c_1.conda
osx-arm64::tiledb-2.17.1-hc77a09f_0.conda
osx-arm64::openpmd-api-0.15.2-mpi_mpich_py310h8fad26c_1.conda
osx-arm64::r-base-4.2.3-hc95f692_9.conda
osx-arm64::vigra-1.11.1-py311ha2bab4f_1048.conda
osx-arm64::polycap-1.2-py311h361db0b_4.conda
osx-arm64::nest-simulator-3.6-py311h93b7820_0.conda
osx-arm64::heyoka-llvm-13-2.0.0-h122378b_0.conda
osx-arm64::paraview-5.11.1-py39h62f2103_102_qt.conda
osx-arm64::python-igraph-0.10.8-py311hd69ccbd_0.conda
osx-arm64::openbabel-3.1.1-py39hcdff8ce_8.conda
osx-arm64::lxml-4.9.3-py310h78afa71_1.conda
osx-arm64::folly-2023.09.25.00-h4c49ebf_0_jemalloc.conda
osx-arm64::mysql-libs-8.0.33-hb292caa_3.conda
osx-arm64::openpmd-api-0.15.2-mpi_mpich_py39h759645d_1.conda
osx-arm64::imagecodecs-2023.9.4-py310hfbe61c4_2.conda
osx-arm64::vigra-1.11.1-py310h97de400_1047.conda
osx-arm64::sdl2_image-2.6.3-ha1c14ff_3.conda
osx-arm64::connectorx-0.3.2-py39h57e6d9e_1.conda
osx-arm64::folly-2023.09.11.00-hdc4976f_0.conda
osx-arm64::paraview-5.11.1-py310hd701fd5_102_qt.conda
osx-arm64::llvm-17.0.1-h2b67075_0.conda
osx-arm64::arrow-cpp-9.0.0-py38h620fda1_47_cpu.conda
osx-arm64::folly-2023.09.25.00-hdc4976f_0.conda
osx-arm64::r-harp-1.20-py310he2ee789_0.conda
osx-arm64::folly-2023.09.11.00-hd189c9a_0_jemalloc.conda
osx-arm64::lammps-2023.08.02-cpu_py311_hd466178_mpich_1.conda
osx-arm64::libarrow-13.0.0-h1ffad42_2_cpu.conda
osx-arm64::vigra-1.11.1-py311h2a48e55_1047.conda
osx-arm64::vigra-1.11.1-py39hb8f20d0_1048.conda
osx-arm64::util-linux-2.39.2-py310hdf428d3_0.conda
osx-arm64::libarrow-13.0.0-h145d1cc_1_cpu.conda
osx-arm64::mysql-libs-8.0.33-hb292caa_4.conda
osx-arm64::folly-2023.09.18.00-h1e8fca9_0.conda
osx-arm64::gtk4-4.12.1-h64ad1fa_2.conda
osx-arm64::libzip-1.10.1-ha0bc3c6_1.conda
osx-arm64::libopencv-4.8.1-py311h59bfeaa_0.conda
osx-arm64::openbabel-3.1.1-py38hf10facd_8.conda
osx-arm64::r-base-4.1.3-h8ca35e0_11.conda
osx-arm64::folly-2023.09.04.00-h1e8fca9_0.conda
osx-arm64::lammps-2023.08.02-cpu_py38_h9d40a62_openmpi_1.conda
osx-arm64::tiledb-2.17.1-he15c4da_0.conda
osx-arm64::netcdf4-1.6.4-mpi_openmpi_py311hf8f91c4_3.conda
osx-arm64::openbabel-3.1.1-py310h5029d14_8.conda
osx-arm64::netcdf4-1.6.4-mpi_mpich_py312h3fa5ebd_3.conda
osx-arm64::python-igraph-0.10.6-py311hd69ccbd_1.conda
osx-arm64::lxml-4.9.3-py39hb67b4e4_1.conda
osx-arm64::vigra-1.11.1-py310h1c48c27_1048.conda
osx-arm64::triqs-3.2.0-py39hf0d0bb3_5.conda
osx-arm64::triqs-3.2.0-py38h20ddde0_4.conda
osx-arm64::folly-2023.09.25.00-h1e8fca9_0.conda
osx-arm64::vtk-base-9.2.6-qt_py311h1234567_214.conda
osx-arm64::r-base-4.3.1-haf7632b_6.conda
osx-arm64::folly-2023.09.11.00-h03318f1_0.conda
osx-arm64::orc-1.9.0-hbfdecac_2.conda
osx-arm64::libgdal-3.7.2-hcae775b_4.conda
osx-arm64::paraview-5.11.1-py38he7efa54_102_qt.conda
osx-arm64::geotiff-1.7.1-h94e20d0_13.conda
osx-arm64::libarrow-12.0.1-h1ffad42_11_cpu.conda
osx-arm64::paraview-5.11.1-py38hd65e701_102_qt.conda
osx-arm64::gfortran_impl_osx-64-13.2.0-he0186f3_1.conda
osx-arm64::libtiff-4.6.0-h77c4dce_1.conda
osx-arm64::pygplates-0.39-py310h2552272_9.conda
osx-arm64::libarrow-11.0.0-h43f999d_37_cpu.conda
osx-arm64::pygame-2.5.2-py39h57bbbc0_0.conda
osx-arm64::photochem-0.4.2-py38h43e5262_2.conda
osx-arm64::postgresql-plpython-16.0-py39h620b887_0.conda
osx-arm64::libgdal-3.6.4-h7180e24_18.conda
osx-arm64::libpq-16.0-hcea71ed_1.conda
osx-arm64::paraview-5.11.1-py311h29cf3ff_102_qt.conda
osx-arm64::postgresql-plpython-15.4-py310h94ee204_2.conda
osx-arm64::libopencv-4.8.1-py39hc7c818c_0.conda
osx-arm64::triqs-3.2.0-py38hfe7a5d8_2.conda
osx-arm64::pyinstaller-6.0.0-py39ha52a465_0.conda
osx-arm64::postgresql-plpython-15.4-py310h94ee204_1.conda
osx-arm64::pillow-10.0.0-py38hf19b724_1.conda
osx-arm64::libarchive-minimal-static-3.7.2-h840afe0_0.conda
osx-arm64::folly-2023.09.04.00-hdc4976f_0.conda
osx-arm64::freeimage-3.18.0-h0c8dc6b_16.conda
osx-arm64::r-base-4.3.1-h8ca35e0_4.conda
osx-arm64::netcdf4-1.6.4-nompi_py311hbb54521_103.conda
osx-arm64::connectorx-0.3.2-py38hb05e41b_3.conda
osx-arm64::tiledb-2.17.1-h5345278_0.conda
osx-arm64::connectorx-0.3.2-py39h57e6d9e_3.conda
osx-arm64::folly-2023.09.11.00-h2c5142d_0_jemalloc.conda
osx-arm64::aimrocks-0.4.0-py39h997cd4c_1.conda
osx-arm64::python-igraph-0.10.6-py310hade86c1_1.conda
osx-arm64::libopencv-4.8.1-py310h5fd056f_0.conda
osx-arm64::r-harp-1.20-py38h51824f0_0.conda
osx-arm64::bytewax-0.17.1-py39haac67bd_1.conda
osx-arm64::triqs-3.2.0-py310h216340d_5.conda
osx-arm64::octave-8.2.0-h2d8008e_2.conda
osx-arm64::python-igraph-0.10.6-py38h095d86c_1.conda
osx-arm64::paraview-5.11.2-py38h7228d88_102_qt.conda
osx-arm64::xrootd-5.6.2-py311h4e7788a_0.conda
osx-arm64::libarrow-10.0.1-hbb7de18_41_cpu.conda
osx-arm64::triqs-3.2.0-py39h35c07b5_2.conda
osx-arm64::photochem-0.4.2-py310h9882c97_2.conda
osx-arm64::libopencv-4.8.0-py310h63b3f07_3.conda
osx-arm64::pygplates-0.39-py311h4514a16_9.conda
osx-arm64::lammps-2023.08.02-cpu_py310_hd4ac30c_openmpi_2.conda
osx-arm64::mlir-17.0.1-h2d3518b_0.conda
osx-arm64::pygame-2.5.2-py310h06173bb_2.conda
osx-arm64::irrlicht-1.8.5-h1344824_4.conda
osx-arm64::lammps-2023.08.02-cpu_py38_h9d40a62_openmpi_2.conda
osx-arm64::mold-2.2.0-h5d4715a_0.conda
osx-arm64::coda-2.25-py38h51824f0_0.conda
osx-arm64::folly-2023.09.25.00-hd189c9a_0_jemalloc.conda
osx-arm64::imagecodecs-2023.9.4-py39h3e42920_0.conda
osx-arm64::heyoka-llvm-16-2.0.0-h59ae33d_0.conda
osx-arm64::minizip-4.0.1-h5a7aac7_3.conda
osx-arm64::tiledb-2.17.0-h1cdaec1_1.conda
osx-arm64::xrootd-5.6.2-py312h014cd37_1.conda
osx-arm64::openpmd-api-0.15.2-mpi_openmpi_py38hfd522a7_1.conda
osx-arm64::libcurl-static-8.3.0-hc52a3a8_0.conda
osx-arm64::lxml-4.9.3-py38hbfa3897_1.conda
osx-arm64::postgresql-plpython-16.0-py310h94ee204_1.conda
osx-arm64::triqs-3.2.0-py39hf0d0bb3_4.conda
osx-arm64::triqs-3.2.0-py38h20ddde0_3.conda
osx-arm64::pillow-10.0.1-py38hf19b724_1.conda
osx-arm64::pyhdf-0.11.3-py311h6fbf6ec_1.conda
osx-arm64::pillow-10.0.1-py38hf19b724_0.conda
osx-arm64::heyoka-2.0.0-h038e230_0.conda
osx-arm64::pillow-10.0.1-py310hadb9e77_1.conda
osx-arm64::vigra-1.11.1-py38h2a0fd8e_1048.conda
osx-arm64::postgresql-16.0-h00cd704_1.conda
osx-arm64::folly-2023.09.04.00-h03318f1_0.conda
osx-arm64::gdstk-0.9.42-py312h6b10a91_1.conda
osx-arm64::connectorx-0.3.2-py38hb05e41b_2.conda
osx-arm64::libgdal-arrow-parquet-3.7.2-h80cf745_0.conda
osx-arm64::lammps-2023.08.02-cpu_py39_h382c4a1_mpich_2.conda
osx-arm64::arrow-cpp-9.0.0-py38hf658983_49_cpu.conda
osx-arm64::pytables-3.8.0-py311h5f09214_3.conda
osx-arm64::cargo-c-0.9.24-hf070fb9_1.conda
osx-arm64::qt6-3d-6.5.2-h0e64545_1.conda
osx-arm64::libarrow-11.0.0-h0c25ffe_38_cpu.conda
osx-arm64::triqs-3.2.0-py311h358a192_2.conda
osx-arm64::heyoka-2.0.0-h0c400c2_0.conda
osx-arm64::netcdf4-1.6.4-nompi_py310h05def64_103.conda
osx-arm64::nco-5.1.7-h02e1429_1.conda
osx-arm64::triqs-3.2.0-py310hc920bd7_3.conda
osx-arm64::fltk-1.3.8-h0c34365_2.conda
osx-arm64::libgdal-3.6.4-h7f6fb27_17.conda
osx-arm64::util-linux-2.39.2-py39h2ad0120_1.conda
osx-arm64::tiledb-2.17.0-h06cf9ee_1.conda
osx-arm64::postgresql-plpython-16.0-py39h620b887_1.conda
osx-arm64::connectorx-0.3.2-py39h57e6d9e_0.conda
osx-arm64::vigra-1.11.1-py39hf229da3_1048.conda
osx-arm64::pyhdf-0.11.3-py39h4d9767a_1.conda
osx-arm64::wxwidgets-3.2.2.1-hf2d1198_5.conda
osx-arm64::lld-17.0.1-h1753c5f_0.conda
osx-arm64::libopencv-4.8.0-py311he247fa4_2.conda
osx-arm64::lammps-2023.08.02-cpu_py310_h7a37da0_mpich_2.conda
osx-arm64::libnetcdf-4.9.2-mpi_openmpi_h01c98f5_12.conda
osx-arm64::libgdal-3.7.2-h1f9bd4d_3.conda
osx-arm64::folly-2023.09.04.00-h2c5142d_0_jemalloc.conda
osx-arm64::postgresql-plpython-15.4-py39h620b887_1.conda
osx-arm64::postgresql-plpython-15.4-py311h885f1b6_2.conda
osx-arm64::paraview-5.11.1-py38h0b299e8_102_qt.conda
osx-arm64::libllvm17-17.0.1-he79909e_0.conda
osx-arm64::openslide-3.4.1-hb0fab19_11.conda
osx-arm64::heyoka-2.0.0-hb511701_0.conda
osx-arm64::libgdal-3.7.2-h18de841_0.conda
osx-arm64::pillow-10.0.1-py39hef383c8_1.conda
osx-arm64::lammps-2023.08.02-cpu_py39_hdb5a862_openmpi_2.conda
osx-arm64::pyinstaller-6.0.0-py38he9a9ba6_1.conda
osx-arm64::openpmd-api-0.15.2-mpi_mpich_py38h6687834_1.conda
osx-arm64::coda-2.25-py39h15bc620_0.conda
osx-arm64::ogre-1.10.12-h5c04fa6_14.conda
osx-arm64::vigra-1.11.2-py311ha2bab4f_0.conda
osx-arm64::arrow-cpp-9.0.0-py38h0126e18_48_cpu.conda
osx-arm64::osmium-tool-1.16.0-h1dcb447_1.conda
osx-arm64::folly-2023.09.25.00-h2c5142d_0_jemalloc.conda
osx-arm64::postgresql-plpython-15.4-py39h620b887_2.conda
osx-arm64::libpano13-2.9.20rc2-pl5321h2e7cf75_6.conda
osx-arm64::ogre-14.1.0-hcda7b2a_1.conda
osx-arm64::photochem-0.4.2-py39h990cb30_2.conda
osx-arm64::bytewax-0.17.1-py311h6a762d3_0.conda
osx-arm64::vtk-base-9.2.6-qt_py38h1234567_213.conda
osx-arm64::openpmd-api-0.15.2-mpi_openmpi_py310h0e09de3_1.conda
osx-arm64::util-linux-2.39.2-py310hdf428d3_1.conda
osx-arm64::pygame-2.5.2-py311ha589028_2.conda
osx-arm64::libgdal-3.6.4-h57c3c3b_16.conda
osx-arm64::vigra-1.11.1-py38h9324990_1047.conda
osx-arm64::postgresql-plpython-16.0-py38h3275ed9_0.conda
osx-arm64::postgresql-plpython-15.4-py312h77596db_2.conda
osx-arm64::libarrow-12.0.1-h43f999d_12_cpu.conda
osx-arm64::netcdf4-1.6.4-mpi_openmpi_py310hba20a2b_3.conda
osx-arm64::imagecodecs-2023.9.4-py311ha7c5239_0.conda
osx-arm64::postgresql-15.4-h00cd704_1.conda
osx-arm64::triqs-3.2.0-py310h216340d_2.conda
osx-arm64::qt6-main-6.5.2-hcf9e17a_3.conda
osx-arm64::triqs-3.2.0-py311h6ca355d_2.conda
osx-arm64::verilator-5.016-h5c8d968_0.conda
osx-arm64::polycap-1.2-py38h28765ba_4.conda
osx-arm64::aimrocks-0.4.0-py38h48ba14d_1.conda
osx-arm64::libnetcdf-4.9.2-nompi_hb2fb864_112.conda
osx-arm64::connectorx-0.3.2-py38hb05e41b_1.conda
osx-arm64::netcdf4-1.6.4-nompi_py39h9f3a5de_103.conda
osx-arm64::ogre-14.1.0-h0044ca7_0.conda
osx-arm64::aimrocks-0.4.0-py312h225bf35_1.conda
osx-arm64::triqs-3.2.0-py311h6ca355d_5.conda
osx-arm64::triqs-3.2.0-py38hfe7a5d8_3.conda
osx-arm64::tiledb-2.16.3-h37162ba_2.conda
osx-arm64::imagemagick-7.1.1_17-pl5321hec8f2ed_0.conda
osx-arm64::libarrow-12.0.1-h0c25ffe_14_cpu.conda
osx-arm64::lfortran-0.20.3-hbe7ddab_0.conda
osx-arm64::libthrift-0.19.0-h026a170_1.conda
osx-arm64::libpq-16.0-hcea71ed_0.conda
osx-arm64::postgresql-15.4-h00cd704_2.conda
osx-arm64::triqs-3.2.0-py311h358a192_5.conda
osx-arm64::libgdal-arrow-parquet-3.7.2-h680bec0_4.conda
osx-arm64::libarrow-10.0.1-hdccf3e8_39_cpu.conda
osx-arm64::paraview-5.11.1-py311h08b7a8a_102_qt.conda
osx-arm64::connectorx-0.3.2-py39h57e6d9e_2.conda
osx-arm64::libspatialite-5.1.0-h32510b6_0.conda
osx-arm64::libmediainfo-23.09-hbb71fad_0.conda
osx-arm64::paraview-5.11.1-py38h7228d88_102_qt.conda
osx-arm64::gst-plugins-good-1.22.6-h2008d30_0.conda
osx-arm64::bytewax-0.17.1-py38he930795_0.conda
osx-arm64::libvips-8.14.4-hf9ba9f2_1.conda
osx-arm64::omniorb-4.3.1-py312hf13160d_1.conda
osx-arm64::vigra-1.11.1-py38h473d8b2_1047.conda
osx-arm64::libnetcdf-4.9.2-mpi_mpich_hedaff35_12.conda
osx-arm64::libgdal-arrow-parquet-3.6.4-h6bc834b_18.conda
osx-arm64::postgresql-plpython-15.4-py38h3275ed9_2.conda
osx-arm64::pygame-2.5.2-py312h26bdd92_2.conda
osx-arm64::triqs-3.2.0-py39h35c07b5_5.conda
osx-arm64::imagecodecs-2023.9.4-py311hb0b7dac_1.conda
osx-arm64::folly-2023.09.18.00-h4c49ebf_0_jemalloc.conda
osx-arm64::arrow-cpp-9.0.0-py310h0871189_49_cpu.conda
osx-arm64::omniorb-libs-4.3.1-h13d9943_1.conda
osx-arm64::nco-5.1.8-h02e1429_0.conda
osx-arm64::arrow-cpp-9.0.0-py310ha94c8e3_48_cpu.conda
osx-arm64::gazebo-11.13.0-h4bed19e_7.conda
osx-arm64::coda-2.25-py310ha763d1a_1.conda
osx-arm64::libgdal-3.7.2-h19e0ef3_1.conda
osx-arm64::ogre-1.10.12-h5c04fa6_13.conda
osx-arm64::triqs-3.2.0-py311h358a192_4.conda
osx-arm64::lfortran-0.20.0-hbe7ddab_0.conda
osx-arm64::pillow-10.0.0-py310hadb9e77_1.conda
osx-arm64::nodejs-20.6.1-h5f47a4d_0.conda
osx-arm64::gdstk-0.9.42-py38h7c075a7_1.conda
osx-arm64::libpulsar-3.2.0-h569a6aa_3.conda
osx-arm64::nest-simulator-3.6-py39h4f52a62_0.conda
osx-arm64::netcdf4-1.6.4-nompi_py38h260f13c_103.conda
osx-arm64::libpq-15.4-hcea71ed_1.conda
osx-arm64::pyhdf-0.11.3-py310h47f437e_1.conda
osx-arm64::pyinstaller-6.0.0-py311h79498d2_1.conda
osx-arm64::python-igraph-0.10.6-py39ha133bd5_2.conda
osx-arm64::libopencv-4.8.0-py38h004a68a_3.conda
osx-arm64::qt6-main-6.5.2-h1272cd5_2.conda
osx-arm64::nodejs-20.7.0-h5f47a4d_0.conda
osx-arm64::fltk-1.3.8-he0fb936_3.conda
osx-arm64::boost-cpp-1.82.0-hca5e981_3.conda
osx-arm64::lxml-4.9.3-py312hfb440ac_1.conda
osx-arm64::boost-cpp-1.82.0-h4ae65de_2.conda
osx-arm64::pygame-2.5.2-py39ha1ca32f_1.conda
osx-arm64::libopencv-4.8.0-py39hc7c818c_4.conda
osx-arm64::vigra-1.11.1-py311hf88a2d6_1047.conda
osx-arm64::lammps-2023.08.02-cpu_py311_hb114475_openmpi_1.conda
osx-arm64::triqs-3.2.0-py311h6ca355d_4.conda
osx-arm64::folly-2023.09.04.00-hd189c9a_0_jemalloc.conda
osx-arm64::openbabel-3.1.1-py312h9f15883_8.conda
osx-arm64::triqs-3.2.0-py310hc920bd7_5.conda
osx-arm64::vigra-1.11.2-py39hf229da3_0.conda
osx-arm64::libboost-1.82.0-h3f31f7c_2.conda
osx-arm64::jaxlib-0.4.14-cpu_py39hcbbb391_1.conda
osx-arm64::mesalib-23.2.1-h7bfda7a_0.conda
osx-arm64::photochem-0.4.2-py311h44dfbdf_2.conda
osx-arm64::r-base-4.1.3-hc95f692_12.conda
osx-arm64::lammps-2023.08.02-cpu_py310_h7a37da0_mpich_1.conda
osx-arm64::folly-2023.09.11.00-h4c49ebf_0_jemalloc.conda
osx-arm64::gst-plugins-good-1.22.6-hd0bd010_1.conda
osx-arm64::mcpl-1.6.2-py39ha52a465_1.conda
osx-arm64::fltk-1.3.8-h49d0875_1.conda
osx-arm64::harp-1.20-py310hb4c5174_0.conda
osx-arm64::magics-metview-4.14.2-h54eacea_1.conda
osx-arm64::pillow-10.0.0-py311he9c13d2_1.conda
osx-arm64::triqs-3.2.0-py39h35c07b5_4.conda
osx-arm64::coda-2.25-py311he85e523_1.conda
osx-arm64::pdal-2.5.6-h5abc494_2.conda
osx-arm64::xrootd-5.6.2-py310he177ee0_0.conda
osx-arm64::libarrow-10.0.1-he713f65_42_cpu.conda
osx-arm64::imagecodecs-2023.9.18-py39h450eed6_0.conda
osx-arm64::libarrow-11.0.0-h145d1cc_35_cpu.conda
osx-arm64::minizip-4.0.1-h5a7aac7_1.conda
osx-arm64::triqs-3.2.0-py38h20ddde0_5.conda
osx-arm64::glib-networking-2.78.0-he79f396_0.conda
osx-arm64::pygame-2.5.2-py310heeb1dd7_0.conda
osx-arm64::paraview-5.11.1-py311ha3866db_102_qt.conda
osx-arm64::folly-2023.09.18.00-hdc4976f_0.conda
osx-arm64::pygplates-0.39-py39h0a53f17_9.conda
osx-arm64::poppler-23.08.0-h05ca32a_1.conda
osx-arm64::bytewax-0.17.1-py310h738ff09_0.conda
osx-arm64::aws-sdk-cpp-1.11.156-he404d52_1.conda
osx-arm64::libtiff-4.6.0-h23a1a89_0.conda
osx-arm64::python-igraph-0.10.8-py310hade86c1_0.conda
osx-arm64::triqs-3.2.0-py38hfe7a5d8_5.conda
osx-arm64::qt6-main-6.5.2-he484b70_1.conda
osx-arm64::libarrow-11.0.0-h1ffad42_36_cpu.conda
osx-arm64::r-base-4.3.1-h7fa7ea6_4.conda
osx-arm64::paraview-5.11.1-py310h56c0d40_102_qt.conda
osx-arm64::arrow-cpp-9.0.0-py310hb0a29dc_47_cpu.conda
osx-arm64::postgresql-plpython-16.0-py310h94ee204_0.conda
osx-arm64::openpmd-api-0.15.2-mpi_mpich_py311h96d1b2f_1.conda
osx-arm64::polycap-1.2-py312ha2acd61_4.conda
osx-arm64::gazebo-11.13.0-h188e9c9_8.conda
osx-arm64::paraview-5.11.1-py38hc10f730_102_qt.conda
osx-arm64::netcdf4-1.6.4-mpi_mpich_py310h5c42483_3.conda
osx-arm64::libopencv-4.8.0-py39h4d479a1_3.conda
osx-arm64::tiledb-2.16.3-he15c4da_3.conda
osx-arm64::libarrow-10.0.1-he713f65_43_cpu.conda
osx-arm64::coda-2.25-py39hb13cb4f_1.conda
osx-arm64::mcpl-1.6.2-py312h1609c5e_1.conda
osx-arm64::gtk4-4.12.1-hafba4f5_3.conda
osx-arm64::r-base-4.3.1-h3c76fbc_5.conda
osx-arm64::aws-sdk-cpp-1.11.158-he404d52_1.conda
osx-arm64::folly-2023.09.04.00-h4c49ebf_0_jemalloc.conda
osx-arm64::polycap-1.2-py310he2349d3_4.conda
osx-arm64::libgdal-arrow-parquet-3.7.2-h1337460_3.conda
osx-arm64::qt-main-5.15.8-h219f738_16.conda
osx-arm64::r-harp-1.20-py39h15bc620_0.conda
osx-arm64::heyoka-2.0.0-h2293f1e_0.conda
osx-arm64::arrow-cpp-9.0.0-py311hc3a63f0_48_cpu.conda
osx-arm64::netcdf4-1.6.4-mpi_openmpi_py38h3e1fb96_3.conda
osx-arm64::lfortran-0.20.2-hbe7ddab_0.conda
osx-arm64::bytewax-0.17.1-py39h66a509b_0.conda
osx-arm64::libvips-8.14.5-hf9ba9f2_0.conda
osx-arm64::tiledb-2.17.0-he15c4da_0.conda
osx-arm64::arrow-cpp-9.0.0-py311h2d96359_49_cpu.conda
osx-arm64::grpcio-1.58.1-py312h5729958_0.conda
osx-arm64::libarchive-3.7.2-h82b9b87_0.conda
osx-arm64::pygame-2.5.2-py311h4d8e0db_0.conda
osx-arm64::util-linux-2.39.2-py311hfacc263_0.conda
osx-arm64::libtiff-4.6.0-ha8a6c65_2.conda
osx-arm64::mcpl-1.6.2-py310hab90de1_1.conda
osx-arm64::glib-2.78.0-ha614eb4_0.conda
osx-arm64::coda-2.25-py310he2ee789_0.conda
osx-arm64::heyoka-llvm-14-2.0.0-hc9d117a_0.conda
osx-arm64::curl-8.3.0-hc52a3a8_0.conda
osx-arm64::libgrpc-1.58.1-h941e00e_0.conda
osx-arm64::python-igraph-0.10.6-py310hade86c1_2.conda
osx-arm64::triqs-3.2.0-py310h216340d_3.conda
osx-arm64::libzip-1.10.1-ha0bc3c6_2.conda
osx-arm64::hugin-base-2022.0.0-pl5321hebcb205_7.conda
osx-arm64::nodejs-18.17.1-ha2ed473_0.conda
osx-arm64::xrootd-5.6.2-py39h8c5c091_1.conda
osx-arm64::coda-2.25-py38h5b49fee_1.conda
osx-arm64::mysql-client-8.0.33-h41974c7_4.conda
osx-arm64::lxml-4.9.3-py311hbafe683_1.conda
osx-arm64::python-igraph-0.10.6-py311hd69ccbd_2.conda
osx-arm64::magics-metview-batch-4.14.2-h5a25f2c_1.conda
osx-arm64::nest-simulator-3.6-py38he6344e4_0.conda
osx-arm64::triqs-3.2.0-py310h216340d_4.conda
osx-arm64::vigra-1.11.1-py39h037b64a_1047.conda
osx-arm64::glibmm-2.68-2.78.0-h355405b_0.conda
osx-arm64::libarrow-13.0.0-h43f999d_3_cpu.conda
osx-arm64::lammps-2023.08.02-cpu_py38_ha19c33e_mpich_2.conda
osx-arm64::pygame-2.5.2-py39ha1ca32f_2.conda
osx-arm64::pyinstaller-6.0.0-py39ha52a465_1.conda
osx-arm64::geotiff-1.7.1-h71398c0_14.conda
osx-arm64::folly-2023.09.18.00-h2c5142d_0_jemalloc.conda
osx-arm64::pytables-3.8.0-py310h441c2ec_3.conda
osx-arm64::jaxlib-0.4.14-cpu_py311hc4e5dba_1.conda
osx-arm64::triqs-3.2.0-py310hc920bd7_2.conda
osx-arm64::xrootd-5.6.2-py311h4e7788a_1.conda
osx-arm64::gdstk-0.9.42-py311h73b73c0_1.conda
osx-arm64::netcdf4-1.6.4-mpi_mpich_py39hc500b05_3.conda
osx-arm64::pdal-2.5.6-hb8312d3_3.conda
osx-arm64::omniorb-4.3.1-py39h014b858_1.conda
osx-arm64::heyoka-llvm-11-2.0.0-h709b639_0.conda
osx-arm64::geotiff-1.7.1-h8fcada3_12.conda
osx-arm64::arrow-cpp-9.0.0-py39h6a9d352_48_cpu.conda
osx-arm64::yarp-cxx-3.8.1-h8dc61a0_5.conda
osx-arm64::openpmd-api-0.15.2-nompi_py38h0953568_101.conda
osx-arm64::vigra-1.11.2-py38h4530baa_0.conda
osx-arm64::libgd-2.3.3-h574d10c_8.conda
osx-arm64::pyinstaller-6.0.0-py311h79498d2_0.conda
osx-arm64::pyhdf-0.11.3-py312ha66ae45_1.conda
osx-arm64::libarrow-12.0.1-h0c25ffe_13_cpu.conda
osx-arm64::coda-2.25-py311h44628bf_0.conda
osx-arm64::pygplates-0.39-py38hbd6f680_9.conda
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
================================================================================
================================================================================
linux-ppc64le
linux-ppc64le::libraw-0.21.1-h5e294c4_2.conda
linux-ppc64le::cudnn-8.8.0.121-h734afba_3.conda
linux-ppc64le::gst-libav-1.22.6-h95e5f97_0.conda
linux-ppc64le::libsolv-0.7.24-hff1ad0c_4.conda
linux-ppc64le::openjpeg-2.5.0-h1c3486c_3.conda
linux-ppc64le::libmlir17-17.0.1-hae84d68_0.conda
linux-ppc64le::libprotobuf-static-4.24.3-h9ce2175_0.conda
linux-ppc64le::hdf4-4.2.15-h5e294c4_7.conda
linux-ppc64le::libprotobuf-4.23.4-h9ce2175_6.conda
linux-ppc64le::cudnn-8.8.0.121-h30cf0ba_3.conda
linux-ppc64le::tk-8.6.13-hd4bbf49_0.conda
linux-ppc64le::liblal-7.3.1-fftw_hb2f3d55_102.conda
linux-ppc64le::libsolv-0.7.25-hff1ad0c_0.conda
linux-ppc64le::gdk-pixbuf-2.42.10-hfb3fcaf_4.conda
linux-ppc64le::libsolv-static-0.7.25-hff1ad0c_0.conda
linux-ppc64le::libprotobuf-static-4.23.4-h9ce2175_5.conda
linux-ppc64le::freetype-2.12.1-h5baba08_2.conda
linux-ppc64le::libprotobuf-static-4.23.3-h31f4ac3_1.conda
linux-ppc64le::libprotobuf-static-4.23.4-h9ce2175_6.conda
linux-ppc64le::libsolv-static-0.7.24-hff1ad0c_4.conda
linux-ppc64le::openexr-3.2.1-h4843ef4_0.conda
linux-ppc64le::libprotobuf-4.23.3-h31f4ac3_1.conda
linux-ppc64le::cudnn-8.8.0.121-h6252efc_3.conda
linux-ppc64le::micromamba-1.5.1-0.tar.bz2
linux-ppc64le::libprotobuf-4.24.3-h9ce2175_0.conda
linux-ppc64le::libmlir-17.0.1-hae84d68_0.conda
linux-ppc64le::glib-tools-2.78.0-hff1ad0c_0.conda
linux-ppc64le::gdk-pixbuf-2.42.10-hdb90aed_3.conda
-    "libzlib >=1.2.13,<1.3.0a0"
+    "libzlib >=1.2.13,<2.0.0a0"
linux-ppc64le::vigra-1.11.1-py39hfbbc495_1047.conda
linux-ppc64le::cpp-opentelemetry-sdk-1.11.0-h46cea53_1.conda
linux-ppc64le::omniorb-4.3.1-py310h94f889b_1.conda
linux-ppc64le::llvm-17.0.1-h381f82a_0.conda
linux-ppc64le::grpcio-1.57.0-py312h930df82_1.conda
linux-ppc64le::vigra-1.11.2-py38h440fec3_0.conda
linux-ppc64le::coda-2.25-py39h718e066_0.conda
linux-ppc64le::pillow-10.0.1-py39ha6a510e_0.conda
linux-ppc64le::geotiff-1.7.1-hd82d71c_14.conda
linux-ppc64le::imagemagick-7.1.1_18-pl5321hea77106_0.conda
linux-ppc64le::linux-perf-6.3.10-py310hbf4c414_1.conda
linux-ppc64le::libarrow-11.0.0-h2f05933_36_cpu.conda
linux-ppc64le::libgdal-3.6.4-h40bf273_16.conda
linux-ppc64le::mysql-server-8.0.33-h9d13350_3.conda
linux-ppc64le::octave-8.2.0-he9197b6_2.conda
linux-ppc64le::wxwidgets-3.2.2.1-h71f4985_4.conda
linux-ppc64le::libopencv-4.8.0-py39h5eda576_3.conda
linux-ppc64le::arrow-cpp-9.0.0-py39hab8358c_47_cuda.conda
linux-ppc64le::vigra-1.11.1-py39h931dcf5_1047.conda
linux-ppc64le::xrootd-5.6.2-py39h8efc160_1.conda
linux-ppc64le::gstlal-1.12.0-py38he54f31f_0.conda
linux-ppc64le::python-3.12.0rc3-rc3_h3332dee_1_cpython.conda
linux-ppc64le::tiledb-2.17.0-h4ed4581_0.conda
linux-ppc64le::libarrow-13.0.0-hb122801_5_cpu.conda
linux-ppc64le::grpcio-1.58.1-py312h930df82_0.conda
linux-ppc64le::libarrow-11.0.0-hb122801_39_cpu.conda
linux-ppc64le::pytables-3.8.0-py38h97b587e_3.conda
linux-ppc64le::vtk-base-9.2.6-qt_py311h1234567_214.conda
linux-ppc64le::llvmdev-17.0.1-h8d57982_0.conda
linux-ppc64le::xrootd-5.6.2-py39hde03b8a_1.conda
linux-ppc64le::rust-1.72.1-hb12b0c0_0.conda
linux-ppc64le::openbabel-3.1.1-py312hec39ec1_8.conda
linux-ppc64le::pillow-10.0.1-py39ha6a510e_1.conda
linux-ppc64le::libcurl-static-8.3.0-ha571e8f_0.conda
linux-ppc64le::openpmd-api-0.15.2-nompi_py38h0d09d59_101.conda
linux-ppc64le::openpmd-api-0.15.2-nompi_py311hf45da4e_101.conda
linux-ppc64le::imagecodecs-2023.9.4-py310h862ac23_2.conda
linux-ppc64le::pygame-2.5.2-py38h4206018_1.conda
linux-ppc64le::symengine-0.11.1-h93d9feb_0.conda
linux-ppc64le::pillow-10.0.0-py311h37be7ef_1.conda
linux-ppc64le::postgresql-plpython-15.4-py311hba550cb_1.conda
linux-ppc64le::openjdk-17.0.8-h376f05d_0.conda
linux-ppc64le::r-harp-1.19-r43h75a40ef_1.conda
linux-ppc64le::harp-1.20-py310h145e6f2_0.conda
linux-ppc64le::pdal-2.5.6-h26c395a_3.conda
linux-ppc64le::harp-1.20-py39hbe2c71a_0.conda
linux-ppc64le::tiledb-2.17.1-hd5af256_0.conda
linux-ppc64le::imagecodecs-2023.9.18-py39hb7c279d_0.conda
linux-ppc64le::mapserver-8.0.1-py311hde8e01c_5.conda
linux-ppc64le::util-linux-2.39.2-py310h3fcec6a_1.conda
linux-ppc64le::python-igraph-0.10.8-py311hcc91f2c_0.conda
linux-ppc64le::vigra-1.11.1-py311h89041d5_1047.conda
linux-ppc64le::libtiff-4.6.0-hb1021a9_2.conda
linux-ppc64le::python-igraph-0.10.6-py311hcc91f2c_2.conda
linux-ppc64le::coda-2.24.2-py311he3b1496_3.conda
linux-ppc64le::libpq-15.4-h9d99649_2.conda
linux-ppc64le::mysql-router-8.0.33-h63c6f82_4.conda
linux-ppc64le::folly-2023.09.25.00-h361900a_0.conda
linux-ppc64le::ogre-1.10.12-h1a7ea67_14.conda
linux-ppc64le::libnetcdf-4.9.2-mpi_openmpi_he2133e4_12.conda
linux-ppc64le::libarrow-10.0.1-h2f05933_40_cpu.conda
linux-ppc64le::libgdal-3.7.2-h41b821e_4.conda
linux-ppc64le::rust-1.72.0-hb12b0c0_2.conda
linux-ppc64le::tiledb-2.17.0-h5238623_1.conda
linux-ppc64le::libarrow-11.0.0-h8fc3d9e_37_cuda.conda
linux-ppc64le::pyhdf-0.11.3-py39h3e46586_1.conda
linux-ppc64le::xrootd-5.6.2-py310h4b060cd_1.conda
linux-ppc64le::minizip-4.0.1-ha7cce9c_4.conda
linux-ppc64le::mapserver-8.0.1-py39hfd54bb8_5.conda
linux-ppc64le::libopencv-4.8.0-py310h86ff407_4.conda
linux-ppc64le::gst-plugins-base-1.22.6-he115d4a_0.conda
linux-ppc64le::arrow-cpp-9.0.0-py310hc8cbcc1_48_cpu.conda
linux-ppc64le::coda-2.25-py310hfd510e7_1.conda
linux-ppc64le::libsoup-3.4.3-hc050987_0.conda
linux-ppc64le::r-harp-1.19-r43he3b1496_1.conda
linux-ppc64le::mysql-libs-8.0.33-h3ac40eb_3.conda
linux-ppc64le::vigra-1.11.2-py39h5a0b921_0.conda
linux-ppc64le::arrow-cpp-9.0.0-py38h161d40d_47_cuda.conda
linux-ppc64le::libopencv-4.8.0-py39h9e7ce18_4.conda
linux-ppc64le::folly-2023.09.25.00-hbe59455_0_jemalloc.conda
linux-ppc64le::vigra-1.11.1-py39h5a0b921_1048.conda
linux-ppc64le::openpmd-api-0.15.2-mpi_openmpi_py38h51eaa99_1.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.2-hd9d0da0_2.conda
linux-ppc64le::lxml-4.9.3-py311h1860687_1.conda
linux-ppc64le::postgresql-plpython-15.4-py310h33ccb9c_2.conda
linux-ppc64le::nco-5.1.7-hfeafa31_1.conda
linux-ppc64le::openpmd-api-0.15.2-nompi_py39hd3ca6be_101.conda
linux-ppc64le::harp-1.20-py39h0228d32_0.conda
linux-ppc64le::vtk-base-9.2.6-qt_py38h1234567_214.conda
linux-ppc64le::pyinstaller-6.0.0-py38h36029d9_0.conda
linux-ppc64le::vigra-1.11.2-py39h9e8839c_0.conda
linux-ppc64le::gstlal-1.12.0-py311h96b2c23_0.conda
linux-ppc64le::vigra-1.11.1-py38he5ab26c_1047.conda
linux-ppc64le::boost-cpp-1.82.0-h1102270_3.conda
linux-ppc64le::aws-sdk-cpp-1.11.156-hb96febf_3.conda
linux-ppc64le::libopencv-4.8.0-py39hd5145f0_4.conda
linux-ppc64le::linux-perf-6.3.10-py38h5192f5b_1.conda
linux-ppc64le::pyhdf-0.11.3-py310h8c28756_1.conda
linux-ppc64le::mapserver-8.0.1-py311h7b9f399_8.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.2-hb18610b_4.conda
linux-ppc64le::vtk-base-9.2.6-qt_py39h1234567_213.conda
linux-ppc64le::sdl_image-1.2.12-h14db9fe_5.conda
linux-ppc64le::minizip-4.0.1-ha7cce9c_1.conda
linux-ppc64le::pyhdf-0.11.3-py312hb7dc6c4_1.conda
linux-ppc64le::imagecodecs-2023.9.4-py310hd0227c0_1.conda
linux-ppc64le::arrow-cpp-9.0.0-py310h49fb11f_47_cpu.conda
linux-ppc64le::libarrow-10.0.1-hdcb10ac_39_cpu.conda
linux-ppc64le::linux-perf-6.3.10-py311h52552ba_1.conda
linux-ppc64le::util-linux-2.39.2-py38h5193096_0.conda
linux-ppc64le::geotiff-1.7.1-h29534cc_13.conda
linux-ppc64le::omniorb-4.3.1-py39ha8da32a_1.conda
linux-ppc64le::util-linux-2.39.2-py310h3fcec6a_0.conda
linux-ppc64le::vigra-1.11.1-py39h9e8839c_1048.conda
linux-ppc64le::mysql-router-8.0.33-hce96e34_3.conda
linux-ppc64le::postgresql-plpython-15.4-py311hba550cb_2.conda
linux-ppc64le::arrow-cpp-9.0.0-py310h80fec46_49_cuda.conda
linux-ppc64le::openpmd-api-0.15.2-mpi_openmpi_py311h76a134e_1.conda
linux-ppc64le::irrlicht-1.8.5-hfbe4480_4.conda
linux-ppc64le::vigra-1.11.1-py39h2dfd1ef_1048.conda
linux-ppc64le::curl-8.3.0-ha571e8f_0.conda
linux-ppc64le::libarrow-10.0.1-h99f3c47_39_cuda.conda
linux-ppc64le::libopencv-4.8.0-py39h0a52bbc_2.conda
linux-ppc64le::netcdf4-1.6.4-nompi_py311hf4c972e_103.conda
linux-ppc64le::arrow-cpp-9.0.0-py311hbcb3acc_47_cuda.conda
linux-ppc64le::python-igraph-0.10.8-py310ha727447_0.conda
linux-ppc64le::coda-2.24.2-py39h718e066_3.conda
linux-ppc64le::libarrow-12.0.1-h4dd44d1_14_cuda.conda
linux-ppc64le::folly-2023.09.18.00-h864cb69_0_jemalloc.conda
linux-ppc64le::pillow-10.0.1-py38h818f570_1.conda
linux-ppc64le::libtiff-4.6.0-h2d54639_1.conda
linux-ppc64le::mysql-libs-8.0.33-h3ac40eb_4.conda
linux-ppc64le::pillow-10.0.0-py38h818f570_1.conda
linux-ppc64le::openpmd-api-0.15.2-mpi_mpich_py310h8b3a226_1.conda
linux-ppc64le::libzip-1.10.1-hb84b332_1.conda
linux-ppc64le::pygame-2.5.2-py38h4206018_2.conda
linux-ppc64le::python-igraph-0.10.8-py39h3bf30a8_0.conda
linux-ppc64le::freeimage-3.18.0-h9dd297e_16.conda
linux-ppc64le::coda-2.25-py39h7349751_1.conda
linux-ppc64le::vigra-1.11.2-py39h2dfd1ef_0.conda
linux-ppc64le::ogre-14.1.0-hf5224f0_1.conda
linux-ppc64le::vigra-1.11.1-py311h7ec7fd0_1048.conda
linux-ppc64le::netcdf4-1.6.4-mpi_openmpi_py310hd51dc40_3.conda
linux-ppc64le::mapserver-8.0.1-py38h57cd9ad_8.conda
linux-ppc64le::libopencv-4.8.1-py310h86ff407_0.conda
linux-ppc64le::vigra-1.11.1-py310h3ef6560_1047.conda
linux-ppc64le::libopencv-4.8.0-py38hc56e753_2.conda
linux-ppc64le::arrow-cpp-9.0.0-py39hf5b0a07_49_cuda.conda
linux-ppc64le::r-harp-1.19-r43had2d9a1_1.conda
linux-ppc64le::libnetcdf-4.9.2-mpi_mpich_hf1a50d0_12.conda
linux-ppc64le::folly-2023.09.18.00-hfccd340_0_jemalloc.conda
linux-ppc64le::libopencv-4.8.0-py311h2ef983e_2.conda
linux-ppc64le::gst-plugins-base-1.22.6-he115d4a_1.conda
linux-ppc64le::postgresql-plpython-16.0-py312h35a7702_1.conda
linux-ppc64le::libarrow-13.0.0-h99f3c47_1_cuda.conda
linux-ppc64le::pygame-2.5.2-py39h7cb4e43_2.conda
linux-ppc64le::libgdal-3.6.4-haf6957c_18.conda
linux-ppc64le::libspatialite-5.1.0-h4b91802_0.conda
linux-ppc64le::coda-2.25-py311h8a84315_1.conda
linux-ppc64le::postgresql-plpython-16.0-py310h33ccb9c_1.conda
linux-ppc64le::vigra-1.11.1-py38h531f233_1047.conda
linux-ppc64le::imagecodecs-2023.9.4-py39hb7c279d_2.conda
linux-ppc64le::libnetcdf-4.9.2-nompi_h2606ec2_112.conda
linux-ppc64le::gstlal-1.12.0-py310h461e14c_0.conda
linux-ppc64le::lld-17.0.1-he12c2f4_0.conda
linux-ppc64le::mysql-server-8.0.33-h02d1b8c_4.conda
linux-ppc64le::vigra-1.11.1-py310hcd10abb_1048.conda
linux-ppc64le::r-base-4.1.3-h501a4a9_11.conda
linux-ppc64le::libarrow-13.0.0-h36240a6_2_cuda.conda
linux-ppc64le::xrootd-5.6.2-py39hde03b8a_0.conda
linux-ppc64le::harp-1.19-py39hbe2c71a_1.conda
linux-ppc64le::libarrow-13.0.0-h4dd44d1_5_cuda.conda
linux-ppc64le::arrow-cpp-9.0.0-py38h6a91f8a_47_cpu.conda
linux-ppc64le::python-igraph-0.10.6-py39h3bf30a8_1.conda
linux-ppc64le::arrow-cpp-9.0.0-py310h52cf919_47_cuda.conda
linux-ppc64le::postgresql-plpython-15.4-py312h35a7702_2.conda
linux-ppc64le::mysql-client-8.0.33-hfff87ee_3.conda
linux-ppc64le::libarrow-11.0.0-hdcb10ac_35_cpu.conda
linux-ppc64le::imagemagick-7.1.1_17-pl5321hea77106_0.conda
linux-ppc64le::folly-2023.09.25.00-h864cb69_0_jemalloc.conda
linux-ppc64le::util-linux-2.39.2-py39hf65199f_1.conda
linux-ppc64le::folly-2023.09.18.00-hd692e58_0.conda
linux-ppc64le::postgresql-plpython-15.4-py38he255f0a_2.conda
linux-ppc64le::libarrow-12.0.1-h36240a6_11_cuda.conda
linux-ppc64le::vigra-1.11.1-py310h8a6dd1b_1047.conda
linux-ppc64le::pillow-10.0.0-py39h11dca36_1.conda
linux-ppc64le::netcdf4-1.6.4-mpi_mpich_py38hd340d46_3.conda
linux-ppc64le::ogre-1.10.12-h1a7ea67_13.conda
linux-ppc64le::fltk-1.3.8-h92e44d1_3.conda
linux-ppc64le::arrow-cpp-9.0.0-py311haf088fb_47_cpu.conda
linux-ppc64le::postgresql-15.4-h0ebe0f4_1.conda
linux-ppc64le::libopencv-4.8.0-py311ha9c2c0a_3.conda
linux-ppc64le::openjdk-11.0.15-h376f05d_7.conda
linux-ppc64le::tiledb-2.17.0-h5fbc0c9_1.conda
linux-ppc64le::mapserver-8.0.1-py39h466cee5_8.conda
linux-ppc64le::r-base-4.3.1-h33316b5_6.conda
linux-ppc64le::libopencv-4.8.0-py38h938c996_4.conda
linux-ppc64le::lxml-4.9.3-py312h3409d76_1.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.2-h58053f4_1.conda
linux-ppc64le::python-igraph-0.10.6-py38h38e6de1_2.conda
linux-ppc64le::arrow-cpp-9.0.0-py39h1b28327_49_cpu.conda
linux-ppc64le::libarrow-11.0.0-h99f3c47_35_cuda.conda
linux-ppc64le::poppler-23.08.0-hf9ad398_1.conda
linux-ppc64le::libarrow-12.0.1-hdce260d_12_cpu.conda
linux-ppc64le::libopencv-4.8.1-py311h94f8a46_0.conda
linux-ppc64le::openpmd-api-0.15.2-mpi_openmpi_py310h80afca9_1.conda
linux-ppc64le::folly-2023.09.25.00-hfccd340_0_jemalloc.conda
linux-ppc64le::tiledb-2.17.0-hac2e0cb_0.conda
linux-ppc64le::util-linux-2.39.2-py39hb455f50_0.conda
linux-ppc64le::sdl2_image-2.6.3-h2fc395b_4.conda
linux-ppc64le::fltk-1.3.8-hfe76b7c_2.conda
linux-ppc64le::harp-1.19-py311h9e8cec8_1.conda
linux-ppc64le::mapserver-8.0.1-py310h6345f2d_5.conda
linux-ppc64le::xrootd-5.6.2-py312hce53ec0_1.conda
linux-ppc64le::pillow-10.0.1-py39h11dca36_0.conda
linux-ppc64le::coda-2.24.2-py38had2d9a1_3.conda
linux-ppc64le::openpmd-api-0.15.2-mpi_mpich_py311he797d23_1.conda
linux-ppc64le::openjdk-17.0.8-h88a5b0c_3.conda
linux-ppc64le::imagecodecs-2023.9.4-py311had10391_0.conda
linux-ppc64le::libarrow-13.0.0-h4dd44d1_4_cuda.conda
linux-ppc64le::netcdf4-1.6.4-nompi_py38hc970dc1_103.conda
linux-ppc64le::assimp-5.3.1-h649da8f_1.conda
linux-ppc64le::pygame-2.5.2-py311h42637e2_1.conda
linux-ppc64le::folly-2023.09.11.00-h361900a_0.conda
linux-ppc64le::linux-perf-6.3.10-py39he243d86_1.conda
linux-ppc64le::geotiff-1.7.1-h809eece_12.conda
linux-ppc64le::python-igraph-0.10.6-py39hbcbd794_2.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.2-h96fba36_3.conda
linux-ppc64le::libgdal-arrow-parquet-3.6.4-h9f173fc_18.conda
linux-ppc64le::libarchive-3.7.2-h087afff_0.conda
linux-ppc64le::arrow-cpp-9.0.0-py39h5f0e461_48_cuda.conda
linux-ppc64le::lxml-4.9.3-py39hbb791fb_1.conda
linux-ppc64le::pygplates-0.39-py38h081ca2b_9.conda
linux-ppc64le::libcurl-8.3.0-ha571e8f_0.conda
linux-ppc64le::coda-2.25-py311he3b1496_0.conda
linux-ppc64le::libarrow-10.0.1-hb122801_43_cpu.conda
linux-ppc64le::libopentelemetry-cpp-1.11.0-h46cea53_1.conda
linux-ppc64le::libgdal-arrow-parquet-3.6.4-h8bacceb_19.conda
linux-ppc64le::folly-2023.09.04.00-h361900a_0.conda
linux-ppc64le::libthrift-0.19.0-h464a2bb_1.conda
linux-ppc64le::openbabel-3.1.1-py311h62e3513_8.conda
linux-ppc64le::harp-1.19-py38hd51d6db_1.conda
linux-ppc64le::util-linux-2.39.2-py312hbe3015e_1.conda
linux-ppc64le::minizip-4.0.1-ha7cce9c_3.conda
linux-ppc64le::openjdk-11.0.15-h7025949_6.conda
linux-ppc64le::openjdk-17.0.3-h7025949_9.conda
linux-ppc64le::openpmd-api-0.15.2-mpi_openmpi_py39ha7b6021_1.conda
linux-ppc64le::python-igraph-0.10.8-py38h38e6de1_0.conda
linux-ppc64le::elfutils-0.189-h8ac0f3d_1.conda
linux-ppc64le::libarrow-11.0.0-hdce260d_37_cpu.conda
linux-ppc64le::netcdf4-1.6.4-nompi_py39hdb904ae_103.conda
linux-ppc64le::postgresql-15.4-h0ebe0f4_2.conda
linux-ppc64le::pygame-2.5.2-py310he53e978_0.conda
linux-ppc64le::coda-2.25-py310h99fdfb2_0.conda
linux-ppc64le::arrow-cpp-9.0.0-py311h87a8942_49_cpu.conda
linux-ppc64le::python-igraph-0.10.6-py38h38e6de1_1.conda
linux-ppc64le::fltk-1.3.8-h7bfd562_1.conda
linux-ppc64le::libopencv-4.8.0-py38he6266ba_3.conda
linux-ppc64le::folly-2023.09.04.00-hfccd340_0_jemalloc.conda
linux-ppc64le::r-harp-1.20-r43he3b1496_0.conda
linux-ppc64le::coda-2.25-py38he254095_1.conda
linux-ppc64le::imagecodecs-2023.9.4-py310h13c0f2e_0.conda
linux-ppc64le::gst-plugins-bad-1.22.6-h9565abf_0.conda
linux-ppc64le::aws-sdk-cpp-1.11.158-hffb8590_1.conda
linux-ppc64le::folly-2023.09.25.00-h79ae0fe_0.conda
linux-ppc64le::harp-1.20-py311h9e8cec8_0.conda
linux-ppc64le::vigra-1.11.2-py310hff0043e_0.conda
linux-ppc64le::folly-2023.09.18.00-h79ae0fe_0.conda
linux-ppc64le::qtwebkit-5.212-h37bc6e8_13.conda
linux-ppc64le::pytables-3.8.0-py311h3f57c28_3.conda
linux-ppc64le::libpq-16.0-h9d99649_0.conda
linux-ppc64le::imagecodecs-2023.9.18-py39hb65aa40_0.conda
linux-ppc64le::llvm-tools-17.0.1-h8d57982_0.conda
linux-ppc64le::r-base-4.3.1-hf3b521f_4.conda
linux-ppc64le::util-linux-2.39.2-py311h0232d2a_0.conda
linux-ppc64le::libspatialite-5.0.1-h4b91802_29.conda
linux-ppc64le::lxml-4.9.3-py38h12de51e_1.conda
linux-ppc64le::tiledb-2.16.3-hac2e0cb_3.conda
linux-ppc64le::poppler-23.08.0-h7fc0ac6_2.conda
linux-ppc64le::vigra-1.11.1-py311h0634aba_1047.conda
linux-ppc64le::folly-2023.09.18.00-hbe59455_0_jemalloc.conda
linux-ppc64le::xrootd-5.6.2-py38h9683abd_1.conda
linux-ppc64le::netcdf4-1.6.4-mpi_openmpi_py311h2d08ffa_3.conda
linux-ppc64le::python-igraph-0.10.6-py38hb60408d_1.conda
linux-ppc64le::aws-sdk-cpp-1.10.57-h1f80e50_23.conda
linux-ppc64le::libvips-8.14.4-h127e9da_1.conda
linux-ppc64le::openjdk-11.0.15-h2e1fb60_5.conda
linux-ppc64le::glib-2.78.0-hff1ad0c_0.conda
linux-ppc64le::libopencv-4.8.0-py310h9b4bb29_2.conda
linux-ppc64le::pygame-2.5.2-py310hdb4f84d_2.conda
linux-ppc64le::pyinstaller-6.0.0-py311h5a86d3c_1.conda
linux-ppc64le::postgresql-16.0-h0ebe0f4_0.conda
linux-ppc64le::libgdal-3.7.2-hfbbd4ec_3.conda
linux-ppc64le::tiledb-2.16.3-h66aeb34_2.conda
linux-ppc64le::libgd-2.3.3-h4c8f653_8.conda
linux-ppc64le::gst-plugins-good-1.22.6-h199ceca_0.conda
linux-ppc64le::openpmd-api-0.15.2-nompi_py38haf02786_101.conda
linux-ppc64le::libopencv-4.8.0-py311h94f8a46_4.conda
linux-ppc64le::vigra-1.11.1-py38hcf69bf5_1047.conda
linux-ppc64le::graphicsmagick-1.3.40-hce701d6_3.conda
linux-ppc64le::libopencv-4.8.1-py39h9e7ce18_0.conda
linux-ppc64le::postgresql-plpython-15.4-py39h8e6b938_1.conda
linux-ppc64le::python-igraph-0.10.8-py39hbcbd794_0.conda
linux-ppc64le::xrootd-5.6.2-py39h8efc160_0.conda
linux-ppc64le::libarrow-12.0.1-hb122801_14_cpu.conda
linux-ppc64le::tiledb-2.17.0-h6820701_1.conda
linux-ppc64le::r-harp-1.20-r43h75a40ef_0.conda
linux-ppc64le::imagecodecs-2023.9.4-py39hb65aa40_2.conda
linux-ppc64le::util-linux-2.39.2-py311h0232d2a_1.conda
linux-ppc64le::libarrow-12.0.1-h4dd44d1_13_cuda.conda
linux-ppc64le::libgrpc-1.58.1-h68d966a_0.conda
linux-ppc64le::tiledb-2.17.1-hac2e0cb_0.conda
linux-ppc64le::mapserver-8.0.1-py310hf75df58_7.conda
linux-ppc64le::libpulsar-3.2.0-h84158f9_3.conda
linux-ppc64le::imagecodecs-2023.9.4-py311h632305b_1.conda
linux-ppc64le::imagemagick-7.1.1_15-pl5321hea77106_1.conda
linux-ppc64le::aws-sdk-cpp-1.11.158-h7c2b61e_0.conda
linux-ppc64le::pygame-2.5.2-py39hd7f27fc_2.conda
linux-ppc64le::pygplates-0.39-py310hdc20a6d_9.conda
linux-ppc64le::pygame-2.5.2-py39h7cb4e43_1.conda
linux-ppc64le::arrow-cpp-9.0.0-py38h7a8b7ee_48_cuda.conda
linux-ppc64le::pillow-10.0.1-py39h11dca36_1.conda
linux-ppc64le::libopencv-4.8.0-py39h7b968a4_3.conda
linux-ppc64le::aws-sdk-cpp-1.11.156-h7c2b61e_0.conda
linux-ppc64le::pyinstaller-6.0.0-py39hf0cda86_1.conda
linux-ppc64le::libarrow-12.0.1-h99f3c47_10_cuda.conda
linux-ppc64le::pygame-2.5.2-py311h0cc10f5_0.conda
linux-ppc64le::python-igraph-0.10.6-py310ha727447_1.conda
linux-ppc64le::libgdal-3.6.4-hd1abc68_19.conda
linux-ppc64le::pillow-10.0.1-py311h37be7ef_1.conda
linux-ppc64le::pygplates-0.39-py39hf99fe72_9.conda
linux-ppc64le::folly-2023.09.11.00-hbe59455_0_jemalloc.conda
linux-ppc64le::pytables-3.8.0-py310h8713445_3.conda
linux-ppc64le::omniorb-4.3.1-py311h7d8a50b_1.conda
linux-ppc64le::folly-2023.09.04.00-h864cb69_0_jemalloc.conda
linux-ppc64le::imagecodecs-2023.9.4-py311h92edf6b_2.conda
linux-ppc64le::libarrow-11.0.0-h36240a6_36_cuda.conda
linux-ppc64le::libarrow-12.0.1-hb122801_13_cpu.conda
linux-ppc64le::imagecodecs-2023.9.18-py311h92edf6b_0.conda
linux-ppc64le::libarrow-10.0.1-h4dd44d1_42_cuda.conda
linux-ppc64le::thrift-compiler-0.19.0-h81b47c4_0.conda
linux-ppc64le::blosc-1.21.5-h791411d_0.conda
linux-ppc64le::glibmm-2.68-2.78.0-h8df1eea_0.conda
linux-ppc64le::pygame-2.5.2-py311h42637e2_2.conda
linux-ppc64le::xrootd-5.6.2-py38h9683abd_0.conda
linux-ppc64le::openpmd-api-0.15.2-mpi_mpich_py39hf5aa837_1.conda
linux-ppc64le::coda-2.25-py38had2d9a1_0.conda
linux-ppc64le::folly-2023.09.11.00-h864cb69_0_jemalloc.conda
linux-ppc64le::pillow-10.0.1-py310h99b1c74_0.conda
linux-ppc64le::vigra-1.11.1-py38hb9ea286_1047.conda
linux-ppc64le::boost-cpp-1.82.0-haf4ba2d_2.conda
linux-ppc64le::libarrow-13.0.0-h2f05933_2_cpu.conda
linux-ppc64le::libarrow-10.0.1-h4dd44d1_43_cuda.conda
linux-ppc64le::omniorb-4.3.1-py312h0bb3dca_1.conda
linux-ppc64le::openpmd-api-0.15.2-mpi_mpich_py38hcbe0d2d_1.conda
linux-ppc64le::vigra-1.11.1-py39hcb4f3b9_1047.conda
linux-ppc64le::libpq-15.4-h9d99649_1.conda
linux-ppc64le::postgresql-plpython-16.0-py39h8e6b938_0.conda
linux-ppc64le::pyinstaller-6.0.0-py38h36029d9_1.conda
linux-ppc64le::folly-2023.09.11.00-h79ae0fe_0.conda
linux-ppc64le::python-igraph-0.10.6-py39hbcbd794_1.conda
linux-ppc64le::arrow-cpp-9.0.0-py310h3071cf8_48_cuda.conda
linux-ppc64le::tiledb-2.17.0-hd5af256_0.conda
linux-ppc64le::wxwidgets-3.2.2.1-h78d0b3a_5.conda
linux-ppc64le::util-linux-2.39.2-py39hb455f50_1.conda
linux-ppc64le::netcdf4-1.6.4-mpi_mpich_py39h5cc4e33_3.conda
linux-ppc64le::tiledb-2.16.3-hd5af256_2.conda
linux-ppc64le::vtk-base-9.2.6-qt_py311h1234567_213.conda
linux-ppc64le::openjdk-11.0.20-hf148617_2.conda
linux-ppc64le::pytables-3.8.0-py38he64dfca_3.conda
linux-ppc64le::mlir-17.0.1-hae84d68_0.conda
linux-ppc64le::libarrow-13.0.0-h8fc3d9e_3_cuda.conda
linux-ppc64le::libzip-1.10.1-hb84b332_3.conda
linux-ppc64le::pyinstaller-6.0.0-py311h5a86d3c_0.conda
linux-ppc64le::arrow-cpp-9.0.0-py311h0f16d03_48_cuda.conda
linux-ppc64le::libopencv-4.8.1-py39hd5145f0_0.conda
linux-ppc64le::libarrow-12.0.1-h8fc3d9e_12_cuda.conda
linux-ppc64le::openpmd-api-0.15.2-mpi_openmpi_py38h3f1c117_1.conda
linux-ppc64le::netcdf4-1.6.4-mpi_mpich_py311hbcdc183_3.conda
linux-ppc64le::vigra-1.11.1-py310hff0043e_1048.conda
linux-ppc64le::coda-2.25-py39h75a40ef_0.conda
linux-ppc64le::lxml-4.9.3-py310h0e28d95_1.conda
linux-ppc64le::folly-2023.09.25.00-hd692e58_0.conda
linux-ppc64le::libarrow-10.0.1-h36240a6_40_cuda.conda
linux-ppc64le::pygame-2.5.2-py39hd7f27fc_1.conda
linux-ppc64le::grpcio-1.58.1-py311h3997ded_0.conda
linux-ppc64le::orc-1.9.0-hca25665_2.conda
linux-ppc64le::libgdal-3.7.2-h8e8a3e7_0.conda
linux-ppc64le::pytables-3.8.0-py39h6b88dcf_3.conda
linux-ppc64le::octave-8.3.0-he9197b6_0.conda
linux-ppc64le::pygame-2.5.2-py310hdb4f84d_1.conda
linux-ppc64le::libarrow-10.0.1-hb122801_42_cpu.conda
linux-ppc64le::postgresql-plpython-15.4-py310h33ccb9c_1.conda
linux-ppc64le::ogre-14.1.0-h0853ee1_1.conda
linux-ppc64le::mapserver-8.0.1-py310h829f995_8.conda
linux-ppc64le::postgresql-plpython-16.0-py311hba550cb_0.conda
linux-ppc64le::pyinstaller-6.0.0-py310h0719273_1.conda
linux-ppc64le::linux-perf-6.3.10-py312h6e17dbf_1.conda
linux-ppc64le::arrow-cpp-9.0.0-py311hdaf9e4e_48_cpu.conda
linux-ppc64le::pyhdf-0.11.3-py39he3a5649_1.conda
linux-ppc64le::pygame-2.5.2-py39hf33c4b3_0.conda
linux-ppc64le::tiledb-2.16.3-h4ed4581_3.conda
linux-ppc64le::mapserver-8.0.1-py38h3d62054_7.conda
linux-ppc64le::ogre-14.0.1-h0702fb7_2.conda
linux-ppc64le::imagemagick-7.1.1_16-pl5321hea77106_0.conda
linux-ppc64le::libglib-2.78.0-hd7af32a_0.conda
linux-ppc64le::vigra-1.11.1-py38h3bbaf52_1048.conda
linux-ppc64le::python-igraph-0.10.6-py311hcc91f2c_1.conda
linux-ppc64le::pillow-10.0.1-py310h99b1c74_1.conda
linux-ppc64le::vigra-1.11.2-py39hdab3d78_0.conda
linux-ppc64le::pygame-2.5.2-py312h49e6291_2.conda
linux-ppc64le::openpmd-api-0.15.2-mpi_mpich_py39h0081349_1.conda
linux-ppc64le::coda-2.25-py39hc78dc1f_1.conda
linux-ppc64le::arrow-cpp-9.0.0-py38heac82c6_48_cpu.conda
linux-ppc64le::postgresql-plpython-16.0-py38he255f0a_1.conda
linux-ppc64le::openpmd-api-0.15.2-mpi_mpich_py38h9212c1e_1.conda
linux-ppc64le::pillow-10.0.0-py310h99b1c74_1.conda
linux-ppc64le::pygplates-0.39-py311he07c489_9.conda
linux-ppc64le::ogre-14.1.0-h0702fb7_0.conda
linux-ppc64le::gst-plugins-good-1.22.6-hcf0ac4c_1.conda
linux-ppc64le::vigra-1.11.1-py39h0d114a5_1047.conda
linux-ppc64le::openpmd-api-0.15.2-mpi_openmpi_py39h4258fc8_1.conda
linux-ppc64le::minizip-4.0.1-ha7cce9c_2.conda
linux-ppc64le::yarp-cxx-3.8.1-h633eef5_5.conda
linux-ppc64le::tiledb-2.16.3-hd5af256_3.conda
linux-ppc64le::openslide-3.4.1-h2d68027_10.conda
linux-ppc64le::netcdf4-1.6.4-mpi_mpich_py310h50b4216_3.conda
linux-ppc64le::folly-2023.09.04.00-h79ae0fe_0.conda
linux-ppc64le::netcdf4-1.6.4-mpi_mpich_py312h03f8c67_3.conda
linux-ppc64le::gstlal-1.12.0-py39h8423a0a_0.conda
linux-ppc64le::sdl2_image-2.6.3-hf8488ec_3.conda
linux-ppc64le::grpcio-1.58.1-py310h8eb8f48_0.conda
linux-ppc64le::libzip-1.10.1-hb84b332_2.conda
linux-ppc64le::arrow-cpp-9.0.0-py39ha13ec12_48_cpu.conda
linux-ppc64le::pyinstaller-6.0.0-py39hf0cda86_0.conda
linux-ppc64le::pillow-10.0.0-py39ha6a510e_1.conda
linux-ppc64le::vigra-1.11.1-py38h440fec3_1048.conda
linux-ppc64le::openjdk-17.0.8-hf148617_2.conda
linux-ppc64le::openjdk-11.0.20-h376f05d_0.conda
linux-ppc64le::pyhdf-0.11.3-py311h68f7c1f_1.conda
linux-ppc64le::libopencv-4.8.0-py39hffca715_2.conda
linux-ppc64le::libarchive-minimal-static-3.7.2-h009e8c7_0.conda
linux-ppc64le::folly-2023.09.11.00-hd692e58_0.conda
linux-ppc64le::lxml-4.9.3-py39h9d2759b_1.conda
linux-ppc64le::libarrow-10.0.1-hdce260d_41_cpu.conda
linux-ppc64le::util-linux-2.39.2-py39hf65199f_0.conda
linux-ppc64le::aws-sdk-cpp-1.11.156-h9b18104_2.conda
linux-ppc64le::libarrow-12.0.1-hdcb10ac_10_cpu.conda
linux-ppc64le::libtiff-4.6.0-h50938e9_0.conda
linux-ppc64le::openbabel-3.1.1-py310hfb8b204_8.conda
linux-ppc64le::r-base-4.2.3-h1cb2c7c_9.conda
linux-ppc64le::libgdal-3.6.4-h95b9e60_17.conda
linux-ppc64le::r-harp-1.20-r43h718e066_0.conda
linux-ppc64le::imagecodecs-2023.9.4-py39hfdf937b_1.conda
linux-ppc64le::gst-plugins-good-1.22.5-h199ceca_1.conda
linux-ppc64le::cargo-c-0.9.24-hd6e3413_1.conda
linux-ppc64le::mapserver-8.0.1-py39h58fbc13_7.conda
linux-ppc64le::libarrow-11.0.0-h4dd44d1_38_cuda.conda
linux-ppc64le::netcdf4-1.6.4-mpi_openmpi_py39hd0890ac_3.conda
linux-ppc64le::sdl2_image-2.6.3-h4ac3111_2.conda
linux-ppc64le::mesalib-23.2.1-hb6f7a19_0.conda
linux-ppc64le::imagecodecs-2023.9.18-py310h862ac23_0.conda
linux-ppc64le::libpq-16.0-h9d99649_1.conda
linux-ppc64le::aws-sdk-cpp-1.11.156-hffb8590_1.conda
linux-ppc64le::openjdk-17.0.8-hf148617_1.conda
linux-ppc64le::mapserver-8.0.1-py311hea9c8ff_6.conda
linux-ppc64le::nco-5.1.8-hfeafa31_0.conda
linux-ppc64le::openbabel-3.1.1-py39hd0e508d_8.conda
linux-ppc64le::pdal-2.5.6-h847bbe8_2.conda
linux-ppc64le::libarrow-11.0.0-hb122801_38_cpu.conda
linux-ppc64le::vtk-base-9.2.6-qt_py310h1234567_213.conda
linux-ppc64le::libopencv-4.8.0-py310hd9a6c1a_3.conda
linux-ppc64le::tiledb-2.16.3-hac2e0cb_2.conda
linux-ppc64le::netcdf4-1.6.4-nompi_py310h24b77d7_103.conda
linux-ppc64le::r-base-4.1.3-h0d22f70_12.conda
linux-ppc64le::libarrow-13.0.0-hb122801_4_cpu.conda
linux-ppc64le::vtk-base-9.2.6-qt_py38h1234567_213.conda
linux-ppc64le::libarrow-10.0.1-h8fc3d9e_41_cuda.conda
linux-ppc64le::r-harp-1.20-r43h99fdfb2_0.conda
linux-ppc64le::folly-2023.09.18.00-h361900a_0.conda
linux-ppc64le::openslide-3.4.1-h291995e_11.conda
linux-ppc64le::folly-2023.09.04.00-hd692e58_0.conda
linux-ppc64le::postgresql-16.0-h0ebe0f4_1.conda
linux-ppc64le::libarrow-12.0.1-h2f05933_11_cpu.conda
linux-ppc64le::vigra-1.11.2-py311hbf9a1f0_0.conda
linux-ppc64le::omniorb-libs-4.3.1-h64e73a3_1.conda
linux-ppc64le::openpmd-api-0.15.2-nompi_py310h8735542_101.conda
linux-ppc64le::netcdf4-1.6.4-mpi_openmpi_py38hcf908bf_3.conda
linux-ppc64le::postgresql-plpython-16.0-py38he255f0a_0.conda
linux-ppc64le::util-linux-2.39.2-py38h5193096_1.conda
linux-ppc64le::gst-plugins-base-1.22.5-he115d4a_1.conda
linux-ppc64le::mapserver-8.0.1-py38h6045bdc_6.conda
linux-ppc64le::mapserver-8.0.1-py310h2e7008a_6.conda
linux-ppc64le::omniorb-4.3.1-py38h7db1d0b_1.conda
linux-ppc64le::arrow-cpp-9.0.0-py311h6378a85_49_cuda.conda
linux-ppc64le::r-base-4.3.1-he067f73_4.conda
linux-ppc64le::vigra-1.11.2-py38h3bbaf52_0.conda
linux-ppc64le::mapserver-8.0.1-py39hce08726_6.conda
linux-ppc64le::folly-2023.09.11.00-hfccd340_0_jemalloc.conda
linux-ppc64le::libboost-1.82.0-hd92d057_2.conda
linux-ppc64le::cmake-3.27.6-h1403f77_0.conda
linux-ppc64le::vtk-base-9.2.6-qt_py39h1234567_214.conda
linux-ppc64le::mapserver-8.0.1-py311h9b713ab_7.conda
linux-ppc64le::libarrow-13.0.0-hdce260d_3_cpu.conda
linux-ppc64le::pillow-10.0.1-py311h37be7ef_0.conda
linux-ppc64le::folly-2023.09.04.00-hbe59455_0_jemalloc.conda
linux-ppc64le::assimp-5.3.0-h649da8f_0.conda
linux-ppc64le::mysql-client-8.0.33-hfff87ee_4.conda
linux-ppc64le::harp-1.20-py38hd51d6db_0.conda
linux-ppc64le::postgresql-plpython-16.0-py39h8e6b938_1.conda
linux-ppc64le::libgdal-arrow-parquet-3.6.4-hb0fdfdd_16.conda
linux-ppc64le::xrootd-5.6.2-py311hf00abcb_0.conda
linux-ppc64le::r-base-4.1.3-h0d09941_11.conda
linux-ppc64le::pygame-2.5.2-py38h00f7aa6_0.conda
linux-ppc64le::libarrow-11.0.0-h4dd44d1_39_cuda.conda
linux-ppc64le::vigra-1.11.2-py310hcd10abb_0.conda
linux-ppc64le::pillow-10.0.1-py38h818f570_0.conda
linux-ppc64le::python-igraph-0.10.6-py310ha727447_2.conda
linux-ppc64le::arrow-cpp-9.0.0-py310hced8b58_49_cpu.conda
linux-ppc64le::arrow-cpp-9.0.0-py39hdc812f9_47_cpu.conda
linux-ppc64le::libopencv-4.8.1-py38h938c996_0.conda
linux-ppc64le::imagecodecs-2023.9.4-py39h713f18e_1.conda
linux-ppc64le::libgdal-3.7.2-hc3cdb9a_2.conda
linux-ppc64le::xrootd-5.6.2-py310h4b060cd_0.conda
linux-ppc64le::pyhdf-0.11.3-py38h58fc349_1.conda
linux-ppc64le::libgdal-3.7.2-hc6b338e_1.conda
linux-ppc64le::libthrift-0.19.0-h81b47c4_0.conda
linux-ppc64le::grpcio-1.58.1-py39h278787b_0.conda
linux-ppc64le::imagecodecs-2023.9.4-py39h4a15c9d_0.conda
linux-ppc64le::mapserver-8.0.1-py38ha4be5d9_5.conda
linux-ppc64le::grpcio-1.58.1-py38hc2aed35_0.conda
linux-ppc64le::openpmd-api-0.15.2-nompi_py39hea7354c_101.conda
linux-ppc64le::openjdk-11.0.20-h88a5b0c_3.conda
linux-ppc64le::arrow-cpp-9.0.0-py38h0b9e055_49_cuda.conda
linux-ppc64le::vigra-1.11.1-py311hbf9a1f0_1048.conda
linux-ppc64le::postgresql-plpython-16.0-py310h33ccb9c_0.conda
linux-ppc64le::arrow-cpp-9.0.0-py38h3499c94_49_cpu.conda
linux-ppc64le::netcdf4-1.6.4-nompi_py312h7d9bdac_103.conda
linux-ppc64le::postgresql-plpython-15.4-py39h8e6b938_2.conda
linux-ppc64le::libarrow-13.0.0-hdcb10ac_1_cpu.conda
linux-ppc64le::libgdal-arrow-parquet-3.6.4-h0c45f83_17.conda
linux-ppc64le::libllvm17-17.0.1-h8d57982_0.conda
linux-ppc64le::libvips-8.14.5-h127e9da_0.conda
linux-ppc64le::glib-networking-2.78.0-h81f63f5_0.conda
linux-ppc64le::r-harp-1.20-r43had2d9a1_0.conda
linux-ppc64le::openbabel-3.1.1-py38h6b41003_8.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.2-h058f715_0.conda
linux-ppc64le::vigra-1.11.1-py39hdab3d78_1048.conda
linux-ppc64le::imagecodecs-2023.9.4-py39h135222f_0.conda
linux-ppc64le::postgresql-plpython-15.4-py38he255f0a_1.conda
linux-ppc64le::openjdk-11.0.20-hf148617_1.conda
linux-ppc64le::aws-sdk-cpp-1.10.57-hffb8590_22.conda
linux-ppc64le::pytables-3.8.0-py39h22b7ba6_3.conda
linux-ppc64le::vtk-base-9.2.6-qt_py310h1234567_214.conda
linux-ppc64le::mosh-1.4.0-pl5321hcf45c83_3.conda
linux-ppc64le::libboost-1.82.0-hfdd0173_3.conda
linux-ppc64le::xrootd-5.6.2-py311hf00abcb_1.conda
linux-ppc64le::vigra-1.11.2-py311h7ec7fd0_0.conda
linux-ppc64le::openjdk-20.0.0-h376f05d_2.conda
linux-ppc64le::python-igraph-0.10.6-py39h3bf30a8_2.conda
linux-ppc64le::pyinstaller-6.0.0-py310h0719273_0.conda
linux-ppc64le::netcdf4-1.6.4-mpi_openmpi_py312hfca56c5_3.conda
linux-ppc64le::tiledb-2.17.1-h4ed4581_0.conda
linux-ppc64le::qt-main-5.15.8-hfc9627c_16.conda
linux-ppc64le::r-base-4.2.3-ha6e4367_8.conda
linux-ppc64le::postgresql-plpython-16.0-py311hba550cb_1.conda
linux-ppc64le::pygame-2.5.2-py39h0c599e8_0.conda
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
================================================================================
================================================================================
linux-aarch64
linux-aarch64::libsolv-0.7.24-hd84c7bf_4.conda
linux-aarch64::liblal-7.3.1-fftw_h22fc402_102.conda
linux-aarch64::gdk-pixbuf-2.42.10-h1db8359_4.conda
linux-aarch64::libsolv-static-0.7.25-hd84c7bf_0.conda
linux-aarch64::openexr-3.2.1-hb924804_0.conda
linux-aarch64::libprotobuf-static-4.23.3-h6b51aa4_1.conda
linux-aarch64::libprotobuf-static-4.23.4-h87e877f_5.conda
linux-aarch64::freetype-2.12.1-hf0a5ef3_2.conda
linux-aarch64::gst-libav-1.22.6-hc4a16bf_0.conda
linux-aarch64::openjpeg-2.5.0-h0d9d63b_3.conda
linux-aarch64::micromamba-1.5.1-0.tar.bz2
linux-aarch64::glib-tools-2.78.0-hd84c7bf_0.conda
linux-aarch64::libmlir-17.0.1-h6acfec4_0.conda
linux-aarch64::hdf4-4.2.15-hb6ba311_7.conda
linux-aarch64::libprotobuf-static-4.23.4-h87e877f_6.conda
linux-aarch64::libprotobuf-4.23.3-h6b51aa4_1.conda
linux-aarch64::libsolv-0.7.25-hd84c7bf_0.conda
linux-aarch64::cudnn-8.8.0.121-h1f32b72_3.conda
linux-aarch64::libprotobuf-static-4.24.3-h87e877f_0.conda
linux-aarch64::libraw-0.21.1-hb6ba311_2.conda
linux-aarch64::libmlir17-17.0.1-h6acfec4_0.conda
linux-aarch64::libsolv-static-0.7.24-hd84c7bf_4.conda
linux-aarch64::tk-8.6.13-h194ca79_0.conda
linux-aarch64::cudnn-8.8.0.121-hc0e3c58_3.conda
linux-aarch64::libprotobuf-4.24.3-h87e877f_0.conda
linux-aarch64::gdk-pixbuf-2.42.10-ha28a4fe_3.conda
linux-aarch64::libprotobuf-4.23.4-h87e877f_6.conda
linux-aarch64::cudnn-8.8.0.121-h9670b63_3.conda
-    "libzlib >=1.2.13,<1.3.0a0"
+    "libzlib >=1.2.13,<2.0.0a0"
linux-aarch64::aws-sdk-cpp-1.11.156-hd27f885_2.conda
linux-aarch64::vigra-1.11.2-py310h78f86d4_0.conda
linux-aarch64::orc-1.9.0-hfcd03c9_2.conda
linux-aarch64::imagecodecs-2023.9.4-py39h3169012_0.conda
linux-aarch64::heyoka-2.0.0-h57bea4f_0.conda
linux-aarch64::heyoka-llvm-14-2.0.0-hc38c2ca_0.conda
linux-aarch64::imagecodecs-2023.9.4-py311h7ed3ca8_0.conda
linux-aarch64::r-base-4.2.3-hf1350d9_9.conda
linux-aarch64::arrow-cpp-9.0.0-py311he887aa8_48_cpu.conda
linux-aarch64::fltk-1.3.8-h5b24465_3.conda
linux-aarch64::pygame-2.5.2-py311h2184b1c_0.conda
linux-aarch64::vtk-base-9.2.6-qt_py311h1234567_213.conda
linux-aarch64::coda-2.25-py39h252d492_1.conda
linux-aarch64::python-igraph-0.10.6-py310h03cc5ac_1.conda
linux-aarch64::openjdk-11.0.20-h565c3cc_0.conda
linux-aarch64::libarrow-10.0.1-h0bf3c04_43_cuda.conda
linux-aarch64::pdal-2.5.6-h67ed07b_2.conda
linux-aarch64::pillow-10.0.1-py310hcb3d0b1_0.conda
linux-aarch64::folly-2023.09.04.00-hdd3c17f_0_jemalloc.conda
linux-aarch64::libarrow-11.0.0-h0bf3c04_39_cuda.conda
linux-aarch64::arrow-cpp-9.0.0-py38h7dccdfc_48_cuda.conda
linux-aarch64::libopencv-4.8.1-py311h8adcad3_0.conda
linux-aarch64::libgdal-arrow-parquet-3.6.4-h6662fbc_16.conda
linux-aarch64::ogre-1.10.12-hb1a949d_14.conda
linux-aarch64::imagecodecs-2023.9.18-py311h2d29a53_0.conda
linux-aarch64::qt6-main-6.5.2-hce9033c_3.conda
linux-aarch64::omniorb-libs-4.3.1-h48ed410_1.conda
linux-aarch64::mapserver-8.0.1-py38h9cb26f9_5.conda
linux-aarch64::mysql-router-8.0.33-hd97bd17_4.conda
linux-aarch64::openbabel-3.1.1-py39h5704ccc_8.conda
linux-aarch64::pygame-2.5.2-py39hf36c5e6_1.conda
linux-aarch64::pyhdf-0.11.3-py39h3ee3c2a_1.conda
linux-aarch64::imagecodecs-2023.9.4-py310h9026c8d_0.conda
linux-aarch64::xrootd-5.6.2-py312haf97bcf_1.conda
linux-aarch64::folly-2023.09.11.00-h8282163_0.conda
linux-aarch64::libarrow-10.0.1-hd78ff56_43_cpu.conda
linux-aarch64::vigra-1.11.2-py38hd6a7194_0.conda
linux-aarch64::tiledb-2.17.0-h2dfc8ae_0.conda
linux-aarch64::mapserver-8.0.1-py39hcb9f1a8_8.conda
linux-aarch64::vigra-1.11.1-py39h17731ed_1047.conda
linux-aarch64::vigra-1.11.1-py39h251b936_1047.conda
linux-aarch64::libarrow-10.0.1-h3d69eca_41_cuda.conda
linux-aarch64::libgdal-3.6.4-hacdf9ff_17.conda
linux-aarch64::xrootd-5.6.2-py39hd868c33_1.conda
linux-aarch64::harp-1.20-py39hf22c6e6_0.conda
linux-aarch64::grpcio-1.58.1-py312hd96c8c9_0.conda
linux-aarch64::curl-8.3.0-h4e8248e_0.conda
linux-aarch64::openjdk-20.0.2-hf79f348_2.conda
linux-aarch64::arrow-cpp-9.0.0-py39h586ccc0_47_cpu.conda
linux-aarch64::libvips-8.14.4-h7a091f4_0.conda
linux-aarch64::netcdf4-1.6.4-nompi_py39h5d0e02b_103.conda
linux-aarch64::pyhdf-0.11.3-py310h196913e_1.conda
linux-aarch64::r-harp-1.20-r43h98456cb_0.conda
linux-aarch64::lxml-4.9.3-py312h107a964_1.conda
linux-aarch64::libarrow-12.0.1-h185fc5d_12_cpu.conda
linux-aarch64::r-harp-1.19-r43h4c30057_1.conda
linux-aarch64::arrow-cpp-9.0.0-py311h450a6ec_47_cpu.conda
linux-aarch64::pygame-2.5.2-py38ha6f1727_1.conda
linux-aarch64::libtiledb-sql-0.25.0-h556e676_0.conda
linux-aarch64::heyoka-2.0.0-he481420_0.conda
linux-aarch64::postgresql-plpython-15.4-py38hf7f31c5_1.conda
linux-aarch64::gst-plugins-good-1.22.5-h8b8d3ca_1.conda
linux-aarch64::libtiff-4.6.0-h360e80f_0.conda
linux-aarch64::postgresql-plpython-15.4-py39he33817a_2.conda
linux-aarch64::libopencv-4.8.1-py38hf779f95_0.conda
linux-aarch64::libarrow-12.0.1-hd78ff56_14_cpu.conda
linux-aarch64::pyhdf-0.11.3-py38h29b6294_1.conda
linux-aarch64::libnetcdf-4.9.2-mpi_mpich_h7df9e21_12.conda
linux-aarch64::openslide-3.4.1-h1229407_10.conda
linux-aarch64::heyoka-llvm-12-2.0.0-h556e612_0.conda
linux-aarch64::folly-2023.09.18.00-hdd3c17f_0_jemalloc.conda
linux-aarch64::pygplates-0.39-py311h1bbd879_9.conda
linux-aarch64::libthrift-0.19.0-h0035360_0.conda
linux-aarch64::libcurl-8.3.0-h4e8248e_0.conda
linux-aarch64::rust-1.72.0-h9d3d833_2.conda
linux-aarch64::octave-8.3.0-h1ece1f5_0.conda
linux-aarch64::heyoka-2.0.0-ha9fcb42_0.conda
linux-aarch64::openpmd-api-0.15.2-mpi_mpich_py39hd6556c9_1.conda
linux-aarch64::postgresql-15.4-he3d1b8e_1.conda
linux-aarch64::openbabel-3.1.1-py312haaa2006_8.conda
linux-aarch64::postgresql-plpython-16.0-py312h75118c5_1.conda
linux-aarch64::vtk-base-9.2.6-qt_py310h1234567_213.conda
linux-aarch64::vtk-base-9.2.6-qt_py38h1234567_213.conda
linux-aarch64::linux-perf-6.3.10-py38h696f14d_1.conda
linux-aarch64::libgdal-3.7.2-h76ee0fe_0.conda
linux-aarch64::xrootd-5.6.2-py38h721d8e5_0.conda
linux-aarch64::lld-17.0.1-h8ef0f76_0.conda
linux-aarch64::netcdf4-1.6.4-mpi_openmpi_py312h3ac0e53_3.conda
linux-aarch64::libopencv-4.8.0-py38h3aef425_3.conda
linux-aarch64::libspatialite-5.1.0-h761fefd_0.conda
linux-aarch64::mapserver-8.0.1-py311had25ec5_5.conda
linux-aarch64::pyinstaller-6.0.0-py310h1aab166_0.conda
linux-aarch64::libgdal-arrow-parquet-3.7.2-h7f838be_4.conda
linux-aarch64::libgdal-arrow-parquet-3.7.2-h4a9e3cd_1.conda
linux-aarch64::libvips-8.14.5-h04eced7_0.conda
linux-aarch64::harp-1.19-py38hb6255c9_1.conda
linux-aarch64::util-linux-2.39.2-py39h493218e_0.conda
linux-aarch64::tiledb-2.16.3-hdb54b9b_3.conda
linux-aarch64::openpmd-api-0.15.2-nompi_py311h818263b_101.conda
linux-aarch64::vigra-1.11.1-py38habc2315_1047.conda
linux-aarch64::vtk-base-9.2.6-qt_py39h1234567_213.conda
linux-aarch64::mapserver-8.0.1-py38h1f13c48_6.conda
linux-aarch64::aws-sdk-cpp-1.11.158-hbc56cf4_0.conda
linux-aarch64::openpmd-api-0.15.2-nompi_py310hd14842b_101.conda
linux-aarch64::ogre-14.1.0-he9b2602_1.conda
linux-aarch64::r-harp-1.19-r43h2e8a8d6_1.conda
linux-aarch64::aws-sdk-cpp-1.11.156-hbc56cf4_0.conda
linux-aarch64::gst-plugins-base-1.22.6-h6d82d15_0.conda
linux-aarch64::util-linux-2.39.2-py311h7022ece_1.conda
linux-aarch64::arrow-cpp-9.0.0-py39hafb7393_49_cuda.conda
linux-aarch64::python-igraph-0.10.6-py38hb651ed9_1.conda
linux-aarch64::libopencv-4.8.0-py311h69dfd39_3.conda
linux-aarch64::qtwebkit-5.212-h303b05c_13.conda
linux-aarch64::imagecodecs-2023.9.4-py39he504e13_2.conda
linux-aarch64::openjdk-17.0.3-hfebe856_9.conda
linux-aarch64::gst-plugins-good-1.22.6-hf2f9846_1.conda
linux-aarch64::libarrow-12.0.1-hb7dbe19_11_cpu.conda
linux-aarch64::libarrow-11.0.0-hd78ff56_38_cpu.conda
linux-aarch64::folly-2023.09.11.00-h81a8a5e_0.conda
linux-aarch64::folly-2023.09.25.00-hbf4f375_0_jemalloc.conda
linux-aarch64::grpcio-1.58.1-py38h95a9722_0.conda
linux-aarch64::coda-2.25-py38h4c30057_0.conda
linux-aarch64::r-base-4.1.3-h142e8b4_11.conda
linux-aarch64::postgresql-plpython-16.0-py310h840c280_1.conda
linux-aarch64::tiledb-2.16.3-h3e6b69a_3.conda
linux-aarch64::ogre-14.1.0-h0169e09_1.conda
linux-aarch64::pygame-2.5.2-py38hfccb3c3_0.conda
linux-aarch64::libarrow-10.0.1-hfd1b322_40_cuda.conda
linux-aarch64::openbabel-3.1.1-py38hcc4b432_8.conda
linux-aarch64::gstlal-1.12.0-py38h9452d73_0.conda
linux-aarch64::imagemagick-7.1.1_18-pl5321h3dc99c5_0.conda
linux-aarch64::openjdk-11.0.15-hfebe856_6.conda
linux-aarch64::libtiledb-sql-0.25.0-h886d7b1_0.conda
linux-aarch64::openjdk-17.0.8-h1a06d65_2.conda
linux-aarch64::vigra-1.11.1-py39hd012815_1048.conda
linux-aarch64::r-base-4.1.3-he200ef1_12.conda
linux-aarch64::freecad-0.21.1-py311hec4543d_0.conda
linux-aarch64::imagecodecs-2023.9.18-py39he504e13_0.conda
linux-aarch64::freeimage-3.18.0-h66dd3b2_16.conda
linux-aarch64::libarrow-11.0.0-h3d69eca_37_cuda.conda
linux-aarch64::vigra-1.11.1-py311hda564ce_1047.conda
linux-aarch64::harp-1.19-py311hdecd9f2_1.conda
linux-aarch64::arrow-cpp-9.0.0-py311heb768df_47_cuda.conda
linux-aarch64::omniorb-4.3.1-py310hae03fa7_1.conda
linux-aarch64::folly-2023.09.04.00-ha9ea14a_0.conda
linux-aarch64::openjdk-20.0.0-h565c3cc_2.conda
linux-aarch64::r-base-4.3.1-h422fad1_5.conda
linux-aarch64::r-harp-1.20-r43hdfebc8f_0.conda
linux-aarch64::libarrow-13.0.0-h9c1a90e_1_cuda.conda
linux-aarch64::libgdal-3.7.2-h01a18aa_2.conda
linux-aarch64::python-igraph-0.10.6-py311h0482bff_2.conda
linux-aarch64::mapserver-8.0.1-py310hddaecaa_5.conda
linux-aarch64::r-harp-1.20-r43h4c30057_0.conda
linux-aarch64::harp-1.20-py39heebcec1_0.conda
linux-aarch64::libopencv-4.8.1-py310hbad3876_0.conda
linux-aarch64::vigra-1.11.1-py38hd6a7194_1048.conda
linux-aarch64::lxml-4.9.3-py39h4de4ef8_1.conda
linux-aarch64::vigra-1.11.1-py310h0bb5053_1047.conda
linux-aarch64::coda-2.24.2-py39hd96fcdd_3.conda
linux-aarch64::gst-plugins-base-1.22.5-h6d82d15_1.conda
linux-aarch64::harp-1.20-py38hb6255c9_0.conda
linux-aarch64::harp-1.20-py311hdecd9f2_0.conda
linux-aarch64::postgresql-plpython-15.4-py310h840c280_1.conda
linux-aarch64::libopencv-4.8.1-py39hb26ba30_0.conda
linux-aarch64::cmake-3.27.5-hef020d8_0.conda
linux-aarch64::geotiff-1.7.1-h57c39b5_12.conda
linux-aarch64::python-igraph-0.10.6-py39h4dec712_2.conda
linux-aarch64::xrootd-5.6.2-py39hd868c33_0.conda
linux-aarch64::openpmd-api-0.15.2-nompi_py39h8acd475_101.conda
linux-aarch64::elfutils-0.189-h682c91b_1.conda
linux-aarch64::geotiff-1.7.1-he43841b_14.conda
linux-aarch64::pillow-10.0.1-py38h7d768ba_1.conda
linux-aarch64::python-igraph-0.10.6-py39h3406a95_1.conda
linux-aarch64::util-linux-2.39.2-py38h24c6ab1_0.conda
linux-aarch64::tiledb-2.16.3-h3e6b69a_2.conda
linux-aarch64::coda-2.25-py39hd96fcdd_0.conda
linux-aarch64::cargo-c-0.9.24-h6a45645_1.conda
linux-aarch64::aws-sdk-cpp-1.11.156-h05a047d_1.conda
linux-aarch64::linux-perf-6.3.10-py311h31656e8_1.conda
linux-aarch64::gst-plugins-good-1.22.6-h8b8d3ca_0.conda
linux-aarch64::libgdal-arrow-parquet-3.6.4-h9b33096_19.conda
linux-aarch64::netcdf4-1.6.4-mpi_openmpi_py310h7bc6f4b_3.conda
linux-aarch64::postgresql-plpython-15.4-py311hc2b6b49_2.conda
linux-aarch64::libarrow-13.0.0-h3d69eca_3_cuda.conda
linux-aarch64::openpmd-api-0.15.2-mpi_mpich_py310h64c8497_1.conda
linux-aarch64::libsoup-3.4.3-h7b0f9e5_0.conda
linux-aarch64::python-igraph-0.10.6-py38h4899f4a_1.conda
linux-aarch64::netcdf4-1.6.4-mpi_mpich_py38h52e48cf_3.conda
linux-aarch64::aws-sdk-cpp-1.11.158-h05a047d_1.conda
linux-aarch64::pytables-3.8.0-py39h6cd1a68_3.conda
linux-aarch64::jaxlib-0.4.14-cpu_py311h7379f6e_1.conda
linux-aarch64::pyinstaller-6.0.0-py38h37f3631_0.conda
linux-aarch64::python-igraph-0.10.6-py39h4dec712_1.conda
linux-aarch64::folly-2023.09.25.00-hdd3c17f_0_jemalloc.conda
linux-aarch64::pytables-3.8.0-py39hca38f38_3.conda
linux-aarch64::vigra-1.11.1-py39h60290f1_1048.conda
linux-aarch64::python-igraph-0.10.8-py310h03cc5ac_0.conda
linux-aarch64::pygame-2.5.2-py311h735aea6_2.conda
linux-aarch64::libvips-8.14.4-h04eced7_1.conda
linux-aarch64::r-base-4.1.3-h7de27ee_11.conda
linux-aarch64::boost-cpp-1.82.0-ha990451_3.conda
linux-aarch64::folly-2023.09.18.00-h81a8a5e_0.conda
linux-aarch64::lxml-4.9.3-py310h4ea8894_1.conda
linux-aarch64::openjdk-11.0.20-h1a06d65_1.conda
linux-aarch64::nodejs-20.8.0-hc1f8a26_0.conda
linux-aarch64::libgdal-arrow-parquet-3.7.2-h5da1d09_0.conda
linux-aarch64::pillow-10.0.0-py39h6ca4121_1.conda
linux-aarch64::mysql-server-8.0.33-h76de21a_3.conda
linux-aarch64::mapserver-8.0.1-py310h40dff11_8.conda
linux-aarch64::tiledb-2.16.3-h6f8c235_2.conda
linux-aarch64::openpmd-api-0.15.2-mpi_mpich_py39h02ac68f_1.conda
linux-aarch64::vigra-1.11.1-py38hba6fa90_1048.conda
linux-aarch64::python-igraph-0.10.8-py39h3406a95_0.conda
linux-aarch64::netcdf4-1.6.4-mpi_openmpi_py311h65ba2fa_3.conda
linux-aarch64::imagecodecs-2023.9.4-py39h3dbbe94_1.conda
linux-aarch64::lxml-4.9.3-py39h03c8186_1.conda
linux-aarch64::pyhdf-0.11.3-py39h292dd60_1.conda
linux-aarch64::libopencv-4.8.0-py310hb7b6b86_3.conda
linux-aarch64::heyoka-llvm-13-2.0.0-h05b4247_0.conda
linux-aarch64::coda-2.24.2-py39hdfebc8f_3.conda
linux-aarch64::libarrow-11.0.0-hb7dbe19_36_cpu.conda
linux-aarch64::netcdf4-1.6.4-nompi_py310h77e224f_103.conda
linux-aarch64::folly-2023.09.11.00-ha9ea14a_0.conda
linux-aarch64::vtk-base-9.2.6-qt_py310h1234567_214.conda
linux-aarch64::vigra-1.11.1-py38h2a801d9_1047.conda
linux-aarch64::pyinstaller-6.0.0-py39hb91f966_0.conda
linux-aarch64::libgd-2.3.3-h71b7332_8.conda
linux-aarch64::python-igraph-0.10.8-py39h4dec712_0.conda
linux-aarch64::assimp-5.3.0-h216a544_0.conda
linux-aarch64::libarrow-10.0.1-h9c1a90e_39_cuda.conda
linux-aarch64::r-base-4.3.1-hbff713c_6.conda
linux-aarch64::mysql-router-8.0.33-hddac939_3.conda
linux-aarch64::libopencv-4.8.0-py39hb26ba30_4.conda
linux-aarch64::lxml-4.9.3-py311h40dcbb3_1.conda
linux-aarch64::arrow-cpp-9.0.0-py310h537a9ec_48_cuda.conda
linux-aarch64::netcdf4-1.6.4-mpi_mpich_py39hfd381cf_3.conda
linux-aarch64::libarrow-11.0.0-hd78ff56_39_cpu.conda
linux-aarch64::tiledb-2.17.0-hdb54b9b_0.conda
linux-aarch64::pdal-2.5.6-h54a7a2a_3.conda
linux-aarch64::netcdf4-1.6.4-nompi_py312h7a984fc_103.conda
linux-aarch64::pygplates-0.39-py39hf74b893_9.conda
linux-aarch64::mapserver-8.0.1-py310h11d67ce_6.conda
linux-aarch64::sdl2_image-2.6.3-habf0803_3.conda
linux-aarch64::xrootd-5.6.2-py38h721d8e5_1.conda
linux-aarch64::mysql-libs-8.0.33-hf629957_3.conda
linux-aarch64::imagemagick-7.1.1_15-pl5321h3dc99c5_1.conda
linux-aarch64::coda-2.25-py39hdfebc8f_0.conda
linux-aarch64::pygame-2.5.2-py310hdb26448_0.conda
linux-aarch64::libarrow-12.0.1-h9c1a90e_10_cuda.conda
linux-aarch64::omniorb-4.3.1-py311h9b119e1_1.conda
linux-aarch64::folly-2023.09.18.00-h8282163_0.conda
linux-aarch64::libarrow-11.0.0-hf79fbb4_35_cpu.conda
linux-aarch64::postgresql-plpython-16.0-py38hf7f31c5_0.conda
linux-aarch64::vigra-1.11.1-py38hfeb9921_1047.conda
linux-aarch64::blosc-1.21.5-h2f3a684_0.conda
linux-aarch64::pytables-3.8.0-py311h9a8bc71_3.conda
linux-aarch64::glibmm-2.68-2.78.0-h6dbd646_0.conda
linux-aarch64::arrow-cpp-9.0.0-py38h69e2d34_49_cpu.conda
linux-aarch64::boost-cpp-1.82.0-h62f3a30_2.conda
linux-aarch64::libarrow-10.0.1-h0bf3c04_42_cuda.conda
linux-aarch64::util-linux-2.39.2-py310hbe9cfeb_1.conda
linux-aarch64::arrow-cpp-9.0.0-py39h877d208_48_cpu.conda
linux-aarch64::mosh-1.4.0-pl5321h2240523_3.conda
linux-aarch64::openpmd-api-0.15.2-mpi_openmpi_py39h7246c96_1.conda
linux-aarch64::libopentelemetry-cpp-1.11.0-hcf906a2_1.conda
linux-aarch64::pygame-2.5.2-py39hb21a50a_2.conda
linux-aarch64::freecad-0.21.1-py39h3025885_0.conda
linux-aarch64::libgdal-3.7.2-hae732e9_1.conda
linux-aarch64::libpq-15.4-h04b8c23_2.conda
linux-aarch64::r-harp-1.19-r43hdfebc8f_1.conda
linux-aarch64::xrootd-5.6.2-py39hb80c9a1_0.conda
linux-aarch64::tiledb-2.17.1-h3e6b69a_0.conda
linux-aarch64::jaxlib-0.4.14-cpu_py310he465324_1.conda
linux-aarch64::postgresql-16.0-he3d1b8e_1.conda
linux-aarch64::pyhdf-0.11.3-py311h3c0e0ee_1.conda
linux-aarch64::harp-1.19-py39heebcec1_1.conda
linux-aarch64::pillow-10.0.1-py39h6ca4121_1.conda
linux-aarch64::util-linux-2.39.2-py311h7022ece_0.conda
linux-aarch64::libarrow-11.0.0-h0bf3c04_38_cuda.conda
linux-aarch64::coda-2.24.2-py310h98456cb_3.conda
linux-aarch64::postgresql-plpython-16.0-py39he33817a_1.conda
linux-aarch64::postgresql-plpython-15.4-py38hf7f31c5_2.conda
linux-aarch64::imagecodecs-2023.9.18-py310h12c7303_0.conda
linux-aarch64::netcdf4-1.6.4-nompi_py38hfe05524_103.conda
linux-aarch64::libopencv-4.8.0-py38hf779f95_4.conda
linux-aarch64::openjdk-17.0.8-h565c3cc_0.conda
linux-aarch64::pygame-2.5.2-py310h8dd59aa_2.conda
linux-aarch64::octave-8.2.0-h1ece1f5_2.conda
linux-aarch64::heyoka-llvm-15-2.0.0-ha13bee3_0.conda
linux-aarch64::pygame-2.5.2-py311h735aea6_1.conda
linux-aarch64::omniorb-4.3.1-py38hc9c3f1f_1.conda
linux-aarch64::util-linux-2.39.2-py312h5ae9330_1.conda
linux-aarch64::libarrow-12.0.1-hd78ff56_13_cpu.conda
linux-aarch64::openslide-3.4.1-hed5e51a_11.conda
linux-aarch64::libarrow-12.0.1-h0bf3c04_13_cuda.conda
linux-aarch64::omniorb-4.3.1-py312h89a05d2_1.conda
linux-aarch64::folly-2023.09.11.00-h7fcaec2_0_jemalloc.conda
linux-aarch64::pygame-2.5.2-py38ha6f1727_2.conda
linux-aarch64::openjdk-11.0.20-hac580f4_3.conda
linux-aarch64::aws-sdk-cpp-1.10.57-hd77d7f3_23.conda
linux-aarch64::minizip-4.0.1-hb75dd74_3.conda
linux-aarch64::vtk-base-9.2.6-qt_py311h1234567_214.conda
linux-aarch64::geotiff-1.7.1-h442b36f_13.conda
linux-aarch64::pillow-10.0.1-py311hc7b0cab_0.conda
linux-aarch64::coda-2.25-py38hd131ec7_1.conda
linux-aarch64::openjdk-17.0.8-hac580f4_3.conda
linux-aarch64::heyoka-2.0.0-h73675cb_0.conda
linux-aarch64::vigra-1.11.2-py39h806c46c_0.conda
linux-aarch64::mapserver-8.0.1-py39hb94bc9a_7.conda
linux-aarch64::arrow-cpp-9.0.0-py38hd866e4c_47_cpu.conda
linux-aarch64::aws-sdk-cpp-1.11.156-haa02287_3.conda
linux-aarch64::libtiff-4.6.0-hffba272_1.conda
linux-aarch64::libarrow-13.0.0-h0bf3c04_4_cuda.conda
linux-aarch64::postgresql-plpython-15.4-py39he33817a_1.conda
linux-aarch64::pytables-3.8.0-py310h6e51920_3.conda
linux-aarch64::grpcio-1.58.1-py39h483cef1_0.conda
linux-aarch64::pytables-3.8.0-py38h8b086c5_3.conda
linux-aarch64::libarrow-13.0.0-h0bf3c04_5_cuda.conda
linux-aarch64::pyinstaller-6.0.0-py311h0dd4530_1.conda
linux-aarch64::libpq-16.0-h04b8c23_0.conda
linux-aarch64::postgresql-plpython-16.0-py311hc2b6b49_0.conda
linux-aarch64::pygame-2.5.2-py39hb769c03_0.conda
linux-aarch64::cmake-3.27.6-hef020d8_0.conda
linux-aarch64::arrow-cpp-9.0.0-py310h45ca14c_47_cuda.conda
linux-aarch64::glib-2.78.0-hd84c7bf_0.conda
linux-aarch64::graphicsmagick-1.3.40-h8d545bc_3.conda
linux-aarch64::coda-2.25-py311h2e8a8d6_0.conda
linux-aarch64::libopencv-4.8.0-py39h5d1fa7c_4.conda
linux-aarch64::postgresql-plpython-15.4-py312h75118c5_2.conda
linux-aarch64::symengine-0.11.1-hee1fd3f_0.conda
linux-aarch64::pyinstaller-6.0.0-py39hb91f966_1.conda
linux-aarch64::vtk-base-9.2.6-qt_py38h1234567_214.conda
linux-aarch64::tiledb-2.16.3-h2dfc8ae_3.conda
linux-aarch64::util-linux-2.39.2-py310hbe9cfeb_0.conda
linux-aarch64::arrow-cpp-9.0.0-py310h6dbed4d_49_cpu.conda
linux-aarch64::gst-plugins-base-1.22.6-h6d82d15_1.conda
linux-aarch64::pillow-10.0.1-py39h6ca4121_0.conda
linux-aarch64::libllvm17-17.0.1-h70e38ee_0.conda
linux-aarch64::openpmd-api-0.15.2-mpi_mpich_py38h661bfae_1.conda
linux-aarch64::libopencv-4.8.0-py310hbad3876_4.conda
linux-aarch64::tiledb-2.17.0-h3e6b69a_0.conda
linux-aarch64::xrootd-5.6.2-py310h0685b57_1.conda
linux-aarch64::arrow-cpp-9.0.0-py311h71823b2_48_cuda.conda
linux-aarch64::folly-2023.09.25.00-ha9ea14a_0.conda
linux-aarch64::tiledb-2.17.0-hddb64f1_1.conda
linux-aarch64::qt6-main-6.5.2-hd39fcfc_4.conda
linux-aarch64::libboost-1.82.0-h133f18d_3.conda
linux-aarch64::postgresql-16.0-he3d1b8e_0.conda
linux-aarch64::openpmd-api-0.15.2-mpi_openmpi_py39h7472676_1.conda
linux-aarch64::pyhdf-0.11.3-py312h96846e4_1.conda
linux-aarch64::vigra-1.11.2-py39hd6e7c08_0.conda
linux-aarch64::openbabel-3.1.1-py310h5178cfb_8.conda
linux-aarch64::grpcio-1.58.1-py310h20b6881_0.conda
linux-aarch64::vigra-1.11.1-py310h78f86d4_1048.conda
linux-aarch64::arrow-cpp-9.0.0-py311h107fe59_49_cpu.conda
linux-aarch64::gstlal-1.12.0-py39h9f00e99_0.conda
linux-aarch64::r-harp-1.20-r43hd96fcdd_0.conda
linux-aarch64::ogre-14.1.0-hb41cdfc_0.conda
linux-aarch64::postgresql-plpython-15.4-py310h840c280_2.conda
linux-aarch64::openpmd-api-0.15.2-nompi_py39h7fa5be0_101.conda
linux-aarch64::nodejs-20.6.1-hc1f8a26_0.conda
linux-aarch64::libopencv-4.8.0-py311hf177792_2.conda
linux-aarch64::arrow-cpp-9.0.0-py310h1372826_49_cuda.conda
linux-aarch64::postgresql-plpython-16.0-py38hf7f31c5_1.conda
linux-aarch64::grpcio-1.57.0-py312hd96c8c9_1.conda
linux-aarch64::netcdf4-1.6.4-mpi_mpich_py312hea60785_3.conda
linux-aarch64::folly-2023.09.25.00-h81a8a5e_0.conda
linux-aarch64::python-3.12.0rc3-rc3_h43d1f9e_1_cpython.conda
linux-aarch64::libgdal-arrow-parquet-3.7.2-hee44dd1_3.conda
linux-aarch64::pygplates-0.39-py38h12115ce_9.conda
linux-aarch64::imagemagick-7.1.1_17-pl5321h3dc99c5_0.conda
linux-aarch64::nodejs-20.6.0-hc1f8a26_0.conda
linux-aarch64::heyoka-2.0.0-h7328b17_0.conda
linux-aarch64::pillow-10.0.1-py311hc7b0cab_1.conda
linux-aarch64::libopencv-4.8.0-py311h8adcad3_4.conda
linux-aarch64::folly-2023.09.25.00-h7fcaec2_0_jemalloc.conda
linux-aarch64::gst-plugins-bad-1.22.6-hb0ba0b1_0.conda
linux-aarch64::qt6-3d-6.5.2-habd9576_1.conda
linux-aarch64::mapserver-8.0.1-py39h718e4f5_5.conda
linux-aarch64::vigra-1.11.1-py39h2fc5b2a_1047.conda
linux-aarch64::sdl2_image-2.6.3-h4267f4e_4.conda
linux-aarch64::arrow-cpp-9.0.0-py39h00e098b_48_cuda.conda
linux-aarch64::fltk-1.3.8-he871f2f_2.conda
linux-aarch64::libarrow-13.0.0-hfd1b322_2_cuda.conda
linux-aarch64::aws-sdk-cpp-1.10.57-h05a047d_22.conda
linux-aarch64::libnetcdf-4.9.2-mpi_openmpi_h05560af_12.conda
linux-aarch64::heyoka-2.0.0-h93c5217_0.conda
linux-aarch64::python-igraph-0.10.6-py310h03cc5ac_2.conda
linux-aarch64::libarrow-13.0.0-h185fc5d_3_cpu.conda
linux-aarch64::python-igraph-0.10.6-py311h0482bff_1.conda
linux-aarch64::mold-2.2.0-h2d6341c_0.conda
linux-aarch64::folly-2023.09.04.00-hbf4f375_0_jemalloc.conda
linux-aarch64::libgrpc-1.58.1-hb1224e5_0.conda
linux-aarch64::openjdk-11.0.15-h0dd39bf_5.conda
linux-aarch64::folly-2023.09.11.00-hbf4f375_0_jemalloc.conda
linux-aarch64::openpmd-api-0.15.2-mpi_openmpi_py38hd528744_1.conda
linux-aarch64::irrlicht-1.8.5-h962fdfd_4.conda
linux-aarch64::vigra-1.11.1-py310hdc69fce_1047.conda
linux-aarch64::r-base-4.2.3-h5191585_8.conda
linux-aarch64::mysql-client-8.0.33-h88b4a5d_3.conda
linux-aarch64::nodejs-20.7.0-hc1f8a26_0.conda
linux-aarch64::postgresql-15.4-he3d1b8e_2.conda
linux-aarch64::libarrow-10.0.1-hd78ff56_42_cpu.conda
linux-aarch64::pillow-10.0.1-py310hcb3d0b1_1.conda
linux-aarch64::libarrow-12.0.1-hf79fbb4_10_cpu.conda
linux-aarch64::openpmd-api-0.15.2-nompi_py38hff2ea3c_101.conda
linux-aarch64::pillow-10.0.1-py38h7d768ba_0.conda
linux-aarch64::qt6-main-6.5.2-h3c13d10_2.conda
linux-aarch64::libarrow-11.0.0-h185fc5d_37_cpu.conda
linux-aarch64::libarrow-12.0.1-hfd1b322_11_cuda.conda
linux-aarch64::pillow-10.0.0-py310hcb3d0b1_1.conda
linux-aarch64::mold-2.1.0-h2d6341c_2.conda
linux-aarch64::imagecodecs-2023.9.4-py39h8c3e54e_2.conda
linux-aarch64::mapserver-8.0.1-py310hcf1365d_7.conda
linux-aarch64::pillow-10.0.1-py39he56f5ac_0.conda
linux-aarch64::python-igraph-0.10.8-py38h4899f4a_0.conda
linux-aarch64::coda-2.24.2-py311h2e8a8d6_3.conda
linux-aarch64::pillow-10.0.0-py39he56f5ac_1.conda
linux-aarch64::r-base-4.3.1-h559ac27_4.conda
linux-aarch64::libarrow-13.0.0-hb7dbe19_2_cpu.conda
linux-aarch64::python-igraph-0.10.8-py311h0482bff_0.conda
linux-aarch64::libopencv-4.8.0-py39h22fa6a3_3.conda
linux-aarch64::mapserver-8.0.1-py38h83b9851_8.conda
linux-aarch64::libopencv-4.8.1-py39h5d1fa7c_0.conda
linux-aarch64::cpp-opentelemetry-sdk-1.11.0-hcf906a2_1.conda
linux-aarch64::openpmd-api-0.15.2-mpi_mpich_py38he568268_1.conda
linux-aarch64::assimp-5.3.1-h216a544_1.conda
linux-aarch64::heyoka-llvm-16-2.0.0-h00d4f47_0.conda
linux-aarch64::imagecodecs-2023.9.4-py310he53b6be_1.conda
linux-aarch64::folly-2023.09.18.00-h7fcaec2_0_jemalloc.conda
linux-aarch64::r-harp-1.19-r43hd96fcdd_1.conda
linux-aarch64::libgdal-arrow-parquet-3.7.2-h1e831b9_2.conda
linux-aarch64::openjdk-17.0.8-h1a06d65_1.conda
linux-aarch64::vigra-1.11.2-py39h60290f1_0.conda
linux-aarch64::ogre-14.0.1-hb41cdfc_2.conda
linux-aarch64::llvm-tools-17.0.1-h70e38ee_0.conda
linux-aarch64::vigra-1.11.1-py311h6e6ad09_1048.conda
linux-aarch64::netcdf4-1.6.4-mpi_mpich_py311h26533c6_3.conda
linux-aarch64::nco-5.1.8-h2866247_0.conda
linux-aarch64::openjdk-11.0.20-h1a06d65_2.conda
linux-aarch64::openjdk-20.0.2-h565c3cc_1.conda
linux-aarch64::sdl_image-1.2.12-he187726_5.conda
linux-aarch64::libzip-1.10.1-h4156a30_2.conda
linux-aarch64::libarchive-minimal-static-3.7.2-h66cf738_0.conda
linux-aarch64::libarrow-12.0.1-h0bf3c04_14_cuda.conda
linux-aarch64::tiledb-2.16.3-hdb54b9b_2.conda
linux-aarch64::arrow-cpp-9.0.0-py310h0195b76_47_cpu.conda
linux-aarch64::vigra-1.11.1-py39hd6e7c08_1048.conda
linux-aarch64::vigra-1.11.2-py39hd012815_0.conda
linux-aarch64::folly-2023.09.25.00-h8282163_0.conda
linux-aarch64::vigra-1.11.1-py38hb6cea30_1047.conda
linux-aarch64::xrootd-5.6.2-py39hb80c9a1_1.conda
linux-aarch64::libopencv-4.8.0-py310h469dd53_2.conda
linux-aarch64::llvmdev-17.0.1-h70e38ee_0.conda
linux-aarch64::xrootd-5.6.2-py311h2e88512_1.conda
linux-aarch64::xrootd-5.6.2-py311h2e88512_0.conda
linux-aarch64::qt-main-5.15.8-h8e8b9a1_16.conda
linux-aarch64::mapserver-8.0.1-py311he998a03_7.conda
linux-aarch64::llvm-17.0.1-h5271726_0.conda
linux-aarch64::openpmd-api-0.15.2-mpi_mpich_py311h81d8e69_1.conda
linux-aarch64::libarrow-10.0.1-h185fc5d_41_cpu.conda
linux-aarch64::vigra-1.11.1-py311hdbc613f_1048.conda
linux-aarch64::sdl2_image-2.6.3-h03dcf29_2.conda
linux-aarch64::pytables-3.8.0-py38h4276b41_3.conda
linux-aarch64::mysql-libs-8.0.33-hf629957_4.conda
linux-aarch64::linux-perf-6.3.10-py39hc5e4ac8_1.conda
linux-aarch64::pyinstaller-6.0.0-py311h0dd4530_0.conda
linux-aarch64::yarp-cxx-3.8.1-h23beb4f_5.conda
linux-aarch64::libcurl-static-8.3.0-h4e8248e_0.conda
linux-aarch64::util-linux-2.39.2-py39h493218e_1.conda
linux-aarch64::openpmd-api-0.15.2-mpi_openmpi_py310h2ee61f2_1.conda
linux-aarch64::poppler-23.08.0-h6ca75e7_1.conda
linux-aarch64::arrow-cpp-9.0.0-py310h4e8aae4_48_cpu.conda
linux-aarch64::folly-2023.09.04.00-h8282163_0.conda
linux-aarch64::jaxlib-0.4.14-cpu_py39he660426_1.conda
linux-aarch64::freecad-0.21.1-py38h47f2513_0.conda
linux-aarch64::libpulsar-3.2.0-hebb6a55_3.conda
linux-aarch64::libarrow-13.0.0-hd78ff56_5_cpu.conda
linux-aarch64::pillow-10.0.1-py39he56f5ac_1.conda
linux-aarch64::arrow-cpp-9.0.0-py39h628bb00_47_cuda.conda
linux-aarch64::libopencv-4.8.0-py39hc83264c_2.conda
linux-aarch64::postgresql-plpython-16.0-py310h840c280_0.conda
linux-aarch64::folly-2023.09.04.00-h7fcaec2_0_jemalloc.conda
linux-aarch64::imagecodecs-2023.9.4-py311h444d741_1.conda
linux-aarch64::imagecodecs-2023.9.4-py39hbe0f1af_0.conda
linux-aarch64::fltk-1.3.8-h55f38b5_1.conda
linux-aarch64::imagecodecs-2023.9.4-py311h2d29a53_2.conda
linux-aarch64::pygame-2.5.2-py39hb21a50a_1.conda
linux-aarch64::arrow-cpp-9.0.0-py38hdca3148_48_cpu.conda
linux-aarch64::imagecodecs-2023.9.18-py39h8c3e54e_0.conda
linux-aarch64::libpq-16.0-h04b8c23_1.conda
linux-aarch64::libgdal-3.7.2-h6858a25_3.conda
linux-aarch64::libnetcdf-4.9.2-nompi_hc188a27_112.conda
linux-aarch64::tiledb-2.17.1-hdb54b9b_0.conda
linux-aarch64::xrootd-5.6.2-py310h0685b57_0.conda
linux-aarch64::openpmd-api-0.15.2-mpi_openmpi_py311ha822e1d_1.conda
linux-aarch64::pygplates-0.39-py310he1dc2de_9.conda
linux-aarch64::pyinstaller-6.0.0-py310h1aab166_1.conda
linux-aarch64::arrow-cpp-9.0.0-py39h01a2916_49_cpu.conda
linux-aarch64::libarchive-3.7.2-h566b526_0.conda
linux-aarch64::lxml-4.9.3-py38h38730af_1.conda
linux-aarch64::vigra-1.11.2-py311hdbc613f_0.conda
linux-aarch64::util-linux-2.39.2-py38h24c6ab1_1.conda
linux-aarch64::vigra-1.11.1-py311h74d3d56_1047.conda
linux-aarch64::arrow-cpp-9.0.0-py311h33278f8_49_cuda.conda
linux-aarch64::minizip-4.0.1-hb75dd74_2.conda
linux-aarch64::libgdal-3.6.4-h434d93f_16.conda
linux-aarch64::libzip-1.10.1-h4156a30_3.conda
linux-aarch64::coda-2.25-py311hc8f05bd_1.conda
linux-aarch64::libopencv-4.8.0-py38hd818d72_2.conda
linux-aarch64::glib-networking-2.78.0-h2c27fa9_0.conda
linux-aarch64::mysql-client-8.0.33-h88b4a5d_4.conda
linux-aarch64::coda-2.24.2-py38h4c30057_3.conda
linux-aarch64::linux-perf-6.3.10-py312h5f80588_1.conda
linux-aarch64::arrow-cpp-9.0.0-py38h993b86a_49_cuda.conda
linux-aarch64::mesalib-23.2.1-h5f6ae44_0.conda
linux-aarch64::mapserver-8.0.1-py311hc002f0f_6.conda
linux-aarch64::r-harp-1.19-r43h98456cb_1.conda
linux-aarch64::libarrow-10.0.1-hf79fbb4_39_cpu.conda
linux-aarch64::libgdal-3.7.2-h52108d7_4.conda
linux-aarch64::libgdal-3.6.4-hc73c54a_19.conda
linux-aarch64::libgdal-3.6.4-h9662bd9_18.conda
linux-aarch64::util-linux-2.39.2-py39hb670eeb_1.conda
linux-aarch64::libpq-15.4-h04b8c23_1.conda
linux-aarch64::libthrift-0.19.0-h043aeee_1.conda
linux-aarch64::wxwidgets-3.2.2.1-h6541cd0_5.conda
linux-aarch64::qt-webengine-5.15.8-h4d62b09_3.conda
linux-aarch64::netcdf4-1.6.4-mpi_openmpi_py39h61f5a0f_3.conda
linux-aarch64::folly-2023.09.18.00-hbf4f375_0_jemalloc.conda
linux-aarch64::pillow-10.0.0-py311hc7b0cab_1.conda
linux-aarch64::omniorb-4.3.1-py39h86dfdcc_1.conda
linux-aarch64::wxwidgets-3.2.2.1-h1f7e432_4.conda
linux-aarch64::pyinstaller-6.0.0-py38h37f3631_1.conda
linux-aarch64::poppler-qt-23.08.0-h71cb2cc_1.conda
linux-aarch64::rust-1.72.1-h9d3d833_0.conda
linux-aarch64::libopencv-4.8.0-py39h6d7ab7e_2.conda
linux-aarch64::netcdf4-1.6.4-nompi_py311hcd50196_103.conda
linux-aarch64::folly-2023.09.11.00-hdd3c17f_0_jemalloc.conda
linux-aarch64::coda-2.25-py310h98456cb_0.conda
linux-aarch64::libarrow-13.0.0-hd78ff56_4_cpu.conda
linux-aarch64::pygame-2.5.2-py310h8dd59aa_1.conda
linux-aarch64::openpmd-api-0.15.2-mpi_openmpi_py38h3e7efc2_1.conda
linux-aarch64::thrift-compiler-0.19.0-h0035360_0.conda
linux-aarch64::vigra-1.11.2-py311h6e6ad09_0.conda
linux-aarch64::poppler-23.08.0-hf3d3125_2.conda
linux-aarch64::arrow-cpp-9.0.0-py38ha50e4a8_47_cuda.conda
linux-aarch64::linux-perf-6.3.10-py310h2bd01cc_1.conda
linux-aarch64::libarrow-11.0.0-h9c1a90e_35_cuda.conda
linux-aarch64::libgdal-arrow-parquet-3.6.4-h006daaf_17.conda
linux-aarch64::minizip-4.0.1-hb75dd74_4.conda
linux-aarch64::vigra-1.11.1-py39h806c46c_1048.conda
linux-aarch64::python-igraph-0.10.6-py38h4899f4a_2.conda
linux-aarch64::pygame-2.5.2-py39h2cc5182_0.conda
linux-aarch64::r-harp-1.20-r43h2e8a8d6_0.conda
linux-aarch64::imagemagick-7.1.1_16-pl5321h3dc99c5_0.conda
linux-aarch64::mysql-server-8.0.33-h2982995_4.conda
linux-aarch64::vtk-base-9.2.6-qt_py39h1234567_214.conda
linux-aarch64::vigra-1.11.2-py310hff2cf2b_0.conda
linux-aarch64::ogre-1.10.12-hb1a949d_13.conda
linux-aarch64::imagecodecs-2023.9.4-py39h783c784_1.conda
linux-aarch64::mapserver-8.0.1-py39hef4faee_6.conda
linux-aarch64::netcdf4-1.6.4-mpi_openmpi_py38h7813e94_3.conda
linux-aarch64::util-linux-2.39.2-py39hb670eeb_0.conda
linux-aarch64::pygame-2.5.2-py312haaa83e4_2.conda
linux-aarch64::postgresql-plpython-15.4-py311hc2b6b49_1.conda
linux-aarch64::libglib-2.78.0-h0464669_0.conda
linux-aarch64::postgresql-plpython-16.0-py39he33817a_0.conda
linux-aarch64::libzip-1.10.1-h4156a30_1.conda
linux-aarch64::openjdk-11.0.15-h565c3cc_7.conda
linux-aarch64::harp-1.20-py310he520163_0.conda
linux-aarch64::libtiff-4.6.0-h1708d11_2.conda
linux-aarch64::harp-1.19-py310he520163_1.conda
linux-aarch64::imagecodecs-2023.9.4-py310h12c7303_2.conda
linux-aarch64::libarrow-10.0.1-hb7dbe19_40_cpu.conda
linux-aarch64::vigra-1.11.1-py310hff2cf2b_1048.conda
linux-aarch64::heyoka-llvm-11-2.0.0-h5bb46a5_0.conda
linux-aarch64::libgdal-arrow-parquet-3.6.4-h54108b9_18.conda
linux-aarch64::gstlal-1.12.0-py310hc7e2d12_0.conda
linux-aarch64::vigra-1.11.1-py39hd26fd6b_1047.conda
linux-aarch64::tiledb-2.17.1-h2dfc8ae_0.conda
linux-aarch64::openjdk-20.0.2-h565c3cc_0.conda
linux-aarch64::nco-5.1.7-h2866247_1.conda
linux-aarch64::minizip-4.0.1-hb75dd74_1.conda
linux-aarch64::openbabel-3.1.1-py311hf02cd11_8.conda
linux-aarch64::harp-1.19-py39hf22c6e6_1.conda
linux-aarch64::mapserver-8.0.1-py311h8d8dd12_8.conda
linux-aarch64::libarrow-11.0.0-hfd1b322_36_cuda.conda
linux-aarch64::coda-2.25-py310h96bca1b_1.conda
linux-aarch64::qt6-main-6.5.2-h675fc9d_1.conda
linux-aarch64::pillow-10.0.0-py38h7d768ba_1.conda
linux-aarch64::gstlal-1.12.0-py311ha13c55a_0.conda
linux-aarch64::libarrow-13.0.0-hf79fbb4_1_cpu.conda
linux-aarch64::libopencv-4.8.0-py39h077294e_3.conda
linux-aarch64::postgresql-plpython-16.0-py311hc2b6b49_1.conda
linux-aarch64::mapserver-8.0.1-py38hf8ba6d4_7.conda
linux-aarch64::openpmd-api-0.15.2-nompi_py38ha7557c4_101.conda
linux-aarch64::netcdf4-1.6.4-mpi_mpich_py310h84864ae_3.conda
linux-aarch64::vigra-1.11.2-py38hba6fa90_0.conda
linux-aarch64::r-base-4.3.1-h763ebdd_4.conda
linux-aarch64::libboost-1.82.0-hbfc56d7_2.conda
linux-aarch64::pygame-2.5.2-py39hf36c5e6_2.conda
linux-aarch64::grpcio-1.58.1-py311h1a7908d_0.conda
linux-aarch64::libarrow-12.0.1-h3d69eca_12_cuda.conda
linux-aarch64::tiledb-2.17.0-hc0eaa86_1.conda
linux-aarch64::mlir-17.0.1-h6acfec4_0.conda
linux-aarch64::folly-2023.09.18.00-ha9ea14a_0.conda
linux-aarch64::libspatialite-5.0.1-h761fefd_29.conda
linux-aarch64::python-igraph-0.10.6-py39h3406a95_2.conda
linux-aarch64::coda-2.25-py39h7f8485b_1.conda
linux-aarch64::tiledb-2.17.0-h886cfdf_1.conda
linux-aarch64::folly-2023.09.04.00-h81a8a5e_0.conda
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
================================================================================
================================================================================
noarch
================================================================================
================================================================================
win-64
win-64::grpcio-1.58.1-py312h7894644_0.conda
win-64::libsolv-static-0.7.25-h12be248_0.conda
win-64::mysql-client-8.0.33-hed9f4ee_3.conda
win-64::ogre-14.1.0-h40007f7_0.conda
win-64::lfortran-0.20.3-h12be248_1.conda
win-64::imagecodecs-2023.9.4-py311ha37d076_2.conda
win-64::openbabel-3.1.1-py311hf54676f_8.conda
win-64::libopencv-4.8.0-py38hfece3f9_3.conda
win-64::libgdal-3.6.4-h395bf9d_19.conda
win-64::pygame-2.5.2-py38h402e528_1.conda
win-64::python-igraph-0.10.6-py39he170af6_2.conda
win-64::libuwebsockets-20.46.0-h12be248_0.conda
win-64::pygame-2.5.2-py39h10a7b85_0.conda
win-64::openexr-python-1.3.9-py311h621f010_2.conda
win-64::hugin-base-2022.0.0-pl5321h370be35_6.conda
win-64::arrow-cpp-9.0.0-py39hd9dfb59_49_cuda.conda
win-64::libarrow-13.0.0-h262543f_1_cuda.conda
win-64::stir-5.1.0-cpu_py39h1deee1a_11.conda
win-64::stir-5.1.2-cuda112_py38h3f84f4e_201.conda
win-64::geotiff-1.7.1-h2b13f92_12.conda
win-64::openexr-python-1.3.9-py310hd4bcbf3_2.conda
win-64::ogre-14.0.1-h40007f7_2.conda
win-64::imagecodecs-2023.9.4-py39h2853370_1.conda
win-64::vtk-base-9.2.6-qt_py38h1234567_213.conda
win-64::openbabel-3.1.1-py312h4832802_8.conda
win-64::heyoka-llvm-13-2.0.0-hf53a8f2_0.conda
win-64::libarrow-12.0.1-hdb90ae5_14_cuda.conda
win-64::postgresql-15.4-hc80876b_2.conda
win-64::pypy3.8-7.3.11-h577050a_4.conda
win-64::arrow-cpp-9.0.0-py311h2cdbfb4_47_cpu.conda
win-64::openpmd-api-0.15.2-nompi_py38h69afc8b_101.conda
win-64::intel-opencl-rt-2023.2.0-hb43f91c_49500.conda
win-64::curl-8.3.0-hd5e4a3a_0.conda
win-64::libsolv-0.7.24-h12be248_4.conda
win-64::aws-sdk-cpp-1.11.156-h02852bd_3.conda
win-64::thrift-compiler-0.19.0-h06f6336_0.conda
win-64::openexr-python-1.3.9-py39he59fe5d_2.conda
win-64::sdl_image-1.2.12-h1e80787_5.conda
win-64::vigra-1.11.1-py310h9eb0d7a_1048.conda
win-64::tiledb-2.16.3-h1ffc264_3.conda
win-64::imagecodecs-2023.9.4-py39h928383b_1.conda
win-64::openvdb-10.0.1-py39h8e79b00_6.conda
win-64::stir-5.1.2-cpu_py311hf7a2716_0.conda
win-64::paraview-5.11.2-py310hd0c7be8_102_qt.conda
win-64::vtk-base-9.2.6-qt_py310h1234567_214.conda
win-64::mysql-server-8.0.33-h1295d25_4.conda
win-64::arrow-cpp-9.0.0-py39h4762a0c_49_cpu.conda
win-64::poppler-23.08.0-ha2b368b_2.conda
win-64::polycap-1.2-py312h357c9af_4.conda
win-64::openexr-python-1.3.9-py39h41fd299_2.conda
win-64::openvdb-10.0.1-py310h0562cec_3.conda
win-64::py-bgzip-0.4.0-py312h3bd2d22_4.conda
win-64::py-bgzip-0.4.0-py311h12e69fa_4.conda
win-64::gtk4-4.12.1-h6f7364b_2.conda
win-64::mysql-router-8.0.33-hc10b068_4.conda
win-64::stir-5.1.2-cuda112_py39h456d3e6_201.conda
win-64::sdl2_image-2.6.3-hf506939_2.conda
win-64::vigra-1.11.1-py38h2b47064_1047.conda
win-64::vigra-1.11.1-py38h04759a5_1047.conda
win-64::minizip-4.0.1-h5bed578_3.conda
win-64::libthrift-0.19.0-ha2b3283_1.conda
win-64::postgresql-plpython-15.4-py310hf838413_1.conda
win-64::pytables-3.8.0-py311heec7198_3.conda
win-64::intel-opencl-rt-2023.2.0-hb43f91c_49498.conda
win-64::omniorb-4.3.1-py39hd2c3553_1.conda
win-64::stir-5.1.2-cpu_py310h05295b1_1.conda
win-64::sdl2_image-2.6.3-he19da31_4.conda
win-64::stir-5.1.1-cuda118_py310h36d4a96_200.conda
win-64::heyoka-llvm-16-2.0.0-h3682df2_0.conda
win-64::pypy3.8-7.3.11-h577050a_5.conda
win-64::pygame-2.5.2-py310hc90abf7_1.conda
win-64::cmake-3.27.5-hf0feee3_0.conda
win-64::libgdal-3.7.2-hd1558ed_2.conda
win-64::libgdal-3.7.2-hfa9c32d_3.conda
win-64::tiledb-2.17.0-hb5f07cc_1.conda
win-64::vigra-1.11.1-py39h4888c6c_1047.conda
win-64::libprotobuf-4.23.3-h1975477_1.conda
win-64::pillow-10.0.1-py38h5c6e75c_0.conda
win-64::pygame-2.5.2-py38h402e528_2.conda
win-64::libarrow-11.0.0-h58a770d_38_cpu.conda
win-64::openexr-python-1.3.9-py312h6975700_3.conda
win-64::r-harp-1.20-r41h6dd871f_0.conda
win-64::vigra-1.11.1-py310h59b976c_1048.conda
win-64::python-igraph-0.10.6-py38h5697605_1.conda
win-64::pyhdk-0.8.0-py311h1234567_0_cpu.conda
win-64::stir-5.1.1-cpu_py38h5c36b7e_0.conda
win-64::libtiff-4.6.0-h6e2ebb7_2.conda
win-64::dpcpp_impl_win-64-2023.2.0-h3055adc_49498.conda
win-64::stir-5.1.1-cuda112_py39h456d3e6_200.conda
win-64::raven-hydro-0.2.4-py311h47b085c_0.conda
win-64::raven-hydro-0.2.4-py310h098a066_1.conda
win-64::polycap-1.2-py311h2ca7b92_4.conda
win-64::postgresql-plpython-15.4-py39h7f24c7b_2.conda
win-64::ogre-1.10.12-ha04c5d8_13.conda
win-64::arrow-cpp-9.0.0-py311hd508f73_48_cuda.conda
win-64::mysql-server-8.0.33-hc2073d5_3.conda
win-64::coda-2.25-py38h56b84b2_1.conda
win-64::qt6-main-6.5.2-h1088b08_4.conda
win-64::stir-5.1.1-cuda112_py310hd4c8a74_200.conda
win-64::openvdb-10.0.1-py310h0562cec_6.conda
win-64::libarrow-11.0.0-hf2e8da2_37_cpu.conda
win-64::postgresql-plpython-15.4-py39h7f24c7b_1.conda
win-64::paraview-5.11.1-py310h0e6c957_102_qt.conda
win-64::r-seqminer-9.1-r41h5bfd6cc_0.conda
win-64::arrow-cpp-9.0.0-py38h6df683d_48_cpu.conda
win-64::imagecodecs-2023.9.4-py39h37c4684_2.conda
win-64::orc-1.9.0-h8dbeef6_2.conda
win-64::folly-2023.09.04.00-h6064ee9_0.conda
win-64::libopencv-4.8.0-py310h14e7d4a_3.conda
win-64::omniorb-4.3.1-py310h2b448b3_1.conda
win-64::python-igraph-0.10.6-py38h49bc9fc_1.conda
win-64::py-bgzip-0.4.0-py39h78ffc47_4.conda
win-64::qt6-3d-6.5.2-h46fdaf4_1.conda
win-64::openexr-python-1.3.9-py39he59fe5d_3.conda
win-64::libarrow-12.0.1-hba3d5be_12_cpu.conda
win-64::pillow-10.0.1-py310h6abe1ea_0.conda
win-64::python-igraph-0.10.6-py311h1e46476_1.conda
win-64::arrow-cpp-9.0.0-py310h727c4ae_47_cpu.conda
win-64::qt6-main-6.5.2-hfa39f04_2.conda
win-64::raven-hydro-0.2.4-py39h4f5c61a_0.conda
win-64::pyinstaller-6.0.0-py39h84a0465_0.conda
win-64::libpq-15.4-h43585b0_1.conda
win-64::arrow-cpp-9.0.0-py38hf5d61b2_48_cuda.conda
win-64::coda-2.25-py311h1fcffe7_1.conda
win-64::heyoka-llvm-15-2.0.0-hec69d8a_0.conda
win-64::lxml-4.9.3-py39hb421182_1.conda
win-64::qt-main-5.15.8-he5a7383_16.conda
win-64::pyhdk-0.8.0-py311h1234567_1_cpu.conda
win-64::libopencv-4.8.1-py39h49802b2_0.conda
win-64::pyinstaller-6.0.0-py310h35269f2_0.conda
win-64::libarrow-13.0.0-hdb90ae5_4_cuda.conda
win-64::gst-libav-1.22.6-hec9340f_0.conda
win-64::minizip-4.0.1-h5bed578_4.conda
win-64::arrow-cpp-9.0.0-py310ha997e8b_49_cpu.conda
win-64::tiledb-2.16.3-hba0c709_2.conda
win-64::stir-5.1.1-cuda118_py38h3e33db5_200.conda
win-64::vigra-1.11.1-py39hf6282f9_1048.conda
win-64::qtwebkit-5.212-h3517a95_13.conda
win-64::libarrow-10.0.1-h58a770d_43_cpu.conda
win-64::raven-hydro-0.2.4-py38h9f5882e_1.conda
win-64::libarrow-12.0.1-h1d4cf54_11_cpu.conda
win-64::gst-plugins-bad-1.22.6-ha2afc39_0.conda
win-64::libarrow-13.0.0-h1d4cf54_2_cpu.conda
win-64::pygame-2.5.2-py312he0927ec_2.conda
win-64::gst-plugins-good-1.22.6-h368eea8_0.conda
win-64::ogre-14.1.0-h649d418_1.conda
win-64::vigra-1.11.1-py310h9ea8a31_1047.conda
win-64::pillow-10.0.0-py39h6ef006c_1.conda
win-64::stir-5.1.1-cpu_py311hf7a2716_0.conda
win-64::omniorb-4.3.1-py312h3946ced_1.conda
win-64::postgresql-plpython-15.4-py312h6a96c9b_2.conda
win-64::clangdev-17.0.1-default_heb8d277_0.conda
win-64::pyretis-2.5.0-py311h3f4f50a_3.conda
win-64::openpmd-api-0.15.2-nompi_py311h988fdc3_101.conda
win-64::dpcpp_impl_win-64-2023.2.0-h3055adc_49501.conda
win-64::gdstk-0.9.42-py39h2b303d1_1.conda
win-64::mlir-python-bindings-16.0.5-py39h32efe87_1.conda
win-64::libgdal-3.6.4-h7d2e013_16.conda
win-64::intel-opencl-rt-2023.2.0-hb43f91c_49497.conda
win-64::gdk-pixbuf-2.42.10-ha7ef95a_3.conda
win-64::bytewax-0.17.1-py310pl5321h65afd28_1.conda
win-64::lfortran-0.20.1-h12be248_0.conda
win-64::blosc-1.21.5-hdccc3a2_0.conda
win-64::paraview-5.11.1-py39h4ef32e4_102_qt.conda
win-64::libgdal-3.6.4-h133fa8f_17.conda
win-64::imread-0.7.4-py39h1237364_5.conda
win-64::glib-tools-2.78.0-h12be248_0.conda
win-64::paraview-5.11.1-py311h0462329_102_qt.conda
win-64::vigra-1.11.1-py39h93d03fe_1048.conda
win-64::gtk4-4.12.1-h63c3e48_3.conda
win-64::libprotobuf-static-4.23.4-hb8276f3_5.conda
win-64::wasmer-4.2.1-h4dd112c_0.conda
win-64::libgdal-arrow-parquet-3.6.4-h0a7561c_19.conda
win-64::pygplates-0.39-py39h9609036_9.conda
win-64::libclang-17.0.1-default_heb8d277_0.conda
win-64::raven-hydro-0.2.4-py39h001a4f1_0.conda
win-64::libspatialite-5.0.1-hbf340bc_29.conda
win-64::stir-5.1.2-cuda112_py311h5e56a69_200.conda
win-64::llvm-tools-17.0.1-h1ab654d_0.conda
win-64::lfortran-0.20.0-h12be248_0.conda
win-64::imagecodecs-2023.9.18-py39h37c4684_0.conda
win-64::openbabel-3.1.1-py39h40c416f_8.conda
win-64::postgresql-plpython-15.4-py38hc2df893_2.conda
win-64::polycap-1.2-py39h1a48880_4.conda
win-64::openexr-python-1.3.9-py311h621f010_3.conda
win-64::stir-5.1.2-cuda112_py310hd4c8a74_200.conda
win-64::poppler-qt-23.08.0-h48bb425_1.conda
win-64::hugin-base-2022.0.0-pl5321ha6c232a_7.conda
win-64::postgresql-plpython-16.0-py39h7f24c7b_0.conda
win-64::openvdb-10.0.1-py38h3d66f32_3.conda
win-64::libarrow-10.0.1-hf2e8da2_41_cpu.conda
win-64::openexr-python-1.3.9-py38h7e07a9d_2.conda
win-64::postgresql-15.4-hc80876b_1.conda
win-64::boost-cpp-1.82.0-h6f18f0d_3.conda
win-64::aws-sdk-cpp-1.11.158-h77892aa_1.conda
win-64::geotiff-1.7.1-hcf4a93f_14.conda
win-64::openexr-python-1.3.9-py38h5199410_2.conda
win-64::libsolv-0.7.25-h12be248_0.conda
win-64::bytewax-0.17.1-py38pl5321hcc47c24_1.conda
win-64::postgresql-plpython-16.0-py311h931fdd5_1.conda
win-64::r-harp-1.20-r41h94a49d3_0.conda
win-64::imagecodecs-2023.9.18-py310ha60090e_0.conda
win-64::netcdf4-1.6.4-nompi_py310h6477780_103.conda
win-64::libarrow-11.0.0-hf2e8da2_36_cpu.conda
win-64::imread-0.7.4-py312h60902bf_5.conda
win-64::postgresql-plpython-16.0-py311h931fdd5_0.conda
win-64::heyoka-2.0.0-h72446dc_0.conda
win-64::stir-5.1.2-cuda118_py311hfbe46ba_201.conda
win-64::imagecodecs-2023.9.4-py39he56a9eb_2.conda
win-64::heyoka-2.0.0-ha28d8e4_0.conda
win-64::libcurl-8.3.0-hd5e4a3a_0.conda
win-64::openjpeg-2.5.0-h3d672ee_3.conda
win-64::gdstk-0.9.42-py310h7dcdc39_1.conda
win-64::tiledb-2.17.0-h6f4ccf1_1.conda
win-64::libsolv-static-0.7.24-h12be248_4.conda
win-64::stir-5.1.2-cpu_py311hf7a2716_1.conda
win-64::tiledb-2.17.0-hec1fcaa_0.conda
win-64::libarrow-12.0.1-h8157bec_10_cpu.conda
win-64::folly-2023.09.25.00-hfbb6214_0.conda
win-64::pytables-3.8.0-py38h4c0c689_3.conda
win-64::gst-plugins-base-1.22.6-h001b923_0.conda
win-64::stir-5.1.2-cpu_py39h1deee1a_0.conda
win-64::libarrow-12.0.1-h1e3473c_14_cpu.conda
win-64::libpq-15.4-h43585b0_2.conda
win-64::imagecodecs-2023.9.4-py310hdd11834_0.conda
win-64::folly-2023.09.11.00-hfbb6214_0.conda
win-64::aws-sdk-cpp-1.11.156-h77892aa_1.conda
win-64::stir-5.1.2-cpu_py38h5c36b7e_1.conda
win-64::geotiff-1.7.1-h2e186c9_13.conda
win-64::bytewax-0.17.1-py311pl5321hd4437ae_1.conda
win-64::libopencv-4.8.0-py39hd12bf4f_2.conda
win-64::pyhdk-0.8.0-py310h1234567_0_cpu.conda
win-64::intel-opencl-rt-2023.2.0-h930cf84_49500.conda
win-64::intel-opencl-rt-2023.2.0-h1112a0d_49497.conda
win-64::pygame-2.5.2-py310hd1d314e_0.conda
win-64::libopencv-4.8.0-py311h165af55_4.conda
win-64::raven-hydro-0.2.4-py310h098a066_0.conda
win-64::stir-5.1.0-cuda118_py310h36d4a96_211.conda
win-64::libopencv-4.8.0-py39hbe5d902_2.conda
win-64::lxml-4.9.3-py311h750ae06_1.conda
win-64::libboost-1.82.0-h65993cd_2.conda
win-64::harp-1.20-py39hc4250a4_0.conda
win-64::mlir-python-bindings-16.0.5-py38h8a2f752_1.conda
win-64::pytables-3.8.0-py310hde27e41_3.conda
win-64::libgdal-3.7.2-h290067a_0.conda
win-64::paraview-5.11.1-py311hf8a1cc6_102_qt.conda
win-64::libraw-0.21.1-h5557f11_2.conda
win-64::mlir-python-bindings-16.0.5-py310h7dcdc39_1.conda
win-64::pygame-2.5.2-py39h3d3616c_1.conda
win-64::folly-2023.09.25.00-h6064ee9_0.conda
win-64::raven-hydro-0.2.4-py39hc465eaa_0.conda
win-64::mlir-python-bindings-16.0.5-py311hc50246e_1.conda
win-64::pytables-3.8.0-py39he845bde_3.conda
win-64::grpcio-1.58.1-py311h5bc0dda_0.conda
win-64::vigra-1.11.2-py311h3c8b6d3_0.conda
win-64::paraview-5.11.2-py311h0462329_102_qt.conda
win-64::tiledb-2.17.1-hbf04793_0.conda
win-64::intel-opencl-rt-2023.2.0-h930cf84_49497.conda
win-64::libarrow-13.0.0-hbeba7f1_2_cuda.conda
win-64::aws-sdk-cpp-1.11.156-h03febf0_2.conda
win-64::mysql-libs-8.0.33-h8b0d2c3_3.conda
win-64::libarrow-11.0.0-h7f8165f_35_cpu.conda
win-64::folly-2023.09.18.00-h6064ee9_0.conda
win-64::libpcm-1.2.3-h41f9d32_5.conda
win-64::pyhdk-0.8.0-py39h1234567_1_cpu.conda
win-64::pyinstaller-6.0.0-py311h12e69fa_1.conda
win-64::python-igraph-0.10.6-py310hc9e38e4_2.conda
win-64::libuwebsockets-20.47.0-h12be248_0.conda
win-64::pyinstaller-6.0.0-py39h84a0465_1.conda
win-64::libopencv-4.8.0-py310h086fb7a_4.conda
win-64::tiledb-2.17.1-hec1fcaa_0.conda
win-64::libopentelemetry-cpp-1.11.0-hb72b896_1.conda
win-64::postgresql-plpython-16.0-py38hc2df893_1.conda
win-64::paraview-5.11.2-py38hc4e8e1d_102_qt.conda
win-64::stir-5.1.2-cuda112_py39h456d3e6_200.conda
win-64::clang-17.0.1-h3dc180e_0.conda
win-64::openpmd-api-0.15.2-nompi_py38h4154134_101.conda
win-64::cmake-3.27.6-hf0feee3_0.conda
win-64::minizip-4.0.1-h5bed578_2.conda
win-64::osmium-tool-1.16.0-h8558f88_0.conda
win-64::vigra-1.11.2-py39hf6282f9_0.conda
win-64::pygame-2.5.2-py311h2fe1268_1.conda
win-64::libarrow-10.0.1-h7f8165f_39_cpu.conda
win-64::bytewax-0.17.1-py310pl5321hdd0a9a3_0.conda
win-64::paraview-5.11.1-py39h1437a77_102_qt.conda
win-64::openbabel-3.1.1-py310h64d7175_8.conda
win-64::tiledb-2.16.3-hbf04793_3.conda
win-64::stir-5.1.2-cuda118_py310h36d4a96_201.conda
win-64::stir-5.1.2-cuda112_py38h3f84f4e_200.conda
win-64::libarrow-13.0.0-hba3d5be_3_cpu.conda
win-64::intel-cmplr-lib-rt-2023.2.0-h12be248_49499.conda
win-64::coda-2.25-py39hdabd458_1.conda
win-64::postgresql-plpython-16.0-py310hf838413_0.conda
win-64::libopencv-4.8.0-py38h83043f6_2.conda
win-64::stir-5.1.2-cuda112_py311h5e56a69_201.conda
win-64::python-igraph-0.10.6-py311h1e46476_2.conda
win-64::nexus-4.4.3-h1210264_12.conda
win-64::intel-opencl-rt-2023.2.0-h1112a0d_49498.conda
win-64::libarrow-11.0.0-h003e665_37_cuda.conda
win-64::gst-plugins-good-1.22.6-hdc28085_1.conda
win-64::libgdal-3.7.2-h25fdbd4_1.conda
win-64::libarrow-12.0.1-h3a55de0_12_cuda.conda
win-64::vigra-1.11.1-py39h1a08ff2_1048.conda
win-64::imread-0.7.4-py38hee1b4e1_4.conda
win-64::dpcpp_impl_win-64-2023.2.0-h3055adc_49500.conda
win-64::arrow-cpp-9.0.0-py38h63d59fa_47_cpu.conda
win-64::folly-2023.09.25.00-hdb74905_0.conda
win-64::libarrow-10.0.1-h9f5ee77_42_cuda.conda
win-64::fltk-1.3.8-h01c93fd_3.conda
win-64::heyoka-llvm-14-2.0.0-h955623a_0.conda
win-64::r-harp-1.20-r41h41308cb_0.conda
win-64::pygplates-0.39-py38h55c0e86_9.conda
win-64::connectorx-0.3.2-py310h9336d17_3.conda
win-64::clangxx-17.0.1-default_heb8d277_0.conda
win-64::pytables-3.8.0-py39h607662a_3.conda
win-64::libzip-1.10.1-h1d365fa_2.conda
win-64::vigra-1.11.2-py38h3a38352_0.conda
win-64::stir-5.1.0-cuda118_py38h3e33db5_211.conda
win-64::glib-2.78.0-h12be248_0.conda
win-64::tiledb-2.16.3-hec1fcaa_2.conda
win-64::pyinstaller-6.0.0-py311h12e69fa_0.conda
win-64::python-igraph-0.10.8-py311h1e46476_0.conda
win-64::postgresql-16.0-hc80876b_0.conda
win-64::py-bgzip-0.4.0-py39h84a0465_4.conda
win-64::gst-plugins-good-1.22.5-h368eea8_1.conda
win-64::libarrow-13.0.0-hdb90ae5_5_cuda.conda
win-64::tiledb-2.17.1-h1ffc264_0.conda
win-64::libopencv-4.8.0-py311h3f56c31_2.conda
win-64::libclang13-17.0.1-default_hc80b9e7_0.conda
win-64::python-3.12.0rc3-rc3_h2628c8c_1_cpython.conda
win-64::gdstk-0.9.42-py38h8a2f752_1.conda
win-64::imagecodecs-2023.9.4-py311hbc0632a_0.conda
win-64::raven-hydro-0.2.4-py311heaa4539_0.conda
win-64::stir-5.1.1-cuda112_py38h3f84f4e_200.conda
win-64::assimp-5.3.1-h4dcb625_1.conda
win-64::arrow-cpp-9.0.0-py39hd0c3f8c_47_cuda.conda
win-64::libgdal-3.7.2-hc5c2e26_4.conda
win-64::postgresql-plpython-16.0-py39h7f24c7b_1.conda
win-64::folly-2023.09.11.00-hdb74905_0.conda
win-64::intel-cmplr-lib-rt-2023.2.0-h12be248_49497.conda
win-64::raven-hydro-0.2.4-py39hc465eaa_1.conda
win-64::mlir-python-bindings-16.0.5-py312h1b3467e_1.conda
win-64::netcdf4-1.6.4-nompi_py38h46ce47e_103.conda
win-64::pygame-2.5.2-py311h2fe1268_2.conda
win-64::omniorb-4.3.1-py38h8a9cac7_1.conda
win-64::connectorx-0.3.2-py310h9336d17_2.conda
win-64::libgrpc-1.58.1-h43eea02_0.conda
win-64::stir-5.1.2-cpu_py39h1deee1a_1.conda
win-64::stir-5.1.0-cuda112_py311h5e56a69_211.conda
win-64::netcdf4-1.6.4-nompi_py39h9a3bb69_103.conda
win-64::connectorx-0.3.2-py310h9336d17_0.conda
win-64::stir-5.1.1-cpu_py39h1deee1a_0.conda
win-64::libgdal-arrow-parquet-3.6.4-hbcb3dbd_18.conda
win-64::vtk-base-9.2.6-qt_py310h1234567_213.conda
win-64::arrow-cpp-9.0.0-py38h52bd03d_47_cuda.conda
win-64::libtiff-4.6.0-h4554b19_1.conda
win-64::openvdb-10.0.1-py311ha48a299_3.conda
win-64::vigra-1.11.1-py311h580c5fe_1047.conda
win-64::u3d-0.3.5-hfab4998_2.conda
win-64::pillow-10.0.1-py39h6ef006c_1.conda
win-64::libprotobuf-4.23.4-hb8276f3_5.conda
win-64::gst-plugins-base-1.22.5-h001b923_1.conda
win-64::dlib-cpp-19.24.2-h2425d5f_5.conda
win-64::wxwidgets-3.2.2.1-h63ad7f6_5.conda
win-64::stir-5.1.2-cuda118_py311hfbe46ba_200.conda
win-64::stir-5.1.0-cpu_py311hf7a2716_11.conda
win-64::libarrow-13.0.0-h3a55de0_3_cuda.conda
win-64::imread-0.7.4-py39h7e87f76_5.conda
win-64::libignition-fuel-tools7-7.1.0-h97b9b37_4.conda
win-64::libarrow-12.0.1-hdb90ae5_13_cuda.conda
win-64::postgresql-plpython-15.4-py311h931fdd5_1.conda
win-64::libignition-fuel-tools4-4.6.0-h97b9b37_3.conda
win-64::openexr-3.2.1-h5fba010_0.conda
win-64::stir-5.1.1-cpu_py310h05295b1_0.conda
win-64::python-igraph-0.10.8-py39he170af6_0.conda
win-64::coda-2.25-py310h5eb019b_1.conda
win-64::vtk-base-9.2.6-qt_py39h1234567_214.conda
win-64::intel-opencl-rt-2023.2.0-h1112a0d_49499.conda
win-64::libarrow-11.0.0-h9655bb5_35_cuda.conda
win-64::minizip-4.0.1-h5bed578_1.conda
win-64::netcdf4-1.6.4-nompi_py311he019f65_103.conda
win-64::libpulsar-3.2.0-h6701e3a_3.conda
win-64::stir-5.1.2-cuda118_py39h21226eb_201.conda
win-64::raven-hydro-0.2.4-py312ha11d1cc_1.conda
win-64::imagecodecs-2023.9.4-py39h2c37967_0.conda
win-64::intel-opencl-rt-2023.2.0-h1112a0d_49501.conda
win-64::libzip-1.10.1-h1d365fa_1.conda
win-64::paraview-5.11.1-py39h152380d_102_qt.conda
win-64::raven-hydro-0.2.4-py39h001a4f1_1.conda
win-64::libllvm17-17.0.1-h1ab654d_0.conda
win-64::connectorx-0.3.2-py310h9336d17_1.conda
win-64::pdal-2.5.6-hcd51f48_3.conda
win-64::python-igraph-0.10.8-py310hc9e38e4_0.conda
win-64::pillow-10.0.0-py38h5c6e75c_1.conda
win-64::grpcio-1.58.1-py38h19421c1_0.conda
win-64::pyinstaller-6.0.0-py38ha959d8a_0.conda
win-64::aws-sdk-cpp-1.10.57-h77892aa_22.conda
win-64::aws-sdk-cpp-1.11.156-hf794bbe_0.conda
win-64::imagecodecs-2023.9.4-py311hcba515f_1.conda
win-64::python-igraph-0.10.6-py310hc9e38e4_1.conda
win-64::stir-5.1.0-cuda112_py39h456d3e6_211.conda
win-64::tiledb-2.17.0-h1ffc264_0.conda
win-64::libarrow-11.0.0-h9f5ee77_38_cuda.conda
win-64::libgdal-arrow-parquet-3.7.2-hde62186_1.conda
win-64::gdstk-0.9.42-py39h32efe87_1.conda
win-64::libpq-16.0-h43585b0_1.conda
win-64::connectorx-0.3.2-py38h47766d6_2.conda
win-64::imagecodecs-2023.9.18-py39he56a9eb_0.conda
win-64::wxwidgets-3.2.2.1-h4c91a18_4.conda
win-64::pygame-2.5.2-py39h52ee4db_2.conda
win-64::pygame-2.5.2-py39h3d3616c_2.conda
win-64::python-igraph-0.10.8-py39hbc72104_0.conda
win-64::stir-5.1.1-cuda118_py39h21226eb_200.conda
win-64::paraview-5.11.1-py310h3672466_102_qt.conda
win-64::pygame-2.5.2-py311h4246bbb_0.conda
win-64::pillow-10.0.0-py310h6abe1ea_1.conda
win-64::pypy3.9-7.3.12-h994e1e7_5.conda
win-64::cpp-opentelemetry-sdk-1.11.0-hb72b896_1.conda
win-64::vigra-1.11.2-py39h1a08ff2_0.conda
win-64::vigra-1.11.1-py38h10c249f_1048.conda
win-64::hugin-2022.0.0-pl5321h455354c_7.conda
win-64::stir-5.1.0-cpu_py310h05295b1_11.conda
win-64::hdf4-4.2.15-h5557f11_7.conda
win-64::cgns-4.4.0-h2a9fa8c_2.conda
win-64::raven-hydro-0.2.4-py38h3b9c276_0.conda
win-64::libopencv-4.8.0-py311h1aa3b8a_3.conda
win-64::arrow-cpp-9.0.0-py310h84aa7e8_49_cuda.conda
win-64::raven-hydro-0.2.4-py38hc2ce60e_0.conda
win-64::paraview-5.11.1-py38hd1bbbe5_102_qt.conda
win-64::harp-1.20-py39haeadfa7_0.conda
win-64::libopencv-4.8.0-py39h49802b2_4.conda
win-64::intel-opencl-rt-2023.2.0-h930cf84_49501.conda
win-64::sdl2_image-2.6.3-hb5038e8_3.conda
win-64::poppler-23.08.0-h35ab50b_1.conda
win-64::nco-5.1.8-hf67abdb_0.conda
win-64::vigra-1.11.2-py38h10c249f_0.conda
win-64::connectorx-0.3.2-py38h47766d6_1.conda
win-64::intel-cmplr-lib-rt-2023.2.0-h12be248_49501.conda
win-64::postgresql-plpython-16.0-py38hc2df893_0.conda
win-64::omniorb-libs-4.3.1-ha7d20b1_1.conda
win-64::openexr-python-1.3.9-py310hd4bcbf3_3.conda
win-64::grpcio-1.57.0-py312h7894644_1.conda
win-64::gdstk-0.9.42-py312h1b3467e_1.conda
win-64::lfortran-0.20.3-h12be248_0.conda
win-64::raven-hydro-0.2.4-py310h9646616_0.conda
win-64::boost-cpp-1.82.0-h6f18f0d_2.conda
win-64::fltk-1.3.8-hdc4bb1d_1.conda
win-64::lxml-4.9.3-py312h2f4f5e2_1.conda
win-64::pdal-2.5.6-h9a7b13a_2.conda
win-64::intel-opencl-rt-2023.2.0-hb43f91c_49501.conda
win-64::stir-5.1.0-cuda112_py310hd4c8a74_211.conda
win-64::raven-hydro-0.2.4-py39hdc7dc00_0.conda
win-64::paraview-5.11.1-py311hf1c5de4_102_qt.conda
win-64::grpcio-1.58.1-py39hd28a505_0.conda
win-64::libarrow-11.0.0-h58a770d_39_cpu.conda
win-64::pillow-10.0.1-py39h6ef006c_0.conda
win-64::vigra-1.11.1-py38h96517eb_1047.conda
win-64::arrow-cpp-9.0.0-py39hd9dfb59_48_cuda.conda
win-64::pillow-10.0.1-py311hd926f49_0.conda
win-64::clang-tools-17.0.1-default_heb8d277_0.conda
win-64::libboost-1.82.0-h65993cd_3.conda
win-64::libopencv-4.8.0-py38h6288f8b_4.conda
win-64::imread-0.7.4-py310h87c1464_5.conda
win-64::imread-0.7.4-py311h7131182_4.conda
win-64::libtiff-4.6.0-h6c8260b_0.conda
win-64::qt6-main-6.5.2-h577db66_1.conda
win-64::stir-5.1.0-cuda118_py39h21226eb_211.conda
win-64::pillow-10.0.0-py311hd926f49_1.conda
win-64::connectorx-0.3.2-py39h03fc0cf_1.conda
win-64::bytewax-0.17.1-py311pl5321he6bd7ae_0.conda
win-64::aws-sdk-cpp-1.11.158-hf794bbe_0.conda
win-64::arrow-cpp-9.0.0-py38h6df683d_49_cpu.conda
win-64::nco-5.1.7-hf67abdb_1.conda
win-64::imread-0.7.4-py311h7131182_5.conda
win-64::libopencv-4.8.1-py39haea54bb_0.conda
win-64::raven-hydro-0.2.4-py311h47b085c_1.conda
win-64::heyoka-2.0.0-hdb83de7_0.conda
win-64::aws-sdk-cpp-1.10.57-hae8d54a_23.conda
win-64::raven-hydro-0.2.4-py38h9f5882e_0.conda
win-64::coda-2.25-py39h6dd871f_0.conda
win-64::pillow-10.0.1-py311hd926f49_1.conda
win-64::pyhdk-0.8.0-py310h1234567_1_cpu.conda
win-64::vigra-1.11.1-py39h99f675e_1048.conda
win-64::paraview-5.11.2-py39h4ef32e4_102_qt.conda
win-64::connectorx-0.3.2-py39h03fc0cf_3.conda
win-64::gdk-pixbuf-2.42.10-h90a7034_4.conda
win-64::heyoka-llvm-12-2.0.0-h8d416ae_0.conda
win-64::libarrow-10.0.1-hf2e8da2_40_cpu.conda
win-64::intel-cmplr-lib-rt-2023.2.0-h12be248_49498.conda
win-64::pyhdk-0.8.0-py39h1234567_0_cpu.conda
win-64::openpmd-api-0.15.2-nompi_py39hfef24c1_101.conda
win-64::minizip-4.0.1-h5bed578_0.conda
win-64::python-igraph-0.10.6-py39hbc72104_2.conda
win-64::glib-networking-2.78.0-h8365e19_0.conda
win-64::vigra-1.11.1-py310hdf9d12b_1047.conda
win-64::libnetcdf-4.9.2-nompi_h8284064_112.conda
win-64::heyoka-2.0.0-h31c11bd_0.conda
win-64::libarrow-10.0.1-h003e665_40_cuda.conda
win-64::pygame-2.5.2-py310hc90abf7_2.conda
win-64::stir-5.1.1-cuda112_py311h5e56a69_200.conda
win-64::postgresql-plpython-16.0-py312h6a96c9b_1.conda
win-64::paraview-5.11.1-py39hc85f15a_102_qt.conda
win-64::libpq-16.0-h43585b0_0.conda
win-64::stir-5.1.2-cuda118_py310h36d4a96_200.conda
win-64::intel-opencl-rt-2023.2.0-he96b08c_49501.conda
win-64::vigra-1.11.1-py311h3c8b6d3_1048.conda
win-64::libopencv-4.8.0-py39haea54bb_4.conda
win-64::paraview-5.11.1-py310hd0c7be8_102_qt.conda
win-64::coda-2.25-py39h8939525_0.conda
win-64::libarrow-10.0.1-h58a770d_42_cpu.conda
win-64::pygplates-0.39-py311hd25bc34_9.conda
win-64::libopencv-4.8.1-py310h086fb7a_0.conda
win-64::libprotobuf-static-4.23.4-hb8276f3_6.conda
win-64::paraview-5.11.1-py38hf1ae3ad_102_qt.conda
win-64::tiledb-2.17.0-h86be035_1.conda
win-64::mysql-client-8.0.33-hed9f4ee_4.conda
win-64::py-bgzip-0.4.0-py310h35269f2_4.conda
win-64::paraview-5.11.1-py38hc4e8e1d_102_qt.conda
win-64::assimp-5.3.0-h4dcb625_0.conda
win-64::vigra-1.11.1-py311h5525c7f_1047.conda
win-64::arrow-cpp-9.0.0-py311hd508f73_49_cuda.conda
win-64::openvdb-10.0.1-py39h811228d_6.conda
win-64::glibmm-2.68-2.78.0-hb2f1372_0.conda
win-64::postgresql-plpython-15.4-py38hc2df893_1.conda
win-64::freetype-2.12.1-hdaf720e_2.conda
win-64::pyinstaller-6.0.0-py38ha959d8a_1.conda
win-64::paraview-5.11.1-py310h0109ea6_102_qt.conda
win-64::pygame-2.5.2-py39h52ee4db_1.conda
win-64::qt6-main-6.5.2-h1088b08_3.conda
win-64::intel-opencl-rt-2023.2.0-hb43f91c_49499.conda
win-64::dcmtk-3.6.7-h5e2a1b2_5.conda
win-64::vigra-1.11.1-py39h2880bbb_1047.conda
win-64::libprotobuf-static-4.24.3-hb8276f3_0.conda
win-64::vigra-1.11.2-py39h99f675e_0.conda
win-64::imread-0.7.4-py39h1237364_4.conda
win-64::folly-2023.09.11.00-h6064ee9_0.conda
win-64::coda-2.25-py310h41308cb_0.conda
win-64::python-igraph-0.10.8-py38h5697605_0.conda
win-64::libgdal-arrow-parquet-3.7.2-h7c7bd20_3.conda
win-64::libprotobuf-4.24.3-hb8276f3_0.conda
win-64::lxml-4.9.3-py310h46d54dd_1.conda
win-64::gdstk-0.9.42-py311hc50246e_1.conda
win-64::stir-5.1.2-cpu_py310h05295b1_0.conda
win-64::pillow-10.0.1-py310h6abe1ea_1.conda
win-64::coda-2.25-py38h94a49d3_0.conda
win-64::libgdal-arrow-parquet-3.7.2-hd3960e2_2.conda
win-64::vigra-1.11.2-py310h9eb0d7a_0.conda
win-64::pytables-3.8.0-py38hd982b11_3.conda
win-64::pygame-2.5.2-py39h9408aed_0.conda
win-64::vtk-base-9.2.6-qt_py38h1234567_214.conda
win-64::imagecodecs-2023.9.18-py311ha37d076_0.conda
win-64::vigra-1.11.1-py38h83a98cb_1047.conda
win-64::libthrift-0.19.0-h06f6336_0.conda
win-64::harp-1.20-py38ha508e55_0.conda
win-64::libarrow-12.0.1-h1e3473c_13_cpu.conda
win-64::freeimage-3.18.0-hec5cf28_16.conda
win-64::dpcpp_impl_win-64-2023.2.0-h3055adc_49497.conda
win-64::pygplates-0.39-py310h6030f9b_9.conda
win-64::lfortran-0.20.2-h12be248_0.conda
win-64::libclang-cpp-17.0.1-default_heb8d277_0.conda
win-64::python-igraph-0.10.6-py39hbc72104_1.conda
win-64::lxml-4.9.3-py39hbae3653_1.conda
win-64::openexr-python-1.3.9-py38h7e07a9d_3.conda
win-64::libgdal-arrow-parquet-3.6.4-h7ba79bf_16.conda
win-64::openexr-python-1.3.9-py39h41fd299_3.conda
win-64::fltk-1.3.8-hc6d25b5_2.conda
win-64::omniorb-4.3.1-py311h55b17b5_1.conda
win-64::stir-5.1.2-cuda112_py310hd4c8a74_201.conda
win-64::pillow-10.0.1-py38h5c6e75c_1.conda
win-64::stir-5.1.0-cuda118_py311hfbe46ba_211.conda
win-64::paraview-5.11.1-py38h2a341a6_102_qt.conda
win-64::mysql-libs-8.0.33-h8b0d2c3_4.conda
win-64::libgd-2.3.3-h4c0c323_8.conda
win-64::arrow-cpp-9.0.0-py38hf5d61b2_49_cuda.conda
win-64::pyinstaller-6.0.0-py310h35269f2_1.conda
win-64::llvm-17.0.1-h3dc180e_0.conda
win-64::libglib-2.78.0-he8f3873_0.conda
win-64::imread-0.7.4-py310h87c1464_4.conda
win-64::ogre-1.10.12-ha04c5d8_14.conda
win-64::tiledb-2.16.3-h1ffc264_2.conda
win-64::gst-plugins-base-1.22.6-h001b923_1.conda
win-64::postgresql-plpython-15.4-py311h931fdd5_2.conda
win-64::libgdal-arrow-parquet-3.6.4-h1c74df3_17.conda
win-64::imagecodecs-2023.9.4-py310ha60090e_2.conda
win-64::libarrow-11.0.0-h9f5ee77_39_cuda.conda
win-64::arrow-cpp-9.0.0-py310h265c7e4_47_cuda.conda
win-64::paraview-5.11.1-py311h1b4d69d_102_qt.conda
win-64::paraview-5.11.1-py310ha2f4b90_102_qt.conda
win-64::stir-5.1.1-cuda118_py311hfbe46ba_200.conda
win-64::libarrow-10.0.1-h9f5ee77_43_cuda.conda
win-64::libarchive-3.7.2-h6f8411a_0.conda
win-64::clang-17-17.0.1-default_heb8d277_0.conda
win-64::libprotobuf-4.23.4-hb8276f3_6.conda
win-64::arrow-cpp-9.0.0-py311h2b52921_48_cpu.conda
win-64::stir-5.1.0-cuda112_py38h3f84f4e_211.conda
win-64::arrow-cpp-9.0.0-py310h84aa7e8_48_cuda.conda
win-64::libcurl-static-8.3.0-hd5e4a3a_0.conda
win-64::postgresql-plpython-15.4-py310hf838413_2.conda
win-64::postgresql-16.0-hc80876b_1.conda
win-64::openvdb-10.0.1-py39h8e79b00_3.conda
win-64::lld-17.0.1-h21f6fed_0.conda
win-64::stir-5.1.2-cpu_py38h5c36b7e_0.conda
win-64::stir-5.1.2-cuda118_py38h3e33db5_201.conda
win-64::arrow-cpp-9.0.0-py311h1c7dd16_47_cuda.conda
win-64::paraview-5.11.1-py39h15aa36b_102_qt.conda
win-64::lpython-0.20.0-h12be248_0.conda
win-64::libopencv-4.8.0-py39h526717e_3.conda
win-64::libmlir-17.0.1-he744812_0.conda
win-64::mysql-router-8.0.33-h8bd79c8_3.conda
win-64::r-harp-1.20-r41h94282dd_0.conda
win-64::py-bgzip-0.4.0-py38ha959d8a_4.conda
win-64::stir-5.1.2-cuda118_py38h3e33db5_200.conda
win-64::harp-1.20-py310h164bfc0_0.conda
win-64::wasmer-4.2.0-h4dd112c_0.conda
win-64::python-igraph-0.10.6-py39he170af6_1.conda
win-64::postgresql-plpython-16.0-py310hf838413_1.conda
win-64::folly-2023.09.04.00-hdb74905_0.conda
win-64::vigra-1.11.1-py39hb29a89f_1047.conda
win-64::vigra-1.11.1-py38h3a38352_1048.conda
win-64::tiledb-2.16.3-hec1fcaa_3.conda
win-64::intel-opencl-rt-2023.2.0-h1112a0d_49500.conda
win-64::connectorx-0.3.2-py38h47766d6_3.conda
win-64::vigra-1.11.2-py311h054fd1b_0.conda
win-64::cargo-c-0.9.24-hbc17221_0.conda
win-64::raven-hydro-0.2.4-py38h5f67dab_0.conda
win-64::grpcio-1.58.1-py310hb84602e_0.conda
win-64::arrow-cpp-9.0.0-py311h2b52921_49_cpu.conda
win-64::libpano13-2.9.20rc2-pl5321h5d457ca_6.conda
win-64::arrow-cpp-9.0.0-py310ha997e8b_48_cpu.conda
win-64::openpmd-api-0.15.2-nompi_py39hacf97e5_101.conda
win-64::libarrow-13.0.0-h8157bec_1_cpu.conda
win-64::bytewax-0.17.1-py39pl5321h23403ee_0.conda
win-64::connectorx-0.3.2-py38h47766d6_0.conda
win-64::libllvm-c17-17.0.1-h1ab654d_0.conda
win-64::bytewax-0.17.1-py38pl5321habc61b1_0.conda
win-64::imread-0.7.4-py38hee1b4e1_5.conda
win-64::openvdb-10.0.1-py38h3d66f32_6.conda
win-64::netcdf4-1.6.4-nompi_py312he4da9c3_103.conda
win-64::polycap-1.2-py310h32ee474_4.conda
win-64::libopencv-4.8.0-py39hcbb1d91_3.conda
win-64::dpcpp_impl_win-64-2023.2.0-h3055adc_49499.conda
win-64::libmediainfo-23.09-h8ec2201_0.conda
win-64::pypy3.9-7.3.13-h994e1e7_0.conda
win-64::stir-5.1.2-cuda118_py39h21226eb_200.conda
win-64::lxml-4.9.3-py38h5a3a0f9_1.conda
win-64::intel-opencl-rt-2023.2.0-h930cf84_49498.conda
win-64::tiledb-2.17.0-hbf04793_0.conda
win-64::arrow-cpp-9.0.0-py39h0fce8e7_47_cpu.conda
win-64::pyhdk-0.8.0-py38h1234567_1_cpu.conda
win-64::coda-2.25-py39ha7d8d4b_1.conda
win-64::libprotobuf-static-4.23.3-h1975477_1.conda
win-64::vtk-base-9.2.6-qt_py39h1234567_213.conda
win-64::polycap-1.2-py38h3ea9b08_4.conda
win-64::imread-0.7.4-py39h7e87f76_4.conda
win-64::pypy3.9-7.3.12-h994e1e7_4.conda
win-64::libopencv-4.8.1-py38h6288f8b_0.conda
win-64::vigra-1.11.1-py311h054fd1b_1048.conda
win-64::osmium-tool-1.16.0-h8558f88_1.conda
win-64::harp-1.20-py311h4b8c79d_0.conda
win-64::libarrow-12.0.1-hbeba7f1_11_cuda.conda
win-64::connectorx-0.3.2-py311h79ff7cf_3.conda
win-64::intel-cmplr-lib-rt-2023.2.0-h12be248_49500.conda
win-64::vigra-1.11.2-py310h59b976c_0.conda
win-64::mlir-17.0.1-he744812_0.conda
win-64::libharu-2.4.4-hdaf720e_0.conda
win-64::paraview-5.11.1-py38h9b985ba_102_qt.conda
win-64::connectorx-0.3.2-py39h03fc0cf_0.conda
win-64::graphicsmagick-1.3.40-h7a19656_3.conda
win-64::folly-2023.09.04.00-hfbb6214_0.conda
win-64::libgdal-arrow-parquet-3.7.2-hce42660_0.conda
win-64::hugin-2022.0.0-pl5321hcc37030_6.conda
win-64::libopencv-4.8.0-py310h70162a4_2.conda
win-64::pyhdk-0.8.0-py38h1234567_0_cpu.conda
win-64::libarrow-11.0.0-h003e665_36_cuda.conda
win-64::yarp-cxx-3.8.1-hf64a05e_5.conda
win-64::libarrow-13.0.0-h1e3473c_5_cpu.conda
win-64::libgdal-arrow-parquet-3.7.2-ha9bf930_4.conda
win-64::folly-2023.09.18.00-hdb74905_0.conda
win-64::vtk-base-9.2.6-qt_py311h1234567_214.conda
win-64::vigra-1.11.1-py39hfa86842_1047.conda
win-64::imagecodecs-2023.9.4-py39h118a8a1_0.conda
win-64::openpmd-api-0.15.2-nompi_py310h60a9cca_101.conda
win-64::libarrow-13.0.0-h1e3473c_4_cpu.conda
win-64::openvdb-10.0.1-py311ha48a299_6.conda
win-64::heyoka-2.0.0-h54f7fc4_0.conda
win-64::r-harp-1.20-r41h8939525_0.conda
win-64::python-igraph-0.10.6-py38h5697605_2.conda
win-64::coda-2.25-py311h94282dd_0.conda
win-64::vigra-1.11.2-py39h93d03fe_0.conda
win-64::vtk-base-9.2.6-qt_py311h1234567_213.conda
win-64::imagecodecs-2023.9.4-py310h744e329_1.conda
win-64::arrow-cpp-9.0.0-py39h4762a0c_48_cpu.conda
win-64::libopencv-4.8.1-py311h165af55_0.conda
win-64::bytewax-0.17.1-py39pl5321h5b14c5f_1.conda
win-64::libzip-1.10.1-h1d365fa_3.conda
win-64::stir-5.1.0-cpu_py38h5c36b7e_11.conda
win-64::connectorx-0.3.2-py39h03fc0cf_2.conda
win-64::libarrow-10.0.1-h003e665_41_cuda.conda
win-64::libgdal-3.6.4-h79fc117_18.conda
win-64::intel-opencl-rt-2023.2.0-h930cf84_49499.conda
win-64::libspatialite-5.1.0-hbf340bc_0.conda
win-64::libarrow-10.0.1-h9655bb5_39_cuda.conda
win-64::llvmdev-17.0.1-h1ab654d_0.conda
win-64::symengine-0.11.1-h7610957_0.conda
win-64::openbabel-3.1.1-py38h3819a12_8.conda
win-64::folly-2023.09.18.00-hfbb6214_0.conda
win-64::ogre-14.1.0-h8afa05d_1.conda
win-64::paraview-5.11.1-py311hcda0b63_102_qt.conda
win-64::irrlicht-1.8.5-h65f4d7e_4.conda
win-64::pygame-2.5.2-py38h6efadab_0.conda
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
================================================================================
================================================================================
osx-64
osx-64::openjdk-11.0.20-h837b0c1_3.conda
osx-64::openjdk-20.0.2-h7d26f99_0.conda
osx-64::libprotobuf-4.23.3-h5feb325_1.conda
osx-64::tippecanoe-2.28.0-h52dd1ee_0.conda
osx-64::libsolv-0.7.25-h7d26f99_0.conda
osx-64::libprotobuf-static-4.23.3-h5feb325_1.conda
osx-64::openjdk-17.0.3-h7d26f99_9.conda
osx-64::libpcm-1.2.3-h89d1a00_5.conda
osx-64::libprotobuf-4.23.4-he0c2237_6.conda
osx-64::openjdk-20.0.0-h7d26f99_2.conda
osx-64::libprotobuf-static-4.23.4-h8f9e0a7_6.conda
osx-64::openjdk-11.0.15-h7d26f99_5.conda
osx-64::openjdk-11.0.20-h837b0c1_2.conda
osx-64::u3d-0.3.5-h2b3963f_2.conda
osx-64::gst-plugins-base-1.22.6-hb5d3a86_0.conda
osx-64::openjpeg-2.5.0-ha4da562_3.conda
osx-64::freetype-2.12.1-h60636b9_2.conda
osx-64::cgns-4.4.0-hc1daee9_2.conda
osx-64::openjdk-11.0.15-h7d26f99_6.conda
osx-64::gdk-pixbuf-2.42.10-h5968b1e_3.conda
osx-64::libsolv-static-0.7.24-h7d26f99_4.conda
osx-64::libprotobuf-4.24.3-he0c2237_0.conda
osx-64::dlib-cpp-19.24.2-hba3b871_5.conda
osx-64::openjdk-17.0.8-h837b0c1_1.conda
osx-64::openjdk-11.0.20-h7d26f99_0.conda
osx-64::gst-plugins-base-1.22.5-hb5d3a86_1.conda
osx-64::openjdk-17.0.8-h837b0c1_3.conda
osx-64::libraw-0.21.1-h8138101_2.conda
osx-64::tippecanoe-2.31.0-h52dd1ee_0.conda
osx-64::libharu-2.4.4-h60636b9_0.conda
osx-64::gst-plugins-base-1.22.6-hb5d3a86_1.conda
osx-64::libsolv-0.7.24-h7d26f99_4.conda
osx-64::hdf4-4.2.15-h8138101_7.conda
osx-64::libcdms-3.1.2-h7f27781_128.conda
osx-64::tk-8.6.13-hef22860_0.conda
osx-64::openjdk-20.0.2-h7d26f99_2.conda
osx-64::libmlir17-17.0.1-h837b0c1_0.conda
osx-64::openjdk-20.0.2-h7d26f99_1.conda
osx-64::libuwebsockets-20.46.0-h7d26f99_0.conda
osx-64::openjdk-11.0.15-h7d26f99_7.conda
osx-64::libprotobuf-static-4.23.4-h396b1fa_5.conda
osx-64::libcdms-3.1.2-h529c47d_129.conda
osx-64::libuwebsockets-20.47.0-h7d26f99_0.conda
osx-64::openjdk-17.0.8-h837b0c1_2.conda
osx-64::tippecanoe-2.28.1-h52dd1ee_0.conda
osx-64::micromamba-1.5.1-0.tar.bz2
osx-64::libmlir-17.0.1-h837b0c1_0.conda
osx-64::libprotobuf-4.23.4-he0c2237_5.conda
osx-64::glib-tools-2.78.0-h7d26f99_0.conda
osx-64::openjdk-17.0.8-h7d26f99_0.conda
osx-64::openjdk-11.0.20-h837b0c1_1.conda
osx-64::openexr-3.2.1-h747cbf1_0.conda
osx-64::liblal-7.3.1-fftw_hcd3d11b_102.conda
osx-64::gdk-pixbuf-2.42.10-hbb5a27d_4.conda
osx-64::libprotobuf-static-4.24.3-h8f9e0a7_0.conda
osx-64::libsolv-static-0.7.25-h7d26f99_0.conda
-    "libzlib >=1.2.13,<1.3.0a0"
+    "libzlib >=1.2.13,<2.0.0a0"
osx-64::triqs-3.2.0-py310h199346d_1.conda
osx-64::mysql-libs-8.0.33-haa61052_3.conda
osx-64::imagemagick-7.1.1_18-pl5321hfd0a208_0.conda
osx-64::xrootd-5.6.2-py39h287db84_1.conda
osx-64::irrlicht-1.8.5-h5bfa9a0_4.conda
osx-64::folly-2023.09.18.00-h8318d5c_0.conda
osx-64::pyinstaller-6.0.0-py39h29f4f0d_1.conda
osx-64::openexr-python-1.3.9-py39hcc9336a_3.conda
osx-64::nco-5.1.8-h6025318_0.conda
osx-64::libcurl-8.3.0-h5f667d7_0.conda
osx-64::mold-2.1.0-hc277f81_2.conda
osx-64::libopencv-4.8.1-py39hffbb2f2_0.conda
osx-64::pillow-10.0.1-py39h0ada47f_1.conda
osx-64::gazebo-11.13.0-h4e69cde_7.conda
osx-64::triqs-3.2.0-py38hd329b4f_0.conda
osx-64::vigra-1.11.2-py38h03214aa_0.conda
osx-64::pygame-2.5.2-py310h2ee45d5_1.conda
osx-64::glibmm-2.68-2.78.0-hebf12a5_0.conda
osx-64::vtk-base-9.2.6-qt_py310h1234567_213.conda
osx-64::connectorx-0.3.2-py38h79a255e_2.conda
osx-64::folly-2023.09.11.00-hd4516f9_0_jemalloc.conda
osx-64::r-harp-1.20-r43h4044976_0.conda
osx-64::netcdf4-1.6.4-nompi_py38ha188ddb_103.conda
osx-64::python-igraph-0.10.6-py39h6c5dab4_2.conda
osx-64::vtk-base-9.2.6-qt_py39h1234567_214.conda
osx-64::vigra-1.11.1-py311h14723a5_1047.conda
osx-64::postgresql-plpython-16.0-py311hbf368a9_0.conda
osx-64::coda-2.25-py311hdb6460f_1.conda
osx-64::llvmdev-17.0.1-he4b1e75_0.conda
osx-64::gstlal-1.12.0-py38hb27644c_0.conda
osx-64::python-igraph-0.10.6-py39h6c5dab4_1.conda
osx-64::libgdal-arrow-parquet-3.7.2-he605e3e_2.conda
osx-64::libopencv-4.8.1-py310h5ca57ac_0.conda
osx-64::mysql-client-8.0.33-hae10958_4.conda
osx-64::gdcm-2.8.9-py310h6020fff_9.conda
osx-64::libarrow-11.0.0-h720f35f_36_cpu.conda
osx-64::osmium-tool-1.16.0-habffc7e_0.conda
osx-64::gdcm-2.8.9-py312hd3f6d68_10.conda
osx-64::wasmer-4.2.0-ha6357cd_0.conda
osx-64::xrootd-5.6.2-py39h65f106e_1.conda
osx-64::vigra-1.11.1-py39ha45929e_1047.conda
osx-64::gtk4-4.12.1-heec2122_2.conda
osx-64::poppler-qt-23.08.0-h979de12_1.conda
osx-64::postgresql-plpython-15.4-py311hbf368a9_1.conda
osx-64::boost-cpp-1.82.0-h07eb623_3.conda
osx-64::openpmd-api-0.15.2-mpi_openmpi_py38h2e7f854_1.conda
osx-64::polycap-1.2-py310hfa47721_4.conda
osx-64::openbabel-3.1.1-py311hb239859_8.conda
osx-64::panda3d-1.10.12-py39h0341054_5.conda
osx-64::netcdf4-1.6.4-mpi_openmpi_py310h1d0c4ba_3.conda
osx-64::triqs-3.2.0-py311h409dd4b_3.conda
osx-64::folly-2023.09.25.00-hd4516f9_0_jemalloc.conda
osx-64::libarrow-12.0.1-h720f35f_11_cpu.conda
osx-64::util-linux-2.39.2-py310h7a77fba_0.conda
osx-64::openpmd-api-0.15.2-mpi_openmpi_py38h1aa3c98_1.conda
osx-64::pypy3.8-7.3.11-h3a77750_4.conda
osx-64::tiledb-2.17.0-h24ec535_0.conda
osx-64::folly-2023.09.11.00-h503270f_0_jemalloc.conda
osx-64::mcpl-1.6.2-py310hb69a1aa_1.conda
osx-64::libnetcdf-4.9.2-mpi_openmpi_he189ced_12.conda
osx-64::openexr-python-1.3.9-py38h6a0b3cd_2.conda
osx-64::nco-5.1.7-h6025318_1.conda
osx-64::triqs-3.2.0-py310he217e82_0.conda
osx-64::postgresql-plpython-15.4-py310he0d0a37_1.conda
osx-64::libgdal-arrow-parquet-3.7.2-hdfd4a49_1.conda
osx-64::openpmd-api-0.15.2-nompi_py311hddc35fa_101.conda
osx-64::postgresql-plpython-15.4-py38h9f95ba2_2.conda
osx-64::qt6-3d-6.5.2-h55491c1_1.conda
osx-64::triqs-3.2.0-py38hd329b4f_3.conda
osx-64::aws-sdk-cpp-1.11.158-h706e9e7_1.conda
osx-64::triqs-3.2.0-py310h199346d_3.conda
osx-64::vigra-1.11.2-py38h6f3680b_0.conda
osx-64::imagecodecs-2023.9.4-py311h8948ecd_2.conda
osx-64::arrow-cpp-9.0.0-py38hf99c5f9_47_cpu.conda
osx-64::lfortran-0.20.1-h7d26f99_0.conda
osx-64::liblal-7.3.1-mkl_h98e3ad8_2.conda
osx-64::sdl2_image-2.6.3-hc980504_3.conda
osx-64::raven-hydro-0.2.4-py39h335d0ad_0.conda
osx-64::coda-2.25-py39hc321bfd_0.conda
osx-64::folly-2023.09.04.00-h1718691_0.conda
osx-64::aws-sdk-cpp-1.11.156-hb534404_2.conda
osx-64::wxwidgets-3.2.2.1-h38c6e64_5.conda
osx-64::heyoka-2.0.0-hf7afb35_0.conda
osx-64::folly-2023.09.18.00-h0d9798a_0.conda
osx-64::bytewax-0.17.1-py38h51ad8f1_0.conda
osx-64::dcmtk-3.6.7-hb5b977c_5.conda
osx-64::heyoka-llvm-11-2.0.0-he311c46_0.conda
osx-64::python-igraph-0.10.6-py39h3ec5f52_1.conda
osx-64::openslide-3.4.1-h0a4156d_10.conda
osx-64::libtiff-4.6.0-hf955e92_0.conda
osx-64::lammps-2023.08.02-cpu_py311_hb61bd1e_mpich_1.conda
osx-64::folly-2023.09.25.00-h503270f_0_jemalloc.conda
osx-64::libvips-8.14.4-h7e59d53_1.conda
osx-64::raven-hydro-0.2.4-py38ha9f8b72_1.conda
osx-64::lfortran-0.20.3-h7d26f99_1.conda
osx-64::vigra-1.11.2-py311hfa61ffa_0.conda
osx-64::gdcm-2.8.9-py38hbf2da0d_10.conda
osx-64::openpmd-api-0.15.2-mpi_openmpi_py39hdcec07c_1.conda
osx-64::hugin-base-2022.0.0-pl5321h63ddf8e_6.conda
osx-64::raven-hydro-0.2.4-py310h6ab6fe6_0.conda
osx-64::aimrocks-0.4.0-py312h28e7029_1.conda
osx-64::pygame-2.5.2-py38h088ed32_1.conda
osx-64::libspatialite-5.0.1-h231fb02_29.conda
osx-64::triqs-3.2.0-py310he217e82_2.conda
osx-64::netcdf4-1.6.4-mpi_mpich_py311h35923ac_3.conda
osx-64::geotiff-1.7.1-h889ec99_14.conda
osx-64::minizip-4.0.1-h64dbd51_0.conda
osx-64::util-linux-2.39.2-py39ha1f00b2_0.conda
osx-64::tiledb-2.16.3-h9b026fb_2.conda
osx-64::lammps-2023.08.02-cpu_py38_h40ed01f_openmpi_1.conda
osx-64::folly-2023.09.25.00-hc30067e_0_jemalloc.conda
osx-64::pytables-3.8.0-py310ha776562_3.conda
osx-64::triqs-3.2.0-py311h3ee9e43_4.conda
osx-64::coda-2.25-py310hcb92ca7_0.conda
osx-64::ogre-14.1.0-hc8e4822_0.conda
osx-64::connectorx-0.3.2-py39h4a9edc7_3.conda
osx-64::triqs-3.2.0-py39h56f4216_4.conda
osx-64::r-harp-1.20-r43hcb92ca7_0.conda
osx-64::xrootd-5.6.2-py38h4148965_1.conda
osx-64::triqs-3.2.0-py311h3ee9e43_5.conda
osx-64::openpmd-api-0.15.2-mpi_openmpi_py310h73f7d29_1.conda
osx-64::arrow-cpp-9.0.0-py39he14c092_49_cpu.conda
osx-64::graphicsmagick-1.3.40-hfea9a6c_3.conda
osx-64::assimp-5.3.0-h5d7385b_0.conda
osx-64::vigra-1.11.1-py38hf70e9de_1047.conda
osx-64::folly-2023.09.04.00-hc30067e_0_jemalloc.conda
osx-64::triqs-3.2.0-py39h56f4216_3.conda
osx-64::util-linux-2.39.2-py312h23d2c39_1.conda
osx-64::vtk-base-9.2.6-qt_py311h1234567_214.conda
osx-64::bytewax-0.17.1-py311h86806bd_1.conda
osx-64::libopencv-4.8.0-py39h20e4532_2.conda
osx-64::r-base-4.3.1-h0ff45fa_6.conda
osx-64::mlir-python-bindings-16.0.5-py312hc347d3e_1.conda
osx-64::r-base-4.2.3-h109b13c_9.conda
osx-64::libnetcdf-4.9.2-mpi_mpich_h7b431e5_12.conda
osx-64::openbabel-3.1.1-py310h313d46c_8.conda
osx-64::coda-2.25-py39h071c3cc_1.conda
osx-64::postgresql-16.0-hc940a54_1.conda
osx-64::imagemagick-7.1.1_16-pl5321hfd0a208_0.conda
osx-64::grpcio-1.58.1-py312h8bf4f9a_0.conda
osx-64::polycap-1.2-py312hac10e84_4.conda
osx-64::vigra-1.11.2-py311h4681b91_0.conda
osx-64::mosh-1.4.0-pl5321h54dbc22_3.conda
osx-64::triqs-3.2.0-py38h2e556f2_0.conda
osx-64::panda3d-1.10.12-py310h25bb023_5.conda
osx-64::triqs-3.2.0-py39h56f4216_5.conda
osx-64::gst-plugins-good-1.22.6-hd62185b_1.conda
osx-64::triqs-3.2.0-py39h61a7ba7_3.conda
osx-64::triqs-3.2.0-py38h2e556f2_1.conda
osx-64::postgresql-plpython-15.4-py39hfacc66a_1.conda
osx-64::imagecodecs-2023.9.18-py310hb72ea00_0.conda
osx-64::imagecodecs-2023.9.18-py39hdd53b90_0.conda
osx-64::pillow-10.0.1-py311hd5308a1_0.conda
osx-64::paraview-5.11.1-py310h0357801_102_qt.conda
osx-64::coda-2.25-py311h4044976_0.conda
osx-64::folly-2023.09.25.00-h8318d5c_0.conda
osx-64::nest-simulator-3.6-py38h5d6ae11_0.conda
osx-64::libgdal-3.7.2-h00ad6d0_3.conda
osx-64::imagecodecs-2023.9.18-py39hca512f1_0.conda
osx-64::tiledb-2.17.0-hd3a41d5_0.conda
osx-64::heyoka-2.0.0-hc2ef373_0.conda
osx-64::rpm-tools-4.17.1-lua54hb48fe71_4.conda
osx-64::r-base-4.3.1-hc77f628_4.conda
osx-64::imagecodecs-2023.9.18-py311h8948ecd_0.conda
osx-64::r-harp-1.20-r43h171fc49_0.conda
osx-64::libarrow-12.0.1-hca2412d_12_cpu.conda
osx-64::netcdf4-1.6.4-mpi_mpich_py38h0ef46f6_3.conda
osx-64::util-linux-2.39.2-py311ha082ef5_0.conda
osx-64::arrow-cpp-9.0.0-py311h310d3e5_48_cpu.conda
osx-64::magics-metview-batch-4.14.2-h419c579_1.conda
osx-64::nest-simulator-3.6-py311h13f248f_0.conda
osx-64::grpcio-1.57.0-py312h8bf4f9a_1.conda
osx-64::imagecodecs-2023.9.4-py39haa70d31_1.conda
osx-64::util-linux-2.39.2-py39h2550083_0.conda
osx-64::pyinstaller-6.0.0-py38h63e6892_0.conda
osx-64::lammps-2023.08.02-cpu_py38_ha83d5b2_mpich_1.conda
osx-64::python-igraph-0.10.6-py311h3ad72c6_1.conda
osx-64::libgdal-3.7.2-h57f23c7_4.conda
osx-64::netcdf4-1.6.4-mpi_openmpi_py311hab965e7_3.conda
osx-64::paraview-5.11.1-py310h2b51595_102_qt.conda
osx-64::connectorx-0.3.2-py310hd8cfebe_3.conda
osx-64::pytables-3.8.0-py39hc10801d_3.conda
osx-64::triqs-3.2.0-py310h199346d_0.conda
osx-64::xrootd-5.6.2-py39h65f106e_0.conda
osx-64::vigra-1.11.1-py38h20d3ef9_1047.conda
osx-64::ncl-6.6.2-h7337e34_49.conda
osx-64::connectorx-0.3.2-py310hd8cfebe_2.conda
osx-64::connectorx-0.3.2-py38h79a255e_1.conda
osx-64::triqs-3.2.0-py311h3ee9e43_1.conda
osx-64::openpmd-api-0.15.2-mpi_mpich_py311hac5f195_1.conda
osx-64::python-igraph-0.10.8-py311h3ad72c6_0.conda
osx-64::python-3.12.0rc3-rc3_h30d4d87_1_cpython.conda
osx-64::pylibmc-1.6.3-py39h29f4f0d_2.conda
osx-64::r-base-4.2.3-hc77f628_8.conda
osx-64::xrootd-5.6.2-py311h728467c_0.conda
osx-64::gstlal-1.12.0-py39h2769d62_0.conda
osx-64::pylibmc-1.6.3-py310hb69a1aa_2.conda
osx-64::triqs-3.2.0-py310he217e82_4.conda
osx-64::raven-hydro-0.2.4-py39h16b9c15_0.conda
osx-64::lammps-2023.08.02-cpu_py39_hb9db24c_openmpi_1.conda
osx-64::sdl2_image-2.6.3-hfc1022d_2.conda
osx-64::libarrow-12.0.1-heeec12f_13_cpu.conda
osx-64::pypy3.9-7.3.12-hc0e9917_5.conda
osx-64::omniorb-4.3.1-py39ha0f51ee_1.conda
osx-64::sdl2_image-2.6.3-hc003a97_4.conda
osx-64::ogre-14.1.0-h5fa7812_1.conda
osx-64::openexr-python-1.3.9-py39hf614b33_3.conda
osx-64::grpcio-1.58.1-py38h4864539_0.conda
osx-64::py-bgzip-0.4.0-py312h44a8920_4.conda
osx-64::gdstk-0.9.42-py312hc347d3e_1.conda
osx-64::triqs-3.2.0-py311h409dd4b_5.conda
osx-64::vigra-1.11.1-py38h03214aa_1048.conda
osx-64::heyoka-llvm-12-2.0.0-hab63cc6_0.conda
osx-64::lfortran-0.20.0-h7d26f99_0.conda
osx-64::ogre-14.0.1-hc8e4822_2.conda
osx-64::py-bgzip-0.4.0-py39h6acae9b_4.conda
osx-64::python-igraph-0.10.8-py39h3ec5f52_0.conda
osx-64::libopencv-4.8.0-py311h0809f14_4.conda
osx-64::vigra-1.11.1-py310hce14334_1048.conda
osx-64::libsoup-3.4.3-h8ff24ff_0.conda
osx-64::llvm-17.0.1-h9c2cb20_0.conda
osx-64::libarrow-11.0.0-heeec12f_38_cpu.conda
osx-64::libgdal-3.7.2-h93a1251_0.conda
osx-64::r-harp-1.20-r43h4485038_0.conda
osx-64::netpbm-10.73.43-pl5321hde32e01_3.conda
osx-64::libarchive-3.7.2-h0b5dc4a_0.conda
osx-64::verilator-5.016-he7f2693_0.conda
osx-64::raven-hydro-0.2.4-py38ha9f8b72_0.conda
osx-64::triqs-3.2.0-py311h3ee9e43_0.conda
osx-64::postgresql-plpython-16.0-py38h9f95ba2_0.conda
osx-64::python-rocksdb-0.7.0-py39ha52a552_8.conda
osx-64::python-igraph-0.10.8-py39h6c5dab4_0.conda
osx-64::netcdf4-1.6.4-mpi_openmpi_py38hf6fe9ce_3.conda
osx-64::libarrow-13.0.0-hdcd9b72_1_cpu.conda
osx-64::paraview-5.11.1-py311h4c6edf4_102_qt.conda
osx-64::astrometry-0.94-py39h48942c9_4.conda
osx-64::bytewax-0.17.1-py311hb29c592_0.conda
osx-64::netcdf4-1.6.4-nompi_py311h710f573_103.conda
osx-64::py-bgzip-0.4.0-py311h958d0e8_4.conda
osx-64::symengine-0.11.1-h9f63a94_0.conda
osx-64::pygplates-0.39-py311h05f1940_9.conda
osx-64::triqs-3.2.0-py39h61a7ba7_4.conda
osx-64::pygame-2.5.2-py310hb6fb842_0.conda
osx-64::wxwidgets-3.2.2.1-h2c48a6d_4.conda
osx-64::tiledb-2.17.1-hd3a41d5_0.conda
osx-64::libarchive-minimal-static-3.7.2-h1b57e4a_0.conda
osx-64::pygame-2.5.2-py38h088ed32_2.conda
osx-64::harp-1.20-py310h45971e9_0.conda
osx-64::postgresql-plpython-16.0-py39hfacc66a_1.conda
osx-64::mcpl-1.6.2-py311hbab40d1_1.conda
osx-64::openpmd-api-0.15.2-mpi_openmpi_py39ha067292_1.conda
osx-64::postgresql-plpython-15.4-py311hbf368a9_2.conda
osx-64::libopencv-4.8.0-py39h6114cbd_3.conda
osx-64::libgdal-arrow-parquet-3.6.4-h9012a92_17.conda
osx-64::paraview-5.11.2-py39hc3a1a5e_102_qt.conda
osx-64::triqs-3.2.0-py38h2e556f2_3.conda
osx-64::raven-hydro-0.2.4-py39h3fbac99_0.conda
osx-64::triqs-3.2.0-py38h2e556f2_5.conda
osx-64::postgresql-15.4-hc940a54_2.conda
osx-64::libtiff-4.6.0-haeeb97c_1.conda
osx-64::boost-cpp-1.82.0-h94d02bd_2.conda
osx-64::python-igraph-0.10.8-py38he3da19a_0.conda
osx-64::triqs-3.2.0-py39h56f4216_0.conda
osx-64::fltk-1.3.8-h2b3963f_1.conda
osx-64::assimp-5.3.1-h5d7385b_1.conda
osx-64::openpmd-api-0.15.2-mpi_mpich_py38hbf84226_1.conda
osx-64::openpmd-api-0.15.2-mpi_mpich_py310h9c0de5c_1.conda
osx-64::mcpl-1.6.2-py39h29f4f0d_1.conda
osx-64::mlir-python-bindings-16.0.5-py39h836d0de_1.conda
osx-64::mysql-server-8.0.33-h9a7ddf8_3.conda
osx-64::mcpl-1.6.2-py312hf019568_1.conda
osx-64::lammps-2023.08.02-cpu_py38_ha83d5b2_mpich_2.conda
osx-64::raven-hydro-0.2.4-py311h5482185_1.conda
osx-64::pytables-3.8.0-py38hcd7cd91_3.conda
osx-64::vigra-1.11.1-py310hec63aa5_1047.conda
osx-64::python-rocksdb-0.7.0-py39h9553f8c_8.conda
osx-64::libopencv-4.8.0-py39hbbb11c1_3.conda
osx-64::tiledb-2.16.3-h24ec535_2.conda
osx-64::pylibmc-1.6.3-py38h63e6892_2.conda
osx-64::libarrow-13.0.0-h720f35f_2_cpu.conda
osx-64::raven-hydro-0.2.4-py39h0edd63f_1.conda
osx-64::libtiff-4.6.0-h684deea_2.conda
osx-64::grpcio-1.58.1-py39h341a990_0.conda
osx-64::openmotif-2.3.8-h6b0d8c2_4.conda
osx-64::nodejs-20.6.1-h119ffd7_0.conda
osx-64::aimrocks-0.4.0-py39h192688f_1.conda
osx-64::python-rocksdb-0.7.0-py38hdfd63aa_8.conda
osx-64::folly-2023.09.04.00-hd4516f9_0_jemalloc.conda
osx-64::vigra-1.11.2-py310ha92708c_0.conda
osx-64::paraview-5.11.1-py39h415fda8_102_qt.conda
osx-64::gdstk-0.9.42-py39hb0af0c5_1.conda
osx-64::poppler-23.08.0-h122f3cb_2.conda
osx-64::heyoka-llvm-16-2.0.0-h13b2b40_0.conda
osx-64::triqs-3.2.0-py39h56f4216_2.conda
osx-64::openexr-python-1.3.9-py311h41145ee_3.conda
osx-64::pillow-10.0.1-py38ha0d9280_1.conda
osx-64::jaxlib-0.4.14-cpu_py39h9a89400_1.conda
osx-64::magics-metview-4.14.2-ha0ba894_1.conda
osx-64::ogre-14.1.0-hc06f80e_1.conda
osx-64::triqs-3.2.0-py39h61a7ba7_0.conda
osx-64::polycap-1.2-py38h794ba6b_4.conda
osx-64::pyhdf-0.11.3-py310he112ce3_1.conda
osx-64::netcdf4-1.6.4-mpi_mpich_py312h0b2af07_3.conda
osx-64::gazebo-11.13.0-h0567d1c_8.conda
osx-64::xrootd-5.6.2-py38h4148965_0.conda
osx-64::netcdf4-1.6.4-nompi_py39h662e83e_103.conda
osx-64::pillow-10.0.0-py311hd5308a1_1.conda
osx-64::gdstk-0.9.42-py38h96fe5d3_1.conda
osx-64::vigra-1.11.1-py39h6b5aad9_1047.conda
osx-64::raven-hydro-0.2.4-py310h0bc48e2_1.conda
osx-64::openexr-python-1.3.9-py310h768d1bd_2.conda
osx-64::vigra-1.11.1-py311hfa61ffa_1048.conda
osx-64::pyhdf-0.11.3-py38haff802b_1.conda
osx-64::paraview-5.11.1-py310he94e120_102_qt.conda
osx-64::pillow-10.0.1-py311hd5308a1_1.conda
osx-64::pyinstaller-6.0.0-py311hbab40d1_0.conda
osx-64::netcdf4-1.6.4-nompi_py312h8ce98be_103.conda
osx-64::pypy3.9-7.3.12-hc0e9917_4.conda
osx-64::postgresql-15.4-hc940a54_1.conda
osx-64::pytables-3.8.0-py311h21e7aa0_3.conda
osx-64::triqs-3.2.0-py39h61a7ba7_2.conda
osx-64::imagecodecs-2023.9.4-py310h8cd5cbe_1.conda
osx-64::folly-2023.09.11.00-h8318d5c_0.conda
osx-64::folly-2023.09.18.00-h1718691_0.conda
osx-64::arrow-cpp-9.0.0-py39h5f0ff93_47_cpu.conda
osx-64::lammps-2023.08.02-cpu_py311_h38df71f_openmpi_2.conda
osx-64::arrow-cpp-9.0.0-py310h9f43b46_48_cpu.conda
osx-64::imagecodecs-2023.9.4-py39heb80827_1.conda
osx-64::pyhdf-0.11.3-py312hf0137b7_1.conda
osx-64::pygame-2.5.2-py39hb83dceb_1.conda
osx-64::netcdf4-1.6.4-mpi_openmpi_py312h7b9181a_3.conda
osx-64::raven-hydro-0.2.4-py39h0edd63f_0.conda
osx-64::libarrow-12.0.1-heeec12f_14_cpu.conda
osx-64::paraview-5.11.1-py38ha1df0a3_102_qt.conda
osx-64::pygame-2.5.2-py38h5fc1981_0.conda
osx-64::libarrow-11.0.0-hca2412d_37_cpu.conda
osx-64::libopencv-4.8.0-py310h44c86d7_3.conda
osx-64::xfig-3.2.6a-h8c72263_1002.conda
osx-64::libgdal-3.6.4-h1acc371_17.conda
osx-64::folly-2023.09.04.00-h503270f_0_jemalloc.conda
osx-64::openexr-python-1.3.9-py38h82a5a32_2.conda
osx-64::aws-sdk-cpp-1.10.57-h706e9e7_22.conda
osx-64::folly-2023.09.11.00-h0d9798a_0.conda
osx-64::ticcutils-0.33.1-hf45976f_0.conda
osx-64::connectorx-0.3.2-py38h79a255e_3.conda
osx-64::lammps-2023.08.02-cpu_py39_h4b01163_openmpi_1.conda
osx-64::aimrocks-0.4.0-py311h3a58d12_1.conda
osx-64::gdstk-0.9.42-py311hd33e98c_1.conda
osx-64::yarp-cxx-3.8.1-h3ec09a2_5.conda
osx-64::raven-hydro-0.2.4-py38h98498c3_0.conda
osx-64::gdcm-2.8.9-py39h9d9e4a4_9.conda
osx-64::postgresql-plpython-16.0-py38h9f95ba2_1.conda
osx-64::openexr-python-1.3.9-py38h82a5a32_3.conda
osx-64::triqs-3.2.0-py311h409dd4b_0.conda
osx-64::pygame-2.5.2-py311h1b6052f_1.conda
osx-64::geotiff-1.7.1-h62489f7_12.conda
osx-64::jaxlib-0.4.14-cpu_py310h77baea7_1.conda
osx-64::minizip-4.0.1-h64dbd51_3.conda
osx-64::gdcm-2.8.9-py310h1676e01_10.conda
osx-64::aws-sdk-cpp-1.11.156-h706e9e7_1.conda
osx-64::gdcm-2.8.9-py311h600b701_9.conda
osx-64::libpano13-2.9.20rc2-pl5321h887111c_6.conda
osx-64::paraview-5.11.1-py311h68ea525_102_qt.conda
osx-64::pdal-2.5.6-h63992ea_2.conda
osx-64::omniorb-4.3.1-py310h0ad2c98_1.conda
osx-64::python-igraph-0.10.6-py38he3da19a_1.conda
osx-64::r-seqminer-9.1-r42he48eb84_0.conda
osx-64::harp-1.20-py38hcd854c7_0.conda
osx-64::openexr-python-1.3.9-py39hcc9336a_2.conda
osx-64::heyoka-llvm-14-2.0.0-hfda5ef7_0.conda
osx-64::connectorx-0.3.2-py310hd8cfebe_0.conda
osx-64::folly-2023.09.18.00-hc30067e_0_jemalloc.conda
osx-64::raven-hydro-0.2.4-py38hf246b68_0.conda
osx-64::libtiledb-sql-0.25.0-h8953216_0.conda
osx-64::python-rocksdb-0.7.0-py311hbae71c2_8.conda
osx-64::openslide-3.4.1-hd8a680f_11.conda
osx-64::lxml-4.9.3-py38h2d3ed51_1.conda
osx-64::photochem-0.4.2-py38hd49e68f_2.conda
osx-64::raven-hydro-0.2.4-py38ha481359_0.conda
osx-64::libmediainfo-23.09-h02ebd30_0.conda
osx-64::libgdal-arrow-parquet-3.6.4-h39324df_16.conda
osx-64::triqs-3.2.0-py39h61a7ba7_5.conda
osx-64::paraview-5.11.1-py39h804bc05_102_qt.conda
osx-64::folly-2023.09.18.00-h503270f_0_jemalloc.conda
osx-64::netpbm-10.73.43-pl5321he8cb118_2.conda
osx-64::polycap-1.2-py39h341f2fb_4.conda
osx-64::gdstk-0.9.42-py310h7a99547_1.conda
osx-64::freeimage-3.18.0-hc5048e5_16.conda
osx-64::openexr-python-1.3.9-py311h41145ee_2.conda
osx-64::vigra-1.11.1-py311h4681b91_1048.conda
osx-64::libthrift-0.19.0-h88b220a_0.conda
osx-64::mlir-python-bindings-16.0.5-py38h96fe5d3_1.conda
osx-64::lammps-2023.08.02-cpu_py39_h4b01163_openmpi_2.conda
osx-64::libgd-2.3.3-h91ac1b9_8.conda
osx-64::lammps-2023.08.02-cpu_py310_h99287ef_openmpi_1.conda
osx-64::pillow-10.0.0-py39h69f69be_1.conda
osx-64::harp-1.20-py39h70fe90c_0.conda
osx-64::raven-hydro-0.2.4-py312h338a089_1.conda
osx-64::gst-plugins-good-1.22.5-h91de58d_1.conda
osx-64::pyinstaller-6.0.0-py311hbab40d1_1.conda
osx-64::vigra-1.11.1-py311hb9be8a6_1047.conda
osx-64::libpq-15.4-h3df487d_1.conda
osx-64::arrow-cpp-9.0.0-py311h2e40684_49_cpu.conda
osx-64::cmake-3.27.5-hf40c264_0.conda
osx-64::pygplates-0.39-py39h7c4f731_9.conda
osx-64::pillow-10.0.1-py39h69f69be_0.conda
osx-64::hdfeos2-2.20-heb3f50c_1004.conda
osx-64::octave-8.3.0-h27b7d24_0.conda
osx-64::openpmd-api-0.15.2-mpi_mpich_py39hdacb9e8_1.conda
osx-64::libgdal-arrow-parquet-3.7.2-hd96a1c3_4.conda
osx-64::libgrpc-1.57.0-ha2534ac_1.conda
osx-64::pillow-10.0.1-py39h69f69be_1.conda
osx-64::r-base-4.1.3-h109b13c_12.conda
osx-64::pygame-2.5.2-py311h231154e_0.conda
osx-64::paraview-5.11.1-py310h98e6b78_102_qt.conda
osx-64::imagecodecs-2023.9.4-py311h79847ed_1.conda
osx-64::python-igraph-0.10.8-py310h23d25ad_0.conda
osx-64::lxml-4.9.3-py311h19a211c_1.conda
osx-64::libnetcdf-4.9.2-nompi_h6a32802_112.conda
osx-64::openbabel-3.1.1-py38h978edfe_8.conda
osx-64::lammps-2023.08.02-cpu_py39_h3431d70_mpich_1.conda
osx-64::libtiledb-sql-0.25.0-h8fa5f5e_0.conda
osx-64::libarrow-13.0.0-heeec12f_5_cpu.conda
osx-64::heyoka-2.0.0-hc78e3bf_0.conda
osx-64::lxml-4.9.3-py310h479f746_1.conda
osx-64::libboost-1.82.0-h4d4a22d_2.conda
osx-64::libopencv-4.8.0-py311he2a6b5d_2.conda
osx-64::pygame-2.5.2-py39h63f80ee_2.conda
osx-64::postgresql-plpython-16.0-py310he0d0a37_1.conda
osx-64::fltk-1.3.8-h1be4f9a_3.conda
osx-64::coda-2.25-py38h5c3d526_1.conda
osx-64::vigra-1.11.1-py38h6f3680b_1048.conda
osx-64::bytewax-0.17.1-py39h1b60fd0_1.conda
osx-64::libarrow-11.0.0-heeec12f_39_cpu.conda
osx-64::harp-1.20-py39hee6e04e_0.conda
osx-64::netcdf4-1.6.4-mpi_mpich_py39hbbf1715_3.conda
osx-64::vtk-base-9.2.6-qt_py310h1234567_214.conda
osx-64::mysql-server-8.0.33-h3cfac7b_4.conda
osx-64::pygame-2.5.2-py311h1b6052f_2.conda
osx-64::libarrow-10.0.1-hce17ce0_42_cpu.conda
osx-64::connectorx-0.3.2-py311h4394348_3.conda
osx-64::libcurl-static-8.3.0-h5f667d7_0.conda
osx-64::nodejs-20.6.0-h119ffd7_0.conda
osx-64::gfortran_impl_osx-arm64-13.2.0-hbfbf36e_1.conda
osx-64::bytewax-0.17.1-py310he76948c_0.conda
osx-64::r-harp-1.20-r43hc321bfd_0.conda
osx-64::xrootd-5.6.2-py311h728467c_1.conda
osx-64::lfortran-0.20.2-h7d26f99_0.conda
osx-64::heyoka-llvm-13-2.0.0-h88ced87_0.conda
osx-64::glib-networking-2.78.0-h84a2965_0.conda
osx-64::r-base-4.1.3-h9e9e7f1_11.conda
osx-64::gdstk-0.9.42-py39h836d0de_1.conda
osx-64::arrow-cpp-9.0.0-py310h14d08e7_47_cpu.conda
osx-64::mcpl-1.6.2-py38h63e6892_1.conda
osx-64::lammps-2023.08.02-cpu_py38_h40ed01f_openmpi_2.conda
osx-64::openbabel-3.1.1-py39hcf68969_8.conda
osx-64::openbabel-3.1.1-py312ha954478_8.conda
osx-64::yosys-0.33-h3b9ae2c_0.conda
osx-64::triqs-3.2.0-py39h61a7ba7_1.conda
osx-64::harp-1.20-py311hb15fc10_0.conda
osx-64::cargo-c-0.9.24-h471a7f2_1.conda
osx-64::raven-hydro-0.2.4-py311h5482185_0.conda
osx-64::omniorb-libs-4.3.1-h9bc8c17_1.conda
osx-64::libpulsar-3.2.0-h26c0d49_3.conda
osx-64::libopencv-4.8.0-py311h60bc479_3.conda
osx-64::qt6-main-6.5.2-h3f4001d_2.conda
osx-64::gst-plugins-good-1.22.6-h91de58d_0.conda
osx-64::util-linux-2.39.2-py39h2550083_1.conda
osx-64::qt-main-5.15.8-hc03889f_16.conda
osx-64::pylibmc-1.6.3-py311hbab40d1_2.conda
osx-64::minizip-4.0.1-h64dbd51_4.conda
osx-64::util-linux-2.39.2-py38h75b9449_1.conda
osx-64::libgdal-3.6.4-hef1cc25_16.conda
osx-64::openexr-python-1.3.9-py39hf614b33_2.conda
osx-64::imagecodecs-2023.9.4-py39hdd53b90_2.conda
osx-64::raven-hydro-0.2.4-py39h16b9c15_1.conda
osx-64::pyinstaller-6.0.0-py310hb69a1aa_0.conda
osx-64::netcdf4-1.6.4-nompi_py310h5076b6f_103.conda
osx-64::qt6-main-6.5.2-ha0e0094_3.conda
osx-64::triqs-3.2.0-py38hd329b4f_1.conda
osx-64::qt6-main-6.5.2-h4b16cc3_1.conda
osx-64::coda-2.25-py310h50e53ba_1.conda
osx-64::lammps-2023.08.02-cpu_py310_h47242cf_mpich_2.conda
osx-64::paraview-5.11.2-py38ha1df0a3_102_qt.conda
osx-64::paraview-5.11.1-py39hd22500e_102_qt.conda
osx-64::triqs-3.2.0-py311h409dd4b_2.conda
osx-64::libopencv-4.8.0-py39h69560c6_4.conda
osx-64::pillow-10.0.1-py310h5e9aaff_0.conda
osx-64::erlang-26.1-pl5321hbb39af3_0.conda
osx-64::python-igraph-0.10.6-py38h58cdb82_1.conda
osx-64::python-igraph-0.10.6-py311h3ad72c6_2.conda
osx-64::connectorx-0.3.2-py310hd8cfebe_1.conda
osx-64::gstlal-1.12.0-py310h5312519_0.conda
osx-64::qtwebkit-5.212-h1aa9e42_13.conda
osx-64::cpp-opentelemetry-sdk-1.11.0-h5bde9cf_1.conda
osx-64::imagecodecs-2023.9.4-py39h77d3984_0.conda
osx-64::grpcio-1.58.1-py311h43071ad_0.conda
osx-64::gazebo-11.13.0-h4e69cde_6.conda
osx-64::sdl_image-1.2.12-hdf666d9_5.conda
osx-64::octave-8.2.0-h27b7d24_2.conda
osx-64::openpmd-api-0.15.2-mpi_mpich_py38h0990953_1.conda
osx-64::pylibmc-1.6.3-py39h35e2f92_2.conda
osx-64::util-linux-2.39.2-py311ha082ef5_1.conda
osx-64::paraview-5.11.2-py310h98e6b78_102_qt.conda
osx-64::postgresql-plpython-16.0-py312he92ef8c_1.conda
osx-64::libthrift-0.19.0-h064b379_1.conda
osx-64::raven-hydro-0.2.4-py311hfdac233_0.conda
osx-64::paraview-5.11.1-py38h4d8cd2c_102_qt.conda
osx-64::imagecodecs-2023.9.4-py39hbc44a19_0.conda
osx-64::imagecodecs-2023.9.4-py310h73ba94e_0.conda
osx-64::pygame-2.5.2-py39h91db508_0.conda
osx-64::pypy3.8-7.3.11-h3a77750_5.conda
osx-64::gdcm-2.8.9-py312hef89a84_9.conda
osx-64::lxml-4.9.3-py39hfa406f7_1.conda
osx-64::omniorb-4.3.1-py312h2838806_1.conda
osx-64::lxml-4.9.3-py312h7bc987c_1.conda
osx-64::py-bgzip-0.4.0-py310h91e19c7_4.conda
osx-64::openpmd-api-0.15.2-mpi_mpich_py39h650998f_1.conda
osx-64::libopencv-4.8.0-py39hb19c074_2.conda
osx-64::libgdal-arrow-parquet-3.6.4-h985b47e_19.conda
osx-64::vtk-base-9.2.6-qt_py38h1234567_214.conda
osx-64::coda-2.25-py39h4abb3f3_1.conda
osx-64::openexr-python-1.3.9-py312h3503da1_3.conda
osx-64::lammps-2023.08.02-cpu_py310_h47242cf_mpich_1.conda
osx-64::hugin-base-2022.0.0-pl5321hfe006b9_7.conda
osx-64::curl-8.3.0-h5f667d7_0.conda
osx-64::lld-17.0.1-h62a38e0_0.conda
osx-64::libgdal-arrow-parquet-3.6.4-h46dd223_18.conda
osx-64::libarrow-10.0.1-h6b1e468_41_cpu.conda
osx-64::llvm-tools-17.0.1-he4b1e75_0.conda
osx-64::aimrocks-0.4.0-py310h2f15a1c_1.conda
osx-64::libllvm17-17.0.1-he4b1e75_0.conda
osx-64::folly-2023.09.11.00-hc30067e_0_jemalloc.conda
osx-64::pyinstaller-6.0.0-py39h29f4f0d_0.conda
osx-64::pygplates-0.39-py38h2581ea6_9.conda
osx-64::coda-2.25-py38h4485038_0.conda
osx-64::r-base-4.3.1-h9e9e7f1_4.conda
osx-64::bytewax-0.17.1-py310h056fd3c_1.conda
osx-64::xeus-cpp-0.0.1-h4e20f1e_2.conda
osx-64::libgdal-arrow-parquet-3.7.2-hb392038_3.conda
osx-64::gfortran_impl_osx-64-13.2.0-h7643cbd_1.conda
osx-64::mcpl-1.6.2-py39h35e2f92_1.conda
osx-64::paraview-5.11.1-py311h83b279d_102_qt.conda
osx-64::libopencv-4.8.0-py38hc5dad62_2.conda
osx-64::postgresql-16.0-hc940a54_0.conda
osx-64::libopencv-4.8.1-py311h0809f14_0.conda
osx-64::imagemagick-7.1.1_15-pl5321hfd0a208_1.conda
osx-64::triqs-3.2.0-py38h2e556f2_2.conda
osx-64::folly-2023.09.11.00-h1718691_0.conda
osx-64::tiledb-2.16.3-hd91d5f4_2.conda
osx-64::cmake-3.27.6-hf40c264_0.conda
osx-64::tiledb-2.17.0-h9b026fb_0.conda
osx-64::pytables-3.8.0-py38h8cbd48f_3.conda
osx-64::folly-2023.09.18.00-hd4516f9_0_jemalloc.conda
osx-64::nest-simulator-3.6-py39h8f63631_0.conda
osx-64::imagecodecs-2023.9.4-py310hb72ea00_2.conda
osx-64::photochem-0.4.2-py310h8c30635_2.conda
osx-64::gdcm-2.8.9-py311he81eadd_10.conda
osx-64::aws-sdk-cpp-1.11.156-h99d1da1_3.conda
osx-64::vigra-1.11.1-py38h1cd8355_1047.conda
osx-64::lammps-2023.08.02-cpu_py311_hb61bd1e_mpich_2.conda
osx-64::xrootd-5.6.2-py310hb3023bb_1.conda
osx-64::pyhdf-0.11.3-py39hf863264_1.conda
osx-64::libopencv-4.8.1-py39h69560c6_0.conda
osx-64::ticcutils-0.33-hf45976f_0.conda
osx-64::panda3d-1.10.12-py311h0f9f0ce_5.conda
osx-64::connectorx-0.3.2-py39h4a9edc7_0.conda
osx-64::libopencv-4.8.0-py38hf6af110_4.conda
osx-64::triqs-3.2.0-py311h409dd4b_4.conda
osx-64::wasmer-4.2.1-ha6357cd_0.conda
osx-64::pytables-3.8.0-py39h5328b58_3.conda
osx-64::python-igraph-0.10.6-py310h23d25ad_1.conda
osx-64::python-rocksdb-0.7.0-py310h39d968c_8.conda
osx-64::triqs-3.2.0-py311h3ee9e43_2.conda
osx-64::connectorx-0.3.2-py39h4a9edc7_2.conda
osx-64::gst-plugins-bad-1.22.6-h70ac916_0.conda
osx-64::thrift-compiler-0.19.0-h88b220a_0.conda
osx-64::libopencv-4.8.0-py39hffbb2f2_4.conda
osx-64::imagecodecs-2023.9.4-py39hca512f1_2.conda
osx-64::orc-1.9.0-ha4ae40d_2.conda
osx-64::minizip-4.0.1-h64dbd51_1.conda
osx-64::vtk-base-9.2.6-qt_py38h1234567_213.conda
osx-64::py-bgzip-0.4.0-py39had93c15_4.conda
osx-64::freefem-4.13-h995e45e_3.conda
osx-64::jaxlib-0.4.14-cpu_py311hde9d678_1.conda
osx-64::util-linux-2.39.2-py38h75b9449_0.conda
osx-64::pyretis-2.5.0-py311h8f92aaa_3.conda
osx-64::gstlal-1.12.0-py311hae03944_0.conda
osx-64::libvips-8.14.5-h7e59d53_0.conda
osx-64::py-bgzip-0.4.0-py38h11bb675_4.conda
osx-64::python-igraph-0.10.6-py39h3ec5f52_2.conda
osx-64::vigra-1.11.1-py39h69129b1_1048.conda
osx-64::ogre-1.10.12-h471aa62_13.conda
osx-64::r-base-4.3.1-h61172b1_5.conda
osx-64::lammps-2023.08.02-cpu_py39_ha9147cc_mpich_1.conda
osx-64::polycap-1.2-py311he033f8a_4.conda
osx-64::triqs-3.2.0-py311h409dd4b_1.conda
osx-64::paraview-5.11.1-py38h55fe954_102_qt.conda
osx-64::triqs-3.2.0-py310he217e82_3.conda
osx-64::paraview-5.11.1-py311h0d91f8f_102_qt.conda
osx-64::omniorb-4.3.1-py311h3c90865_1.conda
osx-64::arrow-cpp-9.0.0-py38hd82eaab_49_cpu.conda
osx-64::tiledb-2.17.1-h9b026fb_0.conda
osx-64::xrootd-5.6.2-py312h704ee90_1.conda
osx-64::pyhdf-0.11.3-py311h7b9276f_1.conda
osx-64::vigra-1.11.1-py39hd4a7952_1047.conda
osx-64::lfortran-0.20.3-h7d26f99_0.conda
osx-64::vigra-1.11.2-py39h7e94b6e_0.conda
osx-64::triqs-3.2.0-py38hd329b4f_2.conda
osx-64::vigra-1.11.2-py39h3d0f01c_0.conda
osx-64::panda3d-1.10.12-py38h92519bf_5.conda
osx-64::pyhdf-0.11.3-py39h646fde2_1.conda
osx-64::minizip-4.0.1-h64dbd51_2.conda
osx-64::erlang-26.1.1-pl5321hbb39af3_0.conda
osx-64::netcdf4-1.6.4-mpi_openmpi_py39hdb87dbe_3.conda
osx-64::libarrow-12.0.1-hdcd9b72_10_cpu.conda
osx-64::libgdal-3.7.2-h75ea8fa_1.conda
osx-64::r-seqminer-9.1-r43he48eb84_0.conda
osx-64::osmium-tool-1.16.0-habffc7e_1.conda
osx-64::vigra-1.11.2-py39h69129b1_0.conda
osx-64::libzip-1.10.1-hc158999_1.conda
osx-64::nodejs-20.7.0-h119ffd7_0.conda
osx-64::lxml-4.9.3-py39h4794613_1.conda
osx-64::vigra-1.11.1-py310he25bc26_1047.conda
osx-64::libpq-16.0-h3df487d_1.conda
osx-64::vtk-base-9.2.6-qt_py39h1234567_213.conda
osx-64::tiledb-2.16.3-h9b026fb_3.conda
osx-64::pillow-10.0.1-py38ha0d9280_0.conda
osx-64::gdcm-2.8.9-py38h25479f6_9.conda
osx-64::triqs-3.2.0-py310he217e82_1.conda
osx-64::tiledb-2.17.1-h24ec535_0.conda
osx-64::libgdal-3.6.4-h7a538ca_18.conda
osx-64::triqs-3.2.0-py38h2e556f2_4.conda
osx-64::arrow-cpp-9.0.0-py310h14ebe1b_49_cpu.conda
osx-64::ncl-6.6.2-h0c4400e_50.conda
osx-64::paraview-5.11.1-py39h5bdb42e_102_qt.conda
osx-64::openpmd-api-0.15.2-nompi_py310h4c14650_101.conda
osx-64::libarrow-13.0.0-heeec12f_4_cpu.conda
osx-64::netcdf4-1.6.4-mpi_mpich_py310h6fcf279_3.conda
osx-64::openpmd-api-0.15.2-nompi_py39h4b6d4f4_101.conda
osx-64::connectorx-0.3.2-py38h79a255e_0.conda
osx-64::pygame-2.5.2-py39h6ccb3b9_0.conda
osx-64::python-igraph-0.10.6-py310h23d25ad_2.conda
osx-64::heyoka-llvm-15-2.0.0-h13f49d6_0.conda
osx-64::xrootd-5.6.2-py39h287db84_0.conda
osx-64::libgrpc-1.58.1-h8962868_0.conda
osx-64::triqs-3.2.0-py310h199346d_4.conda
osx-64::postgresql-plpython-15.4-py310he0d0a37_2.conda
osx-64::folly-2023.09.25.00-h1718691_0.conda
osx-64::postgresql-plpython-16.0-py39hfacc66a_0.conda
osx-64::nodejs-18.17.1-h46e3395_0.conda
osx-64::poppler-23.08.0-h4b016c5_1.conda
osx-64::libopencv-4.8.0-py310h5ca57ac_4.conda
osx-64::magics-4.14.2-h419c579_1.conda
osx-64::triqs-3.2.0-py38hd329b4f_4.conda
osx-64::nodejs-20.8.0-h119ffd7_0.conda
osx-64::vigra-1.11.1-py39h7e94b6e_1048.conda
osx-64::xrootd-5.6.2-py310hb3023bb_0.conda
osx-64::lammps-2023.08.02-cpu_py39_h3431d70_mpich_2.conda
osx-64::mysql-client-8.0.33-hc4c47b9_3.conda
osx-64::lpython-0.20.0-h7d26f99_0.conda
osx-64::libpq-15.4-h3df487d_2.conda
osx-64::astrometry-0.94-py311h47f9283_4.conda
osx-64::paraview-5.11.1-py311h4d8b3c4_102_qt.conda
osx-64::mesalib-23.2.1-hb59017c_0.conda
osx-64::libopencv-4.8.0-py38h6f28b18_3.conda
osx-64::pillow-10.0.0-py310h5e9aaff_1.conda
osx-64::libarrow-10.0.1-hce17ce0_43_cpu.conda
osx-64::glib-2.78.0-h7d26f99_0.conda
osx-64::triqs-3.2.0-py38hd329b4f_5.conda
osx-64::cargo-c-0.9.24-h471a7f2_0.conda
osx-64::postgresql-plpython-16.0-py310he0d0a37_0.conda
osx-64::r-base-4.1.3-hc77f628_11.conda
osx-64::mysql-libs-8.0.33-he48d296_4.conda
osx-64::postgresql-plpython-15.4-py312he92ef8c_2.conda
osx-64::grpcio-1.58.1-py310h0d4bf3c_0.conda
osx-64::libgdal-arrow-parquet-3.7.2-h2cdf25d_0.conda
osx-64::lammps-2023.08.02-cpu_py311_h38df71f_openmpi_1.conda
osx-64::heyoka-2.0.0-h37be4b7_0.conda
osx-64::openpmd-api-0.15.2-nompi_py39h1263ec8_101.conda
osx-64::libopencv-4.8.0-py310h21badc7_2.conda
osx-64::pygame-2.5.2-py39hb83dceb_2.conda
osx-64::mlir-python-bindings-16.0.5-py311hd33e98c_1.conda
osx-64::blosc-1.21.5-heccf04b_0.conda
osx-64::vigra-1.11.2-py39h9e1d444_0.conda
osx-64::libzip-1.10.1-hc158999_2.conda
osx-64::bytewax-0.17.1-py39h06921b3_0.conda
osx-64::lammps-2023.08.02-cpu_py39_ha9147cc_mpich_2.conda
osx-64::photochem-0.4.2-py311haf3ee1a_2.conda
osx-64::arrow-cpp-9.0.0-py311hd93bb85_47_cpu.conda
osx-64::pdal-2.5.6-hbc5c92f_3.conda
osx-64::libarrow-13.0.0-hca2412d_3_cpu.conda
osx-64::vigra-1.11.2-py310hce14334_0.conda
osx-64::heyoka-2.0.0-ha692f19_0.conda
osx-64::vigra-1.11.1-py310ha92708c_1048.conda
osx-64::aimrocks-0.4.0-py38h9b68359_1.conda
osx-64::vigra-1.11.1-py39h9e1d444_1048.conda
osx-64::paraview-5.11.2-py311h4d8b3c4_102_qt.conda
osx-64::imagemagick-7.1.1_17-pl5321hfd0a208_0.conda
osx-64::aws-sdk-cpp-1.11.158-hcbc40b4_0.conda
osx-64::postgresql-plpython-15.4-py39hfacc66a_2.conda
osx-64::fltk-1.3.8-h299f19b_2.conda
osx-64::pylibmc-1.6.3-py312hf019568_2.conda
osx-64::pillow-10.0.0-py39h0ada47f_1.conda
osx-64::libzip-1.10.1-hc158999_3.conda
osx-64::openpmd-api-0.15.2-nompi_py38h7790ef4_101.conda
osx-64::pillow-10.0.1-py39h0ada47f_0.conda
osx-64::paraview-5.11.1-py310h326fd3e_102_qt.conda
osx-64::pygame-2.5.2-py39h63f80ee_1.conda
osx-64::openpmd-api-0.15.2-nompi_py38h83f3cbb_101.conda
osx-64::triqs-3.2.0-py39h56f4216_1.conda
osx-64::python-rocksdb-0.7.0-py312h9537f2a_8.conda
osx-64::arrow-cpp-9.0.0-py39h839a1a6_48_cpu.conda
osx-64::libopentelemetry-cpp-1.11.0-h5bde9cf_1.conda
osx-64::paraview-5.11.1-py38hf8bb1fe_102_qt.conda
osx-64::folly-2023.09.04.00-h0d9798a_0.conda
osx-64::python-igraph-0.10.6-py38he3da19a_2.conda
osx-64::pyinstaller-6.0.0-py38h63e6892_1.conda
osx-64::tiledb-2.16.3-h24ec535_3.conda
osx-64::libopencv-4.8.1-py38hf6af110_0.conda
osx-64::astrometry-0.94-py38h4ee38f3_4.conda
osx-64::connectorx-0.3.2-py39h4a9edc7_1.conda
osx-64::geotiff-1.7.1-hc41fca6_13.conda
osx-64::triqs-3.2.0-py310h199346d_5.conda
osx-64::ogre-1.10.12-h471aa62_14.conda
osx-64::photochem-0.4.2-py39h9201185_2.conda
osx-64::lammps-2023.08.02-cpu_py39_hb9db24c_openmpi_2.conda
osx-64::mlir-python-bindings-16.0.5-py310h7a99547_1.conda
osx-64::vigra-1.11.1-py39h2cf6e5b_1047.conda
osx-64::vigra-1.11.1-py39h3d0f01c_1048.conda
osx-64::tiledb-2.16.3-hd3a41d5_3.conda
osx-64::vtk-base-9.2.6-qt_py311h1234567_213.conda
osx-64::libglib-2.78.0-hc62aa5d_0.conda
osx-64::util-linux-2.39.2-py310h7a77fba_1.conda
osx-64::bytewax-0.17.1-py38ha69c3b9_1.conda
osx-64::pillow-10.0.1-py310h5e9aaff_1.conda
osx-64::libgdal-3.6.4-h72c753c_19.conda
osx-64::triqs-3.2.0-py311h3ee9e43_3.conda
osx-64::qt6-main-6.5.2-h18bfe14_4.conda
osx-64::mlir-17.0.1-h837b0c1_0.conda
osx-64::lammps-2023.08.02-cpu_py310_h99287ef_openmpi_2.conda
osx-64::imagecodecs-2023.9.4-py311h10a763d_0.conda
osx-64::libarrow-10.0.1-ha5fdb95_39_cpu.conda
osx-64::triqs-3.2.0-py310he217e82_5.conda
osx-64::paraview-5.11.1-py38h56b114c_102_qt.conda
osx-64::gdcm-2.8.9-py39h78ff83b_10.conda
osx-64::arrow-cpp-9.0.0-py38h2a98d37_48_cpu.conda
osx-64::aws-sdk-cpp-1.10.57-he261887_23.conda
osx-64::vigra-1.11.1-py38hc74187b_1047.conda
osx-64::libgdal-3.7.2-h9fbd35e_2.conda
osx-64::folly-2023.09.04.00-h8318d5c_0.conda
osx-64::postgresql-plpython-15.4-py38h9f95ba2_1.conda
osx-64::libarrow-10.0.1-h8171123_40_cpu.conda
osx-64::raven-hydro-0.2.4-py310h0bc48e2_0.conda
osx-64::util-linux-2.39.2-py39ha1f00b2_1.conda
osx-64::omniorb-4.3.1-py38h73e9ec3_1.conda
osx-64::libboost-1.82.0-hf0c313a_3.conda
osx-64::pillow-10.0.0-py38ha0d9280_1.conda
osx-64::openexr-python-1.3.9-py310h768d1bd_3.conda
osx-64::triqs-3.2.0-py310h199346d_2.conda
osx-64::coda-2.25-py39h171fc49_0.conda
osx-64::libspatialite-5.1.0-h231fb02_0.conda
osx-64::gtk4-4.12.1-h0ccc30f_3.conda
osx-64::heyoka-2.0.0-hca3e132_0.conda
osx-64::pyretis-2.5.0-py38hdcd5196_3.conda
osx-64::pygplates-0.39-py310h7ae02c9_9.conda
osx-64::paraview-5.11.1-py39hc3a1a5e_102_qt.conda
osx-64::aws-sdk-cpp-1.11.156-hcbc40b4_0.conda
osx-64::pypy3.9-7.3.13-hc0e9917_0.conda
osx-64::libarrow-11.0.0-hdcd9b72_35_cpu.conda
osx-64::libpq-16.0-h3df487d_0.conda
osx-64::pyinstaller-6.0.0-py310hb69a1aa_1.conda
osx-64::abinit-9.8.4-hba7b9ac_3.conda
osx-64::postgresql-plpython-16.0-py311hbf368a9_1.conda
osx-64::astrometry-0.94-py310h9a81ba2_4.conda
osx-64::mold-2.2.0-hc277f81_0.conda
osx-64::folly-2023.09.25.00-h0d9798a_0.conda
osx-64::nexus-4.4.3-h0983bf6_12.conda
osx-64::astrometry-0.94-py39hf2628d4_4.conda
osx-64::pygame-2.5.2-py312hc40150d_2.conda
osx-64::nest-simulator-3.6-py310hc17d38f_0.conda
osx-64::openpmd-api-0.15.2-mpi_openmpi_py311hf1dab15_1.conda
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
================================================================================
================================================================================
linux-64
linux-64::tippecanoe-2.31.0-ha331528_0.conda
linux-64::liblal-7.3.1-fftw_hcb65b59_102.conda
linux-64::u3d-0.3.5-h8daa6b0_2.conda
linux-64::libprotobuf-static-4.24.3-hf27288f_0.conda
linux-64::libcdms-3.1.2-hfa80d88_128.conda
linux-64::libprotobuf-4.23.4-hf27288f_6.conda
linux-64::libsolv-static-0.7.25-hfc55251_0.conda
linux-64::cudnn-8.8.0.121-h264754d_3.conda
linux-64::gst-libav-1.22.6-hd5f137f_0.conda
linux-64::povray-3.7.0.8-hfc037ee_9.conda
linux-64::libprotobuf-static-4.23.4-hf27288f_6.conda
linux-64::libsolv-0.7.25-hfc55251_0.conda
linux-64::cudnn-8.8.0.121-h838ba91_3.conda
linux-64::libuwebsockets-20.46.0-hfc55251_0.conda
linux-64::tk-8.6.13-h2797004_0.conda
linux-64::openexr-3.2.1-h3f0fd8d_0.conda
linux-64::libuwebsockets-20.47.0-hfc55251_0.conda
linux-64::freetype-2.12.1-h267a509_2.conda
linux-64::libsolv-0.7.24-hfc55251_4.conda
linux-64::libprotobuf-static-4.23.3-hd1fb520_1.conda
linux-64::libsolv-static-0.7.24-hfc55251_4.conda
linux-64::povray-3.7.0.8-h5888656_8.conda
linux-64::cudnn-8.8.0.121-h56904bc_3.conda
linux-64::libprotobuf-4.23.3-hd1fb520_1.conda
linux-64::cgns-4.4.0-h1704e6f_2.conda
linux-64::libprotobuf-4.23.4-hf27288f_5.conda
linux-64::hdf4-4.2.15-h2a13503_7.conda
linux-64::libpcm-1.2.3-hf7c02db_5.conda
linux-64::libraw-0.21.1-h2a13503_2.conda
linux-64::libmlir17-17.0.1-hcd5def8_0.conda
linux-64::libharu-2.4.4-h267a509_0.conda
linux-64::openjpeg-2.5.0-h488ebb8_3.conda
linux-64::libprotobuf-static-4.23.4-hf27288f_5.conda
linux-64::gdk-pixbuf-2.42.10-h6c15284_3.conda
linux-64::libmlir-17.0.1-hcd5def8_0.conda
linux-64::libcdms-3.1.2-h0cec689_129.conda
linux-64::glib-tools-2.78.0-hfc55251_0.conda
linux-64::micromamba-1.5.1-0.tar.bz2
linux-64::stress-ng-0.16.05-h2797004_0.conda
linux-64::libprotobuf-4.24.3-hf27288f_0.conda
linux-64::gdk-pixbuf-2.42.10-h829c605_4.conda
linux-64::tippecanoe-2.28.0-ha331528_0.conda
linux-64::tippecanoe-2.28.1-ha331528_0.conda
linux-64::dlib-cpp-19.24.2-h1f83154_5.conda
-    "libzlib >=1.2.13,<1.3.0a0"
+    "libzlib >=1.2.13,<2.0.0a0"
linux-64::thrift-compiler-0.19.0-h8fd135c_0.conda
linux-64::tiledb-2.17.1-h8c794c1_0.conda
linux-64::connectorx-0.3.2-py39h7d5a94b_3.conda
linux-64::folly-2023.09.18.00-h09ac5fe_0.conda
linux-64::postgresql-15.4-h8972f4a_1.conda
linux-64::raven-hydro-0.2.4-py39h5056a20_0.conda
linux-64::openjdk-11.0.15-h6f1e508_6.conda
linux-64::pillow-10.0.0-py38h71741d6_1.conda
linux-64::imagecodecs-2023.9.4-py39h91f3525_0.conda
linux-64::lxml-4.9.3-py310h9b7343a_1.conda
linux-64::omniorb-libs-4.3.1-h1933689_1.conda
linux-64::libarrow-10.0.1-h37b21ae_40_cpu.conda
linux-64::lammps-2023.08.02-cpu_py311_hb661868_openmpi_1.conda
linux-64::arrow-cpp-9.0.0-py39h2c1fdd5_48_cuda.conda
linux-64::jaxlib-0.4.14-cuda112py39h28c4bd0_201.conda
linux-64::connectorx-0.3.2-py39hde1f300_1.conda
linux-64::mcpl-1.6.2-py39hc7d112a_1.conda
linux-64::vigra-1.11.1-py311hff02683_1048.conda
linux-64::postgresql-plpython-16.0-py310hd093153_1.conda
linux-64::netcdf4-1.6.4-nompi_py39h4282601_103.conda
linux-64::coda-2.25-py311ha49c379_0.conda
linux-64::libopencv-4.8.1-py38h9cbf798_0.conda
linux-64::graphicsmagick-1.3.40-hd2258ff_3.conda
linux-64::vigra-1.11.1-py310h87c7a57_1047.conda
linux-64::connectorx-0.3.2-py310heac1918_2.conda
linux-64::netcdf4-1.6.4-mpi_openmpi_py311ha5d6734_3.conda
linux-64::r-harp-1.20-r43h71bbeed_0.conda
linux-64::postgresql-plpython-15.4-py311hf60bfc6_2.conda
linux-64::gst-plugins-base-1.22.5-h8e1006c_1.conda
linux-64::folly-2023.09.11.00-hda79706_0_jemalloc.conda
linux-64::paraview-5.11.1-py311h6e1e116_102_qt.conda
linux-64::dpcpp_impl_linux-64-2023.2.0-hd6dfaa8_49499.conda
linux-64::xrootd-5.6.2-py39hbb686b4_1.conda
linux-64::gdcm-2.8.9-py39h33cf49a_10.conda
linux-64::ogre-14.0.1-h49669e8_2.conda
linux-64::libgdal-3.7.2-h323ed7e_1.conda
linux-64::harp-1.20-py39he46ae98_0.conda
linux-64::omniorb-4.3.1-py311h28f970a_1.conda
linux-64::bytewax-0.17.1-py38h5fd4b22_1.conda
linux-64::raven-hydro-0.2.4-py39hb80b23e_0.conda
linux-64::triqs-3.2.0-py38h72e10a8_4.conda
linux-64::xrootd-5.6.2-py311h7c82654_1.conda
linux-64::bytewax-0.17.1-py38he60ca92_0.conda
linux-64::gst-plugins-base-1.22.6-h8e1006c_1.conda
linux-64::paraview-5.11.1-py38hb8c01d6_102_qt.conda
linux-64::arrow-cpp-9.0.0-py310ha5b06c0_49_cpu.conda
linux-64::lfortran-0.20.0-hfc55251_0.conda
linux-64::triqs-3.2.0-py311h6b9694e_5.conda
linux-64::heyoka-2.0.0-h4eadc13_0.conda
linux-64::openexr-python-1.3.9-py39h730ee47_2.conda
linux-64::heyoka-llvm-13-2.0.0-h1380d4f_0.conda
linux-64::mdsplus-7.139.48-py38pl5321h686a8d3_0.conda
linux-64::mdsplus-7.139.40-py38pl5321h686a8d3_1.conda
linux-64::grpcio-1.58.1-py310h1b8f574_0.conda
linux-64::boost-cpp-1.82.0-h789c474_2.conda
linux-64::lammps-2023.08.02-cpu_py310_hf267ffc_mpich_2.conda
linux-64::paraview-5.11.1-py311h6db61f1_102_qt.conda
linux-64::libarrow-12.0.1-hd3e26bc_14_cuda.conda
linux-64::openpmd-api-0.15.2-mpi_mpich_py311h53be492_1.conda
linux-64::python-igraph-0.10.6-py38h8860397_1.conda
linux-64::nest-simulator-3.6-py311hcb301d6_0.conda
linux-64::symengine-0.11.1-hb29318e_0.conda
linux-64::intel-cmplr-lib-rt-2023.2.0-hfc55251_49500.conda
linux-64::aws-sdk-cpp-1.11.156-h6f6b8fa_0.conda
linux-64::gst-plugins-good-1.22.5-hf7bd3a9_1.conda
linux-64::bytewax-0.17.1-py39hced4d33_1.conda
linux-64::pygame-2.5.2-py311h7bd3ff0_1.conda
linux-64::lammps-2023.08.02-cpu_py310_hf267ffc_mpich_1.conda
linux-64::netcdf4-1.6.4-mpi_openmpi_py39h1b36d35_3.conda
linux-64::raven-hydro-0.2.4-py39h5056a20_1.conda
linux-64::mold-2.1.0-h76aa41c_2.conda
linux-64::polycap-1.2-py38h4ec914e_4.conda
linux-64::r-base-4.1.3-h11e5365_12.conda
linux-64::libgdal-arrow-parquet-3.7.2-h5d92d83_4.conda
linux-64::python-igraph-0.10.6-py39h2c4918a_2.conda
linux-64::libarrow-13.0.0-h860fa02_3_cuda.conda
linux-64::triqs-3.2.0-py310h30ed552_3.conda
linux-64::assimp-5.3.0-h378b44f_0.conda
linux-64::gdcm-2.8.9-py311h0915de0_10.conda
linux-64::rpm-tools-4.17.1-py311lua54h12b5f5a_4.conda
linux-64::util-linux-2.39.2-py311h4285dfd_1.conda
linux-64::tiledb-2.16.3-h8c794c1_3.conda
linux-64::folly-2023.09.04.00-ha1f1437_0_jemalloc.conda
linux-64::libopencv-4.8.0-py310h8ad8f1f_4.conda
linux-64::pyretis-2.5.0-py39h67e0f1a_3.conda
linux-64::py-bgzip-0.4.0-py310h93c3562_4.conda
linux-64::triqs-3.2.0-py39hd083d43_1.conda
linux-64::lammps-2023.08.02-cpu_py39_h00752c8_mpich_1.conda
linux-64::pygame-2.5.2-py39hc998183_1.conda
linux-64::mdsplus-7.139.46-py311pl5321h19eab63_0.conda
linux-64::vtk-base-9.2.6-qt_py38h1234567_214.conda
linux-64::libllvm17-17.0.1-h5cf9203_0.conda
linux-64::python-rocksdb-0.7.0-py39ha620bd8_8.conda
linux-64::openvdb-10.0.1-hc77a128_3.conda
linux-64::vigra-1.11.1-py39hff149b2_1047.conda
linux-64::gtk4-4.12.1-hc601105_2.conda
linux-64::vigra-1.11.2-py39h397cfeb_0.conda
linux-64::libgdal-3.7.2-h3aa23ec_3.conda
linux-64::pygplates-0.39-py39h0f2d542_9.conda
linux-64::mapserver-8.0.1-py38h8dd5b3c_8.conda
linux-64::openslide-3.4.1-hcb9e6c7_11.conda
linux-64::vtk-base-9.2.6-qt_py310h1234567_214.conda
linux-64::libcurl-8.3.0-hca28451_0.conda
linux-64::pypy3.9-7.3.12-h9557127_5.conda
linux-64::libpq-15.4-hfc447b1_1.conda
linux-64::openjdk-20.0.2-hfea2f88_1.conda
linux-64::qtwebkit-5.212-h706289d_13.conda
linux-64::libopencv-4.8.0-py310h9ea11ae_2.conda
linux-64::intel-cmplr-lib-rt-2023.2.0-hfc55251_49496.conda
linux-64::pyretis-2.5.0-py310h523e8d7_3.conda
linux-64::vtk-base-9.2.6-qt_py311h1234567_214.conda
linux-64::linux-perf-6.3.10-py312hc104dfe_1.conda
linux-64::nodejs-20.8.0-hb753e55_0.conda
linux-64::mdsplus-7.139.40-py310pl5321hdeeefa5_1.conda
linux-64::pillow-10.0.1-py38h71741d6_1.conda
linux-64::util-linux-2.39.2-py310h6b057ee_0.conda
linux-64::libsoup-3.4.3-hb337396_0.conda
linux-64::gdcm-2.8.9-py38h5209fd9_10.conda
linux-64::aws-sdk-cpp-1.10.57-h8bde0db_22.conda
linux-64::openbabel-3.1.1-py310h956b46e_8.conda
linux-64::vigra-1.11.1-py39had53cd9_1048.conda
linux-64::lammps-2023.08.02-cpu_py311_h4aafb77_mpich_2.conda
linux-64::lfortran-0.20.3-hfc55251_0.conda
linux-64::imagecodecs-2023.9.4-py39h43e5ab6_2.conda
linux-64::paraview-5.11.1-py310h5b38319_2_egl.conda
linux-64::paraview-5.11.1-py310h8b3917e_102_qt.conda
linux-64::sdl2_image-2.6.3-hd5977a8_2.conda
linux-64::imagemagick-7.1.1_17-pl5321h7e74ff9_0.conda
linux-64::grpcio-1.58.1-py311ha6695c7_0.conda
linux-64::aimrocks-0.4.0-py38h67b9777_1.conda
linux-64::lxml-4.9.3-py38h0ef1326_1.conda
linux-64::pillow-10.0.1-py39h444a776_0.conda
linux-64::mapserver-8.0.1-py39h1da377d_6.conda
linux-64::coda-2.25-py38haeebca4_1.conda
linux-64::gdcm-2.8.9-py312he171554_9.conda
linux-64::paraview-5.11.1-py311h2c6f892_102_qt.conda
linux-64::qt-webengine-5.15.8-h57d7698_3.conda
linux-64::netcdf4-1.6.4-nompi_py311he8ad708_103.conda
linux-64::py-bgzip-0.4.0-py311hdcc4c9d_4.conda
linux-64::lammps-2023.08.02-cpu_py39_h2595f3c_mpich_2.conda
linux-64::python-wasmer-1.2.0-py311hd85059d_0.conda
linux-64::pyinstaller-6.0.0-py39hb6545a3_0.conda
linux-64::openpmd-api-0.15.2-mpi_mpich_py38h2f32745_1.conda
linux-64::libarrow-13.0.0-h1ed0495_3_cpu.conda
linux-64::openjdk-11.0.20-hbf40d96_2.conda
linux-64::libboost-1.82.0-h6fcfa73_3.conda
linux-64::libarrow-10.0.1-h1ed0495_41_cpu.conda
linux-64::pillow-10.0.1-py38h71741d6_0.conda
linux-64::paraprobe-v0.4-mpi_mpich_h8e8da15_0.conda
linux-64::libarrow-12.0.1-ha64140a_11_cuda.conda
linux-64::grpcio-1.58.1-py39h174d805_0.conda
linux-64::raven-hydro-0.2.4-py39h191c732_0.conda
linux-64::libarrow-12.0.1-hdd62870_10_cuda.conda
linux-64::vtk-base-9.2.6-egl_py310h1234567_14.conda
linux-64::postgresql-plpython-15.4-py310hd093153_2.conda
linux-64::paraview-5.11.1-py311h12671d2_2_egl.conda
linux-64::poppler-23.08.0-ha962622_1.conda
linux-64::jaxlib-0.4.14-cpu_py310hf39c648_1.conda
linux-64::openjdk-11.0.20-hbf40d96_1.conda
linux-64::python-rocksdb-0.7.0-py39h321662a_8.conda
linux-64::gtk4-4.12.1-h0210e61_3.conda
linux-64::lfortran-0.20.2-hfc55251_0.conda
linux-64::libopencv-4.8.0-py38h6d7f99c_2.conda
linux-64::arrow-cpp-9.0.0-py311h68ef2c8_49_cpu.conda
linux-64::py-bgzip-0.4.0-py38h502143a_4.conda
linux-64::mysql-router-8.0.33-hf689a3c_3.conda
linux-64::r-harp-1.20-r43ha49c379_0.conda
linux-64::openpmd-api-0.15.2-mpi_mpich_py38h9d35971_1.conda
linux-64::vtk-base-9.2.6-osmesa_py310h1234567_113.conda
linux-64::bytewax-0.17.1-py311h1844ddb_1.conda
linux-64::pdal-2.5.6-h9b972b5_2.conda
linux-64::postgresql-plpython-15.4-py312hcc5c902_2.conda
linux-64::ticcutils-0.33.1-h4b3f524_0.conda
linux-64::libgdal-3.6.4-hdb503af_18.conda
linux-64::pypy3.9-7.3.12-h9557127_4.conda
linux-64::panda3d-1.10.12-py311h9bbe57d_5.conda
linux-64::mlir-python-bindings-16.0.5-py312h7b2b3ac_1.conda
linux-64::openpmd-api-0.15.2-mpi_openmpi_py39ha3955f8_1.conda
linux-64::openexr-python-1.3.9-py310h905be85_2.conda
linux-64::libpano13-2.9.20rc2-pl5321h5888656_6.conda
linux-64::lammps-2023.08.02-cpu_py39_hae2bcb2_openmpi_2.conda
linux-64::pygame-2.5.2-py310h408e605_2.conda
linux-64::pypy3.8-7.3.11-hc3ccb01_4.conda
linux-64::tiledb-2.17.0-hebec990_1.conda
linux-64::openpmd-api-0.15.2-nompi_py310h65c42ef_101.conda
linux-64::triqs-3.2.0-py311h6b9694e_3.conda
linux-64::astrometry-0.94-py39hcbcb0bc_4.conda
linux-64::paraview-5.11.1-py39h773e032_102_qt.conda
linux-64::pillow-10.0.1-py310h29da1c1_1.conda
linux-64::qt-main-5.15.8-hc47bfe8_16.conda
linux-64::triqs-3.2.0-py311h6b9694e_0.conda
linux-64::vigra-1.11.1-py311h835f229_1048.conda
linux-64::mapserver-8.0.1-py311h3f49a6b_5.conda
linux-64::openvdb-10.0.1-py310h120c1bf_6.conda
linux-64::openjdk-11.0.20-h4260e57_3.conda
linux-64::postgresql-16.0-h8972f4a_0.conda
linux-64::lammps-2023.08.02-cpu_py39_h2595f3c_mpich_1.conda
linux-64::mapserver-8.0.1-py310hd41f1d2_5.conda
linux-64::mdsplus-7.139.50-py39pl5321h0371e64_0.conda
linux-64::libarrow-10.0.1-h1935d02_43_cpu.conda
linux-64::postgresql-plpython-15.4-py311hf60bfc6_1.conda
linux-64::pyhdf-0.11.3-py38h3d0ad98_1.conda
linux-64::nodejs-18.17.1-hf52ce11_0.conda
linux-64::openvdb-10.0.1-py310h120c1bf_3.conda
linux-64::libgdal-3.6.4-h6120be2_17.conda
linux-64::imagecodecs-2023.9.4-py39hd73d3df_2.conda
linux-64::python-rocksdb-0.7.0-py311h3a7270a_8.conda
linux-64::openpmd-api-0.15.2-mpi_mpich_py310h1bbaf5f_1.conda
linux-64::python-igraph-0.10.8-py39h3c131a4_0.conda
linux-64::openexr-python-1.3.9-py39h730ee47_3.conda
linux-64::rpm-tools-4.17.1-py310lua54h96070f6_4.conda
linux-64::py-bgzip-0.4.0-py39hc7d112a_4.conda
linux-64::vtk-base-9.2.6-egl_py310h1234567_13.conda
linux-64::folly-2023.09.04.00-hda79706_0_jemalloc.conda
linux-64::mapserver-8.0.1-py39h53f81f5_5.conda
linux-64::triqs-3.2.0-py310h30ed552_0.conda
linux-64::connectorx-0.3.2-py38hbd239f7_0.conda
linux-64::mapserver-8.0.1-py311h790fb26_8.conda
linux-64::lpython-0.20.0-hfc55251_0.conda
linux-64::openexr-python-1.3.9-py38h5d31b1e_3.conda
linux-64::mapserver-8.0.1-py39h3184280_8.conda
linux-64::openjdk-17.0.8-hbf40d96_2.conda
linux-64::postgresql-plpython-15.4-py310hd093153_1.conda
linux-64::lammps-2023.08.02-cpu_py38_hffeb4a5_openmpi_1.conda
linux-64::folly-2023.09.11.00-he8e2169_0_jemalloc.conda
linux-64::libopentelemetry-cpp-1.11.0-he8711a7_1.conda
linux-64::xrootd-5.6.2-py311h7c82654_0.conda
linux-64::pillow-10.0.0-py39hea036a4_1.conda
linux-64::raven-hydro-0.2.4-py38h326e3f4_0.conda
linux-64::openpmd-api-0.15.2-mpi_openmpi_py38ha370c97_1.conda
linux-64::freefem-4.13-hf99da96_3.conda
linux-64::polycap-1.2-py312h7b01a32_4.conda
linux-64::paraview-5.11.1-py39h302450a_2_egl.conda
linux-64::intel-cmplr-lib-rt-2023.2.0-hfc55251_49498.conda
linux-64::gdstk-0.9.42-py311h75db532_1.conda
linux-64::paraview-5.11.1-py39h7e0514d_2_egl.conda
linux-64::omniorb-4.3.1-py39h53428f1_1.conda
linux-64::folly-2023.09.25.00-h55f0c17_0.conda
linux-64::omniorb-4.3.1-py310h5d3106b_1.conda
linux-64::libopencv-4.8.0-py38hdabec7c_3.conda
linux-64::vtk-base-9.2.6-qt_py39h1234567_213.conda
linux-64::ogre-1.10.12-h7b21bec_13.conda
linux-64::vigra-1.11.1-py39h84e0bf7_1047.conda
linux-64::openvdb-10.0.1-py311hd1ce2d7_6.conda
linux-64::libvips-8.14.4-hce56e4d_1.conda
linux-64::raven-hydro-0.2.4-py310h3ce4ad4_1.conda
linux-64::triqs-3.2.0-py311h00d02c3_4.conda
linux-64::heyoka-2.0.0-ha232a6f_0.conda
linux-64::triqs-3.2.0-py38h18e736d_0.conda
linux-64::libarrow-10.0.1-h1935d02_42_cpu.conda
linux-64::paraview-5.11.2-py39ha1a5cf5_102_qt.conda
linux-64::imagecodecs-2023.9.18-py39h43e5ab6_0.conda
linux-64::util-linux-2.39.2-py39h1da25c5_0.conda
linux-64::mlir-python-bindings-16.0.5-py39hc35b29e_1.conda
linux-64::minizip-4.0.1-h0ab5242_1.conda
linux-64::paraview-5.11.1-py310hc733826_102_qt.conda
linux-64::pillow-10.0.1-py311h8aef010_1.conda
linux-64::libarrow-11.0.0-h860fa02_37_cuda.conda
linux-64::libarrow-11.0.0-hb6645e0_35_cpu.conda
linux-64::libopencv-4.8.0-py39h3407137_3.conda
linux-64::postgresql-plpython-15.4-py38h0f07e32_1.conda
linux-64::pyinstaller-6.0.0-py311hdcc4c9d_1.conda
linux-64::pillow-10.0.1-py39hea036a4_1.conda
linux-64::harp-1.20-py310hae178fe_0.conda
linux-64::vigra-1.11.1-py38hc17d7f6_1047.conda
linux-64::liblal-7.3.1-mkl_hd48b831_2.conda
linux-64::libarrow-10.0.1-hb6645e0_39_cpu.conda
linux-64::pylibmc-1.6.3-py39hb6545a3_2.conda
linux-64::raven-hydro-0.2.4-py39h191c732_1.conda
linux-64::vigra-1.11.2-py310hb9b677e_0.conda
linux-64::mdsplus-7.139.50-py311pl5321h19eab63_0.conda
linux-64::vtk-base-9.2.6-egl_py38h1234567_13.conda
linux-64::folly-2023.09.25.00-he8e2169_0_jemalloc.conda
linux-64::netcdf4-1.6.4-nompi_py310hba70d50_103.conda
linux-64::libopencv-4.8.0-py39h5f5e16f_4.conda
linux-64::paraview-5.11.1-py39ha1a5cf5_102_qt.conda
linux-64::llvm-tools-17.0.1-h5cf9203_0.conda
linux-64::imagecodecs-2023.9.4-py310hedc1555_0.conda
linux-64::aws-sdk-cpp-1.11.158-h6f6b8fa_0.conda
linux-64::paraview-5.11.2-py38hfbc58c6_2_egl.conda
linux-64::openvdb-10.0.1-py311hd1ce2d7_4.conda
linux-64::libgdal-arrow-parquet-3.7.2-h158dad4_1.conda
linux-64::mold-2.2.0-h76aa41c_0.conda
linux-64::fltk-1.3.8-hfbcda93_2.conda
linux-64::cmake-3.27.5-hcfe8598_0.conda
linux-64::mdsplus-7.139.49-py38pl5321h686a8d3_0.conda
linux-64::bytewax-0.17.1-py39h82e90d1_0.conda
linux-64::nest-simulator-3.6-py38h60c4312_0.conda
linux-64::rpm-tools-4.17.1-py39lua54hc5d64a4_4.conda
linux-64::paraview-5.11.2-py310h8b3917e_102_qt.conda
linux-64::imagecodecs-2023.9.18-py310h3a85d3a_0.conda
linux-64::arrow-cpp-9.0.0-py38h61c27ec_48_cuda.conda
linux-64::libarrow-12.0.1-h860fa02_12_cuda.conda
linux-64::postgresql-plpython-15.4-py39h5ae07a4_2.conda
linux-64::qt6-main-6.5.2-h07e9947_1.conda
linux-64::lxml-4.9.3-py311h1a07684_1.conda
linux-64::folly-2023.09.25.00-ha1f1437_0_jemalloc.conda
linux-64::astrometry-0.94-py310h53cf094_4.conda
linux-64::connectorx-0.3.2-py310heac1918_3.conda
linux-64::heyoka-2.0.0-h8f27e75_0.conda
linux-64::libzip-1.10.1-h2629f0a_2.conda
linux-64::lammps-2023.08.02-cpu_py39_h00752c8_mpich_2.conda
linux-64::arrow-cpp-9.0.0-py310h7163abb_49_cuda.conda
linux-64::libnetcdf-4.9.2-nompi_h80fb2b6_112.conda
linux-64::libarrow-11.0.0-ha64140a_36_cuda.conda
linux-64::pygame-2.5.2-py310h8df29c8_0.conda
linux-64::gdcm-2.8.9-py310h1bfc968_9.conda
linux-64::openpmd-api-0.15.2-mpi_mpich_py39hc7f5499_1.conda
linux-64::util-linux-2.39.2-py38heb36ba7_0.conda
linux-64::python-rocksdb-0.7.0-py310h872c293_8.conda
linux-64::python-wasmer-compiler-llvm-1.2.0-py311h849ad14_0.conda
linux-64::openvdb-10.0.1-hbdef4f9_3.conda
linux-64::openmotif-2.3.8-h0c37447_4.conda
linux-64::vigra-1.11.2-py38hf3adfd4_0.conda
linux-64::netcdf4-1.6.4-mpi_mpich_py39h6de3821_3.conda
linux-64::raven-hydro-0.2.4-py312h2251fe5_1.conda
linux-64::libopencv-4.8.0-py311ha0eda43_2.conda
linux-64::bytewax-0.17.1-py311he5c60f7_0.conda
linux-64::mapserver-8.0.1-py38h50437d1_5.conda
linux-64::gdcm-2.8.9-py311h9ecb0fe_9.conda
linux-64::wxwidgets-3.2.2.1-h2791fda_5.conda
linux-64::aimrocks-0.4.0-py310h82b3a98_1.conda
linux-64::libgdal-3.6.4-h0da8fbe_19.conda
linux-64::heyoka-llvm-15-2.0.0-he0ec72f_0.conda
linux-64::pillow-10.0.0-py39h444a776_1.conda
linux-64::vigra-1.11.1-py38hf3adfd4_1048.conda
linux-64::netcdf4-1.6.4-mpi_mpich_py312hdc719ce_3.conda
linux-64::folly-2023.09.11.00-h80c46b9_0.conda
linux-64::vtk-base-9.2.6-osmesa_py311h1234567_114.conda
linux-64::grpcio-1.58.1-py38h94a1851_0.conda
linux-64::openvdb-10.0.1-py39hc77a128_6.conda
linux-64::swi-prolog-9.0.4-h2fa8fc1_4.conda
linux-64::bytewax-0.17.1-py310hd3dbc5d_1.conda
linux-64::ncl-6.6.2-h1ca1a7f_49.conda
linux-64::intel-opencl-rt-2023.2.0-heb1d2f6_49498.conda
linux-64::netpbm-10.73.43-pl5321h69c5264_2.conda
linux-64::imagecodecs-2023.9.4-py310h3a85d3a_2.conda
linux-64::folly-2023.09.25.00-hda79706_0_jemalloc.conda
linux-64::mapserver-8.0.1-py38hace482d_7.conda
linux-64::r-harp-1.20-r43hfd4ca42_0.conda
linux-64::gfortran_impl_osx-arm64-13.2.0-h6937658_1.conda
linux-64::pyhdk-0.8.0-py310h1234567_1_cpu.conda
linux-64::poppler-qt-23.08.0-h06469b4_1.conda
linux-64::astrometry-0.94-py39h9701f3a_4.conda
linux-64::openvdb-10.0.1-h120c1bf_3.conda
linux-64::cpp-opentelemetry-sdk-1.11.0-he8711a7_1.conda
linux-64::intel-cmplr-lib-rt-2023.2.0-hfc55251_49497.conda
linux-64::pygplates-0.39-py310h18688ea_9.conda
linux-64::mapserver-8.0.1-py38hf273009_6.conda
linux-64::pyhdk-0.8.0-py38h1234567_1_cpu.conda
linux-64::openjdk-20.0.2-hfea2f88_0.conda
linux-64::lammps-2023.08.02-cpu_py310_h4b5e8b3_openmpi_1.conda
linux-64::coda-2.25-py310hfd4ca42_0.conda
linux-64::triqs-3.2.0-py310h30ed552_4.conda
linux-64::triqs-3.2.0-py310h46b93e6_4.conda
linux-64::triqs-3.2.0-py38h72e10a8_5.conda
linux-64::tiledb-2.16.3-hf0b6e87_3.conda
linux-64::folly-2023.09.18.00-h80c46b9_0.conda
linux-64::triqs-3.2.0-py38h72e10a8_3.conda
linux-64::verilator-5.016-h4f9daa6_0.conda
linux-64::kitty-0.23.1-py38h3cbace5_4.conda
linux-64::mcpl-1.6.2-py311hdcc4c9d_1.conda
linux-64::vigra-1.11.2-py38h1ff91ab_0.conda
linux-64::libopencv-4.8.0-py39hf04408f_3.conda
linux-64::minizip-4.0.1-h0ab5242_3.conda
linux-64::arrow-cpp-9.0.0-py38h1b783b9_47_cpu.conda
linux-64::swi-prolog-9.0.4-h7ffad7a_3.conda
linux-64::pyhdk-0.8.0-py311h1234567_0_cpu.conda
linux-64::linux-perf-6.3.10-py310h3219344_1.conda
linux-64::kitty-0.23.1-py310hbb8b5e1_4.conda
linux-64::gstlal-1.12.0-py311hb526b1d_0.conda
linux-64::coda-2.25-py38h58d957e_0.conda
linux-64::r-harp-1.20-r43h58d957e_0.conda
linux-64::vtk-base-9.2.6-osmesa_py310h1234567_114.conda
linux-64::assimp-5.3.1-h378b44f_1.conda
linux-64::paraview-5.11.1-py38h8fc7d50_102_qt.conda
linux-64::mysql-server-8.0.33-hb7753b3_4.conda
linux-64::py-bgzip-0.4.0-py312hf0b23d7_4.conda
linux-64::mysql-client-8.0.33-h545f5f4_3.conda
linux-64::libarrow-12.0.1-hd3e26bc_13_cuda.conda
linux-64::arrow-cpp-9.0.0-py39h15f288b_48_cpu.conda
linux-64::triqs-3.2.0-py38h18e736d_3.conda
linux-64::elfutils-0.189-h6f2b95c_1.conda
linux-64::pygame-2.5.2-py39h321c859_2.conda
linux-64::libpq-15.4-hfc447b1_2.conda
linux-64::pillow-10.0.1-py39h444a776_1.conda
linux-64::mdsplus-7.139.47-py310pl5321hdeeefa5_0.conda
linux-64::mysql-router-8.0.33-h0342c31_4.conda
linux-64::triqs-3.2.0-py310h46b93e6_0.conda
linux-64::paraview-5.11.1-py39h7e44ac4_2_egl.conda
linux-64::pygame-2.5.2-py311h9818690_0.conda
linux-64::tiledb-2.17.0-h8c794c1_0.conda
linux-64::mesalib-23.2.1-h6b56f8e_0.conda
linux-64::tiledb-2.16.3-h6041edc_3.conda
linux-64::libpq-16.0-hfc447b1_1.conda
linux-64::ncl-6.6.2-he3b17a9_50.conda
linux-64::pylibmc-1.6.3-py310h93c3562_2.conda
linux-64::libopencv-4.8.0-py38h9cbf798_4.conda
linux-64::octave-8.2.0-h664984d_2.conda
linux-64::python-igraph-0.10.6-py311hbb11ce1_2.conda
linux-64::mdsplus-7.139.50-py310pl5321hdeeefa5_0.conda
linux-64::openpmd-api-0.15.2-mpi_openmpi_py311h3f40880_1.conda
linux-64::orc-1.9.0-h52d3b3c_2.conda
linux-64::libgrpc-1.58.1-h30d5116_0.conda
linux-64::heyoka-llvm-12-2.0.0-hd83f851_0.conda
linux-64::pyinstaller-6.0.0-py38h502143a_1.conda
linux-64::libarrow-10.0.1-hd3e26bc_43_cuda.conda
linux-64::vigra-1.11.1-py310h1e2299f_1047.conda
linux-64::mapserver-8.0.1-py311hba2686b_6.conda
linux-64::lfortran-0.20.1-hfc55251_0.conda
linux-64::jaxlib-0.4.14-cpu_py39h5b48c86_1.conda
linux-64::hdfeos2-2.20-h3e53b52_1004.conda
linux-64::python-wasmer-compiler-llvm-1.2.0-py310hb189d54_0.conda
linux-64::mdsplus-7.139.46-py38pl5321h686a8d3_0.conda
linux-64::vtk-base-9.2.6-egl_py39h1234567_14.conda
linux-64::libopencv-4.8.1-py311h643827b_0.conda
linux-64::libthrift-0.19.0-hb90f79a_1.conda
linux-64::tiledb-2.17.0-hd084428_1.conda
linux-64::paraprobe-v0.4-mpi_mpich_h611d6ee_0.conda
linux-64::triqs-3.2.0-py38h18e736d_5.conda
linux-64::postgresql-plpython-16.0-py39h5ae07a4_0.conda
linux-64::linux-perf-6.3.10-py311h502c4cc_1.conda
linux-64::libzip-1.10.1-h2629f0a_1.conda
linux-64::opentype-sanitizer-9.1.0-py38h7f3f72f_1.conda
linux-64::postgresql-plpython-16.0-py39h5ae07a4_1.conda
linux-64::libgdal-3.7.2-h17082cf_4.conda
linux-64::nest-simulator-3.6-py39hee3e16e_0.conda
linux-64::netcdf4-1.6.4-mpi_mpich_py310h1c2af58_3.conda
linux-64::pillow-10.0.1-py39hea036a4_0.conda
linux-64::paraview-5.11.1-py310hc15cd21_102_qt.conda
linux-64::imagecodecs-2023.9.18-py39hd73d3df_0.conda
linux-64::openpmd-api-0.15.2-nompi_py311h0dcbea3_101.conda
linux-64::pyinstaller-6.0.0-py310h93c3562_1.conda
linux-64::folly-2023.09.18.00-he8e2169_0_jemalloc.conda
linux-64::astrometry-0.94-py311h4409ed6_4.conda
linux-64::arrow-cpp-9.0.0-py310h13beae3_47_cpu.conda
linux-64::python-wasmer-compiler-llvm-1.2.0-py39h367b712_0.conda
linux-64::vtk-base-9.2.6-osmesa_py39h1234567_114.conda
linux-64::connectorx-0.3.2-py39h535706e_0.conda
linux-64::heyoka-llvm-16-2.0.0-h2b0c814_0.conda
linux-64::py-bgzip-0.4.0-py39hb6545a3_4.conda
linux-64::vigra-1.11.1-py39h397cfeb_1048.conda
linux-64::pygame-2.5.2-py311h7bd3ff0_2.conda
linux-64::curl-8.3.0-hca28451_0.conda
linux-64::opentype-sanitizer-9.1.0-py311h9547e67_1.conda
linux-64::xrootd-5.6.2-py38h012eebe_1.conda
linux-64::libarrow-11.0.0-hd3e26bc_39_cuda.conda
linux-64::imagecodecs-2023.9.4-py310h4701587_1.conda
linux-64::lammps-2023.08.02-cpu_py38_hffeb4a5_openmpi_2.conda
linux-64::raven-hydro-0.2.4-py38h326e3f4_1.conda
linux-64::vigra-1.11.1-py310hb9b677e_1048.conda
linux-64::vtk-base-9.2.6-qt_py310h1234567_213.conda
linux-64::python-igraph-0.10.6-py38haec740f_1.conda
linux-64::imagecodecs-2023.9.4-py39ha7451d3_1.conda
linux-64::libgdal-3.7.2-h5b94d6b_0.conda
linux-64::imagecodecs-2023.9.4-py311h6ca73b1_1.conda
linux-64::heyoka-2.0.0-hb4d7844_0.conda
linux-64::paraview-5.11.1-py310h1c4690c_2_egl.conda
linux-64::vtk-base-9.2.6-qt_py38h1234567_213.conda
linux-64::pypy3.9-7.3.13-h9557127_0.conda
linux-64::vigra-1.11.1-py311h859335b_1047.conda
linux-64::python-3.12.0rc3-rc3_hab00c5b_1_cpython.conda
linux-64::libopencv-4.8.0-py39hc4f35e8_2.conda
linux-64::mysql-libs-8.0.33-hca2cd23_3.conda
linux-64::vigra-1.11.1-py39h548badd_1047.conda
linux-64::arrow-cpp-9.0.0-py38h5aade08_47_cuda.conda
linux-64::ogre-14.1.0-h49094d3_1.conda
linux-64::intel-cmplr-lib-rt-2023.2.0-hfc55251_49499.conda
linux-64::vigra-1.11.1-py38h1ff91ab_1048.conda
linux-64::openjdk-17.0.3-h6f1e508_9.conda
linux-64::postgresql-plpython-15.4-py38h0f07e32_2.conda
linux-64::grpcio-1.58.1-py312hb06c811_0.conda
linux-64::pylibmc-1.6.3-py311hdcc4c9d_2.conda
linux-64::libarrow-13.0.0-hb6645e0_1_cpu.conda
linux-64::libtiff-4.6.0-h8b53f26_0.conda
linux-64::python-igraph-0.10.6-py311hbb11ce1_1.conda
linux-64::pyhdf-0.11.3-py39hba72f14_1.conda
linux-64::mosh-1.4.0-pl5321hc186570_3.conda
linux-64::libpulsar-3.2.0-h10b2654_3.conda
linux-64::wasmer-4.2.1-he3b15a8_0.conda
linux-64::mdsplus-7.139.49-py311pl5321h19eab63_0.conda
linux-64::paraview-5.11.2-py38h3c1b195_102_qt.conda
linux-64::openvdb-10.0.1-py38hbdef4f9_6.conda
linux-64::xfig-3.2.6a-hf01d962_1002.conda
linux-64::vtk-base-9.2.6-osmesa_py38h1234567_114.conda
linux-64::aws-sdk-cpp-1.11.156-h6600424_3.conda
linux-64::postgresql-plpython-16.0-py311hf60bfc6_0.conda
linux-64::sdl2_image-2.6.3-h53e0c72_4.conda
linux-64::paraview-5.11.1-py38hb65cf3c_2_egl.conda
linux-64::connectorx-0.3.2-py311h4aa2743_3.conda
linux-64::paraview-5.11.1-py311hc0570a4_2_egl.conda
linux-64::intel-opencl-rt-2023.2.0-heb1d2f6_49497.conda
linux-64::triqs-3.2.0-py311h00d02c3_3.conda
linux-64::r-base-4.3.1-h639d9d3_5.conda
linux-64::openpmd-api-0.15.2-mpi_mpich_py39h1df9184_1.conda
linux-64::paraview-5.11.1-py39h6ab8463_102_qt.conda
linux-64::minizip-4.0.1-h0ab5242_2.conda
linux-64::vigra-1.11.1-py39h39c9df2_1048.conda
linux-64::triqs-3.2.0-py311h6b9694e_1.conda
linux-64::openjdk-11.0.15-h8e330f5_5.conda
linux-64::gdstk-0.9.42-py312h7b2b3ac_1.conda
linux-64::photochem-0.4.2-py39h134dccb_2.conda
linux-64::arrow-cpp-9.0.0-py39h80393ce_47_cpu.conda
linux-64::libmediainfo-23.09-had58582_0.conda
linux-64::tiledb-2.16.3-h9b6ba3e_2.conda
linux-64::openjdk-17.0.8-hfea2f88_0.conda
linux-64::paraview-5.11.1-py38h3c1b195_102_qt.conda
linux-64::harp-1.20-py311h211a265_0.conda
linux-64::mcpl-1.6.2-py38h502143a_1.conda
linux-64::vtk-base-9.2.6-egl_py38h1234567_14.conda
linux-64::folly-2023.09.18.00-hda79706_0_jemalloc.conda
linux-64::paraview-5.11.2-py310h512a915_2_egl.conda
linux-64::geotiff-1.7.1-h19bbf84_12.conda
linux-64::vigra-1.11.1-py38h088287c_1047.conda
linux-64::triqs-3.2.0-py311h00d02c3_0.conda
linux-64::pygame-2.5.2-py38h42b80ce_2.conda
linux-64::nodejs-20.6.1-hb753e55_0.conda
linux-64::pygame-2.5.2-py39hc998183_2.conda
linux-64::triqs-3.2.0-py310h46b93e6_3.conda
linux-64::r-base-4.3.1-hc8cfde1_4.conda
linux-64::opentype-sanitizer-9.1.0-py312h8572e83_1.conda
linux-64::pyhdf-0.11.3-py310h947be00_1.conda
linux-64::pygame-2.5.2-py310h408e605_1.conda
linux-64::openpmd-api-0.15.2-nompi_py38he9fd926_101.conda
linux-64::paraview-5.11.1-py38hfbc58c6_2_egl.conda
linux-64::netcdf4-1.6.4-nompi_py38hd72f54f_103.conda
linux-64::mysql-libs-8.0.33-hca2cd23_4.conda
linux-64::libzip-1.10.1-h2629f0a_3.conda
linux-64::libopencv-4.8.1-py39h7d74990_0.conda
linux-64::triqs-3.2.0-py310h30ed552_1.conda
linux-64::fltk-1.3.8-hea138e6_3.conda
linux-64::heyoka-llvm-14-2.0.0-h23ee361_0.conda
linux-64::libarrow-11.0.0-h1935d02_38_cpu.conda
linux-64::qt6-main-6.5.2-hbe3b9ea_4.conda
linux-64::openvdb-10.0.1-py38hbdef4f9_4.conda
linux-64::mcpl-1.6.2-py39hb6545a3_1.conda
linux-64::vigra-1.11.1-py38he618331_1047.conda
linux-64::libarrow-10.0.1-ha64140a_40_cuda.conda
linux-64::gdcm-2.8.9-py38he3e0534_9.conda
linux-64::vigra-1.11.1-py39haa848c2_1047.conda
linux-64::paraview-5.11.1-py311h2cfd3c4_102_qt.conda
linux-64::openpmd-api-0.15.2-nompi_py39h47bce7d_101.conda
linux-64::arrow-cpp-9.0.0-py38h8276124_49_cpu.conda
linux-64::openexr-python-1.3.9-py38h867e365_2.conda
linux-64::triqs-3.2.0-py38h72e10a8_0.conda
linux-64::openjdk-20.0.0-hfea2f88_2.conda
linux-64::libarrow-10.0.1-h860fa02_41_cuda.conda
linux-64::postgresql-plpython-16.0-py38h0f07e32_0.conda
linux-64::connectorx-0.3.2-py39h7d5a94b_2.conda
linux-64::libgdal-arrow-parquet-3.7.2-hcef7442_3.conda
linux-64::libgdal-arrow-parquet-3.7.2-h7765300_2.conda
linux-64::paraview-5.11.1-py39h1d3511c_2_egl.conda
linux-64::netpbm-10.73.43-pl5321hcca32a5_3.conda
linux-64::mysql-server-8.0.33-hb2a8c2b_3.conda
linux-64::openbabel-3.1.1-py311ha3c2874_8.conda
linux-64::linux-perf-6.3.10-py38hd75e30c_1.conda
linux-64::triqs-3.2.0-py38h72e10a8_1.conda
linux-64::openexr-python-1.3.9-py39h7a7aa46_3.conda
linux-64::tiledb-2.16.3-h6041edc_2.conda
linux-64::openpmd-api-0.15.2-mpi_openmpi_py310h018839f_1.conda
linux-64::mapserver-8.0.1-py310h9a0c6a7_6.conda
linux-64::triqs-3.2.0-py311h00d02c3_1.conda
linux-64::openvdb-10.0.1-py311hd1ce2d7_3.conda
linux-64::mdsplus-7.139.48-py39pl5321h0371e64_0.conda
linux-64::actions-runner-2.309.0-hcd5def8_0.conda
linux-64::r-base-4.1.3-h0887e52_11.conda
linux-64::libarchive-minimal-static-3.7.2-h2b6973b_0.conda
linux-64::python-igraph-0.10.8-py310hb1c7c39_0.conda
linux-64::libarrow-11.0.0-h1935d02_39_cpu.conda
linux-64::openpmd-api-0.15.2-mpi_openmpi_py39hb534104_1.conda
linux-64::mdsplus-7.139.47-py311pl5321h19eab63_0.conda
linux-64::tiledb-2.17.1-hf0b6e87_0.conda
linux-64::triqs-3.2.0-py310h30ed552_5.conda
linux-64::r-harp-1.20-r43h5872dc6_0.conda
linux-64::aws-sdk-cpp-1.11.158-h8bde0db_1.conda
linux-64::aimrocks-0.4.0-py39hfa7860e_1.conda
linux-64::paraview-5.11.1-py311h27c6c81_2_egl.conda
linux-64::libopencv-4.8.1-py39h5f5e16f_0.conda
linux-64::mlir-python-bindings-16.0.5-py310h1487c90_1.conda
linux-64::jaxlib-0.4.14-cpu_py311ha7e634b_1.conda
linux-64::paraview-5.11.1-py39h260a063_2_egl.conda
linux-64::triqs-3.2.0-py39h3c449d4_1.conda
linux-64::pyinstaller-6.0.0-py39hb6545a3_1.conda
linux-64::qt6-3d-6.5.2-he847e20_1.conda
linux-64::pypy3.8-7.3.11-hc3ccb01_5.conda
linux-64::vtk-base-9.2.6-qt_py39h1234567_214.conda
linux-64::pyhdk-0.8.0-py310h1234567_0_cpu.conda
linux-64::dpcpp_impl_linux-64-2023.2.0-hd6dfaa8_49500.conda
linux-64::photochem-0.4.2-py310ha431049_2.conda
linux-64::postgresql-plpython-15.4-py39h5ae07a4_1.conda
linux-64::openexr-python-1.3.9-py38h5d31b1e_2.conda
linux-64::triqs-3.2.0-py39h3c449d4_0.conda
linux-64::openjdk-17.0.8-hbf40d96_1.conda
linux-64::aimrocks-0.4.0-py312habd0047_1.conda
linux-64::dpcpp_impl_linux-64-2023.2.0-hd6dfaa8_49497.conda
linux-64::gst-plugins-bad-1.22.6-h06bf7ac_0.conda
linux-64::hugin-2022.0.0-pl5321h757296d_6.conda
linux-64::vigra-1.11.2-py39h39c9df2_0.conda
linux-64::gst-plugins-good-1.22.6-h9701ba8_1.conda
linux-64::gstlal-1.12.0-py38hc529aad_0.conda
linux-64::magics-metview-4.14.2-he4b344a_1.conda
linux-64::paraview-5.11.1-py311hbafe2c3_2_egl.conda
linux-64::mcpl-1.6.2-py310h93c3562_1.conda
linux-64::arrow-cpp-9.0.0-py310h21b0120_48_cuda.conda
linux-64::arrow-cpp-9.0.0-py311h14c7c49_49_cuda.conda
linux-64::mdsplus-7.139.40-py39pl5321h0371e64_0.conda
linux-64::openvdb-10.0.1-py39hc77a128_4.conda
linux-64::vtk-base-9.2.6-osmesa_py311h1234567_113.conda
linux-64::bytewax-0.17.1-py310hbeed47d_0.conda
linux-64::triqs-3.2.0-py310h46b93e6_1.conda
linux-64::folly-2023.09.25.00-h80c46b9_0.conda
linux-64::tiledb-2.17.0-h9504ddb_1.conda
linux-64::openpmd-api-0.15.2-nompi_py39h075047b_101.conda
linux-64::pylibmc-1.6.3-py312hf0b23d7_2.conda
linux-64::libgdal-arrow-parquet-3.7.2-h3d11b2a_0.conda
linux-64::minizip-4.0.1-h0ab5242_4.conda
linux-64::imagecodecs-2023.9.4-py311h35c80e7_0.conda
linux-64::mdsplus-7.139.51-py38pl5321h686a8d3_0.conda
linux-64::imagecodecs-2023.9.4-py39heb570e5_1.conda
linux-64::mapserver-8.0.1-py311hfae4462_7.conda
linux-64::netcdf4-1.6.4-mpi_openmpi_py312h1af69d7_3.conda
linux-64::libarrow-13.0.0-h1935d02_4_cpu.conda
linux-64::pytables-3.8.0-py38h606e206_3.conda
linux-64::libopencv-4.8.0-py39h7d74990_4.conda
linux-64::libgdal-3.7.2-h9868cb8_2.conda
linux-64::openvdb-10.0.1-hd1ce2d7_3.conda
linux-64::libarrow-13.0.0-h1935d02_5_cpu.conda
linux-64::triqs-3.2.0-py311h6b9694e_2.conda
linux-64::openexr-python-1.3.9-py312h9716601_3.conda
linux-64::llvm-17.0.1-ha0738ec_0.conda
linux-64::pillow-10.0.1-py310h29da1c1_0.conda
linux-64::irrlicht-1.8.5-h2a6caf8_4.conda
linux-64::intel-opencl-rt-2023.2.0-heb1d2f6_49500.conda
linux-64::folly-2023.09.11.00-ha1f1437_0_jemalloc.conda
linux-64::openexr-python-1.3.9-py311h039cf95_2.conda
linux-64::triqs-3.2.0-py38h72e10a8_2.conda
linux-64::yosys-0.33-h3bf110c_0.conda
linux-64::paraprobe-v0.4-mpi_mpich_hfd9f523_0.conda
linux-64::triqs-3.2.0-py311h00d02c3_5.conda
linux-64::raven-hydro-0.2.4-py310hee4f699_0.conda
linux-64::gdstk-0.9.42-py39h9bdbfdd_1.conda
linux-64::cmake-3.27.6-hcfe8598_0.conda
linux-64::libarrow-12.0.1-h1935d02_13_cpu.conda
linux-64::triqs-3.2.0-py39hd083d43_5.conda
linux-64::openexr-python-1.3.9-py310h905be85_3.conda
linux-64::omniorb-4.3.1-py312h8992e14_1.conda
linux-64::mdsplus-7.139.47-py38pl5321h686a8d3_0.conda
linux-64::folly-2023.09.11.00-h09ac5fe_0.conda
linux-64::paraview-5.11.1-py39h78ce9fc_102_qt.conda
linux-64::aws-sdk-cpp-1.11.156-h8bde0db_1.conda
linux-64::util-linux-2.39.2-py312h77dc562_1.conda
linux-64::llvmdev-17.0.1-h5cf9203_0.conda
linux-64::coda-2.25-py39h684542f_1.conda
linux-64::libopencv-4.8.0-py39h4919be5_2.conda
linux-64::postgresql-plpython-16.0-py310hd093153_0.conda
linux-64::libtiledb-sql-0.25.0-hb82b279_0.conda
linux-64::postgresql-plpython-16.0-py311hf60bfc6_1.conda
linux-64::sdl_image-1.2.12-ha71580b_5.conda
linux-64::astrometry-0.94-py38he2b7e09_4.conda
linux-64::cargo-c-0.9.24-h5ad674e_1.conda
linux-64::photochem-0.4.2-py311h66fd630_2.conda
linux-64::blosc-1.21.5-h0f2a231_0.conda
linux-64::imagemagick-7.1.1_18-pl5321h7e74ff9_0.conda
linux-64::rust-1.72.0-h70c747d_2.conda
linux-64::rust-1.72.1-h70c747d_0.conda
linux-64::paraview-5.11.2-py311ha4273f6_2_egl.conda
linux-64::python-igraph-0.10.6-py310hb1c7c39_1.conda
linux-64::libtiff-4.6.0-h29866fb_1.conda
linux-64::openjdk-17.0.8-h4260e57_3.conda
linux-64::geotiff-1.7.1-hee599c5_13.conda
linux-64::lammps-2023.08.02-cpu_py39_hae2bcb2_openmpi_1.conda
linux-64::vigra-1.11.2-py310h2c729db_0.conda
linux-64::postgresql-16.0-h8972f4a_1.conda
linux-64::gdcm-2.8.9-py312h06ef6fb_10.conda
linux-64::imagecodecs-2023.9.4-py311h9b38416_2.conda
linux-64::paraview-5.11.1-py38ha2d95a9_102_qt.conda
linux-64::pyhdk-0.8.0-py39h1234567_1_cpu.conda
linux-64::libgdal-arrow-parquet-3.6.4-hcbb5057_17.conda
linux-64::nodejs-20.7.0-hb753e55_0.conda
linux-64::triqs-3.2.0-py39hd083d43_4.conda
linux-64::openbabel-3.1.1-py39h421517d_8.conda
linux-64::libthrift-0.19.0-h8fd135c_0.conda
linux-64::libarrow-11.0.0-h1ed0495_37_cpu.conda
linux-64::arrow-cpp-9.0.0-py310h0bafd55_48_cpu.conda
linux-64::python-wasmer-1.2.0-py38hf9e7164_0.conda
linux-64::tiledb-2.16.3-hf0b6e87_2.conda
linux-64::xrootd-5.6.2-py39hbb686b4_0.conda
linux-64::polycap-1.2-py39h6836f0a_4.conda
linux-64::freeimage-3.18.0-h0da0bed_16.conda
linux-64::magics-4.14.2-haee2765_1.conda
linux-64::openexr-python-1.3.9-py311h039cf95_3.conda
linux-64::tiledb-2.17.0-hf0b6e87_0.conda
linux-64::libgdal-3.6.4-hc48e1f3_16.conda
linux-64::python-rocksdb-0.7.0-py312h705f505_8.conda
linux-64::linux-perf-6.3.10-py39haf0aa1b_1.conda
linux-64::coda-2.25-py39h5872dc6_0.conda
linux-64::paraview-5.11.1-py38h71c90fa_2_egl.conda
linux-64::mdsplus-7.139.48-py310pl5321hdeeefa5_0.conda
linux-64::mapserver-8.0.1-py39ha73beb4_7.conda
linux-64::polycap-1.2-py310hf236282_4.conda
linux-64::triqs-3.2.0-py39h3c449d4_2.conda
linux-64::lfortran-0.20.3-hfc55251_1.conda
linux-64::imagecodecs-2023.9.4-py39hb92b076_0.conda
linux-64::jaxlib-0.4.14-cuda112py310hb0456fb_201.conda
linux-64::netcdf4-1.6.4-mpi_mpich_py38h8af1877_3.conda
linux-64::libarchive-3.7.2-h039dbb9_0.conda
linux-64::libopencv-4.8.0-py311h643827b_4.conda
linux-64::mdsplus-7.139.46-py310pl5321hdeeefa5_0.conda
linux-64::lammps-2023.08.02-cpu_py39_h4b07ac6_openmpi_2.conda
linux-64::mdsplus-7.139.48-py311pl5321h19eab63_0.conda
linux-64::postgresql-plpython-16.0-py312hcc5c902_1.conda
linux-64::xrootd-5.6.2-py39h38afb29_1.conda
linux-64::libarrow-13.0.0-hd3e26bc_4_cuda.conda
linux-64::pyinstaller-6.0.0-py38h502143a_0.conda
linux-64::paraview-5.11.2-py311h6e1e116_102_qt.conda
linux-64::arrow-cpp-9.0.0-py311hd89f8c8_47_cuda.conda
linux-64::libarrow-12.0.1-h1935d02_14_cpu.conda
linux-64::xrootd-5.6.2-py39h38afb29_0.conda
linux-64::vigra-1.11.2-py311h835f229_0.conda
linux-64::libspatialite-5.1.0-h090f1da_0.conda
linux-64::ogre-14.1.0-h49669e8_0.conda
linux-64::pygame-2.5.2-py39h1678059_0.conda
linux-64::r-base-4.3.1-h93585b2_6.conda
linux-64::paraview-5.11.2-py39h302450a_2_egl.conda
linux-64::imagecodecs-2023.9.18-py311h9b38416_0.conda
linux-64::lld-17.0.1-hcfcaf08_0.conda
linux-64::netcdf4-1.6.4-nompi_py312h26027e0_103.conda
linux-64::python-wasmer-compiler-llvm-1.2.0-py38he9d9e4f_0.conda
linux-64::dpcpp_impl_linux-64-2023.2.0-hd6dfaa8_49496.conda
linux-64::openjdk-11.0.20-hfea2f88_0.conda
linux-64::grpcio-1.57.0-py312hb06c811_1.conda
linux-64::folly-2023.09.04.00-h09ac5fe_0.conda
linux-64::python-igraph-0.10.8-py38haec740f_0.conda
linux-64::paraview-5.11.1-py310h512a915_2_egl.conda
linux-64::gdcm-2.8.9-py39hb0992c5_9.conda
linux-64::vtk-base-9.2.6-osmesa_py39h1234567_113.conda
linux-64::paraview-5.11.1-py38h57e71bf_2_egl.conda
linux-64::python-igraph-0.10.6-py310hb1c7c39_2.conda
linux-64::pylibmc-1.6.3-py39hc7d112a_2.conda
linux-64::gdstk-0.9.42-py310h1487c90_1.conda
linux-64::gstlal-1.12.0-py39hef60fd8_0.conda
linux-64::r-base-4.2.3-h0887e52_8.conda
linux-64::openpmd-api-0.15.2-mpi_openmpi_py38hae2d105_1.conda
linux-64::libarrow-10.0.1-hdd62870_39_cuda.conda
linux-64::triqs-3.2.0-py310h30ed552_2.conda
linux-64::util-linux-2.39.2-py39h1da25c5_1.conda
linux-64::hugin-base-2022.0.0-pl5321hd1f61f9_7.conda
linux-64::nest-simulator-3.6-py310h80eecab_0.conda
linux-64::mdsplus-7.139.40-py38pl5321h686a8d3_0.conda
linux-64::pyhdf-0.11.3-py39h11475f6_1.conda
linux-64::lammps-2023.08.02-cpu_py311_hb661868_openmpi_2.conda
linux-64::util-linux-2.39.2-py311h4285dfd_0.conda
linux-64::nco-5.1.8-h67bacd4_0.conda
linux-64::triqs-3.2.0-py39hd083d43_0.conda
linux-64::aimrocks-0.4.0-py311h737a443_1.conda
linux-64::gdstk-0.9.42-py38hab45c01_1.conda
linux-64::triqs-3.2.0-py38h18e736d_2.conda
linux-64::vtk-base-9.2.6-qt_py311h1234567_213.conda
linux-64::cargo-c-0.9.24-h5ad674e_0.conda
linux-64::util-linux-2.39.2-py39h5bc7b3b_0.conda
linux-64::r-base-4.2.3-h11e5365_9.conda
linux-64::paraview-5.11.1-py311h5cf73d0_102_qt.conda
linux-64::openexr-python-1.3.9-py39h7a7aa46_2.conda
linux-64::imagemagick-7.1.1_15-pl5321h7e74ff9_1.conda
linux-64::lammps-2023.08.02-cpu_py310_h4b5e8b3_openmpi_2.conda
linux-64::libtiff-4.6.0-ha9c0a0a_2.conda
linux-64::lxml-4.9.3-py312he528aba_1.conda
linux-64::libarrow-13.0.0-ha64140a_2_cuda.conda
linux-64::triqs-3.2.0-py38h18e736d_4.conda
linux-64::triqs-3.2.0-py38h18e736d_1.conda
linux-64::mlir-python-bindings-16.0.5-py38hab45c01_1.conda
linux-64::pygame-2.5.2-py38h3762873_0.conda
linux-64::yarp-cxx-3.8.1-hc95d4b6_5.conda
linux-64::libarrow-13.0.0-h37b21ae_2_cpu.conda
linux-64::paraview-5.11.1-py310h2b7b683_2_egl.conda
linux-64::openjdk-20.0.2-haa376d0_2.conda
linux-64::r-seqminer-9.1-r43ha661321_0.conda
linux-64::folly-2023.09.18.00-h55f0c17_0.conda
linux-64::libvips-8.14.5-hce56e4d_0.conda
linux-64::qt6-main-6.5.2-h9378c28_3.conda
linux-64::libpq-16.0-hfc447b1_0.conda
linux-64::paraview-5.11.1-py38h61b094e_2_egl.conda
linux-64::qt6-main-6.5.2-h671e25b_2.conda
linux-64::mlir-17.0.1-hcd5def8_0.conda
linux-64::paraview-5.11.1-py310h500474a_2_egl.conda
linux-64::coda-2.25-py39h71bbeed_0.conda
linux-64::connectorx-0.3.2-py38hefb49ed_3.conda
linux-64::pyhdf-0.11.3-py311ha36aa4f_1.conda
linux-64::hugin-2022.0.0-pl5321h24a96e1_7.conda
linux-64::openbabel-3.1.1-py312h8a8b3d1_8.conda
linux-64::triqs-3.2.0-py310h46b93e6_2.conda
linux-64::triqs-3.2.0-py39h3c449d4_3.conda
linux-64::imagemagick-7.1.1_16-pl5321h7e74ff9_0.conda
linux-64::connectorx-0.3.2-py310he1deef9_1.conda
linux-64::vtk-base-9.2.6-osmesa_py38h1234567_113.conda
linux-64::openjdk-11.0.15-hfea2f88_7.conda
linux-64::harp-1.20-py38hdb16ff8_0.conda
linux-64::pillow-10.0.0-py310h29da1c1_1.conda
linux-64::postgresql-15.4-h8972f4a_2.conda
linux-64::libnetcdf-4.9.2-mpi_openmpi_h924110c_12.conda
linux-64::pdal-2.5.6-h713adaf_3.conda
linux-64::pytables-3.8.0-py310h374b01c_3.conda
linux-64::opentype-sanitizer-9.1.0-py39h7633fee_1.conda
linux-64::coda-2.25-py310h5e33110_1.conda
linux-64::libtiledb-sql-0.25.0-hc3826aa_0.conda
linux-64::raven-hydro-0.2.4-py38h0110233_0.conda
linux-64::pylibmc-1.6.3-py38h502143a_2.conda
linux-64::triqs-3.2.0-py311h6b9694e_4.conda
linux-64::vigra-1.11.1-py310h2c729db_1048.conda
linux-64::libarrow-13.0.0-hd3e26bc_5_cuda.conda
linux-64::mdsplus-7.139.40-py310pl5321hdeeefa5_0.conda
linux-64::osmium-tool-1.16.0-he3809c7_0.conda
linux-64::pillow-10.0.1-py311h8aef010_0.conda
linux-64::raven-hydro-0.2.4-py39h8e2dbb5_0.conda
linux-64::pyinstaller-6.0.0-py310h93c3562_0.conda
linux-64::connectorx-0.3.2-py38hefb49ed_2.conda
linux-64::raven-hydro-0.2.4-py38hcf001ca_0.conda
linux-64::folly-2023.09.04.00-h55f0c17_0.conda
linux-64::rpm-tools-4.17.1-py38lua54hd14f742_4.conda
linux-64::erlang-26.1.1-pl5321hde4a2a6_0.conda
linux-64::libglib-2.78.0-hebfc3b9_0.conda
linux-64::arrow-cpp-9.0.0-py39h97d2593_49_cpu.conda
linux-64::mdsplus-7.139.46-py39pl5321h0371e64_0.conda
linux-64::heyoka-2.0.0-h18d30d2_0.conda
linux-64::gst-plugins-base-1.22.6-h8e1006c_0.conda
linux-64::mdsplus-7.139.51-py311pl5321h19eab63_0.conda
linux-64::mapserver-8.0.1-py310h261f782_7.conda
linux-64::lammps-2023.08.02-cpu_py311_h4aafb77_mpich_1.conda
linux-64::dcmtk-3.6.7-h93481db_5.conda
linux-64::raven-hydro-0.2.4-py311h64a4d7b_0.conda
linux-64::mcpl-1.6.2-py312hf0b23d7_1.conda
linux-64::pygplates-0.39-py311h42fd247_9.conda
linux-64::tiledb-2.17.1-h6041edc_0.conda
linux-64::ogre-1.10.12-h7b21bec_14.conda
linux-64::paraview-5.11.1-py38hfc39712_102_qt.conda
linux-64::openbabel-3.1.1-py38hb38ef42_8.conda
linux-64::openvdb-10.0.1-py39h1eab289_6.conda
linux-64::xeus-cpp-0.0.1-hd2493eb_2.conda
linux-64::paraview-5.11.1-py311ha4273f6_2_egl.conda
linux-64::libboost-1.82.0-h1bacd13_2.conda
linux-64::nexus-4.4.3-h116a4eb_12.conda
linux-64::glibmm-2.68-2.78.0-h2f54ecc_0.conda
linux-64::libarrow-12.0.1-hb6645e0_10_cpu.conda
linux-64::lxml-4.9.3-py39hed45dcc_1.conda
linux-64::libarrow-10.0.1-hd3e26bc_42_cuda.conda
linux-64::netcdf4-1.6.4-mpi_mpich_py311h5dcab06_3.conda
linux-64::arrow-cpp-9.0.0-py311hdb0b809_48_cuda.conda
linux-64::boost-cpp-1.82.0-h44aadfe_3.conda
linux-64::vigra-1.11.1-py39h799343b_1048.conda
linux-64::pyhdf-0.11.3-py312had763d5_1.conda
linux-64::arrow-cpp-9.0.0-py310h8f42f9f_47_cuda.conda
linux-64::lammps-2023.08.02-cpu_py38_h459ef18_mpich_2.conda
linux-64::netcdf4-1.6.4-mpi_openmpi_py38hfb7afc8_3.conda
linux-64::xrootd-5.6.2-py312hf334fcc_1.conda
linux-64::libopencv-4.8.0-py311h05c0160_3.conda
linux-64::glib-2.78.0-hfc55251_0.conda
linux-64::libgdal-arrow-parquet-3.6.4-h02df0c4_19.conda
linux-64::python-rocksdb-0.7.0-py38hfdd4582_8.conda
linux-64::mlir-python-bindings-16.0.5-py311h75db532_1.conda
linux-64::opentype-sanitizer-9.1.0-py310hd41b1e2_1.conda
linux-64::vtk-base-9.2.6-egl_py39h1234567_13.conda
linux-64::arrow-cpp-9.0.0-py39h5eb4836_49_cuda.conda
linux-64::arrow-cpp-9.0.0-py39h9b5b4ad_47_cuda.conda
linux-64::intel-opencl-rt-2023.2.0-heb1d2f6_49499.conda
linux-64::paraview-5.11.1-py39h4db2aaa_102_qt.conda
linux-64::pytables-3.8.0-py311h10c7f7f_3.conda
linux-64::heyoka-2.0.0-h2dccf72_0.conda
linux-64::ogre-14.1.0-h1a4f1cf_1.conda
linux-64::libarrow-12.0.1-h37b21ae_11_cpu.conda
linux-64::folly-2023.09.18.00-ha1f1437_0_jemalloc.conda
linux-64::pyhdk-0.8.0-py38h1234567_0_cpu.conda
linux-64::openslide-3.4.1-h4738aba_10.conda
linux-64::r-base-4.3.1-h5cdd412_4.conda
linux-64::triqs-3.2.0-py39h3c449d4_4.conda
linux-64::paraview-5.11.1-py310h8821fef_102_qt.conda
linux-64::gst-plugins-good-1.22.6-hf7bd3a9_0.conda
linux-64::folly-2023.09.11.00-h55f0c17_0.conda
linux-64::libcurl-static-8.3.0-hca28451_0.conda
linux-64::pygame-2.5.2-py38h42b80ce_1.conda
linux-64::nodejs-20.6.0-hb753e55_0.conda
linux-64::mdsplus-7.139.40-py39pl5321h0371e64_1.conda
linux-64::triqs-3.2.0-py310h46b93e6_5.conda
linux-64::vtk-base-9.2.6-egl_py311h1234567_14.conda
linux-64::mdsplus-7.139.49-py39pl5321h0371e64_0.conda
linux-64::gfortran_impl_osx-64-13.2.0-hc8c4513_1.conda
linux-64::lammps-2023.08.02-cpu_py39_h4b07ac6_openmpi_1.conda
linux-64::r-seqminer-9.1-r42ha661321_0.conda
linux-64::python-wasmer-1.2.0-py310h1c8cefa_0.conda
linux-64::vigra-1.11.1-py311h4a2dd87_1047.conda
linux-64::kitty-0.23.1-py39h3ef3376_4.conda
linux-64::ticcutils-0.33-h4b3f524_0.conda
linux-64::mdsplus-7.139.51-py39pl5321h0371e64_0.conda
linux-64::triqs-3.2.0-py39h3c449d4_5.conda
linux-64::raven-hydro-0.2.4-py310h3ce4ad4_0.conda
linux-64::python-igraph-0.10.6-py39h2c4918a_1.conda
linux-64::pillow-10.0.0-py311h8aef010_1.conda
linux-64::python-igraph-0.10.6-py39h3c131a4_1.conda
linux-64::wxwidgets-3.2.2.1-hd6fc380_4.conda
linux-64::nco-5.1.7-h67bacd4_1.conda
linux-64::python-igraph-0.10.6-py39h3c131a4_2.conda
linux-64::mysql-client-8.0.33-h545f5f4_4.conda
linux-64::geotiff-1.7.1-hf074850_14.conda
linux-64::xrootd-5.6.2-py38h012eebe_0.conda
linux-64::vigra-1.11.1-py38h1e07a9c_1047.conda
linux-64::pyinstaller-6.0.0-py311hdcc4c9d_0.conda
linux-64::openpmd-api-0.15.2-nompi_py38h766a7de_101.conda
linux-64::triqs-3.2.0-py311h00d02c3_2.conda
linux-64::xeus-cling-0.15.3-h7bb6b15_1.conda
linux-64::folly-2023.09.04.00-h80c46b9_0.conda
linux-64::arrow-cpp-9.0.0-py38h62e08c5_49_cuda.conda
linux-64::heyoka-llvm-11-2.0.0-hcd51939_0.conda
linux-64::python-igraph-0.10.6-py38haec740f_2.conda
linux-64::netcdf4-1.6.4-mpi_openmpi_py310h884273a_3.conda
linux-64::mdsplus-7.139.47-py39pl5321h0371e64_0.conda
linux-64::pyhdk-0.8.0-py311h1234567_1_cpu.conda
linux-64::coda-2.25-py311h96e6511_1.conda
linux-64::omniorb-4.3.1-py38h0ed79f3_1.conda
linux-64::glib-networking-2.78.0-h8eaaec1_0.conda
linux-64::libgd-2.3.3-he9388d3_8.conda
linux-64::vigra-1.11.2-py39h799343b_0.conda
linux-64::pygame-2.5.2-py39h4244053_0.conda
linux-64::hugin-base-2022.0.0-pl5321h74e7868_6.conda
linux-64::magics-metview-batch-4.14.2-haee2765_1.conda
linux-64::mdsplus-7.139.50-py38pl5321h686a8d3_0.conda
linux-64::python-igraph-0.10.8-py311hbb11ce1_0.conda
linux-64::pygame-2.5.2-py39h321c859_1.conda
linux-64::arrow-cpp-9.0.0-py311hfabe113_48_cpu.conda
linux-64::dpcpp_impl_linux-64-2023.2.0-hd6dfaa8_49498.conda
linux-64::vigra-1.11.2-py311hff02683_0.conda
linux-64::pytables-3.8.0-py39h783497a_3.conda
linux-64::python-igraph-0.10.8-py39h2c4918a_0.conda
linux-64::libopencv-4.8.0-py310ha72e4d8_3.conda
linux-64::raven-hydro-0.2.4-py38ha6b6fe4_0.conda
linux-64::vtk-base-9.2.6-egl_py311h1234567_13.conda
linux-64::intel-opencl-rt-2023.2.0-heb1d2f6_49496.conda
linux-64::fltk-1.3.8-hcdca39e_1.conda
linux-64::mdsplus-7.139.49-py310pl5321hdeeefa5_0.conda
linux-64::harp-1.20-py39hf75bc27_0.conda
linux-64::raven-hydro-0.2.4-py311h14de304_1.conda
linux-64::coda-2.25-py39hdeca0b6_1.conda
linux-64::libopencv-4.8.1-py310h8ad8f1f_0.conda
linux-64::opentype-sanitizer-9.1.0-py39ha90811c_1.conda
linux-64::triqs-3.2.0-py39hd083d43_3.conda
linux-64::photochem-0.4.2-py38h4019cea_2.conda
linux-64::pytables-3.8.0-py38h45ea06b_3.conda
linux-64::folly-2023.09.25.00-h09ac5fe_0.conda
linux-64::libgdal-arrow-parquet-3.6.4-h6bb8a03_16.conda
linux-64::libarrow-11.0.0-hd3e26bc_38_cuda.conda
linux-64::util-linux-2.39.2-py38heb36ba7_1.conda
linux-64::osmium-tool-1.16.0-he3809c7_1.conda
linux-64::panda3d-1.10.12-py38h5a25a97_5.conda
linux-64::connectorx-0.3.2-py38h0474bcf_1.conda
linux-64::abinit-9.8.4-h7bae158_3.conda
linux-64::libgdal-arrow-parquet-3.6.4-h812a101_18.conda
linux-64::openvdb-10.0.1-py39hc77a128_3.conda
linux-64::r-base-4.1.3-h63daf7b_11.conda
linux-64::postgresql-plpython-16.0-py38h0f07e32_1.conda
linux-64::pygplates-0.39-py38hd4787c5_9.conda
linux-64::lxml-4.9.3-py39h40bd5d0_1.conda
linux-64::mdsplus-7.139.51-py310pl5321hdeeefa5_0.conda
linux-64::xrootd-5.6.2-py310h3779284_1.conda
linux-64::octave-8.3.0-h664984d_0.conda
linux-64::vigra-1.11.2-py39had53cd9_0.conda
linux-64::sdl2_image-2.6.3-h17907d7_3.conda
linux-64::util-linux-2.39.2-py310h6b057ee_1.conda
linux-64::wasmer-4.2.0-he3b15a8_0.conda
linux-64::gdcm-2.8.9-py310h59700c5_10.conda
linux-64::util-linux-2.39.2-py39h5bc7b3b_1.conda
linux-64::xrootd-5.6.2-py310h3779284_0.conda
linux-64::pyhdk-0.8.0-py39h1234567_0_cpu.conda
linux-64::libspatialite-5.0.1-h090f1da_29.conda
linux-64::libarrow-13.0.0-hdd62870_1_cuda.conda
linux-64::poppler-23.08.0-hf2349cb_2.conda
linux-64::gstlal-1.12.0-py310h6f6463f_0.conda
linux-64::python-wasmer-1.2.0-py39h0094015_0.conda
linux-64::triqs-3.2.0-py39hd083d43_2.conda
linux-64::swi-prolog-9.0.4-hb97c47e_6.conda
linux-64::polycap-1.2-py311hf368e52_4.conda
linux-64::arrow-cpp-9.0.0-py38h244e92b_48_cpu.conda
linux-64::mapserver-8.0.1-py310hde5fb52_8.conda
linux-64::libarrow-11.0.0-hdd62870_35_cuda.conda
linux-64::libarrow-11.0.0-h37b21ae_36_cpu.conda
linux-64::gdstk-0.9.42-py39hc35b29e_1.conda
linux-64::pygame-2.5.2-py312hdb01fa2_2.conda
linux-64::panda3d-1.10.12-py310h66e5b31_5.conda
linux-64::aws-sdk-cpp-1.11.156-he6c2984_2.conda
linux-64::raven-hydro-0.2.4-py311h14de304_0.conda
linux-64::lammps-2023.08.02-cpu_py38_h459ef18_mpich_1.conda
linux-64::libarrow-12.0.1-h1ed0495_12_cpu.conda
linux-64::libnetcdf-4.9.2-mpi_mpich_hef9003c_12.conda
linux-64::arrow-cpp-9.0.0-py311h1f53524_47_cpu.conda
linux-64::openvdb-10.0.1-py310h120c1bf_4.conda
linux-64::aws-sdk-cpp-1.10.57-h1a84af3_23.conda
linux-64::erlang-26.1-pl5321hde4a2a6_0.conda
linux-64::pytables-3.8.0-py39hfbd31a7_3.conda
linux-64::minizip-4.0.1-h0ab5242_0.conda
linux-64::panda3d-1.10.12-py39hd690b07_5.conda
linux-64::folly-2023.09.04.00-he8e2169_0_jemalloc.conda
linux-64::tiledb-2.17.0-h6041edc_0.conda
linux-64::connectorx-0.3.2-py310h1ba60f9_0.conda
linux-64::openvdb-10.0.1-py38hbdef4f9_3.conda
linux-64::rpm-tools-4.17.1-py312lua54he087bb1_4.conda
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
```

</details>