### PR TITLE
loosen zlib-pin to major level (10/N; August 2023)

### DIFF
--- a/recipe/patch_yaml/zlib.yaml
+++ b/recipe/patch_yaml/zlib.yaml
@@ -79,3 +79,12 @@ then:
   - loosen_depends:
       name: libzlib
       upper_bound: "2"
+---
+if:
+  has_depends: libzlib >=1.2*
+  timestamp_lt: 1693526400000  # 2023-09-01 00:00 UTC
+  timestamp_ge: 1690848000000  # 2023-08-01 00:00 UTC
+then:
+  - loosen_depends:
+      name: libzlib
+      upper_bound: "2"


### PR DESCRIPTION
Follow-up to https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/739, about 3100 artefacts affected.

### Result of `python show_diff.py`

<details>

```diff
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
osx-arm64::micromamba-1.5.0-0.tar.bz2
osx-arm64::openexr-3.1.11-hf12bcc0_0.conda
osx-arm64::libprotobuf-4.23.4-hf32f9b9_0.conda
osx-arm64::libsqlite-3.43.0-hb31c410_0.conda
osx-arm64::libprotobuf-static-3.21.12-ha614eb4_1.conda
osx-arm64::libprotobuf-4.23.4-hf32f9b9_1.conda
osx-arm64::dotnet-sdk-6.0.412-ha99ce8b_0.conda
osx-arm64::dotnet-runtime-7.0.10-ha99ce8b_0.conda
osx-arm64::libprotobuf-static-3.21.12-ha614eb4_2.conda
osx-arm64::libprotobuf-4.23.4-hf590ac1_4.conda
osx-arm64::libprotobuf-static-4.23.4-hf32f9b9_1.conda
osx-arm64::libv8-8.9.83-h342826e_4.conda
osx-arm64::libprotobuf-static-4.23.4-hf590ac1_3.conda
osx-arm64::libprotobuf-static-4.23.4-hf590ac1_4.conda
osx-arm64::libprotobuf-static-4.23.4-hf590ac1_2.conda
osx-arm64::dotnet-sdk-7.0.400-ha99ce8b_0.conda
osx-arm64::libprotobuf-static-4.23.4-hf32f9b9_0.conda
osx-arm64::libass-0.17.1-hf7da4fe_1.conda
osx-arm64::openexr-3.1.10-hf12bcc0_0.conda
osx-arm64::libsolv-static-0.7.24-ha614eb4_3.conda
osx-arm64::libprotobuf-4.23.4-hf590ac1_2.conda
osx-arm64::libprotobuf-3.21.12-ha614eb4_2.conda
osx-arm64::eccodes-2.31.0-h437576b_1.conda
osx-arm64::micromamba-1.5.0-1.tar.bz2
osx-arm64::dotnet-aspnetcore-7.0.10-ha99ce8b_0.conda
osx-arm64::zstd-1.5.5-h4f39d0f_0.conda
osx-arm64::openexr-3.2.0-hf12bcc0_0.conda
osx-arm64::libsolv-0.7.24-ha614eb4_3.conda
osx-arm64::libprotobuf-4.23.4-hf590ac1_3.conda
osx-arm64::dotnet-aspnetcore-6.0.20-ha99ce8b_0.conda
osx-arm64::libprotobuf-3.21.12-ha614eb4_1.conda
osx-arm64::dotnet-runtime-6.0.20-ha99ce8b_0.conda
osx-arm64::adios-1.13.1-nompi_h8cb4857_1123.conda
osx-arm64::openjdk-20.0.0-hbe7ddab_1.conda
-    "libzlib >=1.2.13,<1.3.0a0"
+    "libzlib >=1.2.13,<2.0.0a0"
osx-arm64::ifcopenshell-v0.7.0a9-py38he2d88da_0.conda
osx-arm64::lammps-2023.08.02-cpu_py310_hd4ac30c_openmpi_0.conda
osx-arm64::heyoka-1.0.0-h038e230_0.conda
osx-arm64::heyoka-llvm-16-1.0.0-h59ae33d_0.conda
osx-arm64::libgdal-arrow-parquet-3.7.1-heae2a54_5.conda
osx-arm64::vtk-base-9.2.6-qt_py311h1234567_211.conda
osx-arm64::libadios2-2.9.1-mpi_openmpi_h7fbabbf_0.conda
osx-arm64::libzip-1.10.1-ha0bc3c6_0.conda
osx-arm64::vigra-1.11.1-py38h72b0e1a_1046.conda
osx-arm64::ifcopenshell-v0.7.0a9-py310h6d37856_1.conda
osx-arm64::openmeeg-2.5.6-py310hbbe462d_2.conda
osx-arm64::libadios2-2.9.1-mpi_mpich_h669b64a_2.conda
osx-arm64::openpmd-api-0.15.1-nompi_py310hb789276_105.conda
osx-arm64::libgit2-1.7.1-h2940a35_0.conda
osx-arm64::ovito-3.9.1-h6961929_0.conda
osx-arm64::openpmd-api-0.15.2-mpi_mpich_py311hbbcfcb2_0.conda
osx-arm64::ifcopenshell-v0.7.0a10-py39h0cae4b0_0.conda
osx-arm64::ifcopenshell-v0.7.0a9-py38he2d88da_1.conda
osx-arm64::libadios2-2.9.1-mpi_openmpi_ha7668c6_2.conda
osx-arm64::vigra-1.11.1-py310h2e757d0_1046.conda
osx-arm64::openpmd-api-0.15.2-nompi_py310hee66445_100.conda
osx-arm64::folly-2023.03.20.00-h03318f1_5.conda
osx-arm64::netcdf4-1.6.4-mpi_mpich_py38hf64dcfa_2.conda
osx-arm64::ndcctools-7.6.2-py38h3b9d5fa_0.conda
osx-arm64::libgdal-3.6.4-hc9ea29a_11.conda
osx-arm64::folly-2023.08.07.00-h2c5142d_0_jemalloc.conda
osx-arm64::tectonic-0.14.1-he580da6_1.conda
osx-arm64::tiledb-2.16.2-h5345278_0.conda
osx-arm64::openpmd-api-0.15.1-mpi_mpich_py310hdb4f01a_6.conda
osx-arm64::boost-cpp-1.82.0-h0299754_2.conda
osx-arm64::libopencv-4.8.0-py39he572090_1.conda
osx-arm64::healpy-1.16.5-py311h29c129b_1.conda
osx-arm64::libadios2-2.9.1-nompi_h9c5352c_101.conda
osx-arm64::aws-sdk-cpp-1.11.68-h061ca36_10.conda
osx-arm64::grpcio-1.57.0-py310h95b248a_0.conda
osx-arm64::pyreadr-0.4.9-py310h2b8a472_0.conda
osx-arm64::folly-2023.08.14.00-hd189c9a_1_jemalloc.conda
osx-arm64::coda-2.24.2-py311h44628bf_3.conda
osx-arm64::postgresql-plpython-15.4-py310h94ee204_0.conda
osx-arm64::folly-2023.08.14.00-h2c5142d_2_jemalloc.conda
osx-arm64::lammps-2023.08.02-cpu_py39_h382c4a1_mpich_0.conda
osx-arm64::libvips-8.14.3-hcb42e34_2.conda
osx-arm64::arrow-cpp-9.0.0-py39h446a152_46_cpu.conda
osx-arm64::vtk-base-9.2.6-qt_py310h1234567_212.conda
osx-arm64::vtk-base-9.2.6-qt_py38h1234567_212.conda
osx-arm64::python-3.11.5-h47c9636_0_cpython.conda
osx-arm64::indexed_gzip-1.8.5-py39h800f3a3_0.conda
osx-arm64::libarrow-10.0.1-h3fb1d55_37_cpu.conda
osx-arm64::nodejs-20.1.0-ha2ed473_0.conda
osx-arm64::polycap-1.2-py38h28765ba_3.conda
osx-arm64::libadios2-2.9.1-mpi_openmpi_hd50caee_1.conda
osx-arm64::openpmd-api-0.15.1-mpi_openmpi_py311hfb5bbb9_6.conda
osx-arm64::r-harp-1.19-py311h44628bf_1.conda
osx-arm64::kaldi-5.5.1068-cpu_h012d200_2.conda
osx-arm64::ifcopenshell-v0.7.0a9-py39h3ad519b_1.conda
osx-arm64::coda-2.24.2-py310he2ee789_3.conda
osx-arm64::libgdal-3.6.4-h839ef1e_15.conda
osx-arm64::libopencv-4.8.0-py311hd1551a5_1.conda
osx-arm64::triqs-3.1.1-py310hc920bd7_6.conda
osx-arm64::omniorb-4.3.1-py310hfce7497_0.conda
osx-arm64::ifcopenshell-v0.7.0a10-py311he09cec3_0.conda
osx-arm64::ifcopenshell-v0.7.0a9-py311he09cec3_1.conda
osx-arm64::folly-2023.08.14.00-h03318f1_2.conda
osx-arm64::folly-2023.08.14.00-h1e8fca9_0.conda
osx-arm64::bytewax-0.17.0-py311h6a762d3_5.conda
osx-arm64::lammps-2023.08.02-cpu_py311_hb114475_openmpi_0.conda
osx-arm64::heyoka-llvm-13-0.21.0-h122378b_1.conda
osx-arm64::folly-2023.08.07.00-h2c5142d_1_jemalloc.conda
osx-arm64::heyoka-0.21.0-h1fa1327_1.conda
osx-arm64::libmatio-1.5.23-h73d0b91_4.conda
osx-arm64::openpmd-api-0.15.1-nompi_py39h3cf022a_105.conda
osx-arm64::folly-2023.03.20.00-hd189c9a_5_jemalloc.conda
osx-arm64::heyoka-1.0.0-hb511701_0.conda
osx-arm64::aws-sdk-cpp-1.10.57-h061ca36_18.conda
osx-arm64::libadios2-2.9.1-mpi_mpich_h74d04e3_0.conda
osx-arm64::r-git2r-0.31.0-r42hd848ae8_2.conda
osx-arm64::libadios2-2.9.1-mpi_openmpi_h9ac4f70_0.conda
osx-arm64::ffmpeg-6.0.0-lgpl_hc9ee6cd_4.conda
osx-arm64::heyoka-0.21.0-h2293f1e_1.conda
osx-arm64::nest-simulator-3.5-py39h4f52a62_2.conda
osx-arm64::openpmd-api-0.15.1-mpi_openmpi_py311h3a8c5b6_5.conda
osx-arm64::netcdf4-1.6.4-nompi_py39h9f3a5de_102.conda
osx-arm64::tiledb-2.16.2-h99ee4e4_0.conda
osx-arm64::emacs-28.2-h14ff8fc_4.conda
osx-arm64::ifcopenshell-v0.7.0a9-py39h0cae4b0_0.conda
osx-arm64::libadios2-2.9.1-mpi_mpich_h37257f3_0.conda
osx-arm64::folly-2023.08.28.00-h4c49ebf_0_jemalloc.conda
osx-arm64::ifcopenshell-v0.7.0a9-py310h28676c1_0.conda
osx-arm64::gtk4-4.12.1-ha43ece3_1.conda
osx-arm64::ogre-14.0.1-hfc21bc6_1.conda
osx-arm64::libllvm16-16.0.6-he79909e_2.conda
osx-arm64::lammps-2023.08.02-cpu_py38_h9d40a62_openmpi_0.conda
osx-arm64::openpmd-api-0.15.2-mpi_mpich_py38h4d26ed3_0.conda
osx-arm64::libnetcdf-4.9.2-mpi_openmpi_hfda1b4b_10.conda
osx-arm64::coda-2.24.2-py39h15bc620_3.conda
osx-arm64::mc-4.8.30-h1c19145_0.conda
osx-arm64::indexed_gzip-1.8.5-py311h29dc21d_0.conda
osx-arm64::libgrpc-1.54.3-h0a338ca_0.conda
osx-arm64::folly-2023.03.20.00-h44236e3_5.conda
osx-arm64::healpy-1.16.5-py39he563a90_1.conda
osx-arm64::folly-2023.08.07.00-hd189c9a_0_jemalloc.conda
osx-arm64::omniorb-4.3.1-py39h014b858_0.conda
osx-arm64::vigra-1.11.1-py311h61db444_1046.conda
osx-arm64::folly-2023.08.14.00-hb0130ba_2_jemalloc.conda
osx-arm64::vtk-base-9.2.6-qt_py38h1234567_211.conda
osx-arm64::openpmd-api-0.15.1-nompi_py310hbeef6e5_106.conda
osx-arm64::ifcopenshell-v0.7.0a9-py38h9c88707_0.conda
osx-arm64::grpcio-1.56.2-py39hbad4f83_1.conda
osx-arm64::bytewax-0.17.0-py311h6a762d3_6.conda
osx-arm64::libopentelemetry-cpp-1.11.0-ha34c9a6_0.conda
osx-arm64::libxml2-2.11.5-he3bdae6_0.conda
osx-arm64::netcdf4-1.6.4-mpi_mpich_py310h5c42483_2.conda
osx-arm64::arrow-cpp-9.0.0-py38h9ba62f4_46_cpu.conda
osx-arm64::libgdal-arrow-parquet-3.7.1-h5f602e0_6.conda
osx-arm64::libgdal-3.6.4-h839ef1e_14.conda
osx-arm64::libgdal-arrow-parquet-3.6.4-h58f1915_13.conda
osx-arm64::lammps-2023.08.02-cpu_py39_hdb5a862_openmpi_0.conda
osx-arm64::folly-2023.08.14.00-h03318f1_3.conda
osx-arm64::r-harp-1.19-py39h15bc620_1.conda
osx-arm64::ifcopenshell-v0.7.0a9-py38h9c88707_1.conda
osx-arm64::polycap-1.2-py310he2349d3_3.conda
osx-arm64::vowpalwabbit-9.8.0-py39ha269e3f_1.conda
osx-arm64::folly-2023.08.14.00-h03318f1_0.conda
osx-arm64::soplex-6.0.4-h0ccf5b5_0.conda
osx-arm64::netcdf4-1.6.4-mpi_openmpi_py311hf8f91c4_2.conda
osx-arm64::libarrow-11.0.0-h0b136c2_33_cpu.conda
osx-arm64::llvmdev-16.0.6-he79909e_2.conda
osx-arm64::mcpl-1.6.2-py310hab90de1_0.conda
osx-arm64::ifcopenshell-v0.7.0a10-py310h184cd1e_0.conda
osx-arm64::grpcio-1.57.0-py39hbad4f83_1.conda
osx-arm64::arrow-cpp-9.0.0-py311h6d1a676_46_cpu.conda
osx-arm64::yarp-cxx-3.8.1-hd065baa_4.conda
osx-arm64::arrow-cpp-9.0.0-py39h31e2d63_45_cpu.conda
osx-arm64::verilator-5.014-h5c8d968_0.conda
osx-arm64::folly-2023.08.14.00-h520e11e_2.conda
osx-arm64::nodejs-20.5.1-ha2ed473_0.conda
osx-arm64::folly-2023.08.28.00-h03318f1_0.conda
osx-arm64::heyoka-llvm-14-0.21.0-hc9d117a_1.conda
osx-arm64::folly-2023.08.14.00-h03318f1_1.conda
osx-arm64::bytewax-0.17.0-py310h738ff09_5.conda
osx-arm64::vowpalwabbit-9.9.0-py38heb37505_0.conda
osx-arm64::libgrpc-1.56.2-h9075ed4_1.conda
osx-arm64::libarrow-10.0.1-h2ae5a5a_37_cpu.conda
osx-arm64::netcdf4-1.6.4-nompi_py311hbb54521_102.conda
osx-arm64::cmake-3.27.4-h1c59155_0.conda
osx-arm64::tesseract-5.3.2-h5c6cb5b_0.conda
osx-arm64::pyreadstat-1.2.3-py311h79498d2_0.conda
osx-arm64::openmeeg-2.5.6-py38h0061b94_2.conda
osx-arm64::triqs-3.1.1-py38h20ddde0_6.conda
osx-arm64::netcdf4-1.6.4-mpi_mpich_py39hc500b05_2.conda
osx-arm64::libitk-5.3.0-h8c4a50a_6.conda
osx-arm64::netcdf4-1.6.4-nompi_py310h05def64_102.conda
osx-arm64::cairo-1.16.0-hc5b65c1_1017.conda
osx-arm64::postgresql-plpython-15.4-py38h3275ed9_0.conda
osx-arm64::libadios2-2.9.1-mpi_mpich_h46517f2_1.conda
osx-arm64::imagecodecs-2023.8.12-py311h68e3841_0.conda
osx-arm64::libarrow-12.0.1-hb74b275_8_cpu.conda
osx-arm64::netcdf4-1.6.4-mpi_mpich_py311h3ab5d76_2.conda
osx-arm64::heyoka-llvm-15-1.0.0-hab55ca4_0.conda
osx-arm64::ifcopenshell-v0.7.0a9-py311h8964b31_1.conda
osx-arm64::ifcopenshell-v0.7.0a10-py39h3ad519b_0.conda
osx-arm64::ifcopenshell-v0.7.0a9-py39h3ad519b_0.conda
osx-arm64::arrow-cpp-9.0.0-py38h4859def_45_cpu.conda
osx-arm64::folly-2023.08.14.00-hd189c9a_3_jemalloc.conda
osx-arm64::postgresql-15.4-h00cd704_0.conda
osx-arm64::paraview-5.11.1-py39h531ce63_102_qt.conda
osx-arm64::arrow-cpp-9.0.0-py310hf59b5c8_45_cpu.conda
osx-arm64::freecad-0.21.0-py311h1aa5dbd_1.conda
osx-arm64::heyoka-llvm-15-0.21.0-hab55ca4_1.conda
osx-arm64::libnetcdf-4.9.2-nompi_h8b962ec_110.conda
osx-arm64::heyoka-1.0.0-h0c400c2_0.conda
osx-arm64::arrow-cpp-9.0.0-py311hea5e25c_45_cpu.conda
osx-arm64::harp-1.19-py311h0dc3549_1.conda
osx-arm64::ifcopenshell-v0.7.0a10-py310h28676c1_0.conda
osx-arm64::libgdal-3.7.1-he65860e_6.conda
osx-arm64::libgdal-3.6.4-h20b384a_13.conda
osx-arm64::folly-2023.03.20.00-h1e8fca9_5.conda
osx-arm64::grpcio-1.57.0-py38h761d82c_1.conda
osx-arm64::tectonic-0.14.1-hcba961e_2.conda
osx-arm64::freecad-0.21.0-py39hfc5130e_1.conda
osx-arm64::openpmd-api-0.15.1-mpi_openmpi_py310h29e50d2_5.conda
osx-arm64::vtk-base-9.2.6-qt_py310h1234567_211.conda
osx-arm64::magics-4.14.2-hcee89ea_0.conda
osx-arm64::openpmd-api-0.15.2-nompi_py39h0b9da3f_100.conda
osx-arm64::libgdal-arrow-parquet-3.7.1-he7a3f6c_8.conda
osx-arm64::ifcopenshell-v0.7.0a10-py38h9c88707_0.conda
osx-arm64::heyoka-llvm-14-1.0.0-hc9d117a_0.conda
osx-arm64::triqs-3.1.1-py39h35c07b5_6.conda
osx-arm64::bytewax-0.17.0-py38he930795_6.conda
osx-arm64::magics-metview-batch-4.14.2-hcee89ea_0.conda
osx-arm64::cmake-3.27.4-h1c59155_1.conda
osx-arm64::libadios2-2.9.1-nompi_h6e6decc_102.conda
osx-arm64::openpmd-api-0.15.1-mpi_mpich_py310h9e66e5c_5.conda
osx-arm64::ffmpeg-6.0.0-gpl_hb1d784b_104.conda
osx-arm64::freecad-0.21.1-py311h1aa5dbd_0.conda
osx-arm64::libgdal-3.7.1-h436b0f4_9.conda
osx-arm64::folly-2023.08.14.00-hd189c9a_2_jemalloc.conda
osx-arm64::grpcio-1.56.2-py38h761d82c_1.conda
osx-arm64::libgrpc-1.57.0-hdbe17d8_1.conda
osx-arm64::paraview-5.11.1-py38hfaccb20_102_qt.conda
osx-arm64::openpmd-api-0.15.1-mpi_mpich_py39h03f4d60_5.conda
osx-arm64::heyoka-0.21.0-hb511701_1.conda
osx-arm64::healpy-1.16.5-py311h097237f_0.conda
osx-arm64::openpmd-api-0.15.1-nompi_py39h4ab0d8a_106.conda
osx-arm64::openpmd-api-0.15.1-nompi_py38h215fbd1_105.conda
osx-arm64::libxmlsec1-1.3.1-h9224fd2_1.conda
osx-arm64::libgdal-arrow-parquet-3.6.4-h7f50b62_12.conda
osx-arm64::libitk-5.3.0-ha8566bb_5.conda
osx-arm64::ifcopenshell-v0.7.0a10-py311h8964b31_0.conda
osx-arm64::cpp-opentelemetry-sdk-1.11.0-ha34c9a6_0.conda
osx-arm64::heyoka-llvm-13-1.0.0-h122378b_0.conda
osx-arm64::libgdal-3.6.4-h250aad0_12.conda
osx-arm64::pdal-2.5.5-h26cb510_1.conda
osx-arm64::openpmd-api-0.15.2-mpi_openmpi_py310heaa69f3_0.conda
osx-arm64::aws-sdk-cpp-1.10.57-h0092a47_21.conda
osx-arm64::libadios2-2.9.1-nompi_h0e6994a_100.conda
osx-arm64::nest-simulator-3.5-py38he6344e4_2.conda
osx-arm64::openpmd-api-0.15.1-mpi_mpich_py311hbbcfcb2_6.conda
osx-arm64::nodejs-20.5.1-h5f47a4d_1.conda
osx-arm64::git-2.42.0-pl5321h46e2b6d_0.conda
osx-arm64::heyoka-llvm-12-1.0.0-h7dff583_0.conda
osx-arm64::openpmd-api-0.15.1-mpi_openmpi_py39he3dae0a_6.conda
osx-arm64::libadios2-2.9.1-mpi_openmpi_h66270dc_0.conda
osx-arm64::ifcopenshell-v0.7.0a9-py310h184cd1e_1.conda
osx-arm64::libzip-1.10.0-ha0bc3c6_0.conda
osx-arm64::openpmd-api-0.15.1-mpi_mpich_py311h69fd476_5.conda
osx-arm64::nodejs-16.20.2-ha2ed473_1.conda
osx-arm64::nginx-1.25.2-h364d411_0.conda
osx-arm64::libadios2-2.9.1-nompi_h347ed31_101.conda
osx-arm64::heyoka-1.0.0-h1fa1327_0.conda
osx-arm64::libgdal-arrow-parquet-3.6.4-ha6e063e_11.conda
osx-arm64::python-3.9.18-hfa1ae8a_0_cpython.conda
osx-arm64::folly-2023.08.14.00-h4c49ebf_3_jemalloc.conda
osx-arm64::r-harp-1.19-py38h51824f0_1.conda
osx-arm64::ifcopenshell-v0.7.0a9-py310h28676c1_1.conda
osx-arm64::mcpl-1.6.2-py311h79498d2_0.conda
osx-arm64::ifcopenshell-v0.7.0a9-py311hc8b4096_0.conda
osx-arm64::netcdf4-1.6.4-mpi_openmpi_py38h3e1fb96_2.conda
osx-arm64::folly-2023.08.28.00-h2c5142d_0_jemalloc.conda
osx-arm64::healpy-1.16.5-py310h83b30b2_0.conda
osx-arm64::vowpalwabbit-9.8.0-py311hbd255e7_1.conda
osx-arm64::hdf5-1.14.2-mpi_openmpi_ha832a9f_0.conda
osx-arm64::ndcctools-7.6.2-py311hf3cef61_0.conda
osx-arm64::healpy-1.16.5-py38h8498ddf_1.conda
osx-arm64::ifcopenshell-v0.7.0a9-py38h2c7f20e_0.conda
osx-arm64::bytewax-0.17.0-py310h738ff09_6.conda
osx-arm64::vigra-1.11.1-py311h3cec95f_1046.conda
osx-arm64::ifcopenshell-v0.7.0a9-py311he09cec3_0.conda
osx-arm64::pyreadr-0.4.9-py38hba03813_0.conda
osx-arm64::openpmd-api-0.15.1-mpi_mpich_py39h2f161e1_6.conda
osx-arm64::freecad-0.21.1-py38h8581830_0.conda
osx-arm64::ifcopenshell-v0.7.0a9-py39h161eaf2_1.conda
osx-arm64::libarrow-10.0.1-h93b8820_38_cpu.conda
osx-arm64::papilo-2.1.3-ha38deef_0.conda
osx-arm64::vowpalwabbit-9.8.0-py310h0887c9e_1.conda
osx-arm64::vtk-base-9.2.6-qt_py39h1234567_212.conda
osx-arm64::openpmd-api-0.15.1-nompi_py38h633b4b1_106.conda
osx-arm64::openpmd-api-0.15.2-mpi_openmpi_py38h7136d2e_0.conda
osx-arm64::heyoka-llvm-11-1.0.0-h709b639_0.conda
osx-arm64::pygame-2.5.1-py311h4d8e0db_0.conda
osx-arm64::libgdal-arrow-parquet-3.6.4-hac233b4_14.conda
osx-arm64::freecad-0.21.0-py310h7f56274_0.conda
osx-arm64::grpcio-1.57.0-py39hbad4f83_0.conda
osx-arm64::vtk-base-9.2.6-qt_py39h1234567_211.conda
osx-arm64::magics-metview-4.14.2-h519023f_0.conda
osx-arm64::postgresql-plpython-15.4-py39h620b887_0.conda
osx-arm64::ndcctools-7.6.2-py39h6d2f949_0.conda
osx-arm64::ifcopenshell-v0.7.0a9-py310h184cd1e_0.conda
osx-arm64::aws-sdk-cpp-1.10.57-hd5419b2_20.conda
osx-arm64::libadios2-2.9.1-mpi_openmpi_hcb5871a_2.conda
osx-arm64::openmeeg-2.5.6-py311h9c635c1_2.conda
osx-arm64::ifcopenshell-v0.7.0a10-py39h161eaf2_0.conda
osx-arm64::gmt-6.4.0-h7efddb6_15.conda
osx-arm64::harp-1.19-py39hb4c5174_1.conda
osx-arm64::mcpl-1.6.2-py38he9a9ba6_0.conda
osx-arm64::grpcio-1.56.2-py311hea943cd_1.conda
osx-arm64::ifcopenshell-v0.7.0a10-py311h567d956_0.conda
osx-arm64::tiledb-2.16.3-h99ee4e4_1.conda
osx-arm64::nest-simulator-3.5-py311h93b7820_2.conda
osx-arm64::vigra-1.11.1-py39h86f9cb5_1046.conda
osx-arm64::openpmd-api-0.15.1-nompi_py311h450d273_105.conda
osx-arm64::libgdal-arrow-parquet-3.7.1-he7a3f6c_9.conda
osx-arm64::netcdf4-1.6.4-mpi_openmpi_py310hba20a2b_2.conda
osx-arm64::libadios2-2.9.1-nompi_h79c87c1_100.conda
osx-arm64::folly-2023.08.14.00-h2c5142d_1_jemalloc.conda
osx-arm64::pyreadr-0.4.9-py39h0026de1_0.conda
osx-arm64::cmake-3.27.4-h1c59155_4.conda
osx-arm64::libadios2-2.9.1-mpi_mpich_h881ba8b_2.conda
osx-arm64::indexed_gzip-1.8.5-py38h1f3209e_0.conda
osx-arm64::folly-2023.08.14.00-h2c5142d_0_jemalloc.conda
osx-arm64::heyoka-llvm-12-0.21.0-h7dff583_1.conda
osx-arm64::folly-2023.08.07.00-h1e8fca9_0.conda
osx-arm64::libgrpc-1.57.0-h9075ed4_0.conda
osx-arm64::adios-1.13.1-mpi_mpich_he1b8972_1023.conda
osx-arm64::aws-sdk-cpp-1.10.57-h1190f42_19.conda
osx-arm64::libnetcdf-4.9.2-mpi_mpich_hedaff35_11.conda
osx-arm64::openpmd-api-0.15.2-mpi_mpich_py310h7cc4ade_0.conda
osx-arm64::folly-2023.03.20.00-h8b73916_5_jemalloc.conda
osx-arm64::libarrow-13.0.0-h6e4acf5_0_cpu.conda
osx-arm64::libgdal-3.7.1-hcb6ae6c_5.conda
osx-arm64::libadios2-2.9.1-mpi_mpich_hcf98a40_0.conda
osx-arm64::libgd-2.3.3-h32cdd76_7.conda
osx-arm64::libarrow-11.0.0-hb74b275_33_cpu.conda
osx-arm64::folly-2023.08.14.00-h1e8fca9_1.conda
osx-arm64::tiledb-2.16.2-hc77a09f_0.conda
osx-arm64::folly-2023.03.20.00-h2c5142d_5_jemalloc.conda
osx-arm64::polycap-1.2-py311h361db0b_3.conda
osx-arm64::r-base-4.2.3-h80092d0_7.conda
osx-arm64::arrow-cpp-9.0.0-py311h724f4ad_45_cpu.conda
osx-arm64::openpmd-api-0.15.2-nompi_py311h4cb7621_100.conda
osx-arm64::freecad-0.21.0-py38h8581830_0.conda
osx-arm64::mcpl-1.6.2-py39ha52a465_0.conda
osx-arm64::cmake-3.27.4-h1c59155_3.conda
osx-arm64::folly-2023.08.14.00-h1e8fca9_3.conda
osx-arm64::arrow-cpp-9.0.0-py38h6852b2c_45_cpu.conda
osx-arm64::r-harp-1.19-py310he2ee789_1.conda
osx-arm64::freecad-0.21.0-py38h8581830_1.conda
osx-arm64::triqs-3.1.1-py311h358a192_6.conda
osx-arm64::openpmd-api-0.15.2-mpi_mpich_py39h61ee36d_0.conda
osx-arm64::folly-2023.08.07.00-h03318f1_1.conda
osx-arm64::ogre-1.10.12-h416be8e_11.conda
osx-arm64::vigra-1.11.1-py39hb315b24_1046.conda
osx-arm64::libnetcdf-4.9.2-mpi_mpich_he5d0303_10.conda
osx-arm64::hdf5-1.14.2-mpi_mpich_hb01e5a5_0.conda
osx-arm64::sqlite-3.43.0-h203b68d_0.conda
osx-arm64::grpcio-1.57.0-py310h95b248a_1.conda
osx-arm64::libscotch-7.0.4-hf7fe8bf_0.conda
osx-arm64::folly-2023.08.14.00-hd189c9a_0_jemalloc.conda
osx-arm64::openpmd-api-0.15.1-mpi_openmpi_py38hfb53f66_5.conda
osx-arm64::polycap-1.2-py39h9a92469_3.conda
osx-arm64::bytewax-0.17.0-py38he930795_5.conda
osx-arm64::freecad-0.21.1-py310h7f56274_0.conda
osx-arm64::heyoka-1.0.0-h1ae0666_0.conda
osx-arm64::pygame-2.5.1-py39h57bbbc0_0.conda
osx-arm64::libadios2-2.9.1-nompi_h6f7674d_100.conda
osx-arm64::omniorb-libs-4.3.1-h13d9943_0.conda
osx-arm64::pygame-2.5.1-py38hece1802_0.conda
osx-arm64::freecad-0.21.0-py310h7f56274_1.conda
osx-arm64::libpq-15.4-hcea71ed_0.conda
osx-arm64::pyreadstat-1.2.3-py38he9a9ba6_0.conda
osx-arm64::ifcopenshell-v0.7.0a9-py39hc23ec6f_0.conda
osx-arm64::healpy-1.16.5-py310h4428cd7_1.conda
osx-arm64::arrow-cpp-9.0.0-py310hb2f8c54_46_cpu.conda
osx-arm64::pdal-2.5.6-he242ca8_0.conda
osx-arm64::ndcctools-7.6.2-py310h4b37b16_0.conda
osx-arm64::vtk-base-9.2.6-qt_py311h1234567_212.conda
osx-arm64::ifcopenshell-v0.7.0a10-py310h6d37856_0.conda
osx-arm64::paraview-5.11.1-py310h1fffb53_102_qt.conda
osx-arm64::healpy-1.16.5-py39he8258d9_0.conda
osx-arm64::tiledb-2.16.3-hc77a09f_1.conda
osx-arm64::folly-2023.08.14.00-hdc4976f_3.conda
osx-arm64::openpmd-api-0.15.1-nompi_py311h4cb7621_106.conda
osx-arm64::ifcopenshell-v0.7.0a9-py38hdfea0aa_1.conda
osx-arm64::folly-2023.08.28.00-hd189c9a_0_jemalloc.conda
osx-arm64::freecad-0.21.1-py39hfc5130e_0.conda
osx-arm64::libgdal-3.7.1-hdf35568_7.conda
osx-arm64::ifcopenshell-v0.7.0a10-py38hdfea0aa_0.conda
osx-arm64::mold-2.1.0-h5d4715a_1.conda
osx-arm64::ifcopenshell-v0.7.0a9-py311h567d956_1.conda
osx-arm64::arrow-cpp-9.0.0-py39hb048ed0_45_cpu.conda
osx-arm64::heyoka-llvm-11-0.21.0-h709b639_1.conda
osx-arm64::libadios2-2.9.1-nompi_h0e6994a_101.conda
osx-arm64::ifcopenshell-v0.7.0a9-py310h29111f7_0.conda
osx-arm64::libadios2-2.9.1-nompi_hb40c12d_100.conda
osx-arm64::folly-2023.08.28.00-h1e8fca9_0.conda
osx-arm64::libadios2-2.9.1-mpi_mpich_h1df5735_2.conda
osx-arm64::scip-8.0.4-h94111ae_0.conda
osx-arm64::grpcio-1.56.2-py310h95b248a_1.conda
osx-arm64::libopencv-4.8.0-py38hd3a69e2_1.conda
osx-arm64::vowpalwabbit-9.9.0-py310h0887c9e_0.conda
osx-arm64::libxml2-2.11.5-h25269f3_1.conda
osx-arm64::vigra-1.11.1-py38h1822ee2_1046.conda
osx-arm64::ifcopenshell-v0.7.0a9-py39h0cae4b0_1.conda
osx-arm64::triqs-3.1.1-py311h6ca355d_6.conda
osx-arm64::pyreadstat-1.2.3-py310hab90de1_0.conda
osx-arm64::libgdal-3.7.1-h436b0f4_8.conda
osx-arm64::grpcio-1.57.0-py311hea943cd_1.conda
osx-arm64::harp-1.19-py38hb4c5174_1.conda
osx-arm64::libadios2-2.9.1-mpi_mpich_h37257f3_1.conda
osx-arm64::libadios2-2.9.1-mpi_openmpi_h7fbabbf_1.conda
osx-arm64::ifcopenshell-v0.7.0a9-py311h8964b31_0.conda
osx-arm64::ogre-1.10.12-he6d6d34_12.conda
osx-arm64::libnetcdf-4.9.2-mpi_openmpi_h01c98f5_11.conda
osx-arm64::adios-1.13.1-mpi_openmpi_h74f2ae7_1023.conda
osx-arm64::tiledb-2.16.3-h5345278_1.conda
osx-arm64::libarrow-12.0.1-h0b136c2_8_cpu.conda
osx-arm64::grpcio-1.57.0-py311hea943cd_0.conda
osx-arm64::chemicalite-2022.04.1-h4cda963_11.conda
osx-arm64::libadios2-2.9.1-mpi_mpich_ha7a4453_2.conda
osx-arm64::indexed_gzip-1.8.5-py310hfd46798_0.conda
osx-arm64::triqs-3.1.1-py38hfe7a5d8_6.conda
osx-arm64::harp-1.19-py310hb4c5174_1.conda
osx-arm64::pyreadstat-1.2.3-py39ha52a465_0.conda
osx-arm64::libarrow-12.0.1-h6e4acf5_9_cpu.conda
osx-arm64::aws-sdk-cpp-1.11.68-hd5419b2_12.conda
osx-arm64::libadios2-2.9.1-mpi_openmpi_h770f5e9_2.conda
osx-arm64::gmt-6.4.0-h30de5ce_14.conda
osx-arm64::vowpalwabbit-9.9.0-py311hbd255e7_0.conda
osx-arm64::hdf5-1.14.2-nompi_h3aba7b3_100.conda
osx-arm64::libarrow-11.0.0-h6e4acf5_34_cpu.conda
osx-arm64::libadios2-2.9.1-mpi_openmpi_h78c12d5_1.conda
osx-arm64::libgdal-arrow-parquet-3.7.1-hede47c1_7.conda
osx-arm64::libvips-8.14.4-hcb42e34_0.conda
osx-arm64::r-git2r-0.31.0-r43hd848ae8_2.conda
osx-arm64::openmeeg-2.5.6-py39h237b7dc_2.conda
osx-arm64::openpmd-api-0.15.2-nompi_py38hd977326_100.conda
osx-arm64::openpmd-api-0.15.1-mpi_openmpi_py39h9ad568d_5.conda
osx-arm64::libopencv-4.8.0-py310h5d3c664_1.conda
osx-arm64::freecad-0.21.0-py39hfc5130e_0.conda
osx-arm64::libadios2-2.9.1-mpi_openmpi_h84b0edd_0.conda
osx-arm64::healpy-1.16.5-py38h8ea5272_0.conda
osx-arm64::omniorb-4.3.1-py38h8c06ffa_0.conda
osx-arm64::triqs-3.1.1-py39hf0d0bb3_6.conda
osx-arm64::boost-cpp-1.78.0-h00df5ed_4.conda
osx-arm64::paraview-5.11.1-py311hd9b8b8b_102_qt.conda
osx-arm64::libadios2-2.9.1-mpi_openmpi_hf43b078_1.conda
osx-arm64::libadios2-2.9.1-nompi_h4702e56_102.conda
osx-arm64::bytewax-0.17.0-py39h66a509b_5.conda
osx-arm64::heyoka-1.0.0-h2293f1e_0.conda
osx-arm64::openpmd-api-0.15.2-mpi_openmpi_py39h9fa31c8_0.conda
osx-arm64::lammps-2023.08.02-cpu_py310_h7a37da0_mpich_0.conda
osx-arm64::vigra-1.11.1-py310hd556310_1046.conda
osx-arm64::folly-2023.08.07.00-h1e8fca9_1.conda
osx-arm64::libadios2-2.9.1-mpi_mpich_h1b2a255_0.conda
osx-arm64::folly-2023.08.14.00-h1e8fca9_2.conda
osx-arm64::libadios2-2.9.1-nompi_h986cc0a_102.conda
osx-arm64::nest-simulator-3.5-py310haefc66e_2.conda
osx-arm64::vowpalwabbit-9.9.0-py39ha269e3f_0.conda
osx-arm64::texlive-core-20230313-py310h6bf6ac2_5.conda
osx-arm64::ovito-3.9.0-h6961929_0.conda
osx-arm64::vowpalwabbit-9.8.0-py38heb37505_1.conda
osx-arm64::folly-2023.08.14.00-h2c5142d_3_jemalloc.conda
osx-arm64::folly-2023.08.28.00-hdc4976f_0.conda
osx-arm64::openpmd-api-0.15.1-mpi_mpich_py38h4b99d84_6.conda
osx-arm64::openpmd-api-0.15.2-mpi_openmpi_py311hfb5bbb9_0.conda
osx-arm64::libnetcdf-4.9.2-nompi_hb2fb864_111.conda
osx-arm64::openpmd-api-0.15.1-mpi_mpich_py38hd879443_5.conda
osx-arm64::coda-2.24.2-py38h51824f0_3.conda
osx-arm64::libtiff-4.5.1-h23a1a89_1.conda
osx-arm64::omniorb-4.3.1-py311h8617d33_0.conda
osx-arm64::libscotch-7.0.4-hc938e73_0.conda
osx-arm64::ifcopenshell-v0.7.0a10-py38he2d88da_0.conda
osx-arm64::folly-2023.08.07.00-hd189c9a_1_jemalloc.conda
osx-arm64::libadios2-2.9.1-mpi_mpich_he0e8955_1.conda
osx-arm64::cmake-3.27.4-h1c59155_2.conda
osx-arm64::aws-sdk-cpp-1.11.68-h1190f42_11.conda
osx-arm64::folly-2023.08.07.00-h03318f1_0.conda
osx-arm64::poppler-23.08.0-h16d8c84_0.conda
osx-arm64::pdal-2.5.5-he242ca8_2.conda
osx-arm64::bytewax-0.17.0-py39h66a509b_6.conda
osx-arm64::libadios2-2.9.1-nompi_hbd0e1fc_101.conda
osx-arm64::netcdf4-1.6.4-nompi_py38h260f13c_102.conda
osx-arm64::imagecodecs-2023.8.12-py310h342b742_0.conda
osx-arm64::openpmd-api-0.15.1-mpi_openmpi_py310h75301eb_6.conda
osx-arm64::openpmd-api-0.15.1-mpi_openmpi_py38h97212e3_6.conda
osx-arm64::nss-3.92-hc6b9969_0.conda
osx-arm64::heyoka-0.21.0-h1ae0666_1.conda
osx-arm64::hdfeos5-5.1.16-h3dfb372_15.conda
osx-arm64::postgresql-plpython-15.4-py311h885f1b6_0.conda
osx-arm64::pdal-2.5.6-h5abc494_1.conda
osx-arm64::lammps-2023.08.02-cpu_py311_hd466178_mpich_0.conda
osx-arm64::pygame-2.5.1-py310heeb1dd7_0.conda
osx-arm64::heyoka-0.21.0-h038e230_1.conda
osx-arm64::libadios2-2.9.1-mpi_openmpi_h2d5a834_2.conda
osx-arm64::arrow-cpp-9.0.0-py310h182df2f_45_cpu.conda
osx-arm64::libadios2-2.9.1-nompi_h2706e1b_102.conda
osx-arm64::aws-sdk-cpp-1.11.68-h0092a47_13.conda
osx-arm64::netcdf4-1.6.4-mpi_openmpi_py39hddcacee_2.conda
osx-arm64::pyreadr-0.4.9-py311h824b5d7_0.conda
osx-arm64::imagecodecs-2023.8.12-py39h24b8818_0.conda
osx-arm64::grpcio-1.57.0-py38h761d82c_0.conda
osx-arm64::libadios2-2.9.1-mpi_mpich_h37a2b2b_1.conda
osx-arm64::llvm-16.0.6-h2b67075_2.conda
osx-arm64::lammps-2023.08.02-cpu_py38_ha19c33e_mpich_0.conda
osx-arm64::llvm-tools-16.0.6-he79909e_2.conda
osx-arm64::libgdal-arrow-parquet-3.6.4-hac233b4_15.conda
osx-arm64::triqs-3.1.1-py310h216340d_6.conda
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
================================================================================
================================================================================
linux-ppc64le
linux-ppc64le::libprotobuf-static-4.23.4-h9ce2175_2.conda
linux-ppc64le::libass-0.17.1-h586b5ed_1.conda
linux-ppc64le::libprotobuf-static-3.21.12-hff1ad0c_2.conda
linux-ppc64le::libv8-8.9.83-h0e1fc24_4.conda
linux-ppc64le::libprotobuf-4.23.4-h9ce2175_4.conda
linux-ppc64le::openexr-3.1.10-h4843ef4_0.conda
linux-ppc64le::libsqlite-3.43.0-hd4bbf49_0.conda
linux-ppc64le::openexr-3.1.11-h4843ef4_0.conda
linux-ppc64le::libprotobuf-static-4.23.4-h9ce2175_4.conda
linux-ppc64le::libprotobuf-4.23.4-h31f4ac3_0.conda
linux-ppc64le::micromamba-1.5.0-0.tar.bz2
linux-ppc64le::libprotobuf-4.23.4-h9ce2175_5.conda
linux-ppc64le::libprotobuf-static-4.23.4-h9ce2175_3.conda
linux-ppc64le::libprotobuf-static-4.23.4-h31f4ac3_1.conda
linux-ppc64le::libprotobuf-4.23.4-h9ce2175_3.conda
linux-ppc64le::libprotobuf-static-3.21.12-hff1ad0c_1.conda
linux-ppc64le::libprotobuf-3.21.12-hff1ad0c_2.conda
linux-ppc64le::libprotobuf-4.23.4-h9ce2175_2.conda
linux-ppc64le::libprotobuf-4.23.4-h31f4ac3_1.conda
linux-ppc64le::zstd-1.5.5-h7292585_0.conda
linux-ppc64le::libprotobuf-3.21.12-hff1ad0c_1.conda
linux-ppc64le::libsolv-0.7.24-hff1ad0c_3.conda
linux-ppc64le::cudnn-8.8.0.121-h30cf0ba_2.conda
linux-ppc64le::openexr-3.2.0-h4843ef4_0.conda
linux-ppc64le::micromamba-1.5.0-1.tar.bz2
linux-ppc64le::libsolv-static-0.7.24-hff1ad0c_3.conda
linux-ppc64le::cudnn-8.8.0.121-h6252efc_2.conda
linux-ppc64le::libprotobuf-static-4.23.4-h31f4ac3_0.conda
linux-ppc64le::adios-1.13.1-nompi_h7190537_1123.conda
-    "libzlib >=1.2.13,<1.3.0a0"
+    "libzlib >=1.2.13,<2.0.0a0"
linux-ppc64le::openpmd-api-0.15.1-mpi_mpich_py38h6a3f854_5.conda
linux-ppc64le::openpmd-api-0.15.2-mpi_mpich_py39h7d5846c_0.conda
linux-ppc64le::vigra-1.11.1-py311hea97c9a_1046.conda
linux-ppc64le::arrow-cpp-9.0.0-py310hcb7558c_46_cuda.conda
linux-ppc64le::libgd-2.3.3-h2cf6b8a_7.conda
linux-ppc64le::cpp-opentelemetry-sdk-1.11.0-ha0f27b6_0.conda
linux-ppc64le::texlive-core-20230313-he804754_5.conda
linux-ppc64le::ogre-1.10.12-h8b04491_12.conda
linux-ppc64le::folly-2023.08.14.00-h76ff26f_2_jemalloc.conda
linux-ppc64le::folly-2023.03.20.00-h864cb69_5_jemalloc.conda
linux-ppc64le::openpmd-api-0.15.1-mpi_mpich_py39h08d283b_6.conda
linux-ppc64le::pyreadstat-1.2.3-py311he2df201_0.conda
linux-ppc64le::vigra-1.11.1-py39h46ff6a2_1046.conda
linux-ppc64le::libadios2-2.9.1-mpi_mpich_h2376794_2.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.1-h0c386fb_7.conda
linux-ppc64le::pygame-2.5.1-py38h2dab74b_0.conda
linux-ppc64le::poppler-23.08.0-hcd38bda_0.conda
linux-ppc64le::libgdal-3.7.1-hea41754_5.conda
linux-ppc64le::libgrpc-1.54.3-hf8c08f8_0.conda
linux-ppc64le::aws-sdk-cpp-1.10.57-ha928e5a_20.conda
linux-ppc64le::openpmd-api-0.15.2-mpi_mpich_py310h45e1fc4_0.conda
linux-ppc64le::vigra-1.11.1-py39h3b76d57_1046.conda
linux-ppc64le::vowpalwabbit-9.9.0-py310h5e53493_0.conda
linux-ppc64le::libadios2-2.9.1-nompi_hb248a39_101.conda
linux-ppc64le::libadios2-2.9.1-mpi_mpich_ha8b31ef_1.conda
linux-ppc64le::libnetcdf-4.9.2-mpi_openmpi_hea8e8e5_10.conda
linux-ppc64le::git-2.42.0-pl5321h7a00b28_0.conda
linux-ppc64le::aws-sdk-cpp-1.11.68-h63e68b5_11.conda
linux-ppc64le::imagecodecs-2023.8.12-py311h18ab8cc_0.conda
linux-ppc64le::tesseract-5.3.2-h4e6318b_0.conda
linux-ppc64le::arrow-cpp-9.0.0-py310h94fa2fe_45_cpu.conda
linux-ppc64le::grpcio-1.56.2-py311h3997ded_1.conda
linux-ppc64le::healpy-1.16.5-py38h9ec44cd_1.conda
linux-ppc64le::netcdf4-1.6.4-mpi_openmpi_py39hd0890ac_2.conda
linux-ppc64le::eccodes-2.31.0-h08d12ae_1.conda
linux-ppc64le::folly-2023.08.14.00-h361900a_2.conda
linux-ppc64le::libarrow-11.0.0-h27abc39_34_cuda.conda
linux-ppc64le::libadios2-2.9.1-mpi_mpich_he0ca79e_1.conda
linux-ppc64le::cmake-3.27.4-h1403f77_1.conda
linux-ppc64le::postgresql-plpython-15.4-py311hba550cb_0.conda
linux-ppc64le::cmake-3.27.4-h1403f77_0.conda
linux-ppc64le::vigra-1.11.1-py38hc4e133d_1046.conda
linux-ppc64le::pyreadstat-1.2.3-py38h2b47b73_0.conda
linux-ppc64le::openpmd-api-0.15.2-nompi_py39he45b5b5_100.conda
linux-ppc64le::arrow-cpp-9.0.0-py38h0084673_45_cpu.conda
linux-ppc64le::openpmd-api-0.15.1-mpi_mpich_py38h7368702_6.conda
linux-ppc64le::arrow-cpp-9.0.0-py311h364dd47_45_cuda.conda
linux-ppc64le::adios-1.13.1-mpi_mpich_hbe023fd_1023.conda
linux-ppc64le::openpmd-api-0.15.1-nompi_py38hf4ca0ad_106.conda
linux-ppc64le::vigra-1.11.1-py38ha1e8200_1046.conda
linux-ppc64le::libopencv-4.8.0-py311h08a7f07_1.conda
linux-ppc64le::folly-2023.08.14.00-hd692e58_2.conda
linux-ppc64le::folly-2023.08.14.00-h361900a_3.conda
linux-ppc64le::grpcio-1.56.2-py310h8eb8f48_1.conda
linux-ppc64le::openjdk-20.0.0-h7025949_1.conda
linux-ppc64le::vowpalwabbit-9.9.0-py311h6ab700b_0.conda
linux-ppc64le::healpy-1.16.5-py38he6521ef_0.conda
linux-ppc64le::vigra-1.11.1-py38h9dc56f3_1046.conda
linux-ppc64le::omniorb-4.3.1-py39ha8da32a_0.conda
linux-ppc64le::llvmdev-16.0.6-h8d57982_2.conda
linux-ppc64le::vowpalwabbit-9.9.0-py38h276fb4e_0.conda
linux-ppc64le::folly-2023.08.07.00-h864cb69_1_jemalloc.conda
linux-ppc64le::libadios2-2.9.1-mpi_mpich_hf621a72_0.conda
linux-ppc64le::folly-2023.03.20.00-ha231c81_5.conda
linux-ppc64le::openpmd-api-0.15.1-nompi_py38h55ec67e_106.conda
linux-ppc64le::arrow-cpp-9.0.0-py39hbf85a71_46_cpu.conda
linux-ppc64le::r-git2r-0.31.0-r42h47fe75f_2.conda
linux-ppc64le::arrow-cpp-9.0.0-py311h6b6cec3_45_cpu.conda
linux-ppc64le::vtk-base-9.2.6-qt_py311h1234567_211.conda
linux-ppc64le::nss-3.92-h4237796_0.conda
linux-ppc64le::openpmd-api-0.15.2-mpi_openmpi_py311h1d4006c_0.conda
linux-ppc64le::grpcio-1.57.0-py310h8eb8f48_1.conda
linux-ppc64le::vigra-1.11.1-py38hfaa922b_1046.conda
linux-ppc64le::openpmd-api-0.15.2-nompi_py39h4b1c906_100.conda
linux-ppc64le::cmake-3.27.4-h1403f77_4.conda
linux-ppc64le::libadios2-2.9.1-nompi_hd65b43d_100.conda
linux-ppc64le::libarrow-11.0.0-h910e738_34_cpu.conda
linux-ppc64le::vtk-base-9.2.6-qt_py310h1234567_212.conda
linux-ppc64le::openpmd-api-0.15.2-mpi_openmpi_py38h79ae85b_0.conda
linux-ppc64le::libadios2-2.9.1-nompi_h2eb769f_100.conda
linux-ppc64le::openpmd-api-0.15.1-mpi_openmpi_py38h7f4efc4_6.conda
linux-ppc64le::arrow-cpp-9.0.0-py310he506279_45_cuda.conda
linux-ppc64le::folly-2023.08.14.00-hd692e58_3.conda
linux-ppc64le::pyreadstat-1.2.3-py310h925d916_0.conda
linux-ppc64le::libarrow-13.0.0-h910e738_0_cpu.conda
linux-ppc64le::openpmd-api-0.15.1-mpi_openmpi_py38h58ceeda_6.conda
linux-ppc64le::rust-1.72.0-hb12b0c0_1.conda
linux-ppc64le::libxml2-2.11.5-h02ec90b_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.6.4-h4f6669d_15.conda
linux-ppc64le::netcdf4-1.6.4-mpi_openmpi_py311h2d08ffa_2.conda
linux-ppc64le::libadios2-2.9.1-nompi_h6b349f6_101.conda
linux-ppc64le::ogre-1.10.12-hc00f8ad_11.conda
linux-ppc64le::vtk-base-9.2.6-qt_py39h1234567_211.conda
linux-ppc64le::folly-2023.08.14.00-hbe59455_3_jemalloc.conda
linux-ppc64le::libxmlsec1-1.3.1-h59429d2_1.conda
linux-ppc64le::vtk-base-9.2.6-qt_py311h1234567_212.conda
linux-ppc64le::arrow-cpp-9.0.0-py39hbe035ad_46_cuda.conda
linux-ppc64le::openpmd-api-0.15.2-mpi_mpich_py38h96cc729_0.conda
linux-ppc64le::openpmd-api-0.15.1-mpi_openmpi_py311h8bffa81_5.conda
linux-ppc64le::libscotch-7.0.4-hcd3a5a8_0.conda
linux-ppc64le::libadios2-2.9.1-mpi_mpich_hb65464c_1.conda
linux-ppc64le::postgresql-15.4-h0ebe0f4_0.conda
linux-ppc64le::ffmpeg-6.0.0-gpl_h43fb03d_104.conda
linux-ppc64le::healpy-1.16.5-py310h8bbb151_0.conda
linux-ppc64le::aws-sdk-cpp-1.11.68-h7c2b61e_13.conda
linux-ppc64le::libarrow-13.0.0-h27abc39_0_cuda.conda
linux-ppc64le::libadios2-2.9.1-nompi_ha8a2491_102.conda
linux-ppc64le::libgrpc-1.57.0-h6f946ae_1.conda
linux-ppc64le::grpcio-1.57.0-py39h278787b_0.conda
linux-ppc64le::folly-2023.08.07.00-hfccd340_1_jemalloc.conda
linux-ppc64le::libadios2-2.9.1-mpi_openmpi_h2535527_2.conda
linux-ppc64le::libarrow-12.0.1-hf2d3464_8_cuda.conda
linux-ppc64le::openpmd-api-0.15.2-mpi_mpich_py38hc6d2f7b_0.conda
linux-ppc64le::libopencv-4.8.0-py310h23bc9d5_1.conda
linux-ppc64le::libgrpc-1.57.0-hf11f071_0.conda
linux-ppc64le::arrow-cpp-9.0.0-py311he06dc8e_46_cuda.conda
linux-ppc64le::hdf5-1.14.2-mpi_openmpi_hf8c4a79_0.conda
linux-ppc64le::openpmd-api-0.15.2-nompi_py38hc1161fb_100.conda
linux-ppc64le::libadios2-2.9.1-mpi_mpich_h16fd881_2.conda
linux-ppc64le::sdl2_ttf-2.20.2-hd31ca0a_2.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.1-h3282a2e_5.conda
linux-ppc64le::libarrow-12.0.1-hf7f1dcd_8_cpu.conda
linux-ppc64le::folly-2023.08.07.00-h361900a_0.conda
linux-ppc64le::folly-2023.08.14.00-h864cb69_0_jemalloc.conda
linux-ppc64le::vtk-base-9.2.6-qt_py38h1234567_212.conda
linux-ppc64le::libgdal-3.7.1-he46eb7f_8.conda
linux-ppc64le::openpmd-api-0.15.1-nompi_py311h8d65320_105.conda
linux-ppc64le::openpmd-api-0.15.1-mpi_mpich_py39h6229c39_5.conda
linux-ppc64le::imagecodecs-2023.8.12-py39h9e06246_0.conda
linux-ppc64le::healpy-1.16.5-py39h3dcc1aa_0.conda
linux-ppc64le::libadios2-2.9.1-mpi_openmpi_hcde4a47_2.conda
linux-ppc64le::openpmd-api-0.15.1-mpi_openmpi_py310h568298f_5.conda
linux-ppc64le::r-base-4.2.3-h11a65d1_7.conda
linux-ppc64le::libgdal-arrow-parquet-3.6.4-hb61b655_11.conda
linux-ppc64le::libarrow-12.0.1-hec0d767_8_cuda.conda
linux-ppc64le::hdf5-1.14.2-mpi_mpich_h4d8530d_0.conda
linux-ppc64le::folly-2023.08.14.00-h864cb69_1_jemalloc.conda
linux-ppc64le::omniorb-4.3.1-py311h7d8a50b_0.conda
linux-ppc64le::libadios2-2.9.1-mpi_mpich_h09aab29_0.conda
linux-ppc64le::openpmd-api-0.15.2-nompi_py310h3dbb87d_100.conda
linux-ppc64le::vowpalwabbit-9.8.0-py311h6ab700b_1.conda
linux-ppc64le::healpy-1.16.5-py38h439b5e3_0.conda
linux-ppc64le::tiledb-2.16.3-hd5af256_1.conda
linux-ppc64le::tiledb-2.16.2-hd5af256_0.conda
linux-ppc64le::folly-2023.08.07.00-hfccd340_0_jemalloc.conda
linux-ppc64le::arrow-cpp-9.0.0-py311he982aa7_45_cpu.conda
linux-ppc64le::healpy-1.16.5-py39h4df0a9b_1.conda
linux-ppc64le::libadios2-2.9.1-mpi_openmpi_h788cb01_2.conda
linux-ppc64le::vigra-1.11.1-py39h8d2b365_1046.conda
linux-ppc64le::arrow-cpp-9.0.0-py38h02b51d4_45_cuda.conda
linux-ppc64le::folly-2023.08.07.00-hd692e58_1.conda
linux-ppc64le::libarrow-11.0.0-hec0d767_33_cuda.conda
linux-ppc64le::grpcio-1.57.0-py310h8eb8f48_0.conda
linux-ppc64le::folly-2023.08.28.00-h864cb69_0_jemalloc.conda
linux-ppc64le::libadios2-2.9.1-nompi_h2e7e547_100.conda
linux-ppc64le::pdal-2.5.5-hdf0a6a8_2.conda
linux-ppc64le::libscotch-7.0.4-h1990940_0.conda
linux-ppc64le::openpmd-api-0.15.2-mpi_openmpi_py39h44a1dfa_0.conda
linux-ppc64le::netcdf4-1.6.4-nompi_py39hdb904ae_102.conda
linux-ppc64le::tiledb-2.16.3-hac2e0cb_1.conda
linux-ppc64le::vigra-1.11.1-py311hf0cba7b_1046.conda
linux-ppc64le::grpcio-1.57.0-py311h3997ded_0.conda
linux-ppc64le::nginx-1.25.2-hd111a0b_0.conda
linux-ppc64le::arrow-cpp-9.0.0-py310h7ee8eae_45_cpu.conda
linux-ppc64le::openpmd-api-0.15.1-mpi_mpich_py38h0301415_6.conda
linux-ppc64le::libadios2-2.9.1-mpi_openmpi_h38c5083_1.conda
linux-ppc64le::libadios2-2.9.1-nompi_h1520396_102.conda
linux-ppc64le::openpmd-api-0.15.1-nompi_py38hb671de6_105.conda
linux-ppc64le::libarrow-10.0.1-h27abc39_38_cuda.conda
linux-ppc64le::netcdf4-1.6.4-mpi_mpich_py39h5cc4e33_2.conda
linux-ppc64le::libtiff-4.5.1-h50938e9_1.conda
linux-ppc64le::rust-1.71.1-hb12b0c0_0.conda
linux-ppc64le::netcdf4-1.6.4-mpi_openmpi_py38hcf908bf_2.conda
linux-ppc64le::arrow-cpp-9.0.0-py311habd2a32_46_cpu.conda
linux-ppc64le::libadios2-2.9.1-mpi_mpich_he1f242b_2.conda
linux-ppc64le::folly-2023.08.14.00-h361900a_0.conda
linux-ppc64le::arrow-cpp-9.0.0-py310h58cb859_46_cpu.conda
linux-ppc64le::netcdf4-1.6.4-mpi_mpich_py310h50b4216_2.conda
linux-ppc64le::openpmd-api-0.15.1-mpi_mpich_py311hb47db45_6.conda
linux-ppc64le::libadios2-2.9.1-mpi_openmpi_h773617d_1.conda
linux-ppc64le::openpmd-api-0.15.1-mpi_openmpi_py39hd3bba03_6.conda
linux-ppc64le::libzip-1.10.1-hb84b332_0.conda
linux-ppc64le::aws-sdk-cpp-1.11.68-ha928e5a_12.conda
linux-ppc64le::openpmd-api-0.15.1-mpi_openmpi_py38h6633361_5.conda
linux-ppc64le::folly-2023.08.14.00-h79ae0fe_3.conda
linux-ppc64le::arrow-cpp-9.0.0-py39h547d0d9_45_cpu.conda
linux-ppc64le::folly-2023.08.14.00-h864cb69_2_jemalloc.conda
linux-ppc64le::libadios2-2.9.1-mpi_openmpi_h9917a5b_2.conda
linux-ppc64le::libadios2-2.9.1-nompi_h74f674e_100.conda
linux-ppc64le::libarrow-10.0.1-he582fe7_37_cpu.conda
linux-ppc64le::netcdf4-1.6.4-nompi_py311hf4c972e_102.conda
linux-ppc64le::arrow-cpp-9.0.0-py39h355b537_45_cuda.conda
linux-ppc64le::grpcio-1.56.2-py39h278787b_1.conda
linux-ppc64le::folly-2023.08.14.00-ha93b4a0_2.conda
linux-ppc64le::aws-sdk-cpp-1.11.68-h8a7b76c_10.conda
linux-ppc64le::openpmd-api-0.15.1-mpi_mpich_py38h4a3df3b_5.conda
linux-ppc64le::openpmd-api-0.15.1-nompi_py310h6a05bff_105.conda
linux-ppc64le::folly-2023.08.14.00-h864cb69_3_jemalloc.conda
linux-ppc64le::folly-2023.08.14.00-hfccd340_3_jemalloc.conda
linux-ppc64le::libarrow-10.0.1-hf7f1dcd_37_cpu.conda
linux-ppc64le::libarrow-12.0.1-h910e738_9_cpu.conda
linux-ppc64le::folly-2023.08.14.00-h361900a_1.conda
linux-ppc64le::vigra-1.11.1-py310hf602178_1046.conda
linux-ppc64le::boost-cpp-1.78.0-h6596cfb_4.conda
linux-ppc64le::libgdal-3.6.4-h41690fe_13.conda
linux-ppc64le::vowpalwabbit-9.8.0-py310h5e53493_1.conda
linux-ppc64le::nodejs-16.20.2-h29c4f12_1.conda
linux-ppc64le::libvips-8.14.4-h6f5bdf3_0.conda
linux-ppc64le::r-git2r-0.31.0-r43h47fe75f_2.conda
linux-ppc64le::openpmd-api-0.15.2-mpi_openmpi_py39h83e2e02_0.conda
linux-ppc64le::healpy-1.16.5-py38h75df58b_1.conda
linux-ppc64le::folly-2023.08.07.00-hd692e58_0.conda
linux-ppc64le::netcdf4-1.6.4-nompi_py310h24b77d7_102.conda
linux-ppc64le::healpy-1.16.5-py311he5fe6df_0.conda
linux-ppc64le::netcdf4-1.6.4-mpi_mpich_py38hd340d46_2.conda
linux-ppc64le::boost-cpp-1.82.0-hbaed7d5_2.conda
linux-ppc64le::python-3.11.5-h3332dee_0_cpython.conda
linux-ppc64le::tectonic-0.14.1-h18cc9bf_1.conda
linux-ppc64le::libgdal-3.6.4-h124e430_11.conda
linux-ppc64le::openpmd-api-0.15.1-nompi_py310h4a64e9c_106.conda
linux-ppc64le::libarrow-10.0.1-hf2d3464_37_cuda.conda
linux-ppc64le::libadios2-2.9.1-mpi_mpich_h71aec2e_2.conda
linux-ppc64le::libgdal-arrow-parquet-3.6.4-h4f6669d_14.conda
linux-ppc64le::pygame-2.5.1-py39h0c599e8_0.conda
linux-ppc64le::pdal-2.5.6-hdf0a6a8_0.conda
linux-ppc64le::libxml2-2.11.5-h0545f4b_1.conda
linux-ppc64le::vtk-base-9.2.6-qt_py310h1234567_211.conda
linux-ppc64le::libadios2-2.9.1-nompi_h74f674e_101.conda
linux-ppc64le::arrow-cpp-9.0.0-py39h7e63462_45_cpu.conda
linux-ppc64le::libadios2-2.9.1-mpi_openmpi_hd78801d_0.conda
linux-ppc64le::libpq-15.4-h9d99649_0.conda
linux-ppc64le::openpmd-api-0.15.1-mpi_openmpi_py39h07198dc_5.conda
linux-ppc64le::libnetcdf-4.9.2-nompi_h2606ec2_111.conda
linux-ppc64le::arrow-cpp-9.0.0-py38hf901490_46_cpu.conda
linux-ppc64le::aws-sdk-cpp-1.10.57-h7c2b61e_21.conda
linux-ppc64le::libnetcdf-4.9.2-mpi_mpich_hf1a50d0_11.conda
linux-ppc64le::libllvm16-16.0.6-h8d57982_2.conda
linux-ppc64le::ogre-14.0.1-h8dbfdb5_1.conda
linux-ppc64le::openpmd-api-0.15.2-nompi_py311hc8dce90_100.conda
linux-ppc64le::cmake-3.27.4-h1403f77_2.conda
linux-ppc64le::libadios2-2.9.1-mpi_mpich_h401d2d2_1.conda
linux-ppc64le::folly-2023.03.20.00-hca43526_5_jemalloc.conda
linux-ppc64le::openpmd-api-0.15.1-mpi_mpich_py39h5822df7_5.conda
linux-ppc64le::libnetcdf-4.9.2-mpi_openmpi_he2133e4_11.conda
linux-ppc64le::folly-2023.08.14.00-hd692e58_1.conda
linux-ppc64le::tectonic-0.14.1-h1584b15_0.conda
linux-ppc64le::libadios2-2.9.1-mpi_mpich_ha9b5181_0.conda
linux-ppc64le::cargo-patch-0.3.2-h140379e_0.conda
linux-ppc64le::libarrow-10.0.1-hec0d767_37_cuda.conda
linux-ppc64le::libvips-8.14.3-h6f5bdf3_2.conda
linux-ppc64le::openpmd-api-0.15.2-mpi_mpich_py311hb47db45_0.conda
linux-ppc64le::openpmd-api-0.15.1-nompi_py311hc8dce90_106.conda
linux-ppc64le::libarrow-12.0.1-h27abc39_9_cuda.conda
linux-ppc64le::openpmd-api-0.15.1-nompi_py38hfc3f19f_105.conda
linux-ppc64le::libgdal-3.7.1-he46eb7f_9.conda
linux-ppc64le::libadios2-2.9.1-nompi_h83c59e6_101.conda
linux-ppc64le::libarrow-11.0.0-hf7f1dcd_33_cpu.conda
linux-ppc64le::openpmd-api-0.15.1-mpi_openmpi_py39h1de1282_6.conda
linux-ppc64le::openpmd-api-0.15.1-mpi_openmpi_py38h94ea75c_5.conda
linux-ppc64le::libarrow-12.0.1-he582fe7_8_cpu.conda
linux-ppc64le::arrow-cpp-9.0.0-py311hbcef396_45_cuda.conda
linux-ppc64le::folly-2023.08.28.00-hfccd340_0_jemalloc.conda
linux-ppc64le::pygame-2.5.1-py39hf33c4b3_0.conda
linux-ppc64le::pyreadstat-1.2.3-py39h27550c1_0.conda
linux-ppc64le::openpmd-api-0.15.1-nompi_py39h15f64e7_106.conda
linux-ppc64le::libspral-2023.08.02-haa7499b_0.conda
linux-ppc64le::arrow-cpp-9.0.0-py39h65832e8_45_cuda.conda
linux-ppc64le::libzip-1.10.0-hb84b332_0.conda
linux-ppc64le::pygame-2.5.1-py38h00f7aa6_0.conda
linux-ppc64le::vowpalwabbit-9.8.0-py39h3cd0cf3_1.conda
linux-ppc64le::folly-2023.08.28.00-h361900a_0.conda
linux-ppc64le::omniorb-4.3.1-py310h94f889b_0.conda
linux-ppc64le::vigra-1.11.1-py310h8202019_1046.conda
linux-ppc64le::libopencv-4.8.0-py39h62f4a90_1.conda
linux-ppc64le::openpmd-api-0.15.2-mpi_openmpi_py38h50fe292_0.conda
linux-ppc64le::libadios2-2.9.1-mpi_openmpi_hf35012a_1.conda
linux-ppc64le::openpmd-api-0.15.1-mpi_openmpi_py311h1d4006c_6.conda
linux-ppc64le::openpmd-api-0.15.2-nompi_py38ha6c62af_100.conda
linux-ppc64le::vowpalwabbit-9.9.0-py39h3cd0cf3_0.conda
linux-ppc64le::libgdal-3.6.4-h42e3baf_12.conda
linux-ppc64le::openpmd-api-0.15.1-mpi_mpich_py311hba88df3_5.conda
linux-ppc64le::grpcio-1.57.0-py39h278787b_1.conda
linux-ppc64le::imagecodecs-2023.8.12-py39h7d93c89_0.conda
linux-ppc64le::netcdf4-1.6.4-mpi_mpich_py311hbcdc183_2.conda
linux-ppc64le::hdf5-1.14.2-nompi_hda2ee07_100.conda
linux-ppc64le::folly-2023.08.28.00-h79ae0fe_0.conda
linux-ppc64le::imagecodecs-2023.8.12-py310hf2835e1_0.conda
linux-ppc64le::vtk-base-9.2.6-qt_py39h1234567_212.conda
linux-ppc64le::tectonic-0.14.1-hdb07515_2.conda
linux-ppc64le::healpy-1.16.5-py310hd75c4af_1.conda
linux-ppc64le::libgdal-3.6.4-h0e58838_14.conda
linux-ppc64le::folly-2023.08.14.00-hfccd340_1_jemalloc.conda
linux-ppc64le::libarrow-11.0.0-hf2d3464_33_cuda.conda
linux-ppc64le::folly-2023.08.28.00-hbe59455_0_jemalloc.conda
linux-ppc64le::netcdf4-1.6.4-mpi_openmpi_py310hd51dc40_2.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.1-h256b032_6.conda
linux-ppc64le::folly-2023.03.20.00-hd692e58_5.conda
linux-ppc64le::openpmd-api-0.15.1-mpi_mpich_py310h8d529e3_5.conda
linux-ppc64le::libadios2-2.9.1-mpi_openmpi_h773617d_0.conda
linux-ppc64le::ffmpeg-6.0.0-lgpl_h54d27e8_4.conda
linux-ppc64le::libopencv-4.8.0-py39h88f2e2e_1.conda
linux-ppc64le::vigra-1.11.1-py39h3991c01_1046.conda
linux-ppc64le::libadios2-2.9.1-nompi_hf580554_102.conda
linux-ppc64le::postgresql-plpython-15.4-py39h8e6b938_0.conda
linux-ppc64le::openpmd-api-0.15.1-nompi_py39hcc44589_105.conda
linux-ppc64le::aws-sdk-cpp-1.10.57-h8a7b76c_18.conda
linux-ppc64le::libadios2-2.9.1-nompi_h95651d6_102.conda
linux-ppc64le::pdal-2.5.5-ha8eb682_1.conda
linux-ppc64le::netcdf4-1.6.4-nompi_py38hc970dc1_102.conda
linux-ppc64le::folly-2023.08.14.00-hfccd340_0_jemalloc.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.1-hfdc8f3b_9.conda
linux-ppc64le::libadios2-2.9.1-mpi_openmpi_h8549cef_0.conda
linux-ppc64le::arrow-cpp-9.0.0-py310hab8bcda_45_cuda.conda
linux-ppc64le::arrow-cpp-9.0.0-py38h7184424_45_cpu.conda
linux-ppc64le::llvm-16.0.6-h381f82a_2.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.1-hfdc8f3b_8.conda
linux-ppc64le::folly-2023.08.28.00-hd692e58_0.conda
linux-ppc64le::llvm-tools-16.0.6-h8d57982_2.conda
linux-ppc64le::libadios2-2.9.1-mpi_mpich_ha8b31ef_0.conda
linux-ppc64le::openpmd-api-0.15.1-mpi_openmpi_py39hfde087f_5.conda
linux-ppc64le::python-3.9.18-h7512f2e_0_cpython.conda
linux-ppc64le::libadios2-2.9.1-mpi_openmpi_ha7812b6_0.conda
linux-ppc64le::libgdal-3.7.1-hcf46c04_7.conda
linux-ppc64le::libnetcdf-4.9.2-mpi_mpich_h0ba5e17_10.conda
linux-ppc64le::grpcio-1.57.0-py311h3997ded_1.conda
linux-ppc64le::postgresql-plpython-15.4-py310h33ccb9c_0.conda
linux-ppc64le::sqlite-3.43.0-h63c7444_0.conda
linux-ppc64le::arrow-cpp-9.0.0-py38h9ce2811_46_cuda.conda
linux-ppc64le::folly-2023.08.14.00-hfccd340_2_jemalloc.conda
linux-ppc64le::grpcio-1.57.0-py38hc2aed35_1.conda
linux-ppc64le::rust-1.72.0-hb12b0c0_0.conda
linux-ppc64le::tiledb-2.16.3-hf612678_1.conda
linux-ppc64le::folly-2023.08.07.00-h864cb69_0_jemalloc.conda
linux-ppc64le::openpmd-api-0.15.1-nompi_py39h7a4cd42_106.conda
linux-ppc64le::tiledb-2.16.2-hac2e0cb_0.conda
linux-ppc64le::openpmd-api-0.15.1-mpi_openmpi_py310h654323b_6.conda
linux-ppc64le::vtk-base-9.2.6-qt_py38h1234567_211.conda
linux-ppc64le::libmatio-1.5.23-h125b1b5_4.conda
linux-ppc64le::postgresql-plpython-15.4-py38he255f0a_0.conda
linux-ppc64le::mc-4.8.30-h03feef7_0.conda
linux-ppc64le::yarp-cxx-3.8.1-h45c7e4b_4.conda
linux-ppc64le::pygame-2.5.1-py311h0cc10f5_0.conda
linux-ppc64le::openpmd-api-0.15.2-mpi_mpich_py39hca70808_0.conda
linux-ppc64le::pdal-2.5.6-h847bbe8_1.conda
linux-ppc64le::omniorb-libs-4.3.1-h64e73a3_0.conda
linux-ppc64le::grpcio-1.57.0-py38hc2aed35_0.conda
linux-ppc64le::openpmd-api-0.15.1-mpi_mpich_py39h74b63bb_6.conda
linux-ppc64le::tiledb-2.16.2-hf612678_0.conda
linux-ppc64le::libgdal-3.7.1-h77f1beb_6.conda
linux-ppc64le::python-3.9.17-h7512f2e_0_cpython.conda
linux-ppc64le::healpy-1.16.5-py39hc528f98_1.conda
linux-ppc64le::healpy-1.16.5-py39h5eae8ef_0.conda
linux-ppc64le::libgdal-3.6.4-h0e58838_15.conda
linux-ppc64le::folly-2023.08.07.00-h361900a_1.conda
linux-ppc64le::folly-2023.08.14.00-hd692e58_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.6.4-h0f66333_13.conda
linux-ppc64le::omniorb-4.3.1-py38h7db1d0b_0.conda
linux-ppc64le::openpmd-api-0.15.1-nompi_py39h12cd277_105.conda
linux-ppc64le::libnetcdf-4.9.2-nompi_h1b7c85c_110.conda
linux-ppc64le::squashfuse-0.4.0-h40af005_0.conda
linux-ppc64le::adios-1.13.1-mpi_openmpi_h3f91229_1023.conda
linux-ppc64le::vowpalwabbit-9.8.0-py38h276fb4e_1.conda
linux-ppc64le::aws-sdk-cpp-1.10.57-h63e68b5_19.conda
linux-ppc64le::healpy-1.16.5-py311h7a0c736_1.conda
linux-ppc64le::libgit2-1.7.1-h25ca658_0.conda
linux-ppc64le::openpmd-api-0.15.1-mpi_mpich_py310h778692f_6.conda
linux-ppc64le::cairo-1.16.0-heb82f16_1017.conda
linux-ppc64le::openpmd-api-0.15.2-mpi_openmpi_py310h750be97_0.conda
linux-ppc64le::pygame-2.5.1-py310he53e978_0.conda
linux-ppc64le::arrow-cpp-9.0.0-py38hdb08cdf_45_cuda.conda
linux-ppc64le::libarrow-11.0.0-he582fe7_33_cpu.conda
linux-ppc64le::grpcio-1.56.2-py38hc2aed35_1.conda
linux-ppc64le::libopencv-4.8.0-py38hb4acb9d_1.conda
linux-ppc64le::libarrow-10.0.1-h910e738_38_cpu.conda
linux-ppc64le::libopencv-4.8.0-py38h9e7659a_1.conda
linux-ppc64le::libopentelemetry-cpp-1.11.0-ha0f27b6_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.6.4-h65d044c_12.conda
linux-ppc64le::libgrpc-1.56.2-hf11f071_1.conda
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
================================================================================
================================================================================
linux-aarch64
linux-aarch64::libsqlite-3.43.0-h194ca79_0.conda
linux-aarch64::libprotobuf-4.23.4-h87e877f_5.conda
linux-aarch64::dotnet-runtime-6.0.20-h9e6cf05_0.conda
linux-aarch64::libsolv-0.7.24-hd84c7bf_3.conda
linux-aarch64::libprotobuf-static-3.21.12-hd84c7bf_1.conda
linux-aarch64::libprotobuf-static-3.21.12-hd84c7bf_2.conda
linux-aarch64::dotnet-runtime-7.0.10-h9e6cf05_0.conda
linux-aarch64::libprotobuf-static-4.23.4-h87e877f_4.conda
linux-aarch64::libprotobuf-static-4.23.4-h87e877f_3.conda
linux-aarch64::libprotobuf-3.21.12-hd5e0c6f_1.conda
linux-aarch64::zstd-1.5.5-h4c53e97_0.conda
linux-aarch64::dotnet-sdk-7.0.400-h9e6cf05_0.conda
linux-aarch64::libprotobuf-3.21.12-hd5e0c6f_2.conda
linux-aarch64::libsolv-static-0.7.24-hd84c7bf_3.conda
linux-aarch64::micromamba-1.5.0-1.tar.bz2
linux-aarch64::libprotobuf-static-4.23.4-h6b51aa4_1.conda
linux-aarch64::dotnet-aspnetcore-6.0.20-h9e6cf05_0.conda
linux-aarch64::libprotobuf-static-4.23.4-h87e877f_2.conda
linux-aarch64::dotnet-sdk-6.0.412-h9e6cf05_0.conda
linux-aarch64::libprotobuf-4.23.4-h87e877f_2.conda
linux-aarch64::openexr-3.1.10-hb924804_0.conda
linux-aarch64::openexr-3.1.11-hb924804_0.conda
linux-aarch64::libv8-8.9.83-h1c79f39_4.conda
linux-aarch64::micromamba-1.5.0-0.tar.bz2
linux-aarch64::libprotobuf-4.23.4-h6b51aa4_1.conda
linux-aarch64::libprotobuf-static-4.23.4-h6b51aa4_0.conda
linux-aarch64::libprotobuf-4.23.4-h87e877f_4.conda
linux-aarch64::adios-1.13.1-nompi_hc506e2b_1123.conda
linux-aarch64::openexr-3.2.0-hb924804_0.conda
linux-aarch64::cudnn-8.8.0.121-hc0e3c58_2.conda
linux-aarch64::libprotobuf-4.23.4-h87e877f_3.conda
linux-aarch64::dotnet-aspnetcore-7.0.10-h9e6cf05_0.conda
linux-aarch64::libass-0.17.1-h36b5d3b_1.conda
linux-aarch64::libprotobuf-4.23.4-h6b51aa4_0.conda
linux-aarch64::cudnn-8.8.0.121-h9670b63_2.conda
linux-aarch64::eccodes-2.31.0-h638bc8f_1.conda
-    "libzlib >=1.2.13,<1.3.0a0"
+    "libzlib >=1.2.13,<2.0.0a0"
linux-aarch64::arrow-cpp-9.0.0-py311h84ec0d3_45_cpu.conda
linux-aarch64::grpcio-1.57.0-py38h95a9722_1.conda
linux-aarch64::ogre-1.10.12-h0e80cf0_12.conda
linux-aarch64::pygame-2.5.1-py39h2cc5182_0.conda
linux-aarch64::folly-2023.08.14.00-hdd3c17f_3_jemalloc.conda
linux-aarch64::tectonic-0.14.1-h7f9870a_1.conda
linux-aarch64::netcdf4-1.6.4-mpi_mpich_py38h52e48cf_2.conda
linux-aarch64::folly-2023.08.14.00-hdd3c17f_1_jemalloc.conda
linux-aarch64::postgresql-plpython-15.4-py311hc2b6b49_0.conda
linux-aarch64::folly-2023.08.14.00-h8282163_1.conda
linux-aarch64::heyoka-1.0.0-h73675cb_0.conda
linux-aarch64::pygame-2.5.1-py310hdb26448_0.conda
linux-aarch64::libopentelemetry-cpp-1.11.0-had1d856_0.conda
linux-aarch64::openpmd-api-0.15.2-mpi_openmpi_py310h07b97e4_0.conda
linux-aarch64::vigra-1.11.1-py39h2dab7ce_1046.conda
linux-aarch64::openpmd-api-0.15.1-mpi_openmpi_py38hfa75f65_5.conda
linux-aarch64::mc-4.8.30-h3618a31_0.conda
linux-aarch64::ogre-1.10.12-h87b3093_11.conda
linux-aarch64::heyoka-0.21.0-he481420_1.conda
linux-aarch64::libadios2-2.9.1-mpi_openmpi_h5a18f1a_0.conda
linux-aarch64::libnetcdf-4.9.2-mpi_mpich_h7df9e21_11.conda
linux-aarch64::aws-sdk-cpp-1.10.57-hce41925_18.conda
linux-aarch64::rust-1.72.0-h9d3d833_1.conda
linux-aarch64::libadios2-2.9.1-nompi_h0e897e0_102.conda
linux-aarch64::folly-2023.08.28.00-hbf4f375_0_jemalloc.conda
linux-aarch64::libadios2-2.9.1-mpi_mpich_h996dc08_2.conda
linux-aarch64::tiledb-2.16.3-h127bae7_1.conda
linux-aarch64::openpmd-api-0.15.2-nompi_py310h2914d19_100.conda
linux-aarch64::libadios2-2.9.1-mpi_openmpi_h64543c6_1.conda
linux-aarch64::openpmd-api-0.15.1-mpi_openmpi_py310h666f041_6.conda
linux-aarch64::openpmd-api-0.15.1-mpi_openmpi_py311h85029f0_6.conda
linux-aarch64::libarrow-13.0.0-h20d0dd0_0_cpu.conda
linux-aarch64::grpcio-1.56.2-py38h95a9722_1.conda
linux-aarch64::openpmd-api-0.15.1-nompi_py311h98bf853_106.conda
linux-aarch64::folly-2023.08.14.00-hbf4f375_3_jemalloc.conda
linux-aarch64::r-git2r-0.31.0-r42h7c3d48d_2.conda
linux-aarch64::vigra-1.11.1-py39h54b4e6a_1046.conda
linux-aarch64::healpy-1.16.5-py38he4b4097_0.conda
linux-aarch64::libgdal-arrow-parquet-3.7.1-ha049948_8.conda
linux-aarch64::healpy-1.16.5-py311h6715740_0.conda
linux-aarch64::libgdal-3.6.4-h364755f_12.conda
linux-aarch64::heyoka-1.0.0-ha9fcb42_0.conda
linux-aarch64::libgdal-arrow-parquet-3.6.4-h7c4e116_14.conda
linux-aarch64::libadios2-2.9.1-nompi_hf39fb1f_102.conda
linux-aarch64::aws-sdk-cpp-1.10.57-hbc56cf4_21.conda
linux-aarch64::arrow-cpp-9.0.0-py38h71f9228_46_cuda.conda
linux-aarch64::vtk-base-9.2.6-qt_py311h1234567_212.conda
linux-aarch64::vtk-base-9.2.6-qt_py38h1234567_211.conda
linux-aarch64::imagecodecs-2023.8.12-py39h3aca4f3_0.conda
linux-aarch64::openpmd-api-0.15.1-mpi_openmpi_py310h4862eb3_5.conda
linux-aarch64::openpmd-api-0.15.1-mpi_mpich_py311hd1e7acc_6.conda
linux-aarch64::heyoka-1.0.0-h7328b17_0.conda
linux-aarch64::imagecodecs-2023.8.12-py311ha1539bd_0.conda
linux-aarch64::folly-2023.08.07.00-hbf4f375_0_jemalloc.conda
linux-aarch64::pygame-2.5.1-py311h2184b1c_0.conda
linux-aarch64::folly-2023.08.28.00-h81a8a5e_0.conda
linux-aarch64::libarrow-12.0.1-hb192224_9_cuda.conda
linux-aarch64::libgd-2.3.3-hdcd3aed_7.conda
linux-aarch64::omniorb-4.3.1-py38hc9c3f1f_0.conda
linux-aarch64::folly-2023.08.28.00-h8282163_0.conda
linux-aarch64::heyoka-1.0.0-h93c5217_0.conda
linux-aarch64::libarrow-12.0.1-h5defe00_8_cuda.conda
linux-aarch64::openpmd-api-0.15.2-nompi_py38he26bc57_100.conda
linux-aarch64::arrow-cpp-9.0.0-py310h30d3487_46_cuda.conda
linux-aarch64::libgit2-1.7.1-h9cec674_0.conda
linux-aarch64::boost-cpp-1.78.0-h9565fb1_4.conda
linux-aarch64::libarrow-12.0.1-hbd905e0_8_cpu.conda
linux-aarch64::aws-sdk-cpp-1.10.57-he767cff_19.conda
linux-aarch64::libadios2-2.9.1-mpi_mpich_h4e6f988_0.conda
linux-aarch64::vigra-1.11.1-py38hb9fd84e_1046.conda
linux-aarch64::libtiledb-sql-0.23.2-h886d7b1_0.conda
linux-aarch64::poppler-qt-23.08.0-h9c846af_0.conda
linux-aarch64::heyoka-llvm-13-0.21.0-h05b4247_1.conda
linux-aarch64::libnetcdf-4.9.2-mpi_openmpi_h05560af_11.conda
linux-aarch64::openpmd-api-0.15.1-mpi_mpich_py310h71bbe88_5.conda
linux-aarch64::libzip-1.10.1-h4156a30_0.conda
linux-aarch64::libarrow-10.0.1-hbd905e0_37_cpu.conda
linux-aarch64::folly-2023.08.07.00-h81a8a5e_0.conda
linux-aarch64::omniorb-4.3.1-py310hae03fa7_0.conda
linux-aarch64::pygame-2.5.1-py38hfccb3c3_0.conda
linux-aarch64::heyoka-llvm-14-1.0.0-hc38c2ca_0.conda
linux-aarch64::openpmd-api-0.15.1-mpi_mpich_py39h39df642_5.conda
linux-aarch64::libadios2-2.9.1-nompi_hf07bb53_102.conda
linux-aarch64::libadios2-2.9.1-mpi_mpich_hfbe1fc2_2.conda
linux-aarch64::libarrow-11.0.0-h20d0dd0_34_cpu.conda
linux-aarch64::heyoka-1.0.0-h57bea4f_0.conda
linux-aarch64::vtk-base-9.2.6-qt_py310h1234567_211.conda
linux-aarch64::pdal-2.5.6-h67ed07b_1.conda
linux-aarch64::libadios2-2.9.1-nompi_hb3655a9_102.conda
linux-aarch64::folly-2023.08.14.00-hc4f87e6_2_jemalloc.conda
linux-aarch64::heyoka-llvm-15-0.21.0-ha13bee3_1.conda
linux-aarch64::folly-2023.08.14.00-hbf4f375_0_jemalloc.conda
linux-aarch64::libgdal-3.6.4-h9128d49_13.conda
linux-aarch64::libitk-5.3.0-h9d041f8_6.conda
linux-aarch64::arrow-cpp-9.0.0-py38hbbfa3d1_45_cuda.conda
linux-aarch64::heyoka-1.0.0-he481420_0.conda
linux-aarch64::libarrow-10.0.1-hb192224_38_cuda.conda
linux-aarch64::omniorb-4.3.1-py39h86dfdcc_0.conda
linux-aarch64::tiledb-2.16.2-h127bae7_0.conda
linux-aarch64::freecad-0.21.0-py311hec4543d_1.conda
linux-aarch64::libtiff-4.5.1-h360e80f_1.conda
linux-aarch64::ffmpeg-6.0.0-gpl_hb2797d3_104.conda
linux-aarch64::arrow-cpp-9.0.0-py311h984349c_45_cpu.conda
linux-aarch64::aws-sdk-cpp-1.11.68-hce41925_10.conda
linux-aarch64::folly-2023.08.07.00-hdd3c17f_1_jemalloc.conda
linux-aarch64::arrow-cpp-9.0.0-py311hddda40a_45_cuda.conda
linux-aarch64::tiledb-2.16.3-hdb54b9b_1.conda
linux-aarch64::vowpalwabbit-9.9.0-py38ha41e9a0_0.conda
linux-aarch64::libarrow-11.0.0-h0efd767_33_cuda.conda
linux-aarch64::postgresql-plpython-15.4-py310h840c280_0.conda
linux-aarch64::vowpalwabbit-9.9.0-py311hb0f59be_0.conda
linux-aarch64::libarrow-10.0.1-h5defe00_37_cuda.conda
linux-aarch64::vigra-1.11.1-py38h0a2192c_1046.conda
linux-aarch64::pyreadstat-1.2.3-py310h3516908_0.conda
linux-aarch64::libxmlsec1-1.3.1-h45794a5_1.conda
linux-aarch64::vigra-1.11.1-py310he929f61_1046.conda
linux-aarch64::libgdal-arrow-parquet-3.6.4-h0e8b752_13.conda
linux-aarch64::vowpalwabbit-9.9.0-py310hf3b40a4_0.conda
linux-aarch64::openpmd-api-0.15.2-mpi_mpich_py311hd1e7acc_0.conda
linux-aarch64::openpmd-api-0.15.2-mpi_mpich_py38h65e4732_0.conda
linux-aarch64::netcdf4-1.6.4-mpi_openmpi_py311h65ba2fa_2.conda
linux-aarch64::libgdal-arrow-parquet-3.6.4-hc8727d4_12.conda
linux-aarch64::netcdf4-1.6.4-nompi_py310h77e224f_102.conda
linux-aarch64::libarrow-12.0.1-h5cd536d_8_cpu.conda
linux-aarch64::aws-sdk-cpp-1.10.57-ha2ce5fc_20.conda
linux-aarch64::openpmd-api-0.15.1-mpi_openmpi_py39hdc6a195_5.conda
linux-aarch64::libnetcdf-4.9.2-mpi_openmpi_ha8f80cf_10.conda
linux-aarch64::healpy-1.16.5-py310he815481_0.conda
linux-aarch64::libadios2-2.9.1-mpi_openmpi_h70cb021_2.conda
linux-aarch64::cmake-3.27.4-hef020d8_4.conda
linux-aarch64::grpcio-1.57.0-py311h1a7908d_1.conda
linux-aarch64::libadios2-2.9.1-mpi_mpich_h18090f1_0.conda
linux-aarch64::heyoka-llvm-11-0.21.0-h5bb46a5_1.conda
linux-aarch64::libarrow-10.0.1-h5cd536d_37_cpu.conda
linux-aarch64::libopencv-4.8.0-py39h2bdfdca_1.conda
linux-aarch64::openjdk-20.0.0-hfebe856_1.conda
linux-aarch64::libgdal-arrow-parquet-3.7.1-h4618caa_5.conda
linux-aarch64::libxml2-2.11.5-h164fba4_0.conda
linux-aarch64::libgrpc-1.57.0-h097270e_0.conda
linux-aarch64::pdal-2.5.5-h828947a_2.conda
linux-aarch64::squashfuse-0.4.0-h24ece89_0.conda
linux-aarch64::folly-2023.08.14.00-hbf4f375_1_jemalloc.conda
linux-aarch64::cpp-opentelemetry-sdk-1.11.0-had1d856_0.conda
linux-aarch64::sqlite-3.43.0-h3b3482f_0.conda
linux-aarch64::folly-2023.08.14.00-h81a8a5e_2.conda
linux-aarch64::nginx-1.25.2-h4005cde_0.conda
linux-aarch64::folly-2023.08.14.00-h8282163_0.conda
linux-aarch64::vigra-1.11.1-py311h918e57d_1046.conda
linux-aarch64::vigra-1.11.1-py39habfaf58_1046.conda
linux-aarch64::libadios2-2.9.1-mpi_openmpi_hb0a4856_2.conda
linux-aarch64::git-2.42.0-pl5321h0d979e1_0.conda
linux-aarch64::arrow-cpp-9.0.0-py39had62d34_45_cpu.conda
linux-aarch64::openpmd-api-0.15.1-mpi_mpich_py38ha9111a8_5.conda
linux-aarch64::vtk-base-9.2.6-qt_py38h1234567_212.conda
linux-aarch64::ogre-14.0.1-he520b79_1.conda
linux-aarch64::openpmd-api-0.15.2-mpi_openmpi_py311h85029f0_0.conda
linux-aarch64::folly-2023.03.20.00-hb60f5cd_5.conda
linux-aarch64::adios-1.13.1-mpi_openmpi_h536d158_1023.conda
linux-aarch64::freecad-0.21.0-py39h3025885_0.conda
linux-aarch64::openpmd-api-0.15.1-mpi_openmpi_py39h01f7308_6.conda
linux-aarch64::heyoka-llvm-13-1.0.0-h05b4247_0.conda
linux-aarch64::arrow-cpp-9.0.0-py39h92a3f31_45_cuda.conda
linux-aarch64::aws-sdk-cpp-1.11.68-ha2ce5fc_12.conda
linux-aarch64::heyoka-llvm-12-1.0.0-h556e612_0.conda
linux-aarch64::vowpalwabbit-9.8.0-py38ha41e9a0_1.conda
linux-aarch64::cairo-1.16.0-hd7f43fd_1017.conda
linux-aarch64::netcdf4-1.6.4-mpi_mpich_py39hfd381cf_2.conda
linux-aarch64::folly-2023.08.14.00-h8282163_2.conda
linux-aarch64::libarrow-13.0.0-hb192224_0_cuda.conda
linux-aarch64::netcdf4-1.6.4-mpi_openmpi_py38h7813e94_2.conda
linux-aarch64::libzip-1.10.0-h4156a30_0.conda
linux-aarch64::folly-2023.03.20.00-hbf4f375_5_jemalloc.conda
linux-aarch64::nodejs-20.5.1-hcb20a51_0.conda
linux-aarch64::libopencv-4.8.0-py38h9e0d3fd_1.conda
linux-aarch64::python-3.11.5-h43d1f9e_0_cpython.conda
linux-aarch64::imagecodecs-2023.8.12-py39hab6c1ca_0.conda
linux-aarch64::libgdal-3.7.1-h8ec66a2_5.conda
linux-aarch64::texlive-core-20230313-hd39fab0_5.conda
linux-aarch64::libvips-8.14.3-h7a091f4_2.conda
linux-aarch64::pyreadstat-1.2.3-py39hfca9663_0.conda
linux-aarch64::libadios2-2.9.1-mpi_openmpi_h86fe923_0.conda
linux-aarch64::vigra-1.11.1-py310h3514e6e_1046.conda
linux-aarch64::freecad-0.21.1-py310h9d3d040_0.conda
linux-aarch64::folly-2023.08.14.00-hc394c60_2.conda
linux-aarch64::libarrow-11.0.0-hb192224_34_cuda.conda
linux-aarch64::ffmpeg-6.0.0-lgpl_h1d7d5b7_4.conda
linux-aarch64::openpmd-api-0.15.1-mpi_mpich_py38hb4fe72d_6.conda
linux-aarch64::folly-2023.08.14.00-hdd3c17f_0_jemalloc.conda
linux-aarch64::libspral-2023.08.02-h7876b6f_0.conda
linux-aarch64::heyoka-llvm-12-0.21.0-h556e612_1.conda
linux-aarch64::libtiledb-sql-0.24.0-h556e676_0.conda
linux-aarch64::vtk-base-9.2.6-qt_py311h1234567_211.conda
linux-aarch64::netcdf4-1.6.4-nompi_py39h5d0e02b_102.conda
linux-aarch64::arrow-cpp-9.0.0-py311hf4e08e6_46_cuda.conda
linux-aarch64::libxml2-2.11.5-h3091e33_1.conda
linux-aarch64::libadios2-2.9.1-mpi_openmpi_h43838fa_0.conda
linux-aarch64::openpmd-api-0.15.2-mpi_openmpi_py38h9b380c1_0.conda
linux-aarch64::vtk-base-9.2.6-qt_py310h1234567_212.conda
linux-aarch64::openpmd-api-0.15.1-nompi_py39h7950e70_105.conda
linux-aarch64::healpy-1.16.5-py311ha51fd1d_1.conda
linux-aarch64::rust-1.72.0-h9d3d833_0.conda
linux-aarch64::tiledb-2.16.2-hdb54b9b_0.conda
linux-aarch64::libadios2-2.9.1-mpi_mpich_h5c1dcdf_1.conda
linux-aarch64::heyoka-llvm-14-0.21.0-hc38c2ca_1.conda
linux-aarch64::libadios2-2.9.1-nompi_h39a7b69_100.conda
linux-aarch64::libadios2-2.9.1-mpi_mpich_h798f37a_2.conda
linux-aarch64::libadios2-2.9.1-nompi_h242d37d_101.conda
linux-aarch64::libadios2-2.9.1-mpi_openmpi_hdeab2ad_2.conda
linux-aarch64::pdal-2.5.6-h828947a_0.conda
linux-aarch64::arrow-cpp-9.0.0-py311h8c5538c_46_cpu.conda
linux-aarch64::openpmd-api-0.15.1-nompi_py39hf6c0dae_106.conda
linux-aarch64::libgdal-3.6.4-hc47c230_11.conda
linux-aarch64::libscotch-7.0.4-h16908e7_0.conda
linux-aarch64::libgrpc-1.56.2-h097270e_1.conda
linux-aarch64::folly-2023.08.07.00-h81a8a5e_1.conda
linux-aarch64::folly-2023.08.28.00-ha9ea14a_0.conda
linux-aarch64::libadios2-2.9.1-mpi_mpich_h47a4e66_1.conda
linux-aarch64::freecad-0.21.0-py310h9d3d040_0.conda
linux-aarch64::libadios2-2.9.1-nompi_hea3dcde_100.conda
linux-aarch64::libarrow-12.0.1-h20d0dd0_9_cpu.conda
linux-aarch64::freecad-0.21.0-py39h3025885_1.conda
linux-aarch64::arrow-cpp-9.0.0-py38h134c0ea_45_cpu.conda
linux-aarch64::libnetcdf-4.9.2-nompi_h1dee3a9_110.conda
linux-aarch64::imagecodecs-2023.8.12-py310h0b926b1_0.conda
linux-aarch64::folly-2023.08.28.00-h7fcaec2_0_jemalloc.conda
linux-aarch64::hdf5-1.14.2-nompi_ha486f32_100.conda
linux-aarch64::openpmd-api-0.15.2-nompi_py39hadc6573_100.conda
linux-aarch64::openpmd-api-0.15.1-nompi_py38h169c26c_105.conda
linux-aarch64::vigra-1.11.1-py311h92ddf9f_1046.conda
linux-aarch64::heyoka-0.21.0-h93c5217_1.conda
linux-aarch64::arrow-cpp-9.0.0-py310hd64154d_45_cpu.conda
linux-aarch64::libnetcdf-4.9.2-nompi_hc188a27_111.conda
linux-aarch64::libgrpc-1.54.3-h53d6f9f_0.conda
linux-aarch64::openpmd-api-0.15.1-mpi_openmpi_py38hfdd5ff1_6.conda
linux-aarch64::libgdal-arrow-parquet-3.7.1-ha049948_9.conda
linux-aarch64::postgresql-15.4-he3d1b8e_0.conda
linux-aarch64::libpq-15.4-h04b8c23_0.conda
linux-aarch64::arrow-cpp-9.0.0-py39h0ca9905_46_cuda.conda
linux-aarch64::grpcio-1.57.0-py310h20b6881_0.conda
linux-aarch64::arrow-cpp-9.0.0-py38h459ed7c_45_cpu.conda
linux-aarch64::openpmd-api-0.15.2-nompi_py39h43febd8_100.conda
linux-aarch64::libgdal-arrow-parquet-3.6.4-h7c4e116_15.conda
linux-aarch64::healpy-1.16.5-py38hb18dd0d_1.conda
linux-aarch64::folly-2023.03.20.00-h7a25010_5_jemalloc.conda
linux-aarch64::healpy-1.16.5-py39h7883056_1.conda
linux-aarch64::openpmd-api-0.15.1-mpi_mpich_py311h363c308_5.conda
linux-aarch64::openpmd-api-0.15.2-mpi_mpich_py310hb6dac74_0.conda
linux-aarch64::openpmd-api-0.15.1-nompi_py39hee4c076_105.conda
linux-aarch64::openpmd-api-0.15.1-nompi_py38h4502d6b_106.conda
linux-aarch64::healpy-1.16.5-py310h8745152_1.conda
linux-aarch64::freecad-0.21.0-py38h47f2513_1.conda
linux-aarch64::nodejs-18.17.1-hcb20a51_0.conda
linux-aarch64::heyoka-llvm-16-1.0.0-h00d4f47_0.conda
linux-aarch64::libmatio-1.5.23-hd3396f4_4.conda
linux-aarch64::folly-2023.08.14.00-hbf4f375_2_jemalloc.conda
linux-aarch64::folly-2023.08.07.00-h8282163_0.conda
linux-aarch64::heyoka-llvm-11-1.0.0-h5bb46a5_0.conda
linux-aarch64::libnetcdf-4.9.2-mpi_mpich_hbf81dc6_10.conda
linux-aarch64::vigra-1.11.1-py38h7d360fd_1046.conda
linux-aarch64::netcdf4-1.6.4-mpi_openmpi_py310h7bc6f4b_2.conda
linux-aarch64::aws-sdk-cpp-1.11.68-hbc56cf4_13.conda
linux-aarch64::vowpalwabbit-9.8.0-py39h17a3142_1.conda
linux-aarch64::libgdal-arrow-parquet-3.7.1-ha7079f2_7.conda
linux-aarch64::folly-2023.08.07.00-h8282163_1.conda
linux-aarch64::libarrow-11.0.0-h5defe00_33_cuda.conda
linux-aarch64::adios-1.13.1-mpi_mpich_h99b6088_1023.conda
linux-aarch64::libadios2-2.9.1-mpi_openmpi_hd171938_0.conda
linux-aarch64::folly-2023.08.14.00-ha9ea14a_3.conda
linux-aarch64::libgdal-arrow-parquet-3.7.1-hf79c58b_6.conda
linux-aarch64::libgdal-arrow-parquet-3.6.4-h62ca8ca_11.conda
linux-aarch64::nss-3.92-hc5a5cc2_0.conda
linux-aarch64::llvm-16.0.6-h5271726_2.conda
linux-aarch64::omniorb-libs-4.3.1-h48ed410_0.conda
linux-aarch64::openpmd-api-0.15.1-mpi_openmpi_py38h069d627_5.conda
linux-aarch64::libadios2-2.9.1-nompi_h7b74588_100.conda
linux-aarch64::heyoka-0.21.0-h57bea4f_1.conda
linux-aarch64::grpcio-1.57.0-py310h20b6881_1.conda
linux-aarch64::folly-2023.08.14.00-h81a8a5e_3.conda
linux-aarch64::libtiledb-sql-0.23.2-h556e676_0.conda
linux-aarch64::libadios2-2.9.1-mpi_mpich_h34b7990_1.conda
linux-aarch64::openpmd-api-0.15.1-mpi_openmpi_py39h7bfc831_6.conda
linux-aarch64::openpmd-api-0.15.2-mpi_mpich_py39hd791f4c_0.conda
linux-aarch64::cmake-3.27.4-hef020d8_1.conda
linux-aarch64::libgdal-3.7.1-ha898f2b_7.conda
linux-aarch64::folly-2023.08.28.00-hdd3c17f_0_jemalloc.conda
linux-aarch64::heyoka-0.21.0-h73675cb_1.conda
linux-aarch64::libadios2-2.9.1-mpi_openmpi_hbbc0079_1.conda
linux-aarch64::libopencv-4.8.0-py311ha4cc7c5_1.conda
linux-aarch64::vtk-base-9.2.6-qt_py39h1234567_211.conda
linux-aarch64::tesseract-5.3.2-h782478c_0.conda
linux-aarch64::openpmd-api-0.15.1-nompi_py310hdb460e9_106.conda
linux-aarch64::grpcio-1.56.2-py39h483cef1_1.conda
linux-aarch64::folly-2023.08.14.00-h8282163_3.conda
linux-aarch64::libadios2-2.9.1-mpi_mpich_h86db94c_1.conda
linux-aarch64::python-3.9.17-h4ac3b42_0_cpython.conda
linux-aarch64::cmake-3.27.4-hef020d8_0.conda
linux-aarch64::omniorb-4.3.1-py311h9b119e1_0.conda
linux-aarch64::arrow-cpp-9.0.0-py39hff79d5a_45_cuda.conda
linux-aarch64::cmake-3.27.4-hef020d8_3.conda
linux-aarch64::openpmd-api-0.15.2-nompi_py311h98bf853_100.conda
linux-aarch64::libadios2-2.9.1-mpi_mpich_hf9996c7_2.conda
linux-aarch64::arrow-cpp-9.0.0-py39hde1f1c5_45_cpu.conda
linux-aarch64::netcdf4-1.6.4-nompi_py311hcd50196_102.conda
linux-aarch64::folly-2023.08.14.00-h81a8a5e_1.conda
linux-aarch64::openpmd-api-0.15.1-mpi_openmpi_py39h64aae80_5.conda
linux-aarch64::libopencv-4.8.0-py310haa9ac76_1.conda
linux-aarch64::aws-sdk-cpp-1.11.68-he767cff_11.conda
linux-aarch64::openpmd-api-0.15.1-nompi_py38h97be3d3_105.conda
linux-aarch64::nodejs-16.20.2-hcb20a51_1.conda
linux-aarch64::pdal-2.5.5-ha7abfce_1.conda
linux-aarch64::python-3.9.18-h4ac3b42_0_cpython.conda
linux-aarch64::folly-2023.08.14.00-hdd3c17f_2_jemalloc.conda
linux-aarch64::libadios2-2.9.1-nompi_h109038c_101.conda
linux-aarch64::libarrow-11.0.0-hbd905e0_33_cpu.conda
linux-aarch64::cmake-3.27.4-hef020d8_2.conda
linux-aarch64::grpcio-1.57.0-py39h483cef1_1.conda
linux-aarch64::llvm-tools-16.0.6-h70e38ee_2.conda
linux-aarch64::heyoka-0.21.0-h7328b17_1.conda
linux-aarch64::yarp-cxx-3.8.1-h1e7e099_4.conda
linux-aarch64::boost-cpp-1.82.0-h87e8f43_2.conda
linux-aarch64::libadios2-2.9.1-mpi_openmpi_h5a18f1a_1.conda
linux-aarch64::grpcio-1.56.2-py311h1a7908d_1.conda
linux-aarch64::healpy-1.16.5-py38he1f86f5_0.conda
linux-aarch64::arrow-cpp-9.0.0-py310h00f2270_45_cuda.conda
linux-aarch64::openpmd-api-0.15.1-mpi_openmpi_py38h298c790_6.conda
linux-aarch64::tiledb-2.16.3-h3e6b69a_1.conda
linux-aarch64::folly-2023.08.07.00-hdd3c17f_0_jemalloc.conda
linux-aarch64::libadios2-2.9.1-nompi_h0ea5f15_100.conda
linux-aarch64::libtiledb-sql-0.24.0-h886d7b1_0.conda
linux-aarch64::libarrow-10.0.1-h0efd767_37_cuda.conda
linux-aarch64::openpmd-api-0.15.2-mpi_openmpi_py38h019a41c_0.conda
linux-aarch64::vowpalwabbit-9.9.0-py39h17a3142_0.conda
linux-aarch64::libarrow-10.0.1-h20d0dd0_38_cpu.conda
linux-aarch64::openpmd-api-0.15.1-mpi_mpich_py310he7cf731_6.conda
linux-aarch64::grpcio-1.56.2-py310h20b6881_1.conda
linux-aarch64::libadios2-2.9.1-nompi_h14c1581_101.conda
linux-aarch64::libadios2-2.9.1-mpi_mpich_hd63bfcd_0.conda
linux-aarch64::pyreadstat-1.2.3-py38hbecd58a_0.conda
linux-aarch64::libgdal-3.7.1-h675b03b_8.conda
linux-aarch64::libscotch-7.0.4-h8312190_0.conda
linux-aarch64::postgresql-plpython-15.4-py38hf7f31c5_0.conda
linux-aarch64::rust-1.71.1-h9d3d833_0.conda
linux-aarch64::mold-2.1.0-h87a9c1b_1.conda
linux-aarch64::hdf5-1.14.2-mpi_mpich_hbf85d38_0.conda
linux-aarch64::pyreadstat-1.2.3-py311hf7e8aab_0.conda
linux-aarch64::netcdf4-1.6.4-nompi_py38hfe05524_102.conda
linux-aarch64::tiledb-2.16.2-h3e6b69a_0.conda
linux-aarch64::netcdf4-1.6.4-mpi_mpich_py310h84864ae_2.conda
linux-aarch64::pygame-2.5.1-py39hb769c03_0.conda
linux-aarch64::healpy-1.16.5-py39he15b407_0.conda
linux-aarch64::libgdal-3.7.1-h93003f3_6.conda
linux-aarch64::pygame-2.5.1-py38haf3f993_0.conda
linux-aarch64::libarrow-11.0.0-h5cd536d_33_cpu.conda
linux-aarch64::libllvm16-16.0.6-h70e38ee_2.conda
linux-aarch64::heyoka-llvm-15-1.0.0-ha13bee3_0.conda
linux-aarch64::arrow-cpp-9.0.0-py311h5de246e_45_cuda.conda
linux-aarch64::libitk-5.3.0-h4606515_5.conda
linux-aarch64::openpmd-api-0.15.2-mpi_mpich_py39h0773440_0.conda
linux-aarch64::openpmd-api-0.15.1-mpi_mpich_py39h032f39a_5.conda
linux-aarch64::freecad-0.21.0-py310h9d3d040_1.conda
linux-aarch64::libadios2-2.9.1-mpi_mpich_h34b7990_0.conda
linux-aarch64::r-git2r-0.31.0-r43h7c3d48d_2.conda
linux-aarch64::tectonic-0.14.1-hdfb4b57_0.conda
linux-aarch64::arrow-cpp-9.0.0-py38h7a4723f_46_cpu.conda
linux-aarch64::folly-2023.03.20.00-h8282163_5.conda
linux-aarch64::tectonic-0.14.1-h79ba523_2.conda
linux-aarch64::openpmd-api-0.15.1-mpi_mpich_py38h1fd9694_5.conda
linux-aarch64::vigra-1.11.1-py38h6f8c819_1046.conda
linux-aarch64::cargo-patch-0.3.2-h9fcd45d_0.conda
linux-aarch64::nodejs-20.1.0-hcb20a51_0.conda
linux-aarch64::arrow-cpp-9.0.0-py310h1d1040b_45_cpu.conda
linux-aarch64::grpcio-1.57.0-py39h483cef1_0.conda
linux-aarch64::folly-2023.08.14.00-h81a8a5e_0.conda
linux-aarch64::llvmdev-16.0.6-h70e38ee_2.conda
linux-aarch64::arrow-cpp-9.0.0-py39h224d9f2_46_cpu.conda
linux-aarch64::vowpalwabbit-9.8.0-py310hf3b40a4_1.conda
linux-aarch64::openpmd-api-0.15.2-mpi_openmpi_py39ha1e61f7_0.conda
linux-aarch64::libopencv-4.8.0-py39h562d4c8_1.conda
linux-aarch64::arrow-cpp-9.0.0-py310h7084e58_45_cuda.conda
linux-aarch64::openpmd-api-0.15.1-mpi_openmpi_py311h09b2dfb_5.conda
linux-aarch64::libgdal-3.7.1-h675b03b_9.conda
linux-aarch64::openpmd-api-0.15.1-mpi_mpich_py39hfb691a2_6.conda
linux-aarch64::libadios2-2.9.1-nompi_hea3dcde_101.conda
linux-aarch64::netcdf4-1.6.4-mpi_mpich_py311h26533c6_2.conda
linux-aarch64::folly-2023.08.14.00-h7fcaec2_3_jemalloc.conda
linux-aarch64::openpmd-api-0.15.1-nompi_py311hd3d74d4_105.conda
linux-aarch64::libgdal-3.6.4-hb11554f_14.conda
linux-aarch64::nodejs-20.5.1-hc1f8a26_1.conda
linux-aarch64::folly-2023.08.07.00-hbf4f375_1_jemalloc.conda
linux-aarch64::openpmd-api-0.15.2-nompi_py38h25dd57e_100.conda
linux-aarch64::sdl2_ttf-2.20.2-h2d2b936_2.conda
linux-aarch64::libadios2-2.9.1-mpi_openmpi_h26ecf18_1.conda
linux-aarch64::openpmd-api-0.15.2-mpi_openmpi_py39h447abaa_0.conda
linux-aarch64::libgdal-3.6.4-hb11554f_15.conda
linux-aarch64::hdf5-1.14.2-mpi_openmpi_hae789d2_0.conda
linux-aarch64::libgrpc-1.57.0-h048544f_1.conda
linux-aarch64::postgresql-plpython-15.4-py39he33817a_0.conda
linux-aarch64::vowpalwabbit-9.8.0-py311hb0f59be_1.conda
linux-aarch64::openpmd-api-0.15.1-nompi_py38h433de1c_106.conda
linux-aarch64::healpy-1.16.5-py39h6754ead_1.conda
linux-aarch64::openpmd-api-0.15.1-nompi_py39h4913597_106.conda
linux-aarch64::healpy-1.16.5-py38h4c58f0c_1.conda
linux-aarch64::libarrow-12.0.1-h0efd767_8_cuda.conda
linux-aarch64::openpmd-api-0.15.2-mpi_mpich_py38h2d1c1b6_0.conda
linux-aarch64::poppler-23.08.0-h79703be_0.conda
linux-aarch64::r-base-4.2.3-hfdaf435_7.conda
linux-aarch64::libopencv-4.8.0-py38hfba9280_1.conda
linux-aarch64::grpcio-1.57.0-py38h95a9722_0.conda
linux-aarch64::arrow-cpp-9.0.0-py310hba8724f_46_cpu.conda
linux-aarch64::vigra-1.11.1-py39h527a0e8_1046.conda
linux-aarch64::freecad-0.21.0-py38h47f2513_0.conda
linux-aarch64::openpmd-api-0.15.1-mpi_mpich_py39he4476b1_6.conda
linux-aarch64::netcdf4-1.6.4-mpi_openmpi_py39h61f5a0f_2.conda
linux-aarch64::healpy-1.16.5-py39hd280a0e_0.conda
linux-aarch64::openpmd-api-0.15.1-nompi_py310h80b06fd_105.conda
linux-aarch64::libadios2-2.9.1-mpi_openmpi_h9c94c55_2.conda
linux-aarch64::vtk-base-9.2.6-qt_py39h1234567_212.conda
linux-aarch64::grpcio-1.57.0-py311h1a7908d_0.conda
linux-aarch64::arrow-cpp-9.0.0-py38h2f09403_45_cuda.conda
linux-aarch64::openpmd-api-0.15.1-mpi_mpich_py38h187e921_6.conda
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
================================================================================
================================================================================
noarch
================================================================================
================================================================================
win-64
win-64::r-harp-1.19-r41h120295e_1.conda
win-64::openpmd-api-0.15.1-nompi_py38h658479d_105.conda
win-64::imagecodecs-2023.8.12-py310h997794f_0.conda
win-64::bytewax-0.17.0-py311pl5321he6bd7ae_6.conda
win-64::libopencv-4.8.0-py38h5cc261b_1.conda
win-64::libarrow-13.0.0-h240ed0a_0_cuda.conda
win-64::ifcopenshell-v0.7.0a10-py311h65a13f2_0.conda
win-64::libprotobuf-static-3.21.12-h12be248_1.conda
win-64::folly-2023.08.14.00-hfbb6214_3.conda
win-64::harp-1.19-py39haeadfa7_1.conda
win-64::grpcio-1.54.3-py39h662c1f1_0.conda
win-64::ifcopenshell-v0.7.0a9-py310h5050cb1_0.conda
win-64::folly-2023.08.14.00-hdb74905_3.conda
win-64::openpmd-api-0.15.2-nompi_py311h12ed20f_100.conda
win-64::openpmd-api-0.15.1-nompi_py39h05f23da_106.conda
win-64::ifcopenshell-v0.7.0a10-py38h5fe3429_0.conda
win-64::heyoka-llvm-14-0.21.0-h955623a_1.conda
win-64::vigra-1.11.1-py39hc4b74dd_1046.conda
win-64::cpp-opentelemetry-sdk-1.11.0-h156e78f_0.conda
win-64::vigra-1.11.1-py39h389a5aa_1046.conda
win-64::tectonic-0.14.1-hcf07100_1.conda
win-64::libgdal-3.7.1-hc4c061e_7.conda
win-64::soplex-6.0.4-h949ae46_0.conda
win-64::conduit-0.8.8-py38h79814ef_2.conda
win-64::libgdal-3.6.4-h01df272_13.conda
win-64::ifcopenshell-v0.7.0a10-py310h2374277_0.conda
win-64::netcdf4-1.6.4-nompi_py311he019f65_102.conda
win-64::omniorb-4.3.1-py39hd2c3553_0.conda
win-64::pygame-2.5.1-py310hd1d314e_0.conda
win-64::grpcio-1.54.3-py38h507fca2_0.conda
win-64::r-harp-1.19-r41h8939525_1.conda
win-64::libxml2-2.11.5-hc3477c8_1.conda
win-64::r-harp-1.19-r41h94a49d3_1.conda
win-64::freecad-0.21.0-py310hcd8f1db_1.conda
win-64::harp-1.19-py310h164bfc0_1.conda
win-64::nexus-4.4.3-h06a8cfb_11.conda
win-64::libsolv-static-0.7.24-h12be248_3.conda
win-64::wasmer-4.1.1-h4dd112c_0.conda
win-64::imread-0.7.4-py38h165daf9_2.conda
win-64::ifcopenshell-v0.7.0a10-py38hcd01d1c_0.conda
win-64::libgdal-3.7.1-h6393f06_6.conda
win-64::postgresql-15.4-hc80876b_0.conda
win-64::grpcio-1.56.2-py38h19421c1_1.conda
win-64::libarrow-10.0.1-hbc2f454_38_cpu.conda
win-64::aws-sdk-cpp-1.10.57-h22002f8_20.conda
win-64::openmeeg-2.5.6-py39h366aaa2_2.conda
win-64::arrow-cpp-9.0.0-py311h9306c73_45_cpu.conda
win-64::ifcopenshell-v0.7.0a9-py311h0e2fa1f_1.conda
win-64::libgrpc-1.57.0-h550f6bd_1.conda
win-64::postgresql-plpython-15.4-py311h931fdd5_0.conda
win-64::folly-2023.08.14.00-hfbb6214_2.conda
win-64::zstd-1.5.5-h12be248_0.conda
win-64::ogre-14.0.1-hcf305dc_1.conda
win-64::gtk4-4.12.1-h812e427_0.conda
win-64::openexr-3.2.0-h5fba010_0.conda
win-64::libopencv-4.8.0-py310he2c7b2b_1.conda
win-64::indexed_gzip-1.8.5-py310h617134d_0.conda
win-64::heyoka-llvm-13-1.0.0-hf53a8f2_0.conda
win-64::pdal-2.5.5-hf28c459_2.conda
win-64::folly-2023.08.07.00-h6064ee9_1.conda
win-64::stir-5.1.0-cuda112_py38h3f84f4e_210.conda
win-64::folly-2023.08.14.00-h6064ee9_1.conda
win-64::heyoka-1.0.0-h31c11bd_0.conda
win-64::libarrow-12.0.1-h240ed0a_9_cuda.conda
win-64::imagecodecs-2023.8.12-py39had998c7_0.conda
win-64::libxml2-2.11.5-hc3477c8_0.conda
win-64::arrow-cpp-9.0.0-py311h58d007c_46_cuda.conda
win-64::heyoka-llvm-14-1.0.0-h955623a_0.conda
win-64::freecad-0.21.0-py311hb135cbe_1.conda
win-64::vigra-1.11.1-py311h3ff297c_1046.conda
win-64::imread-0.7.4-py311h58409da_3.conda
win-64::imread-0.7.4-py38he96ca75_3.conda
win-64::poppler-23.08.0-h45d20d0_0.conda
win-64::ifcopenshell-v0.7.0a9-py310h8a2b3e1_0.conda
win-64::heyoka-llvm-13-0.21.0-hf53a8f2_1.conda
win-64::libscotch-7.0.4-h534da82_0.conda
win-64::pyreadr-0.4.9-py39h39b8732_0.conda
win-64::libgdal-3.6.4-h05e35ec_12.conda
win-64::ifcopenshell-v0.7.0a9-py310h5050cb1_1.conda
win-64::netcdf4-1.6.4-nompi_py39h9a3bb69_102.conda
win-64::libllvm16-16.0.6-h1ab654d_2.conda
win-64::folly-2023.08.07.00-hfbb6214_0.conda
win-64::libarrow-12.0.1-h18d808b_8_cuda.conda
win-64::grpcio-1.56.2-py39hd28a505_1.conda
win-64::libgdal-arrow-parquet-3.7.1-h7e06f32_8.conda
win-64::pyreadstat-1.2.3-py38h84023d3_0.conda
win-64::pdal-2.5.5-h1138fa1_1.conda
win-64::libarrow-12.0.1-h9114379_8_cuda.conda
win-64::scip-8.0.4-hc7fd266_0.conda
win-64::python-3.9.17-h4de0772_0_cpython.conda
win-64::arrow-cpp-9.0.0-py310hd12e1dd_46_cuda.conda
win-64::cairo-1.16.0-h412253b_1017.conda
win-64::libprotobuf-static-3.21.12-h12be248_2.conda
win-64::omniorb-4.3.1-py311h55b17b5_0.conda
win-64::ifcopenshell-v0.7.0a9-py311h0e2fa1f_0.conda
win-64::folly-2023.08.14.00-hfbb6214_1.conda
win-64::pyreadr-0.4.9-py38hda8ff42_0.conda
win-64::tiledb-2.16.3-hec1fcaa_1.conda
win-64::heyoka-1.0.0-ha28d8e4_0.conda
win-64::arrow-cpp-9.0.0-py310hbfdd532_45_cpu.conda
win-64::netcdf4-1.6.4-nompi_py38h46ce47e_102.conda
win-64::python-3.9.18-h4de0772_0_cpython.conda
win-64::libgdal-arrow-parquet-3.6.4-h4bdc78b_13.conda
win-64::ifcopenshell-v0.7.0a9-py38hcd01d1c_0.conda
win-64::ifcopenshell-v0.7.0a10-py39h8f534c9_0.conda
win-64::heyoka-llvm-12-0.21.0-h8d416ae_1.conda
win-64::aws-sdk-cpp-1.11.68-h22002f8_12.conda
win-64::tiledb-2.16.2-hd58e885_0.conda
win-64::libgdal-3.7.1-h6393f06_5.conda
win-64::ifcopenshell-v0.7.0a9-py39h83f286c_0.conda
win-64::ifcopenshell-v0.7.0a10-py311hef85837_0.conda
win-64::stir-5.1.0-cuda112_py310hd4c8a74_210.conda
win-64::aws-sdk-cpp-1.10.57-heb7cc7f_19.conda
win-64::libadios2-2.9.1-nompi_h52f8237_102.conda
win-64::harp-1.19-py38ha508e55_1.conda
win-64::vtk-base-9.2.6-qt_py310h1234567_212.conda
win-64::grpcio-1.54.3-py311hfe69050_0.conda
win-64::folly-2023.03.20.00-hfbb6214_5.conda
win-64::gtk4-4.12.1-hd732e2c_1.conda
win-64::ifcopenshell-v0.7.0a9-py311h5751641_0.conda
win-64::openmeeg-2.5.6-py311h2cc70f5_2.conda
win-64::coda-2.24.2-py310h41308cb_3.conda
win-64::ifcopenshell-v0.7.0a9-py39hf0c0d7d_1.conda
win-64::r-harp-1.19-r41h94282dd_1.conda
win-64::openpmd-api-0.15.1-nompi_py310h31abc04_105.conda
win-64::ffmpeg-6.0.0-lgpl_h5263a28_4.conda
win-64::polycap-1.2-py311h2ca7b92_3.conda
win-64::openpmd-api-0.15.2-nompi_py39h8aa3d59_100.conda
win-64::postgresql-plpython-15.4-py38hc2df893_0.conda
win-64::stir-5.1.0-cpu_py311hf7a2716_10.conda
win-64::libarrow-12.0.1-ha06dc20_8_cpu.conda
win-64::pypy3.8-7.3.11-h577050a_3.conda
win-64::libprotobuf-static-4.23.4-h1975477_1.conda
win-64::indexed_gzip-1.8.5-py39h7dfb729_0.conda
win-64::ifcopenshell-v0.7.0a10-py39hf0c0d7d_0.conda
win-64::openpmd-api-0.15.1-nompi_py39h6c7657d_105.conda
win-64::imagecodecs-2023.8.12-py39h8ff80d2_0.conda
win-64::ovito-3.9.1-hf6a3252_0.conda
win-64::coda-2.24.2-py39h6dd871f_3.conda
win-64::polycap-1.2-py38h3ea9b08_3.conda
win-64::arrow-cpp-9.0.0-py39h0acc53e_45_cpu.conda
win-64::cmake-3.27.4-hf0feee3_1.conda
win-64::freecad-0.21.0-py38h7a8e96b_1.conda
win-64::arrow-cpp-9.0.0-py39ha6e8ab7_45_cpu.conda
win-64::tectonic-0.14.1-h1cbdeb6_2.conda
win-64::libprotobuf-4.23.4-h1975477_1.conda
win-64::libprotobuf-static-4.23.4-hb8276f3_2.conda
win-64::ifcopenshell-v0.7.0a9-py39h83f286c_1.conda
win-64::pygame-2.5.1-py311h4246bbb_0.conda
win-64::ifcopenshell-v0.7.0a9-py38hd6b26c0_0.conda
win-64::libarrow-10.0.1-h8a6ae29_37_cpu.conda
win-64::libgrpc-1.57.0-hea2d5f7_0.conda
win-64::libadios2-2.9.1-nompi_h3621ceb_100.conda
win-64::bytewax-0.17.0-py310pl5321hdd0a9a3_6.conda
win-64::imread-0.7.4-py310h811121f_3.conda
win-64::pypy3.8-7.3.11-h577050a_2.conda
win-64::libadios2-2.9.1-nompi_h6e81f23_100.conda
win-64::paraview-5.11.1-py39h3c52f45_102_qt.conda
win-64::paraview-5.11.1-py311h4923653_102_qt.conda
win-64::pdal-2.5.6-h9a7b13a_1.conda
win-64::ifcopenshell-v0.7.0a10-py39h83f286c_0.conda
win-64::harp-1.19-py311h4b8c79d_1.conda
win-64::harp-1.19-py38h780b56f_1.conda
win-64::ifcopenshell-v0.7.0a9-py38h5fe3429_0.conda
win-64::libllvm-c16-16.0.6-h1ab654d_2.conda
win-64::arrow-cpp-9.0.0-py310hf28613f_45_cuda.conda
win-64::gmt-5.4.5-h07359b5_30.conda
win-64::libprotobuf-static-4.23.4-hb8276f3_3.conda
win-64::tesseract-5.3.2-hae9691c_0.conda
win-64::llvm-16.0.6-h3dc180e_2.conda
win-64::arrow-cpp-9.0.0-py39hcc63416_46_cuda.conda
win-64::vigra-1.11.1-py38h6aea222_1046.conda
win-64::openpmd-api-0.15.1-nompi_py38h4792802_105.conda
win-64::r-harp-1.19-r41h41308cb_1.conda
win-64::r-git2r-0.31.0-r41h007cf7e_2.conda
win-64::pypy3.9-7.3.12-h994e1e7_2.conda
win-64::grpcio-1.57.0-py38h19421c1_0.conda
win-64::grpcio-1.57.0-py39hd28a505_0.conda
win-64::heyoka-0.21.0-h31c11bd_1.conda
win-64::libzip-1.10.0-h1d365fa_0.conda
win-64::aws-sdk-cpp-1.10.57-hc0abff2_18.conda
win-64::ifcopenshell-v0.7.0a9-py38h57f4809_1.conda
win-64::arrow-cpp-9.0.0-py39h3f05aa9_46_cpu.conda
win-64::openpmd-api-0.15.1-nompi_py39hc4a1168_106.conda
win-64::pygame-2.5.1-py38hbc751ee_0.conda
win-64::libgdal-3.6.4-hcd4c35f_15.conda
win-64::vigra-1.11.1-py39hb90c94f_1046.conda
win-64::cmake-3.27.4-hf0feee3_3.conda
win-64::folly-2023.08.28.00-hdb74905_0.conda
win-64::libarrow-11.0.0-heb30dd5_33_cpu.conda
win-64::libsolv-0.7.24-h12be248_3.conda
win-64::folly-2023.08.14.00-h6064ee9_2.conda
win-64::python-3.11.5-h2628c8c_0_cpython.conda
win-64::libtiff-4.5.1-h6c8260b_1.conda
win-64::paraview-5.11.1-py310h14e7581_102_qt.conda
win-64::libadios2-2.9.1-nompi_h6db2470_100.conda
win-64::openmeeg-2.5.6-py39he4f259b_2.conda
win-64::openpmd-api-0.15.1-nompi_py39h9afc790_105.conda
win-64::imread-0.7.4-py39h2b9b62d_3.conda
win-64::libadios2-2.9.1-nompi_h72362e8_102.conda
win-64::vigra-1.11.1-py310hb6f7b47_1046.conda
win-64::stir-5.1.0-cpu_py310h05295b1_10.conda
win-64::boost-cpp-1.82.0-h92ca6c8_2.conda
win-64::grpcio-1.57.0-py310hb84602e_1.conda
win-64::conduit-0.8.8-py310h5e9575c_2.conda
win-64::ogre-1.10.12-h4c42d57_11.conda
win-64::vigra-1.11.1-py38h6a6479e_1046.conda
win-64::vtk-base-9.2.6-qt_py311h1234567_212.conda
win-64::libmatio-1.5.23-h8f40fab_4.conda
win-64::libarrow-10.0.1-heb30dd5_37_cpu.conda
win-64::freecad-0.21.0-py310hcd8f1db_0.conda
win-64::libopencv-4.8.0-py39h06fe196_1.conda
win-64::harp-1.19-py39hc4250a4_1.conda
win-64::imread-0.7.4-py39h0d11603_3.conda
win-64::openpmd-api-0.15.2-nompi_py39h9d760d7_100.conda
win-64::gmt-6.4.0-h1a65978_15.conda
win-64::netcdf4-1.6.4-nompi_py310h6477780_102.conda
win-64::ifcopenshell-v0.7.0a9-py38h5fe3429_1.conda
win-64::pypy3.9-7.3.12-h994e1e7_3.conda
win-64::coda-2.24.2-py38h120295e_3.conda
win-64::libgdal-arrow-parquet-3.6.4-hb8575ef_12.conda
win-64::arrow-cpp-9.0.0-py38hcb5fb05_45_cuda.conda
win-64::bytewax-0.17.0-py38pl5321habc61b1_6.conda
win-64::libadios2-2.9.1-nompi_h6db2470_101.conda
win-64::heyoka-1.0.0-hdb83de7_0.conda
win-64::coda-2.24.2-py311h94282dd_3.conda
win-64::libarrow-13.0.0-h10ad630_0_cpu.conda
win-64::vigra-1.11.1-py310h3d61c89_1046.conda
win-64::folly-2023.08.14.00-hfbb6214_0.conda
win-64::ifcopenshell-v0.7.0a9-py38hcd01d1c_1.conda
win-64::r-harp-1.19-r41h6dd871f_1.conda
win-64::grpcio-1.57.0-py310hb84602e_0.conda
win-64::libpq-15.4-h43585b0_0.conda
win-64::grpcio-1.57.0-py38h19421c1_1.conda
win-64::ogre-1.10.12-h0408007_12.conda
win-64::libprotobuf-static-4.23.4-h1975477_0.conda
win-64::libgdal-arrow-parquet-3.7.1-h7e06f32_9.conda
win-64::libadios2-2.9.1-nompi_h82a79a1_101.conda
win-64::arrow-cpp-9.0.0-py38hd335af4_45_cpu.conda
win-64::freecad-0.21.0-py38h7a8e96b_0.conda
win-64::stir-5.1.0-cuda112_py39h456d3e6_210.conda
win-64::libprotobuf-4.23.4-hb8276f3_2.conda
win-64::cmake-3.27.4-hf0feee3_4.conda
win-64::libopencv-4.8.0-py311hf185cdb_1.conda
win-64::libadios2-2.9.1-nompi_h1d0fc58_102.conda
win-64::libgdal-3.7.1-hb1fd9af_9.conda
win-64::arrow-cpp-9.0.0-py311haf286d8_45_cuda.conda
win-64::freecad-0.21.1-py311hb135cbe_0.conda
win-64::libgrpc-1.56.2-hea2d5f7_1.conda
win-64::libarrow-11.0.0-h8a6ae29_33_cpu.conda
win-64::vigra-1.11.1-py38h8567df3_1046.conda
win-64::tiledb-2.16.2-h1ffc264_0.conda
win-64::arrow-cpp-9.0.0-py311h58d007c_45_cuda.conda
win-64::polycap-1.2-py39h1a48880_3.conda
win-64::freecad-0.21.0-py39hfc3595f_1.conda
win-64::arrow-cpp-9.0.0-py311h5cbd681_45_cpu.conda
win-64::tiledb-2.16.2-hec1fcaa_0.conda
win-64::grpcio-1.54.3-py310h8020be6_0.conda
win-64::libgit2-1.7.1-hc6d37dd_0.conda
win-64::libgd-2.3.3-h99fc506_7.conda
win-64::libgdal-arrow-parquet-3.7.1-h56a8b23_7.conda
win-64::openpmd-api-0.15.1-nompi_py311h050fbb8_105.conda
win-64::arrow-cpp-9.0.0-py39h0e96eb8_45_cuda.conda
win-64::arrow-cpp-9.0.0-py38h2373d4d_46_cpu.conda
win-64::arrow-cpp-9.0.0-py38h373d1f1_46_cuda.conda
win-64::stir-5.1.0-cpu_py39h1deee1a_10.conda
win-64::conduit-0.8.8-py39h767d390_2.conda
win-64::ifcopenshell-v0.7.0a10-py311h0e2fa1f_0.conda
win-64::pyreadr-0.4.9-py311ha5690a0_0.conda
win-64::libgdal-arrow-parquet-3.7.1-h5c3ccf9_5.conda
win-64::ifcopenshell-v0.7.0a9-py311hef85837_1.conda
win-64::ffmpeg-6.0.0-gpl_h1f67d4f_104.conda
win-64::freecad-0.21.1-py310hcd8f1db_0.conda
win-64::ifcopenshell-v0.7.0a10-py38h57f4809_0.conda
win-64::imread-0.7.4-py310h811121f_2.conda
win-64::ifcopenshell-v0.7.0a10-py310h5050cb1_0.conda
win-64::ifcopenshell-v0.7.0a9-py311h65a13f2_1.conda
win-64::aws-sdk-cpp-1.10.57-hf794bbe_21.conda
win-64::libgdal-arrow-parquet-3.7.1-h5c3ccf9_6.conda
win-64::libarrow-10.0.1-h7061486_37_cuda.conda
win-64::openpmd-api-0.15.2-nompi_py310h7039a3b_100.conda
win-64::openexr-3.1.10-h5fba010_0.conda
win-64::aws-sdk-cpp-1.11.68-hf794bbe_13.conda
win-64::pyreadstat-1.2.3-py311hd8f7e58_0.conda
win-64::folly-2023.08.28.00-hfbb6214_0.conda
win-64::folly-2023.08.07.00-hfbb6214_1.conda
win-64::kaldi-5.5.1068-cpu_he6cc000_2.conda
win-64::libadios2-2.9.1-nompi_he589150_100.conda
win-64::folly-2023.08.07.00-h6064ee9_0.conda
win-64::folly-2023.03.20.00-h6064ee9_5.conda
win-64::bytewax-0.17.0-py39pl5321h23403ee_6.conda
win-64::libprotobuf-4.23.4-hb8276f3_3.conda
win-64::grpcio-1.56.2-py311h5bc0dda_1.conda
win-64::eccodes-2.31.0-habb35d2_1.conda
win-64::libarrow-11.0.0-h9dc4a8a_34_cuda.conda
win-64::tiledb-2.16.3-hd58e885_1.conda
win-64::pyreadstat-1.2.3-py39h585ecb4_0.conda
win-64::arrow-cpp-9.0.0-py311h5cbd681_46_cpu.conda
win-64::pygame-2.5.1-py39h9408aed_0.conda
win-64::pygame-2.5.1-py38h6efadab_0.conda
win-64::folly-2023.08.14.00-h6064ee9_0.conda
win-64::capnproto-1.0.1-h12be248_0.conda
win-64::pdal-2.5.6-hf28c459_0.conda
win-64::openpmd-api-0.15.1-nompi_py310h3c7ce76_106.conda
win-64::llvmdev-16.0.6-h1ab654d_2.conda
win-64::omniorb-4.3.1-py310h2b448b3_0.conda
win-64::paraview-5.11.1-py38hd04f997_102_qt.conda
win-64::libzip-1.10.1-h1d365fa_0.conda
win-64::stir-5.1.0-cuda112_py311h5e56a69_210.conda
win-64::pyreadr-0.4.9-py310hfdea923_0.conda
win-64::arrow-cpp-9.0.0-py310h1410346_45_cpu.conda
win-64::openpmd-api-0.15.2-nompi_py38h68a6b68_100.conda
win-64::stir-5.1.0-cpu_py38h5c36b7e_10.conda
win-64::wasmer-4.1.2-h4dd112c_0.conda
win-64::ifcopenshell-v0.7.0a9-py39h8f534c9_1.conda
win-64::vtk-base-9.2.6-qt_py38h1234567_212.conda
win-64::boost-cpp-1.78.0-h9f4b32c_4.conda
win-64::arrow-cpp-9.0.0-py38hf4bfbbe_45_cuda.conda
win-64::libprotobuf-3.21.12-h12be248_1.conda
win-64::openmeeg-2.5.6-py310hc0bfa95_2.conda
win-64::libprotobuf-4.23.4-hb8276f3_4.conda
win-64::yarp-cxx-3.8.1-h0130eea_4.conda
win-64::libopencv-4.8.0-py39h5e8c182_1.conda
win-64::hdf5-1.14.2-nompi_h73e8ff5_100.conda
win-64::baumwelch-0.3.7-h1c255cb_5.conda
win-64::libarrow-10.0.1-h9dc4a8a_38_cuda.conda
win-64::libgdal-arrow-parquet-3.6.4-hb8575ef_11.conda
win-64::libprotobuf-static-4.23.4-hb8276f3_4.conda
win-64::ovito-3.9.0-hf6a3252_0.conda
win-64::aws-sdk-cpp-1.11.68-hc0abff2_10.conda
win-64::ifcopenshell-v0.7.0a10-py310h7e140ae_0.conda
win-64::arrow-cpp-9.0.0-py38hc7794f1_45_cpu.conda
win-64::pygame-2.5.1-py39h10a7b85_0.conda
win-64::libadios2-2.9.1-nompi_h530d7cd_102.conda
win-64::polycap-1.2-py310h32ee474_3.conda
win-64::openmeeg-2.5.6-py38ha28e21d_2.conda
win-64::libprotobuf-4.23.4-h1975477_0.conda
win-64::grpcio-1.57.0-py39hd28a505_1.conda
win-64::arrow-cpp-9.0.0-py310h3178777_45_cuda.conda
win-64::heyoka-0.21.0-ha28d8e4_1.conda
win-64::arrow-cpp-9.0.0-py310h15f5923_46_cpu.conda
win-64::libopencv-4.8.0-py38he5cf3ba_1.conda
win-64::coda-2.24.2-py38h94a49d3_3.conda
win-64::openmeeg-2.5.6-py38h3dd427e_2.conda
win-64::postgresql-plpython-15.4-py310hf838413_0.conda
win-64::poppler-qt-23.08.0-hec2a549_0.conda
win-64::gmt-6.4.0-h9cef95e_14.conda
win-64::libnetcdf-4.9.2-nompi_h8284064_111.conda
win-64::openpmd-api-0.15.1-nompi_py38hd041cdc_106.conda
win-64::arrow-cpp-9.0.0-py39h112ca7e_45_cuda.conda
win-64::postgresql-plpython-15.4-py39h7f24c7b_0.conda
win-64::libarrow-10.0.1-h3eb3106_37_cuda.conda
win-64::coda-2.24.2-py39h8939525_3.conda
win-64::openpmd-api-0.15.1-nompi_py38h1483d34_106.conda
win-64::grpcio-1.57.0-py311h5bc0dda_1.conda
win-64::kaldi-5.5.1068-cuda112h2069925_2.conda
win-64::folly-2023.08.14.00-h05345e4_2.conda
win-64::freecad-0.21.1-py38h7a8e96b_0.conda
win-64::imread-0.7.4-py38h165daf9_3.conda
win-64::libarrow-12.0.1-h10ad630_9_cpu.conda
win-64::ifcopenshell-v0.7.0a9-py311hef85837_0.conda
win-64::openpmd-api-0.15.2-nompi_py38h25036b2_100.conda
win-64::freecad-0.21.0-py39hfc3595f_0.conda
win-64::aws-sdk-cpp-1.11.68-heb7cc7f_11.conda
win-64::ifcopenshell-v0.7.0a9-py39h8f534c9_0.conda
win-64::vtk-base-9.2.6-qt_py39h1234567_212.conda
win-64::grpcio-1.57.0-py311h5bc0dda_0.conda
win-64::vigra-1.11.1-py38h3826f5e_1046.conda
win-64::folly-2023.08.28.00-h6064ee9_0.conda
win-64::folly-2023.08.14.00-h6064ee9_3.conda
win-64::vigra-1.11.1-py311h39e1d8a_1046.conda
win-64::imagecodecs-2023.8.12-py311h0b4acc2_0.conda
win-64::openpmd-api-0.15.1-nompi_py311h12ed20f_106.conda
win-64::heyoka-0.21.0-hdb83de7_1.conda
win-64::libgdal-3.6.4-hcd4c35f_14.conda
win-64::tiledb-2.16.3-h1ffc264_1.conda
win-64::libopentelemetry-cpp-1.11.0-h156e78f_0.conda
win-64::freecad-0.21.1-py39hfc3595f_0.conda
win-64::pyreadstat-1.2.3-py310h51ee7fe_0.conda
win-64::libarrow-11.0.0-hbc2f454_34_cpu.conda
win-64::libarrow-11.0.0-h7061486_33_cuda.conda
win-64::libgdal-arrow-parquet-3.6.4-h59fab0b_15.conda
win-64::imread-0.7.4-py39h0d11603_2.conda
win-64::ifcopenshell-v0.7.0a9-py310h7e140ae_0.conda
win-64::ifcopenshell-v0.7.0a9-py310h7e140ae_1.conda
win-64::omniorb-4.3.1-py38h8a9cac7_0.conda
win-64::libprotobuf-3.21.12-h12be248_2.conda
win-64::libgdal-3.7.1-hb1fd9af_8.conda
win-64::ifcopenshell-v0.7.0a9-py39h11f916b_0.conda
win-64::libarrow-11.0.0-h3eb3106_33_cuda.conda
win-64::ifcopenshell-v0.7.0a9-py310h2374277_1.conda
win-64::llvm-tools-16.0.6-h1ab654d_2.conda
win-64::libadios2-2.9.1-nompi_hbe9e422_101.conda
win-64::libadios2-2.9.1-nompi_hc3ceeb0_101.conda
win-64::papilo-2.1.3-h45feaf2_0.conda
win-64::libgrpc-1.54.3-ha177ca7_0.conda
win-64::omniorb-libs-4.3.1-ha7d20b1_0.conda
win-64::libgdal-arrow-parquet-3.6.4-h59fab0b_14.conda
win-64::indexed_gzip-1.8.5-py38h6a43da7_0.conda
win-64::heyoka-llvm-12-1.0.0-h8d416ae_0.conda
win-64::indexed_gzip-1.8.5-py311hcbca1fb_0.conda
win-64::openexr-3.1.11-h5fba010_0.conda
win-64::grpcio-1.56.2-py310hb84602e_1.conda
win-64::libarrow-12.0.1-he3e0f11_8_cpu.conda
win-64::libgdal-3.6.4-h05e35ec_11.conda
win-64::cmake-3.27.4-hf0feee3_2.conda
win-64::vigra-1.11.1-py39hcf442c9_1046.conda
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
================================================================================
================================================================================
osx-64
osx-64::spidermonkey-bin-91.13.0-h4c9933f_2.conda
osx-64::libprotobuf-4.23.4-he0c2237_4.conda
osx-64::libprotobuf-static-4.23.4-h396b1fa_3.conda
osx-64::libsolv-static-0.7.24-h7d26f99_3.conda
osx-64::libv8-8.9.83-h8241635_4.conda
osx-64::libprotobuf-static-3.21.12-h7d26f99_1.conda
osx-64::zstd-1.5.5-h829000d_0.conda
osx-64::openjdk-20.0.0-h7d26f99_1.conda
osx-64::openexr-3.1.10-h747cbf1_0.conda
osx-64::dotnet-sdk-6.0.412-hfce08ca_0.conda
osx-64::openexr-3.1.11-h747cbf1_0.conda
osx-64::libprotobuf-static-4.23.4-h396b1fa_4.conda
osx-64::spidermonkey-91.13.0-h8c620d4_2.conda
osx-64::libprotobuf-4.23.4-he0c2237_3.conda
osx-64::adios-1.13.1-nompi_h2a044d9_1123.conda
osx-64::dotnet-runtime-6.0.20-hfce08ca_0.conda
osx-64::libprotobuf-4.23.4-h5feb325_1.conda
osx-64::libprotobuf-4.23.4-he0c2237_2.conda
osx-64::libcdms-3.1.2-h91df7e7_127.conda
osx-64::openexr-3.2.0-h747cbf1_0.conda
osx-64::micromamba-1.5.0-0.tar.bz2
osx-64::dotnet-aspnetcore-6.0.20-hfce08ca_0.conda
osx-64::libass-0.17.1-h80904bb_1.conda
osx-64::libprotobuf-static-3.21.12-h7d26f99_2.conda
osx-64::libprotobuf-3.21.12-h7d26f99_1.conda
osx-64::dotnet-aspnetcore-7.0.10-hfce08ca_0.conda
osx-64::libprotobuf-static-4.23.4-h396b1fa_2.conda
osx-64::libprotobuf-3.21.12-h7d26f99_2.conda
osx-64::libprotobuf-static-4.23.4-h5feb325_1.conda
osx-64::micromamba-1.5.0-1.tar.bz2
osx-64::eccodes-2.31.0-h008e9a8_1.conda
osx-64::dotnet-runtime-7.0.10-hfce08ca_0.conda
osx-64::dotnet-sdk-7.0.400-hfce08ca_0.conda
osx-64::libsqlite-3.43.0-h58db7d2_0.conda
osx-64::libsolv-0.7.24-h7d26f99_3.conda
osx-64::zimpl-3.5.3-hd956f49_0.conda
-    "libzlib >=1.2.13,<1.3.0a0"
+    "libzlib >=1.2.13,<2.0.0a0"
osx-64::grpcio-1.57.0-py38h4864539_0.conda
osx-64::libadios2-2.9.1-mpi_openmpi_h8fec193_2.conda
osx-64::libarrow-11.0.0-h64fc635_33_cpu.conda
osx-64::libadios2-2.9.1-nompi_hf6350dc_102.conda
osx-64::yosys-0.31-py311h237345f_0.conda
osx-64::openpmd-api-0.15.1-mpi_openmpi_py39h1d5aa59_6.conda
osx-64::openpmd-api-0.15.2-nompi_py38h01dd92d_100.conda
osx-64::openpmd-api-0.15.2-mpi_openmpi_py38h69f9130_0.conda
osx-64::vigra-1.11.1-py310h89c30d0_1046.conda
osx-64::vowpalwabbit-9.9.0-py310h6c2355c_0.conda
osx-64::libopencv-4.8.0-py311h55114f4_1.conda
osx-64::yosys-0.31-py311h5c57d70_0.conda
osx-64::libadios2-2.9.1-nompi_h688d649_102.conda
osx-64::boost-cpp-1.82.0-h46cd7f6_2.conda
osx-64::pygame-2.5.1-py311h231154e_0.conda
osx-64::heyoka-1.0.0-h37be4b7_0.conda
osx-64::libgdal-3.7.1-he59c004_8.conda
osx-64::llvm-tools-16.0.6-he4b1e75_2.conda
osx-64::r-git2r-0.31.0-r42h75b6a36_2.conda
osx-64::heyoka-0.21.0-h37be4b7_1.conda
osx-64::pdal-2.5.5-hadc813f_1.conda
osx-64::libgrpc-1.57.0-he6801ca_0.conda
osx-64::triqs-3.1.1-py310he217e82_7.conda
osx-64::openpmd-api-0.15.1-nompi_py311hb97e902_105.conda
osx-64::pypy3.8-7.3.11-h3a77750_2.conda
osx-64::lammps-2023.08.02-cpu_py310_h47242cf_mpich_0.conda
osx-64::folly-2023.03.20.00-hed31980_5_jemalloc.conda
osx-64::mandrake-1.2.2-py311hcb84e56_3.conda
osx-64::openpmd-api-0.15.1-nompi_py39h99c1919_106.conda
osx-64::magics-4.14.2-hd43c1be_0.conda
osx-64::healpy-1.16.5-py310h4bf081f_1.conda
osx-64::arrow-cpp-9.0.0-py39h7ee1580_45_cpu.conda
osx-64::libadios2-2.9.1-nompi_h497cdf4_101.conda
osx-64::folly-2023.03.20.00-h0d9798a_5.conda
osx-64::lammps-2023.08.02-cpu_py39_hb9db24c_openmpi_0.conda
osx-64::netcdf4-1.6.4-mpi_mpich_py38h0ef46f6_2.conda
osx-64::openpmd-api-0.15.1-mpi_openmpi_py39hcfdbee7_5.conda
osx-64::conduit-0.8.8-py39h6babb07_2.conda
osx-64::git-2.42.0-pl5321hbb4c4ee_0.conda
osx-64::nodejs-16.20.2-h19d5eec_1.conda
osx-64::ogre-1.10.12-h94a77c1_12.conda
osx-64::pypy3.9-7.3.12-hc0e9917_2.conda
osx-64::grpcio-1.56.2-py311h43071ad_1.conda
osx-64::folly-2023.08.07.00-hc30067e_1_jemalloc.conda
osx-64::openpmd-api-0.15.2-nompi_py39h53a4722_100.conda
osx-64::libadios2-2.9.1-nompi_hda11d82_102.conda
osx-64::pp-sketchlib-2.1.1-py38hc4254e9_2.conda
osx-64::vtk-base-9.2.6-qt_py38h1234567_211.conda
osx-64::libllvm16-16.0.6-he4b1e75_2.conda
osx-64::triqs-3.1.1-py310he217e82_6.conda
osx-64::ifcopenshell-v0.7.0a10-py311h29b1115_0.conda
osx-64::ogre-1.10.12-hdd7d167_11.conda
osx-64::adios-1.13.1-mpi_openmpi_habbb3a0_1023.conda
osx-64::libtiledb-sql-0.23.2-h8953216_0.conda
osx-64::openpmd-api-0.15.1-nompi_py310h2c2c04f_105.conda
osx-64::h5utils-1.13.2-nompi_hf9d9770_1102.conda
osx-64::polycap-1.2-py311he033f8a_3.conda
osx-64::heyoka-llvm-11-0.21.0-he311c46_1.conda
osx-64::harp-1.19-py311hb15fc10_1.conda
osx-64::heyoka-llvm-16-1.0.0-h13b2b40_0.conda
osx-64::ifcopenshell-v0.7.0a9-py310h7ca8742_1.conda
osx-64::heyoka-0.21.0-hf7afb35_1.conda
osx-64::libopencv-4.8.0-py38ha72e864_1.conda
osx-64::indexed_gzip-1.8.5-py311h2cbd40e_0.conda
osx-64::netcdf4-1.6.4-nompi_py311h710f573_102.conda
osx-64::arrow-cpp-9.0.0-py310h27b5529_45_cpu.conda
osx-64::ifcopenshell-v0.7.0a9-py311h29b1115_1.conda
osx-64::libadios2-2.9.1-mpi_mpich_h1d18ce5_0.conda
osx-64::pp-sketchlib-2.1.1-py39h339555b_2.conda
osx-64::openpmd-api-0.15.1-mpi_mpich_py38h4ba93b7_5.conda
osx-64::aws-sdk-cpp-1.10.57-h3f720bc_18.conda
osx-64::ifcopenshell-v0.7.0a9-py39h669e0ef_0.conda
osx-64::ifcopenshell-v0.7.0a10-py311hf939a2e_0.conda
osx-64::lammps-2023.08.02-cpu_py38_hba693f7_openmpi_0.conda
osx-64::libgdal-arrow-parquet-3.7.1-h2f7712c_6.conda
osx-64::openpmd-api-0.15.1-mpi_openmpi_py38h2566a63_6.conda
osx-64::pyreadr-0.4.9-py39h33c016d_0.conda
osx-64::libgdal-3.6.4-hf3eeb18_14.conda
osx-64::netcdf4-1.6.4-nompi_py38ha188ddb_102.conda
osx-64::grpcio-1.57.0-py310h0d4bf3c_0.conda
osx-64::arrow-cpp-9.0.0-py311h8374720_45_cpu.conda
osx-64::libadios2-2.9.1-mpi_openmpi_hb42a0a8_1.conda
osx-64::postgresql-plpython-15.4-py310he0d0a37_0.conda
osx-64::harp-1.19-py39h70fe90c_1.conda
osx-64::grpcio-1.57.0-py311h43071ad_1.conda
osx-64::openpmd-api-0.15.1-nompi_py38h6132683_105.conda
osx-64::yosys-0.32-py311h5c57d70_0.conda
osx-64::libadios2-2.9.1-nompi_h1a07a1f_100.conda
osx-64::folly-2023.08.14.00-h1718691_0.conda
osx-64::freecad-0.21.0-py39h448b006_1.conda
osx-64::folly-2023.08.07.00-h1718691_1.conda
osx-64::freecad-0.21.0-py38hef7ffa1_0.conda
osx-64::ifcopenshell-v0.7.0a9-py310h11c943f_1.conda
osx-64::libgrpc-1.56.2-he6801ca_1.conda
osx-64::pygame-2.5.1-py38h5fc1981_0.conda
osx-64::libadios2-2.9.1-mpi_openmpi_h424a5b2_1.conda
osx-64::triqs-3.1.1-py38h2e556f2_6.conda
osx-64::libnetcdf-4.9.2-mpi_openmpi_h1b6b284_10.conda
osx-64::h5utils-1.13.2-mpi_mpich_h8bfd849_1002.conda
osx-64::conduit-0.8.8-py38h63d67b1_2.conda
osx-64::libzip-1.10.1-hc158999_0.conda
osx-64::paraview-5.11.1-py39h2a37ea0_102_qt.conda
osx-64::freecad-0.21.1-py311h96b3bc9_0.conda
osx-64::triqs-3.1.1-py311h3ee9e43_7.conda
osx-64::conduit-0.8.8-py310h81784fe_2.conda
osx-64::arrow-cpp-9.0.0-py310h148432f_46_cpu.conda
osx-64::libgdal-arrow-parquet-3.6.4-hbc892a1_14.conda
osx-64::folly-2023.03.20.00-h6fbac3b_5.conda
osx-64::vowpalwabbit-9.8.0-py39h1317971_1.conda
osx-64::bytewax-0.17.0-py310he76948c_6.conda
osx-64::ffmpeg-6.0.0-gpl_h789f13d_104.conda
osx-64::lammps-2023.08.02-cpu_py310_h99287ef_openmpi_0.conda
osx-64::texlive-core-20230313-h25b69a2_5.conda
osx-64::r-harp-1.19-r43h4485038_1.conda
osx-64::polycap-1.2-py39h341f2fb_3.conda
osx-64::polycap-1.2-py38h794ba6b_3.conda
osx-64::libadios2-2.9.1-mpi_openmpi_he390fec_1.conda
osx-64::omniorb-4.3.1-py311h3c90865_0.conda
osx-64::magics-metview-4.14.2-h75971d5_0.conda
osx-64::openpmd-api-0.15.1-mpi_openmpi_py39h4b75449_6.conda
osx-64::lammps-2023.08.02-cpu_py39_ha9147cc_mpich_0.conda
osx-64::folly-2023.08.14.00-hc30067e_2_jemalloc.conda
osx-64::tiledb-2.16.2-h24ec535_0.conda
osx-64::ifcopenshell-v0.7.0a9-py38h6075e3b_1.conda
osx-64::pygame-2.5.1-py310hb6fb842_0.conda
osx-64::openpmd-api-0.15.2-mpi_mpich_py310hf7d3263_0.conda
osx-64::openpmd-api-0.15.1-mpi_openmpi_py310he2cf012_6.conda
osx-64::openpmd-api-0.15.2-mpi_mpich_py38h17671a9_0.conda
osx-64::ifcopenshell-v0.7.0a10-py310h11c943f_0.conda
osx-64::openpmd-api-0.15.1-nompi_py39hed69e9f_105.conda
osx-64::julia-1.9.3-h8d83f4a_0.conda
osx-64::freecad-0.21.0-py311h96b3bc9_1.conda
osx-64::triqs-3.1.1-py310h199346d_7.conda
osx-64::cpp-opentelemetry-sdk-1.11.0-hb55cd83_0.conda
osx-64::libadios2-2.9.1-mpi_mpich_h0cadb0f_0.conda
osx-64::openmeeg-2.5.6-py38h8bd9ff4_2.conda
osx-64::r-harp-1.19-r43hc321bfd_1.conda
osx-64::papilo-2.1.3-h21bd363_0.conda
osx-64::netcdf4-1.6.4-mpi_openmpi_py311hab965e7_2.conda
osx-64::imagecodecs-2023.8.12-py39hfc0e906_0.conda
osx-64::pypy3.8-7.3.11-h3a77750_3.conda
osx-64::folly-2023.08.14.00-hd4516f9_3_jemalloc.conda
osx-64::ifcopenshell-v0.7.0a9-py39h669e0ef_1.conda
osx-64::hdfeos5-5.1.16-hca3f194_15.conda
osx-64::folly-2023.08.07.00-h503270f_1_jemalloc.conda
osx-64::mold-2.1.0-hc277f81_0.conda
osx-64::python-3.9.18-h07e1443_0_cpython.conda
osx-64::libgdal-3.6.4-hd3d9293_11.conda
osx-64::vigra-1.11.1-py311h7f13616_1046.conda
osx-64::libgdal-3.7.1-he59c004_9.conda
osx-64::nest-simulator-3.5-py39h8f63631_2.conda
osx-64::netcdf4-1.6.4-nompi_py39h662e83e_102.conda
osx-64::ifcopenshell-v0.7.0a10-py310h3e3cdc0_0.conda
osx-64::grpcio-1.57.0-py39h341a990_0.conda
osx-64::julia-1.9.2-h8d83f4a_1.conda
osx-64::tiledb-2.16.3-h0f7503a_1.conda
osx-64::tesseract-5.3.2-h50d54eb_0.conda
osx-64::nss-3.92-hd6ac835_0.conda
osx-64::libgdal-arrow-parquet-3.7.1-hfcc3c3b_8.conda
osx-64::conduit-0.8.8-py38hbe93eb5_2.conda
osx-64::netcdf4-1.6.4-mpi_openmpi_py310h1d0c4ba_2.conda
osx-64::libgrpc-1.57.0-h5e8236e_1.conda
osx-64::mandrake-1.2.2-py38h4e13953_3.conda
osx-64::libadios2-2.9.1-mpi_mpich_hb55f3cf_1.conda
osx-64::folly-2023.08.14.00-h1718691_3.conda
osx-64::netcdf4-1.6.4-mpi_mpich_py311h35923ac_2.conda
osx-64::ogre-14.0.1-h455a79c_1.conda
osx-64::folly-2023.08.28.00-h8318d5c_0.conda
osx-64::libtiledb-sql-0.24.0-h8953216_0.conda
osx-64::netcdf4-1.6.4-mpi_mpich_py39hbbf1715_2.conda
osx-64::libadios2-2.9.1-mpi_mpich_hc118bb5_2.conda
osx-64::vigra-1.11.1-py39hf55be8f_1046.conda
osx-64::pp-sketchlib-2.1.1-py310hda06942_2.conda
osx-64::libxmlsec1-1.3.1-h3ecb50a_1.conda
osx-64::libzip-1.10.0-hc158999_0.conda
osx-64::ifcopenshell-v0.7.0a10-py38hb8c8317_0.conda
osx-64::vigra-1.11.1-py39hb25b7e1_1046.conda
osx-64::libopencv-4.8.0-py39h85fe77b_1.conda
osx-64::ifcopenshell-v0.7.0a10-py38h6075e3b_0.conda
osx-64::aws-sdk-cpp-1.11.68-h3ff9d30_11.conda
osx-64::pyreadstat-1.2.3-py310hb69a1aa_0.conda
osx-64::vtk-base-9.2.6-qt_py39h1234567_212.conda
osx-64::openpmd-api-0.15.2-mpi_mpich_py39h31cf63f_0.conda
osx-64::cmake-3.27.4-hf40c264_2.conda
osx-64::imagecodecs-2023.8.12-py310hd6320be_0.conda
osx-64::gmt-5.4.5-h3cbbdf1_30.conda
osx-64::folly-2023.08.14.00-h503270f_1_jemalloc.conda
osx-64::heyoka-llvm-14-1.0.0-hfda5ef7_0.conda
osx-64::libadios2-2.9.1-mpi_openmpi_hf6dff9f_0.conda
osx-64::paraview-5.11.1-py310ha800eed_102_qt.conda
osx-64::freecad-0.21.0-py310h925a245_0.conda
osx-64::adios-1.13.1-mpi_mpich_hbc12278_1023.conda
osx-64::openpmd-api-0.15.2-mpi_openmpi_py38he798ff7_0.conda
osx-64::ifcopenshell-v0.7.0a9-py38hb8c8317_1.conda
osx-64::folly-2023.08.14.00-hc30067e_0_jemalloc.conda
osx-64::openpmd-api-0.15.1-mpi_openmpi_py310h8c05dfd_5.conda
osx-64::libadios2-2.9.1-mpi_openmpi_hc044665_0.conda
osx-64::libadios2-2.9.1-nompi_h2390f81_101.conda
osx-64::openpmd-api-0.15.1-mpi_mpich_py311h4c707a0_5.conda
osx-64::heyoka-llvm-11-1.0.0-he311c46_0.conda
osx-64::heyoka-1.0.0-ha692f19_0.conda
osx-64::mandrake-1.2.2-py310h4b966ce_3.conda
osx-64::libadios2-2.9.1-mpi_openmpi_h17da8a9_2.conda
osx-64::cairo-1.16.0-hfdb49f2_1017.conda
osx-64::libscotch-7.0.4-h6959927_0.conda
osx-64::folly-2023.08.07.00-hc30067e_0_jemalloc.conda
osx-64::folly-2023.03.20.00-h1718691_5.conda
osx-64::freecad-0.21.0-py39h448b006_0.conda
osx-64::triqs-3.1.1-py38h2e556f2_7.conda
osx-64::pdal-2.5.5-h028e6de_2.conda
osx-64::libxml2-2.11.5-h3346baf_1.conda
osx-64::coda-2.24.2-py311h4044976_3.conda
osx-64::libadios2-2.9.1-mpi_openmpi_h1195010_1.conda
osx-64::tiledb-2.16.3-h9b026fb_1.conda
osx-64::vigra-1.11.1-py38h1c95d58_1046.conda
osx-64::openmeeg-2.5.6-py310h2e72df8_2.conda
osx-64::openpmd-api-0.15.1-mpi_mpich_py38h00c7014_6.conda
osx-64::coda-2.24.2-py39h171fc49_3.conda
osx-64::openpmd-api-0.15.1-mpi_mpich_py311ha827424_6.conda
osx-64::omniorb-4.3.1-py310h0ad2c98_0.conda
osx-64::r-harp-1.19-r43hcb92ca7_1.conda
osx-64::ifcopenshell-v0.7.0a10-py311h5135b92_0.conda
osx-64::bytewax-0.17.0-py38h51ad8f1_6.conda
osx-64::folly-2023.08.14.00-h08fbb52_2.conda
osx-64::python-3.9.17-h07e1443_0_cpython.conda
osx-64::folly-2023.08.28.00-hd4516f9_0_jemalloc.conda
osx-64::bytewax-0.17.0-py311hb29c592_2.conda
osx-64::freecad-0.21.1-py39h448b006_0.conda
osx-64::healpy-1.16.5-py39h8ab6a02_1.conda
osx-64::libadios2-2.9.1-nompi_h2390f81_100.conda
osx-64::healpy-1.16.5-py38h0d1a2e4_0.conda
osx-64::libgdal-arrow-parquet-3.6.4-h0f29829_12.conda
osx-64::pyreadstat-1.2.3-py38h63e6892_0.conda
osx-64::libadios2-2.9.1-mpi_openmpi_h9a8c886_2.conda
osx-64::freecad-0.21.0-py38hef7ffa1_1.conda
osx-64::bytewax-0.17.0-py39h06921b3_6.conda
osx-64::libarrow-12.0.1-hc06ff4a_8_cpu.conda
osx-64::vtk-base-9.2.6-qt_py311h1234567_212.conda
osx-64::folly-2023.08.14.00-hc30067e_3_jemalloc.conda
osx-64::gtk4-4.12.1-h13880ce_0.conda
osx-64::mc-4.8.30-h1a85d7f_0.conda
osx-64::libnetcdf-4.9.2-mpi_mpich_hfa5f96c_10.conda
osx-64::openpmd-api-0.15.1-mpi_mpich_py38ha8e9ee7_5.conda
osx-64::arrow-cpp-9.0.0-py39h3613453_45_cpu.conda
osx-64::bytewax-0.17.0-py310he76948c_2.conda
osx-64::postgresql-plpython-15.4-py39hfacc66a_0.conda
osx-64::libgdal-arrow-parquet-3.7.1-hfcc3c3b_9.conda
osx-64::openpmd-api-0.15.2-mpi_mpich_py39h0059607_0.conda
osx-64::arrow-cpp-9.0.0-py38h67a051d_45_cpu.conda
osx-64::healpy-1.16.5-py38hbfc9f6a_1.conda
osx-64::openpmd-api-0.15.1-mpi_mpich_py39h560c507_6.conda
osx-64::libmatio-1.5.23-hc9e5701_4.conda
osx-64::libnetcdf-4.9.2-mpi_mpich_h7b431e5_11.conda
osx-64::healpy-1.16.5-py310hc3d2c8d_0.conda
osx-64::libarrow-12.0.1-ha268fe5_9_cpu.conda
osx-64::ffmpeg-6.0.0-lgpl_hb92b4b1_4.conda
osx-64::vigra-1.11.1-py38h6461663_1046.conda
osx-64::openpmd-api-0.15.1-nompi_py39h5c3be65_105.conda
osx-64::ifcopenshell-v0.7.0a10-py39h57b1684_0.conda
osx-64::libgdal-3.6.4-hf3eeb18_15.conda
osx-64::conduit-0.8.8-py39h856c047_2.conda
osx-64::bytewax-0.17.0-py39h06921b3_5.conda
osx-64::llvmdev-16.0.6-he4b1e75_2.conda
osx-64::grpcio-1.57.0-py39h341a990_1.conda
osx-64::r-git2r-0.31.0-r43h75b6a36_2.conda
osx-64::ifcopenshell-v0.7.0a10-py39h669e0ef_0.conda
osx-64::ifcopenshell-v0.7.0a9-py311h5135b92_1.conda
osx-64::heyoka-llvm-15-0.21.0-h13f49d6_1.conda
osx-64::hdf5-1.14.2-mpi_mpich_h3618df7_0.conda
osx-64::healpy-1.16.5-py38haf16294_1.conda
osx-64::openpmd-api-0.15.1-nompi_py311h1bebd28_106.conda
osx-64::openpmd-api-0.15.2-nompi_py311h1bebd28_100.conda
osx-64::libadios2-2.9.1-mpi_mpich_hc6ea672_2.conda
osx-64::libadios2-2.9.1-nompi_haf444e8_102.conda
osx-64::libnetcdf-4.9.2-nompi_h7854af7_110.conda
osx-64::heyoka-llvm-13-1.0.0-h88ced87_0.conda
osx-64::libopencv-4.8.0-py310h97e9c00_1.conda
osx-64::openpmd-api-0.15.1-mpi_openmpi_py38h48725d4_5.conda
osx-64::vigra-1.11.1-py39hca6785f_1046.conda
osx-64::postgresql-plpython-15.4-py311hbf368a9_0.conda
osx-64::pygame-2.5.1-py39h6ccb3b9_0.conda
osx-64::pyreadr-0.4.9-py310hfbd5ada_0.conda
osx-64::netcdf4-1.6.4-mpi_mpich_py310h6fcf279_2.conda
osx-64::ifcopenshell-v0.7.0a9-py310h11c943f_0.conda
osx-64::libarrow-11.0.0-hc06ff4a_33_cpu.conda
osx-64::pdal-2.5.6-h63992ea_1.conda
osx-64::libarrow-10.0.1-h5d54e21_37_cpu.conda
osx-64::vowpalwabbit-9.8.0-py38hf0e47d3_1.conda
osx-64::tiledb-2.16.2-h9b026fb_0.conda
osx-64::omniorb-4.3.1-py38h73e9ec3_0.conda
osx-64::scip-8.0.4-h1b39fdf_0.conda
osx-64::ifcopenshell-v0.7.0a9-py311hf939a2e_1.conda
osx-64::openpmd-api-0.15.1-mpi_mpich_py310h8cfb0ac_5.conda
osx-64::libvips-8.14.4-hbb586ce_0.conda
osx-64::lammps-2023.08.02-cpu_py311_hb61bd1e_mpich_0.conda
osx-64::imagecodecs-2023.8.12-py39h49f9d18_0.conda
osx-64::tiledb-2.16.3-h24ec535_1.conda
osx-64::vowpalwabbit-9.9.0-py311hee4d84b_0.conda
osx-64::heyoka-0.21.0-hc2ef373_1.conda
osx-64::openpmd-api-0.15.2-mpi_openmpi_py311h4dcf810_0.conda
osx-64::openpmd-api-0.15.2-mpi_mpich_py38h0b6004f_0.conda
osx-64::kaldi-5.5.1068-cpu_h0f3c836_2.conda
osx-64::libxml2-2.11.5-hd95e348_0.conda
osx-64::r-harp-1.19-r43h171fc49_1.conda
osx-64::folly-2023.08.14.00-h0d9798a_2.conda
osx-64::ticcutils-0.32-hf45976f_3.conda
osx-64::libtiff-4.5.1-hf955e92_1.conda
osx-64::libgdal-arrow-parquet-3.6.4-hfb4b679_11.conda
osx-64::vigra-1.11.1-py38h85816e2_1046.conda
osx-64::ifcopenshell-v0.7.0a9-py38hb8c8317_0.conda
osx-64::llvm-16.0.6-h9c2cb20_2.conda
osx-64::openpmd-api-0.15.1-mpi_openmpi_py38h56fcb61_5.conda
osx-64::pyreadr-0.4.9-py311h3108c81_0.conda
osx-64::magics-metview-batch-4.14.2-hd43c1be_0.conda
osx-64::vtk-base-9.2.6-qt_py310h1234567_211.conda
osx-64::pdal-2.5.6-h028e6de_0.conda
osx-64::triqs-3.1.1-py39h61a7ba7_7.conda
osx-64::harp-1.19-py38h47b5f58_1.conda
osx-64::lammps-2023.08.02-cpu_py38_h40ed01f_openmpi_0.conda
osx-64::ifcopenshell-v0.7.0a9-py39hc59f9c5_0.conda
osx-64::bytewax-0.17.0-py38h51ad8f1_2.conda
osx-64::ifcopenshell-v0.7.0a9-py39h57b1684_1.conda
osx-64::heyoka-1.0.0-hc78e3bf_0.conda
osx-64::openpmd-api-0.15.1-nompi_py38h4e1ee44_106.conda
osx-64::folly-2023.08.14.00-hc30067e_1_jemalloc.conda
osx-64::bytewax-0.17.0-py38h51ad8f1_5.conda
osx-64::folly-2023.08.14.00-h8318d5c_3.conda
osx-64::folly-2023.08.14.00-h1718691_2.conda
osx-64::nginx-1.25.2-h8970da8_0.conda
osx-64::ifcopenshell-v0.7.0a10-py310h7ca8742_0.conda
osx-64::tiledb-2.16.2-h0f7503a_0.conda
osx-64::poppler-23.08.0-he041c3a_0.conda
osx-64::nest-simulator-3.5-py310hc17d38f_2.conda
osx-64::grpcio-1.57.0-py310h0d4bf3c_1.conda
osx-64::folly-2023.08.14.00-h1718691_1.conda
osx-64::nest-simulator-3.5-py311h13f248f_2.conda
osx-64::nodejs-20.1.0-h46e3395_0.conda
osx-64::arrow-cpp-9.0.0-py38h113f735_46_cpu.conda
osx-64::pyreadr-0.4.9-py38h024e269_0.conda
osx-64::openpmd-api-0.15.2-mpi_openmpi_py310h615e0a0_0.conda
osx-64::libarrow-12.0.1-h64fc635_8_cpu.conda
osx-64::cmake-3.27.4-hf40c264_3.conda
osx-64::ifcopenshell-v0.7.0a9-py310h9368bc5_0.conda
osx-64::harp-1.19-py310h45971e9_1.conda
osx-64::heyoka-1.0.0-hf7afb35_0.conda
osx-64::ifcopenshell-v0.7.0a9-py311hba6a9df_0.conda
osx-64::libgdal-arrow-parquet-3.6.4-hbc892a1_15.conda
osx-64::cmake-3.27.4-hf40c264_0.conda
osx-64::vowpalwabbit-9.8.0-py310h6c2355c_1.conda
osx-64::healpy-1.16.5-py39ha7e7bd5_0.conda
osx-64::openpmd-api-0.15.1-mpi_openmpi_py39h6ddb3b2_5.conda
osx-64::bytewax-0.17.0-py310he76948c_5.conda
osx-64::folly-2023.08.07.00-h503270f_0_jemalloc.conda
osx-64::folly-2023.08.14.00-h0d9798a_3.conda
osx-64::openpmd-api-0.15.1-mpi_mpich_py39h7858bce_5.conda
osx-64::ifcopenshell-v0.7.0a9-py311hf939a2e_0.conda
osx-64::folly-2023.08.14.00-h0d9798a_0.conda
osx-64::libarrow-11.0.0-ha268fe5_34_cpu.conda
osx-64::aws-sdk-cpp-1.11.68-hcbc40b4_13.conda
osx-64::arrow-cpp-9.0.0-py38h012a744_45_cpu.conda
osx-64::omniorb-libs-4.3.1-h9bc8c17_0.conda
osx-64::r-harp-1.19-r43h4044976_1.conda
osx-64::mupdf-1.22.2-h1005354_1.conda
osx-64::conduit-0.8.8-py38h2c8d239_2.conda
osx-64::healpy-1.16.5-py311hec0b1b0_0.conda
osx-64::libnetcdf-4.9.2-nompi_h6a32802_111.conda
osx-64::triqs-3.1.1-py311h3ee9e43_6.conda
osx-64::lammps-2023.08.02-cpu_py39_h3431d70_mpich_0.conda
osx-64::ndcctools-7.6.2-py39hd4b95d6_0.conda
osx-64::libadios2-2.9.1-nompi_h0ec5f4d_100.conda
osx-64::heyoka-0.21.0-hca3e132_1.conda
osx-64::pygame-2.5.1-py38h721016a_0.conda
osx-64::openpmd-api-0.15.1-nompi_py38hee9c613_106.conda
osx-64::verilator-5.014-he7f2693_0.conda
osx-64::libgdal-3.7.1-h8723647_5.conda
osx-64::arrow-cpp-9.0.0-py39h358c645_46_cpu.conda
osx-64::libgdal-3.6.4-h347ecc8_12.conda
osx-64::ovito-3.9.0-h7694c12_0.conda
osx-64::heyoka-1.0.0-hc2ef373_0.conda
osx-64::ovito-3.9.1-h7694c12_0.conda
osx-64::omniorb-4.3.1-py39ha0f51ee_0.conda
osx-64::coda-2.24.2-py310hcb92ca7_3.conda
osx-64::heyoka-llvm-14-0.21.0-hfda5ef7_1.conda
osx-64::libadios2-2.9.1-mpi_openmpi_ha0ee66a_2.conda
osx-64::triqs-3.1.1-py38hd329b4f_6.conda
osx-64::netcdf4-1.6.4-nompi_py310h5076b6f_102.conda
osx-64::ifcopenshell-v0.7.0a9-py310h7ca8742_0.conda
osx-64::triqs-3.1.1-py38hd329b4f_7.conda
osx-64::mold-2.1.0-hc277f81_1.conda
osx-64::libarrow-13.0.0-ha268fe5_0_cpu.conda
osx-64::folly-2023.08.14.00-h0d9798a_1.conda
osx-64::libgdal-arrow-parquet-3.7.1-h737a4c0_5.conda
osx-64::libgdal-3.7.1-h7e17b98_7.conda
osx-64::libgdal-3.7.1-h4103fcf_6.conda
osx-64::heyoka-llvm-12-0.21.0-hab63cc6_1.conda
osx-64::openmeeg-2.5.6-py38h80f3bf7_2.conda
osx-64::uproc-1.2.0-h9fdd385_0.conda
osx-64::ifcopenshell-v0.7.0a9-py38h718c106_1.conda
osx-64::mandrake-1.2.2-py39habf0293_3.conda
osx-64::folly-2023.08.28.00-hc30067e_0_jemalloc.conda
osx-64::libadios2-2.9.1-nompi_h4b5bc4d_101.conda
osx-64::folly-2023.08.07.00-h0d9798a_0.conda
osx-64::folly-2023.08.07.00-h0d9798a_1.conda
osx-64::libscotch-7.0.4-hc2ac6e5_0.conda
osx-64::vowpalwabbit-9.9.0-py39h1317971_0.conda
osx-64::libtiledb-sql-0.23.2-h8fa5f5e_0.conda
osx-64::ndcctools-7.6.2-py38h0a8965a_0.conda
osx-64::boost-cpp-1.78.0-h2f2b2fd_4.conda
osx-64::ndcctools-7.6.2-py310h442c573_0.conda
osx-64::emacs-28.2-hff79ea8_4.conda
osx-64::polycap-1.2-py310hfa47721_3.conda
osx-64::openpmd-api-0.15.1-mpi_mpich_py39h2c57403_6.conda
osx-64::vowpalwabbit-9.9.0-py38hf0e47d3_0.conda
osx-64::tectonic-0.14.1-hc9db393_1.conda
osx-64::folly-2023.08.14.00-h503270f_2_jemalloc.conda
osx-64::openmeeg-2.5.6-py311h02aa052_2.conda
osx-64::openpmd-api-0.15.2-nompi_py39hdb1e797_100.conda
osx-64::freecad-0.21.0-py310h925a245_1.conda
osx-64::yosys-0.32-py311h0b92e34_0.conda
osx-64::heyoka-llvm-15-1.0.0-h13f49d6_0.conda
osx-64::folly-2023.08.14.00-h503270f_0_jemalloc.conda
osx-64::freecad-0.21.1-py310h925a245_0.conda
osx-64::openpmd-api-0.15.2-mpi_mpich_py311ha827424_0.conda
osx-64::arrow-cpp-9.0.0-py311hc8210ad_46_cpu.conda
osx-64::triqs-3.1.1-py39h56f4216_6.conda
osx-64::libarrow-10.0.1-hc520aa6_38_cpu.conda
osx-64::imagecodecs-2023.8.12-py311hbb940b5_0.conda
osx-64::openpmd-api-0.15.2-nompi_py38h50e9de7_100.conda
osx-64::healpy-1.16.5-py38hc7d2167_0.conda
osx-64::netcdf4-1.6.4-mpi_openmpi_py38hf6fe9ce_2.conda
osx-64::openpmd-api-0.15.1-mpi_openmpi_py311h9bccdf8_5.conda
osx-64::folly-2023.08.14.00-h86ef9d2_2_jemalloc.conda
osx-64::vtk-base-9.2.6-qt_py38h1234567_212.conda
osx-64::openpmd-api-0.15.2-mpi_openmpi_py39h44e7063_0.conda
osx-64::libopencv-4.8.0-py38ha6b9731_1.conda
osx-64::libarrow-10.0.1-hd1db5d5_37_cpu.conda
osx-64::gtk4-4.12.1-h1aa30d0_1.conda
osx-64::r-harp-1.19-r43hfd928af_1.conda
osx-64::cmake-3.27.4-hf40c264_1.conda
osx-64::openpmd-api-0.15.1-nompi_py38h9973a1a_105.conda
osx-64::aws-sdk-cpp-1.10.57-h3f79503_20.conda
osx-64::openpmd-api-0.15.1-mpi_mpich_py39he57dfb9_5.conda
osx-64::folly-2023.03.20.00-h68897ac_5_jemalloc.conda
osx-64::folly-2023.08.28.00-h0d9798a_0.conda
osx-64::yosys-0.32-h3b9ae2c_1.conda
osx-64::ifcopenshell-v0.7.0a10-py39ha8b2133_0.conda
osx-64::libadios2-2.9.1-mpi_mpich_h032ee77_0.conda
osx-64::libopencv-4.8.0-py39h670ad4f_1.conda
osx-64::vigra-1.11.1-py311h725738f_1046.conda
osx-64::healpy-1.16.5-py39h946ad86_1.conda
osx-64::harp-1.19-py39hee6e04e_1.conda
osx-64::libgd-2.3.3-heb3472c_7.conda
osx-64::wasmer-4.1.2-ha6357cd_0.conda
osx-64::libgrpc-1.54.3-hfaa49da_0.conda
osx-64::ifcopenshell-v0.7.0a10-py38h718c106_0.conda
osx-64::openmeeg-2.5.6-py39h608e745_2.conda
osx-64::nodejs-20.5.1-h46e3395_0.conda
osx-64::ndcctools-7.6.2-py311h54575cd_0.conda
osx-64::openpmd-api-0.15.1-nompi_py39h35ff7e0_106.conda
osx-64::triqs-3.1.1-py39h56f4216_7.conda
osx-64::lammps-2023.08.02-cpu_py38_h69e58df_mpich_0.conda
osx-64::libtiledb-sql-0.24.0-h8fa5f5e_0.conda
osx-64::indexed_gzip-1.8.5-py38h9cd843b_0.conda
osx-64::grpcio-1.57.0-py311h43071ad_0.conda
osx-64::arrow-cpp-9.0.0-py310hf644e00_45_cpu.conda
osx-64::vigra-1.11.1-py38h08025a0_1046.conda
osx-64::libgdal-arrow-parquet-3.7.1-h2c2813a_7.conda
osx-64::ifcopenshell-v0.7.0a9-py39ha8b2133_1.conda
osx-64::yarp-cxx-3.8.1-h6143d09_4.conda
osx-64::conduit-0.8.8-py310h839e5d7_2.conda
osx-64::openpmd-api-0.15.2-mpi_openmpi_py39hddd0135_0.conda
osx-64::ifcopenshell-v0.7.0a9-py38hbf891d7_0.conda
osx-64::cmake-3.27.4-hf40c264_4.conda
osx-64::paraview-5.11.1-py38h5707d4e_102_qt.conda
osx-64::folly-2023.08.14.00-h503270f_3_jemalloc.conda
osx-64::libgdal-arrow-parquet-3.6.4-h8475799_13.conda
osx-64::nexus-4.4.3-hfeb94c6_11.conda
osx-64::libadios2-2.9.1-mpi_mpich_h71aa227_2.conda
osx-64::gmt-6.4.0-hb761bfb_15.conda
osx-64::hdf5-1.14.2-nompi_hedada53_100.conda
osx-64::bytewax-0.17.0-py311hb29c592_6.conda
osx-64::heyoka-1.0.0-hca3e132_0.conda
osx-64::healpy-1.16.5-py311h688fd2b_1.conda
osx-64::pypy3.9-7.3.12-hc0e9917_3.conda
osx-64::libadios2-2.9.1-nompi_h23cc82d_100.conda
osx-64::hdf5-1.14.2-mpi_openmpi_h01be5f8_0.conda
osx-64::folly-2023.03.20.00-h21a4eb5_5.conda
osx-64::nest-simulator-3.5-py38h5d6ae11_2.conda
osx-64::bytewax-0.17.0-py311hb29c592_5.conda
osx-64::coda-2.24.2-py38h4485038_3.conda
osx-64::heyoka-llvm-13-0.21.0-h88ced87_1.conda
osx-64::folly-2023.03.20.00-h503270f_5_jemalloc.conda
osx-64::triqs-3.1.1-py39h61a7ba7_6.conda
osx-64::libadios2-2.9.1-nompi_he345479_101.conda
osx-64::libadios2-2.9.1-mpi_mpich_hd4a5e7b_2.conda
osx-64::openpmd-api-0.15.1-mpi_openmpi_py38h16c4b22_6.conda
osx-64::openpmd-api-0.15.1-mpi_openmpi_py311h4dcf810_6.conda
osx-64::postgresql-15.4-hc940a54_0.conda
osx-64::libadios2-2.9.1-mpi_mpich_h41c2e91_1.conda
osx-64::coda-2.24.2-py38hfd928af_3.conda
osx-64::triqs-3.1.1-py310h199346d_6.conda
osx-64::folly-2023.08.28.00-h503270f_0_jemalloc.conda
osx-64::python-3.11.5-h30d4d87_0_cpython.conda
osx-64::aws-sdk-cpp-1.11.68-h3f79503_12.conda
osx-64::openpmd-api-0.15.1-mpi_mpich_py310h3e4a23e_6.conda
osx-64::libadios2-2.9.1-mpi_openmpi_h424a5b2_0.conda
osx-64::wasmer-4.1.1-ha6357cd_0.conda
osx-64::postgresql-plpython-15.4-py38h9f95ba2_0.conda
osx-64::chemicalite-2022.04.1-h9b1e4e7_11.conda
osx-64::heyoka-llvm-12-1.0.0-hab63cc6_0.conda
osx-64::libgit2-1.7.1-h94d3247_0.conda
osx-64::harp-1.19-py38hcd854c7_1.conda
osx-64::freecad-0.21.1-py38hef7ffa1_0.conda
osx-64::sqlite-3.43.0-h2b0dec6_0.conda
osx-64::lammps-2023.08.02-cpu_py39_h4b01163_openmpi_0.conda
osx-64::tectonic-0.14.1-hc1a919e_2.conda
osx-64::indexed_gzip-1.8.5-py39h4172078_0.conda
osx-64::netcdf4-1.6.4-mpi_openmpi_py39hdb87dbe_2.conda
osx-64::libopentelemetry-cpp-1.11.0-hb55cd83_0.conda
osx-64::soplex-6.0.4-h478c754_0.conda
osx-64::openpmd-api-0.15.1-mpi_mpich_py38h1f3be37_6.conda
osx-64::libitk-5.3.0-hb0c863f_5.conda
osx-64::coda-2.24.2-py39hc321bfd_3.conda
osx-64::pyreadstat-1.2.3-py39h29f4f0d_0.conda
osx-64::capnproto-1.0.1-h268317e_0.conda
osx-64::libnetcdf-4.9.2-mpi_openmpi_he189ced_11.conda
osx-64::libgdal-3.6.4-h12bd886_13.conda
osx-64::pp-sketchlib-2.1.1-py311h07bd319_2.conda
osx-64::libadios2-2.9.1-mpi_mpich_h41c2e91_0.conda
osx-64::arrow-cpp-9.0.0-py311h465228e_45_cpu.conda
osx-64::ncview-2.1.8-h70402de_9.conda
osx-64::heyoka-0.21.0-hc78e3bf_1.conda
osx-64::ifcopenshell-v0.7.0a9-py311h5135b92_0.conda
osx-64::conduit-0.8.8-py310h4e972f0_2.conda
osx-64::nodejs-20.5.1-h119ffd7_1.conda
osx-64::vigra-1.11.1-py310hf6e9866_1046.conda
osx-64::openmeeg-2.5.6-py39hfbdf901_2.conda
osx-64::vtk-base-9.2.6-qt_py39h1234567_211.conda
osx-64::pyreadstat-1.2.3-py311hbab40d1_0.conda
osx-64::ifcopenshell-v0.7.0a9-py310h3e3cdc0_1.conda
osx-64::openpmd-api-0.15.1-nompi_py310h3813170_106.conda
osx-64::ifcopenshell-v0.7.0a9-py38h718c106_0.conda
osx-64::aws-sdk-cpp-1.10.57-h3ff9d30_19.conda
osx-64::grpcio-1.56.2-py39h341a990_1.conda
osx-64::folly-2023.03.20.00-hc30067e_5_jemalloc.conda
osx-64::lammps-2023.08.02-cpu_py311_h38df71f_openmpi_0.conda
osx-64::poppler-qt-23.08.0-h9c7cc81_0.conda
osx-64::libadios2-2.9.1-mpi_mpich_hfd99440_1.conda
osx-64::openpmd-api-0.15.2-nompi_py310h401ef01_100.conda
osx-64::aws-sdk-cpp-1.11.68-h3f720bc_10.conda
osx-64::pygame-2.5.1-py39h91db508_0.conda
osx-64::vigra-1.11.1-py39h2d59051_1046.conda
osx-64::folly-2023.08.07.00-h1718691_0.conda
osx-64::triqs-3.1.1-py311h409dd4b_7.conda
osx-64::r-base-4.2.3-h82ff930_7.conda
osx-64::gmt-6.4.0-h9716759_14.conda
osx-64::grpcio-1.56.2-py310h0d4bf3c_1.conda
osx-64::conduit-0.8.8-py39h50da28c_2.conda
osx-64::bytewax-0.17.0-py39h06921b3_2.conda
osx-64::folly-2023.08.28.00-h1718691_0.conda
osx-64::vowpalwabbit-9.8.0-py311hee4d84b_1.conda
osx-64::lammps-2023.08.02-cpu_py38_ha83d5b2_mpich_0.conda
osx-64::ifcopenshell-v0.7.0a9-py39ha8b2133_0.conda
osx-64::healpy-1.16.5-py39h3dd4897_0.conda
osx-64::grpcio-1.56.2-py38h4864539_1.conda
osx-64::grpcio-1.57.0-py38h4864539_1.conda
osx-64::libadios2-2.9.1-mpi_openmpi_h0c4e814_0.conda
osx-64::paraview-5.11.1-py311hf143640_102_qt.conda
osx-64::libvips-8.14.3-hbb586ce_2.conda
osx-64::libadios2-2.9.1-mpi_mpich_h15e7941_1.conda
osx-64::triqs-3.1.1-py311h409dd4b_6.conda
osx-64::yosys-0.32-py311h237345f_0.conda
osx-64::yosys-0.31-py311h0b92e34_0.conda
osx-64::vtk-base-9.2.6-qt_py310h1234567_212.conda
osx-64::aws-sdk-cpp-1.10.57-hcbc40b4_21.conda
osx-64::libpq-15.4-h3df487d_0.conda
osx-64::indexed_gzip-1.8.5-py310h996c4c5_0.conda
osx-64::libitk-5.3.0-h2da696e_6.conda
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
================================================================================
================================================================================
linux-64
linux-64::openexr-3.1.10-h3f0fd8d_0.conda
linux-64::libass-0.17.1-h8fe9dca_1.conda
linux-64::libsolv-static-0.7.24-hfc55251_3.conda
linux-64::spidermonkey-91.13.0-hc5889f1_2.conda
linux-64::zimpl-3.5.3-h4c00192_0.conda
linux-64::libprotobuf-static-4.23.4-hf27288f_3.conda
linux-64::libsqlite-3.43.0-h2797004_0.conda
linux-64::libprotobuf-static-4.23.4-hd1fb520_1.conda
linux-64::libprotobuf-static-3.21.12-hfc55251_2.conda
linux-64::libprotobuf-static-3.21.12-hfc55251_1.conda
linux-64::libprotobuf-4.23.4-hf27288f_3.conda
linux-64::libprotobuf-3.21.12-hfc55251_2.conda
linux-64::cudnn-8.8.0.121-h838ba91_2.conda
linux-64::libprotobuf-static-4.23.4-hf27288f_4.conda
linux-64::reprimand-1.5.1-h291b3b5_0.conda
linux-64::micromamba-1.5.0-0.tar.bz2
linux-64::libsolv-0.7.24-hfc55251_3.conda
linux-64::libcdms-3.1.2-h4fff3a0_127.conda
linux-64::micromamba-1.5.0-1.tar.bz2
linux-64::libprotobuf-4.23.4-hf27288f_2.conda
linux-64::adios-1.13.1-nompi_h2d609e3_1123.conda
linux-64::libprotobuf-4.23.4-hd1fb520_1.conda
linux-64::reprimand-1.5.1-h4a0f344_1.conda
linux-64::stress-ng-0.16.04-h2797004_0.conda
linux-64::libprotobuf-3.21.12-hfc55251_1.conda
linux-64::zstd-1.5.5-hfc55251_0.conda
linux-64::openexr-3.1.11-h3f0fd8d_0.conda
linux-64::libprotobuf-4.23.4-hf27288f_4.conda
linux-64::libv8-8.9.83-ha8e4f12_4.conda
linux-64::cudnn-8.8.0.121-h264754d_2.conda
linux-64::spidermonkey-bin-91.13.0-hae9bfaf_2.conda
linux-64::openexr-3.2.0-h3f0fd8d_0.conda
linux-64::eccodes-2.31.0-h35c6de3_1.conda
linux-64::libprotobuf-static-4.23.4-hf27288f_2.conda
-    "libzlib >=1.2.13,<1.3.0a0"
+    "libzlib >=1.2.13,<2.0.0a0"
linux-64::libgrpc-1.56.2-h3905398_1.conda
linux-64::llvm-tools-16.0.6-h5cf9203_2.conda
linux-64::conduit-0.8.8-py39h02bd6d6_2.conda
linux-64::postgresql-plpython-15.4-py310hd093153_0.conda
linux-64::hdfeos5-5.1.16-hf1a501a_15.conda
linux-64::libgdal-3.7.1-h3d2b3c2_7.conda
linux-64::ifcopenshell-v0.7.0a9-py38h27d5b0a_0.conda
linux-64::heyoka-llvm-15-0.21.0-he0ec72f_1.conda
linux-64::libopencv-4.8.0-py311h3563e6c_1.conda
linux-64::vtk-base-9.2.6-osmesa_py311h1234567_112.conda
linux-64::vigra-1.11.1-py38hb49ee25_1046.conda
linux-64::libgdal-arrow-parquet-3.7.1-hbbc09af_8.conda
linux-64::folly-2023.08.07.00-he8e2169_1_jemalloc.conda
linux-64::arrow-cpp-9.0.0-py39h6657d4b_45_cpu.conda
linux-64::pyreadstat-1.2.3-py38h502143a_0.conda
linux-64::libitk-5.3.0-h752f22c_5.conda
linux-64::dotnet-runtime-6.0.20-hfbc8c6f_0.conda
linux-64::libadios2-2.9.1-mpi_mpich_h806a3d7_0.conda
linux-64::triqs-3.1.1-py310h30ed552_6.conda
linux-64::tiledb-2.16.2-h6041edc_0.conda
linux-64::libarrow-11.0.0-hb87d912_33_cpu.conda
linux-64::folly-2023.08.14.00-h09ac5fe_3.conda
linux-64::squashfuse-0.4.0-hdfefc0d_0.conda
linux-64::netcdf4-1.6.4-nompi_py39h4282601_102.conda
linux-64::llvm-16.0.6-ha0738ec_2.conda
linux-64::healpy-1.16.5-py38ha49e404_0.conda
linux-64::pygame-2.5.1-py39h4244053_0.conda
linux-64::grpcio-1.57.0-py311ha6695c7_0.conda
linux-64::conduit-0.8.8-py39h1c3a72c_2.conda
linux-64::freecad-0.21.1-py311h71ce39b_0.conda
linux-64::harp-1.19-py310hae178fe_1.conda
linux-64::paraview-5.11.1-py310h5f6a85a_102_qt.conda
linux-64::aws-sdk-cpp-1.11.68-h6f6b8fa_13.conda
linux-64::folly-2023.08.14.00-he067f64_2_jemalloc.conda
linux-64::heyoka-llvm-11-0.21.0-hcd51939_1.conda
linux-64::openmeeg-2.5.6-py38h0e64206_2.conda
linux-64::healpy-1.16.5-py311hc06c28d_0.conda
linux-64::ifcopenshell-v0.7.0a10-py38h27d5b0a_0.conda
linux-64::kaldi-5.5.1068-cuda120h41cae9c_2.conda
linux-64::bytewax-0.17.0-py310hbeed47d_5.conda
linux-64::libadios2-2.9.1-mpi_openmpi_h55f04b4_0.conda
linux-64::libadios2-2.9.1-mpi_openmpi_h11a6eb6_2.conda
linux-64::arrow-cpp-9.0.0-py39h6c5a5b3_45_cuda.conda
linux-64::bytewax-0.17.0-py310hbeed47d_2.conda
linux-64::vowpalwabbit-9.9.0-py38h9fb09af_0.conda
linux-64::libgdal-arrow-parquet-3.7.1-h45b5273_5.conda
linux-64::ifcopenshell-v0.7.0a9-py310h42a5faa_0.conda
linux-64::triqs-3.1.1-py311h00d02c3_7.conda
linux-64::cmake-3.27.4-hcfe8598_1.conda
linux-64::libadios2-2.9.1-mpi_openmpi_h6c22632_1.conda
linux-64::grpcio-1.57.0-py310h1b8f574_1.conda
linux-64::libadios2-2.9.1-nompi_h52f7759_102.conda
linux-64::pp-sketchlib-2.1.1-py310h8ef7433_2.conda
linux-64::libtiledb-sql-0.23.2-hb82b279_0.conda
linux-64::libopencv-4.8.0-py38he4b2ccc_1.conda
linux-64::folly-2023.08.28.00-h80c46b9_0.conda
linux-64::tiledb-2.16.2-hf0b6e87_0.conda
linux-64::netcdf4-1.6.4-mpi_mpich_py310h1c2af58_2.conda
linux-64::libnetcdf-4.9.2-mpi_openmpi_h924110c_11.conda
linux-64::aws-sdk-cpp-1.10.57-hd831e9c_20.conda
linux-64::conduit-0.8.8-py38hbe55cc6_2.conda
linux-64::r-harp-1.19-r43h58d957e_1.conda
linux-64::openpmd-api-0.15.1-nompi_py311h2252293_106.conda
linux-64::yosys-0.32-py311he00c579_0.conda
linux-64::grpcio-1.56.2-py39h174d805_1.conda
linux-64::lammps-2023.08.02-cpu_py38_h71b0944_openmpi_0.conda
linux-64::openvdb-10.0.1-h18189cd_0.conda
linux-64::libgdal-3.6.4-hb613c87_14.conda
linux-64::pygame-2.5.1-py38hc1798b0_0.conda
linux-64::ifcopenshell-v0.7.0a10-py39h09583a3_0.conda
linux-64::imagecodecs-2023.8.12-py310hc929067_0.conda
linux-64::folly-2023.08.07.00-h80c46b9_1.conda
linux-64::pypy3.8-7.3.11-hc3ccb01_3.conda
linux-64::libgd-2.3.3-h74d50f4_7.conda
linux-64::r-git2r-0.31.0-r42hbae1c7c_2.conda
linux-64::arrow-cpp-9.0.0-py38h6da4a27_45_cpu.conda
linux-64::python-3.11.5-hab00c5b_0_cpython.conda
linux-64::bytewax-0.17.0-py39h82e90d1_2.conda
linux-64::r-harp-1.19-r43ha49c379_1.conda
linux-64::r-harp-1.19-r43he621bb9_1.conda
linux-64::coda-2.24.2-py39h71bbeed_3.conda
linux-64::r-harp-1.19-r43hfd4ca42_1.conda
linux-64::vtk-base-9.2.6-egl_py310h1234567_11.conda
linux-64::triqs-3.1.1-py39h3c449d4_7.conda
linux-64::arrow-cpp-9.0.0-py311hfd1feba_45_cuda.conda
linux-64::tesseract-5.3.2-h4838625_0.conda
linux-64::healpy-1.16.5-py39h87602db_1.conda
linux-64::tectonic-0.14.1-h8ffc123_1.conda
linux-64::vigra-1.11.1-py311hcba7fdc_1046.conda
linux-64::vtk-base-9.2.6-egl_py38h1234567_12.conda
linux-64::vtk-base-9.2.6-osmesa_py39h1234567_112.conda
linux-64::mold-2.1.0-h913df21_1.conda
linux-64::conduit-0.8.8-py38h105464a_2.conda
linux-64::ndcctools-7.6.2-py310he2ed3e8_0.conda
linux-64::adios-1.13.1-mpi_mpich_hf822389_1023.conda
linux-64::libgdal-arrow-parquet-3.6.4-h90ad2cd_15.conda
linux-64::openmeeg-2.5.6-py310h2aca7da_2.conda
linux-64::pp-sketchlib-2.1.1-py38h9861542_2.conda
linux-64::openpmd-api-0.15.1-mpi_openmpi_py311hb12e34b_6.conda
linux-64::ifcopenshell-v0.7.0a9-py39h09583a3_1.conda
linux-64::vowpalwabbit-9.9.0-py39h01275cd_0.conda
linux-64::fimex-1.9.6-py39h1fe5c1b_0.conda
linux-64::libspral-2023.08.02-h2baf039_0.conda
linux-64::libadios2-2.9.1-mpi_openmpi_h9d08ed3_1.conda
linux-64::boost-cpp-1.78.0-h2c5509c_4.conda
linux-64::libarrow-12.0.1-hb87d912_8_cpu.conda
linux-64::folly-2023.08.14.00-he8e2169_3_jemalloc.conda
linux-64::ifcopenshell-v0.7.0a9-py38h0804e63_1.conda
linux-64::folly-2023.08.07.00-h09ac5fe_1.conda
linux-64::ogre-1.10.12-h4e7cb37_12.conda
linux-64::ifcopenshell-v0.7.0a9-py310h5b2c44e_0.conda
linux-64::mandrake-1.2.2-py310h347102c_3.conda
linux-64::grpcio-1.57.0-py39h174d805_1.conda
linux-64::openpmd-api-0.15.2-nompi_py39h33ebdc2_100.conda
linux-64::libgdal-3.7.1-h880a63b_8.conda
linux-64::vowpalwabbit-9.8.0-py38h9fb09af_1.conda
linux-64::heyoka-llvm-13-1.0.0-h1380d4f_0.conda
linux-64::folly-2023.08.07.00-he8e2169_0_jemalloc.conda
linux-64::folly-2023.03.20.00-h5e7e832_5_jemalloc.conda
linux-64::texlive-core-20230313-h4ed7ef6_5.conda
linux-64::libxml2-2.11.5-h0d562d8_0.conda
linux-64::libarrow-12.0.1-h10ac928_8_cpu.conda
linux-64::heyoka-0.21.0-h4eadc13_1.conda
linux-64::heyoka-llvm-16-1.0.0-h2b0c814_0.conda
linux-64::libadios2-2.9.1-mpi_mpich_h86f79d2_0.conda
linux-64::libadios2-2.9.1-nompi_hdf556c1_100.conda
linux-64::libadios2-2.9.1-mpi_openmpi_h2278c24_0.conda
linux-64::vtk-base-9.2.6-egl_py39h1234567_11.conda
linux-64::ifcopenshell-v0.7.0a9-py39h09583a3_0.conda
linux-64::fimex-1.9.6-py310h653b8f6_0.conda
linux-64::grpcio-1.57.0-py38h94a1851_1.conda
linux-64::mandrake-1.2.2-py38h9777dac_3.conda
linux-64::grpcio-1.56.2-py310h1b8f574_1.conda
linux-64::libgdal-3.6.4-hb613c87_15.conda
linux-64::paraprobe-v0.3.1-mpi_mpich_h611d6ee_5.conda
linux-64::fimex-1.9.6-py311h55e12ba_0.conda
linux-64::vowpalwabbit-9.8.0-py311hb464d54_1.conda
linux-64::libadios2-2.9.1-mpi_mpich_he561f49_1.conda
linux-64::netcdf4-1.6.4-nompi_py311he8ad708_102.conda
linux-64::paraview-5.11.1-py38h90f0a3d_102_qt.conda
linux-64::ncview-2.1.8-hdb1c94d_9.conda
linux-64::coda-2.24.2-py39h5872dc6_3.conda
linux-64::openpmd-api-0.15.1-mpi_mpich_py39h68acae5_5.conda
linux-64::aws-sdk-cpp-1.11.68-h7062fed_10.conda
linux-64::libarrow-12.0.1-hb9dc469_9_cpu.conda
linux-64::heyoka-0.21.0-h2dccf72_1.conda
linux-64::libgdal-arrow-parquet-3.7.1-hbbc09af_9.conda
linux-64::gmt-5.4.5-h00d4b64_30.conda
linux-64::paraview-5.11.1-py39h37e646b_102_qt.conda
linux-64::wasmer-4.1.2-he3b15a8_0.conda
linux-64::heyoka-llvm-14-0.21.0-h23ee361_1.conda
linux-64::libadios2-2.9.1-mpi_openmpi_hbfd91ea_0.conda
linux-64::openpmd-api-0.15.2-mpi_mpich_py38h42dc16b_0.conda
linux-64::openpmd-api-0.15.1-mpi_openmpi_py310h542fcda_5.conda
linux-64::pygame-2.5.1-py311h9818690_0.conda
linux-64::arrow-cpp-9.0.0-py311hc65593f_45_cpu.conda
linux-64::vigra-1.11.1-py311h107021c_1046.conda
linux-64::heyoka-1.0.0-h4eadc13_0.conda
linux-64::omniorb-4.3.1-py310h5d3106b_0.conda
linux-64::freecad-0.21.0-py310heb712a3_0.conda
linux-64::libtiff-4.5.1-h8b53f26_1.conda
linux-64::pyreadr-0.4.9-py39h9037f83_0.conda
linux-64::healpy-1.16.5-py310he5dbd59_0.conda
linux-64::lammps-2023.08.02-cpu_py39_h4b07ac6_openmpi_0.conda
linux-64::nodejs-16.20.2-hf52ce11_1.conda
linux-64::ifcopenshell-v0.7.0a10-py311hbe4e43f_0.conda
linux-64::git-2.42.0-pl5321h86e50cf_0.conda
linux-64::pyreadr-0.4.9-py38h34a9683_0.conda
linux-64::folly-2023.08.14.00-he8e2169_2_jemalloc.conda
linux-64::libopencv-4.8.0-py38h7b5f835_1.conda
linux-64::freecad-0.21.0-py38hc520578_0.conda
linux-64::fimex-1.9.6-py38hbf50d41_0.conda
linux-64::lammps-2023.08.02-cpu_py310_hf267ffc_mpich_0.conda
linux-64::vigra-1.11.1-py39h3477251_1046.conda
linux-64::openpmd-api-0.15.1-nompi_py310h48532be_105.conda
linux-64::openpmd-api-0.15.1-mpi_mpich_py39h96b6dcc_5.conda
linux-64::verilator-5.014-h4f9daa6_0.conda
linux-64::bytewax-0.17.0-py310hbeed47d_6.conda
linux-64::heyoka-0.21.0-hb4d7844_1.conda
linux-64::paraview-5.11.1-py311hbb8d8bf_2_egl.conda
linux-64::libopencv-4.8.0-py310h4a3e0cf_1.conda
linux-64::folly-2023.08.14.00-h09ac5fe_2.conda
linux-64::h5utils-1.13.2-mpi_mpich_h0b2737e_1002.conda
linux-64::paraview-5.11.1-py38hb3ac32d_2_egl.conda
linux-64::pp-sketchlib-2.1.1-py311hca817cb_2.conda
linux-64::hdf5-1.14.2-nompi_h4f84152_100.conda
linux-64::coda-2.24.2-py311ha49c379_3.conda
linux-64::bytewax-0.17.0-py311he5c60f7_5.conda
linux-64::vtk-base-9.2.6-osmesa_py38h1234567_112.conda
linux-64::nest-simulator-3.5-py38h60c4312_2.conda
linux-64::vtk-base-9.2.6-egl_py310h1234567_12.conda
linux-64::libgdal-arrow-parquet-3.6.4-h90ad2cd_14.conda
linux-64::folly-2023.08.28.00-h55f0c17_0.conda
linux-64::postgresql-plpython-15.4-py311hf60bfc6_0.conda
linux-64::openpmd-api-0.15.2-nompi_py39hb5de715_100.conda
linux-64::grpcio-1.57.0-py311ha6695c7_1.conda
linux-64::libnetcdf-4.9.2-mpi_openmpi_h474790c_10.conda
linux-64::libadios2-2.9.1-mpi_openmpi_h4c4a84b_2.conda
linux-64::libxmlsec1-1.3.1-hbd49946_1.conda
linux-64::folly-2023.03.20.00-h80c46b9_5.conda
linux-64::nss-3.92-h1d7d5a4_0.conda
linux-64::folly-2023.08.14.00-h80c46b9_3.conda
linux-64::mandrake-1.2.2-py311h8d25daf_3.conda
linux-64::triqs-3.1.1-py311h6b9694e_7.conda
linux-64::cmake-3.27.4-hcfe8598_0.conda
linux-64::nginx-1.25.2-he2eb08b_0.conda
linux-64::pypy3.9-7.3.12-h9557127_2.conda
linux-64::conduit-0.8.8-py310h879695e_2.conda
linux-64::libopentelemetry-cpp-1.11.0-h9f3eacc_0.conda
linux-64::openpmd-api-0.15.1-mpi_openmpi_py38h47b8cef_6.conda
linux-64::vtk-base-9.2.6-qt_py39h1234567_211.conda
linux-64::folly-2023.08.14.00-h80c46b9_2.conda
linux-64::aws-sdk-cpp-1.11.68-h85b1a90_11.conda
linux-64::indexed_gzip-1.8.5-py39h0fd56e7_0.conda
linux-64::pp-sketchlib-2.1.1-py38h1eec743_2.conda
linux-64::healpy-1.16.5-py311h14766d7_1.conda
linux-64::netcdf4-1.6.4-nompi_py310hba70d50_102.conda
linux-64::openpmd-api-0.15.2-mpi_mpich_py310hdf0294a_0.conda
linux-64::mandrake-1.2.2-py39h8209192_3.conda
linux-64::arrow-cpp-9.0.0-py310h76a1bbb_45_cpu.conda
linux-64::heyoka-1.0.0-ha232a6f_0.conda
linux-64::r-git2r-0.31.0-r43hbae1c7c_2.conda
linux-64::ifcopenshell-v0.7.0a9-py310h5b2c44e_1.conda
linux-64::wasmer-4.1.1-he3b15a8_0.conda
linux-64::tiledb-2.16.2-h84d19f0_0.conda
linux-64::ifcopenshell-v0.7.0a10-py310h5b2c44e_0.conda
linux-64::libadios2-2.9.1-nompi_hd4a9029_102.conda
linux-64::coda-2.24.2-py310hfd4ca42_3.conda
linux-64::pyreadstat-1.2.3-py310h93c3562_0.conda
linux-64::openpmd-api-0.15.2-mpi_openmpi_py39h8eded31_0.conda
linux-64::libadios2-2.9.1-mpi_mpich_h741444d_2.conda
linux-64::paraview-5.11.1-py39he783ffe_2_egl.conda
linux-64::gtk4-4.12.1-ha5c96b3_1.conda
linux-64::dotnet-aspnetcore-7.0.10-hb8a3ed7_0.conda
linux-64::netcdf4-1.6.4-mpi_mpich_py38h8af1877_2.conda
linux-64::pyreadstat-1.2.3-py39hb6545a3_0.conda
linux-64::netcdf4-1.6.4-mpi_mpich_py39h6de3821_2.conda
linux-64::openpmd-api-0.15.1-nompi_py38h13d01f4_106.conda
linux-64::ifcopenshell-v0.7.0a10-py311h79fa3ea_0.conda
linux-64::openmeeg-2.5.6-py39h2c314b4_2.conda
linux-64::r-base-4.2.3-hbfee4d0_7.conda
linux-64::arrow-cpp-9.0.0-py39h07a8f68_45_cuda.conda
linux-64::chemicalite-2022.04.1-h5ced5f6_11.conda
linux-64::openpmd-api-0.15.2-mpi_openmpi_py311hb12e34b_0.conda
linux-64::cmake-3.27.4-hcfe8598_2.conda
linux-64::conduit-0.8.8-py39h2ff8c71_2.conda
linux-64::yarp-cxx-3.8.1-h264dbdb_4.conda
linux-64::libvips-8.14.4-hb433468_0.conda
linux-64::libadios2-2.9.1-nompi_h221b914_101.conda
linux-64::pp-sketchlib-2.1.1-py39h8fe022a_2.conda
linux-64::cargo-patch-0.3.2-h8079fbb_0.conda
linux-64::vigra-1.11.1-py39hdd16458_1046.conda
linux-64::ogre-1.10.12-h3683af6_11.conda
linux-64::vtk-base-9.2.6-qt_py39h1234567_212.conda
linux-64::folly-2023.03.20.00-hf69079e_5.conda
linux-64::vtk-base-9.2.6-egl_py39h1234567_12.conda
linux-64::vigra-1.11.1-py39h07df95d_1046.conda
linux-64::tiledb-2.16.3-h6041edc_1.conda
linux-64::cpp-opentelemetry-sdk-1.11.0-h9f3eacc_0.conda
linux-64::arrow-cpp-9.0.0-py311h9f4e53b_45_cuda.conda
linux-64::polycap-1.2-py310hf236282_3.conda
linux-64::triqs-3.1.1-py38h18e736d_7.conda
linux-64::papilo-2.1.3-h7134f8c_0.conda
linux-64::actions-runner-2.308.0-hcd5def8_0.conda
linux-64::folly-2023.08.28.00-hda79706_0_jemalloc.conda
linux-64::ndcctools-7.6.2-py311h689c632_0.conda
linux-64::folly-2023.08.14.00-ha1f1437_3_jemalloc.conda
linux-64::yosys-0.32-py311h0f9a78a_0.conda
linux-64::openpmd-api-0.15.1-nompi_py39h5f28115_106.conda
linux-64::pp-sketchlib-2.1.1-py311h466f419_2.conda
linux-64::libscotch-7.0.4-h0c89965_0.conda
linux-64::libadios2-2.9.1-mpi_mpich_h806a3d7_1.conda
linux-64::ifcopenshell-v0.7.0a9-py311hd5c05e9_0.conda
linux-64::dotnet-runtime-7.0.10-hb8a3ed7_0.conda
linux-64::yosys-0.31-py311h0f9a78a_0.conda
linux-64::ifcopenshell-v0.7.0a9-py310hb3edaf1_0.conda
linux-64::mandrake-1.2.2-py38h5741f39_3.conda
linux-64::openpmd-api-0.15.1-mpi_openmpi_py39hb1202af_5.conda
linux-64::uproc-1.2.0-h2797004_0.conda
linux-64::triqs-3.1.1-py38h72e10a8_6.conda
linux-64::dotnet-aspnetcore-6.0.20-hfbc8c6f_0.conda
linux-64::openvdb-10.0.1-py310h120c1bf_2.conda
linux-64::folly-2023.08.14.00-he8e2169_1_jemalloc.conda
linux-64::libadios2-2.9.1-mpi_mpich_h2fc4611_1.conda
linux-64::aws-sdk-cpp-1.11.68-hd831e9c_12.conda
linux-64::libadios2-2.9.1-nompi_h214baa7_100.conda
linux-64::bytewax-0.17.0-py39h82e90d1_5.conda
linux-64::netcdf4-1.6.4-mpi_openmpi_py38hfb7afc8_2.conda
linux-64::vtk-base-9.2.6-osmesa_py310h1234567_112.conda
linux-64::hdf5-1.14.2-mpi_mpich_ha2c2bf8_0.conda
linux-64::libzip-1.10.0-h2629f0a_0.conda
linux-64::openpmd-api-0.15.1-mpi_mpich_py311h2b1532f_6.conda
linux-64::freecad-0.21.0-py310heb712a3_1.conda
linux-64::folly-2023.03.20.00-h09ac5fe_5.conda
linux-64::openpmd-api-0.15.2-mpi_mpich_py38h3445d9c_0.conda
linux-64::dotnet-sdk-6.0.412-hfbc8c6f_0.conda
linux-64::folly-2023.08.14.00-hda79706_2_jemalloc.conda
linux-64::imagecodecs-2023.8.12-py39h06dc04d_0.conda
linux-64::conduit-0.8.8-py310h62e43e0_2.conda
linux-64::vtk-base-9.2.6-qt_py310h1234567_211.conda
linux-64::mandrake-1.2.2-py39h67bc505_3.conda
linux-64::ifcopenshell-v0.7.0a10-py310hcc00ccc_0.conda
linux-64::sdl2_ttf-2.20.2-ha14f88b_2.conda
linux-64::mold-2.1.0-h913df21_0.conda
linux-64::libarrow-10.0.1-hf8fed9e_38_cuda.conda
linux-64::libadios2-2.9.1-mpi_openmpi_h55f04b4_1.conda
linux-64::healpy-1.16.5-py39hdbd5955_1.conda
linux-64::paraprobe-v0.3.1-mpi_mpich_h8e8da15_5.conda
linux-64::nodejs-20.1.0-hf52ce11_0.conda
linux-64::ifcopenshell-v0.7.0a9-py38h57d3409_1.conda
linux-64::harp-1.19-py311h211a265_1.conda
linux-64::arrow-cpp-9.0.0-py39hbd393be_45_cpu.conda
linux-64::openpmd-api-0.15.1-mpi_mpich_py38h3c0ee9d_6.conda
linux-64::postgresql-plpython-15.4-py38h0f07e32_0.conda
linux-64::openpmd-api-0.15.2-nompi_py311h2252293_100.conda
linux-64::openpmd-api-0.15.2-mpi_mpich_py39h8bd3e6a_0.conda
linux-64::triqs-3.1.1-py310h46b93e6_6.conda
linux-64::libgrpc-1.54.3-hb20ce57_0.conda
linux-64::triqs-3.1.1-py39h3c449d4_6.conda
linux-64::libadios2-2.9.1-mpi_mpich_h863adcc_0.conda
linux-64::libarrow-13.0.0-hf8fed9e_0_cuda.conda
linux-64::soplex-6.0.4-ha4ec6ac_0.conda
linux-64::openpmd-api-0.15.1-mpi_mpich_py311h15cef80_5.conda
linux-64::rust-1.72.0-h70c747d_1.conda
linux-64::vtk-base-9.2.6-qt_py310h1234567_212.conda
linux-64::ticcutils-0.32-h4b3f524_3.conda
linux-64::pyreadr-0.4.9-py311h3cc738f_0.conda
linux-64::ifcopenshell-v0.7.0a9-py38h7acee80_0.conda
linux-64::openpmd-api-0.15.2-nompi_py38h5da1201_100.conda
linux-64::r-harp-1.19-r43h71bbeed_1.conda
linux-64::folly-2023.08.14.00-he8e2169_0_jemalloc.conda
linux-64::mandrake-1.2.2-py38h4c0ebfd_3.conda
linux-64::pdal-2.5.6-h615b4e8_0.conda
linux-64::magics-metview-4.14.2-h40b8c56_0.conda
linux-64::openpmd-api-0.15.2-mpi_mpich_py39h48b5f10_0.conda
linux-64::ifcopenshell-v0.7.0a9-py311hd5c05e9_1.conda
linux-64::openpmd-api-0.15.1-mpi_mpich_py39hdfa6f69_6.conda
linux-64::openpmd-api-0.15.1-mpi_openmpi_py39h74c5029_6.conda
linux-64::vigra-1.11.1-py38h7035bff_1046.conda
linux-64::harp-1.19-py38hdb16ff8_1.conda
linux-64::nest-simulator-3.5-py39hee3e16e_2.conda
linux-64::imagecodecs-2023.8.12-py39he027151_0.conda
linux-64::libarrow-10.0.1-hb9dc469_38_cpu.conda
linux-64::openvdb-10.0.1-py310h120c1bf_1.conda
linux-64::pp-sketchlib-2.1.1-py39hb1184a5_2.conda
linux-64::libgdal-3.6.4-h94e0181_12.conda
linux-64::folly-2023.08.28.00-ha1f1437_0_jemalloc.conda
linux-64::fimex-1.9.6-py39h1d82614_0.conda
linux-64::libtiledb-sql-0.24.0-hc3826aa_0.conda
linux-64::paraprobe-v0.3.1-mpi_mpich_hfd9f523_5.conda
linux-64::scip-8.0.4-h4a32fe0_0.conda
linux-64::libitk-5.3.0-h75c54af_6.conda
linux-64::triqs-3.1.1-py38h18e736d_6.conda
linux-64::ifcopenshell-v0.7.0a9-py310hb3edaf1_1.conda
linux-64::openpmd-api-0.15.1-nompi_py39h34fc903_105.conda
linux-64::pdal-2.5.6-h9b972b5_1.conda
linux-64::vowpalwabbit-9.9.0-py311hb464d54_0.conda
linux-64::openpmd-api-0.15.1-nompi_py38hc2f9c3d_105.conda
linux-64::folly-2023.03.20.00-he8e2169_5_jemalloc.conda
linux-64::emacs-28.2-h41efbed_4.conda
linux-64::ifcopenshell-v0.7.0a10-py39hd378db9_0.conda
linux-64::openpmd-api-0.15.2-mpi_openmpi_py39h622ef63_0.conda
linux-64::ovito-3.9.1-h4da3077_0.conda
linux-64::omniorb-4.3.1-py38h0ed79f3_0.conda
linux-64::libarrow-12.0.1-habf9eaf_8_cuda.conda
linux-64::openpmd-api-0.15.1-mpi_mpich_py38h1d64b76_5.conda
linux-64::capnproto-1.0.1-hfc55251_0.conda
linux-64::ifcopenshell-v0.7.0a9-py310hcc00ccc_1.conda
linux-64::freecad-0.21.1-py310heb712a3_0.conda
linux-64::julia-1.9.3-h06b7c97_0.conda
linux-64::vtk-base-9.2.6-osmesa_py311h1234567_111.conda
linux-64::ifcopenshell-v0.7.0a10-py39h726b84a_0.conda
linux-64::ifcopenshell-v0.7.0a9-py311h79fa3ea_0.conda
linux-64::yosys-0.31-py311he00c579_0.conda
linux-64::libgdal-3.6.4-he8493b3_11.conda
linux-64::libgdal-arrow-parquet-3.6.4-h62cb37e_11.conda
linux-64::folly-2023.08.28.00-h09ac5fe_0.conda
linux-64::heyoka-llvm-14-1.0.0-h23ee361_0.conda
linux-64::pp-sketchlib-2.1.1-py39h65024dc_2.conda
linux-64::mupdf-1.22.2-he976d8a_1.conda
linux-64::vtk-base-9.2.6-egl_py311h1234567_12.conda
linux-64::openpmd-api-0.15.2-mpi_openmpi_py310h22b312c_0.conda
linux-64::aws-sdk-cpp-1.10.57-h7062fed_18.conda
linux-64::sqlite-3.43.0-h2c6b66d_0.conda
linux-64::lammps-2023.08.02-cpu_py311_hb661868_openmpi_0.conda
linux-64::mandrake-1.2.2-py39h00c8eec_3.conda
linux-64::openpmd-api-0.15.2-nompi_py38haabb852_100.conda
linux-64::folly-2023.08.14.00-h09ac5fe_1.conda
linux-64::openpmd-api-0.15.1-mpi_mpich_py38h7403642_5.conda
linux-64::libvips-8.14.3-hb433468_2.conda
linux-64::kaldi-5.5.1068-cuda112h971fcfb_2.conda
linux-64::libgdal-3.7.1-h1d4a2ba_5.conda
linux-64::pypy3.9-7.3.12-h9557127_3.conda
linux-64::libadios2-2.9.1-nompi_h31dd0b9_101.conda
linux-64::openpmd-api-0.15.1-mpi_openmpi_py38h695232e_5.conda
linux-64::libadios2-2.9.1-nompi_hbc473cc_100.conda
linux-64::heyoka-1.0.0-h18d30d2_0.conda
linux-64::healpy-1.16.5-py39h9674c9c_0.conda
linux-64::libgdal-3.6.4-h178578c_13.conda
linux-64::libgdal-arrow-parquet-3.7.1-hbac65c4_7.conda
linux-64::pyreadstat-1.2.3-py311hdcc4c9d_0.conda
linux-64::pp-sketchlib-2.1.1-py310h48aeff4_2.conda
linux-64::libscotch-7.0.4-h91e35bf_0.conda
linux-64::lammps-2023.08.02-cpu_py310_h4b5e8b3_openmpi_0.conda
linux-64::heyoka-llvm-15-1.0.0-he0ec72f_0.conda
linux-64::libadios2-2.9.1-mpi_mpich_h69321e2_2.conda
linux-64::python-3.9.17-h0755675_0_cpython.conda
linux-64::vowpalwabbit-9.8.0-py310he2729fb_1.conda
linux-64::freecad-0.21.0-py39h05a92db_1.conda
linux-64::heyoka-1.0.0-hb4d7844_0.conda
linux-64::ifcopenshell-v0.7.0a9-py39hd378db9_0.conda
linux-64::llvmdev-16.0.6-h5cf9203_2.conda
linux-64::gmt-6.4.0-hf1dbac9_15.conda
linux-64::lammps-2023.08.02-cpu_py38_h297bd8b_mpich_0.conda
linux-64::magics-4.14.2-hd3d5bb6_0.conda
linux-64::ffmpeg-6.0.0-gpl_h14e97fc_104.conda
linux-64::vigra-1.11.1-py38h653f204_1046.conda
linux-64::ifcopenshell-v0.7.0a9-py39hd378db9_1.conda
linux-64::libopencv-4.8.0-py39h0e2efb3_1.conda
linux-64::grpcio-1.56.2-py311ha6695c7_1.conda
linux-64::lammps-2023.08.02-cpu_py39_h2595f3c_mpich_0.conda
linux-64::openpmd-api-0.15.2-mpi_mpich_py311h2b1532f_0.conda
linux-64::ffmpeg-6.0.0-lgpl_hff7ba3f_4.conda
linux-64::grpcio-1.57.0-py39h174d805_0.conda
linux-64::pp-sketchlib-2.1.1-py311h1999d3e_2.conda
linux-64::fimex-1.9.6-py38ha6a48d1_0.conda
linux-64::vtk-base-9.2.6-qt_py311h1234567_212.conda
linux-64::freecad-0.21.0-py38hc520578_1.conda
linux-64::paraview-5.11.1-py310h78eb5bc_2_egl.conda
linux-64::netcdf4-1.6.4-nompi_py38hd72f54f_102.conda
linux-64::openvdb-10.0.1-py38hbdef4f9_2.conda
linux-64::libadios2-2.9.1-mpi_openmpi_h4e62573_2.conda
linux-64::coda-2.24.2-py38he621bb9_3.conda
linux-64::ifcopenshell-v0.7.0a9-py311hbe4e43f_1.conda
linux-64::rust-1.72.0-h70c747d_0.conda
linux-64::healpy-1.16.5-py38h9fcc61b_1.conda
linux-64::libadios2-2.9.1-mpi_openmpi_h6c98294_1.conda
linux-64::libarrow-10.0.1-heb40526_37_cuda.conda
linux-64::pdal-2.5.5-hc88f41b_1.conda
linux-64::arrow-cpp-9.0.0-py39he7f2207_46_cuda.conda
linux-64::cmake-3.27.4-hcfe8598_4.conda
linux-64::indexed_gzip-1.8.5-py38h019822b_0.conda
linux-64::arrow-cpp-9.0.0-py310hf88ea5e_45_cuda.conda
linux-64::tiledb-2.16.3-hf0b6e87_1.conda
linux-64::arrow-cpp-9.0.0-py310hac876ad_45_cpu.conda
linux-64::bytewax-0.17.0-py39h82e90d1_6.conda
linux-64::julia-1.9.2-h06b7c97_1.conda
linux-64::imagecodecs-2023.8.12-py311h67b54e4_0.conda
linux-64::hdf5-1.14.2-mpi_openmpi_h327c9cf_0.conda
linux-64::libadios2-2.9.1-nompi_h32fdd87_102.conda
linux-64::libgdal-3.7.1-hd2ada2b_6.conda
linux-64::folly-2023.08.07.00-hda79706_1_jemalloc.conda
linux-64::healpy-1.16.5-py39hf751b5c_0.conda
linux-64::ifcopenshell-v0.7.0a10-py38h57d3409_0.conda
linux-64::folly-2023.08.07.00-h09ac5fe_0.conda
linux-64::arrow-cpp-9.0.0-py310ha422632_46_cpu.conda
linux-64::folly-2023.08.14.00-h55f0c17_3.conda
linux-64::openpmd-api-0.15.2-mpi_openmpi_py38hc4c9712_0.conda
linux-64::libtiledb-sql-0.23.2-hc3826aa_0.conda
linux-64::freecad-0.21.1-py39h05a92db_0.conda
linux-64::polycap-1.2-py311hf368e52_3.conda
linux-64::triqs-3.1.1-py39hd083d43_6.conda
linux-64::dotnet-sdk-7.0.400-hb8a3ed7_0.conda
linux-64::ovito-3.9.0-h4da3077_0.conda
linux-64::libadios2-2.9.1-mpi_openmpi_hbc8a4eb_2.conda
linux-64::openpmd-api-0.15.1-mpi_mpich_py310hcb641c4_6.conda
linux-64::triqs-3.1.1-py310h30ed552_7.conda
linux-64::bytewax-0.17.0-py311he5c60f7_2.conda
linux-64::vtk-base-9.2.6-osmesa_py38h1234567_111.conda
linux-64::folly-2023.08.14.00-hda79706_0_jemalloc.conda
linux-64::libarrow-11.0.0-hb9dc469_34_cpu.conda
linux-64::harp-1.19-py39he46ae98_1.conda
linux-64::aws-sdk-cpp-1.10.57-h6f6b8fa_21.conda
linux-64::ifcopenshell-v0.7.0a9-py311hd2a0f0d_0.conda
linux-64::libarrow-12.0.1-hf8fed9e_9_cuda.conda
linux-64::nodejs-20.5.1-hb753e55_1.conda
linux-64::libzip-1.10.1-h2629f0a_0.conda
linux-64::boost-cpp-1.82.0-h8013b2b_2.conda
linux-64::libmatio-1.5.23-h31675a7_4.conda
linux-64::mc-4.8.30-h6a540d1_0.conda
linux-64::openpmd-api-0.15.2-mpi_openmpi_py38h418ef53_0.conda
linux-64::postgresql-15.4-h8972f4a_0.conda
linux-64::nodejs-20.5.1-hf52ce11_0.conda
linux-64::openpmd-api-0.15.1-mpi_mpich_py38hf085800_6.conda
linux-64::poppler-qt-23.08.0-hedeba34_0.conda
linux-64::paraview-5.11.1-py311hc5894d6_102_qt.conda
linux-64::openpmd-api-0.15.1-mpi_openmpi_py311h9d98028_5.conda
linux-64::gmt-6.4.0-hb5fd6f7_14.conda
linux-64::cmake-3.27.4-hcfe8598_3.conda
linux-64::vtk-base-9.2.6-qt_py311h1234567_211.conda
linux-64::arrow-cpp-9.0.0-py311hd4aa4bc_46_cuda.conda
linux-64::mandrake-1.2.2-py310h36ea18d_3.conda
linux-64::libarrow-11.0.0-heb40526_33_cuda.conda
linux-64::triqs-3.1.1-py311h6b9694e_6.conda
linux-64::libarrow-11.0.0-hf8fed9e_34_cuda.conda
linux-64::omniorb-4.3.1-py311h28f970a_0.conda
linux-64::libadios2-2.9.1-nompi_h7afb0c3_101.conda
linux-64::libopencv-4.8.0-py39h8c1a80c_1.conda
linux-64::openpmd-api-0.15.2-nompi_py310h9ad767f_100.conda
linux-64::vtk-base-9.2.6-qt_py38h1234567_211.conda
linux-64::openpmd-api-0.15.1-mpi_openmpi_py39h6a5d34b_5.conda
linux-64::harp-1.19-py38h8dbc32b_1.conda
linux-64::triqs-3.1.1-py310h46b93e6_7.conda
linux-64::harp-1.19-py39hf75bc27_1.conda
linux-64::openpmd-api-0.15.1-mpi_openmpi_py38ha8006ac_5.conda
linux-64::libadios2-2.9.1-mpi_mpich_h4b52df8_0.conda
linux-64::pygame-2.5.1-py310h8df29c8_0.conda
linux-64::mandrake-1.2.2-py311h120d690_3.conda
linux-64::polycap-1.2-py39h6836f0a_3.conda
linux-64::omniorb-4.3.1-py39h53428f1_0.conda
linux-64::ogre-14.0.1-h4e038b6_1.conda
linux-64::libgit2-1.7.1-hca3a8ce_0.conda
linux-64::folly-2023.08.28.00-he8e2169_0_jemalloc.conda
linux-64::ifcopenshell-v0.7.0a10-py38h0804e63_0.conda
linux-64::ifcopenshell-v0.7.0a9-py311h79fa3ea_1.conda
linux-64::omniorb-libs-4.3.1-h1933689_0.conda
linux-64::kaldi-5.5.1068-cpu_h31769b2_2.conda
linux-64::triqs-3.1.1-py38h72e10a8_7.conda
linux-64::arrow-cpp-9.0.0-py311ha6562b6_46_cpu.conda
linux-64::openvdb-10.0.1-py39hc77a128_2.conda
linux-64::yosys-0.31-py311hc5db6ba_0.conda
linux-64::lammps-2023.08.02-cpu_py39_h00752c8_mpich_0.conda
linux-64::vigra-1.11.1-py310h8b8b67d_1046.conda
linux-64::pp-sketchlib-2.1.1-py38h0f01a5e_2.conda
linux-64::grpcio-1.57.0-py38h94a1851_0.conda
linux-64::adios-1.13.1-mpi_openmpi_h0e4b0de_1023.conda
linux-64::pyreadr-0.4.9-py310h3e6beee_0.conda
linux-64::folly-2023.08.14.00-h80c46b9_1.conda
linux-64::rust-1.71.1-h70c747d_0.conda
linux-64::indexed_gzip-1.8.5-py310h7d11597_0.conda
linux-64::folly-2023.08.14.00-h5a97fb6_2.conda
linux-64::openpmd-api-0.15.1-nompi_py311h5918f1b_105.conda
linux-64::yosys-0.32-h3bf110c_1.conda
linux-64::netcdf4-1.6.4-mpi_openmpi_py39h1b36d35_2.conda
linux-64::vowpalwabbit-9.9.0-py310he2729fb_0.conda
linux-64::ifcopenshell-v0.7.0a10-py311hd5c05e9_0.conda
linux-64::libarrow-10.0.1-hb87d912_37_cpu.conda
linux-64::bytewax-0.17.0-py38he60ca92_5.conda
linux-64::lammps-2023.08.02-cpu_py39_hae2bcb2_openmpi_0.conda
linux-64::vtk-base-9.2.6-egl_py311h1234567_11.conda
linux-64::libarrow-10.0.1-h10ac928_37_cpu.conda
linux-64::folly-2023.08.07.00-hda79706_0_jemalloc.conda
linux-64::triqs-3.1.1-py311h00d02c3_6.conda
linux-64::libtiledb-sql-0.24.0-hb82b279_0.conda
linux-64::aws-sdk-cpp-1.10.57-h85b1a90_19.conda
linux-64::pypy3.8-7.3.11-hc3ccb01_2.conda
linux-64::vigra-1.11.1-py38hff527ec_1046.conda
linux-64::poppler-23.08.0-hd18248d_0.conda
linux-64::openpmd-api-0.15.1-mpi_mpich_py39hfe64f19_6.conda
linux-64::libnetcdf-4.9.2-nompi_h80fb2b6_111.conda
linux-64::folly-2023.03.20.00-hda79706_5_jemalloc.conda
linux-64::magics-metview-batch-4.14.2-hd3d5bb6_0.conda
linux-64::heyoka-1.0.0-h2dccf72_0.conda
linux-64::libarrow-11.0.0-h10ac928_33_cpu.conda
linux-64::folly-2023.08.14.00-h80c46b9_0.conda
linux-64::libadios2-2.9.1-mpi_mpich_hf454005_1.conda
linux-64::arrow-cpp-9.0.0-py38hc5cccdd_46_cuda.conda
linux-64::healpy-1.16.5-py38h61517ae_0.conda
linux-64::vigra-1.11.1-py39h5ec6d97_1046.conda
linux-64::nexus-4.4.3-h2e46a9d_11.conda
linux-64::mandrake-1.2.2-py311h05b977c_3.conda
linux-64::bytewax-0.17.0-py38he60ca92_6.conda
linux-64::postgresql-plpython-15.4-py39h5ae07a4_0.conda
linux-64::freecad-0.21.1-py38hc520578_0.conda
linux-64::folly-2023.08.14.00-h09ac5fe_0.conda
linux-64::arrow-cpp-9.0.0-py38h9065a2a_45_cuda.conda
linux-64::openpmd-api-0.15.1-mpi_mpich_py310h60df2c0_5.conda
linux-64::openpmd-api-0.15.1-nompi_py39h3f3d1b0_105.conda
linux-64::folly-2023.08.14.00-hda79706_1_jemalloc.conda
linux-64::heyoka-0.21.0-ha232a6f_1.conda
linux-64::arrow-cpp-9.0.0-py38h59fde5d_46_cpu.conda
linux-64::vtk-base-9.2.6-qt_py38h1234567_212.conda
linux-64::libadios2-2.9.1-nompi_hda08243_102.conda
linux-64::libadios2-2.9.1-mpi_mpich_h6378ecc_2.conda
linux-64::python-3.9.18-h0755675_0_cpython.conda
linux-64::libgdal-arrow-parquet-3.7.1-h59dd923_6.conda
linux-64::vigra-1.11.1-py310h66ea3a9_1046.conda
linux-64::openvdb-10.0.1-py38hbdef4f9_1.conda
linux-64::lammps-2023.08.02-cpu_py38_hffeb4a5_openmpi_0.conda
linux-64::pygame-2.5.1-py39h1678059_0.conda
linux-64::openpmd-api-0.15.1-mpi_openmpi_py39hf95baae_6.conda
linux-64::libnetcdf-4.9.2-mpi_mpich_h2a8cb2d_10.conda
linux-64::r-harp-1.19-r43h5872dc6_1.conda
linux-64::arrow-cpp-9.0.0-py311ha5ff4ba_45_cpu.conda
linux-64::conduit-0.8.8-py310h9ed50a4_2.conda
linux-64::libgrpc-1.57.0-h3905398_0.conda
linux-64::openvdb-10.0.1-py311hd1ce2d7_2.conda
linux-64::openmeeg-2.5.6-py311h1837e4e_2.conda
linux-64::openmeeg-2.5.6-py39heea12aa_2.conda
linux-64::nest-simulator-3.5-py311hcb301d6_2.conda
linux-64::libpq-15.4-hfc447b1_0.conda
linux-64::arrow-cpp-9.0.0-py310h5f398a6_46_cuda.conda
linux-64::openpmd-api-0.15.1-nompi_py38h3b57f00_105.conda
linux-64::gtk4-4.12.1-hc50ba83_0.conda
linux-64::ifcopenshell-v0.7.0a9-py38h27d5b0a_1.conda
linux-64::pygame-2.5.1-py38h3762873_0.conda
linux-64::ifcopenshell-v0.7.0a9-py39h726b84a_1.conda
linux-64::freecad-0.21.0-py311h71ce39b_1.conda
linux-64::triqs-3.1.1-py39hd083d43_7.conda
linux-64::tectonic-0.14.1-hffe7e2f_2.conda
linux-64::conduit-0.8.8-py38hcc73ae6_2.conda
linux-64::arrow-cpp-9.0.0-py39h8c05d18_46_cpu.conda
linux-64::libgrpc-1.57.0-ha4d0f93_1.conda
linux-64::libarrow-11.0.0-habf9eaf_33_cuda.conda
linux-64::openvdb-10.0.1-py39hc77a128_1.conda
linux-64::vtk-base-9.2.6-osmesa_py39h1234567_111.conda
linux-64::heyoka-llvm-12-1.0.0-hd83f851_0.conda
linux-64::openpmd-api-0.15.1-nompi_py38h3603c88_106.conda
linux-64::netcdf4-1.6.4-mpi_mpich_py311h5dcab06_2.conda
linux-64::openpmd-api-0.15.1-mpi_openmpi_py310hb7a44ac_6.conda
linux-64::heyoka-llvm-13-0.21.0-h1380d4f_1.conda
linux-64::pp-sketchlib-2.1.1-py310hfe27807_2.conda
linux-64::heyoka-1.0.0-h8f27e75_0.conda
linux-64::openmeeg-2.5.6-py38h805d933_2.conda
linux-64::grpcio-1.56.2-py38h94a1851_1.conda
linux-64::libnetcdf-4.9.2-mpi_mpich_hef9003c_11.conda
linux-64::libarrow-13.0.0-hb9dc469_0_cpu.conda
linux-64::openpmd-api-0.15.1-mpi_openmpi_py38h908319a_6.conda
linux-64::pdal-2.5.5-h615b4e8_2.conda
linux-64::polycap-1.2-py38h4ec914e_3.conda
linux-64::libarrow-10.0.1-habf9eaf_37_cuda.conda
linux-64::indexed_gzip-1.8.5-py311hb2be122_0.conda
linux-64::yosys-0.32-py311hc5db6ba_0.conda
linux-64::libnetcdf-4.9.2-nompi_h9db66fd_110.conda
linux-64::libxml2-2.11.5-h232c23b_1.conda
linux-64::h5utils-1.13.2-nompi_ha1fc32c_1102.conda
linux-64::libadios2-2.9.1-mpi_mpich_h11b1e74_2.conda
linux-64::openjdk-20.0.0-h6f1e508_1.conda
linux-64::bytewax-0.17.0-py38he60ca92_2.conda
linux-64::mandrake-1.2.2-py310h8561f69_3.conda
linux-64::libgdal-3.7.1-h880a63b_9.conda
linux-64::netcdf4-1.6.4-mpi_openmpi_py310h884273a_2.conda
linux-64::healpy-1.16.5-py38h0ddf57f_1.conda
linux-64::arrow-cpp-9.0.0-py38h3e6be24_45_cuda.conda
linux-64::openpmd-api-0.15.1-nompi_py310h10b8811_106.conda
linux-64::libgdal-arrow-parquet-3.6.4-hff20efd_13.conda
linux-64::folly-2023.08.07.00-h80c46b9_0.conda
linux-64::heyoka-llvm-11-1.0.0-hcd51939_0.conda
linux-64::freecad-0.21.0-py39h05a92db_0.conda
linux-64::nest-simulator-3.5-py310h80eecab_2.conda
linux-64::libarrow-12.0.1-heb40526_8_cuda.conda
linux-64::tiledb-2.16.3-h84d19f0_1.conda
linux-64::vtk-base-9.2.6-osmesa_py310h1234567_111.conda
linux-64::vowpalwabbit-9.8.0-py39h01275cd_1.conda
linux-64::netcdf4-1.6.4-mpi_openmpi_py311ha5d6734_2.conda
linux-64::ndcctools-7.6.2-py38h514f0f6_0.conda
linux-64::openpmd-api-0.15.1-nompi_py39haaed723_106.conda
linux-64::cairo-1.16.0-h0c91306_1017.conda
linux-64::vtk-base-9.2.6-egl_py38h1234567_11.conda
linux-64::ifcopenshell-v0.7.0a9-py38h57d3409_0.conda
linux-64::ndcctools-7.6.2-py39h4841754_0.conda
linux-64::lammps-2023.08.02-cpu_py311_h4aafb77_mpich_0.conda
linux-64::coda-2.24.2-py38h58d957e_3.conda
linux-64::libllvm16-16.0.6-h5cf9203_2.conda
linux-64::bytewax-0.17.0-py311he5c60f7_6.conda
linux-64::heyoka-llvm-12-0.21.0-hd83f851_1.conda
linux-64::grpcio-1.57.0-py310h1b8f574_0.conda
linux-64::libadios2-2.9.1-nompi_h221b914_100.conda
linux-64::libadios2-2.9.1-mpi_openmpi_h09787ba_0.conda
linux-64::libadios2-2.9.1-nompi_h4c47aef_101.conda
linux-64::healpy-1.16.5-py310h09b46ba_1.conda
linux-64::arrow-cpp-9.0.0-py38h3d714db_45_cpu.conda
linux-64::folly-2023.08.14.00-hda79706_3_jemalloc.conda
linux-64::ifcopenshell-v0.7.0a10-py310hb3edaf1_0.conda
linux-64::ifcopenshell-v0.7.0a9-py39hcf65ed2_0.conda
linux-64::libgdal-arrow-parquet-3.6.4-h3b6f481_12.conda
linux-64::arrow-cpp-9.0.0-py310hc50bd5e_45_cuda.conda
linux-64::heyoka-0.21.0-h8f27e75_1.conda
linux-64::lammps-2023.08.02-cpu_py38_h459ef18_mpich_0.conda
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
```

</details>