### PR TITLE
loosen zlib-pin to major level (12/N; June 2023)

### DIFF
--- a/recipe/patch_yaml/zlib.yaml
+++ b/recipe/patch_yaml/zlib.yaml
@@ -97,3 +97,12 @@ then:
   - loosen_depends:
       name: libzlib
       upper_bound: "2"
+---
+if:
+  has_depends: libzlib >=1.2*
+  timestamp_lt: 1688169600000  # 2023-07-01 00:00 UTC
+  timestamp_ge: 1685577600000  # 2023-06-01 00:00 UTC
+then:
+  - loosen_depends:
+      name: libzlib
+      upper_bound: "2"


### PR DESCRIPTION
Follow-up to https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/739, about 3800 artefacts affected.

### Result of `python show_diff.py`

<details>

```diff
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
osx-arm64::micromamba-1.4.4-0.tar.bz2
osx-arm64::libllvm14-14.0.6-hd1a9a77_3.conda
osx-arm64::gst-plugins-base-1.22.4-h27255cc_0.conda
osx-arm64::llvm-spirv-15.0.0-h25aad90_0.conda
osx-arm64::liblal-7.3.1-fftw_h69c6439_101.conda
osx-arm64::imath-3.1.9-ha614eb4_0.conda
osx-arm64::llvm-tools-14.0.6-hd1a9a77_3.conda
osx-arm64::llvm-14.0.6-h95d0606_3.conda
osx-arm64::nceplibs-g2c-1.7.0-h286e93f_4.conda
osx-arm64::dlib-cpp-19.24.2-h245f2dc_1.conda
osx-arm64::libsolv-0.7.24-ha614eb4_1.conda
osx-arm64::openexr-3.1.7-hf12bcc0_2.conda
osx-arm64::libprotobuf-4.23.2-hf32f9b9_3.conda
osx-arm64::openexr-3.1.9-hf12bcc0_0.conda
osx-arm64::g2clib-1.7.0-h286e93f_3.conda
osx-arm64::libdap4-3.20.6-h30c0175_3.conda
osx-arm64::cgns-4.4.0-h246a93d_0.conda
osx-arm64::adios-1.13.1-nompi_h8cb4857_1122.conda
osx-arm64::libmlir-16.0.5-h2d3518b_0.conda
osx-arm64::git-delta-0.16.4-h2b5a0f1_0.conda
osx-arm64::libdap4-3.20.6-hccef43f_4.conda
osx-arm64::libmlir16-16.0.6-h2d3518b_0.conda
osx-arm64::libmlir16-16.0.5-h2d3518b_0.conda
osx-arm64::libprotobuf-static-4.23.2-hf32f9b9_5.conda
osx-arm64::micromamba-1.4.5-0.tar.bz2
osx-arm64::libprotobuf-4.23.3-hf32f9b9_0.conda
osx-arm64::git-delta-0.16.5-h2b5a0f1_0.conda
osx-arm64::libprotobuf-static-4.23.2-hf32f9b9_4.conda
osx-arm64::libprotobuf-4.23.2-hf32f9b9_4.conda
osx-arm64::git-delta-0.16.0-h2b5a0f1_0.conda
osx-arm64::eccodes-2.30.2-hfc33491_1.conda
osx-arm64::dlib-cpp-19.24.2-hfff07be_3.conda
osx-arm64::libsolv-static-0.7.24-hb5ab8b9_0.conda
osx-arm64::libsolv-static-0.7.24-ha614eb4_1.conda
osx-arm64::metal-llvm-tools-15-0.5.1-hdd6e3b6_0.conda
osx-arm64::libv8-8.9.83-h0a4decb_3.conda
osx-arm64::openexr-3.1.8-hf12bcc0_0.conda
osx-arm64::cgns-4.4.0-hcea3687_1.conda
osx-arm64::libprotobuf-static-4.23.2-hf32f9b9_3.conda
osx-arm64::dlib-cpp-19.24.2-hfff07be_2.conda
osx-arm64::libprotobuf-static-4.23.3-hf32f9b9_0.conda
osx-arm64::libmlir-16.0.6-h2d3518b_0.conda
osx-arm64::libsolv-0.7.24-hb5ab8b9_0.conda
osx-arm64::eccodes-2.30.2-hb26de55_0.conda
osx-arm64::lilly-medchem-rules-1.0.1-hbe7ddab_1.conda
osx-arm64::libprotobuf-4.23.2-hf32f9b9_5.conda
-    "libzlib >=1.2.13,<1.3.0a0"
+    "libzlib >=1.2.13,<2.0.0a0"
osx-arm64::gazebo-11.13.0-h83e9e8a_0.conda
osx-arm64::python-3.10.12-h01493a6_0_cpython.conda
osx-arm64::vigra-1.11.1-py39hfd78368_1043.conda
osx-arm64::lammps-2023.03.28-cpu_py38_h72943ce_openmpi_2.conda
osx-arm64::libadios2-2.8.3-nompi_h6f7674d_107.conda
osx-arm64::libarrow-12.0.0-heca9b86_9_cpu.conda
osx-arm64::libtiff-4.5.1-h23a1a89_0.conda
osx-arm64::vigra-1.11.1-py39h8e933d2_1044.conda
osx-arm64::paraview-5.11.1-py310hff25784_101_qt.conda
osx-arm64::mesalib-23.1.2-h7bfda7a_0.conda
osx-arm64::arrow-cpp-9.0.0-py38h19ecdc7_40_cpu.conda
osx-arm64::libadios2-2.8.3-nompi_h7443c59_106.conda
osx-arm64::gnupg1-1.4.23-he8486bc_0.conda
osx-arm64::lammps-2023.03.28-cpu_py38_h62cdab2_mpich_4.conda
osx-arm64::libarrow-12.0.0-h5027e3d_9_cpu.conda
osx-arm64::vigra-1.11.1-py38h26a871a_1045.conda
osx-arm64::libadios2-2.8.3-mpi_openmpi_hab5f8f0_6.conda
osx-arm64::lpython-0.17.0-ha614eb4_0.conda
osx-arm64::lammps-2023.03.28-cpu_py38_h8140eb0_mpich_3.conda
osx-arm64::netcdf4-1.6.4-mpi_mpich_py39h3d9ac5b_0.conda
osx-arm64::r-harp-1.18-py310hcb8dffb_1.conda
osx-arm64::nifty-1.2.1-py38h2d3cc67_4.conda
osx-arm64::folly-2023.06.08.00-h1e8fca9_0.conda
osx-arm64::folly-2023.06.26.00-h2c5142d_0_jemalloc.conda
osx-arm64::r-git2r-0.31.0-r43h7b2db81_1.conda
osx-arm64::libarrow-10.0.1-h2fe1218_29_cpu.conda
osx-arm64::netcdf4-1.6.4-nompi_py310h84508ad_100.conda
osx-arm64::r-harp-1.18-py311h83a779d_0.conda
osx-arm64::mysql-libs-8.0.32-hb292caa_3.conda
osx-arm64::llvmlite-0.40.1-py310h95b248a_0.conda
osx-arm64::qt6-main-6.5.1-h372468e_2.conda
osx-arm64::libopencv-4.7.0-py311h883be0d_5.conda
osx-arm64::harp-1.18-py38h3d2e54c_1.conda
osx-arm64::libgdal-3.6.4-hb028f37_6.conda
osx-arm64::pyreadstat-1.2.2-py311h79498d2_0.conda
osx-arm64::netcdf4-1.6.4-mpi_mpich_py38hecc4eee_0.conda
osx-arm64::vtk-base-9.2.6-qt_py38h1234567_208.conda
osx-arm64::ambertools-23.3-py311ha883923_1.conda
osx-arm64::libitk-5.3.0-ha8566bb_4.conda
osx-arm64::gazebo-11.13.0-he9da979_2.conda
osx-arm64::pytables-3.8.0-py310hc9e091c_2.conda
osx-arm64::gazebo-11.13.0-h2067851_3.conda
osx-arm64::nco-5.1.6-h1b3a3bc_1.conda
osx-arm64::libpulsar-3.2.0-hc8199c2_1.conda
osx-arm64::coda-2.24.2-py311h09dc9a0_2.conda
osx-arm64::pyinstaller-5.12.0-py38he9a9ba6_1.conda
osx-arm64::netcdf4-1.6.4-nompi_py38hd4cc7a0_101.conda
osx-arm64::polycap-1.2-py311h9b89549_2.conda
osx-arm64::libgdal-arrow-parquet-3.6.4-h2535e84_5.conda
osx-arm64::llvm-tools-16.0.6-he79909e_0.conda
osx-arm64::folly-2023.06.26.00-h1e8fca9_0.conda
osx-arm64::ambertools-23.3-py38hf78641e_1.conda
osx-arm64::folly-2023.06.26.00-h03318f1_0.conda
osx-arm64::harp-1.18-py39h3d2e54c_1.conda
osx-arm64::nginx-1.25.1-h364d411_1.conda
osx-arm64::libadios2-2.8.3-mpi_mpich_hcf98a40_7.conda
osx-arm64::mysql-connector-python-8.0.32-py38hf45ffde_0.conda
osx-arm64::libadios2-2.8.3-nompi_h0e6994a_107.conda
osx-arm64::pytables-3.8.0-py311ha2ad9a0_2.conda
osx-arm64::vtk-base-9.2.6-qt_py39h1234567_207.conda
osx-arm64::aws-sdk-cpp-1.11.68-h9b90b14_6.conda
osx-arm64::lammps-2023.03.28-cpu_py39_h01793bf_openmpi_7.conda
osx-arm64::sagelib-10.0-py311ha07c8a7_1.conda
osx-arm64::folly-2023.06.08.00-h44236e3_0.conda
osx-arm64::libarrow-12.0.1-h5027e3d_0_cpu.conda
osx-arm64::arrow-cpp-9.0.0-py39ha9764af_37_cpu.conda
osx-arm64::pygplates-0.39-py310h9a7b5d6_8.conda
osx-arm64::gst-plugins-good-1.22.4-h4983274_0.conda
osx-arm64::arrow-cpp-9.0.0-py38h310950d_39_cpu.conda
osx-arm64::vtk-base-9.2.6-qt_py310h1234567_207.conda
osx-arm64::yarp-cxx-3.8.0-hd505e7d_3.conda
osx-arm64::git-2.41.0-pl5321h46e2b6d_0.conda
osx-arm64::lammps-2023.03.28-cpu_py311_hd466178_mpich_4.conda
osx-arm64::ambertools-23.3-py39hdb62838_1.conda
osx-arm64::libadios2-2.8.3-mpi_openmpi_h9ac4f70_7.conda
osx-arm64::libopencv-4.7.0-py39h6a99d3f_5.conda
osx-arm64::vigra-1.11.1-py311h23eaf05_1043.conda
osx-arm64::tiledb-2.15.4-h5530f2e_0.conda
osx-arm64::arrow-cpp-9.0.0-py311h613176a_37_cpu.conda
osx-arm64::vigra-1.11.1-py38h26a871a_1044.conda
osx-arm64::tiledb-2.15.3-h5530f2e_1.conda
osx-arm64::folly-2023.06.08.00-h2c5142d_0_jemalloc.conda
osx-arm64::omniorb-4.2.5-py39hdd7bd9c_7.conda
osx-arm64::z5py-2.0.16-py311h4adbb64_1.conda
osx-arm64::libgrpc-1.56.0-he248d5f_1.conda
osx-arm64::lammps-2023.03.28-cpu_py311_hb114475_openmpi_4.conda
osx-arm64::lammps-2023.03.28-cpu_py310_hbba249a_mpich_4.conda
osx-arm64::libllvm16-16.0.6-he79909e_0.conda
osx-arm64::lammps-2023.03.28-cpu_py310_h30d5764_mpich_3.conda
osx-arm64::xrootd-5.5.4-py38h71b7c2f_1.conda
osx-arm64::lammps-2023.03.28-cpu_py310_hbba249a_mpich_6.conda
osx-arm64::gmt-6.4.0-ha1267e2_11.conda
osx-arm64::libarrow-11.0.0-hba0abc1_24_cpu.conda
osx-arm64::gdstk-0.9.42-py38hd91e53e_0.conda
osx-arm64::pyinstaller-5.12.0-py39ha52a465_0.conda
osx-arm64::lammps-2023.03.28-cpu_py39_h205487e_mpich_4.conda
osx-arm64::jaxlib-0.4.11-cpu_py311h328a48b_0.conda
osx-arm64::libarrow-12.0.1-he2eba56_1_cpu.conda
osx-arm64::mysql-client-8.0.32-h41974c7_3.conda
osx-arm64::gdstk-0.9.42-py310he5462bb_0.conda
osx-arm64::pocl-core-4.0-h422b2f1_0.conda
osx-arm64::libarrow-10.0.1-he2904f1_27_cpu.conda
osx-arm64::libgdal-arrow-parquet-3.7.0-h559f67f_3.conda
osx-arm64::lld-16.0.5-h1753c5f_0.conda
osx-arm64::grpcio-1.55.1-py39hbad4f83_0.conda
osx-arm64::lammps-2023.03.28-cpu_py310_hbba249a_mpich_5.conda
osx-arm64::hdf5-1.14.1-mpi_mpich_hb01e5a5_0.conda
osx-arm64::lammps-2023.03.28-cpu_py39_hc8f1364_openmpi_3.conda
osx-arm64::kaldi-5.5.1068-cpu_h9f6ebf1_1.conda
osx-arm64::nginx-1.25.1-h364d411_2.conda
osx-arm64::pygame-2.5.0-py311h4d8e0db_0.conda
osx-arm64::libarrow-12.0.0-h2f988b0_4_cpu.conda
osx-arm64::r-harp-1.18-py38hf52e936_1.conda
osx-arm64::libpulsar-3.2.0-he0484e9_1.conda
osx-arm64::vigra-1.11.1-py311h3cec95f_1045.conda
osx-arm64::libarrow-11.0.0-hba0abc1_23_cpu.conda
osx-arm64::paraview-5.11.1-py39h5dbeabb_101_qt.conda
osx-arm64::lammps-2023.03.28-cpu_py38_h13566b0_openmpi_5.conda
osx-arm64::adios-1.13.1-mpi_openmpi_h74f2ae7_1022.conda
osx-arm64::paraview-5.11.1-py39h49fa145_101_qt.conda
osx-arm64::jaxlib-0.4.11-cpu_py39h1d8eb90_0.conda
osx-arm64::ffmpeg-6.0.0-gpl_h474fd3e_103.conda
osx-arm64::r-harp-1.18-py310he0fee6e_0.conda
osx-arm64::arrow-cpp-9.0.0-py311h0bf5e7f_41_cpu.conda
osx-arm64::netcdf4-1.6.4-mpi_openmpi_py39h244332f_0.conda
osx-arm64::pygplates-0.39-py39h16a0492_8.conda
osx-arm64::r-harp-1.18-py39h86a4e4f_0.conda
osx-arm64::lammps-2023.03.28-cpu_py39_h205487e_mpich_7.conda
osx-arm64::libllvm16-16.0.5-he79909e_0.conda
osx-arm64::python-3.11.4-h47c9636_0_cpython.conda
osx-arm64::pyinstaller-5.12.0-py311h79498d2_1.conda
osx-arm64::pygplates-0.39-py311h8d7554d_8.conda
osx-arm64::graphicsmagick-1.3.40-h5ae400f_2.conda
osx-arm64::pyhdf-0.11.3-py310h2085333_0.conda
osx-arm64::magics-metview-batch-4.13.0-hcee89ea_4.conda
osx-arm64::nodejs-18.16.1-ha2ed473_0.conda
osx-arm64::mysql-server-8.0.32-h70a98ac_3.conda
osx-arm64::xrootd-5.5.4-py39h1eaaa1c_1.conda
osx-arm64::verilator-5.012-h5c8d968_0.conda
osx-arm64::polycap-1.2-py38ha38b89d_2.conda
osx-arm64::jaxlib-0.4.12-cpu_py39h1d8eb90_0.conda
osx-arm64::vtk-base-9.2.6-qt_py311h1234567_207.conda
osx-arm64::gazebo-11.13.0-h1f0c065_3.conda
osx-arm64::arrow-cpp-9.0.0-py310h8b2a965_40_cpu.conda
osx-arm64::grpcio-1.56.0-py311hea943cd_1.conda
osx-arm64::gazebo-11.13.0-h7606d12_2.conda
osx-arm64::orc-1.8.4-ha98e9e8_0.conda
osx-arm64::coda-2.24.2-py39h3f58a0f_2.conda
osx-arm64::tiledb-2.15.4-he79ed24_1.conda
osx-arm64::gmt-6.4.0-h30de5ce_13.conda
osx-arm64::lammps-2023.03.28-cpu_py38_h62cdab2_mpich_5.conda
osx-arm64::omniorb-4.2.5-py311he3b646b_7.conda
osx-arm64::pyinstaller-5.12.0-py310hab90de1_1.conda
osx-arm64::vtk-base-9.2.6-qt_py39h1234567_208.conda
osx-arm64::ffmpeg-5.1.2-lgpl_h4dda560_11.conda
osx-arm64::nifty-1.2.1-py310hf354d2b_4.conda
osx-arm64::jaxlib-0.4.12-cpu_py38h7aa3e66_1.conda
osx-arm64::pyreadstat-1.2.2-py310hab90de1_0.conda
osx-arm64::libadios2-2.8.3-mpi_openmpi_hd91e132_6.conda
osx-arm64::coda-2.24.2-py38hf52e936_2.conda
osx-arm64::grpcio-1.55.1-py311hea943cd_1.conda
osx-arm64::folly-2023.06.08.00-hd189c9a_1_jemalloc.conda
osx-arm64::libssh2-static-1.11.0-hbbb52b4_0.conda
osx-arm64::grpcio-1.55.1-py311hea943cd_0.conda
osx-arm64::folly-2023.06.12.00-h03318f1_0.conda
osx-arm64::mlir-16.0.6-h2d3518b_0.conda
osx-arm64::folly-2023.06.26.00-hd189c9a_0_jemalloc.conda
osx-arm64::tiledb-2.15.4-hc0ba2d2_1.conda
osx-arm64::lammps-2023.03.28-cpu_py311_hb114475_openmpi_7.conda
osx-arm64::yarp-cxx-3.8.1-hd505e7d_0.conda
osx-arm64::paraview-5.11.1-py38h232b447_101_qt.conda
osx-arm64::pyinstaller-5.13.0-py39ha52a465_0.conda
osx-arm64::orc-1.9.0-ha98e9e8_0.conda
osx-arm64::lammps-2023.03.28-cpu_py39_h01793bf_openmpi_4.conda
osx-arm64::z5py-2.0.16-py39hcb2ea7b_1.conda
osx-arm64::sagelib-10.0-py39h177c099_1.conda
osx-arm64::lammps-2023.03.28-cpu_py38_h62cdab2_mpich_7.conda
osx-arm64::vigra-1.11.1-py311h795a241_1044.conda
osx-arm64::omniorb-libs-4.2.5-h9964277_7.conda
osx-arm64::lammps-2023.03.28-cpu_py39_h205487e_mpich_6.conda
osx-arm64::libopencv-4.7.0-py311h6e04221_5.conda
osx-arm64::libadios2-2.8.3-nompi_h01b59e6_106.conda
osx-arm64::openmeeg-2.5.6-py38he93ba84_1.conda
osx-arm64::vigra-1.11.1-py39h92a2894_1044.conda
osx-arm64::arrow-cpp-9.0.0-py38heca85e6_41_cpu.conda
osx-arm64::lxml-4.9.2-py39hb67b4e4_1.conda
osx-arm64::vigra-1.11.1-py38h9ed6904_1044.conda
osx-arm64::openbabel-3.1.1-py310h5029d14_7.conda
osx-arm64::libspatialite-5.0.1-h6193c13_28.conda
osx-arm64::smesh-9.9.0.0-h769b78e_5.conda
osx-arm64::llvmlite-0.40.1-py39hbad4f83_0.conda
osx-arm64::mysql-connector-python-8.0.32-py311hd5a37ad_0.conda
osx-arm64::libgdal-arrow-parquet-3.6.4-hf97c125_6.conda
osx-arm64::mysql-connector-python-8.0.32-py310h11e2b57_0.conda
osx-arm64::jaxlib-0.4.12-cpu_py311h328a48b_1.conda
osx-arm64::pyinstaller-5.13.0-py310hab90de1_0.conda
osx-arm64::pocl-core-4.0-hbf99284_1.conda
osx-arm64::llvm-tools-16.0.5-he79909e_0.conda
osx-arm64::netcdf4-1.6.4-mpi_openmpi_py39h47417e5_1.conda
osx-arm64::netcdf4-1.6.4-mpi_mpich_py310ha14f643_0.conda
osx-arm64::orc-1.8.3-h13b7ede_1.conda
osx-arm64::nest-simulator-3.4-py39h0cba884_0.conda
osx-arm64::vigra-1.11.1-py38h9ed6904_1043.conda
osx-arm64::mysql-connector-python-8.0.32-py39h68b4dde_0.conda
osx-arm64::pyreadstat-1.2.2-py39ha52a465_0.conda
osx-arm64::jaxlib-0.4.12-cpu_py311h328a48b_0.conda
osx-arm64::lammps-2023.03.28-cpu_py38_h13566b0_openmpi_7.conda
osx-arm64::lammps-2023.03.28-cpu_py38_h62cdab2_mpich_6.conda
osx-arm64::lxml-4.9.2-py310h78afa71_1.conda
osx-arm64::pdal-2.5.5-hd7f2dcb_0.conda
osx-arm64::libmatio-1.5.23-hc41f82a_3.conda
osx-arm64::mysql-server-8.0.33-h8d2d40f_0.conda
osx-arm64::libgdal-arrow-parquet-3.7.0-hc6196e3_4.conda
osx-arm64::pyinstaller-5.12.0-py39ha52a465_1.conda
osx-arm64::arrow-cpp-9.0.0-py311h65f9828_40_cpu.conda
osx-arm64::nifty-1.2.1-py311h78cd012_4.conda
osx-arm64::lammps-2023.03.28-cpu_py38_h13566b0_openmpi_4.conda
osx-arm64::lammps-2023.03.28-cpu_py39_hc8f1364_openmpi_2.conda
osx-arm64::netcdf4-1.6.4-mpi_mpich_py311h33ff202_0.conda
osx-arm64::vigra-1.11.1-py311h795a241_1045.conda
osx-arm64::arrow-cpp-9.0.0-py310hd85100d_39_cpu.conda
osx-arm64::aws-sdk-cpp-1.10.57-h9b90b14_14.conda
osx-arm64::pyhdf-0.11.3-py39habe27e1_0.conda
osx-arm64::nest-simulator-3.4-py38hbb9dc6a_0.conda
osx-arm64::arrow-cpp-9.0.0-py311h613176a_38_cpu.conda
osx-arm64::lammps-2023.03.28-cpu_py311_h6f761fa_mpich_2.conda
osx-arm64::tiledb-2.15.3-he79ed24_1.conda
osx-arm64::netcdf4-1.6.4-mpi_openmpi_py311h72573bd_0.conda
osx-arm64::openbabel-3.1.1-py38hf10facd_6.conda
osx-arm64::pyhdf-0.11.3-py38hac70979_0.conda
osx-arm64::libadios2-2.8.3-mpi_mpich_h2122014_6.conda
osx-arm64::libarrow-12.0.0-hbfb5349_8_cpu.conda
osx-arm64::libadios2-2.8.3-mpi_openmpi_h7a36927_6.conda
osx-arm64::tiledb-2.15.3-h1cdaec1_2.conda
osx-arm64::libadios2-2.8.3-mpi_mpich_h1247b48_6.conda
osx-arm64::pygplates-0.39-py38h097affd_8.conda
osx-arm64::openbabel-3.1.1-py311h4f068e6_7.conda
osx-arm64::vigra-1.11.1-py310h01167d6_1044.conda
osx-arm64::orc-1.8.3-ha98e9e8_1.conda
osx-arm64::tiledb-2.15.3-h5530f2e_2.conda
osx-arm64::thrift-compiler-0.18.1-ha061701_2.conda
osx-arm64::yarp-cxx-3.8.0-h0b4bcb8_3.conda
osx-arm64::vtk-base-9.2.6-qt_py38h1234567_207.conda
osx-arm64::hdf5-1.14.1-mpi_openmpi_ha832a9f_0.conda
osx-arm64::libarrow-11.0.0-h5027e3d_26_cpu.conda
osx-arm64::lammps-2023.03.28-cpu_py39_h205487e_mpich_5.conda
osx-arm64::ntbtls-0.3.1-ha614eb4_1.conda
osx-arm64::libopencv-4.7.0-py38haec4208_5.conda
osx-arm64::lammps-2023.03.28-cpu_py38_h8140eb0_mpich_2.conda
osx-arm64::libopencv-4.7.0-py38h0545c13_5.conda
osx-arm64::mysql-libs-8.0.33-hb292caa_0.conda
osx-arm64::polycap-1.2-py39h3aebd09_2.conda
osx-arm64::netcdf4-1.6.4-mpi_mpich_py310h515722d_1.conda
osx-arm64::ffmpeg-6.0.0-lgpl_h21dc7ef_3.conda
osx-arm64::r-harp-1.18-py39h3f58a0f_1.conda
osx-arm64::lammps-2023.03.28-cpu_py311_h586da94_openmpi_3.conda
osx-arm64::octave-8.2.0-hdafeedd_1.conda
osx-arm64::libgdal-3.6.4-he0872e7_4.conda
osx-arm64::grpcio-1.55.1-py310h95b248a_1.conda
osx-arm64::libarrow-12.0.0-h6e3ec2a_8_cpu.conda
osx-arm64::ovito-3.8.5-h175df37_0.conda
osx-arm64::magics-4.13.0-hcee89ea_5.conda
osx-arm64::lld-16.0.6-h1753c5f_0.conda
osx-arm64::folly-2023.06.12.00-h03318f1_1.conda
osx-arm64::grpcio-1.56.0-py310h95b248a_1.conda
osx-arm64::libgdal-3.7.0-h714e44a_4.conda
osx-arm64::netcdf4-1.6.4-mpi_mpich_py39hc2ab78f_1.conda
osx-arm64::pyinstaller-5.12.0-py38he9a9ba6_0.conda
osx-arm64::paraview-5.11.1-py311hc6c3064_101_qt.conda
osx-arm64::jaxlib-0.4.11-cpu_py38h7aa3e66_0.conda
osx-arm64::lammps-2023.03.28-cpu_py310_h30d5764_mpich_2.conda
osx-arm64::libspatialite-5.0.1-h31468cf_27.conda
osx-arm64::arrow-cpp-9.0.0-py39he36a728_39_cpu.conda
osx-arm64::netcdf4-1.6.4-nompi_py39h7147c39_101.conda
osx-arm64::lammps-2023.03.28-cpu_py310_hc94156c_openmpi_2.conda
osx-arm64::arrow-cpp-9.0.0-py38hf7889d1_37_cpu.conda
osx-arm64::tiledb-2.15.4-he79ed24_0.conda
osx-arm64::libxmlsec1-1.3.1-h6a2d6b9_0.conda
osx-arm64::libnetcdf-4.9.2-nompi_hd95b5de_106.conda
osx-arm64::lammps-2023.03.28-cpu_py310_h98c4839_openmpi_5.conda
osx-arm64::tiledb-2.15.3-he79ed24_2.conda
osx-arm64::jaxlib-0.4.12-cpu_py310haddac25_1.conda
osx-arm64::libssh2-1.11.0-h7a5bd25_0.conda
osx-arm64::ffmpeg-6.0.0-gpl_h3183737_102.conda
osx-arm64::lammps-2023.03.28-cpu_py311_h586da94_openmpi_2.conda
osx-arm64::lammps-2023.03.28-cpu_py311_hd466178_mpich_5.conda
osx-arm64::pyhdf-0.11.3-py311h6fbf6ec_0.conda
osx-arm64::arrow-cpp-9.0.0-py39ha9764af_38_cpu.conda
osx-arm64::nest-simulator-3.4-py311he22643c_0.conda
osx-arm64::llvmdev-16.0.5-h504e6bf_0.conda
osx-arm64::libadios2-2.8.3-mpi_mpich_h74d04e3_7.conda
osx-arm64::tectonic-0.14.0-h116b827_0.conda
osx-arm64::magics-metview-4.13.0-h519023f_4.conda
osx-arm64::gdstk-0.9.42-py311h73b73c0_0.conda
osx-arm64::libadios2-2.8.3-mpi_openmpi_h84b0edd_7.conda
osx-arm64::vigra-1.11.1-py310h01167d6_1045.conda
osx-arm64::llvmdev-14.0.6-hd1a9a77_3.conda
osx-arm64::coda-2.24.2-py310hcb8dffb_2.conda
osx-arm64::harp-1.18-py311h60c0f7b_1.conda
osx-arm64::llvmdev-16.0.6-h504e6bf_0.conda
osx-arm64::nifty-1.2.1-py39ha77a3c7_4.conda
osx-arm64::lammps-2023.03.28-cpu_py39_h01793bf_openmpi_6.conda
osx-arm64::gazebo-11.13.0-h961c9e9_2.conda
osx-arm64::harp-1.18-py311h48ca11e_0.conda
osx-arm64::gazebo-11.13.0-h9da9ba2_1.conda
osx-arm64::tiledb-2.15.4-h1cdaec1_0.conda
osx-arm64::mysql-client-8.0.33-h41974c7_0.conda
osx-arm64::paraview-5.11.1-py310h3559d45_101_qt.conda
osx-arm64::libgrpc-1.55.1-hc384137_1.conda
osx-arm64::magics-metview-batch-4.13.0-hbcb5b6f_3.conda
osx-arm64::pyinstaller-5.12.0-py310hab90de1_0.conda
osx-arm64::ambertools-23.3-py310hd4daa78_1.conda
osx-arm64::arrow-cpp-9.0.0-py38hf7889d1_38_cpu.conda
osx-arm64::openmeeg-2.5.6-py311h682a77d_1.conda
osx-arm64::netcdf4-1.6.4-nompi_py311h6a8bb3c_100.conda
osx-arm64::libadios2-2.8.3-nompi_hb40c12d_107.conda
osx-arm64::libadios2-2.8.3-mpi_mpich_h37257f3_7.conda
osx-arm64::geotiff-1.7.1-h00e2a8a_9.conda
osx-arm64::jaxlib-0.4.12-cpu_py310haddac25_0.conda
osx-arm64::libgrpc-1.55.1-hc384137_0.conda
osx-arm64::folly-2023.06.08.00-h8b73916_0_jemalloc.conda
osx-arm64::pyreadstat-1.2.2-py38he9a9ba6_0.conda
osx-arm64::libadios2-2.8.3-mpi_openmpi_h367574f_6.conda
osx-arm64::libarrow-10.0.1-haf3a520_30_cpu.conda
osx-arm64::arrow-cpp-9.0.0-py310hd5d3570_38_cpu.conda
osx-arm64::lammps-2023.03.28-cpu_py311_hd466178_mpich_6.conda
osx-arm64::xrootd-5.5.4-py310h59780b5_1.conda
osx-arm64::nest-simulator-3.4-py310h6613f0c_0.conda
osx-arm64::adios-1.13.1-mpi_mpich_he1b8972_1022.conda
osx-arm64::grpcio-1.56.0-py39hbad4f83_1.conda
osx-arm64::netcdf4-1.6.4-nompi_py311h724ebb5_101.conda
osx-arm64::mysql-server-8.0.33-h70a98ac_0.conda
osx-arm64::chemicalite-2022.04.1-h4cda963_10.conda
osx-arm64::netcdf4-1.6.4-nompi_py38h508e367_100.conda
osx-arm64::lpython-0.16.0-ha614eb4_0.conda
osx-arm64::lxml-4.9.2-py311hbafe683_1.conda
osx-arm64::lammps-2023.03.28-cpu_py311_hb114475_openmpi_5.conda
osx-arm64::pygame-2.5.0-py38hece1802_0.conda
osx-arm64::arrow-cpp-9.0.0-py310h3cd8dea_41_cpu.conda
osx-arm64::libopencv-4.7.0-py310h382be34_5.conda
osx-arm64::libopencv-4.7.0-py38haa78c38_5.conda
osx-arm64::libadios2-2.8.3-mpi_mpich_h704e794_6.conda
osx-arm64::tiledb-2.15.3-h1cdaec1_1.conda
osx-arm64::libnetcdf-4.9.2-mpi_openmpi_h21e0892_6.conda
osx-arm64::lammps-2023.03.28-cpu_py39_h01793bf_openmpi_5.conda
osx-arm64::libarrow-11.0.0-h2f988b0_22_cpu.conda
osx-arm64::sagelib-10.0-py38h8aa816a_1.conda
osx-arm64::vigra-1.11.1-py310h862b030_1045.conda
osx-arm64::lammps-2023.03.28-cpu_py311_hd466178_mpich_7.conda
osx-arm64::llvm-16.0.6-h2b67075_0.conda
osx-arm64::openmeeg-2.5.6-py310h2d2325a_1.conda
osx-arm64::libnetcdf-4.9.2-mpi_mpich_hda6c7a0_6.conda
osx-arm64::folly-2023.06.12.00-hd189c9a_0_jemalloc.conda
osx-arm64::arrow-cpp-9.0.0-py39h018e770_40_cpu.conda
osx-arm64::lammps-2023.03.28-cpu_py39_h08a55b2_mpich_2.conda
osx-arm64::lammps-2023.03.28-cpu_py310_h98c4839_openmpi_4.conda
osx-arm64::jaxlib-0.4.11-cpu_py310haddac25_0.conda
osx-arm64::vtk-base-9.2.6-qt_py310h1234567_208.conda
osx-arm64::pytables-3.8.0-py38h2008f4c_2.conda
osx-arm64::grpcio-1.55.1-py38h761d82c_0.conda
osx-arm64::libadios2-2.8.3-nompi_h789a14b_106.conda
osx-arm64::lammps-2023.03.28-cpu_py38_h13566b0_openmpi_6.conda
osx-arm64::ffmpeg-5.1.2-gpl_he347a24_111.conda
osx-arm64::lammps-2023.03.28-cpu_py38_h72943ce_openmpi_3.conda
osx-arm64::gst-plugins-bad-1.22.4-haedc527_0.conda
osx-arm64::harp-1.18-py310h3d2e54c_1.conda
osx-arm64::libgdal-3.6.4-h00a5901_5.conda
osx-arm64::libarrow-12.0.0-hba0abc1_6_cpu.conda
osx-arm64::llvmlite-0.40.1-py38h761d82c_0.conda
osx-arm64::vigra-1.11.1-py39h8e933d2_1043.conda
osx-arm64::yarp-cxx-3.8.1-h0b4bcb8_0.conda
osx-arm64::netcdf4-1.6.4-mpi_openmpi_py310h9409509_0.conda
osx-arm64::libadios2-2.8.3-nompi_h673b72c_106.conda
osx-arm64::qt-main-5.15.8-hcac2fde_14.conda
osx-arm64::lammps-2023.03.28-cpu_py311_hb114475_openmpi_6.conda
osx-arm64::libopencv-4.7.0-py310h0087914_5.conda
osx-arm64::libgdal-arrow-parquet-3.6.4-h4f24011_4.conda
osx-arm64::libmediainfo-23.06-hbb71fad_0.conda
osx-arm64::libopencv-4.7.0-py39h326aabb_5.conda
osx-arm64::gdstk-0.9.42-py39h201c926_0.conda
osx-arm64::libopencv-4.7.0-py39h5a4d745_5.conda
osx-arm64::qt6-main-6.5.1-h372468e_1.conda
osx-arm64::netcdf4-1.6.4-mpi_openmpi_py38hb4d1a6d_0.conda
osx-arm64::netcdf4-1.6.4-mpi_mpich_py38h152dc2b_1.conda
osx-arm64::vtk-base-9.2.6-qt_py311h1234567_208.conda
osx-arm64::grpcio-1.55.1-py38h761d82c_1.conda
osx-arm64::openbabel-3.1.1-py311h4f068e6_6.conda
osx-arm64::lammps-2023.03.28-cpu_py39_h08a55b2_mpich_3.conda
osx-arm64::libadios2-2.8.3-mpi_mpich_h4660c3b_6.conda
osx-arm64::arrow-cpp-9.0.0-py39haf10d6d_41_cpu.conda
osx-arm64::mysql-server-8.0.32-h8d2d40f_3.conda
osx-arm64::netcdf4-1.6.4-mpi_openmpi_py310h67f4089_1.conda
osx-arm64::libopencv-4.7.0-py38he340ff8_5.conda
osx-arm64::netcdf4-1.6.4-mpi_mpich_py311h527f807_1.conda
osx-arm64::vigra-1.11.1-py311h3cec95f_1043.conda
osx-arm64::libopencv-4.7.0-py311h8f5aa86_5.conda
osx-arm64::omniorb-4.2.5-py310hb0331d7_7.conda
osx-arm64::lammps-2023.03.28-cpu_py310_hbba249a_mpich_7.conda
osx-arm64::hdf5-1.14.1-nompi_h3aba7b3_100.conda
osx-arm64::hdfeos5-5.1.16-hd27ad65_14.conda
osx-arm64::libarrow-11.0.0-h6e3ec2a_25_cpu.conda
osx-arm64::r-data.table-1.14.8-r43h5bdffde_2.conda
osx-arm64::libarrow-10.0.1-he2904f1_28_cpu.conda
osx-arm64::python-3.8.17-h3ba56d0_0_cpython.conda
osx-arm64::z5py-2.0.16-py310hd805275_1.conda
osx-arm64::gazebo-11.13.0-h6dd43ea_1.conda
osx-arm64::lammps-2023.03.28-cpu_py310_h98c4839_openmpi_7.conda
osx-arm64::hugin-base-2022.0.0-pl5321h26dd22f_5.conda
osx-arm64::mesalib-23.1.3-h7bfda7a_0.conda
osx-arm64::r-harp-1.18-py311h09dc9a0_1.conda
osx-arm64::omniorb-4.2.5-py38hd84bcb6_7.conda
osx-arm64::netcdf4-1.6.4-mpi_openmpi_py311h6202530_1.conda
osx-arm64::paraview-5.11.1-py311h3ec37c3_101_qt.conda
osx-arm64::paraview-5.11.1-py38h6cedb3f_101_qt.conda
osx-arm64::llvmlite-0.40.1-py311hea943cd_0.conda
osx-arm64::wxwidgets-3.2.2.1-h600d17c_3.conda
osx-arm64::gmt-6.4.0-hd9024d0_12.conda
osx-arm64::harp-1.18-py39ha8320be_0.conda
osx-arm64::pyinstaller-5.13.0-py38he9a9ba6_0.conda
osx-arm64::openmeeg-2.5.6-py39h9de7825_1.conda
osx-arm64::sagelib-10.0-py310h3aecabe_1.conda
osx-arm64::polycap-1.2-py310he1b6d69_2.conda
osx-arm64::libarrow-12.0.0-hba0abc1_7_cpu.conda
osx-arm64::pyinstaller-5.13.0-py311h79498d2_0.conda
osx-arm64::libopencv-4.7.0-py311h0691dac_5.conda
osx-arm64::ovito-3.8.5-h6961929_0.conda
osx-arm64::harp-1.18-py38ha8320be_0.conda
osx-arm64::openbabel-3.1.1-py38hf10facd_7.conda
osx-arm64::tiledb-2.15.4-h1cdaec1_1.conda
osx-arm64::libopencv-4.7.0-py310he2bef16_5.conda
osx-arm64::vigra-1.11.1-py310h9c75d4f_1043.conda
osx-arm64::vigra-1.11.1-py38h9ed6904_1045.conda
osx-arm64::libarrow-10.0.1-h6b36ddd_31_cpu.conda
osx-arm64::netcdf4-1.6.4-nompi_py310h75c7371_101.conda
osx-arm64::libgdal-arrow-parquet-3.7.0-h75c9f64_2.conda
osx-arm64::libopencv-4.7.0-py39ha183434_5.conda
osx-arm64::libthrift-0.18.1-ha061701_2.conda
osx-arm64::orc-1.8.4-h13b7ede_0.conda
osx-arm64::folly-2023.06.08.00-h03318f1_1.conda
osx-arm64::harp-1.18-py310ha8320be_0.conda
osx-arm64::tectonic-0.14.1-h116b827_0.conda
osx-arm64::pytables-3.8.0-py39h0da393b_2.conda
osx-arm64::folly-2023.06.12.00-hd189c9a_1_jemalloc.conda
osx-arm64::lammps-2023.03.28-cpu_py311_h6f761fa_mpich_3.conda
osx-arm64::openbabel-3.1.1-py39hcdff8ce_7.conda
osx-arm64::libadios2-2.8.3-nompi_h79c87c1_107.conda
osx-arm64::folly-2023.06.12.00-h1e8fca9_1.conda
osx-arm64::ffmpeg-6.0.0-lgpl_he593215_2.conda
osx-arm64::r-git2r-0.31.0-r42h7b2db81_1.conda
osx-arm64::mlir-16.0.5-h2d3518b_0.conda
osx-arm64::openbabel-3.1.1-py39hcdff8ce_6.conda
osx-arm64::r-harp-1.18-py38hbdccba1_0.conda
osx-arm64::arrow-cpp-9.0.0-py310hd5d3570_37_cpu.conda
osx-arm64::imagemagick-7.1.1_12-pl5321h903c885_0.conda
osx-arm64::gazebo-11.13.0-h78dc374_1.conda
osx-arm64::z5py-2.0.16-py38he0b8184_1.conda
osx-arm64::netcdf4-1.6.4-mpi_openmpi_py38h363c040_1.conda
osx-arm64::vigra-1.11.1-py311h3cec95f_1044.conda
osx-arm64::jaxlib-0.4.12-cpu_py38h7aa3e66_0.conda
osx-arm64::netcdf4-1.6.4-nompi_py39hce53f29_100.conda
osx-arm64::pygame-2.5.0-py310heeb1dd7_0.conda
osx-arm64::libarrow-10.0.1-h6786480_26_cpu.conda
osx-arm64::lammps-2023.03.28-cpu_py310_hc94156c_openmpi_3.conda
osx-arm64::lammps-2023.03.28-cpu_py310_h98c4839_openmpi_6.conda
osx-arm64::libarrow-12.0.1-heca9b86_0_cpu.conda
osx-arm64::gazebo-11.13.0-h83e9e8a_1.conda
osx-arm64::folly-2023.06.12.00-h2c5142d_1_jemalloc.conda
osx-arm64::lxml-4.9.2-py38hbfa3897_1.conda
osx-arm64::arrow-cpp-9.0.0-py311h8fa06e8_39_cpu.conda
osx-arm64::libgdal-3.7.0-ha0783c4_3.conda
osx-arm64::vigra-1.11.1-py310h862b030_1044.conda
osx-arm64::openbabel-3.1.1-py310h5029d14_6.conda
osx-arm64::libopencv-4.7.0-py310hdc0018b_5.conda
osx-arm64::vigra-1.11.1-py310h01167d6_1043.conda
osx-arm64::libarrow-12.0.0-h2f988b0_5_cpu.conda
osx-arm64::grpcio-1.55.1-py39hbad4f83_1.conda
osx-arm64::magics-metview-4.13.0-h9ab9642_3.conda
osx-arm64::libadios2-2.8.3-mpi_mpich_h1b2a255_7.conda
osx-arm64::pygame-2.5.0-py39h57bbbc0_0.conda
osx-arm64::grpcio-1.56.0-py38h761d82c_1.conda
osx-arm64::libgdal-3.7.0-h03b46a8_2.conda
osx-arm64::gazebo-11.13.0-h2f0dabd_2.conda
osx-arm64::qtwebkit-5.212-hfc9f050_12.conda
osx-arm64::libadios2-2.8.3-mpi_openmpi_h66270dc_7.conda
osx-arm64::vigra-1.11.1-py38h61a1b16_1043.conda
osx-arm64::r-data.table-1.14.8-r42h5bdffde_2.conda
osx-arm64::libarrow-12.0.1-h3f25899_1_cpu.conda
osx-arm64::vigra-1.11.1-py39h8e933d2_1045.conda
osx-arm64::orc-1.9.0-h13b7ede_0.conda
osx-arm64::xrootd-5.5.4-py311h449bba7_1.conda
osx-arm64::llvm-16.0.5-h2b67075_0.conda
osx-arm64::libadios2-2.8.3-mpi_openmpi_h7fbabbf_7.conda
osx-arm64::grpcio-1.55.1-py310h95b248a_0.conda
osx-arm64::vigra-1.11.1-py39h92a2894_1045.conda
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
================================================================================
================================================================================
linux-ppc64le
linux-ppc64le::libsolv-static-0.7.24-hff1ad0c_1.conda
linux-ppc64le::cudnn-8.8.0.121-h6252efc_1.conda
linux-ppc64le::liblal-7.3.1-fftw_h41e83e0_101.conda
linux-ppc64le::llvm-spirv-15.0.0-h96faf4b_0.conda
linux-ppc64le::libprotobuf-4.23.3-h31f4ac3_0.conda
linux-ppc64le::libmlir16-16.0.6-hae84d68_0.conda
linux-ppc64le::g2clib-1.7.0-hc3f092f_3.conda
linux-ppc64le::git-delta-0.16.4-h8d97faf_0.conda
linux-ppc64le::llvm-14.0.6-h12068cf_3.conda
linux-ppc64le::adios-1.13.1-nompi_h7190537_1122.conda
linux-ppc64le::micromamba-1.4.5-0.tar.bz2
linux-ppc64le::imath-3.1.9-hff1ad0c_0.conda
linux-ppc64le::libsolv-0.7.24-hff1ad0c_1.conda
linux-ppc64le::gst-libav-1.22.4-hcdd5cfa_0.conda
linux-ppc64le::libdap4-3.20.6-he4c6ef0_3.conda
linux-ppc64le::libv8-8.9.83-h983d11c_3.conda
linux-ppc64le::libprotobuf-4.23.2-h31f4ac3_4.conda
linux-ppc64le::cudnn-8.8.0.121-hc9efd5c_1.conda
linux-ppc64le::libmlir-16.0.6-hae84d68_0.conda
linux-ppc64le::openexr-3.1.8-h4843ef4_0.conda
linux-ppc64le::openexr-3.1.7-h4843ef4_2.conda
linux-ppc64le::openexr-3.1.9-h4843ef4_0.conda
linux-ppc64le::libprotobuf-4.23.2-h31f4ac3_3.conda
linux-ppc64le::metal-llvm-tools-15-0.5.1-hf7e7dc2_0.conda
linux-ppc64le::libprotobuf-static-4.23.2-h31f4ac3_5.conda
linux-ppc64le::libmlir-16.0.5-hae84d68_0.conda
linux-ppc64le::libprotobuf-static-4.23.3-h31f4ac3_0.conda
linux-ppc64le::gst-libav-1.22.4-h95e5f97_0.conda
linux-ppc64le::libprotobuf-static-4.23.2-h31f4ac3_4.conda
linux-ppc64le::libllvm14-14.0.6-hf7e7dc2_3.conda
linux-ppc64le::llvm-tools-14.0.6-hf7e7dc2_3.conda
linux-ppc64le::libmlir16-16.0.5-hae84d68_0.conda
linux-ppc64le::nceplibs-g2c-1.7.0-hc3f092f_4.conda
linux-ppc64le::libprotobuf-static-4.23.2-h31f4ac3_3.conda
linux-ppc64le::libprotobuf-4.23.2-h31f4ac3_5.conda
linux-ppc64le::libsolv-0.7.24-h26001cd_0.conda
linux-ppc64le::micromamba-1.4.4-0.tar.bz2
linux-ppc64le::git-delta-0.16.5-h8d97faf_0.conda
linux-ppc64le::libdap4-3.20.6-h215a1bd_4.conda
linux-ppc64le::libsolv-static-0.7.24-h26001cd_0.conda
linux-ppc64le::git-delta-0.16.0-h8d97faf_0.conda
-    "libzlib >=1.2.13,<1.3.0a0"
+    "libzlib >=1.2.13,<2.0.0a0"
linux-ppc64le::libopencv-4.7.0-py310hfa15cf6_5.conda
linux-ppc64le::libopencv-4.7.0-py311h91ac5c7_5.conda
linux-ppc64le::lld-16.0.6-he12c2f4_0.conda
linux-ppc64le::arrow-cpp-9.0.0-py310h3024d74_38_cuda.conda
linux-ppc64le::mysql-connector-python-8.0.32-py39h91b38d1_0.conda
linux-ppc64le::tiledb-2.15.4-h4dc2441_0.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-h71abe44_37.conda
linux-ppc64le::libarrow-12.0.0-h233d34d_8_cuda.conda
linux-ppc64le::libarrow-12.0.0-haa6df50_9_cuda.conda
linux-ppc64le::pyhdf-0.11.3-py310hf4e3bf9_0.conda
linux-ppc64le::omniorb-4.2.5-py310hae66743_7.conda
linux-ppc64le::arrow-cpp-9.0.0-py39hca45159_39_cpu.conda
linux-ppc64le::mysql-server-8.0.33-h3aa03ee_0.conda
linux-ppc64le::vigra-1.11.1-py38hb96de1b_1045.conda
linux-ppc64le::arrow-cpp-9.0.0-py310h8e34add_41_cpu.conda
linux-ppc64le::netcdf4-1.6.4-nompi_py38h50476d2_101.conda
linux-ppc64le::python-3.11.4-h3332dee_0_cpython.conda
linux-ppc64le::libpulsar-3.2.0-hd6976e3_1.conda
linux-ppc64le::folly-2023.06.12.00-h864cb69_1_jemalloc.conda
linux-ppc64le::mysql-server-8.0.33-h930179c_0.conda
linux-ppc64le::netcdf4-1.6.4-mpi_mpich_py39h5316477_1.conda
linux-ppc64le::libadios2-2.8.3-mpi_openmpi_h2e736a2_6.conda
linux-ppc64le::llvmlite-0.40.1-py39h278787b_0.conda
linux-ppc64le::pygame-2.5.0-py39hf33c4b3_0.conda
linux-ppc64le::linux-perf-6.3.8-py39he243d86_0.conda
linux-ppc64le::ntbtls-0.3.1-hff1ad0c_1.conda
linux-ppc64le::openbabel-3.1.1-py310hfb8b204_6.conda
linux-ppc64le::openbabel-3.1.1-py38h6b41003_7.conda
linux-ppc64le::rust-1.69.0-hb12b0c0_4.conda
linux-ppc64le::libarrow-10.0.1-hd5a762c_30_cpu.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-h71abe44_36.conda
linux-ppc64le::vtk-base-9.2.6-qt_py39h1234567_208.conda
linux-ppc64le::arrow-cpp-9.0.0-py38h8aaf4df_40_cpu.conda
linux-ppc64le::libgdal-arrow-parquet-3.6.4-h3e15613_5.conda
linux-ppc64le::libopencv-4.7.0-py38hbf8f3c2_5.conda
linux-ppc64le::libarrow-12.0.0-hcc49858_9_cuda.conda
linux-ppc64le::libarrow-12.0.1-h3e651f5_1_cuda.conda
linux-ppc64le::qtkeychain-0.14.1-h8d0edd8_0.conda
linux-ppc64le::grpcio-1.55.1-py39h278787b_1.conda
linux-ppc64le::mapserver-8.0.1-py310hb786eca_4.conda
linux-ppc64le::libadios2-2.8.3-mpi_openmpi_h853d7c2_6.conda
linux-ppc64le::folly-2023.06.26.00-hd692e58_0.conda
linux-ppc64le::magic-8.3.401-h7eb73fb_0.conda
linux-ppc64le::mysql-libs-8.0.33-h3ac40eb_0.conda
linux-ppc64le::folly-2023.06.08.00-h361900a_1.conda
linux-ppc64le::arrow-cpp-9.0.0-py38hc5c9e9b_41_cpu.conda
linux-ppc64le::arrow-cpp-9.0.0-py38h5e0d422_40_cuda.conda
linux-ppc64le::thrift-compiler-0.18.1-h81b47c4_2.conda
linux-ppc64le::mlir-16.0.5-hae84d68_0.conda
linux-ppc64le::mapserver-8.0.1-py39h6f80cd4_4.conda
linux-ppc64le::arrow-cpp-9.0.0-py311hc5b296c_37_cuda.conda
linux-ppc64le::libgdal-3.6.4-h304a175_4.conda
linux-ppc64le::linux-perf-6.3.10-py311h52552ba_0.conda
linux-ppc64le::aws-sdk-cpp-1.10.57-h00a0b2e_14.conda
linux-ppc64le::xrootd-5.5.4-py38h5169e4d_1.conda
linux-ppc64le::libopencv-4.7.0-py38h178e5b6_5.conda
linux-ppc64le::libarrow-12.0.0-hb984a1a_5_cpu.conda
linux-ppc64le::libopencv-4.7.0-py38h364d9e3_5.conda
linux-ppc64le::libgrpc-1.55.1-h1cf4055_1.conda
linux-ppc64le::mysql-connector-python-8.0.32-py311h30da4cc_0.conda
linux-ppc64le::ffmpeg-5.1.2-gpl_h78a278c_111.conda
linux-ppc64le::pyinstaller-5.12.0-py310h0719273_0.conda
linux-ppc64le::pygame-2.5.0-py310he53e978_0.conda
linux-ppc64le::llvmdev-16.0.6-h7c8ec72_0.conda
linux-ppc64le::libopencv-4.7.0-py38he892bff_5.conda
linux-ppc64le::mysql-connector-python-8.0.32-py38hd5a0080_0.conda
linux-ppc64le::netcdf4-1.6.4-mpi_openmpi_py310he15b688_1.conda
linux-ppc64le::arrow-cpp-9.0.0-py39h207c43b_37_cuda.conda
linux-ppc64le::folly-2023.06.12.00-hfccd340_1_jemalloc.conda
linux-ppc64le::pdal-2.5.5-h8689c27_0.conda
linux-ppc64le::libadios2-2.8.3-mpi_mpich_ha8b31ef_7.conda
linux-ppc64le::libopencv-4.7.0-py38hb691b3e_5.conda
linux-ppc64le::libadios2-2.8.3-nompi_hda8f420_106.conda
linux-ppc64le::libnetcdf-4.9.2-nompi_h2e8c9d2_106.conda
linux-ppc64le::libopencv-4.7.0-py311h0c0e2eb_5.conda
linux-ppc64le::pytables-3.8.0-py38h6f1c65e_2.conda
linux-ppc64le::folly-2023.06.08.00-hfccd340_1_jemalloc.conda
linux-ppc64le::linux-perf-6.3.8-py310hbf4c414_0.conda
linux-ppc64le::gst-plugins-good-1.22.4-h13f931b_0.conda
linux-ppc64le::orc-1.8.3-hdbada09_1.conda
linux-ppc64le::pytables-3.8.0-py311h1cc5bc1_2.conda
linux-ppc64le::yarp-cxx-3.8.1-h2b8ed06_0.conda
linux-ppc64le::arrow-cpp-9.0.0-py38h869d914_37_cpu.conda
linux-ppc64le::adios-1.13.1-mpi_mpich_hbe023fd_1022.conda
linux-ppc64le::openbabel-3.1.1-py310hfb8b204_7.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-h9370f0f_36.conda
linux-ppc64le::vigra-1.11.1-py38h06ab0aa_1045.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-h3326213_36.conda
linux-ppc64le::llvmlite-0.40.1-py311h3997ded_0.conda
linux-ppc64le::folly-2023.06.12.00-hfccd340_0_jemalloc.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.0-h41e9af0_4.conda
linux-ppc64le::netcdf4-1.6.4-nompi_py310h77418f6_100.conda
linux-ppc64le::grpcio-1.55.1-py310h8eb8f48_0.conda
linux-ppc64le::omniorb-libs-4.2.5-had385bd_7.conda
linux-ppc64le::libarrow-10.0.1-hdad3ba0_26_cuda.conda
linux-ppc64le::folly-2023.06.08.00-hd692e58_0.conda
linux-ppc64le::libarrow-10.0.1-h1e2c587_31_cuda.conda
linux-ppc64le::netcdf4-1.6.4-mpi_mpich_py38h7f3685f_0.conda
linux-ppc64le::libspatialite-5.0.1-haa85ed4_28.conda
linux-ppc64le::arrow-cpp-9.0.0-py39h16a007f_40_cpu.conda
linux-ppc64le::geotiff-1.7.1-h764e20a_9.conda
linux-ppc64le::mapserver-8.0.1-py311h787c813_4.conda
linux-ppc64le::netcdf4-1.6.4-mpi_mpich_py310h59362f7_0.conda
linux-ppc64le::linux-perf-6.3.7-py310hbf4c414_0.conda
linux-ppc64le::llvm-tools-16.0.5-h8d57982_0.conda
linux-ppc64le::pyreadstat-1.2.2-py310h925d916_0.conda
linux-ppc64le::mysql-server-8.0.32-h930179c_3.conda
linux-ppc64le::xrootd-5.5.4-py39h82c12fb_1.conda
linux-ppc64le::netcdf4-1.6.4-mpi_openmpi_py38had0f4a0_0.conda
linux-ppc64le::nginx-1.25.1-hd111a0b_1.conda
linux-ppc64le::arrow-cpp-9.0.0-py310heba0cf2_41_cuda.conda
linux-ppc64le::pyhdf-0.11.3-py39hddd4a25_0.conda
linux-ppc64le::mysql-client-8.0.32-hfff87ee_3.conda
linux-ppc64le::libxmlsec1-1.3.1-h5b53232_0.conda
linux-ppc64le::git-2.41.0-pl5321h7a00b28_0.conda
linux-ppc64le::lxml-4.9.2-py39hbb791fb_1.conda
linux-ppc64le::arrow-cpp-9.0.0-py311h18bb02f_38_cuda.conda
linux-ppc64le::mesalib-23.1.3-hb6f7a19_0.conda
linux-ppc64le::aws-sdk-cpp-1.11.68-h00a0b2e_6.conda
linux-ppc64le::libarrow-12.0.1-haa6df50_0_cuda.conda
linux-ppc64le::vtk-base-9.2.6-qt_py311h1234567_208.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-hc945107_36.conda
linux-ppc64le::pytables-3.8.0-py39hcb9148a_2.conda
linux-ppc64le::arrow-cpp-9.0.0-py311h28f6f3b_41_cpu.conda
linux-ppc64le::libarrow-11.0.0-h233d34d_25_cuda.conda
linux-ppc64le::tiledb-2.15.3-h6820701_1.conda
linux-ppc64le::libgrpc-1.55.1-h1cf4055_0.conda
linux-ppc64le::arrow-cpp-9.0.0-py39h409e9a7_41_cuda.conda
linux-ppc64le::mapserver-8.0.1-py38h7d241c6_4.conda
linux-ppc64le::libadios2-2.8.3-mpi_mpich_hf621a72_7.conda
linux-ppc64le::mysql-connector-python-8.0.32-py310hacfde7c_0.conda
linux-ppc64le::libopencv-4.7.0-py311h5c29aea_5.conda
linux-ppc64le::arrow-cpp-9.0.0-py310hd3995a2_38_cpu.conda
linux-ppc64le::libarrow-10.0.1-hb1090c1_28_cuda.conda
linux-ppc64le::grpcio-1.55.1-py38hc2aed35_0.conda
linux-ppc64le::libadios2-2.8.3-mpi_mpich_h4691e52_6.conda
linux-ppc64le::vigra-1.11.1-py310h4e6cf5b_1045.conda
linux-ppc64le::libarrow-12.0.1-he0f22a4_1_cpu.conda
linux-ppc64le::arrow-cpp-9.0.0-py310h748d12d_40_cuda.conda
linux-ppc64le::vigra-1.11.1-py310haa9f0d8_1045.conda
linux-ppc64le::libgdal-3.7.0-hdae1ccb_4.conda
linux-ppc64le::pygame-2.5.0-py311h0cc10f5_0.conda
linux-ppc64le::libarrow-12.0.0-hb6cc026_8_cuda.conda
linux-ppc64le::arrow-cpp-9.0.0-py39he6f9d99_38_cuda.conda
linux-ppc64le::magic-8.3.403-h7eb73fb_0.conda
linux-ppc64le::pytables-3.8.0-py39hdfa34b5_2.conda
linux-ppc64le::libllvm16-16.0.6-h8d57982_0.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-he792b03_37.conda
linux-ppc64le::llvmlite-0.40.1-py310h8eb8f48_0.conda
linux-ppc64le::openbabel-3.1.1-py39hd0e508d_6.conda
linux-ppc64le::lxml-4.9.2-py39h9d2759b_1.conda
linux-ppc64le::mysql-router-8.0.33-hf77073f_0.conda
linux-ppc64le::netcdf4-1.6.4-mpi_openmpi_py38hd5c26d6_1.conda
linux-ppc64le::linux-perf-6.3.10-py38h5192f5b_0.conda
linux-ppc64le::pyreadstat-1.2.2-py311he2df201_0.conda
linux-ppc64le::python-3.10.12-h4005451_0_cpython.conda
linux-ppc64le::libmatio-1.5.23-h78dc06f_3.conda
linux-ppc64le::libadios2-2.8.3-mpi_openmpi_h8549cef_7.conda
linux-ppc64le::pyinstaller-5.12.0-py39hf0cda86_0.conda
linux-ppc64le::yarp-cxx-3.8.0-h2b8ed06_3.conda
linux-ppc64le::libgdal-3.6.4-hd68c762_6.conda
linux-ppc64le::libarrow-12.0.1-hd997030_1_cpu.conda
linux-ppc64le::libarrow-11.0.0-hf5cad51_24_cpu.conda
linux-ppc64le::libadios2-2.8.3-nompi_h2eb769f_107.conda
linux-ppc64le::arrow-cpp-9.0.0-py311had80eb3_39_cuda.conda
linux-ppc64le::ffmpeg-6.0.0-lgpl_h230c217_3.conda
linux-ppc64le::libarrow-12.0.0-ha4e96a5_6_cuda.conda
linux-ppc64le::pygame-2.5.0-py38h00f7aa6_0.conda
linux-ppc64le::linux-perf-6.3.7-py311h52552ba_0.conda
linux-ppc64le::folly-2023.06.08.00-h864cb69_0_jemalloc.conda
linux-ppc64le::libarrow-11.0.0-haa6df50_26_cuda.conda
linux-ppc64le::magic-8.3.402-h7eb73fb_0.conda
linux-ppc64le::pyhdf-0.11.3-py39h031b9fc_0.conda
linux-ppc64le::libadios2-2.8.3-mpi_mpich_h21a48e4_6.conda
linux-ppc64le::cargo-patch-0.3.1-h140379e_0.conda
linux-ppc64le::tiledb-2.15.4-h6820701_0.conda
linux-ppc64le::libarrow-11.0.0-ha4e96a5_24_cuda.conda
linux-ppc64le::libgdal-arrow-parquet-3.6.4-h6de8242_6.conda
linux-ppc64le::pygplates-0.39-py310hfc78093_8.conda
linux-ppc64le::libarrow-10.0.1-h8a45fd1_26_cpu.conda
linux-ppc64le::libopencv-4.7.0-py39h679112a_5.conda
linux-ppc64le::libopencv-4.7.0-py39hbe4f659_5.conda
linux-ppc64le::libopencv-4.7.0-py38h50c82a0_5.conda
linux-ppc64le::netcdf4-1.6.4-mpi_openmpi_py311h6777d5d_0.conda
linux-ppc64le::llvm-16.0.6-h381f82a_0.conda
linux-ppc64le::linux-perf-6.3.10-py310hbf4c414_0.conda
linux-ppc64le::pyhdf-0.11.3-py38h86af889_0.conda
linux-ppc64le::linux-perf-6.3.8-py38h5192f5b_0.conda
linux-ppc64le::vtk-base-9.2.6-qt_py38h1234567_207.conda
linux-ppc64le::omniorb-4.2.5-py38h39d38ac_7.conda
linux-ppc64le::xrootd-5.5.4-py311h4bc39fc_1.conda
linux-ppc64le::libnetcdf-4.9.2-mpi_openmpi_h5470c62_6.conda
linux-ppc64le::arrow-cpp-9.0.0-py310hfa7926d_39_cpu.conda
linux-ppc64le::orc-1.8.4-hdbada09_0.conda
linux-ppc64le::vtk-base-9.2.6-qt_py39h1234567_207.conda
linux-ppc64le::nginx-1.25.1-hd111a0b_2.conda
linux-ppc64le::orc-1.9.0-hdbada09_0.conda
linux-ppc64le::llvm-16.0.5-h381f82a_0.conda
linux-ppc64le::libarrow-11.0.0-hb76745c_25_cpu.conda
linux-ppc64le::mlir-16.0.6-hae84d68_0.conda
linux-ppc64le::vigra-1.11.1-py38h4d7ddd8_1045.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-h0d76a71_36.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-hc945107_37.conda
linux-ppc64le::linux-perf-6.3.7-py39he243d86_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.0-hca4c3c0_2.conda
linux-ppc64le::libssh2-static-1.11.0-hb363fe5_0.conda
linux-ppc64le::libopencv-4.7.0-py39h7d88c0c_5.conda
linux-ppc64le::wxwidgets-3.2.2.1-h3f3c8dc_3.conda
linux-ppc64le::folly-2023.06.08.00-hca43526_0_jemalloc.conda
linux-ppc64le::libarrow-12.0.0-hf5cad51_6_cpu.conda
linux-ppc64le::libarrow-12.0.0-h86b2077_8_cpu.conda
linux-ppc64le::arrow-cpp-9.0.0-py39hf2dcfa6_39_cuda.conda
linux-ppc64le::orc-1.8.3-h4d9d82a_1.conda
linux-ppc64le::xrootd-5.5.4-py310hc98085c_1.conda
linux-ppc64le::arrow-cpp-9.0.0-py311hbf3834d_40_cuda.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-hfa361c1_36.conda
linux-ppc64le::magic-8.3.406-h7eb73fb_0.conda
linux-ppc64le::libpulsar-3.2.0-h14e0310_1.conda
linux-ppc64le::qtwebkit-5.212-h360db41_12.conda
linux-ppc64le::netcdf4-1.6.4-mpi_openmpi_py310hc1346b2_0.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-hfa361c1_37.conda
linux-ppc64le::vtk-base-9.2.6-qt_py311h1234567_207.conda
linux-ppc64le::tiledb-2.15.4-h5fbc0c9_0.conda
linux-ppc64le::libadios2-2.8.3-mpi_openmpi_hafc2a7d_6.conda
linux-ppc64le::libarrow-10.0.1-haa6df50_30_cuda.conda
linux-ppc64le::libarrow-10.0.1-hb76745c_29_cpu.conda
linux-ppc64le::mysql-router-8.0.32-hf77073f_3.conda
linux-ppc64le::folly-2023.06.26.00-h361900a_0.conda
linux-ppc64le::arrow-cpp-9.0.0-py311h67a0f71_38_cpu.conda
linux-ppc64le::libadios2-2.8.3-mpi_mpich_hb82a6bd_6.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-h3326213_37.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-h9370f0f_37.conda
linux-ppc64le::openbabel-3.1.1-py38h6b41003_6.conda
linux-ppc64le::xrootd-5.5.4-py39h54b5dd5_1.conda
linux-ppc64le::libadios2-2.8.3-mpi_mpich_h09aab29_7.conda
linux-ppc64le::gnupg1-1.4.23-h20ae9e4_0.conda
linux-ppc64le::llvm-openmp-16.0.5-h8759ddb_0.conda
linux-ppc64le::mysql-connector-python-8.0.32-py38h708c479_0.conda
linux-ppc64le::vigra-1.11.1-py39h4d61f62_1045.conda
linux-ppc64le::openbabel-3.1.1-py311h62e3513_7.conda
linux-ppc64le::pygplates-0.39-py311h50e23a6_8.conda
linux-ppc64le::hdf5-1.14.1-mpi_openmpi_hf8c4a79_0.conda
linux-ppc64le::vigra-1.11.1-py311hf0cba7b_1045.conda
linux-ppc64le::gst-plugins-base-1.22.4-hb6c1c46_0.conda
linux-ppc64le::netcdf4-1.6.4-nompi_py38h1f02fb4_100.conda
linux-ppc64le::libarrow-11.0.0-hd5a762c_26_cpu.conda
linux-ppc64le::llvm-openmp-16.0.6-h8759ddb_0.conda
linux-ppc64le::arrow-cpp-9.0.0-py311he8a8e47_39_cpu.conda
linux-ppc64le::arrow-cpp-9.0.0-py38hf09cf0f_39_cpu.conda
linux-ppc64le::llvm-tools-16.0.6-h8d57982_0.conda
linux-ppc64le::grpcio-1.55.1-py311h3997ded_0.conda
linux-ppc64le::pygplates-0.39-py38hdbc0118_8.conda
linux-ppc64le::libadios2-2.8.3-nompi_h74f674e_107.conda
linux-ppc64le::lxml-4.9.2-py311h1860687_1.conda
linux-ppc64le::libopencv-4.7.0-py310hc40daf1_5.conda
linux-ppc64le::omniorb-4.2.5-py39h0a3bc98_7.conda
linux-ppc64le::libgdal-3.7.0-ha318c2b_2.conda
linux-ppc64le::grpcio-1.55.1-py38hc2aed35_1.conda
linux-ppc64le::libssh2-1.11.0-hb363fe5_0.conda
linux-ppc64le::r-git2r-0.31.0-r42h984f8ce_1.conda
linux-ppc64le::mysql-connector-python-8.0.32-py39hceab3dc_0.conda
linux-ppc64le::omniorb-4.2.5-py311h7f187ac_7.conda
linux-ppc64le::pytables-3.8.0-py38hd080621_2.conda
linux-ppc64le::imagemagick-7.1.1_12-pl5321hc264ee1_0.conda
linux-ppc64le::libopencv-4.7.0-py38hda3e363_5.conda
linux-ppc64le::openbabel-3.1.1-py39hd0e508d_7.conda
linux-ppc64le::libarrow-12.0.0-h23a40c2_5_cuda.conda
linux-ppc64le::mysql-libs-8.0.32-h3ac40eb_3.conda
linux-ppc64le::linux-perf-6.3.9-py39he243d86_0.conda
linux-ppc64le::vigra-1.11.1-py38hf3480cd_1045.conda
linux-ppc64le::libadios2-2.8.3-nompi_h8b6e0a5_106.conda
linux-ppc64le::arrow-cpp-9.0.0-py38h603e6b9_37_cuda.conda
linux-ppc64le::vigra-1.11.1-py39h56b29a3_1045.conda
linux-ppc64le::folly-2023.06.26.00-hfccd340_0_jemalloc.conda
linux-ppc64le::libopencv-4.7.0-py39hc18d2f5_5.conda
linux-ppc64le::nco-5.1.6-h284e5aa_1.conda
linux-ppc64le::arrow-cpp-9.0.0-py311h67a0f71_37_cpu.conda
linux-ppc64le::libarrow-10.0.1-hb1090c1_27_cuda.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-h0d76a71_37.conda
linux-ppc64le::netcdf4-1.6.4-nompi_py310hfbad956_101.conda
linux-ppc64le::arrow-cpp-9.0.0-py311h665cc94_41_cuda.conda
linux-ppc64le::smesh-9.9.0.0-h739d9a8_5.conda
linux-ppc64le::libopencv-4.7.0-py310h42e93dd_5.conda
linux-ppc64le::tiledb-2.15.3-h5fbc0c9_2.conda
linux-ppc64le::grpcio-1.56.0-py310h8eb8f48_1.conda
linux-ppc64le::tiledb-2.15.3-h5fbc0c9_1.conda
linux-ppc64le::libarrow-12.0.0-hb76745c_8_cpu.conda
linux-ppc64le::tiledb-2.15.3-h6820701_2.conda
linux-ppc64le::r-git2r-0.31.0-r43h984f8ce_1.conda
linux-ppc64le::libllvm16-16.0.5-h8d57982_0.conda
linux-ppc64le::magic-8.3.404-h7eb73fb_0.conda
linux-ppc64le::netcdf4-1.6.4-mpi_mpich_py39h3b11998_0.conda
linux-ppc64le::arrow-cpp-9.0.0-py310hd3995a2_37_cpu.conda
linux-ppc64le::pyreadstat-1.2.2-py39h27550c1_0.conda
linux-ppc64le::libadios2-2.8.3-mpi_openmpi_hde96d59_6.conda
linux-ppc64le::eccodes-2.30.2-he961d41_0.conda
linux-ppc64le::libarrow-10.0.1-h08ef003_28_cpu.conda
linux-ppc64le::hdf5-1.14.1-nompi_hda2ee07_100.conda
linux-ppc64le::libarrow-12.0.0-h61679c5_9_cpu.conda
linux-ppc64le::libadios2-2.8.3-mpi_mpich_ha9b5181_7.conda
linux-ppc64le::vigra-1.11.1-py39h2dfb6fe_1045.conda
linux-ppc64le::netcdf4-1.6.4-nompi_py311h01f477c_100.conda
linux-ppc64le::pyinstaller-5.12.0-py38h36029d9_1.conda
linux-ppc64le::arrow-cpp-9.0.0-py38h86459a5_39_cuda.conda
linux-ppc64le::vtk-base-9.2.6-qt_py310h1234567_207.conda
linux-ppc64le::libadios2-2.8.3-nompi_hdf74c8b_106.conda
linux-ppc64le::graphicsmagick-1.3.40-h699e8ef_2.conda
linux-ppc64le::libspatialite-5.0.1-ha121984_27.conda
linux-ppc64le::llvmlite-0.40.1-py38h5641305_0.conda
linux-ppc64le::libadios2-2.8.3-mpi_openmpi_ha7812b6_7.conda
linux-ppc64le::adios-1.13.1-mpi_openmpi_h3f91229_1022.conda
linux-ppc64le::yarp-cxx-3.8.1-h7ae4908_0.conda
linux-ppc64le::ffmpeg-6.0.0-lgpl_h85294de_2.conda
linux-ppc64le::ffmpeg-6.0.0-gpl_h982fb22_103.conda
linux-ppc64le::grpcio-1.56.0-py39h278787b_1.conda
linux-ppc64le::libopencv-4.7.0-py38he4452ef_5.conda
linux-ppc64le::gst-plugins-bad-1.22.4-hb89a448_0.conda
linux-ppc64le::libarrow-12.0.0-ha4e96a5_7_cuda.conda
linux-ppc64le::arrow-cpp-9.0.0-py38h36aef69_41_cuda.conda
linux-ppc64le::vigra-1.11.1-py311he17b585_1045.conda
linux-ppc64le::libadios2-2.8.3-mpi_mpich_h7ff6528_6.conda
linux-ppc64le::netcdf4-1.6.4-mpi_openmpi_py39h5d37a95_1.conda
linux-ppc64le::netcdf4-1.6.4-nompi_py39h91c685d_100.conda
linux-ppc64le::octave-8.2.0-h2f412ae_1.conda
linux-ppc64le::arrow-cpp-9.0.0-py39hf97f201_40_cuda.conda
linux-ppc64le::libarrow-12.0.1-h1e2c587_1_cuda.conda
linux-ppc64le::libgdal-3.6.4-ha9ed8dd_5.conda
linux-ppc64le::hdf5-1.14.1-mpi_mpich_h4d8530d_0.conda
linux-ppc64le::llvmdev-14.0.6-hf7e7dc2_3.conda
linux-ppc64le::vigra-1.11.1-py39h160a1ce_1045.conda
linux-ppc64le::gstlal-1.11.0-py311h96b2c23_0.conda
linux-ppc64le::libopencv-4.7.0-py310ha028324_5.conda
linux-ppc64le::mysql-client-8.0.33-hfff87ee_0.conda
linux-ppc64le::linux-perf-6.3.9-py311h52552ba_0.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-hd03bfc2_37.conda
linux-ppc64le::libadios2-2.8.3-nompi_hd65b43d_107.conda
linux-ppc64le::netcdf4-1.6.4-mpi_openmpi_py311h5a5a4ba_1.conda
linux-ppc64le::llvmdev-16.0.5-h7c8ec72_0.conda
linux-ppc64le::pyreadstat-1.2.2-py38h2b47b73_0.conda
linux-ppc64le::netcdf4-1.6.4-mpi_mpich_py310h5f3b200_1.conda
linux-ppc64le::libthrift-0.18.1-h81b47c4_2.conda
linux-ppc64le::gstlal-1.11.0-py310hc00f107_0.conda
linux-ppc64le::pygplates-0.39-py39h7c66940_8.conda
linux-ppc64le::python-3.8.17-h062392f_0_cpython.conda
linux-ppc64le::r-data.table-1.14.8-r42hb163d15_2.conda
linux-ppc64le::arrow-cpp-9.0.0-py39h5e67918_37_cpu.conda
linux-ppc64le::libnetcdf-4.9.2-mpi_mpich_hd2aeaef_6.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-he792b03_36.conda
linux-ppc64le::vtk-base-9.2.6-qt_py38h1234567_208.conda
linux-ppc64le::arrow-cpp-9.0.0-py39h5e67918_38_cpu.conda
linux-ppc64le::arrow-cpp-9.0.0-py38hec0d8d2_38_cuda.conda
linux-ppc64le::lxml-4.9.2-py38h6e2f636_1.conda
linux-ppc64le::libarrow-12.0.0-hd5a762c_9_cpu.conda
linux-ppc64le::folly-2023.06.12.00-hd692e58_1.conda
linux-ppc64le::tiledb-2.15.4-heedfb45_1.conda
linux-ppc64le::libarrow-11.0.0-ha4e96a5_23_cuda.conda
linux-ppc64le::libarrow-11.0.0-h23a40c2_22_cuda.conda
linux-ppc64le::grpcio-1.55.1-py311h3997ded_1.conda
linux-ppc64le::tiledb-2.15.4-h5fbc0c9_1.conda
linux-ppc64le::netcdf4-1.6.4-mpi_mpich_py38hc430146_1.conda
linux-ppc64le::folly-2023.06.12.00-h361900a_0.conda
linux-ppc64le::grpcio-1.56.0-py311h3997ded_1.conda
linux-ppc64le::arrow-cpp-9.0.0-py310hfd498f8_40_cpu.conda
linux-ppc64le::mysql-router-8.0.32-hc4f5b10_3.conda
linux-ppc64le::linux-perf-6.3.9-py38h5192f5b_0.conda
linux-ppc64le::netcdf4-1.6.4-nompi_py311he759188_101.conda
linux-ppc64le::libarrow-12.0.1-hd5a762c_0_cpu.conda
linux-ppc64le::lxml-4.9.2-py38h12de51e_1.conda
linux-ppc64le::libopencv-4.7.0-py39hef11d34_5.conda
linux-ppc64le::arrow-cpp-9.0.0-py39h16e9256_41_cpu.conda
linux-ppc64le::xrootd-5.5.4-py38h8ecbf98_1.conda
linux-ppc64le::orc-1.8.4-h4d9d82a_0.conda
linux-ppc64le::openbabel-3.1.1-py311h62e3513_6.conda
linux-ppc64le::mysql-server-8.0.32-h3aa03ee_3.conda
linux-ppc64le::arrow-cpp-9.0.0-py38h869d914_38_cpu.conda
linux-ppc64le::linux-perf-6.3.9-py310hbf4c414_0.conda
linux-ppc64le::yarp-cxx-3.8.0-h7ae4908_3.conda
linux-ppc64le::folly-2023.06.12.00-h361900a_1.conda
linux-ppc64le::linux-perf-6.3.7-py38h5192f5b_0.conda
linux-ppc64le::arrow-cpp-9.0.0-py311hdc66dd3_40_cpu.conda
linux-ppc64le::vtk-base-9.2.6-qt_py310h1234567_208.conda
linux-ppc64le::lxml-4.9.2-py310h0e28d95_1.conda
linux-ppc64le::libgdal-3.7.0-h3148ac5_3.conda
linux-ppc64le::libadios2-2.8.3-nompi_h28a6e12_106.conda
linux-ppc64le::netcdf4-1.6.4-mpi_mpich_py311h87e6ca2_0.conda
linux-ppc64le::orc-1.9.0-h4d9d82a_0.conda
linux-ppc64le::netcdf4-1.6.4-nompi_py39he355a5b_101.conda
linux-ppc64le::tiledb-2.15.3-h4dc2441_1.conda
linux-ppc64le::netcdf4-1.6.4-mpi_openmpi_py39h748ed34_0.conda
linux-ppc64le::r-data.table-1.14.8-r43hb163d15_2.conda
linux-ppc64le::tiledb-2.15.4-h6820701_1.conda
linux-ppc64le::libopencv-4.7.0-py39hf1fdee9_5.conda
linux-ppc64le::libopencv-4.7.0-py311ha8eaab4_5.conda
linux-ppc64le::pyhdf-0.11.3-py311h68f7c1f_0.conda
linux-ppc64le::pyinstaller-5.12.0-py38h36029d9_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.0-h5ab8e83_3.conda
linux-ppc64le::libarrow-10.0.1-he0f22a4_31_cpu.conda
linux-ppc64le::pytables-3.8.0-py310hc505468_2.conda
linux-ppc64le::llvmlite-0.40.1-py38hc2aed35_0.conda
linux-ppc64le::libopencv-4.7.0-py39h8e2efd5_5.conda
linux-ppc64le::libarrow-12.0.0-hf5cad51_7_cpu.conda
linux-ppc64le::gstlal-1.11.0-py38haac8a23_0.conda
linux-ppc64le::gstlal-1.11.0-py39hd494bf6_0.conda
linux-ppc64le::linux-perf-6.3.10-py39he243d86_0.conda
linux-ppc64le::libarrow-10.0.1-h08ef003_27_cpu.conda
linux-ppc64le::folly-2023.06.26.00-h864cb69_0_jemalloc.conda
linux-ppc64le::pygame-2.5.0-py38h2dab74b_0.conda
linux-ppc64le::linux-perf-6.3.8-py311h52552ba_0.conda
linux-ppc64le::tiledb-2.15.3-h4dc2441_2.conda
linux-ppc64le::eccodes-2.30.2-h611b61c_1.conda
linux-ppc64le::libarrow-10.0.1-h233d34d_29_cuda.conda
linux-ppc64le::folly-2023.06.08.00-ha231c81_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.6.4-h3f83a6e_4.conda
linux-ppc64le::mesalib-23.1.2-hb6f7a19_0.conda
linux-ppc64le::mysql-router-8.0.33-hc4f5b10_0.conda
linux-ppc64le::libgrpc-1.56.0-hae00bc5_1.conda
linux-ppc64le::arrow-cpp-9.0.0-py310h3bec3f2_39_cuda.conda
linux-ppc64le::grpcio-1.56.0-py38hc2aed35_1.conda
linux-ppc64le::llvmlite-0.40.1-py39h27cb1e9_0.conda
linux-ppc64le::libarrow-11.0.0-hf5cad51_23_cpu.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-hd03bfc2_36.conda
linux-ppc64le::libtiff-4.5.1-h50938e9_0.conda
linux-ppc64le::pyinstaller-5.12.0-py310h0719273_1.conda
linux-ppc64le::ffmpeg-5.1.2-lgpl_hc9fb987_11.conda
linux-ppc64le::libadios2-2.8.3-nompi_h2e7e547_107.conda
linux-ppc64le::libarrow-11.0.0-hb984a1a_22_cpu.conda
linux-ppc64le::libopencv-4.7.0-py39hd6d3313_5.conda
linux-ppc64le::magic-8.3.409-h7eb73fb_0.conda
linux-ppc64le::libarrow-12.0.1-h61679c5_0_cpu.conda
linux-ppc64le::lld-16.0.5-he12c2f4_0.conda
linux-ppc64le::grpcio-1.55.1-py39h278787b_0.conda
linux-ppc64le::pyhdf-0.11.3-py38he5ba4bc_0.conda
linux-ppc64le::netcdf4-1.6.4-mpi_mpich_py311h40722ce_1.conda
linux-ppc64le::arrow-cpp-9.0.0-py310h68fdf8a_37_cuda.conda
linux-ppc64le::pygame-2.5.0-py39h0c599e8_0.conda
linux-ppc64le::rust-1.70.0-hb12b0c0_0.conda
linux-ppc64le::libarrow-12.0.1-hcc49858_0_cuda.conda
linux-ppc64le::grpcio-1.55.1-py310h8eb8f48_1.conda
linux-ppc64le::ffmpeg-6.0.0-gpl_hf8eafcc_102.conda
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
================================================================================
================================================================================
linux-aarch64
linux-aarch64::llvm-tools-14.0.6-h966f666_3.conda
linux-aarch64::llvm-spirv-15.0.0-hb3b5123_0.conda
linux-aarch64::git-delta-0.16.4-h101c413_0.conda
linux-aarch64::liblal-7.3.1-fftw_h6b4c300_101.conda
linux-aarch64::libprotobuf-4.23.2-h6b51aa4_3.conda
linux-aarch64::git-delta-0.16.0-h101c413_0.conda
linux-aarch64::libv8-8.9.83-h2b0ceca_3.conda
linux-aarch64::cudnn-8.8.0.121-h9670b63_1.conda
linux-aarch64::libprotobuf-static-4.23.2-h6b51aa4_4.conda
linux-aarch64::metal-llvm-tools-15-0.5.1-h966f666_0.conda
linux-aarch64::micromamba-1.4.4-0.tar.bz2
linux-aarch64::openexr-3.1.8-hb924804_0.conda
linux-aarch64::eccodes-2.30.2-hdd3f537_0.conda
linux-aarch64::libsolv-0.7.24-h3cb9bc8_0.conda
linux-aarch64::nceplibs-g2c-1.7.0-hfb2e540_4.conda
linux-aarch64::libprotobuf-static-4.23.2-h6b51aa4_3.conda
linux-aarch64::micromamba-1.4.5-0.tar.bz2
linux-aarch64::imath-3.1.9-hd84c7bf_0.conda
linux-aarch64::libprotobuf-4.23.2-h6b51aa4_4.conda
linux-aarch64::libprotobuf-4.23.3-h6b51aa4_0.conda
linux-aarch64::libsolv-0.7.24-hd84c7bf_1.conda
linux-aarch64::openexr-3.1.7-hb924804_2.conda
linux-aarch64::libmlir16-16.0.5-h6acfec4_0.conda
linux-aarch64::libprotobuf-static-4.23.2-h6b51aa4_5.conda
linux-aarch64::gst-libav-1.22.4-hc4a16bf_0.conda
linux-aarch64::libmlir16-16.0.6-h6acfec4_0.conda
linux-aarch64::openexr-3.1.9-hb924804_0.conda
linux-aarch64::libmlir-16.0.5-h6acfec4_0.conda
linux-aarch64::eccodes-2.30.2-he7871a9_1.conda
linux-aarch64::libllvm14-14.0.6-h966f666_3.conda
linux-aarch64::libdap4-3.20.6-ha8b9582_3.conda
linux-aarch64::libsolv-static-0.7.24-h3cb9bc8_0.conda
linux-aarch64::gst-libav-1.22.4-hc93b6a6_0.conda
linux-aarch64::libsolv-static-0.7.24-hd84c7bf_1.conda
linux-aarch64::git-delta-0.16.5-h101c413_0.conda
linux-aarch64::adios-1.13.1-nompi_hc506e2b_1122.conda
linux-aarch64::libprotobuf-static-4.23.3-h6b51aa4_0.conda
linux-aarch64::llvm-14.0.6-h40ce709_3.conda
linux-aarch64::libmlir-16.0.6-h6acfec4_0.conda
linux-aarch64::cudnn-8.8.0.121-h053a8ab_1.conda
linux-aarch64::g2clib-1.7.0-hfb2e540_3.conda
linux-aarch64::libprotobuf-4.23.2-h6b51aa4_5.conda
linux-aarch64::libdap4-3.20.6-h0301e80_4.conda
-    "libzlib >=1.2.13,<1.3.0a0"
+    "libzlib >=1.2.13,<2.0.0a0"
linux-aarch64::folly-2023.06.08.00-hbf4f375_0_jemalloc.conda
linux-aarch64::fenics-libdolfin-2019.1.0-h1fc3836_37.conda
linux-aarch64::arrow-cpp-9.0.0-py311hee86f94_39_cpu.conda
linux-aarch64::ffmpeg-6.0.0-lgpl_he274252_2.conda
linux-aarch64::ffmpeg-6.0.0-gpl_h3aa3611_102.conda
linux-aarch64::arrow-cpp-9.0.0-py311h7386c77_38_cuda.conda
linux-aarch64::arrow-cpp-9.0.0-py311hb88efd2_40_cuda.conda
linux-aarch64::fenics-libdolfin-2019.1.0-hf0a5eb8_36.conda
linux-aarch64::vtk-base-9.2.6-qt_py311h1234567_208.conda
linux-aarch64::folly-2023.06.08.00-h8282163_0.conda
linux-aarch64::arrow-cpp-9.0.0-py39ha400e28_40_cpu.conda
linux-aarch64::pyhdf-0.11.3-py311h3c0e0ee_0.conda
linux-aarch64::libarrow-10.0.1-hbf0ba84_31_cuda.conda
linux-aarch64::mysql-server-8.0.33-h9e1a5d7_0.conda
linux-aarch64::ffmpeg-6.0.0-gpl_h6b43c64_103.conda
linux-aarch64::openbabel-3.1.1-py310h5178cfb_7.conda
linux-aarch64::magic-8.3.402-h4e13689_0.conda
linux-aarch64::libopencv-4.7.0-py38hc317e53_5.conda
linux-aarch64::mysql-connector-python-8.0.32-py38h8354cbf_0.conda
linux-aarch64::imagemagick-7.1.1_12-pl5321hac3f1fc_0.conda
linux-aarch64::arrow-cpp-9.0.0-py310hf3bbd57_39_cuda.conda
linux-aarch64::libopencv-4.7.0-py311h607048f_5.conda
linux-aarch64::libadios2-2.8.3-nompi_hea3dcde_107.conda
linux-aarch64::vigra-1.11.1-py38hac78c56_1045.conda
linux-aarch64::libgdal-3.7.0-h66f8d78_4.conda
linux-aarch64::folly-2023.06.12.00-h81a8a5e_1.conda
linux-aarch64::libarrow-10.0.1-h3d326dd_28_cuda.conda
linux-aarch64::libarrow-12.0.0-h901c870_5_cpu.conda
linux-aarch64::gnupg1-1.4.23-h9e69772_0.conda
linux-aarch64::netcdf4-1.6.4-mpi_mpich_py310h1b2b53a_0.conda
linux-aarch64::hdf5-1.14.1-mpi_mpich_hbf85d38_0.conda
linux-aarch64::libarrow-11.0.0-hefbe673_26_cpu.conda
linux-aarch64::vigra-1.11.1-py39he9eadbc_1045.conda
linux-aarch64::hdf5-1.14.1-nompi_ha486f32_100.conda
linux-aarch64::geotiff-1.7.1-h8619d26_9.conda
linux-aarch64::linux-perf-6.3.10-py38h696f14d_0.conda
linux-aarch64::orc-1.9.0-h4e271f3_0.conda
linux-aarch64::libopencv-4.7.0-py38hfa08d4a_5.conda
linux-aarch64::libarrow-12.0.1-hefbe673_0_cpu.conda
linux-aarch64::pygplates-0.39-py38h993b065_8.conda
linux-aarch64::omniorb-4.2.5-py38hececb54_7.conda
linux-aarch64::gstlal-1.11.0-py310h4d54d3c_0.conda
linux-aarch64::vigra-1.11.1-py39heffa411_1045.conda
linux-aarch64::ffmpeg-6.0.0-lgpl_hfb2b739_3.conda
linux-aarch64::libtiledb-sql-0.22.4-h22c4fd6_0.conda
linux-aarch64::linux-perf-6.3.7-py311h31656e8_0.conda
linux-aarch64::libadios2-2.8.3-mpi_openmpi_h55b2275_6.conda
linux-aarch64::mlir-16.0.6-h6acfec4_0.conda
linux-aarch64::libopencv-4.7.0-py39hd1c8b74_5.conda
linux-aarch64::lxml-4.9.2-py38h986c409_1.conda
linux-aarch64::arrow-cpp-9.0.0-py311h149deb6_37_cpu.conda
linux-aarch64::pygame-2.5.0-py38haf3f993_0.conda
linux-aarch64::arrow-cpp-9.0.0-py310h1c16a14_41_cuda.conda
linux-aarch64::fenics-libdolfin-2019.1.0-hf0a5eb8_37.conda
linux-aarch64::vtk-base-9.2.6-qt_py310h1234567_207.conda
linux-aarch64::qt6-main-6.5.1-hf4b49fe_1.conda
linux-aarch64::libarrow-10.0.1-h3d326dd_27_cuda.conda
linux-aarch64::libarrow-12.0.0-h71705c3_9_cuda.conda
linux-aarch64::fenics-libdolfin-2019.1.0-hbe34df9_36.conda
linux-aarch64::arrow-cpp-9.0.0-py39h54af4e0_37_cpu.conda
linux-aarch64::libadios2-2.8.3-mpi_openmpi_ha8cc6c4_6.conda
linux-aarch64::pygame-2.5.0-py38hfccb3c3_0.conda
linux-aarch64::mysql-connector-python-8.0.32-py311h7b38523_0.conda
linux-aarch64::linux-perf-6.3.10-py310h2bd01cc_0.conda
linux-aarch64::grpcio-1.55.1-py311h1a7908d_0.conda
linux-aarch64::tiledb-2.15.4-hddb64f1_0.conda
linux-aarch64::qtwebkit-5.212-h723af77_12.conda
linux-aarch64::mysql-libs-8.0.33-hf629957_0.conda
linux-aarch64::libarrow-12.0.0-hd573807_7_cuda.conda
linux-aarch64::arrow-cpp-9.0.0-py39h82d767e_39_cuda.conda
linux-aarch64::omniorb-libs-4.2.5-heb3f89f_7.conda
linux-aarch64::libarrow-12.0.1-hc9e4e54_1_cuda.conda
linux-aarch64::folly-2023.06.26.00-h81a8a5e_0.conda
linux-aarch64::netcdf4-1.6.4-mpi_openmpi_py39ha64410e_1.conda
linux-aarch64::libtiledb-sql-0.22.4-h886d7b1_1.conda
linux-aarch64::sagelib-10.0-py39h0c97323_1.conda
linux-aarch64::folly-2023.06.08.00-h81a8a5e_1.conda
linux-aarch64::nginx-1.25.1-h4005cde_2.conda
linux-aarch64::libadios2-2.8.3-mpi_mpich_h23f469b_6.conda
linux-aarch64::sagelib-10.0-py310h055e31b_1.conda
linux-aarch64::libllvm16-16.0.5-h70e38ee_0.conda
linux-aarch64::libarrow-12.0.1-h7bc9c71_0_cuda.conda
linux-aarch64::libopencv-4.7.0-py310h7c0295a_5.conda
linux-aarch64::arrow-cpp-9.0.0-py39h39fd01c_37_cuda.conda
linux-aarch64::libopencv-4.7.0-py39h7f1c724_5.conda
linux-aarch64::jaxlib-0.4.12-cpu_py38hae599f4_1.conda
linux-aarch64::libarrow-11.0.0-h9b7a6d0_25_cpu.conda
linux-aarch64::fenics-libdolfin-2019.1.0-h89d0ad6_37.conda
linux-aarch64::libarrow-12.0.0-h7bc9c71_9_cuda.conda
linux-aarch64::pygame-2.5.0-py39h2cc5182_0.conda
linux-aarch64::lld-16.0.5-h8ef0f76_0.conda
linux-aarch64::grpcio-1.56.0-py39h483cef1_1.conda
linux-aarch64::libssh2-static-1.11.0-h492db2e_0.conda
linux-aarch64::libspatialite-5.0.1-hd284395_27.conda
linux-aarch64::libopencv-4.7.0-py39hd7a3968_5.conda
linux-aarch64::netcdf4-1.6.4-mpi_mpich_py311hb65dd6b_0.conda
linux-aarch64::llvm-openmp-16.0.5-h8b0cb96_0.conda
linux-aarch64::libpulsar-3.2.0-hc0c0eab_1.conda
linux-aarch64::fenics-libdolfin-2019.1.0-hb403dcd_37.conda
linux-aarch64::pyinstaller-5.12.0-py311h0dd4530_1.conda
linux-aarch64::arrow-cpp-9.0.0-py39h54af4e0_38_cpu.conda
linux-aarch64::libtiledb-sql-0.22.4-he661781_0.conda
linux-aarch64::libopencv-4.7.0-py311h7ecd498_5.conda
linux-aarch64::arrow-cpp-9.0.0-py310hb49a538_41_cpu.conda
linux-aarch64::lxml-4.9.2-py310h4ea8894_1.conda
linux-aarch64::netcdf4-1.6.4-nompi_py311h4b3d20a_101.conda
linux-aarch64::magic-8.3.401-h4e13689_0.conda
linux-aarch64::pytables-3.8.0-py38hf64af7f_2.conda
linux-aarch64::libarrow-12.0.1-hd3ea93b_1_cpu.conda
linux-aarch64::netcdf4-1.6.4-mpi_openmpi_py310h3e4a870_0.conda
linux-aarch64::pyinstaller-5.12.0-py38h37f3631_0.conda
linux-aarch64::libarrow-10.0.1-h834fc4b_26_cpu.conda
linux-aarch64::orc-1.8.4-h4e271f3_0.conda
linux-aarch64::llvmlite-0.40.1-py38h95a9722_0.conda
linux-aarch64::pygame-2.5.0-py310hdb26448_0.conda
linux-aarch64::mysql-client-8.0.32-h88b4a5d_3.conda
linux-aarch64::libarrow-10.0.1-h9b7a6d0_29_cpu.conda
linux-aarch64::netcdf4-1.6.4-mpi_openmpi_py39h2acd2b5_0.conda
linux-aarch64::tiledb-2.15.4-h782a210_1.conda
linux-aarch64::libgdal-3.7.0-h574206e_2.conda
linux-aarch64::libadios2-2.8.3-nompi_h0ea5f15_107.conda
linux-aarch64::lxml-4.9.2-py38h38730af_1.conda
linux-aarch64::r-git2r-0.31.0-r43h635aefc_1.conda
linux-aarch64::libarrow-12.0.0-h2e06495_7_cpu.conda
linux-aarch64::libarrow-10.0.1-h6aec937_29_cuda.conda
linux-aarch64::pygplates-0.39-py39h18f3461_8.conda
linux-aarch64::aws-sdk-cpp-1.10.57-h4eeedb6_14.conda
linux-aarch64::vtk-base-9.2.6-qt_py39h1234567_208.conda
linux-aarch64::lld-16.0.6-h8ef0f76_0.conda
linux-aarch64::pygplates-0.39-py310ha256b62_8.conda
linux-aarch64::libopencv-4.7.0-py311hdf06407_5.conda
linux-aarch64::mapserver-8.0.1-py310h068a74e_4.conda
linux-aarch64::libopencv-4.7.0-py310h5a9acf9_5.conda
linux-aarch64::netcdf4-1.6.4-mpi_openmpi_py38ha5c16f1_0.conda
linux-aarch64::pyinstaller-5.12.0-py39hb91f966_0.conda
linux-aarch64::pyinstaller-5.13.0-py311h0dd4530_0.conda
linux-aarch64::smesh-9.9.0.0-he73c767_5.conda
linux-aarch64::libgrpc-1.55.1-haa74edf_1.conda
linux-aarch64::libadios2-2.8.3-nompi_h0d0f302_106.conda
linux-aarch64::libopencv-4.7.0-py39h6175bb5_5.conda
linux-aarch64::yarp-cxx-3.8.0-h09f7a61_3.conda
linux-aarch64::arrow-cpp-9.0.0-py311h7510ee1_40_cpu.conda
linux-aarch64::linux-perf-6.3.7-py39hc5e4ac8_0.conda
linux-aarch64::magic-8.3.409-h4e13689_0.conda
linux-aarch64::folly-2023.06.08.00-hdd3c17f_1_jemalloc.conda
linux-aarch64::linux-perf-6.3.10-py311h31656e8_0.conda
linux-aarch64::netcdf4-1.6.4-mpi_openmpi_py38h0853973_1.conda
linux-aarch64::thrift-compiler-0.18.1-h0035360_2.conda
linux-aarch64::netcdf4-1.6.4-mpi_openmpi_py311h85c86a4_1.conda
linux-aarch64::netcdf4-1.6.4-mpi_mpich_py39h9bcdee9_0.conda
linux-aarch64::fenics-libdolfin-2019.1.0-hbe34df9_37.conda
linux-aarch64::libopencv-4.7.0-py39h6588cf7_5.conda
linux-aarch64::libgdal-3.6.4-ha6e6945_5.conda
linux-aarch64::libarrow-11.0.0-h2e06495_24_cpu.conda
linux-aarch64::netcdf4-1.6.4-nompi_py310hb677a65_101.conda
linux-aarch64::arrow-cpp-9.0.0-py39h401521d_41_cpu.conda
linux-aarch64::libadios2-2.8.3-nompi_h3b6d28f_106.conda
linux-aarch64::libgdal-arrow-parquet-3.6.4-h5cc525d_6.conda
linux-aarch64::mysql-router-8.0.33-h1f5bcb8_0.conda
linux-aarch64::libarrow-12.0.1-hd466f35_0_cpu.conda
linux-aarch64::nginx-1.25.1-h4005cde_1.conda
linux-aarch64::libarrow-10.0.1-hf50a860_31_cpu.conda
linux-aarch64::llvmlite-0.40.1-py311h1a7908d_0.conda
linux-aarch64::arrow-cpp-9.0.0-py311h0521946_41_cpu.conda
linux-aarch64::pytables-3.8.0-py310hfc55967_2.conda
linux-aarch64::orc-1.8.3-h4e271f3_1.conda
linux-aarch64::libopencv-4.7.0-py38hacece6b_5.conda
linux-aarch64::openbabel-3.1.1-py39h5704ccc_7.conda
linux-aarch64::mesalib-23.1.3-h5f6ae44_0.conda
linux-aarch64::folly-2023.06.12.00-h81a8a5e_0.conda
linux-aarch64::folly-2023.06.26.00-hdd3c17f_0_jemalloc.conda
linux-aarch64::libarrow-11.0.0-h2e06495_23_cpu.conda
linux-aarch64::llvmdev-16.0.5-hc720cd8_0.conda
linux-aarch64::jaxlib-0.4.12-cpu_py311h8c5eb01_1.conda
linux-aarch64::r-git2r-0.31.0-r42h635aefc_1.conda
linux-aarch64::pytables-3.8.0-py38ha6379ce_2.conda
linux-aarch64::pyhdf-0.11.3-py39h53b51e4_0.conda
linux-aarch64::libgdal-3.6.4-h4aa0f85_4.conda
linux-aarch64::fenics-libdolfin-2019.1.0-hb403dcd_36.conda
linux-aarch64::arrow-cpp-9.0.0-py310h7babe43_38_cuda.conda
linux-aarch64::libopencv-4.7.0-py39h93c7af4_5.conda
linux-aarch64::arrow-cpp-9.0.0-py311he90cef1_41_cuda.conda
linux-aarch64::libgdal-3.6.4-heeb126f_6.conda
linux-aarch64::pygame-2.5.0-py311h2184b1c_0.conda
linux-aarch64::lxml-4.9.2-py39h03c8186_1.conda
linux-aarch64::pyhdf-0.11.3-py310hbc5335f_0.conda
linux-aarch64::vigra-1.11.1-py311hbda2dab_1045.conda
linux-aarch64::libpulsar-3.2.0-ha39ba29_1.conda
linux-aarch64::wxwidgets-3.2.2.1-h976fe2f_3.conda
linux-aarch64::libadios2-2.8.3-mpi_openmpi_h43838fa_7.conda
linux-aarch64::netcdf4-1.6.4-mpi_mpich_py38hc511f32_1.conda
linux-aarch64::libxmlsec1-1.3.1-h7ef0265_0.conda
linux-aarch64::vigra-1.11.1-py38hd8fcf87_1045.conda
linux-aarch64::openbabel-3.1.1-py38hcc4b432_6.conda
linux-aarch64::folly-2023.06.26.00-hbf4f375_0_jemalloc.conda
linux-aarch64::netcdf4-1.6.4-nompi_py38h62dc7ff_100.conda
linux-aarch64::libarrow-12.0.1-hbf0ba84_1_cuda.conda
linux-aarch64::llvm-tools-16.0.6-h70e38ee_0.conda
linux-aarch64::mysql-router-8.0.32-h1f5bcb8_3.conda
linux-aarch64::tiledb-2.15.4-hc0eaa86_0.conda
linux-aarch64::vigra-1.11.1-py38hb1129ce_1045.conda
linux-aarch64::sagelib-10.0-py311he22122c_1.conda
linux-aarch64::libarrow-11.0.0-h7bc9c71_26_cuda.conda
linux-aarch64::r-data.table-1.14.8-r43hb4ebc13_2.conda
linux-aarch64::linux-perf-6.3.9-py310h2bd01cc_0.conda
linux-aarch64::netcdf4-1.6.4-mpi_mpich_py310h9a3eb35_1.conda
linux-aarch64::libadios2-2.8.3-mpi_openmpi_hb1c773f_6.conda
linux-aarch64::fenics-libdolfin-2019.1.0-h28dc1fa_37.conda
linux-aarch64::jaxlib-0.4.12-cpu_py310hc16dadb_1.conda
linux-aarch64::xrootd-5.5.4-py38hca82f46_1.conda
linux-aarch64::grpcio-1.55.1-py39h483cef1_1.conda
linux-aarch64::rust-1.70.0-h9d3d833_0.conda
linux-aarch64::python-3.8.17-ha43d526_0_cpython.conda
linux-aarch64::tiledb-2.15.3-h97f58e1_2.conda
linux-aarch64::vtk-base-9.2.6-qt_py39h1234567_207.conda
linux-aarch64::arrow-cpp-9.0.0-py38h933c346_39_cpu.conda
linux-aarch64::arrow-cpp-9.0.0-py310hb3151fd_39_cpu.conda
linux-aarch64::jaxlib-0.4.12-cpu_py39hb57d1a0_1.conda
linux-aarch64::libopencv-4.7.0-py310h01197f5_5.conda
linux-aarch64::llvm-16.0.5-h5271726_0.conda
linux-aarch64::arrow-cpp-9.0.0-py38h39d7424_40_cuda.conda
linux-aarch64::libadios2-2.8.3-mpi_mpich_h34b7990_7.conda
linux-aarch64::omniorb-4.2.5-py39h847cd71_7.conda
linux-aarch64::libarrow-11.0.0-hd573807_24_cuda.conda
linux-aarch64::pyinstaller-5.13.0-py310h1aab166_0.conda
linux-aarch64::vigra-1.11.1-py310hc53198d_1045.conda
linux-aarch64::ntbtls-0.3.1-hd84c7bf_1.conda
linux-aarch64::linux-perf-6.3.9-py311h31656e8_0.conda
linux-aarch64::pdal-2.5.5-hff47823_0.conda
linux-aarch64::linux-perf-6.3.7-py38h696f14d_0.conda
linux-aarch64::libarrow-12.0.0-h9b7a6d0_8_cpu.conda
linux-aarch64::adios-1.13.1-mpi_mpich_h99b6088_1022.conda
linux-aarch64::tiledb-2.15.3-hddb64f1_1.conda
linux-aarch64::pygplates-0.39-py311ha84991e_8.conda
linux-aarch64::llvmlite-0.40.1-py38h31dfe59_0.conda
linux-aarch64::mysql-libs-8.0.32-hf629957_3.conda
linux-aarch64::mysql-connector-python-8.0.32-py39hb32bc82_0.conda
linux-aarch64::fenics-libdolfin-2019.1.0-heb2beba_36.conda
linux-aarch64::linux-perf-6.3.8-py310h2bd01cc_0.conda
linux-aarch64::git-2.41.0-pl5321h0d979e1_0.conda
linux-aarch64::libopencv-4.7.0-py38hc70e684_5.conda
linux-aarch64::xrootd-5.5.4-py39h7ccaeba_1.conda
linux-aarch64::pyhdf-0.11.3-py38hbebd9ce_0.conda
linux-aarch64::magic-8.3.403-h4e13689_0.conda
linux-aarch64::arrow-cpp-9.0.0-py38h655cdd8_37_cuda.conda
linux-aarch64::netcdf4-1.6.4-mpi_mpich_py39h62edb6a_1.conda
linux-aarch64::omniorb-4.2.5-py311h8274deb_7.conda
linux-aarch64::linux-perf-6.3.10-py39hc5e4ac8_0.conda
linux-aarch64::arrow-cpp-9.0.0-py310h231a77c_40_cpu.conda
linux-aarch64::sagelib-10.0-py38h66bba7d_1.conda
linux-aarch64::vigra-1.11.1-py310h1ba3d84_1045.conda
linux-aarch64::grpcio-1.55.1-py38h95a9722_0.conda
linux-aarch64::libarrow-12.0.0-hb56d620_8_cuda.conda
linux-aarch64::llvmlite-0.40.1-py39h2ec6326_0.conda
linux-aarch64::yarp-cxx-3.8.1-h4c076a4_0.conda
linux-aarch64::libarrow-12.0.1-h71705c3_0_cuda.conda
linux-aarch64::libadios2-2.8.3-nompi_h7b74588_107.conda
linux-aarch64::orc-1.8.3-hc144153_1.conda
linux-aarch64::cargo-patch-0.3.1-h9fcd45d_0.conda
linux-aarch64::libarrow-10.0.1-ha2fa209_28_cpu.conda
linux-aarch64::libgdal-arrow-parquet-3.7.0-h5cb3e7d_4.conda
linux-aarch64::libarrow-12.0.0-h1ee5167_8_cpu.conda
linux-aarch64::mysql-client-8.0.33-h88b4a5d_0.conda
linux-aarch64::arrow-cpp-9.0.0-py311ha4a8f35_37_cuda.conda
linux-aarch64::python-3.10.12-hbbe8eec_0_cpython.conda
linux-aarch64::libnetcdf-4.9.2-nompi_h577d0dc_106.conda
linux-aarch64::folly-2023.06.12.00-hdd3c17f_0_jemalloc.conda
linux-aarch64::mysql-server-8.0.33-h06e55e8_0.conda
linux-aarch64::libadios2-2.8.3-mpi_openmpi_h5a18f1a_7.conda
linux-aarch64::orc-1.9.0-hc144153_0.conda
linux-aarch64::magic-8.3.406-h4e13689_0.conda
linux-aarch64::libnetcdf-4.9.2-mpi_mpich_h06661ef_6.conda
linux-aarch64::ffmpeg-5.1.2-gpl_h08bcc58_111.conda
linux-aarch64::pytables-3.8.0-py39hf23716f_2.conda
linux-aarch64::pygame-2.5.0-py39hb769c03_0.conda
linux-aarch64::libopencv-4.7.0-py39hb93cb46_5.conda
linux-aarch64::grpcio-1.55.1-py38h95a9722_1.conda
linux-aarch64::mysql-connector-python-8.0.32-py39hd74382b_0.conda
linux-aarch64::folly-2023.06.12.00-h8282163_1.conda
linux-aarch64::linux-perf-6.3.9-py38h696f14d_0.conda
linux-aarch64::pyinstaller-5.12.0-py39hb91f966_1.conda
linux-aarch64::arrow-cpp-9.0.0-py39h3d3e818_41_cuda.conda
linux-aarch64::mysql-router-8.0.32-heff8103_3.conda
linux-aarch64::xrootd-5.5.4-py39h776bf55_1.conda
linux-aarch64::gstlal-1.11.0-py39hffc1e39_0.conda
linux-aarch64::libspatialite-5.0.1-h1f5fd70_28.conda
linux-aarch64::arrow-cpp-9.0.0-py39hba22e0e_39_cpu.conda
linux-aarch64::openbabel-3.1.1-py311hf02cd11_7.conda
linux-aarch64::xrootd-5.5.4-py310haa9ade6_1.conda
linux-aarch64::vigra-1.11.1-py39h14f4168_1045.conda
linux-aarch64::mysql-server-8.0.32-h9e1a5d7_3.conda
linux-aarch64::llvmlite-0.40.1-py310h20b6881_0.conda
linux-aarch64::fenics-libdolfin-2019.1.0-h28dc1fa_36.conda
linux-aarch64::nodejs-18.16.1-hcb20a51_0.conda
linux-aarch64::linux-perf-6.3.8-py311h31656e8_0.conda
linux-aarch64::yarp-cxx-3.8.0-h4c076a4_3.conda
linux-aarch64::fenics-libdolfin-2019.1.0-h1fc3836_36.conda
linux-aarch64::gst-plugins-base-1.22.4-hc44d83b_0.conda
linux-aarch64::qt6-main-6.5.1-h3d23ec0_2.conda
linux-aarch64::libtiff-4.5.1-h360e80f_0.conda
linux-aarch64::tiledb-2.15.3-hc0eaa86_1.conda
linux-aarch64::pytables-3.8.0-py311hb8ca588_2.conda
linux-aarch64::libarrow-12.0.0-hd466f35_9_cpu.conda
linux-aarch64::tiledb-2.15.4-hddb64f1_1.conda
linux-aarch64::llvm-openmp-16.0.6-h8b0cb96_0.conda
linux-aarch64::netcdf4-1.6.4-mpi_openmpi_py311h5e12699_0.conda
linux-aarch64::grpcio-1.55.1-py310h20b6881_1.conda
linux-aarch64::libadios2-2.8.3-mpi_openmpi_hf915c51_6.conda
linux-aarch64::fenics-libdolfin-2019.1.0-h89d0ad6_36.conda
linux-aarch64::magic-8.3.404-h4e13689_0.conda
linux-aarch64::openbabel-3.1.1-py38hcc4b432_7.conda
linux-aarch64::lxml-4.9.2-py311h40dcbb3_1.conda
linux-aarch64::libopencv-4.7.0-py39h240c543_5.conda
linux-aarch64::libadios2-2.8.3-mpi_mpich_hfe19bc3_6.conda
linux-aarch64::pyinstaller-5.13.0-py38h37f3631_0.conda
linux-aarch64::grpcio-1.55.1-py311h1a7908d_1.conda
linux-aarch64::netcdf4-1.6.4-nompi_py38h05aa93a_101.conda
linux-aarch64::mapserver-8.0.1-py39h43f12e7_4.conda
linux-aarch64::libllvm16-16.0.6-h70e38ee_0.conda
linux-aarch64::gst-plugins-bad-1.22.4-h627acee_0.conda
linux-aarch64::gstlal-1.11.0-py38h701a7df_0.conda
linux-aarch64::libarrow-10.0.1-ha2fa209_27_cpu.conda
linux-aarch64::llvmlite-0.40.1-py39h483cef1_0.conda
linux-aarch64::r-data.table-1.14.8-r42hb4ebc13_2.conda
linux-aarch64::pyinstaller-5.12.0-py38h37f3631_1.conda
linux-aarch64::nco-5.1.6-ha58f4e6_1.conda
linux-aarch64::netcdf4-1.6.4-mpi_mpich_py38hea1be00_0.conda
linux-aarch64::arrow-cpp-9.0.0-py38hdf1f5c2_41_cpu.conda
linux-aarch64::netcdf4-1.6.4-mpi_mpich_py311ha52e7bf_1.conda
linux-aarch64::folly-2023.06.08.00-hb60f5cd_0.conda
linux-aarch64::libadios2-2.8.3-nompi_hac4985a_106.conda
linux-aarch64::netcdf4-1.6.4-nompi_py39hf49215a_101.conda
linux-aarch64::libadios2-2.8.3-nompi_h39a7b69_107.conda
linux-aarch64::libopencv-4.7.0-py38h8b47e65_5.conda
linux-aarch64::libadios2-2.8.3-mpi_mpich_heb8b73a_6.conda
linux-aarch64::mlir-16.0.5-h6acfec4_0.conda
linux-aarch64::adios-1.13.1-mpi_openmpi_h536d158_1022.conda
linux-aarch64::pyinstaller-5.12.0-py310h1aab166_1.conda
linux-aarch64::grpcio-1.56.0-py38h95a9722_1.conda
linux-aarch64::vigra-1.11.1-py38he8f392a_1045.conda
linux-aarch64::libgdal-arrow-parquet-3.7.0-h74c6c0a_2.conda
linux-aarch64::openbabel-3.1.1-py39h5704ccc_6.conda
linux-aarch64::libadios2-2.8.3-mpi_mpich_hfb68cf6_6.conda
linux-aarch64::libarrow-11.0.0-hd573807_23_cuda.conda
linux-aarch64::libopencv-4.7.0-py38ha2851a5_5.conda
linux-aarch64::libgrpc-1.56.0-h9b32312_1.conda
linux-aarch64::grpcio-1.55.1-py310h20b6881_0.conda
linux-aarch64::linux-perf-6.3.9-py39hc5e4ac8_0.conda
linux-aarch64::lxml-4.9.2-py39h4de4ef8_1.conda
linux-aarch64::pyreadstat-1.2.2-py39hfca9663_0.conda
linux-aarch64::mapserver-8.0.1-py311h0510657_4.conda
linux-aarch64::octave-8.2.0-h6ada7f8_1.conda
linux-aarch64::openbabel-3.1.1-py311hf02cd11_6.conda
linux-aarch64::libopencv-4.7.0-py310h81d4185_5.conda
linux-aarch64::mysql-server-8.0.32-h06e55e8_3.conda
linux-aarch64::arrow-cpp-9.0.0-py39h99d5cbd_38_cuda.conda
linux-aarch64::folly-2023.06.08.00-h7a25010_0_jemalloc.conda
linux-aarch64::yarp-cxx-3.8.1-h09f7a61_0.conda
linux-aarch64::libgdal-arrow-parquet-3.6.4-he9b18a3_4.conda
linux-aarch64::linux-perf-6.3.8-py38h696f14d_0.conda
linux-aarch64::tiledb-2.15.4-h97f58e1_0.conda
linux-aarch64::pyreadstat-1.2.2-py310h3516908_0.conda
linux-aarch64::openbabel-3.1.1-py310h5178cfb_6.conda
linux-aarch64::linux-perf-6.3.7-py310h2bd01cc_0.conda
linux-aarch64::gst-plugins-good-1.22.4-h09e3e68_0.conda
linux-aarch64::omniorb-4.2.5-py310hf2f0f6e_7.conda
linux-aarch64::rust-1.69.0-h9d3d833_4.conda
linux-aarch64::aws-sdk-cpp-1.11.68-h4eeedb6_6.conda
linux-aarch64::libarrow-10.0.1-hefbe673_30_cpu.conda
linux-aarch64::llvm-16.0.6-h5271726_0.conda
linux-aarch64::libgdal-arrow-parquet-3.6.4-h6bef558_5.conda
linux-aarch64::libmatio-1.5.23-hac23492_3.conda
linux-aarch64::libopencv-4.7.0-py38hdefb6ef_5.conda
linux-aarch64::libadios2-2.8.3-nompi_h5e92b03_106.conda
linux-aarch64::arrow-cpp-9.0.0-py38hb462454_40_cpu.conda
linux-aarch64::arrow-cpp-9.0.0-py310hf743170_40_cuda.conda
linux-aarch64::llvmdev-14.0.6-h966f666_3.conda
linux-aarch64::fenics-libdolfin-2019.1.0-hd1beec9_36.conda
linux-aarch64::hdf5-1.14.1-mpi_openmpi_hae789d2_0.conda
linux-aarch64::libopencv-4.7.0-py311h7df1ea0_5.conda
linux-aarch64::pyhdf-0.11.3-py39h8d2d5fa_0.conda
linux-aarch64::gstlal-1.11.0-py311ha13c55a_0.conda
linux-aarch64::netcdf4-1.6.4-nompi_py39h8ab5fa2_100.conda
linux-aarch64::pyinstaller-5.13.0-py39hb91f966_0.conda
linux-aarch64::libitk-5.3.0-h4606515_4.conda
linux-aarch64::llvm-tools-16.0.5-h70e38ee_0.conda
linux-aarch64::qtkeychain-0.14.1-h54d81ea_0.conda
linux-aarch64::arrow-cpp-9.0.0-py310hdde26d4_37_cuda.conda
linux-aarch64::arrow-cpp-9.0.0-py38h59efa55_38_cuda.conda
linux-aarch64::arrow-cpp-9.0.0-py38hbefb1e1_39_cuda.conda
linux-aarch64::fenics-libdolfin-2019.1.0-hd1beec9_37.conda
linux-aarch64::pyreadstat-1.2.2-py311hf7e8aab_0.conda
linux-aarch64::libarrow-11.0.0-h901c870_22_cpu.conda
linux-aarch64::libssh2-1.11.0-h492db2e_0.conda
linux-aarch64::vtk-base-9.2.6-qt_py38h1234567_208.conda
linux-aarch64::grpcio-1.55.1-py39h483cef1_0.conda
linux-aarch64::llvmdev-16.0.6-hc720cd8_0.conda
linux-aarch64::folly-2023.06.12.00-hbf4f375_1_jemalloc.conda
linux-aarch64::libadios2-2.8.3-mpi_mpich_h4e6f988_7.conda
linux-aarch64::libgrpc-1.55.1-haa74edf_0.conda
linux-aarch64::orc-1.8.4-hc144153_0.conda
linux-aarch64::folly-2023.06.12.00-hdd3c17f_1_jemalloc.conda
linux-aarch64::arrow-cpp-9.0.0-py310h03fd824_38_cpu.conda
linux-aarch64::libtiledb-sql-0.22.4-h556e676_1.conda
linux-aarch64::libadios2-2.8.3-mpi_openmpi_h86fe923_7.conda
linux-aarch64::pyinstaller-5.12.0-py310h1aab166_0.conda
linux-aarch64::vtk-base-9.2.6-qt_py311h1234567_207.conda
linux-aarch64::arrow-cpp-9.0.0-py38h238f788_38_cpu.conda
linux-aarch64::pyhdf-0.11.3-py38hf94a868_0.conda
linux-aarch64::mesalib-23.1.2-h5f6ae44_0.conda
linux-aarch64::linux-perf-6.3.8-py39hc5e4ac8_0.conda
linux-aarch64::netcdf4-1.6.4-nompi_py310h3de3d6f_100.conda
linux-aarch64::tiledb-2.15.4-hc0eaa86_1.conda
linux-aarch64::graphicsmagick-1.3.40-h307706d_2.conda
linux-aarch64::libarrow-12.0.1-hf50a860_1_cpu.conda
linux-aarch64::mapserver-8.0.1-py38h13a50f6_4.conda
linux-aarch64::mysql-connector-python-8.0.32-py310h8b564ae_0.conda
linux-aarch64::pyreadstat-1.2.2-py38hbecd58a_0.conda
linux-aarch64::qt-main-5.15.8-h6015ebc_14.conda
linux-aarch64::grpcio-1.56.0-py311h1a7908d_1.conda
linux-aarch64::libadios2-2.8.3-mpi_openmpi_hd171938_7.conda
linux-aarch64::tiledb-2.15.3-h97f58e1_1.conda
linux-aarch64::arrow-cpp-9.0.0-py310h03fd824_37_cpu.conda
linux-aarch64::xrootd-5.5.4-py38hd953884_1.conda
linux-aarch64::arrow-cpp-9.0.0-py311he7b896d_39_cuda.conda
linux-aarch64::folly-2023.06.26.00-h8282163_0.conda
linux-aarch64::libarrow-12.0.0-hefbe673_9_cpu.conda
linux-aarch64::xrootd-5.5.4-py311h7efa6b2_1.conda
linux-aarch64::libnetcdf-4.9.2-mpi_openmpi_hd4808d0_6.conda
linux-aarch64::libadios2-2.8.3-mpi_mpich_h18090f1_7.conda
linux-aarch64::python-3.11.4-h43d1f9e_0_cpython.conda
linux-aarch64::mysql-connector-python-8.0.32-py38h6bba647_0.conda
linux-aarch64::arrow-cpp-9.0.0-py311h149deb6_38_cpu.conda
linux-aarch64::tiledb-2.15.3-hc0eaa86_2.conda
linux-aarch64::libarrow-12.0.0-h2e06495_6_cpu.conda
linux-aarch64::libadios2-2.8.3-mpi_mpich_hd63bfcd_7.conda
linux-aarch64::tiledb-2.15.3-hddb64f1_2.conda
linux-aarch64::netcdf4-1.6.4-mpi_openmpi_py310hffb74a8_1.conda
linux-aarch64::ffmpeg-5.1.2-lgpl_ha4417b7_11.conda
linux-aarch64::arrow-cpp-9.0.0-py38h238f788_37_cpu.conda
linux-aarch64::netcdf4-1.6.4-nompi_py311h7ac56f1_100.conda
linux-aarch64::libarrow-10.0.1-h7bc9c71_30_cuda.conda
linux-aarch64::vigra-1.11.1-py311h918e57d_1045.conda
linux-aarch64::vtk-base-9.2.6-qt_py310h1234567_208.conda
linux-aarch64::libopencv-4.7.0-py38h3f8771e_5.conda
linux-aarch64::mysql-router-8.0.33-heff8103_0.conda
linux-aarch64::grpcio-1.56.0-py310h20b6881_1.conda
linux-aarch64::libgdal-arrow-parquet-3.7.0-h9b87c83_3.conda
linux-aarch64::libgdal-3.7.0-h04ba24c_3.conda
linux-aarch64::vtk-base-9.2.6-qt_py38h1234567_207.conda
linux-aarch64::arrow-cpp-9.0.0-py39h2ee845a_40_cuda.conda
linux-aarch64::libthrift-0.18.1-h0035360_2.conda
linux-aarch64::vigra-1.11.1-py39hf96df1e_1045.conda
linux-aarch64::pytables-3.8.0-py39h3e34cfa_2.conda
linux-aarch64::arrow-cpp-9.0.0-py38h540a7d3_41_cuda.conda
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
================================================================================
================================================================================
noarch
================================================================================
================================================================================
win-64
win-64::coda-2.24.2-py310h0f4d3c9_2.conda
win-64::aiokafka-0.8.1-py310h35269f2_0.conda
win-64::orc-1.8.4-h08d22ad_0.conda
win-64::vigra-1.11.1-py38h6dadfc5_1044.conda
win-64::pygame-2.5.0-py311h4246bbb_0.conda
win-64::pygplates-0.39-py39he5b0fed_8.conda
win-64::harp-1.18-py39h5534f61_0.conda
win-64::mlir-python-bindings-16.0.5-py39hbf0fdad_0.conda
win-64::libopencv-4.7.0-py311h416818d_5.conda
win-64::tiledb-2.15.3-h64e2a1b_2.conda
win-64::libgdal-arrow-parquet-3.6.4-h709fcb8_6.conda
win-64::imath-3.1.9-h12be248_0.conda
win-64::libllvm14-14.0.6-h97333cc_3.conda
win-64::lld-16.0.6-h21f6fed_0.conda
win-64::arrow-cpp-9.0.0-py38hb11766d_37_cpu.conda
win-64::libopencv-4.7.0-py39hbd58657_5.conda
win-64::llvmlite-0.40.1-py311h5bc0dda_0.conda
win-64::mysql-connector-python-8.0.32-py310h6a47d84_0.conda
win-64::folly-2023.06.12.00-h6064ee9_0.conda
win-64::libgdal-arrow-parquet-3.7.0-hb7c107e_3.conda
win-64::aiokafka-0.8.1-py39h84a0465_0.conda
win-64::lxml-4.9.2-py310h46d54dd_1.conda
win-64::tiledb-2.15.4-h64e2a1b_0.conda
win-64::git-delta-0.16.4-h00abf1b_0.conda
win-64::pyinstaller-5.13.0-py310h35269f2_0.conda
win-64::libarrow-12.0.0-h118a2b5_8_cpu.conda
win-64::libssh2-static-1.11.0-h7dfc565_0.conda
win-64::dlib-cpp-19.24.2-hfab4998_2.conda
win-64::tiledb-2.15.4-h616f04a_1.conda
win-64::ffmpeg-6.0.0-gpl_h2b371f0_103.conda
win-64::conduit-0.8.8-py38h13f01f2_1.conda
win-64::libmlir-16.0.5-he744812_0.conda
win-64::mysql-router-8.0.33-hb3df6c7_0.conda
win-64::libgdal-arrow-parquet-3.6.4-h5a0d01a_5.conda
win-64::pygame-2.5.0-py39h10a7b85_0.conda
win-64::r-vcfr-1.14.0-r41h67098fc_1.conda
win-64::paraview-5.11.1-py39h772ed55_101_qt.conda
win-64::libprotobuf-static-4.23.2-h1975477_5.conda
win-64::tiledb-2.15.3-h86be035_1.conda
win-64::yarp-cxx-3.8.1-hd4d9f11_0.conda
win-64::libarrow-12.0.0-hc883df4_7_cuda.conda
win-64::coda-2.24.2-py38hd044e7d_2.conda
win-64::lxml-4.9.2-py39hbae3653_1.conda
win-64::libmediainfo-23.06-h8ec2201_0.conda
win-64::arrow-cpp-9.0.0-py311h4015445_39_cpu.conda
win-64::arrow-cpp-9.0.0-py39h4d170c2_38_cpu.conda
win-64::llvm-tools-16.0.6-h1ab654d_0.conda
win-64::gdstk-0.9.42-py38h6137a70_0.conda
win-64::qt6-main-6.5.1-hf0c6fff_1.conda
win-64::folly-2023.06.12.00-hfbb6214_1.conda
win-64::libarrow-12.0.1-hab6ffb9_0_cpu.conda
win-64::harp-1.18-py38hb5a5460_1.conda
win-64::r-harp-1.18-r41h1c8a71e_0.conda
win-64::netcdf4-1.6.4-nompi_py38ha335e1a_101.conda
win-64::folly-2023.06.08.00-h6064ee9_1.conda
win-64::ffmpeg-6.0.0-lgpl_hb701c11_3.conda
win-64::llvm-tools-14.0.6-hac7d729_3.conda
win-64::vigra-1.11.1-py38h48431cc_1044.conda
win-64::libarrow-10.0.1-ha9e25ae_29_cuda.conda
win-64::gdstk-0.9.42-py38h6cd9458_0.conda
win-64::mysql-server-8.0.32-hdf5bdb2_3.conda
win-64::vtk-base-9.2.6-qt_py39h1234567_207.conda
win-64::openexr-3.1.7-h5fba010_2.conda
win-64::libadios2-2.8.3-nompi_h6e81f23_107.conda
win-64::polycap-1.2-py311hef88ec6_2.conda
win-64::mysql-server-8.0.33-hc5a09fc_0.conda
win-64::libclang-cpp-16.0.5-default_heb8d277_0.conda
win-64::vigra-1.11.1-py39h5397cfd_1044.conda
win-64::paraview-5.11.1-py311hd3ae190_101_qt.conda
win-64::libllvm16-16.0.6-h1ab654d_0.conda
win-64::ffmpeg-6.0.0-gpl_hae12f06_102.conda
win-64::libopencv-4.7.0-py311h787696b_5.conda
win-64::clang-16-16.0.5-default_heb8d277_0.conda
win-64::lpython-0.16.0-h12be248_0.conda
win-64::libarrow-11.0.0-ha096e86_22_cpu.conda
win-64::pygame-2.5.0-py310hd1d314e_0.conda
win-64::libadios2-2.8.3-nompi_h357899a_106.conda
win-64::python-3.10.12-h4de0772_0_cpython.conda
win-64::tiledb-2.15.3-h6f4ccf1_1.conda
win-64::arrow-cpp-9.0.0-py38hb11766d_38_cpu.conda
win-64::openmeeg-2.5.6-py310h2578624_1.conda
win-64::libarrow-12.0.1-hd503b12_1_cpu.conda
win-64::arrow-cpp-9.0.0-py311h4943da1_37_cpu.conda
win-64::libarrow-12.0.0-h71d8ae8_9_cpu.conda
win-64::python-3.8.17-h4de0772_0_cpython.conda
win-64::libprotobuf-4.23.2-h1975477_4.conda
win-64::libmlir-16.0.6-he744812_0.conda
win-64::grpcio-1.56.0-py39hd28a505_1.conda
win-64::pyinstaller-5.13.0-py38ha959d8a_0.conda
win-64::libarrow-11.0.0-hd971356_24_cpu.conda
win-64::vigra-1.11.1-py39h6324230_1045.conda
win-64::aws-sdk-cpp-1.11.68-ha442f66_6.conda
win-64::mysql-server-8.0.32-hc5a09fc_3.conda
win-64::libignition-fuel-tools4-4.6.0-h873da47_1.conda
win-64::omniorb-4.2.5-py39h0a8b3da_7.conda
win-64::kaldi-5.5.1068-cuda111hbcaf4cb_1.conda
win-64::libgdal-3.6.4-h4bcdf59_6.conda
win-64::eccodes-2.30.2-ha10300a_1.conda
win-64::ovito-3.8.5-ha2990a6_0.conda
win-64::pyinstaller-5.12.0-py38ha959d8a_1.conda
win-64::vigra-1.11.1-py39hfd7fe71_1045.conda
win-64::harp-1.18-py39haf6c738_1.conda
win-64::gst-plugins-base-1.22.4-h001b923_0.conda
win-64::harp-1.18-py39h441a838_1.conda
win-64::libarrow-10.0.1-he9e13d1_28_cuda.conda
win-64::openbabel-3.1.1-py311hf54676f_7.conda
win-64::python-3.11.4-h2628c8c_0_cpython.conda
win-64::vigra-1.11.1-py311h39e1d8a_1043.conda
win-64::coda-2.24.2-py39h5e6021e_2.conda
win-64::vigra-1.11.1-py38h6dadfc5_1043.conda
win-64::libopencv-4.7.0-py39h31bfa86_5.conda
win-64::libarrow-12.0.1-h2176e01_1_cuda.conda
win-64::pdal-2.5.5-h22e3bf8_0.conda
win-64::libarrow-11.0.0-ha9e25ae_25_cuda.conda
win-64::vigra-1.11.1-py310h7fe678d_1044.conda
win-64::coda-2.24.2-py311h0d7f73b_2.conda
win-64::libopencv-4.7.0-py39hcf3dae8_5.conda
win-64::llvmdev-14.0.6-h97333cc_3.conda
win-64::libarrow-11.0.0-hc076a2f_26_cuda.conda
win-64::netcdf4-1.6.4-nompi_py311h91f5014_101.conda
win-64::eccodes-2.30.2-h2993e7e_0.conda
win-64::z5py-2.0.16-py39h1f31114_1.conda
win-64::orc-1.8.4-hada7b9e_0.conda
win-64::libadios2-2.8.3-nompi_h1786dfd_106.conda
win-64::libgdal-arrow-parquet-3.7.0-h9e98e37_2.conda
win-64::r-harp-1.18-r41h6d9200e_0.conda
win-64::libarrow-12.0.0-hba48b7f_7_cpu.conda
win-64::arrow-cpp-9.0.0-py38h786bf40_38_cuda.conda
win-64::vigra-1.11.1-py38hac40cf4_1045.conda
win-64::pytables-3.8.0-py311h8fc43b8_2.conda
win-64::libsolv-0.7.24-h12be248_1.conda
win-64::nifty-1.2.1-py38hd9fd656_4.conda
win-64::aiokafka-0.8.1-py39h78ffc47_0.conda
win-64::pytables-3.8.0-py38h1fc5953_2.conda
win-64::r-harp-1.18-r41h0f4d3c9_1.conda
win-64::arrow-cpp-9.0.0-py310h2c602b1_37_cuda.conda
win-64::libarrow-12.0.1-h2b9eda4_1_cpu.conda
win-64::cgns-4.4.0-h9f7afaf_0.conda
win-64::vigra-1.11.1-py38hd70ca0c_1044.conda
win-64::libarrow-12.0.0-hc883df4_6_cuda.conda
win-64::folly-2023.06.26.00-h6064ee9_0.conda
win-64::mysql-client-8.0.32-hed9f4ee_3.conda
win-64::coda-2.24.2-py39hb143bc4_2.conda
win-64::vigra-1.11.1-py39hfd7fe71_1043.conda
win-64::harp-1.18-py38he1e2a99_0.conda
win-64::nifty-1.2.1-py311he880798_4.conda
win-64::harp-1.18-py38h9258f87_0.conda
win-64::nifty-1.2.1-py39h9fe8808_4.conda
win-64::vigra-1.11.1-py310h7fe678d_1045.conda
win-64::omniorb-libs-4.2.5-h27dd91c_7.conda
win-64::arrow-cpp-9.0.0-py311hd5611c8_38_cuda.conda
win-64::pytables-3.8.0-py310h5351e0d_2.conda
win-64::grpcio-1.55.1-py38h19421c1_0.conda
win-64::libgdal-3.6.4-h4b32e24_5.conda
win-64::libopencv-4.7.0-py310hea656e8_5.conda
win-64::grpcio-1.56.0-py310hb84602e_1.conda
win-64::git-delta-0.16.0-h00abf1b_0.conda
win-64::mysql-connector-python-8.0.32-py38hee1428b_0.conda
win-64::netcdf4-1.6.4-nompi_py38h3d2d793_100.conda
win-64::libadios2-2.8.3-nompi_h6db2470_107.conda
win-64::pytables-3.8.0-py39h4fda6da_2.conda
win-64::libarrow-10.0.1-h92b9ad0_27_cpu.conda
win-64::conduit-0.8.8-py310hab155bc_1.conda
win-64::arrow-cpp-9.0.0-py310h4d39830_38_cpu.conda
win-64::mysql-connector-python-8.0.32-py39h6904d88_0.conda
win-64::harp-1.18-py311h4c3a82d_1.conda
win-64::smesh-9.9.0.0-h7c74c8f_5.conda
win-64::arrow-cpp-9.0.0-py39hb3291a9_38_cuda.conda
win-64::netcdf4-1.6.4-nompi_py311h896b27b_100.conda
win-64::libopencv-4.7.0-py310h2cd55a3_5.conda
win-64::gdstk-0.9.42-py39hbf0fdad_0.conda
win-64::libgdal-3.7.0-h32ef8ef_2.conda
win-64::wasmer-4.0.0-h4dd112c_0.conda
win-64::r-popgenome-2.7.5-r41h67098fc_3.conda
win-64::pyinstaller-5.12.0-py310h35269f2_0.conda
win-64::mysql-libs-8.0.33-h8b0d2c3_0.conda
win-64::vigra-1.11.1-py39h6324230_1043.conda
win-64::libopencv-4.7.0-py38h8d3b7e7_5.conda
win-64::vigra-1.11.1-py38hac40cf4_1044.conda
win-64::libopencv-4.7.0-py38h7d77f59_5.conda
win-64::lxml-4.9.2-py39hb421182_1.conda
win-64::z5py-2.0.16-py310h51f9496_1.conda
win-64::arrow-cpp-9.0.0-py38hc7794f1_41_cpu.conda
win-64::pygame-2.5.0-py38hbc751ee_0.conda
win-64::dlib-cpp-19.24.2-h08a0898_1.conda
win-64::yarp-cxx-3.8.0-hd4d9f11_3.conda
win-64::openbabel-3.1.1-py39h40c416f_6.conda
win-64::openbabel-3.1.1-py38h3819a12_6.conda
win-64::arrow-cpp-9.0.0-py38h9bbb44a_40_cpu.conda
win-64::libspatialite-5.0.1-hc49ff46_28.conda
win-64::libadios2-2.8.3-nompi_he589150_107.conda
win-64::openbabel-3.1.1-py310h64d7175_6.conda
win-64::tiledb-2.15.4-h6f4ccf1_0.conda
win-64::ffmpeg-5.1.2-lgpl_he575030_11.conda
win-64::tiledb-2.15.4-h86be035_0.conda
win-64::llvmdev-16.0.5-h1ab654d_0.conda
win-64::libopencv-4.7.0-py38h1cea11b_5.conda
win-64::openbabel-3.1.1-py38h3819a12_7.conda
win-64::libclang13-16.0.5-default_hc80b9e7_0.conda
win-64::vigra-1.11.1-py310h7dde578_1043.conda
win-64::arrow-cpp-9.0.0-py38h0fd8f72_40_cuda.conda
win-64::thrift-compiler-0.18.1-h06f6336_2.conda
win-64::libopencv-4.7.0-py39h25944ff_5.conda
win-64::libprotobuf-4.23.2-h1975477_5.conda
win-64::libarrow-11.0.0-h9032d85_25_cpu.conda
win-64::arrow-cpp-9.0.0-py39hbd8108f_40_cpu.conda
win-64::arrow-cpp-9.0.0-py38hc719ca3_41_cuda.conda
win-64::netcdf4-1.6.4-nompi_py39h6379b8f_101.conda
win-64::libgrpc-1.56.0-ha02fd9f_1.conda
win-64::arrow-cpp-9.0.0-py39h7bc3e6a_40_cuda.conda
win-64::clang-tools-16.0.6-default_heb8d277_0.conda
win-64::graphicsmagick-1.3.40-he3cf71d_2.conda
win-64::pygame-2.5.0-py39h9408aed_0.conda
win-64::lpython-0.17.0-h12be248_0.conda
win-64::vigra-1.11.1-py310hd3b6984_1044.conda
win-64::paraview-5.11.1-py311h9eeb57c_101_qt.conda
win-64::mysql-router-8.0.32-hb3df6c7_3.conda
win-64::paraview-5.11.1-py310hda59b30_101_qt.conda
win-64::clangdev-16.0.5-default_heb8d277_0.conda
win-64::arrow-cpp-9.0.0-py39hb238a53_39_cpu.conda
win-64::gst-libav-1.22.4-hd74c2e4_0.conda
win-64::openmeeg-2.5.6-py38hce27a1d_1.conda
win-64::grpcio-1.55.1-py310hb84602e_1.conda
win-64::r-harp-1.18-r41h74a33d5_0.conda
win-64::libadios2-2.8.3-nompi_h2ba8506_106.conda
win-64::r-harp-1.18-r41hb60f65e_0.conda
win-64::libopencv-4.7.0-py39heefb252_5.conda
win-64::libnetcdf-4.9.2-nompi_h5729074_106.conda
win-64::arrow-cpp-9.0.0-py310h4d39830_37_cpu.conda
win-64::folly-2023.06.08.00-h62734b8_0.conda
win-64::libopencv-4.7.0-py310h352d95a_5.conda
win-64::vigra-1.11.1-py39h5c385c1_1044.conda
win-64::vigra-1.11.1-py310hd3b6984_1045.conda
win-64::libopencv-4.7.0-py311h98d3206_5.conda
win-64::llvmlite-0.40.1-py38hf225c54_0.conda
win-64::paraview-5.11.1-py39h330c446_101_qt.conda
win-64::llvmdev-16.0.6-h1ab654d_0.conda
win-64::openbabel-3.1.1-py310h64d7175_7.conda
win-64::gmt-6.4.0-h9cef95e_13.conda
win-64::libarrow-10.0.1-h92b9ad0_28_cpu.conda
win-64::vigra-1.11.1-py38h389a828_1043.conda
win-64::libtiff-4.5.1-h6c8260b_0.conda
win-64::qtwebkit-5.212-h1efe6ef_12.conda
win-64::lxml-4.9.2-py311h750ae06_1.conda
win-64::gdstk-0.9.42-py311hc50246e_0.conda
win-64::mysql-client-8.0.33-hed9f4ee_0.conda
win-64::aiokafka-0.8.1-py38hed8690e_0.conda
win-64::llvm-16.0.6-h3dc180e_0.conda
win-64::arrow-cpp-9.0.0-py311hc25ff5e_40_cpu.conda
win-64::pyinstaller-5.12.0-py39h84a0465_0.conda
win-64::paraview-5.11.1-py310h8a5c5e3_101_qt.conda
win-64::r-harp-1.18-r41hd044e7d_1.conda
win-64::arrow-cpp-9.0.0-py310hcf382b6_39_cpu.conda
win-64::lxml-4.9.2-py38hca7eb16_1.conda
win-64::gmt-5.4.5-h7ad327f_28.conda
win-64::aws-sdk-cpp-1.10.57-ha442f66_14.conda
win-64::libarrow-11.0.0-h88b1d19_23_cuda.conda
win-64::libprotobuf-4.23.3-h1975477_0.conda
win-64::pygame-2.5.0-py38h6efadab_0.conda
win-64::libthrift-0.18.1-h06f6336_2.conda
win-64::libarrow-11.0.0-hd971356_23_cpu.conda
win-64::libgdal-arrow-parquet-3.7.0-h29302ae_4.conda
win-64::mysql-router-8.0.32-hf1a93ab_3.conda
win-64::vtk-base-9.2.6-qt_py311h1234567_208.conda
win-64::libopencv-4.7.0-py311hcdc55d4_5.conda
win-64::ffmpeg-6.0.0-lgpl_h4eaa601_2.conda
win-64::libarrow-10.0.1-h0ac4353_26_cpu.conda
win-64::libarrow-12.0.0-h950202d_9_cuda.conda
win-64::netcdf4-1.6.4-nompi_py39h5f77c00_100.conda
win-64::arrow-cpp-9.0.0-py38hd8e50f2_37_cuda.conda
win-64::folly-2023.06.12.00-h6064ee9_1.conda
win-64::vtk-base-9.2.6-qt_py39h1234567_208.conda
win-64::arrow-cpp-9.0.0-py311h2c5f31a_41_cuda.conda
win-64::libsolv-static-0.7.24-h12be248_0.conda
win-64::mlir-16.0.6-he744812_0.conda
win-64::polycap-1.2-py39h3fcc0b8_2.conda
win-64::hugin-base-2022.0.0-pl5321ha1b934c_5.conda
win-64::grpcio-1.55.1-py311h5bc0dda_0.conda
win-64::libgdal-3.7.0-h123a834_3.conda
win-64::vigra-1.11.1-py39h5397cfd_1045.conda
win-64::libarrow-10.0.1-heddad62_21_cuda.conda
win-64::mlir-python-bindings-16.0.5-py310h8f0d0a4_0.conda
win-64::libssh2-1.11.0-h7dfc565_0.conda
win-64::vigra-1.11.1-py311hfbe81d1_1045.conda
win-64::grpcio-1.55.1-py39hd28a505_1.conda
win-64::clangxx-16.0.5-default_heb8d277_0.conda
win-64::pytables-3.8.0-py39hf7d678f_2.conda
win-64::grpcio-1.56.0-py311h5bc0dda_1.conda
win-64::libarrow-12.0.1-h950202d_0_cuda.conda
win-64::grpcio-1.56.0-py38h19421c1_1.conda
win-64::match-series-1.0.4-hd391cef_3.conda
win-64::libopencv-4.7.0-py310h2cb6a50_5.conda
win-64::r-strawr-0.0.91-r41h45fc98e_1.conda
win-64::openmeeg-2.5.6-py38hf788b62_1.conda
win-64::clang-tools-16.0.5-default_heb8d277_0.conda
win-64::r-harp-1.18-r41hcdd259e_0.conda
win-64::libarrow-10.0.1-h2ae64b6_30_cpu.conda
win-64::libarrow-12.0.0-h8f71f9a_5_cuda.conda
win-64::libadios2-2.8.3-nompi_h3621ceb_107.conda
win-64::vtk-base-9.2.6-qt_py38h1234567_208.conda
win-64::libopencv-4.7.0-py39h8cc9dc1_5.conda
win-64::libarrow-10.0.1-hc51b828_31_cuda.conda
win-64::libprotobuf-4.23.2-h1975477_3.conda
win-64::r-harp-1.18-r41hb143bc4_1.conda
win-64::pygplates-0.39-py310hff692de_8.conda
win-64::omniorb-4.2.5-py310h281aaab_7.conda
win-64::nexus-4.4.3-h295cbbf_10.conda
win-64::hugin-2022.0.0-pl5321had2dea9_5.conda
win-64::tiledb-2.15.3-h64e2a1b_1.conda
win-64::gmt-6.4.0-h2b80164_12.conda
win-64::arrow-cpp-9.0.0-py311h9306c73_41_cpu.conda
win-64::libopencv-4.7.0-py39h8b78f8a_5.conda
win-64::dlib-cpp-19.24.2-hfab4998_3.conda
win-64::pyinstaller-5.12.0-py311h12e69fa_1.conda
win-64::libclang-16.0.6-default_heb8d277_0.conda
win-64::r-harp-1.18-r41ha632019_0.conda
win-64::libspatialite-5.0.1-hf8d749d_27.conda
win-64::vigra-1.11.1-py39h37142e5_1043.conda
win-64::libclang-cpp-16.0.6-default_heb8d277_0.conda
win-64::arrow-cpp-9.0.0-py39ha6e8ab7_41_cpu.conda
win-64::vigra-1.11.1-py39h5c385c1_1045.conda
win-64::libarrow-11.0.0-h2ae64b6_26_cpu.conda
win-64::r-harp-1.18-r41hd632797_1.conda
win-64::pygplates-0.39-py311he93ff77_8.conda
win-64::arrow-cpp-9.0.0-py311h5f9065c_40_cuda.conda
win-64::libopencv-4.7.0-py38h06bf295_5.conda
win-64::vtk-base-9.2.6-qt_py310h1234567_207.conda
win-64::gmt-5.4.5-h6c42d1b_29.conda
win-64::gst-libav-1.22.4-hec9340f_0.conda
win-64::openmeeg-2.5.6-py311h953547f_1.conda
win-64::libopencv-4.7.0-py38h556c24c_5.conda
win-64::z5py-2.0.16-py311h7bb1f51_1.conda
win-64::libgrpc-1.55.1-h0c1e3fa_0.conda
win-64::libignition-fuel-tools4-4.6.0-h1b9f13a_1.conda
win-64::vtk-base-9.2.6-qt_py38h1234567_207.conda
win-64::kaldi-5.5.1068-cpu_hb4323e9_1.conda
win-64::qt-main-5.15.8-h2c8576c_14.conda
win-64::libarrow-10.0.1-heb30dd5_31_cpu.conda
win-64::mysql-connector-python-8.0.32-py311hd40f987_0.conda
win-64::openexr-3.1.8-h5fba010_0.conda
win-64::git-delta-0.16.5-h00abf1b_0.conda
win-64::pyinstaller-5.12.0-py39h84a0465_1.conda
win-64::yarp-cxx-3.8.0-h26e88d7_3.conda
win-64::lxml-4.9.2-py38h5a3a0f9_1.conda
win-64::orc-1.9.0-hada7b9e_0.conda
win-64::libopencv-4.7.0-py38h1d88b88_5.conda
win-64::libignition-fuel-tools7-7.1.0-h1b9f13a_2.conda
win-64::nifty-1.2.1-py310hc6e0a6f_4.conda
win-64::python-igraph-0.10.3-py38h595c5dd_0.conda
win-64::libarrow-12.0.0-hb92e93a_8_cuda.conda
win-64::libclang13-16.0.6-default_hc80b9e7_0.conda
win-64::pyreadstat-1.2.2-py39h585ecb4_0.conda
win-64::llvm-16.0.5-h3dc180e_0.conda
win-64::mlir-python-bindings-16.0.5-py38h6cd9458_0.conda
win-64::llvmlite-0.40.1-py38h19421c1_0.conda
win-64::libarrow-10.0.1-he9e13d1_27_cuda.conda
win-64::arrow-cpp-9.0.0-py310h100c941_39_cuda.conda
win-64::arrow-cpp-9.0.0-py311h52465e4_37_cuda.conda
win-64::libadios2-2.8.3-nompi_h2508d18_106.conda
win-64::vigra-1.11.1-py38hd70ca0c_1045.conda
win-64::arrow-cpp-9.0.0-py39h4d170c2_37_cpu.conda
win-64::arrow-cpp-9.0.0-py39h39811e2_41_cuda.conda
win-64::libprotobuf-static-4.23.2-h1975477_4.conda
win-64::vigra-1.11.1-py311h39e1d8a_1044.conda
win-64::wxwidgets-3.2.2.1-h20cb418_3.conda
win-64::libarrow-12.0.1-hb327e38_0_cuda.conda
win-64::libarrow-12.0.1-h208ba7f_1_cuda.conda
win-64::tectonic-0.14.1-h8e80d7b_0.conda
win-64::vigra-1.11.1-py38h5f7ed82_1043.conda
win-64::harp-1.18-py38h08b0ee8_1.conda
win-64::libarrow-11.0.0-h2de714e_22_cuda.conda
win-64::libarrow-12.0.0-hab6ffb9_9_cpu.conda
win-64::tiledb-2.15.3-h86be035_2.conda
win-64::folly-2023.06.08.00-hfbb6214_0.conda
win-64::vigra-1.11.1-py311h39e1d8a_1045.conda
win-64::openmeeg-2.5.6-py39ha0542c9_1.conda
win-64::clang-16.0.5-h3dc180e_0.conda
win-64::harp-1.18-py39hbb2b95e_0.conda
win-64::harp-1.18-py311h97f811b_0.conda
win-64::libarrow-12.0.0-hba48b7f_6_cpu.conda
win-64::llvmlite-0.40.1-py310hb84602e_0.conda
win-64::vigra-1.11.1-py39h6324230_1044.conda
win-64::paraview-5.11.1-py38hbc43635_101_qt.conda
win-64::libgdal-3.6.4-h5bae1c1_4.conda
win-64::pyreadstat-1.2.2-py311hd8f7e58_0.conda
win-64::mysql-connector-python-8.0.32-py38h4aa7f50_0.conda
win-64::libarrow-11.0.0-h88b1d19_24_cuda.conda
win-64::vigra-1.11.1-py38hac40cf4_1043.conda
win-64::openexr-3.1.9-h5fba010_0.conda
win-64::netcdf4-1.6.4-nompi_py310he12c0ce_101.conda
win-64::orc-1.8.3-h08d22ad_1.conda
win-64::qt6-main-6.5.1-hf0c6fff_2.conda
win-64::libarrow-12.0.0-he0bb4c4_8_cuda.conda
win-64::libignition-fuel-tools7-7.1.0-h873da47_2.conda
win-64::clang-16.0.6-h3dc180e_0.conda
win-64::libgdal-3.7.0-h8de8401_4.conda
win-64::ovito-3.8.5-hf6a3252_0.conda
win-64::libarrow-12.0.1-h71d8ae8_0_cpu.conda
win-64::pygplates-0.39-py38hfa34f1b_8.conda
win-64::yarp-cxx-3.8.1-h26e88d7_0.conda
win-64::libclang-16.0.5-default_heb8d277_0.conda
win-64::kaldi-5.5.1068-cuda112h9d48c5b_1.conda
win-64::arrow-cpp-9.0.0-py311hae0264b_39_cuda.conda
win-64::gdstk-0.9.42-py310h8f0d0a4_0.conda
win-64::lld-16.0.5-h21f6fed_0.conda
win-64::libopencv-4.7.0-py39h88c7f46_5.conda
win-64::vigra-1.11.1-py311h0e74710_1043.conda
win-64::libprotobuf-static-4.23.3-h1975477_0.conda
win-64::hdf5-1.14.1-nompi_h73e8ff5_100.conda
win-64::openmeeg-2.5.6-py39hd6e1c11_1.conda
win-64::tiledb-2.15.3-h6f4ccf1_2.conda
win-64::polycap-1.2-py310he5af3bc_2.conda
win-64::folly-2023.06.26.00-hfbb6214_0.conda
win-64::kaldi-5.5.1068-cuda110h1463fd9_1.conda
win-64::openbabel-3.1.1-py311hf54676f_6.conda
win-64::omniorb-4.2.5-py38h78b27f5_7.conda
win-64::clangxx-16.0.6-default_heb8d277_0.conda
win-64::mysql-router-8.0.33-hf1a93ab_0.conda
win-64::libprotobuf-static-4.23.2-h1975477_3.conda
win-64::netcdf4-1.6.4-nompi_py310h2d18aa5_100.conda
win-64::openbabel-3.1.1-py39h40c416f_7.conda
win-64::r-seqminer-8.9-r41h5bfd6cc_1.conda
win-64::tiledb-2.15.4-h86be035_1.conda
win-64::arrow-cpp-9.0.0-py39had94d33_37_cuda.conda
win-64::harp-1.18-py310ha95e0a6_0.conda
win-64::harp-1.18-py310hd502204_1.conda
win-64::libarrow-10.0.1-h9032d85_29_cpu.conda
win-64::vtk-base-9.2.6-qt_py310h1234567_208.conda
win-64::pyreadstat-1.2.2-py310h51ee7fe_0.conda
win-64::pyreadstat-1.2.2-py38h84023d3_0.conda
win-64::arrow-cpp-9.0.0-py310h1410346_41_cpu.conda
win-64::vigra-1.11.1-py38h48431cc_1045.conda
win-64::vigra-1.11.1-py38h6dadfc5_1045.conda
win-64::ffmpeg-5.1.2-gpl_he426399_111.conda
win-64::libllvm16-16.0.5-h1ab654d_0.conda
win-64::arrow-cpp-9.0.0-py38h722dc94_39_cuda.conda
win-64::r-gaston-1.5.9-r41h67098fc_1.conda
win-64::libsolv-0.7.24-h12be248_0.conda
win-64::arrow-cpp-9.0.0-py310h3c7f456_40_cuda.conda
win-64::orc-1.8.3-hada7b9e_1.conda
win-64::paraview-5.11.1-py38ha8dd060_101_qt.conda
win-64::tiledb-2.15.4-h6f4ccf1_1.conda
win-64::mysql-libs-8.0.32-h8b0d2c3_3.conda
win-64::libgrpc-1.55.1-h0c1e3fa_1.conda
win-64::r-harp-1.18-r41h5e6021e_1.conda
win-64::nco-5.1.6-hbd9a884_1.conda
win-64::z5py-2.0.16-py38h793a5f6_1.conda
win-64::libmatio-1.5.23-h13b7530_3.conda
win-64::pyinstaller-5.13.0-py39h84a0465_0.conda
win-64::clangdev-16.0.6-default_heb8d277_0.conda
win-64::gdstk-0.9.42-py39ha81e884_0.conda
win-64::arrow-cpp-9.0.0-py311h4943da1_38_cpu.conda
win-64::libgdal-arrow-parquet-3.6.4-hbd214ce_4.conda
win-64::vigra-1.11.1-py310h7fe678d_1043.conda
win-64::libarrow-12.0.0-hb327e38_9_cuda.conda
win-64::grpcio-1.55.1-py310hb84602e_0.conda
win-64::arrow-cpp-9.0.0-py39h5297641_39_cuda.conda
win-64::libopencv-4.7.0-py38h0f1fb87_5.conda
win-64::grpcio-1.55.1-py311h5bc0dda_1.conda
win-64::pyinstaller-5.13.0-py311h12e69fa_0.conda
win-64::arrow-cpp-9.0.0-py310hc7489ad_38_cuda.conda
win-64::gmt-6.4.0-hab73919_11.conda
win-64::arrow-cpp-9.0.0-py310h727b2f2_41_cuda.conda
win-64::arrow-cpp-9.0.0-py310h430f746_40_cpu.conda
win-64::libarrow-12.0.0-h5f84808_8_cpu.conda
win-64::llvmlite-0.40.1-py39hd28a505_0.conda
win-64::tectonic-0.14.0-h8e80d7b_0.conda
win-64::orc-1.9.0-h08d22ad_0.conda
win-64::geotiff-1.7.1-h4e61e90_9.conda
win-64::polycap-1.2-py38hde5eafc_2.conda
win-64::gst-plugins-good-1.22.4-heb2bbf8_0.conda
win-64::r-git2r-0.31.0-r41h007cf7e_1.conda
win-64::pyinstaller-5.12.0-py38ha959d8a_0.conda
win-64::coda-2.24.2-py38hd632797_2.conda
win-64::vigra-1.11.1-py39hfd7fe71_1044.conda
win-64::gst-plugins-bad-1.22.4-ha2afc39_0.conda
win-64::mysql-connector-python-8.0.32-py39h725d275_0.conda
win-64::mlir-python-bindings-16.0.5-py311hc50246e_0.conda
win-64::clang-16-16.0.6-default_heb8d277_0.conda
win-64::r-harp-1.18-r41h0d7f73b_1.conda
win-64::libarrow-12.0.0-hf91c391_5_cpu.conda
win-64::aiokafka-0.8.1-py38ha959d8a_0.conda
win-64::aiokafka-0.8.1-py311h12e69fa_0.conda
win-64::vtk-base-9.2.6-qt_py311h1234567_207.conda
win-64::llvm-tools-16.0.5-h1ab654d_0.conda
win-64::pytables-3.8.0-py38hcd4a0c8_2.conda
win-64::arrow-cpp-9.0.0-py38hf0d5951_39_cpu.conda
win-64::vigra-1.11.1-py311hfbe81d1_1044.conda
win-64::mysql-server-8.0.33-hdf5bdb2_0.conda
win-64::vigra-1.11.1-py39ha52c20e_1043.conda
win-64::libarrow-10.0.1-h8dba4ea_26_cuda.conda
win-64::omniorb-4.2.5-py311h40cf3c0_7.conda
win-64::cgns-4.4.0-hce4b968_1.conda
win-64::libopencv-4.7.0-py38h6504e80_5.conda
win-64::grpcio-1.55.1-py39hd28a505_0.conda
win-64::pyinstaller-5.12.0-py310h35269f2_1.conda
win-64::libarrow-10.0.1-hc076a2f_30_cuda.conda
win-64::llvmlite-0.40.1-py39h6848017_0.conda
win-64::libsolv-static-0.7.24-h12be248_1.conda
win-64::conduit-0.8.8-py39hb989ee6_1.conda
win-64::grpcio-1.55.1-py38h19421c1_1.conda
win-64::mlir-16.0.5-he744812_0.conda
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
win-64::llvm-14.0.6-h6fda50d_3.conda
-    "libzlib >=1.2.13,<1.3.0a0"
+    "libzlib >=1.2.13,<2.0.0a0"
================================================================================
================================================================================
osx-64
osx-64::dlib-cpp-19.24.2-h36d161f_2.conda
osx-64::lilly-medchem-rules-1.0.1-h7d26f99_0.conda
osx-64::libprotobuf-static-4.23.2-h5feb325_3.conda
osx-64::libmlir16-16.0.6-h837b0c1_0.conda
osx-64::dlib-cpp-19.24.2-h36d161f_3.conda
osx-64::libcdms-3.1.2-ha5aa0d5_125.conda
osx-64::cgns-4.4.0-h367ffb8_1.conda
osx-64::liblal-7.3.1-fftw_h7aac882_101.conda
osx-64::libprotobuf-4.23.2-h5feb325_3.conda
osx-64::libprotobuf-4.23.2-h5feb325_4.conda
osx-64::libdap4-3.20.6-h8af5f6c_3.conda
osx-64::g2clib-1.7.0-h48f9dc5_3.conda
osx-64::micromamba-1.4.5-0.tar.bz2
osx-64::adios-1.13.1-nompi_h2a044d9_1122.conda
osx-64::lilly-medchem-rules-1.0.1-h7d26f99_1.conda
osx-64::libprotobuf-4.23.2-h5feb325_5.conda
osx-64::llvm-spirv-15.0.0-h07d71dc_0.conda
osx-64::libmlir-16.0.5-h837b0c1_0.conda
osx-64::libsolv-static-0.7.24-hbc0c0cd_0.conda
osx-64::pandoc-3.1.3-h9d075a6_0.conda
osx-64::libprotobuf-4.23.3-h5feb325_0.conda
osx-64::llvm-14.0.6-h9d075a6_3.conda
osx-64::eccodes-2.30.2-he60ccd1_1.conda
osx-64::libv8-8.9.83-hf406619_3.conda
osx-64::metal-llvm-tools-15-0.5.1-h74fccab_0.conda
osx-64::libprotobuf-static-4.23.2-h5feb325_4.conda
osx-64::micromamba-1.4.4-0.tar.bz2
osx-64::libsolv-0.7.24-h7d26f99_1.conda
osx-64::libmlir16-16.0.5-h837b0c1_0.conda
osx-64::libsolv-0.7.24-hbc0c0cd_0.conda
osx-64::nceplibs-g2c-1.7.0-h48f9dc5_4.conda
osx-64::llvm-tools-14.0.6-hc8e404f_3.conda
osx-64::git-delta-0.16.0-h40666ff_0.conda
osx-64::libcdms-3.1.2-h55b60fb_124.conda
osx-64::git-delta-0.16.5-h40666ff_0.conda
osx-64::libprotobuf-static-4.23.2-h5feb325_5.conda
osx-64::libcdms-3.1.2-h80e58da_126.conda
osx-64::openexr-3.1.8-h747cbf1_0.conda
osx-64::dlib-cpp-19.24.2-h3adf3c7_1.conda
osx-64::openexr-3.1.7-h747cbf1_2.conda
osx-64::cgns-4.4.0-h99ce58a_0.conda
osx-64::libprotobuf-static-4.23.3-h5feb325_0.conda
osx-64::imath-3.1.9-h7d26f99_0.conda
osx-64::libdap4-3.20.6-h53e6dc5_4.conda
osx-64::git-delta-0.16.4-h40666ff_0.conda
osx-64::openexr-3.1.9-h747cbf1_0.conda
osx-64::libsolv-static-0.7.24-h7d26f99_1.conda
osx-64::libllvm14-14.0.6-hc8e404f_3.conda
osx-64::gst-plugins-base-1.22.4-hb5d3a86_0.conda
osx-64::eccodes-2.30.2-hecd1f2b_0.conda
osx-64::libmlir-16.0.6-h837b0c1_0.conda
-    "libzlib >=1.2.13,<1.3.0a0"
+    "libzlib >=1.2.13,<2.0.0a0"
osx-64::lxml-4.9.2-py311h19a211c_1.conda
osx-64::libpulsar-3.2.0-hac9bbb8_1.conda
osx-64::harp-1.18-py310h8b4e2e5_0.conda
osx-64::openmeeg-2.5.6-py38h7cb9a03_1.conda
osx-64::lammps-2023.03.28-cpu_py38_h7228914_openmpi_5.conda
osx-64::mupdf-1.22.2-he328532_0.conda
osx-64::r-data.table-1.14.8-r43h7eccc33_2.conda
osx-64::pyinstaller-5.12.0-py310hb69a1aa_0.conda
osx-64::libarrow-12.0.0-hc7cb4ed_8_cpu.conda
osx-64::mlir-16.0.5-h837b0c1_0.conda
osx-64::fenics-libdolfin-2019.1.0-ha7a47a0_37.conda
osx-64::libopencv-4.7.0-py38hccf63eb_5.conda
osx-64::libgdal-arrow-parquet-3.6.4-hab2f7db_4.conda
osx-64::ncl-6.6.2-h3a28f1b_47.conda
osx-64::lammps-2023.03.28-cpu_py311_h38df71f_openmpi_7.conda
osx-64::nest-simulator-3.4-py38h9636a1a_0.conda
osx-64::fenics-libdolfin-2019.1.0-h095b1e0_37.conda
osx-64::r-rmatio-0.18.0-r43h6dc245f_1.conda
osx-64::r-popgenome-2.7.5-r43ha73a074_3.conda
osx-64::pyinstaller-5.13.0-py310hb69a1aa_0.conda
osx-64::folly-2023.06.08.00-h503270f_1_jemalloc.conda
osx-64::coda-2.24.2-py311hbb3c0c7_2.conda
osx-64::tiledb-2.15.4-hc645918_0.conda
osx-64::sagelib-10.0-py310hc208e89_1.conda
osx-64::gazebo-11.13.0-hfdead7a_3.conda
osx-64::aiokafka-0.8.1-py311hbab40d1_0.conda
osx-64::lammps-2023.03.28-cpu_py311_hb61bd1e_mpich_7.conda
osx-64::libmediainfo-23.06-h02ebd30_0.conda
osx-64::vigra-1.11.1-py310h093879f_1044.conda
osx-64::r-popgenome-2.7.5-r42ha73a074_3.conda
osx-64::lammps-2023.03.28-cpu_py310_h396db8c_openmpi_7.conda
osx-64::pygplates-0.39-py311h82fd02c_8.conda
osx-64::fenics-libdolfin-2019.1.0-hc3da004_37.conda
osx-64::libgdal-3.6.4-h768f472_5.conda
osx-64::lxml-4.9.2-py310h479f746_1.conda
osx-64::jaxlib-0.4.12-cpu_py38hb3b8497_0.conda
osx-64::openbabel-3.1.1-py38h978edfe_7.conda
osx-64::mlir-python-bindings-16.0.5-py38hf3ea1e6_0.conda
osx-64::ambertools-23.3-py310h9dd47ba_1.conda
osx-64::netcdf4-1.6.4-nompi_py38h47ac6a0_100.conda
osx-64::lammps-2023.03.28-cpu_py310_h7ffbb60_openmpi_3.conda
osx-64::pyinstaller-5.13.0-py38h63e6892_0.conda
osx-64::mysql-server-8.0.33-ha12f4ff_0.conda
osx-64::lpython-0.17.0-h7d26f99_0.conda
osx-64::lammps-2023.03.28-cpu_py39_hbf27a6c_mpich_4.conda
osx-64::libopencv-4.7.0-py310h2da63cc_5.conda
osx-64::r-harp-1.18-r43hcd2b954_0.conda
osx-64::sagelib-10.0-py39hb452f22_1.conda
osx-64::julia-1.9.1-h8d83f4a_0.conda
osx-64::pyinstaller-5.12.0-py38h63e6892_0.conda
osx-64::mlir-16.0.6-h837b0c1_0.conda
osx-64::gstlal-1.11.0-py39h7fcd09a_0.conda
osx-64::pyreadstat-1.2.2-py311hbab40d1_0.conda
osx-64::tectonic-0.14.1-h429e7d8_0.conda
osx-64::folly-2023.06.12.00-h503270f_0_jemalloc.conda
osx-64::vigra-1.11.1-py39h514b6a7_1044.conda
osx-64::libopencv-4.7.0-py39h7a2f2b2_5.conda
osx-64::mysql-connector-python-8.0.32-py39h3bbc195_0.conda
osx-64::graphicsmagick-1.3.40-h41aadfa_2.conda
osx-64::octave-8.2.0-hd5800ab_1.conda
osx-64::z5py-2.0.16-py38h4a2fd63_1.conda
osx-64::omniorb-libs-4.2.5-he09fda9_7.conda
osx-64::lammps-2023.03.28-cpu_py38_h0cc894a_openmpi_7.conda
osx-64::libopencv-4.7.0-py310h3bf44a5_5.conda
osx-64::gst-plugins-bad-1.22.4-h70ac916_0.conda
osx-64::libarrow-12.0.0-h7bc8ed6_7_cpu.conda
osx-64::r-seqminer-8.9-r42he48eb84_1.conda
osx-64::lammps-2023.03.28-cpu_py38_ha00d12e_openmpi_2.conda
osx-64::vigra-1.11.1-py39hb8bd86f_1045.conda
osx-64::freefem-4.13-h5aa83a9_2.conda
osx-64::lammps-2023.03.28-cpu_py39_h202f2ed_mpich_6.conda
osx-64::tiledb-2.15.3-hde0c290_1.conda
osx-64::lxml-4.9.2-py38h2d3ed51_1.conda
osx-64::freefem-4.13-hdad0732_1.conda
osx-64::vtk-base-9.2.6-qt_py311h1234567_208.conda
osx-64::lammps-2023.03.28-cpu_py39_h89200ab_openmpi_6.conda
osx-64::hdf5-1.14.1-mpi_openmpi_h01be5f8_0.conda
osx-64::mlir-python-bindings-16.0.5-py310h5cafd22_0.conda
osx-64::aiokafka-0.8.1-py38h63e6892_0.conda
osx-64::jaxlib-0.4.12-cpu_py310h27fbe1d_0.conda
osx-64::netcdf4-1.6.4-nompi_py311ha27cd03_101.conda
osx-64::libgdal-3.6.4-hda23263_6.conda
osx-64::tiledb-2.15.4-h5215c2a_1.conda
osx-64::arrow-cpp-9.0.0-py38hc0af535_38_cpu.conda
osx-64::netcdf4-1.6.4-mpi_mpich_py311hf88ed30_1.conda
osx-64::netcdf4-1.6.4-mpi_openmpi_py310h56d339f_1.conda
osx-64::magics-metview-4.13.0-hd68800d_3.conda
osx-64::aiokafka-0.8.1-py39h35e2f92_0.conda
osx-64::harp-1.18-py39h4aca66a_0.conda
osx-64::libopencv-4.7.0-py39hf92d598_5.conda
osx-64::conduit-0.8.8-py39hd274219_1.conda
osx-64::pytables-3.8.0-py310hd1bf580_2.conda
osx-64::hugin-base-2022.0.0-pl5321h02ae937_5.conda
osx-64::libthrift-0.18.1-h88b220a_2.conda
osx-64::folly-2023.06.26.00-hc30067e_0_jemalloc.conda
osx-64::libadios2-2.8.3-nompi_h1a07a1f_107.conda
osx-64::libadios2-2.8.3-mpi_mpich_h1d18ce5_7.conda
osx-64::libadios2-2.8.3-mpi_mpich_h09b1d89_6.conda
osx-64::libopencv-4.7.0-py39h893b4ad_5.conda
osx-64::lammps-2023.03.28-cpu_py39_h30bcea4_mpich_2.conda
osx-64::r-git2r-0.31.0-r43ha4b72e8_1.conda
osx-64::libarrow-12.0.0-hd5f21ce_9_cpu.conda
osx-64::grpcio-1.55.1-py310hd8379ad_0.conda
osx-64::orc-1.9.0-hec59b76_0.conda
osx-64::libarrow-10.0.1-hcf3117f_30_cpu.conda
osx-64::gazebo-11.13.0-h4fa1784_1.conda
osx-64::libpulsar-3.2.0-h436fc51_1.conda
osx-64::pyinstaller-5.13.0-py39h29f4f0d_0.conda
osx-64::harp-1.18-py38h4bf41e0_1.conda
osx-64::libadios2-2.8.3-nompi_h95a1131_106.conda
osx-64::vigra-1.11.1-py310h0d632c9_1043.conda
osx-64::netcdf4-1.6.4-nompi_py310h845552d_101.conda
osx-64::r-harp-1.18-r43h7343328_1.conda
osx-64::nodejs-18.16.1-h46e3395_0.conda
osx-64::r-harp-1.18-r43hbd8561d_0.conda
osx-64::netcdf4-1.6.4-mpi_openmpi_py39hab9e8ac_1.conda
osx-64::jaxlib-0.4.11-cpu_py38hb3b8497_0.conda
osx-64::vigra-1.11.1-py39h12d125a_1045.conda
osx-64::netcdf4-1.6.4-mpi_openmpi_py311h3754897_1.conda
osx-64::tiledb-2.15.3-h4e090e4_1.conda
osx-64::mysql-connector-python-8.0.32-py39h9853fde_0.conda
osx-64::r-harp-1.18-r43ha82715f_1.conda
osx-64::lammps-2023.03.28-cpu_py39_h89200ab_openmpi_4.conda
osx-64::vtk-base-9.2.6-qt_py39h1234567_207.conda
osx-64::harp-1.18-py38h8b6ecde_0.conda
osx-64::openbabel-3.1.1-py39hcf68969_7.conda
osx-64::grpcio-1.55.1-py311hcbb5c6d_1.conda
osx-64::r-vcfr-1.14.0-r42ha73a074_1.conda
osx-64::grpcio-1.55.1-py38hf646772_0.conda
osx-64::libadios2-2.8.3-nompi_heaf9cef_106.conda
osx-64::libtiledb-sql-0.22.4-hcc7727a_0.conda
osx-64::xrootd-5.5.4-py38hd457fa0_1.conda
osx-64::llvmlite-0.40.1-py39hc281fc9_0.conda
osx-64::magics-4.13.0-hb1c45c1_5.conda
osx-64::mysql-client-8.0.33-hc4c47b9_0.conda
osx-64::openmeeg-2.5.6-py39h1604ba5_1.conda
osx-64::lammps-2023.03.28-cpu_py39_h5b93783_openmpi_6.conda
osx-64::lammps-2023.03.28-cpu_py39_h5b93783_openmpi_5.conda
osx-64::pytables-3.8.0-py39h91e7277_2.conda
osx-64::openbabel-3.1.1-py39hcf68969_6.conda
osx-64::libadios2-2.8.3-mpi_mpich_h915b4dc_6.conda
osx-64::pyreadstat-1.2.2-py38h63e6892_0.conda
osx-64::vigra-1.11.1-py38h9b04465_1043.conda
osx-64::arrow-cpp-9.0.0-py310h6b39678_40_cpu.conda
osx-64::omniorb-4.2.5-py39h0f23dde_7.conda
osx-64::abinit-9.8.4-hbd4199a_1.conda
osx-64::vigra-1.11.1-py39h514b6a7_1045.conda
osx-64::vigra-1.11.1-py39h7ceb91b_1045.conda
osx-64::arrow-cpp-9.0.0-py38h3cc9a4f_41_cpu.conda
osx-64::gazebo-11.13.0-hb6d618e_1.conda
osx-64::lammps-2023.03.28-cpu_py311_hbf34646_mpich_3.conda
osx-64::polycap-1.2-py310h25a4cc0_2.conda
osx-64::mysql-client-8.0.32-hc4c47b9_3.conda
osx-64::tiledb-2.15.4-hde0c290_0.conda
osx-64::verilator-5.012-he7f2693_0.conda
osx-64::openmeeg-2.5.6-py310h02bb39c_1.conda
osx-64::nifty-1.2.1-py310h1c09904_4.conda
osx-64::vigra-1.11.1-py38h1d053c6_1045.conda
osx-64::llvmdev-16.0.5-he4b1e75_0.conda
osx-64::paraview-5.11.1-py310hbe8619e_101_qt.conda
osx-64::vigra-1.11.1-py311h20ee354_1043.conda
osx-64::gst-plugins-good-1.22.4-hcffa465_0.conda
osx-64::arrow-cpp-9.0.0-py311h706b865_41_cpu.conda
osx-64::arrow-cpp-9.0.0-py39h4c794bd_37_cpu.conda
osx-64::folly-2023.06.26.00-h0d9798a_0.conda
osx-64::python-3.8.17-hf9b03c3_0_cpython.conda
osx-64::libgdal-arrow-parquet-3.7.0-hdeff0c1_2.conda
osx-64::libarrow-12.0.0-h3aa1ecd_8_cpu.conda
osx-64::lammps-2023.03.28-cpu_py311_hf04fa53_openmpi_3.conda
osx-64::mcpl-1.6.2-py39h35e2f92_0.conda
osx-64::z5py-2.0.16-py310h527a728_1.conda
osx-64::lammps-2023.03.28-cpu_py310_hb1d222f_mpich_2.conda
osx-64::vigra-1.11.1-py38h3288db6_1044.conda
osx-64::kaldi-5.5.1068-cpu_h0a45c7f_1.conda
osx-64::r-harp-1.18-r43hbb3c0c7_1.conda
osx-64::gdstk-0.9.42-py311hd33e98c_0.conda
osx-64::libxmlsec1-1.3.1-h260cc6a_0.conda
osx-64::harp-1.18-py311h24ed59d_0.conda
osx-64::arrow-cpp-9.0.0-py310h6b488b4_39_cpu.conda
osx-64::ovito-3.8.5-h7694c12_0.conda
osx-64::pyhdf-0.11.3-py39h53bac22_0.conda
osx-64::libopencv-4.7.0-py310h10b68d3_5.conda
osx-64::arrow-cpp-9.0.0-py38hce39d58_39_cpu.conda
osx-64::lammps-2023.03.28-cpu_py38_h0cc894a_openmpi_6.conda
osx-64::sagelib-10.0-py311h3b1e84e_1.conda
osx-64::coda-2.24.2-py39h5bfec1e_2.conda
osx-64::libpulsar-3.2.0-h436fc51_0.conda
osx-64::chemicalite-2022.04.1-h9b1e4e7_10.conda
osx-64::lammps-2023.03.28-cpu_py38_h5289e36_mpich_2.conda
osx-64::libgdal-arrow-parquet-3.6.4-hde8d238_5.conda
osx-64::libitk-5.3.0-hb0c863f_4.conda
osx-64::libopencv-4.7.0-py39h2818007_5.conda
osx-64::vigra-1.11.1-py311h7f13616_1043.conda
osx-64::h5utils-1.13.2-mpi_mpich_h5dfea56_1001.conda
osx-64::gnupg1-1.4.23-h4578372_0.conda
osx-64::python-3.10.12-had23ca6_0_cpython.conda
osx-64::pygame-2.5.0-py311h231154e_0.conda
osx-64::lammps-2023.03.28-cpu_py38_hf0e7f22_mpich_6.conda
osx-64::wxwidgets-3.2.2.1-h254b04c_3.conda
osx-64::pytables-3.8.0-py39h8cfc1d5_2.conda
osx-64::libadios2-2.8.3-mpi_mpich_h41c2e91_7.conda
osx-64::yarp-cxx-3.8.1-he29e89f_0.conda
osx-64::xrootd-5.5.4-py311h5e6077c_1.conda
osx-64::netcdf4-1.6.4-mpi_mpich_py310h1622245_0.conda
osx-64::hdf5-1.14.1-nompi_hedada53_100.conda
osx-64::nifty-1.2.1-py38hcc5959f_4.conda
osx-64::python-3.11.4-h30d4d87_0_cpython.conda
osx-64::netcdf4-1.6.4-mpi_openmpi_py38h57fe3f3_1.conda
osx-64::llvmdev-14.0.6-hc8e404f_3.conda
osx-64::libopencv-4.7.0-py311h6e95cb2_5.conda
osx-64::tiledb-2.15.3-hc645918_1.conda
osx-64::lammps-2023.03.28-cpu_py311_h38df71f_openmpi_5.conda
osx-64::libllvm16-16.0.5-he4b1e75_0.conda
osx-64::vigra-1.11.1-py310hc8b788f_1044.conda
osx-64::pocl-core-4.0-h6d67a90_1.conda
osx-64::libgdal-3.6.4-h4b16431_4.conda
osx-64::llvm-tools-16.0.5-he4b1e75_0.conda
osx-64::ffmpeg-6.0.0-lgpl_h048a335_2.conda
osx-64::lammps-2023.03.28-cpu_py38_ha9468fb_mpich_6.conda
osx-64::folly-2023.06.08.00-h889bfc7_0_jemalloc.conda
osx-64::lammps-2023.03.28-cpu_py310_h3cce830_mpich_5.conda
osx-64::arrow-cpp-9.0.0-py311hf24001f_39_cpu.conda
osx-64::pygplates-0.39-py310hc8a194f_8.conda
osx-64::nginx-1.25.1-h8970da8_0.conda
osx-64::arrow-cpp-9.0.0-py38ha868879_40_cpu.conda
osx-64::conduit-0.8.8-py310h0c3b2b8_1.conda
osx-64::libopencv-4.7.0-py311h7b12f46_5.conda
osx-64::lammps-2023.03.28-cpu_py38_h96e7bcc_openmpi_3.conda
osx-64::libarrow-11.0.0-h3aa1ecd_25_cpu.conda
osx-64::fenics-libdolfin-2019.1.0-h4b08a33_36.conda
osx-64::ovito-3.8.5-h861d1ee_0.conda
osx-64::paraview-5.11.1-py39h2dabb05_101_qt.conda
osx-64::qt6-main-6.5.1-h35278ed_2.conda
osx-64::lammps-2023.03.28-cpu_py39_hcdb5133_openmpi_3.conda
osx-64::fenics-libdolfin-2019.1.0-hc3da004_36.conda
osx-64::lammps-2023.03.28-cpu_py38_h0cc894a_openmpi_5.conda
osx-64::libarrow-11.0.0-h7bc8ed6_24_cpu.conda
osx-64::nexus-4.4.3-ha2ddfd6_10.conda
osx-64::pyinstaller-5.12.0-py38h63e6892_1.conda
osx-64::lammps-2023.03.28-cpu_py39_hbf27a6c_mpich_5.conda
osx-64::pyreadstat-1.2.2-py39h29f4f0d_0.conda
osx-64::folly-2023.06.12.00-h1718691_1.conda
osx-64::folly-2023.06.12.00-hc30067e_1_jemalloc.conda
osx-64::geotiff-1.7.1-h5cf5d3c_9.conda
osx-64::lammps-2023.03.28-cpu_py38_h7228914_openmpi_4.conda
osx-64::lammps-2023.03.28-cpu_py310_h396db8c_openmpi_5.conda
osx-64::pp-sketchlib-2.1.1-py38hc4254e9_1.conda
osx-64::arrow-cpp-9.0.0-py311h97e2f36_40_cpu.conda
osx-64::grpcio-1.55.1-py310hd8379ad_1.conda
osx-64::openbabel-3.1.1-py311hb239859_6.conda
osx-64::z5py-2.0.16-py311h97d5115_1.conda
osx-64::adios-1.13.1-mpi_openmpi_habbb3a0_1022.conda
osx-64::libopencv-4.7.0-py38ha9fd826_5.conda
osx-64::lld-16.0.5-h62a38e0_0.conda
osx-64::r-strawr-0.0.91-r42h519547d_1.conda
osx-64::r-vcfr-1.14.0-r43ha73a074_1.conda
osx-64::gazebo-11.13.0-hf6b3e29_2.conda
osx-64::pygame-2.5.0-py39h6ccb3b9_0.conda
osx-64::lammps-2023.03.28-cpu_py310_h3cce830_mpich_7.conda
osx-64::r-qpdf-1.3.2-r43h3eaf563_3.conda
osx-64::netcdf4-1.6.4-mpi_mpich_py311h34ca591_0.conda
osx-64::lammps-2023.03.28-cpu_py39_he7971d7_mpich_2.conda
osx-64::netcdf4-1.6.4-mpi_mpich_py310h37e9edd_1.conda
osx-64::pyhdf-0.11.3-py38h3381de9_0.conda
osx-64::pocl-core-4.0-h8b4fca9_0.conda
osx-64::r-harp-1.18-r43h5bfec1e_1.conda
osx-64::mlir-python-bindings-16.0.5-py39h048d6a6_0.conda
osx-64::pygame-2.5.0-py38h721016a_0.conda
osx-64::fenics-libdolfin-2019.1.0-h4b08a33_37.conda
osx-64::coda-2.24.2-py310h797c575_2.conda
osx-64::lammps-2023.03.28-cpu_py311_hb61bd1e_mpich_5.conda
osx-64::aws-sdk-cpp-1.11.68-h3009220_6.conda
osx-64::libarrow-12.0.0-hb051df6_9_cpu.conda
osx-64::ambertools-23.3-py39hfb6888d_1.conda
osx-64::folly-2023.06.12.00-h1718691_0.conda
osx-64::fenics-libdolfin-2019.1.0-h095b1e0_36.conda
osx-64::nest-simulator-3.4-py311hef84927_0.conda
osx-64::lxml-4.9.2-py39hfa406f7_1.conda
osx-64::r-gaston-1.5.9-r43ha73a074_1.conda
osx-64::r-httpgd-1.3.1-r42h40a7a93_1.conda
osx-64::netcdf4-1.6.4-mpi_openmpi_py310h188d6e0_0.conda
osx-64::harp-1.18-py38h5f6ef58_1.conda
osx-64::fenics-libdolfin-2019.1.0-h1e0a1c0_37.conda
osx-64::libarrow-11.0.0-h8fc5235_22_cpu.conda
osx-64::polycap-1.2-py311hb5608aa_2.conda
osx-64::gstlal-1.11.0-py310h1498c98_0.conda
osx-64::ambertools-23.3-py38h51c3a6d_0.conda
osx-64::erlang-26.0.1-pl5321hbb39af3_0.conda
osx-64::lammps-2023.03.28-cpu_py39_h202f2ed_mpich_7.conda
osx-64::vigra-1.11.1-py310h093879f_1045.conda
osx-64::wasmer-4.0.0-ha6357cd_0.conda
osx-64::lammps-2023.03.28-cpu_py39_hee5904a_openmpi_2.conda
osx-64::folly-2023.06.26.00-h503270f_0_jemalloc.conda
osx-64::grpcio-1.56.0-py310h0d4bf3c_1.conda
osx-64::lammps-2023.03.28-cpu_py38_h5289e36_mpich_3.conda
osx-64::lxml-4.9.2-py39h4794613_1.conda
osx-64::magics-metview-batch-4.13.0-hd1352d7_3.conda
osx-64::openmeeg-2.5.6-py39hf6a5884_1.conda
osx-64::vigra-1.11.1-py38haa9f591_1044.conda
osx-64::libtiff-4.5.1-hf955e92_0.conda
osx-64::jaxlib-0.4.11-cpu_py311h7d5d4fd_0.conda
osx-64::vigra-1.11.1-py311h7f13616_1044.conda
osx-64::aiokafka-0.8.1-py38hd9e109c_0.conda
osx-64::openmeeg-2.5.6-py311h6c97e2f_1.conda
osx-64::pp-sketchlib-2.1.1-py311h07bd319_1.conda
osx-64::lammps-2023.03.28-cpu_py311_h38df71f_openmpi_6.conda
osx-64::lammps-2023.03.28-cpu_py38_hf0e7f22_mpich_7.conda
osx-64::sagelib-10.0-py38hb144cf9_1.conda
osx-64::clspv-0.0.0.2023.06.25-h74fccab_0.conda
osx-64::libopencv-4.7.0-py38ha9e8791_5.conda
osx-64::vigra-1.11.1-py39h12d125a_1043.conda
osx-64::libarrow-12.0.1-hb051df6_0_cpu.conda
osx-64::libtiledb-sql-0.22.4-h8cb3c6c_0.conda
osx-64::gazebo-11.13.0-h4985b7d_1.conda
osx-64::libarrow-12.0.1-hecdf8c6_1_cpu.conda
osx-64::mysql-connector-python-8.0.32-py38h1be8c80_0.conda
osx-64::libnetcdf-4.9.2-mpi_openmpi_hd2b15c6_6.conda
osx-64::gazebo-11.13.0-h27810ae_2.conda
osx-64::lammps-2023.03.28-cpu_py311_hf04fa53_openmpi_2.conda
osx-64::libgrpc-1.56.0-hb64326a_1.conda
osx-64::r-harp-1.18-r43h60837c0_0.conda
osx-64::lpython-0.16.0-h7d26f99_0.conda
osx-64::libarrow-11.0.0-h7bc8ed6_23_cpu.conda
osx-64::r-httpgd-1.3.1-r43h40a7a93_1.conda
osx-64::fenics-libdolfin-2019.1.0-hc247975_37.conda
osx-64::netcdf4-1.6.4-nompi_py39h9ed30c6_101.conda
osx-64::aiokafka-0.8.1-py310hb69a1aa_0.conda
osx-64::orc-1.8.3-hb35b808_1.conda
osx-64::xrootd-5.5.4-py310hf4aae75_1.conda
osx-64::mesalib-23.1.2-hb59017c_0.conda
osx-64::gmt-5.4.5-h0d32c6b_29.conda
osx-64::libadios2-2.8.3-mpi_openmpi_h931771e_6.conda
osx-64::xrootd-5.5.4-py38h300efcb_1.conda
osx-64::grpcio-1.56.0-py311h43071ad_1.conda
osx-64::libadios2-2.8.3-nompi_h0ec5f4d_107.conda
osx-64::tiledb-2.15.4-h4e090e4_0.conda
osx-64::fenics-libdolfin-2019.1.0-hc247975_36.conda
osx-64::libadios2-2.8.3-mpi_openmpi_hf6dff9f_7.conda
osx-64::pygplates-0.39-py39h0b9a611_8.conda
osx-64::qt-main-5.15.8-h23c57ac_14.conda
osx-64::ffmpeg-5.1.2-gpl_h926ceef_111.conda
osx-64::vtk-base-9.2.6-qt_py38h1234567_207.conda
osx-64::liblal-7.3.1-mkl_h7c34464_1.conda
osx-64::vigra-1.11.1-py310h093879f_1043.conda
osx-64::lammps-2023.03.28-cpu_py38_ha9468fb_mpich_5.conda
osx-64::orc-1.8.4-hec59b76_0.conda
osx-64::libadios2-2.8.3-mpi_mpich_hdbe2315_6.conda
osx-64::lammps-2023.03.28-cpu_py38_h7228914_openmpi_7.conda
osx-64::paraview-5.11.1-py38h3ced40e_101_qt.conda
osx-64::libarrow-12.0.1-h3ab5e84_1_cpu.conda
osx-64::vigra-1.11.1-py39h7cd8bc0_1043.conda
osx-64::tiledb-2.15.4-h4e090e4_1.conda
osx-64::folly-2023.06.08.00-h1718691_1.conda
osx-64::llvmlite-0.40.1-py38hf646772_0.conda
osx-64::grpcio-1.56.0-py39h341a990_1.conda
osx-64::arrow-cpp-9.0.0-py310he43be27_38_cpu.conda
osx-64::openbabel-3.1.1-py311hb239859_7.conda
osx-64::mysql-libs-8.0.32-haa61052_3.conda
osx-64::ffmpeg-6.0.0-gpl_h74aebd8_103.conda
osx-64::r-strawr-0.0.91-r43h519547d_1.conda
osx-64::pyinstaller-5.12.0-py39h29f4f0d_0.conda
osx-64::libopencv-4.7.0-py310hd8ac186_5.conda
osx-64::r-seqminer-8.9-r43he48eb84_1.conda
osx-64::lammps-2023.03.28-cpu_py39_hbf27a6c_mpich_6.conda
osx-64::nifty-1.2.1-py311h6816990_4.conda
osx-64::vtk-base-9.2.6-qt_py310h1234567_207.conda
osx-64::netcdf4-1.6.4-mpi_mpich_py39h1591049_1.conda
osx-64::magics-metview-4.13.0-h08397e9_4.conda
osx-64::xrootd-5.5.4-py39ha4dc794_1.conda
osx-64::hdf5-1.14.1-mpi_mpich_h3618df7_0.conda
osx-64::gmt-6.4.0-h9716759_13.conda
osx-64::libadios2-2.8.3-mpi_mpich_h0cadb0f_7.conda
osx-64::gazebo-11.13.0-h74355ce_1.conda
osx-64::folly-2023.06.12.00-h0d9798a_1.conda
osx-64::coda-2.24.2-py38h7343328_2.conda
osx-64::coda-2.24.2-py39ha82715f_2.conda
osx-64::nifty-1.2.1-py39h362ab8b_4.conda
osx-64::mysql-connector-python-8.0.32-py310hb2ed6fa_0.conda
osx-64::omniorb-4.2.5-py310h3a57a48_7.conda
osx-64::libgdal-arrow-parquet-3.7.0-h95124bc_4.conda
osx-64::grpcio-1.55.1-py311hcbb5c6d_0.conda
osx-64::gstlal-1.11.0-py38hd78074e_0.conda
osx-64::gazebo-11.13.0-h4ab8887_3.conda
osx-64::lammps-2023.03.28-cpu_py310_h7ffbb60_openmpi_2.conda
osx-64::pygame-2.5.0-py310hb6fb842_0.conda
osx-64::lammps-2023.03.28-cpu_py39_h89200ab_openmpi_7.conda
osx-64::nest-simulator-3.4-py310h5ce9844_0.conda
osx-64::lammps-2023.03.28-cpu_py38_h7228914_openmpi_6.conda
osx-64::libopencv-4.7.0-py38h2f3dde2_5.conda
osx-64::gmt-5.4.5-h4320f1e_28.conda
osx-64::pyinstaller-5.12.0-py310hb69a1aa_1.conda
osx-64::openmeeg-2.5.6-py38h191c3e9_1.conda
osx-64::netcdf4-1.6.4-nompi_py38ha129777_101.conda
osx-64::mcpl-1.6.2-py311hbab40d1_0.conda
osx-64::vigra-1.11.1-py39h514b6a7_1043.conda
osx-64::arrow-cpp-9.0.0-py310h240271d_41_cpu.conda
osx-64::libopencv-4.7.0-py39h43b5454_5.conda
osx-64::mysql-server-8.0.32-h619a37a_3.conda
osx-64::llvm-16.0.6-h9c2cb20_0.conda
osx-64::libopencv-4.7.0-py38h5ce7a0c_5.conda
osx-64::nginx-1.25.1-h8970da8_1.conda
osx-64::yarp-cxx-3.8.0-he29e89f_3.conda
osx-64::pyinstaller-5.12.0-py39h29f4f0d_1.conda
osx-64::pygplates-0.39-py38h82da329_8.conda
osx-64::nest-simulator-3.4-py39hb8aae54_0.conda
osx-64::vtk-base-9.2.6-qt_py38h1234567_208.conda
osx-64::folly-2023.06.08.00-h0d9798a_0.conda
osx-64::r-git2r-0.31.0-r42ha4b72e8_1.conda
osx-64::vigra-1.11.1-py38h3bc6e48_1044.conda
osx-64::lammps-2023.03.28-cpu_py38_ha9468fb_mpich_4.conda
osx-64::pyhdf-0.11.3-py39hceb1baa_0.conda
osx-64::libadios2-2.8.3-nompi_h6b31068_106.conda
osx-64::libadios2-2.8.3-mpi_openmpi_h68a9da4_6.conda
osx-64::libgdal-3.7.0-hc13fe4b_4.conda
osx-64::git-2.41.0-pl5321h5c607e1_0.conda
osx-64::coda-2.24.2-py38hc3803ab_2.conda
osx-64::libadios2-2.8.3-mpi_openmpi_h424a5b2_7.conda
osx-64::pdal-2.5.5-h126b50f_0.conda
osx-64::pyinstaller-5.13.0-py311hbab40d1_0.conda
osx-64::harp-1.18-py39h3db4c0d_1.conda
osx-64::lammps-2023.03.28-cpu_py38_hf0e7f22_mpich_5.conda
osx-64::arrow-cpp-9.0.0-py311hb5da024_38_cpu.conda
osx-64::libadios2-2.8.3-mpi_openmpi_hb9d78ad_6.conda
osx-64::libgdal-3.7.0-heafcddf_2.conda
osx-64::fenics-libdolfin-2019.1.0-ha7a47a0_36.conda
osx-64::vigra-1.11.1-py310hc8b788f_1045.conda
osx-64::hdfeos5-5.1.16-h0ddbdb2_14.conda
osx-64::lammps-2023.03.28-cpu_py38_h0cc894a_openmpi_4.conda
osx-64::mysql-server-8.0.33-h619a37a_0.conda
osx-64::vtk-base-9.2.6-qt_py310h1234567_208.conda
osx-64::ncview-2.1.8-hbf55115_8.conda
osx-64::ambertools-23.3-py311h954e64c_1.conda
osx-64::vigra-1.11.1-py39hb8bd86f_1044.conda
osx-64::libadios2-2.8.3-nompi_h23cc82d_107.conda
osx-64::grpcio-1.55.1-py39hc281fc9_0.conda
osx-64::llvmdev-16.0.6-he4b1e75_0.conda
osx-64::libspatialite-5.0.1-h8e1b34b_28.conda
osx-64::magics-metview-batch-4.13.0-hb1c45c1_4.conda
osx-64::h5utils-1.13.2-nompi_hfb939e2_1101.conda
osx-64::lammps-2023.03.28-cpu_py39_h89200ab_openmpi_5.conda
osx-64::polycap-1.2-py38h837aa6c_2.conda
osx-64::gmt-6.4.0-hf48f7ff_11.conda
osx-64::pygame-2.5.0-py38h5fc1981_0.conda
osx-64::lammps-2023.03.28-cpu_py311_hb61bd1e_mpich_4.conda
osx-64::gazebo-11.13.0-h4fa1784_0.conda
osx-64::libopencv-4.7.0-py311h1f162bf_5.conda
osx-64::gdstk-0.9.42-py310h5cafd22_0.conda
osx-64::libarrow-10.0.1-h2d1375b_29_cpu.conda
osx-64::r-harp-1.18-r43hcc69121_0.conda
osx-64::libnetcdf-4.9.2-mpi_mpich_h287b1f4_6.conda
osx-64::ambertools-23.3-py311h954e64c_0.conda
osx-64::r-harp-1.18-r43hed2f75c_0.conda
osx-64::libopencv-4.7.0-py39h571fb4c_5.conda
osx-64::gazebo-11.13.0-h60f280c_2.conda
osx-64::polycap-1.2-py39h08dda2b_2.conda
osx-64::mcpl-1.6.2-py310hb69a1aa_0.conda
osx-64::netcdf4-1.6.4-mpi_mpich_py39h96ee5e7_0.conda
osx-64::mcpl-1.6.2-py38hd9e109c_0.conda
osx-64::llvmlite-0.40.1-py310hd8379ad_0.conda
osx-64::gdstk-0.9.42-py39h7dc8517_0.conda
osx-64::lammps-2023.03.28-cpu_py310_hb1d222f_mpich_3.conda
osx-64::grpcio-1.55.1-py39hc281fc9_1.conda
osx-64::vtk-base-9.2.6-qt_py39h1234567_208.conda
osx-64::vigra-1.11.1-py38haa9f591_1045.conda
osx-64::r-data.table-1.14.8-r42h7eccc33_2.conda
osx-64::libadios2-2.8.3-mpi_mpich_h032ee77_7.conda
osx-64::libtiledb-sql-0.22.4-h8fa5f5e_1.conda
osx-64::lammps-2023.03.28-cpu_py311_hb61bd1e_mpich_6.conda
osx-64::libarrow-11.0.0-hd5f21ce_26_cpu.conda
osx-64::libopencv-4.7.0-py39h19bf48f_5.conda
osx-64::arrow-cpp-9.0.0-py310he43be27_37_cpu.conda
osx-64::openbabel-3.1.1-py310h313d46c_6.conda
osx-64::libarrow-10.0.1-h7d6d730_26_cpu.conda
osx-64::netcdf4-1.6.4-mpi_openmpi_py39h6fb9d78_0.conda
osx-64::vigra-1.11.1-py38h3288db6_1043.conda
osx-64::libgdal-arrow-parquet-3.6.4-he7d39cd_6.conda
osx-64::harp-1.18-py311h94f2c77_1.conda
osx-64::libarrow-12.0.0-h8fc5235_5_cpu.conda
osx-64::ffmpeg-5.1.2-lgpl_hf1d5fb7_11.conda
osx-64::vigra-1.11.1-py38h25d0c3c_1043.conda
osx-64::harp-1.18-py310h8825a47_1.conda
osx-64::match-series-1.0.4-h30f6f69_3.conda
osx-64::pyreadstat-1.2.2-py310hb69a1aa_0.conda
osx-64::pytables-3.8.0-py311hfa5fc9a_2.conda
osx-64::aws-sdk-cpp-1.10.57-h3009220_14.conda
osx-64::mcpl-1.6.2-py39h29f4f0d_0.conda
osx-64::vigra-1.11.1-py39h7ceb91b_1044.conda
osx-64::lammps-2023.03.28-cpu_py39_h5b93783_openmpi_4.conda
osx-64::lammps-2023.03.28-cpu_py39_hee5904a_openmpi_3.conda
osx-64::orc-1.9.0-hb35b808_0.conda
osx-64::libgrpc-1.55.1-h73e6b18_1.conda
osx-64::conduit-0.8.8-py310h2d7af64_1.conda
osx-64::lammps-2023.03.28-cpu_py310_h3cce830_mpich_6.conda
osx-64::pocl-core-4.0-h7ae6de7_1.conda
osx-64::llvm-16.0.5-h9c2cb20_0.conda
osx-64::adios-1.13.1-mpi_mpich_hbc12278_1022.conda
osx-64::lld-16.0.6-h62a38e0_0.conda
osx-64::netcdf4-1.6.4-nompi_py311h6222480_100.conda
osx-64::orc-1.8.3-hec59b76_1.conda
osx-64::vigra-1.11.1-py39hd5ac698_1043.conda
osx-64::libopencv-4.7.0-py38h143a880_5.conda
osx-64::r-rmatio-0.18.0-r42h6dc245f_1.conda
osx-64::harp-1.18-py38h7531756_0.conda
osx-64::grpcio-1.56.0-py38h4864539_1.conda
osx-64::gdstk-0.9.42-py38hb45a76b_0.conda
osx-64::ambertools-23.3-py38h51c3a6d_1.conda
osx-64::conduit-0.8.8-py39h5567fc9_1.conda
osx-64::ntbtls-0.3.1-h7d26f99_1.conda
osx-64::jaxlib-0.4.12-cpu_py38hb3b8497_1.conda
osx-64::r-harp-1.18-r43hc3803ab_1.conda
osx-64::libarrow-12.0.1-hd5f21ce_0_cpu.conda
osx-64::r-gaston-1.5.9-r42ha73a074_1.conda
osx-64::paraview-5.11.1-py38h54a78f1_101_qt.conda
osx-64::vtk-base-9.2.6-qt_py311h1234567_207.conda
osx-64::arrow-cpp-9.0.0-py39h32f856c_40_cpu.conda
osx-64::pp-sketchlib-2.1.1-py39h339555b_1.conda
osx-64::lammps-2023.03.28-cpu_py39_h202f2ed_mpich_4.conda
osx-64::lammps-2023.03.28-cpu_py38_h96e7bcc_openmpi_2.conda
osx-64::lammps-2023.03.28-cpu_py39_h30bcea4_mpich_3.conda
osx-64::libllvm16-16.0.6-he4b1e75_0.conda
osx-64::gdstk-0.9.42-py39h048d6a6_0.conda
osx-64::folly-2023.06.08.00-hc30067e_0_jemalloc.conda
osx-64::r-harp-1.18-r43h797c575_1.conda
osx-64::libopencv-4.7.0-py38h9cd21e5_5.conda
osx-64::lammps-2023.03.28-cpu_py39_he7971d7_mpich_3.conda
osx-64::mysql-connector-python-8.0.32-py38h45be50d_0.conda
osx-64::smesh-9.9.0.0-h3a9112e_5.conda
osx-64::jaxlib-0.4.12-cpu_py311h7d5d4fd_0.conda
osx-64::lammps-2023.03.28-cpu_py38_h96b2fb8_mpich_2.conda
osx-64::lammps-2023.03.28-cpu_py39_h202f2ed_mpich_5.conda
osx-64::jaxlib-0.4.11-cpu_py310h27fbe1d_0.conda
osx-64::arrow-cpp-9.0.0-py39hcd68c54_41_cpu.conda
osx-64::conduit-0.8.8-py38hc461679_1.conda
osx-64::nco-5.1.6-h26cc95b_1.conda
osx-64::r-qpdf-1.3.2-r42h3eaf563_3.conda
osx-64::libspatialite-5.0.1-h54d511b_27.conda
osx-64::libopencv-4.7.0-py39h68aa194_5.conda
osx-64::conduit-0.8.8-py38h5c01cbb_1.conda
osx-64::fenics-libdolfin-2019.1.0-ha987527_36.conda
osx-64::netcdf4-1.6.4-nompi_py39h8e0d163_100.conda
osx-64::vigra-1.11.1-py311hdebeac5_1045.conda
osx-64::harp-1.18-py39h3671dbc_0.conda
osx-64::fenics-libdolfin-2019.1.0-h1e0a1c0_36.conda
osx-64::tiledb-2.15.4-hc645918_1.conda
osx-64::lammps-2023.03.28-cpu_py310_h3cce830_mpich_4.conda
osx-64::libarrow-12.0.0-h7bc8ed6_6_cpu.conda
osx-64::libadios2-2.8.3-mpi_mpich_hb787f0a_6.conda
osx-64::lammps-2023.03.28-cpu_py38_hf0e7f22_mpich_4.conda
osx-64::libopencv-4.7.0-py311ha6d609b_5.conda
osx-64::libadios2-2.8.3-mpi_openmpi_h2b0873b_6.conda
osx-64::llvm-tools-16.0.6-he4b1e75_0.conda
osx-64::omniorb-4.2.5-py311hc49bed8_7.conda
osx-64::yarp-cxx-3.8.1-hafdfd46_0.conda
osx-64::thrift-compiler-0.18.1-h88b220a_2.conda
osx-64::libarrow-10.0.1-h2ba2d65_31_cpu.conda
osx-64::ffmpeg-6.0.0-gpl_hbba2f9c_102.conda
osx-64::lammps-2023.03.28-cpu_py38_ha9468fb_mpich_7.conda
osx-64::fenics-libdolfin-2019.1.0-ha987527_37.conda
osx-64::pyhdf-0.11.3-py38he714bae_0.conda
osx-64::netcdf4-1.6.4-nompi_py310h3504ac7_100.conda
osx-64::pocl-core-4.0-h5552be4_0.conda
osx-64::paraview-5.11.1-py310hc8d066a_101_qt.conda
osx-64::llvmlite-0.40.1-py311hcbb5c6d_0.conda
osx-64::pytables-3.8.0-py38h3c32be3_2.conda
osx-64::lammps-2023.03.28-cpu_py311_h38df71f_openmpi_4.conda
osx-64::openbabel-3.1.1-py310h313d46c_7.conda
osx-64::tiledb-2.15.3-hc645918_2.conda
osx-64::conduit-0.8.8-py310hda672a7_1.conda
osx-64::fenics-libdolfin-2019.1.0-h6cc1711_37.conda
osx-64::llvmlite-0.40.1-py39h6ada40c_0.conda
osx-64::pyhdf-0.11.3-py311h7b9276f_0.conda
osx-64::folly-2023.06.08.00-h49bef9d_0.conda
osx-64::lammps-2023.03.28-cpu_py310_h396db8c_openmpi_6.conda
osx-64::vigra-1.11.1-py38h1d053c6_1044.conda
osx-64::lammps-2023.03.28-cpu_py311_hbf34646_mpich_2.conda
osx-64::libarrow-10.0.1-h8870db5_28_cpu.conda
osx-64::libnetcdf-4.9.2-nompi_hfeda9e8_106.conda
osx-64::ffmpeg-6.0.0-lgpl_h442ab89_3.conda
osx-64::pp-sketchlib-2.1.1-py310hda06942_1.conda
osx-64::mysql-libs-8.0.33-haa61052_0.conda
osx-64::ambertools-23.3-py39hfb6888d_0.conda
osx-64::libssh2-static-1.11.0-hd019ec5_0.conda
osx-64::netcdf4-1.6.4-mpi_mpich_py38h471d43c_0.conda
osx-64::xrootd-5.5.4-py39hdbfe476_1.conda
osx-64::mcpl-1.6.2-py38h63e6892_0.conda
osx-64::folly-2023.06.12.00-h503270f_1_jemalloc.conda
osx-64::lammps-2023.03.28-cpu_py39_hcdb5133_openmpi_2.conda
osx-64::netcdf4-1.6.4-mpi_openmpi_py38h20a7637_0.conda
osx-64::harp-1.18-py39h9af1791_1.conda
osx-64::qt6-main-6.5.1-h35278ed_1.conda
osx-64::fenics-libdolfin-2019.1.0-h6cc1711_36.conda
osx-64::lammps-2023.03.28-cpu_py38_ha00d12e_openmpi_3.conda
osx-64::arrow-cpp-9.0.0-py39h0ca3426_39_cpu.conda
osx-64::qtwebkit-5.212-h2bef28d_12.conda
osx-64::vigra-1.11.1-py38h3bc6e48_1043.conda
osx-64::lammps-2023.03.28-cpu_py310_h396db8c_openmpi_4.conda
osx-64::arrow-cpp-9.0.0-py38hc0af535_37_cpu.conda
osx-64::conduit-0.8.8-py39hfc97f55_1.conda
osx-64::mysql-connector-python-8.0.32-py311h315668a_0.conda
osx-64::paraview-5.11.1-py311hab73b75_101_qt.conda
osx-64::gmt-6.4.0-he36305a_12.conda
osx-64::libadios2-2.8.3-nompi_h2390f81_107.conda
osx-64::pygame-2.5.0-py39h91db508_0.conda
osx-64::libopencv-4.7.0-py38h1623a75_5.conda
osx-64::pyhdf-0.11.3-py310h320e44f_0.conda
osx-64::lammps-2023.03.28-cpu_py38_h96b2fb8_mpich_3.conda
osx-64::orc-1.8.4-hb35b808_0.conda
osx-64::openbabel-3.1.1-py38h978edfe_6.conda
osx-64::arrow-cpp-9.0.0-py311hb5da024_37_cpu.conda
osx-64::pytables-3.8.0-py38h5cccd43_2.conda
osx-64::mysql-server-8.0.32-ha12f4ff_3.conda
osx-64::libtiledb-sql-0.22.4-h8953216_1.conda
osx-64::gazebo-11.13.0-hbe5a154_2.conda
osx-64::libadios2-2.8.3-mpi_openmpi_h0c4e814_7.conda
osx-64::libmatio-1.5.23-h66c8109_3.conda
osx-64::libgdal-3.7.0-h1aad74f_3.conda
osx-64::libgrpc-1.55.1-h73e6b18_0.conda
osx-64::grpcio-1.55.1-py38hf646772_1.conda
osx-64::ncl-6.6.2-hf555e93_48.conda
osx-64::omniorb-4.2.5-py38hb69dc55_7.conda
osx-64::mesalib-23.1.3-hb59017c_0.conda
osx-64::libadios2-2.8.3-mpi_openmpi_hc044665_7.conda
osx-64::mlir-python-bindings-16.0.5-py311hd33e98c_0.conda
osx-64::gdstk-0.9.42-py38hf3ea1e6_0.conda
osx-64::erlang-26.0.2-pl5321hbb39af3_0.conda
osx-64::r-harp-1.18-r43hb271583_0.conda
osx-64::jaxlib-0.4.12-cpu_py39h511c999_0.conda
osx-64::tiledb-2.15.3-hde0c290_2.conda
osx-64::imagemagick-7.1.1_12-pl5321hcd3a149_0.conda
osx-64::netcdf4-1.6.4-mpi_openmpi_py311h518f4de_0.conda
osx-64::vigra-1.11.1-py38h3288db6_1045.conda
osx-64::z5py-2.0.16-py39ha273961_1.conda
osx-64::yarp-cxx-3.8.0-hafdfd46_3.conda
osx-64::llvmlite-0.40.1-py38ha1392ea_0.conda
osx-64::libadios2-2.8.3-nompi_hedcf358_106.conda
osx-64::ambertools-23.3-py310h9dd47ba_0.conda
osx-64::abinit-9.8.4-hcbee643_2.conda
osx-64::pyinstaller-5.12.0-py311hbab40d1_1.conda
osx-64::aiokafka-0.8.1-py39h29f4f0d_0.conda
osx-64::tiledb-2.15.3-h4e090e4_2.conda
osx-64::libssh2-1.11.0-hd019ec5_0.conda
osx-64::conduit-0.8.8-py38h76a1982_1.conda
osx-64::netcdf4-1.6.4-mpi_mpich_py38hb51c665_1.conda
osx-64::tectonic-0.14.0-h429e7d8_0.conda
osx-64::paraview-5.11.1-py39h2357fcb_101_qt.conda
osx-64::paraview-5.11.1-py311hcb58a2e_101_qt.conda
osx-64::lxml-4.9.2-py38h5dfb560_1.conda
osx-64::nginx-1.25.1-h8970da8_2.conda
osx-64::gstlal-1.11.0-py311hae03944_0.conda
osx-64::vigra-1.11.1-py38h3bc6e48_1045.conda
osx-64::vigra-1.11.1-py311hdebeac5_1044.conda
osx-64::vigra-1.11.1-py311h7f13616_1045.conda
osx-64::libarrow-10.0.1-h8870db5_27_cpu.conda
osx-64::vigra-1.11.1-py39h12d125a_1044.conda
osx-64::arrow-cpp-9.0.0-py39h4c794bd_38_cpu.conda
osx-64::lammps-2023.03.28-cpu_py39_hbf27a6c_mpich_7.conda
osx-64::folly-2023.06.26.00-h1718691_0.conda
osx-64::lammps-2023.03.28-cpu_py39_h5b93783_openmpi_7.conda
osx-64::libgdal-arrow-parquet-3.7.0-h82681f0_3.conda
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
================================================================================
================================================================================
linux-64
linux-64::libllvm14-14.0.6-hcd5def8_3.conda
linux-64::cudnn-8.8.0.121-h0800d71_1.conda
linux-64::openexr-3.1.7-h3f0fd8d_2.conda
linux-64::gst-libav-1.22.4-hda7e68b_0.conda
linux-64::libmlir16-16.0.6-hcd5def8_0.conda
linux-64::cudnn-8.8.0.121-h459966d_1.conda
linux-64::llvm-tools-14.0.6-hcd5def8_3.conda
linux-64::dlib-cpp-19.24.2-h8bfcc28_1.conda
linux-64::git-delta-0.16.0-h2ca70b0_0.conda
linux-64::g2clib-1.7.0-hd026740_3.conda
linux-64::gst-libav-1.22.4-hd5f137f_0.conda
linux-64::libmlir-16.0.5-hcd5def8_0.conda
linux-64::adios-1.13.1-nompi_h2d609e3_1122.conda
linux-64::libdap4-3.20.6-h866cc35_3.conda
linux-64::nceplibs-g2c-1.7.0-hd026740_4.conda
linux-64::libprotobuf-static-4.23.2-hd1fb520_3.conda
linux-64::git-delta-0.16.5-h2ca70b0_0.conda
linux-64::stress-ng-0.15.10-h2797004_0.conda
linux-64::llvm-spirv-15.0.0-h0cdce71_0.conda
linux-64::imath-3.1.9-hfc55251_0.conda
linux-64::libprotobuf-static-4.23.3-hd1fb520_0.conda
linux-64::libsolv-static-0.7.24-hfc55251_1.conda
linux-64::dlib-cpp-19.24.2-h71df52f_2.conda
linux-64::libprotobuf-4.23.2-hd1fb520_3.conda
linux-64::libcdms-3.1.2-hb301266_124.conda
linux-64::micromamba-1.4.4-0.tar.bz2
linux-64::git-delta-0.16.4-h2ca70b0_0.conda
linux-64::lilly-medchem-rules-1.0.1-hfc55251_1.conda
linux-64::libsolv-0.7.24-hfc55251_1.conda
linux-64::metal-llvm-tools-15-0.5.1-hcd5def8_0.conda
linux-64::libcdms-3.1.2-h09df33b_126.conda
linux-64::openexr-3.1.8-h3f0fd8d_0.conda
linux-64::dlib-cpp-19.24.2-h71df52f_3.conda
linux-64::libprotobuf-static-4.23.2-hd1fb520_4.conda
linux-64::libsolv-static-0.7.24-h3eb15da_0.conda
linux-64::libcdms-3.1.2-hb8a8fc3_125.conda
linux-64::libmlir-16.0.6-hcd5def8_0.conda
linux-64::eccodes-2.30.2-h1f30a5c_0.conda
linux-64::cgns-4.4.0-h6a3a0de_0.conda
linux-64::libprotobuf-4.23.2-hd1fb520_5.conda
linux-64::libprotobuf-4.23.3-hd1fb520_0.conda
linux-64::liblal-7.3.1-fftw_h648628b_101.conda
linux-64::lilly-medchem-rules-1.0.1-hfc55251_0.conda
linux-64::micromamba-1.4.5-0.tar.bz2
linux-64::eccodes-2.30.2-h73bf81c_1.conda
linux-64::libsolv-0.7.24-h3eb15da_0.conda
linux-64::cgns-4.4.0-hfaf7e62_1.conda
linux-64::libprotobuf-static-4.23.2-hd1fb520_5.conda
linux-64::libmlir16-16.0.5-hcd5def8_0.conda
linux-64::llvm-14.0.6-h32600fe_3.conda
linux-64::libdap4-3.20.6-h8384fce_4.conda
linux-64::openexr-3.1.9-h3f0fd8d_0.conda
linux-64::libprotobuf-4.23.2-hd1fb520_4.conda
linux-64::stress-ng-0.15.09-h2797004_0.conda
-    "libzlib >=1.2.13,<1.3.0a0"
+    "libzlib >=1.2.13,<2.0.0a0"
linux-64::pygplates-0.39-py310he4cb789_8.conda
linux-64::fenics-libdolfin-2019.1.0-h1a369f5_37.conda
linux-64::rust-1.70.0-h70c747d_0.conda
linux-64::libarrow-10.0.1-h3bdf5bc_31_cpu.conda
linux-64::r-harp-1.18-r43h8148971_1.conda
linux-64::magic-8.3.403-h9abf892_0.conda
linux-64::openmeeg-2.5.6-py310had43e02_1.conda
linux-64::vigra-1.11.1-py38h111891d_1044.conda
linux-64::netcdf4-1.6.4-nompi_py310hde23a83_100.conda
linux-64::vigra-1.11.1-py38h76c5eed_1045.conda
linux-64::lammps-2023.03.28-cpu_py310_h413fddf_mpich_4.conda
linux-64::lammps-2023.03.28-cuda110_py311_h034ec9a_openmpi_7.conda
linux-64::folly-2023.06.12.00-he8e2169_0_jemalloc.conda
linux-64::libadios2-2.8.3-mpi_mpich_hd6517ff_6.conda
linux-64::lammps-2023.03.28-cuda110_py39_h38d7a4e_mpich_2.conda
linux-64::libarrow-10.0.1-h17fb9fa_28_cpu.conda
linux-64::libadios2-2.8.3-mpi_mpich_h5ee1e10_6.conda
linux-64::mysql-connector-python-8.0.32-py311h381d6c5_0.conda
linux-64::libopencv-4.7.0-py38h498c9be_5.conda
linux-64::libgrpc-1.55.1-h59456c1_1.conda
linux-64::llvmlite-0.40.1-py38h7784e29_0.conda
linux-64::nest-simulator-3.4-py38hb67078f_0.conda
linux-64::libllvm16-16.0.6-h5cf9203_0.conda
linux-64::ncview-2.1.8-h8a77629_8.conda
linux-64::ambertools-23.3-py311hbcc7a2f_0.conda
linux-64::lammps-2023.03.28-cuda111_py39_h7ac4076_mpich_2.conda
linux-64::r-strawr-0.0.91-r42h308e8a1_1.conda
linux-64::lammps-2023.03.28-cpu_py310_h2b87cb3_mpich_2.conda
linux-64::lammps-2023.03.28-cuda112_py39_h63e1e39_openmpi_2.conda
linux-64::geotiff-1.7.1-h22adcc9_9.conda
linux-64::yarp-cxx-3.8.1-h245b40a_0.conda
linux-64::libnetcdf-4.9.2-nompi_h78c856c_106.conda
linux-64::lammps-2023.03.28-cpu_py39_h722c966_openmpi_5.conda
linux-64::arrow-cpp-9.0.0-py38h7fd568a_37_cpu.conda
linux-64::ffmpeg-6.0.0-gpl_hdbbbd96_103.conda
linux-64::lammps-2023.03.28-cuda110_py38_h601cda9_openmpi_6.conda
linux-64::r-harp-1.18-r43hf63d83c_1.conda
linux-64::libarrow-10.0.1-h1dee523_27_cuda.conda
linux-64::r-data.table-1.14.8-r43h029312a_2.conda
linux-64::tiledb-2.15.4-h9504ddb_0.conda
linux-64::lammps-2023.03.28-cuda111_py39_hcd52809_openmpi_6.conda
linux-64::tiledb-2.15.3-hebec990_2.conda
linux-64::libarrow-11.0.0-h6c7d76a_24_cuda.conda
linux-64::openmeeg-2.5.6-py38hc6e0025_1.conda
linux-64::pp-sketchlib-2.1.1-py39h8fe022a_1.conda
linux-64::arrow-cpp-9.0.0-py39hefa1bb2_38_cuda.conda
linux-64::jaxlib-0.4.12-cuda112py310h5656b0c_201.conda
linux-64::octave-8.2.0-h65fc901_1.conda
linux-64::gnupg1-1.4.23-h59136b9_0.conda
linux-64::pyreadstat-1.2.2-py310h93c3562_0.conda
linux-64::harp-1.18-py39h2ead2e0_1.conda
linux-64::aws-sdk-cpp-1.11.68-h8101662_6.conda
linux-64::lammps-2023.03.28-cpu_py39_hd1161dc_openmpi_2.conda
linux-64::mysql-libs-8.0.32-hca2cd23_3.conda
linux-64::netcdf4-1.6.4-mpi_mpich_py311hdfd729c_0.conda
linux-64::magics-metview-4.13.0-h2793fdc_3.conda
linux-64::jaxlib-0.4.11-cpu_py38hb25f6ba_0.conda
linux-64::mcpl-1.6.2-py38hbf0532a_0.conda
linux-64::arrow-cpp-9.0.0-py310hdd2edb7_37_cuda.conda
linux-64::tectonic-0.14.1-h03309ca_0.conda
linux-64::gdstk-0.9.42-py311h75db532_0.conda
linux-64::lammps-2023.03.28-cuda112_py39_h2ed2070_mpich_2.conda
linux-64::vigra-1.11.1-py39hdd23b48_1044.conda
linux-64::netcdf4-1.6.4-mpi_mpich_py39h650d8b0_0.conda
linux-64::arrow-cpp-9.0.0-py311hdb01164_40_cuda.conda
linux-64::libnetcdf-4.9.2-mpi_mpich_h4e4d8b4_6.conda
linux-64::conduit-0.8.8-py39h850bac5_1.conda
linux-64::magic-8.3.404-h9abf892_0.conda
linux-64::lammps-2023.03.28-cpu_py38_h4d58ba0_openmpi_2.conda
linux-64::grpcio-1.55.1-py311ha6695c7_1.conda
linux-64::harp-1.18-py310hacb68df_0.conda
linux-64::libarrow-12.0.1-h5245840_1_cuda.conda
linux-64::arrow-cpp-9.0.0-py311hab8f4b2_41_cpu.conda
linux-64::r-harp-1.18-r43hb5d9694_0.conda
linux-64::lammps-2023.03.28-cuda112_py310_hff62755_openmpi_3.conda
linux-64::lammps-2023.03.28-cuda110_py311_h034259f_openmpi_2.conda
linux-64::libarrow-12.0.1-hef14207_1_cpu.conda
linux-64::smesh-9.9.0.0-hdacd966_5.conda
linux-64::arrow-cpp-9.0.0-py311h01047c6_38_cuda.conda
linux-64::jaxlib-0.4.11-cuda112py311h7d292f2_200.conda
linux-64::netcdf4-1.6.4-mpi_openmpi_py39h52d83d6_0.conda
linux-64::llvmlite-0.40.1-py311ha6695c7_0.conda
linux-64::lammps-2023.03.28-cuda112_py39_haac3b19_openmpi_5.conda
linux-64::lammps-2023.03.28-cuda111_py39_h4fef882_mpich_7.conda
linux-64::netcdf4-1.6.4-nompi_py38hdfa7aa7_100.conda
linux-64::lammps-2023.03.28-cuda110_py311_h11264be_mpich_2.conda
linux-64::vigra-1.11.1-py311hcba7fdc_1044.conda
linux-64::magics-metview-batch-4.13.0-hc80596e_3.conda
linux-64::freefem-4.13-hc157639_0.conda
linux-64::libarrow-10.0.1-hc410076_30_cpu.conda
linux-64::libarrow-10.0.1-hc00ebf5_29_cpu.conda
linux-64::vigra-1.11.1-py38h111891d_1045.conda
linux-64::pygame-2.5.0-py39h4244053_0.conda
linux-64::arrow-cpp-9.0.0-py311hd083617_39_cuda.conda
linux-64::xrootd-5.5.4-py39ha53f741_1.conda
linux-64::magics-4.13.0-hd3d5bb6_5.conda
linux-64::jaxlib-0.4.12-cpu_py39h4646849_1.conda
linux-64::harp-1.18-py39h3fa017a_0.conda
linux-64::lammps-2023.03.28-cuda112_py39_ha5096fd_mpich_5.conda
linux-64::lammps-2023.03.28-cuda110_py38_h451a9a6_openmpi_3.conda
linux-64::vtk-base-9.2.6-osmesa_py38h1234567_107.conda
linux-64::gmt-6.4.0-hf38afcc_11.conda
linux-64::vigra-1.11.1-py310h561c6db_1043.conda
linux-64::llvm-openmp-16.0.6-h4dfa4b3_0.conda
linux-64::vtk-base-9.2.6-osmesa_py310h1234567_107.conda
linux-64::lammps-2023.03.28-cuda110_py311_h8f22a92_mpich_7.conda
linux-64::mcpl-1.6.2-py311hdcc4c9d_0.conda
linux-64::fenics-libdolfin-2019.1.0-h789a71a_36.conda
linux-64::r-harp-1.18-r43h39e59c0_1.conda
linux-64::arrow-cpp-9.0.0-py310hddd7baf_38_cuda.conda
linux-64::mysql-connector-python-8.0.32-py38h48d9fd9_0.conda
linux-64::r-httpgd-1.3.1-r43hcce77e3_1.conda
linux-64::mysql-connector-python-8.0.32-py310h6eefaca_0.conda
linux-64::xrootd-5.5.4-py38h03a7c77_1.conda
linux-64::libopencv-4.7.0-py39h046f4c6_5.conda
linux-64::jaxlib-0.4.12-cuda112py39ha2564ec_200.conda
linux-64::vigra-1.11.1-py39hc283c87_1043.conda
linux-64::libarrow-12.0.1-h7efa76e_0_cuda.conda
linux-64::netcdf4-1.6.4-mpi_mpich_py39h8c9c007_1.conda
linux-64::libopencv-4.7.0-py39h367c5ee_5.conda
linux-64::netcdf4-1.6.4-nompi_py39h4218a78_101.conda
linux-64::lammps-2023.03.28-cuda111_py311_hee88fc5_openmpi_7.conda
linux-64::openbabel-3.1.1-py39h421517d_7.conda
linux-64::lammps-2023.03.28-cpu_py311_h9dabdd9_openmpi_3.conda
linux-64::lammps-2023.03.28-cuda111_py310_h88d6e0a_openmpi_7.conda
linux-64::conduit-0.8.8-py38hdd0fd2d_1.conda
linux-64::linux-perf-6.3.8-py310h2f7a385_0.conda
linux-64::lammps-2023.03.28-cpu_py38_h4d58ba0_openmpi_3.conda
linux-64::arrow-cpp-9.0.0-py311h39c62a3_37_cpu.conda
linux-64::libarrow-12.0.0-h6c7d76a_6_cuda.conda
linux-64::lammps-2023.03.28-cuda110_py38_h86752b8_mpich_6.conda
linux-64::vigra-1.11.1-py39hd116d7d_1044.conda
linux-64::lammps-2023.03.28-cuda112_py310_h81b7dee_openmpi_4.conda
linux-64::python-3.8.17-he550d4f_0_cpython.conda
linux-64::vtk-base-9.2.6-qt_py39h1234567_207.conda
linux-64::pyhdf-0.11.3-py311ha36aa4f_0.conda
linux-64::libssh2-static-1.11.0-h0841786_0.conda
linux-64::coda-2.24.2-py38h9de6278_2.conda
linux-64::r-harp-1.18-r43h87e1c4c_1.conda
linux-64::lammps-2023.03.28-cuda112_py310_h6d7ea9e_mpich_2.conda
linux-64::libopencv-4.7.0-py311h642dc2d_5.conda
linux-64::pp-sketchlib-2.1.1-py38h1eec743_1.conda
linux-64::omniorb-4.2.5-py38ha65ae18_7.conda
linux-64::libopencv-4.7.0-py38hb7a91e4_5.conda
linux-64::lammps-2023.03.28-cuda111_py38_hf3157db_openmpi_4.conda
linux-64::kaldi-5.5.1068-cuda112h961d610_1.conda
linux-64::linux-perf-6.3.9-py310h3219344_0.conda
linux-64::lxml-4.9.2-py310h9b7343a_1.conda
linux-64::lammps-2023.03.28-cuda111_py38_hb436908_mpich_5.conda
linux-64::arrow-cpp-9.0.0-py310hf4ff3ec_39_cpu.conda
linux-64::openmeeg-2.5.6-py38h33887f0_1.conda
linux-64::vtk-base-9.2.6-osmesa_py311h1234567_108.conda
linux-64::nest-simulator-3.4-py311h1e43deb_0.conda
linux-64::vigra-1.11.1-py311hec70f64_1044.conda
linux-64::abinit-9.8.4-h8aa2086_2.conda
linux-64::openbabel-3.1.1-py310h956b46e_7.conda
linux-64::r-data.table-1.14.8-r42h029312a_2.conda
linux-64::mapserver-8.0.1-py39h70988df_4.conda
linux-64::aws-sdk-cpp-1.10.57-h8101662_14.conda
linux-64::lammps-2023.03.28-cuda112_py38_h9bee1bc_openmpi_3.conda
linux-64::arrow-cpp-9.0.0-py39h7691572_37_cuda.conda
linux-64::lammps-2023.03.28-cpu_py39_hd1161dc_openmpi_3.conda
linux-64::lmod-8.7.25-lua54h7bfae61_0.conda
linux-64::lammps-2023.03.28-cpu_py39_h71714aa_mpich_2.conda
linux-64::xrootd-5.5.4-py310h8e19c30_1.conda
linux-64::arrow-cpp-9.0.0-py310h84985d0_39_cuda.conda
linux-64::mysql-server-8.0.32-ha473b58_3.conda
linux-64::lammps-2023.03.28-cpu_py38_habb205f_openmpi_7.conda
linux-64::lammps-2023.03.28-cuda112_py311_h5a4feed_mpich_3.conda
linux-64::nifty-1.2.1-py38h144f5e2_4.conda
linux-64::nifty-1.2.1-py310h16739e1_4.conda
linux-64::git-2.41.0-pl5321h86e50cf_0.conda
linux-64::mysql-libs-8.0.33-hca2cd23_0.conda
linux-64::libarrow-12.0.1-hce8178f_0_cuda.conda
linux-64::arrow-cpp-9.0.0-py311hee86d0c_39_cpu.conda
linux-64::lammps-2023.03.28-cuda111_py38_h36dc16f_mpich_5.conda
linux-64::libopencv-4.7.0-py39h76ed197_5.conda
linux-64::linux-perf-6.3.10-py38hd75e30c_0.conda
linux-64::libadios2-2.8.3-mpi_openmpi_hcdfbd5b_6.conda
linux-64::gdstk-0.9.42-py39h2b14ec4_0.conda
linux-64::hdf5-1.14.1-mpi_openmpi_h327c9cf_0.conda
linux-64::libtiledb-sql-0.22.4-hb90626f_0.conda
linux-64::r-gaston-1.5.9-r43h33b523d_1.conda
linux-64::lammps-2023.03.28-cpu_py39_hc260df5_mpich_3.conda
linux-64::lammps-2023.03.28-cuda111_py39_hffbc052_mpich_7.conda
linux-64::fenics-libdolfin-2019.1.0-h1a369f5_36.conda
linux-64::r-harp-1.18-r43hc20d63e_0.conda
linux-64::r-harp-1.18-r43h6771260_0.conda
linux-64::lammps-2023.03.28-cpu_py39_h8760928_openmpi_3.conda
linux-64::ambertools-23.3-py310he275f01_1.conda
linux-64::openmeeg-2.5.6-py39h6b7aeb2_1.conda
linux-64::lammps-2023.03.28-cuda112_py39_hfa4ea64_mpich_5.conda
linux-64::z5py-2.0.16-py39h6290ec9_1.conda
linux-64::r-seqminer-8.9-r43ha661321_1.conda
linux-64::lxml-4.9.2-py38h7ad5e35_1.conda
linux-64::pp-sketchlib-2.1.1-py39h65024dc_1.conda
linux-64::lammps-2023.03.28-cuda112_py311_h5a4feed_mpich_2.conda
linux-64::ffmpeg-6.0.0-lgpl_h0f4d868_2.conda
linux-64::r-popgenome-2.7.5-r43h33b523d_3.conda
linux-64::mesalib-23.1.3-h2f194a4_0.conda
linux-64::openbabel-3.1.1-py311ha3c2874_6.conda
linux-64::libarrow-11.0.0-hed73b3e_23_cpu.conda
linux-64::lammps-2023.03.28-cuda111_py38_hb492ffa_mpich_3.conda
linux-64::libadios2-2.8.3-nompi_hbc473cc_107.conda
linux-64::lammps-2023.03.28-cpu_py38_h6cc3dfa_openmpi_4.conda
linux-64::libadios2-2.8.3-mpi_openmpi_h55f04b4_7.conda
linux-64::pandoc-3.1.3-h32600fe_0.conda
linux-64::lammps-2023.03.28-cpu_py310_h8f53010_openmpi_2.conda
linux-64::vtk-base-9.2.6-egl_py311h1234567_8.conda
linux-64::arrow-cpp-9.0.0-py38hf3687e2_41_cuda.conda
linux-64::paraview-5.11.1-py39h4d1deb2_101_qt.conda
linux-64::lammps-2023.03.28-cpu_py39_h71714aa_mpich_3.conda
linux-64::pytables-3.8.0-py38hfb8f983_2.conda
linux-64::grpcio-1.55.1-py38h94a1851_1.conda
linux-64::nifty-1.2.1-py39hc81e8ff_4.conda
linux-64::vigra-1.11.1-py38hbdb0dee_1045.conda
linux-64::arrow-cpp-9.0.0-py39h57fac37_41_cpu.conda
linux-64::vtk-base-9.2.6-egl_py38h1234567_7.conda
linux-64::r-gaston-1.5.9-r42h33b523d_1.conda
linux-64::lammps-2023.03.28-cuda111_py39_ha384574_openmpi_5.conda
linux-64::arrow-cpp-9.0.0-py38h0dca0b5_39_cpu.conda
linux-64::netcdf4-1.6.4-nompi_py311h4d7c953_100.conda
linux-64::libadios2-2.8.3-nompi_hdf556c1_107.conda
linux-64::grpcio-1.55.1-py311ha6695c7_0.conda
linux-64::orc-1.9.0-h2f23424_0.conda
linux-64::libopencv-4.7.0-py39hddcce75_5.conda
linux-64::jaxlib-0.4.12-cuda112py38h74aa024_201.conda
linux-64::python-3.11.4-hab00c5b_0_cpython.conda
linux-64::wxwidgets-3.2.2.1-hd8eb5fa_3.conda
linux-64::mysql-client-8.0.33-h545f5f4_0.conda
linux-64::libtiledb-sql-0.22.4-h47935f9_0.conda
linux-64::jaxlib-0.4.12-cuda112py311hf2474b9_201.conda
linux-64::fenics-libdolfin-2019.1.0-h390fade_36.conda
linux-64::libadios2-2.8.3-mpi_mpich_hbfab6ec_6.conda
linux-64::lammps-2023.03.28-cuda111_py38_h08e2e07_openmpi_2.conda
linux-64::gdstk-0.9.42-py38h7e89657_0.conda
linux-64::pp-sketchlib-2.1.1-py311hca817cb_1.conda
linux-64::r-httpgd-1.3.1-r42hcce77e3_1.conda
linux-64::clspv-0.0.0.2023.06.25-hcd5def8_0.conda
linux-64::mlir-python-bindings-16.0.5-py310hc662f57_0.conda
linux-64::harp-1.18-py38h8099cb5_0.conda
linux-64::nginx-1.25.1-he2eb08b_2.conda
linux-64::lld-16.0.6-hcfcaf08_0.conda
linux-64::orc-1.8.4-h2f23424_0.conda
linux-64::orc-1.8.4-h893ba9d_0.conda
linux-64::mapserver-8.0.1-py311h01476de_4.conda
linux-64::lammps-2023.03.28-cuda111_py39_h98118c0_openmpi_3.conda
linux-64::tiledb-2.15.4-h5c58516_1.conda
linux-64::conduit-0.8.8-py39ha3b268d_1.conda
linux-64::mysql-client-8.0.32-h545f5f4_3.conda
linux-64::r-vcfr-1.14.0-r43h33b523d_1.conda
linux-64::opentype-sanitizer-9.1.0-py38h6cb4028_0.conda
linux-64::linux-perf-6.3.8-py311h063b91e_0.conda
linux-64::folly-2023.06.08.00-h80c46b9_0.conda
linux-64::libmatio-1.5.23-hde58830_3.conda
linux-64::libopencv-4.7.0-py39hf99ad11_5.conda
linux-64::ffmpeg-5.1.2-gpl_hcbfe3e7_111.conda
linux-64::vtk-base-9.2.6-qt_py310h1234567_207.conda
linux-64::harp-1.18-py38h5db66a4_0.conda
linux-64::libopencv-4.7.0-py311h685a45d_5.conda
linux-64::lammps-2023.03.28-cpu_py310_h88a5792_openmpi_7.conda
linux-64::lammps-2023.03.28-cuda110_py38_h6b26ad3_mpich_7.conda
linux-64::vigra-1.11.1-py310h1e11933_1043.conda
linux-64::lammps-2023.03.28-cuda111_py39_hffbc052_mpich_6.conda
linux-64::libarrow-11.0.0-h96638e8_22_cpu.conda
linux-64::libarrow-12.0.0-hce8178f_9_cuda.conda
linux-64::grpcio-1.55.1-py310h1b8f574_0.conda
linux-64::vtk-base-9.2.6-osmesa_py310h1234567_108.conda
linux-64::lammps-2023.03.28-cuda111_py311_he4552b3_openmpi_5.conda
linux-64::lammps-2023.03.28-cpu_py311_h32ea382_mpich_2.conda
linux-64::vtk-base-9.2.6-qt_py310h1234567_208.conda
linux-64::lammps-2023.03.28-cuda111_py310_haf729c2_openmpi_4.conda
linux-64::nest-simulator-3.4-py39h18a2b99_0.conda
linux-64::ffmpeg-5.1.2-lgpl_h766a043_11.conda
linux-64::pygplates-0.39-py39h07a1462_8.conda
linux-64::lammps-2023.03.28-cpu_py311_h32ea382_mpich_3.conda
linux-64::fenics-libdolfin-2019.1.0-h1740a1e_37.conda
linux-64::libpulsar-3.2.0-h76eacb3_1.conda
linux-64::lammps-2023.03.28-cuda110_py38_hf91a5f8_openmpi_3.conda
linux-64::r-harp-1.18-r43h9de6278_1.conda
linux-64::netcdf4-1.6.4-mpi_openmpi_py310h2bc2d6a_0.conda
linux-64::lammps-2023.03.28-cuda111_py39_hcd52809_openmpi_7.conda
linux-64::openmeeg-2.5.6-py39h25a26ff_1.conda
linux-64::fenics-libdolfin-2019.1.0-h1740a1e_36.conda
linux-64::libarrow-11.0.0-h1496dd7_25_cuda.conda
linux-64::jaxlib-0.4.12-cpu_py311h7b5b818_0.conda
linux-64::tiledb-2.15.4-hebec990_1.conda
linux-64::conduit-0.8.8-py310hfb778b2_1.conda
linux-64::lammps-2023.03.28-cuda111_py311_h2df118c_mpich_3.conda
linux-64::lammps-2023.03.28-cuda110_py38_h451a9a6_openmpi_2.conda
linux-64::polycap-1.2-py310h3157e84_2.conda
linux-64::pytables-3.8.0-py311h504fbfb_2.conda
linux-64::arrow-cpp-9.0.0-py39haeafb6b_37_cpu.conda
linux-64::libgdal-arrow-parquet-3.6.4-h0b9a458_4.conda
linux-64::lammps-2023.03.28-cuda111_py38_h08e2e07_openmpi_3.conda
linux-64::pp-sketchlib-2.1.1-py310h48aeff4_1.conda
linux-64::gstlal-1.11.0-py310h922a1c5_0.conda
linux-64::lammps-2023.03.28-cuda111_py39_hc825479_openmpi_4.conda
linux-64::lammps-2023.03.28-cuda111_py38_hb436908_mpich_6.conda
linux-64::libnetcdf-4.9.2-mpi_openmpi_h7aae9c9_6.conda
linux-64::gstlal-1.11.0-py38h0725ab3_0.conda
linux-64::libgdal-arrow-parquet-3.7.0-h8edfbe3_2.conda
linux-64::libadios2-2.8.3-mpi_openmpi_h2278c24_7.conda
linux-64::arrow-cpp-9.0.0-py39h3a83d9f_39_cuda.conda
linux-64::magic-8.3.406-h9abf892_0.conda
linux-64::pp-sketchlib-2.1.1-py310hb8eee47_1.conda
linux-64::qtkeychain-0.14.1-hbc31b07_0.conda
linux-64::lammps-2023.03.28-cuda110_py38_h33ab9ea_mpich_7.conda
linux-64::lammps-2023.03.28-cuda112_py38_h9bee1bc_openmpi_2.conda
linux-64::adios-1.13.1-mpi_openmpi_h0e4b0de_1022.conda
linux-64::libarrow-12.0.0-ha836711_8_cpu.conda
linux-64::pyhdf-0.11.3-py39h4fd2b1f_0.conda
linux-64::vigra-1.11.1-py311hcba7fdc_1043.conda
linux-64::lammps-2023.03.28-cpu_py39_h8760928_openmpi_2.conda
linux-64::lammps-2023.03.28-cuda111_py39_h4663696_openmpi_3.conda
linux-64::gmt-6.4.0-hb5fd6f7_13.conda
linux-64::libssh2-1.11.0-h0841786_0.conda
linux-64::lammps-2023.03.28-cuda112_py310_h5a395ac_mpich_4.conda
linux-64::lammps-2023.03.28-cuda111_py39_h4fef882_mpich_4.conda
linux-64::libthrift-0.18.1-h8fd135c_2.conda
linux-64::folly-2023.06.12.00-hda79706_1_jemalloc.conda
linux-64::libarrow-12.0.0-h96638e8_5_cpu.conda
linux-64::libxmlsec1-1.3.1-h9a021bc_0.conda
linux-64::lammps-2023.03.28-cuda112_py310_h6d7ea9e_mpich_3.conda
linux-64::gmt-5.4.5-h6868b52_29.conda
linux-64::netcdf4-1.6.4-mpi_mpich_py38h821a72e_0.conda
linux-64::lammps-2023.03.28-cpu_py39_h4a6f353_openmpi_4.conda
linux-64::lammps-2023.03.28-cpu_py39_hba983e3_mpich_6.conda
linux-64::lammps-2023.03.28-cuda110_py310_hcc3e88c_openmpi_6.conda
linux-64::lammps-2023.03.28-cuda111_py310_h5bbe1a5_mpich_6.conda
linux-64::paraview-5.11.1-py38hf416c10_1_egl.conda
linux-64::lammps-2023.03.28-cuda110_py310_h2ac7bf9_mpich_4.conda
linux-64::netcdf4-1.6.4-mpi_openmpi_py310h4d979f4_1.conda
linux-64::libadios2-2.8.3-mpi_mpich_h863adcc_7.conda
linux-64::sagelib-10.0-py311h9409a4c_1.conda
linux-64::jaxlib-0.4.12-cpu_py311h7b5b818_1.conda
linux-64::folly-2023.06.08.00-he8e2169_1_jemalloc.conda
linux-64::lammps-2023.03.28-cpu_py38_h7efb62b_mpich_5.conda
linux-64::libgrpc-1.56.0-h460b9ca_1.conda
linux-64::ovito-3.8.5-h4da3077_0.conda
linux-64::grpcio-1.55.1-py39h174d805_1.conda
linux-64::lammps-2023.03.28-cuda111_py38_h36dc16f_mpich_6.conda
linux-64::yarp-cxx-3.8.0-h245b40a_3.conda
linux-64::jaxlib-0.4.12-cpu_py39h4646849_0.conda
linux-64::pygame-2.5.0-py310h8df29c8_0.conda
linux-64::r-qpdf-1.3.2-r42h6d82397_3.conda
linux-64::vigra-1.11.1-py311hc28c911_1043.conda
linux-64::lammps-2023.03.28-cuda112_py38_h78ffd95_mpich_2.conda
linux-64::pp-sketchlib-2.1.1-py311h466f419_1.conda
linux-64::folly-2023.06.26.00-he8e2169_0_jemalloc.conda
linux-64::tiledb-2.15.3-hc1c73f8_2.conda
linux-64::libspatialite-5.0.1-h15f6e67_28.conda
linux-64::fenics-libdolfin-2019.1.0-h390fade_37.conda
linux-64::lammps-2023.03.28-cpu_py311_hb661868_openmpi_4.conda
linux-64::paraview-5.11.1-py38hb34be86_1_egl.conda
linux-64::lammps-2023.03.28-cuda112_py39_h4b7dab0_openmpi_2.conda
linux-64::lammps-2023.03.28-cuda110_py39_h936e41d_openmpi_3.conda
linux-64::lammps-2023.03.28-cuda110_py38_h86752b8_mpich_4.conda
linux-64::vigra-1.11.1-py39hd116d7d_1045.conda
linux-64::grpcio-1.56.0-py310h1b8f574_1.conda
linux-64::pyreadstat-1.2.2-py39hb6545a3_0.conda
linux-64::pyinstaller-5.12.0-py310h93c3562_1.conda
linux-64::mcpl-1.6.2-py38h502143a_0.conda
linux-64::libadios2-2.8.3-mpi_openmpi_h8b25264_6.conda
linux-64::lammps-2023.03.28-cuda110_py310_hcc3e88c_openmpi_7.conda
linux-64::libarrow-10.0.1-hf815326_26_cpu.conda
linux-64::libarrow-12.0.1-hc410076_0_cpu.conda
linux-64::lammps-2023.03.28-cuda111_py38_hbe59ff7_openmpi_6.conda
linux-64::lammps-2023.03.28-cuda110_py39_h3b2872f_openmpi_5.conda
linux-64::rust-1.69.0-h70c747d_4.conda
linux-64::mysql-router-8.0.33-h247314d_0.conda
linux-64::vigra-1.11.1-py39hc283c87_1045.conda
linux-64::julia-1.9.1-hb81c242_0.conda
linux-64::pyhdf-0.11.3-py310h3532cbf_0.conda
linux-64::pyhdf-0.11.3-py38he3d7b75_0.conda
linux-64::vigra-1.11.1-py38h769fafb_1045.conda
linux-64::lammps-2023.03.28-cuda112_py38_h64b70e9_mpich_2.conda
linux-64::lammps-2023.03.28-cpu_py39_h722c966_openmpi_4.conda
linux-64::polycap-1.2-py38hfd61637_2.conda
linux-64::libadios2-2.8.3-nompi_h72669d3_106.conda
linux-64::omniorb-4.2.5-py310h2147c48_7.conda
linux-64::thrift-compiler-0.18.1-h8fd135c_2.conda
linux-64::libopencv-4.7.0-py39h736b924_5.conda
linux-64::tectonic-0.14.0-h03309ca_0.conda
linux-64::lammps-2023.03.28-cuda110_py39_hed5f4ef_mpich_6.conda
linux-64::match-series-1.0.4-h2417ca7_3.conda
linux-64::vigra-1.11.1-py38h111891d_1043.conda
linux-64::paraview-5.11.1-py310h8e45ce8_1_egl.conda
linux-64::graphicsmagick-1.3.40-ha3dd57d_2.conda
linux-64::lammps-2023.03.28-cuda111_py311_he4552b3_openmpi_6.conda
linux-64::libarrow-12.0.1-h3bdf5bc_1_cpu.conda
linux-64::linux-perf-6.3.10-py311h502c4cc_0.conda
linux-64::paraview-5.11.1-py311hfd59fb4_101_qt.conda
linux-64::fenics-libdolfin-2019.1.0-h2575477_37.conda
linux-64::lammps-2023.03.28-cuda112_py311_h5e4c2f5_openmpi_4.conda
linux-64::lammps-2023.03.28-cuda112_py39_h2ed2070_mpich_3.conda
linux-64::fenics-libdolfin-2019.1.0-h789a71a_37.conda
linux-64::mlir-python-bindings-16.0.5-py38h7e89657_0.conda
linux-64::pp-sketchlib-2.1.1-py39h5cde211_1.conda
linux-64::tiledb-2.15.4-hc1c73f8_0.conda
linux-64::libopencv-4.7.0-py310h7a152ed_5.conda
linux-64::vtk-base-9.2.6-qt_py38h1234567_207.conda
linux-64::llvmlite-0.40.1-py39h7d5b425_0.conda
linux-64::aiokafka-0.8.1-py38h502143a_0.conda
linux-64::lammps-2023.03.28-cpu_py38_h6df2e9b_mpich_6.conda
linux-64::lammps-2023.03.28-cuda112_py39_h63e1e39_openmpi_3.conda
linux-64::llvmdev-16.0.6-h5cf9203_0.conda
linux-64::paraprobe-v0.3.1-mpi_mpich_h7dda731_4.conda
linux-64::arrow-cpp-9.0.0-py310h25aa248_41_cuda.conda
linux-64::lammps-2023.03.28-cuda110_py310_hb7220d1_mpich_2.conda
linux-64::folly-2023.06.12.00-h80c46b9_1.conda
linux-64::libadios2-2.8.3-mpi_openmpi_h09787ba_7.conda
linux-64::qtwebkit-5.212-h0396763_12.conda
linux-64::lammps-2023.03.28-cpu_py311_h4aafb77_mpich_7.conda
linux-64::lammps-2023.03.28-cuda110_py39_h421681f_openmpi_5.conda
linux-64::vtk-base-9.2.6-osmesa_py311h1234567_107.conda
linux-64::lammps-2023.03.28-cuda110_py311_h6410dc1_openmpi_6.conda
linux-64::ambertools-23.3-py39h4856ba4_1.conda
linux-64::paraview-5.11.1-py38hcc3cb31_101_qt.conda
linux-64::lammps-2023.03.28-cpu_py38_h7efb62b_mpich_6.conda
linux-64::magic-8.3.409-h9abf892_0.conda
linux-64::pyreadstat-1.2.2-py311hdcc4c9d_0.conda
linux-64::vigra-1.11.1-py38hce9c906_1043.conda
linux-64::pp-sketchlib-2.1.1-py38h0f01a5e_1.conda
linux-64::libarrow-10.0.1-hce8178f_30_cuda.conda
linux-64::pp-sketchlib-2.1.1-py311h1999d3e_1.conda
linux-64::fenics-libdolfin-2019.1.0-h2575477_36.conda
linux-64::lammps-2023.03.28-cpu_py310_h8f53010_openmpi_3.conda
linux-64::lammps-2023.03.28-cuda112_py38_h78ffd95_mpich_3.conda
linux-64::vigra-1.11.1-py310he77709f_1044.conda
linux-64::lammps-2023.03.28-cuda111_py38_h790e05f_openmpi_4.conda
linux-64::lammps-2023.03.28-cuda111_py311_h8ced7dc_mpich_5.conda
linux-64::lammps-2023.03.28-cuda112_py38_h350a06d_openmpi_3.conda
linux-64::magic-8.3.401-h9abf892_0.conda
linux-64::arrow-cpp-9.0.0-py38hf4129de_41_cpu.conda
linux-64::lammps-2023.03.28-cpu_py310_h413fddf_mpich_7.conda
linux-64::openbabel-3.1.1-py311ha3c2874_7.conda
linux-64::jaxlib-0.4.12-cpu_py38hb25f6ba_0.conda
linux-64::r-harp-1.18-r43h1a73d88_1.conda
linux-64::libllvm16-16.0.5-h5cf9203_0.conda
linux-64::lammps-2023.03.28-cpu_py38_h6cc3dfa_openmpi_7.conda
linux-64::lammps-2023.03.28-cpu_py38_h6df2e9b_mpich_7.conda
linux-64::libarrow-12.0.1-hd562fea_0_cpu.conda
linux-64::libadios2-2.8.3-mpi_openmpi_h24e6939_6.conda
linux-64::r-harp-1.18-r43hce7ca7a_0.conda
linux-64::libarrow-12.0.0-hb3168b4_5_cuda.conda
linux-64::jaxlib-0.4.11-cpu_py39h4646849_0.conda
linux-64::pp-sketchlib-2.1.1-py38hd114f96_1.conda
linux-64::lammps-2023.03.28-cuda111_py38_h2eb93a9_openmpi_5.conda
linux-64::opentype-sanitizer-9.1.0-py39ha90811c_0.conda
linux-64::ambertools-23.3-py310he275f01_0.conda
linux-64::lammps-2023.03.28-cpu_py38_habb205f_openmpi_6.conda
linux-64::lammps-2023.03.28-cpu_py310_h88a5792_openmpi_5.conda
linux-64::coda-2.24.2-py311h8148971_2.conda
linux-64::lammps-2023.03.28-cuda111_py310_hbd2f93e_mpich_7.conda
linux-64::r-strawr-0.0.91-r43h308e8a1_1.conda
linux-64::lammps-2023.03.28-cpu_py311_hb661868_openmpi_7.conda
linux-64::lammps-2023.03.28-cpu_py39_hba983e3_mpich_7.conda
linux-64::paraview-5.11.1-py310ha38648f_101_qt.conda
linux-64::lammps-2023.03.28-cuda111_py39_hf45de20_mpich_6.conda
linux-64::lammps-2023.03.28-cuda110_py39_h3b2872f_openmpi_7.conda
linux-64::lammps-2023.03.28-cuda110_py311_h034259f_openmpi_3.conda
linux-64::libadios2-2.8.3-nompi_h214baa7_107.conda
linux-64::lammps-2023.03.28-cuda110_py311_h6410dc1_openmpi_5.conda
linux-64::libadios2-2.8.3-nompi_h5526e36_106.conda
linux-64::lammps-2023.03.28-cuda111_py311_h58eeeb7_openmpi_2.conda
linux-64::libadios2-2.8.3-nompi_h221b914_107.conda
linux-64::folly-2023.06.08.00-h09ac5fe_1.conda
linux-64::vigra-1.11.1-py39h239e5b6_1043.conda
linux-64::nginx-1.25.1-he2eb08b_0.conda
linux-64::actions-runner-2.305.0-hcd5def8_0.conda
linux-64::kaldi-5.5.1068-cuda110h4284680_1.conda
linux-64::libarrow-12.0.0-h1496dd7_8_cuda.conda
linux-64::hdf5-1.14.1-mpi_mpich_ha2c2bf8_0.conda
linux-64::lammps-2023.03.28-cuda112_py39_hc24beba_mpich_4.conda
linux-64::vigra-1.11.1-py39hd116d7d_1043.conda
linux-64::harp-1.18-py39hfa2690e_0.conda
linux-64::mysql-connector-python-8.0.32-py39h43026c6_0.conda
linux-64::lammps-2023.03.28-cuda111_py311_h9d9b504_mpich_4.conda
linux-64::pyinstaller-5.13.0-py38h502143a_0.conda
linux-64::pytables-3.8.0-py39hb8e3aad_2.conda
linux-64::netcdf4-1.6.4-nompi_py38h383a0a3_101.conda
linux-64::lammps-2023.03.28-cpu_py311_h4aafb77_mpich_4.conda
linux-64::lammps-2023.03.28-cuda111_py38_h05dc403_openmpi_3.conda
linux-64::vtk-base-9.2.6-egl_py311h1234567_7.conda
linux-64::omniorb-4.2.5-py311h01cb96d_7.conda
linux-64::lammps-2023.03.28-cuda112_py38_h18661a2_mpich_4.conda
linux-64::fenics-libdolfin-2019.1.0-h9a980d7_37.conda
linux-64::lammps-2023.03.28-cpu_py38_ha3d69ea_mpich_3.conda
linux-64::freefem-4.13-h2382517_1.conda
linux-64::llvmlite-0.40.1-py310h1b8f574_0.conda
linux-64::lammps-2023.03.28-cuda112_py39_h159fbe9_openmpi_4.conda
linux-64::coda-2.24.2-py39hf63d83c_2.conda
linux-64::arrow-cpp-9.0.0-py311h39c62a3_38_cpu.conda
linux-64::lpython-0.16.0-hfc55251_0.conda
linux-64::lammps-2023.03.28-cuda110_py311_h8f22a92_mpich_6.conda
linux-64::tiledb-2.15.3-h9504ddb_2.conda
linux-64::mysql-router-8.0.32-h3e7c513_3.conda
linux-64::netcdf4-1.6.4-mpi_openmpi_py311hd401626_1.conda
linux-64::gdstk-0.9.42-py310hc662f57_0.conda
linux-64::ambertools-23.3-py39h4856ba4_0.conda
linux-64::folly-2023.06.12.00-h09ac5fe_1.conda
linux-64::lammps-2023.03.28-cuda111_py311_h58eeeb7_openmpi_3.conda
linux-64::libadios2-2.8.3-mpi_mpich_h86f79d2_7.conda
linux-64::folly-2023.06.08.00-hda79706_0_jemalloc.conda
linux-64::mysql-connector-python-8.0.32-py39habddd97_0.conda
linux-64::paraview-5.11.1-py38h31f0794_101_qt.conda
linux-64::linux-perf-6.3.7-py310h2f7a385_0.conda
linux-64::lammps-2023.03.28-cuda110_py310_hb4a5257_openmpi_5.conda
linux-64::vigra-1.11.1-py39h7cac6b3_1045.conda
linux-64::conduit-0.8.8-py38h9abf6da_1.conda
linux-64::linux-perf-6.3.8-py39h43c8743_0.conda
linux-64::libgdal-3.6.4-h9f85045_4.conda
linux-64::lammps-2023.03.28-cuda110_py311_h11264be_mpich_3.conda
linux-64::lammps-2023.03.28-cuda111_py38_hf3157db_openmpi_7.conda
linux-64::arrow-cpp-9.0.0-py310he5ba608_41_cpu.conda
linux-64::pyinstaller-5.13.0-py311hdcc4c9d_0.conda
linux-64::libtiledb-sql-0.22.4-hb82b279_1.conda
linux-64::pp-sketchlib-2.1.1-py310hfe27807_1.conda
linux-64::verilator-5.012-h4f9daa6_0.conda
linux-64::libarrow-10.0.1-h1496dd7_29_cuda.conda
linux-64::lammps-2023.03.28-cuda110_py38_h575b63d_openmpi_7.conda
linux-64::lammps-2023.03.28-cuda110_py38_hd07a159_mpich_6.conda
linux-64::libgdal-arrow-parquet-3.7.0-hdbc7f4a_3.conda
linux-64::grpcio-1.56.0-py39h174d805_1.conda
linux-64::gst-plugins-base-1.22.4-hf7dbed1_0.conda
linux-64::orc-1.8.3-h2f23424_1.conda
linux-64::pyinstaller-5.13.0-py310h93c3562_0.conda
linux-64::lammps-2023.03.28-cpu_py38_habb205f_openmpi_4.conda
linux-64::lammps-2023.03.28-cuda111_py39_h4663696_openmpi_2.conda
linux-64::fenics-libdolfin-2019.1.0-h3156292_36.conda
linux-64::gdstk-0.9.42-py39h6356eae_0.conda
linux-64::libadios2-2.8.3-nompi_hc1b4514_106.conda
linux-64::gstlal-1.11.0-py39hcc277a1_0.conda
linux-64::nest-simulator-3.4-py310h6e68187_0.conda
linux-64::libadios2-2.8.3-mpi_mpich_h4b52df8_7.conda
linux-64::qt6-main-6.5.1-h2b880b2_2.conda
linux-64::lammps-2023.03.28-cuda110_py39_h421681f_openmpi_4.conda
linux-64::lammps-2023.03.28-cuda110_py39_h5dc7b02_mpich_4.conda
linux-64::llvm-16.0.6-ha0738ec_0.conda
linux-64::grpcio-1.55.1-py38h94a1851_0.conda
linux-64::harp-1.18-py310h8a439ba_1.conda
linux-64::libopencv-4.7.0-py38h2f1dfbd_5.conda
linux-64::lammps-2023.03.28-cuda111_py39_hb1ed587_openmpi_7.conda
linux-64::libtiff-4.5.1-h8b53f26_0.conda
linux-64::lammps-2023.03.28-cuda111_py311_h8ced7dc_mpich_6.conda
linux-64::qt-main-5.15.8-hf9e2b05_14.conda
linux-64::libgdal-3.7.0-h5418a03_2.conda
linux-64::lammps-2023.03.28-cuda111_py310_hfe47cf1_mpich_2.conda
linux-64::lammps-2023.03.28-cpu_py38_h6df2e9b_mpich_4.conda
linux-64::lammps-2023.03.28-cpu_py38_h60d8d75_openmpi_3.conda
linux-64::lammps-2023.03.28-cpu_py39_h4a6f353_openmpi_7.conda
linux-64::ffmpeg-6.0.0-gpl_h17d8df4_102.conda
linux-64::lammps-2023.03.28-cuda111_py310_h5bbe1a5_mpich_5.conda
linux-64::opentype-sanitizer-9.1.0-py311h9547e67_0.conda
linux-64::llvmlite-0.40.1-py38h94a1851_0.conda
linux-64::vigra-1.11.1-py311hec70f64_1045.conda
linux-64::mlir-16.0.5-hcd5def8_0.conda
linux-64::libopencv-4.7.0-py38hde6e744_5.conda
linux-64::libopencv-4.7.0-py39hc2f4b75_5.conda
linux-64::arrow-cpp-9.0.0-py39h4c0684a_41_cuda.conda
linux-64::libopencv-4.7.0-py311h8aafb54_5.conda
linux-64::ambertools-23.3-py38h3974a27_0.conda
linux-64::folly-2023.06.08.00-hf69079e_0.conda
linux-64::pp-sketchlib-2.1.1-py39hb1184a5_1.conda
linux-64::libadios2-2.8.3-nompi_h22a4dcc_106.conda
linux-64::pytables-3.8.0-py39h37f5a5d_2.conda
linux-64::mcpl-1.6.2-py39hb6545a3_0.conda
linux-64::hdf5-1.14.1-nompi_h4f84152_100.conda
linux-64::opentype-sanitizer-9.1.0-py310hd41b1e2_0.conda
linux-64::pyreadstat-1.2.2-py38h502143a_0.conda
linux-64::lammps-2023.03.28-cuda111_py310_h88d6e0a_openmpi_5.conda
linux-64::lxml-4.9.2-py39hed45dcc_1.conda
linux-64::lammps-2023.03.28-cpu_py39_h643d260_mpich_4.conda
linux-64::imagemagick-7.1.1_12-pl5321hf48ede7_0.conda
linux-64::libarrow-12.0.1-h5b6691e_1_cuda.conda
linux-64::lammps-2023.03.28-cuda111_py310_h5bbe1a5_mpich_4.conda
linux-64::openmeeg-2.5.6-py311hbe1ed31_1.conda
linux-64::lammps-2023.03.28-cuda110_py39_h936e41d_openmpi_2.conda
linux-64::lammps-2023.03.28-cuda110_py38_h601cda9_openmpi_5.conda
linux-64::jaxlib-0.4.12-cuda112py38h2a7d48f_200.conda
linux-64::mesalib-23.1.2-h2f194a4_0.conda
linux-64::r-seqminer-8.9-r42ha661321_1.conda
linux-64::folly-2023.06.12.00-he8e2169_1_jemalloc.conda
linux-64::vigra-1.11.1-py38h769fafb_1043.conda
linux-64::libpulsar-3.2.0-h2dfa9f6_1.conda
linux-64::arrow-cpp-9.0.0-py38h7fd568a_38_cpu.conda
linux-64::libgrpc-1.55.1-h59456c1_0.conda
linux-64::ncl-6.6.2-hf70af60_47.conda
linux-64::pytables-3.8.0-py310ha028ce3_2.conda
linux-64::lammps-2023.03.28-cuda110_py39_h5dc7b02_mpich_7.conda
linux-64::lxml-4.9.2-py311h1a07684_1.conda
linux-64::vtk-base-9.2.6-qt_py39h1234567_208.conda
linux-64::lammps-2023.03.28-cuda110_py310_h2ac7bf9_mpich_7.conda
linux-64::lammps-2023.03.28-cuda110_py38_h575b63d_openmpi_4.conda
linux-64::openbabel-3.1.1-py38hb38ef42_7.conda
linux-64::vtk-base-9.2.6-egl_py39h1234567_7.conda
linux-64::ntbtls-0.3.1-hfc55251_1.conda
linux-64::jaxlib-0.4.11-cuda112py39ha2564ec_200.conda
linux-64::arrow-cpp-9.0.0-py38h6fa803e_39_cuda.conda
linux-64::lammps-2023.03.28-cuda110_py310_h007d4e1_openmpi_2.conda
linux-64::lammps-2023.03.28-cuda111_py38_hb436908_mpich_4.conda
linux-64::libarrow-12.0.0-h6c7d76a_7_cuda.conda
linux-64::pyinstaller-5.13.0-py39hb6545a3_0.conda
linux-64::fenics-libdolfin-2019.1.0-h3efe49b_36.conda
linux-64::mysql-router-8.0.32-h247314d_3.conda
linux-64::ncl-6.6.2-h8c350bb_48.conda
linux-64::llvm-16.0.5-ha0738ec_0.conda
linux-64::lammps-2023.03.28-cuda110_py310_h007d4e1_openmpi_3.conda
linux-64::lammps-2023.03.28-cpu_py39_hba983e3_mpich_5.conda
linux-64::lammps-2023.03.28-cuda110_py39_haab9677_mpich_5.conda
linux-64::jaxlib-0.4.12-cpu_py310hc0ddb09_0.conda
linux-64::tiledb-2.15.4-hebec990_0.conda
linux-64::libarrow-11.0.0-hc00ebf5_25_cpu.conda
linux-64::grpcio-1.55.1-py39h174d805_0.conda
linux-64::lammps-2023.03.28-cuda112_py38_hc352ca8_mpich_5.conda
linux-64::lpython-0.17.0-hfc55251_0.conda
linux-64::arrow-cpp-9.0.0-py39h3ac3223_40_cpu.conda
linux-64::lammps-2023.03.28-cuda112_py311_h7ce1248_openmpi_5.conda
linux-64::conduit-0.8.8-py310h3c76131_1.conda
linux-64::aiokafka-0.8.1-py311hdcc4c9d_0.conda
linux-64::lammps-2023.03.28-cpu_py311_h4aafb77_mpich_6.conda
linux-64::gst-plugins-good-1.22.4-h7d8624f_0.conda
linux-64::pygame-2.5.0-py38h3762873_0.conda
linux-64::r-harp-1.18-r43h673289e_0.conda
linux-64::libarrow-12.0.0-h4360c7e_8_cuda.conda
linux-64::lammps-2023.03.28-cuda111_py38_hb492ffa_mpich_2.conda
linux-64::openbabel-3.1.1-py38hb38ef42_6.conda
linux-64::paraprobe-v0.3.1-mpi_mpich_h1c6b114_4.conda
linux-64::libopencv-4.7.0-py311h8597cb6_5.conda
linux-64::mlir-python-bindings-16.0.5-py39h6356eae_0.conda
linux-64::libmediainfo-23.06-had58582_0.conda
linux-64::paraview-5.11.1-py39h688eaa2_101_qt.conda
linux-64::liblal-7.3.1-mkl_hebc41f3_1.conda
linux-64::libopencv-4.7.0-py310h3e876cf_5.conda
linux-64::lammps-2023.03.28-cuda112_py39_h4b7dab0_openmpi_3.conda
linux-64::lammps-2023.03.28-cuda112_py311_h21df41c_openmpi_2.conda
linux-64::tiledb-2.15.3-hebec990_1.conda
linux-64::lammps-2023.03.28-cuda112_py39_haac3b19_openmpi_4.conda
linux-64::harp-1.18-py39haeafd41_1.conda
linux-64::libarrow-12.0.0-hed73b3e_7_cpu.conda
linux-64::lammps-2023.03.28-cpu_py38_ha3d69ea_mpich_2.conda
linux-64::vigra-1.11.1-py310h1e11933_1045.conda
linux-64::polycap-1.2-py39h2117972_2.conda
linux-64::linux-perf-6.3.10-py310h3219344_0.conda
linux-64::ambertools-23.3-py38h3974a27_1.conda
linux-64::pytables-3.8.0-py38h5dedbee_2.conda
linux-64::z5py-2.0.16-py38h3d4fbbe_1.conda
linux-64::linux-perf-6.3.10-py39haf0aa1b_0.conda
linux-64::arrow-cpp-9.0.0-py310h5f33b6b_38_cpu.conda
linux-64::libspatialite-5.0.1-hca56755_27.conda
linux-64::lammps-2023.03.28-cuda110_py310_hb7220d1_mpich_3.conda
linux-64::libadios2-2.8.3-mpi_mpich_hb4d2fc1_6.conda
linux-64::lammps-2023.03.28-cuda110_py38_hfbb69b4_openmpi_4.conda
linux-64::arrow-cpp-9.0.0-py310h528ac6c_40_cpu.conda
linux-64::lammps-2023.03.28-cpu_py310_h413fddf_mpich_6.conda
linux-64::vigra-1.11.1-py39hc283c87_1044.conda
linux-64::lammps-2023.03.28-cpu_py38_h39dc859_mpich_3.conda
linux-64::lammps-2023.03.28-cuda112_py38_h7691981_mpich_5.conda
linux-64::lammps-2023.03.28-cuda112_py38_hc352ca8_mpich_4.conda
linux-64::paraview-5.11.1-py311hf821d88_1_egl.conda
linux-64::opentype-sanitizer-9.1.0-py38h7f3f72f_0.conda
linux-64::lammps-2023.03.28-cpu_py310_h88a5792_openmpi_6.conda
linux-64::lammps-2023.03.28-cuda111_py39_hc825479_openmpi_5.conda
linux-64::netcdf4-1.6.4-mpi_openmpi_py38h28205af_1.conda
linux-64::nodejs-18.16.1-hf52ce11_0.conda
linux-64::libarrow-11.0.0-h6c7d76a_23_cuda.conda
linux-64::chemicalite-2022.04.1-h5ced5f6_10.conda
linux-64::paraview-5.11.1-py310hce1da01_1_egl.conda
linux-64::lammps-2023.03.28-cuda111_py311_h9d9b504_mpich_7.conda
linux-64::lammps-2023.03.28-cuda110_py39_h0b43194_openmpi_2.conda
linux-64::linux-perf-6.3.9-py311h502c4cc_0.conda
linux-64::lammps-2023.03.28-cuda111_py311_h2df118c_mpich_2.conda
linux-64::orc-1.9.0-h893ba9d_0.conda
linux-64::erlang-26.0.1-pl5321h949266c_0.conda
linux-64::z5py-2.0.16-py311hc6f357e_1.conda
linux-64::erlang-26.0.2-pl5321hde4a2a6_0.conda
linux-64::vtk-base-9.2.6-egl_py39h1234567_8.conda
linux-64::lammps-2023.03.28-cuda110_py310_h8bfe3ce_mpich_6.conda
linux-64::lammps-2023.03.28-cpu_py311_hb661868_openmpi_5.conda
linux-64::pp-sketchlib-2.1.1-py310h8ef7433_1.conda
linux-64::libopencv-4.7.0-py310h5efe7ff_5.conda
linux-64::nifty-1.2.1-py311h6e55cdc_4.conda
linux-64::pp-sketchlib-2.1.1-py311h67ed826_1.conda
linux-64::lammps-2023.03.28-cuda112_py310_h5a395ac_mpich_5.conda
linux-64::libarrow-11.0.0-hce8178f_26_cuda.conda
linux-64::omniorb-4.2.5-py39h15d7a37_7.conda
linux-64::freefem-4.13-he300dc6_0.conda
linux-64::coda-2.24.2-py38h39e59c0_2.conda
linux-64::netcdf4-1.6.4-mpi_mpich_py310h628a664_1.conda
linux-64::lammps-2023.03.28-cuda110_py311_h034ec9a_openmpi_4.conda
linux-64::ambertools-23.3-py311hbcc7a2f_1.conda
linux-64::lld-16.0.5-hcfcaf08_0.conda
linux-64::aiokafka-0.8.1-py38hbf0532a_0.conda
linux-64::grpcio-1.56.0-py38h94a1851_1.conda
linux-64::grpcio-1.55.1-py310h1b8f574_1.conda
linux-64::lammps-2023.03.28-cuda110_py311_h8f22a92_mpich_5.conda
linux-64::lammps-2023.03.28-cpu_py38_habb205f_openmpi_5.conda
linux-64::libopencv-4.7.0-py38h63092d6_5.conda
linux-64::lammps-2023.03.28-cuda112_py38_h9a0a0b5_openmpi_4.conda
linux-64::sagelib-10.0-py38h749e0f1_1.conda
linux-64::lammps-2023.03.28-cuda110_py38_h575b63d_openmpi_5.conda
linux-64::lammps-2023.03.28-cuda111_py39_hc2dd905_mpich_3.conda
linux-64::llvm-openmp-16.0.5-h4dfa4b3_0.conda
linux-64::lammps-2023.03.28-cpu_py39_h4a6f353_openmpi_6.conda
linux-64::mysql-server-8.0.33-ha473b58_0.conda
linux-64::netcdf4-1.6.4-nompi_py310h6f5dce6_101.conda
linux-64::lammps-2023.03.28-cuda110_py39_h5026a73_mpich_2.conda
linux-64::jaxlib-0.4.12-cpu_py38hb25f6ba_1.conda
linux-64::libgdal-arrow-parquet-3.6.4-h3865135_6.conda
linux-64::kaldi-5.5.1068-cpu_h05f3a92_1.conda
linux-64::lammps-2023.03.28-cuda112_py39_h159fbe9_openmpi_5.conda
linux-64::libarrow-11.0.0-hc410076_26_cpu.conda
linux-64::abinit-9.8.4-h04af664_1.conda
linux-64::lammps-2023.03.28-cuda111_py310_haf729c2_openmpi_6.conda
linux-64::harp-1.18-py311he25ec6d_0.conda
linux-64::pyinstaller-5.12.0-py39hb6545a3_1.conda
linux-64::pygame-2.5.0-py38hc1798b0_0.conda
linux-64::orc-1.8.3-h893ba9d_1.conda
linux-64::r-popgenome-2.7.5-r42h33b523d_3.conda
linux-64::vtk-base-9.2.6-egl_py310h1234567_7.conda
linux-64::conduit-0.8.8-py310he61bb19_1.conda
linux-64::linux-perf-6.3.7-py311h063b91e_0.conda
linux-64::lammps-2023.03.28-cuda111_py38_hbe59ff7_openmpi_7.conda
linux-64::coda-2.24.2-py310h87e1c4c_2.conda
linux-64::lammps-2023.03.28-cpu_py39_h4a6f353_openmpi_5.conda
linux-64::lammps-2023.03.28-cpu_py39_h722c966_openmpi_7.conda
linux-64::arrow-cpp-9.0.0-py310h5f33b6b_37_cpu.conda
linux-64::omniorb-libs-4.2.5-h6bbaf85_7.conda
linux-64::mcpl-1.6.2-py310h93c3562_0.conda
linux-64::conduit-0.8.8-py39h2ac0e3e_1.conda
linux-64::lammps-2023.03.28-cpu_py39_h722c966_openmpi_6.conda
linux-64::lammps-2023.03.28-cuda111_py38_h790e05f_openmpi_5.conda
linux-64::lammps-2023.03.28-cuda110_py310_h2ac7bf9_mpich_5.conda
linux-64::magics-metview-4.13.0-h40b8c56_4.conda
linux-64::tiledb-2.15.3-hc1c73f8_1.conda
linux-64::xrootd-5.5.4-py311he1aa323_1.conda
linux-64::lammps-2023.03.28-cuda110_py39_h421681f_openmpi_7.conda
linux-64::linux-perf-6.3.7-py39h43c8743_0.conda
linux-64::libgdal-3.6.4-hd54c316_5.conda
linux-64::llvm-tools-16.0.5-h5cf9203_0.conda
linux-64::python-igraph-0.10.4-py310hc734324_0.conda
linux-64::netcdf4-1.6.4-nompi_py39h4e81c44_100.conda
linux-64::netcdf4-1.6.4-mpi_openmpi_py38h3ebf66d_0.conda
linux-64::lammps-2023.03.28-cuda112_py38_he52cfe6_openmpi_4.conda
linux-64::lammps-2023.03.28-cuda110_py38_h27cc18a_mpich_2.conda
linux-64::grpcio-1.56.0-py311ha6695c7_1.conda
linux-64::mysql-server-8.0.33-h924002b_0.conda
linux-64::lammps-2023.03.28-cuda111_py310_hfe47cf1_mpich_3.conda
linux-64::vigra-1.11.1-py39h7cac6b3_1044.conda
linux-64::netcdf4-1.6.4-nompi_py311h9a7c333_101.conda
linux-64::lammps-2023.03.28-cuda110_py39_h7b0575a_mpich_7.conda
linux-64::ffmpeg-6.0.0-lgpl_h1f16c6c_3.conda
linux-64::lammps-2023.03.28-cuda111_py310_h062e84d_openmpi_3.conda
linux-64::ovito-3.8.5-h12c506e_0.conda
linux-64::arrow-cpp-9.0.0-py39haeafb6b_38_cpu.conda
linux-64::lammps-2023.03.28-cpu_py311_hb661868_openmpi_6.conda
linux-64::llvmdev-14.0.6-hcd5def8_3.conda
linux-64::folly-2023.06.08.00-h5e7e832_0_jemalloc.conda
linux-64::arrow-cpp-9.0.0-py310hea6e809_40_cuda.conda
linux-64::polycap-1.2-py311h7209844_2.conda
linux-64::lammps-2023.03.28-cpu_py38_h6cc3dfa_openmpi_5.conda
linux-64::lammps-2023.03.28-cpu_py39_h643d260_mpich_7.conda
linux-64::lammps-2023.03.28-cuda111_py39_hc2dd905_mpich_2.conda
linux-64::vtk-base-9.2.6-qt_py311h1234567_208.conda
linux-64::sagelib-10.0-py39h995b525_1.conda
linux-64::llvm-tools-16.0.6-h5cf9203_0.conda
linux-64::lammps-2023.03.28-cuda111_py39_h7ac4076_mpich_3.conda
linux-64::hugin-base-2022.0.0-pl5321h6b3c902_5.conda
linux-64::lammps-2023.03.28-cuda110_py39_h0b43194_openmpi_3.conda
linux-64::magics-metview-batch-4.13.0-hd3d5bb6_4.conda
linux-64::arrow-cpp-9.0.0-py39h79b8b31_39_cpu.conda
linux-64::netcdf4-1.6.4-mpi_mpich_py38he23bcfd_1.conda
linux-64::graalpy-23.0.0-0_graalvm_native.conda
linux-64::nexus-4.4.3-hd79c5ce_10.conda
linux-64::lammps-2023.03.28-cuda110_py39_h421681f_openmpi_6.conda
linux-64::h5utils-1.13.2-nompi_hf400f13_1101.conda
linux-64::python-3.10.12-hd12c33a_0_cpython.conda
linux-64::netcdf4-1.6.4-mpi_mpich_py311h8fc53a5_1.conda
linux-64::vtk-base-9.2.6-egl_py310h1234567_8.conda
linux-64::mysql-connector-python-8.0.32-py38h4bdff42_0.conda
linux-64::lammps-2023.03.28-cuda112_py310_h81b7dee_openmpi_5.conda
linux-64::lammps-2023.03.28-cuda110_py38_h33ab9ea_mpich_5.conda
linux-64::lammps-2023.03.28-cpu_py38_h60d8d75_openmpi_2.conda
linux-64::lammps-2023.03.28-cuda111_py39_ha384574_openmpi_4.conda
linux-64::lammps-2023.03.28-cuda111_py39_h4fef882_mpich_5.conda
linux-64::sagelib-10.0-py310h551a372_1.conda
linux-64::paraview-5.11.1-py311hefe06ba_1_egl.conda
linux-64::fenics-libdolfin-2019.1.0-h3efe49b_37.conda
linux-64::fenics-libdolfin-2019.1.0-h9a980d7_36.conda
linux-64::vigra-1.11.1-py310h1e11933_1044.conda
linux-64::libopencv-4.7.0-py38h8258ff5_5.conda
linux-64::libgdal-3.6.4-hc50c542_6.conda
linux-64::libadios2-2.8.3-mpi_openmpi_h36e2c2e_6.conda
linux-64::pyhdf-0.11.3-py39h4aa7ace_0.conda
linux-64::llvmdev-16.0.5-h5cf9203_0.conda
linux-64::lammps-2023.03.28-cuda111_py39_h98118c0_openmpi_2.conda
linux-64::arrow-cpp-9.0.0-py39he6a3f72_40_cuda.conda
linux-64::libadios2-2.8.3-mpi_openmpi_hbfd91ea_7.conda
linux-64::vigra-1.11.1-py38h769fafb_1044.conda
linux-64::lammps-2023.03.28-cuda110_py38_h67e13c3_mpich_3.conda
linux-64::lammps-2023.03.28-cuda111_py38_hf3157db_openmpi_6.conda
linux-64::adios-1.13.1-mpi_mpich_hf822389_1022.conda
linux-64::lammps-2023.03.28-cuda111_py38_h36dc16f_mpich_7.conda
linux-64::z5py-2.0.16-py310h97613c2_1.conda
linux-64::lammps-2023.03.28-cuda110_py39_h7b0575a_mpich_5.conda
linux-64::paraview-5.11.1-py311hce441cb_101_qt.conda
linux-64::netcdf4-1.6.4-mpi_openmpi_py39h54b710c_1.conda
linux-64::libarrow-12.0.0-hc410076_9_cpu.conda
linux-64::lammps-2023.03.28-cuda111_py39_hb1ed587_openmpi_6.conda
linux-64::wasmer-4.0.0-he3b15a8_0.conda
linux-64::arrow-cpp-9.0.0-py311hc2bbab1_37_cuda.conda
linux-64::lammps-2023.03.28-cuda110_py39_hf6505f6_openmpi_6.conda
linux-64::arrow-cpp-9.0.0-py311hc140227_41_cuda.conda
linux-64::folly-2023.06.12.00-h09ac5fe_0.conda
linux-64::libgdal-arrow-parquet-3.6.4-h844083d_5.conda
linux-64::jaxlib-0.4.12-cuda112py39hc98a809_201.conda
linux-64::linux-perf-6.3.9-py39haf0aa1b_0.conda
linux-64::linux-perf-6.3.7-py38h3fbeceb_0.conda
linux-64::lammps-2023.03.28-cuda110_py38_h601cda9_openmpi_7.conda
linux-64::lammps-2023.03.28-cpu_py38_h6cc3dfa_openmpi_6.conda
linux-64::vtk-base-9.2.6-qt_py311h1234567_207.conda
linux-64::r-qpdf-1.3.2-r43h6d82397_3.conda
linux-64::lammps-2023.03.28-cuda111_py38_h36dc16f_mpich_4.conda
linux-64::lammps-2023.03.28-cpu_py39_h643d260_mpich_5.conda
linux-64::mysql-router-8.0.33-h3e7c513_0.conda
linux-64::lammps-2023.03.28-cuda111_py38_h05dc403_openmpi_2.conda
linux-64::vtk-base-9.2.6-osmesa_py39h1234567_107.conda
linux-64::aiokafka-0.8.1-py310h93c3562_0.conda
linux-64::tiledb-2.15.3-h9504ddb_1.conda
linux-64::gst-plugins-bad-1.22.4-h57c5c21_0.conda
linux-64::lammps-2023.03.28-cuda112_py311_h21df41c_openmpi_3.conda
linux-64::libopencv-4.7.0-py38h16dcf2c_5.conda
linux-64::freefem-4.13-h46dfa5c_2.conda
linux-64::lammps-2023.03.28-cuda110_py38_hd07a159_mpich_4.conda
linux-64::lammps-2023.03.28-cuda110_py38_hbe6c6f7_openmpi_6.conda
linux-64::folly-2023.06.26.00-h80c46b9_0.conda
linux-64::arrow-cpp-9.0.0-py38h352a101_37_cuda.conda
linux-64::libarrow-10.0.1-h17fb9fa_27_cpu.conda
linux-64::libgdal-arrow-parquet-3.7.0-hd4096be_4.conda
linux-64::lxml-4.9.2-py39h40bd5d0_1.conda
linux-64::pyinstaller-5.12.0-py311hdcc4c9d_1.conda
linux-64::lammps-2023.03.28-cuda110_py39_h5dc7b02_mpich_6.conda
linux-64::jaxlib-0.4.12-cpu_py310hc0ddb09_1.conda
linux-64::libarrow-10.0.1-hc21d6b4_26_cuda.conda
linux-64::mlir-python-bindings-16.0.5-py311h75db532_0.conda
linux-64::vigra-1.11.1-py38h2c21c5d_1043.conda
linux-64::pygame-2.5.0-py311h9818690_0.conda
linux-64::lammps-2023.03.28-cuda111_py39_h96f8fb1_mpich_4.conda
linux-64::harp-1.18-py38h5e441e9_1.conda
linux-64::nco-5.1.6-h91f859b_1.conda
linux-64::coda-2.24.2-py39h1a73d88_2.conda
linux-64::lammps-2023.03.28-cuda110_py311_h8f22a92_mpich_4.conda
linux-64::lammps-2023.03.28-cpu_py39_h643d260_mpich_6.conda
linux-64::netcdf4-1.6.4-mpi_openmpi_py311hb8bd564_0.conda
linux-64::arrow-cpp-9.0.0-py38h40de194_38_cuda.conda
linux-64::pdal-2.5.5-hee5d408_0.conda
linux-64::harp-1.18-py38hf28a8a0_1.conda
linux-64::h5utils-1.13.2-mpi_mpich_h0260469_1001.conda
linux-64::linux-perf-6.3.9-py38hd75e30c_0.conda
linux-64::gdstk-0.9.42-py38h5ec06fb_0.conda
linux-64::gstlal-1.11.0-py311hb526b1d_0.conda
linux-64::lammps-2023.03.28-cuda111_py311_he4552b3_openmpi_4.conda
linux-64::fenics-libdolfin-2019.1.0-h3156292_37.conda
linux-64::mcpl-1.6.2-py39hc7d112a_0.conda
linux-64::lammps-2023.03.28-cuda111_py38_h5058bbe_mpich_3.conda
linux-64::harp-1.18-py311h40de960_1.conda
linux-64::arrow-cpp-9.0.0-py38h4654ca3_40_cpu.conda
linux-64::lammps-2023.03.28-cuda110_py39_hf6505f6_openmpi_4.conda
linux-64::lammps-2023.03.28-cuda112_py39_h82ef9c4_mpich_2.conda
linux-64::pygplates-0.39-py38h8826908_8.conda
linux-64::libpulsar-3.2.0-h76eacb3_0.conda
linux-64::libarrow-12.0.0-hc00ebf5_8_cpu.conda
linux-64::lammps-2023.03.28-cuda112_py38_h350a06d_openmpi_2.conda
linux-64::jaxlib-0.4.11-cpu_py310hc0ddb09_0.conda
linux-64::lammps-2023.03.28-cuda110_py38_hf91a5f8_openmpi_2.conda
linux-64::libarrow-10.0.1-h5b6691e_31_cuda.conda
linux-64::mlir-16.0.6-hcd5def8_0.conda
linux-64::lammps-2023.03.28-cpu_py38_h7efb62b_mpich_7.conda
linux-64::lammps-2023.03.28-cpu_py311_h4aafb77_mpich_5.conda
linux-64::xrootd-5.5.4-py39h88d736d_1.conda
linux-64::r-git2r-0.31.0-r42hf74695a_1.conda
linux-64::llvmlite-0.40.1-py39h174d805_0.conda
linux-64::lammps-2023.03.28-cuda112_py39_h82ef9c4_mpich_3.conda
linux-64::vigra-1.11.1-py38h76c5eed_1044.conda
linux-64::lammps-2023.03.28-cuda110_py39_h7b0575a_mpich_4.conda
linux-64::mysql-server-8.0.32-h924002b_3.conda
linux-64::mupdf-1.22.2-h81a98bf_0.conda
linux-64::graalpy-22.3.2-0_graalvm_native.conda
linux-64::paraprobe-v0.3.1-mpi_mpich_hfbbe63e_4.conda
linux-64::libarrow-11.0.0-hed73b3e_24_cpu.conda
linux-64::lammps-2023.03.28-cuda112_py39_ha7ea165_mpich_4.conda
linux-64::folly-2023.06.26.00-h09ac5fe_0.conda
linux-64::lammps-2023.03.28-cpu_py310_h88a5792_openmpi_4.conda
linux-64::xrootd-5.5.4-py38h879601d_1.conda
linux-64::lammps-2023.03.28-cuda112_py38_h1818b85_openmpi_5.conda
linux-64::vtk-base-9.2.6-osmesa_py38h1234567_108.conda
linux-64::pygplates-0.39-py311h94d1c0f_8.conda
linux-64::libarrow-12.0.0-hd562fea_9_cpu.conda
linux-64::openbabel-3.1.1-py39h421517d_6.conda
linux-64::libarrow-12.0.0-hed73b3e_6_cpu.conda
linux-64::libgdal-3.7.0-h5a391c5_4.conda
linux-64::lammps-2023.03.28-cpu_py311_h9dabdd9_openmpi_2.conda
linux-64::r-git2r-0.31.0-r43hf74695a_1.conda
linux-64::pyhdf-0.11.3-py38hd399493_0.conda
linux-64::lammps-2023.03.28-cuda111_py310_h062e84d_openmpi_2.conda
linux-64::hugin-2022.0.0-pl5321h42cd7aa_5.conda
linux-64::lammps-2023.03.28-cuda111_py38_hb436908_mpich_7.conda
linux-64::r-harp-1.18-r43h0080974_0.conda
linux-64::lammps-2023.03.28-cuda112_py38_h73b93e3_openmpi_5.conda
linux-64::vigra-1.11.1-py38hbdb0dee_1044.conda
linux-64::jaxlib-0.4.11-cpu_py311h7b5b818_0.conda
linux-64::vigra-1.11.1-py39hfd76663_1043.conda
linux-64::lammps-2023.03.28-cuda110_py310_hcc3e88c_openmpi_4.conda
linux-64::linux-perf-6.3.8-py38h3fbeceb_0.conda
linux-64::vigra-1.11.1-py311hcba7fdc_1045.conda
linux-64::pyinstaller-5.12.0-py38h502143a_1.conda
linux-64::libarrow-10.0.1-h1dee523_28_cuda.conda
linux-64::arrow-cpp-9.0.0-py311hf001057_40_cpu.conda
linux-64::gmt-6.4.0-hc1d54ec_12.conda
linux-64::libopencv-4.7.0-py39hfcbda02_5.conda
linux-64::cargo-patch-0.3.1-h8079fbb_0.conda
linux-64::mapserver-8.0.1-py310h8cd7a58_4.conda
linux-64::lammps-2023.03.28-cuda110_py38_h27cc18a_mpich_3.conda
linux-64::libarrow-11.0.0-hb3168b4_22_cuda.conda
linux-64::hdfeos5-5.1.16-h13a6de7_14.conda
linux-64::libopencv-4.7.0-py310h264d524_5.conda
linux-64::lammps-2023.03.28-cpu_py39_hc260df5_mpich_2.conda
linux-64::folly-2023.06.26.00-hda79706_0_jemalloc.conda
linux-64::lammps-2023.03.28-cpu_py38_h6df2e9b_mpich_5.conda
linux-64::libitk-5.3.0-h752f22c_4.conda
linux-64::lammps-2023.03.28-cuda110_py39_h38d7a4e_mpich_3.conda
linux-64::libarrow-12.0.0-h7efa76e_9_cuda.conda
linux-64::lammps-2023.03.28-cpu_py310_h413fddf_mpich_5.conda
linux-64::magic-8.3.402-h9abf892_0.conda
linux-64::r-vcfr-1.14.0-r42h33b523d_1.conda
linux-64::lammps-2023.03.28-cuda112_py38_h64b70e9_mpich_3.conda
linux-64::lammps-2023.03.28-cuda110_py38_h6b26ad3_mpich_5.conda
linux-64::pygame-2.5.0-py39h1678059_0.conda
linux-64::vtk-base-9.2.6-egl_py38h1234567_8.conda
linux-64::lammps-2023.03.28-cuda112_py310_hff62755_openmpi_2.conda
linux-64::libadios2-2.8.3-mpi_mpich_h806a3d7_7.conda
linux-64::aiokafka-0.8.1-py39hc7d112a_0.conda
linux-64::libgdal-3.7.0-h4a547c6_3.conda
linux-64::lammps-2023.03.28-cuda110_py38_h67e13c3_mpich_2.conda
linux-64::libopencv-4.7.0-py38h5f638ed_5.conda
linux-64::conduit-0.8.8-py38hb28bff7_1.conda
linux-64::paraview-5.11.1-py39h3c540a8_1_egl.conda
linux-64::pp-sketchlib-2.1.1-py38h9861542_1.conda
linux-64::yarp-cxx-3.8.0-h267a709_3.conda
linux-64::lammps-2023.03.28-cuda111_py38_h5058bbe_mpich_2.conda
linux-64::lammps-2023.03.28-cuda111_py39_h96f8fb1_mpich_5.conda
linux-64::lammps-2023.03.28-cpu_py310_h2b87cb3_mpich_3.conda
linux-64::lammps-2023.03.28-cuda112_py311_h19d466e_mpich_4.conda
linux-64::libtiledb-sql-0.22.4-hc3826aa_1.conda
linux-64::arrow-cpp-9.0.0-py38hc1fbb3d_40_cuda.conda
linux-64::tiledb-2.15.4-h9504ddb_1.conda
linux-64::paraview-5.11.1-py39h54d732c_1_egl.conda
linux-64::lammps-2023.03.28-cpu_py38_h7efb62b_mpich_4.conda
linux-64::lxml-4.9.2-py38h0ef1326_1.conda
linux-64::jaxlib-0.4.12-cuda112py311h7d292f2_200.conda
linux-64::lammps-2023.03.28-cpu_py39_hba983e3_mpich_4.conda
linux-64::vtk-base-9.2.6-osmesa_py39h1234567_108.conda
linux-64::lammps-2023.03.28-cpu_py38_h39dc859_mpich_2.conda
linux-64::paraview-5.11.1-py310h7ccbf2d_101_qt.conda
linux-64::lammps-2023.03.28-cuda112_py311_h19d466e_mpich_5.conda
linux-64::vigra-1.11.1-py310he77709f_1045.conda
linux-64::r-rmatio-0.18.0-r43h57805ef_1.conda
linux-64::opentype-sanitizer-9.1.0-py39h7633fee_0.conda
linux-64::lammps-2023.03.28-cuda110_py39_h5026a73_mpich_3.conda
linux-64::mapserver-8.0.1-py38h0df45e4_4.conda
linux-64::r-rmatio-0.18.0-r42h57805ef_1.conda
linux-64::yarp-cxx-3.8.1-h267a709_0.conda
linux-64::nginx-1.25.1-he2eb08b_1.conda
linux-64::vigra-1.11.1-py39hdd23b48_1045.conda
linux-64::openbabel-3.1.1-py310h956b46e_6.conda
linux-64::aiokafka-0.8.1-py39hb6545a3_0.conda
linux-64::netcdf4-1.6.4-mpi_mpich_py310h05b3189_0.conda
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
```

</details>