### PR TITLE
loosen zlib-pin to major level (13/N; May 2023)

### DIFF
--- a/recipe/patch_yaml/zlib.yaml
+++ b/recipe/patch_yaml/zlib.yaml
@@ -106,3 +106,12 @@ then:
   - loosen_depends:
       name: libzlib
       upper_bound: "2"
+---
+if:
+  has_depends: libzlib >=1.2*
+  timestamp_lt: 1685577600000  # 2023-06-01 00:00 UTC
+  timestamp_ge: 1682899200000  # 2023-05-01 00:00 UTC
+then:
+  - loosen_depends:
+      name: libzlib
+      upper_bound: "2"


### PR DESCRIPTION
Follow-up to https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/739, about 3200 artefacts affected.

### Result of `python show_diff.py`

<details>

```diff
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
linux-ppc64le
linux-ppc64le::micromamba-1.4.2-2.tar.bz2
linux-ppc64le::clang-tools-15.0.7-default_hb66b9a5_2.conda
linux-ppc64le::clang-14-14.0.6-default_hb66b9a5_1.conda
linux-ppc64le::gst-plugins-good-1.22.3-h4915e9d_1.conda
linux-ppc64le::libprotobuf-static-4.22.3-h31f4ac3_0.conda
linux-ppc64le::libprotobuf-4.23.1-h31f4ac3_0.conda
linux-ppc64le::libclang-cpp14-14.0.6-default_hb66b9a5_1.conda
linux-ppc64le::libmlir-16.0.3-hae84d68_0.conda
linux-ppc64le::libclang13-15.0.7-default_h6cf0fa1_2.conda
linux-ppc64le::libclang13-14.0.6-default_h6cf0fa1_1.conda
linux-ppc64le::libass-0.17.1-h72404ea_0.conda
linux-ppc64le::libprotobuf-static-4.23.2-h31f4ac3_0.conda
linux-ppc64le::gst-plugins-base-1.22.3-h8115ff9_1.conda
linux-ppc64le::libprotobuf-4.23.0-h31f4ac3_0.conda
linux-ppc64le::glib-tools-2.76.3-hff1ad0c_0.conda
linux-ppc64le::imath-3.1.8-hff1ad0c_0.conda
linux-ppc64le::gst-plugins-good-1.22.3-hb32fb5e_0.conda
linux-ppc64le::msgpack-cxx-6.0.0-he4ce5e0_1.conda
linux-ppc64le::libmlir16-16.0.3-hae84d68_0.conda
linux-ppc64le::libprotobuf-4.22.3-h31f4ac3_0.conda
linux-ppc64le::libllvm15-15.0.7-h7c8ec72_2.conda
linux-ppc64le::gst-plugins-base-1.22.3-h66bc5c0_0.conda
linux-ppc64le::libprotobuf-static-4.22.5-h31f4ac3_0.conda
linux-ppc64le::gst-libav-1.22.3-hcdd5cfa_0.conda
linux-ppc64le::micromamba-1.4.2-1.tar.bz2
linux-ppc64le::clang-format-14-14.0.6-default_hb66b9a5_1.conda
linux-ppc64le::msgpack-c-6.0.0-hff1ad0c_0.conda
linux-ppc64le::lld-15.0.7-he9f3fe3_1.conda
linux-ppc64le::libsqlite-3.42.0-hd4bbf49_0.conda
linux-ppc64le::clang-format-14.0.6-default_hb66b9a5_1.conda
linux-ppc64le::libmlir16-16.0.4-hae84d68_0.conda
linux-ppc64le::llvm-14.0.6-h12068cf_2.conda
linux-ppc64le::lld-14.0.6-he9f3fe3_1.conda
linux-ppc64le::clang-tools-14.0.6-default_hb66b9a5_1.conda
linux-ppc64le::libprotobuf-4.22.5-h31f4ac3_0.conda
linux-ppc64le::llvm-tools-14.0.6-hf7e7dc2_2.conda
linux-ppc64le::libprotobuf-4.23.2-h31f4ac3_2.conda
linux-ppc64le::libmlir-16.0.4-hae84d68_0.conda
linux-ppc64le::plumed-2.9.0-nompi_h4263cfa_100.conda
linux-ppc64le::libclang-cpp-15.0.7-default_hb66b9a5_2.conda
linux-ppc64le::clang-format-15.0.7-default_hb66b9a5_2.conda
linux-ppc64le::libprotobuf-4.23.2-h31f4ac3_0.conda
linux-ppc64le::libsqlite-3.41.2-hd4bbf49_1.conda
linux-ppc64le::libclang-14.0.6-default_hb66b9a5_1.conda
linux-ppc64le::libprotobuf-4.23.2-h31f4ac3_1.conda
linux-ppc64le::libprotobuf-static-4.23.0-h31f4ac3_0.conda
linux-ppc64le::libclang-15.0.7-default_hb66b9a5_2.conda
linux-ppc64le::libprotobuf-static-4.23.2-h31f4ac3_2.conda
linux-ppc64le::libclang-cpp15-15.0.7-default_hb66b9a5_2.conda
linux-ppc64le::openexr-3.1.7-h138ba55_1.conda
linux-ppc64le::libprotobuf-static-4.23.2-h31f4ac3_1.conda
linux-ppc64le::llvm-tools-15.0.7-h7c8ec72_2.conda
linux-ppc64le::libclang-cpp-14.0.6-default_hb66b9a5_1.conda
linux-ppc64le::gst-libav-1.22.3-hcdd5cfa_1.conda
linux-ppc64le::clang-15-15.0.7-default_hb66b9a5_2.conda
linux-ppc64le::micromamba-1.4.3-0.tar.bz2
linux-ppc64le::llvm-15.0.7-h8c9a019_2.conda
linux-ppc64le::libllvm14-14.0.6-hf7e7dc2_2.conda
linux-ppc64le::clang-format-15-15.0.7-default_hb66b9a5_2.conda
linux-ppc64le::gst-libav-1.22.3-h95e5f97_1.conda
linux-ppc64le::libprotobuf-static-4.23.1-h31f4ac3_0.conda
-    "libzlib >=1.2.13,<1.3.0a0"
+    "libzlib >=1.2.13,<2.0.0a0"
linux-ppc64le::libortools-9.6-h58c626b_1.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.0-h1ad6e73_1.conda
linux-ppc64le::libarrow-11.0.0-h23a40c2_21_cuda.conda
linux-ppc64le::ogre-next-2.3.1-hecdd2b9_4.conda
linux-ppc64le::folly-2023.04.17.00-ha231c81_0.conda
linux-ppc64le::libopencv-4.7.0-py38he07abfd_4.conda
linux-ppc64le::vtk-base-9.2.6-qt_py310h1234567_206.conda
linux-ppc64le::grpcio-1.55.0-py311h3997ded_0.conda
linux-ppc64le::llvm-16.0.4-h381f82a_0.conda
linux-ppc64le::libopentelemetry-cpp-1.9.1-hf5b854c_2.conda
linux-ppc64le::openjdk-17.0.3-h270f43a_7.conda
linux-ppc64le::libarrow-11.0.0-hb984a1a_21_cpu.conda
linux-ppc64le::arrow-cpp-8.0.1-py310hffb699a_31_cpu.conda
linux-ppc64le::linux-perf-6.3.4-py310hbf4c414_0.conda
linux-ppc64le::folly-2023.04.24.00-ha231c81_0.conda
linux-ppc64le::arrow-cpp-9.0.0-py39h17e29ae_35_cpu.conda
linux-ppc64le::mapserver-8.0.1-py311h8658867_2.conda
linux-ppc64le::llvmdev-16.0.3-hafd99fb_1.conda
linux-ppc64le::libarrow-11.0.0-h0f662be_19_cuda.conda
linux-ppc64le::tiledb-2.15.2-h5fbc0c9_1.conda
linux-ppc64le::arrow-cpp-9.0.0-py38h00cd185_35_cuda.conda
linux-ppc64le::linux-perf-6.3.2-py38h5192f5b_0.conda
linux-ppc64le::arrow-cpp-9.0.0-py39h5ac77e9_34_cuda.conda
linux-ppc64le::arrow-cpp-8.0.1-py39h17e29ae_32_cpu.conda
linux-ppc64le::libnetcdf-4.9.2-mpi_openmpi_hd7eb045_5.conda
linux-ppc64le::folly-2023.05.22.00-ha231c81_0.conda
linux-ppc64le::linux-perf-6.3.4-py39he243d86_0.conda
linux-ppc64le::libopencv-4.7.0-py310h065fbf2_4.conda
linux-ppc64le::cpp-opentelemetry-sdk-1.9.0-hf353e75_3.conda
linux-ppc64le::vtk-base-9.2.6-qt_py310h1234567_205.conda
linux-ppc64le::libgdal-3.5.3-hea6fee0_28.conda
linux-ppc64le::plumed-2.9.0-mpi_mpich_h22184e8_0.conda
linux-ppc64le::pillow-9.5.0-py39ha1c4a29_1.conda
linux-ppc64le::nco-5.1.6-h9032693_0.conda
linux-ppc64le::pillow-9.5.0-py38h3b13620_1.conda
linux-ppc64le::postgresql-plpython-15.3-py311he396289_1.conda
linux-ppc64le::arrow-cpp-9.0.0-py38hb96df10_33_cuda.conda
linux-ppc64le::libarrow-12.0.0-h0a9da2a_1_cpu.conda
linux-ppc64le::libpq-14.5-h7442559_6.conda
linux-ppc64le::postgresql-plpython-15.3-py38h833a243_1.conda
linux-ppc64le::vtk-base-9.2.6-qt_py38h1234567_205.conda
linux-ppc64le::ffmpeg-5.1.2-gpl_hf33b199_107.conda
linux-ppc64le::r-base-4.1.3-h5956602_6.conda
linux-ppc64le::libopentelemetry-cpp-1.9.0-hf353e75_3.conda
linux-ppc64le::ffmpeg-5.1.2-gpl_hf2a171c_108.conda
linux-ppc64le::arrow-cpp-8.0.1-py38h45557b4_31_cpu.conda
linux-ppc64le::linux-perf-6.3.2-py310hbf4c414_0.conda
linux-ppc64le::magic-8.3.394-h7eb73fb_0.conda
linux-ppc64le::python-3.10.11-h062392f_0_cpython.conda
linux-ppc64le::libopentelemetry-cpp-1.9.1-hdb32d07_2.conda
linux-ppc64le::folly-2023.03.27.00-hca43526_0_jemalloc.conda
linux-ppc64le::postgresql-14.5-h6d6279e_6.conda
linux-ppc64le::libnetcdf-4.9.2-mpi_mpich_h79624ab_5.conda
linux-ppc64le::folly-2023.04.24.00-hd692e58_0.conda
linux-ppc64le::mapserver-8.0.1-py311h6ef94ea_3.conda
linux-ppc64le::libarrow-11.0.0-h49aa95e_20_cuda.conda
linux-ppc64le::libopencv-4.7.0-py39h38811bc_4.conda
linux-ppc64le::folly-2023.04.10.00-ha231c81_0.conda
linux-ppc64le::arrow-cpp-9.0.0-py310hf1b3cf6_35_cpu.conda
linux-ppc64le::ffmpeg-6.0.0-gpl_hd0f547c_101.conda
linux-ppc64le::mlir-16.0.3-hae84d68_0.conda
linux-ppc64le::linux-perf-6.3.3-py311h52552ba_0.conda
linux-ppc64le::libopencv-4.7.0-py311h8a6580d_4.conda
linux-ppc64le::libcurl-static-8.1.0-hdd5ecfa_0.conda
linux-ppc64le::grpcio-1.55.0-py38hc2aed35_1.conda
linux-ppc64le::folly-2023.05.15.00-hca43526_0_jemalloc.conda
linux-ppc64le::vtk-base-9.2.6-qt_py38h1234567_206.conda
linux-ppc64le::postgresql-15.3-h3a16c23_0.conda
linux-ppc64le::libxml2-2.11.4-h02ec90b_0.conda
linux-ppc64le::aws-sdk-cpp-1.11.68-hf45d1ef_2.conda
linux-ppc64le::folly-2023.05.22.00-hd692e58_0.conda
linux-ppc64le::libopencv-4.7.0-py311h759072a_4.conda
linux-ppc64le::vtk-base-9.2.6-qt_py311h1234567_206.conda
linux-ppc64le::folly-2023.05.01.00-ha231c81_0.conda
linux-ppc64le::libgsf-1.14.50-ha4aa3fc_1.conda
linux-ppc64le::gmsh-4.11.1-h94c1b17_2.conda
linux-ppc64le::arrow-cpp-8.0.1-py311hc10e12d_31_cpu.conda
linux-ppc64le::llvmdev-15.0.7-h7c8ec72_2.conda
linux-ppc64le::folly-2023.05.22.00-hca43526_1_jemalloc.conda
linux-ppc64le::llvm-16.0.3-h97a5904_1.conda
linux-ppc64le::folly-2023.04.10.00-hca43526_0_jemalloc.conda
linux-ppc64le::libarrow-11.0.0-ha541e08_20_cpu.conda
linux-ppc64le::llvmlite-0.40.0-py310h8eb8f48_0.conda
linux-ppc64le::libarrow-12.0.0-hb984a1a_4_cpu.conda
linux-ppc64le::arrow-cpp-9.0.0-py311hc4211fb_35_cuda.conda
linux-ppc64le::folly-2023.03.27.00-hd692e58_0.conda
linux-ppc64le::libarrow-12.0.0-h96e3b71_0_cuda.conda
linux-ppc64le::libgdal-arrow-parquet-3.7.0-h0b8d804_0.conda
linux-ppc64le::pygplates-0.39-py310hefa4129_7.conda
linux-ppc64le::vtk-base-9.2.6-qt_py311h1234567_205.conda
linux-ppc64le::libopencv-4.7.0-py38h0090409_3.conda
linux-ppc64le::mlir-16.0.4-hae84d68_0.conda
linux-ppc64le::clangdev-15.0.7-default_hb66b9a5_2.conda
linux-ppc64le::lld-16.0.3-he12c2f4_1.conda
linux-ppc64le::pyinstaller-5.11.0-py310h0719273_0.conda
linux-ppc64le::folly-2023.05.08.00-h864cb69_0_jemalloc.conda
linux-ppc64le::libarrow-12.0.0-h23a40c2_3_cuda.conda
linux-ppc64le::llvmlite-0.40.0-py311h3997ded_0.conda
linux-ppc64le::libcurl-8.1.0-hdd5ecfa_0.conda
linux-ppc64le::arrow-cpp-9.0.0-py38h64dd081_34_cuda.conda
linux-ppc64le::folly-2023.03.20.00-ha231c81_4.conda
linux-ppc64le::pillow-9.5.0-py38hb352ec4_1.conda
linux-ppc64le::folly-2023.04.24.00-h864cb69_0_jemalloc.conda
linux-ppc64le::sqlite-3.42.0-h63c7444_0.conda
linux-ppc64le::llvm-16.0.3-h381f82a_2.conda
linux-ppc64le::libarrow-10.0.1-h6416cd9_23_cpu.conda
linux-ppc64le::libgdal-3.6.4-ha018d15_2.conda
linux-ppc64le::libortools-9.6-hba37442_2.conda
linux-ppc64le::libgdal-3.7.0-he643c81_0.conda
linux-ppc64le::grpcio-1.55.0-py39h278787b_1.conda
linux-ppc64le::libarrow-11.0.0-h96e3b71_18_cuda.conda
linux-ppc64le::libgdal-arrow-parquet-3.6.4-hc96d762_1.conda
linux-ppc64le::libopencv-4.7.0-py39h2cb6c5f_3.conda
linux-ppc64le::llvmlite-0.40.0-py38hc2aed35_0.conda
linux-ppc64le::arrow-cpp-8.0.1-py39hf1631d7_31_cpu.conda
linux-ppc64le::libgdal-arrow-parquet-3.6.4-h9370b1b_3.conda
linux-ppc64le::libllvm16-16.0.3-hc314733_0.conda
linux-ppc64le::aws-sdk-cpp-1.11.68-h00a0b2e_5.conda
linux-ppc64le::arrow-cpp-9.0.0-py311h4e6dcde_36_cuda.conda
linux-ppc64le::poppler-23.05.0-hcd38bda_1.conda
linux-ppc64le::libpq-15.3-h7442559_1.conda
linux-ppc64le::linux-perf-6.3.4-py311h52552ba_0.conda
linux-ppc64le::linux-perf-6.3.1-py38h5192f5b_0.conda
linux-ppc64le::aws-sdk-cpp-1.11.68-he244971_4.conda
linux-ppc64le::texlive-core-20230313-h789b069_3.conda
linux-ppc64le::llvm-tools-16.0.3-hc314733_0.conda
linux-ppc64le::libopentelemetry-cpp-1.9.1-hf353e75_1.conda
linux-ppc64le::libsoup-3.4.2-h1d14ca2_0.conda
linux-ppc64le::pillow-9.5.0-py310h0fec2d4_1.conda
linux-ppc64le::llvm-openmp-16.0.4-h8759ddb_0.conda
linux-ppc64le::cpp-opentelemetry-sdk-1.9.1-hf353e75_0.conda
linux-ppc64le::openjdk-20.0.0-h2e1fb60_0.conda
linux-ppc64le::llvm-tools-16.0.4-h8d57982_0.conda
linux-ppc64le::arrow-cpp-9.0.0-py310hffb699a_34_cpu.conda
linux-ppc64le::folly-2023.03.20.00-hca43526_4_jemalloc.conda
linux-ppc64le::arrow-cpp-9.0.0-py310hc66b1ba_34_cuda.conda
linux-ppc64le::folly-2023.04.03.00-hd692e58_0.conda
linux-ppc64le::tiledb-2.15.2-h5a29478_2.conda
linux-ppc64le::llvmlite-0.40.0-py38h5641305_0.conda
linux-ppc64le::postgresql-plpython-14.5-py39hb43596d_6.conda
linux-ppc64le::ffmpeg-5.1.2-lgpl_h72f2bfd_7.conda
linux-ppc64le::libarrow-10.0.1-h1873cfd_24_cuda.conda
linux-ppc64le::libopencv-4.7.0-py39hd9bf936_3.conda
linux-ppc64le::tiledb-2.15.2-h5fbc0c9_2.conda
linux-ppc64le::ortools-python-9.6-py310hd3b661c_1.conda
linux-ppc64le::llvmlite-0.40.0-py39h278787b_0.conda
linux-ppc64le::pygplates-0.39-py39h5298636_7.conda
linux-ppc64le::lld-16.0.4-he12c2f4_0.conda
linux-ppc64le::r-base-4.2.3-h2bca5a3_3.conda
linux-ppc64le::llvmdev-16.0.3-h7c8ec72_2.conda
linux-ppc64le::llvm-tools-16.0.3-hc314733_1.conda
linux-ppc64le::libnetcdf-4.9.2-nompi_h5d668c3_105.conda
linux-ppc64le::libxml2-2.11.3-h02ec90b_1.conda
linux-ppc64le::arrow-cpp-8.0.1-py39h5ac77e9_31_cuda.conda
linux-ppc64le::postgresql-plpython-15.3-py39hbd28b6a_0.conda
linux-ppc64le::folly-2023.05.15.00-hd692e58_0.conda
linux-ppc64le::mysql-router-8.0.32-hf77073f_2.conda
linux-ppc64le::folly-2023.04.17.00-hd692e58_0.conda
linux-ppc64le::arrow-cpp-9.0.0-py311hc10e12d_34_cpu.conda
linux-ppc64le::libarrow-10.0.1-hdad3ba0_25_cuda.conda
linux-ppc64le::aws-sdk-cpp-1.10.57-h3b9a285_13.conda
linux-ppc64le::aws-sdk-cpp-1.10.57-hf45d1ef_12.conda
linux-ppc64le::arrow-cpp-9.0.0-py310hb21a5c8_35_cuda.conda
linux-ppc64le::tiledb-2.15.2-h5fbc0c9_0.conda
linux-ppc64le::arrow-cpp-8.0.1-py311h54aa68b_31_cuda.conda
linux-ppc64le::folly-2023.05.22.00-ha231c81_1.conda
linux-ppc64le::libsoup-3.4.2-hc050987_1.conda
linux-ppc64le::arrow-cpp-9.0.0-py39heb55b63_35_cuda.conda
linux-ppc64le::pygplates-0.39-py311hf8f3cd0_7.conda
linux-ppc64le::libopencv-4.7.0-py39he24ffc1_4.conda
linux-ppc64le::libcurl-static-8.1.1-hdd5ecfa_0.conda
linux-ppc64le::postgresql-plpython-15.3-py310h12395e2_0.conda
linux-ppc64le::linux-perf-6.3.2-py39he243d86_0.conda
linux-ppc64le::folly-2023.04.24.00-hca43526_0_jemalloc.conda
linux-ppc64le::libgdal-3.6.4-h356125f_3.conda
linux-ppc64le::arrow-cpp-8.0.1-py311hc4211fb_32_cuda.conda
linux-ppc64le::libopencv-4.7.0-py38h7083443_4.conda
linux-ppc64le::arrow-cpp-9.0.0-py311h5446356_33_cpu.conda
linux-ppc64le::libllvm16-16.0.4-h8d57982_0.conda
linux-ppc64le::aws-sdk-cpp-1.10.57-he4c2e78_11.conda
linux-ppc64le::cairo-1.16.0-h5633222_1016.conda
linux-ppc64le::arrow-cpp-8.0.1-py310hc66b1ba_31_cuda.conda
linux-ppc64le::magic-8.3.400-h7eb73fb_0.conda
linux-ppc64le::libllvm16-16.0.3-h8d57982_2.conda
linux-ppc64le::pyinstaller-5.11.0-py39hf0cda86_0.conda
linux-ppc64le::ffmpeg-6.0.0-lgpl_hbd5a1e8_0.conda
linux-ppc64le::mapserver-8.0.1-py38h974e00a_3.conda
linux-ppc64le::libarrow-10.0.1-h15bb3c4_23_cuda.conda
linux-ppc64le::libopencv-4.7.0-py38hc5c464f_3.conda
linux-ppc64le::tiledb-2.15.2-h9607087_0.conda
linux-ppc64le::libgrpc-1.54.2-hf8c08f8_1.conda
linux-ppc64le::libcurl-static-8.1.2-hdd5ecfa_0.conda
linux-ppc64le::libopencv-4.7.0-py38h08bd484_3.conda
linux-ppc64le::cpp-opentelemetry-sdk-1.9.0-hf353e75_2.conda
linux-ppc64le::arrow-cpp-9.0.0-py311h54aa68b_34_cuda.conda
linux-ppc64le::cmake-3.26.4-h1403f77_0.conda
linux-ppc64le::folly-2023.05.15.00-h864cb69_0_jemalloc.conda
linux-ppc64le::linux-perf-6.3.1-py311h52552ba_0.conda
linux-ppc64le::postgresql-plpython-15.3-py310h4a4b6b6_1.conda
linux-ppc64le::pyinstaller-5.11.0-py38h36029d9_0.conda
linux-ppc64le::pdal-2.5.4-h2881d3a_1.conda
linux-ppc64le::tiledb-2.15.3-hb6e242a_0.conda
linux-ppc64le::cpp-opentelemetry-sdk-1.9.1-h91273c2_1.conda
linux-ppc64le::linux-perf-6.3.3-py39he243d86_0.conda
linux-ppc64le::omniorb-4.2.5-py39h273f291_6.conda
linux-ppc64le::arrow-cpp-9.0.0-py38h6c562ba_33_cpu.conda
linux-ppc64le::arrow-cpp-9.0.0-py311hfe8e34e_33_cuda.conda
linux-ppc64le::libgdal-3.5.3-h935af22_27.conda
linux-ppc64le::cpp-opentelemetry-sdk-1.9.1-hf353e75_1.conda
linux-ppc64le::aws-sdk-cpp-1.11.68-h3b9a285_3.conda
linux-ppc64le::libxmlsec1-1.3.0-h5b53232_1.conda
linux-ppc64le::folly-2023.03.20.00-h864cb69_4_jemalloc.conda
linux-ppc64le::arrow-cpp-9.0.0-py38h52df359_35_cpu.conda
linux-ppc64le::librdkafka-2.1.1-h8da8c2a_0.conda
linux-ppc64le::tiledb-2.15.2-hef4c170_1.conda
linux-ppc64le::libopencv-4.7.0-py38h08bd484_4.conda
linux-ppc64le::libpq-15.3-h7442559_0.conda
linux-ppc64le::libgrpc-1.55.0-h1cf4055_0.conda
linux-ppc64le::arrow-cpp-9.0.0-py39h3a045fb_33_cpu.conda
linux-ppc64le::llvmdev-16.0.3-hafd99fb_0.conda
linux-ppc64le::folly-2023.05.08.00-ha231c81_0.conda
linux-ppc64le::arrow-cpp-8.0.1-py310hf1b3cf6_32_cpu.conda
linux-ppc64le::arrow-cpp-9.0.0-py39hde1937e_36_cuda.conda
linux-ppc64le::libarchive-3.6.2-h087afff_1.conda
linux-ppc64le::mosh-1.4.0-pl5321h20e5bb1_1.conda
linux-ppc64le::omniorb-4.2.5-py38haf11259_6.conda
linux-ppc64le::curl-8.1.1-hdd5ecfa_0.conda
linux-ppc64le::pillow-9.5.0-py39h4f537d2_1.conda
linux-ppc64le::freeimage-3.18.0-h0ceaa8c_15.conda
linux-ppc64le::postgresql-plpython-14.5-py310h4a4b6b6_6.conda
linux-ppc64le::mapserver-8.0.1-py39hd159a30_2.conda
linux-ppc64le::libarrow-12.0.0-h3befad6_0_cpu.conda
linux-ppc64le::libxml2-2.11.3-h02ec90b_0.conda
linux-ppc64le::arrow-cpp-9.0.0-py310h35055f5_36_cpu.conda
linux-ppc64le::libglib-2.76.3-hd7af32a_0.conda
linux-ppc64le::libarrow-12.0.0-hb984a1a_3_cpu.conda
linux-ppc64le::arrow-cpp-8.0.1-py310hb21a5c8_32_cuda.conda
linux-ppc64le::folly-2023.04.03.00-hca43526_0_jemalloc.conda
linux-ppc64le::libarrow-12.0.0-h0f662be_1_cuda.conda
linux-ppc64le::arrow-cpp-8.0.1-py38h64dd081_31_cuda.conda
linux-ppc64le::clangdev-14.0.6-default_hb66b9a5_1.conda
linux-ppc64le::libopencv-4.7.0-py311h759072a_3.conda
linux-ppc64le::postgresql-15.3-h6d6279e_1.conda
linux-ppc64le::imagemagick-7.1.1_9-pl5321hc264ee1_1.conda
linux-ppc64le::mapserver-8.0.1-py310h74af57f_2.conda
linux-ppc64le::openslide-3.4.1-he44cbd6_9.conda
linux-ppc64le::grpcio-1.55.0-py310h8eb8f48_0.conda
linux-ppc64le::libopencv-4.7.0-py310hae4eda6_3.conda
linux-ppc64le::libgdal-3.6.4-ha479dd4_1.conda
linux-ppc64le::arrow-cpp-9.0.0-py39haa65ec2_36_cpu.conda
linux-ppc64le::grpcio-1.55.0-py39h278787b_0.conda
linux-ppc64le::libllvm16-16.0.3-hc314733_1.conda
linux-ppc64le::postgresql-plpython-15.3-py311h0ea390a_0.conda
linux-ppc64le::arrow-cpp-9.0.0-py38h45557b4_34_cpu.conda
linux-ppc64le::mapserver-8.0.1-py39hba23d2c_3.conda
linux-ppc64le::folly-2023.05.08.00-hca43526_0_jemalloc.conda
linux-ppc64le::rust-1.69.0-hb12b0c0_2.conda
linux-ppc64le::openjdk-17.0.3-h2e1fb60_8.conda
linux-ppc64le::libopencv-4.7.0-py39h1c6bc6b_4.conda
linux-ppc64le::libarrow-10.0.1-h8a45fd1_25_cpu.conda
linux-ppc64le::omniorb-libs-4.2.5-haf9a9e6_6.conda
linux-ppc64le::libopencv-4.7.0-py310h35874b7_3.conda
linux-ppc64le::folly-2023.05.01.00-hd692e58_0.conda
linux-ppc64le::folly-2023.05.08.00-hd692e58_0.conda
linux-ppc64le::arrow-cpp-9.0.0-py39h758d6b0_33_cuda.conda
linux-ppc64le::libxml2-2.11.3-h02ec90b_2.conda
linux-ppc64le::llvmlite-0.40.0-py39h27cb1e9_0.conda
linux-ppc64le::libopencv-4.7.0-py39h1c6bc6b_3.conda
linux-ppc64le::rust-1.69.0-hb12b0c0_3.conda
linux-ppc64le::arrow-cpp-8.0.1-py311h825a4fe_32_cpu.conda
linux-ppc64le::qtkeychain-0.14.0-h8d0edd8_0.conda
linux-ppc64le::gst-plugins-bad-1.22.0-h9a528e2_1.conda
linux-ppc64le::folly-2023.03.27.00-h864cb69_0_jemalloc.conda
linux-ppc64le::folly-2023.04.03.00-h864cb69_0_jemalloc.conda
linux-ppc64le::postgresql-plpython-15.3-py38h3f7085f_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.6.4-h95519c1_2.conda
linux-ppc64le::libarchive-minimal-static-3.6.2-h009e8c7_1.conda
linux-ppc64le::arrow-cpp-8.0.1-py39heb55b63_32_cuda.conda
linux-ppc64le::llvm-openmp-16.0.3-h8759ddb_0.conda
linux-ppc64le::libopencv-4.7.0-py39haaf2972_2.conda
linux-ppc64le::ffmpeg-5.1.2-lgpl_hc0499a8_8.conda
linux-ppc64le::llvm-16.0.3-h97a5904_0.conda
linux-ppc64le::libopencv-4.7.0-py38h3afff24_4.conda
linux-ppc64le::linux-perf-6.3.3-py38h5192f5b_0.conda
linux-ppc64le::postgresql-plpython-14.5-py311he396289_6.conda
linux-ppc64le::libcurl-8.1.1-hdd5ecfa_0.conda
linux-ppc64le::libvips-8.14.2-h7f2ac44_1.conda
linux-ppc64le::arrow-cpp-9.0.0-py311h825a4fe_35_cpu.conda
linux-ppc64le::linux-perf-6.3.3-py310hbf4c414_0.conda
linux-ppc64le::folly-2023.03.20.00-hd692e58_4.conda
linux-ppc64le::r-base-4.1.3-hdd52d59_8.conda
linux-ppc64le::libgrpc-1.52.1-hf8c08f8_2.conda
linux-ppc64le::grpcio-1.55.0-py311h3997ded_1.conda
linux-ppc64le::imagemagick-7.1.1_9-pl5321h2d46223_0.conda
linux-ppc64le::linux-perf-6.3.4-py38h5192f5b_0.conda
linux-ppc64le::folly-2023.05.22.00-hd692e58_1.conda
linux-ppc64le::ffmpeg-6.0.0-lgpl_h92caa2b_1.conda
linux-ppc64le::libopentelemetry-cpp-1.9.0-hf353e75_2.conda
linux-ppc64le::ffmpeg-5.1.2-gpl_h845438d_109.conda
linux-ppc64le::qt-main-5.15.8-h23834b5_12.conda
linux-ppc64le::mapserver-8.0.1-py38hbd63fc0_2.conda
linux-ppc64le::mysql-client-8.0.32-hfff87ee_2.conda
linux-ppc64le::pygplates-0.39-py38h74c64e5_7.conda
linux-ppc64le::ffmpeg-5.1.2-gpl_hb607175_110.conda
linux-ppc64le::folly-2023.05.22.00-h864cb69_0_jemalloc.conda
linux-ppc64le::mysql-server-8.0.32-h3aa03ee_2.conda
linux-ppc64le::libspatialite-5.0.1-h2db5e4d_26.conda
linux-ppc64le::ffmpeg-5.1.2-lgpl_hc66f32a_9.conda
linux-ppc64le::folly-2023.05.15.00-ha231c81_0.conda
linux-ppc64le::linux-perf-6.3.1-py39he243d86_0.conda
linux-ppc64le::folly-2023.04.10.00-h864cb69_0_jemalloc.conda
linux-ppc64le::lld-16.0.3-hf8408dd_0.conda
linux-ppc64le::ffmpeg-6.0.0-gpl_h15ae63b_100.conda
linux-ppc64le::libopentelemetry-cpp-1.9.1-h91273c2_1.conda
linux-ppc64le::linux-perf-6.3.1-py310hbf4c414_0.conda
linux-ppc64le::libarrow-10.0.1-ha8134b6_24_cpu.conda
linux-ppc64le::folly-2023.04.17.00-hca43526_0_jemalloc.conda
linux-ppc64le::curl-8.1.2-hdd5ecfa_0.conda
linux-ppc64le::llvmdev-14.0.6-hf7e7dc2_2.conda
linux-ppc64le::libgrpc-1.54.2-hf8c08f8_2.conda
linux-ppc64le::libgdal-3.7.0-h671900d_1.conda
linux-ppc64le::folly-2023.04.17.00-h864cb69_0_jemalloc.conda
linux-ppc64le::r-base-4.1.3-h3d14514_9.conda
linux-ppc64le::arrow-cpp-8.0.1-py38h52df359_32_cpu.conda
linux-ppc64le::pdal-2.5.4-h8689c27_1.conda
linux-ppc64le::folly-2023.04.03.00-ha231c81_0.conda
linux-ppc64le::qt-main-5.15.8-hfd7f2fd_11.conda
linux-ppc64le::libopencv-4.7.0-py38h3afff24_3.conda
linux-ppc64le::arrow-cpp-8.0.1-py38h00cd185_32_cuda.conda
linux-ppc64le::glib-2.76.3-hff1ad0c_0.conda
linux-ppc64le::llvmdev-16.0.4-h7c8ec72_0.conda
linux-ppc64le::mysql-libs-8.0.32-h3ac40eb_2.conda
linux-ppc64le::aws-sdk-cpp-1.11.68-he4c2e78_1.conda
linux-ppc64le::mapserver-8.0.1-py310hbbaf421_3.conda
linux-ppc64le::r-base-4.1.3-h93c7c08_7.conda
linux-ppc64le::blosc-1.21.4-h791411d_0.conda
linux-ppc64le::grpcio-1.55.0-py38hc2aed35_0.conda
linux-ppc64le::libarrow-12.0.0-ha541e08_2_cpu.conda
linux-ppc64le::libopencv-4.7.0-py311h27c24dc_3.conda
linux-ppc64le::ffmpeg-5.1.2-lgpl_hbbd3a88_10.conda
linux-ppc64le::pillow-9.5.0-py311h0a7ca29_1.conda
linux-ppc64le::imagemagick-7.1.1_10-pl5321hc264ee1_0.conda
linux-ppc64le::postgresql-plpython-15.3-py39hb43596d_1.conda
linux-ppc64le::grpcio-1.55.0-py310h8eb8f48_1.conda
linux-ppc64le::plumed-2.9.0-mpi_openmpi_hcb863c6_0.conda
linux-ppc64le::folly-2023.03.27.00-ha231c81_0.conda
linux-ppc64le::libopentelemetry-cpp-1.9.1-hf353e75_0.conda
linux-ppc64le::libarrow-11.0.0-h0a9da2a_19_cpu.conda
linux-ppc64le::libopencv-4.7.0-py39h1443b94_4.conda
linux-ppc64le::graphviz-8.0.5-h3732cb2_0.conda
linux-ppc64le::libgrpc-1.54.1-h5803959_0.conda
linux-ppc64le::gst-plugins-bad-1.22.3-hb89a448_1.conda
linux-ppc64le::sqlite-3.41.2-h63c7444_1.conda
linux-ppc64le::libopencv-4.7.0-py310h35874b7_4.conda
linux-ppc64le::folly-2023.05.22.00-hca43526_0_jemalloc.conda
linux-ppc64le::libgrpc-1.54.2-h5803959_0.conda
linux-ppc64le::r-base-4.3.0-h2bca5a3_1.conda
linux-ppc64le::vtk-base-9.2.6-qt_py39h1234567_206.conda
linux-ppc64le::mesalib-23.0.2-hb6f7a19_1.conda
linux-ppc64le::libcurl-8.1.2-hdd5ecfa_0.conda
linux-ppc64le::libgrpc-1.55.0-h1cf4055_1.conda
linux-ppc64le::gst-plugins-bad-1.22.3-hd7e7281_0.conda
linux-ppc64le::arrow-cpp-9.0.0-py38hc20b17b_36_cuda.conda
linux-ppc64le::libarrow-12.0.0-h49aa95e_2_cuda.conda
linux-ppc64le::omniorb-4.2.5-py310h9576d76_6.conda
linux-ppc64le::arrow-cpp-9.0.0-py310hd156dfb_36_cuda.conda
linux-ppc64le::arrow-cpp-9.0.0-py39hf1631d7_34_cpu.conda
linux-ppc64le::arrow-cpp-9.0.0-py38h8e3dc1c_36_cpu.conda
linux-ppc64le::vtk-base-9.2.6-qt_py39h1234567_205.conda
linux-ppc64le::openjdk-11.0.15-h270f43a_4.conda
linux-ppc64le::tiledb-2.15.3-h5fbc0c9_0.conda
linux-ppc64le::folly-2023.05.01.00-h864cb69_0_jemalloc.conda
linux-ppc64le::folly-2023.04.10.00-hd692e58_0.conda
linux-ppc64le::libortools-9.6-hba37442_3.conda
linux-ppc64le::imagemagick-7.1.1_11-pl5321hc264ee1_0.conda
linux-ppc64le::omniorb-4.2.5-py311h0e56fba_6.conda
linux-ppc64le::magic-8.3.384-h0bd16fa_0.conda
linux-ppc64le::folly-2023.05.22.00-h864cb69_1_jemalloc.conda
linux-ppc64le::folly-2023.05.01.00-hca43526_0_jemalloc.conda
linux-ppc64le::arrow-cpp-9.0.0-py311hba05d62_36_cpu.conda
linux-ppc64le::postgresql-plpython-14.5-py38h833a243_6.conda
linux-ppc64le::llvm-tools-16.0.3-h8d57982_2.conda
linux-ppc64le::linux-perf-6.3.2-py311h52552ba_0.conda
linux-ppc64le::libopencv-4.7.0-py39h1443b94_3.conda
linux-ppc64le::pdal-2.5.4-h7c6821b_0.conda
linux-ppc64le::cpp-opentelemetry-sdk-1.9.1-hf5b854c_2.conda
linux-ppc64le::qt-main-5.15.8-h23834b5_13.conda
linux-ppc64le::curl-8.1.0-hdd5ecfa_0.conda
linux-ppc64le::mosh-1.4.0-pl5321h0187939_1.conda
linux-ppc64le::cpp-opentelemetry-sdk-1.9.1-hdb32d07_2.conda
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
================================================================================
================================================================================
osx-arm64
osx-arm64::libprotobuf-4.23.1-hf32f9b9_0.conda
osx-arm64::libxmlpp-4.0-4.0.2-ha8cb560_1.conda
osx-arm64::libprotobuf-4.23.2-hf32f9b9_0.conda
osx-arm64::libllvm14-14.0.6-hd1a9a77_2.conda
osx-arm64::micromamba-1.4.2-1.tar.bz2
osx-arm64::libllvm15-15.0.7-h504e6bf_2.conda
osx-arm64::llvm-tools-15.0.7-h504e6bf_2.conda
osx-arm64::micromamba-1.4.2-2.tar.bz2
osx-arm64::libprotobuf-4.22.3-hf32f9b9_0.conda
osx-arm64::glib-tools-2.76.3-ha614eb4_0.conda
osx-arm64::libv8-8.9.83-h3c3c24a_3.conda
osx-arm64::libprotobuf-static-4.22.3-hf32f9b9_0.conda
osx-arm64::libsqlite-3.42.0-hb31c410_0.conda
osx-arm64::libass-0.17.1-h4da34ad_0.conda
osx-arm64::libsqlite-3.41.2-hb31c410_1.conda
osx-arm64::libprotobuf-static-4.22.5-hf32f9b9_0.conda
osx-arm64::openjdk-17.0.3-hbe7ddab_7.conda
osx-arm64::lld-14.0.6-h6fc9e18_1.conda
osx-arm64::msgpack-cxx-6.0.0-hcb94ee5_1.conda
osx-arm64::openjdk-20.0.0-hbe7ddab_0.conda
osx-arm64::openjdk-17.0.3-hbe7ddab_8.conda
osx-arm64::llvm-15.0.7-hd9f5176_2.conda
osx-arm64::llvm-tools-14.0.6-hd1a9a77_2.conda
osx-arm64::libprotobuf-4.23.0-hf32f9b9_0.conda
osx-arm64::libmlir16-16.0.4-h2d3518b_0.conda
osx-arm64::libprotobuf-static-4.23.2-hf32f9b9_2.conda
osx-arm64::libprotobuf-static-4.23.2-hf32f9b9_1.conda
osx-arm64::libprotobuf-4.23.2-hf32f9b9_1.conda
osx-arm64::libmlir-16.0.3-h2d3518b_0.conda
osx-arm64::gst-plugins-base-1.22.3-h27255cc_0.conda
osx-arm64::llvm-14.0.6-h95d0606_2.conda
osx-arm64::libmlir-16.0.4-h2d3518b_0.conda
osx-arm64::libprotobuf-static-4.23.2-hf32f9b9_0.conda
osx-arm64::lld-15.0.7-h6fc9e18_1.conda
osx-arm64::openjdk-11.0.15-hbe7ddab_4.conda
osx-arm64::libprotobuf-static-4.23.1-hf32f9b9_0.conda
osx-arm64::libmlir16-16.0.3-h2d3518b_0.conda
osx-arm64::openexr-3.1.7-ha1e33a5_1.conda
osx-arm64::imath-3.1.8-ha614eb4_0.conda
osx-arm64::libprotobuf-4.22.5-hf32f9b9_0.conda
osx-arm64::libprotobuf-static-4.23.0-hf32f9b9_0.conda
osx-arm64::micromamba-1.4.3-0.tar.bz2
osx-arm64::libprotobuf-4.23.2-hf32f9b9_2.conda
osx-arm64::libpcm-1.2.3-hb19c430_4.conda
osx-arm64::gst-plugins-base-1.22.3-h27255cc_1.conda
-    "libzlib >=1.2.13,<1.3.0a0"
+    "libzlib >=1.2.13,<2.0.0a0"
osx-arm64::cmake-3.26.4-hc0af03a_0.conda
osx-arm64::libgrpc-1.55.0-hc384137_1.conda
osx-arm64::folly-2023.05.01.00-h44236e3_0.conda
osx-arm64::graphviz-8.0.5-h10878c0_0.conda
osx-arm64::arrow-cpp-9.0.0-py311h8078c8d_34_cpu.conda
osx-arm64::omniorb-4.2.5-py310h7dcfcf1_6.conda
osx-arm64::vigra-1.11.1-py38hc59121b_1042.conda
osx-arm64::postgresql-plpython-15.3-py39h2115d11_0.conda
osx-arm64::pdal-2.5.4-haf1df21_0.conda
osx-arm64::openconnect-9.10-h74e4191_0.conda
osx-arm64::folly-2023.03.20.00-h44236e3_4.conda
osx-arm64::folly-2023.03.27.00-h2c5142d_0_jemalloc.conda
osx-arm64::llvm-16.0.3-h5856a0c_0.conda
osx-arm64::gdstk-0.9.41-py38hd91e53e_0.conda
osx-arm64::folly-2023.04.03.00-h2c5142d_0_jemalloc.conda
osx-arm64::r-base-4.1.3-hc39b4fc_7.conda
osx-arm64::arrow-cpp-8.0.1-py310h70d00f2_32_cpu.conda
osx-arm64::pillow-9.5.0-py310h60ecbdf_1.conda
osx-arm64::libopencv-4.7.0-py311hfc0fa3d_3.conda
osx-arm64::tiledb-2.15.2-h1cdaec1_2.conda
osx-arm64::ndcctools-7.5.3-py38h3b9d5fa_0.conda
osx-arm64::jaxlib-0.4.9-cpu_py310haddac25_0.conda
osx-arm64::postgresql-plpython-15.3-py310h94ee204_1.conda
osx-arm64::ffmpeg-5.1.2-gpl_h811ebc7_109.conda
osx-arm64::lammps-2023.03.28-py310h8e6cc48_mpich_2.conda
osx-arm64::grpcio-1.55.0-py38h761d82c_1.conda
osx-arm64::openscenegraph-3.6.5-h3494f9e_16.conda
osx-arm64::gazebo-11.12.0-h0d6933f_10.conda
osx-arm64::jaxlib-0.4.9-cpu_py38h7aa3e66_0.conda
osx-arm64::vigra-1.11.1-py310h035172c_1042.conda
osx-arm64::lld-16.0.4-h1753c5f_0.conda
osx-arm64::folly-2023.05.08.00-h44236e3_0.conda
osx-arm64::folly-2023.05.22.00-h1e8fca9_0.conda
osx-arm64::folly-2023.04.03.00-h1e8fca9_0.conda
osx-arm64::poppler-23.05.0-h16d8c84_1.conda
osx-arm64::libvips-8.14.2-h3094e21_1.conda
osx-arm64::qt6-main-6.5.0-h372468e_8.conda
osx-arm64::r-base-4.1.3-hb14bfe5_8.conda
osx-arm64::libarchive-3.6.2-h82b9b87_1.conda
osx-arm64::libgdal-3.6.4-h8ba6edc_2.conda
osx-arm64::lammps-2023.03.28-py311ha0c7d89_mpich_2.conda
osx-arm64::ffmpeg-6.0.0-lgpl_h8fe7c65_0.conda
osx-arm64::folly-2023.05.22.00-h2c5142d_1_jemalloc.conda
osx-arm64::ndcctools-7.5.4-py38h3b9d5fa_1.conda
osx-arm64::jaxlib-0.4.10-cpu_py310haddac25_0.conda
osx-arm64::folly-2023.04.24.00-h8b73916_0_jemalloc.conda
osx-arm64::tectonic-0.12.0-h116b827_3.conda
osx-arm64::omniorb-4.2.5-py311h0918f0e_6.conda
osx-arm64::r-base-4.2.3-h4b3f977_3.conda
osx-arm64::folly-2023.04.17.00-h44236e3_0.conda
osx-arm64::pygplates-0.39-py311h366adcc_7.conda
osx-arm64::papilo-2.1.2-ha38deef_2.conda
osx-arm64::postgresql-plpython-15.3-py38h3275ed9_1.conda
osx-arm64::folly-2023.05.08.00-h8b73916_0_jemalloc.conda
osx-arm64::gst-plugins-bad-1.22.3-haedc527_1.conda
osx-arm64::wxpython-4.2.0-py311hc820d88_7.conda
osx-arm64::llvmdev-16.0.3-h09a3ea2_1.conda
osx-arm64::imagemagick-7.1.1_10-pl5321h903c885_0.conda
osx-arm64::libarrow-11.0.0-hff97baf_20_cpu.conda
osx-arm64::vtk-base-9.2.6-qt_py39h1234567_206.conda
osx-arm64::libcurl-static-8.1.0-h912dcd9_0.conda
osx-arm64::libgrpc-1.54.2-h9dbdbd0_0.conda
osx-arm64::libopentelemetry-cpp-1.9.1-h14c407c_2.conda
osx-arm64::vigra-1.11.1-py38h018f6f7_1042.conda
osx-arm64::folly-2023.04.03.00-h8b73916_0_jemalloc.conda
osx-arm64::libarrow-12.0.0-h3b4cbd9_0_cpu.conda
osx-arm64::llvm-tools-16.0.3-he79909e_2.conda
osx-arm64::arrow-cpp-9.0.0-py39h7e3a37e_36_cpu.conda
osx-arm64::libopentelemetry-cpp-1.9.0-h3bbf078_3.conda
osx-arm64::libopentelemetry-cpp-1.9.1-h3bbf078_1.conda
osx-arm64::libxmlsec1-1.3.0-h6a2d6b9_1.conda
osx-arm64::texlive-core-20230313-py310h394c0b0_3.conda
osx-arm64::omniorb-libs-4.2.5-h19e3c78_6.conda
osx-arm64::paraview-5.11.1-py311h31a843d_101_qt.conda
osx-arm64::folly-2023.05.01.00-h1e8fca9_0.conda
osx-arm64::vigra-1.11.1-py311h6f76412_1042.conda
osx-arm64::llvmdev-15.0.7-h504e6bf_2.conda
osx-arm64::postgresql-15.3-ha51c797_0.conda
osx-arm64::pyinstaller-5.11.0-py38he9a9ba6_0.conda
osx-arm64::ffmpeg-5.1.2-lgpl_h86597bc_10.conda
osx-arm64::ndcctools-7.5.5-py38h3b9d5fa_0.conda
osx-arm64::vigra-1.11.1-py39h55e505b_1042.conda
osx-arm64::gazebo-11.12.0-h83e9e8a_13.conda
osx-arm64::openconnect-9.12-h74e4191_0.conda
osx-arm64::wxpython-4.2.0-py39hc68f845_7.conda
osx-arm64::sagelib-10.0-py310h3aecabe_0.conda
osx-arm64::folly-2023.04.10.00-h44236e3_0.conda
osx-arm64::arrow-cpp-9.0.0-py310h70d00f2_35_cpu.conda
osx-arm64::grpcio-1.55.0-py311hea943cd_0.conda
osx-arm64::libopencv-4.7.0-py310h7a1b33c_4.conda
osx-arm64::postgresql-plpython-14.5-py38h3275ed9_6.conda
osx-arm64::gst-plugins-good-1.22.3-h6f657da_1.conda
osx-arm64::imagemagick-7.1.1_11-pl5321h903c885_0.conda
osx-arm64::libnetcdf-4.9.2-mpi_mpich_hc09835b_5.conda
osx-arm64::vtk-base-9.2.6-qt_py38h1234567_205.conda
osx-arm64::aws-sdk-cpp-1.10.57-ha2d740e_11.conda
osx-arm64::aws-sdk-cpp-1.11.68-h189dbfb_2.conda
osx-arm64::grpcio-1.55.0-py39hbad4f83_1.conda
osx-arm64::ndcctools-7.5.5-py311hf3cef61_0.conda
osx-arm64::mlir-16.0.3-h2d3518b_0.conda
osx-arm64::vigra-1.11.1-py310h5318e85_1042.conda
osx-arm64::kaldi-5.5.1068-cpu_h9f6ebf1_0.conda
osx-arm64::ndcctools-7.5.3-py311hf3cef61_0.conda
osx-arm64::lpython-0.13.0-ha614eb4_1.conda
osx-arm64::magics-4.13.0-hf7eefee_4.conda
osx-arm64::grpcio-1.55.0-py39hbad4f83_0.conda
osx-arm64::grpcio-1.55.0-py311hea943cd_1.conda
osx-arm64::llvm-tools-16.0.3-hc12c677_1.conda
osx-arm64::folly-2023.05.08.00-h2c5142d_0_jemalloc.conda
osx-arm64::magics-4.13.0-hd745255_3.conda
osx-arm64::hdfeos5-5.1.16-h8f66c48_11.conda
osx-arm64::pillow-9.5.0-py38h3f590de_1.conda
osx-arm64::tiledb-2.15.2-h1cdaec1_1.conda
osx-arm64::r-base-4.1.3-h9c4d319_6.conda
osx-arm64::ffmpeg-5.1.2-lgpl_h6af09e4_7.conda
osx-arm64::aws-sdk-cpp-1.11.68-h015ea4b_3.conda
osx-arm64::gmsh-4.11.1-h6e0c8fd_2.conda
osx-arm64::folly-2023.03.27.00-h44236e3_0.conda
osx-arm64::pdal-2.5.4-hd7f2dcb_1.conda
osx-arm64::postgresql-plpython-15.3-py311h885f1b6_1.conda
osx-arm64::libllvm16-16.0.3-hc12c677_1.conda
osx-arm64::qt-main-5.15.8-hcac2fde_13.conda
osx-arm64::cpp-opentelemetry-sdk-1.9.0-h3bbf078_2.conda
osx-arm64::libgdal-arrow-parquet-3.6.4-h5e4ab1b_2.conda
osx-arm64::gst-plugins-good-1.22.3-h6f657da_0.conda
osx-arm64::hdfeos5-5.1.16-h496e685_13.conda
osx-arm64::ndcctools-7.5.4-py311hf3cef61_0.conda
osx-arm64::cpp-opentelemetry-sdk-1.9.1-h14c407c_2.conda
osx-arm64::libopentelemetry-cpp-1.9.1-h3d26802_2.conda
osx-arm64::llvmdev-16.0.3-h504e6bf_2.conda
osx-arm64::imagemagick-7.1.1_9-pl5321hb67800a_0.conda
osx-arm64::mlir-16.0.4-h2d3518b_0.conda
osx-arm64::grpcio-1.55.0-py310h95b248a_0.conda
osx-arm64::libllvm16-16.0.3-hc12c677_0.conda
osx-arm64::glib-2.76.3-ha614eb4_0.conda
osx-arm64::libgsf-1.14.50-h0784537_1.conda
osx-arm64::pygplates-0.39-py39h32fdcd5_7.conda
osx-arm64::libnetcdf-4.9.2-nompi_h0a2dbf5_105.conda
osx-arm64::gdstk-0.9.41-py39h201c926_0.conda
osx-arm64::libgrpc-1.54.2-h0a338ca_2.conda
osx-arm64::ndcctools-7.5.4-py38h3b9d5fa_0.conda
osx-arm64::libgrpc-1.52.1-h0a338ca_2.conda
osx-arm64::vigra-1.11.1-py39hf68d295_1042.conda
osx-arm64::qt6-main-6.5.0-h372468e_7.conda
osx-arm64::libcurl-8.1.2-h912dcd9_0.conda
osx-arm64::gazebo-11.12.0-h979b1e9_12.conda
osx-arm64::freeimage-3.18.0-ha6430b2_15.conda
osx-arm64::r-base-4.3.0-h4b3f977_1.conda
osx-arm64::ndcctools-7.5.4-py39h6d2f949_0.conda
osx-arm64::aws-sdk-cpp-1.10.57-h015ea4b_13.conda
osx-arm64::wxpython-4.2.0-py38ha92163b_7.conda
osx-arm64::arrow-cpp-9.0.0-py311h0c8bdf6_36_cpu.conda
osx-arm64::qt-main-5.15.8-hcac2fde_11.conda
osx-arm64::ndcctools-7.5.4-py311hf3cef61_1.conda
osx-arm64::aws-sdk-cpp-1.11.68-hbc5f3b5_4.conda
osx-arm64::libgrpc-1.55.0-hc384137_0.conda
osx-arm64::llvm-16.0.4-h2b67075_0.conda
osx-arm64::folly-2023.05.22.00-h44236e3_0.conda
osx-arm64::libgdal-3.5.3-h818eb9f_27.conda
osx-arm64::llvmlite-0.40.0-py310h95b248a_0.conda
osx-arm64::postgresql-plpython-15.3-py310hda5fa44_0.conda
osx-arm64::arrow-cpp-8.0.1-py38h6a321b8_31_cpu.conda
osx-arm64::tectonic-0.12.0-hda762aa_2.conda
osx-arm64::arrow-cpp-8.0.1-py310h7a9fb2f_31_cpu.conda
osx-arm64::libxml2-2.11.3-he3bdae6_2.conda
osx-arm64::mysql-client-8.0.32-h41974c7_2.conda
osx-arm64::folly-2023.05.22.00-h44236e3_1.conda
osx-arm64::libopencv-4.7.0-py38hdc4ec17_4.conda
osx-arm64::folly-2023.05.15.00-h8b73916_0_jemalloc.conda
osx-arm64::libgdal-arrow-parquet-3.6.4-h0227db6_3.conda
osx-arm64::libgdal-3.5.3-hdd459a3_28.conda
osx-arm64::pygplates-0.39-py310h916fa02_7.conda
osx-arm64::ndcctools-7.5.5-py310h4b37b16_0.conda
osx-arm64::qt-main-5.15.8-h8c42f20_10.conda
osx-arm64::libllvm16-16.0.3-he79909e_2.conda
osx-arm64::folly-2023.04.17.00-h1e8fca9_0.conda
osx-arm64::libcurl-static-8.1.2-h912dcd9_0.conda
osx-arm64::jaxlib-0.4.9-cpu_py311h328a48b_0.conda
osx-arm64::protozfits-2.2.0-py311h58b6786_0.conda
osx-arm64::folly-2023.05.15.00-h1e8fca9_0.conda
osx-arm64::tectonic-0.13.0-h116b827_0.conda
osx-arm64::arrow-cpp-8.0.1-py39ha71d1d5_31_cpu.conda
osx-arm64::gazebo-11.12.0-hd9a0464_11.conda
osx-arm64::libgdal-3.6.4-hcb28f89_3.conda
osx-arm64::libgdal-3.7.0-ha582146_0.conda
osx-arm64::paraview-5.11.1-py311h108d42c_101_qt.conda
osx-arm64::libopencv-4.7.0-py39hca6e4ce_3.conda
osx-arm64::soplex-6.0.3-h0ccf5b5_2.conda
osx-arm64::postgresql-plpython-14.5-py39h620b887_6.conda
osx-arm64::postgresql-14.5-hb5ad9d5_6.conda
osx-arm64::vtk-base-9.2.6-qt_py311h1234567_206.conda
osx-arm64::curl-8.1.1-h912dcd9_0.conda
osx-arm64::libarrow-11.0.0-h5d58556_19_cpu.conda
osx-arm64::postgresql-plpython-14.5-py310h94ee204_6.conda
osx-arm64::hdfeos5-5.1.16-h8f66c48_12.conda
osx-arm64::libopencv-4.7.0-py311h84083eb_3.conda
osx-arm64::ogre-next-2.3.1-h4b7faf7_4.conda
osx-arm64::libarrow-10.0.1-hb50b599_23_cpu.conda
osx-arm64::cpp-opentelemetry-sdk-1.9.1-h3d26802_2.conda
osx-arm64::folly-2023.04.10.00-h2c5142d_0_jemalloc.conda
osx-arm64::gdstk-0.9.41-py310he5462bb_0.conda
osx-arm64::libllvm16-16.0.4-he79909e_0.conda
osx-arm64::libcurl-8.1.0-h912dcd9_0.conda
osx-arm64::ffmpeg-6.0.0-gpl_hc7e3b81_101.conda
osx-arm64::lld-16.0.3-h1753c5f_1.conda
osx-arm64::paraview-5.11.1-py310he4f6916_101_qt.conda
osx-arm64::ffmpeg-5.1.2-lgpl_h717e7ab_8.conda
osx-arm64::paraview-5.11.1-py39h4410c82_101_qt.conda
osx-arm64::libxml2-2.11.3-py310h10ef0e2_0.conda
osx-arm64::paraview-5.11.1-py38h33c68c0_101_qt.conda
osx-arm64::libarrow-12.0.0-h5d58556_1_cpu.conda
osx-arm64::pyinstaller-5.11.0-py39ha52a465_0.conda
osx-arm64::postgresql-plpython-15.3-py311h1e2ccc0_0.conda
osx-arm64::ndcctools-7.5.4-py310h4b37b16_1.conda
osx-arm64::folly-2023.03.27.00-h8b73916_0_jemalloc.conda
osx-arm64::pillow-9.5.0-py39h1641143_1.conda
osx-arm64::lld-16.0.3-h49d628f_0.conda
osx-arm64::llvmlite-0.40.0-py311hea943cd_0.conda
osx-arm64::mysql-server-8.0.32-h8d2d40f_2.conda
osx-arm64::arrow-cpp-9.0.0-py38h630a808_36_cpu.conda
osx-arm64::libsoup-3.4.2-h4fb8bbe_0.conda
osx-arm64::libxml2-2.11.3-py310h10ef0e2_1.conda
osx-arm64::libgdal-3.7.0-h33c4f09_1.conda
osx-arm64::libglib-2.76.3-h24e9cb9_0.conda
osx-arm64::sqlite-3.41.2-h203b68d_1.conda
osx-arm64::libopentelemetry-cpp-1.9.0-h3bbf078_2.conda
osx-arm64::cpp-opentelemetry-sdk-1.9.1-h3bbf078_1.conda
osx-arm64::folly-2023.05.22.00-h2c5142d_0_jemalloc.conda
osx-arm64::qt6-main-6.5.1-h372468e_0.conda
osx-arm64::python-3.10.11-h3ba56d0_0_cpython.conda
osx-arm64::ndcctools-7.5.3-py39h6d2f949_0.conda
osx-arm64::postgresql-plpython-15.3-py39h620b887_1.conda
osx-arm64::librdkafka-2.1.1-hb5b8459_0.conda
osx-arm64::llvm-tools-16.0.4-he79909e_0.conda
osx-arm64::arrow-cpp-9.0.0-py39ha71d1d5_34_cpu.conda
osx-arm64::paraview-5.11.1-py310hd75eb15_101_qt.conda
osx-arm64::folly-2023.05.15.00-h2c5142d_0_jemalloc.conda
osx-arm64::lammps-2023.03.28-py38h6fb3128_mpich_2.conda
osx-arm64::protozfits-2.2.0-py38h180d630_0.conda
osx-arm64::openslide-3.4.1-hf870f79_9.conda
osx-arm64::folly-2023.04.10.00-h1e8fca9_0.conda
osx-arm64::tiledb-2.15.3-h1cdaec1_0.conda
osx-arm64::libopencv-4.7.0-py310h7a1b33c_3.conda
osx-arm64::libopentelemetry-cpp-1.9.1-h51cb19a_1.conda
osx-arm64::folly-2023.04.17.00-h2c5142d_0_jemalloc.conda
osx-arm64::libgrpc-1.54.2-h0a338ca_1.conda
osx-arm64::arrow-cpp-9.0.0-py310h7a9fb2f_34_cpu.conda
osx-arm64::mosh-1.4.0-pl5321h78761c0_1.conda
osx-arm64::vtk-base-9.2.6-qt_py39h1234567_205.conda
osx-arm64::libpq-15.3-h7126958_1.conda
osx-arm64::libopencv-4.7.0-py311h175e936_4.conda
osx-arm64::cpp-opentelemetry-sdk-1.9.1-h3bbf078_0.conda
osx-arm64::arrow-cpp-8.0.1-py311h8078c8d_31_cpu.conda
osx-arm64::nco-5.1.6-hcbcebd6_0.conda
osx-arm64::folly-2023.04.10.00-h8b73916_0_jemalloc.conda
osx-arm64::libopencv-4.7.0-py38hb13779e_3.conda
osx-arm64::ndcctools-7.5.4-py310h4b37b16_0.conda
osx-arm64::lpython-0.15.0-ha614eb4_0.conda
osx-arm64::llvm-16.0.3-h2b67075_2.conda
osx-arm64::arrow-cpp-9.0.0-py39he2e2ecf_35_cpu.conda
osx-arm64::libgdal-arrow-parquet-3.6.4-h7112d2d_1.conda
osx-arm64::llvmlite-0.40.0-py39hbad4f83_0.conda
osx-arm64::jaxlib-0.4.10-cpu_py38h7aa3e66_0.conda
osx-arm64::curl-8.1.0-h912dcd9_0.conda
osx-arm64::vtk-base-9.2.6-qt_py311h1234567_205.conda
osx-arm64::plumed-2.9.0-nompi_haf67379_100.conda
osx-arm64::folly-2023.05.01.00-h2c5142d_0_jemalloc.conda
osx-arm64::arrow-cpp-8.0.1-py39he2e2ecf_32_cpu.conda
osx-arm64::pygplates-0.39-py38h4a80a6d_7.conda
osx-arm64::paraview-5.11.1-py39h66ff29f_101_qt.conda
osx-arm64::arrow-cpp-8.0.1-py38hbb10450_32_cpu.conda
osx-arm64::postgresql-plpython-14.5-py311h885f1b6_6.conda
osx-arm64::libopencv-4.7.0-py310h78f96a1_3.conda
osx-arm64::qt-webengine-5.15.8-hc1a9d58_1.conda
osx-arm64::cairo-1.16.0-h1e71087_1016.conda
osx-arm64::ffmpeg-6.0.0-lgpl_he934155_1.conda
osx-arm64::grpcio-1.55.0-py38h761d82c_0.conda
osx-arm64::ffmpeg-6.0.0-gpl_hb37b814_100.conda
osx-arm64::tiledb-2.15.2-h0e480cf_1.conda
osx-arm64::sagelib-10.0-py38h8aa816a_0.conda
osx-arm64::libopencv-4.7.0-py39h7ff21a5_4.conda
osx-arm64::libspatialite-5.0.1-h229630b_26.conda
osx-arm64::libopencv-4.7.0-py310h36012a9_4.conda
osx-arm64::folly-2023.05.08.00-h1e8fca9_0.conda
osx-arm64::folly-2023.03.27.00-h1e8fca9_0.conda
osx-arm64::folly-2023.05.22.00-h1e8fca9_1.conda
osx-arm64::hugin-base-2022.0.0-pl5321h7c63f6a_4.conda
osx-arm64::llvm-16.0.3-h5856a0c_1.conda
osx-arm64::gdstk-0.9.41-py311h73b73c0_0.conda
osx-arm64::sagelib-10.0-py311ha07c8a7_0.conda
osx-arm64::tiledb-2.15.3-haa1bfee_0.conda
osx-arm64::folly-2023.05.15.00-h44236e3_0.conda
osx-arm64::folly-2023.05.22.00-h8b73916_1_jemalloc.conda
osx-arm64::libgdal-arrow-parquet-3.7.0-h16c3c38_0.conda
osx-arm64::lammps-2023.03.28-py39hf0ab505_mpich_2.conda
osx-arm64::libcurl-8.1.1-h912dcd9_0.conda
osx-arm64::arrow-cpp-9.0.0-py310h369bc68_36_cpu.conda
osx-arm64::mesalib-23.0.2-h7bfda7a_1.conda
osx-arm64::grpcio-1.55.0-py310h95b248a_1.conda
osx-arm64::folly-2023.03.20.00-h1e8fca9_4.conda
osx-arm64::tiledb-2.15.2-h5509c38_2.conda
osx-arm64::folly-2023.04.03.00-h44236e3_0.conda
osx-arm64::sqlite-3.42.0-h203b68d_0.conda
osx-arm64::mysql-libs-8.0.32-hb292caa_2.conda
osx-arm64::imagemagick-7.1.1_9-pl5321h903c885_1.conda
osx-arm64::libarrow-10.0.1-h6786480_25_cpu.conda
osx-arm64::chemicalite-2022.04.1-h4cda963_9.conda
osx-arm64::llvm-tools-16.0.3-hc12c677_0.conda
osx-arm64::jaxlib-0.4.9-cpu_py39h1d8eb90_0.conda
osx-arm64::ndcctools-7.5.4-py39h6d2f949_1.conda
osx-arm64::blosc-1.21.4-hc338f07_0.conda
osx-arm64::protozfits-2.2.0-py39h0fcd919_0.conda
osx-arm64::qt6-3d-6.5.1-hb40c1b2_0.conda
osx-arm64::ovito-3.8.4-h7b9fb56_1.conda
osx-arm64::vigra-1.11.1-py311h01db218_1042.conda
osx-arm64::libnetcdf-4.9.2-mpi_openmpi_he5635fa_5.conda
osx-arm64::ffmpeg-5.1.2-gpl_hb9565b2_107.conda
osx-arm64::libarrow-12.0.0-h2f988b0_3_cpu.conda
osx-arm64::aws-sdk-cpp-1.11.68-ha2d740e_1.conda
osx-arm64::ovito-3.8.4-h480faf3_1.conda
osx-arm64::vtk-base-9.2.6-qt_py310h1234567_206.conda
osx-arm64::llvmdev-16.0.4-h504e6bf_0.conda
osx-arm64::libopencv-4.7.0-py39h0420ec6_4.conda
osx-arm64::libsoup-3.4.2-h771374c_1.conda
osx-arm64::ovito-3.8.4-h7b9fb56_0.conda
osx-arm64::libopentelemetry-cpp-1.9.1-h3bbf078_0.conda
osx-arm64::arrow-cpp-9.0.0-py38hbb10450_35_cpu.conda
osx-arm64::pdal-2.5.4-he530b75_1.conda
osx-arm64::libarrow-11.0.0-h2f988b0_21_cpu.conda
osx-arm64::ndcctools-7.5.3-py310h4b37b16_0.conda
osx-arm64::folly-2023.04.24.00-h1e8fca9_0.conda
osx-arm64::scip-8.0.3-h94111ae_2.conda
osx-arm64::vtk-base-9.2.6-qt_py38h1234567_206.conda
osx-arm64::arrow-cpp-9.0.0-py38h6a321b8_34_cpu.conda
osx-arm64::libpq-14.5-h7126958_6.conda
osx-arm64::libarrow-10.0.1-hc113c37_24_cpu.conda
osx-arm64::libcurl-static-8.1.1-h912dcd9_0.conda
osx-arm64::vtk-base-9.2.6-qt_py310h1234567_205.conda
osx-arm64::aws-sdk-cpp-1.11.68-h9b90b14_5.conda
osx-arm64::libpq-15.3-h7126958_0.conda
osx-arm64::libgrpc-1.54.1-h9dbdbd0_0.conda
osx-arm64::folly-2023.04.24.00-h44236e3_0.conda
osx-arm64::jaxlib-0.4.10-cpu_py39h1d8eb90_0.conda
osx-arm64::libopencv-4.7.0-py39h7ff21a5_3.conda
osx-arm64::r-base-4.1.3-h4b3f977_9.conda
osx-arm64::qt-main-5.15.8-hcac2fde_12.conda
osx-arm64::cpp-opentelemetry-sdk-1.9.0-h3bbf078_3.conda
osx-arm64::lpython-0.15.0-ha614eb4_1.conda
osx-arm64::libgdal-arrow-parquet-3.7.0-h1f9f12d_1.conda
osx-arm64::curl-8.1.2-h912dcd9_0.conda
osx-arm64::libopencv-4.7.0-py38hb165ca5_3.conda
osx-arm64::folly-2023.05.01.00-h8b73916_0_jemalloc.conda
osx-arm64::wxpython-4.2.0-py310hfa888ef_7.conda
osx-arm64::omniorb-4.2.5-py38hc1f8488_6.conda
osx-arm64::folly-2023.05.22.00-h8b73916_0_jemalloc.conda
osx-arm64::postgresql-15.3-hb5ad9d5_1.conda
osx-arm64::libxml2-2.11.4-he3bdae6_0.conda
osx-arm64::libopencv-4.7.0-py311h84083eb_4.conda
osx-arm64::nodejs-18.15.0-h7f372e8_1.conda
osx-arm64::ffmpeg-5.1.2-lgpl_hd297541_9.conda
osx-arm64::qt6-main-6.5.0-h372468e_6.conda
osx-arm64::folly-2023.04.17.00-h8b73916_0_jemalloc.conda
osx-arm64::llvmdev-14.0.6-hd1a9a77_2.conda
osx-arm64::folly-2023.03.20.00-h8b73916_4_jemalloc.conda
osx-arm64::libgdal-3.6.4-h3a06809_1.conda
osx-arm64::ffmpeg-5.1.2-gpl_h6c0125a_110.conda
osx-arm64::lammps-2023.03.28-py310h4724fc5_openmpi_2.conda
osx-arm64::lammps-2023.03.28-py311h2789dc3_openmpi_2.conda
osx-arm64::aws-sdk-cpp-1.10.57-h189dbfb_12.conda
osx-arm64::arrow-cpp-8.0.1-py311he168ad1_32_cpu.conda
osx-arm64::llvmdev-16.0.3-h09a3ea2_0.conda
osx-arm64::pyinstaller-5.11.0-py310hab90de1_0.conda
osx-arm64::folly-2023.03.20.00-h2c5142d_4_jemalloc.conda
osx-arm64::cpp-opentelemetry-sdk-1.9.1-h51cb19a_1.conda
osx-arm64::tiledb-2.15.2-h1cdaec1_0.conda
osx-arm64::tiledb-2.15.2-h5722a7d_0.conda
osx-arm64::jaxlib-0.4.10-cpu_py311h328a48b_0.conda
osx-arm64::libopencv-4.7.0-py38hb13779e_4.conda
osx-arm64::postgresql-plpython-15.3-py38hf2dde94_0.conda
osx-arm64::libarrow-12.0.0-hff97baf_2_cpu.conda
osx-arm64::lammps-2023.03.28-py38hfcb1ce5_openmpi_2.conda
osx-arm64::folly-2023.04.24.00-h2c5142d_0_jemalloc.conda
osx-arm64::omniorb-4.2.5-py39h717bbcb_6.conda
osx-arm64::arrow-cpp-9.0.0-py311he168ad1_35_cpu.conda
osx-arm64::ndcctools-7.5.5-py39h6d2f949_0.conda
osx-arm64::sagelib-10.0-py39h177c099_0.conda
osx-arm64::paraview-5.11.1-py38he80f3b4_101_qt.conda
osx-arm64::libarchive-minimal-static-3.6.2-h840afe0_1.conda
osx-arm64::mosh-1.4.0-pl5321h0ca0bd1_1.conda
osx-arm64::pillow-9.5.0-py311h095fde6_1.conda
osx-arm64::lammps-2023.03.28-py39h92cf481_openmpi_2.conda
osx-arm64::llvmlite-0.40.0-py38h761d82c_0.conda
osx-arm64::protozfits-2.2.0-py310h64140a1_0.conda
osx-arm64::ffmpeg-5.1.2-gpl_h16f37a4_108.conda
osx-arm64::tectonic-0.13.1-h116b827_0.conda
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
================================================================================
================================================================================
linux-aarch64
linux-aarch64::git-credential-manager-2.1.1-h28fcf69_1.conda
linux-aarch64::gst-plugins-good-1.22.3-h098df01_0.conda
linux-aarch64::gst-plugins-base-1.22.3-h746d1cd_1.conda
linux-aarch64::libclang13-15.0.7-default_hc086480_2.conda
linux-aarch64::plumed-2.9.0-nompi_hb2c3b54_100.conda
linux-aarch64::libprotobuf-static-4.23.1-h6b51aa4_0.conda
linux-aarch64::libmlir16-16.0.4-h6acfec4_0.conda
linux-aarch64::libass-0.17.1-h4ecd5f7_0.conda
linux-aarch64::micromamba-1.4.2-1.tar.bz2
linux-aarch64::msgpack-cxx-6.0.0-hb8f0cd6_1.conda
linux-aarch64::clang-tools-15.0.7-default_hdf9a116_2.conda
linux-aarch64::git-credential-manager-2.1.2-h28fcf69_0.conda
linux-aarch64::lld-15.0.7-h54a4ff4_1.conda
linux-aarch64::clang-format-14.0.6-default_hdf9a116_1.conda
linux-aarch64::git-credential-manager-2.1.1-h28fcf69_0.conda
linux-aarch64::libclang-cpp14-14.0.6-default_hdf9a116_1.conda
linux-aarch64::libprotobuf-static-4.22.5-h6b51aa4_0.conda
linux-aarch64::msgpack-c-6.0.0-hd84c7bf_0.conda
linux-aarch64::libprotobuf-static-4.22.3-h6b51aa4_0.conda
linux-aarch64::libprotobuf-4.23.2-h6b51aa4_2.conda
linux-aarch64::libprotobuf-static-4.23.0-h6b51aa4_0.conda
linux-aarch64::libclang13-14.0.6-default_hc086480_1.conda
linux-aarch64::libllvm15-15.0.7-hc720cd8_2.conda
linux-aarch64::libprotobuf-4.23.0-h6b51aa4_0.conda
linux-aarch64::libprotobuf-4.23.2-h6b51aa4_1.conda
linux-aarch64::llvm-15.0.7-h70e32f0_2.conda
linux-aarch64::micromamba-1.4.2-2.tar.bz2
linux-aarch64::gst-plugins-good-1.22.3-h691f456_1.conda
linux-aarch64::clang-tools-14.0.6-default_hdf9a116_1.conda
linux-aarch64::libprotobuf-static-4.23.2-h6b51aa4_0.conda
linux-aarch64::libprotobuf-4.22.5-h6b51aa4_0.conda
linux-aarch64::libprotobuf-static-4.23.2-h6b51aa4_1.conda
linux-aarch64::gst-libav-1.22.3-hc93b6a6_0.conda
linux-aarch64::libclang-cpp15-15.0.7-default_hdf9a116_2.conda
linux-aarch64::gst-libav-1.22.3-hc4a16bf_1.conda
linux-aarch64::libmlir-16.0.3-h6acfec4_0.conda
linux-aarch64::libprotobuf-4.22.3-h6b51aa4_0.conda
linux-aarch64::libclang-cpp-15.0.7-default_hdf9a116_2.conda
linux-aarch64::micromamba-1.4.3-0.tar.bz2
linux-aarch64::libprotobuf-4.23.1-h6b51aa4_0.conda
linux-aarch64::libprotobuf-4.23.2-h6b51aa4_0.conda
linux-aarch64::libclang-15.0.7-default_hdf9a116_2.conda
linux-aarch64::libmlir-16.0.4-h6acfec4_0.conda
linux-aarch64::imath-3.1.8-hd84c7bf_0.conda
linux-aarch64::llvm-tools-15.0.7-hc720cd8_2.conda
linux-aarch64::libprotobuf-static-4.23.2-h6b51aa4_2.conda
linux-aarch64::git-credential-manager-2.1.0-h28fcf69_1.conda
linux-aarch64::lld-14.0.6-h54a4ff4_1.conda
linux-aarch64::libsqlite-3.42.0-h194ca79_0.conda
linux-aarch64::clang-15-15.0.7-default_hdf9a116_2.conda
linux-aarch64::clang-format-15-15.0.7-default_hdf9a116_2.conda
linux-aarch64::libllvm14-14.0.6-h966f666_2.conda
linux-aarch64::llvm-tools-14.0.6-h966f666_2.conda
linux-aarch64::libclang-14.0.6-default_hdf9a116_1.conda
linux-aarch64::openexr-3.1.7-h42b27c5_1.conda
linux-aarch64::clang-format-15.0.7-default_hdf9a116_2.conda
linux-aarch64::clang-14-14.0.6-default_hdf9a116_1.conda
linux-aarch64::gst-libav-1.22.3-hc93b6a6_1.conda
linux-aarch64::libclang-cpp-14.0.6-default_hdf9a116_1.conda
linux-aarch64::clang-format-14-14.0.6-default_hdf9a116_1.conda
linux-aarch64::llvm-14.0.6-h40ce709_2.conda
linux-aarch64::libmlir16-16.0.3-h6acfec4_0.conda
linux-aarch64::libsqlite-3.41.2-h194ca79_1.conda
linux-aarch64::glib-tools-2.76.3-hd84c7bf_0.conda
linux-aarch64::gst-plugins-base-1.22.3-hf334e42_0.conda
-    "libzlib >=1.2.13,<1.3.0a0"
+    "libzlib >=1.2.13,<2.0.0a0"
linux-aarch64::magic-8.3.394-h4e13689_0.conda
linux-aarch64::openjdk-17.0.3-h56e244d_7.conda
linux-aarch64::folly-2023.04.10.00-hb60f5cd_0.conda
linux-aarch64::tiledb-2.15.2-hc0eaa86_1.conda
linux-aarch64::arrow-cpp-8.0.1-py311h5a8fc20_32_cuda.conda
linux-aarch64::arrow-cpp-8.0.1-py38h6a42431_31_cpu.conda
linux-aarch64::arrow-cpp-8.0.1-py39hcf7189d_32_cpu.conda
linux-aarch64::arrow-cpp-9.0.0-py311h5a8fc20_35_cuda.conda
linux-aarch64::cpp-opentelemetry-sdk-1.9.0-h509e711_2.conda
linux-aarch64::arrow-cpp-8.0.1-py310h5e2a741_31_cuda.conda
linux-aarch64::libxml2-2.11.3-py310he2cb0cb_1.conda
linux-aarch64::mosh-1.4.0-pl5321h9ae2958_1.conda
linux-aarch64::folly-2023.04.17.00-hbf4f375_0_jemalloc.conda
linux-aarch64::llvmlite-0.40.0-py38h31dfe59_0.conda
linux-aarch64::llvmlite-0.40.0-py38h95a9722_0.conda
linux-aarch64::linux-perf-6.3.2-py39hc5e4ac8_0.conda
linux-aarch64::libarchive-minimal-static-3.6.2-h66cf738_1.conda
linux-aarch64::imagemagick-7.1.1_10-pl5321hac3f1fc_0.conda
linux-aarch64::libopencv-4.7.0-py38h48f526e_4.conda
linux-aarch64::r-base-4.1.3-hcbb63aa_7.conda
linux-aarch64::curl-8.1.2-hc34909b_0.conda
linux-aarch64::pyinstaller-5.11.0-py310h1aab166_0.conda
linux-aarch64::mapserver-8.0.1-py39h6172d11_2.conda
linux-aarch64::arrow-cpp-8.0.1-py39h57d0d76_32_cuda.conda
linux-aarch64::folly-2023.03.27.00-hb60f5cd_0.conda
linux-aarch64::folly-2023.04.24.00-h8282163_0.conda
linux-aarch64::cpp-opentelemetry-sdk-1.9.1-h509e711_1.conda
linux-aarch64::grpcio-1.55.0-py311h1a7908d_1.conda
linux-aarch64::gst-plugins-bad-1.22.3-h627acee_1.conda
linux-aarch64::imagemagick-7.1.1_9-pl5321he389789_0.conda
linux-aarch64::linux-perf-6.3.3-py310h2bd01cc_0.conda
linux-aarch64::omniorb-4.2.5-py311h73dc86d_6.conda
linux-aarch64::ogre-next-2.3.1-h736244c_4.conda
linux-aarch64::libarrow-11.0.0-he5b84aa_20_cuda.conda
linux-aarch64::arrow-cpp-8.0.1-py38h9866075_32_cuda.conda
linux-aarch64::ffmpeg-5.1.2-lgpl_ha4f8616_10.conda
linux-aarch64::folly-2023.05.08.00-h7a25010_0_jemalloc.conda
linux-aarch64::libopencv-4.7.0-py310hc251929_3.conda
linux-aarch64::ortools-python-9.6-py311h994815e_1.conda
linux-aarch64::arrow-cpp-9.0.0-py38hbdf4669_35_cpu.conda
linux-aarch64::libgdal-3.5.3-h0f87154_28.conda
linux-aarch64::arrow-cpp-9.0.0-py39hcf7189d_35_cpu.conda
linux-aarch64::folly-2023.04.03.00-hbf4f375_0_jemalloc.conda
linux-aarch64::arrow-cpp-9.0.0-py38h9866075_35_cuda.conda
linux-aarch64::libopentelemetry-cpp-1.9.1-h7385a69_1.conda
linux-aarch64::ortools-python-9.6-py310ha60177e_1.conda
linux-aarch64::arrow-cpp-9.0.0-py311h8721e50_35_cpu.conda
linux-aarch64::postgresql-plpython-15.3-py311h9f5d4e8_1.conda
linux-aarch64::r-base-4.2.3-h60a3b74_3.conda
linux-aarch64::postgresql-plpython-15.3-py310h8d76202_0.conda
linux-aarch64::vtk-base-9.2.6-qt_py38h1234567_205.conda
linux-aarch64::linux-perf-6.3.4-py311h31656e8_0.conda
linux-aarch64::libopencv-4.7.0-py39ha30da68_3.conda
linux-aarch64::texlive-core-20230313-h752228b_3.conda
linux-aarch64::folly-2023.03.20.00-hbf4f375_4_jemalloc.conda
linux-aarch64::libcurl-8.1.0-hc34909b_0.conda
linux-aarch64::postgresql-plpython-15.3-py310hb8ce058_1.conda
linux-aarch64::libopencv-4.7.0-py311h54bd336_4.conda
linux-aarch64::ffmpeg-5.1.2-lgpl_hc683fe5_7.conda
linux-aarch64::libarrow-12.0.0-h6e79272_1_cuda.conda
linux-aarch64::libgrpc-1.54.2-h86a7dc4_0.conda
linux-aarch64::libopencv-4.7.0-py39h8527831_3.conda
linux-aarch64::folly-2023.04.24.00-hbf4f375_0_jemalloc.conda
linux-aarch64::libgdal-3.6.4-hecd018c_2.conda
linux-aarch64::vtk-base-9.2.6-qt_py311h1234567_205.conda
linux-aarch64::folly-2023.05.22.00-hbf4f375_0_jemalloc.conda
linux-aarch64::postgresql-plpython-14.5-py39h51b70d6_6.conda
linux-aarch64::libgdal-arrow-parquet-3.7.0-hca3801b_0.conda
linux-aarch64::pygplates-0.39-py310h7aed74c_7.conda
linux-aarch64::qt6-wayland-6.5.0-h80f0686_0.conda
linux-aarch64::imagemagick-7.1.1_11-pl5321hac3f1fc_0.conda
linux-aarch64::gst-plugins-bad-1.22.0-h22b0a75_1.conda
linux-aarch64::grpcio-1.55.0-py38h95a9722_0.conda
linux-aarch64::grpcio-1.55.0-py311h1a7908d_0.conda
linux-aarch64::libxml2-2.11.3-py310he2cb0cb_0.conda
linux-aarch64::qt-webengine-5.15.8-he068465_2.conda
linux-aarch64::arrow-cpp-8.0.1-py38h0be6374_31_cuda.conda
linux-aarch64::libpq-15.3-hf616e62_1.conda
linux-aarch64::vtk-base-9.2.6-qt_py38h1234567_206.conda
linux-aarch64::arrow-cpp-9.0.0-py310hf3a5522_35_cpu.conda
linux-aarch64::nco-5.1.6-h0337189_0.conda
linux-aarch64::linux-perf-6.3.4-py310h2bd01cc_0.conda
linux-aarch64::arrow-cpp-9.0.0-py310h5e2a741_34_cuda.conda
linux-aarch64::vtk-base-9.2.6-qt_py311h1234567_206.conda
linux-aarch64::libxmlsec1-1.3.0-h7ef0265_1.conda
linux-aarch64::mysql-router-8.0.32-h1f5bcb8_2.conda
linux-aarch64::python-3.10.11-ha43d526_0_cpython.conda
linux-aarch64::rust-1.69.0-h9d3d833_3.conda
linux-aarch64::folly-2023.04.24.00-hb60f5cd_0.conda
linux-aarch64::pdal-2.5.4-hc9d408e_0.conda
linux-aarch64::libarrow-11.0.0-h6e79272_19_cuda.conda
linux-aarch64::libarrow-12.0.0-h901c870_4_cpu.conda
linux-aarch64::llvm-openmp-16.0.3-h8b0cb96_0.conda
linux-aarch64::sqlite-3.41.2-h3b3482f_1.conda
linux-aarch64::tiledb-2.15.2-hc0eaa86_0.conda
linux-aarch64::libcurl-static-8.1.2-hc34909b_0.conda
linux-aarch64::arrow-cpp-9.0.0-py310h799abcf_35_cuda.conda
linux-aarch64::folly-2023.05.22.00-hbf4f375_1_jemalloc.conda
linux-aarch64::qtkeychain-0.14.0-h54d81ea_0.conda
linux-aarch64::libopencv-4.7.0-py39ha30da68_4.conda
linux-aarch64::linux-perf-6.3.1-py311h31656e8_0.conda
linux-aarch64::libgdal-3.6.4-h296b50a_1.conda
linux-aarch64::libgdal-3.5.3-hd9a9fed_27.conda
linux-aarch64::linux-perf-6.3.1-py39hc5e4ac8_0.conda
linux-aarch64::folly-2023.04.17.00-h7a25010_0_jemalloc.conda
linux-aarch64::llvm-tools-16.0.3-h70e38ee_2.conda
linux-aarch64::sqlite-3.42.0-h3b3482f_0.conda
linux-aarch64::imagemagick-7.1.1_9-pl5321hac3f1fc_1.conda
linux-aarch64::postgresql-plpython-15.3-py39h9e03179_0.conda
linux-aarch64::nodejs-18.15.0-hcab9400_1.conda
linux-aarch64::clangdev-15.0.7-default_hdf9a116_2.conda
linux-aarch64::sagelib-10.0-py38h66bba7d_0.conda
linux-aarch64::magic-8.3.384-hf0419cf_0.conda
linux-aarch64::postgresql-plpython-14.5-py311h9f5d4e8_6.conda
linux-aarch64::folly-2023.03.20.00-h8282163_4.conda
linux-aarch64::qt-main-5.15.8-he1f70d2_11.conda
linux-aarch64::llvmdev-16.0.3-hc720cd8_2.conda
linux-aarch64::postgresql-14.5-h2721a49_6.conda
linux-aarch64::freeimage-3.18.0-h517df17_15.conda
linux-aarch64::libarrow-12.0.0-he12189f_4_cuda.conda
linux-aarch64::libllvm16-16.0.4-h70e38ee_0.conda
linux-aarch64::libllvm16-16.0.3-h70e38ee_2.conda
linux-aarch64::pygplates-0.39-py39ha75a1ed_7.conda
linux-aarch64::postgresql-15.3-h2721a49_1.conda
linux-aarch64::libopencv-4.7.0-py311h3a087bb_2.conda
linux-aarch64::libpq-15.3-hf616e62_0.conda
linux-aarch64::libcurl-8.1.1-hc34909b_0.conda
linux-aarch64::libarrow-10.0.1-hc4f31f2_24_cpu.conda
linux-aarch64::libnetcdf-4.9.2-mpi_mpich_h8d1de6d_5.conda
linux-aarch64::postgresql-15.3-hf4c9870_0.conda
linux-aarch64::libarrow-12.0.0-ha190411_1_cpu.conda
linux-aarch64::libgsf-1.14.50-h75dfdf1_1.conda
linux-aarch64::libopencv-4.7.0-py38h707bd68_3.conda
linux-aarch64::libarrow-10.0.1-h834fc4b_25_cpu.conda
linux-aarch64::openjdk-17.0.3-h0dd39bf_8.conda
linux-aarch64::libopencv-4.7.0-py39h0aafc05_3.conda
linux-aarch64::aws-sdk-cpp-1.10.57-h42fcb7c_13.conda
linux-aarch64::folly-2023.04.24.00-h7a25010_0_jemalloc.conda
linux-aarch64::llvmlite-0.40.0-py39h2ec6326_0.conda
linux-aarch64::arrow-cpp-8.0.1-py39h5b03dd9_31_cpu.conda
linux-aarch64::llvmdev-16.0.4-hc720cd8_0.conda
linux-aarch64::lld-16.0.4-h8ef0f76_0.conda
linux-aarch64::arrow-cpp-9.0.0-py38h763947b_36_cuda.conda
linux-aarch64::arrow-cpp-9.0.0-py311h204a455_34_cuda.conda
linux-aarch64::folly-2023.05.22.00-h8282163_0.conda
linux-aarch64::libopencv-4.7.0-py310hc251929_4.conda
linux-aarch64::sagelib-10.0-py311he22122c_0.conda
linux-aarch64::cpp-opentelemetry-sdk-1.9.1-h509e711_0.conda
linux-aarch64::postgresql-plpython-14.5-py310hb8ce058_6.conda
linux-aarch64::libglib-2.76.3-h0464669_0.conda
linux-aarch64::ffmpeg-5.1.2-gpl_ha557aa8_110.conda
linux-aarch64::postgresql-plpython-15.3-py38h12f8259_0.conda
linux-aarch64::pillow-9.5.0-py310hd04a61c_1.conda
linux-aarch64::libgdal-arrow-parquet-3.6.4-h6939f76_1.conda
linux-aarch64::folly-2023.04.03.00-hb60f5cd_0.conda
linux-aarch64::llvm-tools-16.0.3-h11d3cc5_1.conda
linux-aarch64::libopentelemetry-cpp-1.9.1-h509e711_1.conda
linux-aarch64::llvm-tools-16.0.4-h70e38ee_0.conda
linux-aarch64::folly-2023.03.27.00-h7a25010_0_jemalloc.conda
linux-aarch64::magic-8.3.400-h4e13689_0.conda
linux-aarch64::folly-2023.05.01.00-hbf4f375_0_jemalloc.conda
linux-aarch64::libortools-9.6-h49c5803_3.conda
linux-aarch64::libortools-9.6-h00fbe4f_1.conda
linux-aarch64::libnetcdf-4.9.2-nompi_hc2a3fc6_105.conda
linux-aarch64::libgrpc-1.54.2-h53d6f9f_1.conda
linux-aarch64::tiledb-2.15.2-hc0eaa86_2.conda
linux-aarch64::ffmpeg-6.0.0-gpl_h5460286_100.conda
linux-aarch64::libgdal-arrow-parquet-3.6.4-h676f9a2_2.conda
linux-aarch64::folly-2023.04.17.00-hb60f5cd_0.conda
linux-aarch64::linux-perf-6.3.2-py38h696f14d_0.conda
linux-aarch64::pillow-9.5.0-py39hc5b5638_1.conda
linux-aarch64::ortools-python-9.6-py38h1b96e49_1.conda
linux-aarch64::folly-2023.04.17.00-h8282163_0.conda
linux-aarch64::llvmlite-0.40.0-py39h483cef1_0.conda
linux-aarch64::libarrow-10.0.1-hf58d9e2_23_cpu.conda
linux-aarch64::qt6-main-6.5.0-h7a07723_6.conda
linux-aarch64::folly-2023.04.10.00-h7a25010_0_jemalloc.conda
linux-aarch64::postgresql-plpython-15.3-py311h9b7fc12_0.conda
linux-aarch64::libarrow-10.0.1-h119057b_24_cuda.conda
linux-aarch64::ffmpeg-5.1.2-gpl_h460edcf_107.conda
linux-aarch64::linux-perf-6.3.4-py39hc5e4ac8_0.conda
linux-aarch64::arrow-cpp-8.0.1-py310h48e077b_31_cpu.conda
linux-aarch64::aws-sdk-cpp-1.11.68-h42de668_2.conda
linux-aarch64::llvm-16.0.3-he38e8dc_0.conda
linux-aarch64::cpp-opentelemetry-sdk-1.9.1-h44394fa_2.conda
linux-aarch64::libgrpc-1.52.1-h53d6f9f_2.conda
linux-aarch64::arrow-cpp-9.0.0-py311h45c21be_36_cpu.conda
linux-aarch64::mapserver-8.0.1-py310h834ea68_3.conda
linux-aarch64::qt-main-5.15.8-h0396913_13.conda
linux-aarch64::ffmpeg-6.0.0-lgpl_h3623ebe_1.conda
linux-aarch64::libopencv-4.7.0-py38h89998a9_3.conda
linux-aarch64::folly-2023.05.15.00-hb60f5cd_0.conda
linux-aarch64::llvmdev-14.0.6-h966f666_2.conda
linux-aarch64::llvmlite-0.40.0-py310h20b6881_0.conda
linux-aarch64::plumed-2.9.0-mpi_mpich_h9b68d0a_0.conda
linux-aarch64::libopencv-4.7.0-py311hdc54d6c_3.conda
linux-aarch64::folly-2023.03.20.00-h7a25010_4_jemalloc.conda
linux-aarch64::folly-2023.03.27.00-hbf4f375_0_jemalloc.conda
linux-aarch64::libopencv-4.7.0-py38hda60cc0_3.conda
linux-aarch64::linux-perf-6.3.1-py310h2bd01cc_0.conda
linux-aarch64::pyinstaller-5.11.0-py38h37f3631_0.conda
linux-aarch64::cmake-3.26.4-hef020d8_0.conda
linux-aarch64::folly-2023.05.08.00-h8282163_0.conda
linux-aarch64::qt-main-5.15.8-h0396913_12.conda
linux-aarch64::blosc-1.21.4-h2f3a684_0.conda
linux-aarch64::r-base-4.1.3-hfe4c01d_6.conda
linux-aarch64::linux-perf-6.3.3-py39hc5e4ac8_0.conda
linux-aarch64::cpp-opentelemetry-sdk-1.9.1-h04e467d_2.conda
linux-aarch64::arrow-cpp-9.0.0-py39hf8dc01b_34_cuda.conda
linux-aarch64::mysql-libs-8.0.32-hf629957_2.conda
linux-aarch64::folly-2023.05.22.00-h7a25010_0_jemalloc.conda
linux-aarch64::arrow-cpp-8.0.1-py310hf3a5522_32_cpu.conda
linux-aarch64::folly-2023.05.01.00-hb60f5cd_0.conda
linux-aarch64::mapserver-8.0.1-py311h6682cb8_2.conda
linux-aarch64::llvm-tools-16.0.3-h11d3cc5_0.conda
linux-aarch64::linux-perf-6.3.2-py310h2bd01cc_0.conda
linux-aarch64::folly-2023.05.15.00-h8282163_0.conda
linux-aarch64::omniorb-libs-4.2.5-h73a623e_6.conda
linux-aarch64::postgresql-plpython-14.5-py38h9a15a79_6.conda
linux-aarch64::grpcio-1.55.0-py39h483cef1_0.conda
linux-aarch64::libxml2-2.11.4-h164fba4_0.conda
linux-aarch64::grpcio-1.55.0-py310h20b6881_1.conda
linux-aarch64::tiledb-2.15.2-h63b8963_0.conda
linux-aarch64::pillow-9.5.0-py39hd811ef5_1.conda
linux-aarch64::libgrpc-1.55.0-haa74edf_1.conda
linux-aarch64::mapserver-8.0.1-py38hfec9b18_3.conda
linux-aarch64::omniorb-4.2.5-py38h4a58c09_6.conda
linux-aarch64::poppler-qt-23.05.0-h9c846af_1.conda
linux-aarch64::omniorb-4.2.5-py39h372938c_6.conda
linux-aarch64::libsoup-3.4.2-h7b0f9e5_1.conda
linux-aarch64::r-base-4.3.0-h60a3b74_1.conda
linux-aarch64::libarrow-11.0.0-ha190411_19_cpu.conda
linux-aarch64::libarrow-10.0.1-h6c1484c_25_cuda.conda
linux-aarch64::arrow-cpp-9.0.0-py39h95f74fa_36_cpu.conda
linux-aarch64::llvmdev-16.0.3-hd8ae89b_0.conda
linux-aarch64::llvmdev-16.0.3-hd8ae89b_1.conda
linux-aarch64::libsoup-3.4.2-h7adf874_0.conda
linux-aarch64::mesalib-23.0.2-h5f6ae44_1.conda
linux-aarch64::plumed-2.9.0-mpi_openmpi_had6379e_0.conda
linux-aarch64::libopencv-4.7.0-py39hba84997_3.conda
linux-aarch64::arrow-cpp-9.0.0-py310h48e077b_34_cpu.conda
linux-aarch64::mapserver-8.0.1-py38h8a8c11d_2.conda
linux-aarch64::ffmpeg-6.0.0-gpl_hb65179d_101.conda
linux-aarch64::cpp-opentelemetry-sdk-1.9.1-h7385a69_1.conda
linux-aarch64::arrow-cpp-9.0.0-py39he9e6dff_36_cuda.conda
linux-aarch64::pillow-9.5.0-py38hc8bea21_1.conda
linux-aarch64::linux-perf-6.3.1-py38h696f14d_0.conda
linux-aarch64::libxml2-2.11.3-h164fba4_2.conda
linux-aarch64::qt6-3d-6.5.1-h746663d_0.conda
linux-aarch64::vtk-base-9.2.6-qt_py310h1234567_205.conda
linux-aarch64::llvmdev-15.0.7-hc720cd8_2.conda
linux-aarch64::libgrpc-1.54.2-h53d6f9f_2.conda
linux-aarch64::libarchive-3.6.2-h566b526_1.conda
linux-aarch64::libgrpc-1.55.0-haa74edf_0.conda
linux-aarch64::openjdk-20.0.0-h0dd39bf_0.conda
linux-aarch64::libopencv-4.7.0-py38h91fe9e3_3.conda
linux-aarch64::omniorb-4.2.5-py310h3adfcad_6.conda
linux-aarch64::openconnect-9.10-he2996b4_0.conda
linux-aarch64::vtk-base-9.2.6-qt_py39h1234567_206.conda
linux-aarch64::folly-2023.05.08.00-hbf4f375_0_jemalloc.conda
linux-aarch64::folly-2023.05.22.00-h8282163_1.conda
linux-aarch64::arrow-cpp-8.0.1-py311h8721e50_32_cpu.conda
linux-aarch64::librdkafka-2.1.1-hb18e517_0.conda
linux-aarch64::openconnect-9.12-he2996b4_0.conda
linux-aarch64::folly-2023.04.10.00-hbf4f375_0_jemalloc.conda
linux-aarch64::tiledb-2.15.3-h8c30abc_0.conda
linux-aarch64::folly-2023.05.15.00-h7a25010_0_jemalloc.conda
linux-aarch64::ffmpeg-5.1.2-gpl_h6b50878_109.conda
linux-aarch64::libarrow-12.0.0-hc1d00d8_0_cuda.conda
linux-aarch64::arrow-cpp-9.0.0-py310h9162303_36_cuda.conda
linux-aarch64::openjdk-11.0.15-h56e244d_4.conda
linux-aarch64::glib-2.76.3-hd84c7bf_0.conda
linux-aarch64::curl-8.1.0-hc34909b_0.conda
linux-aarch64::ortools-python-9.6-py39h54b31c9_1.conda
linux-aarch64::folly-2023.04.03.00-h8282163_0.conda
linux-aarch64::aws-sdk-cpp-1.11.68-h4eeedb6_5.conda
linux-aarch64::r-base-4.1.3-h4ea049c_8.conda
linux-aarch64::folly-2023.04.03.00-h7a25010_0_jemalloc.conda
linux-aarch64::llvm-openmp-16.0.4-h8b0cb96_0.conda
linux-aarch64::libarrow-11.0.0-h901c870_21_cpu.conda
linux-aarch64::grpcio-1.55.0-py310h20b6881_0.conda
linux-aarch64::libllvm16-16.0.3-h11d3cc5_0.conda
linux-aarch64::pdal-2.5.4-hff47823_1.conda
linux-aarch64::sagelib-10.0-py310h055e31b_0.conda
linux-aarch64::mapserver-8.0.1-py310h64ee303_2.conda
linux-aarch64::libarrow-12.0.0-h4b34595_2_cpu.conda
linux-aarch64::libopentelemetry-cpp-1.9.0-h509e711_2.conda
linux-aarch64::cpp-opentelemetry-sdk-1.9.0-h509e711_3.conda
linux-aarch64::libopencv-4.7.0-py310h73e6f32_3.conda
linux-aarch64::libopencv-4.7.0-py39hcbe65d6_4.conda
linux-aarch64::arrow-cpp-9.0.0-py38hb12e407_36_cpu.conda
linux-aarch64::libvips-8.14.2-h583e2e0_1.conda
linux-aarch64::arrow-cpp-8.0.1-py311h204a455_31_cuda.conda
linux-aarch64::pdal-2.5.4-h89f9092_1.conda
linux-aarch64::rust-1.69.0-h9d3d833_2.conda
linux-aarch64::qt6-main-6.5.0-hf4b49fe_8.conda
linux-aarch64::tiledb-2.15.3-hc0eaa86_0.conda
linux-aarch64::mlir-16.0.4-h6acfec4_0.conda
linux-aarch64::libopentelemetry-cpp-1.9.1-h04e467d_2.conda
linux-aarch64::arrow-cpp-9.0.0-py38h6a42431_34_cpu.conda
linux-aarch64::r-base-4.1.3-hfd1a1da_9.conda
linux-aarch64::grpcio-1.55.0-py39h483cef1_1.conda
linux-aarch64::vtk-base-9.2.6-qt_py310h1234567_206.conda
linux-aarch64::libopencv-4.7.0-py38h91fe9e3_4.conda
linux-aarch64::libcurl-static-8.1.0-hc34909b_0.conda
linux-aarch64::libortools-9.6-h080b24f_1.conda
linux-aarch64::libgdal-arrow-parquet-3.7.0-hc4fdc60_1.conda
linux-aarch64::arrow-cpp-9.0.0-py311h8f8d159_34_cpu.conda
linux-aarch64::mapserver-8.0.1-py311h7b96b51_3.conda
linux-aarch64::libopentelemetry-cpp-1.9.0-h509e711_3.conda
linux-aarch64::qt6-main-6.5.0-h1366576_7.conda
linux-aarch64::qt6-main-6.5.1-hf4b49fe_0.conda
linux-aarch64::llvmlite-0.40.0-py311h1a7908d_0.conda
linux-aarch64::arrow-cpp-9.0.0-py311hee5a7ef_36_cuda.conda
linux-aarch64::aws-sdk-cpp-1.11.68-ha42ebf8_1.conda
linux-aarch64::aws-sdk-cpp-1.10.57-h42de668_12.conda
linux-aarch64::tiledb-2.15.2-ha9c24b0_2.conda
linux-aarch64::libarrow-12.0.0-h8c7c092_0_cpu.conda
linux-aarch64::pygplates-0.39-py311h7d3cb49_7.conda
linux-aarch64::vtk-base-9.2.6-qt_py39h1234567_205.conda
linux-aarch64::cairo-1.16.0-h3b99fb1_1016.conda
linux-aarch64::postgresql-plpython-15.3-py39h51b70d6_1.conda
linux-aarch64::libllvm16-16.0.3-h11d3cc5_1.conda
linux-aarch64::curl-8.1.1-hc34909b_0.conda
linux-aarch64::mysql-client-8.0.32-h88b4a5d_2.conda
linux-aarch64::poppler-23.05.0-h79703be_1.conda
linux-aarch64::sagelib-10.0-py39h0c97323_0.conda
linux-aarch64::arrow-cpp-9.0.0-py39h57d0d76_35_cuda.conda
linux-aarch64::arrow-cpp-8.0.1-py311h8f8d159_31_cpu.conda
linux-aarch64::gst-plugins-bad-1.22.3-hfaa0fbe_0.conda
linux-aarch64::libarrow-12.0.0-he5b84aa_2_cuda.conda
linux-aarch64::pygplates-0.39-py38h9df833a_7.conda
linux-aarch64::mapserver-8.0.1-py39hdf0d1cc_3.conda
linux-aarch64::libspatialite-5.0.1-hf36e144_26.conda
linux-aarch64::libarrow-12.0.0-he12189f_3_cuda.conda
linux-aarch64::ffmpeg-5.1.2-lgpl_h2798eb2_9.conda
linux-aarch64::libortools-9.6-h49c5803_2.conda
linux-aarch64::folly-2023.03.20.00-hb60f5cd_4.conda
linux-aarch64::ffmpeg-5.1.2-gpl_h3db0220_108.conda
linux-aarch64::libcurl-static-8.1.1-hc34909b_0.conda
linux-aarch64::libopencv-4.7.0-py38hda25c40_4.conda
linux-aarch64::gmsh-4.11.1-h031e559_2.conda
linux-aarch64::libcurl-8.1.2-hc34909b_0.conda
linux-aarch64::arrow-cpp-9.0.0-py310hb6450b8_36_cpu.conda
linux-aarch64::clangdev-14.0.6-default_hdf9a116_1.conda
linux-aarch64::libortools-9.6-heae7649_1.conda
linux-aarch64::libarrow-11.0.0-he12189f_21_cuda.conda
linux-aarch64::graphviz-8.0.5-h1e60024_0.conda
linux-aarch64::aws-sdk-cpp-1.10.57-ha42ebf8_11.conda
linux-aarch64::arrow-cpp-8.0.1-py310h799abcf_32_cuda.conda
linux-aarch64::pillow-9.5.0-py311h170abe6_1.conda
linux-aarch64::tiledb-2.15.2-h1eb7352_1.conda
linux-aarch64::libarrow-10.0.1-h0c41637_23_cuda.conda
linux-aarch64::libopencv-4.7.0-py310he506731_4.conda
linux-aarch64::pillow-9.5.0-py38h5cbf20c_1.conda
linux-aarch64::libarrow-11.0.0-h4b34595_20_cpu.conda
linux-aarch64::lld-16.0.3-h8ef0f76_1.conda
linux-aarch64::libnetcdf-4.9.2-mpi_openmpi_hf4c1741_5.conda
linux-aarch64::linux-perf-6.3.3-py38h696f14d_0.conda
linux-aarch64::folly-2023.05.15.00-hbf4f375_0_jemalloc.conda
linux-aarch64::libgrpc-1.54.1-h86a7dc4_0.conda
linux-aarch64::libgdal-3.7.0-h3abcd22_1.conda
linux-aarch64::llvm-16.0.3-h5271726_2.conda
linux-aarch64::mlir-16.0.3-h6acfec4_0.conda
linux-aarch64::arrow-cpp-9.0.0-py39h5b03dd9_34_cpu.conda
linux-aarch64::ffmpeg-5.1.2-lgpl_hbcfc100_8.conda
linux-aarch64::folly-2023.05.22.00-hb60f5cd_1.conda
linux-aarch64::lld-16.0.3-hc252c2d_0.conda
linux-aarch64::arrow-cpp-9.0.0-py39h268e5e1_33_cpu.conda
linux-aarch64::libopentelemetry-cpp-1.9.1-h44394fa_2.conda
linux-aarch64::qt-webengine-5.15.8-h0b9e7e1_1.conda
linux-aarch64::folly-2023.05.01.00-h7a25010_0_jemalloc.conda
linux-aarch64::libopencv-4.7.0-py38h89998a9_4.conda
linux-aarch64::libortools-9.6-h1bd0279_1.conda
linux-aarch64::folly-2023.04.10.00-h8282163_0.conda
linux-aarch64::openslide-3.4.1-h30bce20_9.conda
linux-aarch64::libarrow-12.0.0-h901c870_3_cpu.conda
linux-aarch64::libopencv-4.7.0-py39h8527831_4.conda
linux-aarch64::libpq-14.5-hf616e62_6.conda
linux-aarch64::libopencv-4.7.0-py311hc138e0e_3.conda
linux-aarch64::mosh-1.4.0-pl5321hd3affc3_1.conda
linux-aarch64::arrow-cpp-9.0.0-py311h9c027a0_33_cpu.conda
linux-aarch64::libopentelemetry-cpp-1.9.1-h509e711_0.conda
linux-aarch64::arrow-cpp-8.0.1-py38hbdf4669_32_cpu.conda
linux-aarch64::libopencv-4.7.0-py39h6d3355a_4.conda
linux-aarch64::libgdal-arrow-parquet-3.6.4-h8b9a5e6_3.conda
linux-aarch64::folly-2023.05.22.00-hb60f5cd_0.conda
linux-aarch64::llvm-16.0.3-he38e8dc_1.conda
linux-aarch64::libgdal-3.7.0-heb68a5c_0.conda
linux-aarch64::llvm-16.0.4-h5271726_0.conda
linux-aarch64::arrow-cpp-8.0.1-py39hf8dc01b_31_cuda.conda
linux-aarch64::folly-2023.05.08.00-hb60f5cd_0.conda
linux-aarch64::aws-sdk-cpp-1.11.68-hb172e25_4.conda
linux-aarch64::libgdal-3.6.4-hfb38a16_3.conda
linux-aarch64::postgresql-plpython-15.3-py38h9a15a79_1.conda
linux-aarch64::linux-perf-6.3.2-py311h31656e8_0.conda
linux-aarch64::linux-perf-6.3.4-py38h696f14d_0.conda
linux-aarch64::ffmpeg-6.0.0-lgpl_h4c927e3_0.conda
linux-aarch64::arrow-cpp-9.0.0-py38h0be6374_34_cuda.conda
linux-aarch64::folly-2023.05.01.00-h8282163_0.conda
linux-aarch64::grpcio-1.55.0-py38h95a9722_1.conda
linux-aarch64::libopencv-4.7.0-py311hdc54d6c_4.conda
linux-aarch64::folly-2023.03.27.00-h8282163_0.conda
linux-aarch64::aws-sdk-cpp-1.11.68-h42fcb7c_3.conda
linux-aarch64::linux-perf-6.3.3-py311h31656e8_0.conda
linux-aarch64::mysql-server-8.0.32-h9e1a5d7_2.conda
linux-aarch64::arrow-cpp-9.0.0-py38h95cafec_33_cpu.conda
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
================================================================================
================================================================================
noarch
================================================================================
================================================================================
win-64
win-64::libopencv-4.7.0-py39h4327c74_4.conda
win-64::libgrpc-1.52.1-ha177ca7_2.conda
win-64::libllvm16-16.0.3-h1ab654d_2.conda
win-64::stir-5.1.0-cuda102_py38h3a82125_206.conda
win-64::imath-3.1.8-h12be248_0.conda
win-64::librdkafka-2.1.1-h78d1f3c_0.conda
win-64::libprotobuf-4.23.2-h1975477_1.conda
win-64::libprotobuf-static-4.23.2-h1975477_2.conda
win-64::libgrpc-1.55.0-h0c1e3fa_0.conda
win-64::grpcio-1.54.2-py39hd0003e1_0.conda
win-64::libclang-cpp-16.0.3-default_h8b4101f_1.conda
win-64::clang-tools-15.0.7-default_h66ee7f4_2.conda
win-64::mysql-libs-8.0.32-h8b0d2c3_2.conda
win-64::grpcio-1.54.2-py311hfe69050_2.conda
win-64::tiledb-2.15.2-h5d2f514_0.conda
win-64::libpq-15.3-ha9684e8_0.conda
win-64::libpcm-1.2.3-h41f9d32_2.conda
win-64::arrow-cpp-9.0.0-py39h6c36fc9_35_cuda.conda
win-64::clangxx-16.0.3-default_h8b4101f_0.conda
win-64::postgresql-plpython-14.5-py38h1728808_6.conda
win-64::grpcio-1.54.1-py311h5f90226_0.conda
win-64::arrow-cpp-9.0.0-py311h10cc4d8_36_cpu.conda
win-64::llvm-tools-15.0.7-h1ab654d_2.conda
win-64::grpcio-1.55.0-py311h5bc0dda_0.conda
win-64::llvm-16.0.3-h3dc180e_2.conda
win-64::libgdal-arrow-parquet-3.7.0-hfb13953_1.conda
win-64::stir-5.1.0-cpu_py38hc1d9697_6.conda
win-64::grpcio-1.54.2-py310h8020be6_1.conda
win-64::ffmpeg-6.0.0-gpl_h3a5b8a7_100.conda
win-64::llvm-16.0.3-h38bddbe_1.conda
win-64::libxml2-2.11.3-hc3477c8_2.conda
win-64::libarrow-12.0.0-h6a877a0_1_cuda.conda
win-64::raven-hydro-0.2.1-py311heaa4539_1.conda
win-64::arrow-cpp-9.0.0-py38had5f33e_36_cpu.conda
win-64::scip-8.0.3-hc7fd266_2.conda
win-64::libgdal-arrow-parquet-3.6.4-hdece852_2.conda
win-64::lld-16.0.3-h5520ce9_0.conda
win-64::libgdal-3.7.0-hdf18f8d_0.conda
win-64::raven-hydro-0.2.0-py310h098a066_0.conda
win-64::libprotobuf-static-4.23.2-h1975477_1.conda
win-64::raven-hydro-0.2.0rc0-py310h098a066_0.conda
win-64::libcurl-static-8.1.2-h68f0423_0.conda
win-64::tiledb-2.15.3-h86be035_0.conda
win-64::qt6-main-6.5.0-hf0c6fff_7.conda
win-64::ffmpeg-5.1.2-lgpl_h6be244c_10.conda
win-64::stir-5.1.0-cuda110_py39h6468bd3_206.conda
win-64::arrow-cpp-9.0.0-py310h2c858d8_35_cpu.conda
win-64::raven-hydro-0.2.0-py39hc465eaa_1.conda
win-64::lpython-0.13.0-h12be248_1.conda
win-64::stir-5.1.0-cpu_py39hcb2e9d6_6.conda
win-64::libprotobuf-4.22.5-h1975477_0.conda
win-64::stir-5.1.0-cuda102_py39h33d3e11_206.conda
win-64::papilo-2.1.2-h45feaf2_2.conda
win-64::tiledb-2.15.2-hc95769d_2.conda
win-64::ffmpeg-5.1.2-gpl_h97595f5_108.conda
win-64::arrow-cpp-9.0.0-py38he18c823_34_cpu.conda
win-64::arrow-cpp-8.0.1-py310h72189d4_31_cuda.conda
win-64::libarrow-11.0.0-h91bed3e_19_cpu.conda
win-64::libopencv-4.7.0-py310h5030a11_3.conda
win-64::raven-hydro-0.2.1-py39h001a4f1_1.conda
win-64::libxml2-2.11.4-hc3477c8_0.conda
win-64::libopencv-4.7.0-py39he1e1a9f_3.conda
win-64::grpcio-1.54.2-py311h5f90226_0.conda
win-64::clangdev-15.0.7-default_h66ee7f4_2.conda
win-64::gst-plugins-bad-1.22.0-ha2afc39_1.conda
win-64::libprotobuf-static-4.22.5-h1975477_0.conda
win-64::cpp-opentelemetry-sdk-1.9.1-h4dcfd69_2.conda
win-64::arrow-cpp-8.0.1-py38had5f33e_32_cpu.conda
win-64::libclang-14.0.6-default_h77d9078_1.conda
win-64::gdstk-0.9.41-py311hc50246e_0.conda
win-64::gmsh-4.11.1-h55117c2_2.conda
win-64::cairo-1.16.0-hdecc03f_1016.conda
win-64::raven-hydro-0.2.0-py310h098a066_2.conda
win-64::paraview-5.11.1-py310h835bfb1_101_qt.conda
win-64::pypy3.9-7.3.11-h994e1e7_1.conda
win-64::omniorb-4.2.5-py311h40cf3c0_6.conda
win-64::arrow-cpp-9.0.0-py38h9115b5a_34_cuda.conda
win-64::libpq-15.3-ha9684e8_1.conda
win-64::omniorb-4.2.5-py38h78b27f5_6.conda
win-64::arrow-cpp-9.0.0-py38hc7e6405_36_cuda.conda
win-64::qt6-main-6.5.0-hf0c6fff_8.conda
win-64::libopencv-4.7.0-py38h17b58e0_4.conda
win-64::vtk-base-9.2.6-qt_py39h1234567_205.conda
win-64::stir-5.1.0-cuda102_py310h3d1776b_206.conda
win-64::llvm-tools-16.0.3-h2c25772_1.conda
win-64::libxml2-2.11.3-hc3477c8_0.conda
win-64::libarrow-11.0.0-h2de714e_20_cuda.conda
win-64::grpcio-1.54.1-py39hd0003e1_0.conda
win-64::clang-15-15.0.7-default_h66ee7f4_2.conda
win-64::tectonic-0.12.0-h8e80d7b_3.conda
win-64::raven-hydro-0.2.1-py38hc2ce60e_1.conda
win-64::libclang-16.0.4-default_heb8d277_0.conda
win-64::libprotobuf-static-4.22.3-h1975477_0.conda
win-64::conduit-0.8.8-py310ha8ed64a_0.conda
win-64::postgresql-plpython-15.3-py38h1728808_1.conda
win-64::clang-tools-16.0.3-default_heb8d277_2.conda
win-64::grpcio-1.55.0-py38h19421c1_0.conda
win-64::llvmlite-0.40.0-py311h5bc0dda_0.conda
win-64::raven-hydro-0.2.0-py39h001a4f1_2.conda
win-64::openexr-3.1.7-h9f7af22_1.conda
win-64::raven-hydro-0.2.1-py38h9f5882e_0.conda
win-64::arrow-cpp-9.0.0-py39hb0bc455_36_cpu.conda
win-64::libclang-16.0.3-default_h8b4101f_0.conda
win-64::libclang-15.0.7-default_h77d9078_2.conda
win-64::nco-5.1.6-hc1ab86c_0.conda
win-64::libgrpc-1.54.2-ha177ca7_1.conda
win-64::gst-libav-1.22.3-hec9340f_1.conda
win-64::stir-5.1.0-cuda112_py39h4f81ae0_206.conda
win-64::raven-hydro-0.2.0-py311h47b085c_1.conda
win-64::conduit-0.8.8-py38h9f2d3ba_0.conda
win-64::grpcio-1.54.2-py311hfe69050_1.conda
win-64::gdstk-0.9.41-py38h6137a70_0.conda
win-64::raven-hydro-0.2.0-py38h9f5882e_1.conda
win-64::libopencv-4.7.0-py38h0656caa_3.conda
win-64::vtk-base-9.2.6-qt_py311h1234567_206.conda
win-64::aws-sdk-cpp-1.11.68-h5afbc05_4.conda
win-64::conduit-0.8.8-py39h0e288bf_0.conda
win-64::libgdal-3.7.0-h4083641_1.conda
win-64::libopencv-4.7.0-py38h9083cfb_4.conda
win-64::raven-hydro-0.2.1-py311h47b085c_1.conda
win-64::llvm-16.0.4-h3dc180e_0.conda
win-64::mysql-client-8.0.32-hed9f4ee_2.conda
win-64::grpcio-1.54.1-py310h76bb054_0.conda
win-64::curl-8.1.1-h68f0423_0.conda
win-64::glib-tools-2.76.3-h12be248_0.conda
win-64::llvmdev-16.0.4-h1ab654d_0.conda
win-64::libcurl-8.1.2-h68f0423_0.conda
win-64::arrow-cpp-9.0.0-py311ha6a32f2_35_cuda.conda
win-64::libpcm-1.2.3-h41f9d32_1.conda
win-64::cpp-opentelemetry-sdk-1.9.0-h4bd2ebb_3.conda
win-64::libarrow-10.0.1-h8517699_23_cpu.conda
win-64::libxmlpp-4.0-4.0.2-h330a226_1.conda
win-64::clang-16-16.0.4-default_heb8d277_0.conda
win-64::stir-5.1.0-cuda110_py38h31b3527_206.conda
win-64::libopencv-4.7.0-py311h827ab90_4.conda
win-64::postgresql-15.3-h96452e4_1.conda
win-64::paraview-5.11.1-py310h1e8792a_101_qt.conda
win-64::qt6-main-6.5.1-hf0c6fff_0.conda
win-64::grpcio-1.55.0-py310hb84602e_0.conda
win-64::pillow-9.5.0-py311hde623f7_1.conda
win-64::gdstk-0.9.41-py310h8f0d0a4_0.conda
win-64::stir-5.1.0-cuda111_py39h18beeb6_206.conda
win-64::arrow-cpp-8.0.1-py310h6712fdc_31_cpu.conda
win-64::clangxx-16.0.3-default_h8b4101f_1.conda
win-64::libprotobuf-static-4.23.1-h1975477_0.conda
win-64::kaldi-5.5.1068-cuda112h9d48c5b_0.conda
win-64::curl-8.1.0-h68f0423_0.conda
win-64::grpcio-1.54.2-py39h662c1f1_1.conda
win-64::libopentelemetry-cpp-1.9.1-h03fb4e4_0.conda
win-64::clang-16.0.4-h3dc180e_0.conda
win-64::libopencv-4.7.0-py310h74ad70b_4.conda
win-64::libgdal-arrow-parquet-3.6.4-h2b5a39b_3.conda
win-64::llvmdev-15.0.7-h1ab654d_2.conda
win-64::lld-16.0.4-h21f6fed_0.conda
win-64::vtk-base-9.2.6-qt_py38h1234567_205.conda
win-64::arrow-cpp-9.0.0-py311ha6a32f2_36_cuda.conda
win-64::libgdal-3.6.4-h69cf491_1.conda
win-64::ffmpeg-5.1.2-lgpl_hdafa457_7.conda
win-64::stir-5.1.0-cuda112_py38hd7a7af3_206.conda
win-64::libcurl-8.1.1-h68f0423_0.conda
win-64::llvmdev-16.0.3-h1ab654d_2.conda
win-64::aws-sdk-cpp-1.11.68-ha442f66_5.conda
win-64::nexus-4.4.3-h752f2f8_9.conda
win-64::libprotobuf-4.23.2-h1975477_2.conda
win-64::libarrow-10.0.1-h0ac4353_25_cpu.conda
win-64::libuwebsockets-20.44.0-h12be248_0.conda
win-64::libllvm16-16.0.3-h2c25772_0.conda
win-64::libmlir-16.0.4-he744812_0.conda
win-64::raven-hydro-0.2.0-py39hc465eaa_2.conda
win-64::libcurl-static-8.1.0-h68f0423_0.conda
win-64::clang-tools-16.0.3-default_h8b4101f_0.conda
win-64::gdstk-0.9.41-py39ha81e884_0.conda
win-64::libpcm-1.2.3-h41f9d32_4.conda
win-64::libllvm15-15.0.7-h1ab654d_2.conda
win-64::clang-16.0.3-h38bddbe_1.conda
win-64::tiledb-2.15.3-hb2c53ee_0.conda
win-64::clang-16-16.0.3-default_heb8d277_2.conda
win-64::clang-16-16.0.3-default_h8b4101f_1.conda
win-64::libmlir-16.0.3-he744812_0.conda
win-64::raven-hydro-0.2.1-py39hc465eaa_1.conda
win-64::postgresql-plpython-15.3-py310hd1fc835_1.conda
win-64::libopencv-4.7.0-py311h57b83a9_3.conda
win-64::libgrpc-1.54.2-h32da247_0.conda
win-64::raven-hydro-0.2.1-py39h001a4f1_0.conda
win-64::hugin-2022.0.0-pl5321hda98913_4.conda
win-64::ffmpeg-5.1.2-gpl_h2896fe5_110.conda
win-64::pyinstaller-5.11.0-py39h84a0465_0.conda
win-64::omniorb-libs-4.2.5-h27dd91c_6.conda
win-64::arrow-cpp-8.0.1-py311hdac512a_31_cpu.conda
win-64::arrow-cpp-9.0.0-py38had5f33e_35_cpu.conda
win-64::libcurl-8.1.0-h68f0423_0.conda
win-64::qt-main-5.15.8-h2c8576c_13.conda
win-64::pygplates-0.39-py311hfcb9d6a_7.conda
win-64::libprotobuf-static-4.23.2-h1975477_0.conda
win-64::vtk-base-9.2.6-qt_py310h1234567_206.conda
win-64::poppler-qt-23.05.0-hec2a549_1.conda
win-64::grpcio-1.55.0-py38h19421c1_1.conda
win-64::libarrow-11.0.0-ha096e86_21_cpu.conda
win-64::tiledb-2.15.2-h86be035_0.conda
win-64::clang-tools-16.0.3-default_h8b4101f_1.conda
win-64::raven-hydro-0.2.1-py38h3b9c276_0.conda
win-64::postgresql-plpython-15.3-py39hc82172b_0.conda
win-64::grpcio-1.52.1-py39h662c1f1_2.conda
win-64::libprotobuf-4.23.0-h1975477_0.conda
win-64::postgresql-plpython-15.3-py39ha748b4c_1.conda
win-64::libopencv-4.7.0-py39ha7aead3_4.conda
win-64::libopencv-4.7.0-py39hc7ed3a1_4.conda
win-64::arrow-cpp-9.0.0-py310h6bbbdca_36_cuda.conda
win-64::arrow-cpp-8.0.1-py311ha6a32f2_32_cuda.conda
win-64::libgrpc-1.54.2-ha177ca7_2.conda
win-64::llvm-tools-16.0.3-h1ab654d_2.conda
win-64::pillow-9.5.0-py38h9043d50_1.conda
win-64::ffmpeg-5.1.2-gpl_h5037a79_109.conda
win-64::ovito-3.8.4-hf966e04_1.conda
win-64::ovito-3.8.4-h11e26ef_1.conda
win-64::paraview-5.11.1-py39h5df513f_101_qt.conda
win-64::ffmpeg-5.1.2-lgpl_h88e3a8a_8.conda
win-64::libarrow-11.0.0-h2de714e_21_cuda.conda
win-64::clangdev-16.0.3-default_h8b4101f_0.conda
win-64::libopentelemetry-cpp-1.9.1-h03fb4e4_2.conda
win-64::grpcio-1.54.2-py310h8020be6_2.conda
win-64::libprotobuf-4.23.1-h1975477_0.conda
win-64::raven-hydro-0.2.1-py38h3b9c276_1.conda
win-64::raven-hydro-0.2.0-py310h098a066_1.conda
win-64::libarchive-3.6.2-h6f8411a_1.conda
win-64::aws-sdk-cpp-1.11.68-ha156882_3.conda
win-64::libgrpc-1.55.0-h0c1e3fa_1.conda
win-64::libpcm-1.2.3-h41f9d32_3.conda
win-64::grpcio-1.52.1-py38h507fca2_2.conda
win-64::libarrow-12.0.0-h91bed3e_1_cpu.conda
win-64::libarrow-12.0.0-h13185c8_2_cuda.conda
win-64::raven-hydro-0.2.0-py38h9f5882e_2.conda
win-64::arrow-cpp-9.0.0-py38hc7e6405_35_cuda.conda
win-64::grpcio-1.54.2-py310h76bb054_0.conda
win-64::gst-plugins-bad-1.22.3-ha2afc39_1.conda
win-64::aws-sdk-cpp-1.10.57-ha156882_13.conda
win-64::vigra-1.11.1-py38h4a75314_1042.conda
win-64::ogre-next-2.3.1-h606bb5d_4.conda
win-64::libopencv-4.7.0-py38hcea7214_4.conda
win-64::kaldi-5.5.1068-cuda110h1463fd9_0.conda
win-64::libarrow-12.0.0-he116c7c_0_cpu.conda
win-64::omniorb-4.2.5-py310h281aaab_6.conda
win-64::raven-hydro-0.2.1-py38h9f5882e_1.conda
win-64::grpcio-1.55.0-py39hd28a505_1.conda
win-64::libarrow-11.0.0-ha096e86_20_cpu.conda
win-64::grpcio-1.55.0-py311h5bc0dda_1.conda
win-64::llvm-16.0.3-h38bddbe_0.conda
win-64::vigra-1.11.1-py38h336221f_1042.conda
win-64::libxml2-2.11.3-hc3477c8_1.conda
win-64::raven-hydro-0.2.0-py38h9f5882e_0.conda
win-64::glib-2.76.3-h12be248_0.conda
win-64::libarrow-12.0.0-hf91c391_3_cpu.conda
win-64::ffmpeg-5.1.2-gpl_h5b1d025_107.conda
win-64::pdal-2.5.4-h2314002_1.conda
win-64::clang-16.0.3-h3dc180e_2.conda
win-64::postgresql-15.3-hd87cd2b_0.conda
win-64::grpcio-1.54.2-py39h662c1f1_2.conda
win-64::freeimage-3.18.0-hcff1195_15.conda
win-64::pygplates-0.39-py38h26cc5ff_7.conda
win-64::pillow-9.5.0-py38ha7eb54a_1.conda
win-64::qt-main-5.15.8-h7f2b912_10.conda
win-64::gst-libav-1.22.3-hd74c2e4_1.conda
win-64::libclang13-16.0.3-default_h45d3cf4_1.conda
win-64::arrow-cpp-9.0.0-py39h6c36fc9_36_cuda.conda
win-64::libarrow-10.0.1-hdba4435_23_cuda.conda
win-64::libopentelemetry-cpp-1.9.1-h03fb4e4_1.conda
win-64::libarrow-10.0.1-h8dba4ea_25_cuda.conda
win-64::libclang13-15.0.7-default_h77d9078_2.conda
win-64::arrow-cpp-9.0.0-py310h6712fdc_34_cpu.conda
win-64::stir-5.1.0-cpu_py310hcc1c5a5_6.conda
win-64::mysql-router-8.0.32-hb3df6c7_2.conda
win-64::libclang-16.0.3-default_h8b4101f_1.conda
win-64::arrow-cpp-9.0.0-py310h6bbbdca_35_cuda.conda
win-64::vigra-1.11.1-py310hb9e416d_1042.conda
win-64::llvm-tools-16.0.4-h1ab654d_0.conda
win-64::libnetcdf-4.9.2-nompi_ha5afab8_105.conda
win-64::grpcio-1.52.1-py311hfe69050_2.conda
win-64::libllvm16-16.0.4-h1ab654d_0.conda
win-64::kaldi-5.5.1068-cpu_hb4323e9_0.conda
win-64::lld-14.0.6-h3740485_1.conda
win-64::vigra-1.11.1-py310h33d0020_1042.conda
win-64::libclang13-14.0.6-default_h77d9078_1.conda
win-64::aws-sdk-cpp-1.10.57-h353f050_12.conda
win-64::libcurl-static-8.1.1-h68f0423_0.conda
win-64::gst-plugins-base-1.22.3-h001b923_1.conda
win-64::libprotobuf-4.23.2-h1975477_0.conda
win-64::llvm-tools-16.0.3-h2c25772_0.conda
win-64::libarrow-10.0.1-h8dba4ea_24_cuda.conda
win-64::qt6-3d-6.5.1-heb9d8b4_0.conda
win-64::grpcio-1.55.0-py310hb84602e_1.conda
win-64::libuwebsockets-20.40.0-h12be248_0.conda
win-64::llvm-tools-14.0.6-hac7d729_2.conda
win-64::postgresql-plpython-15.3-py38hb66759c_0.conda
win-64::llvm-15.0.7-h3dc180e_2.conda
win-64::fossil-2.22-h00fea9b_0.conda
win-64::libopencv-4.7.0-py310h8aaf05f_4.conda
win-64::raven-hydro-0.2.0rc0-py38h9f5882e_0.conda
win-64::libopentelemetry-cpp-1.9.0-h03fb4e4_3.conda
win-64::arrow-cpp-8.0.1-py39hb0bc455_32_cpu.conda
win-64::raven-hydro-0.2.0-py39hc465eaa_0.conda
win-64::stir-5.1.0-cuda110_py310h2da3567_206.conda
win-64::clangdev-16.0.4-default_heb8d277_0.conda
win-64::llvmlite-0.40.0-py310hb84602e_0.conda
win-64::arrow-cpp-8.0.1-py39h02cd8ea_31_cuda.conda
win-64::libgdal-3.5.3-h69cf491_27.conda
win-64::libpcm-1.2.3-h41f9d32_0.conda
win-64::llvmlite-0.40.0-py38h19421c1_0.conda
win-64::libuwebsockets-20.41.0-h12be248_0.conda
win-64::libopencv-4.7.0-py39hf423fa5_4.conda
win-64::aws-sdk-cpp-1.11.68-h353f050_2.conda
win-64::grpcio-1.52.1-py310h8020be6_2.conda
win-64::grpcio-1.54.2-py38h507fca2_1.conda
win-64::raven-hydro-0.2.1-py310h098a066_0.conda
win-64::pillow-9.5.0-py310hb653ca7_1.conda
win-64::curl-8.1.2-h68f0423_0.conda
win-64::libclang-cpp-16.0.3-default_heb8d277_2.conda
win-64::libclang13-16.0.3-default_h45d3cf4_0.conda
win-64::hugin-base-2022.0.0-pl5321ha1a6b5d_4.conda
win-64::folly-2023.05.22.00-h62734b8_1.conda
win-64::cpp-opentelemetry-sdk-1.9.1-h4bd2ebb_0.conda
win-64::pdal-2.5.4-h22e3bf8_1.conda
win-64::postgresql-plpython-15.3-py310hf69896a_0.conda
win-64::folly-2023.05.22.00-hfbb6214_1.conda
win-64::libopentelemetry-cpp-1.9.0-h60dec20_2.conda
win-64::clang-format-14.0.6-default_h66ee7f4_1.conda
win-64::clang-tools-16.0.4-default_heb8d277_0.conda
win-64::gdstk-0.9.41-py38h6cd9458_0.conda
win-64::llvmlite-0.40.0-py39h6848017_0.conda
win-64::vtk-base-9.2.6-qt_py311h1234567_205.conda
win-64::vtk-base-9.2.6-qt_py38h1234567_206.conda
win-64::libllvm14-14.0.6-h97333cc_2.conda
win-64::arrow-cpp-8.0.1-py39hbdb2954_31_cpu.conda
win-64::kaldi-5.5.1068-cuda111hbcaf4cb_0.conda
win-64::libarrow-12.0.0-h022f8cc_0_cuda.conda
win-64::postgresql-plpython-15.3-py311h3f918d0_1.conda
win-64::grpcio-1.54.1-py38h7cc6c9e_0.conda
win-64::raven-hydro-0.2.1-py311h47b085c_0.conda
win-64::mlir-16.0.4-he744812_0.conda
win-64::pygplates-0.39-py39hfede89c_7.conda
win-64::pypy3.8-7.3.11-h577050a_1.conda
win-64::gdstk-0.9.41-py39hbf0fdad_0.conda
win-64::tectonic-0.12.0-h079606a_2.conda
win-64::libglib-2.76.3-he8f3873_0.conda
win-64::vigra-1.11.1-py311h818b158_1042.conda
win-64::mlir-16.0.3-he744812_0.conda
win-64::clang-16.0.3-h38bddbe_0.conda
win-64::clang-16-16.0.3-default_h8b4101f_0.conda
win-64::grpcio-1.54.2-py38h507fca2_2.conda
win-64::lld-16.0.3-h21f6fed_1.conda
win-64::clangxx-16.0.3-default_heb8d277_2.conda
win-64::libgdal-3.6.4-hf26a062_3.conda
win-64::ffmpeg-6.0.0-gpl_haa4fc56_101.conda
win-64::raven-hydro-0.2.1-py310h9646616_1.conda
win-64::clangxx-16.0.4-default_heb8d277_0.conda
win-64::tectonic-0.13.1-h8e80d7b_0.conda
win-64::libgdal-arrow-parquet-3.7.0-h037f8eb_0.conda
win-64::vigra-1.11.1-py39hd25e55e_1042.conda
win-64::arrow-cpp-8.0.1-py311h10cc4d8_32_cpu.conda
win-64::arrow-cpp-9.0.0-py310h2c858d8_36_cpu.conda
win-64::libopentelemetry-cpp-1.9.1-h403948d_2.conda
win-64::libgdal-3.5.3-h36c8192_28.conda
win-64::raven-hydro-0.2.1-py310h098a066_1.conda
win-64::qt-main-5.15.8-h2c8576c_12.conda
win-64::stir-5.1.0-cuda112_py310hc117243_206.conda
win-64::blosc-1.21.4-hdccc3a2_0.conda
win-64::vtk-base-9.2.6-qt_py310h1234567_205.conda
win-64::libgdal-arrow-parquet-3.6.4-h198fabd_1.conda
win-64::libclang-cpp-16.0.3-default_h8b4101f_0.conda
win-64::llvmdev-16.0.3-h2c25772_0.conda
win-64::clangdev-16.0.3-default_h8b4101f_1.conda
win-64::raven-hydro-0.2.0-py311h47b085c_2.conda
win-64::paraview-5.11.1-py311h88cf644_101_qt.conda
win-64::arrow-cpp-8.0.1-py38he18c823_31_cpu.conda
win-64::libprotobuf-4.22.3-h1975477_0.conda
win-64::arrow-cpp-8.0.1-py310h6bbbdca_32_cuda.conda
win-64::pillow-9.5.0-py39ha9166d5_1.conda
win-64::libopentelemetry-cpp-1.9.1-h98382db_1.conda
win-64::raven-hydro-0.2.1-py38h5f67dab_1.conda
win-64::cpp-opentelemetry-sdk-1.9.1-h4dcfd69_1.conda
win-64::llvmlite-0.40.0-py38hf225c54_0.conda
win-64::paraview-5.11.1-py311hb923036_101_qt.conda
win-64::libllvm16-16.0.3-h2c25772_1.conda
win-64::lpython-0.13.0-h12be248_0.conda
win-64::clang-format-15.0.7-default_h66ee7f4_2.conda
win-64::arrow-cpp-8.0.1-py38hc7e6405_32_cuda.conda
win-64::cpp-opentelemetry-sdk-1.9.1-h98382db_1.conda
win-64::arrow-cpp-9.0.0-py310h72189d4_34_cuda.conda
win-64::vigra-1.11.1-py39hae28b4e_1042.conda
win-64::arrow-cpp-9.0.0-py311hee57cfc_34_cuda.conda
win-64::libclang13-16.0.4-default_hc80b9e7_0.conda
win-64::raven-hydro-0.2.1-py39hc465eaa_0.conda
win-64::raven-hydro-0.2.1-py39h4f5c61a_1.conda
win-64::paraview-5.11.1-py38h6f8dcd5_101_qt.conda
win-64::libprotobuf-static-4.23.0-h1975477_0.conda
win-64::grpcio-1.54.2-py38h7cc6c9e_0.conda
win-64::arrow-cpp-8.0.1-py310h2c858d8_32_cpu.conda
win-64::lpython-0.15.0-h12be248_0.conda
win-64::lld-15.0.7-h3740485_1.conda
win-64::libopencv-4.7.0-py38h13ec99e_3.conda
win-64::stir-5.1.0-cuda111_py38h676434f_206.conda
win-64::tiledb-2.15.2-h86be035_1.conda
win-64::pillow-9.5.0-py39hf8900f3_1.conda
win-64::arrow-cpp-9.0.0-py39hbdb2954_34_cpu.conda
win-64::libuwebsockets-20.42.0-h12be248_0.conda
win-64::tectonic-0.13.0-h8e80d7b_0.conda
win-64::llvmlite-0.40.0-py39hd28a505_0.conda
win-64::clang-14-14.0.6-default_h66ee7f4_1.conda
win-64::postgresql-plpython-15.3-py311h7623089_0.conda
win-64::vtk-base-9.2.6-qt_py39h1234567_206.conda
win-64::arrow-cpp-8.0.1-py39h6c36fc9_32_cuda.conda
win-64::arrow-cpp-9.0.0-py39hb0bc455_35_cpu.conda
win-64::raven-hydro-0.2.0rc0-py39hc465eaa_0.conda
win-64::libarrow-11.0.0-h6a877a0_19_cuda.conda
win-64::ffmpeg-5.1.2-lgpl_hda1e2fe_9.conda
win-64::soplex-6.0.3-h949ae46_2.conda
win-64::paraview-5.11.1-py39hb1a1aae_101_qt.conda
win-64::ovito-3.8.4-h11e26ef_0.conda
win-64::aws-sdk-cpp-1.10.57-h0fa2e13_11.conda
win-64::cpp-opentelemetry-sdk-1.9.0-h4bd2ebb_2.conda
win-64::mysql-server-8.0.32-hdf5bdb2_2.conda
win-64::llvmdev-14.0.6-h97333cc_2.conda
win-64::gst-libav-1.22.3-hd74c2e4_0.conda
win-64::vigra-1.11.1-py311h3875bef_1042.conda
win-64::libgrpc-1.54.1-h32da247_0.conda
win-64::gst-plugins-base-1.22.3-h001b923_0.conda
win-64::ffmpeg-6.0.0-lgpl_h6aff86d_1.conda
win-64::libarrow-12.0.0-hf91c391_4_cpu.conda
win-64::postgresql-14.5-h96452e4_6.conda
win-64::libarrow-12.0.0-h8f71f9a_4_cuda.conda
win-64::gst-plugins-bad-1.22.3-ha2afc39_0.conda
win-64::gst-plugins-good-1.22.3-hc7bee6c_1.conda
win-64::libopencv-4.7.0-py311h4392a68_4.conda
win-64::vigra-1.11.1-py38hc41d480_1042.conda
win-64::gst-plugins-good-1.22.3-hc7bee6c_0.conda
win-64::aws-sdk-cpp-1.11.68-h0fa2e13_1.conda
win-64::pyinstaller-5.11.0-py310h35269f2_0.conda
win-64::omniorb-4.2.5-py39h0a8b3da_6.conda
win-64::lpython-0.15.0-h12be248_1.conda
win-64::arrow-cpp-9.0.0-py311hdac512a_34_cpu.conda
win-64::openscenegraph-3.6.5-hdec0542_16.conda
win-64::qt-main-5.15.8-h2c8576c_11.conda
win-64::tiledb-2.15.2-h86be035_2.conda
win-64::poppler-23.05.0-h45d20d0_1.conda
win-64::clangdev-16.0.3-default_heb8d277_2.conda
win-64::libarrow-10.0.1-h0ac4353_24_cpu.conda
win-64::arrow-cpp-8.0.1-py311hee57cfc_31_cuda.conda
win-64::libclang13-16.0.3-default_hc80b9e7_2.conda
win-64::libarrow-12.0.0-h8f71f9a_3_cuda.conda
win-64::libopencv-4.7.0-py38h4d5978f_4.conda
win-64::raven-hydro-0.2.0-py38h3b9c276_2.conda
win-64::libspatialite-5.0.1-hca1f1ac_26.conda
win-64::pygplates-0.39-py310h1e2242c_7.conda
win-64::wasmer-3.3.0-h4dd112c_0.conda
win-64::libpq-14.5-ha9684e8_6.conda
win-64::paraview-5.11.1-py38hd6580b0_101_qt.conda
win-64::ffmpeg-6.0.0-lgpl_hfeed10d_0.conda
win-64::postgresql-plpython-14.5-py311h3f918d0_6.conda
win-64::vigra-1.11.1-py39ha1bb1a3_1042.conda
win-64::libgdal-3.6.4-h36c8192_2.conda
win-64::postgresql-plpython-14.5-py39ha748b4c_6.conda
win-64::clang-tools-14.0.6-default_h66ee7f4_1.conda
win-64::pyinstaller-5.11.0-py38ha959d8a_0.conda
win-64::postgresql-plpython-14.5-py310hd1fc835_6.conda
win-64::python-3.10.11-h4de0772_0_cpython.conda
win-64::grpcio-1.55.0-py39hd28a505_0.conda
win-64::stir-5.1.0-cuda111_py310h1db0acb_206.conda
win-64::libarrow-12.0.0-h9bf75db_2_cpu.conda
win-64::cpp-opentelemetry-sdk-1.9.1-h403948d_2.conda
win-64::clangdev-14.0.6-default_h66ee7f4_1.conda
win-64::arrow-cpp-9.0.0-py311h10cc4d8_35_cpu.conda
win-64::qt6-main-6.5.0-hf0c6fff_6.conda
win-64::tiledb-2.15.2-h7fa38cf_1.conda
win-64::msgpack-cxx-6.0.0-hc2a4d42_1.conda
win-64::arrow-cpp-9.0.0-py39h02cd8ea_34_cuda.conda
win-64::libclang-cpp-16.0.4-default_heb8d277_0.conda
win-64::vigra-1.11.1-py39hfd7471e_1042.conda
win-64::vigra-1.11.1-py38h72082c2_1042.conda
win-64::arrow-cpp-8.0.1-py38h9115b5a_31_cuda.conda
win-64::llvmdev-16.0.3-h2c25772_1.conda
win-64::libopencv-4.7.0-py39hc6aeebd_3.conda
win-64::libclang-16.0.3-default_heb8d277_2.conda
win-64::raven-hydro-0.2.1-py39hdc7dc00_1.conda
win-64::pdal-2.5.4-hac3c4d1_0.conda
win-64::libuwebsockets-20.43.0-h12be248_0.conda
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
win-64::llvm-14.0.6-h6fda50d_2.conda
win-64::clang-14.0.6-h8e541a6_1.conda
win-64::clangxx-15.0.7-default_h66ee7f4_2.conda
win-64::clang-15.0.7-h8e541a6_2.conda
win-64::clangxx-14.0.6-default_h66ee7f4_1.conda
-    "libzlib >=1.2.13,<1.3.0a0"
+    "libzlib >=1.2.13,<2.0.0a0"
================================================================================
================================================================================
osx-64
osx-64::libsqlite-3.41.2-h58db7d2_1.conda
osx-64::libllvm14-14.0.6-hc8e404f_2.conda
osx-64::libprotobuf-static-4.22.5-h5feb325_0.conda
osx-64::libpcm-1.2.3-h89d1a00_0.conda
osx-64::libprotobuf-static-4.23.2-h5feb325_2.conda
osx-64::libpcm-1.2.3-h89d1a00_4.conda
osx-64::glib-tools-2.76.3-h7d26f99_0.conda
osx-64::libmlir-16.0.3-h837b0c1_0.conda
osx-64::libcdms-3.1.2-h371850e_123.conda
osx-64::libprotobuf-static-4.23.2-h5feb325_1.conda
osx-64::zimpl-3.5.3-hd956f49_2.conda
osx-64::libuwebsockets-20.44.0-h7d26f99_0.conda
osx-64::libpcm-1.2.3-h89d1a00_1.conda
osx-64::libuwebsockets-20.40.0-h7d26f99_0.conda
osx-64::micromamba-1.4.2-2.tar.bz2
osx-64::libsqlite-3.42.0-h58db7d2_0.conda
osx-64::libprotobuf-4.23.2-h5feb325_2.conda
osx-64::aria2-1.36.0-h504a9d1_4.conda
osx-64::libmlir16-16.0.3-h837b0c1_0.conda
osx-64::libxmlpp-4.0-4.0.2-h7dba648_1.conda
osx-64::libprotobuf-4.22.5-h5feb325_0.conda
osx-64::openjdk-17.0.3-h7d26f99_7.conda
osx-64::libprotobuf-static-4.23.1-h5feb325_0.conda
osx-64::libpcm-1.2.3-h89d1a00_3.conda
osx-64::micromamba-1.4.3-0.tar.bz2
osx-64::libass-0.17.1-h66d2fa1_0.conda
osx-64::libprotobuf-4.22.3-h5feb325_0.conda
osx-64::libpcm-1.2.3-h89d1a00_2.conda
osx-64::libprotobuf-4.23.1-h5feb325_0.conda
osx-64::openjdk-11.0.15-h7d26f99_4.conda
osx-64::spidermonkey-bin-91.13.0-hca8cd1d_1.conda
osx-64::libass-0.14.0-h66d2fa1_4.conda
osx-64::libv8-8.9.83-hb1e5e1c_3.conda
osx-64::msgpack-cxx-6.0.0-h6fcd042_1.conda
osx-64::llvm-14.0.6-h9d075a6_2.conda
osx-64::pandoc-3.1.2-h9d075a6_1.conda
osx-64::llvm-tools-14.0.6-hc8e404f_2.conda
osx-64::libmlir-16.0.4-h837b0c1_0.conda
osx-64::imath-3.1.8-h7d26f99_0.conda
osx-64::openexr-3.1.7-h1d84623_1.conda
osx-64::micromamba-1.4.2-1.tar.bz2
osx-64::lld-14.0.6-hc20ea95_1.conda
osx-64::libprotobuf-4.23.2-h5feb325_1.conda
osx-64::libmlir16-16.0.4-h837b0c1_0.conda
osx-64::libprotobuf-static-4.23.2-h5feb325_0.conda
osx-64::lld-15.0.7-hc20ea95_1.conda
osx-64::openjdk-17.0.3-h7d26f99_8.conda
osx-64::libprotobuf-static-4.22.3-h5feb325_0.conda
osx-64::gst-plugins-base-1.22.3-hb5d3a86_0.conda
osx-64::spidermonkey-91.13.0-habcac57_1.conda
osx-64::pandoc-3.1.2-h9d075a6_0.conda
osx-64::libuwebsockets-20.41.0-h7d26f99_0.conda
osx-64::libprotobuf-static-4.23.0-h5feb325_0.conda
osx-64::libuwebsockets-20.43.0-h7d26f99_0.conda
osx-64::libcdms-3.1.2-h737a050_122.conda
osx-64::gst-plugins-base-1.22.3-hb5d3a86_1.conda
osx-64::openjdk-20.0.0-h7d26f99_0.conda
osx-64::libprotobuf-4.23.0-h5feb325_0.conda
osx-64::libuwebsockets-20.42.0-h7d26f99_0.conda
osx-64::libprotobuf-4.23.2-h5feb325_0.conda
-    "libzlib >=1.2.13,<1.3.0a0"
+    "libzlib >=1.2.13,<2.0.0a0"
osx-64::aws-sdk-cpp-1.10.57-hd56652f_12.conda
osx-64::ndcctools-7.5.4-py311h54575cd_1.conda
osx-64::libsoup-3.4.2-h8ff24ff_1.conda
osx-64::pdal-2.5.4-h7ac72c3_1.conda
osx-64::raven-hydro-0.2.1-py310h6ab6fe6_1.conda
osx-64::erlang-25.3.2-pl5321hbb39af3_0.conda
osx-64::pillow-9.5.0-py311h7cb0e2d_1.conda
osx-64::mlir-16.0.3-h837b0c1_0.conda
osx-64::panda3d-1.10.12-py39h40820a8_3.conda
osx-64::openconnect-9.10-h7266fad_0.conda
osx-64::raven-hydro-0.2.0rc0-py39h0edd63f_0.conda
osx-64::postgresql-plpython-15.3-py38h61506ca_0.conda
osx-64::lammps-2023.03.28-py38hc0e224d_mpich_2.conda
osx-64::libarchive-minimal-static-3.6.2-h1b57e4a_1.conda
osx-64::aws-sdk-cpp-1.10.57-hf90da8b_13.conda
osx-64::folly-2023.03.27.00-h6fbac3b_0.conda
osx-64::libarrow-11.0.0-hc8386e2_19_cpu.conda
osx-64::lammps-2023.03.28-py39h7d7a4bd_mpich_2.conda
osx-64::wxpython-4.2.0-py311h7162ac5_7.conda
osx-64::plumed-2.9.0-nompi_he44c322_100.conda
osx-64::raven-hydro-0.2.0-py39h0edd63f_2.conda
osx-64::cpp-opentelemetry-sdk-1.9.1-h9779858_2.conda
osx-64::raven-hydro-0.2.1-py310h0bc48e2_0.conda
osx-64::pdal-2.5.4-h126b50f_1.conda
osx-64::cpp-opentelemetry-sdk-1.9.1-hac0930c_2.conda
osx-64::lammps-2023.03.28-py310hefde702_openmpi_2.conda
osx-64::lammps-2023.03.28-py311hb3177c8_mpich_2.conda
osx-64::libopentelemetry-cpp-1.9.0-h377de98_2.conda
osx-64::tiledb-2.15.2-h5f072ce_0.conda
osx-64::gst-plugins-bad-1.22.3-h70ac916_1.conda
osx-64::libgdal-3.7.0-hcef25f8_0.conda
osx-64::gazebo-11.12.0-h0b66798_11.conda
osx-64::libgdal-arrow-parquet-3.6.4-h4453f95_3.conda
osx-64::mysql-libs-8.0.32-haa61052_2.conda
osx-64::panda3d-1.10.12-py311h190755c_3.conda
osx-64::pillow-9.5.0-py39h3178bab_1.conda
osx-64::gdstk-0.9.41-py39h048d6a6_0.conda
osx-64::llvm-16.0.3-hbf068ea_0.conda
osx-64::libpq-15.3-h9dc22bb_0.conda
osx-64::ffmpeg-6.0.0-lgpl_h4d11df2_0.conda
osx-64::libopencv-4.7.0-py39h167342f_4.conda
osx-64::libsoup-3.4.2-hc48e74a_0.conda
osx-64::ndcctools-7.5.4-py38h0a8965a_0.conda
osx-64::wasmer-3.3.0-ha6357cd_0.conda
osx-64::gst-plugins-bad-1.22.3-h70ac916_0.conda
osx-64::arrow-cpp-8.0.1-py39h6906cd9_32_cpu.conda
osx-64::libgrpc-1.55.0-h73e6b18_0.conda
osx-64::libgrpc-1.54.2-h0eeb599_0.conda
osx-64::magics-4.13.0-hf28fdce_3.conda
osx-64::qt6-3d-6.5.1-hb907767_0.conda
osx-64::libvips-8.14.2-h7ae62d0_1.conda
osx-64::lpython-0.13.0-h7d26f99_1.conda
osx-64::ndcctools-7.5.3-py38h0a8965a_0.conda
osx-64::panda3d-1.10.12-py310h25bb023_4.conda
osx-64::libgrpc-1.54.2-hfaa49da_1.conda
osx-64::libopencv-4.7.0-py310h41d2c2e_4.conda
osx-64::astrometry-0.94-py39h2d176a9_0.conda
osx-64::omniorb-4.2.5-py39h8bad868_6.conda
osx-64::folly-2023.05.15.00-h49bef9d_0.conda
osx-64::vtk-base-9.2.6-qt_py311h1234567_206.conda
osx-64::sagelib-10.0-py38hb144cf9_0.conda
osx-64::ndcctools-7.5.3-py310h442c573_0.conda
osx-64::libopentelemetry-cpp-1.9.1-h7f030e6_1.conda
osx-64::lammps-2023.03.28-py310ha65cd3b_mpich_2.conda
osx-64::libllvm15-15.0.7-he4b1e75_2.conda
osx-64::libopentelemetry-cpp-1.9.1-h377de98_0.conda
osx-64::llvm-tools-16.0.3-he4b1e75_2.conda
osx-64::folly-2023.05.22.00-h0d9798a_0.conda
osx-64::ambertools-23.0-py310h9dd47ba_0.conda
osx-64::llvm-tools-16.0.4-he4b1e75_0.conda
osx-64::ndcctools-7.5.5-py310h442c573_0.conda
osx-64::tiledb-2.15.2-h4e090e4_0.conda
osx-64::tiledb-2.15.2-hedca662_1.conda
osx-64::llvmdev-16.0.3-hf646ca0_0.conda
osx-64::libllvm16-16.0.3-he4b1e75_2.conda
osx-64::postgresql-14.5-h325e403_6.conda
osx-64::raven-hydro-0.2.1-py38hf246b68_0.conda
osx-64::libnetcdf-4.9.2-nompi_hf077d52_105.conda
osx-64::libglib-2.76.3-hc62aa5d_0.conda
osx-64::vigra-1.11.1-py39hd8608e6_1042.conda
osx-64::folly-2023.05.22.00-h49bef9d_1.conda
osx-64::mupdf-1.22.1-h6a0f10e_0.conda
osx-64::wxpython-4.2.0-py39h6b130f8_7.conda
osx-64::libopencv-4.7.0-py310h7528119_3.conda
osx-64::cpp-opentelemetry-sdk-1.9.1-h7f030e6_1.conda
osx-64::raven-hydro-0.2.0-py311h5482185_2.conda
osx-64::llvmlite-0.40.0-py38hf646772_0.conda
osx-64::libdwarf-dev-0.7.0-h217ab76_0.conda
osx-64::ndcctools-7.5.4-py38h0a8965a_1.conda
osx-64::postgresql-plpython-15.3-py310he0d0a37_1.conda
osx-64::postgresql-15.3-hb6430be_0.conda
osx-64::hdfeos5-5.1.16-hb81ba31_13.conda
osx-64::lld-16.0.3-h62a38e0_1.conda
osx-64::vtk-base-9.2.6-qt_py39h1234567_205.conda
osx-64::curl-8.1.1-hbee3ae8_0.conda
osx-64::libgdal-arrow-parquet-3.7.0-hab02323_0.conda
osx-64::libllvm16-16.0.3-hf646ca0_1.conda
osx-64::llvm-tools-16.0.3-hf646ca0_1.conda
osx-64::grpcio-1.55.0-py39hc281fc9_1.conda
osx-64::postgresql-15.3-h325e403_1.conda
osx-64::lpython-0.13.0-h7d26f99_0.conda
osx-64::libarrow-12.0.0-h8fc5235_3_cpu.conda
osx-64::panda3d-1.10.12-py39h0341054_4.conda
osx-64::ambertools-23.0-py38h51c3a6d_0.conda
osx-64::gst-plugins-good-1.22.3-h3ac7b97_0.conda
osx-64::libopencv-4.7.0-py38hc19782d_3.conda
osx-64::arrow-cpp-9.0.0-py38ha0848b0_35_cpu.conda
osx-64::mold-1.11.0-hc277f81_0.conda
osx-64::arrow-cpp-9.0.0-py38h93e045a_34_cpu.conda
osx-64::tiledb-2.15.3-h4e090e4_0.conda
osx-64::raven-hydro-0.2.0-py310h0bc48e2_2.conda
osx-64::raven-hydro-0.2.0-py311h5482185_1.conda
osx-64::panda3d-1.10.12-py38h92519bf_4.conda
osx-64::r-qpdf-1.3.2-r41h3eaf563_2.conda
osx-64::raven-hydro-0.2.0-py310h0bc48e2_0.conda
osx-64::ffmpeg-5.1.2-lgpl_hf7a6185_7.conda
osx-64::r-qpdf-1.3.2-r42h3eaf563_2.conda
osx-64::qt-main-5.15.8-h23c57ac_11.conda
osx-64::ovito-3.8.4-h5622f4c_1.conda
osx-64::raven-hydro-0.2.1-py38ha9f8b72_0.conda
osx-64::llvmlite-0.40.0-py310hd8379ad_0.conda
osx-64::vtk-base-9.2.6-qt_py311h1234567_205.conda
osx-64::ffmpeg-5.1.2-lgpl_h730d3f9_10.conda
osx-64::postgresql-plpython-15.3-py311hbf368a9_1.conda
osx-64::chemicalite-2022.04.1-h9b1e4e7_9.conda
osx-64::pygplates-0.39-py310he28c0f6_7.conda
osx-64::raven-hydro-0.2.1-py38ha9f8b72_1.conda
osx-64::grpcio-1.55.0-py310hd8379ad_1.conda
osx-64::panda3d-1.10.12-py311h0f9f0ce_4.conda
osx-64::mosh-1.4.0-pl5321h9fefacb_1.conda
osx-64::libgdal-3.6.4-ha1138dd_2.conda
osx-64::llvmdev-16.0.4-he4b1e75_0.conda
osx-64::aws-sdk-cpp-1.11.68-h3009220_5.conda
osx-64::arrow-cpp-8.0.1-py310h0c6bbd7_32_cpu.conda
osx-64::pillow-9.5.0-py38h16710f9_1.conda
osx-64::arrow-cpp-9.0.0-py39hf22c89f_34_cpu.conda
osx-64::arrow-cpp-9.0.0-py310h0c6bbd7_35_cpu.conda
osx-64::llvmdev-16.0.3-hf646ca0_1.conda
osx-64::raven-hydro-0.2.0-py39h0edd63f_1.conda
osx-64::folly-2023.05.08.00-h0d9798a_0.conda
osx-64::ffmpeg-5.1.2-lgpl_h51dc675_8.conda
osx-64::glib-2.76.3-h7d26f99_0.conda
osx-64::raven-hydro-0.2.1-py39h0edd63f_1.conda
osx-64::panda3d-1.10.12-py310h7d48c3a_3.conda
osx-64::raven-hydro-0.2.0-py310h0bc48e2_1.conda
osx-64::vtk-base-9.2.6-qt_py310h1234567_205.conda
osx-64::llvmlite-0.40.0-py311hcbb5c6d_0.conda
osx-64::folly-2023.03.20.00-h21a4eb5_4.conda
osx-64::qt6-main-6.5.1-h35278ed_0.conda
osx-64::protozfits-2.2.0-py311h23acff2_0.conda
osx-64::raven-hydro-0.2.1-py310h0bc48e2_1.conda
osx-64::lammps-2023.03.28-py39hd7def19_openmpi_2.conda
osx-64::lammps-2023.03.28-py39h48aa9f9_mpich_2.conda
osx-64::sagelib-10.0-py310hc208e89_0.conda
osx-64::raven-hydro-0.2.0-py38hf246b68_2.conda
osx-64::folly-2023.04.03.00-h6fbac3b_0.conda
osx-64::lammps-2023.03.28-py38h466c93f_openmpi_2.conda
osx-64::llvmlite-0.40.0-py38ha1392ea_0.conda
osx-64::llvm-tools-15.0.7-he4b1e75_2.conda
osx-64::lammps-2023.03.28-py311hcf1788a_openmpi_2.conda
osx-64::astrometry-0.94-py311haeb4bca_0.conda
osx-64::ffmpeg-5.1.2-gpl_h1024f2e_109.conda
osx-64::lammps-2023.03.28-py38hb7eaf8a_openmpi_2.conda
osx-64::paraview-5.11.1-py38h6481c5b_101_qt.conda
osx-64::folly-2023.05.15.00-h889bfc7_0_jemalloc.conda
osx-64::arrow-cpp-9.0.0-py39h6906cd9_35_cpu.conda
osx-64::panda3d-1.10.12-py38hd633d00_3.conda
osx-64::folly-2023.05.22.00-hc30067e_0_jemalloc.conda
osx-64::libopencv-4.7.0-py38h41afbab_4.conda
osx-64::libopencv-4.7.0-py39hc399bf1_4.conda
osx-64::cpp-opentelemetry-sdk-1.9.0-h377de98_3.conda
osx-64::erlang-26.0-pl5321hbb39af3_0.conda
osx-64::julia-1.9.0-h5ae1205_0.conda
osx-64::libopencv-4.7.0-py39hc399bf1_3.conda
osx-64::libarrow-10.0.1-hb6686dc_24_cpu.conda
osx-64::ovito-3.8.4-h7bcd8f4_1.conda
osx-64::openscenegraph-3.6.5-h1eb5763_16.conda
osx-64::llvmdev-14.0.6-hc8e404f_2.conda
osx-64::libgsf-1.14.50-he6f6c35_1.conda
osx-64::llvmlite-0.40.0-py39hc281fc9_0.conda
osx-64::qt-main-5.15.8-h23c57ac_12.conda
osx-64::llvm-16.0.4-h9c2cb20_0.conda
osx-64::loos-4.0.4-py39h723c7a0_2.conda
osx-64::aws-sdk-cpp-1.10.57-ha5f73a7_11.conda
osx-64::panda3d-1.10.12-py311h649e1bd_3.conda
osx-64::paraview-5.11.1-py39hdc343ad_101_qt.conda
osx-64::libcurl-static-8.1.1-hbee3ae8_0.conda
osx-64::grpcio-1.55.0-py38hf646772_0.conda
osx-64::pypy3.8-7.3.11-h3a77750_1.conda
osx-64::protozfits-2.2.0-py38h3955d30_0.conda
osx-64::paraview-5.11.1-py38h96531f9_101_qt.conda
osx-64::folly-2023.04.10.00-h68897ac_0_jemalloc.conda
osx-64::libopencv-4.7.0-py38h0a50863_3.conda
osx-64::wxpython-4.2.0-py310h12da54f_7.conda
osx-64::folly-2023.04.17.00-h68897ac_0_jemalloc.conda
osx-64::imagemagick-7.1.1_9-pl5321hcd3a149_1.conda
osx-64::loos-4.0.4-py38hc04ebe0_2.conda
osx-64::folly-2023.05.01.00-hed31980_0_jemalloc.conda
osx-64::mysql-server-8.0.32-h619a37a_2.conda
osx-64::libgdal-arrow-parquet-3.6.4-hb4fd048_1.conda
osx-64::hdfeos5-5.1.16-h344f4d9_11.conda
osx-64::raven-hydro-0.2.1-py39h0edd63f_0.conda
osx-64::gdstk-0.9.41-py311hd33e98c_0.conda
osx-64::paraview-5.11.1-py311ha282fef_101_qt.conda
osx-64::raven-hydro-0.2.0-py39h16b9c15_2.conda
osx-64::aws-sdk-cpp-1.11.68-hc95e8b8_4.conda
osx-64::arrow-cpp-9.0.0-py310hf0cf13f_34_cpu.conda
osx-64::librdkafka-2.1.1-hec4bce0_0.conda
osx-64::libopencv-4.7.0-py38h5cb5f5a_4.conda
osx-64::llvmdev-16.0.3-he4b1e75_2.conda
osx-64::folly-2023.05.01.00-h68897ac_0_jemalloc.conda
osx-64::tectonic-0.13.1-h06e290d_0.conda
osx-64::postgresql-plpython-14.5-py39hfacc66a_6.conda
osx-64::sqlite-3.41.2-h2b0dec6_1.conda
osx-64::folly-2023.05.01.00-h6fbac3b_0.conda
osx-64::loos-4.0.4-py310h49c9f9c_2.conda
osx-64::arrow-cpp-8.0.1-py311h6370082_31_cpu.conda
osx-64::vigra-1.11.1-py38hc158e33_1042.conda
osx-64::ncl-6.6.2-ha2a024e_45.conda
osx-64::cpp-opentelemetry-sdk-1.9.1-h377de98_1.conda
osx-64::postgresql-plpython-14.5-py38h9f95ba2_6.conda
osx-64::ndcctools-7.5.4-py310h442c573_0.conda
osx-64::libcurl-8.1.0-hbee3ae8_0.conda
osx-64::ambertools-23.0-py310h9dd47ba_1.conda
osx-64::gdstk-0.9.41-py39h7dc8517_0.conda
osx-64::llvm-16.0.3-h9c2cb20_2.conda
osx-64::mesalib-23.0.2-hb59017c_1.conda
osx-64::nco-5.1.6-h0317220_0.conda
osx-64::ffmpeg-6.0.0-lgpl_h135fd1f_1.conda
osx-64::pygplates-0.39-py311h058b27a_7.conda
osx-64::folly-2023.05.08.00-h889bfc7_0_jemalloc.conda
osx-64::ffmpeg-5.1.2-gpl_h113d92c_107.conda
osx-64::jaxlib-0.4.10-cpu_py310h27fbe1d_0.conda
osx-64::grpcio-1.55.0-py38hf646772_1.conda
osx-64::python-3.10.11-he7542f4_0_cpython.conda
osx-64::llvmdev-15.0.7-he4b1e75_2.conda
osx-64::ogre-next-2.3.1-h7603aad_4.conda
osx-64::llvm-tools-16.0.3-hf646ca0_0.conda
osx-64::folly-2023.04.03.00-h68897ac_0_jemalloc.conda
osx-64::r-base-4.1.3-h783c689_6.conda
osx-64::libxml2-2.11.3-hd95e348_0.conda
osx-64::raven-hydro-0.2.1-py311hfdac233_1.conda
osx-64::ambertools-23.0-py39hfb6888d_1.conda
osx-64::ffmpeg-5.1.2-gpl_hbef8d76_108.conda
osx-64::folly-2023.05.22.00-h889bfc7_1_jemalloc.conda
osx-64::raven-hydro-0.2.0rc0-py310h0bc48e2_0.conda
osx-64::raven-hydro-0.2.1-py39h16b9c15_0.conda
osx-64::pillow-9.5.0-py38hdd5cec0_1.conda
osx-64::raven-hydro-0.2.1-py39h3fbac99_1.conda
osx-64::raven-hydro-0.2.0rc0-py38ha9f8b72_0.conda
osx-64::ndcctools-7.5.5-py39hd4b95d6_0.conda
osx-64::pyinstaller-5.11.0-py310hb69a1aa_0.conda
osx-64::postgresql-plpython-15.3-py311hc88af6e_0.conda
osx-64::folly-2023.05.22.00-hc30067e_1_jemalloc.conda
osx-64::libgrpc-1.55.0-h73e6b18_1.conda
osx-64::mysql-client-8.0.32-hc4c47b9_2.conda
osx-64::gdstk-0.9.41-py310h5cafd22_0.conda
osx-64::lpython-0.15.0-h7d26f99_1.conda
osx-64::ndcctools-7.5.4-py39hd4b95d6_1.conda
osx-64::vigra-1.11.1-py311h81dd145_1042.conda
osx-64::raven-hydro-0.2.0-py38ha9f8b72_2.conda
osx-64::libarchive-3.6.2-h0b5dc4a_1.conda
osx-64::postgresql-plpython-14.5-py310he0d0a37_6.conda
osx-64::raven-hydro-0.2.1-py311h5482185_1.conda
osx-64::ovito-3.8.4-h7bcd8f4_0.conda
osx-64::protozfits-2.2.0-py310he1f557a_0.conda
osx-64::lammps-2023.03.28-py39h1e39239_openmpi_2.conda
osx-64::tectonic-0.13.0-h06e290d_0.conda
osx-64::r-base-4.1.3-hf0cfa4d_7.conda
osx-64::vtk-base-9.2.6-qt_py39h1234567_206.conda
osx-64::blosc-1.21.4-heccf04b_0.conda
osx-64::folly-2023.04.03.00-hed31980_0_jemalloc.conda
osx-64::r-qpdf-1.3.2-r41h76ec28b_1.conda
osx-64::loos-4.0.4-py310h49c9f9c_1.conda
osx-64::protozfits-2.2.0-py39h3fe8126_0.conda
osx-64::qt-webengine-5.15.8-h66b1b81_1.conda
osx-64::pypy3.9-7.3.11-hc0e9917_1.conda
osx-64::libarrow-12.0.0-hc8386e2_1_cpu.conda
osx-64::graphviz-8.0.5-hc7f41f9_0.conda
osx-64::loos-4.0.4-py311hfb820b6_2.conda
osx-64::lld-16.0.3-h232a910_0.conda
osx-64::libopencv-4.7.0-py39h167342f_3.conda
osx-64::tiledb-2.15.2-h7b8e0f4_2.conda
osx-64::poppler-qt-23.05.0-h9c7cc81_1.conda
osx-64::ffmpeg-6.0.0-gpl_h9b64a9e_101.conda
osx-64::aws-sdk-cpp-1.11.68-hf90da8b_3.conda
osx-64::libopencv-4.7.0-py38h54e3b51_4.conda
osx-64::libarrow-10.0.1-haaf9e61_23_cpu.conda
osx-64::vigra-1.11.1-py39hddf58eb_1042.conda
osx-64::arrow-cpp-9.0.0-py311h04bd02d_36_cpu.conda
osx-64::grpcio-1.55.0-py311hcbb5c6d_0.conda
osx-64::lammps-2023.03.28-py38h8fd1abe_mpich_2.conda
osx-64::libgdal-3.5.3-hb0d652f_28.conda
osx-64::libcurl-8.1.1-hbee3ae8_0.conda
osx-64::folly-2023.05.22.00-h49bef9d_0.conda
osx-64::poppler-23.05.0-he041c3a_1.conda
osx-64::gdstk-0.9.41-py38hf3ea1e6_0.conda
osx-64::omniorb-4.2.5-py311hda15e10_6.conda
osx-64::libopencv-4.7.0-py311hd31abef_3.conda
osx-64::folly-2023.04.10.00-hed31980_0_jemalloc.conda
osx-64::panda3d-1.10.12-py39h0b732d2_3.conda
osx-64::folly-2023.03.27.00-hed31980_0_jemalloc.conda
osx-64::r-base-4.2.3-h4373c2c_3.conda
osx-64::paraview-5.11.1-py310h20612c1_101_qt.conda
osx-64::tectonic-0.12.0-h06e290d_3.conda
osx-64::postgresql-plpython-14.5-py311hbf368a9_6.conda
osx-64::vigra-1.11.1-py38hf59d4d7_1042.conda
osx-64::raven-hydro-0.2.1-py311h5482185_0.conda
osx-64::libopentelemetry-cpp-1.9.1-h377de98_1.conda
osx-64::libgrpc-1.54.2-hfaa49da_2.conda
osx-64::conduit-0.8.8-py38h3b30493_0.conda
osx-64::vigra-1.11.1-py38h8b2ef98_1042.conda
osx-64::libopencv-4.7.0-py310hf06b907_3.conda
osx-64::loos-4.0.4-py39h723c7a0_1.conda
osx-64::ambertools-23.0-py39hfb6888d_0.conda
osx-64::libopencv-4.7.0-py39h0656ea2_4.conda
osx-64::vtk-base-9.2.6-qt_py310h1234567_206.conda
osx-64::pillow-9.5.0-py39he6683de_1.conda
osx-64::libopencv-4.7.0-py39h9c3d6a5_4.conda
osx-64::kaldi-5.5.1068-cpu_h0a45c7f_0.conda
osx-64::sagelib-10.0-py311h3b1e84e_0.conda
osx-64::grpcio-1.55.0-py39hc281fc9_0.conda
osx-64::pyinstaller-5.11.0-py38h63e6892_0.conda
osx-64::ndcctools-7.5.3-py311h54575cd_0.conda
osx-64::vigra-1.11.1-py311h3cc73a2_1042.conda
osx-64::hdfeos5-5.1.16-h344f4d9_12.conda
osx-64::folly-2023.05.08.00-hc30067e_0_jemalloc.conda
osx-64::postgresql-plpython-15.3-py310h9e110d8_0.conda
osx-64::libpq-15.3-h9dc22bb_1.conda
osx-64::arrow-cpp-9.0.0-py310h909edb9_36_cpu.conda
osx-64::tiledb-2.15.3-hd031760_0.conda
osx-64::libdwarf-0.7.0-h217ab76_0.conda
osx-64::conduit-0.8.8-py38h32a0be0_0.conda
osx-64::arrow-cpp-9.0.0-py38h2055a32_36_cpu.conda
osx-64::omniorb-4.2.5-py38h732d4a6_6.conda
osx-64::libgdal-arrow-parquet-3.7.0-h46af9e6_1.conda
osx-64::libgrpc-1.54.1-h0eeb599_0.conda
osx-64::folly-2023.04.17.00-hed31980_0_jemalloc.conda
osx-64::jaxlib-0.4.10-cpu_py39h511c999_0.conda
osx-64::libopencv-4.7.0-py38h5cb5f5a_3.conda
osx-64::cpp-opentelemetry-sdk-1.9.1-h377de98_0.conda
osx-64::folly-2023.04.17.00-h21a4eb5_0.conda
osx-64::soplex-6.0.3-h478c754_2.conda
osx-64::postgresql-plpython-15.3-py39hfacc66a_1.conda
osx-64::raven-hydro-0.2.1-py39h16b9c15_1.conda
osx-64::hugin-base-2022.0.0-pl5321h66c0b5b_4.conda
osx-64::arrow-cpp-9.0.0-py39hc32a39e_36_cpu.conda
osx-64::gmsh-4.11.1-h7afe76d_2.conda
osx-64::ticcutils-0.32-hf42d1bf_2.conda
osx-64::gst-plugins-good-1.22.3-h3ac7b97_1.conda
osx-64::raven-hydro-0.2.1-py38ha481359_1.conda
osx-64::folly-2023.05.15.00-h0d9798a_0.conda
osx-64::ncl-6.6.2-hf6a4b2b_46.conda
osx-64::lld-16.0.4-h62a38e0_0.conda
osx-64::libopencv-4.7.0-py38h0a50863_4.conda
osx-64::libxml2-2.11.3-hd95e348_1.conda
osx-64::vigra-1.11.1-py38hd326707_1042.conda
osx-64::astrometry-0.94-py38h049ee44_0.conda
osx-64::arrow-cpp-9.0.0-py311hfb07c32_35_cpu.conda
osx-64::dwarfdump-0.7.0-h217ab76_0.conda
osx-64::tectonic-0.12.0-h7b56c11_2.conda
osx-64::r-qpdf-1.3.2-r42h76ec28b_1.conda
osx-64::folly-2023.05.15.00-hc30067e_0_jemalloc.conda
osx-64::folly-2023.03.20.00-hed31980_4_jemalloc.conda
osx-64::folly-2023.04.24.00-h6fbac3b_0.conda
osx-64::nexus-4.4.3-hb777e5c_9.conda
osx-64::libarrow-11.0.0-h8fc5235_21_cpu.conda
osx-64::conduit-0.8.8-py39hd2c9ea4_0.conda
osx-64::conduit-0.8.8-py310hc3bf848_0.conda
osx-64::libopencv-4.7.0-py311hd514ebb_4.conda
osx-64::arrow-cpp-8.0.1-py38h93e045a_31_cpu.conda
osx-64::folly-2023.03.20.00-h68897ac_4_jemalloc.conda
osx-64::tiledb-2.15.2-h4e090e4_2.conda
osx-64::ffmpeg-5.1.2-lgpl_h6ef2dee_9.conda
osx-64::texlive-core-20230313-h54be645_3.conda
osx-64::qt6-main-6.5.0-h35278ed_7.conda
osx-64::raven-hydro-0.2.1-py38h98498c3_1.conda
osx-64::folly-2023.03.27.00-h68897ac_0_jemalloc.conda
osx-64::ambertools-23.0-py38h51c3a6d_1.conda
osx-64::sqlite-3.42.0-h2b0dec6_0.conda
osx-64::libllvm16-16.0.4-he4b1e75_0.conda
osx-64::libopencv-4.7.0-py311hd514ebb_3.conda
osx-64::arrow-cpp-8.0.1-py311hfb07c32_32_cpu.conda
osx-64::ffmpeg-6.0.0-gpl_hda31a47_100.conda
osx-64::grpcio-1.55.0-py311hcbb5c6d_1.conda
osx-64::ndcctools-7.5.4-py311h54575cd_0.conda
osx-64::vtk-base-9.2.6-qt_py38h1234567_205.conda
osx-64::conduit-0.8.8-py38h548b4a1_0.conda
osx-64::folly-2023.04.24.00-h21a4eb5_0.conda
osx-64::llvmlite-0.40.0-py39h6ada40c_0.conda
osx-64::libxml2-2.11.4-hd95e348_0.conda
osx-64::raven-hydro-0.2.0-py39h0edd63f_0.conda
osx-64::libopencv-4.7.0-py39h3af9463_3.conda
osx-64::libpq-14.5-h9dc22bb_6.conda
osx-64::libarrow-12.0.0-h8fc5235_4_cpu.conda
osx-64::curl-8.1.0-hbee3ae8_0.conda
osx-64::omniorb-libs-4.2.5-h0108ac9_6.conda
osx-64::panda3d-1.10.12-py311h620a140_4.conda
osx-64::libopencv-4.7.0-py38hdfb6d10_3.conda
osx-64::libopentelemetry-cpp-1.9.1-hac0930c_2.conda
osx-64::grpcio-1.55.0-py310hd8379ad_0.conda
osx-64::ffmpeg-5.1.2-gpl_hd6d2617_110.conda
osx-64::folly-2023.05.08.00-h49bef9d_0.conda
osx-64::vigra-1.11.1-py39hc9d46ce_1042.conda
osx-64::cairo-1.16.0-h09dd18c_1016.conda
osx-64::qt6-main-6.5.0-h35278ed_8.conda
osx-64::folly-2023.03.20.00-h6fbac3b_4.conda
osx-64::vigra-1.11.1-py310hc780a38_1042.conda
osx-64::ndcctools-7.5.3-py39hd4b95d6_0.conda
osx-64::r-base-4.3.0-h4373c2c_1.conda
osx-64::fossil-2.22-h8f9e4de_0.conda
osx-64::gazebo-11.12.0-h4fa1784_13.conda
osx-64::libgdal-3.6.4-hf60d4ee_1.conda
osx-64::pygplates-0.39-py39h9e819e6_7.conda
osx-64::paraview-5.11.1-py311hfea4d5e_101_qt.conda
osx-64::magics-4.13.0-h6fa1f44_4.conda
osx-64::postgresql-plpython-15.3-py38h9f95ba2_1.conda
osx-64::pyinstaller-5.11.0-py39h29f4f0d_0.conda
osx-64::libopentelemetry-cpp-1.9.1-h9779858_2.conda
osx-64::libllvm16-16.0.3-hf646ca0_0.conda
osx-64::pygplates-0.39-py38h29c963e_7.conda
osx-64::folly-2023.04.17.00-h6fbac3b_0.conda
osx-64::gst-plugins-bad-1.22.0-h70ac916_1.conda
osx-64::arrow-cpp-8.0.1-py38ha0848b0_32_cpu.conda
osx-64::openslide-3.4.1-hdc20c34_9.conda
osx-64::libopencv-4.7.0-py310hf06b907_4.conda
osx-64::folly-2023.05.01.00-h21a4eb5_0.conda
osx-64::arrow-cpp-9.0.0-py311h6370082_34_cpu.conda
osx-64::folly-2023.05.22.00-h0d9798a_1.conda
osx-64::mlir-16.0.4-h837b0c1_0.conda
osx-64::libdwarf-testing-meta-0.7.0-h217ab76_0.conda
osx-64::pillow-9.5.0-py310hd63a8c7_1.conda
osx-64::panda3d-1.10.12-py38h61ad74e_4.conda
osx-64::postgresql-plpython-15.3-py39h002cf3f_0.conda
osx-64::astrometry-0.94-py310h2fe57eb_0.conda
osx-64::libgdal-arrow-parquet-3.6.4-hd87dc24_2.conda
osx-64::openconnect-9.12-h7266fad_0.conda
osx-64::folly-2023.04.10.00-h21a4eb5_0.conda
osx-64::libgrpc-1.52.1-hfaa49da_2.conda
osx-64::astrometry-0.94-py39h70266e9_0.conda
osx-64::r-base-4.1.3-h7a6543b_8.conda
osx-64::aws-sdk-cpp-1.11.68-ha5f73a7_1.conda
osx-64::libopencv-4.7.0-py311he9f1b76_4.conda
osx-64::libgdal-3.7.0-hd7102d7_1.conda
osx-64::folly-2023.04.24.00-hed31980_0_jemalloc.conda
osx-64::libarrow-11.0.0-h71098f9_20_cpu.conda
osx-64::panda3d-1.10.12-py310he22e8d7_3.conda
osx-64::ndcctools-7.5.5-py38h0a8965a_0.conda
osx-64::paraview-5.11.1-py39hc65c9a1_101_qt.conda
osx-64::libxml2-2.11.3-hd95e348_2.conda
osx-64::folly-2023.04.24.00-h68897ac_0_jemalloc.conda
osx-64::arrow-cpp-8.0.1-py310hf0cf13f_31_cpu.conda
osx-64::imagemagick-7.1.1_10-pl5321hcd3a149_0.conda
osx-64::raven-hydro-0.2.1-py39h335d0ad_1.conda
osx-64::libspatialite-5.0.1-h8e1627f_26.conda
osx-64::panda3d-1.10.12-py310h084034e_4.conda
osx-64::folly-2023.05.22.00-h889bfc7_0_jemalloc.conda
osx-64::libcurl-static-8.1.0-hbee3ae8_0.conda
osx-64::libopencv-4.7.0-py39h58c7650_3.conda
osx-64::gazebo-11.12.0-hf06b611_10.conda
osx-64::loos-4.0.4-py38hc04ebe0_1.conda
osx-64::panda3d-1.10.12-py39h40a1ae4_4.conda
osx-64::libxmlsec1-1.3.0-h260cc6a_1.conda
osx-64::aws-sdk-cpp-1.11.68-hd56652f_2.conda
osx-64::folly-2023.03.27.00-h21a4eb5_0.conda
osx-64::conduit-0.8.8-py310hbe3f35b_0.conda
osx-64::libnetcdf-4.9.2-mpi_openmpi_h45c3e4e_5.conda
osx-64::netpbm-10.73.43-pl5321h57d4e0a_1.conda
osx-64::cpp-opentelemetry-sdk-1.9.0-h377de98_2.conda
osx-64::folly-2023.04.03.00-h21a4eb5_0.conda
osx-64::vtk-base-9.2.6-qt_py38h1234567_206.conda
osx-64::folly-2023.04.10.00-h6fbac3b_0.conda
osx-64::conduit-0.8.8-py310h9afde27_0.conda
osx-64::libarrow-12.0.0-h71098f9_2_cpu.conda
osx-64::libcurl-static-8.1.2-hbee3ae8_0.conda
osx-64::llvm-15.0.7-h9c2cb20_2.conda
osx-64::astrometry-0.94-py38hf219e7e_0.conda
osx-64::conduit-0.8.8-py39h86d7568_0.conda
osx-64::omniorb-4.2.5-py310h601326b_6.conda
osx-64::cmake-3.26.4-hf40c264_0.conda
osx-64::raven-hydro-0.2.1-py38hf246b68_1.conda
osx-64::curl-8.1.2-hbee3ae8_0.conda
osx-64::qt-main-5.15.8-h0afe88e_10.conda
osx-64::lpython-0.15.0-h7d26f99_0.conda
osx-64::raven-hydro-0.2.0-py38ha9f8b72_1.conda
osx-64::ndcctools-7.5.4-py310h442c573_1.conda
osx-64::vigra-1.11.1-py310hf8d4ba8_1042.conda
osx-64::pdal-2.5.4-h5ca4672_0.conda
osx-64::libarrow-12.0.0-h2698f8f_0_cpu.conda
osx-64::ndcctools-7.5.4-py39hd4b95d6_0.conda
osx-64::llvm-16.0.3-hbf068ea_1.conda
osx-64::wxpython-4.2.0-py38h6cc8c6c_7.conda
osx-64::r-base-4.1.3-h4373c2c_9.conda
osx-64::sagelib-10.0-py39hb452f22_0.conda
osx-64::imagemagick-7.1.1_9-pl5321hce4e031_0.conda
osx-64::ndcctools-7.5.5-py311h54575cd_0.conda
osx-64::libopentelemetry-cpp-1.9.0-h377de98_3.conda
osx-64::imagemagick-7.1.1_11-pl5321hcd3a149_0.conda
osx-64::mosh-1.4.0-pl5321hd37528d_1.conda
osx-64::plumed-2.9.0-mpi_mpich_he08531d_0.conda
osx-64::libcurl-8.1.2-hbee3ae8_0.conda
osx-64::vigra-1.11.1-py39h9e7bf6d_1042.conda
osx-64::qt-main-5.15.8-h23c57ac_13.conda
osx-64::gdstk-0.9.41-py38hb45a76b_0.conda
osx-64::conduit-0.8.8-py39hee97190_0.conda
osx-64::papilo-2.1.2-h21bd363_2.conda
osx-64::paraview-5.11.1-py310h128b97c_101_qt.conda
osx-64::libarrow-10.0.1-h7d6d730_25_cpu.conda
osx-64::libgdal-3.5.3-hed7cd6d_27.conda
osx-64::raven-hydro-0.2.0-py38ha9f8b72_0.conda
osx-64::qt6-main-6.5.0-h35278ed_6.conda
osx-64::scip-8.0.3-h1b39fdf_2.conda
osx-64::libgdal-3.6.4-ha3a963f_3.conda
osx-64::arrow-cpp-8.0.1-py39hf22c89f_31_cpu.conda
osx-64::freeimage-3.18.0-h09bcc04_15.conda
osx-64::plumed-2.9.0-mpi_openmpi_h313374a_0.conda
osx-64::tiledb-2.15.2-h4e090e4_1.conda
osx-64::libnetcdf-4.9.2-mpi_mpich_h4b56550_5.conda
osx-64::panda3d-1.10.12-py38hb5ffac9_3.conda
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
================================================================================
================================================================================
linux-64
linux-64::libprotobuf-4.23.2-hd1fb520_1.conda
linux-64::libclang-14.0.6-default_h7634d5b_1.conda
linux-64::libclang-cpp-15.0.7-default_h7634d5b_2.conda
linux-64::clang-format-14-14.0.6-default_h7634d5b_1.conda
linux-64::libprotobuf-static-4.23.2-hd1fb520_0.conda
linux-64::libv8-8.9.83-h3f08ab5_3.conda
linux-64::libuwebsockets-20.42.0-hfc55251_0.conda
linux-64::libprotobuf-static-4.23.0-hd1fb520_0.conda
linux-64::libuwebsockets-20.41.0-hfc55251_0.conda
linux-64::libclang13-14.0.6-default_h9986a30_1.conda
linux-64::lld-15.0.7-h07fd6de_1.conda
linux-64::libclang-15.0.7-default_h7634d5b_2.conda
linux-64::clang-14-14.0.6-default_h7634d5b_1.conda
linux-64::llvm-14.0.6-h32600fe_2.conda
linux-64::plumed-2.9.0-nompi_h752ec8b_100.conda
linux-64::libpcm-1.2.3-hf7c02db_2.conda
linux-64::libprotobuf-4.22.5-hd1fb520_0.conda
linux-64::glib-tools-2.76.3-hfc55251_0.conda
linux-64::spidermonkey-91.13.0-h32de77b_1.conda
linux-64::openexr-3.1.7-h92431a3_1.conda
linux-64::libclang-cpp14-14.0.6-default_h7634d5b_1.conda
linux-64::imath-3.1.8-hfc55251_0.conda
linux-64::libuwebsockets-20.44.0-hfc55251_0.conda
linux-64::micromamba-1.4.2-2.tar.bz2
linux-64::libmlir16-16.0.3-hcd5def8_0.conda
linux-64::clang-format-14.0.6-default_h7634d5b_1.conda
linux-64::clang-format-15-15.0.7-default_h7634d5b_2.conda
linux-64::gst-libav-1.22.3-h9ff8bb6_1.conda
linux-64::libass-0.17.1-hc9aadba_0.conda
linux-64::gst-libav-1.22.3-h9ff8bb6_0.conda
linux-64::micromamba-1.4.2-1.tar.bz2
linux-64::libcdms-3.1.2-hddf7c25_122.conda
linux-64::libprotobuf-4.23.0-hd1fb520_0.conda
linux-64::libcdms-3.1.2-h0834af3_123.conda
linux-64::libxmlpp-4.0-4.0.2-h550762b_1.conda
linux-64::libuwebsockets-20.43.0-hfc55251_0.conda
linux-64::lld-14.0.6-h07fd6de_1.conda
linux-64::clang-15-15.0.7-default_h7634d5b_2.conda
linux-64::pandoc-3.1.2-h32600fe_0.conda
linux-64::libprotobuf-4.23.2-hd1fb520_2.conda
linux-64::libclang13-15.0.7-default_h9986a30_2.conda
linux-64::libprotobuf-static-4.23.2-hd1fb520_1.conda
linux-64::libmlir-16.0.4-hcd5def8_0.conda
linux-64::libuwebsockets-20.40.0-hfc55251_0.conda
linux-64::libprotobuf-4.23.2-hd1fb520_0.conda
linux-64::libprotobuf-4.23.1-hd1fb520_0.conda
linux-64::clang-tools-15.0.7-default_h7634d5b_2.conda
linux-64::llvm-tools-14.0.6-hcd5def8_2.conda
linux-64::gst-plugins-base-1.22.3-h938bd60_1.conda
linux-64::gst-libav-1.22.3-h6f5dc50_1.conda
linux-64::libpcm-1.2.3-hf7c02db_4.conda
linux-64::libass-0.14.0-hc9aadba_4.conda
linux-64::libsqlite-3.41.2-h2797004_1.conda
linux-64::libprotobuf-static-4.22.3-hd1fb520_0.conda
linux-64::libprotobuf-static-4.23.2-hd1fb520_2.conda
linux-64::libsqlite-3.42.0-h2797004_0.conda
linux-64::msgpack-cxx-6.0.0-h9f19972_1.conda
linux-64::libpcm-1.2.3-hf7c02db_0.conda
linux-64::libpcm-1.2.3-hf7c02db_3.conda
linux-64::libprotobuf-static-4.23.1-hd1fb520_0.conda
linux-64::libclang-cpp15-15.0.7-default_h7634d5b_2.conda
linux-64::zimpl-3.5.3-h4c00192_2.conda
linux-64::libclang-cpp-14.0.6-default_h7634d5b_1.conda
linux-64::libmlir16-16.0.4-hcd5def8_0.conda
linux-64::libmlir-16.0.3-hcd5def8_0.conda
linux-64::clang-format-15.0.7-default_h7634d5b_2.conda
linux-64::spidermonkey-bin-91.13.0-hd8c27b6_1.conda
linux-64::micromamba-1.4.3-0.tar.bz2
linux-64::libpcm-1.2.3-hf7c02db_1.conda
linux-64::libllvm14-14.0.6-hcd5def8_2.conda
linux-64::libprotobuf-4.22.3-hd1fb520_0.conda
linux-64::libprotobuf-static-4.22.5-hd1fb520_0.conda
linux-64::gst-plugins-base-1.22.3-h25e5d2c_0.conda
linux-64::clang-tools-14.0.6-default_h7634d5b_1.conda
-    "libzlib >=1.2.13,<1.3.0a0"
+    "libzlib >=1.2.13,<2.0.0a0"
linux-64::linux-perf-6.3.4-py311h063b91e_0.conda
linux-64::magic-8.3.394-h9abf892_0.conda
linux-64::raven-hydro-0.2.0-py38h326e3f4_0.conda
linux-64::llvm-openmp-16.0.3-h4dfa4b3_0.conda
linux-64::linux-perf-6.3.4-py38h3fbeceb_0.conda
linux-64::linux-perf-6.3.1-py310h2f7a385_0.conda
linux-64::libopencv-4.7.0-py38hf2e4d04_3.conda
linux-64::ovito-3.8.4-h0557118_1.conda
linux-64::llvmdev-14.0.6-hcd5def8_2.conda
linux-64::ovito-3.8.4-h02b97e4_0.conda
linux-64::libarchive-minimal-static-3.6.2-h2b6973b_1.conda
linux-64::libllvm16-16.0.3-hbf9e925_1.conda
linux-64::nco-5.1.6-hd62b316_0.conda
linux-64::libopencv-4.7.0-py39hbcf5388_3.conda
linux-64::ambertools-23.0-py310he275f01_0.conda
linux-64::r-base-4.3.0-hfabd6f2_1.conda
linux-64::pillow-9.5.0-py38h885162f_1.conda
linux-64::libgdal-3.7.0-h9f4e061_1.conda
linux-64::libdwarf-testing-meta-0.7.0-hecc041a_0.conda
linux-64::libarrow-12.0.0-h4c9df9b_0_cpu.conda
linux-64::llvmdev-15.0.7-h5cf9203_2.conda
linux-64::arrow-cpp-9.0.0-py310hfc266dc_36_cpu.conda
linux-64::ffmpeg-5.1.2-lgpl_h98679f4_8.conda
linux-64::ortools-python-9.6-py39h0a24eaf_1.conda
linux-64::raven-hydro-0.2.0rc0-py38h326e3f4_0.conda
linux-64::ogre-next-2.3.1-h1b25c05_4.conda
linux-64::r-base-4.1.3-h0fc540b_8.conda
linux-64::openconnect-9.10-h8f97634_0.conda
linux-64::libgrpc-1.55.0-h59456c1_0.conda
linux-64::paraview-5.11.1-py310h2e268bd_101_qt.conda
linux-64::libgdal-arrow-parquet-3.7.0-h9cfa285_1.conda
linux-64::paraview-5.11.1-py310ha1345a5_1_egl.conda
linux-64::omniorb-4.2.5-py38h18920d9_6.conda
linux-64::arrow-cpp-8.0.1-py39hcbcaf9a_32_cuda.conda
linux-64::libopencv-4.7.0-py311hfd9f270_3.conda
linux-64::lammps-2023.03.28-py39h9b61139_mpich_2.conda
linux-64::freeimage-3.18.0-h00dfb44_15.conda
linux-64::aws-sdk-cpp-1.11.68-hce39858_1.conda
linux-64::vtk-base-9.2.6-qt_py39h1234567_206.conda
linux-64::folly-2023.03.27.00-hf69079e_0.conda
linux-64::ndcctools-7.5.3-py311h689c632_0.conda
linux-64::libortools-9.6-hf3fc2c2_1.conda
linux-64::r-base-4.1.3-hfabd6f2_9.conda
linux-64::vtk-base-9.2.6-egl_py39h1234567_6.conda
linux-64::lammps-2023.03.28-py311hc2e2a5f_mpich_2.conda
linux-64::loos-4.0.4-py38h94d54b6_1.conda
linux-64::libarrow-10.0.1-he8ef7bf_23_cuda.conda
linux-64::arrow-cpp-9.0.0-py311h32a044f_35_cpu.conda
linux-64::raven-hydro-0.2.1-py38h0110233_0.conda
linux-64::raven-hydro-0.2.0-py38h326e3f4_1.conda
linux-64::ndcctools-7.5.5-py311h689c632_0.conda
linux-64::libgsf-1.14.50-heb02ada_1.conda
linux-64::libortools-9.6-heb0c687_1.conda
linux-64::ndcctools-7.5.4-py38h514f0f6_0.conda
linux-64::hdfeos5-5.1.16-hc55c121_12.conda
linux-64::pillow-9.5.0-py39hb514683_1.conda
linux-64::texlive-core-20230313-hab8b11c_3.conda
linux-64::vigra-1.11.1-py311hd7c5fd2_1042.conda
linux-64::ndcctools-7.5.4-py39h4841754_1.conda
linux-64::folly-2023.05.01.00-hda79706_0_jemalloc.conda
linux-64::llvm-16.0.3-h110208f_0.conda
linux-64::postgresql-plpython-14.5-py38h260f7d5_6.conda
linux-64::astrometry-0.94-py38h20260eb_0.conda
linux-64::mysql-server-8.0.32-ha473b58_2.conda
linux-64::ndcctools-7.5.4-py311h689c632_0.conda
linux-64::vtk-base-9.2.6-qt_py311h1234567_205.conda
linux-64::arrow-cpp-9.0.0-py38h7a2a628_34_cpu.conda
linux-64::chemicalite-2022.04.1-h5ced5f6_9.conda
linux-64::qtkeychain-0.14.0-hbc31b07_0.conda
linux-64::vigra-1.11.1-py38h832de8b_1042.conda
linux-64::folly-2023.04.24.00-h80c46b9_0.conda
linux-64::arrow-cpp-9.0.0-py310h4eb96da_35_cuda.conda
linux-64::lpython-0.15.0-hfc55251_0.conda
linux-64::pypy3.9-7.3.11-h9557127_1.conda
linux-64::libortools-9.6-hcb37b0f_3.conda
linux-64::mysql-client-8.0.32-h545f5f4_2.conda
linux-64::triton-2.0.0-cuda110py39h03fb359_1.conda
linux-64::mosh-1.4.0-pl5321h61fc75a_1.conda
linux-64::libcurl-8.1.1-h409715c_0.conda
linux-64::folly-2023.05.15.00-h5e7e832_0_jemalloc.conda
linux-64::paraview-5.11.1-py311he199314_101_qt.conda
linux-64::tectonic-0.13.0-h03309ca_0.conda
linux-64::mesalib-23.0.2-h2f194a4_1.conda
linux-64::jaxlib-0.4.9-cuda112py38h2a7d48f_200.conda
linux-64::vtk-base-9.2.6-egl_py310h1234567_5.conda
linux-64::raven-hydro-0.2.1-py310hee4f699_1.conda
linux-64::arrow-cpp-8.0.1-py38h271401c_31_cuda.conda
linux-64::loos-4.0.4-py310hfd6d7b6_1.conda
linux-64::ortools-python-9.6-py311he0c7779_1.conda
linux-64::postgresql-plpython-14.5-py310h4358bab_6.conda
linux-64::arrow-cpp-9.0.0-py311h12a7141_36_cuda.conda
linux-64::ffmpeg-6.0.0-gpl_h5bb71f3_100.conda
linux-64::curl-8.1.2-h409715c_0.conda
linux-64::libarrow-12.0.0-h96638e8_3_cpu.conda
linux-64::tectonic-0.12.0-h03309ca_3.conda
linux-64::ffmpeg-5.1.2-lgpl_h58d86f9_7.conda
linux-64::git-annex-10.20230407-alldep_h97b9560_100.conda
linux-64::libarrow-12.0.0-h96638e8_4_cpu.conda
linux-64::panda3d-1.10.12-py39h157094a_4.conda
linux-64::linux-perf-6.3.3-py311h063b91e_0.conda
linux-64::panda3d-1.10.12-py39hd690b07_4.conda
linux-64::tiledb-2.15.2-heaeb544_0.conda
linux-64::r-base-4.1.3-h6479b40_7.conda
linux-64::raven-hydro-0.2.1-py39hb80b23e_1.conda
linux-64::wxpython-4.2.0-py39he9b0109_7.conda
linux-64::libgrpc-1.54.2-hcf146ea_0.conda
linux-64::libdwarf-dev-0.7.0-hecc041a_0.conda
linux-64::tiledb-2.15.2-hebec990_0.conda
linux-64::vtk-base-9.2.6-osmesa_py311h1234567_106.conda
linux-64::qt-webengine-5.15.8-h8a331fa_1.conda
linux-64::gst-plugins-good-1.22.3-h370c101_0.conda
linux-64::vigra-1.11.1-py39h8dd7e92_1042.conda
linux-64::libopencv-4.7.0-py39h894d418_4.conda
linux-64::vtk-base-9.2.6-osmesa_py38h1234567_105.conda
linux-64::conduit-0.8.8-py310h84d236a_0.conda
linux-64::loos-4.0.4-py310hfd6d7b6_2.conda
linux-64::ncl-6.6.2-hd9e1afa_45.conda
linux-64::libarrow-12.0.0-h07599e3_0_cuda.conda
linux-64::wxpython-4.2.0-py310h6c5a8eb_7.conda
linux-64::kitty-0.23.1-py38h8e21364_3.conda
linux-64::mfront-4.1.0-py39h24690a3_1.conda
linux-64::mapserver-8.0.1-py311h9fd8176_3.conda
linux-64::vtk-base-9.2.6-egl_py38h1234567_5.conda
linux-64::vtk-base-9.2.6-qt_py310h1234567_205.conda
linux-64::libarrow-10.0.1-h3e0c18e_24_cpu.conda
linux-64::cpp-opentelemetry-sdk-1.9.1-hedca983_2.conda
linux-64::ffmpeg-5.1.2-lgpl_h7eee9c5_9.conda
linux-64::vigra-1.11.1-py39h1f22c3f_1042.conda
linux-64::astrometry-0.94-py38h0c87b15_0.conda
linux-64::curl-8.1.1-h409715c_0.conda
linux-64::r-base-4.2.3-hfabd6f2_3.conda
linux-64::libarrow-12.0.0-hb3168b4_3_cuda.conda
linux-64::openjdk-17.0.3-h8e330f5_8.conda
linux-64::lammps-2023.03.28-py311h260d5c4_openmpi_2.conda
linux-64::folly-2023.04.24.00-h5e7e832_0_jemalloc.conda
linux-64::folly-2023.03.27.00-h80c46b9_0.conda
linux-64::raven-hydro-0.2.0-py39h5056a20_2.conda
linux-64::clangdev-15.0.7-default_h7634d5b_2.conda
linux-64::sagelib-10.0-py38h749e0f1_0.conda
linux-64::libgrpc-1.54.2-hb20ce57_2.conda
linux-64::folly-2023.05.08.00-h5e7e832_0_jemalloc.conda
linux-64::arrow-cpp-8.0.1-py311h1b1befb_31_cuda.conda
linux-64::imagemagick-7.1.1_10-pl5321hf48ede7_0.conda
linux-64::libgrpc-1.54.2-hb20ce57_1.conda
linux-64::triton-2.0.0-cuda110py39h03fb359_0.conda
linux-64::mapserver-8.0.1-py310h3cba860_2.conda
linux-64::libopencv-4.7.0-py311hfd9f270_4.conda
linux-64::erlang-26.0-pl5321h949266c_0.conda
linux-64::raven-hydro-0.2.1-py310h3ce4ad4_1.conda
linux-64::pygplates-0.39-py310h074014d_7.conda
linux-64::loos-4.0.4-py311hc1e8167_2.conda
linux-64::panda3d-1.10.12-py38he27731d_3.conda
linux-64::kitty-0.23.1-py39h2aa4872_3.conda
linux-64::vigra-1.11.1-py39h5d0e789_1042.conda
linux-64::kaldi-5.5.1068-cpu_h05f3a92_0.conda
linux-64::r-qpdf-1.3.2-r41h31c590b_1.conda
linux-64::paraview-5.11.1-py38hf8fae22_101_qt.conda
linux-64::hdfeos5-5.1.16-h8b5b2df_13.conda
linux-64::arrow-cpp-9.0.0-py311h1b1befb_34_cuda.conda
linux-64::libarrow-11.0.0-h9bd7ee1_20_cuda.conda
linux-64::ticcutils-0.32-h14e3477_2.conda
linux-64::mfront-4.1.0-py311hf4ddd97_1.conda
linux-64::panda3d-1.10.12-py38ha7cad78_4.conda
linux-64::astrometry-0.94-py311he329c82_0.conda
linux-64::raven-hydro-0.2.0-py39h5056a20_1.conda
linux-64::protozfits-2.2.0-py310h6c8afb8_0.conda
linux-64::tiledb-2.15.3-hb9fe1d2_0.conda
linux-64::folly-2023.04.17.00-h80c46b9_0.conda
linux-64::grpcio-1.55.0-py311ha6695c7_1.conda
linux-64::lammps-2023.03.28-py39h56169d6_openmpi_2.conda
linux-64::pdal-2.5.4-h3283ea9_0.conda
linux-64::openslide-3.4.1-ha896ae7_9.conda
linux-64::jaxlib-0.4.10-cuda112py311h7d292f2_200.conda
linux-64::lld-16.0.3-hcfcaf08_1.conda
linux-64::libopencv-4.7.0-py38h8a5b990_4.conda
linux-64::paraview-5.11.1-py38h46ed0e1_101_qt.conda
linux-64::llvmlite-0.40.0-py310h1b8f574_0.conda
linux-64::lpython-0.15.0-hfc55251_1.conda
linux-64::libarrow-10.0.1-h2d8a318_24_cuda.conda
linux-64::libgdal-arrow-parquet-3.7.0-h6a21798_0.conda
linux-64::magics-4.13.0-h8ea9e15_4.conda
linux-64::nodejs-18.15.0-h4abf6b9_1.conda
linux-64::arrow-cpp-8.0.1-py311h32a044f_32_cpu.conda
linux-64::raven-hydro-0.2.0rc0-py310h3ce4ad4_0.conda
linux-64::ortools-python-9.6-py310h5b4334d_1.conda
linux-64::jaxlib-0.4.9-cpu_py311h7b5b818_0.conda
linux-64::tiledb-2.15.2-ha71cd97_1.conda
linux-64::triton-2.0.0-cuda111py310hacfba7e_0.conda
linux-64::paraview-5.11.1-py38h0a7d0ef_1_egl.conda
linux-64::jaxlib-0.4.9-cpu_py38hb25f6ba_0.conda
linux-64::raven-hydro-0.2.0-py311h14de304_1.conda
linux-64::triton-2.0.0-cuda112py310he6af95e_1.conda
linux-64::linux-perf-6.3.4-py39h43c8743_0.conda
linux-64::arrow-cpp-8.0.1-py310h4eb96da_32_cuda.conda
linux-64::libarrow-11.0.0-hb3168b4_21_cuda.conda
linux-64::libopencv-4.7.0-py311he25f01e_4.conda
linux-64::llvm-tools-16.0.3-hbf9e925_1.conda
linux-64::folly-2023.04.17.00-h5e7e832_0_jemalloc.conda
linux-64::llvm-tools-15.0.7-h5cf9203_2.conda
linux-64::libopencv-4.7.0-py38h7b4a18f_3.conda
linux-64::erlang-25.3.2-pl5321h949266c_0.conda
linux-64::ambertools-23.0-py310he275f01_1.conda
linux-64::cmake-3.26.4-hcfe8598_0.conda
linux-64::mfront-3.3.2-py38h96aac5d_0.conda
linux-64::libarrow-11.0.0-h6564b11_20_cpu.conda
linux-64::llvmlite-0.40.0-py38h94a1851_0.conda
linux-64::protozfits-2.2.0-py39hf3bd010_0.conda
linux-64::julia-1.9.0-hfacc78c_0.conda
linux-64::arrow-cpp-9.0.0-py39h5d797e4_34_cuda.conda
linux-64::panda3d-1.10.12-py39hb8a5f1f_3.conda
linux-64::triton-2.0.0-cuda111py39h0c7cf85_0.conda
linux-64::ffmpeg-6.0.0-lgpl_h49dbbf2_0.conda
linux-64::libgrpc-1.54.1-hcf146ea_0.conda
linux-64::arrow-cpp-9.0.0-py39hc553871_34_cpu.conda
linux-64::imagemagick-7.1.1_9-pl5321hfda792c_0.conda
linux-64::arrow-cpp-8.0.1-py39hc553871_31_cpu.conda
linux-64::raven-hydro-0.2.0-py310h3ce4ad4_1.conda
linux-64::openjdk-20.0.0-h8e330f5_0.conda
linux-64::vtk-base-9.2.6-osmesa_py311h1234567_105.conda
linux-64::arrow-cpp-9.0.0-py311h17222b5_35_cuda.conda
linux-64::r-base-4.1.3-h05c0162_6.conda
linux-64::aws-sdk-cpp-1.10.57-hb0b1f3a_12.conda
linux-64::arrow-cpp-9.0.0-py39hf6261c9_36_cpu.conda
linux-64::ndcctools-7.5.5-py310he2ed3e8_0.conda
linux-64::libopencv-4.7.0-py39h894d418_3.conda
linux-64::linux-perf-6.3.4-py310h2f7a385_0.conda
linux-64::jaxlib-0.4.10-cpu_py39h4646849_0.conda
linux-64::openjdk-17.0.3-h19c1b89_7.conda
linux-64::ndcctools-7.5.4-py310he2ed3e8_0.conda
linux-64::graphviz-8.0.5-h28d9a01_0.conda
linux-64::vtk-base-9.2.6-egl_py38h1234567_6.conda
linux-64::magics-4.13.0-hdc36dfe_3.conda
linux-64::pandoc-3.1.2-h32600fe_1.conda
linux-64::pyinstaller-5.11.0-py38h502143a_0.conda
linux-64::libnetcdf-4.9.2-mpi_openmpi_h9e645d0_5.conda
linux-64::libcurl-8.1.2-h409715c_0.conda
linux-64::sagelib-10.0-py310h551a372_0.conda
linux-64::ndcctools-7.5.5-py39h4841754_0.conda
linux-64::omniorb-4.2.5-py311hcb49f0c_6.conda
linux-64::lammps-2023.03.28-py38h6b9bcbe_openmpi_2.conda
linux-64::kaldi-5.5.1068-cuda112h961d610_0.conda
linux-64::libllvm15-15.0.7-h5cf9203_2.conda
linux-64::libortools-9.6-hd05b653_1.conda
linux-64::folly-2023.04.10.00-hf69079e_0.conda
linux-64::libopencv-4.7.0-py310h2947053_4.conda
linux-64::vtk-base-9.2.6-osmesa_py310h1234567_106.conda
linux-64::raven-hydro-0.2.1-py38hcf001ca_1.conda
linux-64::vigra-1.11.1-py39h63946f1_1042.conda
linux-64::libarrow-10.0.1-h9a2e805_23_cpu.conda
linux-64::paraview-5.11.1-py311h109a5b0_1_egl.conda
linux-64::libgdal-3.7.0-he76be6c_0.conda
linux-64::folly-2023.03.20.00-hf69079e_4.conda
linux-64::libortools-9.6-hcb37b0f_2.conda
linux-64::jaxlib-0.4.10-cuda112py310h1be305f_200.conda
linux-64::panda3d-1.10.12-py311h9bbe57d_4.conda
linux-64::git-credential-manager-2.1.0-hd0a3927_0.conda
linux-64::libllvm16-16.0.3-hbf9e925_0.conda
linux-64::sagelib-10.0-py39h995b525_0.conda
linux-64::lammps-2023.03.28-py38h2ec319d_mpich_2.conda
linux-64::lammps-2023.03.28-py39h2769463_mpich_2.conda
linux-64::pdal-2.5.4-hee5d408_1.conda
linux-64::mfront-3.2.1-py310heb670ec_0.conda
linux-64::postgresql-15.3-h814edd5_0.conda
linux-64::arrow-cpp-9.0.0-py310h70ffa4b_34_cuda.conda
linux-64::magic-8.3.400-h9abf892_0.conda
linux-64::grpcio-1.55.0-py39h174d805_1.conda
linux-64::ambertools-23.0-py39h4856ba4_1.conda
linux-64::jaxlib-0.4.9-cpu_py39h4646849_0.conda
linux-64::pyinstaller-5.11.0-py39hb6545a3_0.conda
linux-64::ndcctools-7.5.4-py311h689c632_1.conda
linux-64::qt-main-5.15.8-haa3a1c2_11.conda
linux-64::libvips-8.14.2-h975c68b_1.conda
linux-64::llvmdev-16.0.4-h5cf9203_0.conda
linux-64::libarrow-11.0.0-h96638e8_21_cpu.conda
linux-64::folly-2023.05.15.00-hda79706_0_jemalloc.conda
linux-64::libgdal-arrow-parquet-3.6.4-hf2fabca_2.conda
linux-64::lpython-0.13.0-hfc55251_0.conda
linux-64::gdstk-0.9.41-py310hc662f57_0.conda
linux-64::qt-webengine-5.15.8-h27f4a20_2.conda
linux-64::linux-perf-6.3.3-py310h2f7a385_0.conda
linux-64::ambertools-23.0-py38h3974a27_0.conda
linux-64::gmsh-4.11.1-h28bb747_2.conda
linux-64::ffmpeg-5.1.2-gpl_h670944f_108.conda
linux-64::raven-hydro-0.2.1-py311h14de304_1.conda
linux-64::libpq-14.5-hbcd7760_6.conda
linux-64::libopencv-4.7.0-py39h0cf8573_4.conda
linux-64::ovito-3.8.4-h02b97e4_1.conda
linux-64::raven-hydro-0.2.0-py38h326e3f4_2.conda
linux-64::qt6-main-6.5.1-ha2ff4f7_0.conda
linux-64::libopentelemetry-cpp-1.9.1-h3a04492_1.conda
linux-64::plumed-2.9.0-mpi_openmpi_h7b2badc_0.conda
linux-64::arrow-cpp-8.0.1-py38hc3817f7_32_cpu.conda
linux-64::paraview-5.11.1-py38hcb5776e_1_egl.conda
linux-64::mysql-libs-8.0.32-hca2cd23_2.conda
linux-64::raven-hydro-0.2.1-py39h5056a20_0.conda
linux-64::arrow-cpp-8.0.1-py39h4160b5d_32_cpu.conda
linux-64::qt-main-5.15.8-h5c52f38_10.conda
linux-64::qt-main-5.15.8-h01ceb2d_13.conda
linux-64::arrow-cpp-8.0.1-py311h17222b5_32_cuda.conda
linux-64::vtk-base-9.2.6-qt_py311h1234567_206.conda
linux-64::folly-2023.04.03.00-hf69079e_0.conda
linux-64::mysql-router-8.0.32-h247314d_2.conda
linux-64::lammps-2023.03.28-py310had8d3a2_mpich_2.conda
linux-64::raven-hydro-0.2.1-py311h14de304_0.conda
linux-64::panda3d-1.10.12-py38hf5c2c14_3.conda
linux-64::linux-perf-6.3.2-py39h43c8743_0.conda
linux-64::folly-2023.03.20.00-h5e7e832_4_jemalloc.conda
linux-64::gdstk-0.9.41-py39h6356eae_0.conda
linux-64::gst-plugins-bad-1.22.0-h69c2fec_1.conda
linux-64::cpp-opentelemetry-sdk-1.9.1-h3a04492_0.conda
linux-64::soplex-6.0.3-ha4ec6ac_2.conda
linux-64::qt6-main-6.5.0-h871d45a_7.conda
linux-64::mfront-4.1.0-py38h46abc22_1.conda
linux-64::arrow-cpp-8.0.1-py310h70ffa4b_31_cuda.conda
linux-64::wgrib2-3.1.2-h0db9b95_1.conda
linux-64::libpq-15.3-hbcd7760_1.conda
linux-64::llvmlite-0.40.0-py311ha6695c7_0.conda
linux-64::arrow-cpp-9.0.0-py310h4e03f60_35_cpu.conda
linux-64::conduit-0.8.8-py39hfc9f353_0.conda
linux-64::pillow-9.5.0-py39haaeba84_1.conda
linux-64::folly-2023.05.01.00-h5e7e832_0_jemalloc.conda
linux-64::ndcctools-7.5.4-py38h514f0f6_1.conda
linux-64::qt-main-5.15.8-h01ceb2d_12.conda
linux-64::conduit-0.8.8-py310h34734e4_0.conda
linux-64::llvm-tools-16.0.3-hbf9e925_0.conda
linux-64::triton-2.0.0-cuda110py310ha9dceb4_1.conda
linux-64::r-qpdf-1.3.2-r41h6d82397_2.conda
linux-64::libsoup-3.4.2-hb337396_1.conda
linux-64::plumed-2.9.0-mpi_mpich_hf90d2c9_0.conda
linux-64::folly-2023.04.24.00-hf69079e_0.conda
linux-64::llvm-15.0.7-ha0738ec_2.conda
linux-64::arrow-cpp-8.0.1-py38h102b5a6_32_cuda.conda
linux-64::mapserver-8.0.1-py39h38e269c_2.conda
linux-64::linux-perf-6.3.3-py38h3fbeceb_0.conda
linux-64::imagemagick-7.1.1_11-pl5321hf48ede7_0.conda
linux-64::imagemagick-7.1.1_9-pl5321hf48ede7_1.conda
linux-64::conduit-0.8.8-py38h21e7b15_0.conda
linux-64::mfront-3.2.1-py38h96aac5d_0.conda
linux-64::jaxlib-0.4.10-cuda112py39ha2564ec_200.conda
linux-64::pillow-9.5.0-py310h582fbeb_1.conda
linux-64::folly-2023.04.17.00-hda79706_0_jemalloc.conda
linux-64::linux-perf-6.3.1-py38h3fbeceb_0.conda
linux-64::ndcctools-7.5.3-py39h4841754_0.conda
linux-64::wxpython-4.2.0-py311h5c9e8ae_7.conda
linux-64::triton-2.0.0-cuda110py310ha9dceb4_0.conda
linux-64::libsoup-3.4.2-h6a603f4_0.conda
linux-64::aws-sdk-cpp-1.10.57-hce39858_11.conda
linux-64::libgdal-3.6.4-h272c690_3.conda
linux-64::linux-perf-6.3.1-py311h063b91e_0.conda
linux-64::libdwarf-0.7.0-hecc041a_0.conda
linux-64::llvmdev-16.0.3-h5cf9203_2.conda
linux-64::grpcio-1.55.0-py311ha6695c7_0.conda
linux-64::ndcctools-7.5.5-py38h514f0f6_0.conda
linux-64::arrow-cpp-9.0.0-py38h0f11917_36_cuda.conda
linux-64::mfront-3.3.2-py39h56ed60a_1.conda
linux-64::jaxlib-0.4.9-cuda112py310h1be305f_200.conda
linux-64::libxml2-2.11.4-h0d562d8_0.conda
linux-64::libspatialite-5.0.1-hb46c372_26.conda
linux-64::dwarfdump-0.7.0-hecc041a_0.conda
linux-64::astrometry-0.94-py39h102dc7c_0.conda
linux-64::tiledb-2.15.2-hebec990_1.conda
linux-64::ndcctools-7.5.3-py310he2ed3e8_0.conda
linux-64::libgdal-3.6.4-h7239d12_1.conda
linux-64::raven-hydro-0.2.0-py39h5056a20_0.conda
linux-64::llvmdev-16.0.3-hbf9e925_0.conda
linux-64::pypy3.8-7.3.11-hc3ccb01_1.conda
linux-64::linux-perf-6.3.3-py39h43c8743_0.conda
linux-64::aws-sdk-cpp-1.11.68-h8101662_5.conda
linux-64::ambertools-23.0-py38h3974a27_1.conda
linux-64::arrow-cpp-8.0.1-py38h7a2a628_31_cpu.conda
linux-64::libgrpc-1.55.0-h59456c1_1.conda
linux-64::llvm-tools-16.0.4-h5cf9203_0.conda
linux-64::tiledb-2.15.3-hebec990_0.conda
linux-64::folly-2023.05.08.00-h80c46b9_0.conda
linux-64::mapserver-8.0.1-py38h2eae8a4_3.conda
linux-64::triton-2.0.0-cuda112py38h11896f8_1.conda
linux-64::libarrow-12.0.0-h9bd7ee1_2_cuda.conda
linux-64::folly-2023.05.01.00-hf69079e_0.conda
linux-64::aws-sdk-cpp-1.11.68-hb0b1f3a_2.conda
linux-64::cpp-opentelemetry-sdk-1.9.1-h268cab6_2.conda
linux-64::curl-8.1.0-h409715c_0.conda
linux-64::arrow-cpp-9.0.0-py39hcbcaf9a_35_cuda.conda
linux-64::mfront-3.2.1-py39h56ed60a_0.conda
linux-64::libnetcdf-4.9.2-mpi_mpich_h6e9ae28_5.conda
linux-64::pygplates-0.39-py39h495995e_7.conda
linux-64::raven-hydro-0.2.1-py38h0110233_1.conda
linux-64::mapserver-8.0.1-py38hd030fa6_2.conda
linux-64::ndcctools-7.5.4-py39h4841754_0.conda
linux-64::paraview-5.11.1-py39h4ad0bfc_101_qt.conda
linux-64::paraview-5.11.1-py39h9ef8f55_1_egl.conda
linux-64::panda3d-1.10.12-py311h980ec20_4.conda
linux-64::gst-plugins-bad-1.22.3-h57c5c21_1.conda
linux-64::raven-hydro-0.2.0-py310h3ce4ad4_0.conda
linux-64::mfront-3.3.2-py38h96aac5d_1.conda
linux-64::postgresql-plpython-14.5-py39h602d4f0_6.conda
linux-64::triton-2.0.0-cuda112py310he6af95e_0.conda
linux-64::gdstk-0.9.41-py38h5ec06fb_0.conda
linux-64::libopencv-4.7.0-py38h413103c_3.conda
linux-64::aws-sdk-cpp-1.11.68-h059227d_3.conda
linux-64::libopentelemetry-cpp-1.9.1-hedca983_2.conda
linux-64::gst-plugins-good-1.22.3-ha6f60c5_1.conda
linux-64::ffmpeg-5.1.2-gpl_hb250762_110.conda
linux-64::triton-2.0.0-cuda110py38h797e173_1.conda
linux-64::postgresql-plpython-15.3-py39ha97b618_0.conda
linux-64::libopencv-4.7.0-py310h245f934_4.conda
linux-64::lammps-2023.03.28-py39hb96d42f_openmpi_2.conda
linux-64::grpcio-1.55.0-py310h1b8f574_0.conda
linux-64::conduit-0.8.8-py38he11109b_0.conda
linux-64::omniorb-4.2.5-py310h735a52a_6.conda
linux-64::librdkafka-2.1.1-hfe68a65_0.conda
linux-64::raven-hydro-0.2.1-py38ha6b6fe4_1.conda
linux-64::paraview-5.11.1-py310h370ab5b_1_egl.conda
linux-64::llvm-openmp-16.0.4-h4dfa4b3_0.conda
linux-64::sqlite-3.42.0-h2c6b66d_0.conda
linux-64::libarrow-10.0.1-hc21d6b4_25_cuda.conda
linux-64::omniorb-libs-4.2.5-h9cb18e5_6.conda
linux-64::magic-8.3.384-h130c0f9_0.conda
linux-64::postgresql-plpython-14.5-py311h6958051_6.conda
linux-64::protozfits-2.2.0-py38h47c13de_0.conda
linux-64::wgrib2-3.1.2-hd234156_2.conda
linux-64::libopencv-4.7.0-py39h01ea3e4_4.conda
linux-64::hugin-2022.0.0-pl5321hc0cb56e_4.conda
linux-64::openconnect-9.12-h8f97634_0.conda
linux-64::postgresql-15.3-hd458b1d_1.conda
linux-64::lammps-2023.03.28-py38h7411a03_openmpi_2.conda
linux-64::raven-hydro-0.2.1-py39h191c732_1.conda
linux-64::openscenegraph-3.6.5-hcbd9b17_16.conda
linux-64::linux-perf-6.3.2-py311h063b91e_0.conda
linux-64::linux-perf-6.3.2-py38h3fbeceb_0.conda
linux-64::libarrow-12.0.0-h1cdf7b0_1_cpu.conda
linux-64::python-3.10.11-he550d4f_0_cpython.conda
linux-64::triton-2.0.0-cuda111py38h457c3dd_1.conda
linux-64::folly-2023.04.17.00-hf69079e_0.conda
linux-64::tiledb-2.15.2-h26774de_2.conda
linux-64::pillow-9.5.0-py311h0b84326_1.conda
linux-64::cairo-1.16.0-hbbf8b49_1016.conda
linux-64::arrow-cpp-8.0.1-py311h0184b6c_31_cpu.conda
linux-64::libglib-2.76.3-hebfc3b9_0.conda
linux-64::wasmer-3.3.0-he3b15a8_0.conda
linux-64::raven-hydro-0.2.1-py39h8e2dbb5_1.conda
linux-64::folly-2023.05.22.00-hf69079e_1.conda
linux-64::llvm-16.0.3-ha0738ec_2.conda
linux-64::scip-8.0.3-h4a32fe0_2.conda
linux-64::qt6-main-6.5.0-hae41e4f_6.conda
linux-64::folly-2023.03.27.00-h5e7e832_0_jemalloc.conda
linux-64::libgdal-3.6.4-hada8d5e_2.conda
linux-64::paraview-5.11.1-py39hd97540c_101_qt.conda
linux-64::arrow-cpp-9.0.0-py38h271401c_34_cuda.conda
linux-64::folly-2023.04.03.00-hda79706_0_jemalloc.conda
linux-64::folly-2023.05.22.00-hf69079e_0.conda
linux-64::sqlite-3.41.2-h2c6b66d_1.conda
linux-64::kitty-0.23.1-py310hdd748c9_3.conda
linux-64::mlir-16.0.3-hcd5def8_0.conda
linux-64::pygplates-0.39-py38h436afc7_7.conda
linux-64::mapserver-8.0.1-py311h7203c18_2.conda
linux-64::pygplates-0.39-py311hc649ae1_7.conda
linux-64::ncl-6.6.2-hcf71a85_46.conda
linux-64::postgresql-plpython-15.3-py310h4358bab_1.conda
linux-64::vigra-1.11.1-py38h615e33e_1042.conda
linux-64::arrow-cpp-9.0.0-py311h0184b6c_34_cpu.conda
linux-64::vigra-1.11.1-py38hf52dcb3_1042.conda
linux-64::libopencv-4.7.0-py38habc0419_4.conda
linux-64::arrow-cpp-9.0.0-py39h4160b5d_35_cpu.conda
linux-64::grpcio-1.55.0-py38h94a1851_0.conda
linux-64::triton-2.0.0-cuda111py38h457c3dd_0.conda
linux-64::libllvm16-16.0.4-h5cf9203_0.conda
linux-64::cpp-opentelemetry-sdk-1.9.0-h3a04492_3.conda
linux-64::grpcio-1.55.0-py39h174d805_0.conda
linux-64::cpp-opentelemetry-sdk-1.9.1-h7ee5030_1.conda
linux-64::r-qpdf-1.3.2-r42h6d82397_2.conda
linux-64::folly-2023.04.10.00-hda79706_0_jemalloc.conda
linux-64::sagelib-10.0-py311h9409a4c_0.conda
linux-64::vtk-base-9.2.6-osmesa_py39h1234567_105.conda
linux-64::llvm-tools-16.0.3-h5cf9203_2.conda
linux-64::libcurl-static-8.1.2-h409715c_0.conda
linux-64::libopencv-4.7.0-py39hee88a40_4.conda
linux-64::blosc-1.21.4-h0f2a231_0.conda
linux-64::pillow-9.5.0-py38hc4ca088_1.conda
linux-64::postgresql-plpython-15.3-py311h6958051_1.conda
linux-64::jaxlib-0.4.10-cpu_py310hc0ddb09_0.conda
linux-64::lpython-0.13.0-hfc55251_1.conda
linux-64::llvmlite-0.40.0-py38h7784e29_0.conda
linux-64::raven-hydro-0.2.0-py39h191c732_2.conda
linux-64::folly-2023.03.27.00-hda79706_0_jemalloc.conda
linux-64::libopentelemetry-cpp-1.9.1-h268cab6_2.conda
linux-64::ndcctools-7.5.3-py38h514f0f6_0.conda
linux-64::llvmlite-0.40.0-py39h174d805_0.conda
linux-64::jaxlib-0.4.10-cuda112py38h2a7d48f_200.conda
linux-64::tectonic-0.13.1-h03309ca_0.conda
linux-64::papilo-2.1.2-h7134f8c_2.conda
linux-64::libarrow-12.0.0-hb3168b4_4_cuda.conda
linux-64::mfront-3.3.2-py39h56ed60a_0.conda
linux-64::vtk-base-9.2.6-qt_py38h1234567_205.conda
linux-64::paraview-5.11.1-py310hbacfc04_101_qt.conda
linux-64::postgresql-plpython-15.3-py39h602d4f0_1.conda
linux-64::libpq-15.3-hbcd7760_0.conda
linux-64::libopentelemetry-cpp-1.9.1-h3a04492_0.conda
linux-64::vtk-base-9.2.6-egl_py311h1234567_6.conda
linux-64::folly-2023.04.10.00-h80c46b9_0.conda
linux-64::gdstk-0.9.41-py311h75db532_0.conda
linux-64::gst-plugins-bad-1.22.3-h57c5c21_0.conda
linux-64::conduit-0.8.8-py39h4f27557_0.conda
linux-64::netpbm-10.73.43-pl5321h28740c6_1.conda
linux-64::vtk-base-9.2.6-qt_py38h1234567_206.conda
linux-64::nexus-4.4.3-h4456b2f_9.conda
linux-64::vtk-base-9.2.6-qt_py39h1234567_205.conda
linux-64::llvm-16.0.3-h110208f_1.conda
linux-64::paraview-5.11.1-py311h81197b7_1_egl.conda
linux-64::linux-perf-6.3.1-py39h43c8743_0.conda
linux-64::folly-2023.03.20.00-h80c46b9_4.conda
linux-64::raven-hydro-0.2.0-py311h14de304_2.conda
linux-64::folly-2023.05.15.00-h80c46b9_0.conda
linux-64::mupdf-1.22.1-h46340d1_0.conda
linux-64::triton-2.0.0-cuda111py310hacfba7e_1.conda
linux-64::panda3d-1.10.12-py38h5a25a97_4.conda
linux-64::rust-1.69.0-h70c747d_2.conda
linux-64::jaxlib-0.4.10-cpu_py38hb25f6ba_0.conda
linux-64::raven-hydro-0.2.0-py310h3ce4ad4_2.conda
linux-64::fossil-2.22-h5158675_0.conda
linux-64::postgresql-plpython-15.3-py38hb110b9d_0.conda
linux-64::llvmlite-0.40.0-py39h7d5b425_0.conda
linux-64::folly-2023.05.22.00-h80c46b9_1.conda
linux-64::openjdk-11.0.15-h19c1b89_4.conda
linux-64::libarchive-3.6.2-h039dbb9_1.conda
linux-64::folly-2023.05.08.00-hda79706_0_jemalloc.conda
linux-64::jaxlib-0.4.10-cpu_py311h7b5b818_0.conda
linux-64::mapserver-8.0.1-py310hbdfb2f8_3.conda
linux-64::conduit-0.8.8-py310hac8f8c0_0.conda
linux-64::tiledb-2.15.2-hebec990_2.conda
linux-64::lld-16.0.3-hff4d9d6_0.conda
linux-64::triton-2.0.0-cuda112py38h11896f8_0.conda
linux-64::libnetcdf-4.9.2-nompi_h0f3d0bb_105.conda
linux-64::folly-2023.03.20.00-hda79706_4_jemalloc.conda
linux-64::vtk-base-9.2.6-egl_py39h1234567_5.conda
linux-64::folly-2023.04.10.00-h5e7e832_0_jemalloc.conda
linux-64::aws-sdk-cpp-1.10.57-h059227d_13.conda
linux-64::panda3d-1.10.12-py39h6ee992c_3.conda
linux-64::libopencv-4.7.0-py38hf2e4d04_4.conda
linux-64::libgdal-3.5.3-h89c0d6d_28.conda
linux-64::arrow-cpp-9.0.0-py39hb423e0c_36_cuda.conda
linux-64::mold-1.11.0-h913df21_0.conda
linux-64::arrow-cpp-9.0.0-py310hcc3d841_34_cpu.conda
linux-64::protozfits-2.2.0-py311hce45070_0.conda
linux-64::folly-2023.05.08.00-hf69079e_0.conda
linux-64::libopencv-4.7.0-py310hbab4fdf_3.conda
linux-64::wxpython-4.2.0-py38hb9b80a8_7.conda
linux-64::pyinstaller-5.11.0-py310h93c3562_0.conda
linux-64::lld-16.0.4-hcfcaf08_0.conda
linux-64::arrow-cpp-8.0.1-py310hcc3d841_31_cpu.conda
linux-64::arrow-cpp-8.0.1-py39h5d797e4_31_cuda.conda
linux-64::libllvm16-16.0.3-h5cf9203_2.conda
linux-64::folly-2023.05.22.00-h80c46b9_0.conda
linux-64::hugin-base-2022.0.0-pl5321h8b39be8_4.conda
linux-64::grpcio-1.55.0-py310h1b8f574_1.conda
linux-64::raven-hydro-0.2.1-py39h5056a20_1.conda
linux-64::libopentelemetry-cpp-1.9.0-h3a04492_3.conda
linux-64::paraview-5.11.1-py311h502b6f9_101_qt.conda
linux-64::raven-hydro-0.2.0-py38h0110233_2.conda
linux-64::folly-2023.04.24.00-hda79706_0_jemalloc.conda
linux-64::vtk-base-9.2.6-osmesa_py39h1234567_106.conda
linux-64::raven-hydro-0.2.1-py38h326e3f4_0.conda
linux-64::panda3d-1.10.12-py310hf3d1b8c_3.conda
linux-64::conduit-0.8.8-py39hbe7aed1_0.conda
linux-64::folly-2023.05.22.00-h5e7e832_1_jemalloc.conda
linux-64::panda3d-1.10.12-py311h4bb40f4_3.conda
linux-64::lammps-2023.03.28-py310h578e4bf_openmpi_2.conda
linux-64::folly-2023.05.01.00-h80c46b9_0.conda
linux-64::ffmpeg-5.1.2-gpl_h4a169a1_107.conda
linux-64::mapserver-8.0.1-py39h878a431_3.conda
linux-64::arrow-cpp-9.0.0-py38h225b9df_36_cpu.conda
linux-64::libcurl-static-8.1.0-h409715c_0.conda
linux-64::rust-1.69.0-h70c747d_3.conda
linux-64::postgresql-14.5-hd458b1d_6.conda
linux-64::libarrow-10.0.1-hf815326_25_cpu.conda
linux-64::arrow-cpp-9.0.0-py310hdd59ffc_36_cuda.conda
linux-64::ffmpeg-6.0.0-gpl_hc9fb8ae_101.conda
linux-64::omniorb-4.2.5-py39h1c1d4ea_6.conda
linux-64::vigra-1.11.1-py310h939b2f9_1042.conda
linux-64::qt6-3d-6.5.1-hcdfd84b_0.conda
linux-64::postgresql-plpython-15.3-py311heef5088_0.conda
linux-64::mfront-4.1.0-py310he126ae4_1.conda
linux-64::folly-2023.05.22.00-h5e7e832_0_jemalloc.conda
linux-64::folly-2023.05.15.00-hf69079e_0.conda
linux-64::libarrow-12.0.0-h6564b11_2_cpu.conda
linux-64::linux-perf-6.3.2-py310h2f7a385_0.conda
linux-64::jaxlib-0.4.9-cpu_py310hc0ddb09_0.conda
linux-64::loos-4.0.4-py38h94d54b6_2.conda
linux-64::loos-4.0.4-py39h0ec44d4_1.conda
linux-64::conduit-0.8.8-py38hb3db638_0.conda
linux-64::gdstk-0.9.41-py38h7e89657_0.conda
linux-64::libopencv-4.7.0-py310h2947053_3.conda
linux-64::vtk-base-9.2.6-egl_py310h1234567_6.conda
linux-64::libarrow-11.0.0-h1cdf7b0_19_cpu.conda
linux-64::mosh-1.4.0-pl5321h4605741_1.conda
linux-64::ambertools-23.0-py39h4856ba4_0.conda
linux-64::libopencv-4.7.0-py38ha410d47_3.conda
linux-64::hdfeos5-5.1.16-hc55c121_11.conda
linux-64::arrow-cpp-9.0.0-py38h102b5a6_35_cuda.conda
linux-64::postgresql-plpython-15.3-py310hc6d6dec_0.conda
linux-64::libopentelemetry-cpp-1.9.1-h7ee5030_1.conda
linux-64::mlir-16.0.4-hcd5def8_0.conda
linux-64::poppler-qt-23.05.0-hedeba34_1.conda
linux-64::mfront-3.3.2-py311hc1da77b_1.conda
linux-64::grpcio-1.55.0-py38h94a1851_1.conda
linux-64::postgresql-plpython-15.3-py38h260f7d5_1.conda
linux-64::panda3d-1.10.12-py310h66e5b31_4.conda
linux-64::raven-hydro-0.2.1-py38h326e3f4_1.conda
linux-64::poppler-23.05.0-hd18248d_1.conda
linux-64::tectonic-0.12.0-hc1a2f9b_2.conda
linux-64::libcurl-8.1.0-h409715c_0.conda
linux-64::libopencv-4.7.0-py38ha410d47_4.conda
linux-64::qt6-main-6.5.0-ha2ff4f7_8.conda
linux-64::kaldi-5.5.1068-cuda110h4284680_0.conda
linux-64::mfront-3.3.2-py310heb670ec_0.conda
linux-64::libarrow-11.0.0-h45d318b_19_cuda.conda
linux-64::llvmdev-16.0.3-hbf9e925_1.conda
linux-64::libopencv-4.7.0-py311hc926134_3.conda
linux-64::libgdal-arrow-parquet-3.6.4-h050f149_3.conda
linux-64::raven-hydro-0.2.0rc0-py39h5056a20_0.conda
linux-64::libarrow-12.0.0-h45d318b_1_cuda.conda
linux-64::ffmpeg-5.1.2-gpl_h9866456_109.conda
linux-64::libxml2-2.11.3-h0d562d8_0.conda
linux-64::panda3d-1.10.12-py311h56a55ed_3.conda
linux-64::vigra-1.11.1-py310h91ccf9f_1042.conda
linux-64::libopentelemetry-cpp-1.9.0-h3a04492_2.conda
linux-64::lammps-2023.03.28-py38h15135a8_mpich_2.conda
linux-64::vtk-base-9.2.6-qt_py310h1234567_206.conda
linux-64::cpp-opentelemetry-sdk-1.9.0-h3a04492_2.conda
linux-64::r-qpdf-1.3.2-r42h31c590b_1.conda
linux-64::libopencv-4.7.0-py39hb8940a9_3.conda
linux-64::libxml2-2.11.3-h0d562d8_1.conda
linux-64::arrow-cpp-9.0.0-py311hc42b95b_36_cpu.conda
linux-64::loos-4.0.4-py39h0ec44d4_2.conda
linux-64::libxmlsec1-1.3.0-h9a021bc_1.conda
linux-64::gdstk-0.9.41-py39h2b14ec4_0.conda
linux-64::paraview-5.11.1-py39h752b10b_1_egl.conda
linux-64::libgdal-arrow-parquet-3.6.4-h31bbf47_1.conda
linux-64::vtk-base-9.2.6-osmesa_py310h1234567_105.conda
linux-64::triton-2.0.0-cuda110py38h797e173_0.conda
linux-64::qt6-wayland-6.5.0-h67b3eb1_0.conda
linux-64::glib-2.76.3-hfc55251_0.conda
linux-64::arrow-cpp-9.0.0-py38hc3817f7_35_cpu.conda
linux-64::libxml2-2.11.3-h0d562d8_2.conda
linux-64::libgdal-3.5.3-h2a8271e_27.conda
linux-64::pdal-2.5.4-h4d2ec2e_1.conda
linux-64::vtk-base-9.2.6-egl_py311h1234567_5.conda
linux-64::ffmpeg-5.1.2-lgpl_h06812e1_10.conda
linux-64::clangdev-14.0.6-default_h7634d5b_1.conda
linux-64::raven-hydro-0.2.1-py39h191c732_0.conda
linux-64::llvm-16.0.4-ha0738ec_0.conda
linux-64::libortools-9.6-h8d02792_1.conda
linux-64::raven-hydro-0.2.1-py311h64a4d7b_1.conda
linux-64::ffmpeg-6.0.0-lgpl_h5cc4593_1.conda
linux-64::astrometry-0.94-py310h9571af7_0.conda
linux-64::aws-sdk-cpp-1.11.68-h03e98ba_4.conda
linux-64::mfront-3.3.2-py310heb670ec_1.conda
linux-64::vigra-1.11.1-py311hbbb49f4_1042.conda
linux-64::libcurl-static-8.1.1-h409715c_0.conda
linux-64::folly-2023.04.03.00-h80c46b9_0.conda
linux-64::ortools-python-9.6-py38hc5af39d_1.conda
linux-64::libopencv-4.7.0-py39h0cf8573_3.conda
linux-64::folly-2023.04.03.00-h5e7e832_0_jemalloc.conda
linux-64::arrow-cpp-8.0.1-py310h4e03f60_32_cpu.conda
linux-64::vigra-1.11.1-py38h22f8ba8_1042.conda
linux-64::astrometry-0.94-py39h8a23525_0.conda
linux-64::cpp-opentelemetry-sdk-1.9.1-h3a04492_1.conda
linux-64::panda3d-1.10.12-py310h5721cee_4.conda
linux-64::folly-2023.05.22.00-hda79706_0_jemalloc.conda
linux-64::folly-2023.05.22.00-hda79706_1_jemalloc.conda
linux-64::vtk-base-9.2.6-osmesa_py38h1234567_106.conda
linux-64::panda3d-1.10.12-py310h9ffe736_3.conda
linux-64::aria2-1.36.0-h43d1f13_4.conda
linux-64::raven-hydro-0.2.1-py310h3ce4ad4_0.conda
linux-64::ndcctools-7.5.4-py310he2ed3e8_1.conda
linux-64::libgrpc-1.52.1-hb20ce57_2.conda
linux-64::triton-2.0.0-cuda111py39h0c7cf85_1.conda
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
```

</details>