### PR TITLE
remove optional dependencies from ray constraint in awswrangler

### DIFF
--- a/recipe/README.md
+++ b/recipe/README.md
@@ -119,7 +119,7 @@ then:
       new: ${old},<1.4.0  # you can refer to the "old" value as well
 
   # rename a dependency - this preserves the version information and simply renames the package
-  - rename_depends:
+  - rename_<depends or constrains>:
       # str of thing to be renamed
       old: matplotlib
       # new name for thing

--- a/recipe/patch_yaml/awswrangler.yaml
+++ b/recipe/patch_yaml/awswrangler.yaml
@@ -1,0 +1,8 @@
+# https://github.com/conda-forge/awswrangler-feedstock/pull/126
+if:
+  name: awswrangler
+  subdir_in: noarch
+then:
+  - rename_constrains: 
+      old: "ray[default,data]"
+      new: ray

--- a/recipe/patch_yaml/awswrangler.yaml
+++ b/recipe/patch_yaml/awswrangler.yaml
@@ -2,7 +2,8 @@
 if:
   name: awswrangler
   subdir_in: noarch
+  timestamp_lt: 1717407771000
 then:
-  - rename_constrains: 
+  - rename_constrains:
       old: "ray[default,data]"
       new: ray

--- a/recipe/patch_yaml_utils.py
+++ b/recipe/patch_yaml_utils.py
@@ -246,16 +246,12 @@ def _replace_pin(old_pin, new_pin, deps, record, target="depends"):
 def _rename_dependency(fn, record, old_name, new_name, target="depends"):
     if target not in ("depends", "constrains"):
         raise ValueError(target)
-
     if target not in record:
         return
-
     specs = record[target]
-    
     dep_idx = next(
         (q for q, dep in enumerate(specs) if dep.split(" ")[0] == old_name), None
     )
-    
     if dep_idx is not None:
         parts = specs[dep_idx].split(" ")
         remainder = (" " + " ".join(parts[1:])) if len(parts) > 1 else ""
@@ -501,7 +497,7 @@ def _apply_patch_yaml(patch_yaml, record, subdir, fn):
                     record,
                     _maybe_process_template(v["old"], record, subdir),
                     _maybe_process_template(v["new"], record, subdir),
-                    target=subk
+                    target=subk,
                 )
 
             elif k == "relax_exact_depends":

--- a/recipe/patch_yaml_utils.py
+++ b/recipe/patch_yaml_utils.py
@@ -243,16 +243,24 @@ def _replace_pin(old_pin, new_pin, deps, record, target="depends"):
             record[target].pop(i)
 
 
-def _rename_dependency(fn, record, old_name, new_name):
-    depends = record["depends"]
+def _rename_dependency(fn, record, old_name, new_name, target="depends"):
+    if target not in ("depends", "constrains"):
+        raise ValueError(target)
+
+    if target not in record:
+        return
+
+    specs = record[target]
+    
     dep_idx = next(
-        (q for q, dep in enumerate(depends) if dep.split(" ")[0] == old_name), None
+        (q for q, dep in enumerate(specs) if dep.split(" ")[0] == old_name), None
     )
+    
     if dep_idx is not None:
-        parts = depends[dep_idx].split(" ")
+        parts = specs[dep_idx].split(" ")
         remainder = (" " + " ".join(parts[1:])) if len(parts) > 1 else ""
-        depends[dep_idx] = new_name + remainder
-        record["depends"] = depends
+        specs[dep_idx] = new_name + remainder
+        record[target] = specs
 
 
 def pad_list(lst, num):
@@ -483,12 +491,17 @@ def _apply_patch_yaml(patch_yaml, record, subdir, fn):
                             target=subk,
                         )
 
-            elif k == "rename_depends":
+            elif k.startswith("rename_") and k[len("rename_") :] in [
+                "depends",
+                "constrains",
+            ]:
+                subk = k[len("rename_") :]
                 _rename_dependency(
                     fn,
                     record,
                     _maybe_process_template(v["old"], record, subdir),
                     _maybe_process_template(v["new"], record, subdir),
+                    target=subk
                 )
 
             elif k == "relax_exact_depends":


### PR DESCRIPTION
Checklist

* [ ] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

See: https://github.com/conda-forge/awswrangler-feedstock/pull/126

```
================================================================================
================================================================================
noarch
noarch::awswrangler-3.0.0-pyhd8ed1ab_0.conda
noarch::awswrangler-3.1.1-pyhd8ed1ab_0.conda
noarch::awswrangler-3.2.0-pyhd8ed1ab_0.conda
noarch::awswrangler-3.2.1-pyhd8ed1ab_0.conda
-    "ray[default,data] >=2.0.0,<2.4.0",
+    "ray >=2.0.0,<2.4.0",
noarch::awswrangler-3.4.0-pyhd8ed1ab_0.conda
noarch::awswrangler-3.3.0-pyhd8ed1ab_0.conda
noarch::awswrangler-3.4.1-pyhd8ed1ab_0.conda
noarch::awswrangler-3.4.2-pyhd8ed1ab_0.conda
-    "ray[default,data] >=2.0.0,<2.7.0",
+    "ray >=2.0.0,<2.7.0",
noarch::awswrangler-3.7.3-pyhd8ed1ab_0.conda
noarch::awswrangler-3.7.2-pyhd8ed1ab_0.conda
noarch::awswrangler-3.7.0-pyhd8ed1ab_0.conda
noarch::awswrangler-3.5.1-pyhd8ed1ab_0.conda
noarch::awswrangler-3.7.1-pyhd8ed1ab_0.conda
noarch::awswrangler-3.6.0-pyhd8ed1ab_0.conda
noarch::awswrangler-3.5.2-pyhd8ed1ab_0.conda
noarch::awswrangler-3.5.0-pyhd8ed1ab_0.conda
-    "ray[default,data] >=2.9.0,<3.0.0",
+    "ray >=2.9.0,<3.0.0",
```