### PR TITLE
loosen zlib-pin to major level (11/N; July 2023)

### DIFF
--- a/recipe/patch_yaml/zlib.yaml
+++ b/recipe/patch_yaml/zlib.yaml
@@ -88,3 +88,12 @@ then:
   - loosen_depends:
       name: libzlib
       upper_bound: "2"
+---
+if:
+  has_depends: libzlib >=1.2*
+  timestamp_lt: 1690848000000  # 2023-08-01 00:00 UTC
+  timestamp_ge: 1688169600000  # 2023-07-01 00:00 UTC
+then:
+  - loosen_depends:
+      name: libzlib
+      upper_bound: "2"


### PR DESCRIPTION
Follow-up to https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/739, about 3300 artefacts affected.

### Result of `python show_diff.py`

<details>

```diff
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
osx-arm64::msgpack-cxx-6.1.0-hcb94ee5_0.conda
osx-arm64::llvm-14.0.6-h95d0606_4.conda
osx-arm64::llvm-15.0.7-hd9f5176_3.conda
osx-arm64::zstd-1.5.2-h4f39d0f_7.conda
osx-arm64::libllvm15-15.0.7-h504e6bf_3.conda
osx-arm64::cfitsio-4.3.0-hca87796_0.conda
osx-arm64::micromamba-1.4.7-0.tar.bz2
osx-arm64::gst-plugins-base-1.22.5-h27255cc_0.conda
osx-arm64::micromamba-1.4.6-0.tar.bz2
osx-arm64::dlib-cpp-19.24.2-hfff07be_4.conda
osx-arm64::gst-plugins-base-1.22.4-h27255cc_1.conda
osx-arm64::libllvm14-14.0.6-hd1a9a77_4.conda
osx-arm64::micromamba-1.4.9-0.tar.bz2
osx-arm64::libuwebsockets-20.45.0-ha614eb4_0.conda
osx-arm64::llvm-tools-15.0.7-h504e6bf_3.conda
osx-arm64::glib-tools-2.76.4-ha614eb4_0.conda
osx-arm64::llvm-tools-14.0.6-hd1a9a77_4.conda
osx-arm64::micromamba-1.4.8-0.tar.bz2
osx-arm64::eccodes-2.31.0-hfc33491_0.conda
-    "libzlib >=1.2.13,<1.3.0a0"
+    "libzlib >=1.2.13,<2.0.0a0"
osx-arm64::vtk-base-9.2.6-qt_py39h1234567_209.conda
osx-arm64::imagecodecs-2023.7.10-py39h52e0b1e_0.conda
osx-arm64::postgresql-plpython-14.5-py310h94ee204_7.conda
osx-arm64::ndcctools-7.6.0rc1-py38h3b9d5fa_0.conda
osx-arm64::gfortran_impl_osx-64-11.4.0-hd10cd46_1.conda
osx-arm64::postgresql-plpython-14.5-py38h3275ed9_7.conda
osx-arm64::arrow-cpp-9.0.0-py39hafae4ac_43_cpu.conda
osx-arm64::root_base-6.28.4-py310h38a37bc_1.conda
osx-arm64::libopencv-4.8.0-py39h0595e9a_0.conda
osx-arm64::r-harp-1.19-py39h3f58a0f_0.conda
osx-arm64::gfortran_impl_osx-arm64-11.4.0-h5548130_0.conda
osx-arm64::mdtraj-1.9.9-py39hd7a7df8_0.conda
osx-arm64::libarrow-10.0.1-hecf3162_35_cpu.conda
osx-arm64::openpmd-api-0.15.1-mpi_mpich_py310h9e66e5c_4.conda
osx-arm64::openssh-9.3p1-hcea71ed_2.conda
osx-arm64::libopencv-4.8.0-py38h321d7fe_0.conda
osx-arm64::mosh-1.4.0-pl5321h78761c0_2.conda
osx-arm64::postgresql-plpython-15.3-py310h94ee204_2.conda
osx-arm64::pillow-10.0.0-py39h1641143_0.conda
osx-arm64::libgdal-3.7.1-hfd1e897_4.conda
osx-arm64::ndcctools-7.6.1-py311hf3cef61_0.conda
osx-arm64::nest-simulator-3.5-py311h93b7820_0.conda
osx-arm64::arrow-cpp-9.0.0-py311hf190ae7_44_cpu.conda
osx-arm64::folly-2023.07.17.00-h03318f1_0.conda
osx-arm64::paraview-5.11.1-py39hc3d3ab6_102_qt.conda
osx-arm64::jaxlib-0.4.12-cpu_py311h2dd720e_1.conda
osx-arm64::nest-simulator-3.5-py310hd87ccbb_0.conda
osx-arm64::aws-sdk-cpp-1.11.68-h6c89a89_7.conda
osx-arm64::yarp-cxx-3.8.1-h0b4bcb8_3.conda
osx-arm64::imagecodecs-2023.7.10-py311hc6ed791_1.conda
osx-arm64::libsoup-2.74.3-h4fb8bbe_0.conda
osx-arm64::pillow-10.0.0-py38h3f590de_0.conda
osx-arm64::grpcio-1.56.1-py310h95b248a_0.conda
osx-arm64::imagemagick-7.1.1_14-pl5321h903c885_0.conda
osx-arm64::lxml-4.9.3-py310h78afa71_0.conda
osx-arm64::xrootd-5.6.1-py311h4e7788a_0.conda
osx-arm64::davix-0.8.4-hc6ff85c_2.conda
osx-arm64::paraview-5.11.1-py310h98c83d3_102_qt.conda
osx-arm64::lpython-0.18.2-ha614eb4_0.conda
osx-arm64::aws-sdk-cpp-1.10.57-h090cfb9_16.conda
osx-arm64::ogre-14.0.1-h86394e4_0.conda
osx-arm64::indexed_gzip-1.8.3-py310hd2fdded_0.conda
osx-arm64::arrow-cpp-9.0.0-py38hd07f9fe_42_cpu.conda
osx-arm64::imagecodecs-2023.7.10-py310h342b742_2.conda
osx-arm64::postgresql-15.3-h00cd704_2.conda
osx-arm64::ndcctools-7.6.0-py311hf3cef61_0.conda
osx-arm64::mysql-server-8.0.33-h8d2d40f_1.conda
osx-arm64::jaxlib-0.4.12-cpu_py38he7bdf63_1.conda
osx-arm64::libcurl-8.2.1-hc52a3a8_0.conda
osx-arm64::wxpython-4.2.1-py311hc820d88_0.conda
osx-arm64::jaxlib-0.4.12-cpu_py39hdce1265_1.conda
osx-arm64::openpmd-api-0.15.1-nompi_py39h3cf022a_104.conda
osx-arm64::vtk-base-9.2.6-qt_py310h1234567_209.conda
osx-arm64::libopentelemetry-cpp-1.9.1-ha34c9a6_3.conda
osx-arm64::libopencv-4.8.0-py38haec4208_0.conda
osx-arm64::omniorb-4.3.0-py311h8617d33_0.conda
osx-arm64::photochem-0.4.2-py310hd59d9a9_0.conda
osx-arm64::libvips-8.14.3-hd934089_0.conda
osx-arm64::mdtraj-1.9.8-py38h713f041_2.conda
osx-arm64::libarrow-11.0.0-hdeb1470_30_cpu.conda
osx-arm64::emacs-28.2-h14ff8fc_3.conda
osx-arm64::libadios2-2.9.0-nompi_h6f7674d_100.conda
osx-arm64::libadios2-2.9.0-nompi_h79c87c1_100.conda
osx-arm64::libnetcdf-4.9.2-mpi_mpich_h4c2882b_8.conda
osx-arm64::tiledb-2.16.0-h5345278_3.conda
osx-arm64::arrow-cpp-9.0.0-py310h8094765_44_cpu.conda
osx-arm64::grpcio-1.56.1-py38h761d82c_0.conda
osx-arm64::yoda-1.9.6-py310hd739576_4.conda
osx-arm64::mdtraj-1.9.9-py38h713f041_0.conda
osx-arm64::libopencv-4.7.0-py38h321d7fe_6.conda
osx-arm64::libcurl-static-8.1.2-hc52a3a8_1.conda
osx-arm64::afterimage-1.21-hbeb1001_1004.conda
osx-arm64::photochem-0.4.2-py39h2350e8a_1.conda
osx-arm64::yoda-1.9.6-py38h61c0ff5_4.conda
osx-arm64::libgrpc-1.56.2-h9075ed4_0.conda
osx-arm64::cctools_osx-arm64-973.0.1-h62378fb_14.conda
osx-arm64::xrootd-5.6.1-py38h16fb1ff_0.conda
osx-arm64::gfortran_impl_osx-arm64-12.2.0-hbdd0a80_32.conda
osx-arm64::nest-simulator-3.5-py39h5120e94_1.conda
osx-arm64::libarrow-10.0.1-h8c5da8f_35_cpu.conda
osx-arm64::imagecodecs-2023.7.10-py311h68e3841_2.conda
osx-arm64::root_base-6.28.4-py311h8e5954a_1.conda
osx-arm64::orc-1.9.0-h858f345_1.conda
osx-arm64::arrow-cpp-9.0.0-py39h4b608d4_44_cpu.conda
osx-arm64::libsoup-2.74.2-h4fb8bbe_0.conda
osx-arm64::ndcctools-7.6.0rc1-py310h4b37b16_0.conda
osx-arm64::libarrow-12.0.1-h59b625a_4_cpu.conda
osx-arm64::libarrow-12.0.1-h3f25899_2_cpu.conda
osx-arm64::libsoup-2.74.3-h771374c_1.conda
osx-arm64::aws-sdk-cpp-1.10.57-h6c89a89_15.conda
osx-arm64::libllvm16-16.0.6-he79909e_1.conda
osx-arm64::libgdal-3.6.4-h148ccd5_10.conda
osx-arm64::qt6-main-6.5.2-he484b70_0.conda
osx-arm64::omniorb-4.3.0-py310hfce7497_0.conda
osx-arm64::aws-sdk-cpp-1.11.68-h090cfb9_8.conda
osx-arm64::glib-networking-2.76.1-he79f396_0.conda
osx-arm64::libpulsar-3.2.0-hc8199c2_2.conda
osx-arm64::graphviz-8.1.0-h10878c0_0.conda
osx-arm64::nest-simulator-3.5-py310hd87ccbb_1.conda
osx-arm64::libnetcdf-4.9.2-nompi_hf3c790a_107.conda
osx-arm64::imagecodecs-2023.7.10-py310h3433c7e_0.conda
osx-arm64::photochem-0.4.2-py310h3fec0c4_1.conda
osx-arm64::libarrow-11.0.0-h59b625a_28_cpu.conda
osx-arm64::libopencv-4.7.0-py39h6a99d3f_6.conda
osx-arm64::gfortran_impl_osx-arm64-11.4.0-h5548130_1.conda
osx-arm64::folly-2023.07.03.00-h1e8fca9_0.conda
osx-arm64::r-harp-1.19-py311h09dc9a0_0.conda
osx-arm64::vtk-base-9.2.6-qt_py311h1234567_210.conda
osx-arm64::tensorflow-base-2.12.1-cpu_py38h7d4b6f8_0.conda
osx-arm64::harp-1.19-py39h3d2e54c_0.conda
osx-arm64::openpmd-api-0.15.1-nompi_py310hb789276_104.conda
osx-arm64::imagecodecs-2023.7.10-py39hbc22df0_1.conda
osx-arm64::libarrow-11.0.0-h59b625a_29_cpu.conda
osx-arm64::mdtraj-1.9.8-py310h7c9e852_1.conda
osx-arm64::folly-2023.07.24.00-h03318f1_0.conda
osx-arm64::libarrow-10.0.1-h8c5da8f_34_cpu.conda
osx-arm64::tiledb-2.16.0-h5345278_2.conda
osx-arm64::cctools_osx-64-973.0.1-hf0ce4cb_14.conda
osx-arm64::ndcctools-7.6.0-py39h6d2f949_0.conda
osx-arm64::imagemagick-7.1.1_15-pl5321h903c885_0.conda
osx-arm64::paraview-5.11.1-py311hc352156_102_qt.conda
osx-arm64::gfortran_impl_osx-arm64-12.3.0-hbbb9e1e_0.conda
osx-arm64::r-base-4.3.0-h4b3f977_3.conda
osx-arm64::nest-simulator-3.5-py311h93b7820_1.conda
osx-arm64::jaxlib-0.4.14-cpu_py39hf52c407_1.conda
osx-arm64::cpp-opentelemetry-sdk-1.10.0-ha34c9a6_0.conda
osx-arm64::lpython-0.18.4-ha614eb4_0.conda
osx-arm64::r-base-4.3.1-h4b3f977_0.conda
osx-arm64::r-harp-1.19-py310hcb8dffb_0.conda
osx-arm64::libgdal-arrow-parquet-3.7.1-h5ebab21_0.conda
osx-arm64::imagecodecs-2023.7.10-py311h334bf23_0.conda
osx-arm64::xrootd-5.6.1-py39h8c5c091_0.conda
osx-arm64::libpq-14.5-hcea71ed_7.conda
osx-arm64::libopencv-4.8.0-py39h6a99d3f_0.conda
osx-arm64::nco-5.1.6-had0d954_2.conda
osx-arm64::gst-plugins-good-1.22.4-h2008d30_1.conda
osx-arm64::libarrow-12.0.1-hdeb1470_4_cpu.conda
osx-arm64::harp-1.19-py38h3d2e54c_0.conda
osx-arm64::paraview-5.11.1-py310h66781a6_102_qt.conda
osx-arm64::root_base-6.28.4-py311h8e5954a_0.conda
osx-arm64::openpmd-api-0.15.1-mpi_mpich_py311h69fd476_4.conda
osx-arm64::paraview-5.11.1-py311h7a8e6ae_102_qt.conda
osx-arm64::libfido2-1.13.0-h19e3c78_0.conda
osx-arm64::root_base-6.28.4-py310h38a37bc_0.conda
osx-arm64::libcurl-static-8.2.1-hc52a3a8_0.conda
osx-arm64::mesalib-23.1.4-h7bfda7a_0.conda
osx-arm64::nco-5.1.7-had0d954_0.conda
osx-arm64::libgrpc-1.56.0-h9075ed4_2.conda
osx-arm64::libarrow-12.0.1-h88bd06b_2_cpu.conda
osx-arm64::libgdal-arrow-parquet-3.7.1-h99c0ea5_2.conda
osx-arm64::arrow-cpp-9.0.0-py38hd07f9fe_43_cpu.conda
osx-arm64::xrootd-5.6.1-py310he177ee0_0.conda
osx-arm64::libtensorflow_cc-2.12.1-cpu_h34875b8_0.conda
osx-arm64::libvips-8.14.3-h5ad2d5b_1.conda
osx-arm64::gfortran_impl_osx-arm64-12.3.0-hbbb9e1e_1.conda
osx-arm64::cpp-opentelemetry-sdk-1.9.1-h3d26802_3.conda
osx-arm64::libarrow-12.0.1-h59b625a_7_cpu.conda
osx-arm64::libgdal-arrow-parquet-3.7.1-h99c0ea5_1.conda
osx-arm64::smesh-9.9.0.0-h27f135c_6.conda
osx-arm64::grpcio-1.56.0-py39hbad4f83_2.conda
osx-arm64::libopencv-4.7.0-py39h0595e9a_6.conda
osx-arm64::openpmd-api-0.15.1-mpi_openmpi_py311h3a8c5b6_4.conda
osx-arm64::jaxlib-0.4.14-cpu_py311hbb3eef1_1.conda
osx-arm64::libarrow-10.0.1-hecf3162_34_cpu.conda
osx-arm64::libarrow-10.0.1-h8c5da8f_33_cpu.conda
osx-arm64::tesseract-5.3.1-heffc8ea_0.conda
osx-arm64::ndcctools-7.6.1-py38h3b9d5fa_0.conda
osx-arm64::paraview-5.11.1-py39he4e27c8_102_qt.conda
osx-arm64::arrow-cpp-9.0.0-py39hafae4ac_42_cpu.conda
osx-arm64::ndcctools-7.6.0-py310h4b37b16_0.conda
osx-arm64::wxpython-4.2.1-py39hc68f845_0.conda
osx-arm64::libadios2-2.9.0-nompi_h0e6994a_100.conda
osx-arm64::yoda-1.9.6-py39he63495f_4.conda
osx-arm64::libopencv-4.8.0-py310he1ee2cc_0.conda
osx-arm64::lpython-0.18.1-ha614eb4_0.conda
osx-arm64::libvips-8.14.2-hd934089_2.conda
osx-arm64::ndcctools-7.6.0-py38h3b9d5fa_0.conda
osx-arm64::libarrow-12.0.1-h59b625a_5_cpu.conda
osx-arm64::mdtraj-1.9.8-py39hd7a7df8_1.conda
osx-arm64::yarp-cxx-3.8.1-h0b4bcb8_1.conda
osx-arm64::libarrow-12.0.1-h59b625a_3_cpu.conda
osx-arm64::libadios2-2.9.0-mpi_openmpi_h7fbabbf_0.conda
osx-arm64::leptonica-1.83.1-hce3091f_1.conda
osx-arm64::vtk-base-9.2.6-qt_py310h1234567_210.conda
osx-arm64::geotiff-1.7.1-h00e2a8a_11.conda
osx-arm64::mdtraj-1.9.8-py310h7c9e852_0.conda
osx-arm64::grpcio-1.56.2-py39hbad4f83_0.conda
osx-arm64::ogre-13.6.5-h86394e4_0.conda
osx-arm64::photochem-0.4.2-py38hc0bbd45_0.conda
osx-arm64::folly-2023.07.10.00-h03318f1_0.conda
osx-arm64::libnetcdf-4.9.2-mpi_mpich_h797b8ff_7.conda
osx-arm64::mysql-libs-8.0.33-hb292caa_1.conda
osx-arm64::pocl-core-4.0-hbf99284_2.conda
osx-arm64::qt6-main-6.5.1-h372468e_3.conda
osx-arm64::xrootd-5.5.5-py311h4e7788a_2.conda
osx-arm64::libcurl-8.2.0-hc52a3a8_0.conda
osx-arm64::magics-4.14.1-hcee89ea_0.conda
osx-arm64::gfortran_impl_osx-arm64-11.3.0-h0f47096_32.conda
osx-arm64::xrootd-5.5.5-py39h1eaaa1c_1.conda
osx-arm64::gfortran_impl_osx-64-11.3.0-h585fe66_32.conda
osx-arm64::libarrow-10.0.1-hecf3162_33_cpu.conda
osx-arm64::libarrow-12.0.1-hdeb1470_7_cpu.conda
osx-arm64::leptonica-1.83.1-hc5693f2_0.conda
osx-arm64::r-base-4.3.1-h8babed3_2.conda
osx-arm64::libgdal-3.6.4-ha17daef_7.conda
osx-arm64::libgdal-arrow-parquet-3.7.1-h87b0dfd_4.conda
osx-arm64::libadios2-2.9.0-mpi_openmpi_h66270dc_0.conda
osx-arm64::libarrow-11.0.0-hdeb1470_29_cpu.conda
osx-arm64::folly-2023.07.24.00-h1e8fca9_0.conda
osx-arm64::qt-main-5.15.8-hab52160_15.conda
osx-arm64::photochem-0.4.2-py311h0acae09_1.conda
osx-arm64::jaxlib-0.4.14-cpu_py311h1354b63_1.conda
osx-arm64::mosh-1.4.0-pl5321h1746cb1_2.conda
osx-arm64::libcurl-static-8.2.0-hc52a3a8_0.conda
osx-arm64::libarrow-12.0.1-hdeb1470_5_cpu.conda
osx-arm64::wxpython-4.2.1-py310hfa888ef_0.conda
osx-arm64::jaxlib-0.4.12-cpu_py39h1d8eb90_1.conda
osx-arm64::mysql-server-8.0.33-h8d2d40f_2.conda
osx-arm64::root_base-6.28.4-py38h4e07059_0.conda
osx-arm64::vtk-base-9.2.6-qt_py38h1234567_210.conda
osx-arm64::tiledb-2.16.0-h99ee4e4_3.conda
osx-arm64::python-igraph-0.10.6-py311h21d7fee_0.conda
osx-arm64::openpmd-api-0.15.1-mpi_openmpi_py38hfb53f66_4.conda
osx-arm64::libgdal-3.7.1-h587dc96_0.conda
osx-arm64::postgresql-plpython-14.5-py39h620b887_7.conda
osx-arm64::libtensorflow-2.12.1-cpu_h3438d36_0.conda
osx-arm64::folly-2023.07.10.00-h1e8fca9_0.conda
osx-arm64::python-igraph-0.10.4-py38hce957be_1.conda
osx-arm64::ambertools-23.3-py311ha883923_2.conda
osx-arm64::libopencv-4.8.0-py310hdc0018b_0.conda
osx-arm64::libcurl-8.1.2-hc52a3a8_1.conda
osx-arm64::tiledb-2.16.0-hc77a09f_2.conda
osx-arm64::aws-sdk-cpp-1.10.57-h6f3a27c_17.conda
osx-arm64::libarrow-11.0.0-hdeb1470_32_cpu.conda
osx-arm64::mdtraj-1.9.9-py311h06bfd7f_0.conda
osx-arm64::wxpython-4.2.1-py38ha92163b_0.conda
osx-arm64::indexed_gzip-1.8.3-py38h9a7ff8e_0.conda
osx-arm64::openpmd-api-0.15.1-mpi_mpich_py39h03f4d60_4.conda
osx-arm64::cctools_osx-64-973.0.1-h4f2729c_14.conda
osx-arm64::openpmd-api-0.15.1-mpi_openmpi_py310h29e50d2_4.conda
osx-arm64::dcap-2.47.14-hb5af9f8_1.conda
osx-arm64::libopencv-4.7.0-py311h6e04221_6.conda
osx-arm64::libgdal-3.7.0-h587dc96_5.conda
osx-arm64::harp-1.19-py310h3d2e54c_0.conda
osx-arm64::omniorb-libs-4.3.0-h13d9943_0.conda
osx-arm64::vtk-base-9.2.6-qt_py39h1234567_210.conda
osx-arm64::libgdal-arrow-parquet-3.7.1-h99c0ea5_3.conda
osx-arm64::libmediainfo-23.07-hbb71fad_0.conda
osx-arm64::python-igraph-0.10.6-py310h94f578b_0.conda
osx-arm64::mdtraj-1.9.8-py311h06bfd7f_2.conda
osx-arm64::ambertools-23.3-py310hd4daa78_2.conda
osx-arm64::librdkafka-2.2.0-hb5b8459_0.conda
osx-arm64::libnetcdf-4.9.2-mpi_openmpi_hdeef9d7_8.conda
osx-arm64::vtk-base-9.2.6-qt_py38h1234567_209.conda
osx-arm64::libarrow-12.0.1-hdeb1470_3_cpu.conda
osx-arm64::gazebo-11.13.0-h2067851_4.conda
osx-arm64::tensorflow-base-2.12.1-cpu_py311hdc87d94_0.conda
osx-arm64::lpython-0.19.0-ha614eb4_0.conda
osx-arm64::nest-simulator-3.5-py39h5120e94_0.conda
osx-arm64::folly-2023.07.10.00-h2c5142d_0_jemalloc.conda
osx-arm64::python-igraph-0.10.5-py38hce957be_0.conda
osx-arm64::arrow-cpp-9.0.0-py311hf190ae7_42_cpu.conda
osx-arm64::libarrow-11.0.0-h59b625a_31_cpu.conda
osx-arm64::aws-sdk-cpp-1.11.68-h6f3a27c_9.conda
osx-arm64::libgdal-arrow-parquet-3.6.4-h5ffcfcf_10.conda
osx-arm64::tensorflow-base-2.12.1-cpu_py310hb09a367_0.conda
osx-arm64::xrootd-5.5.5-py38h71b7c2f_1.conda
osx-arm64::pillow-10.0.0-py311h095fde6_0.conda
osx-arm64::grpcio-1.56.0-py310h95b248a_2.conda
osx-arm64::texlive-core-20230313-py310h8f5c236_4.conda
osx-arm64::mdtraj-1.9.8-py311h06bfd7f_0.conda
osx-arm64::tiledb-2.16.0-hc77a09f_3.conda
osx-arm64::r-base-4.3.1-h8babed3_3.conda
osx-arm64::yoda-1.9.6-py311h035cf47_4.conda
osx-arm64::libgdal-3.7.1-hd845ade_1.conda
osx-arm64::jaxlib-0.4.12-cpu_py310h07108a6_1.conda
osx-arm64::libadios2-2.9.0-mpi_mpich_hcf98a40_0.conda
osx-arm64::geotiff-1.7.1-h00e2a8a_10.conda
osx-arm64::grpcio-1.56.2-py311hea943cd_0.conda
osx-arm64::magics-metview-4.14.1-h519023f_0.conda
osx-arm64::libadios2-2.9.0-mpi_mpich_h1b2a255_0.conda
osx-arm64::libarrow-12.0.1-hdeb1470_6_cpu.conda
osx-arm64::curl-8.1.2-hc52a3a8_1.conda
osx-arm64::arrow-cpp-9.0.0-py310h8094765_43_cpu.conda
osx-arm64::lxml-4.9.3-py38hbfa3897_0.conda
osx-arm64::python-igraph-0.10.4-py39h4273bee_1.conda
osx-arm64::libgdal-3.6.4-h148ccd5_8.conda
osx-arm64::qt6-3d-6.5.1-hb40c1b2_1.conda
osx-arm64::libopentelemetry-cpp-1.10.0-h3d26802_0.conda
osx-arm64::libgdal-3.6.4-h148ccd5_9.conda
osx-arm64::postgresql-plpython-14.5-py311h885f1b6_7.conda
osx-arm64::gfortran_impl_osx-64-12.3.0-h721ce5f_1.conda
osx-arm64::lpython-0.18.0-ha614eb4_0.conda
osx-arm64::folly-2023.07.17.00-h2c5142d_0_jemalloc.conda
osx-arm64::mysql-client-8.0.33-h41974c7_1.conda
osx-arm64::postgresql-plpython-15.3-py38h3275ed9_2.conda
osx-arm64::gst-plugins-good-1.22.5-h2008d30_0.conda
osx-arm64::smesh-9.9.0.0-h9ff214d_6.conda
osx-arm64::magics-metview-batch-4.14.1-hcee89ea_0.conda
osx-arm64::paraview-5.11.1-py38h659cdf2_102_qt.conda
osx-arm64::llvmdev-16.0.6-h504e6bf_1.conda
osx-arm64::cpp-opentelemetry-sdk-1.10.0-h3d26802_0.conda
osx-arm64::openpmd-api-0.15.1-nompi_py38h215fbd1_104.conda
osx-arm64::arrow-cpp-9.0.0-py310h8094765_42_cpu.conda
osx-arm64::libopentelemetry-cpp-1.9.1-h3d26802_3.conda
osx-arm64::libopencv-4.8.0-py311hb1728df_0.conda
osx-arm64::libopencv-4.7.0-py311hb1728df_6.conda
osx-arm64::ambertools-23.3-py38hf78641e_2.conda
osx-arm64::qt6-main-6.5.1-he484b70_4.conda
osx-arm64::jaxlib-0.4.14-cpu_py310h368a38e_1.conda
osx-arm64::libgdal-arrow-parquet-3.6.4-h3550b90_7.conda
osx-arm64::lpython-0.18.3-ha614eb4_0.conda
osx-arm64::root_base-6.28.4-py39hfe5a6d5_1.conda
osx-arm64::grpcio-1.56.0-py311hea943cd_2.conda
osx-arm64::xrootd-5.5.5-py310he177ee0_2.conda
osx-arm64::libnetcdf-4.9.2-nompi_h9fa6108_108.conda
osx-arm64::imagecodecs-2023.7.10-py310h1259d31_1.conda
osx-arm64::openpmd-api-0.15.1-mpi_mpich_py38hd879443_4.conda
osx-arm64::arrow-cpp-9.0.0-py311hf190ae7_43_cpu.conda
osx-arm64::jaxlib-0.4.14-cpu_py310hec32d7d_1.conda
osx-arm64::tensorflow-base-2.12.1-cpu_py39hc36e8ce_0.conda
osx-arm64::postgresql-14.5-h00cd704_7.conda
osx-arm64::libglib-2.76.4-h24e9cb9_0.conda
osx-arm64::python-igraph-0.10.5-py310h94f578b_0.conda
osx-arm64::cpp-opentelemetry-sdk-1.9.1-ha34c9a6_3.conda
osx-arm64::vtk-base-9.2.6-qt_py311h1234567_209.conda
osx-arm64::libadios2-2.9.0-mpi_openmpi_h84b0edd_0.conda
osx-arm64::llvm-16.0.6-h2b67075_1.conda
osx-arm64::imagecodecs-2023.7.10-py39h24b8818_2.conda
osx-arm64::libnetcdf-4.9.2-mpi_mpich_h4c2882b_9.conda
osx-arm64::pgplot-5.2.2-h86977c9_1008.conda
osx-arm64::arrow-cpp-9.0.0-py310habaf184_43_cpu.conda
osx-arm64::orc-1.9.0-ha98e9e8_1.conda
osx-arm64::libpq-15.3-hcea71ed_2.conda
osx-arm64::arrow-cpp-9.0.0-py39h4b608d4_43_cpu.conda
osx-arm64::libarrow-10.0.1-h8c5da8f_32_cpu.conda
osx-arm64::libarrow-12.0.1-h59b625a_6_cpu.conda
osx-arm64::libarrow-11.0.0-hdeb1470_31_cpu.conda
osx-arm64::libgdal-arrow-parquet-3.7.0-h5ebab21_5.conda
osx-arm64::mdtraj-1.9.8-py38h713f041_0.conda
osx-arm64::tiledb-2.16.1-hc77a09f_0.conda
osx-arm64::folly-2023.07.24.00-h2c5142d_0_jemalloc.conda
osx-arm64::nest-simulator-3.5-py38h82a93d1_0.conda
osx-arm64::r-base-4.3.0-h4b3f977_2.conda
osx-arm64::r-base-4.3.1-h4b3f977_1.conda
osx-arm64::tiledb-2.16.1-h99ee4e4_0.conda
osx-arm64::xrootd-5.5.5-py311h449bba7_1.conda
osx-arm64::libadios2-2.9.0-mpi_mpich_h74d04e3_0.conda
osx-arm64::grpcio-1.56.1-py39hbad4f83_0.conda
osx-arm64::grpcio-1.56.2-py38h761d82c_0.conda
osx-arm64::arrow-cpp-9.0.0-py311h98fdc99_43_cpu.conda
osx-arm64::xrootd-5.5.5-py310h59780b5_1.conda
osx-arm64::root_base-6.28.4-py39hfe5a6d5_0.conda
osx-arm64::nest-simulator-3.5-py38h82a93d1_1.conda
osx-arm64::r-base-4.2.3-h4b3f977_5.conda
osx-arm64::r-base-4.2.3-h4b3f977_4.conda
osx-arm64::xrootd-5.5.5-py39h8c5c091_2.conda
osx-arm64::indexed_gzip-1.8.3-py311h29dc21d_0.conda
osx-arm64::libarrow-11.0.0-h59b625a_32_cpu.conda
osx-arm64::qt6-3d-6.5.2-hb40c1b2_0.conda
osx-arm64::libnetcdf-4.9.2-mpi_openmpi_hdeef9d7_9.conda
osx-arm64::libvips-8.14.2-hd934089_3.conda
osx-arm64::llvm-tools-16.0.6-he79909e_1.conda
osx-arm64::paraview-5.11.1-py38hdbad562_102_qt.conda
osx-arm64::r-base-4.2.3-h8babed3_6.conda
osx-arm64::gfortran_impl_osx-64-12.2.0-hc02e272_32.conda
osx-arm64::openpmd-api-0.15.1-mpi_openmpi_py39h9ad568d_4.conda
osx-arm64::libopencv-4.7.0-py38haec4208_6.conda
osx-arm64::libopencv-4.8.0-py311h6e04221_0.conda
osx-arm64::python-igraph-0.10.6-py39h4273bee_0.conda
osx-arm64::tiledb-2.16.1-h5345278_0.conda
osx-arm64::postgresql-plpython-15.3-py311h885f1b6_2.conda
osx-arm64::yoda-1.9.6-py310hd739576_3.conda
osx-arm64::libadios2-2.9.0-nompi_hb40c12d_100.conda
osx-arm64::glib-2.76.4-ha614eb4_0.conda
osx-arm64::photochem-0.4.2-py311h1b736e2_0.conda
osx-arm64::arrow-cpp-9.0.0-py38h202536e_43_cpu.conda
osx-arm64::gazebo-11.13.0-h6d74803_4.conda
osx-arm64::curl-8.2.0-hc52a3a8_0.conda
osx-arm64::yoda-1.9.6-py39he63495f_3.conda
osx-arm64::folly-2023.07.03.00-h03318f1_0.conda
osx-arm64::arrow-cpp-9.0.0-py311h98fdc99_44_cpu.conda
osx-arm64::jaxlib-0.4.14-cpu_py39h095f3ce_1.conda
osx-arm64::mdtraj-1.9.9-py310h7c9e852_0.conda
osx-arm64::python-igraph-0.10.5-py39h4273bee_0.conda
osx-arm64::libadios2-2.9.0-mpi_openmpi_h9ac4f70_0.conda
osx-arm64::libgdal-arrow-parquet-3.6.4-h5ffcfcf_8.conda
osx-arm64::mdtraj-1.9.8-py39hd7a7df8_2.conda
osx-arm64::grpcio-1.56.1-py311hea943cd_0.conda
osx-arm64::mysql-libs-8.0.33-hb292caa_2.conda
osx-arm64::postgresql-plpython-15.3-py39h620b887_2.conda
osx-arm64::xrootd-5.5.5-py38h16fb1ff_2.conda
osx-arm64::libgdal-3.7.1-hd845ade_2.conda
osx-arm64::libarrow-11.0.0-h59b625a_30_cpu.conda
osx-arm64::libopentelemetry-cpp-1.10.0-ha34c9a6_0.conda
osx-arm64::libnetcdf-4.9.2-nompi_h9fa6108_109.conda
osx-arm64::libgdal-3.7.1-hd845ade_3.conda
osx-arm64::mdtraj-1.9.8-py310h7c9e852_2.conda
osx-arm64::photochem-0.4.2-py38h30c83be_1.conda
osx-arm64::collada-dom-2.5.0-hc8b405f_6.conda
osx-arm64::ndcctools-7.6.1-py39h6d2f949_0.conda
osx-arm64::mysql-server-8.0.33-hdad01d3_2.conda
osx-arm64::mysql-server-8.0.33-hdad01d3_1.conda
osx-arm64::root_base-6.28.4-py38h4e07059_1.conda
osx-arm64::arrow-cpp-9.0.0-py39hafae4ac_44_cpu.conda
osx-arm64::libgrpc-1.56.1-h9075ed4_0.conda
osx-arm64::folly-2023.07.24.00-hd189c9a_0_jemalloc.conda
osx-arm64::lxml-4.9.3-py39hb67b4e4_0.conda
osx-arm64::mdtraj-1.9.8-py311h06bfd7f_1.conda
osx-arm64::imagemagick-7.1.1_13-pl5321h903c885_0.conda
osx-arm64::libpulsar-3.2.0-he838ab4_2.conda
osx-arm64::libnetcdf-4.9.2-mpi_openmpi_habd4e93_7.conda
osx-arm64::libarrow-10.0.1-h8c5da8f_36_cpu.conda
osx-arm64::folly-2023.07.03.00-hd189c9a_0_jemalloc.conda
osx-arm64::mysql-client-8.0.33-h41974c7_2.conda
osx-arm64::libopencv-4.7.0-py310he1ee2cc_6.conda
osx-arm64::pillow-10.0.0-py310h60ecbdf_0.conda
osx-arm64::r-harp-1.19-py38hf52e936_0.conda
osx-arm64::tiledb-2.16.0-h99ee4e4_2.conda
osx-arm64::harp-1.19-py311h60c0f7b_0.conda
osx-arm64::photochem-0.4.2-py39h20f5ef6_0.conda
osx-arm64::libarrow-11.0.0-h3f25899_27_cpu.conda
osx-arm64::yarp-cxx-3.8.1-h0b4bcb8_2.conda
osx-arm64::leptonica-1.83.1-hce3091f_3.conda
osx-arm64::libadios2-2.9.0-mpi_mpich_h37257f3_0.conda
osx-arm64::libopencv-4.7.0-py310hdc0018b_6.conda
osx-arm64::ndcctools-7.6.1-py310h4b37b16_0.conda
osx-arm64::grpcio-1.56.0-py38h761d82c_2.conda
osx-arm64::lxml-4.9.3-py311hbafe683_0.conda
osx-arm64::python-igraph-0.10.6-py38hce957be_0.conda
osx-arm64::ambertools-23.3-py39hdb62838_2.conda
osx-arm64::gfortran_impl_osx-64-11.4.0-hd10cd46_0.conda
osx-arm64::python-igraph-0.10.5-py311h21d7fee_0.conda
osx-arm64::llvmdev-15.0.7-h504e6bf_3.conda
osx-arm64::folly-2023.07.10.00-hd189c9a_0_jemalloc.conda
osx-arm64::gmsh-4.11.1-hcaa16b8_3.conda
osx-arm64::python-igraph-0.10.4-py311h21d7fee_1.conda
osx-arm64::folly-2023.07.03.00-h2c5142d_0_jemalloc.conda
osx-arm64::indexed_gzip-1.8.3-py39h374918a_0.conda
osx-arm64::omniorb-4.3.0-py38h8c06ffa_0.conda
osx-arm64::mdtraj-1.9.8-py39hd7a7df8_0.conda
osx-arm64::curl-8.2.1-hc52a3a8_0.conda
osx-arm64::r-base-4.1.3-h8babed3_10.conda
osx-arm64::omniorb-4.3.0-py39h014b858_0.conda
osx-arm64::folly-2023.07.17.00-h1e8fca9_0.conda
osx-arm64::openpmd-api-0.15.1-nompi_py311h450d273_104.conda
osx-arm64::arrow-cpp-9.0.0-py310habaf184_44_cpu.conda
osx-arm64::cctools_osx-arm64-973.0.1-h2a25c60_14.conda
osx-arm64::folly-2023.07.17.00-hd189c9a_0_jemalloc.conda
osx-arm64::llvmdev-14.0.6-hd1a9a77_4.conda
osx-arm64::grpcio-1.56.2-py310h95b248a_0.conda
osx-arm64::libarrow-10.0.1-hecf3162_36_cpu.conda
osx-arm64::arrow-cpp-9.0.0-py38h202536e_44_cpu.conda
osx-arm64::arrow-cpp-9.0.0-py38hd07f9fe_44_cpu.conda
osx-arm64::yoda-1.9.6-py38h61c0ff5_3.conda
osx-arm64::ndcctools-7.6.0rc1-py39h6d2f949_0.conda
osx-arm64::ndcctools-7.6.0rc1-py311hf3cef61_0.conda
osx-arm64::leptonica-1.83.1-hce3091f_2.conda
osx-arm64::gfortran_impl_osx-64-12.3.0-h721ce5f_0.conda
osx-arm64::poppler-23.07.0-h16d8c84_0.conda
osx-arm64::libgdal-arrow-parquet-3.6.4-h5ffcfcf_9.conda
osx-arm64::python-igraph-0.10.4-py310h94f578b_1.conda
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
================================================================================
================================================================================
linux-ppc64le
linux-ppc64le::libclang-cpp-13.0.1-default_he4a137d_2.conda
linux-ppc64le::clang-format-13-13.0.1-root_62804_h7d07acf_3.conda
linux-ppc64le::clang-format-13.0.1-root_62804_h7d07acf_2.conda
linux-ppc64le::clang-13-13.0.1-root_62804_h7d07acf_2.conda
linux-ppc64le::clang-15-15.0.7-default_hb66b9a5_3.conda
linux-ppc64le::llvm-15.0.7-h8c9a019_3.conda
linux-ppc64le::clang-tools-13.0.1-root_62804_h7d07acf_3.conda
linux-ppc64le::clang-format-15-15.0.7-default_hb66b9a5_3.conda
linux-ppc64le::libclang-15.0.7-default_hb66b9a5_3.conda
linux-ppc64le::glib-tools-2.76.4-hff1ad0c_0.conda
linux-ppc64le::libclang-13.0.1-root_62804_h7d07acf_2.conda
linux-ppc64le::llvm-tools-15.0.7-h7c8ec72_3.conda
linux-ppc64le::micromamba-1.4.8-0.tar.bz2
linux-ppc64le::micromamba-1.4.7-0.tar.bz2
linux-ppc64le::libclang-cpp15-15.0.7-default_hb66b9a5_3.conda
linux-ppc64le::clang-tools-15.0.7-default_hb66b9a5_3.conda
linux-ppc64le::clang-format-13-13.0.1-root_62804_h7d07acf_2.conda
linux-ppc64le::libclang-cpp-13.0.1-default_he4a137d_3.conda
linux-ppc64le::libclang-cpp13-13.0.1-root_62804_h7d07acf_3.conda
linux-ppc64le::clang-tools-13.0.1-default_he4a137d_2.conda
linux-ppc64le::clang-format-13-13.0.1-default_he4a137d_2.conda
linux-ppc64le::libclang-cpp-15.0.7-default_hb66b9a5_3.conda
linux-ppc64le::clang-13-13.0.1-default_he4a137d_2.conda
linux-ppc64le::clang-format-13.0.1-root_62804_h7d07acf_3.conda
linux-ppc64le::cfitsio-4.3.0-hde815af_0.conda
linux-ppc64le::libclang-13.0.1-root_62804_h7d07acf_3.conda
linux-ppc64le::clang-13-13.0.1-root_62804_h7d07acf_3.conda
linux-ppc64le::clang-format-15.0.7-default_hb66b9a5_3.conda
linux-ppc64le::libclang-13.0.1-default_he4a137d_2.conda
linux-ppc64le::libclang-cpp13-13.0.1-root_62804_h7d07acf_2.conda
linux-ppc64le::libclang-cpp-13.0.1-root_62804_h7d07acf_3.conda
linux-ppc64le::libclang-cpp13-13.0.1-default_he4a137d_2.conda
linux-ppc64le::clang-tools-13.0.1-default_he4a137d_3.conda
linux-ppc64le::libllvm15-15.0.7-h7c8ec72_3.conda
linux-ppc64le::zstd-1.5.2-h7292585_7.conda
linux-ppc64le::micromamba-1.4.6-0.tar.bz2
linux-ppc64le::micromamba-1.4.9-0.tar.bz2
linux-ppc64le::libclang-cpp13-13.0.1-default_he4a137d_3.conda
linux-ppc64le::libllvm14-14.0.6-hf7e7dc2_4.conda
linux-ppc64le::llvm-14.0.6-h12068cf_4.conda
linux-ppc64le::gst-libav-1.22.5-h95e5f97_0.conda
linux-ppc64le::clang-format-13.0.1-default_he4a137d_3.conda
linux-ppc64le::clang-tools-13.0.1-root_62804_h7d07acf_2.conda
linux-ppc64le::clang-format-13-13.0.1-default_he4a137d_3.conda
linux-ppc64le::msgpack-cxx-6.1.0-he4ce5e0_0.conda
linux-ppc64le::libclang13-15.0.7-default_h6cf0fa1_3.conda
linux-ppc64le::libclang-cpp-13.0.1-root_62804_h7d07acf_2.conda
linux-ppc64le::clang-format-13.0.1-default_he4a137d_2.conda
linux-ppc64le::libclang-13.0.1-default_he4a137d_3.conda
linux-ppc64le::clang-13-13.0.1-default_he4a137d_3.conda
linux-ppc64le::llvm-tools-14.0.6-hf7e7dc2_4.conda
linux-ppc64le::libcups-2.3.3-hdb7e4ed_4.conda
-    "libzlib >=1.2.13,<1.3.0a0"
+    "libzlib >=1.2.13,<2.0.0a0"
linux-ppc64le::vtk-base-9.2.6-qt_py311h1234567_210.conda
linux-ppc64le::libarrow-10.0.1-h94b1af3_35_cpu.conda
linux-ppc64le::grpcio-1.56.2-py310h8eb8f48_0.conda
linux-ppc64le::libarrow-11.0.0-h1e2c587_27_cuda.conda
linux-ppc64le::libadios2-2.9.0-mpi_openmpi_h773617d_0.conda
linux-ppc64le::libcurl-8.1.2-ha571e8f_1.conda
linux-ppc64le::curl-8.2.0-ha571e8f_0.conda
linux-ppc64le::omniorb-4.3.0-py39ha8da32a_0.conda
linux-ppc64le::python-igraph-0.10.5-py311hbff4574_0.conda
linux-ppc64le::magic-8.3.413-h7eb73fb_0.conda
linux-ppc64le::llvmdev-16.0.6-h7c8ec72_1.conda
linux-ppc64le::libgdal-3.7.0-h7e07ef2_5.conda
linux-ppc64le::vtk-base-9.2.6-qt_py39h1234567_209.conda
linux-ppc64le::arrow-cpp-9.0.0-py39h40c8dd4_43_cuda.conda
linux-ppc64le::arrow-cpp-9.0.0-py39hded6c56_43_cuda.conda
linux-ppc64le::arrow-cpp-9.0.0-py38h572932e_43_cuda.conda
linux-ppc64le::grpcio-1.56.2-py311h3997ded_0.conda
linux-ppc64le::tiledb-2.16.1-hac2e0cb_0.conda
linux-ppc64le::libarrow-11.0.0-h482c825_32_cpu.conda
linux-ppc64le::openpmd-api-0.15.1-mpi_mpich_py39h5822df7_4.conda
linux-ppc64le::python-igraph-0.10.4-py310hc803601_1.conda
linux-ppc64le::xrootd-5.5.5-py39h82c12fb_1.conda
linux-ppc64le::libarrow-12.0.1-h482c825_4_cpu.conda
linux-ppc64le::libpulsar-3.2.0-hf118e2e_2.conda
linux-ppc64le::openpmd-api-0.15.1-mpi_mpich_py39h6229c39_4.conda
linux-ppc64le::tesseract-5.3.1-h6b5b2ab_0.conda
linux-ppc64le::arrow-cpp-9.0.0-py39hded6c56_44_cuda.conda
linux-ppc64le::nordugrid-arc-6.17.0-py39hbf8ffea_1.conda
linux-ppc64le::libvips-8.14.3-hdae6d06_1.conda
linux-ppc64le::libarrow-11.0.0-he661863_32_cuda.conda
linux-ppc64le::healpy-1.16.3-py38he6521ef_0.conda
linux-ppc64le::glib-networking-2.76.1-h81f63f5_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.1-h9a18b86_4.conda
linux-ppc64le::libnetcdf-4.9.2-mpi_mpich_h42c5080_7.conda
linux-ppc64le::libarrow-11.0.0-h94b1af3_31_cpu.conda
linux-ppc64le::clangdev-13.0.1-default_he4a137d_3.conda
linux-ppc64le::openpmd-api-0.15.1-mpi_openmpi_py39h07198dc_4.conda
linux-ppc64le::libopencv-4.7.0-py311h0c0e2eb_6.conda
linux-ppc64le::libarrow-10.0.1-h924aa32_33_cuda.conda
linux-ppc64le::postgresql-plpython-15.3-py39h8e6b938_2.conda
linux-ppc64le::libarrow-11.0.0-h482c825_29_cpu.conda
linux-ppc64le::libadios2-2.9.0-mpi_mpich_h09aab29_0.conda
linux-ppc64le::openpmd-api-0.15.1-mpi_openmpi_py310h568298f_4.conda
linux-ppc64le::openpmd-api-0.15.1-nompi_py38hb671de6_104.conda
linux-ppc64le::libopencv-4.8.0-py39hef11d34_0.conda
linux-ppc64le::arrow-cpp-9.0.0-py39h880642c_44_cpu.conda
linux-ppc64le::tiledb-2.16.0-hac2e0cb_3.conda
linux-ppc64le::libopencv-4.8.0-py38h4e57135_0.conda
linux-ppc64le::imagecodecs-2023.7.10-py311h18ab8cc_2.conda
linux-ppc64le::libopencv-4.8.0-py38h364d9e3_0.conda
linux-ppc64le::python-igraph-0.10.6-py39h25c36b7_0.conda
linux-ppc64le::llvm-16.0.6-h381f82a_1.conda
linux-ppc64le::arrow-cpp-9.0.0-py38h8f899f5_43_cpu.conda
linux-ppc64le::postgresql-plpython-14.5-py311hba550cb_7.conda
linux-ppc64le::mysql-libs-8.0.33-h3ac40eb_1.conda
linux-ppc64le::arrow-cpp-9.0.0-py38h9176beb_43_cuda.conda
linux-ppc64le::arrow-cpp-9.0.0-py311h5795f53_44_cuda.conda
linux-ppc64le::folly-2023.07.03.00-hd692e58_0.conda
linux-ppc64le::imagecodecs-2023.7.10-py310hacf2c7f_0.conda
linux-ppc64le::libpq-15.3-h9d99649_2.conda
linux-ppc64le::arrow-cpp-9.0.0-py310hba6c020_44_cpu.conda
linux-ppc64le::arrow-cpp-9.0.0-py39hded6c56_42_cuda.conda
linux-ppc64le::omniorb-4.3.0-py311h7d8a50b_0.conda
linux-ppc64le::libarrow-11.0.0-h73da52b_31_cuda.conda
linux-ppc64le::openpmd-api-0.15.1-nompi_py311h8d65320_104.conda
linux-ppc64le::libadios2-2.9.0-nompi_h74f674e_100.conda
linux-ppc64le::geotiff-1.7.1-h764e20a_10.conda
linux-ppc64le::nordugrid-arc-6.17.0-py38heab44e5_1.conda
linux-ppc64le::arrow-cpp-9.0.0-py310hc1ecd97_42_cpu.conda
linux-ppc64le::gst-plugins-base-1.22.5-hb6c1c46_0.conda
linux-ppc64le::mysql-server-8.0.33-h3aa03ee_1.conda
linux-ppc64le::libgdal-arrow-parquet-3.6.4-hb50efc4_7.conda
linux-ppc64le::libopentelemetry-cpp-1.9.1-hdb32d07_3.conda
linux-ppc64le::vtk-base-9.2.6-qt_py310h1234567_209.conda
linux-ppc64le::libarrow-12.0.1-h1e2c587_2_cuda.conda
linux-ppc64le::pillow-10.0.0-py38hb352ec4_0.conda
linux-ppc64le::pillow-10.0.0-py39ha1c4a29_0.conda
linux-ppc64le::libadios2-2.9.0-mpi_openmpi_ha7812b6_0.conda
linux-ppc64le::xrootd-5.5.5-py39h8efc160_2.conda
linux-ppc64le::lxml-4.9.3-py39h9d2759b_0.conda
linux-ppc64le::openpmd-api-0.15.1-nompi_py39h12cd277_104.conda
linux-ppc64le::gmsh-4.11.1-ha49ee91_3.conda
linux-ppc64le::libnetcdf-4.9.2-nompi_h38a15cc_107.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.1-h5e07c55_0.conda
linux-ppc64le::arrow-cpp-9.0.0-py39h880642c_43_cpu.conda
linux-ppc64le::folly-2023.07.10.00-h361900a_0.conda
linux-ppc64le::mysql-libs-8.0.33-h3ac40eb_2.conda
linux-ppc64le::pgplot-5.2.2-hfa2a1f1_1008.conda
linux-ppc64le::libarrow-10.0.1-h16eb990_32_cuda.conda
linux-ppc64le::grpcio-1.56.0-py39h278787b_2.conda
linux-ppc64le::libadios2-2.9.0-mpi_openmpi_h8549cef_0.conda
linux-ppc64le::libarrow-12.0.1-he661863_6_cuda.conda
linux-ppc64le::libarrow-12.0.1-h482c825_7_cpu.conda
linux-ppc64le::libgdal-3.6.4-h1bdb74f_7.conda
linux-ppc64le::arrow-cpp-9.0.0-py38h9176beb_44_cuda.conda
linux-ppc64le::clangdev-13.0.1-default_he4a137d_2.conda
linux-ppc64le::libarrow-10.0.1-he661863_35_cuda.conda
linux-ppc64le::libgdal-3.7.1-hb943191_3.conda
linux-ppc64le::leptonica-1.83.1-h6b92841_0.conda
linux-ppc64le::libopencv-4.7.0-py38hbf8f3c2_6.conda
linux-ppc64le::libarrow-12.0.1-h73da52b_7_cuda.conda
linux-ppc64le::libopencv-4.8.0-py39h7d88c0c_0.conda
linux-ppc64le::r-base-4.2.3-h2bca5a3_4.conda
linux-ppc64le::libarrow-10.0.1-h73da52b_36_cuda.conda
linux-ppc64le::aws-sdk-cpp-1.10.57-h033a498_17.conda
linux-ppc64le::xrootd-5.6.1-py38h1a35e86_0.conda
linux-ppc64le::openssh-9.3p1-h9d99649_2.conda
linux-ppc64le::arrow-cpp-9.0.0-py311hd55eadd_43_cpu.conda
linux-ppc64le::libadios2-2.8.3-mpi_openmpi_hd78801d_7.conda
linux-ppc64le::lxml-4.9.3-py311h1860687_0.conda
linux-ppc64le::mysql-router-8.0.33-hce96e34_2.conda
linux-ppc64le::yarp-cxx-3.8.1-h2b8ed06_1.conda
linux-ppc64le::libopencv-4.8.0-py39h8bdbc30_0.conda
linux-ppc64le::libcurl-static-8.2.0-ha571e8f_0.conda
linux-ppc64le::libarrow-11.0.0-he0f22a4_27_cpu.conda
linux-ppc64le::arrow-cpp-9.0.0-py39h2332043_42_cpu.conda
linux-ppc64le::mysql-client-8.0.33-hfff87ee_1.conda
linux-ppc64le::libarrow-12.0.1-h482c825_6_cpu.conda
linux-ppc64le::libgrpc-1.56.0-hf11f071_2.conda
linux-ppc64le::grpcio-1.56.2-py39h278787b_0.conda
linux-ppc64le::libsoup-2.74.3-h1d14ca2_0.conda
linux-ppc64le::curl-8.2.1-ha571e8f_0.conda
linux-ppc64le::libopentelemetry-cpp-1.9.1-ha0f27b6_3.conda
linux-ppc64le::libgdal-3.7.1-hb943191_2.conda
linux-ppc64le::libvips-8.14.2-h331240f_2.conda
linux-ppc64le::libadios2-2.9.0-mpi_mpich_hf621a72_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.6.4-hcead826_9.conda
linux-ppc64le::libnetcdf-4.9.2-mpi_openmpi_hca41cff_9.conda
linux-ppc64le::healpy-1.16.3-py39h3dcc1aa_0.conda
linux-ppc64le::libgdal-3.7.1-hb943191_1.conda
linux-ppc64le::clangdev-13.0.1-root_62804_h7d07acf_3.conda
linux-ppc64le::imagecodecs-2023.7.10-py39h7d93c89_2.conda
linux-ppc64le::postgresql-14.5-h0ebe0f4_7.conda
linux-ppc64le::libarrow-12.0.1-h94b1af3_7_cpu.conda
linux-ppc64le::libopencv-4.7.0-py38h4e57135_6.conda
linux-ppc64le::libpulsar-3.2.0-h14e0310_2.conda
linux-ppc64le::libcurl-8.2.1-ha571e8f_0.conda
linux-ppc64le::imagemagick-7.1.1_15-pl5321hc264ee1_0.conda
linux-ppc64le::libarrow-10.0.1-h482c825_33_cpu.conda
linux-ppc64le::gst-plugins-base-1.22.4-hb6c1c46_1.conda
linux-ppc64le::libopentelemetry-cpp-1.10.0-hdb32d07_0.conda
linux-ppc64le::folly-2023.07.03.00-hfccd340_0_jemalloc.conda
linux-ppc64le::libarrow-11.0.0-h94b1af3_30_cpu.conda
linux-ppc64le::nco-5.1.6-h0f553bf_2.conda
linux-ppc64le::dcap-2.47.14-h83e7f9e_1.conda
linux-ppc64le::python-igraph-0.10.4-py39h25c36b7_1.conda
linux-ppc64le::libarrow-10.0.1-h94b1af3_33_cpu.conda
linux-ppc64le::leptonica-1.83.1-h6a51e6f_1.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.1-h676f787_2.conda
linux-ppc64le::lxml-4.9.3-py310h0e28d95_0.conda
linux-ppc64le::postgresql-plpython-14.5-py38he255f0a_7.conda
linux-ppc64le::libgrpc-1.56.2-hf11f071_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.0-h5e07c55_5.conda
linux-ppc64le::vtk-base-9.2.6-qt_py38h1234567_209.conda
linux-ppc64le::nco-5.1.7-h0f553bf_0.conda
linux-ppc64le::cpp-opentelemetry-sdk-1.10.0-ha0f27b6_0.conda
linux-ppc64le::libopencv-4.8.0-py38hbf8f3c2_0.conda
linux-ppc64le::gst-plugins-good-1.22.5-h199ceca_0.conda
linux-ppc64le::vtk-base-9.2.6-qt_py39h1234567_210.conda
linux-ppc64le::openpmd-api-0.15.1-mpi_openmpi_py38h94ea75c_4.conda
linux-ppc64le::grpcio-1.56.1-py38hc2aed35_0.conda
linux-ppc64le::postgresql-plpython-15.3-py311hba550cb_2.conda
linux-ppc64le::imagecodecs-2023.7.10-py310hf2835e1_2.conda
linux-ppc64le::openpmd-api-0.15.1-mpi_mpich_py310h8d529e3_4.conda
linux-ppc64le::libarrow-12.0.1-h16eb990_3_cuda.conda
linux-ppc64le::imagecodecs-2023.7.10-py39h63c1ab5_0.conda
linux-ppc64le::lxml-4.9.3-py38h12de51e_0.conda
linux-ppc64le::libgdal-3.6.4-h99ef657_8.conda
linux-ppc64le::libadios2-2.9.0-nompi_h2eb769f_100.conda
linux-ppc64le::xrootd-5.5.5-py38h8ecbf98_1.conda
linux-ppc64le::xrootd-5.5.5-py38h5169e4d_1.conda
linux-ppc64le::llvmdev-15.0.7-h7c8ec72_3.conda
linux-ppc64le::smesh-9.9.0.0-h79dfd53_6.conda
linux-ppc64le::python-igraph-0.10.5-py38h7b07f22_0.conda
linux-ppc64le::r-base-4.3.0-h2bca5a3_2.conda
linux-ppc64le::healpy-1.16.3-py39h5eae8ef_0.conda
linux-ppc64le::arrow-cpp-9.0.0-py311h9d6f373_43_cpu.conda
linux-ppc64le::folly-2023.07.17.00-hd692e58_0.conda
linux-ppc64le::pillow-10.0.0-py38h3b13620_0.conda
linux-ppc64le::libopencv-4.8.0-py38h84342df_0.conda
linux-ppc64le::libnetcdf-4.9.2-nompi_h6cf6fef_108.conda
linux-ppc64le::grpcio-1.56.1-py311h3997ded_0.conda
linux-ppc64le::gfortran_impl_osx-arm64-12.3.0-hd6d2b38_1.conda
linux-ppc64le::clangdev-13.0.1-root_62804_h7d07acf_2.conda
linux-ppc64le::libadios2-2.9.0-nompi_hd65b43d_100.conda
linux-ppc64le::aws-sdk-cpp-1.10.57-h9af5d64_15.conda
linux-ppc64le::aws-sdk-cpp-1.11.68-h033a498_9.conda
linux-ppc64le::squashfuse-0.2.0-h40af005_0.conda
linux-ppc64le::libadios2-2.9.0-nompi_h2e7e547_100.conda
linux-ppc64le::libopencv-4.7.0-py38h364d9e3_6.conda
linux-ppc64le::libcurl-8.2.0-ha571e8f_0.conda
linux-ppc64le::xrootd-5.6.1-py310h4b060cd_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.1-h676f787_3.conda
linux-ppc64le::libopencv-4.7.0-py310h42e93dd_6.conda
linux-ppc64le::xrootd-5.5.5-py39hde03b8a_2.conda
linux-ppc64le::clangdev-15.0.7-default_hb66b9a5_3.conda
linux-ppc64le::r-base-4.2.3-h8dfa0d7_6.conda
linux-ppc64le::python-igraph-0.10.6-py311hbff4574_0.conda
linux-ppc64le::cpp-opentelemetry-sdk-1.9.1-ha0f27b6_3.conda
linux-ppc64le::tiledb-2.16.1-hd5af256_0.conda
linux-ppc64le::libarrow-10.0.1-h94b1af3_34_cpu.conda
linux-ppc64le::libarrow-11.0.0-h94b1af3_28_cpu.conda
linux-ppc64le::python-igraph-0.10.4-py39he5b21eb_1.conda
linux-ppc64le::poppler-23.07.0-hcd38bda_0.conda
linux-ppc64le::python-igraph-0.10.5-py39h25c36b7_0.conda
linux-ppc64le::libgdal-3.7.1-h7e07ef2_0.conda
linux-ppc64le::folly-2023.07.03.00-h361900a_0.conda
linux-ppc64le::pillow-10.0.0-py311h0a7ca29_0.conda
linux-ppc64le::grpcio-1.56.1-py310h8eb8f48_0.conda
linux-ppc64le::arrow-cpp-9.0.0-py311hdba10d2_43_cuda.conda
linux-ppc64le::folly-2023.07.10.00-hd692e58_0.conda
linux-ppc64le::r-base-4.3.1-h2bca5a3_0.conda
linux-ppc64le::python-igraph-0.10.5-py38h6c555b0_0.conda
linux-ppc64le::healpy-1.16.3-py38h439b5e3_0.conda
linux-ppc64le::librdkafka-2.2.0-h8da8c2a_0.conda
linux-ppc64le::arrow-cpp-9.0.0-py39h40c8dd4_44_cuda.conda
linux-ppc64le::arrow-cpp-9.0.0-py311h5795f53_43_cuda.conda
linux-ppc64le::vtk-base-9.2.6-qt_py310h1234567_210.conda
linux-ppc64le::libarrow-11.0.0-h94b1af3_32_cpu.conda
linux-ppc64le::libarrow-11.0.0-h94b1af3_29_cpu.conda
linux-ppc64le::postgresql-15.3-h0ebe0f4_2.conda
linux-ppc64le::imagecodecs-2023.7.10-py311h1587191_1.conda
linux-ppc64le::libnetcdf-4.9.2-nompi_h6cf6fef_109.conda
linux-ppc64le::libopencv-4.7.0-py39h8bdbc30_6.conda
linux-ppc64le::curl-8.1.2-ha571e8f_1.conda
linux-ppc64le::libarrow-11.0.0-h482c825_30_cpu.conda
linux-ppc64le::imagecodecs-2023.7.10-py39h01f73ae_1.conda
linux-ppc64le::libgdal-arrow-parquet-3.6.4-hcead826_8.conda
linux-ppc64le::llvm-tools-16.0.6-h8d57982_1.conda
linux-ppc64le::imagecodecs-2023.7.10-py39h9e06246_2.conda
linux-ppc64le::libarrow-12.0.1-h94b1af3_6_cpu.conda
linux-ppc64le::libfido2-1.13.0-haf9a9e6_0.conda
linux-ppc64le::libarrow-12.0.1-h924aa32_3_cuda.conda
linux-ppc64le::arrow-cpp-9.0.0-py311hdba10d2_44_cuda.conda
linux-ppc64le::mosh-1.4.0-pl5321h20e5bb1_2.conda
linux-ppc64le::r-base-4.3.1-h0f43554_2.conda
linux-ppc64le::libarrow-10.0.1-h16eb990_33_cuda.conda
linux-ppc64le::libarrow-12.0.1-he7153da_2_cpu.conda
linux-ppc64le::mysql-router-8.0.33-hf77073f_1.conda
linux-ppc64le::texlive-core-20230313-h3cff5c3_4.conda
linux-ppc64le::folly-2023.07.17.00-h361900a_0.conda
linux-ppc64le::orc-1.9.0-h4d9d82a_1.conda
linux-ppc64le::grpcio-1.56.2-py38hc2aed35_0.conda
linux-ppc64le::openpmd-api-0.15.1-mpi_mpich_py38h6a3f854_4.conda
linux-ppc64le::ogre-13.6.5-hc3415f0_0.conda
linux-ppc64le::libarrow-12.0.1-h94b1af3_3_cpu.conda
linux-ppc64le::libarrow-10.0.1-h94b1af3_32_cpu.conda
linux-ppc64le::libpq-14.5-h9d99649_7.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.1-h676f787_1.conda
linux-ppc64le::mysql-client-8.0.33-hfff87ee_2.conda
linux-ppc64le::r-base-4.3.1-h8dfa0d7_2.conda
linux-ppc64le::openpmd-api-0.15.1-nompi_py310h6a05bff_104.conda
linux-ppc64le::libarrow-12.0.1-he661863_7_cuda.conda
linux-ppc64le::libgdal-3.6.4-h99ef657_10.conda
linux-ppc64le::nsight-compute-2022.4.0.15-h2bdc722_0.conda
linux-ppc64le::libcurl-static-8.1.2-ha571e8f_1.conda
linux-ppc64le::postgresql-plpython-15.3-py38he255f0a_2.conda
linux-ppc64le::libopentelemetry-cpp-1.10.0-ha0f27b6_0.conda
linux-ppc64le::ogre-14.0.1-hc3415f0_0.conda
linux-ppc64le::lxml-4.9.3-py39hbb791fb_0.conda
linux-ppc64le::arrow-cpp-9.0.0-py310h1bbc24f_43_cuda.conda
linux-ppc64le::aws-sdk-cpp-1.11.68-h9af5d64_7.conda
linux-ppc64le::libarrow-10.0.1-he661863_36_cuda.conda
linux-ppc64le::xrootd-5.5.5-py310h4b060cd_2.conda
linux-ppc64le::gfortran_impl_osx-arm64-11.3.0-h66caea2_32.conda
linux-ppc64le::postgresql-plpython-14.5-py310h33ccb9c_7.conda
linux-ppc64le::libarrow-10.0.1-h73da52b_35_cuda.conda
linux-ppc64le::arrow-cpp-9.0.0-py38h8f899f5_44_cpu.conda
linux-ppc64le::libarrow-10.0.1-h924aa32_34_cuda.conda
linux-ppc64le::cpp-opentelemetry-sdk-1.10.0-hdb32d07_0.conda
linux-ppc64le::imagecodecs-2023.7.10-py310h319411c_1.conda
linux-ppc64le::python-igraph-0.10.5-py310hc803601_0.conda
linux-ppc64le::xrootd-5.5.5-py311hf00abcb_2.conda
linux-ppc64le::rust-1.71.0-hb12b0c0_0.conda
linux-ppc64le::xrootd-5.6.1-py38h9683abd_0.conda
linux-ppc64le::libopencv-4.8.0-py311h0c0e2eb_0.conda
linux-ppc64le::libopencv-4.7.0-py39hbcf5460_6.conda
linux-ppc64le::arrow-cpp-9.0.0-py39h2332043_43_cpu.conda
linux-ppc64le::r-base-4.3.1-h0f43554_3.conda
linux-ppc64le::qt-main-5.15.8-h2859831_15.conda
linux-ppc64le::imagemagick-7.1.1_13-pl5321hc264ee1_0.conda
linux-ppc64le::tiledb-2.16.1-hf612678_0.conda
linux-ppc64le::folly-2023.07.03.00-h864cb69_0_jemalloc.conda
linux-ppc64le::mesalib-23.1.4-hb6f7a19_0.conda
linux-ppc64le::arrow-cpp-9.0.0-py310hc1ecd97_43_cpu.conda
linux-ppc64le::glib-2.76.4-hff1ad0c_0.conda
linux-ppc64le::libarrow-10.0.1-h482c825_36_cpu.conda
linux-ppc64le::libsoup-2.74.3-hc050987_1.conda
linux-ppc64le::omniorb-4.3.0-py38h7db1d0b_0.conda
linux-ppc64le::arrow-cpp-9.0.0-py311h9d6f373_44_cpu.conda
linux-ppc64le::openpmd-api-0.15.1-mpi_openmpi_py38h6633361_4.conda
linux-ppc64le::leptonica-1.83.1-h6a51e6f_3.conda
linux-ppc64le::arrow-cpp-9.0.0-py38h3907995_44_cpu.conda
linux-ppc64le::arrow-cpp-9.0.0-py310h638396c_43_cuda.conda
linux-ppc64le::orc-1.9.0-hccbfcb4_1.conda
linux-ppc64le::libvips-8.14.3-h331240f_0.conda
linux-ppc64le::imagecodecs-2023.7.10-py39h0c00fd5_1.conda
linux-ppc64le::tiledb-2.16.0-hd5af256_2.conda
linux-ppc64le::libarrow-12.0.1-h94b1af3_4_cpu.conda
linux-ppc64le::python-igraph-0.10.4-py38h7b07f22_1.conda
linux-ppc64le::libarrow-12.0.1-h94b1af3_5_cpu.conda
linux-ppc64le::libarrow-10.0.1-h94b1af3_36_cpu.conda
linux-ppc64le::libopencv-4.7.0-py39hef11d34_6.conda
linux-ppc64le::r-base-4.2.3-h2bca5a3_5.conda
linux-ppc64le::xrootd-5.5.5-py38h1a35e86_2.conda
linux-ppc64le::libarrow-10.0.1-h16eb990_34_cuda.conda
linux-ppc64le::libnetcdf-4.9.2-mpi_mpich_hb10901e_8.conda
linux-ppc64le::arrow-cpp-9.0.0-py310hc1ecd97_44_cpu.conda
linux-ppc64le::nordugrid-arc-6.17.0-py310h9c84844_1.conda
linux-ppc64le::openpmd-api-0.15.1-nompi_py38hfc3f19f_104.conda
linux-ppc64le::folly-2023.07.17.00-hfccd340_0_jemalloc.conda
linux-ppc64le::gfortran_impl_osx-64-11.4.0-ha4a30d0_1.conda
linux-ppc64le::libnetcdf-4.9.2-mpi_openmpi_hca41cff_8.conda
linux-ppc64le::grpcio-1.56.0-py38hc2aed35_2.conda
linux-ppc64le::xrootd-5.5.5-py310hc98085c_1.conda
linux-ppc64le::xorg-libxft-2.3.8-hb89d557_0.conda
linux-ppc64le::openpmd-api-0.15.1-mpi_mpich_py38h4a3df3b_4.conda
linux-ppc64le::arrow-cpp-9.0.0-py38h572932e_44_cuda.conda
linux-ppc64le::libarrow-11.0.0-h16eb990_28_cuda.conda
linux-ppc64le::arrow-cpp-9.0.0-py311h9d6f373_42_cpu.conda
linux-ppc64le::folly-2023.07.10.00-hfccd340_0_jemalloc.conda
linux-ppc64le::afterimage-1.21-h0edc79f_1004.conda
linux-ppc64le::python-igraph-0.10.5-py39he5b21eb_0.conda
linux-ppc64le::python-igraph-0.10.6-py38h7b07f22_0.conda
linux-ppc64le::arrow-cpp-9.0.0-py311hd55eadd_44_cpu.conda
linux-ppc64le::graphviz-8.1.0-h3732cb2_0.conda
linux-ppc64le::r-base-4.3.0-h2bca5a3_3.conda
linux-ppc64le::libarrow-10.0.1-h482c825_34_cpu.conda
linux-ppc64le::python-igraph-0.10.6-py310hc803601_0.conda
linux-ppc64le::xrootd-5.5.5-py39h54b5dd5_1.conda
linux-ppc64le::mysql-router-8.0.33-hf77073f_2.conda
linux-ppc64le::mysql-server-8.0.33-hed4504f_2.conda
linux-ppc64le::libcurl-static-8.2.1-ha571e8f_0.conda
linux-ppc64le::arrow-cpp-9.0.0-py39h2332043_44_cpu.conda
linux-ppc64le::python-igraph-0.10.6-py39he5b21eb_0.conda
linux-ppc64le::openpmd-api-0.15.1-mpi_mpich_py311hba88df3_4.conda
linux-ppc64le::tiledb-2.16.0-hac2e0cb_2.conda
linux-ppc64le::libarrow-12.0.1-he0f22a4_2_cpu.conda
linux-ppc64le::tiledb-2.16.0-hd5af256_3.conda
linux-ppc64le::libnetcdf-4.9.2-mpi_openmpi_hd22e50f_7.conda
linux-ppc64le::python-igraph-0.10.4-py38h6c555b0_1.conda
linux-ppc64le::davix-0.8.4-he923fdd_2.conda
linux-ppc64le::xrootd-5.5.5-py311h4bc39fc_1.conda
linux-ppc64le::pillow-10.0.0-py39h4f537d2_0.conda
linux-ppc64le::cpp-opentelemetry-sdk-1.9.1-hdb32d07_3.conda
linux-ppc64le::r-base-4.3.1-h2bca5a3_1.conda
linux-ppc64le::libopencv-4.8.0-py311h6d2cb00_0.conda
linux-ppc64le::xrootd-5.5.5-py38h9683abd_2.conda
linux-ppc64le::python-igraph-0.10.4-py311hbff4574_1.conda
linux-ppc64le::gfortran_impl_osx-arm64-12.3.0-hd6d2b38_0.conda
linux-ppc64le::folly-2023.07.17.00-h864cb69_0_jemalloc.conda
linux-ppc64le::libarrow-11.0.0-h73da52b_32_cuda.conda
linux-ppc64le::folly-2023.07.24.00-h361900a_0.conda
linux-ppc64le::folly-2023.07.24.00-hfccd340_0_jemalloc.conda
linux-ppc64le::openpmd-api-0.15.1-mpi_openmpi_py39hfde087f_4.conda
linux-ppc64le::lxml-4.9.3-py38h6e2f636_0.conda
linux-ppc64le::libopencv-4.7.0-py310h79c7107_6.conda
linux-ppc64le::python-igraph-0.10.6-py38h6c555b0_0.conda
linux-ppc64le::leptonica-1.83.1-h6a51e6f_2.conda
linux-ppc64le::libopencv-4.8.0-py39hbcf5460_0.conda
linux-ppc64le::libopencv-4.7.0-py311h6d2cb00_6.conda
linux-ppc64le::gst-plugins-good-1.22.4-h199ceca_1.conda
linux-ppc64le::yarp-cxx-3.8.1-h2b8ed06_3.conda
linux-ppc64le::xrootd-5.6.1-py39h8efc160_0.conda
linux-ppc64le::llvmdev-14.0.6-hf7e7dc2_4.conda
linux-ppc64le::tiledb-2.16.0-hac2e0cb_1.conda
linux-ppc64le::aws-sdk-cpp-1.11.68-h6f60616_8.conda
linux-ppc64le::geotiff-1.7.1-h764e20a_11.conda
linux-ppc64le::xrootd-5.6.1-py311hf00abcb_0.conda
linux-ppc64le::openpmd-api-0.15.1-nompi_py39hcc44589_104.conda
linux-ppc64le::omniorb-4.3.0-py310h94f889b_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.6.4-hcead826_10.conda
linux-ppc64le::libadios2-2.9.0-mpi_mpich_ha8b31ef_0.conda
linux-ppc64le::folly-2023.07.10.00-h864cb69_0_jemalloc.conda
linux-ppc64le::grpcio-1.56.0-py310h8eb8f48_2.conda
linux-ppc64le::smesh-9.9.0.0-h99dd2f7_6.conda
linux-ppc64le::eccodes-2.31.0-h611b61c_0.conda
linux-ppc64le::arrow-cpp-9.0.0-py310h638396c_44_cuda.conda
linux-ppc64le::pillow-10.0.0-py310h0fec2d4_0.conda
linux-ppc64le::folly-2023.07.24.00-h864cb69_0_jemalloc.conda
linux-ppc64le::libnetcdf-4.9.2-mpi_mpich_hb10901e_9.conda
linux-ppc64le::libarrow-12.0.1-h09ac494_2_cuda.conda
linux-ppc64le::arrow-cpp-9.0.0-py311hdba10d2_42_cuda.conda
linux-ppc64le::libopencv-4.7.0-py39h7d88c0c_6.conda
linux-ppc64le::vtk-base-9.2.6-qt_py38h1234567_210.conda
linux-ppc64le::libllvm16-16.0.6-h8d57982_1.conda
linux-ppc64le::imagecodecs-2023.7.10-py39hd97505f_0.conda
linux-ppc64le::arrow-cpp-9.0.0-py38h8f899f5_42_cpu.conda
linux-ppc64le::r-base-4.1.3-h307d64e_10.conda
linux-ppc64le::arrow-cpp-9.0.0-py310h638396c_42_cuda.conda
linux-ppc64le::arrow-cpp-9.0.0-py38h572932e_42_cuda.conda
linux-ppc64le::postgresql-plpython-15.3-py310h33ccb9c_2.conda
linux-ppc64le::xrootd-5.6.1-py39hde03b8a_0.conda
linux-ppc64le::libgrpc-1.56.1-hf11f071_0.conda
linux-ppc64le::libarrow-11.0.0-h482c825_31_cpu.conda
linux-ppc64le::libadios2-2.9.0-mpi_openmpi_hd78801d_0.conda
linux-ppc64le::libarrow-12.0.1-h482c825_5_cpu.conda
linux-ppc64le::postgresql-plpython-14.5-py39h8e6b938_7.conda
linux-ppc64le::imagemagick-7.1.1_14-pl5321hc264ee1_0.conda
linux-ppc64le::grpcio-1.56.1-py39h278787b_0.conda
linux-ppc64le::nordugrid-arc-6.17.0-py311h7197808_1.conda
linux-ppc64le::healpy-1.16.3-py310h8bbb151_0.conda
linux-ppc64le::tiledb-2.16.0-hf612678_2.conda
linux-ppc64le::libopencv-4.7.0-py38h84342df_6.conda
linux-ppc64le::openpmd-api-0.15.1-mpi_openmpi_py311h8bffa81_4.conda
linux-ppc64le::libopencv-4.8.0-py310h42e93dd_0.conda
linux-ppc64le::mysql-router-8.0.33-hce96e34_1.conda
linux-ppc64le::mysql-server-8.0.33-h3aa03ee_2.conda
linux-ppc64le::omniorb-libs-4.3.0-h64e73a3_0.conda
linux-ppc64le::yarp-cxx-3.8.1-h2b8ed06_2.conda
linux-ppc64le::arrow-cpp-9.0.0-py310h1bbc24f_44_cuda.conda
linux-ppc64le::libadios2-2.9.0-mpi_mpich_ha9b5181_0.conda
linux-ppc64le::libarrow-12.0.1-h482c825_3_cpu.conda
linux-ppc64le::gfortran_impl_osx-arm64-11.4.0-h5ca1b74_1.conda
linux-ppc64le::healpy-1.16.3-py311he5fe6df_0.conda
linux-ppc64le::folly-2023.07.24.00-hd692e58_0.conda
linux-ppc64le::imagecodecs-2023.7.10-py311h3838878_0.conda
linux-ppc64le::grpcio-1.56.0-py311h3997ded_2.conda
linux-ppc64le::arrow-cpp-9.0.0-py38h3907995_43_cpu.conda
linux-ppc64le::libarrow-12.0.1-h73da52b_6_cuda.conda
linux-ppc64le::libglib-2.76.4-hd7af32a_0.conda
linux-ppc64le::tiledb-2.16.0-hf612678_3.conda
linux-ppc64le::libgdal-3.7.1-h455b0a4_4.conda
linux-ppc64le::mosh-1.4.0-pl5321h9d5336f_2.conda
linux-ppc64le::mysql-server-8.0.33-hed4504f_1.conda
linux-ppc64le::vtk-base-9.2.6-qt_py311h1234567_209.conda
linux-ppc64le::aws-sdk-cpp-1.10.57-h6f60616_16.conda
linux-ppc64le::libarrow-11.0.0-he661863_31_cuda.conda
linux-ppc64le::libgdal-3.6.4-h99ef657_9.conda
linux-ppc64le::libvips-8.14.2-h331240f_3.conda
linux-ppc64le::libopencv-4.8.0-py310h79c7107_0.conda
linux-ppc64le::libarrow-10.0.1-h482c825_35_cpu.conda
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
================================================================================
================================================================================
linux-aarch64
linux-aarch64::libclang-cpp-13.0.1-root_62804_h6f8a30d_3.conda
linux-aarch64::clang-format-13-13.0.1-root_62804_h6f8a30d_2.conda
linux-aarch64::llvm-15.0.7-h70e32f0_3.conda
linux-aarch64::clang-tools-13.0.1-root_62804_h6f8a30d_3.conda
linux-aarch64::clang-format-15.0.7-default_hdf9a116_3.conda
linux-aarch64::clang-tools-13.0.1-root_62804_h6f8a30d_2.conda
linux-aarch64::clang-15-15.0.7-default_hdf9a116_3.conda
linux-aarch64::clang-format-15-15.0.7-default_hdf9a116_3.conda
linux-aarch64::libclang-cpp-13.0.1-root_62804_h6f8a30d_2.conda
linux-aarch64::clang-13-13.0.1-root_62804_h6f8a30d_3.conda
linux-aarch64::clang-tools-13.0.1-default_hdf9a116_3.conda
linux-aarch64::clang-13-13.0.1-root_62804_h6f8a30d_2.conda
linux-aarch64::zstd-1.5.2-h4c53e97_7.conda
linux-aarch64::clang-format-13.0.1-root_62804_h6f8a30d_3.conda
linux-aarch64::micromamba-1.4.6-0.tar.bz2
linux-aarch64::libllvm15-15.0.7-hc720cd8_3.conda
linux-aarch64::clang-13-13.0.1-default_hdf9a116_3.conda
linux-aarch64::eccodes-2.31.0-he7871a9_0.conda
linux-aarch64::clang-format-13-13.0.1-default_hdf9a116_2.conda
linux-aarch64::libllvm14-14.0.6-h966f666_4.conda
linux-aarch64::micromamba-1.4.9-0.tar.bz2
linux-aarch64::libclang-13.0.1-default_hdf9a116_3.conda
linux-aarch64::clang-format-13.0.1-default_hdf9a116_3.conda
linux-aarch64::clang-tools-13.0.1-default_hdf9a116_2.conda
linux-aarch64::msgpack-cxx-6.1.0-hb8f0cd6_0.conda
linux-aarch64::libclang-13.0.1-default_hdf9a116_2.conda
linux-aarch64::libclang13-15.0.7-default_hc086480_3.conda
linux-aarch64::libclang-cpp-15.0.7-default_hdf9a116_3.conda
linux-aarch64::libclang-13.0.1-root_62804_h6f8a30d_2.conda
linux-aarch64::libclang-cpp-13.0.1-default_hdf9a116_2.conda
linux-aarch64::glib-tools-2.76.4-hd84c7bf_0.conda
linux-aarch64::clang-tools-15.0.7-default_hdf9a116_3.conda
linux-aarch64::clang-format-13.0.1-default_hdf9a116_2.conda
linux-aarch64::micromamba-1.4.7-0.tar.bz2
linux-aarch64::clang-format-13-13.0.1-default_hdf9a116_3.conda
linux-aarch64::clang-format-13.0.1-root_62804_h6f8a30d_2.conda
linux-aarch64::cfitsio-4.3.0-hf28c5f1_0.conda
linux-aarch64::libclang-15.0.7-default_hdf9a116_3.conda
linux-aarch64::llvm-tools-15.0.7-hc720cd8_3.conda
linux-aarch64::libclang-cpp13-13.0.1-root_62804_h6f8a30d_3.conda
linux-aarch64::libcups-2.3.3-h405e4a8_4.conda
linux-aarch64::libclang-cpp-13.0.1-default_hdf9a116_3.conda
linux-aarch64::gst-libav-1.22.5-hc4a16bf_0.conda
linux-aarch64::llvm-tools-14.0.6-h966f666_4.conda
linux-aarch64::micromamba-1.4.8-0.tar.bz2
linux-aarch64::libclang-cpp15-15.0.7-default_hdf9a116_3.conda
linux-aarch64::clang-13-13.0.1-default_hdf9a116_2.conda
linux-aarch64::libclang-cpp13-13.0.1-default_hdf9a116_3.conda
linux-aarch64::libclang-13.0.1-root_62804_h6f8a30d_3.conda
linux-aarch64::libclang-cpp13-13.0.1-root_62804_h6f8a30d_2.conda
linux-aarch64::libclang-cpp13-13.0.1-default_hdf9a116_2.conda
linux-aarch64::clang-format-13-13.0.1-root_62804_h6f8a30d_3.conda
linux-aarch64::llvm-14.0.6-h40ce709_4.conda
-    "libzlib >=1.2.13,<1.3.0a0"
+    "libzlib >=1.2.13,<2.0.0a0"
linux-aarch64::gfortran_impl_osx-64-12.3.0-h266455c_0.conda
linux-aarch64::jaxlib-0.4.14-cpu_py310h93b19c8_1.conda
linux-aarch64::vtk-base-9.2.6-qt_py310h1234567_210.conda
linux-aarch64::libarrow-10.0.1-hfde44de_36_cuda.conda
linux-aarch64::xrootd-5.6.1-py310h0685b57_0.conda
linux-aarch64::libgdal-3.7.1-h48890f2_3.conda
linux-aarch64::postgresql-plpython-14.5-py310h840c280_7.conda
linux-aarch64::libarrow-11.0.0-hfde44de_32_cuda.conda
linux-aarch64::libopencv-4.8.0-py311h7df1ea0_0.conda
linux-aarch64::openpmd-api-0.15.1-mpi_openmpi_py38h069d627_4.conda
linux-aarch64::grpcio-1.56.2-py310h20b6881_0.conda
linux-aarch64::libarrow-12.0.1-h25fba4a_2_cpu.conda
linux-aarch64::qt6-3d-6.5.2-h43fd37b_0.conda
linux-aarch64::arrow-cpp-9.0.0-py38hdedc978_43_cpu.conda
linux-aarch64::yoda-1.9.6-py310h59adc75_3.conda
linux-aarch64::r-base-4.3.1-h60a3b74_0.conda
linux-aarch64::libarrow-11.0.0-h57a027d_31_cpu.conda
linux-aarch64::libllvm16-16.0.6-h70e38ee_1.conda
linux-aarch64::libarrow-10.0.1-h57a027d_33_cpu.conda
linux-aarch64::grpcio-1.56.2-py38h95a9722_0.conda
linux-aarch64::libcurl-static-8.1.2-h4e8248e_1.conda
linux-aarch64::jaxlib-0.4.14-cpu_py311h11cf1b7_1.conda
linux-aarch64::r-base-4.3.1-h60a3b74_1.conda
linux-aarch64::nco-5.1.6-h0fb79a7_2.conda
linux-aarch64::arrow-cpp-9.0.0-py310h5e464ff_44_cuda.conda
linux-aarch64::folly-2023.07.24.00-hdd3c17f_0_jemalloc.conda
linux-aarch64::arrow-cpp-9.0.0-py311h29e2525_44_cpu.conda
linux-aarch64::jaxlib-0.4.12-cpu_py39h8860f5f_1.conda
linux-aarch64::arrow-cpp-9.0.0-py311hc2083dc_44_cuda.conda
linux-aarch64::imagecodecs-2023.7.10-py310ha5819ed_0.conda
linux-aarch64::libgdal-arrow-parquet-3.7.1-h0aa848b_0.conda
linux-aarch64::libadios2-2.9.0-mpi_mpich_h34b7990_0.conda
linux-aarch64::libarrow-12.0.1-hde3a418_7_cpu.conda
linux-aarch64::vtk-base-9.2.6-qt_py311h1234567_210.conda
linux-aarch64::gfortran_impl_osx-64-12.3.0-h266455c_1.conda
linux-aarch64::libarrow-12.0.1-h32277cc_7_cuda.conda
linux-aarch64::openpmd-api-0.15.1-mpi_mpich_py311h363c308_4.conda
linux-aarch64::libarrow-12.0.1-hde3a418_4_cpu.conda
linux-aarch64::geotiff-1.7.1-h8619d26_11.conda
linux-aarch64::jaxlib-0.4.12-cpu_py310h539dc2b_1.conda
linux-aarch64::grpcio-1.56.2-py311h1a7908d_0.conda
linux-aarch64::llvmdev-15.0.7-hc720cd8_3.conda
linux-aarch64::lxml-4.9.3-py38h38730af_0.conda
linux-aarch64::python-igraph-0.10.5-py39h170532c_0.conda
linux-aarch64::xrootd-5.6.1-py38h721d8e5_0.conda
linux-aarch64::mysql-server-8.0.33-h3e01392_2.conda
linux-aarch64::xrootd-5.6.1-py38h2af6c93_0.conda
linux-aarch64::yoda-1.9.6-py38hc2f1901_3.conda
linux-aarch64::libarrow-10.0.1-ha0fa26c_33_cuda.conda
linux-aarch64::imagecodecs-2023.7.10-py310h11aa805_1.conda
linux-aarch64::arrow-cpp-9.0.0-py311hc3713a0_44_cpu.conda
linux-aarch64::healpy-1.16.3-py39he15b407_0.conda
linux-aarch64::lxml-4.9.3-py38h986c409_0.conda
linux-aarch64::libadios2-2.9.0-mpi_mpich_hd63bfcd_0.conda
linux-aarch64::libvips-8.14.3-h9f74bfa_0.conda
linux-aarch64::postgresql-plpython-15.3-py310h840c280_2.conda
linux-aarch64::folly-2023.07.17.00-hdd3c17f_0_jemalloc.conda
linux-aarch64::libvips-8.14.2-h9f74bfa_2.conda
linux-aarch64::leptonica-1.83.1-h9abde11_3.conda
linux-aarch64::postgresql-plpython-14.5-py39he33817a_7.conda
linux-aarch64::qt6-3d-6.5.1-h43fd37b_1.conda
linux-aarch64::jaxlib-0.4.12-cpu_py38hafbaab2_1.conda
linux-aarch64::tiledb-2.16.0-h127bae7_2.conda
linux-aarch64::gfortran_impl_osx-64-11.4.0-hff20256_0.conda
linux-aarch64::mysql-server-8.0.33-h9e1a5d7_1.conda
linux-aarch64::libgdal-arrow-parquet-3.6.4-h2d6bbd0_10.conda
linux-aarch64::arrow-cpp-9.0.0-py38hb0477ee_43_cuda.conda
linux-aarch64::jaxlib-0.4.14-cpu_py310hf48e4fc_1.conda
linux-aarch64::omniorb-4.3.0-py311h9b119e1_0.conda
linux-aarch64::llvmdev-14.0.6-h966f666_4.conda
linux-aarch64::libarrow-12.0.1-hde3a418_6_cpu.conda
linux-aarch64::nordugrid-arc-6.17.0-py39had732f9_1.conda
linux-aarch64::arrow-cpp-9.0.0-py39h1358091_43_cuda.conda
linux-aarch64::yarp-cxx-3.8.1-h4c076a4_2.conda
linux-aarch64::libopencv-4.8.0-py38h02987de_0.conda
linux-aarch64::arrow-cpp-9.0.0-py310hffd325c_44_cpu.conda
linux-aarch64::mysql-router-8.0.33-hddac939_2.conda
linux-aarch64::libvips-8.14.3-hf0ed0c9_1.conda
linux-aarch64::librdkafka-2.2.0-hb18e517_0.conda
linux-aarch64::libarrow-10.0.1-hde3a418_36_cpu.conda
linux-aarch64::python-igraph-0.10.6-py38hf09050e_0.conda
linux-aarch64::python-igraph-0.10.6-py39h170532c_0.conda
linux-aarch64::arrow-cpp-9.0.0-py310h684e183_42_cuda.conda
linux-aarch64::imagecodecs-2023.7.10-py39h5f6d0f9_1.conda
linux-aarch64::libarrow-10.0.1-h0f22f25_32_cuda.conda
linux-aarch64::libarrow-11.0.0-hde3a418_30_cpu.conda
linux-aarch64::grpcio-1.56.1-py39h483cef1_0.conda
linux-aarch64::arrow-cpp-9.0.0-py39h5d73291_42_cpu.conda
linux-aarch64::libarrow-11.0.0-hde3a418_29_cpu.conda
linux-aarch64::cpp-opentelemetry-sdk-1.9.1-had1d856_3.conda
linux-aarch64::nordugrid-arc-6.17.0-py311h9975213_1.conda
linux-aarch64::libarrow-10.0.1-hde3a418_35_cpu.conda
linux-aarch64::libarrow-12.0.1-h57a027d_4_cpu.conda
linux-aarch64::libnetcdf-4.9.2-nompi_hbafca18_109.conda
linux-aarch64::python-igraph-0.10.5-py310h3d2d514_0.conda
linux-aarch64::yoda-1.9.6-py39h9694db2_4.conda
linux-aarch64::geotiff-1.7.1-h8619d26_10.conda
linux-aarch64::healpy-1.16.3-py310he815481_0.conda
linux-aarch64::arrow-cpp-9.0.0-py38hb0477ee_42_cuda.conda
linux-aarch64::libopencv-4.7.0-py38h02987de_6.conda
linux-aarch64::gfortran_impl_osx-arm64-11.3.0-h1376884_32.conda
linux-aarch64::openpmd-api-0.15.1-nompi_py38h97be3d3_104.conda
linux-aarch64::arrow-cpp-9.0.0-py310h684e183_43_cuda.conda
linux-aarch64::libarrow-10.0.1-h32277cc_35_cuda.conda
linux-aarch64::healpy-1.16.3-py38he1f86f5_0.conda
linux-aarch64::libopencv-4.7.0-py38hacece6b_6.conda
linux-aarch64::arrow-cpp-9.0.0-py39hff80e83_43_cuda.conda
linux-aarch64::r-base-4.3.1-h7539d2d_2.conda
linux-aarch64::imagecodecs-2023.7.10-py310h0b926b1_2.conda
linux-aarch64::python-igraph-0.10.4-py310h3d2d514_1.conda
linux-aarch64::libopencv-4.7.0-py39hd7a3968_6.conda
linux-aarch64::imagecodecs-2023.7.10-py39h6210c5f_0.conda
linux-aarch64::postgresql-plpython-15.3-py39he33817a_2.conda
linux-aarch64::mysql-router-8.0.33-h1f5bcb8_2.conda
linux-aarch64::imagecodecs-2023.7.10-py39hab6c1ca_2.conda
linux-aarch64::libarrow-11.0.0-h32277cc_32_cuda.conda
linux-aarch64::libadios2-2.9.0-mpi_openmpi_hd171938_0.conda
linux-aarch64::folly-2023.07.17.00-hbf4f375_0_jemalloc.conda
linux-aarch64::root_base-6.28.4-py310hffff704_0.conda
linux-aarch64::libarrow-12.0.1-hfde44de_7_cuda.conda
linux-aarch64::libgdal-arrow-parquet-3.6.4-h2d6bbd0_8.conda
linux-aarch64::grpcio-1.56.0-py311h1a7908d_2.conda
linux-aarch64::libgrpc-1.56.0-h097270e_2.conda
linux-aarch64::r-base-4.3.0-h60a3b74_2.conda
linux-aarch64::tesseract-5.3.1-h8af561e_0.conda
linux-aarch64::gfortran_impl_osx-arm64-12.2.0-h895c755_32.conda
linux-aarch64::omniorb-libs-4.3.0-h48ed410_0.conda
linux-aarch64::nco-5.1.7-h0fb79a7_0.conda
linux-aarch64::libopencv-4.7.0-py38hd73c7d9_6.conda
linux-aarch64::libopencv-4.7.0-py39hc4c53e7_6.conda
linux-aarch64::llvm-16.0.6-h5271726_1.conda
linux-aarch64::lxml-4.9.3-py39h4de4ef8_0.conda
linux-aarch64::poppler-23.07.0-h79703be_0.conda
linux-aarch64::llvm-tools-16.0.6-h70e38ee_1.conda
linux-aarch64::arrow-cpp-9.0.0-py311h29e2525_43_cpu.conda
linux-aarch64::yarp-cxx-3.8.1-h4c076a4_3.conda
linux-aarch64::poppler-qt-23.07.0-h9c846af_0.conda
linux-aarch64::arrow-cpp-9.0.0-py39ha0ca044_43_cpu.conda
linux-aarch64::folly-2023.07.10.00-hdd3c17f_0_jemalloc.conda
linux-aarch64::libcurl-static-8.2.0-h4e8248e_0.conda
linux-aarch64::libnetcdf-4.9.2-nompi_hbafca18_108.conda
linux-aarch64::clangdev-13.0.1-root_62804_h6f8a30d_3.conda
linux-aarch64::libnetcdf-4.9.2-mpi_openmpi_hda4392f_7.conda
linux-aarch64::arrow-cpp-9.0.0-py38h561d0cd_42_cpu.conda
linux-aarch64::gfortran_impl_osx-arm64-11.4.0-h35f1752_1.conda
linux-aarch64::pillow-10.0.0-py311h170abe6_0.conda
linux-aarch64::libsoup-2.74.3-h7adf874_0.conda
linux-aarch64::arrow-cpp-9.0.0-py311hc3713a0_43_cpu.conda
linux-aarch64::libarrow-11.0.0-hde3a418_32_cpu.conda
linux-aarch64::gst-plugins-good-1.22.5-h8b8d3ca_0.conda
linux-aarch64::libgdal-arrow-parquet-3.6.4-hdfbe344_7.conda
linux-aarch64::imagecodecs-2023.7.10-py311ha1539bd_2.conda
linux-aarch64::folly-2023.07.24.00-hbf4f375_0_jemalloc.conda
linux-aarch64::libarrow-10.0.1-h57a027d_36_cpu.conda
linux-aarch64::nordugrid-arc-6.17.0-py38ha812910_1.conda
linux-aarch64::tiledb-2.16.1-h3e6b69a_0.conda
linux-aarch64::arrow-cpp-9.0.0-py311hf7b87f1_43_cuda.conda
linux-aarch64::libgdal-3.7.1-h48890f2_1.conda
linux-aarch64::gfortran_impl_osx-64-11.4.0-hff20256_1.conda
linux-aarch64::libtiledb-sql-0.23.1-h556e676_0.conda
linux-aarch64::libgdal-3.7.0-hffc3127_5.conda
linux-aarch64::folly-2023.07.03.00-hbf4f375_0_jemalloc.conda
linux-aarch64::libadios2-2.9.0-mpi_openmpi_h5a18f1a_0.conda
linux-aarch64::smesh-9.9.0.0-hc26899e_6.conda
linux-aarch64::imagecodecs-2023.7.10-py39h7be245f_1.conda
linux-aarch64::libgdal-arrow-parquet-3.7.1-hef7226a_3.conda
linux-aarch64::libadios2-2.9.0-nompi_h7b74588_100.conda
linux-aarch64::davix-0.8.4-hf855ebf_2.conda
linux-aarch64::r-base-4.1.3-hc9dfe8b_10.conda
linux-aarch64::r-base-4.3.1-h7539d2d_3.conda
linux-aarch64::tiledb-2.16.0-h3e6b69a_3.conda
linux-aarch64::arrow-cpp-9.0.0-py38h561d0cd_44_cpu.conda
linux-aarch64::arrow-cpp-9.0.0-py310hffd325c_43_cpu.conda
linux-aarch64::grpcio-1.56.0-py39h483cef1_2.conda
linux-aarch64::libarrow-12.0.1-h57a027d_6_cpu.conda
linux-aarch64::libopencv-4.7.0-py39hb8d0d35_6.conda
linux-aarch64::openssh-9.3p1-h04b8c23_2.conda
linux-aarch64::pillow-10.0.0-py38hc8bea21_0.conda
linux-aarch64::libgrpc-1.56.1-h097270e_0.conda
linux-aarch64::openpmd-api-0.15.1-mpi_openmpi_py310h4862eb3_4.conda
linux-aarch64::libarrow-11.0.0-h57a027d_28_cpu.conda
linux-aarch64::libopencv-4.8.0-py38hd73c7d9_0.conda
linux-aarch64::openpmd-api-0.15.1-mpi_mpich_py39h39df642_4.conda
linux-aarch64::python-igraph-0.10.4-py311hd7d10d7_1.conda
linux-aarch64::mosh-1.4.0-pl5321hd3affc3_2.conda
linux-aarch64::squashfuse-0.2.0-h24ece89_0.conda
linux-aarch64::mysql-server-8.0.33-h9e1a5d7_2.conda
linux-aarch64::arrow-cpp-9.0.0-py39h5d73291_44_cpu.conda
linux-aarch64::libadios2-2.9.0-mpi_openmpi_h86fe923_0.conda
linux-aarch64::aws-sdk-cpp-1.11.68-h8c6ac9c_9.conda
linux-aarch64::xorg-libxft-2.3.8-h4227235_0.conda
linux-aarch64::libgrpc-1.56.2-h097270e_0.conda
linux-aarch64::rust-1.71.0-h9d3d833_0.conda
linux-aarch64::aws-sdk-cpp-1.10.57-hccb6cd8_16.conda
linux-aarch64::omniorb-4.3.0-py38hc9c3f1f_0.conda
linux-aarch64::qt-main-5.15.8-h5633377_15.conda
linux-aarch64::libadios2-2.9.0-nompi_hea3dcde_100.conda
linux-aarch64::libarrow-12.0.1-h0f22f25_3_cuda.conda
linux-aarch64::gfortran_impl_osx-arm64-12.3.0-hd4e6d05_1.conda
linux-aarch64::libcurl-8.2.0-h4e8248e_0.conda
linux-aarch64::grpcio-1.56.1-py311h1a7908d_0.conda
linux-aarch64::folly-2023.07.10.00-h81a8a5e_0.conda
linux-aarch64::libarrow-12.0.1-hde3a418_5_cpu.conda
linux-aarch64::xrootd-5.6.1-py311h2e88512_0.conda
linux-aarch64::ogre-14.0.1-ha14d9e0_0.conda
linux-aarch64::folly-2023.07.17.00-h8282163_0.conda
linux-aarch64::python-igraph-0.10.4-py39habebdc4_1.conda
linux-aarch64::arrow-cpp-9.0.0-py310h31d9f09_43_cpu.conda
linux-aarch64::llvmdev-16.0.6-hc720cd8_1.conda
linux-aarch64::libopencv-4.7.0-py310h01197f5_6.conda
linux-aarch64::grpcio-1.56.1-py38h95a9722_0.conda
linux-aarch64::libarrow-11.0.0-h57a027d_30_cpu.conda
linux-aarch64::vtk-base-9.2.6-qt_py38h1234567_210.conda
linux-aarch64::libcurl-8.1.2-h4e8248e_1.conda
linux-aarch64::libglib-2.76.4-h0464669_0.conda
linux-aarch64::folly-2023.07.17.00-h81a8a5e_0.conda
linux-aarch64::mysql-client-8.0.33-h88b4a5d_2.conda
linux-aarch64::openpmd-api-0.15.1-nompi_py39hee4c076_104.conda
linux-aarch64::grpcio-1.56.0-py310h20b6881_2.conda
linux-aarch64::dcap-2.47.14-h7c544c4_1.conda
linux-aarch64::tiledb-2.16.0-h3e6b69a_2.conda
linux-aarch64::libpulsar-3.2.0-hf58ce6e_2.conda
linux-aarch64::r-base-4.2.3-haa72b06_6.conda
linux-aarch64::libpq-14.5-h04b8c23_7.conda
linux-aarch64::imagecodecs-2023.7.10-py39h3aca4f3_2.conda
linux-aarch64::curl-8.1.2-h4e8248e_1.conda
linux-aarch64::tiledb-2.16.1-h127bae7_0.conda
linux-aarch64::grpcio-1.56.0-py38h95a9722_2.conda
linux-aarch64::libarrow-11.0.0-h32277cc_31_cuda.conda
linux-aarch64::libarrow-12.0.1-h57a027d_3_cpu.conda
linux-aarch64::nsight-compute-2022.4.0.15-h0c3d132_0.conda
linux-aarch64::libsoup-2.74.3-h7b0f9e5_1.conda
linux-aarch64::openpmd-api-0.15.1-mpi_mpich_py310h71bbe88_4.conda
linux-aarch64::xrootd-5.5.5-py38h721d8e5_2.conda
linux-aarch64::libgdal-3.7.1-h48890f2_2.conda
linux-aarch64::libnetcdf-4.9.2-mpi_openmpi_h3c3bf52_9.conda
linux-aarch64::pgplot-5.2.2-h9f0f376_1008.conda
linux-aarch64::healpy-1.16.3-py311h6715740_0.conda
linux-aarch64::libarrow-12.0.1-h62ebf01_2_cuda.conda
linux-aarch64::libgdal-3.7.1-h6aa95ac_4.conda
linux-aarch64::mesalib-23.1.4-h5f6ae44_0.conda
linux-aarch64::postgresql-15.3-he3d1b8e_2.conda
linux-aarch64::aws-sdk-cpp-1.11.68-h4e80173_7.conda
linux-aarch64::folly-2023.07.03.00-hdd3c17f_0_jemalloc.conda
linux-aarch64::arrow-cpp-9.0.0-py38h274750a_44_cuda.conda
linux-aarch64::clangdev-13.0.1-root_62804_h6f8a30d_2.conda
linux-aarch64::r-base-4.3.1-haa72b06_2.conda
linux-aarch64::r-base-4.3.0-h60a3b74_3.conda
linux-aarch64::libarrow-11.0.0-h57a027d_29_cpu.conda
linux-aarch64::clangdev-13.0.1-default_hdf9a116_2.conda
linux-aarch64::libarrow-10.0.1-hde3a418_34_cpu.conda
linux-aarch64::xrootd-5.5.5-py311h2e88512_2.conda
linux-aarch64::qt6-main-6.5.1-h3d23ec0_3.conda
linux-aarch64::libopentelemetry-cpp-1.10.0-h44394fa_0.conda
linux-aarch64::arrow-cpp-9.0.0-py39h1358091_44_cuda.conda
linux-aarch64::libnetcdf-4.9.2-mpi_mpich_hbd0026d_8.conda
linux-aarch64::gfortran_impl_osx-arm64-12.3.0-hd4e6d05_0.conda
linux-aarch64::mosh-1.4.0-pl5321h8928e67_2.conda
linux-aarch64::xrootd-5.5.5-py310haa9ade6_1.conda
linux-aarch64::yoda-1.9.6-py311h5b77e3f_4.conda
linux-aarch64::arrow-cpp-9.0.0-py311h29e2525_42_cpu.conda
linux-aarch64::libnetcdf-4.9.2-mpi_mpich_hbd0026d_9.conda
linux-aarch64::jaxlib-0.4.14-cpu_py311h37b86ca_1.conda
linux-aarch64::gmsh-4.11.1-hfeaf2d2_3.conda
linux-aarch64::libtiledb-sql-0.23.0-h556e676_0.conda
linux-aarch64::cpp-opentelemetry-sdk-1.9.1-h44394fa_3.conda
linux-aarch64::gfortran_impl_osx-64-12.2.0-h63f031b_32.conda
linux-aarch64::omniorb-4.3.0-py39h86dfdcc_0.conda
linux-aarch64::lxml-4.9.3-py310h4ea8894_0.conda
linux-aarch64::root_base-6.28.4-py310hffff704_1.conda
linux-aarch64::libcurl-8.2.1-h4e8248e_0.conda
linux-aarch64::libopencv-4.8.0-py310hf14278c_0.conda
linux-aarch64::xrootd-5.5.5-py39h776bf55_1.conda
linux-aarch64::folly-2023.07.24.00-h81a8a5e_0.conda
linux-aarch64::mysql-router-8.0.33-h1f5bcb8_1.conda
linux-aarch64::libarrow-12.0.1-hde3a418_3_cpu.conda
linux-aarch64::leptonica-1.83.1-hde0b234_0.conda
linux-aarch64::yoda-1.9.6-py38hc2f1901_4.conda
linux-aarch64::postgresql-plpython-15.3-py38hf7f31c5_2.conda
linux-aarch64::folly-2023.07.03.00-h81a8a5e_0.conda
linux-aarch64::cpp-opentelemetry-sdk-1.10.0-h44394fa_0.conda
linux-aarch64::libarrow-11.0.0-hfde44de_31_cuda.conda
linux-aarch64::xrootd-5.6.1-py39hb80c9a1_0.conda
linux-aarch64::imagecodecs-2023.7.10-py311ha3bf19e_0.conda
linux-aarch64::graphviz-8.1.0-h1e60024_0.conda
linux-aarch64::root_base-6.28.4-py39h6a2432a_1.conda
linux-aarch64::glib-networking-2.76.1-h2c27fa9_0.conda
linux-aarch64::pillow-10.0.0-py39hd811ef5_0.conda
linux-aarch64::python-igraph-0.10.6-py39habebdc4_0.conda
linux-aarch64::libadios2-2.9.0-mpi_mpich_h4e6f988_0.conda
linux-aarch64::libopencv-4.7.0-py311h7df1ea0_6.conda
linux-aarch64::xrootd-5.5.5-py38hca82f46_1.conda
linux-aarch64::vtk-base-9.2.6-qt_py39h1234567_210.conda
linux-aarch64::openpmd-api-0.15.1-mpi_mpich_py38ha9111a8_4.conda
linux-aarch64::yoda-1.9.6-py39h9694db2_3.conda
linux-aarch64::root_base-6.28.4-py38hf563a0c_0.conda
linux-aarch64::imagecodecs-2023.7.10-py311h48a00de_1.conda
linux-aarch64::python-igraph-0.10.5-py38hf09050e_0.conda
linux-aarch64::libgdal-3.6.4-he85f961_9.conda
linux-aarch64::libcurl-static-8.2.1-h4e8248e_0.conda
linux-aarch64::libvips-8.14.2-h9f74bfa_3.conda
linux-aarch64::xrootd-5.5.5-py310h0685b57_2.conda
linux-aarch64::postgresql-14.5-he3d1b8e_7.conda
linux-aarch64::ogre-13.6.5-ha14d9e0_0.conda
linux-aarch64::mysql-libs-8.0.33-hf629957_2.conda
linux-aarch64::libgdal-arrow-parquet-3.6.4-h2d6bbd0_9.conda
linux-aarch64::vtk-base-9.2.6-qt_py39h1234567_209.conda
linux-aarch64::arrow-cpp-9.0.0-py38h274750a_43_cuda.conda
linux-aarch64::libgdal-3.7.1-hffc3127_0.conda
linux-aarch64::libgdal-arrow-parquet-3.7.1-hef7226a_2.conda
linux-aarch64::libfido2-1.13.0-h73a623e_0.conda
linux-aarch64::xrootd-5.5.5-py39hb80c9a1_2.conda
linux-aarch64::libadios2-2.9.0-nompi_h39a7b69_100.conda
linux-aarch64::arrow-cpp-9.0.0-py38hb0477ee_44_cuda.conda
linux-aarch64::libopencv-4.7.0-py310hf14278c_6.conda
linux-aarch64::vtk-base-9.2.6-qt_py310h1234567_209.conda
linux-aarch64::arrow-cpp-9.0.0-py310h31d9f09_44_cpu.conda
linux-aarch64::libarrow-11.0.0-h57a027d_32_cpu.conda
linux-aarch64::vtk-base-9.2.6-qt_py311h1234567_209.conda
linux-aarch64::root_base-6.28.4-py39h6a2432a_0.conda
linux-aarch64::orc-1.9.0-hf378395_1.conda
linux-aarch64::libopentelemetry-cpp-1.10.0-had1d856_0.conda
linux-aarch64::libarrow-12.0.1-hf50a860_2_cpu.conda
linux-aarch64::folly-2023.07.10.00-h8282163_0.conda
linux-aarch64::arrow-cpp-9.0.0-py311hc2083dc_43_cuda.conda
linux-aarch64::arrow-cpp-9.0.0-py311hf7b87f1_42_cuda.conda
linux-aarch64::root_base-6.28.4-py311heaf0982_1.conda
linux-aarch64::libadios2-2.9.0-mpi_openmpi_h43838fa_0.conda
linux-aarch64::curl-8.2.0-h4e8248e_0.conda
linux-aarch64::python-igraph-0.10.4-py38hf09050e_1.conda
linux-aarch64::jaxlib-0.4.14-cpu_py39he6b5510_1.conda
linux-aarch64::openpmd-api-0.15.1-mpi_mpich_py38h1fd9694_4.conda
linux-aarch64::libopencv-4.8.0-py39hc4c53e7_0.conda
linux-aarch64::arrow-cpp-9.0.0-py310h5e464ff_43_cuda.conda
linux-aarch64::gst-plugins-base-1.22.5-hc44d83b_0.conda
linux-aarch64::qt6-main-6.5.1-h3b63a86_4.conda
linux-aarch64::python-igraph-0.10.4-py39h170532c_1.conda
linux-aarch64::aws-sdk-cpp-1.11.68-hccb6cd8_8.conda
linux-aarch64::aws-sdk-cpp-1.10.57-h4e80173_15.conda
linux-aarch64::tiledb-2.16.0-hdb54b9b_2.conda
linux-aarch64::libarrow-10.0.1-h57a027d_32_cpu.conda
linux-aarch64::tiledb-2.16.0-hdb54b9b_3.conda
linux-aarch64::mysql-client-8.0.33-h88b4a5d_1.conda
linux-aarch64::jaxlib-0.4.12-cpu_py311h8cf9c13_1.conda
linux-aarch64::libarrow-10.0.1-hde3a418_33_cpu.conda
linux-aarch64::nordugrid-arc-6.17.0-py310h46bc994_1.conda
linux-aarch64::qt6-main-6.5.2-h3b63a86_0.conda
linux-aarch64::libnetcdf-4.9.2-mpi_openmpi_h3c3bf52_8.conda
linux-aarch64::libarrow-12.0.1-h57a027d_5_cpu.conda
linux-aarch64::pillow-10.0.0-py39hc5b5638_0.conda
linux-aarch64::libarrow-10.0.1-h57a027d_35_cpu.conda
linux-aarch64::tiledb-2.16.1-hdb54b9b_0.conda
linux-aarch64::nsight-compute-2022.4.0.15-hfc718e1_0.conda
linux-aarch64::openpmd-api-0.15.1-nompi_py39h7950e70_104.conda
linux-aarch64::openpmd-api-0.15.1-mpi_openmpi_py38hfa75f65_4.conda
linux-aarch64::python-igraph-0.10.5-py311hd7d10d7_0.conda
linux-aarch64::postgresql-plpython-14.5-py38hf7f31c5_7.conda
linux-aarch64::root_base-6.28.4-py311heaf0982_0.conda
linux-aarch64::lxml-4.9.3-py311h40dcbb3_0.conda
linux-aarch64::glib-2.76.4-hd84c7bf_0.conda
linux-aarch64::python-igraph-0.10.5-py38h7eae0ad_0.conda
linux-aarch64::libopentelemetry-cpp-1.9.1-had1d856_3.conda
linux-aarch64::xrootd-5.5.5-py311h7efa6b2_1.conda
linux-aarch64::libarrow-10.0.1-h0f22f25_33_cuda.conda
linux-aarch64::libtiledb-sql-0.23.0-h886d7b1_0.conda
linux-aarch64::libarrow-12.0.1-hfde44de_6_cuda.conda
linux-aarch64::python-igraph-0.10.6-py38h7eae0ad_0.conda
linux-aarch64::openpmd-api-0.15.1-mpi_openmpi_py39h64aae80_4.conda
linux-aarch64::folly-2023.07.24.00-h8282163_0.conda
linux-aarch64::arrow-cpp-9.0.0-py310h684e183_44_cuda.conda
linux-aarch64::libarrow-12.0.1-h57a027d_7_cpu.conda
linux-aarch64::imagemagick-7.1.1_14-pl5321hac3f1fc_0.conda
linux-aarch64::libarrow-10.0.1-h32277cc_36_cuda.conda
linux-aarch64::cpp-opentelemetry-sdk-1.10.0-had1d856_0.conda
linux-aarch64::texlive-core-20230313-h444f51b_4.conda
linux-aarch64::libopencv-4.7.0-py38h8b47e65_6.conda
linux-aarch64::libpq-15.3-h04b8c23_2.conda
linux-aarch64::magic-8.3.413-h4e13689_0.conda
linux-aarch64::healpy-1.16.3-py39hd280a0e_0.conda
linux-aarch64::orc-1.9.0-h4e271f3_1.conda
linux-aarch64::grpcio-1.56.1-py310h20b6881_0.conda
linux-aarch64::libopencv-4.8.0-py38h8b47e65_0.conda
linux-aarch64::gfortran_impl_osx-arm64-11.4.0-h35f1752_0.conda
linux-aarch64::postgresql-plpython-15.3-py311hc2b6b49_2.conda
linux-aarch64::libopencv-4.7.0-py39h6175bb5_6.conda
linux-aarch64::r-base-4.2.3-h60a3b74_4.conda
linux-aarch64::libopencv-4.8.0-py39hd7a3968_0.conda
linux-aarch64::openpmd-api-0.15.1-nompi_py311hd3d74d4_104.conda
linux-aarch64::libnetcdf-4.9.2-mpi_mpich_hadc5eeb_7.conda
linux-aarch64::root_base-6.28.4-py38hf563a0c_1.conda
linux-aarch64::vtk-base-9.2.6-qt_py38h1234567_209.conda
linux-aarch64::libnetcdf-4.9.2-nompi_hd6e25ae_107.conda
linux-aarch64::libarrow-10.0.1-h0f22f25_34_cuda.conda
linux-aarch64::libopencv-4.8.0-py39h6175bb5_0.conda
linux-aarch64::grpcio-1.56.2-py39h483cef1_0.conda
linux-aarch64::arrow-cpp-9.0.0-py39hff80e83_44_cuda.conda
linux-aarch64::libopencv-4.7.0-py311h1c2908f_6.conda
linux-aarch64::libopentelemetry-cpp-1.9.1-h44394fa_3.conda
linux-aarch64::xrootd-5.5.5-py39h7ccaeba_1.conda
linux-aarch64::openpmd-api-0.15.1-nompi_py310h80b06fd_104.conda
linux-aarch64::imagecodecs-2023.7.10-py39h57ef2cd_0.conda
linux-aarch64::curl-8.2.1-h4e8248e_0.conda
linux-aarch64::openpmd-api-0.15.1-nompi_py38h169c26c_104.conda
linux-aarch64::imagemagick-7.1.1_13-pl5321hac3f1fc_0.conda
linux-aarch64::libarrow-10.0.1-ha0fa26c_34_cuda.conda
linux-aarch64::libpulsar-3.2.0-ha39ba29_2.conda
linux-aarch64::mysql-libs-8.0.33-hf629957_1.conda
linux-aarch64::libgdal-3.6.4-he85f961_8.conda
linux-aarch64::xrootd-5.5.5-py38hd953884_1.conda
linux-aarch64::arrow-cpp-9.0.0-py311hf7b87f1_44_cuda.conda
linux-aarch64::yarp-cxx-3.8.1-h4c076a4_1.conda
linux-aarch64::healpy-1.16.3-py38he4b4097_0.conda
linux-aarch64::xrootd-5.5.5-py39hd868c33_2.conda
linux-aarch64::openpmd-api-0.15.1-mpi_openmpi_py311h09b2dfb_4.conda
linux-aarch64::xrootd-5.6.1-py39hd868c33_0.conda
linux-aarch64::arrow-cpp-9.0.0-py39h1358091_42_cuda.conda
linux-aarch64::libadios2-2.9.0-mpi_mpich_h18090f1_0.conda
linux-aarch64::python-igraph-0.10.6-py311hd7d10d7_0.conda
linux-aarch64::libopencv-4.8.0-py38hacece6b_0.conda
linux-aarch64::mysql-router-8.0.33-hddac939_1.conda
linux-aarch64::libarrow-10.0.1-hfde44de_35_cuda.conda
linux-aarch64::postgresql-plpython-14.5-py311hc2b6b49_7.conda
linux-aarch64::arrow-cpp-9.0.0-py310hffd325c_42_cpu.conda
linux-aarch64::gst-plugins-base-1.22.4-hc44d83b_1.conda
linux-aarch64::arrow-cpp-9.0.0-py39ha0ca044_44_cpu.conda
linux-aarch64::libtiledb-sql-0.23.1-h886d7b1_0.conda
linux-aarch64::folly-2023.07.10.00-hbf4f375_0_jemalloc.conda
linux-aarch64::qt6-wayland-6.5.1-h06b39ba_0.conda
linux-aarch64::clangdev-13.0.1-default_hdf9a116_3.conda
linux-aarch64::libarrow-12.0.1-h32277cc_6_cuda.conda
linux-aarch64::imagemagick-7.1.1_15-pl5321hac3f1fc_0.conda
linux-aarch64::pillow-10.0.0-py38h5cbf20c_0.conda
linux-aarch64::openpmd-api-0.15.1-mpi_openmpi_py39hdc6a195_4.conda
linux-aarch64::pillow-10.0.0-py310hd04a61c_0.conda
linux-aarch64::afterimage-1.21-h6d4adff_1004.conda
linux-aarch64::r-base-4.2.3-h60a3b74_5.conda
linux-aarch64::python-igraph-0.10.6-py310h3d2d514_0.conda
linux-aarch64::openpmd-api-0.15.1-mpi_mpich_py39h032f39a_4.conda
linux-aarch64::gfortran_impl_osx-64-11.3.0-hcbd9799_32.conda
linux-aarch64::libopencv-4.8.0-py39hb8d0d35_0.conda
linux-aarch64::libopencv-4.8.0-py311h1c2908f_0.conda
linux-aarch64::folly-2023.07.03.00-h8282163_0.conda
linux-aarch64::libarrow-12.0.1-hbf0ba84_2_cuda.conda
linux-aarch64::libgdal-3.6.4-he85f961_10.conda
linux-aarch64::arrow-cpp-9.0.0-py39h5d73291_43_cpu.conda
linux-aarch64::libopencv-4.8.0-py310h01197f5_0.conda
linux-aarch64::aws-sdk-cpp-1.10.57-h8c6ac9c_17.conda
linux-aarch64::arrow-cpp-9.0.0-py38h561d0cd_43_cpu.conda
linux-aarch64::omniorb-4.3.0-py310hae03fa7_0.conda
linux-aarch64::leptonica-1.83.1-h9abde11_1.conda
linux-aarch64::python-igraph-0.10.5-py39habebdc4_0.conda
linux-aarch64::yoda-1.9.6-py310h59adc75_4.conda
linux-aarch64::clangdev-15.0.7-default_hdf9a116_3.conda
linux-aarch64::lxml-4.9.3-py39h03c8186_0.conda
linux-aarch64::tiledb-2.16.0-h127bae7_3.conda
linux-aarch64::libadios2-2.9.0-nompi_h0ea5f15_100.conda
linux-aarch64::libgdal-arrow-parquet-3.7.1-h38f2f33_4.conda
linux-aarch64::mysql-server-8.0.33-h3e01392_1.conda
linux-aarch64::libarrow-11.0.0-hf50a860_27_cpu.conda
linux-aarch64::libarrow-10.0.1-h57a027d_34_cpu.conda
linux-aarch64::libgdal-arrow-parquet-3.7.0-h0aa848b_5.conda
linux-aarch64::libgdal-3.6.4-hd8780f7_7.conda
linux-aarch64::leptonica-1.83.1-h9abde11_2.conda
linux-aarch64::jaxlib-0.4.14-cpu_py39hdc8d39d_1.conda
linux-aarch64::xrootd-5.5.5-py38h2af6c93_2.conda
linux-aarch64::libarrow-11.0.0-hde3a418_31_cpu.conda
linux-aarch64::python-igraph-0.10.4-py38h7eae0ad_1.conda
linux-aarch64::arrow-cpp-9.0.0-py38hdedc978_44_cpu.conda
linux-aarch64::libgdal-arrow-parquet-3.7.1-hef7226a_1.conda
linux-aarch64::gst-plugins-good-1.22.4-h8b8d3ca_1.conda
linux-aarch64::smesh-9.9.0.0-h92557ab_6.conda
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
================================================================================
================================================================================
noarch
================================================================================
================================================================================
win-64
win-64::omniorb-4.3.0-py38h8a9cac7_0.conda
win-64::libclang-13.0.1-default_h66ee7f4_2.conda
win-64::orc-1.9.0-hada7b9e_1.conda
win-64::libarrow-12.0.1-h0578746_6_cpu.conda
win-64::glib-tools-2.76.4-h12be248_0.conda
win-64::libpq-14.5-h43585b0_7.conda
win-64::lpython-0.18.2-h12be248_0.conda
win-64::libarrow-11.0.0-h3eb3106_32_cuda.conda
win-64::libignition-fuel-tools4-4.6.0-hd22afc4_2.conda
win-64::postgresql-15.3-hc80876b_2.conda
win-64::lpython-0.19.0-h12be248_0.conda
win-64::mysql-router-8.0.33-h8bd79c8_1.conda
win-64::mdtraj-1.9.8-py310h1431f1b_0.conda
win-64::libopencv-4.8.0-py38hf3fd54b_0.conda
win-64::mdtraj-1.9.8-py311h3f4f50a_0.conda
win-64::curl-8.2.1-hd5e4a3a_0.conda
win-64::libopencv-4.7.0-py38h0f1fb87_6.conda
win-64::stir-5.1.0-cpu_py311hf7a2716_9.conda
win-64::libarrow-11.0.0-heb30dd5_30_cpu.conda
win-64::stir-5.1.0-cuda110_py39heaf2f63_209.conda
win-64::arrow-cpp-9.0.0-py311h85f3ccd_44_cuda.conda
win-64::qt6-main-6.5.1-h577db66_4.conda
win-64::raven-hydro-0.2.3-py310h098a066_0.conda
win-64::imagecodecs-2023.7.10-py311h2c9abbb_0.conda
win-64::libarrow-11.0.0-h8a6ae29_32_cpu.conda
win-64::libarrow-10.0.1-hc51b828_34_cuda.conda
win-64::raven-hydro-0.2.3-py38h9f5882e_0.conda
win-64::arrow-cpp-9.0.0-py39ha6e8ab7_42_cpu.conda
win-64::raven-hydro-0.2.3-py38h5f67dab_0.conda
win-64::folly-2023.07.03.00-hfbb6214_0.conda
win-64::stir-5.1.0-cpu_py310hcc1c5a5_9.conda
win-64::leptonica-1.83.1-h7b8bf50_1.conda
win-64::python-igraph-0.10.4-py39ha09ebdf_1.conda
win-64::stir-5.1.0-cuda112_py311h5e56a69_209.conda
win-64::python-igraph-0.10.6-py39h668eeb6_0.conda
win-64::libglib-2.76.4-he8f3873_0.conda
win-64::folly-2023.07.17.00-h6064ee9_0.conda
win-64::lpython-0.18.0-h12be248_0.conda
win-64::libopencv-4.8.0-py38he61d1cf_0.conda
win-64::stir-5.1.0-cuda110_py38h9b6dfa3_207.conda
win-64::arrow-cpp-9.0.0-py310h234b940_43_cuda.conda
win-64::paraview-5.11.1-py38h5e7e1c9_102_qt.conda
win-64::folly-2023.07.17.00-hfbb6214_0.conda
win-64::libopencv-4.7.0-py39hbd58657_6.conda
win-64::mysql-server-8.0.33-hdf5bdb2_2.conda
win-64::pillow-10.0.0-py38ha7eb54a_0.conda
win-64::llvm-16.0.6-h3dc180e_1.conda
win-64::llvmdev-14.0.6-h97333cc_4.conda
win-64::raven-hydro-0.2.3-py310h9646616_0.conda
win-64::libopencv-4.8.0-py38h0f1fb87_0.conda
win-64::stir-5.1.0-cpu_py311hf7a2716_8.conda
win-64::libarrow-12.0.1-h0578746_5_cpu.conda
win-64::libuwebsockets-20.45.0-h12be248_0.conda
win-64::mdtraj-1.9.8-py39h23b186c_1.conda
win-64::intel-opencl-rt-2023.2.0-h1e68c65_49496.conda
win-64::mysql-router-8.0.33-hb3df6c7_2.conda
win-64::arrow-cpp-9.0.0-py39h39811e2_42_cuda.conda
win-64::libclang-cpp-16.0.6-default_heb8d277_1.conda
win-64::tiledb-2.16.1-hec1fcaa_0.conda
win-64::libclang13-16.0.6-default_hc80b9e7_1.conda
win-64::clang-format-13.0.1-default_h66ee7f4_2.conda
win-64::libcurl-8.2.0-hd5e4a3a_0.conda
win-64::stir-5.1.0-cuda112_py39hfeadef7_207.conda
win-64::libarrow-12.0.1-h6783b6d_4_cuda.conda
win-64::libopencv-4.8.0-py311h241c61f_0.conda
win-64::stir-5.1.0-cuda111_py310he3dbb2b_207.conda
win-64::openpmd-api-0.15.1-nompi_py39h9afc790_104.conda
win-64::libarrow-12.0.1-h12e5d06_4_cpu.conda
win-64::cfitsio-4.3.0-h9b0cee5_0.conda
win-64::omniorb-4.3.0-py310h2b448b3_0.conda
win-64::libopencv-4.7.0-py310h46c874d_6.conda
win-64::postgresql-plpython-14.5-py310hf838413_7.conda
win-64::libarrow-11.0.0-hc51b828_28_cuda.conda
win-64::indexed_gzip-1.8.3-py311hcbca1fb_0.conda
win-64::tiledb-2.16.0-hec1fcaa_2.conda
win-64::vtk-base-9.2.6-qt_py39h1234567_209.conda
win-64::libcurl-static-8.2.1-hd5e4a3a_0.conda
win-64::raven-hydro-0.2.3-py311h47b085c_0.conda
win-64::imagecodecs-2023.7.10-py39had998c7_2.conda
win-64::gmsh-4.11.1-hf392c44_3.conda
win-64::arrow-cpp-9.0.0-py39hd8764ba_44_cuda.conda
win-64::libpulsar-3.2.0-h074dd01_2.conda
win-64::arrow-cpp-9.0.0-py38hb562b93_44_cuda.conda
win-64::clangdev-16.0.6-default_heb8d277_1.conda
win-64::libclang-16.0.6-default_heb8d277_1.conda
win-64::lxml-4.9.3-py39hbae3653_0.conda
win-64::tiledb-2.16.0-hd58e885_2.conda
win-64::clang-tools-16.0.6-default_heb8d277_1.conda
win-64::libarrow-11.0.0-hc51b828_30_cuda.conda
win-64::yarp-cxx-3.8.1-h26e88d7_2.conda
win-64::libarrow-10.0.1-h3eb3106_36_cuda.conda
win-64::libopencv-4.8.0-py310hea656e8_0.conda
win-64::python-igraph-0.10.6-py38h268d0ab_0.conda
win-64::mdtraj-1.9.8-py310h1431f1b_2.conda
win-64::stir-5.1.0-cuda110_py310h054932e_209.conda
win-64::harp-1.19-py39h441a838_0.conda
win-64::postgresql-14.5-hc80876b_7.conda
win-64::clang-13-13.0.1-default_h66ee7f4_3.conda
win-64::arrow-cpp-9.0.0-py310hbfdd532_43_cpu.conda
win-64::glib-networking-2.76.1-h8365e19_0.conda
win-64::mysql-router-8.0.33-h8bd79c8_2.conda
win-64::python-igraph-0.10.4-py310ha2478e4_1.conda
win-64::libclang-15.0.7-default_h77d9078_3.conda
win-64::smesh-9.9.0.0-h262ffcb_6.conda
win-64::libopentelemetry-cpp-1.9.1-h156e78f_3.conda
win-64::dcmtk-3.6.7-hf6c5ea5_4.conda
win-64::mdtraj-1.9.9-py38h9fbe819_0.conda
win-64::lpython-0.18.4-h12be248_0.conda
win-64::gst-plugins-good-1.22.4-h368eea8_1.conda
win-64::libopencv-4.7.0-py38he61d1cf_6.conda
win-64::grpcio-1.56.0-py310hb84602e_2.conda
win-64::arrow-cpp-9.0.0-py39h0acc53e_44_cpu.conda
win-64::arrow-cpp-9.0.0-py39h0acc53e_43_cpu.conda
win-64::libgdal-3.7.1-hff0c8fc_2.conda
win-64::libpq-15.3-h43585b0_2.conda
win-64::libgrpc-1.56.1-hea2d5f7_0.conda
win-64::mysql-libs-8.0.33-h8b0d2c3_1.conda
win-64::paraview-5.11.1-py310h03fe996_102_qt.conda
win-64::libarrow-10.0.1-heb30dd5_33_cpu.conda
win-64::lpython-0.18.3-h12be248_0.conda
win-64::libignition-fuel-tools4-4.6.0-h4ed5c76_2.conda
win-64::mysql-client-8.0.33-hed9f4ee_1.conda
win-64::raven-hydro-0.2.3-py38h3b9c276_0.conda
win-64::python-igraph-0.10.5-py38he0e89a5_0.conda
win-64::intel-opencl-rt-2023.2.0-ha79b245_49496.conda
win-64::clangdev-15.0.7-default_h66ee7f4_3.conda
win-64::libarrow-10.0.1-h6bcc697_34_cuda.conda
win-64::libarrow-11.0.0-hc51b828_27_cuda.conda
win-64::arrow-cpp-9.0.0-py38hc7794f1_43_cpu.conda
win-64::libgdal-3.6.4-h25f0b3c_9.conda
win-64::raven-hydro-0.2.3-py39h001a4f1_0.conda
win-64::clangdev-13.0.1-default_h66ee7f4_3.conda
win-64::libarrow-11.0.0-heb30dd5_32_cpu.conda
win-64::libarrow-12.0.1-hbe2dfe2_3_cuda.conda
win-64::python-igraph-0.10.5-py39ha09ebdf_0.conda
win-64::geotiff-1.7.1-h4e61e90_10.conda
win-64::arrow-cpp-9.0.0-py38hd335af4_44_cpu.conda
win-64::mysql-libs-8.0.33-h8b0d2c3_2.conda
win-64::stir-5.1.0-cpu_py38hc1d9697_9.conda
win-64::gst-plugins-good-1.22.5-h368eea8_0.conda
win-64::cpp-opentelemetry-sdk-1.10.0-h156e78f_0.conda
win-64::libgdal-arrow-parquet-3.7.1-hdece7f0_0.conda
win-64::imagecodecs-2023.7.10-py39h8ff80d2_2.conda
win-64::intel-opencl-rt-2023.2.0-h887a12f_49496.conda
win-64::stir-5.1.0-cpu_py38hc1d9697_7.conda
win-64::libgdal-arrow-parquet-3.7.1-h75626d2_1.conda
win-64::libarrow-10.0.1-h8a6ae29_33_cpu.conda
win-64::libgdal-arrow-parquet-3.7.1-h75626d2_2.conda
win-64::libarrow-11.0.0-heb30dd5_31_cpu.conda
win-64::mysql-server-8.0.33-h59fb016_1.conda
win-64::omniorb-4.3.0-py39hd2c3553_0.conda
win-64::libarrow-11.0.0-hc51b828_29_cuda.conda
win-64::qt-main-5.15.8-h063a7da_15.conda
win-64::ogre-13.6.5-h5bf801f_0.conda
win-64::poppler-qt-23.07.0-hec2a549_0.conda
win-64::python-igraph-0.10.5-py310ha2478e4_0.conda
win-64::stir-5.1.0-cuda111_py38hfd014f0_207.conda
win-64::libclang13-15.0.7-default_h77d9078_3.conda
win-64::arrow-cpp-9.0.0-py311h2c5f31a_43_cuda.conda
win-64::lxml-4.9.3-py311h750ae06_0.conda
win-64::grpcio-1.56.0-py39hd28a505_2.conda
win-64::r-harp-1.19-r41h5e6021e_0.conda
win-64::lpython-0.18.1-h12be248_0.conda
win-64::python-igraph-0.10.5-py311h51d0c2f_0.conda
win-64::stir-5.1.0-cuda112_py310hc6bcfdd_208.conda
win-64::libarrow-10.0.1-heb30dd5_35_cpu.conda
win-64::stir-5.1.0-cuda111_py310he3dbb2b_209.conda
win-64::ogre-14.0.1-h5bf801f_0.conda
win-64::libopencv-4.8.0-py39heefb252_0.conda
win-64::arrow-cpp-9.0.0-py39ha6e8ab7_44_cpu.conda
win-64::mdtraj-1.9.8-py311h3f4f50a_1.conda
win-64::harp-1.19-py38hb5a5460_0.conda
win-64::libgdal-3.6.4-hadd3c02_7.conda
win-64::stir-5.1.0-cuda110_py38h9b6dfa3_209.conda
win-64::postgresql-plpython-14.5-py39h7f24c7b_7.conda
win-64::libopencv-4.8.0-py311h787696b_0.conda
win-64::librdkafka-2.2.0-h78d1f3c_0.conda
win-64::libopencv-4.8.0-py39h65bee9d_0.conda
win-64::lxml-4.9.3-py310h46d54dd_0.conda
win-64::llvmdev-15.0.7-h1ab654d_3.conda
win-64::arrow-cpp-9.0.0-py38hc7794f1_42_cpu.conda
win-64::leptonica-1.83.1-h6c4be76_0.conda
win-64::arrow-cpp-9.0.0-py310h727b2f2_42_cuda.conda
win-64::stir-5.1.0-cuda110_py310h054932e_207.conda
win-64::stir-5.1.0-cuda102_py310h97e09a4_208.conda
win-64::llvm-15.0.7-h3dc180e_3.conda
win-64::intel-cmplr-lib-rt-2023.2.0-h12be248_49496.conda
win-64::zstd-1.5.2-h12be248_7.conda
win-64::arrow-cpp-9.0.0-py310h727b2f2_44_cuda.conda
win-64::llvm-tools-15.0.7-h1ab654d_3.conda
win-64::clang-tools-15.0.7-default_h66ee7f4_3.conda
win-64::imagecodecs-2023.7.10-py39hc6a4b30_1.conda
win-64::stir-5.1.0-cpu_py38hc1d9697_8.conda
win-64::libopencv-4.8.0-py39h377d6c7_0.conda
win-64::gst-plugins-base-1.22.4-h001b923_1.conda
win-64::imagecodecs-2023.7.10-py311h0b4acc2_2.conda
win-64::libarrow-10.0.1-h8a6ae29_36_cpu.conda
win-64::python-igraph-0.10.6-py39ha09ebdf_0.conda
win-64::arrow-cpp-9.0.0-py39h39811e2_44_cuda.conda
win-64::arrow-cpp-9.0.0-py310h1410346_42_cpu.conda
win-64::arrow-cpp-9.0.0-py310h1410346_43_cpu.conda
win-64::arrow-cpp-9.0.0-py38hc7794f1_44_cpu.conda
win-64::stir-5.1.0-cuda112_py310hc6bcfdd_209.conda
win-64::mysql-router-8.0.33-hb3df6c7_1.conda
win-64::imagecodecs-2023.7.10-py310h997794f_2.conda
win-64::imagecodecs-2023.7.10-py311h4ebb3dc_1.conda
win-64::libopentelemetry-cpp-1.10.0-h156e78f_0.conda
win-64::arrow-cpp-9.0.0-py38hc719ca3_43_cuda.conda
win-64::python-igraph-0.10.6-py310ha2478e4_0.conda
win-64::libcurl-8.2.1-hd5e4a3a_0.conda
win-64::tiledb-2.16.0-hec1fcaa_3.conda
win-64::raven-hydro-0.2.3-py311heaa4539_0.conda
win-64::libarrow-10.0.1-h7061486_36_cuda.conda
win-64::libarrow-11.0.0-heb30dd5_27_cpu.conda
win-64::clang-15-15.0.7-default_h66ee7f4_3.conda
win-64::mysql-server-8.0.33-hdf5bdb2_1.conda
win-64::stir-5.1.0-cuda102_py311hac9f262_209.conda
win-64::pillow-10.0.0-py38h9043d50_0.conda
win-64::libsoup-2.74.3-hef79ac6_1.conda
win-64::stir-5.1.0-cuda111_py39h826d9da_208.conda
win-64::imagecodecs-2023.7.10-py39h3a19354_1.conda
win-64::libgdal-3.7.1-hc47cf30_0.conda
win-64::libarrow-10.0.1-heb30dd5_34_cpu.conda
win-64::raven-hydro-0.2.3-py39hdc7dc00_0.conda
win-64::mdtraj-1.9.8-py38h9fbe819_2.conda
win-64::mysql-server-8.0.33-h59fb016_2.conda
win-64::grpcio-1.56.0-py311h5bc0dda_2.conda
win-64::stir-5.1.0-cuda102_py38hd7fc2cb_209.conda
win-64::aws-sdk-cpp-1.11.68-h1a0519f_9.conda
win-64::r-harp-1.19-r41hd044e7d_0.conda
win-64::libllvm15-15.0.7-h1ab654d_3.conda
win-64::stir-5.1.0-cuda112_py310hc6bcfdd_207.conda
win-64::lxml-4.9.3-py38h5a3a0f9_0.conda
win-64::stir-5.1.0-cpu_py39hcb2e9d6_9.conda
win-64::arrow-cpp-9.0.0-py38hb562b93_43_cuda.conda
win-64::folly-2023.07.24.00-h6064ee9_0.conda
win-64::clangdev-13.0.1-default_h66ee7f4_2.conda
win-64::aws-sdk-cpp-1.10.57-h90d02da_16.conda
win-64::aws-sdk-cpp-1.11.68-h90d02da_8.conda
win-64::arrow-cpp-9.0.0-py311h9306c73_42_cpu.conda
win-64::libarrow-10.0.1-h7061486_35_cuda.conda
win-64::grpcio-1.56.1-py310hb84602e_0.conda
win-64::stir-5.1.0-cuda111_py311hb99f80f_208.conda
win-64::wasmer-4.1.0-h4dd112c_0.conda
win-64::postgresql-plpython-15.3-py39h7f24c7b_2.conda
win-64::stir-5.1.0-cuda102_py311hac9f262_208.conda
win-64::libadios2-2.9.0-nompi_h6e81f23_100.conda
win-64::pillow-10.0.0-py310hb653ca7_0.conda
win-64::libarrow-11.0.0-h7061486_31_cuda.conda
win-64::libopencv-4.7.0-py311h787696b_6.conda
win-64::paraview-5.11.1-py311he28099a_102_qt.conda
win-64::libarrow-12.0.1-h12e5d06_5_cpu.conda
win-64::mdtraj-1.9.8-py38h9fbe819_0.conda
win-64::libadios2-2.9.0-nompi_h3621ceb_100.conda
win-64::vtk-base-9.2.6-qt_py311h1234567_209.conda
win-64::stir-5.1.0-cpu_py310hcc1c5a5_7.conda
win-64::stir-5.1.0-cpu_py39hcb2e9d6_8.conda
win-64::mdtraj-1.9.8-py38h9fbe819_1.conda
win-64::libarrow-11.0.0-h6bcc697_29_cuda.conda
win-64::libarrow-11.0.0-h3eb3106_31_cuda.conda
win-64::libignition-fuel-tools7-7.1.0-h4ed5c76_3.conda
win-64::vtk-base-9.2.6-qt_py39h1234567_210.conda
win-64::vtk-base-9.2.6-qt_py311h1234567_210.conda
win-64::cpp-opentelemetry-sdk-1.9.1-h4dcfd69_3.conda
win-64::glib-2.76.4-h12be248_0.conda
win-64::qt6-3d-6.5.2-heb9d8b4_0.conda
win-64::mdtraj-1.9.8-py311h3f4f50a_2.conda
win-64::libllvm16-16.0.6-h1ab654d_1.conda
win-64::libgdal-arrow-parquet-3.6.4-ha142455_8.conda
win-64::python-igraph-0.10.4-py39h668eeb6_1.conda
win-64::python-igraph-0.10.6-py311h51d0c2f_0.conda
win-64::postgresql-plpython-15.3-py311h931fdd5_2.conda
win-64::llvm-tools-14.0.6-hac7d729_4.conda
win-64::libarrow-11.0.0-h8a6ae29_30_cpu.conda
win-64::raven-hydro-0.2.3-py38hc2ce60e_0.conda
win-64::tiledb-2.16.1-hd58e885_0.conda
win-64::stir-5.1.0-cuda102_py39hb7f6369_207.conda
win-64::libgdal-3.7.1-h807262c_4.conda
win-64::arrow-cpp-9.0.0-py38hc719ca3_42_cuda.conda
win-64::arrow-cpp-9.0.0-py311h2c5f31a_44_cuda.conda
win-64::clang-16-16.0.6-default_heb8d277_1.conda
win-64::aws-sdk-cpp-1.10.57-h1a0519f_17.conda
win-64::arrow-cpp-9.0.0-py311h85f3ccd_43_cuda.conda
win-64::libopencv-4.7.0-py310hea656e8_6.conda
win-64::gst-plugins-base-1.22.5-h001b923_0.conda
win-64::grpcio-1.56.2-py39hd28a505_0.conda
win-64::indexed_gzip-1.8.3-py310hff18152_0.conda
win-64::stir-5.1.0-cuda112_py39hfeadef7_209.conda
win-64::libarrow-10.0.1-hc51b828_33_cuda.conda
win-64::tiledb-2.16.0-hd58e885_3.conda
win-64::libarrow-12.0.1-hbf49b3f_2_cpu.conda
win-64::tiledb-2.16.1-h1ffc264_0.conda
win-64::lxml-4.9.3-py39hb421182_0.conda
win-64::r-harp-1.19-r41hb143bc4_0.conda
win-64::libmediainfo-23.07-h8ec2201_0.conda
win-64::omniorb-4.3.0-py311h55b17b5_0.conda
win-64::grpcio-1.56.2-py310hb84602e_0.conda
win-64::python-igraph-0.10.6-py38he0e89a5_0.conda
win-64::postgresql-plpython-15.3-py38hc2df893_2.conda
win-64::tiledb-2.16.0-h1ffc264_3.conda
win-64::vtk-base-9.2.6-qt_py310h1234567_209.conda
win-64::clang-format-13.0.1-default_h66ee7f4_3.conda
win-64::arrow-cpp-9.0.0-py310hbfdd532_44_cpu.conda
win-64::folly-2023.07.03.00-h6064ee9_0.conda
win-64::nsight-compute-2022.4.0.15-h3ac718b_0.conda
win-64::indexed_gzip-1.8.3-py38h8df4070_0.conda
win-64::stir-5.1.0-cuda111_py38hfd014f0_208.conda
win-64::libarrow-11.0.0-h8a6ae29_29_cpu.conda
win-64::indexed_gzip-1.8.3-py39h858d21e_0.conda
win-64::python-igraph-0.10.4-py311h51d0c2f_1.conda
win-64::poppler-23.07.0-h45d20d0_0.conda
win-64::leptonica-1.83.1-h7b8bf50_3.conda
win-64::stir-5.1.0-cuda110_py311he4398c6_209.conda
win-64::libgdal-arrow-parquet-3.6.4-hbf5843c_7.conda
win-64::python-igraph-0.10.4-py38he0e89a5_1.conda
win-64::mdtraj-1.9.9-py311h3f4f50a_0.conda
win-64::python-igraph-0.10.5-py38h268d0ab_0.conda
win-64::libarrow-12.0.1-h12e5d06_6_cpu.conda
win-64::stir-5.1.0-cuda111_py311hb99f80f_209.conda
win-64::stir-5.1.0-cuda112_py38hf44ba56_209.conda
win-64::postgresql-plpython-14.5-py311h931fdd5_7.conda
win-64::libgdal-arrow-parquet-3.7.0-hdece7f0_5.conda
win-64::libarrow-12.0.1-he0d9d9e_6_cuda.conda
win-64::tesseract-5.3.1-hcb5f61f_0.conda
win-64::stir-5.1.0-cuda110_py38h9b6dfa3_208.conda
win-64::openpmd-api-0.15.1-nompi_py38h658479d_104.conda
win-64::grpcio-1.56.1-py311h5bc0dda_0.conda
win-64::libarrow-12.0.1-h6783b6d_3_cuda.conda
win-64::libgdal-arrow-parquet-3.6.4-ha142455_9.conda
win-64::paraview-5.11.1-py39h1706384_102_qt.conda
win-64::mdtraj-1.9.8-py39h23b186c_0.conda
win-64::libadios2-2.9.0-nompi_he589150_100.conda
win-64::stir-5.1.0-cuda102_py38hd7fc2cb_208.conda
win-64::mdtraj-1.9.9-py39h23b186c_0.conda
win-64::python-igraph-0.10.4-py38h268d0ab_1.conda
win-64::stir-5.1.0-cuda110_py310h054932e_208.conda
win-64::libarrow-10.0.1-heb30dd5_32_cpu.conda
win-64::arrow-cpp-9.0.0-py311h2c5f31a_42_cuda.conda
win-64::arrow-cpp-9.0.0-py311h5cbd681_43_cpu.conda
win-64::pillow-10.0.0-py311hde623f7_0.conda
win-64::imagecodecs-2023.7.10-py310habf4aba_0.conda
win-64::libarrow-12.0.1-hbe2dfe2_5_cuda.conda
win-64::arrow-cpp-9.0.0-py39ha6e8ab7_43_cpu.conda
win-64::stir-5.1.0-cuda111_py310he3dbb2b_208.conda
win-64::paraview-5.11.1-py311hf89dea1_102_qt.conda
win-64::aws-sdk-cpp-1.11.68-h38c1a0f_7.conda
win-64::grpcio-1.56.0-py38h19421c1_2.conda
win-64::arrow-cpp-9.0.0-py311h9306c73_43_cpu.conda
win-64::paraview-5.11.1-py38hf8728ce_102_qt.conda
win-64::libgrpc-1.56.0-hea2d5f7_2.conda
win-64::stir-5.1.0-cuda102_py38hd7fc2cb_207.conda
win-64::harp-1.19-py311h4c3a82d_0.conda
win-64::paraview-5.11.1-py310h6008076_102_qt.conda
win-64::libarrow-11.0.0-h7061486_32_cuda.conda
win-64::stir-5.1.0-cuda102_py310h97e09a4_207.conda
win-64::mdtraj-1.9.8-py39h23b186c_2.conda
win-64::clang-13-13.0.1-default_h66ee7f4_2.conda
win-64::libarrow-12.0.1-hd503b12_2_cpu.conda
win-64::nco-5.1.6-hbd9a884_2.conda
win-64::libarrow-12.0.1-h12e5d06_7_cpu.conda
win-64::grpcio-1.56.2-py38h19421c1_0.conda
win-64::clang-tools-13.0.1-default_h66ee7f4_3.conda
win-64::smesh-9.9.0.0-hd85d2f4_6.conda
win-64::stir-5.1.0-cuda112_py38hf44ba56_208.conda
win-64::raven-hydro-0.2.3-py39hc465eaa_0.conda
win-64::libcurl-static-8.2.0-hd5e4a3a_0.conda
win-64::libarrow-10.0.1-h8a6ae29_34_cpu.conda
win-64::libllvm14-14.0.6-h97333cc_4.conda
win-64::python-igraph-0.10.5-py39h668eeb6_0.conda
win-64::curl-8.2.0-hd5e4a3a_0.conda
win-64::cpp-opentelemetry-sdk-1.9.1-h156e78f_3.conda
win-64::openpmd-api-0.15.1-nompi_py310h31abc04_104.conda
win-64::clang-16.0.6-h3dc180e_1.conda
win-64::grpcio-1.56.1-py39hd28a505_0.conda
win-64::libgdal-3.7.1-hff0c8fc_1.conda
win-64::libopencv-4.7.0-py311h241c61f_6.conda
win-64::curl-8.1.2-hd5e4a3a_1.conda
win-64::libarrow-10.0.1-h6bcc697_33_cuda.conda
win-64::clang-format-15.0.7-default_h66ee7f4_3.conda
win-64::stir-5.1.0-cuda112_py38hf44ba56_207.conda
win-64::qt6-3d-6.5.1-heb9d8b4_1.conda
win-64::libopencv-4.7.0-py39h65bee9d_6.conda
win-64::libadios2-2.9.0-nompi_h6db2470_100.conda
win-64::cpp-opentelemetry-sdk-1.10.0-h4dcfd69_0.conda
win-64::qt6-main-6.5.1-hf0c6fff_3.conda
win-64::imagecodecs-2023.7.10-py39h2d00102_0.conda
win-64::libarrow-11.0.0-h6bcc697_30_cuda.conda
win-64::libopencv-4.8.0-py38h8d3b7e7_0.conda
win-64::lxml-4.9.3-py38hca7eb16_0.conda
win-64::libignition-fuel-tools7-7.1.0-hd22afc4_3.conda
win-64::openpmd-api-0.15.1-nompi_py38h4792802_104.conda
win-64::libarrow-12.0.1-h12e5d06_3_cpu.conda
win-64::clang-tools-13.0.1-default_h66ee7f4_2.conda
win-64::stir-5.1.0-cuda102_py39hb7f6369_209.conda
win-64::dpcpp_impl_win-64-2023.2.0-h3338d26_49496.conda
win-64::libarrow-12.0.1-h0578746_3_cpu.conda
win-64::libopencv-4.7.0-py39h377d6c7_6.conda
win-64::arrow-cpp-9.0.0-py310h1410346_44_cpu.conda
win-64::libgdal-arrow-parquet-3.7.1-h75626d2_3.conda
win-64::stir-5.1.0-cuda110_py311he4398c6_208.conda
win-64::mdtraj-1.9.8-py310h1431f1b_1.conda
win-64::llvmdev-16.0.6-h1ab654d_1.conda
win-64::mysql-client-8.0.33-hed9f4ee_2.conda
win-64::libarrow-11.0.0-h8a6ae29_31_cpu.conda
win-64::libopencv-4.8.0-py39hbd58657_0.conda
win-64::yarp-cxx-3.8.1-h26e88d7_1.conda
win-64::geotiff-1.7.1-h4e61e90_11.conda
win-64::libarrow-10.0.1-h8a6ae29_35_cpu.conda
win-64::libopencv-4.7.0-py38h8d3b7e7_6.conda
win-64::arrow-cpp-9.0.0-py310h234b940_44_cuda.conda
win-64::harp-1.19-py38h08b0ee8_0.conda
win-64::grpcio-1.56.1-py38h19421c1_0.conda
win-64::postgresql-plpython-14.5-py38hc2df893_7.conda
win-64::stir-5.1.0-cuda110_py39heaf2f63_207.conda
win-64::libarrow-10.0.1-hc51b828_32_cuda.conda
win-64::stir-5.1.0-cuda102_py310h97e09a4_209.conda
win-64::arrow-cpp-9.0.0-py38hd335af4_43_cpu.conda
win-64::libarrow-10.0.1-heb30dd5_36_cpu.conda
win-64::openpmd-api-0.15.1-nompi_py39h6c7657d_104.conda
win-64::paraview-5.11.1-py39hf35ee14_102_qt.conda
win-64::libarrow-12.0.1-h0578746_4_cpu.conda
win-64::libclang-13.0.1-default_h66ee7f4_3.conda
win-64::arrow-cpp-9.0.0-py39h39811e2_43_cuda.conda
win-64::libarrow-12.0.1-h04568e6_6_cuda.conda
win-64::libarrow-11.0.0-heb30dd5_28_cpu.conda
win-64::stir-5.1.0-cuda111_py39h826d9da_207.conda
win-64::vtk-base-9.2.6-qt_py310h1234567_210.conda
win-64::libarrow-12.0.1-he0d9d9e_7_cuda.conda
win-64::libarrow-12.0.1-h6783b6d_5_cuda.conda
win-64::collada-dom-2.5.0-ha6903d2_6.conda
win-64::arrow-cpp-9.0.0-py39hd8764ba_43_cuda.conda
win-64::pillow-10.0.0-py39ha9166d5_0.conda
win-64::r-harp-1.19-r41h0d7f73b_0.conda
win-64::aws-sdk-cpp-1.10.57-h38c1a0f_15.conda
win-64::arrow-cpp-9.0.0-py38hc719ca3_44_cuda.conda
win-64::harp-1.19-py310hd502204_0.conda
win-64::stir-5.1.0-cuda110_py39heaf2f63_208.conda
win-64::libgdal-3.7.0-hc47cf30_5.conda
win-64::libgdal-arrow-parquet-3.7.1-h9bd5fb0_4.conda
win-64::omniorb-libs-4.3.0-ha7d20b1_0.conda
win-64::msgpack-cxx-6.1.0-hc2a4d42_0.conda
win-64::vtk-base-9.2.6-qt_py38h1234567_210.conda
win-64::libopencv-4.7.0-py38hf3fd54b_6.conda
win-64::stir-5.1.0-cuda112_py39hfeadef7_208.conda
win-64::harp-1.19-py39haf6c738_0.conda
win-64::libarrow-11.0.0-heb30dd5_29_cpu.conda
win-64::orc-1.9.0-hf2b8f0d_1.conda
win-64::pillow-10.0.0-py39hf8900f3_0.conda
win-64::libarrow-12.0.1-hf44680d_2_cuda.conda
win-64::dlib-cpp-19.24.2-hfab4998_4.conda
win-64::tiledb-2.16.0-h1ffc264_2.conda
win-64::grpcio-1.56.2-py311h5bc0dda_0.conda
win-64::libgdal-3.6.4-h25f0b3c_8.conda
win-64::libsoup-2.74.3-h1728b60_0.conda
win-64::llvm-tools-16.0.6-h1ab654d_1.conda
win-64::arrow-cpp-9.0.0-py310h727b2f2_43_cuda.conda
win-64::gst-libav-1.22.5-hec9340f_0.conda
win-64::libnetcdf-4.9.2-nompi_h5902ca5_107.conda
win-64::libarrow-12.0.1-h208ba7f_2_cuda.conda
win-64::r-harp-1.19-r41hd632797_0.conda
win-64::libopentelemetry-cpp-1.9.1-h03fb4e4_3.conda
win-64::arrow-cpp-9.0.0-py311h9306c73_44_cpu.conda
win-64::mdtraj-1.9.9-py310h1431f1b_0.conda
win-64::nco-5.1.7-hbd9a884_0.conda
win-64::libopencv-4.8.0-py310h46c874d_0.conda
win-64::stir-5.1.0-cpu_py39hcb2e9d6_7.conda
win-64::r-harp-1.19-r41h0f4d3c9_0.conda
win-64::postgresql-plpython-15.3-py310hf838413_2.conda
win-64::libarrow-12.0.1-hbe2dfe2_4_cuda.conda
win-64::libpulsar-3.2.0-h066f7b4_2.conda
win-64::arrow-cpp-9.0.0-py311h5cbd681_44_cpu.conda
win-64::libarrow-12.0.1-h0578746_7_cpu.conda
win-64::stir-5.1.0-cuda111_py38hfd014f0_209.conda
win-64::libcurl-static-8.1.2-hd5e4a3a_1.conda
win-64::clangxx-16.0.6-default_heb8d277_1.conda
win-64::openpmd-api-0.15.1-nompi_py311h050fbb8_104.conda
win-64::stir-5.1.0-cpu_py310hcc1c5a5_8.conda
win-64::eccodes-2.31.0-ha10300a_0.conda
win-64::libarrow-12.0.1-h04568e6_7_cuda.conda
win-64::libgdal-arrow-parquet-3.6.4-ha142455_10.conda
win-64::qt6-main-6.5.2-h577db66_0.conda
win-64::folly-2023.07.10.00-hfbb6214_0.conda
win-64::stir-5.1.0-cuda112_py311h5e56a69_208.conda
win-64::stir-5.1.0-cuda111_py39h826d9da_209.conda
win-64::imagecodecs-2023.7.10-py310h962b57c_1.conda
win-64::imagecodecs-2023.7.10-py39ha21a766_0.conda
win-64::libgdal-3.6.4-h25f0b3c_10.conda
win-64::raven-hydro-0.2.3-py39h4f5c61a_0.conda
win-64::libcurl-8.1.2-hd5e4a3a_1.conda
win-64::libopentelemetry-cpp-1.10.0-h03fb4e4_0.conda
win-64::libgdal-3.7.1-hff0c8fc_3.conda
win-64::libopencv-4.7.0-py39heefb252_6.conda
win-64::vtk-base-9.2.6-qt_py38h1234567_209.conda
win-64::stir-5.1.0-cuda102_py39hb7f6369_208.conda
win-64::libgrpc-1.56.2-hea2d5f7_0.conda
win-64::folly-2023.07.10.00-h6064ee9_0.conda
win-64::libarrow-10.0.1-h3eb3106_35_cuda.conda
win-64::folly-2023.07.24.00-hfbb6214_0.conda
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
win-64::clangxx-13.0.1-default_h66ee7f4_2.conda
win-64::llvm-14.0.6-h6fda50d_4.conda
win-64::clangxx-15.0.7-default_h66ee7f4_3.conda
win-64::clang-15.0.7-h8e541a6_3.conda
win-64::clangxx-13.0.1-default_h66ee7f4_3.conda
win-64::clang-13.0.1-h8e541a6_2.conda
win-64::clang-13.0.1-default_h46fc674_3.conda
-    "libzlib >=1.2.13,<1.3.0a0"
+    "libzlib >=1.2.13,<2.0.0a0"
================================================================================
================================================================================
osx-64
osx-64::gst-plugins-base-1.22.5-hb5d3a86_0.conda
osx-64::libllvm14-14.0.6-hc8e404f_4.conda
osx-64::micromamba-1.4.9-0.tar.bz2
osx-64::glib-tools-2.76.4-h7d26f99_0.conda
osx-64::zstd-1.5.2-h829000d_7.conda
osx-64::xapian-core-1.4.23-h837b0c1_0.conda
osx-64::eccodes-2.31.0-he60ccd1_0.conda
osx-64::llvm-14.0.6-h9d075a6_4.conda
osx-64::msgpack-cxx-6.1.0-h6fcd042_0.conda
osx-64::libuwebsockets-20.45.0-h7d26f99_0.conda
osx-64::micromamba-1.4.8-0.tar.bz2
osx-64::cfitsio-4.3.0-h66f91ea_0.conda
osx-64::llvm-tools-14.0.6-hc8e404f_4.conda
osx-64::micromamba-1.4.7-0.tar.bz2
osx-64::gst-plugins-base-1.22.4-hb5d3a86_1.conda
osx-64::dlib-cpp-19.24.2-h36d161f_4.conda
osx-64::micromamba-1.4.6-0.tar.bz2
-    "libzlib >=1.2.13,<1.3.0a0"
+    "libzlib >=1.2.13,<2.0.0a0"
osx-64::yoda-1.9.6-py38h2aceae1_3.conda
osx-64::folly-2023.07.10.00-h1718691_0.conda
osx-64::tesseract-5.3.1-h9177755_0.conda
osx-64::imagecodecs-2023.7.10-py311h24e4b62_0.conda
osx-64::mysql-server-8.0.33-h2e8d4b4_1.conda
osx-64::wxpython-4.2.1-py38h6cc8c6c_0.conda
osx-64::openpmd-api-0.15.1-nompi_py39h5c3be65_104.conda
osx-64::photochem-0.4.2-py310h2bd49c5_0.conda
osx-64::tiledb-2.16.0-h0f7503a_3.conda
osx-64::astrometry-0.94-py311hd46749d_2.conda
osx-64::cpp-opentelemetry-sdk-1.9.1-hb55cd83_3.conda
osx-64::raven-hydro-0.2.3-py38h98498c3_0.conda
osx-64::libadios2-2.9.0-nompi_h0ec5f4d_100.conda
osx-64::python-igraph-0.10.4-py38h4f64032_1.conda
osx-64::astrometry-0.94-py39h2c7e526_1.conda
osx-64::mdtraj-1.9.8-py310h8e8bc97_2.conda
osx-64::libarrow-12.0.1-h7094540_2_cpu.conda
osx-64::libadios2-2.9.0-mpi_openmpi_h424a5b2_0.conda
osx-64::pocl-core-4.0-h6d67a90_2.conda
osx-64::raven-hydro-0.2.3-py38ha481359_0.conda
osx-64::r-base-4.2.3-h4373c2c_5.conda
osx-64::libadios2-2.9.0-mpi_openmpi_hf6dff9f_0.conda
osx-64::photochem-0.4.2-py311h9a8d235_0.conda
osx-64::libadios2-2.9.0-nompi_h1a07a1f_100.conda
osx-64::gmsh-4.11.1-h0adee99_3.conda
osx-64::leptonica-1.83.1-h02e98bb_0.conda
osx-64::cctools_osx-arm64-973.0.1-h7bb7a8e_14.conda
osx-64::gfortran_impl_osx-arm64-12.2.0-h3800619_32.conda
osx-64::python-igraph-0.10.5-py39h9ac0049_0.conda
osx-64::root_base-6.28.4-py39h8bc755e_1.conda
osx-64::libarrow-11.0.0-h5b8112e_28_cpu.conda
osx-64::openpmd-api-0.15.1-mpi_openmpi_py38h56fcb61_4.conda
osx-64::openpmd-api-0.15.1-mpi_openmpi_py311h9bccdf8_4.conda
osx-64::gst-plugins-good-1.22.4-h91de58d_1.conda
osx-64::xrootd-5.5.5-py39hdbfe476_1.conda
osx-64::folly-2023.07.03.00-hc30067e_0_jemalloc.conda
osx-64::photochem-0.4.1-py38h32f496a_1.conda
osx-64::tiledb-2.16.1-h24ec535_0.conda
osx-64::bytewax-0.16.2-py310he76948c_1.conda
osx-64::wxpython-4.2.1-py39h6b130f8_0.conda
osx-64::mdtraj-1.9.8-py38hc638d36_2.conda
osx-64::xrootd-5.5.5-py310hf4aae75_1.conda
osx-64::mysql-client-8.0.33-hc4c47b9_2.conda
osx-64::ambertools-23.3-py39hfb6888d_2.conda
osx-64::arrow-cpp-9.0.0-py39h9ac03de_42_cpu.conda
osx-64::harp-1.19-py39h9af1791_0.conda
osx-64::vtk-base-9.2.6-qt_py311h1234567_209.conda
osx-64::python-igraph-0.10.5-py38h4f64032_0.conda
osx-64::libvips-8.14.3-hbd671d3_1.conda
osx-64::aws-sdk-cpp-1.11.68-h8d6e493_8.conda
osx-64::imagecodecs-2023.7.10-py310hd6320be_2.conda
osx-64::arrow-cpp-9.0.0-py310h96062e2_44_cpu.conda
osx-64::folly-2023.07.10.00-h503270f_0_jemalloc.conda
osx-64::mdtraj-1.9.8-py310h8e8bc97_1.conda
osx-64::ndcctools-7.6.1-py38h0a8965a_0.conda
osx-64::libadios2-2.9.0-mpi_mpich_h41c2e91_0.conda
osx-64::mdtraj-1.9.8-py39h1f7e74c_0.conda
osx-64::imagecodecs-2023.7.10-py311hbb940b5_2.conda
osx-64::openpmd-api-0.15.1-nompi_py39hed69e9f_104.conda
osx-64::arrow-cpp-9.0.0-py38h04ca655_43_cpu.conda
osx-64::texlive-core-20230313-h2a7d65d_4.conda
osx-64::bytewax-0.16.2-py311hb29c592_1.conda
osx-64::libarrow-11.0.0-h5b8112e_32_cpu.conda
osx-64::libnetcdf-4.9.2-mpi_openmpi_h2b1fd54_7.conda
osx-64::libtensorflow-2.12.1-cpu_h95d091f_0.conda
osx-64::r-base-4.3.1-had2b78c_2.conda
osx-64::lpython-0.18.3-h7d26f99_0.conda
osx-64::nest-simulator-3.5-py311hb4e21ca_0.conda
osx-64::harp-1.19-py38h5f6ef58_0.conda
osx-64::libsoup-2.74.3-h8ff24ff_1.conda
osx-64::libgdal-arrow-parquet-3.7.1-h0005417_4.conda
osx-64::magics-4.14.1-hd43c1be_0.conda
osx-64::astrometry-0.94-py310h7fc100c_1.conda
osx-64::yoda-1.9.6-py39h8d2ba71_4.conda
osx-64::bytewax-0.16.2-py38h51ad8f1_1.conda
osx-64::mesalib-23.1.4-hb59017c_0.conda
osx-64::arrow-cpp-9.0.0-py38h04ca655_44_cpu.conda
osx-64::mdtraj-1.9.8-py39h1f7e74c_2.conda
osx-64::nest-simulator-3.5-py310h8f12a07_0.conda
osx-64::dcap-2.47.14-h583d8d1_1.conda
osx-64::libopencv-4.8.0-py39h52eb06d_0.conda
osx-64::xorg-libxft-2.3.8-h7c25f85_0.conda
osx-64::libopencv-4.7.0-py310h10b68d3_6.conda
osx-64::libarrow-10.0.1-hcbe7614_32_cpu.conda
osx-64::libgdal-3.7.1-h4460828_3.conda
osx-64::libarrow-11.0.0-h5b8112e_31_cpu.conda
osx-64::pillow-10.0.0-py38hdd5cec0_0.conda
osx-64::magics-metview-batch-4.14.1-hd43c1be_0.conda
osx-64::omniorb-libs-4.3.0-h9bc8c17_0.conda
osx-64::xrootd-5.6.1-py310hb3023bb_0.conda
osx-64::imagecodecs-2023.7.10-py39h933016d_0.conda
osx-64::gazebo-11.13.0-h4ab8887_4.conda
osx-64::openssh-9.3p1-h3df487d_2.conda
osx-64::imagecodecs-2023.7.10-py310h7232ec0_1.conda
osx-64::tensorflow-base-2.12.1-cpu_py311h682096a_0.conda
osx-64::python-igraph-0.10.4-py39haffe10a_1.conda
osx-64::libarrow-10.0.1-h0b3ac1b_35_cpu.conda
osx-64::python-igraph-0.10.5-py39haffe10a_0.conda
osx-64::libtiledb-sql-0.23.0-h8953216_0.conda
osx-64::root_base-6.28.4-py310hebda605_1.conda
osx-64::photochem-0.4.2-py38hed9df5a_1.conda
osx-64::libvips-8.14.3-hece3a03_0.conda
osx-64::qt-main-5.15.8-heb9da5c_15.conda
osx-64::postgresql-plpython-14.5-py39hfacc66a_7.conda
osx-64::ndcctools-7.6.0-py39hd4b95d6_0.conda
osx-64::python-igraph-0.10.5-py310h8331c2e_0.conda
osx-64::gfortran_impl_osx-64-11.4.0-h2a33dde_1.conda
osx-64::afterimage-1.21-hb107d78_1004.conda
osx-64::ndcctools-7.6.0-py311h54575cd_0.conda
osx-64::lxml-4.9.3-py38h5dfb560_0.conda
osx-64::tiledb-2.16.0-h9b026fb_2.conda
osx-64::postgresql-plpython-14.5-py310he0d0a37_7.conda
osx-64::arrow-cpp-9.0.0-py310h96062e2_43_cpu.conda
osx-64::mysql-libs-8.0.33-haa61052_2.conda
osx-64::harp-1.19-py38h4bf41e0_0.conda
osx-64::libsoup-2.74.3-hc48e74a_0.conda
osx-64::libarrow-11.0.0-h5b8112e_30_cpu.conda
osx-64::jaxlib-0.4.14-cpu_py311h8b48d28_1.conda
osx-64::mdtraj-1.9.8-py310h8e8bc97_0.conda
osx-64::libopencv-4.8.0-py310hfd94445_0.conda
osx-64::lpython-0.18.2-h7d26f99_0.conda
osx-64::libllvm15-15.0.7-he4b1e75_3.conda
osx-64::libopencv-4.8.0-py310haa4d745_0.conda
osx-64::gfortran_impl_osx-arm64-11.4.0-hcde412f_0.conda
osx-64::cpp-opentelemetry-sdk-1.10.0-hb55cd83_0.conda
osx-64::libgdal-3.7.0-h61a083c_5.conda
osx-64::libarrow-10.0.1-hcbe7614_34_cpu.conda
osx-64::xrootd-5.6.1-py39h65f106e_0.conda
osx-64::r-base-4.2.3-h4373c2c_4.conda
osx-64::pocl-core-4.0-h7ae6de7_2.conda
osx-64::vtk-base-9.2.6-qt_py38h1234567_210.conda
osx-64::pillow-10.0.0-py310hd63a8c7_0.conda
osx-64::libopentelemetry-cpp-1.10.0-hac0930c_0.conda
osx-64::libopencv-4.7.0-py311h7b08e11_6.conda
osx-64::r-harp-1.19-r43hbb3c0c7_0.conda
osx-64::tiledb-2.16.0-h24ec535_3.conda
osx-64::libarrow-12.0.1-h5b8112e_4_cpu.conda
osx-64::arrow-cpp-9.0.0-py39h0df8cbe_44_cpu.conda
osx-64::folly-2023.07.17.00-h503270f_0_jemalloc.conda
osx-64::yoda-1.9.6-py39h8d2ba71_3.conda
osx-64::mdtraj-1.9.9-py310h8e8bc97_0.conda
osx-64::nest-simulator-3.5-py38he671bcf_1.conda
osx-64::jaxlib-0.4.12-cpu_py311h7d5d4fd_1.conda
osx-64::ndcctools-7.6.1-py310h442c573_0.conda
osx-64::pillow-10.0.0-py39he6683de_0.conda
osx-64::libopencv-4.7.0-py38hd4ac334_6.conda
osx-64::curl-8.2.0-h5f667d7_0.conda
osx-64::gfortran_impl_osx-64-11.4.0-h2a33dde_0.conda
osx-64::lpython-0.18.1-h7d26f99_0.conda
osx-64::libarrow-11.0.0-h8d37b20_31_cpu.conda
osx-64::gfortran_impl_osx-arm64-11.4.0-hcde412f_1.conda
osx-64::arrow-cpp-9.0.0-py39h0df8cbe_43_cpu.conda
osx-64::imagecodecs-2023.7.10-py39h5723b0a_1.conda
osx-64::libopencv-4.8.0-py38h67358bd_0.conda
osx-64::python-igraph-0.10.6-py311h33945ab_0.conda
osx-64::lxml-4.9.3-py39h4794613_0.conda
osx-64::libtiledb-sql-0.23.1-h8953216_0.conda
osx-64::openpmd-api-0.15.1-mpi_openmpi_py39hcfdbee7_4.conda
osx-64::libopencv-4.8.0-py311h6d37c64_0.conda
osx-64::photochem-0.4.2-py310h9f567aa_1.conda
osx-64::raven-hydro-0.2.3-py39h335d0ad_0.conda
osx-64::vtk-base-9.2.6-qt_py311h1234567_210.conda
osx-64::mdtraj-1.9.8-py311h8f92aaa_2.conda
osx-64::r-base-4.3.1-h4373c2c_1.conda
osx-64::arrow-cpp-9.0.0-py310hb53f40d_44_cpu.conda
osx-64::mdtraj-1.9.8-py38hc638d36_0.conda
osx-64::xrootd-5.6.1-py38h8e14efd_0.conda
osx-64::libopentelemetry-cpp-1.9.1-hac0930c_3.conda
osx-64::gfortran_impl_osx-arm64-11.3.0-hd6c4dc6_32.conda
osx-64::jaxlib-0.4.12-cpu_py39h511c999_1.conda
osx-64::bytewax-0.16.2-py39h06921b3_1.conda
osx-64::bytewax-0.16.2-py38h51ad8f1_0.conda
osx-64::yoda-1.9.6-py38h2aceae1_4.conda
osx-64::xrootd-5.5.5-py311h728467c_2.conda
osx-64::orc-1.9.0-hef23039_1.conda
osx-64::xrootd-5.5.5-py38h4148965_2.conda
osx-64::imagecodecs-2023.7.10-py311hce274e6_1.conda
osx-64::mysql-server-8.0.33-h619a37a_1.conda
osx-64::libopencv-4.8.0-py39h8a7669e_0.conda
osx-64::gfortran_impl_osx-arm64-12.3.0-h73c6311_0.conda
osx-64::gfortran_impl_osx-arm64-12.3.0-h73c6311_1.conda
osx-64::paraview-5.11.1-py39h51e6e22_102_qt.conda
osx-64::libfido2-1.13.0-h14e1388_0.conda
osx-64::vtk-base-9.2.6-qt_py39h1234567_209.conda
osx-64::libcurl-static-8.2.1-h5f667d7_0.conda
osx-64::arrow-cpp-9.0.0-py39h9ac03de_44_cpu.conda
osx-64::tensorflow-base-2.12.1-cpu_py38h2d44dff_0.conda
osx-64::paraview-5.11.1-py310h56295df_102_qt.conda
osx-64::geotiff-1.7.1-h5cf5d3c_11.conda
osx-64::libadios2-2.9.0-mpi_mpich_h1d18ce5_0.conda
osx-64::tiledb-2.16.0-h9b026fb_3.conda
osx-64::libpulsar-3.2.0-h5ac6cd4_2.conda
osx-64::llvm-tools-15.0.7-he4b1e75_3.conda
osx-64::astrometry-0.94-py39h9f3641f_3.conda
osx-64::mysql-client-8.0.33-hc4c47b9_1.conda
osx-64::libgdal-arrow-parquet-3.7.1-hcefb9c6_0.conda
osx-64::libarrow-11.0.0-h8d37b20_29_cpu.conda
osx-64::ndcctools-7.6.0-py38h0a8965a_0.conda
osx-64::r-base-4.3.0-h4373c2c_3.conda
osx-64::openpmd-api-0.15.1-mpi_mpich_py38ha8e9ee7_4.conda
osx-64::openpmd-api-0.15.1-mpi_openmpi_py39h6ddb3b2_4.conda
osx-64::arrow-cpp-9.0.0-py38h1623df8_43_cpu.conda
osx-64::mdtraj-1.9.8-py311h8f92aaa_0.conda
osx-64::root_base-6.28.4-py311hf9b29c1_0.conda
osx-64::folly-2023.07.24.00-hc30067e_0_jemalloc.conda
osx-64::libarrow-12.0.1-h8d37b20_4_cpu.conda
osx-64::libmediainfo-23.07-h02ebd30_0.conda
osx-64::r-harp-1.19-r43h5bfec1e_0.conda
osx-64::qt6-main-6.5.2-h4b16cc3_0.conda
osx-64::libopencv-4.7.0-py38hacfa1a3_6.conda
osx-64::paraview-5.11.1-py38hf1f3827_102_qt.conda
osx-64::imagemagick-7.1.1_14-pl5321hcd3a149_0.conda
osx-64::postgresql-plpython-14.5-py311hbf368a9_7.conda
osx-64::paraview-5.11.1-py311h2e8a03c_102_qt.conda
osx-64::python-igraph-0.10.6-py38h742b1f6_0.conda
osx-64::libtiledb-sql-0.23.0-h8fa5f5e_0.conda
osx-64::yarp-cxx-3.8.1-hafdfd46_1.conda
osx-64::raven-hydro-0.2.3-py38ha9f8b72_0.conda
osx-64::grpcio-1.56.1-py39h341a990_0.conda
osx-64::astrometry-0.94-py310h0f0fa9e_2.conda
osx-64::ogre-13.6.5-hfaafa9b_0.conda
osx-64::libopencv-4.8.0-py39hc7bd09b_0.conda
osx-64::raven-hydro-0.2.3-py311h5482185_0.conda
osx-64::vtk-base-9.2.6-qt_py310h1234567_210.conda
osx-64::xrootd-5.5.5-py311h5e6077c_1.conda
osx-64::libgdal-3.6.4-h9521c00_7.conda
osx-64::omniorb-4.3.0-py310h0ad2c98_0.conda
osx-64::omniorb-4.3.0-py311h3c90865_0.conda
osx-64::xrootd-5.5.5-py38h300efcb_1.conda
osx-64::python-igraph-0.10.4-py38h742b1f6_1.conda
osx-64::libcurl-static-8.1.2-h5f667d7_1.conda
osx-64::mdtraj-1.9.9-py311h8f92aaa_0.conda
osx-64::lpython-0.18.4-h7d26f99_0.conda
osx-64::tiledb-2.16.0-h0f7503a_2.conda
osx-64::openpmd-api-0.15.1-mpi_mpich_py311h4c707a0_4.conda
osx-64::photochem-0.4.1-py310h2bd49c5_0.conda
osx-64::libopencv-4.7.0-py39h0ccbe3f_6.conda
osx-64::r-harp-1.19-r43ha82715f_0.conda
osx-64::indexed_gzip-1.8.3-py38hbee975c_0.conda
osx-64::libpulsar-3.2.0-h436fc51_2.conda
osx-64::llvmdev-14.0.6-hc8e404f_4.conda
osx-64::libnetcdf-4.9.2-nompi_hb79a6a3_109.conda
osx-64::libarrow-12.0.1-h8d37b20_5_cpu.conda
osx-64::astrometry-0.94-py39h98bfd84_3.conda
osx-64::libopencv-4.7.0-py39h783c20a_6.conda
osx-64::ambertools-23.3-py311h954e64c_2.conda
osx-64::libopencv-4.7.0-py310h12e1fec_6.conda
osx-64::libgdal-arrow-parquet-3.6.4-h9b619d4_7.conda
osx-64::libopentelemetry-cpp-1.10.0-hb55cd83_0.conda
osx-64::bytewax-0.16.2-py39h06921b3_0.conda
osx-64::cctools_osx-arm64-973.0.1-h2f5fd4a_14.conda
osx-64::cpp-opentelemetry-sdk-1.9.1-hac0930c_3.conda
osx-64::astrometry-0.94-py38hea3ff27_2.conda
osx-64::r-base-4.1.3-had2b78c_10.conda
osx-64::aws-sdk-cpp-1.11.68-h6c51782_9.conda
osx-64::jaxlib-0.4.14-cpu_py39h909501c_1.conda
osx-64::raven-hydro-0.2.3-py311hfdac233_0.conda
osx-64::glib-networking-2.76.1-h84a2965_0.conda
osx-64::lxml-4.9.3-py310h479f746_0.conda
osx-64::libopencv-4.7.0-py311h6e95cb2_6.conda
osx-64::poppler-23.07.0-he041c3a_0.conda
osx-64::smesh-9.9.0.0-h2f14231_6.conda
osx-64::vtk-base-9.2.6-qt_py310h1234567_209.conda
osx-64::libopencv-4.8.0-py38h3c3c41b_0.conda
osx-64::imagemagick-7.1.1_15-pl5321hcd3a149_0.conda
osx-64::llvmdev-16.0.6-he4b1e75_1.conda
osx-64::postgresql-plpython-14.5-py38h9f95ba2_7.conda
osx-64::libnetcdf-4.9.2-mpi_mpich_h1b65c1c_9.conda
osx-64::leptonica-1.83.1-h63f1de6_1.conda
osx-64::collada-dom-2.5.0-h4aacfb4_6.conda
osx-64::libgdal-3.7.1-h2a6992d_4.conda
osx-64::wxpython-4.2.1-py311h7162ac5_0.conda
osx-64::tensorflow-base-2.12.1-cpu_py310h235f313_0.conda
osx-64::arrow-cpp-9.0.0-py311h84359e6_43_cpu.conda
osx-64::arrow-cpp-9.0.0-py310h96062e2_42_cpu.conda
osx-64::astrometry-0.94-py39h22b172e_2.conda
osx-64::folly-2023.07.03.00-h0d9798a_0.conda
osx-64::davix-0.8.4-hfa71a59_2.conda
osx-64::libgrpc-1.56.2-he6801ca_0.conda
osx-64::python-igraph-0.10.6-py38h4f64032_0.conda
osx-64::libcurl-8.2.1-h5f667d7_0.conda
osx-64::libopentelemetry-cpp-1.9.1-hb55cd83_3.conda
osx-64::astrometry-0.94-py311h0afc3d8_3.conda
osx-64::xrootd-5.5.5-py39h287db84_2.conda
osx-64::libadios2-2.9.0-mpi_openmpi_h0c4e814_0.conda
osx-64::tensorflow-base-2.12.1-cpu_py39h905e513_0.conda
osx-64::photochem-0.4.2-py38h32f496a_0.conda
osx-64::harp-1.19-py311h94f2c77_0.conda
osx-64::wxpython-4.2.1-py310h12da54f_0.conda
osx-64::xrootd-5.5.5-py38hd457fa0_1.conda
osx-64::magics-metview-4.14.1-h75971d5_0.conda
osx-64::lxml-4.9.3-py39hfa406f7_0.conda
osx-64::libarrow-10.0.1-hcbe7614_35_cpu.conda
osx-64::xrootd-5.5.5-py39ha4dc794_1.conda
osx-64::libopencv-4.8.0-py38h3bca07c_0.conda
osx-64::openpmd-api-0.15.1-mpi_openmpi_py310h8c05dfd_4.conda
osx-64::libgrpc-1.56.0-he6801ca_2.conda
osx-64::jaxlib-0.4.12-cpu_py310he8b71ff_1.conda
osx-64::folly-2023.07.10.00-h0d9798a_0.conda
osx-64::ogre-14.0.1-hfaafa9b_0.conda
osx-64::libgdal-arrow-parquet-3.7.1-hcb878d7_2.conda
osx-64::libnetcdf-4.9.2-mpi_openmpi_h7732aed_9.conda
osx-64::vtk-base-9.2.6-qt_py39h1234567_210.conda
osx-64::smesh-9.9.0.0-he871828_6.conda
osx-64::openpmd-api-0.15.1-nompi_py310h2c2c04f_104.conda
osx-64::nest-simulator-3.5-py39h1a18340_1.conda
osx-64::postgresql-plpython-15.3-py311hbf368a9_2.conda
osx-64::libarrow-12.0.1-h8d37b20_6_cpu.conda
osx-64::libarrow-12.0.1-h5b8112e_6_cpu.conda
osx-64::bytewax-0.16.2-py310he76948c_2.conda
osx-64::libllvm16-16.0.6-he4b1e75_1.conda
osx-64::smesh-9.9.0.0-h44ca8be_5.conda
osx-64::photochem-0.4.2-py39hb4d6418_1.conda
osx-64::astrometry-0.94-py310h6ef244b_3.conda
osx-64::jaxlib-0.4.12-cpu_py311hf7b7f2a_1.conda
osx-64::astrometry-0.94-py38h5775283_2.conda
osx-64::python-igraph-0.10.5-py38h742b1f6_0.conda
osx-64::libarrow-12.0.1-hecdf8c6_2_cpu.conda
osx-64::mosh-1.4.0-pl5321hdd9218e_2.conda
osx-64::xrootd-5.5.5-py38h8e14efd_2.conda
osx-64::imagecodecs-2023.7.10-py39h49f9d18_2.conda
osx-64::leptonica-1.83.1-h63f1de6_3.conda
osx-64::r-harp-1.19-r43hc3803ab_0.conda
osx-64::astrometry-0.94-py39h5ec54d0_2.conda
osx-64::libvips-8.14.2-hece3a03_3.conda
osx-64::mdtraj-1.9.9-py39h1f7e74c_0.conda
osx-64::jaxlib-0.4.14-cpu_py39h7d52e87_1.conda
osx-64::python-igraph-0.10.5-py311h33945ab_0.conda
osx-64::gfortran_impl_osx-64-12.3.0-h54fd467_1.conda
osx-64::grpcio-1.56.2-py38h4864539_0.conda
osx-64::libgdal-arrow-parquet-3.6.4-hae10833_9.conda
osx-64::libtensorflow_cc-2.12.1-cpu_h93a332a_0.conda
osx-64::arrow-cpp-9.0.0-py311h84359e6_44_cpu.conda
osx-64::bytewax-0.16.2-py38h51ad8f1_2.conda
osx-64::postgresql-plpython-15.3-py39hfacc66a_2.conda
osx-64::libpq-14.5-h3df487d_7.conda
osx-64::emacs-28.2-hff79ea8_3.conda
osx-64::aws-sdk-cpp-1.10.57-h39307cc_15.conda
osx-64::bytewax-0.16.2-py311hb29c592_2.conda
osx-64::tiledb-2.16.0-h24ec535_2.conda
osx-64::libgdal-3.6.4-h6737f13_9.conda
osx-64::grpcio-1.56.0-py311h43071ad_2.conda
osx-64::openpmd-api-0.15.1-mpi_mpich_py39he57dfb9_4.conda
osx-64::graphviz-8.1.0-hc7f41f9_0.conda
osx-64::libtiledb-sql-0.23.1-h8fa5f5e_0.conda
osx-64::libopencv-4.7.0-py39hf92d598_6.conda
osx-64::libopencv-4.8.0-py38h1c50f23_0.conda
osx-64::jaxlib-0.4.12-cpu_py39hb8fba7b_1.conda
osx-64::raven-hydro-0.2.3-py310h0bc48e2_0.conda
osx-64::omniorb-4.3.0-py39ha0f51ee_0.conda
osx-64::imagecodecs-2023.7.10-py39hfc0e906_2.conda
osx-64::r-base-4.2.3-had2b78c_6.conda
osx-64::mosh-1.4.0-pl5321h9fefacb_2.conda
osx-64::photochem-0.4.1-py311h9a8d235_1.conda
osx-64::paraview-5.11.1-py311hae5e469_102_qt.conda
osx-64::photochem-0.4.2-py311h8406eb7_1.conda
osx-64::lpython-0.19.0-h7d26f99_0.conda
osx-64::grpcio-1.56.2-py310h0d4bf3c_0.conda
osx-64::nest-simulator-3.5-py311hb4e21ca_1.conda
osx-64::r-harp-1.19-r43h7343328_0.conda
osx-64::libcurl-8.2.0-h5f667d7_0.conda
osx-64::python-igraph-0.10.4-py311h33945ab_1.conda
osx-64::lxml-4.9.3-py311h19a211c_0.conda
osx-64::photochem-0.4.1-py38h32f496a_0.conda
osx-64::yoda-1.9.6-py310hbc3d455_4.conda
osx-64::python-igraph-0.10.6-py310h8331c2e_0.conda
osx-64::arrow-cpp-9.0.0-py311ha9cf4f6_43_cpu.conda
osx-64::root_base-6.28.4-py311hf9b29c1_1.conda
osx-64::folly-2023.07.17.00-h1718691_0.conda
osx-64::folly-2023.07.24.00-h1718691_0.conda
osx-64::xrootd-5.6.1-py39h287db84_0.conda
osx-64::nest-simulator-3.5-py38he671bcf_0.conda
osx-64::indexed_gzip-1.8.3-py310h8b4f519_0.conda
osx-64::openpmd-api-0.15.1-nompi_py311hb97e902_104.conda
osx-64::ndcctools-7.6.1-py311h54575cd_0.conda
osx-64::postgresql-plpython-15.3-py310he0d0a37_2.conda
osx-64::xrootd-5.6.1-py38h4148965_0.conda
osx-64::mold-2.0.0-hc277f81_0.conda
osx-64::libarrow-10.0.1-h0b3ac1b_36_cpu.conda
osx-64::postgresql-14.5-hc940a54_7.conda
osx-64::yoda-1.9.6-py311h3a52ed1_4.conda
osx-64::cctools_osx-64-973.0.1-habff3f6_14.conda
osx-64::nest-simulator-3.5-py39h1a18340_0.conda
osx-64::libgdal-arrow-parquet-3.7.0-hcefb9c6_5.conda
osx-64::libnetcdf-4.9.2-mpi_mpich_h1b65c1c_8.conda
osx-64::poppler-qt-23.07.0-h9c7cc81_0.conda
osx-64::astrometry-0.94-py39h4cd1dee_1.conda
osx-64::libgdal-3.7.1-h4460828_1.conda
osx-64::libarrow-11.0.0-h5b8112e_29_cpu.conda
osx-64::geotiff-1.7.1-h5cf5d3c_10.conda
osx-64::libopencv-4.7.0-py38h5ce7a0c_6.conda
osx-64::wasmer-4.1.0-ha6357cd_0.conda
osx-64::curl-8.1.2-h5f667d7_1.conda
osx-64::root_base-6.28.4-py38h30565de_0.conda
osx-64::yoda-1.9.6-py310hbc3d455_3.conda
osx-64::ndcctools-7.6.1-py39hd4b95d6_0.conda
osx-64::r-harp-1.19-r43h797c575_0.conda
osx-64::curl-8.2.1-h5f667d7_0.conda
osx-64::python-igraph-0.10.6-py39h9ac0049_0.conda
osx-64::gfortran_impl_osx-64-12.2.0-hdfd80ef_32.conda
osx-64::gfortran_impl_osx-64-12.3.0-h54fd467_0.conda
osx-64::mdtraj-1.9.9-py38hc638d36_0.conda
osx-64::python-igraph-0.10.6-py39haffe10a_0.conda
osx-64::astrometry-0.94-py38hd5ea4f0_1.conda
osx-64::libnetcdf-4.9.2-nompi_hb79a6a3_108.conda
osx-64::libarrow-12.0.1-h5b8112e_5_cpu.conda
osx-64::glib-2.76.4-h7d26f99_0.conda
osx-64::astrometry-0.94-py38h8480431_1.conda
osx-64::openpmd-api-0.15.1-nompi_py38h6132683_104.conda
osx-64::pgplot-5.2.2-h36c7cbc_1008.conda
osx-64::openpmd-api-0.15.1-nompi_py38h9973a1a_104.conda
osx-64::folly-2023.07.10.00-hc30067e_0_jemalloc.conda
osx-64::arrow-cpp-9.0.0-py38h04ca655_42_cpu.conda
osx-64::lpython-0.18.0-h7d26f99_0.conda
osx-64::libarrow-12.0.1-h5b8112e_7_cpu.conda
osx-64::ndcctools-7.6.0-py310h442c573_0.conda
osx-64::libopencv-4.8.0-py311h7e27ade_0.conda
osx-64::libgdal-arrow-parquet-3.6.4-hae10833_8.conda
osx-64::qt6-3d-6.5.2-hb907767_0.conda
osx-64::imagecodecs-2023.7.10-py310hb6b3c85_0.conda
osx-64::bytewax-0.16.2-py310he76948c_0.conda
osx-64::grpcio-1.56.2-py311h43071ad_0.conda
osx-64::libgdal-3.6.4-h6737f13_10.conda
osx-64::mdtraj-1.9.8-py311h8f92aaa_1.conda
osx-64::folly-2023.07.17.00-hc30067e_0_jemalloc.conda
osx-64::bytewax-0.16.2-py39h06921b3_2.conda
osx-64::xrootd-5.6.1-py311h728467c_0.conda
osx-64::libarrow-11.0.0-h8d37b20_32_cpu.conda
osx-64::libnetcdf-4.9.2-mpi_openmpi_h7732aed_8.conda
osx-64::paraview-5.11.1-py39hec420a2_102_qt.conda
osx-64::dcmtk-3.6.7-h1e7bb77_4.conda
osx-64::libadios2-2.9.0-nompi_h23cc82d_100.conda
osx-64::llvmdev-15.0.7-he4b1e75_3.conda
osx-64::cctools_osx-64-973.0.1-ha1c5b94_14.conda
osx-64::libarrow-10.0.1-hcbe7614_36_cpu.conda
osx-64::xrootd-5.5.5-py39h65f106e_2.conda
osx-64::pillow-10.0.0-py311h7cb0e2d_0.conda
osx-64::gazebo-11.13.0-h329e4fc_4.conda
osx-64::llvm-tools-16.0.6-he4b1e75_1.conda
osx-64::postgresql-plpython-15.3-py38h9f95ba2_2.conda
osx-64::grpcio-1.56.2-py39h341a990_0.conda
osx-64::libarrow-10.0.1-h0b3ac1b_33_cpu.conda
osx-64::openpmd-api-0.15.1-mpi_openmpi_py38h48725d4_4.conda
osx-64::rpm-tools-4.17.1-lua54hb48fe71_3.conda
osx-64::libarrow-10.0.1-hcbe7614_33_cpu.conda
osx-64::libarrow-12.0.1-h5b8112e_3_cpu.conda
osx-64::paraview-5.11.1-py310hacfc5a3_102_qt.conda
osx-64::cpp-opentelemetry-sdk-1.10.0-hac0930c_0.conda
osx-64::imagecodecs-2023.7.10-py39hdf5f211_0.conda
osx-64::imagecodecs-2023.7.10-py39h0307f3d_1.conda
osx-64::paraview-5.11.1-py38h01bb243_102_qt.conda
osx-64::openpmd-api-0.15.1-mpi_mpich_py38h4ba93b7_4.conda
osx-64::raven-hydro-0.2.3-py39h3fbac99_0.conda
osx-64::libgdal-arrow-parquet-3.7.1-hcb878d7_3.conda
osx-64::mysql-server-8.0.33-h2e8d4b4_2.conda
osx-64::gst-plugins-good-1.22.5-h91de58d_0.conda
osx-64::grpcio-1.56.0-py38h4864539_2.conda
osx-64::photochem-0.4.2-py39h74009df_0.conda
osx-64::libsoup-2.74.2-hc48e74a_0.conda
osx-64::libarrow-11.0.0-h8d37b20_30_cpu.conda
osx-64::xrootd-5.5.5-py310hb3023bb_2.conda
osx-64::grpcio-1.56.0-py39h341a990_2.conda
osx-64::arrow-cpp-9.0.0-py39h9ac03de_43_cpu.conda
osx-64::lxml-4.9.3-py38h2d3ed51_0.conda
osx-64::grpcio-1.56.1-py310h0d4bf3c_0.conda
osx-64::arrow-cpp-9.0.0-py311h84359e6_42_cpu.conda
osx-64::raven-hydro-0.2.3-py39h16b9c15_0.conda
osx-64::photochem-0.4.1-py39h74009df_1.conda
osx-64::astrometry-0.94-py311h1baa3c9_1.conda
osx-64::grpcio-1.56.1-py38h4864539_0.conda
osx-64::root_base-6.28.4-py310hebda605_0.conda
osx-64::aws-sdk-cpp-1.10.57-h8d6e493_16.conda
osx-64::harp-1.19-py39h3db4c0d_0.conda
osx-64::pillow-10.0.0-py39h3178bab_0.conda
osx-64::julia-1.9.2-h8d83f4a_0.conda
osx-64::libopencv-4.8.0-py39h25a1be7_0.conda
osx-64::libgdal-arrow-parquet-3.7.1-hcb878d7_1.conda
osx-64::harp-1.19-py310h8825a47_0.conda
osx-64::arrow-cpp-9.0.0-py38h1623df8_44_cpu.conda
osx-64::leptonica-1.83.1-h63f1de6_2.conda
osx-64::nco-5.1.6-hd45b51c_2.conda
osx-64::jaxlib-0.4.14-cpu_py311hd8ff182_1.conda
osx-64::grpcio-1.56.0-py310h0d4bf3c_2.conda
osx-64::llvm-16.0.6-h9c2cb20_1.conda
osx-64::openpmd-api-0.15.1-mpi_mpich_py310h8cfb0ac_4.conda
osx-64::ambertools-23.3-py310h9dd47ba_2.conda
osx-64::gfortran_impl_osx-64-11.3.0-hd49a413_32.conda
osx-64::qt6-main-6.5.1-h35278ed_3.conda
osx-64::r-base-4.3.0-h4373c2c_2.conda
osx-64::tiledb-2.16.1-h0f7503a_0.conda
osx-64::libarrow-11.0.0-hecdf8c6_27_cpu.conda
osx-64::folly-2023.07.03.00-h503270f_0_jemalloc.conda
osx-64::tiledb-2.16.1-h9b026fb_0.conda
osx-64::libcurl-8.1.2-h5f667d7_1.conda
osx-64::photochem-0.4.1-py39h74009df_0.conda
osx-64::libvips-8.14.2-hece3a03_2.conda
osx-64::vtk-base-9.2.6-qt_py38h1234567_209.conda
osx-64::grpcio-1.56.1-py311h43071ad_0.conda
osx-64::libarrow-10.0.1-h0b3ac1b_34_cpu.conda
osx-64::jaxlib-0.4.12-cpu_py310h27fbe1d_1.conda
osx-64::arrow-cpp-9.0.0-py311ha9cf4f6_44_cpu.conda
osx-64::qt6-3d-6.5.1-hb907767_1.conda
osx-64::qt6-main-6.5.1-h4b16cc3_4.conda
osx-64::folly-2023.07.24.00-h0d9798a_0.conda
osx-64::imagemagick-7.1.1_13-pl5321hcd3a149_0.conda
osx-64::libpq-15.3-h3df487d_2.conda
osx-64::librdkafka-2.2.0-hec4bce0_0.conda
osx-64::openpmd-api-0.15.1-mpi_mpich_py39h7858bce_4.conda
osx-64::libgdal-3.6.4-h6737f13_8.conda
osx-64::libgdal-3.7.1-h4460828_2.conda
osx-64::mysql-libs-8.0.33-haa61052_1.conda
osx-64::r-base-4.3.1-had2b78c_3.conda
osx-64::astrometry-0.94-py38hafab21a_3.conda
osx-64::libadios2-2.9.0-mpi_mpich_h0cadb0f_0.conda
osx-64::astrometry-0.94-py38h8954d2d_3.conda
osx-64::raven-hydro-0.2.3-py310h6ab6fe6_0.conda
osx-64::nest-simulator-3.5-py310h8f12a07_1.conda
osx-64::folly-2023.07.03.00-h1718691_0.conda
osx-64::postgresql-15.3-hc940a54_2.conda
osx-64::libgdal-3.7.1-h61a083c_0.conda
osx-64::raven-hydro-0.2.3-py38hf246b68_0.conda
osx-64::indexed_gzip-1.8.3-py311h2cbd40e_0.conda
osx-64::libarrow-12.0.1-h8d37b20_7_cpu.conda
osx-64::r-base-4.3.1-h4373c2c_0.conda
osx-64::python-igraph-0.10.4-py39h9ac0049_1.conda
osx-64::aws-sdk-cpp-1.11.68-h39307cc_7.conda
osx-64::folly-2023.07.24.00-h503270f_0_jemalloc.conda
osx-64::libglib-2.76.4-hc62aa5d_0.conda
osx-64::python-igraph-0.10.4-py310h8331c2e_1.conda
osx-64::yarp-cxx-3.8.1-hafdfd46_2.conda
osx-64::libopencv-4.7.0-py39h43b5454_6.conda
osx-64::libgdal-arrow-parquet-3.6.4-hae10833_10.conda
osx-64::libopencv-4.7.0-py38h1623a75_6.conda
osx-64::photochem-0.4.1-py310h2bd49c5_1.conda
osx-64::root_base-6.28.4-py38h30565de_1.conda
osx-64::libarrow-12.0.1-h8d37b20_3_cpu.conda
osx-64::libnetcdf-4.9.2-mpi_mpich_h68cb16d_7.conda
osx-64::jaxlib-0.4.14-cpu_py310hb488f57_1.conda
osx-64::arrow-cpp-9.0.0-py310hb53f40d_43_cpu.conda
osx-64::aws-sdk-cpp-1.10.57-h6c51782_17.conda
osx-64::raven-hydro-0.2.3-py39h0edd63f_0.conda
osx-64::omniorb-4.3.0-py38h73e9ec3_0.conda
osx-64::orc-1.9.0-hec59b76_1.conda
osx-64::libadios2-2.9.0-nompi_h2390f81_100.conda
osx-64::mysql-server-8.0.33-h619a37a_2.conda
osx-64::ambertools-23.3-py38h51c3a6d_2.conda
osx-64::pillow-10.0.0-py38h16710f9_0.conda
osx-64::libadios2-2.9.0-mpi_mpich_h032ee77_0.conda
osx-64::root_base-6.28.4-py39h8bc755e_0.conda
osx-64::llvm-15.0.7-h9c2cb20_3.conda
osx-64::libadios2-2.9.0-mpi_openmpi_hc044665_0.conda
osx-64::jaxlib-0.4.14-cpu_py310hfd4b58e_1.conda
osx-64::libcurl-static-8.2.0-h5f667d7_0.conda
osx-64::libgrpc-1.56.1-he6801ca_0.conda
osx-64::libnetcdf-4.9.2-nompi_h6ba5aa8_107.conda
osx-64::nco-5.1.7-hd45b51c_0.conda
osx-64::folly-2023.07.17.00-h0d9798a_0.conda
osx-64::indexed_gzip-1.8.3-py39h03f97f2_0.conda
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
================================================================================
================================================================================
linux-64
linux-64::clang-format-15.0.7-default_h7634d5b_3.conda
linux-64::stress-ng-0.16.00-h2797004_0.conda
linux-64::micromamba-1.4.8-0.tar.bz2
linux-64::libclang-cpp-13.0.1-root_62804_h3ca262a_2.conda
linux-64::clang-format-13-13.0.1-default_h7634d5b_3.conda
linux-64::msgpack-cxx-6.1.0-h9f19972_0.conda
linux-64::clang-format-13.0.1-root_62804_h3ca262a_2.conda
linux-64::libclang-cpp-13.0.1-default_h7634d5b_3.conda
linux-64::libclang-cpp15-15.0.7-default_h7634d5b_3.conda
linux-64::libclang-13.0.1-default_h7634d5b_3.conda
linux-64::stress-ng-0.16.01-h2797004_0.conda
linux-64::clang-format-13.0.1-root_62804_h3ca262a_3.conda
linux-64::clang-13-13.0.1-default_h7634d5b_3.conda
linux-64::dlib-cpp-19.24.2-h71df52f_4.conda
linux-64::clang-tools-13.0.1-default_h7634d5b_2.conda
linux-64::clang-tools-15.0.7-default_h7634d5b_3.conda
linux-64::libclang-cpp13-13.0.1-default_h7634d5b_2.conda
linux-64::xapian-core-1.4.23-hcd5def8_0.conda
linux-64::clang-13-13.0.1-default_h7634d5b_2.conda
linux-64::zstd-1.5.2-hfc55251_7.conda
linux-64::libllvm14-14.0.6-hcd5def8_4.conda
linux-64::libclang-13.0.1-root_62804_h3ca262a_2.conda
linux-64::libclang-13.0.1-default_h7634d5b_2.conda
linux-64::libclang-13.0.1-root_62804_h3ca262a_3.conda
linux-64::eccodes-2.31.0-h73bf81c_0.conda
linux-64::libcups-2.3.3-h4637d8d_4.conda
linux-64::clang-format-13-13.0.1-default_h7634d5b_2.conda
linux-64::clang-format-15-15.0.7-default_h7634d5b_3.conda
linux-64::clang-tools-13.0.1-default_h7634d5b_3.conda
linux-64::libuwebsockets-20.45.0-hfc55251_0.conda
linux-64::llvm-tools-14.0.6-hcd5def8_4.conda
linux-64::clang-13-13.0.1-root_62804_h3ca262a_3.conda
linux-64::libclang-cpp-13.0.1-default_h7634d5b_2.conda
linux-64::libclang-cpp-15.0.7-default_h7634d5b_3.conda
linux-64::cfitsio-4.3.0-hbdc6101_0.conda
linux-64::micromamba-1.4.7-0.tar.bz2
linux-64::clang-format-13.0.1-default_h7634d5b_2.conda
linux-64::micromamba-1.4.6-0.tar.bz2
linux-64::clang-tools-13.0.1-root_62804_h3ca262a_2.conda
linux-64::libclang-cpp13-13.0.1-root_62804_h3ca262a_3.conda
linux-64::glib-tools-2.76.4-hfc55251_0.conda
linux-64::clang-format-13-13.0.1-root_62804_h3ca262a_3.conda
linux-64::clang-format-13-13.0.1-root_62804_h3ca262a_2.conda
linux-64::libclang-cpp-13.0.1-root_62804_h3ca262a_3.conda
linux-64::micromamba-1.4.9-0.tar.bz2
linux-64::libclang13-15.0.7-default_h9986a30_3.conda
linux-64::llvm-14.0.6-h32600fe_4.conda
linux-64::clang-tools-13.0.1-root_62804_h3ca262a_3.conda
linux-64::clang-15-15.0.7-default_h7634d5b_3.conda
linux-64::gst-libav-1.22.5-hd5f137f_0.conda
linux-64::clang-13-13.0.1-root_62804_h3ca262a_2.conda
linux-64::libclang-15.0.7-default_h7634d5b_3.conda
linux-64::clang-format-13.0.1-default_h7634d5b_3.conda
linux-64::libclang-cpp13-13.0.1-default_h7634d5b_3.conda
linux-64::libclang-cpp13-13.0.1-root_62804_h3ca262a_2.conda
-    "libzlib >=1.2.13,<1.3.0a0"
+    "libzlib >=1.2.13,<2.0.0a0"
linux-64::mdtraj-1.9.8-py310h8e08b51_1.conda
linux-64::grpcio-1.56.0-py311ha6695c7_2.conda
linux-64::raven-hydro-0.2.3-py39hb80b23e_0.conda
linux-64::libgdal-3.6.4-h39519b0_8.conda
linux-64::jaxlib-0.4.14-cuda112py39he289ae4_201.conda
linux-64::arrow-cpp-9.0.0-py310hcf3f697_43_cuda.conda
linux-64::libarrow-11.0.0-hd2d78f0_30_cpu.conda
linux-64::leptonica-1.83.1-h65e01fd_0.conda
linux-64::vtk-base-9.2.6-osmesa_py39h1234567_110.conda
linux-64::r-base-4.3.0-hfabd6f2_2.conda
linux-64::rpm-tools-4.17.1-py311lua54h12b5f5a_3.conda
linux-64::libadios2-2.9.0-mpi_openmpi_h09787ba_0.conda
linux-64::libarrow-12.0.1-h5047b4e_7_cuda.conda
linux-64::tesseract-5.3.1-he1868e8_0.conda
linux-64::tensorflow-base-2.12.1-cpu_py39hde87686_0.conda
linux-64::r-base-4.3.0-hfabd6f2_3.conda
linux-64::r-harp-1.19-r43h9de6278_0.conda
linux-64::python-igraph-0.10.6-py39hd49abe8_0.conda
linux-64::triton-2.0.0-cuda112py311h629ee27_1.conda
linux-64::createrepo_c-0.21.1-py310ha8b270f_1.conda
linux-64::folly-2023.07.24.00-he8e2169_0_jemalloc.conda
linux-64::xrootd-5.5.5-py310h3779284_2.conda
linux-64::createrepo_c-1.0.0-py310ha8b270f_0.conda
linux-64::libvips-8.14.3-h344dd91_1.conda
linux-64::xeus-cling-0.15.3-hcd5def8_0.conda
linux-64::pgplot-5.2.2-hf4b3394_1008.conda
linux-64::tiledb-2.16.0-h84d19f0_2.conda
linux-64::postgresql-15.3-h8972f4a_2.conda
linux-64::python-igraph-0.10.5-py38hbfe76d8_0.conda
linux-64::createrepo_c-0.21.1-py39hcf0f48c_1.conda
linux-64::libarrow-10.0.1-h70c079b_33_cuda.conda
linux-64::libgdal-arrow-parquet-3.7.1-haa835f8_3.conda
linux-64::libarrow-12.0.1-h5b6691e_2_cuda.conda
linux-64::libpulsar-3.2.0-h76eacb3_2.conda
linux-64::xrootd-5.5.5-py38h25e64c5_2.conda
linux-64::nest-simulator-3.5-py38h6ea6bc2_0.conda
linux-64::libpq-14.5-hfc447b1_7.conda
linux-64::libopencv-4.8.0-py38h4f31995_0.conda
linux-64::libarrow-12.0.1-hbae3e69_7_cuda.conda
linux-64::paraview-5.11.1-py38h9cb89ca_102_qt.conda
linux-64::mosh-1.4.0-pl5321hc529e37_2.conda
linux-64::gst-plugins-base-1.22.4-hf7dbed1_1.conda
linux-64::astrometry-0.94-py310h30e4ed4_2.conda
linux-64::indexed_gzip-1.8.3-py311hb2be122_0.conda
linux-64::python-igraph-0.10.5-py38h189e466_0.conda
linux-64::paraview-5.11.1-py38h3e25cda_102_qt.conda
linux-64::dpcpp_impl_linux-64-2023.2.0-hb92ea50_49495.conda
linux-64::libopencv-4.7.0-py310h3e876cf_6.conda
linux-64::ndcctools-7.6.0-py39h4841754_0.conda
linux-64::ndcctools-7.6.0rc1-py39h4841754_0.conda
linux-64::cpp-opentelemetry-sdk-1.10.0-h9f3eacc_0.conda
linux-64::folly-2023.07.24.00-h80c46b9_0.conda
linux-64::raven-hydro-0.2.3-py311h64a4d7b_0.conda
linux-64::actions-runner-2.306.0-hcd5def8_0.conda
linux-64::omniorb-4.3.0-py39h53428f1_0.conda
linux-64::python-igraph-0.10.6-py38h189e466_0.conda
linux-64::libarrow-11.0.0-h657c46f_31_cpu.conda
linux-64::libgdal-arrow-parquet-3.7.1-h990c665_4.conda
linux-64::clangdev-13.0.1-default_h7634d5b_2.conda
linux-64::libadios2-2.9.0-nompi_hdf556c1_100.conda
linux-64::xrootd-5.6.1-py311h7c82654_0.conda
linux-64::grpcio-1.56.0-py310h1b8f574_2.conda
linux-64::jaxlib-0.4.12-cpu_py310h56c674a_1.conda
linux-64::mysql-server-8.0.33-ha473b58_1.conda
linux-64::gfortran_impl_osx-arm64-11.4.0-hb40c162_0.conda
linux-64::lxml-4.9.3-py311h1a07684_0.conda
linux-64::libnetcdf-4.9.2-nompi_h7e745eb_109.conda
linux-64::libarrow-11.0.0-h70c079b_30_cuda.conda
linux-64::mold-2.0.0-h913df21_0.conda
linux-64::libnetcdf-4.9.2-mpi_mpich_hde7fb9e_8.conda
linux-64::slurm-22.05.9-h1efd704_1.conda
linux-64::rust-1.71.0-h70c747d_0.conda
linux-64::openpmd-api-0.15.1-nompi_py38hc2f9c3d_104.conda
linux-64::libvips-8.14.2-h500aa3b_3.conda
linux-64::arrow-cpp-9.0.0-py39h188651e_44_cpu.conda
linux-64::folly-2023.07.03.00-he8e2169_0_jemalloc.conda
linux-64::xrootd-5.5.5-py39ha53f741_1.conda
linux-64::llvmdev-15.0.7-h5cf9203_3.conda
linux-64::astrometry-0.94-py39h2191a9e_3.conda
linux-64::libopencv-4.7.0-py39hfdaeec5_6.conda
linux-64::jaxlib-0.4.14-cuda112py311hf2474b9_201.conda
linux-64::afterimage-1.21-h5d2e036_1004.conda
linux-64::wxpython-4.2.1-py310h6c5a8eb_0.conda
linux-64::mdtraj-1.9.8-py310h8e08b51_2.conda
linux-64::folly-2023.07.17.00-h09ac5fe_0.conda
linux-64::mdtraj-1.9.8-py39h031bd0f_0.conda
linux-64::cpp-opentelemetry-sdk-1.9.1-h268cab6_3.conda
linux-64::mdtraj-1.9.8-py310h8e08b51_0.conda
linux-64::pillow-10.0.0-py39hb514683_0.conda
linux-64::libopencv-4.7.0-py38h2f1dfbd_6.conda
linux-64::imagecodecs-2023.7.10-py39h06dc04d_2.conda
linux-64::paraview-5.11.1-py310hd64ba8a_102_qt.conda
linux-64::libarrow-10.0.1-hd2d78f0_35_cpu.conda
linux-64::arrow-cpp-9.0.0-py311ha7b854d_44_cpu.conda
linux-64::vtk-base-9.2.6-qt_py310h1234567_209.conda
linux-64::wxpython-4.2.1-py38hb9b80a8_0.conda
linux-64::mysql-router-8.0.33-h247314d_2.conda
linux-64::nordugrid-arc-6.17.0-py310hce1116f_1.conda
linux-64::libvips-8.14.3-h500aa3b_0.conda
linux-64::omniorb-libs-4.3.0-h1933689_0.conda
linux-64::texlive-core-20230313-hc0e8fe8_4.conda
linux-64::libtensorflow-2.12.1-cpu_h505da87_0.conda
linux-64::pillow-10.0.0-py310h582fbeb_0.conda
linux-64::photochem-0.4.1-py38hfea99d6_0.conda
linux-64::libgdal-3.7.1-ha66225b_2.conda
linux-64::arrow-cpp-9.0.0-py39hd0188b2_44_cuda.conda
linux-64::r-harp-1.19-r43h8148971_0.conda
linux-64::qt-webengine-5.15.8-h92031a0_3.conda
linux-64::photochem-0.4.1-py39ha0904e1_0.conda
linux-64::python-igraph-0.10.6-py38hbfe76d8_0.conda
linux-64::clangdev-13.0.1-root_62804_h3ca262a_3.conda
linux-64::curl-8.1.2-hca28451_1.conda
linux-64::jaxlib-0.4.12-cpu_py38h854d387_1.conda
linux-64::imagecodecs-2023.7.10-py311h67b54e4_2.conda
linux-64::libglib-2.76.4-hebfc3b9_0.conda
linux-64::imagemagick-7.1.1_14-pl5321hf48ede7_0.conda
linux-64::photochem-0.4.2-py310h19aaeee_1.conda
linux-64::root_base-6.28.4-py311hf9f499e_0.conda
linux-64::arrow-cpp-9.0.0-py38h43e5d08_42_cuda.conda
linux-64::yoda-1.9.6-py310h0987d74_4.conda
linux-64::openpmd-api-0.15.1-mpi_openmpi_py39h6a5d34b_4.conda
linux-64::libopencv-4.8.0-py38h2f1dfbd_0.conda
linux-64::paraview-5.11.1-py39h5a1f283_2_egl.conda
linux-64::ndcctools-7.6.0-py38h514f0f6_0.conda
linux-64::astrometry-0.94-py310ha2e9c3a_3.conda
linux-64::vtk-base-9.2.6-osmesa_py38h1234567_110.conda
linux-64::libarrow-12.0.1-h70c079b_3_cuda.conda
linux-64::libadios2-2.9.0-nompi_hbc473cc_100.conda
linux-64::photochem-0.4.1-py311h65cc0b1_1.conda
linux-64::libadios2-2.9.0-mpi_mpich_h863adcc_0.conda
linux-64::bytewax-0.16.2-py39h82e90d1_2.conda
linux-64::grpcio-1.56.0-py39h174d805_2.conda
linux-64::yoda-1.9.6-py39hbb3abb4_4.conda
linux-64::imagecodecs-2023.7.10-py310h4c4fb95_0.conda
linux-64::vtk-base-9.2.6-osmesa_py38h1234567_109.conda
linux-64::libopencv-4.7.0-py39hea38a9e_6.conda
linux-64::folly-2023.07.10.00-he8e2169_0_jemalloc.conda
linux-64::libadios2-2.9.0-mpi_mpich_h4b52df8_0.conda
linux-64::actions-runner-2.307.0-hcd5def8_0.conda
linux-64::libarrow-11.0.0-h5b6691e_27_cuda.conda
linux-64::xrootd-5.6.1-py38h25e64c5_0.conda
linux-64::gfortran_impl_osx-arm64-11.3.0-hd144e78_32.conda
linux-64::yoda-1.9.6-py38h98305a2_3.conda
linux-64::llvm-15.0.7-ha0738ec_3.conda
linux-64::arrow-cpp-9.0.0-py39h40719d3_44_cpu.conda
linux-64::libarrow-12.0.1-h86bfbe0_3_cuda.conda
linux-64::magics-metview-batch-4.14.1-hd3d5bb6_0.conda
linux-64::yoda-1.9.6-py310h0987d74_3.conda
linux-64::cpp-opentelemetry-sdk-1.10.0-h268cab6_0.conda
linux-64::squashfuse-0.2.0-hdfefc0d_0.conda
linux-64::jaxlib-0.4.12-cpu_py39h67a3324_1.conda
linux-64::bytewax-0.16.2-py311he5c60f7_1.conda
linux-64::aws-sdk-cpp-1.11.68-h7b9373a_8.conda
linux-64::libarrow-12.0.1-h657c46f_5_cpu.conda
linux-64::vtk-base-9.2.6-egl_py38h1234567_9.conda
linux-64::libarrow-11.0.0-h86bfbe0_30_cuda.conda
linux-64::git-annex-10.20230626-alldep_h97b9560_100.conda
linux-64::cctools_osx-arm64-973.0.1-h05ba045_14.conda
linux-64::arrow-cpp-9.0.0-py311h7aa411c_43_cuda.conda
linux-64::tensorflow-base-2.12.1-cpu_py311h743e7a3_0.conda
linux-64::libopentelemetry-cpp-1.10.0-h9f3eacc_0.conda
linux-64::astrometry-0.94-py38he6301ea_2.conda
linux-64::healpy-1.16.3-py38h61517ae_0.conda
linux-64::bytewax-0.16.2-py310hbeed47d_1.conda
linux-64::tensorflow-base-2.12.1-cuda112py310h622e808_0.conda
linux-64::libarrow-10.0.1-h5047b4e_36_cuda.conda
linux-64::python-igraph-0.10.4-py311h4b1723a_1.conda
linux-64::libopencv-4.8.0-py311h55ebc8a_0.conda
linux-64::libopencv-4.8.0-py39h76ed197_0.conda
linux-64::r-harp-1.19-r43h87e1c4c_0.conda
linux-64::nest-simulator-3.5-py311hcb301d6_1.conda
linux-64::libgdal-arrow-parquet-3.6.4-hbd26d2c_7.conda
linux-64::vtk-base-9.2.6-egl_py39h1234567_10.conda
linux-64::postgresql-plpython-14.5-py38h0f07e32_7.conda
linux-64::openpmd-api-0.15.1-nompi_py311h5918f1b_104.conda
linux-64::mysql-libs-8.0.33-hca2cd23_1.conda
linux-64::libarrow-10.0.1-hbae3e69_35_cuda.conda
linux-64::lxml-4.9.3-py38h0ef1326_0.conda
linux-64::tiledb-2.16.0-h6041edc_2.conda
linux-64::ambertools-23.3-py39h4856ba4_2.conda
linux-64::pillow-10.0.0-py38h885162f_0.conda
linux-64::qt6-main-6.5.2-h16008ae_0.conda
linux-64::gst-plugins-base-1.22.5-hf7dbed1_0.conda
linux-64::libarrow-11.0.0-hd2d78f0_32_cpu.conda
linux-64::actions-runner-2.307.1-hcd5def8_0.conda
linux-64::vtk-base-9.2.6-egl_py311h1234567_9.conda
linux-64::mdtraj-1.9.8-py311h90fe790_1.conda
linux-64::pillow-10.0.0-py311h0b84326_0.conda
linux-64::grpcio-1.56.1-py39h174d805_0.conda
linux-64::aws-sdk-cpp-1.11.68-hbc2ea52_9.conda
linux-64::libfido2-1.13.0-h2e5b2a7_0.conda
linux-64::qt6-main-6.5.1-h16008ae_4.conda
linux-64::lxml-4.9.3-py38h7ad5e35_0.conda
linux-64::libarrow-11.0.0-hbae3e69_31_cuda.conda
linux-64::intel-cmplr-lib-rt-2023.2.0-hfc55251_49495.conda
linux-64::arrow-cpp-9.0.0-py39h188651e_42_cpu.conda
linux-64::slurm-22.05.9-he58e4cc_0.conda
linux-64::xrootd-5.5.5-py311h7c82654_2.conda
linux-64::photochem-0.4.2-py38h6fb069e_1.conda
linux-64::libarrow-10.0.1-h657c46f_36_cpu.conda
linux-64::imagecodecs-2023.7.10-py311h25e0658_0.conda
linux-64::qt6-3d-6.5.2-h2aac1d2_0.conda
linux-64::r-base-4.3.1-hfabd6f2_0.conda
linux-64::arrow-cpp-9.0.0-py311h4c46794_44_cuda.conda
linux-64::orc-1.9.0-h2f23424_1.conda
linux-64::gst-plugins-good-1.22.4-hf7bd3a9_1.conda
linux-64::mysql-router-8.0.33-hf689a3c_1.conda
linux-64::libadios2-2.9.0-mpi_openmpi_h2278c24_0.conda
linux-64::python-igraph-0.10.6-py310h33b8572_0.conda
linux-64::nsight-compute-2022.4.0.15-h992b93f_0.conda
linux-64::r-harp-1.19-r43h39e59c0_0.conda
linux-64::qt-main-5.15.8-h7fe3ca9_15.conda
linux-64::vtk-base-9.2.6-qt_py310h1234567_210.conda
linux-64::root_base-6.28.4-py38h00bbca2_0.conda
linux-64::openpmd-api-0.15.1-nompi_py310h48532be_104.conda
linux-64::libpq-15.3-hfc447b1_2.conda
linux-64::lpython-0.18.1-hfc55251_0.conda
linux-64::mdtraj-1.9.8-py39h031bd0f_2.conda
linux-64::libarrow-11.0.0-h5047b4e_32_cuda.conda
linux-64::wgrib2-3.1.2-h8965f03_3.conda
linux-64::openpmd-api-0.15.1-mpi_openmpi_py38h695232e_4.conda
linux-64::paraview-5.11.1-py310hece543b_2_egl.conda
linux-64::xrootd-5.6.1-py310h3779284_0.conda
linux-64::geotiff-1.7.1-h22adcc9_11.conda
linux-64::libopencv-4.7.0-py38h4f31995_6.conda
linux-64::indexed_gzip-1.8.3-py310hed85b92_0.conda
linux-64::slurm-22.05.7-hcee77ff_0.conda
linux-64::jaxlib-0.4.14-cuda112py39h15d8236_201.conda
linux-64::imagecodecs-2023.7.10-py39hff229a0_0.conda
linux-64::bytewax-0.16.2-py38he60ca92_0.conda
linux-64::mysql-router-8.0.33-h247314d_1.conda
linux-64::python-igraph-0.10.6-py39hf9a6591_0.conda
linux-64::arrow-cpp-9.0.0-py311h7aa411c_42_cuda.conda
linux-64::arrow-cpp-9.0.0-py38h9767291_43_cpu.conda
linux-64::magics-4.14.1-hd3d5bb6_0.conda
linux-64::mysql-server-8.0.33-ha473b58_2.conda
linux-64::arrow-cpp-9.0.0-py39h40719d3_43_cpu.conda
linux-64::geotiff-1.7.1-h22adcc9_10.conda
linux-64::tensorflow-base-2.12.1-cuda112py39h7e9974e_0.conda
linux-64::tiledb-2.16.0-hf0b6e87_2.conda
linux-64::glib-2.76.4-hfc55251_0.conda
linux-64::arrow-cpp-9.0.0-py38he9f994b_43_cpu.conda
linux-64::bytewax-0.16.2-py310hbeed47d_2.conda
linux-64::r-base-4.3.1-h29c4799_3.conda
linux-64::r-base-4.3.1-hb1b9b86_2.conda
linux-64::mdtraj-1.9.8-py38h028faf2_1.conda
linux-64::libcurl-8.2.1-hca28451_0.conda
linux-64::libarrow-12.0.1-hdf4a2a7_2_cuda.conda
linux-64::libarrow-12.0.1-hbae3e69_6_cuda.conda
linux-64::libopencv-4.7.0-py38hb4d4081_6.conda
linux-64::raven-hydro-0.2.3-py38h0110233_0.conda
linux-64::harp-1.19-py38h5e441e9_0.conda
linux-64::lpython-0.18.2-hfc55251_0.conda
linux-64::indexed_gzip-1.8.3-py38hd4412fc_0.conda
linux-64::librdkafka-2.2.0-hfe68a65_0.conda
linux-64::postgresql-plpython-15.3-py38h0f07e32_2.conda
linux-64::libarrow-10.0.1-hbae3e69_36_cuda.conda
linux-64::ambertools-23.3-py310he275f01_2.conda
linux-64::xrootd-5.5.5-py39h88d736d_1.conda
linux-64::folly-2023.07.17.00-he8e2169_0_jemalloc.conda
linux-64::leptonica-1.83.1-h73bee87_2.conda
linux-64::folly-2023.07.24.00-h09ac5fe_0.conda
linux-64::vtk-base-9.2.6-egl_py310h1234567_9.conda
linux-64::ndcctools-7.6.0-py311h689c632_0.conda
linux-64::gfortran_impl_osx-64-11.3.0-h5f20bad_32.conda
linux-64::vtk-base-9.2.6-egl_py311h1234567_10.conda
linux-64::libarrow-12.0.1-hd2d78f0_7_cpu.conda
linux-64::libarrow-10.0.1-h70c079b_32_cuda.conda
linux-64::libarrow-10.0.1-hd2d78f0_33_cpu.conda
linux-64::emacs-28.2-h8564e9b_3.conda
linux-64::mdtraj-1.9.8-py38h028faf2_2.conda
linux-64::libarrow-10.0.1-h657c46f_35_cpu.conda
linux-64::raven-hydro-0.2.3-py39h8e2dbb5_0.conda
linux-64::ndcctools-7.6.0rc1-py38h514f0f6_0.conda
linux-64::cpp-opentelemetry-sdk-1.9.1-h9f3eacc_3.conda
linux-64::python-igraph-0.10.5-py310h33b8572_0.conda
linux-64::libarrow-12.0.1-h657c46f_4_cpu.conda
linux-64::lpython-0.18.4-hfc55251_0.conda
linux-64::photochem-0.4.2-py311h65cc0b1_0.conda
linux-64::slurm-22.05.7-hbe0ef40_0.conda
linux-64::root_base-6.28.4-py39h624df37_1.conda
linux-64::tensorflow-base-2.12.1-cpu_py310h57e0714_0.conda
linux-64::libmediainfo-23.07-had58582_0.conda
linux-64::arrow-cpp-9.0.0-py38h43e5d08_43_cuda.conda
linux-64::libarrow-10.0.1-h5047b4e_35_cuda.conda
linux-64::arrow-cpp-9.0.0-py311h7aa411c_44_cuda.conda
linux-64::r-harp-1.19-r43hf63d83c_0.conda
linux-64::jaxlib-0.4.14-cpu_py39hc2c80b9_1.conda
linux-64::rpm-tools-4.17.1-py38lua54hd14f742_3.conda
linux-64::openpmd-api-0.15.1-nompi_py39h34fc903_104.conda
linux-64::photochem-0.4.1-py38hfea99d6_1.conda
linux-64::mesalib-23.1.4-h6b56f8e_0.conda
linux-64::nest-simulator-3.5-py39hd8da8f2_0.conda
linux-64::clangdev-15.0.7-default_h7634d5b_3.conda
linux-64::grpcio-1.56.1-py310h1b8f574_0.conda
linux-64::ambertools-23.3-py311hbcc7a2f_2.conda
linux-64::libarrow-10.0.1-hd2d78f0_34_cpu.conda
linux-64::libllvm16-16.0.6-h5cf9203_1.conda
linux-64::omniorb-4.3.0-py38h0ed79f3_0.conda
linux-64::libarrow-12.0.1-h657c46f_3_cpu.conda
linux-64::photochem-0.4.2-py311hd905e2f_1.conda
linux-64::vtk-base-9.2.6-egl_py310h1234567_10.conda
linux-64::libgdal-arrow-parquet-3.6.4-h829b136_8.conda
linux-64::grpcio-1.56.1-py311ha6695c7_0.conda
linux-64::gfortran_impl_osx-arm64-12.2.0-h7b0fa44_32.conda
linux-64::leptonica-1.83.1-h73bee87_3.conda
linux-64::photochem-0.4.2-py38hfea99d6_0.conda
linux-64::arrow-cpp-9.0.0-py38he9f994b_44_cpu.conda
linux-64::libnetcdf-4.9.2-mpi_mpich_hd696bd7_7.conda
linux-64::lighttpd-1.4.64-lua54h30b985f_3.conda
linux-64::mdtraj-1.9.9-py311h90fe790_0.conda
linux-64::openpmd-api-0.15.1-mpi_mpich_py38h7403642_4.conda
linux-64::mysql-router-8.0.33-hf689a3c_2.conda
linux-64::pillow-10.0.0-py39haaeba84_0.conda
linux-64::xrootd-5.5.5-py310h8e19c30_1.conda
linux-64::slurm-22.05.7-he58e4cc_1.conda
linux-64::lxml-4.9.3-py39h40bd5d0_0.conda
linux-64::mysql-server-8.0.33-hdebdf4b_1.conda
linux-64::slurm-22.05.6-hbe0ef40_0.conda
linux-64::python-igraph-0.10.4-py310h33b8572_1.conda
linux-64::clangdev-13.0.1-root_62804_h3ca262a_2.conda
linux-64::folly-2023.07.03.00-h80c46b9_0.conda
linux-64::nsight-compute-2022.4.0.15-h1166182_0.conda
linux-64::xrootd-5.5.5-py38h03a7c77_1.conda
linux-64::mdtraj-1.9.9-py38h028faf2_0.conda
linux-64::arrow-cpp-9.0.0-py38hb264932_43_cuda.conda
linux-64::libgdal-3.6.4-h39519b0_10.conda
linux-64::kaldi-5.5.1068-cuda112h9c89dd3_1.conda
linux-64::pdfmm-0.9.22-hae7d61c_4.conda
linux-64::xrootd-5.6.1-py39h38afb29_0.conda
linux-64::libtiledb-sql-0.23.0-hc3826aa_0.conda
linux-64::raven-hydro-0.2.3-py38hcf001ca_0.conda
linux-64::arrow-cpp-9.0.0-py39h188651e_43_cpu.conda
linux-64::clangdev-13.0.1-default_h7634d5b_3.conda
linux-64::libgrpc-1.56.2-h3905398_0.conda
linux-64::libopentelemetry-cpp-1.10.0-h268cab6_0.conda
linux-64::xeus-cling-0.15.2-hcd5def8_0.conda
linux-64::gfortran_impl_osx-64-11.4.0-h3d3a104_1.conda
linux-64::root_base-6.28.4-py38h00bbca2_1.conda
linux-64::raven-hydro-0.2.3-py38h326e3f4_0.conda
linux-64::libnetcdf-4.9.2-mpi_mpich_hde7fb9e_9.conda
linux-64::nest-simulator-3.5-py39hd8da8f2_1.conda
linux-64::libopencv-4.8.0-py38h63092d6_0.conda
linux-64::yarp-cxx-3.8.1-h245b40a_2.conda
linux-64::tiledb-2.16.1-h84d19f0_0.conda
linux-64::astrometry-0.94-py38heeea738_1.conda
linux-64::astrometry-0.94-py38h69d120b_3.conda
linux-64::nordugrid-arc-6.17.0-py39hef661be_1.conda
linux-64::arrow-cpp-9.0.0-py310hcf3f697_44_cuda.conda
linux-64::root_base-6.28.4-py310h15855b9_0.conda
linux-64::arrow-cpp-9.0.0-py311h7b5d564_43_cpu.conda
linux-64::yoda-1.9.6-py38h98305a2_4.conda
linux-64::libarrow-11.0.0-h657c46f_29_cpu.conda
linux-64::lighttpd-1.4.64-lua54h8ca90d1_4.conda
linux-64::libadios2-2.9.0-mpi_mpich_h806a3d7_0.conda
linux-64::intel-opencl-rt-2023.2.0-ha0c49d2_49495.conda
linux-64::libarrow-11.0.0-h5047b4e_31_cuda.conda
linux-64::createrepo_c-1.0.0-py39hcf0f48c_0.conda
linux-64::grpcio-1.56.2-py39h174d805_0.conda
linux-64::libgdal-3.7.1-ha66225b_3.conda
linux-64::jaxlib-0.4.12-cuda112py38h67cd1f8_201.conda
linux-64::libarrow-10.0.1-h86bfbe0_33_cuda.conda
linux-64::imagecodecs-2023.7.10-py39h818e04c_1.conda
linux-64::vtk-base-9.2.6-osmesa_py310h1234567_109.conda
linux-64::xrootd-5.5.5-py39h38afb29_2.conda
linux-64::paraview-5.11.1-py39h6dc28dd_102_qt.conda
linux-64::arrow-cpp-9.0.0-py38h9767291_44_cpu.conda
linux-64::folly-2023.07.10.00-h09ac5fe_0.conda
linux-64::xorg-libxft-2.3.8-hf69aa0a_0.conda
linux-64::smesh-9.9.0.0-h804fc18_6.conda
linux-64::libgrpc-1.56.0-h3905398_2.conda
linux-64::arrow-cpp-9.0.0-py39h1aeab9f_44_cuda.conda
linux-64::libarrow-12.0.1-hd2d78f0_3_cpu.conda
linux-64::raven-hydro-0.2.3-py39h191c732_0.conda
linux-64::gfortran_impl_osx-64-11.4.0-h3d3a104_0.conda
linux-64::mysql-server-8.0.33-hdebdf4b_2.conda
linux-64::libarrow-12.0.1-h32ed672_2_cpu.conda
linux-64::cctools_osx-64-973.0.1-h9f43cba_14.conda
linux-64::openpmd-api-0.15.1-mpi_mpich_py39h96b6dcc_4.conda
linux-64::openpmd-api-0.15.1-mpi_openmpi_py311h9d98028_4.conda
linux-64::astrometry-0.94-py38h67dbd8c_1.conda
linux-64::tiledb-2.16.1-h6041edc_0.conda
linux-64::libcurl-8.2.0-hca28451_0.conda
linux-64::vtk-base-9.2.6-qt_py38h1234567_209.conda
linux-64::lpython-0.19.0-hfc55251_0.conda
linux-64::postgresql-plpython-14.5-py310hd093153_7.conda
linux-64::astrometry-0.94-py310hb0a1fec_1.conda
linux-64::astrometry-0.94-py311h015869a_2.conda
linux-64::grpcio-1.56.2-py311ha6695c7_0.conda
linux-64::curl-8.2.1-hca28451_0.conda
linux-64::nordugrid-arc-6.17.0-py38h079651d_1.conda
linux-64::jaxlib-0.4.12-cpu_py311h211765a_1.conda
linux-64::orc-1.9.0-h385abfd_1.conda
linux-64::python-igraph-0.10.4-py39hd49abe8_1.conda
linux-64::arrow-cpp-9.0.0-py310h08ccd61_44_cuda.conda
linux-64::curl-8.2.0-hca28451_0.conda
linux-64::arrow-cpp-9.0.0-py311h4c46794_43_cuda.conda
linux-64::yarp-cxx-3.8.1-h245b40a_3.conda
linux-64::folly-2023.07.10.00-h80c46b9_0.conda
linux-64::libopencv-4.7.0-py38h63092d6_6.conda
linux-64::imagemagick-7.1.1_15-pl5321hf48ede7_0.conda
linux-64::libopencv-4.7.0-py39h76ed197_6.conda
linux-64::libpulsar-3.2.0-hacb5a09_2.conda
linux-64::tiledb-2.16.0-h6041edc_3.conda
linux-64::libgdal-arrow-parquet-3.7.1-haa835f8_1.conda
linux-64::arrow-cpp-9.0.0-py310hcf3f697_42_cuda.conda
linux-64::lpython-0.18.0-hfc55251_0.conda
linux-64::r-base-4.3.1-h29c4799_2.conda
linux-64::paraview-5.11.1-py310h2be671e_102_qt.conda
linux-64::libarrow-12.0.1-h3bdf5bc_2_cpu.conda
linux-64::paraview-5.11.1-py311hfb4303b_102_qt.conda
linux-64::libarrow-12.0.1-hd2d78f0_4_cpu.conda
linux-64::cctools_osx-arm64-973.0.1-hbb834dd_14.conda
linux-64::python-igraph-0.10.5-py311h4b1723a_0.conda
linux-64::folly-2023.07.03.00-h09ac5fe_0.conda
linux-64::pillow-10.0.0-py38hc4ca088_0.conda
linux-64::xrootd-5.6.1-py39hbb686b4_0.conda
linux-64::paraview-5.11.1-py311h7500a62_102_qt.conda
linux-64::libarrow-12.0.1-h657c46f_7_cpu.conda
linux-64::healpy-1.16.3-py310he5dbd59_0.conda
linux-64::paraview-5.11.1-py310h225f0e0_2_egl.conda
linux-64::tensorflow-base-2.12.1-cpu_py38h92f4423_0.conda
linux-64::libarrow-12.0.1-h657c46f_6_cpu.conda
linux-64::libopencv-4.8.0-py39hfcbda02_0.conda
linux-64::qt6-3d-6.5.1-h2aac1d2_1.conda
linux-64::xrootd-5.5.5-py39hbb686b4_2.conda
linux-64::libopencv-4.8.0-py310hd58e3cd_0.conda
linux-64::libarrow-12.0.1-h70c079b_5_cuda.conda
linux-64::jaxlib-0.4.14-cpu_py311hc48ce71_1.conda
linux-64::imagecodecs-2023.7.10-py39he027151_2.conda
linux-64::createrepo_c-1.0.0-py311hbf74cd1_0.conda
linux-64::arrow-cpp-9.0.0-py38h43e5d08_44_cuda.conda
linux-64::mdtraj-1.9.9-py39h031bd0f_0.conda
linux-64::libtiledb-sql-0.23.0-hb82b279_0.conda
linux-64::arrow-cpp-9.0.0-py310h614a90d_44_cpu.conda
linux-64::libarrow-10.0.1-hd2d78f0_36_cpu.conda
linux-64::libarrow-10.0.1-h657c46f_33_cpu.conda
linux-64::triton-2.0.0-cuda112py310h08c069c_1.conda
linux-64::harp-1.19-py38hf28a8a0_0.conda
linux-64::libgdal-3.6.4-h9a62611_7.conda
linux-64::libarrow-10.0.1-h70c079b_34_cuda.conda
linux-64::libgdal-arrow-parquet-3.6.4-h829b136_10.conda
linux-64::arrow-cpp-9.0.0-py39h1aeab9f_42_cuda.conda
linux-64::ogre-14.0.1-h35a0b1b_0.conda
linux-64::triton-2.0.0-cuda112py38h446d0bc_1.conda
linux-64::astrometry-0.94-py39h0d7c9de_1.conda
linux-64::vtk-base-9.2.6-qt_py39h1234567_210.conda
linux-64::llvmdev-16.0.6-h5cf9203_1.conda
linux-64::jaxlib-0.4.14-cpu_py310h46886e1_1.conda
linux-64::libopencv-4.7.0-py311h55ebc8a_6.conda
linux-64::vtk-base-9.2.6-osmesa_py39h1234567_109.conda
linux-64::openpmd-api-0.15.1-mpi_openmpi_py39hb1202af_4.conda
linux-64::poppler-qt-23.07.0-hedeba34_0.conda
linux-64::grpcio-1.56.1-py38h94a1851_0.conda
linux-64::cctools_osx-64-973.0.1-h5e73dee_14.conda
linux-64::poppler-23.07.0-hd18248d_0.conda
linux-64::python-igraph-0.10.6-py311h4b1723a_0.conda
linux-64::raven-hydro-0.2.3-py310h3ce4ad4_0.conda
linux-64::harp-1.19-py39haeafd41_0.conda
linux-64::libarrow-12.0.1-hd2d78f0_6_cpu.conda
linux-64::root_base-6.28.4-py311hf9f499e_1.conda
linux-64::libarrow-11.0.0-h70c079b_28_cuda.conda
linux-64::mdtraj-1.9.8-py38h028faf2_0.conda
linux-64::healpy-1.16.3-py39hf751b5c_0.conda
linux-64::arrow-cpp-9.0.0-py311ha7b854d_42_cpu.conda
linux-64::graphviz-8.1.0-h28d9a01_0.conda
linux-64::postgresql-plpython-15.3-py310hd093153_2.conda
linux-64::arrow-cpp-9.0.0-py310h799c0db_43_cpu.conda
linux-64::grpcio-1.56.2-py310h1b8f574_0.conda
linux-64::vtk-base-9.2.6-egl_py39h1234567_9.conda
linux-64::libarrow-12.0.1-h5047b4e_6_cuda.conda
linux-64::folly-2023.07.17.00-h80c46b9_0.conda
linux-64::folly-2023.07.10.00-hda79706_0_jemalloc.conda
linux-64::libopentelemetry-cpp-1.9.1-h268cab6_3.conda
linux-64::lxml-4.9.3-py310h9b7343a_0.conda
linux-64::paraview-5.11.1-py311h3cbb51e_2_egl.conda
linux-64::astrometry-0.94-py39h7e5d8ae_3.conda
linux-64::python-igraph-0.10.4-py38hbfe76d8_1.conda
linux-64::arrow-cpp-9.0.0-py39h1aeab9f_43_cuda.conda
linux-64::yoda-1.9.6-py311hcba14de_4.conda
linux-64::bytewax-0.16.2-py38he60ca92_1.conda
linux-64::drpm-0.5.2-hd60e2a3_0.conda
linux-64::bytewax-0.16.2-py39h82e90d1_1.conda
linux-64::libarrow-11.0.0-h3bdf5bc_27_cpu.conda
linux-64::aws-sdk-cpp-1.10.57-hbc2ea52_17.conda
linux-64::createrepo_c-0.21.1-py38hc8e658a_1.conda
linux-64::createrepo_c-1.0.0-py38hc8e658a_0.conda
linux-64::libadios2-2.9.0-mpi_openmpi_h55f04b4_0.conda
linux-64::photochem-0.4.2-py39ha0904e1_0.conda
linux-64::libopencv-4.8.0-py311h8aafb54_0.conda
linux-64::libcurl-static-8.2.0-hca28451_0.conda
linux-64::libcurl-static-8.1.2-hca28451_1.conda
linux-64::libopencv-4.8.0-py39hfdaeec5_0.conda
linux-64::root_base-6.28.4-py310h15855b9_1.conda
linux-64::gfortran_impl_osx-64-12.3.0-ha36a433_0.conda
linux-64::r-base-4.1.3-hb1b9b86_10.conda
linux-64::rpm-tools-4.17.1-py39lua54hc5d64a4_3.conda
linux-64::arrow-cpp-9.0.0-py311ha7b854d_43_cpu.conda
linux-64::harp-1.19-py311h40de960_0.conda
linux-64::arrow-cpp-9.0.0-py38h9767291_42_cpu.conda
linux-64::libgdal-3.7.1-h8bc334e_4.conda
linux-64::mdtraj-1.9.8-py311h90fe790_0.conda
linux-64::arrow-cpp-9.0.0-py311h7b5d564_44_cpu.conda
linux-64::photochem-0.4.1-py310hfffa7c4_1.conda
linux-64::libarrow-11.0.0-hd2d78f0_28_cpu.conda
linux-64::vtk-base-9.2.6-osmesa_py311h1234567_110.conda
linux-64::libgdal-arrow-parquet-3.6.4-h829b136_9.conda
linux-64::python-igraph-0.10.4-py38h189e466_1.conda
linux-64::r-base-4.2.3-hfabd6f2_4.conda
linux-64::photochem-0.4.2-py39hb2311a4_1.conda
linux-64::ndcctools-7.6.0-py310he2ed3e8_0.conda
linux-64::openpmd-api-0.15.1-mpi_openmpi_py310h542fcda_4.conda
linux-64::raven-hydro-0.2.3-py38ha6b6fe4_0.conda
linux-64::imagecodecs-2023.7.10-py310h4ecbf5d_1.conda
linux-64::libadios2-2.9.0-mpi_openmpi_hbfd91ea_0.conda
linux-64::aws-sdk-cpp-1.10.57-he0ca162_15.conda
linux-64::imagecodecs-2023.7.10-py39hea27cfc_1.conda
linux-64::arrow-cpp-9.0.0-py310h614a90d_42_cpu.conda
linux-64::slurm-22.05.6-hcee77ff_0.conda
linux-64::healpy-1.16.3-py39h9674c9c_0.conda
linux-64::astrometry-0.94-py311h4436661_1.conda
linux-64::libnetcdf-4.9.2-mpi_openmpi_h71b16d3_8.conda
linux-64::bytewax-0.16.2-py311he5c60f7_2.conda
linux-64::r-base-4.2.3-hfabd6f2_5.conda
linux-64::dcap-2.47.14-hc03aca7_1.conda
linux-64::ndcctools-7.6.1-py38h514f0f6_0.conda
linux-64::bytewax-0.16.2-py38he60ca92_2.conda
linux-64::gfortran_impl_osx-arm64-11.4.0-hb40c162_1.conda
linux-64::libarrow-11.0.0-h657c46f_32_cpu.conda
linux-64::yoda-1.9.6-py39hbb3abb4_3.conda
linux-64::r-base-4.2.3-hb1b9b86_6.conda
linux-64::nordugrid-arc-6.17.0-py311h0390422_1.conda
linux-64::mosh-1.4.0-pl5321h61fc75a_2.conda
linux-64::nest-simulator-3.5-py310hc33a80f_0.conda
linux-64::jaxlib-0.4.14-cuda112py310h8c6a9b4_201.conda
linux-64::bytewax-0.16.2-py310hbeed47d_0.conda
linux-64::libllvm15-15.0.7-h5cf9203_3.conda
linux-64::libopencv-4.7.0-py311h8aafb54_6.conda
linux-64::photochem-0.4.1-py310hfffa7c4_0.conda
linux-64::postgresql-plpython-14.5-py311hf60bfc6_7.conda
linux-64::folly-2023.07.17.00-hda79706_0_jemalloc.conda
linux-64::libarrow-11.0.0-h657c46f_30_cpu.conda
linux-64::root_base-6.28.4-py39h624df37_0.conda
linux-64::vtk-base-9.2.6-osmesa_py310h1234567_110.conda
linux-64::libarrow-10.0.1-hd2d78f0_32_cpu.conda
linux-64::python-igraph-0.10.5-py39hf9a6591_0.conda
linux-64::astrometry-0.94-py311h501750d_3.conda
linux-64::raven-hydro-0.2.3-py311h14de304_0.conda
linux-64::libtensorflow_cc-2.12.1-cpu_h196a00b_0.conda
linux-64::arrow-cpp-9.0.0-py310h799c0db_44_cpu.conda
linux-64::vtk-base-9.2.6-qt_py311h1234567_209.conda
linux-64::mysql-client-8.0.33-h545f5f4_1.conda
linux-64::libgdal-arrow-parquet-3.7.1-haa835f8_2.conda
linux-64::postgresql-plpython-15.3-py311hf60bfc6_2.conda
linux-64::tiledb-2.16.1-hf0b6e87_0.conda
linux-64::jaxlib-0.4.12-cuda112py310h7b441b9_201.conda
linux-64::xrootd-5.5.5-py311he1aa323_1.conda
linux-64::nco-5.1.7-h10d77ae_0.conda
linux-64::yarp-cxx-3.8.1-h245b40a_1.conda
linux-64::openpmd-api-0.15.1-mpi_mpich_py310h60df2c0_4.conda
linux-64::libcurl-static-8.2.1-hca28451_0.conda
linux-64::libopentelemetry-cpp-1.9.1-h9f3eacc_3.conda
linux-64::libarrow-11.0.0-hbae3e69_32_cuda.conda
linux-64::libnetcdf-4.9.2-nompi_he09a3a9_107.conda
linux-64::gst-plugins-good-1.22.5-hf7bd3a9_0.conda
linux-64::libvips-8.14.2-h500aa3b_2.conda
linux-64::arrow-cpp-9.0.0-py38hb264932_44_cuda.conda
linux-64::llvm-tools-16.0.6-h5cf9203_1.conda
linux-64::nest-simulator-3.5-py38h6ea6bc2_1.conda
linux-64::tensorflow-base-2.12.1-cuda112py38h501018f_0.conda
linux-64::libopencv-4.8.0-py39hea38a9e_0.conda
linux-64::imagecodecs-2023.7.10-py310hc929067_2.conda
linux-64::libarrow-12.0.1-h86bfbe0_5_cuda.conda
linux-64::jaxlib-0.4.14-cpu_py311h2be0998_1.conda
linux-64::magics-metview-4.14.1-h40b8c56_0.conda
linux-64::ndcctools-7.6.0rc1-py310he2ed3e8_0.conda
linux-64::ndcctools-7.6.1-py39h4841754_0.conda
linux-64::libadios2-2.9.0-nompi_h221b914_100.conda
linux-64::python-igraph-0.10.4-py39hf9a6591_1.conda
linux-64::imagemagick-7.1.1_13-pl5321hf48ede7_0.conda
linux-64::libgdal-3.7.1-hba0e483_0.conda
linux-64::raven-hydro-0.2.3-py310hee4f699_0.conda
linux-64::mysql-client-8.0.33-h545f5f4_2.conda
linux-64::arrow-cpp-9.0.0-py310h614a90d_43_cpu.conda
linux-64::llvm-16.0.6-ha0738ec_1.conda
linux-64::nest-simulator-3.5-py311hcb301d6_0.conda
linux-64::tiledb-2.16.0-h84d19f0_3.conda
linux-64::paraview-5.11.1-py38h1d76521_2_egl.conda
linux-64::libopencv-4.7.0-py39hfcbda02_6.conda
linux-64::gfortran_impl_osx-64-12.2.0-h3d15c4d_32.conda
linux-64::xrootd-5.5.5-py38h879601d_1.conda
linux-64::photochem-0.4.2-py310hfffa7c4_0.conda
linux-64::astrometry-0.94-py38h54c11d4_2.conda
linux-64::grpcio-1.56.0-py38h94a1851_2.conda
linux-64::ndcctools-7.6.1-py311h689c632_0.conda
linux-64::ambertools-23.3-py38h3974a27_2.conda
linux-64::jaxlib-0.4.14-cpu_py310h67d73b5_1.conda
linux-64::ndcctools-7.6.1-py310he2ed3e8_0.conda
linux-64::libadios2-2.9.0-mpi_mpich_h86f79d2_0.conda
linux-64::libarrow-12.0.1-h86bfbe0_4_cuda.conda
linux-64::openpmd-api-0.15.1-mpi_mpich_py311h15cef80_4.conda
linux-64::imagecodecs-2023.7.10-py311h9220970_1.conda
linux-64::openpmd-api-0.15.1-mpi_mpich_py39h68acae5_4.conda
linux-64::libarrow-11.0.0-h70c079b_29_cuda.conda
linux-64::smesh-9.9.0.0-h7368e35_6.conda
linux-64::libopencv-4.8.0-py38hb4d4081_0.conda
linux-64::r-base-4.3.1-hfabd6f2_1.conda
linux-64::xrootd-5.6.1-py38h012eebe_0.conda
linux-64::bytewax-0.16.2-py39h82e90d1_0.conda
linux-64::paraview-5.11.1-py39hbafabb9_102_qt.conda
linux-64::libgrpc-1.56.1-h3905398_0.conda
linux-64::paraview-5.11.1-py39hb8bbfc0_2_egl.conda
linux-64::postgresql-plpython-14.5-py39h5ae07a4_7.conda
linux-64::vtk-base-9.2.6-qt_py39h1234567_209.conda
linux-64::libgdal-arrow-parquet-3.7.0-h891746b_5.conda
linux-64::libopencv-4.7.0-py310hd58e3cd_6.conda
linux-64::omniorb-4.3.0-py311h28f970a_0.conda
linux-64::openpmd-api-0.15.1-nompi_py38h3b57f00_104.conda
linux-64::rpm-tools-4.17.1-py310lua54h96070f6_3.conda
linux-64::photochem-0.4.1-py39ha0904e1_1.conda
linux-64::libgdal-arrow-parquet-3.7.1-h891746b_0.conda
linux-64::triton-2.0.0-cuda112py39hafd0abc_1.conda
linux-64::omniorb-4.3.0-py310h5d3106b_0.conda
linux-64::wasmer-4.1.0-he3b15a8_0.conda
linux-64::openssh-9.3p1-h2d3b35a_2.conda
linux-64::indexed_gzip-1.8.3-py39hb7c0032_0.conda
linux-64::libtiledb-sql-0.23.1-hb82b279_0.conda
linux-64::wxpython-4.2.1-py39he9b0109_0.conda
linux-64::ipe-7.2.26-lua54ha800d42_0.conda
linux-64::kaldi-5.5.1068-cuda120h6a63ba3_1.conda
linux-64::aws-sdk-cpp-1.11.68-he0ca162_7.conda
linux-64::arrow-cpp-9.0.0-py310h08ccd61_43_cuda.conda
linux-64::qt6-wayland-6.5.1-h35d8138_0.conda
linux-64::lpython-0.18.3-hfc55251_0.conda
linux-64::libarrow-12.0.1-hd2d78f0_5_cpu.conda
linux-64::julia-1.9.2-hb81c242_0.conda
linux-64::arrow-cpp-9.0.0-py39hd0188b2_43_cuda.conda
linux-64::gfortran_impl_osx-arm64-12.3.0-h67cdea9_0.conda
linux-64::harp-1.19-py310h8a439ba_0.conda
linux-64::libarrow-11.0.0-h86bfbe0_29_cuda.conda
linux-64::astrometry-0.94-py39ha809d75_2.conda
linux-64::imagecodecs-2023.7.10-py39hd8aee2b_0.conda
linux-64::ndcctools-7.6.0rc1-py311h689c632_0.conda
linux-64::healpy-1.16.3-py311hc06c28d_0.conda
linux-64::aws-sdk-cpp-1.10.57-h7b9373a_16.conda
linux-64::mdtraj-1.9.8-py39h031bd0f_1.conda
linux-64::createrepo_c-0.21.1-py311hbf74cd1_1.conda
linux-64::dcmtk-3.6.7-he56de54_4.conda
linux-64::libtensorflow-2.12.1-cuda112hd5e1dc4_0.conda
linux-64::paraview-5.11.1-py38hba56271_2_egl.conda
linux-64::r-harp-1.19-r43h1a73d88_0.conda
linux-64::tensorflow-base-2.12.1-cuda112py311hb0f8ee9_0.conda
linux-64::vtk-base-9.2.6-qt_py38h1234567_210.conda
linux-64::libnetcdf-4.9.2-mpi_openmpi_hbfe4392_7.conda
linux-64::ogre-13.6.5-h35a0b1b_0.conda
linux-64::libsoup-2.74.3-hb337396_1.conda
linux-64::mdtraj-1.9.9-py310h8e08b51_0.conda
linux-64::qt6-main-6.5.1-h2b880b2_3.conda
linux-64::lxml-4.9.3-py39hed45dcc_0.conda
linux-64::vtk-base-9.2.6-egl_py38h1234567_10.conda
linux-64::libsoup-2.74.3-h6a603f4_0.conda
linux-64::jaxlib-0.4.14-cpu_py39h9f41c60_1.conda
linux-64::davix-0.8.4-h6b9e765_2.conda
linux-64::mdtraj-1.9.8-py311h90fe790_2.conda
linux-64::libadios2-2.9.0-nompi_h214baa7_100.conda
linux-64::wxpython-4.2.1-py311h5c9e8ae_0.conda
linux-64::libarrow-10.0.1-h86bfbe0_34_cuda.conda
linux-64::gfortran_impl_osx-64-12.3.0-ha36a433_1.conda
linux-64::jaxlib-0.4.12-cuda112py39h6291980_201.conda
linux-64::libopencv-4.8.0-py310h3e876cf_0.conda
linux-64::libarrow-10.0.1-h657c46f_34_cpu.conda
linux-64::healpy-1.16.3-py38ha49e404_0.conda
linux-64::openpmd-api-0.15.1-mpi_mpich_py38h1d64b76_4.conda
linux-64::llvm-tools-15.0.7-h5cf9203_3.conda
linux-64::jaxlib-0.4.12-cuda112py311h8308670_201.conda
linux-64::vtk-base-9.2.6-qt_py311h1234567_210.conda
linux-64::openpmd-api-0.15.1-mpi_openmpi_py38ha8006ac_4.conda
linux-64::python-igraph-0.10.5-py39hd49abe8_0.conda
linux-64::libcurl-8.1.2-hca28451_1.conda
linux-64::astrometry-0.94-py38h7f3a5f1_3.conda
linux-64::llvmdev-14.0.6-hcd5def8_4.conda
linux-64::libgdal-3.7.0-hba0e483_5.conda
linux-64::grpcio-1.56.2-py38h94a1851_0.conda
linux-64::postgresql-plpython-15.3-py39h5ae07a4_2.conda
linux-64::libgdal-3.7.1-ha66225b_1.conda
linux-64::folly-2023.07.24.00-hda79706_0_jemalloc.conda
linux-64::magic-8.3.413-h9abf892_0.conda
linux-64::libarrow-12.0.1-h70c079b_4_cuda.conda
linux-64::collada-dom-2.5.0-hc257951_6.conda
linux-64::astrometry-0.94-py39h7a04e8d_1.conda
linux-64::tiledb-2.16.0-hf0b6e87_3.conda
linux-64::libtensorflow_cc-2.12.1-cuda112hd89a937_0.conda
linux-64::nest-simulator-3.5-py310hc33a80f_1.conda
linux-64::mysql-libs-8.0.33-hca2cd23_2.conda
linux-64::libgdal-3.6.4-h39519b0_9.conda
linux-64::leptonica-1.83.1-h73bee87_1.conda
linux-64::openpmd-api-0.15.1-nompi_py39h3f3d1b0_104.conda
linux-64::libarrow-11.0.0-hd2d78f0_29_cpu.conda
linux-64::postgresql-14.5-h8972f4a_7.conda
linux-64::gmsh-4.11.1-h51d60e7_3.conda
linux-64::glib-networking-2.76.1-h8eaaec1_0.conda
linux-64::libarrow-11.0.0-hd2d78f0_31_cpu.conda
linux-64::xrootd-5.5.5-py38h012eebe_2.conda
linux-64::raven-hydro-0.2.3-py39h5056a20_0.conda
linux-64::folly-2023.07.03.00-hda79706_0_jemalloc.conda
linux-64::libtiledb-sql-0.23.1-hc3826aa_0.conda
linux-64::harp-1.19-py39h2ead2e0_0.conda
linux-64::libnetcdf-4.9.2-nompi_h7e745eb_108.conda
linux-64::vtk-base-9.2.6-osmesa_py311h1234567_109.conda
linux-64::nco-5.1.6-h10d77ae_2.conda
linux-64::gfortran_impl_osx-arm64-12.3.0-h67cdea9_1.conda
linux-64::astrometry-0.94-py39ha21a4b5_2.conda
linux-64::paraview-5.11.1-py311h7978520_2_egl.conda
linux-64::libnetcdf-4.9.2-mpi_openmpi_h71b16d3_9.conda
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
```

</details>