### PR TITLE
loosen zlib-pin to major level (18/N; December 2022)

### DIFF
--- a/recipe/patch_yaml/zlib.yaml
+++ b/recipe/patch_yaml/zlib.yaml
@@ -151,3 +151,12 @@ then:
   - loosen_depends:
       name: libzlib
       upper_bound: "2"
+---
+if:
+  has_depends: libzlib >=1.2*
+  timestamp_lt: 1672531200000  # 2023-01-01 00:00 UTC
+  timestamp_ge: 1669852800000  # 2022-12-01 00:00 UTC
+then:
+  - loosen_depends:
+      name: libzlib
+      upper_bound: "2"


### PR DESCRIPTION
Follow-up to https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/739, about 4200 artefacts affected.

### Result of `python show_diff.py`

<details>

```diff
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
osx-arm64::libgdal-3.5.3-hb5190eb_9.conda
osx-arm64::libssh-0.10.4-h631333d_3.conda
osx-arm64::libpano13-2.9.20rc2-pl5321h2cef87d_4.conda
osx-arm64::arrow-cpp-9.0.0-py310h627cc0f_12_cpu.conda
osx-arm64::libvips-8.13.3-h116b2fc_3.conda
osx-arm64::arrow-cpp-9.0.0-py310h074efd1_13_cpu.conda
osx-arm64::imagecodecs-2022.12.22-py310hdf9a3a5_0.conda
osx-arm64::postgresql-15.1-h45c140d_2.conda
osx-arm64::aws-sdk-cpp-1.10.27-h7a0aef1_0.conda
osx-arm64::arrow-cpp-9.0.0-py311hcbf1517_11_cpu.conda
osx-arm64::ale-py-0.8.0-py39hdb76652_1.conda
osx-arm64::aws-sdk-cpp-1.10.28-h0d16128_0.conda
osx-arm64::postgresql-plpython-15.1-py38he4ed30e_1.conda
osx-arm64::arrow-cpp-7.0.1-py38h612026e_11_cpu.conda
osx-arm64::aws-sdk-cpp-1.10.38-hb0e8427_0.conda
osx-arm64::postgresql-plpython-14.5-py310h7ef1f41_2.conda
osx-arm64::ale-py-0.8.0-py310h168fa61_2.conda
osx-arm64::postgresql-plpython-14.5-py39hfbcb2bf_2.conda
osx-arm64::arrow-cpp-8.0.1-py311h86efc9c_10_cpu.conda
osx-arm64::libopencv-4.6.0-py311h703949b_9.conda
osx-arm64::graphicsmagick-1.3.37-h4331071_0.conda
osx-arm64::aws-sdk-cpp-1.10.20-h7a0aef1_0.conda
osx-arm64::libgdal-3.4.3-hd25ad38_1.conda
osx-arm64::postgresql-plpython-14.5-py38he4ed30e_4.conda
osx-arm64::arrow-cpp-8.0.1-py311hadc3bdf_11_cpu.conda
osx-arm64::dcap-2.47.12-h9ad5d7c_6.conda
osx-arm64::postgresql-plpython-14.5-py311h3157436_3.conda
osx-arm64::arrow-cpp-7.0.1-py39h66e0e44_11_cpu.conda
osx-arm64::arrow-cpp-7.0.1-py311h1fcef70_12_cpu.conda
osx-arm64::aws-sdk-cpp-1.10.31-h7a0aef1_0.conda
osx-arm64::libarrow-10.0.1-h10410d3_0_cpu.conda
osx-arm64::netcdf4-1.6.0-mpi_openmpi_py311h157bc16_3.conda
osx-arm64::xrootd-5.5.1-py39ha964134_3.conda
osx-arm64::jaxlib-0.4.1-cpu_py38ha029f96_1.conda
osx-arm64::arrow-cpp-8.0.1-py310h5b20de6_13_cpu.conda
osx-arm64::sdl_image-1.2.12-h59d9d18_3.conda
osx-arm64::libgdal-3.5.3-h4b2bd58_11.conda
osx-arm64::netcdf4-1.6.0-mpi_openmpi_py310h3b2823a_3.conda
osx-arm64::arrow-cpp-6.0.2-py38hfd9115e_8_cpu.conda
osx-arm64::tesseract-5.3.0-heffc8ea_0.conda
osx-arm64::arrow-cpp-6.0.2-py310hb05ad4b_8_cpu.conda
osx-arm64::libitk-5.3.0-ha86bd1f_2.conda
osx-arm64::paraview-5.11.0-py311h304ec7d_101_qt.conda
osx-arm64::arrow-cpp-7.0.1-py38h683db37_12_cpu.conda
osx-arm64::libopencv-4.6.0-py311h8f65ed9_7.conda
osx-arm64::aws-sdk-cpp-1.10.31-h0d16128_0.conda
osx-arm64::arrow-cpp-6.0.2-py311h8ea1e70_8_cpu.conda
osx-arm64::libarchive-3.6.2-h83f22c9_0.conda
osx-arm64::libgdal-3.6.0-h8eb8d95_11.conda
osx-arm64::aws-sdk-cpp-1.10.36-he22300a_0.conda
osx-arm64::imagemagick-7.1.0_53-pl5321h60b8f5c_0.conda
osx-arm64::postgresql-plpython-15.1-py39hab893bc_2.conda
osx-arm64::ovito-3.7.12-h24bc78c_0.conda
osx-arm64::aws-sdk-cpp-1.10.24-h7a0aef1_0.conda
osx-arm64::r-base-4.2.2-hf5a2755_2.conda
osx-arm64::qt6-3d-6.4.1-hde51eb9_2.conda
osx-arm64::folly-2022.12.12.00-h1234567_3_jemalloc.conda
osx-arm64::postgresql-plpython-14.5-py38h81ea511_3.conda
osx-arm64::gemmi-0.5.8-py310h1e34944_0.conda
osx-arm64::libcurl-7.86.0-hbe9bab4_2.conda
osx-arm64::qt-main-5.15.6-hda43d4a_5.conda
osx-arm64::hdf5-1.12.2-nompi_h55deafc_101.conda
osx-arm64::arrow-cpp-8.0.1-py38h2f5283c_11_cpu.conda
osx-arm64::vigra-1.11.1-py310hae0a153_1037.conda
osx-arm64::libgdal-3.6.0-hc1fcc79_13.conda
osx-arm64::aws-sdk-cpp-1.10.29-h7a0aef1_0.conda
osx-arm64::arrow-cpp-8.0.1-py311h6371423_13_cpu.conda
osx-arm64::postgresql-plpython-14.5-py39hab893bc_2.conda
osx-arm64::arrow-cpp-9.0.0-py38h653a517_15_cpu.conda
osx-arm64::ffmpeg-4.4.2-lgpl_hb1a5ad0_12.conda
osx-arm64::aws-sdk-cpp-1.10.21-h7a0aef1_0.conda
osx-arm64::aws-sdk-cpp-1.10.35-he22300a_0.conda
osx-arm64::heyoka-0.20.0-he3cf1e5_0.conda
osx-arm64::arrow-cpp-8.0.1-py39h0526b3f_9_cpu.conda
osx-arm64::postgresql-plpython-14.5-py310hfb75807_2.conda
osx-arm64::orc-1.8.1-hef0d403_0.conda
osx-arm64::arrow-cpp-9.0.0-py311h6371423_15_cpu.conda
osx-arm64::chemicalite-2022.04.1-ha0a74e4_6.conda
osx-arm64::arrow-cpp-6.0.2-py310h7f9e94f_8_cpu.conda
osx-arm64::jaxlib-0.3.25-cpu_py39h5dfa362_1.conda
osx-arm64::libarrow-10.0.1-hc0a4ee7_2_cpu.conda
osx-arm64::libcurl-7.87.0-h9049daf_0.conda
osx-arm64::libgdal-3.5.3-h1258dd4_9.conda
osx-arm64::postgresql-plpython-14.5-py38he4ed30e_2.conda
osx-arm64::libcurl-static-7.86.0-hbe9bab4_2.conda
osx-arm64::paraview-5.11.0-py310h4942ca2_101_qt.conda
osx-arm64::libvips-8.13.3-h1edc360_4.conda
osx-arm64::libgdal-3.5.3-h7f92e72_12.conda
osx-arm64::tectonic-0.12.0-hc4dce4b_1.conda
osx-arm64::arrow-cpp-6.0.2-py310hf235b00_9_cpu.conda
osx-arm64::openmpi-4.1.4-h4e676fc_102.conda
osx-arm64::netcdf4-1.6.0-nompi_py310haaa361f_103.conda
osx-arm64::postgresql-plpython-15.1-py311h0aaaf5e_2.conda
osx-arm64::arrow-cpp-7.0.1-py38h488b50a_11_cpu.conda
osx-arm64::libgdal-arrow-parquet-3.6.1-hd33cf20_1.conda
osx-arm64::arrow-cpp-8.0.1-py39h7144bb3_13_cpu.conda
osx-arm64::netcdf4-1.6.0-nompi_py38he52ce97_103.conda
osx-arm64::aws-sdk-cpp-1.10.29-h0d16128_0.conda
osx-arm64::aws-sdk-cpp-1.10.41-hb0e8427_0.conda
osx-arm64::arrow-cpp-6.0.2-py311h17324de_9_cpu.conda
osx-arm64::tiledb-2.13.0-hc7ac4c9_1.conda
osx-arm64::arrow-cpp-8.0.1-py311h353c742_11_cpu.conda
osx-arm64::jaxlib-0.3.25-cpu_py39h99d3290_1.conda
osx-arm64::jaxlib-0.4.1-cpu_py310h58c045a_1.conda
osx-arm64::postgresql-plpython-15.1-py310hfb75807_1.conda
osx-arm64::aws-sdk-cpp-1.10.32-h0d16128_0.conda
osx-arm64::imagemagick-7.1.0_55-pl5321h059bd01_1.conda
osx-arm64::lammps-2022.06.23-py39h146d5b3_openmpi_5.conda
osx-arm64::arrow-cpp-9.0.0-py310h5b20de6_15_cpu.conda
osx-arm64::ale-py-0.8.0-py38h446a2b0_1.conda
osx-arm64::qt6-main-6.4.1-h572c9ff_6.conda
osx-arm64::arrow-cpp-9.0.0-py39h1e08873_13_cpu.conda
osx-arm64::arrow-cpp-8.0.1-py310hdb4f275_9_cpu.conda
osx-arm64::libpq-15.1-hbce9e56_2.conda
osx-arm64::aws-sdk-cpp-1.10.40-hb0e8427_0.conda
osx-arm64::hugin-base-2022.0.0-pl5321h0e46edd_0.conda
osx-arm64::ale-py-0.8.0-py311h7755536_2.conda
osx-arm64::gemmi-0.5.8-py311h7b25133_0.conda
osx-arm64::aws-sdk-cpp-1.10.42-hc7b7603_0.conda
osx-arm64::aws-sdk-cpp-1.10.40-he22300a_0.conda
osx-arm64::hugin-base-2022.0.0-pl5321h520be52_1.conda
osx-arm64::heyoka-llvm-12-0.20.0-h3c11831_0.conda
osx-arm64::aws-sdk-cpp-1.10.23-h0d16128_0.conda
osx-arm64::libgdal-3.6.1-hc4fb213_1.conda
osx-arm64::poppler-22.12.0-h9564b9f_1.conda
osx-arm64::aws-sdk-cpp-1.9.379-h38b2add_7.conda
osx-arm64::gst-plugins-base-1.21.3-h8b7775e_0.conda
osx-arm64::arrow-cpp-6.0.2-py311h8ab4ffe_7_cpu.conda
osx-arm64::gfortran_impl_osx-64-11.3.0-hdc8cc4b_27.conda
osx-arm64::magics-metview-batch-4.12.1-h7c981a8_2.conda
osx-arm64::arrow-cpp-8.0.1-py39he7897fc_12_cpu.conda
osx-arm64::netcdf4-1.6.0-mpi_mpich_py38h8a74167_3.conda
osx-arm64::libgdal-3.6.1-hf393d26_1.conda
osx-arm64::poppler-22.12.0-hae7f5f0_0.conda
osx-arm64::arrow-cpp-8.0.1-py39h1e08873_12_cpu.conda
osx-arm64::xrootd-5.5.1-py311h8ee6e45_3.conda
osx-arm64::harp-1.17-py39hb72c553_0.conda
osx-arm64::folly-2022.12.05.00-h1234567_3_jemalloc.conda
osx-arm64::ale-py-0.8.0-py39hdb76652_2.conda
osx-arm64::pytng-0.3.0-py38h2346e95_0.conda
osx-arm64::arrow-cpp-7.0.1-py311h3a4b41d_12_cpu.conda
osx-arm64::nco-5.1.3-hca8063b_2.conda
osx-arm64::paraview-5.11.0-py38hfc8db69_101_qt.conda
osx-arm64::arrow-cpp-8.0.1-py38h3746bec_11_cpu.conda
osx-arm64::ndcctools-7.4.16-py38hc1332ea_0.conda
osx-arm64::postgresql-plpython-14.5-py38h81ea511_2.conda
osx-arm64::heyoka-llvm-11-0.20.0-h0d59376_0.conda
osx-arm64::lammps-2022.06.23-py39h44150e4_mpich_5.conda
osx-arm64::imagemagick-7.1.0_54-pl5321h60b8f5c_0.conda
osx-arm64::arrow-cpp-7.0.1-py38hd66804d_9_cpu.conda
osx-arm64::imagecodecs-2022.9.26-py310hdf9a3a5_5.conda
osx-arm64::tiledb-2.13.0-h9bd36d0_1.conda
osx-arm64::arrow-cpp-9.0.0-py39h0526b3f_11_cpu.conda
osx-arm64::xrootd-5.5.1-py38h07c3c01_3.conda
osx-arm64::curl-7.86.0-hbe9bab4_2.conda
osx-arm64::libgdal-arrow-parquet-3.6.0-h30df1ad_13.conda
osx-arm64::aws-sdk-cpp-1.10.41-hc7b7603_1.conda
osx-arm64::libpq-14.5-hb650857_2.conda
osx-arm64::curl-7.87.0-h9049daf_0.conda
osx-arm64::libgdal-3.6.1-h522d41c_3.conda
osx-arm64::pytng-0.3.0-py311he179b1b_0.conda
osx-arm64::aws-sdk-cpp-1.10.34-he22300a_1.conda
osx-arm64::xrootd-5.5.1-py38hf1575a4_3.conda
osx-arm64::libgdal-3.5.3-h28a98fa_10.conda
osx-arm64::imagecodecs-2022.12.22-py38h5446371_0.conda
osx-arm64::libpq-15.1-h998ac43_1.conda
osx-arm64::netcdf4-1.6.0-nompi_py39h8ded8ba_103.conda
osx-arm64::arrow-cpp-7.0.1-py39h47dbc28_10_cpu.conda
osx-arm64::arrow-cpp-7.0.1-py310h08876ed_11_cpu.conda
osx-arm64::pillow-9.2.0-py311h627eb56_4.conda
osx-arm64::postgresql-15.1-hf80b784_1.conda
osx-arm64::libgdal-3.5.3-ha4d3e34_8.conda
osx-arm64::r-base-4.1.3-h0bdf8d0_5.conda
osx-arm64::imagecodecs-2022.9.26-py39h18f4f30_5.conda
osx-arm64::arrow-cpp-9.0.0-py39haacf7b3_13_cpu.conda
osx-arm64::ffmpeg-4.4.2-lgpl_h125f0f0_11.conda
osx-arm64::libarchive-3.6.2-h0a93236_0.conda
osx-arm64::jaxlib-0.4.1-cpu_py311hb2ca01d_1.conda
osx-arm64::postgresql-plpython-15.1-py310hfb75807_2.conda
osx-arm64::arrow-cpp-9.0.0-py310hdb4f275_11_cpu.conda
osx-arm64::ndcctools-7.4.16-py311hf06ad48_0.conda
osx-arm64::libgrpc-1.50.1-h503f348_0.conda
osx-arm64::gdstk-0.9.35-py310h1408f53_0.conda
osx-arm64::heyoka-llvm-15-0.20.0-hd417c94_0.conda
osx-arm64::qt6-3d-6.4.1-hde51eb9_3.conda
osx-arm64::imagecodecs-2022.12.24-py39h18f4f30_0.conda
osx-arm64::libgdal-3.6.0-h00b3b25_12.conda
osx-arm64::postgresql-plpython-15.1-py39hfbcb2bf_1.conda
osx-arm64::nco-5.1.3-ha1e0cd5_1.conda
osx-arm64::pdal-2.4.3-h2895cbe_4.conda
osx-arm64::netcdf4-1.6.0-mpi_openmpi_py39h671b1b9_3.conda
osx-arm64::aws-sdk-cpp-1.10.39-hb0e8427_0.conda
osx-arm64::postgresql-plpython-15.1-py39hab893bc_1.conda
osx-arm64::arrow-cpp-7.0.1-py38h3b5c1a1_10_cpu.conda
osx-arm64::arrow-cpp-8.0.1-py38h653a517_13_cpu.conda
osx-arm64::harp-1.17-py38h8b41f1f_0.conda
osx-arm64::tiledb-2.13.0-hc7ac4c9_0.conda
osx-arm64::ale-py-0.8.0-py39hdb76652_3.conda
osx-arm64::pytng-0.2.3-py39h4fa970e_1.conda
osx-arm64::arrow-cpp-9.0.0-py38h2f5283c_13_cpu.conda
osx-arm64::libopencv-4.6.0-py38hb58081f_9.conda
osx-arm64::harp-1.17-py310hb1b509d_0.conda
osx-arm64::arrow-cpp-8.0.1-py310h9ecba04_13_cpu.conda
osx-arm64::arrow-cpp-7.0.1-py310h8c1b5bd_12_cpu.conda
osx-arm64::arrow-cpp-9.0.0-py311haaa1460_14_cpu.conda
osx-arm64::lxml-4.9.2-py39h0520ce3_0.conda
osx-arm64::imagecodecs-2022.12.24-py38h5446371_0.conda
osx-arm64::libitk-5.3.0-h112da86_1.conda
osx-arm64::arrow-cpp-6.0.2-py39h886c37f_8_cpu.conda
osx-arm64::paraview-5.11.0-py38hbf7b021_101_qt.conda
osx-arm64::sdl2_image-2.6.2-hb71b326_3.conda
osx-arm64::libgdal-arrow-parquet-3.6.1-h38966d1_2.conda
osx-arm64::openconnect-9.01-h7be4144_6.conda
osx-arm64::arrow-cpp-7.0.1-py39h5352d5a_11_cpu.conda
osx-arm64::aws-sdk-cpp-1.10.24-h0d16128_0.conda
osx-arm64::ffmpeg-4.4.2-gpl_h4ccb4f7_111.conda
osx-arm64::netcdf4-1.6.0-nompi_py311hf175f78_103.conda
osx-arm64::cpp-opentelemetry-sdk-1.8.1-hb55f54b_1.conda
osx-arm64::arrow-cpp-8.0.1-py310h627cc0f_10_cpu.conda
osx-arm64::qt6-main-6.4.1-h167edd9_4.conda
osx-arm64::graphicsmagick-1.3.37-h3379935_1.conda
osx-arm64::postgresql-plpython-14.5-py311h0aaaf5e_4.conda
osx-arm64::aws-sdk-cpp-1.10.42-h38b2add_0.conda
osx-arm64::libarrow-10.0.1-hc5f4219_3_cpu.conda
osx-arm64::libgrpc-1.51.1-h55edf5b_0.conda
osx-arm64::arrow-cpp-7.0.1-py310ha10c464_10_cpu.conda
osx-arm64::ale-py-0.8.0-py311h7755536_3.conda
osx-arm64::paraview-5.11.0-py311h784fc5d_101_qt.conda
osx-arm64::jaxlib-0.4.1-cpu_py39h99d3290_1.conda
osx-arm64::heyoka-0.20.0-h7c6b765_0.conda
osx-arm64::libitk-5.3.0-h112da86_0.conda
osx-arm64::arrow-cpp-7.0.1-py310h2f19742_11_cpu.conda
osx-arm64::qt-main-5.15.6-h12604de_4.conda
osx-arm64::coda-2.24.1-py310hb1b509d_0.conda
osx-arm64::aws-sdk-cpp-1.10.26-h0d16128_0.conda
osx-arm64::gdstk-0.9.35-py39hacb9366_0.conda
osx-arm64::arrow-cpp-8.0.1-py311haaa1460_13_cpu.conda
osx-arm64::vigra-1.11.1-py38h4cb48ff_1037.conda
osx-arm64::libopencv-4.6.0-py39h9ebde8a_7.conda
osx-arm64::graphicsmagick-1.3.39-h3379935_0.conda
osx-arm64::libgdal-arrow-parquet-3.6.1-hc5b450d_3.conda
osx-arm64::pytng-0.2.3-py311he179b1b_1.conda
osx-arm64::netcdf4-1.6.0-mpi_mpich_py310h9db3456_3.conda
osx-arm64::smesh-9.9.0.0-h4a5f032_3.conda
osx-arm64::arrow-cpp-9.0.0-py39he7897fc_15_cpu.conda
osx-arm64::arrow-cpp-8.0.1-py310h074efd1_12_cpu.conda
osx-arm64::aws-sdk-cpp-1.10.30-h7a0aef1_0.conda
osx-arm64::lxml-4.9.2-py310h85b680a_0.conda
osx-arm64::postgresql-plpython-14.5-py39hfbcb2bf_4.conda
osx-arm64::gst-plugins-good-1.21.3-h7afbf54_0.conda
osx-arm64::pytng-0.3.0-py310h0292dfd_0.conda
osx-arm64::arrow-cpp-8.0.1-py38hdc54697_9_cpu.conda
osx-arm64::postgresql-plpython-15.1-py39hfbcb2bf_2.conda
osx-arm64::ale-py-0.8.0-py38h446a2b0_2.conda
osx-arm64::ndcctools-7.4.16-py310hbaff3d7_0.conda
osx-arm64::pyinstaller-5.7.0-py38hc53b772_0.conda
osx-arm64::postgresql-plpython-14.5-py311h0aaaf5e_3.conda
osx-arm64::arrow-cpp-7.0.1-py310hd72bb7d_9_cpu.conda
osx-arm64::postgresql-plpython-14.5-py39hab893bc_3.conda
osx-arm64::libssh-0.10.4-h6431875_3.conda
osx-arm64::libgrpc-1.51.1-h503f348_0.conda
osx-arm64::postgresql-plpython-15.1-py311h3157436_2.conda
osx-arm64::libgdal-3.5.3-h1ad68c0_12.conda
osx-arm64::aws-sdk-cpp-1.10.34-h7a0aef1_0.conda
osx-arm64::pdal-2.4.3-h1d203bf_5.conda
osx-arm64::aws-sdk-cpp-1.10.39-he22300a_0.conda
osx-arm64::postgresql-plpython-14.5-py38h81ea511_4.conda
osx-arm64::postgresql-plpython-15.1-py311h0aaaf5e_1.conda
osx-arm64::aws-sdk-cpp-1.10.22-h0d16128_0.conda
osx-arm64::arrow-cpp-9.0.0-py39h7144bb3_15_cpu.conda
osx-arm64::openmeeg-2.5.5-py38h7953b23_2.conda
osx-arm64::libtiff-4.5.0-heb92581_0.conda
osx-arm64::aws-sdk-cpp-1.9.379-hb0e8427_6.conda
osx-arm64::postgresql-plpython-15.1-py38h81ea511_1.conda
osx-arm64::r-base-4.2.2-heabe65b_3.conda
osx-arm64::arrow-cpp-9.0.0-py311hadc3bdf_13_cpu.conda
osx-arm64::arrow-cpp-8.0.1-py39h1e08873_11_cpu.conda
osx-arm64::gdk-pixbuf-2.42.8-h9bcf4fe_2.conda
osx-arm64::libgdal-3.4.3-h5b06229_1.conda
osx-arm64::arrow-cpp-6.0.2-py38he5e2e63_8_cpu.conda
osx-arm64::libpq-14.5-h1a28acd_4.conda
osx-arm64::libgdal-arrow-parquet-3.6.1-h18c7df3_3.conda
osx-arm64::postgresql-plpython-14.5-py311h3157436_4.conda
osx-arm64::lammps-2022.06.23-py310ha3f3991_openmpi_5.conda
osx-arm64::aws-sdk-cpp-1.9.379-he22300a_6.conda
osx-arm64::openmeeg-2.5.5-py311ha82dad6_2.conda
osx-arm64::postgresql-14.5-hdc8ad1f_4.conda
osx-arm64::gdstk-0.9.35-py311ha1cbdfd_0.conda
osx-arm64::geotiff-1.7.1-heeaeb2e_5.conda
osx-arm64::aws-sdk-cpp-1.10.34-hb0e8427_1.conda
osx-arm64::scip-8.0.3-h0b19ae7_0.conda
osx-arm64::postgresql-plpython-14.5-py310h7ef1f41_3.conda
osx-arm64::libgdal-3.6.1-h84315aa_2.conda
osx-arm64::gemmi-0.5.8-py39h8ca5d33_0.conda
osx-arm64::libgdal-arrow-parquet-3.6.1-h1d9202b_1.conda
osx-arm64::arrow-cpp-9.0.0-py38hdc54697_11_cpu.conda
osx-arm64::libopencv-4.6.0-py39hcd7568c_9.conda
osx-arm64::aws-sdk-cpp-1.10.21-h0d16128_0.conda
osx-arm64::gfortran_impl_osx-arm64-11.3.0-h2a9d086_27.conda
osx-arm64::sdl2_image-2.6.2-hc3f3f05_0.conda
osx-arm64::arrow-cpp-6.0.2-py311h2845aba_9_cpu.conda
osx-arm64::qt-main-5.15.6-h2166da0_3.conda
osx-arm64::jaxlib-0.3.25-cpu_py38h6beaf4d_1.conda
osx-arm64::imagemagick-7.1.0_56-pl5321h059bd01_0.conda
osx-arm64::heyoka-0.20.0-h3ad8ef3_0.conda
osx-arm64::arrow-cpp-6.0.2-py310hd4055c8_7_cpu.conda
osx-arm64::tesseract-5.2.0-h864804b_2.conda
osx-arm64::libarrow-10.0.1-h86e165f_1_cpu.conda
osx-arm64::arrow-cpp-7.0.1-py311h3a4b41d_11_cpu.conda
osx-arm64::aws-sdk-cpp-1.10.33-h7a0aef1_0.conda
osx-arm64::hdf5-1.12.2-mpi_mpich_h4e1c725_1.conda
osx-arm64::jaxlib-0.4.1-cpu_py310h7fcaf06_1.conda
osx-arm64::arrow-cpp-9.0.0-py38h653a517_14_cpu.conda
osx-arm64::jaxlib-0.3.25-cpu_py311h44f3c64_1.conda
osx-arm64::libopencv-4.6.0-py311h1f484ca_8.conda
osx-arm64::postgresql-plpython-15.1-py310h7ef1f41_2.conda
osx-arm64::imagecodecs-2022.12.24-py311h79be52a_0.conda
osx-arm64::postgresql-14.5-hf80b784_2.conda
osx-arm64::libmediainfo-22.12-h94a21ce_0.conda
osx-arm64::arrow-cpp-8.0.1-py310h074efd1_11_cpu.conda
osx-arm64::paraview-5.11.0-py39hc8bd62d_101_qt.conda
osx-arm64::jaxlib-0.4.1-cpu_py38h6beaf4d_1.conda
osx-arm64::arrow-cpp-6.0.2-py39h8d754bb_7_cpu.conda
osx-arm64::aws-sdk-cpp-1.10.37-he22300a_0.conda
osx-arm64::folly-2022.12.26.00-h1234567_3_jemalloc.conda
osx-arm64::libopencv-4.6.0-py310h57d381e_9.conda
osx-arm64::arrow-cpp-6.0.2-py38h5e5625d_7_cpu.conda
osx-arm64::aws-sdk-cpp-1.10.26-h7a0aef1_0.conda
osx-arm64::hdf5-1.12.2-mpi_openmpi_hcd39aa7_1.conda
osx-arm64::qtwebkit-5.212-hbfb98c5_7.conda
osx-arm64::postgresql-plpython-14.5-py310h7ef1f41_4.conda
osx-arm64::magics-4.12.1-h7c981a8_2.conda
osx-arm64::arrow-cpp-9.0.0-py310h9ecba04_15_cpu.conda
osx-arm64::libcurl-static-7.86.0-h9049daf_2.conda
osx-arm64::libcurl-7.87.0-hbe9bab4_0.conda
osx-arm64::heyoka-llvm-14-0.20.0-h685c03d_0.conda
osx-arm64::libgdal-arrow-parquet-3.6.0-h864aa58_12.conda
osx-arm64::arrow-cpp-7.0.1-py311hd7ab823_9_cpu.conda
osx-arm64::ale-py-0.8.0-py310h168fa61_3.conda
osx-arm64::libgdal-3.5.3-h4e9bc54_11.conda
osx-arm64::aws-sdk-cpp-1.10.38-he22300a_0.conda
osx-arm64::libopencv-4.6.0-py38hee6e03b_8.conda
osx-arm64::wxpython-4.2.0-py38hd04b11d_3.conda
osx-arm64::folly-2022.12.12.00-h1234567_3.conda
osx-arm64::papilo-2.1.2-h9cc07e0_0.conda
osx-arm64::coda-2.24.1-py311h4489670_0.conda
osx-arm64::libopencv-4.6.0-py310h5ab14b7_7.conda
osx-arm64::postgresql-plpython-14.5-py39hab893bc_4.conda
osx-arm64::pdal-2.4.3-h2bcfba7_4.conda
osx-arm64::libgdal-arrow-parquet-3.6.1-h4293b09_2.conda
osx-arm64::ffmpeg-4.4.2-gpl_hf318d42_112.conda
osx-arm64::libgdal-3.6.1-he8687b4_0.conda
osx-arm64::vigra-1.11.1-py311h5b1dc48_1037.conda
osx-arm64::libpq-14.5-h998ac43_3.conda
osx-arm64::arrow-cpp-6.0.2-py38h9355cf3_9_cpu.conda
osx-arm64::jaxlib-0.4.1-cpu_py39h5dfa362_1.conda
osx-arm64::postgresql-plpython-14.5-py311h3157436_2.conda
osx-arm64::postgresql-plpython-14.5-py311h0aaaf5e_2.conda
osx-arm64::sdl2_image-2.6.2-hc3f3f05_1.conda
osx-arm64::openconnect-9.01-hd591a71_5.conda
osx-arm64::aws-sdk-cpp-1.10.41-h38b2add_1.conda
osx-arm64::lammps-2022.06.23-py310h7f81c99_mpich_5.conda
osx-arm64::jaxlib-0.3.25-cpu_py310h58c045a_1.conda
osx-arm64::folly-2022.12.19.00-h1234567_3_jemalloc.conda
osx-arm64::postgresql-14.5-ha48369c_3.conda
osx-arm64::folly-2022.12.19.00-h1234567_3.conda
osx-arm64::pdal-2.4.3-h0b95922_5.conda
osx-arm64::qt6-3d-6.4.1-hd2b27f6_1.conda
osx-arm64::arrow-cpp-9.0.0-py38h2f5283c_14_cpu.conda
osx-arm64::aws-sdk-cpp-1.10.23-h7a0aef1_0.conda
osx-arm64::jaxlib-0.3.25-cpu_py38ha029f96_1.conda
osx-arm64::xrootd-5.5.1-py310h0005e94_3.conda
osx-arm64::arrow-cpp-9.0.0-py38h4c07622_15_cpu.conda
osx-arm64::libgdal-3.6.0-h8eb8d95_12.conda
osx-arm64::aws-sdk-cpp-1.10.37-hb0e8427_0.conda
osx-arm64::openssh-9.1p1-hbce9e56_1.conda
osx-arm64::heyoka-llvm-13-0.20.0-h6b9636b_0.conda
osx-arm64::postgresql-plpython-15.1-py38h81ea511_2.conda
osx-arm64::libgrpc-1.50.1-h55edf5b_0.conda
osx-arm64::pytng-0.2.3-py310h0292dfd_1.conda
osx-arm64::hdf5-1.12.2-mpi_openmpi_hf812ffc_1.conda
osx-arm64::arrow-cpp-9.0.0-py310h074efd1_14_cpu.conda
osx-arm64::arrow-cpp-9.0.0-py311h353c742_13_cpu.conda
osx-arm64::qt-main-5.15.6-h7b8d792_3.conda
osx-arm64::gdstk-0.9.35-py38hf6acb95_0.conda
osx-arm64::qt6-main-6.4.1-h5dc23fd_5.conda
osx-arm64::postgresql-15.1-ha48369c_1.conda
osx-arm64::aws-sdk-cpp-1.10.36-hb0e8427_0.conda
osx-arm64::gemmi-0.5.8-py38he6bf707_0.conda
osx-arm64::libgdal-arrow-parquet-3.6.0-hbe1719e_14.conda
osx-arm64::ndcctools-7.4.16-py39hfef7b1a_0.conda
osx-arm64::arrow-cpp-8.0.1-py311h353c742_12_cpu.conda
osx-arm64::wxpython-4.2.0-py311hf132ccb_3.conda
osx-arm64::magics-metview-4.12.1-hf55d45e_2.conda
osx-arm64::postgresql-plpython-14.5-py310hfb75807_4.conda
osx-arm64::lxml-4.9.2-py311h246f609_0.conda
osx-arm64::pytng-0.3.0-py39h4fa970e_0.conda
osx-arm64::imagecodecs-2022.12.22-py311h79be52a_0.conda
osx-arm64::arrow-cpp-7.0.1-py311hd41db94_11_cpu.conda
osx-arm64::hdf5-1.12.2-nompi_ha7af310_101.conda
osx-arm64::wxpython-4.2.0-py39hc712ad6_3.conda
osx-arm64::pyinstaller-5.7.0-py39h019302e_0.conda
osx-arm64::qt6-main-6.4.1-h4adae9c_6.conda
osx-arm64::libspatialite-5.0.1-h14115fc_23.conda
osx-arm64::openssh-9.1p1-h1a28acd_1.conda
osx-arm64::pillow-9.2.0-py310h5a7539a_4.conda
osx-arm64::arrow-cpp-7.0.1-py38h488b50a_12_cpu.conda
osx-arm64::arrow-cpp-7.0.1-py39h84aab3b_9_cpu.conda
osx-arm64::dcap-2.47.12-h763467d_6.conda
osx-arm64::lammps-2022.06.23-py38h0225e28_openmpi_5.conda
osx-arm64::paraview-5.11.0-py310h4a4ced6_101_qt.conda
osx-arm64::netcdf4-1.6.0-mpi_mpich_py39hd6d6928_3.conda
osx-arm64::arrow-cpp-6.0.2-py39h23d5898_9_cpu.conda
osx-arm64::wxwidgets-3.2.1-py311hc346f94_3.conda
osx-arm64::arrow-cpp-9.0.0-py310h5b20de6_14_cpu.conda
osx-arm64::libarrow-10.0.1-h6a31525_3_cpu.conda
osx-arm64::ale-py-0.8.0-py311h7755536_1.conda
osx-arm64::libarrow-10.0.1-haf415e0_0_cpu.conda
osx-arm64::libgdal-arrow-parquet-3.6.0-h6c5d58d_12.conda
osx-arm64::qt-main-5.15.6-h160f5ef_4.conda
osx-arm64::libpq-15.1-h1a28acd_2.conda
osx-arm64::libcurl-static-7.87.0-hbe9bab4_0.conda
osx-arm64::arrow-cpp-8.0.1-py38h2f5283c_12_cpu.conda
osx-arm64::folly-2022.12.26.00-h1234567_3.conda
osx-arm64::arrow-cpp-8.0.1-py310h5b20de6_12_cpu.conda
osx-arm64::qt6-main-6.4.1-hced4fab_3.conda
osx-arm64::libgdal-3.6.1-hf9f7efc_2.conda
osx-arm64::arrow-cpp-8.0.1-py311hcbf1517_9_cpu.conda
osx-arm64::libopencv-4.6.0-py39h8253260_8.conda
osx-arm64::xrootd-5.5.1-py310hd1b323b_3.conda
osx-arm64::arrow-cpp-8.0.1-py39h95ae5d6_10_cpu.conda
osx-arm64::ndcctools-7.4.16-py310he1c76cb_0.conda
osx-arm64::arrow-cpp-9.0.0-py310hf4c99e9_13_cpu.conda
osx-arm64::pyinstaller-5.7.0-py310h5d88ba1_0.conda
osx-arm64::postgresql-plpython-15.1-py311h3157436_1.conda
osx-arm64::ffmpeg-5.1.2-gpl_h4ccb4f7_104.conda
osx-arm64::git-2.39.0-pl5321h7727c56_0.conda
osx-arm64::arrow-cpp-8.0.1-py39he7897fc_13_cpu.conda
osx-arm64::postgresql-plpython-15.1-py310h7ef1f41_1.conda
osx-arm64::libarrow-10.0.1-hba65968_1_cpu.conda
osx-arm64::libgdal-arrow-parquet-3.6.0-hee9ae9f_14.conda
osx-arm64::aws-sdk-cpp-1.10.41-he22300a_0.conda
osx-arm64::vigra-1.11.1-py39h5d666f0_1037.conda
osx-arm64::postgresql-plpython-14.5-py38he4ed30e_3.conda
osx-arm64::libcurl-static-7.87.0-h9049daf_0.conda
osx-arm64::arrow-cpp-9.0.0-py39he7897fc_14_cpu.conda
osx-arm64::qt6-main-6.4.1-h167edd9_5.conda
osx-arm64::aws-sdk-cpp-1.10.27-h0d16128_0.conda
osx-arm64::arrow-cpp-7.0.1-py39h66e0e44_12_cpu.conda
osx-arm64::openmeeg-2.5.5-py310h1aab2e9_2.conda
osx-arm64::cpp-opentelemetry-sdk-1.8.1-h40dc6d1_0.conda
osx-arm64::arrow-cpp-6.0.2-py39hed174f7_8_cpu.conda
osx-arm64::coda-2.24.1-py39hb72c553_0.conda
osx-arm64::ffmpeg-5.1.2-lgpl_hb1a5ad0_5.conda
osx-arm64::graphviz-7.0.5-h4f8fbd6_0.conda
osx-arm64::arrow-cpp-9.0.0-py38h298f16f_12_cpu.conda
osx-arm64::arrow-cpp-8.0.1-py39haacf7b3_11_cpu.conda
osx-arm64::jaxlib-0.3.25-cpu_py310h7fcaf06_1.conda
osx-arm64::netcdf4-1.6.0-mpi_openmpi_py38h31dcd80_3.conda
osx-arm64::aws-sdk-cpp-1.10.35-hb0e8427_0.conda
osx-arm64::aws-sdk-cpp-1.10.33-h0d16128_0.conda
osx-arm64::libpq-14.5-hbce9e56_4.conda
osx-arm64::libgdal-arrow-parquet-3.6.0-hff328d4_13.conda
osx-arm64::libgdal-3.6.1-h7214a69_0.conda
osx-arm64::libopencv-4.6.0-py310h57eab40_8.conda
osx-arm64::aws-sdk-cpp-1.10.30-h0d16128_0.conda
osx-arm64::imagecodecs-2022.9.26-py38h5446371_5.conda
osx-arm64::jaxlib-0.3.25-cpu_py311hb2ca01d_1.conda
osx-arm64::geotiff-1.7.1-hdcdc974_6.conda
osx-arm64::openmeeg-2.5.5-py39h5996a6b_2.conda
osx-arm64::postgresql-plpython-15.1-py38he4ed30e_2.conda
osx-arm64::libarrow-10.0.1-h8916b46_2_cpu.conda
osx-arm64::arrow-cpp-9.0.0-py38h3746bec_13_cpu.conda
osx-arm64::ndcctools-7.4.16-py311hc81a0f4_0.conda
osx-arm64::ffmpeg-5.1.2-gpl_hf318d42_105.conda
osx-arm64::hdf5-1.12.2-mpi_mpich_ha18f50a_1.conda
osx-arm64::qt6-main-6.4.1-h5dc23fd_4.conda
osx-arm64::arrow-cpp-9.0.0-py311haaa1460_15_cpu.conda
osx-arm64::arrow-cpp-9.0.0-py311h353c742_14_cpu.conda
osx-arm64::arrow-cpp-8.0.1-py310hf4c99e9_11_cpu.conda
osx-arm64::xrootd-5.5.1-py39h00850fd_3.conda
osx-arm64::curl-7.87.0-hbe9bab4_0.conda
osx-arm64::libgdal-arrow-parquet-3.6.1-hbe1719e_0.conda
osx-arm64::curl-7.86.0-h9049daf_2.conda
osx-arm64::arrow-cpp-7.0.1-py39haadfdc3_12_cpu.conda
osx-arm64::libgdal-3.6.1-h94a8bcb_3.conda
osx-arm64::coda-2.24.1-py38h8b41f1f_0.conda
osx-arm64::ffmpeg-5.1.2-lgpl_h125f0f0_4.conda
osx-arm64::sdl2_image-2.6.2-hc3f3f05_2.conda
osx-arm64::arrow-cpp-8.0.1-py311haaa1460_12_cpu.conda
osx-arm64::openscenegraph-3.6.5-h51bb309_15.conda
osx-arm64::libcurl-7.86.0-h9049daf_2.conda
osx-arm64::arrow-cpp-9.0.0-py39h95ae5d6_12_cpu.conda
osx-arm64::ndcctools-7.4.16-py39h1c7e63e_0.conda
osx-arm64::libpq-14.5-h998ac43_2.conda
osx-arm64::arrow-cpp-6.0.2-py310hb05ad4b_9_cpu.conda
osx-arm64::ndcctools-7.4.16-py38h05a9a42_0.conda
osx-arm64::imagemagick-7.1.0_55-pl5321hec3de2e_0.conda
osx-arm64::soplex-6.0.3-h3da912a_0.conda
osx-arm64::folly-2022.12.05.00-h1234567_3.conda
osx-arm64::mlir-15.0.6-hcb86549_0.conda
osx-arm64::libtiff-4.4.0-heb92581_5.conda
osx-arm64::aws-sdk-cpp-1.10.32-h7a0aef1_0.conda
osx-arm64::aws-sdk-cpp-1.9.379-hc7b7603_7.conda
osx-arm64::netcdf4-1.6.0-mpi_mpich_py311h991e30d_3.conda
osx-arm64::arrow-cpp-8.0.1-py38h4c07622_13_cpu.conda
osx-arm64::harp-1.17-py311h4489670_0.conda
osx-arm64::arrow-cpp-9.0.0-py311h86efc9c_12_cpu.conda
osx-arm64::postgresql-plpython-14.5-py310hfb75807_3.conda
osx-arm64::cpp-opentelemetry-sdk-1.8.0-h40dc6d1_0.conda
osx-arm64::libpq-14.5-hb650857_3.conda
osx-arm64::libopencv-4.6.0-py38h6e4ee2f_7.conda
osx-arm64::aws-sdk-cpp-1.10.28-h7a0aef1_0.conda
osx-arm64::gst-plugins-good-1.21.3-h7afbf54_1.conda
osx-arm64::arrow-cpp-6.0.2-py311h2845aba_8_cpu.conda
osx-arm64::jaxlib-0.4.1-cpu_py311h44f3c64_1.conda
osx-arm64::arrow-cpp-9.0.0-py39h1e08873_14_cpu.conda
osx-arm64::aws-sdk-cpp-1.10.34-h0d16128_0.conda
osx-arm64::wxpython-4.2.0-py310h1f7849d_3.conda
osx-arm64::arrow-cpp-7.0.1-py310h2f19742_12_cpu.conda
osx-arm64::libgdal-arrow-parquet-3.6.1-hee9ae9f_0.conda
osx-arm64::libgdal-3.6.0-h00b3b25_11.conda
osx-arm64::pillow-9.2.0-py38h1bb68ce_4.conda
osx-arm64::postgresql-15.1-hdc8ad1f_2.conda
osx-arm64::postgresql-14.5-ha48369c_2.conda
osx-arm64::git-2.39.0-pl5321hd6a5f80_0.conda
osx-arm64::pytng-0.2.3-py38h2346e95_1.conda
osx-arm64::blosc-1.21.2-h1d6ff8b_0.conda
osx-arm64::arrow-cpp-6.0.2-py38he5e2e63_9_cpu.conda
osx-arm64::libgdal-3.5.3-h58c1bc0_8.conda
osx-arm64::arrow-cpp-6.0.2-py39h886c37f_9_cpu.conda
osx-arm64::openslide-3.4.1-ha537b0c_6.conda
osx-arm64::aws-sdk-cpp-1.10.20-h0d16128_0.conda
osx-arm64::postgresql-14.5-h45c140d_4.conda
osx-arm64::ale-py-0.8.0-py310h168fa61_1.conda
osx-arm64::pillow-9.2.0-py39h8bd98a6_4.conda
osx-arm64::ale-py-0.8.0-py38h446a2b0_3.conda
osx-arm64::lxml-4.9.2-py38h43d3e64_0.conda
osx-arm64::libarchive-minimal-static-3.6.2-hc8698cb_0.conda
osx-arm64::lammps-2022.06.23-py38hc96dc77_mpich_5.conda
osx-arm64::arrow-cpp-8.0.1-py38h298f16f_10_cpu.conda
osx-arm64::imagecodecs-2022.12.22-py39h18f4f30_0.conda
osx-arm64::postgresql-plpython-14.5-py39hfbcb2bf_3.conda
osx-arm64::libgdal-3.6.0-h2b43c17_13.conda
osx-arm64::qt-webengine-5.15.4-h3a00a3b_3.conda
osx-arm64::qt-main-5.15.6-ha0e8b26_4.conda
osx-arm64::blosc-1.21.3-h1d6ff8b_0.conda
osx-arm64::libgdal-3.6.0-h7214a69_14.conda
osx-arm64::gmsh-4.11.0-h83e6c55_1.conda
osx-arm64::paraview-5.11.0-py39hff8cb8e_101_qt.conda
osx-arm64::tiledb-2.13.0-h9bd36d0_0.conda
osx-arm64::arrow-cpp-7.0.1-py311h723d090_10_cpu.conda
osx-arm64::imagecodecs-2022.12.24-py310hdf9a3a5_0.conda
osx-arm64::libpq-15.1-hb650857_1.conda
osx-arm64::aws-sdk-cpp-1.10.22-h7a0aef1_0.conda
osx-arm64::libgdal-3.5.3-h61387e7_10.conda
osx-arm64::libgdal-3.6.0-he8687b4_14.conda
osx-arm64::aws-sdk-cpp-1.10.25-h0d16128_0.conda
osx-arm64::imagemagick-7.1.0_57-pl5321h059bd01_0.conda
osx-arm64::tectonic-0.12.0-h842ef36_1.conda
osx-arm64::heyoka-0.20.0-h9fc4738_0.conda
osx-arm64::libgd-2.3.3-h90fb8ed_4.conda
osx-arm64::postgresql-14.5-hf80b784_3.conda
osx-arm64::heyoka-0.20.0-h1f79b10_0.conda
osx-arm64::aws-sdk-cpp-1.10.25-h7a0aef1_0.conda
osx-arm64::xrootd-5.5.1-py311h9ec2a30_3.conda
osx-arm64::cmake-3.25.1-hf234bd0_0.conda
osx-arm64::freeimage-3.18.0-h9cfb71a_11.conda
osx-arm64::imagecodecs-2022.9.26-py311h79be52a_5.conda
osx-arm64::arrow-cpp-8.0.1-py38h653a517_12_cpu.conda
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
osx-arm64::openjpeg-2.5.0-hbc2ba62_2.conda
osx-arm64::msgpack-c-3.3.0-h276577b_5.conda
osx-arm64::gds-base-3.0.0-h646526f_3.conda
osx-arm64::libmlir15-15.0.6-hcb86549_0.conda
osx-arm64::gds-base-3.0.0-h646526f_2.conda
osx-arm64::liblal-7.2.4-fftw_h6e50f36_104.conda
osx-arm64::gcab-1.5-h1f3578d_0.conda
osx-arm64::libsolv-0.7.23-hb5ab8b9_0.conda
osx-arm64::libprotobuf-static-3.21.12-hb5ab8b9_0.conda
osx-arm64::libprotobuf-3.21.11-hb5ab8b9_0.conda
osx-arm64::gst-plugins-base-1.21.3-h8b7775e_1.conda
osx-arm64::openjdk-17.0.3-hf913c23_5.conda
osx-arm64::libprotobuf-static-3.21.11-hb5ab8b9_0.conda
osx-arm64::libxmlpp-4.0-4.0.1-h2d19cdb_0.conda
osx-arm64::eccodes-2.27.1-hcbf30ee_0.conda
osx-arm64::libprotobuf-3.21.12-hb5ab8b9_0.conda
osx-arm64::libmlir-15.0.6-hcb86549_0.conda
osx-arm64::libsolv-static-0.7.23-hb5ab8b9_0.conda
-    "libzlib >=1.2.13,<1.3.0a0"
+    "libzlib >=1.2.13,<2.0.0a0"
================================================================================
================================================================================
linux-ppc64le
linux-ppc64le::libgdal-3.5.3-h25bb93f_9.conda
linux-ppc64le::mapserver-8.0.0-py39h4fbaad4_7.conda
linux-ppc64le::libcurl-static-7.86.0-h735e58a_2.conda
linux-ppc64le::postgresql-plpython-15.1-py38hfcfb3a0_1.conda
linux-ppc64le::aws-sdk-cpp-1.10.30-hfbf9da7_0.conda
linux-ppc64le::postgresql-plpython-14.5-py311h0c8e791_3.conda
linux-ppc64le::ale-py-0.8.0-py39h368212c_3.conda
linux-ppc64le::ale-py-0.8.0-py311he105684_3.conda
linux-ppc64le::xrootd-5.5.1-py38h379f34b_3.conda
linux-ppc64le::arrow-cpp-6.0.2-py310hf3f0ed0_9_cpu.conda
linux-ppc64le::arrow-cpp-9.0.0-py39hc05c8aa_13_cpu.conda
linux-ppc64le::postgresql-plpython-14.5-py310h70bf364_3.conda
linux-ppc64le::libopencv-4.6.0-py310h7b8afbe_8.conda
linux-ppc64le::gst-plugins-bad-1.21.2-h3409f87_1.conda
linux-ppc64le::arrow-cpp-8.0.1-py38hcf2c1f9_11_cpu.conda
linux-ppc64le::libgdal-arrow-parquet-3.6.1-h421a43f_2.conda
linux-ppc64le::xrootd-5.5.1-py310he2efc96_3.conda
linux-ppc64le::arrow-cpp-8.0.1-py310h4b1e0e5_10_cpu.conda
linux-ppc64le::imagecodecs-2022.12.22-py311h53ca587_0.conda
linux-ppc64le::postgresql-plpython-14.5-py39h49b413b_4.conda
linux-ppc64le::arrow-cpp-9.0.0-py39h13b7e61_15_cpu.conda
linux-ppc64le::git-2.39.0-pl5321h8969c65_0.conda
linux-ppc64le::arrow-cpp-7.0.1-py310h4b1e0e5_10_cpu.conda
linux-ppc64le::xrootd-5.5.1-py311haf01439_3.conda
linux-ppc64le::imagemagick-7.1.0_55-pl5321ha7bdc32_1.conda
linux-ppc64le::xrootd-5.5.1-py39h7749031_3.conda
linux-ppc64le::arrow-cpp-7.0.1-py38hdaa6467_12_cpu.conda
linux-ppc64le::postgresql-plpython-14.5-py39h82d8dc6_2.conda
linux-ppc64le::xrootd-5.5.1-py38h5ec95b4_3.conda
linux-ppc64le::pdal-2.4.3-h17ef33f_4.conda
linux-ppc64le::gdk-pixbuf-2.42.8-hb8ea6f8_2.conda
linux-ppc64le::mlir-15.0.6-h96f6aa1_0.conda
linux-ppc64le::aws-sdk-cpp-1.10.29-hfbf9da7_0.conda
linux-ppc64le::aws-sdk-cpp-1.10.33-h427624f_0.conda
linux-ppc64le::aws-sdk-cpp-1.10.25-hfbf9da7_0.conda
linux-ppc64le::arrow-cpp-6.0.2-py311ha444425_9_cpu.conda
linux-ppc64le::aws-sdk-cpp-1.10.32-h427624f_0.conda
linux-ppc64le::arrow-cpp-9.0.0-py39h3805bbe_14_cpu.conda
linux-ppc64le::aws-sdk-cpp-1.10.36-ha7b0375_0.conda
linux-ppc64le::nco-5.1.3-hdbb88d5_1.conda
linux-ppc64le::aws-sdk-cpp-1.10.26-h427624f_0.conda
linux-ppc64le::postgresql-plpython-14.5-py38hfcfb3a0_2.conda
linux-ppc64le::aws-sdk-cpp-1.10.40-h9a39a3e_0.conda
linux-ppc64le::magic-8.3.346-h578791d_0.conda
linux-ppc64le::netcdf4-1.6.0-mpi_mpich_py38hb48e42a_3.conda
linux-ppc64le::lxml-4.9.2-py39h1db2c6d_0.conda
linux-ppc64le::ale-py-0.8.0-py39heeb2f53_1.conda
linux-ppc64le::libgrpc-1.51.1-h210c47d_0.conda
linux-ppc64le::postgresql-plpython-14.5-py39hd2608f7_3.conda
linux-ppc64le::arrow-cpp-7.0.1-py310h4d2d7d6_9_cpu.conda
linux-ppc64le::libpq-14.5-hc678a61_3.conda
linux-ppc64le::netcdf4-1.6.0-mpi_openmpi_py38hb74c226_3.conda
linux-ppc64le::libarchive-minimal-static-3.6.2-h4e77ab6_0.conda
linux-ppc64le::arrow-cpp-8.0.1-py38h15d4a79_12_cpu.conda
linux-ppc64le::tesseract-5.3.0-h6b5b2ab_0.conda
linux-ppc64le::arrow-cpp-8.0.1-py38hfecec73_11_cpu.conda
linux-ppc64le::postgresql-14.5-h072eaac_4.conda
linux-ppc64le::postgresql-plpython-14.5-py38h0e8b2eb_4.conda
linux-ppc64le::pillow-9.2.0-py39he35be8a_4.conda
linux-ppc64le::aws-sdk-cpp-1.10.28-hfbf9da7_0.conda
linux-ppc64le::arrow-cpp-6.0.2-py311hc59cd75_9_cpu.conda
linux-ppc64le::lxml-4.9.2-py38hcf3e3cf_0.conda
linux-ppc64le::pyinstaller-5.7.0-py38h005d3bb_0.conda
linux-ppc64le::imagecodecs-2022.9.26-py39h4eed867_5.conda
linux-ppc64le::netcdf4-1.6.0-mpi_mpich_py39h64b83ff_3.conda
linux-ppc64le::arrow-cpp-7.0.1-py39hc05c8aa_11_cpu.conda
linux-ppc64le::arrow-cpp-8.0.1-py38hdaa6467_12_cpu.conda
linux-ppc64le::libopencv-4.6.0-py311h7fc7993_9.conda
linux-ppc64le::ffmpeg-4.4.2-gpl_h1e8deb8_112.conda
linux-ppc64le::arrow-cpp-6.0.2-py310h28cf2ca_9_cpu.conda
linux-ppc64le::libgdal-3.5.3-he98a83a_12.conda
linux-ppc64le::openssh-9.1p1-hfea8670_1.conda
linux-ppc64le::libopencv-4.6.0-py38h6c11ed8_7.conda
linux-ppc64le::arrow-cpp-9.0.0-py38h15d4a79_15_cpu.conda
linux-ppc64le::netcdf4-1.6.0-mpi_openmpi_py310h923a7d7_3.conda
linux-ppc64le::mapserver-8.0.0-py38haac599b_7.conda
linux-ppc64le::arrow-cpp-6.0.2-py311h902aa1a_7_cpu.conda
linux-ppc64le::arrow-cpp-9.0.0-py38hdaa6467_14_cpu.conda
linux-ppc64le::postgresql-15.1-h072eaac_2.conda
linux-ppc64le::libgdal-3.6.1-hf86a80c_0.conda
linux-ppc64le::arrow-cpp-6.0.2-py38hddd11cb_9_cpu.conda
linux-ppc64le::postgresql-14.5-h62d6b9d_2.conda
linux-ppc64le::libopencv-4.6.0-py39h52bd70e_7.conda
linux-ppc64le::libgdal-arrow-parquet-3.6.0-he009fa4_13.conda
linux-ppc64le::libpq-14.5-hbe330f9_2.conda
linux-ppc64le::aws-sdk-cpp-1.10.20-hb37fb60_0.conda
linux-ppc64le::arrow-cpp-6.0.2-py38hbd51ddb_9_cpu.conda
linux-ppc64le::aws-sdk-cpp-1.10.23-h427624f_0.conda
linux-ppc64le::pillow-9.2.0-py311h5bdcea0_4.conda
linux-ppc64le::aws-sdk-cpp-1.10.42-h417c902_0.conda
linux-ppc64le::ale-py-0.8.0-py39heeb2f53_0.conda
linux-ppc64le::cpp-opentelemetry-sdk-1.8.1-hb7213d2_1.conda
linux-ppc64le::libspatialite-5.0.1-hcb19bac_23.conda
linux-ppc64le::arrow-cpp-9.0.0-py39h88b086b_11_cpu.conda
linux-ppc64le::folly-2022.12.19.00-h1234567_3.conda
linux-ppc64le::arrow-cpp-8.0.1-py311he3ffdb2_13_cpu.conda
linux-ppc64le::imagecodecs-2022.12.22-py38h9225700_0.conda
linux-ppc64le::netcdf4-1.6.0-mpi_openmpi_py311h8447d0d_3.conda
linux-ppc64le::lxml-4.9.2-py39h5b8d685_0.conda
linux-ppc64le::postgresql-plpython-15.1-py311h665c32c_1.conda
linux-ppc64le::libarchive-3.6.2-h447a6af_0.conda
linux-ppc64le::libcurl-7.86.0-hea9912c_2.conda
linux-ppc64le::netcdf4-1.6.0-nompi_py39h49123c4_103.conda
linux-ppc64le::arrow-cpp-8.0.1-py310hdd2e632_12_cpu.conda
linux-ppc64le::libgdal-3.4.3-h6e9f71a_1.conda
linux-ppc64le::aws-sdk-cpp-1.10.22-hb37fb60_0.conda
linux-ppc64le::libopencv-4.6.0-py38ha3cf719_8.conda
linux-ppc64le::graphviz-7.0.5-hf84b6e5_0.conda
linux-ppc64le::libgdal-3.6.1-h2e3a6a5_2.conda
linux-ppc64le::nordugrid-arc-6.17.0-py310h6f86a99_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.6.1-h896dabe_3.conda
linux-ppc64le::mapserver-8.0.0-py38h01e674d_6.conda
linux-ppc64le::arrow-cpp-6.0.2-py38h0e8ce49_8_cpu.conda
linux-ppc64le::arrow-cpp-7.0.1-py311hf0b9ca7_12_cpu.conda
linux-ppc64le::libgdal-3.5.3-h761380b_8.conda
linux-ppc64le::libpq-14.5-h38393a0_4.conda
linux-ppc64le::arrow-cpp-9.0.0-py39h3805bbe_15_cpu.conda
linux-ppc64le::libgdal-3.6.0-h0d77503_11.conda
linux-ppc64le::postgresql-plpython-15.1-py311h070f9de_2.conda
linux-ppc64le::arrow-cpp-8.0.1-py39h3805bbe_13_cpu.conda
linux-ppc64le::arrow-cpp-7.0.1-py310h136be57_11_cpu.conda
linux-ppc64le::aws-sdk-cpp-1.10.42-h472aa01_0.conda
linux-ppc64le::hdf5-1.12.2-mpi_openmpi_h31519e4_1.conda
linux-ppc64le::arrow-cpp-7.0.1-py39h88b086b_9_cpu.conda
linux-ppc64le::libgdal-arrow-parquet-3.6.0-h6882b42_12.conda
linux-ppc64le::tiledb-2.13.0-hd899d3e_1.conda
linux-ppc64le::netcdf4-1.6.0-nompi_py311hc324fa9_103.conda
linux-ppc64le::mapserver-8.0.0-py39hd750e75_6.conda
linux-ppc64le::postgresql-15.1-h2c861b0_1.conda
linux-ppc64le::imagecodecs-2022.12.24-py38h9225700_0.conda
linux-ppc64le::libgdal-3.6.0-ha284008_11.conda
linux-ppc64le::ale-py-0.8.0-py38h38a2af7_2.conda
linux-ppc64le::aws-sdk-cpp-1.9.379-ha7b0375_6.conda
linux-ppc64le::arrow-cpp-9.0.0-py39h13b7e61_14_cpu.conda
linux-ppc64le::imagecodecs-2022.9.26-py38h9225700_5.conda
linux-ppc64le::postgresql-15.1-h62d6b9d_1.conda
linux-ppc64le::imagemagick-7.1.0_55-pl5321h7eb00bc_0.conda
linux-ppc64le::arrow-cpp-8.0.1-py38h4975b25_10_cpu.conda
linux-ppc64le::xrootd-5.5.1-py310h8501701_3.conda
linux-ppc64le::postgresql-plpython-14.5-py38hf0156e4_2.conda
linux-ppc64le::hdf5-1.12.2-nompi_h85f07b9_101.conda
linux-ppc64le::arrow-cpp-9.0.0-py38h188969e_11_cpu.conda
linux-ppc64le::freeimage-3.18.0-hb0a489d_11.conda
linux-ppc64le::ffmpeg-5.1.2-lgpl_h559f090_4.conda
linux-ppc64le::gmsh-4.11.0-h8f3b4cd_1.conda
linux-ppc64le::wxwidgets-3.2.1-py311h5f68573_3.conda
linux-ppc64le::libssh-0.10.4-h3a9bf53_3.conda
linux-ppc64le::libgdal-arrow-parquet-3.6.0-h9d56cd8_12.conda
linux-ppc64le::texlive-core-20210325-hdebdb3a_7.conda
linux-ppc64le::arrow-cpp-8.0.1-py310h19833dc_11_cpu.conda
linux-ppc64le::aws-sdk-cpp-1.10.34-ha7b0375_1.conda
linux-ppc64le::arrow-cpp-6.0.2-py39h923c2eb_8_cpu.conda
linux-ppc64le::nordugrid-arc-6.17.0-py311h8a85e5e_0.conda
linux-ppc64le::libvips-8.13.3-h200fb7e_3.conda
linux-ppc64le::postgresql-plpython-14.5-py310h6fc3d0f_4.conda
linux-ppc64le::arrow-cpp-7.0.1-py311h18b5776_11_cpu.conda
linux-ppc64le::postgresql-plpython-14.5-py310h03174d6_2.conda
linux-ppc64le::poppler-22.12.0-h3718e61_1.conda
linux-ppc64le::arrow-cpp-8.0.1-py39h58c5d17_10_cpu.conda
linux-ppc64le::postgresql-plpython-14.5-py311h070f9de_4.conda
linux-ppc64le::magic-8.3.351-h0bd16fa_0.conda
linux-ppc64le::arrow-cpp-8.0.1-py38hdaa6467_13_cpu.conda
linux-ppc64le::aws-sdk-cpp-1.10.26-hfbf9da7_0.conda
linux-ppc64le::aws-sdk-cpp-1.10.30-h427624f_0.conda
linux-ppc64le::hdf5-1.12.2-mpi_openmpi_hd7df8e7_1.conda
linux-ppc64le::postgresql-14.5-hdc11c40_3.conda
linux-ppc64le::libpq-15.1-hfea8670_2.conda
linux-ppc64le::postgresql-plpython-14.5-py311hb62b3d2_3.conda
linux-ppc64le::libpq-14.5-haac5f4d_3.conda
linux-ppc64le::mapserver-8.0.0-py310h404d138_6.conda
linux-ppc64le::libpq-14.5-h41524dc_2.conda
linux-ppc64le::arrow-cpp-6.0.2-py38h22aea4a_7_cpu.conda
linux-ppc64le::libgdal-3.5.3-h3203607_11.conda
linux-ppc64le::aws-sdk-cpp-1.10.39-ha7b0375_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.6.1-h1684ebc_1.conda
linux-ppc64le::postgresql-plpython-14.5-py39h143d73a_3.conda
linux-ppc64le::aws-sdk-cpp-1.10.29-h427624f_0.conda
linux-ppc64le::aws-sdk-cpp-1.10.35-ha7b0375_0.conda
linux-ppc64le::libarrow-10.0.1-hbefd921_0_cpu.conda
linux-ppc64le::ale-py-0.8.0-py310h55e8391_2.conda
linux-ppc64le::libcurl-static-7.86.0-hea9912c_2.conda
linux-ppc64le::imagecodecs-2022.12.22-py39he03b7e9_0.conda
linux-ppc64le::arrow-cpp-9.0.0-py39h58c5d17_12_cpu.conda
linux-ppc64le::curl-7.86.0-h735e58a_2.conda
linux-ppc64le::xrootd-5.5.1-py39h132548f_3.conda
linux-ppc64le::aws-sdk-cpp-1.10.38-ha7b0375_0.conda
linux-ppc64le::arrow-cpp-6.0.2-py311h2d4d5cc_8_cpu.conda
linux-ppc64le::libpq-14.5-hfea8670_4.conda
linux-ppc64le::libgrpc-1.50.1-h210c47d_0.conda
linux-ppc64le::aws-sdk-cpp-1.10.40-ha7b0375_0.conda
linux-ppc64le::arrow-cpp-8.0.1-py311h18b5776_11_cpu.conda
linux-ppc64le::folly-2022.12.05.00-h1234567_3_jemalloc.conda
linux-ppc64le::tiledb-2.13.0-h209563e_1.conda
linux-ppc64le::libopencv-4.6.0-py38h4fd0d0d_9.conda
linux-ppc64le::aws-sdk-cpp-1.10.27-hfbf9da7_0.conda
linux-ppc64le::aws-sdk-cpp-1.10.39-h9a39a3e_0.conda
linux-ppc64le::nordugrid-arc-6.17.0-py39h359556e_0.conda
linux-ppc64le::libgdal-3.6.0-h338e5dc_13.conda
linux-ppc64le::libarrow-10.0.1-hd063cc7_3_cpu.conda
linux-ppc64le::hdf5-1.12.2-mpi_mpich_h3c62663_1.conda
linux-ppc64le::postgresql-plpython-14.5-py38h562c45f_3.conda
linux-ppc64le::arrow-cpp-9.0.0-py310hdd2e632_15_cpu.conda
linux-ppc64le::libgdal-arrow-parquet-3.6.0-h109e95b_13.conda
linux-ppc64le::imagecodecs-2022.12.22-py310he7605b9_0.conda
linux-ppc64le::ale-py-0.8.0-py310h55e8391_3.conda
linux-ppc64le::imagecodecs-2022.12.24-py39he03b7e9_0.conda
linux-ppc64le::arrow-cpp-9.0.0-py38hfecec73_13_cpu.conda
linux-ppc64le::aws-sdk-cpp-1.10.41-h417c902_1.conda
linux-ppc64le::imagemagick-7.1.0_54-pl5321ha4c6c89_0.conda
linux-ppc64le::arrow-cpp-9.0.0-py38h4975b25_12_cpu.conda
linux-ppc64le::postgresql-plpython-15.1-py39he8617e0_2.conda
linux-ppc64le::aws-sdk-cpp-1.10.31-h427624f_0.conda
linux-ppc64le::imagemagick-7.1.0_53-pl5321ha4c6c89_0.conda
linux-ppc64le::libcurl-7.87.0-hea9912c_0.conda
linux-ppc64le::aws-sdk-cpp-1.10.35-h9a39a3e_0.conda
linux-ppc64le::arrow-cpp-8.0.1-py39he77636e_11_cpu.conda
linux-ppc64le::nordugrid-arc-6.17.0-py311h8d9c728_0.conda
linux-ppc64le::graphicsmagick-1.3.37-hea5a672_0.conda
linux-ppc64le::postgresql-plpython-15.1-py38hf0156e4_1.conda
linux-ppc64le::arrow-cpp-7.0.1-py38h15d4a79_12_cpu.conda
linux-ppc64le::libssh-0.10.4-h267f361_3.conda
linux-ppc64le::mapserver-8.0.0-py310had3bc33_7.conda
linux-ppc64le::aws-sdk-cpp-1.9.379-h9a39a3e_6.conda
linux-ppc64le::sdl_image-1.2.12-hf5287ab_3.conda
linux-ppc64le::folly-2022.12.19.00-h1234567_3_jemalloc.conda
linux-ppc64le::postgresql-plpython-15.1-py39h96f0f12_1.conda
linux-ppc64le::netcdf4-1.6.0-mpi_mpich_py310he851ded_3.conda
linux-ppc64le::arrow-cpp-7.0.1-py39h3805bbe_12_cpu.conda
linux-ppc64le::arrow-cpp-9.0.0-py311he3ffdb2_15_cpu.conda
linux-ppc64le::r-base-4.2.2-h0370347_2.conda
linux-ppc64le::libarrow-10.0.1-hf9c9934_3_cpu.conda
linux-ppc64le::blosc-1.21.3-h9f7f848_0.conda
linux-ppc64le::arrow-cpp-8.0.1-py311hf150118_9_cpu.conda
linux-ppc64le::poppler-22.12.0-hc3169ea_0.conda
linux-ppc64le::aws-sdk-cpp-1.9.379-h472aa01_7.conda
linux-ppc64le::geotiff-1.7.1-h8db1a2d_6.conda
linux-ppc64le::lxml-4.9.2-py310ha9d6aea_0.conda
linux-ppc64le::arrow-cpp-6.0.2-py310h020f5e2_8_cpu.conda
linux-ppc64le::tiledb-2.13.0-ha4bc364_0.conda
linux-ppc64le::libgdal-3.5.3-h56ea2e9_10.conda
linux-ppc64le::libgdal-3.6.1-h979e740_1.conda
linux-ppc64le::cmake-3.25.1-h88b25fa_0.conda
linux-ppc64le::arrow-cpp-7.0.1-py310hdd2e632_12_cpu.conda
linux-ppc64le::libgdal-3.6.1-hf96a592_2.conda
linux-ppc64le::postgresql-plpython-14.5-py39h96f0f12_2.conda
linux-ppc64le::xrootd-5.5.1-py311h5db9744_3.conda
linux-ppc64le::aws-sdk-cpp-1.10.41-h472aa01_1.conda
linux-ppc64le::arrow-cpp-8.0.1-py310hc650c37_12_cpu.conda
linux-ppc64le::postgresql-plpython-14.5-py38h9a682bc_3.conda
linux-ppc64le::arrow-cpp-9.0.0-py310h136be57_13_cpu.conda
linux-ppc64le::ale-py-0.8.0-py39heeb2f53_2.conda
linux-ppc64le::arrow-cpp-8.0.1-py310h136be57_11_cpu.conda
linux-ppc64le::pillow-9.2.0-py39h845a511_4.conda
linux-ppc64le::arrow-cpp-7.0.1-py38h4975b25_10_cpu.conda
linux-ppc64le::arrow-cpp-9.0.0-py310hdd2e632_14_cpu.conda
linux-ppc64le::arrow-cpp-7.0.1-py39h13b7e61_12_cpu.conda
linux-ppc64le::libpq-15.1-hbe330f9_1.conda
linux-ppc64le::arrow-cpp-9.0.0-py311he3ffdb2_14_cpu.conda
linux-ppc64le::aws-sdk-cpp-1.9.379-h417c902_7.conda
linux-ppc64le::postgresql-plpython-14.5-py310hf09cc13_4.conda
linux-ppc64le::nordugrid-arc-6.17.0-py38he417ea4_0.conda
linux-ppc64le::postgresql-plpython-15.1-py38h0e8b2eb_2.conda
linux-ppc64le::libgdal-arrow-parquet-3.6.1-hc99caf7_3.conda
linux-ppc64le::pdal-2.4.3-h1f067d0_4.conda
linux-ppc64le::arrow-cpp-8.0.1-py311he3ffdb2_12_cpu.conda
linux-ppc64le::libarrow-10.0.1-h9911f79_1_cpu.conda
linux-ppc64le::ale-py-0.8.0-py38hde6938a_3.conda
linux-ppc64le::libgdal-3.5.3-h069dd2e_12.conda
linux-ppc64le::aws-sdk-cpp-1.10.38-h9a39a3e_0.conda
linux-ppc64le::postgresql-plpython-14.5-py38h9831e03_4.conda
linux-ppc64le::pillow-9.2.0-py310h6333e9e_4.conda
linux-ppc64le::imagecodecs-2022.9.26-py38hdc70197_5.conda
linux-ppc64le::nco-5.1.3-hd899646_2.conda
linux-ppc64le::aws-sdk-cpp-1.10.25-h427624f_0.conda
linux-ppc64le::mapserver-8.0.0-py311h213a92b_6.conda
linux-ppc64le::netcdf4-1.6.0-nompi_py310hf0fccba_103.conda
linux-ppc64le::aws-sdk-cpp-1.10.37-ha7b0375_0.conda
linux-ppc64le::arrow-cpp-7.0.1-py311h5844363_11_cpu.conda
linux-ppc64le::arrow-cpp-9.0.0-py311hf150118_11_cpu.conda
linux-ppc64le::arrow-cpp-8.0.1-py38h188969e_9_cpu.conda
linux-ppc64le::imagecodecs-2022.12.22-py39h4eed867_0.conda
linux-ppc64le::geotiff-1.7.1-h8a929bb_5.conda
linux-ppc64le::libcurl-static-7.87.0-hea9912c_0.conda
linux-ppc64le::arrow-cpp-7.0.1-py38hfecec73_11_cpu.conda
linux-ppc64le::arrow-cpp-6.0.2-py311h0c57b50_8_cpu.conda
linux-ppc64le::arrow-cpp-8.0.1-py310hc650c37_13_cpu.conda
linux-ppc64le::libgdal-3.5.3-h6b15a49_8.conda
linux-ppc64le::postgresql-plpython-15.1-py310hf09cc13_2.conda
linux-ppc64le::libopencv-4.6.0-py310h61b06cf_9.conda
linux-ppc64le::libcurl-static-7.87.0-h735e58a_0.conda
linux-ppc64le::nordugrid-arc-6.17.0-py310h1f1b4b3_0.conda
linux-ppc64le::nordugrid-arc-6.17.0-py39hbc0878f_0.conda
linux-ppc64le::pyinstaller-5.7.0-py310h35a950f_0.conda
linux-ppc64le::nordugrid-arc-6.17.0-py38he3e1f9c_0.conda
linux-ppc64le::postgresql-plpython-15.1-py310h10a37cb_1.conda
linux-ppc64le::libgd-2.3.3-h5eb0a3c_4.conda
linux-ppc64le::dcap-2.47.12-h0e6c979_6.conda
linux-ppc64le::aws-sdk-cpp-1.10.27-h427624f_0.conda
linux-ppc64le::ale-py-0.8.0-py38hde6938a_2.conda
linux-ppc64le::arrow-cpp-6.0.2-py310h72374ae_7_cpu.conda
linux-ppc64le::magic-8.3.349-h0bd16fa_0.conda
linux-ppc64le::libgdal-3.6.1-h14296dc_3.conda
linux-ppc64le::lxml-4.9.2-py38h784313d_0.conda
linux-ppc64le::arrow-cpp-9.0.0-py38hdaa6467_15_cpu.conda
linux-ppc64le::ffmpeg-4.4.2-lgpl_h559f090_11.conda
linux-ppc64le::orc-1.8.1-h341c9a4_0.conda
linux-ppc64le::libarrow-10.0.1-h27f083c_1_cpu.conda
linux-ppc64le::arrow-cpp-7.0.1-py38h188969e_9_cpu.conda
linux-ppc64le::hdf5-1.12.2-nompi_he7b1174_101.conda
linux-ppc64le::ffmpeg-5.1.2-lgpl_h9f2f7fb_5.conda
linux-ppc64le::r-base-4.2.2-h28ec8b7_3.conda
linux-ppc64le::graphicsmagick-1.3.39-h26fad99_0.conda
linux-ppc64le::imagecodecs-2022.12.24-py310he7605b9_0.conda
linux-ppc64le::hdf5-1.12.2-mpi_mpich_hdcbb436_1.conda
linux-ppc64le::libarrow-10.0.1-ha84bc2d_2_cpu.conda
linux-ppc64le::ffmpeg-5.1.2-gpl_h1e8deb8_105.conda
linux-ppc64le::arrow-cpp-6.0.2-py39h21e1586_9_cpu.conda
linux-ppc64le::libgdal-3.6.1-hf721c5e_1.conda
linux-ppc64le::ffmpeg-4.4.2-gpl_h875a0ae_111.conda
linux-ppc64le::libpq-15.1-h41524dc_1.conda
linux-ppc64le::aws-sdk-cpp-1.10.34-h9a39a3e_1.conda
linux-ppc64le::magic-8.3.348-h0bd16fa_0.conda
linux-ppc64le::postgresql-14.5-h2c861b0_2.conda
linux-ppc64le::libgdal-3.6.0-ha284008_12.conda
linux-ppc64le::aws-sdk-cpp-1.10.41-h9a39a3e_0.conda
linux-ppc64le::aws-sdk-cpp-1.10.21-h0ecb8e5_0.conda
linux-ppc64le::netcdf4-1.6.0-nompi_py38hd0608af_103.conda
linux-ppc64le::arrow-cpp-7.0.1-py38hcf2c1f9_11_cpu.conda
linux-ppc64le::libgdal-3.6.0-h0d77503_12.conda
linux-ppc64le::arrow-cpp-7.0.1-py311he3ffdb2_12_cpu.conda
linux-ppc64le::arrow-cpp-6.0.2-py38h13975e1_8_cpu.conda
linux-ppc64le::postgresql-plpython-14.5-py311h665c32c_2.conda
linux-ppc64le::mapserver-8.0.0-py311h6b9e299_7.conda
linux-ppc64le::libcurl-7.86.0-h735e58a_2.conda
linux-ppc64le::libopencv-4.6.0-py39hb5b9c5d_9.conda
linux-ppc64le::libgdal-3.6.0-hf86a80c_14.conda
linux-ppc64le::postgresql-plpython-15.1-py39h82d8dc6_1.conda
linux-ppc64le::arrow-cpp-8.0.1-py38h15d4a79_13_cpu.conda
linux-ppc64le::ale-py-0.8.0-py38h38a2af7_1.conda
linux-ppc64le::libgdal-arrow-parquet-3.6.0-h4d20d15_14.conda
linux-ppc64le::aws-sdk-cpp-1.10.21-hb37fb60_0.conda
linux-ppc64le::arrow-cpp-9.0.0-py38hcf2c1f9_13_cpu.conda
linux-ppc64le::git-2.39.0-pl5321h354956a_0.conda
linux-ppc64le::folly-2022.12.26.00-h1234567_3_jemalloc.conda
linux-ppc64le::aws-sdk-cpp-1.10.24-hfbf9da7_0.conda
linux-ppc64le::libgdal-3.6.1-h37b0791_3.conda
linux-ppc64le::arrow-cpp-9.0.0-py311h76c399d_12_cpu.conda
linux-ppc64le::ale-py-0.8.0-py38h38a2af7_0.conda
linux-ppc64le::imagecodecs-2022.12.24-py38hdc70197_0.conda
linux-ppc64le::postgresql-plpython-15.1-py38h9831e03_2.conda
linux-ppc64le::r-base-4.1.3-h9662e11_5.conda
linux-ppc64le::arrow-cpp-7.0.1-py39h58c5d17_10_cpu.conda
linux-ppc64le::eccodes-2.27.1-ha6a2edc_0.conda
linux-ppc64le::ale-py-0.8.0-py310h55e8391_1.conda
linux-ppc64le::postgresql-plpython-15.1-py310h03174d6_1.conda
linux-ppc64le::libarrow-10.0.1-h4cea9f7_2_cpu.conda
linux-ppc64le::arrow-cpp-9.0.0-py311hf0b9ca7_15_cpu.conda
linux-ppc64le::libopencv-4.6.0-py38h55fb453_8.conda
linux-ppc64le::imagecodecs-2022.12.22-py38hdc70197_0.conda
linux-ppc64le::aws-sdk-cpp-1.10.41-ha7b0375_0.conda
linux-ppc64le::folly-2022.12.12.00-h1234567_3_jemalloc.conda
linux-ppc64le::folly-2022.12.05.00-h1234567_3.conda
linux-ppc64le::libtiff-4.4.0-h7f9fe1d_5.conda
linux-ppc64le::aws-sdk-cpp-1.10.34-hfbf9da7_0.conda
linux-ppc64le::libpq-15.1-h38393a0_2.conda
linux-ppc64le::postgresql-plpython-14.5-py39he8617e0_4.conda
linux-ppc64le::cpp-opentelemetry-sdk-1.8.0-h648540d_0.conda
linux-ppc64le::libgdal-3.6.1-h1251e16_0.conda
linux-ppc64le::postgresql-14.5-hd45c747_3.conda
linux-ppc64le::aws-sdk-cpp-1.10.20-h0ecb8e5_0.conda
linux-ppc64le::arrow-cpp-7.0.1-py310hc650c37_12_cpu.conda
linux-ppc64le::ale-py-0.8.0-py310h55e8391_0.conda
linux-ppc64le::arrow-cpp-7.0.1-py311h76c399d_10_cpu.conda
linux-ppc64le::xrootd-5.5.1-py38hcddaa7b_3.conda
linux-ppc64le::ale-py-0.8.0-py38h38a2af7_3.conda
linux-ppc64le::mapserver-8.0.0-py38hef644cb_5.conda
linux-ppc64le::postgresql-plpython-15.1-py311hf900df1_1.conda
linux-ppc64le::arrow-cpp-9.0.0-py38h15d4a79_14_cpu.conda
linux-ppc64le::libopencv-4.6.0-py311h529770c_7.conda
linux-ppc64le::gst-plugins-bad-1.21.2-he214f5d_1.conda
linux-ppc64le::arrow-cpp-9.0.0-py310h4b1e0e5_12_cpu.conda
linux-ppc64le::pyinstaller-5.7.0-py39hfb2fb05_0.conda
linux-ppc64le::folly-2022.12.12.00-h1234567_3.conda
linux-ppc64le::ffmpeg-5.1.2-gpl_h875a0ae_104.conda
linux-ppc64le::aws-sdk-cpp-1.10.34-h427624f_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.6.1-ha85e468_1.conda
linux-ppc64le::aws-sdk-cpp-1.10.22-h0ecb8e5_0.conda
linux-ppc64le::libopencv-4.6.0-py39h39ae07f_8.conda
linux-ppc64le::libgdal-3.5.3-h723a78a_9.conda
linux-ppc64le::pillow-9.2.0-py38h0e258c3_4.conda
linux-ppc64le::libgdal-3.6.0-h1251e16_14.conda
linux-ppc64le::postgresql-plpython-14.5-py311he5265cc_4.conda
linux-ppc64le::libgdal-3.5.3-h1f9f238_11.conda
linux-ppc64le::cpp-opentelemetry-sdk-1.8.1-h334d51d_0.conda
linux-ppc64le::imagecodecs-2022.9.26-py39he03b7e9_5.conda
linux-ppc64le::openmpi-4.1.4-h317bbcb_102.conda
linux-ppc64le::imagecodecs-2022.12.24-py311h53ca587_0.conda
linux-ppc64le::libopencv-4.6.0-py310h2e052fa_7.conda
linux-ppc64le::arrow-cpp-9.0.0-py310hc650c37_14_cpu.conda
linux-ppc64le::ale-py-0.8.0-py311he105684_1.conda
linux-ppc64le::aws-sdk-cpp-1.10.37-h9a39a3e_0.conda
linux-ppc64le::arrow-cpp-7.0.1-py39he77636e_11_cpu.conda
linux-ppc64le::arrow-cpp-8.0.1-py311hf0b9ca7_12_cpu.conda
linux-ppc64le::arrow-cpp-6.0.2-py310hed0ecad_8_cpu.conda
linux-ppc64le::postgresql-plpython-14.5-py310h10a37cb_2.conda
linux-ppc64le::aws-sdk-cpp-1.10.28-h427624f_0.conda
linux-ppc64le::libgdal-arrow-parquet-3.6.1-h7bd6328_2.conda
linux-ppc64le::netcdf4-1.6.0-mpi_mpich_py311h613c483_3.conda
linux-ppc64le::libgrpc-1.51.1-h84ebf72_0.conda
linux-ppc64le::postgresql-plpython-14.5-py311hf900df1_2.conda
linux-ppc64le::imagemagick-7.1.0_57-pl5321ha7bdc32_0.conda
linux-ppc64le::arrow-cpp-6.0.2-py39hd337b7f_8_cpu.conda
linux-ppc64le::arrow-cpp-7.0.1-py310h19833dc_11_cpu.conda
linux-ppc64le::libgdal-arrow-parquet-3.6.0-h0255458_14.conda
linux-ppc64le::curl-7.86.0-hea9912c_2.conda
linux-ppc64le::libgdal-arrow-parquet-3.6.1-h0255458_0.conda
linux-ppc64le::blosc-1.21.2-h9f7f848_0.conda
linux-ppc64le::arrow-cpp-9.0.0-py310h4d2d7d6_11_cpu.conda
linux-ppc64le::libopencv-4.6.0-py38h5fc6d7a_9.conda
linux-ppc64le::mapserver-8.0.0-py310h21a2775_5.conda
linux-ppc64le::arrow-cpp-8.0.1-py39hc05c8aa_11_cpu.conda
linux-ppc64le::postgresql-plpython-15.1-py311he5265cc_2.conda
linux-ppc64le::imagemagick-7.1.0_56-pl5321ha7bdc32_0.conda
linux-ppc64le::openslide-3.4.1-h7013b17_6.conda
linux-ppc64le::arrow-cpp-6.0.2-py39h903285e_7_cpu.conda
linux-ppc64le::postgresql-15.1-h8e392d1_2.conda
linux-ppc64le::libgdal-3.5.3-h2ccfd4e_10.conda
linux-ppc64le::arrow-cpp-9.0.0-py311h5844363_13_cpu.conda
linux-ppc64le::folly-2022.12.26.00-h1234567_3.conda
linux-ppc64le::arrow-cpp-8.0.1-py311h5844363_11_cpu.conda
linux-ppc64le::arrow-cpp-8.0.1-py39h88b086b_9_cpu.conda
linux-ppc64le::xrootd-5.5.1-py39h98a18a3_3.conda
linux-ppc64le::libgdal-3.4.3-hb2ac9b8_1.conda
linux-ppc64le::libgdal-3.6.0-h0f1e2a4_13.conda
linux-ppc64le::arrow-cpp-9.0.0-py311h18b5776_13_cpu.conda
linux-ppc64le::pdal-2.4.3-he7e03b7_5.conda
linux-ppc64le::arrow-cpp-8.0.1-py39h13b7e61_13_cpu.conda
linux-ppc64le::aws-sdk-cpp-1.10.32-hfbf9da7_0.conda
linux-ppc64le::aws-sdk-cpp-1.10.36-h9a39a3e_0.conda
linux-ppc64le::netcdf4-1.6.0-mpi_openmpi_py39h6fb6ae0_3.conda
linux-ppc64le::arrow-cpp-8.0.1-py310h4d2d7d6_9_cpu.conda
linux-ppc64le::aws-sdk-cpp-1.10.24-h427624f_0.conda
linux-ppc64le::postgresql-plpython-15.1-py39h49b413b_2.conda
linux-ppc64le::smesh-9.9.0.0-h9bd8447_3.conda
linux-ppc64le::libopencv-4.6.0-py39h3ac104e_7.conda
linux-ppc64le::libcurl-7.87.0-h735e58a_0.conda
linux-ppc64le::imagecodecs-2022.12.24-py39h4eed867_0.conda
linux-ppc64le::lxml-4.9.2-py311haf4e93e_0.conda
linux-ppc64le::xrootd-5.5.1-py38hcadb2ef_3.conda
linux-ppc64le::libvips-8.13.3-h7eaa53e_4.conda
linux-ppc64le::openjdk-17.0.3-hce3afb9_5.conda
linux-ppc64le::arrow-cpp-9.0.0-py311hf0b9ca7_14_cpu.conda
linux-ppc64le::imagecodecs-2022.9.26-py311h53ca587_5.conda
linux-ppc64le::ale-py-0.8.0-py39heeb2f53_3.conda
linux-ppc64le::postgresql-plpython-14.5-py310h731d24c_3.conda
linux-ppc64le::arrow-cpp-8.0.1-py311hf0b9ca7_13_cpu.conda
linux-ppc64le::pillow-9.2.0-py38h2d31301_4.conda
linux-ppc64le::openssh-9.1p1-h38393a0_1.conda
linux-ppc64le::aws-sdk-cpp-1.10.33-hfbf9da7_0.conda
linux-ppc64le::arrow-cpp-8.0.1-py39h13b7e61_12_cpu.conda
linux-ppc64le::tesseract-5.2.0-h2c1a7f0_2.conda
linux-ppc64le::aws-sdk-cpp-1.10.23-hfbf9da7_0.conda
linux-ppc64le::pdal-2.4.3-h789a978_5.conda
linux-ppc64le::arrow-cpp-9.0.0-py39he77636e_13_cpu.conda
linux-ppc64le::libgdal-arrow-parquet-3.6.1-h4d20d15_0.conda
linux-ppc64le::libopencv-4.6.0-py39h6403797_8.conda
linux-ppc64le::postgresql-plpython-15.1-py310h6fc3d0f_2.conda
linux-ppc64le::postgresql-14.5-h8e392d1_4.conda
linux-ppc64le::curl-7.87.0-h735e58a_0.conda
linux-ppc64le::libarrow-10.0.1-h10a4abb_0_cpu.conda
linux-ppc64le::imagecodecs-2022.9.26-py310he7605b9_5.conda
linux-ppc64le::mapserver-8.0.0-py311h9c8077c_5.conda
linux-ppc64le::libopencv-4.6.0-py39hbe08cc8_9.conda
linux-ppc64le::tiledb-2.13.0-h11b1e19_0.conda
linux-ppc64le::libtiff-4.5.0-h7f9fe1d_0.conda
linux-ppc64le::arrow-cpp-6.0.2-py39h851dd9e_9_cpu.conda
linux-ppc64le::arrow-cpp-9.0.0-py310hc650c37_15_cpu.conda
linux-ppc64le::arrow-cpp-8.0.1-py39h3805bbe_12_cpu.conda
linux-ppc64le::magic-8.3.350-h0bd16fa_0.conda
linux-ppc64le::elfutils-0.188-hbd6c073_1.conda
linux-ppc64le::dcap-2.47.12-h53f5d54_6.conda
linux-ppc64le::mapserver-8.0.0-py39h89b908c_5.conda
linux-ppc64le::arrow-cpp-7.0.1-py311hf150118_9_cpu.conda
linux-ppc64le::ffmpeg-4.4.2-lgpl_h9f2f7fb_12.conda
linux-ppc64le::arrow-cpp-8.0.1-py311h76c399d_10_cpu.conda
linux-ppc64le::arrow-cpp-8.0.1-py310hdd2e632_13_cpu.conda
linux-ppc64le::ale-py-0.8.0-py311he105684_2.conda
linux-ppc64le::ale-py-0.8.0-py39h368212c_2.conda
linux-ppc64le::graphicsmagick-1.3.37-h26fad99_1.conda
linux-ppc64le::xrootd-5.5.1-py39h05b1874_3.conda
linux-ppc64le::libopencv-4.6.0-py311h8f1bc7c_8.conda
linux-ppc64le::libgrpc-1.50.1-h84ebf72_0.conda
linux-ppc64le::arrow-cpp-9.0.0-py310h19833dc_13_cpu.conda
linux-ppc64le::libopencv-4.6.0-py38hf3f5ee6_7.conda
linux-ppc64le::curl-7.87.0-hea9912c_0.conda
linux-ppc64le::libarchive-3.6.2-h5a2b0a6_0.conda
linux-ppc64le::aws-sdk-cpp-1.10.31-hfbf9da7_0.conda
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
linux-ppc64le::gst-plugins-good-1.21.3-h233c741_1.conda
linux-ppc64le::libmlir-15.0.6-h96f6aa1_0.conda
linux-ppc64le::libprotobuf-static-3.21.12-h26001cd_0.conda
linux-ppc64le::libmlir15-15.0.6-h96f6aa1_0.conda
linux-ppc64le::libprotobuf-3.21.11-h26001cd_0.conda
linux-ppc64le::libprotobuf-static-3.21.11-h26001cd_0.conda
linux-ppc64le::gds-base-3.0.0-h597ff09_2.conda
linux-ppc64le::gst-plugins-base-1.21.3-hda5291d_1.conda
linux-ppc64le::gst-plugins-base-1.21.3-hda5291d_0.conda
linux-ppc64le::gds-base-3.0.0-h115a11f_3.conda
linux-ppc64le::libsolv-0.7.23-h26001cd_0.conda
linux-ppc64le::gcab-1.5-h59b4d82_0.conda
linux-ppc64le::liblal-7.2.4-fftw_h8338b0a_104.conda
linux-ppc64le::libprotobuf-3.21.12-h26001cd_0.conda
linux-ppc64le::openjpeg-2.5.0-hbcaec15_2.conda
linux-ppc64le::gst-plugins-good-1.21.3-h233c741_0.conda
linux-ppc64le::libcups-2.3.3-h2dc76cc_3.conda
linux-ppc64le::libsolv-static-0.7.23-h26001cd_0.conda
-    "libzlib >=1.2.13,<1.3.0a0"
+    "libzlib >=1.2.13,<2.0.0a0"
================================================================================
================================================================================
linux-aarch64
linux-aarch64::libarrow-10.0.1-h8038862_3_cpu.conda
linux-aarch64::arrow-cpp-8.0.1-py39h318fdd1_12_cuda.conda
linux-aarch64::mapserver-8.0.0-py310h812e8ea_6.conda
linux-aarch64::postgresql-plpython-14.5-py38h986e477_3.conda
linux-aarch64::aws-sdk-cpp-1.10.37-hd7da748_0.conda
linux-aarch64::arrow-cpp-8.0.1-py310hfe4e10d_12_cuda.conda
linux-aarch64::arrow-cpp-7.0.1-py39h671320c_11_cpu.conda
linux-aarch64::aws-sdk-cpp-1.10.35-hd7da748_0.conda
linux-aarch64::postgresql-plpython-14.5-py39hc824ae8_3.conda
linux-aarch64::gfortran_impl_osx-64-11.3.0-hb7979ed_27.conda
linux-aarch64::postgresql-plpython-14.5-py38h90b34db_4.conda
linux-aarch64::ale-py-0.8.0-py38h95e0686_3.conda
linux-aarch64::postgresql-15.1-he4d23a4_2.conda
linux-aarch64::aws-sdk-cpp-1.10.23-h13c370d_0.conda
linux-aarch64::postgresql-plpython-14.5-py311h5260d65_3.conda
linux-aarch64::postgresql-plpython-14.5-py310h953db2b_2.conda
linux-aarch64::libgdal-arrow-parquet-3.6.0-h2b56996_14.conda
linux-aarch64::xrootd-5.5.1-py39he8a6ff4_3.conda
linux-aarch64::tiledb-2.13.0-he69c9f4_1.conda
linux-aarch64::libcurl-7.86.0-h6ad7c7a_2.conda
linux-aarch64::arrow-cpp-6.0.2-py38h66e963c_8_cpu.conda
linux-aarch64::graphicsmagick-1.3.39-h427c933_0.conda
linux-aarch64::imagecodecs-2022.12.22-py310hc7f909d_0.conda
linux-aarch64::git-2.39.0-pl5321hf85ec50_0.conda
linux-aarch64::heyoka-0.20.0-he9547df_0.conda
linux-aarch64::heyoka-llvm-15-0.20.0-h410ef35_0.conda
linux-aarch64::libitk-5.3.0-h376824e_1.conda
linux-aarch64::arrow-cpp-8.0.1-py310ha6c268c_11_cpu.conda
linux-aarch64::arrow-cpp-8.0.1-py39h64fee42_9_cpu.conda
linux-aarch64::arrow-cpp-9.0.0-py39h6076928_13_cuda.conda
linux-aarch64::pdal-2.4.3-h13fbf65_5.conda
linux-aarch64::mapserver-8.0.0-py38h4aba58b_6.conda
linux-aarch64::poppler-22.12.0-h87d1cd5_1.conda
linux-aarch64::libgd-2.3.3-h99c6b3b_4.conda
linux-aarch64::libgdal-3.5.3-hf4e9927_9.conda
linux-aarch64::arrow-cpp-8.0.1-py39h12c7c88_10_cuda.conda
linux-aarch64::pillow-9.2.0-py39h72365ce_4.conda
linux-aarch64::libopencv-4.6.0-py38h59c5fc7_9.conda
linux-aarch64::arrow-cpp-6.0.2-py38h50f21c1_9_cpu.conda
linux-aarch64::aws-sdk-cpp-1.9.379-h878810d_7.conda
linux-aarch64::postgresql-plpython-15.1-py311he331da4_1.conda
linux-aarch64::curl-7.86.0-h6ad7c7a_2.conda
linux-aarch64::folly-2022.12.12.00-h1234567_3.conda
linux-aarch64::ale-py-0.8.0-py38h95e0686_0.conda
linux-aarch64::arrow-cpp-7.0.1-py310haf07c55_10_cpu.conda
linux-aarch64::postgresql-14.5-h2340c80_3.conda
linux-aarch64::arrow-cpp-9.0.0-py311h470c4c4_14_cpu.conda
linux-aarch64::libgrpc-1.51.1-h2efb554_0.conda
linux-aarch64::magic-8.3.348-hf0419cf_0.conda
linux-aarch64::arrow-cpp-9.0.0-py39h64fee42_11_cpu.conda
linux-aarch64::libopencv-4.6.0-py310h7005eab_9.conda
linux-aarch64::libgdal-3.6.0-h787918d_12.conda
linux-aarch64::arrow-cpp-8.0.1-py38h4428b00_13_cpu.conda
linux-aarch64::arrow-cpp-7.0.1-py38hfcd7aff_9_cpu.conda
linux-aarch64::arrow-cpp-6.0.2-py311h4974332_9_cpu.conda
linux-aarch64::libgdal-3.6.1-h558fec6_0.conda
linux-aarch64::aws-sdk-cpp-1.10.41-hb66cc7a_1.conda
linux-aarch64::qt6-main-6.4.1-h4f37c40_4.conda
linux-aarch64::openconnect-9.01-hfa26e8f_6.conda
linux-aarch64::arrow-cpp-9.0.0-py311h74add98_13_cuda.conda
linux-aarch64::lxml-4.9.2-py38hb130219_0.conda
linux-aarch64::arrow-cpp-8.0.1-py311h6e7ad2c_12_cuda.conda
linux-aarch64::qt6-main-6.4.1-h541ca42_6.conda
linux-aarch64::arrow-cpp-8.0.1-py311h74add98_11_cuda.conda
linux-aarch64::arrow-cpp-9.0.0-py311hf8d7f8f_11_cuda.conda
linux-aarch64::aws-sdk-cpp-1.9.379-hd7da748_6.conda
linux-aarch64::arrow-cpp-9.0.0-py311hf55d379_14_cpu.conda
linux-aarch64::nordugrid-arc-6.17.0-py311ha3842b5_0.conda
linux-aarch64::libcurl-7.86.0-h4f97d7c_2.conda
linux-aarch64::arrow-cpp-8.0.1-py38h21860d4_12_cuda.conda
linux-aarch64::libgdal-3.5.3-h618f85d_11.conda
linux-aarch64::netcdf4-1.6.0-nompi_py311hb2ce54b_103.conda
linux-aarch64::netcdf4-1.6.0-nompi_py39ha2b77a5_103.conda
linux-aarch64::lxml-4.9.2-py38h4c23a9c_0.conda
linux-aarch64::aws-sdk-cpp-1.10.39-hc896aaf_0.conda
linux-aarch64::libgdal-3.6.0-h558fec6_14.conda
linux-aarch64::arrow-cpp-8.0.1-py310h6716c20_9_cpu.conda
linux-aarch64::arrow-cpp-9.0.0-py311he3db4bb_11_cpu.conda
linux-aarch64::postgresql-plpython-14.5-py311he331da4_2.conda
linux-aarch64::postgresql-14.5-h8376ac0_2.conda
linux-aarch64::postgresql-plpython-14.5-py310h9a0f15a_2.conda
linux-aarch64::arrow-cpp-7.0.1-py311h1cff330_11_cpu.conda
linux-aarch64::arrow-cpp-6.0.2-py310h698870a_9_cpu.conda
linux-aarch64::blosc-1.21.3-h9515e8b_0.conda
linux-aarch64::libgdal-3.4.3-h26f1e6a_1.conda
linux-aarch64::openjdk-17.0.3-h1a274e0_5.conda
linux-aarch64::hdf5-1.12.2-mpi_mpich_hdab57eb_1.conda
linux-aarch64::arrow-cpp-8.0.1-py311haa64292_13_cpu.conda
linux-aarch64::libopencv-4.6.0-py39h911383a_7.conda
linux-aarch64::mapserver-8.0.0-py38hc2aeea3_7.conda
linux-aarch64::libopencv-4.6.0-py39h417407c_9.conda
linux-aarch64::aws-sdk-cpp-1.10.36-hc896aaf_0.conda
linux-aarch64::libgdal-3.5.3-hcc8ffc9_12.conda
linux-aarch64::ale-py-0.8.0-py310h5da260a_2.conda
linux-aarch64::imagecodecs-2022.9.26-py39hd0c2a40_5.conda
linux-aarch64::arrow-cpp-9.0.0-py39ha0b7a99_11_cuda.conda
linux-aarch64::aws-sdk-cpp-1.10.29-h13c370d_0.conda
linux-aarch64::arrow-cpp-9.0.0-py310h175a14d_15_cuda.conda
linux-aarch64::aws-sdk-cpp-1.10.28-h13c370d_0.conda
linux-aarch64::libgdal-3.5.3-h5e2e49e_10.conda
linux-aarch64::pdal-2.4.3-hf3d4ff6_4.conda
linux-aarch64::nordugrid-arc-6.17.0-py311h5eb8942_0.conda
linux-aarch64::arrow-cpp-9.0.0-py38h64df659_13_cpu.conda
linux-aarch64::libpq-14.5-h9991ba5_3.conda
linux-aarch64::libgdal-arrow-parquet-3.6.1-h6522976_3.conda
linux-aarch64::blosc-1.21.2-h9515e8b_0.conda
linux-aarch64::xrootd-5.5.1-py39h3c8a9a0_3.conda
linux-aarch64::postgresql-plpython-14.5-py310he96ca99_3.conda
linux-aarch64::arrow-cpp-8.0.1-py310h4919ab3_12_cpu.conda
linux-aarch64::arrow-cpp-9.0.0-py310h6815a65_14_cpu.conda
linux-aarch64::arrow-cpp-8.0.1-py310h6d92912_13_cuda.conda
linux-aarch64::qt6-main-6.4.1-hf5b8e27_4.conda
linux-aarch64::aws-sdk-cpp-1.10.31-h13c370d_0.conda
linux-aarch64::arrow-cpp-8.0.1-py38hff083ce_9_cuda.conda
linux-aarch64::libcurl-static-7.87.0-h6ad7c7a_0.conda
linux-aarch64::qt-main-5.15.6-ha38de10_3.conda
linux-aarch64::arrow-cpp-9.0.0-py38hb7cc428_11_cpu.conda
linux-aarch64::libarrow-10.0.1-hfb459bb_0_cpu.conda
linux-aarch64::elfutils-0.188-h83c4931_1.conda
linux-aarch64::folly-2022.12.05.00-h1234567_3_jemalloc.conda
linux-aarch64::aws-sdk-cpp-1.10.30-h86cfa9b_0.conda
linux-aarch64::gfortran_impl_osx-64-9.5.0-hbb9a57b_27.conda
linux-aarch64::arrow-cpp-8.0.1-py311hf55d379_12_cpu.conda
linux-aarch64::libgdal-3.5.3-hbd8f71b_10.conda
linux-aarch64::netcdf4-1.6.0-mpi_mpich_py39h7ad2734_3.conda
linux-aarch64::arrow-cpp-8.0.1-py38h64df659_11_cpu.conda
linux-aarch64::ale-py-0.8.0-py38hee75df5_3.conda
linux-aarch64::cpp-opentelemetry-sdk-1.8.0-h9206765_0.conda
linux-aarch64::arrow-cpp-8.0.1-py39h5faf326_11_cpu.conda
linux-aarch64::qt6-3d-6.4.1-hef8f2b0_2.conda
linux-aarch64::qt6-main-6.4.1-hf5b8e27_5.conda
linux-aarch64::arrow-cpp-8.0.1-py39h545f077_12_cpu.conda
linux-aarch64::texlive-core-20210325-h26c68b6_7.conda
linux-aarch64::netcdf4-1.6.0-mpi_openmpi_py39h5376271_3.conda
linux-aarch64::arrow-cpp-7.0.1-py311hb7ab4fe_9_cpu.conda
linux-aarch64::aws-sdk-cpp-1.10.34-hd7da748_1.conda
linux-aarch64::arrow-cpp-7.0.1-py311h9a2e52e_11_cpu.conda
linux-aarch64::arrow-cpp-9.0.0-py39h3e420bc_12_cpu.conda
linux-aarch64::ale-py-0.8.0-py39h29792d1_3.conda
linux-aarch64::arrow-cpp-8.0.1-py39h34b0f29_11_cuda.conda
linux-aarch64::imagemagick-7.1.0_57-pl5321h18f45f3_0.conda
linux-aarch64::postgresql-plpython-15.1-py311hc8eda8e_1.conda
linux-aarch64::libopencv-4.6.0-py39hbd4f3bf_9.conda
linux-aarch64::nordugrid-arc-6.17.0-py39hb0bd8df_0.conda
linux-aarch64::pyinstaller-5.7.0-py39h4099708_0.conda
linux-aarch64::postgresql-plpython-15.1-py310had0907c_2.conda
linux-aarch64::postgresql-plpython-15.1-py39h4a65419_1.conda
linux-aarch64::libgdal-arrow-parquet-3.6.1-h938f804_2.conda
linux-aarch64::arrow-cpp-8.0.1-py310h4919ab3_11_cpu.conda
linux-aarch64::libarchive-minimal-static-3.6.2-h94ef9a3_0.conda
linux-aarch64::postgresql-plpython-15.1-py310h953db2b_1.conda
linux-aarch64::pyinstaller-5.7.0-py38h602f700_0.conda
linux-aarch64::imagecodecs-2022.12.24-py311h136b579_0.conda
linux-aarch64::libgdal-3.6.0-h457d1e6_11.conda
linux-aarch64::libgdal-arrow-parquet-3.6.1-h59b4b33_0.conda
linux-aarch64::aws-sdk-cpp-1.10.33-h86cfa9b_0.conda
linux-aarch64::ffmpeg-5.1.2-gpl_h8bd3c30_105.conda
linux-aarch64::libvips-8.13.3-ha8f5a0d_3.conda
linux-aarch64::arrow-cpp-8.0.1-py39h2cd343a_12_cpu.conda
linux-aarch64::postgresql-plpython-14.5-py38hd352f8c_2.conda
linux-aarch64::arrow-cpp-8.0.1-py39h545f077_13_cpu.conda
linux-aarch64::qt-webengine-5.15.4-h2c62f47_3.conda
linux-aarch64::xrootd-5.5.1-py39ha8b2de8_3.conda
linux-aarch64::folly-2022.12.05.00-h1234567_3.conda
linux-aarch64::arrow-cpp-6.0.2-py311hdc521fd_8_cpu.conda
linux-aarch64::arrow-cpp-7.0.1-py310h4d5c132_12_cpu.conda
linux-aarch64::arrow-cpp-8.0.1-py310h1df6bd5_10_cuda.conda
linux-aarch64::openssh-9.1p1-hd7ccf0a_1.conda
linux-aarch64::imagecodecs-2022.12.24-py39hd0c2a40_0.conda
linux-aarch64::arrow-cpp-6.0.2-py38h1b19548_8_cpu.conda
linux-aarch64::hdf5-1.12.2-mpi_openmpi_hf150c17_1.conda
linux-aarch64::nordugrid-arc-6.17.0-py310h07a9f05_0.conda
linux-aarch64::nordugrid-arc-6.17.0-py38h60333e4_0.conda
linux-aarch64::graphicsmagick-1.3.37-h9f8ddc2_0.conda
linux-aarch64::libgdal-3.6.1-hb5b7c64_3.conda
linux-aarch64::xrootd-5.5.1-py38ha0f4106_3.conda
linux-aarch64::postgresql-plpython-14.5-py38h7c4bb08_2.conda
linux-aarch64::ale-py-0.8.0-py38hee75df5_2.conda
linux-aarch64::hdf5-1.12.2-mpi_mpich_h7253f08_1.conda
linux-aarch64::libarrow-10.0.1-ha323506_3_cpu.conda
linux-aarch64::arrow-cpp-8.0.1-py38h9b02db9_10_cuda.conda
linux-aarch64::ffmpeg-4.4.2-lgpl_h77810cd_12.conda
linux-aarch64::imagecodecs-2022.12.22-py38h45a8245_0.conda
linux-aarch64::folly-2022.12.19.00-h1234567_3.conda
linux-aarch64::aws-sdk-cpp-1.10.37-hc896aaf_0.conda
linux-aarch64::libpq-14.5-hd21d9e6_4.conda
linux-aarch64::arrow-cpp-9.0.0-py311haa64292_15_cpu.conda
linux-aarch64::pillow-9.2.0-py311hf18358d_4.conda
linux-aarch64::libpq-15.1-h0f47c37_1.conda
linux-aarch64::libopencv-4.6.0-py311h599827d_8.conda
linux-aarch64::aws-sdk-cpp-1.10.34-h86cfa9b_0.conda
linux-aarch64::aws-sdk-cpp-1.10.34-h13c370d_0.conda
linux-aarch64::libtiff-4.4.0-hfcd36d1_5.conda
linux-aarch64::curl-7.87.0-h4f97d7c_0.conda
linux-aarch64::libgdal-3.5.3-h8b705b2_8.conda
linux-aarch64::postgresql-plpython-14.5-py39h4638dc0_2.conda
linux-aarch64::postgresql-plpython-14.5-py311h7ca8af6_3.conda
linux-aarch64::xrootd-5.5.1-py310h4a48856_3.conda
linux-aarch64::arrow-cpp-8.0.1-py310h6815a65_12_cpu.conda
linux-aarch64::arrow-cpp-6.0.2-py38hc2b6a86_7_cpu.conda
linux-aarch64::ale-py-0.8.0-py39h29792d1_0.conda
linux-aarch64::arrow-cpp-9.0.0-py310h6815a65_15_cpu.conda
linux-aarch64::libarchive-3.6.2-h601e2b1_0.conda
linux-aarch64::arrow-cpp-9.0.0-py38hff083ce_11_cuda.conda
linux-aarch64::arrow-cpp-9.0.0-py39h545f077_15_cpu.conda
linux-aarch64::libcurl-static-7.86.0-h4f97d7c_2.conda
linux-aarch64::libgdal-3.6.1-h9b91b78_1.conda
linux-aarch64::wxwidgets-3.2.1-py311hf502a5c_3.conda
linux-aarch64::aws-sdk-cpp-1.10.24-h13c370d_0.conda
linux-aarch64::ffmpeg-5.1.2-lgpl_hcb9cb6c_4.conda
linux-aarch64::ffmpeg-4.4.2-lgpl_hcb9cb6c_11.conda
linux-aarch64::imagemagick-7.1.0_54-pl5321hacf8c65_0.conda
linux-aarch64::arrow-cpp-8.0.1-py38h10b1703_12_cuda.conda
linux-aarch64::imagecodecs-2022.9.26-py38hbea6eeb_5.conda
linux-aarch64::mapserver-8.0.0-py310h9f1433e_5.conda
linux-aarch64::tesseract-5.3.0-h8af561e_0.conda
linux-aarch64::libopencv-4.6.0-py38h84303b2_8.conda
linux-aarch64::aws-sdk-cpp-1.10.42-hb66cc7a_0.conda
linux-aarch64::graphviz-7.0.5-h4b7b8df_0.conda
linux-aarch64::arrow-cpp-8.0.1-py39h2cd343a_11_cpu.conda
linux-aarch64::arrow-cpp-6.0.2-py38h1b19548_9_cpu.conda
linux-aarch64::imagecodecs-2022.9.26-py311h136b579_5.conda
linux-aarch64::arrow-cpp-9.0.0-py311hc36898b_12_cpu.conda
linux-aarch64::libpq-14.5-hfbf4865_3.conda
linux-aarch64::ale-py-0.8.0-py311hfe8ac3e_1.conda
linux-aarch64::postgresql-15.1-hd1047a9_2.conda
linux-aarch64::imagemagick-7.1.0_53-pl5321hacf8c65_0.conda
linux-aarch64::imagecodecs-2022.12.24-py38hbea6eeb_0.conda
linux-aarch64::imagecodecs-2022.9.26-py310hc7f909d_5.conda
linux-aarch64::aws-sdk-cpp-1.10.32-h86cfa9b_0.conda
linux-aarch64::aws-sdk-cpp-1.10.22-h6b63173_0.conda
linux-aarch64::postgresql-plpython-14.5-py38hdcdba6c_3.conda
linux-aarch64::ale-py-0.8.0-py39h29792d1_1.conda
linux-aarch64::libgdal-3.6.1-h1b2a5fa_1.conda
linux-aarch64::imagecodecs-2022.12.24-py39h8688234_0.conda
linux-aarch64::pyinstaller-5.7.0-py310h418eb90_0.conda
linux-aarch64::arrow-cpp-9.0.0-py310h4919ab3_13_cpu.conda
linux-aarch64::imagemagick-7.1.0_55-pl5321h18f45f3_1.conda
linux-aarch64::freeimage-3.18.0-h1dc0bb0_11.conda
linux-aarch64::tesseract-5.2.0-hb5ac655_2.conda
linux-aarch64::aws-sdk-cpp-1.10.29-h86cfa9b_0.conda
linux-aarch64::libcurl-static-7.87.0-h4f97d7c_0.conda
linux-aarch64::qt6-3d-6.4.1-hef8f2b0_3.conda
linux-aarch64::orc-1.8.1-h3aebf57_0.conda
linux-aarch64::postgresql-plpython-15.1-py39h302c7cb_2.conda
linux-aarch64::arrow-cpp-7.0.1-py39h820c713_12_cpu.conda
linux-aarch64::arrow-cpp-9.0.0-py310hfb5fbbe_13_cuda.conda
linux-aarch64::folly-2022.12.26.00-h1234567_3.conda
linux-aarch64::arrow-cpp-8.0.1-py311hae65ce2_11_cpu.conda
linux-aarch64::arrow-cpp-6.0.2-py39hee14811_8_cpu.conda
linux-aarch64::netcdf4-1.6.0-mpi_mpich_py38h4ea9a3c_3.conda
linux-aarch64::aws-sdk-cpp-1.10.33-h13c370d_0.conda
linux-aarch64::postgresql-plpython-15.1-py311h8b3cb05_2.conda
linux-aarch64::pillow-9.2.0-py39ha432683_4.conda
linux-aarch64::arrow-cpp-9.0.0-py39h12c7c88_12_cuda.conda
linux-aarch64::ale-py-0.8.0-py310h5da260a_1.conda
linux-aarch64::pillow-9.2.0-py38h208c526_4.conda
linux-aarch64::arrow-cpp-9.0.0-py311h1c0950b_15_cuda.conda
linux-aarch64::arrow-cpp-8.0.1-py38h851af18_10_cpu.conda
linux-aarch64::mapserver-8.0.0-py39hf4d248c_7.conda
linux-aarch64::arrow-cpp-7.0.1-py39h43fac50_12_cpu.conda
linux-aarch64::arrow-cpp-8.0.1-py311he3db4bb_9_cpu.conda
linux-aarch64::arrow-cpp-8.0.1-py311h470c4c4_11_cpu.conda
linux-aarch64::arrow-cpp-9.0.0-py39h5faf326_13_cpu.conda
linux-aarch64::libarrow-10.0.1-h8ebc272_1_cpu.conda
linux-aarch64::aws-sdk-cpp-1.10.41-h878810d_1.conda
linux-aarch64::arrow-cpp-9.0.0-py38ha3c754e_14_cpu.conda
linux-aarch64::arrow-cpp-9.0.0-py311hae65ce2_13_cpu.conda
linux-aarch64::arrow-cpp-9.0.0-py38ha3c754e_13_cpu.conda
linux-aarch64::arrow-cpp-8.0.1-py311hf55d379_13_cpu.conda
linux-aarch64::arrow-cpp-6.0.2-py39h25df98f_9_cpu.conda
linux-aarch64::imagecodecs-2022.9.26-py39h8688234_5.conda
linux-aarch64::arrow-cpp-9.0.0-py38h851af18_12_cpu.conda
linux-aarch64::arrow-cpp-9.0.0-py311h64ba11d_14_cuda.conda
linux-aarch64::arrow-cpp-9.0.0-py38h2b26253_13_cuda.conda
linux-aarch64::imagecodecs-2022.9.26-py38h45a8245_5.conda
linux-aarch64::pdal-2.4.3-h629b3f4_5.conda
linux-aarch64::tiledb-2.13.0-h354e0e1_0.conda
linux-aarch64::heyoka-0.20.0-hb10856b_0.conda
linux-aarch64::libgrpc-1.51.1-h177ec6a_0.conda
linux-aarch64::folly-2022.12.19.00-h1234567_3_jemalloc.conda
linux-aarch64::arrow-cpp-8.0.1-py39h6076928_11_cuda.conda
linux-aarch64::aws-sdk-cpp-1.10.27-h86cfa9b_0.conda
linux-aarch64::arrow-cpp-6.0.2-py311h4fefce5_8_cpu.conda
linux-aarch64::netcdf4-1.6.0-nompi_py38h15eb2d6_103.conda
linux-aarch64::arrow-cpp-8.0.1-py39h3e420bc_10_cpu.conda
linux-aarch64::smesh-9.9.0.0-hfdfca26_3.conda
linux-aarch64::nordugrid-arc-6.17.0-py38hd36240b_0.conda
linux-aarch64::arrow-cpp-8.0.1-py38h2b26253_11_cuda.conda
linux-aarch64::postgresql-plpython-15.1-py38hd352f8c_1.conda
linux-aarch64::aws-sdk-cpp-1.10.32-h13c370d_0.conda
linux-aarch64::magic-8.3.351-hf0419cf_0.conda
linux-aarch64::cmake-3.25.1-hc6ca916_0.conda
linux-aarch64::qt6-main-6.4.1-h6c0eb6a_3.conda
linux-aarch64::arrow-cpp-8.0.1-py311he3c0835_13_cuda.conda
linux-aarch64::postgresql-plpython-15.1-py310hbbae8fc_2.conda
linux-aarch64::hdf5-1.12.2-nompi_h3900512_101.conda
linux-aarch64::aws-sdk-cpp-1.10.30-h13c370d_0.conda
linux-aarch64::arrow-cpp-9.0.0-py310hdd1afe9_12_cpu.conda
linux-aarch64::imagecodecs-2022.12.22-py39h8688234_0.conda
linux-aarch64::libpq-15.1-hd21d9e6_2.conda
linux-aarch64::gdk-pixbuf-2.42.8-he2d62fc_2.conda
linux-aarch64::arrow-cpp-9.0.0-py310h6716c20_11_cpu.conda
linux-aarch64::postgresql-plpython-15.1-py39h4638dc0_1.conda
linux-aarch64::arrow-cpp-6.0.2-py310h9b7d067_8_cpu.conda
linux-aarch64::ffmpeg-4.4.2-gpl_h0e6723b_111.conda
linux-aarch64::r-base-4.1.3-ha74fc48_5.conda
linux-aarch64::libpq-15.1-h68e116c_1.conda
linux-aarch64::aws-sdk-cpp-1.10.38-hd7da748_0.conda
linux-aarch64::arrow-cpp-7.0.1-py39h9034ecd_9_cpu.conda
linux-aarch64::arrow-cpp-8.0.1-py38heaafdc0_13_cuda.conda
linux-aarch64::tiledb-2.13.0-h80afde6_1.conda
linux-aarch64::arrow-cpp-8.0.1-py310h6815a65_13_cpu.conda
linux-aarch64::aws-sdk-cpp-1.10.20-h6b63173_0.conda
linux-aarch64::aws-sdk-cpp-1.10.39-hd7da748_0.conda
linux-aarch64::poppler-22.12.0-h054b39a_0.conda
linux-aarch64::arrow-cpp-8.0.1-py38h4164c14_13_cuda.conda
linux-aarch64::arrow-cpp-9.0.0-py310h5d5ed10_15_cpu.conda
linux-aarch64::nco-5.1.3-he43bf31_1.conda
linux-aarch64::aws-sdk-cpp-1.10.23-h86cfa9b_0.conda
linux-aarch64::imagemagick-7.1.0_55-pl5321hee4996a_0.conda
linux-aarch64::arrow-cpp-8.0.1-py311h470c4c4_12_cpu.conda
linux-aarch64::aws-sdk-cpp-1.9.379-hb66cc7a_7.conda
linux-aarch64::octave-7.3.0-hfd367a4_2.conda
linux-aarch64::libgdal-3.6.1-h60d5c75_3.conda
linux-aarch64::ale-py-0.8.0-py39heeb0a45_2.conda
linux-aarch64::poppler-qt-22.12.0-haf01173_0.conda
linux-aarch64::libarchive-3.6.2-hc81d4a0_0.conda
linux-aarch64::imagecodecs-2022.12.24-py38h45a8245_0.conda
linux-aarch64::mlir-15.0.6-h5ca471e_0.conda
linux-aarch64::r-base-4.2.2-h620ca72_3.conda
linux-aarch64::qt6-main-6.4.1-h173fc36_3.conda
linux-aarch64::libgdal-arrow-parquet-3.6.0-h59dc9cb_12.conda
linux-aarch64::arrow-cpp-9.0.0-py310hfe4e10d_14_cuda.conda
linux-aarch64::libarrow-10.0.1-h0988928_2_cpu.conda
linux-aarch64::heyoka-0.20.0-h4c9d3ef_0.conda
linux-aarch64::aws-sdk-cpp-1.10.21-h0782703_0.conda
linux-aarch64::libgdal-3.6.0-hfecb511_13.conda
linux-aarch64::libgdal-arrow-parquet-3.6.1-h87f8c57_2.conda
linux-aarch64::aws-sdk-cpp-1.10.40-hc896aaf_0.conda
linux-aarch64::xrootd-5.5.1-py38h8dff6fe_3.conda
linux-aarch64::libgdal-3.6.0-h457d1e6_12.conda
linux-aarch64::imagecodecs-2022.12.22-py39hd0c2a40_0.conda
linux-aarch64::aws-sdk-cpp-1.10.31-h86cfa9b_0.conda
linux-aarch64::arrow-cpp-6.0.2-py39h499f2dd_9_cpu.conda
linux-aarch64::openssh-9.1p1-hd21d9e6_1.conda
linux-aarch64::libtiledb-sql-0.20.0-h971c22c_0.conda
linux-aarch64::arrow-cpp-9.0.0-py311he3c0835_15_cuda.conda
linux-aarch64::gfortran_impl_osx-arm64-11.3.0-h6efd69f_27.conda
linux-aarch64::imagemagick-7.1.0_56-pl5321h18f45f3_0.conda
linux-aarch64::magic-8.3.349-hf0419cf_0.conda
linux-aarch64::postgresql-plpython-15.1-py310h9a0f15a_1.conda
linux-aarch64::libopencv-4.6.0-py311ha87275e_9.conda
linux-aarch64::lxml-4.9.2-py310h4455969_0.conda
linux-aarch64::libgdal-3.6.1-hcb9daef_0.conda
linux-aarch64::hdf5-1.12.2-nompi_h7bde11e_101.conda
linux-aarch64::libopencv-4.6.0-py310h7b04e73_7.conda
linux-aarch64::libssh-0.10.4-h3b5d397_3.conda
linux-aarch64::arrow-cpp-8.0.1-py311hc36898b_10_cpu.conda
linux-aarch64::arrow-cpp-8.0.1-py310hfb5fbbe_11_cuda.conda
linux-aarch64::mapserver-8.0.0-py311h66041db_6.conda
linux-aarch64::aws-sdk-cpp-1.10.25-h86cfa9b_0.conda
linux-aarch64::mapserver-8.0.0-py39h7329491_5.conda
linux-aarch64::arrow-cpp-9.0.0-py38h10b1703_14_cuda.conda
linux-aarch64::heyoka-llvm-12-0.20.0-hd4d3397_0.conda
linux-aarch64::arrow-cpp-7.0.1-py310h2e70e48_11_cpu.conda
linux-aarch64::aws-sdk-cpp-1.10.40-hd7da748_0.conda
linux-aarch64::arrow-cpp-9.0.0-py38h9b02db9_12_cuda.conda
linux-aarch64::postgresql-plpython-14.5-py39h302c7cb_4.conda
linux-aarch64::libgdal-arrow-parquet-3.6.1-had4887b_3.conda
linux-aarch64::libgdal-arrow-parquet-3.6.0-h59b4b33_14.conda
linux-aarch64::aws-sdk-cpp-1.10.20-h0782703_0.conda
linux-aarch64::postgresql-plpython-14.5-py310had0907c_4.conda
linux-aarch64::postgresql-plpython-14.5-py39h4a65419_2.conda
linux-aarch64::libgdal-3.6.1-h45ae7c1_2.conda
linux-aarch64::postgresql-plpython-14.5-py311hc8eda8e_2.conda
linux-aarch64::arrow-cpp-7.0.1-py39h6ca5bea_10_cpu.conda
linux-aarch64::xrootd-5.5.1-py39h071c2ea_3.conda
linux-aarch64::libarrow-10.0.1-h8481fac_0_cpu.conda
linux-aarch64::libssh-0.10.4-h516404d_3.conda
linux-aarch64::postgresql-15.1-hc0ee1c8_1.conda
linux-aarch64::folly-2022.12.12.00-h1234567_3_jemalloc.conda
linux-aarch64::arrow-cpp-6.0.2-py311h4fefce5_9_cpu.conda
linux-aarch64::arrow-cpp-8.0.1-py310hfe4e10d_11_cuda.conda
linux-aarch64::arrow-cpp-8.0.1-py38h4428b00_12_cpu.conda
linux-aarch64::libarrow-10.0.1-hf325bf3_2_cpu.conda
linux-aarch64::heyoka-0.20.0-h74df9e4_0.conda
linux-aarch64::libgdal-3.5.3-he511616_12.conda
linux-aarch64::cpp-opentelemetry-sdk-1.8.1-h6dae3c9_1.conda
linux-aarch64::pdal-2.4.3-h05e81f5_4.conda
linux-aarch64::libpq-15.1-hd7ccf0a_2.conda
linux-aarch64::lxml-4.9.2-py39h737f9a4_0.conda
linux-aarch64::arrow-cpp-9.0.0-py39h6fb4ef8_15_cpu.conda
linux-aarch64::arrow-cpp-9.0.0-py39h2cd343a_14_cpu.conda
linux-aarch64::arrow-cpp-8.0.1-py310hdd1afe9_10_cpu.conda
linux-aarch64::aws-sdk-cpp-1.10.34-hc896aaf_1.conda
linux-aarch64::heyoka-llvm-13-0.20.0-h1b20742_0.conda
linux-aarch64::arrow-cpp-9.0.0-py310hfe4e10d_13_cuda.conda
linux-aarch64::aws-sdk-cpp-1.10.41-hd7da748_0.conda
linux-aarch64::libopencv-4.6.0-py38h58c7249_7.conda
linux-aarch64::nordugrid-arc-6.17.0-py310ha5aa5c6_0.conda
linux-aarch64::openmpi-4.1.4-hcfdb870_102.conda
linux-aarch64::ffmpeg-5.1.2-lgpl_h77810cd_5.conda
linux-aarch64::arrow-cpp-9.0.0-py310h1df6bd5_12_cuda.conda
linux-aarch64::libgrpc-1.50.1-h177ec6a_0.conda
linux-aarch64::nordugrid-arc-6.17.0-py39h7a95e08_0.conda
linux-aarch64::ffmpeg-4.4.2-gpl_h8bd3c30_112.conda
linux-aarch64::libcurl-7.87.0-h4f97d7c_0.conda
linux-aarch64::geotiff-1.7.1-hfc2f904_5.conda
linux-aarch64::poppler-qt-22.12.0-h30490b2_1.conda
linux-aarch64::arrow-cpp-8.0.1-py38hb7cc428_9_cpu.conda
linux-aarch64::postgresql-14.5-hc0ee1c8_2.conda
linux-aarch64::arrow-cpp-8.0.1-py311h64ba11d_11_cuda.conda
linux-aarch64::nco-5.1.3-ha9443e2_2.conda
linux-aarch64::arrow-cpp-7.0.1-py311h6b80523_10_cpu.conda
linux-aarch64::mapserver-8.0.0-py311h59e7b12_5.conda
linux-aarch64::arrow-cpp-8.0.1-py310h7d9adc5_12_cuda.conda
linux-aarch64::aws-sdk-cpp-1.10.24-h86cfa9b_0.conda
linux-aarch64::aws-sdk-cpp-1.10.26-h86cfa9b_0.conda
linux-aarch64::arrow-cpp-6.0.2-py39h499f2dd_8_cpu.conda
linux-aarch64::libarrow-10.0.1-h91f38e1_1_cpu.conda
linux-aarch64::arrow-cpp-9.0.0-py310h9b51b4e_11_cuda.conda
linux-aarch64::postgresql-15.1-h8376ac0_1.conda
linux-aarch64::postgresql-14.5-h495b899_3.conda
linux-aarch64::qt-main-5.15.6-h9e5b47b_5.conda
linux-aarch64::arrow-cpp-8.0.1-py39ha0b7a99_9_cuda.conda
linux-aarch64::postgresql-plpython-14.5-py310h84765f5_3.conda
linux-aarch64::arrow-cpp-9.0.0-py39h34c79e5_15_cuda.conda
linux-aarch64::postgresql-plpython-14.5-py310hbbae8fc_4.conda
linux-aarch64::arrow-cpp-7.0.1-py38h37fe09f_10_cpu.conda
linux-aarch64::arrow-cpp-6.0.2-py311h0b7364f_7_cpu.conda
linux-aarch64::lxml-4.9.2-py311hd392328_0.conda
linux-aarch64::xrootd-5.5.1-py38hd878a8a_3.conda
linux-aarch64::ale-py-0.8.0-py38h95e0686_1.conda
linux-aarch64::libgdal-3.5.3-h8e1e014_8.conda
linux-aarch64::qtwebkit-5.212-hdbb987d_7.conda
linux-aarch64::octave-7.3.0-h7d81925_2.conda
linux-aarch64::arrow-cpp-9.0.0-py311h470c4c4_13_cpu.conda
linux-aarch64::arrow-cpp-6.0.2-py310h6de476f_7_cpu.conda
linux-aarch64::qt6-main-6.4.1-h9629ddd_6.conda
linux-aarch64::arrow-cpp-6.0.2-py310h698870a_8_cpu.conda
linux-aarch64::postgresql-plpython-14.5-py311h8b3cb05_4.conda
linux-aarch64::aws-sdk-cpp-1.10.22-h0782703_0.conda
linux-aarch64::gmsh-4.11.0-hfe6a82c_1.conda
linux-aarch64::libcurl-static-7.86.0-h6ad7c7a_2.conda
linux-aarch64::arrow-cpp-7.0.1-py311h6c46d06_12_cpu.conda
linux-aarch64::arrow-cpp-8.0.1-py311h1c0950b_13_cuda.conda
linux-aarch64::git-2.39.0-pl5321h94aa16f_0.conda
linux-aarch64::arrow-cpp-9.0.0-py39h34b0f29_13_cuda.conda
linux-aarch64::postgresql-plpython-14.5-py39h3f30916_3.conda
linux-aarch64::arrow-cpp-7.0.1-py311h1cff330_12_cpu.conda
linux-aarch64::libgdal-arrow-parquet-3.6.0-h16a26d8_12.conda
linux-aarch64::aws-sdk-cpp-1.10.42-h878810d_0.conda
linux-aarch64::postgresql-plpython-15.1-py38h90b34db_2.conda
linux-aarch64::arrow-cpp-9.0.0-py39h318fdd1_14_cuda.conda
linux-aarch64::netcdf4-1.6.0-mpi_openmpi_py310hcb6cbc7_3.conda
linux-aarch64::openslide-3.4.1-h8fa15e4_6.conda
linux-aarch64::libopencv-4.6.0-py311h270816b_7.conda
linux-aarch64::netcdf4-1.6.0-mpi_mpich_py310h35d723c_3.conda
linux-aarch64::dcap-2.47.12-h336aac3_6.conda
linux-aarch64::qt-main-5.15.6-h96cabaa_5.conda
linux-aarch64::netcdf4-1.6.0-mpi_mpich_py311hc5b5909_3.conda
linux-aarch64::ale-py-0.8.0-py311hfe8ac3e_2.conda
linux-aarch64::libitk-5.3.0-hd727ebf_2.conda
linux-aarch64::arrow-cpp-8.0.1-py39h34b0f29_12_cuda.conda
linux-aarch64::arrow-cpp-9.0.0-py310h7d9adc5_14_cuda.conda
linux-aarch64::arrow-cpp-7.0.1-py310ha0a53c4_9_cpu.conda
linux-aarch64::postgresql-plpython-15.1-py38h701b0f7_2.conda
linux-aarch64::pillow-9.2.0-py310h2843b5e_4.conda
linux-aarch64::libpq-14.5-hd7ccf0a_4.conda
linux-aarch64::postgresql-plpython-15.1-py38h7c4bb08_1.conda
linux-aarch64::arrow-cpp-9.0.0-py310ha6c268c_13_cpu.conda
linux-aarch64::heyoka-llvm-11-0.20.0-h126ff69_0.conda
linux-aarch64::mapserver-8.0.0-py38h42fe3d9_5.conda
linux-aarch64::aws-sdk-cpp-1.10.26-h13c370d_0.conda
linux-aarch64::libopencv-4.6.0-py39hdea3069_8.conda
linux-aarch64::ale-py-0.8.0-py39heeb0a45_3.conda
linux-aarch64::libgdal-3.6.0-he902e53_13.conda
linux-aarch64::geotiff-1.7.1-h8fccb16_6.conda
linux-aarch64::libopencv-4.6.0-py38h04a8b0f_7.conda
linux-aarch64::ale-py-0.8.0-py39h29792d1_2.conda
linux-aarch64::arrow-cpp-9.0.0-py310h6d92912_15_cuda.conda
linux-aarch64::aws-sdk-cpp-1.10.35-hc896aaf_0.conda
linux-aarch64::postgresql-plpython-14.5-py38h701b0f7_4.conda
linux-aarch64::qt6-3d-6.4.1-hef8f2b0_1.conda
linux-aarch64::arrow-cpp-7.0.1-py38h576d99f_11_cpu.conda
linux-aarch64::arrow-cpp-8.0.1-py310h9b51b4e_9_cuda.conda
linux-aarch64::libgdal-arrow-parquet-3.6.0-hc226363_13.conda
linux-aarch64::libgdal-arrow-parquet-3.6.1-h61a9c7c_1.conda
linux-aarch64::netcdf4-1.6.0-mpi_openmpi_py311h4e0a920_3.conda
linux-aarch64::libvips-8.13.3-h5c0b04a_4.conda
linux-aarch64::curl-7.87.0-h6ad7c7a_0.conda
linux-aarch64::arrow-cpp-8.0.1-py39h6fb4ef8_13_cpu.conda
linux-aarch64::ale-py-0.8.0-py38h95e0686_2.conda
linux-aarch64::libtiff-4.5.0-hfcd36d1_0.conda
linux-aarch64::libopencv-4.6.0-py310hb8a943d_8.conda
linux-aarch64::aws-sdk-cpp-1.9.379-hc896aaf_6.conda
linux-aarch64::arrow-cpp-9.0.0-py38heaafdc0_15_cuda.conda
linux-aarch64::libgdal-3.5.3-h1f4161e_9.conda
linux-aarch64::gst-plugins-bad-1.21.2-hf80b131_1.conda
linux-aarch64::libopencv-4.6.0-py39h739b805_7.conda
linux-aarch64::arrow-cpp-8.0.1-py311hf8d7f8f_9_cuda.conda
linux-aarch64::magic-8.3.346-h011aa66_0.conda
linux-aarch64::arrow-cpp-8.0.1-py38h80dfe51_13_cpu.conda
linux-aarch64::libopencv-4.6.0-py38h6ef2146_9.conda
linux-aarch64::arrow-cpp-8.0.1-py39h2f5d929_13_cuda.conda
linux-aarch64::arrow-cpp-8.0.1-py39h34c79e5_13_cuda.conda
linux-aarch64::libspatialite-5.0.1-h84efba4_23.conda
linux-aarch64::libcurl-7.87.0-h6ad7c7a_0.conda
linux-aarch64::postgresql-14.5-he4d23a4_4.conda
linux-aarch64::arrow-cpp-9.0.0-py39h34b0f29_14_cuda.conda
linux-aarch64::arrow-cpp-8.0.1-py38ha3c754e_11_cpu.conda
linux-aarch64::xrootd-5.5.1-py310hf493d9a_3.conda
linux-aarch64::libgdal-3.6.0-hcb9daef_14.conda
linux-aarch64::arrow-cpp-7.0.1-py38hcb11b3e_12_cpu.conda
linux-aarch64::arrow-cpp-9.0.0-py311h6e7ad2c_14_cuda.conda
linux-aarch64::arrow-cpp-8.0.1-py311hff39142_10_cuda.conda
linux-aarch64::arrow-cpp-9.0.0-py39h2cd343a_13_cpu.conda
linux-aarch64::arrow-cpp-6.0.2-py39hce4ed8b_7_cpu.conda
linux-aarch64::imagecodecs-2022.12.22-py38hbea6eeb_0.conda
linux-aarch64::aws-sdk-cpp-1.10.28-h86cfa9b_0.conda
linux-aarch64::arrow-cpp-8.0.1-py311h64ba11d_12_cuda.conda
linux-aarch64::ale-py-0.8.0-py311hfe8ac3e_3.conda
linux-aarch64::arrow-cpp-9.0.0-py310h4919ab3_14_cpu.conda
linux-aarch64::aws-sdk-cpp-1.10.25-h13c370d_0.conda
linux-aarch64::gfortran_impl_osx-64-10.4.0-h825d47c_27.conda
linux-aarch64::arrow-cpp-6.0.2-py310h28f5d91_9_cpu.conda
linux-aarch64::libgdal-3.4.3-h6de9537_1.conda
linux-aarch64::arrow-cpp-9.0.0-py311hff39142_12_cuda.conda
linux-aarch64::libgdal-3.5.3-h10b9244_11.conda
linux-aarch64::arrow-cpp-7.0.1-py310hd076928_11_cpu.conda
linux-aarch64::aws-sdk-cpp-1.10.41-hc896aaf_0.conda
linux-aarch64::libopencv-4.6.0-py39h4d76ee4_8.conda
linux-aarch64::imagecodecs-2022.12.22-py311h136b579_0.conda
linux-aarch64::arrow-cpp-9.0.0-py38h10b1703_13_cuda.conda
linux-aarch64::aws-sdk-cpp-1.10.27-h13c370d_0.conda
linux-aarch64::curl-7.86.0-h4f97d7c_2.conda
linux-aarch64::imagecodecs-2022.12.24-py310hc7f909d_0.conda
linux-aarch64::r-base-4.2.2-he088d64_2.conda
linux-aarch64::libgdal-3.6.0-h787918d_11.conda
linux-aarch64::cpp-opentelemetry-sdk-1.8.1-h436c0eb_0.conda
linux-aarch64::arrow-cpp-9.0.0-py39h545f077_14_cpu.conda
linux-aarch64::libgrpc-1.50.1-h2efb554_0.conda
linux-aarch64::ale-py-0.8.0-py310h5da260a_0.conda
linux-aarch64::libgdal-arrow-parquet-3.6.1-h46e6db4_1.conda
linux-aarch64::pillow-9.2.0-py38h4225b63_4.conda
linux-aarch64::mapserver-8.0.0-py310h2c6fe41_7.conda
linux-aarch64::mapserver-8.0.0-py39h198fda1_6.conda
linux-aarch64::arrow-cpp-7.0.1-py310hd076928_12_cpu.conda
linux-aarch64::graphicsmagick-1.3.37-h427c933_1.conda
linux-aarch64::arrow-cpp-9.0.0-py311hf55d379_15_cpu.conda
linux-aarch64::aws-sdk-cpp-1.10.36-hd7da748_0.conda
linux-aarch64::libpq-14.5-h0f47c37_2.conda
linux-aarch64::postgresql-plpython-14.5-py311hbd0e9f8_4.conda
linux-aarch64::mapserver-8.0.0-py311h09ec11f_7.conda
linux-aarch64::arrow-cpp-9.0.0-py38h80dfe51_15_cpu.conda
linux-aarch64::magic-8.3.350-hf0419cf_0.conda
linux-aarch64::arrow-cpp-7.0.1-py39h43fac50_11_cpu.conda
linux-aarch64::aws-sdk-cpp-1.10.21-h6b63173_0.conda
linux-aarch64::arrow-cpp-9.0.0-py38h4164c14_15_cuda.conda
linux-aarch64::xrootd-5.5.1-py38hd7033fa_3.conda
linux-aarch64::ale-py-0.8.0-py310h5da260a_3.conda
linux-aarch64::lxml-4.9.2-py39h5798cf5_0.conda
linux-aarch64::openconnect-9.01-hdd3e927_5.conda
linux-aarch64::libtiledb-sql-0.20.0-ha54459c_0.conda
linux-aarch64::xrootd-5.5.1-py311hc9a958a_3.conda
linux-aarch64::arrow-cpp-9.0.0-py311h64ba11d_13_cuda.conda
linux-aarch64::gst-plugins-bad-1.21.2-h2d17172_1.conda
linux-aarch64::dcap-2.47.12-haf057d8_6.conda
linux-aarch64::aws-sdk-cpp-1.10.38-hc896aaf_0.conda
linux-aarch64::ffmpeg-5.1.2-gpl_h0e6723b_104.conda
linux-aarch64::postgresql-plpython-15.1-py311hbd0e9f8_2.conda
linux-aarch64::postgresql-plpython-14.5-py39h12c30fb_4.conda
linux-aarch64::sdl_image-1.2.12-hfcade82_3.conda
linux-aarch64::arrow-cpp-9.0.0-py38h4428b00_15_cpu.conda
linux-aarch64::gfortran_impl_osx-arm64-10.3.0-h970f3f0_27.conda
linux-aarch64::libgdal-arrow-parquet-3.6.1-h2b56996_0.conda
linux-aarch64::libopencv-4.6.0-py38h1f7838b_8.conda
linux-aarch64::arrow-cpp-8.0.1-py310h5d5ed10_13_cpu.conda
linux-aarch64::netcdf4-1.6.0-nompi_py310ha29014f_103.conda
linux-aarch64::arrow-cpp-9.0.0-py38h21860d4_14_cuda.conda
linux-aarch64::folly-2022.12.26.00-h1234567_3_jemalloc.conda
linux-aarch64::libpq-14.5-h68e116c_2.conda
linux-aarch64::tiledb-2.13.0-h6866cf4_0.conda
linux-aarch64::libgdal-3.6.1-h71182fd_2.conda
linux-aarch64::heyoka-0.20.0-h382dc41_0.conda
linux-aarch64::heyoka-llvm-14-0.20.0-h4317dc1_0.conda
linux-aarch64::hdf5-1.12.2-mpi_openmpi_h4189069_1.conda
linux-aarch64::arrow-cpp-7.0.1-py38h0a821d9_11_cpu.conda
linux-aarch64::arrow-cpp-8.0.1-py310h175a14d_13_cuda.conda
linux-aarch64::postgresql-14.5-hd1047a9_4.conda
linux-aarch64::netcdf4-1.6.0-mpi_openmpi_py38hd76a68a_3.conda
linux-aarch64::postgresql-plpython-15.1-py39h12c30fb_2.conda
linux-aarch64::arrow-cpp-9.0.0-py39h2f5d929_15_cuda.conda
linux-aarch64::arrow-cpp-8.0.1-py38h10b1703_11_cuda.conda
linux-aarch64::xrootd-5.5.1-py311hebe9b31_3.conda
linux-aarch64::qt6-main-6.4.1-h4f37c40_5.conda
linux-aarch64::libgdal-arrow-parquet-3.6.0-h720a8ed_13.conda
linux-aarch64::arrow-cpp-7.0.1-py38h576d99f_12_cpu.conda
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
linux-aarch64::libprotobuf-3.21.11-h7fe2111_0.conda
linux-aarch64::eccodes-2.27.1-h4493c21_0.conda
linux-aarch64::gst-plugins-base-1.21.3-h8a62080_0.conda
linux-aarch64::libsolv-static-0.7.23-h3cb9bc8_0.conda
linux-aarch64::libsolv-0.7.23-h3cb9bc8_0.conda
linux-aarch64::gcab-1.5-haf78a14_0.conda
linux-aarch64::gst-plugins-good-1.21.3-hf363d5f_1.conda
linux-aarch64::libprotobuf-static-3.21.11-h3cb9bc8_0.conda
linux-aarch64::openjpeg-2.5.0-h9508984_2.conda
linux-aarch64::gds-base-3.0.0-haf03645_2.conda
linux-aarch64::libmlir15-15.0.6-h5ca471e_0.conda
linux-aarch64::gds-base-3.0.0-h8ddaef3_3.conda
linux-aarch64::libprotobuf-static-3.21.12-h3cb9bc8_0.conda
linux-aarch64::gst-plugins-base-1.21.3-h8a62080_1.conda
linux-aarch64::libmlir-15.0.6-h5ca471e_0.conda
linux-aarch64::libcups-2.3.3-h4303303_3.conda
linux-aarch64::libprotobuf-3.21.12-h7fe2111_0.conda
linux-aarch64::gst-plugins-good-1.21.3-hf363d5f_0.conda
linux-aarch64::liblal-7.2.4-fftw_he26ac06_104.conda
-    "libzlib >=1.2.13,<1.3.0a0"
+    "libzlib >=1.2.13,<2.0.0a0"
================================================================================
================================================================================
noarch
================================================================================
================================================================================
win-64
win-64::intel-opencl-rt-2023.0.0-h78c0d30_25923.conda
win-64::arrow-cpp-7.0.1-py38he27c648_9_cuda.conda
win-64::freecad-0.20.2-py39hf545f7d_0.conda
win-64::aws-sdk-cpp-1.10.36-h4d30238_0.conda
win-64::geotiff-1.7.1-h720ab47_5.conda
win-64::ale-py-0.8.0-py311haa5eaab_2.conda
win-64::freecad-0.20.2-py37h44010d8_0.conda
win-64::arrow-cpp-9.0.0-py311hd2e3e2b_13_cuda.conda
win-64::aws-sdk-cpp-1.9.379-h72dcc63_7.conda
win-64::libarrow-10.0.1-h058dbc9_0_cpu.conda
win-64::libgdal-arrow-parquet-3.6.1-hce37fd6_1.conda
win-64::ffmpeg-4.4.2-gpl_hfff1fce_111.conda
win-64::libpq-14.5-h04fd8be_2.conda
win-64::arrow-cpp-9.0.0-py310h0329283_14_cuda.conda
win-64::arrow-cpp-9.0.0-py38he02c075_12_cuda.conda
win-64::arrow-cpp-7.0.1-py38h3fbcbd5_12_cuda.conda
win-64::arrow-cpp-7.0.1-py38h1b13883_9_cpu.conda
win-64::libarrow-10.0.1-h96d9594_2_cpu.conda
win-64::paraview-5.11.0-py39h8c4626f_101_qt.conda
win-64::aws-sdk-cpp-1.10.27-h2768dcf_0.conda
win-64::imagecodecs-2022.12.22-py310hcad817f_0.conda
win-64::paraview-5.11.0-py310h874f2ab_101_qt.conda
win-64::arrow-cpp-6.0.2-py38h96804c5_7_cpu.conda
win-64::pillow-9.2.0-py38h087119c_4.conda
win-64::libcurl-7.87.0-h68f0423_0.conda
win-64::arrow-cpp-9.0.0-py39h3ea1b9e_12_cuda.conda
win-64::arrow-cpp-8.0.1-py39hd6dadda_11_cpu.conda
win-64::arrow-cpp-9.0.0-py39h4dc5c54_14_cpu.conda
win-64::geotiff-1.7.1-hc256dc0_6.conda
win-64::libgdal-arrow-parquet-3.6.1-h0179b09_2.conda
win-64::libgdal-3.6.0-h1a413ac_14.conda
win-64::arrow-cpp-8.0.1-py310h501cca4_10_cpu.conda
win-64::arrow-cpp-8.0.1-py311hd2e3e2b_11_cuda.conda
win-64::libpq-15.1-hf15792c_1.conda
win-64::hugin-2022.0.0-pl5321h3066e14_0.conda
win-64::libpano13-2.9.20rc2-pl5321h8ad0ef4_4.conda
win-64::libgdal-3.5.3-h1a413ac_10.conda
win-64::arrow-cpp-7.0.1-py311h434fdba_10_cpu.conda
win-64::arrow-cpp-9.0.0-py311h434fdba_12_cpu.conda
win-64::arrow-cpp-6.0.2-py39h151caba_9_cuda.conda
win-64::aws-sdk-cpp-1.10.30-h2768dcf_0.conda
win-64::arrow-cpp-6.0.2-py39h151caba_8_cuda.conda
win-64::imagecodecs-2022.9.26-py39h17e3817_5.conda
win-64::aws-sdk-cpp-1.10.23-h2768dcf_0.conda
win-64::aws-sdk-cpp-1.10.29-h8422197_0.conda
win-64::libarrow-10.0.1-hb26e182_0_cuda.conda
win-64::freeimage-3.18.0-h775a65d_11.conda
win-64::arrow-cpp-9.0.0-py38he17c6ad_14_cuda.conda
win-64::stir-5.0.2-py310h60465ec_6.conda
win-64::arrow-cpp-9.0.0-py310h9497d45_15_cpu.conda
win-64::postgresql-14.5-h58a5ca5_3.conda
win-64::libopencv-4.6.0-py311h0442f2a_9.conda
win-64::arrow-cpp-9.0.0-py311h29796c4_15_cpu.conda
win-64::heyoka-llvm-12-0.20.0-h9b27782_0.conda
win-64::postgresql-plpython-14.5-py38ha2f05b0_3.conda
win-64::arrow-cpp-7.0.1-py310hf58943e_11_cuda.conda
win-64::paraview-5.11.0-py39hf0f293a_101_qt.conda
win-64::arrow-cpp-9.0.0-py38h8c764ff_14_cpu.conda
win-64::sdl2_image-2.6.2-h22b4670_1.conda
win-64::postgresql-14.5-h392df6f_2.conda
win-64::postgresql-plpython-15.1-py311h7623089_2.conda
win-64::libopencv-4.6.0-py38h3a0c1ff_9.conda
win-64::postgresql-plpython-15.1-py38hb66759c_2.conda
win-64::arrow-cpp-8.0.1-py310h9497d45_11_cpu.conda
win-64::intel-cmplr-lib-rt-2023.0.0-h12be248_25923.conda
win-64::libgdal-3.5.3-hcdc7a77_9.conda
win-64::arrow-cpp-9.0.0-py38h5f63bb8_12_cpu.conda
win-64::aws-sdk-cpp-1.10.25-h2768dcf_0.conda
win-64::arrow-cpp-9.0.0-py38h1b13883_11_cpu.conda
win-64::libgdal-3.6.0-h9e334dc_13.conda
win-64::curl-7.86.0-h68f0423_2.conda
win-64::netcdf4-1.6.0-nompi_py38h78680c8_103.conda
win-64::tiledb-2.13.0-h5689973_1.conda
win-64::libmediainfo-22.12-h0650ae2_0.conda
win-64::harp-1.17-py311r41h0120304_0.conda
win-64::ale-py-0.8.0-py310h2021ac3_0.conda
win-64::arrow-cpp-7.0.1-py39hb8a7c1e_10_cpu.conda
win-64::qt6-main-6.4.1-h9901510_6.conda
win-64::libsolv-static-0.7.23-h12be248_0.conda
win-64::imagecodecs-2022.12.22-py38h3af18dc_0.conda
win-64::arrow-cpp-7.0.1-py38he02c075_10_cuda.conda
win-64::openscenegraph-3.6.5-hb10f911_15.conda
win-64::libarrow-10.0.1-h2d1fcc7_2_cuda.conda
win-64::arrow-cpp-9.0.0-py39hc9c33e1_14_cuda.conda
win-64::arrow-cpp-8.0.1-py311hff6b32f_11_cuda.conda
win-64::aws-sdk-cpp-1.10.34-he71221d_1.conda
win-64::arrow-cpp-9.0.0-py38he27c648_11_cuda.conda
win-64::harp-1.17-py38r41h2706d8f_0.conda
win-64::arrow-cpp-6.0.2-py311h63618d0_7_cpu.conda
win-64::imagecodecs-2022.12.24-py38h4b8945e_0.conda
win-64::postgresql-14.5-h58a5ca5_2.conda
win-64::imagecodecs-2022.9.26-py39hbac47be_5.conda
win-64::arrow-cpp-8.0.1-py39h3de39ee_12_cuda.conda
win-64::arrow-cpp-9.0.0-py39h958ad16_15_cuda.conda
win-64::pillow-9.2.0-py310hdbb7713_4.conda
win-64::sdl2_image-2.6.2-h090e09f_3.conda
win-64::libgrpc-1.50.1-h535cfc9_0.conda
win-64::arrow-cpp-9.0.0-py311hbfcb821_15_cuda.conda
win-64::poppler-22.12.0-h183ae7b_1.conda
win-64::ale-py-0.8.0-py39hc6c698a_2.conda
win-64::aws-sdk-cpp-1.9.379-haf3c795_7.conda
win-64::arrow-cpp-9.0.0-py311hf6a8ae8_11_cuda.conda
win-64::arrow-cpp-9.0.0-py39h3de39ee_14_cuda.conda
win-64::libopencv-4.6.0-py39ha9d37a1_9.conda
win-64::imagecodecs-2022.12.24-py310hcad817f_0.conda
win-64::postgresql-plpython-15.1-py311hf6a82bc_1.conda
win-64::pypy3.8-7.3.9-h577050a_7.conda
win-64::arrow-cpp-9.0.0-py38h602b2d6_15_cuda.conda
win-64::gdstk-0.9.35-py38h2029624_0.conda
win-64::lxml-4.9.2-py311h5942461_0.conda
win-64::aws-sdk-cpp-1.10.33-h2768dcf_0.conda
win-64::arrow-cpp-8.0.1-py311h29796c4_12_cpu.conda
win-64::aws-sdk-cpp-1.10.34-h4d30238_1.conda
win-64::libgdal-3.6.0-hefe12b1_14.conda
win-64::arrow-cpp-8.0.1-py311h29796c4_13_cpu.conda
win-64::aws-sdk-cpp-1.10.29-h2768dcf_0.conda
win-64::aws-sdk-cpp-1.10.40-he71221d_0.conda
win-64::postgresql-plpython-14.5-py39h15dfc06_3.conda
win-64::arrow-cpp-7.0.1-py38h3fbcbd5_11_cuda.conda
win-64::gemmi-0.5.8-py310hb84602e_0.conda
win-64::qt6-main-6.4.1-hc8e46b8_3.conda
win-64::libgdal-arrow-parquet-3.6.1-hd930267_2.conda
win-64::arrow-cpp-7.0.1-py311h3ff6de7_11_cuda.conda
win-64::postgresql-15.1-h392df6f_1.conda
win-64::aws-sdk-cpp-1.10.32-h8422197_0.conda
win-64::paraview-5.11.0-py38h451df11_101_qt.conda
win-64::aws-sdk-cpp-1.10.41-h72dcc63_1.conda
win-64::libarrow-10.0.1-h2d1fcc7_3_cuda.conda
win-64::arrow-cpp-8.0.1-py311hcfebf5d_11_cpu.conda
win-64::libgdal-3.6.0-h74b97fb_11.conda
win-64::arrow-cpp-9.0.0-py39h19f0306_15_cuda.conda
win-64::arrow-cpp-8.0.1-py310h95fa42c_9_cuda.conda
win-64::arrow-cpp-7.0.1-py310h78c3a49_12_cpu.conda
win-64::arrow-cpp-9.0.0-py311hfd373be_11_cpu.conda
win-64::coda-2.24.1-py38h2706d8f_0.conda
win-64::arrow-cpp-8.0.1-py38hc846b74_11_cuda.conda
win-64::arrow-cpp-6.0.2-py39h8f25e9b_7_cpu.conda
win-64::arrow-cpp-9.0.0-py39hf5579cb_11_cpu.conda
win-64::vigra-1.11.1-py310h8b90056_1037.conda
win-64::qt6-main-6.4.1-hc8e46b8_5.conda
win-64::postgresql-plpython-15.1-py38hcf00bc8_1.conda
win-64::libopencv-4.6.0-py39hedeca96_7.conda
win-64::libtiff-4.5.0-hc4f729c_0.conda
win-64::arrow-cpp-9.0.0-py39hc9c33e1_13_cuda.conda
win-64::aws-sdk-cpp-1.10.42-haf3c795_0.conda
win-64::libgdal-3.6.1-ha74bd8d_3.conda
win-64::arrow-cpp-7.0.1-py39h4dc5c54_11_cpu.conda
win-64::libgdal-3.5.3-h9e334dc_9.conda
win-64::libgdal-3.5.3-h5c71946_12.conda
win-64::arrow-cpp-6.0.2-py311hea412e5_8_cuda.conda
win-64::arrow-cpp-9.0.0-py310h501cca4_12_cpu.conda
win-64::fossil-2.20-h00fea9b_1.conda
win-64::arrow-cpp-8.0.1-py310hf58943e_13_cuda.conda
win-64::arrow-cpp-9.0.0-py311h3ff6de7_15_cuda.conda
win-64::libcurl-static-7.87.0-h68f0423_0.conda
win-64::nco-5.1.3-h343d473_2.conda
win-64::coda-2.24.1-py39h763b820_0.conda
win-64::libopencv-4.6.0-py39h635b0dd_8.conda
win-64::ale-py-0.8.0-py311haa5eaab_3.conda
win-64::postgresql-15.1-h58a5ca5_1.conda
win-64::libopencv-4.6.0-py38h671439d_7.conda
win-64::aws-sdk-cpp-1.10.28-h8422197_0.conda
win-64::poppler-qt-22.12.0-hb9cfb58_1.conda
win-64::arrow-cpp-9.0.0-py39h4dc5c54_13_cpu.conda
win-64::libarchive-3.6.2-h62576cb_0.conda
win-64::ovito-3.7.12-habef550_0.conda
win-64::pillow-9.2.0-py311h76d9071_4.conda
win-64::arrow-cpp-9.0.0-py311h29796c4_14_cpu.conda
win-64::arrow-cpp-9.0.0-py38hc846b74_14_cuda.conda
win-64::openmeeg-2.5.5-py39hd2e712d_2.conda
win-64::imagecodecs-2022.12.22-py39h17e3817_0.conda
win-64::arrow-cpp-7.0.1-py310h69160df_9_cpu.conda
win-64::wasmer-3.1.0-h6192c45_0.conda
win-64::libgdal-arrow-parquet-3.6.0-haac60c0_14.conda
win-64::gst-plugins-base-1.21.3-h001b923_0.conda
win-64::arrow-cpp-6.0.2-py38h43b1507_9_cuda.conda
win-64::aws-sdk-cpp-1.10.24-h2768dcf_0.conda
win-64::hugin-base-2022.0.0-pl5321hb58d289_1.conda
win-64::qt-main-5.15.6-h11209a8_4.conda
win-64::postgresql-plpython-15.1-py310hb7c6211_1.conda
win-64::arrow-cpp-9.0.0-py38h30bf176_13_cpu.conda
win-64::libgdal-arrow-parquet-3.6.0-h287b214_12.conda
win-64::aws-sdk-cpp-1.10.30-h8422197_0.conda
win-64::arrow-cpp-8.0.1-py39h3de39ee_11_cuda.conda
win-64::cpp-opentelemetry-sdk-1.8.1-ha55d2dd_0.conda
win-64::postgresql-plpython-14.5-py38hb66759c_4.conda
win-64::aws-sdk-cpp-1.10.35-he71221d_0.conda
win-64::ffmpeg-4.4.2-lgpl_h6a34b9d_11.conda
win-64::arrow-cpp-6.0.2-py311hea412e5_9_cuda.conda
win-64::postgresql-plpython-14.5-py310h8578712_4.conda
win-64::postgresql-plpython-14.5-py39hbe02685_2.conda
win-64::sdl2_image-2.6.2-h22b4670_0.conda
win-64::arrow-cpp-8.0.1-py38h30bf176_13_cpu.conda
win-64::netcdf4-1.6.0-nompi_py310h459bb5f_103.conda
win-64::arrow-cpp-9.0.0-py310h9497d45_14_cpu.conda
win-64::intel-opencl-rt-2023.0.0-h927a3ec_25923.conda
win-64::tesseract-5.2.0-h2fb217d_2.conda
win-64::lxml-4.9.2-py39h5462cdd_0.conda
win-64::pygame-2.1.3.dev8-py310hf962f48_1.conda
win-64::qt6-main-6.4.1-hf2f3ee8_6.conda
win-64::ale-py-0.8.0-py38h246ea8d_2.conda
win-64::imagecodecs-2022.12.24-py38h3af18dc_0.conda
win-64::aws-sdk-cpp-1.10.32-h2768dcf_0.conda
win-64::arrow-cpp-6.0.2-py311hd57b895_8_cpu.conda
win-64::libgdal-3.4.3-h43f05fc_1.conda
win-64::libgdal-3.6.1-h4fec149_2.conda
win-64::r-gaston-1.5.8-r41h67098fc_0.conda
win-64::postgresql-plpython-14.5-py38hcf00bc8_3.conda
win-64::libarrow-10.0.1-hc065288_1_cuda.conda
win-64::stir-5.0.2-py38h9224444_6.conda
win-64::arrow-cpp-7.0.1-py311hd4fa1f9_10_cuda.conda
win-64::stir-5.0.2-py310h60465ec_9.conda
win-64::freecad-0.20.2-py38h96d28ce_0.conda
win-64::poppler-qt-22.12.0-hf8b1922_0.conda
win-64::postgresql-plpython-14.5-py39h15dfc06_2.conda
win-64::harp-1.17-py310r41h40b6f39_0.conda
win-64::arrow-cpp-8.0.1-py310h78c3a49_12_cpu.conda
win-64::imagecodecs-2022.9.26-py311h92556bb_5.conda
win-64::vigra-1.11.1-py311h588fd84_1037.conda
win-64::qt6-3d-6.4.1-hef61a30_1.conda
win-64::arrow-cpp-8.0.1-py311hcfebf5d_13_cpu.conda
win-64::fossil-2.20-hb34730b_1.conda
win-64::arrow-cpp-8.0.1-py39hd6dadda_12_cpu.conda
win-64::libopencv-4.6.0-py39h41f83ff_9.conda
win-64::libgdal-3.5.3-h74b97fb_8.conda
win-64::heyoka-0.20.0-h957b0b3_0.conda
win-64::arrow-cpp-7.0.1-py310hc60980a_10_cuda.conda
win-64::katago-1.11.0-cpu_hf79927b_1.conda
win-64::arrow-cpp-8.0.1-py311h3ff6de7_13_cuda.conda
win-64::arrow-cpp-9.0.0-py311hd2e3e2b_14_cuda.conda
win-64::dpcpp_impl_win-64-2023.0.0-h3338d26_25922.conda
win-64::arrow-cpp-6.0.2-py310h560898d_7_cpu.conda
win-64::heyoka-0.20.0-h6d78c09_0.conda
win-64::soplex-6.0.3-h949ae46_0.conda
win-64::qt6-main-6.4.1-hc8e46b8_4.conda
win-64::postgresql-14.5-h392df6f_3.conda
win-64::arrow-cpp-9.0.0-py311hcfebf5d_15_cpu.conda
win-64::arrow-cpp-8.0.1-py311hcfebf5d_12_cpu.conda
win-64::libgdal-arrow-parquet-3.6.0-h6c7f856_13.conda
win-64::lxml-4.9.2-py38h8e95c58_0.conda
win-64::arrow-cpp-8.0.1-py310h69160df_9_cpu.conda
win-64::libxmlpp-4.0-4.0.1-h084c788_0.conda
win-64::qt-main-5.15.6-h11209a8_3.conda
win-64::aws-sdk-cpp-1.10.36-he71221d_0.conda
win-64::libgdal-3.6.0-hc44c3d3_11.conda
win-64::ffmpeg-5.1.2-lgpl_hdafa457_5.conda
win-64::qt6-3d-6.4.1-hef61a30_4.conda
win-64::libgrpc-1.51.1-h535cfc9_0.conda
win-64::imagecodecs-2022.12.22-py38h4b8945e_0.conda
win-64::tiledb-2.13.0-h3132609_1.conda
win-64::arrow-cpp-7.0.1-py38h5f63bb8_10_cpu.conda
win-64::arrow-cpp-7.0.1-py311hcfebf5d_11_cpu.conda
win-64::gdstk-0.9.35-py38hf76a6cb_0.conda
win-64::arrow-cpp-8.0.1-py310h9497d45_13_cpu.conda
win-64::postgresql-plpython-14.5-py310h25eba5b_3.conda
win-64::libgdal-arrow-parquet-3.6.0-hc9f9f4a_13.conda
win-64::dcmtk-3.6.7-h68a3deb_3.conda
win-64::arrow-cpp-8.0.1-py39h4dc5c54_12_cpu.conda
win-64::aws-sdk-cpp-1.10.41-he71221d_0.conda
win-64::cpp-opentelemetry-sdk-1.8.0-ha55d2dd_0.conda
win-64::arrow-cpp-7.0.1-py311hbfcb821_12_cuda.conda
win-64::arrow-cpp-7.0.1-py310h95fa42c_9_cuda.conda
win-64::paraview-5.11.0-py311h4e24be7_101_qt.conda
win-64::arrow-cpp-9.0.0-py39hd6dadda_13_cpu.conda
win-64::gemmi-0.5.8-py38h19421c1_0.conda
win-64::arrow-cpp-7.0.1-py39h4dc5c54_12_cpu.conda
win-64::pytng-0.3.0-py39hcb05468_0.conda
win-64::postgresql-plpython-15.1-py39h15dfc06_1.conda
win-64::lxml-4.9.2-py38h9b876ae_0.conda
win-64::postgresql-plpython-15.1-py310hf69896a_2.conda
win-64::katago-1.11.0-cpu_hd199232_1.conda
win-64::arrow-cpp-9.0.0-py39hb8a7c1e_12_cpu.conda
win-64::arrow-cpp-7.0.1-py38h30bf176_11_cpu.conda
win-64::vigra-1.11.1-py39h217886f_1037.conda
win-64::yarp-cxx-3.7.2-ha672ae2_6.conda
win-64::arrow-cpp-6.0.2-py310h2a35203_8_cpu.conda
win-64::ale-py-0.8.0-py38hfecfa7e_3.conda
win-64::qt-webengine-5.15.4-h0bdee70_3.tar.bz2
win-64::arrow-cpp-6.0.2-py311h8b9abb6_9_cuda.conda
win-64::postgresql-plpython-14.5-py311h7623089_4.conda
win-64::coda-2.24.1-py310h40b6f39_0.conda
win-64::libgdal-3.4.3-h7997e40_1.conda
win-64::arrow-cpp-7.0.1-py310h78c3a49_11_cpu.conda
win-64::imagecodecs-2022.12.22-py311h92556bb_0.conda
win-64::dpcpp_impl_win-64-2023.0.0-h3338d26_25923.conda
win-64::arrow-cpp-8.0.1-py310h54c6eec_11_cuda.conda
win-64::libgdal-3.6.1-h1a413ac_0.conda
win-64::arrow-cpp-9.0.0-py310h95fa42c_11_cuda.conda
win-64::postgresql-plpython-14.5-py38ha2f05b0_2.conda
win-64::arrow-cpp-9.0.0-py310h69160df_11_cpu.conda
win-64::gst-plugins-good-1.21.3-h76f0265_1.conda
win-64::arrow-cpp-7.0.1-py39hf5579cb_9_cpu.conda
win-64::postgresql-plpython-14.5-py310hb7c6211_3.conda
win-64::libgd-2.3.3-hf5a96e7_4.conda
win-64::arrow-cpp-8.0.1-py310h78c3a49_13_cpu.conda
win-64::arrow-cpp-9.0.0-py39hd6dadda_15_cpu.conda
win-64::aws-sdk-cpp-1.10.37-h4d30238_0.conda
win-64::postgresql-plpython-15.1-py310h25eba5b_1.conda
win-64::imagecodecs-2022.12.24-py311h92556bb_0.conda
win-64::arrow-cpp-8.0.1-py38he17c6ad_11_cuda.conda
win-64::postgresql-plpython-14.5-py311hf6a82bc_2.conda
win-64::dcmtk-3.6.7-h6f8f022_3.conda
win-64::aws-sdk-cpp-1.10.33-h8422197_0.conda
win-64::arrow-cpp-8.0.1-py310h78c3a49_11_cpu.conda
win-64::arrow-cpp-8.0.1-py38he17c6ad_12_cuda.conda
win-64::arrow-cpp-7.0.1-py39h3ea1b9e_10_cuda.conda
win-64::arrow-cpp-7.0.1-py310h9e8fea1_11_cuda.conda
win-64::stir-5.0.2-py38h9224444_9.conda
win-64::qt6-main-6.4.1-h5679a45_5.conda
win-64::libpq-14.5-ha9684e8_4.conda
win-64::ale-py-0.8.0-py38h246ea8d_1.conda
win-64::ale-py-0.8.0-py39h130f6a1_3.conda
win-64::libgdal-arrow-parquet-3.6.0-h6744213_14.conda
win-64::libprotobuf-static-3.21.12-h12be248_0.conda
win-64::libsolv-0.7.23-h12be248_0.conda
win-64::aws-sdk-cpp-1.10.21-h8422197_0.conda
win-64::aws-sdk-cpp-1.9.379-he71221d_6.conda
win-64::arrow-cpp-8.0.1-py38h1b13883_9_cpu.conda
win-64::blosc-1.21.2-hdccc3a2_0.conda
win-64::libgdal-3.5.3-hffd0036_11.conda
win-64::arrow-cpp-9.0.0-py38h8c764ff_15_cpu.conda
win-64::libarrow-10.0.1-h913198b_3_cuda.conda
win-64::vigra-1.11.1-py39h3ec58a4_1037.conda
win-64::libcurl-static-7.86.0-h68f0423_2.conda
win-64::imagecodecs-2022.12.24-py39hbac47be_0.conda
win-64::ale-py-0.8.0-py38h246ea8d_0.conda
win-64::aws-sdk-cpp-1.10.38-he71221d_0.conda
win-64::arrow-cpp-6.0.2-py38h0647710_8_cpu.conda
win-64::arrow-cpp-8.0.1-py311h434fdba_10_cpu.conda
win-64::postgresql-plpython-14.5-py39hbe02685_3.conda
win-64::libarrow-10.0.1-h913198b_2_cuda.conda
win-64::libarrow-10.0.1-hb8ba4c8_0_cuda.conda
win-64::libopencv-4.6.0-py310h90026ac_9.conda
win-64::arrow-cpp-8.0.1-py38he27c648_9_cuda.conda
win-64::pypy3.9-7.3.9-h4bd5010_7.conda
win-64::libgdal-arrow-parquet-3.6.1-h6b3c8bf_3.conda
win-64::pyinstaller-5.7.0-py38ha959d8a_0.conda
win-64::stir-5.0.2-py39h7e74d93_9.conda
win-64::aws-sdk-cpp-1.10.31-h2768dcf_0.conda
win-64::qt6-3d-6.4.1-h0ea7e44_0.conda
win-64::pdal-2.4.3-hc77d612_4.conda
win-64::arrow-cpp-6.0.2-py39h6606fb2_8_cpu.conda
win-64::libarrow-10.0.1-h11499f1_1_cpu.conda
win-64::arrow-cpp-8.0.1-py310h0329283_11_cuda.conda
win-64::aws-sdk-cpp-1.10.31-h8422197_0.conda
win-64::intel-opencl-rt-2023.0.0-hd72ace9_25923.conda
win-64::qt6-3d-6.4.1-hef61a30_2.conda
win-64::openmeeg-2.5.5-py38h28af8a8_2.conda
win-64::graphicsmagick-1.3.37-h25afbf9_0.conda
win-64::arrow-cpp-9.0.0-py311hff6b32f_14_cuda.conda
win-64::coda-2.24.1-py39h3d955e7_0.conda
win-64::arrow-cpp-6.0.2-py310hc988553_7_cuda.conda
win-64::netcdf4-1.6.0-nompi_py39h34fa13a_103.conda
win-64::arrow-cpp-7.0.1-py311h3ff6de7_12_cuda.conda
win-64::arrow-cpp-8.0.1-py39hd6dadda_13_cpu.conda
win-64::libgdal-3.5.3-ha74bd8d_12.conda
win-64::heyoka-llvm-14-0.20.0-h25b3dac_0.conda
win-64::pypy3.8-7.3.9-hd438790_7.conda
win-64::stir-5.0.2-py39h7e74d93_6.conda
win-64::pygame-2.1.3.dev8-py311h6ef553b_1.conda
win-64::libgdal-3.6.1-h5c71946_3.conda
win-64::aws-sdk-cpp-1.10.40-h4d30238_0.conda
win-64::ale-py-0.8.0-py310h2021ac3_2.conda
win-64::arrow-cpp-7.0.1-py39h958ad16_11_cuda.conda
win-64::arrow-cpp-8.0.1-py39h4dc5c54_11_cpu.conda
win-64::aws-sdk-cpp-1.10.25-h8422197_0.conda
win-64::r-gaston-1.5.9-r41h67098fc_0.conda
win-64::arrow-cpp-9.0.0-py39h4dc5c54_15_cpu.conda
win-64::libpq-14.5-h04fd8be_3.conda
win-64::libpq-15.1-h04fd8be_1.conda
win-64::arrow-cpp-6.0.2-py38hc3a3766_9_cuda.conda
win-64::arrow-cpp-7.0.1-py310h9497d45_11_cpu.conda
win-64::arrow-cpp-9.0.0-py311hcfebf5d_14_cpu.conda
win-64::gst-plugins-good-1.21.3-h76f0265_0.conda
win-64::pyinstaller-5.7.0-py310h35269f2_0.conda
win-64::arrow-cpp-8.0.1-py311hff6b32f_12_cuda.conda
win-64::arrow-cpp-8.0.1-py38he02c075_10_cuda.conda
win-64::aws-sdk-cpp-1.10.41-haf3c795_1.conda
win-64::arrow-cpp-8.0.1-py39h4dc5c54_13_cpu.conda
win-64::aws-sdk-cpp-1.10.26-h2768dcf_0.conda
win-64::aws-sdk-cpp-1.10.38-h4d30238_0.conda
win-64::qt-webengine-5.15.4-hd018be4_3.tar.bz2
win-64::imagecodecs-2022.9.26-py38h3af18dc_5.conda
win-64::arrow-cpp-6.0.2-py310h2a35203_9_cpu.conda
win-64::papilo-2.1.2-h45feaf2_0.conda
win-64::arrow-cpp-8.0.1-py310h9497d45_12_cpu.conda
win-64::postgresql-plpython-15.1-py39hc82172b_2.conda
win-64::ale-py-0.8.0-py311haa5eaab_1.conda
win-64::nco-5.1.3-h343d473_1.conda
win-64::ale-py-0.8.0-py39hc6c698a_0.conda
win-64::libgdal-3.6.0-hcdc7a77_13.conda
win-64::libgdal-3.5.3-h930b568_6.conda
win-64::arrow-cpp-6.0.2-py39hb9f526f_7_cuda.conda
win-64::postgresql-15.1-hd87cd2b_2.conda
win-64::arrow-cpp-7.0.1-py311h29796c4_11_cpu.conda
win-64::stir-5.0.2-py38h9224444_8.conda
win-64::qt6-main-6.4.1-h5679a45_3.conda
win-64::heavydb-6.2.0-h1234567_0_cpu.conda
win-64::pygame-2.1.3.dev8-py39h928c5e4_1.conda
win-64::arrow-cpp-9.0.0-py311hff6b32f_13_cuda.conda
win-64::arrow-cpp-9.0.0-py310h78c3a49_13_cpu.conda
win-64::pytng-0.3.0-py39had03f03_0.conda
win-64::ffmpeg-4.4.2-lgpl_hdafa457_12.conda
win-64::postgresql-plpython-14.5-py38hcf00bc8_2.conda
win-64::pillow-9.2.0-py39hcebd2be_4.conda
win-64::postgresql-plpython-14.5-py310hf69896a_4.conda
win-64::stir-5.0.2-py310h60465ec_7.conda
win-64::arrow-cpp-6.0.2-py38h10bed8b_9_cpu.conda
win-64::imagecodecs-2022.9.26-py38h4b8945e_5.conda
win-64::netcdf4-1.6.0-nompi_py311h45b207f_103.conda
win-64::heyoka-llvm-13-0.20.0-h38c615f_0.conda
win-64::arrow-cpp-8.0.1-py38h8c764ff_11_cpu.conda
win-64::libgdal-arrow-parquet-3.6.1-haac60c0_0.conda
win-64::arrow-cpp-9.0.0-py311hcfebf5d_13_cpu.conda
win-64::arrow-cpp-8.0.1-py39h6043d89_9_cuda.conda
win-64::pytng-0.3.0-py38hde45749_0.conda
win-64::libgdal-3.5.3-h4fec149_11.conda
win-64::gdk-pixbuf-2.42.8-he721a9a_2.conda
win-64::arrow-cpp-9.0.0-py310h78c3a49_15_cpu.conda
win-64::libgdal-arrow-parquet-3.6.1-h2dfe955_3.conda
win-64::arrow-cpp-7.0.1-py39h958ad16_12_cuda.conda
win-64::openmeeg-2.5.5-py310hc62f8df_2.conda
win-64::arrow-cpp-7.0.1-py38h8c764ff_11_cpu.conda
win-64::libspatialite-5.0.1-hfdcade0_23.conda
win-64::graphicsmagick-1.3.39-h0eae420_0.conda
win-64::arrow-cpp-7.0.1-py311hcfebf5d_12_cpu.conda
win-64::sdl_image-1.2.12-h7043300_3.conda
win-64::postgresql-plpython-14.5-py310h25eba5b_2.conda
win-64::arrow-cpp-9.0.0-py310h78c3a49_14_cpu.conda
win-64::postgresql-plpython-14.5-py311hf773433_4.conda
win-64::postgresql-plpython-15.1-py311hdb0844a_1.conda
win-64::pillow-9.2.0-py39h82d6ea9_4.conda
win-64::arrow-cpp-9.0.0-py38h8c764ff_13_cpu.conda
win-64::yarp-cxx-3.7.2-ha672ae2_7.conda
win-64::mlir-15.0.6-he744812_0.conda
win-64::ffmpeg-4.4.2-gpl_h5b1d025_112.conda
win-64::aws-sdk-cpp-1.9.379-h4d30238_6.conda
win-64::qt6-main-6.4.1-h5679a45_4.conda
win-64::arrow-cpp-7.0.1-py310h9e8fea1_12_cuda.conda
win-64::postgresql-plpython-14.5-py39h60cde0d_4.conda
win-64::gst-plugins-base-1.21.3-h001b923_1.conda
win-64::arrow-cpp-9.0.0-py310hc60980a_12_cuda.conda
win-64::arrow-cpp-8.0.1-py311hbfcb821_13_cuda.conda
win-64::harp-1.17-py39r41h763b820_0.conda
win-64::arrow-cpp-8.0.1-py310h54c6eec_12_cuda.conda
win-64::harp-1.17-py38r41hdd1a290_0.conda
win-64::ale-py-0.8.0-py38hfecfa7e_2.conda
win-64::libgrpc-1.50.1-h6a6baca_0.conda
win-64::aws-sdk-cpp-1.10.22-h2768dcf_0.conda
win-64::libpq-14.5-he840576_4.conda
win-64::libopencv-4.6.0-py39h0c67194_7.conda
win-64::pyinstaller-5.7.0-py39h84a0465_0.conda
win-64::qt6-charts-6.4.1-h0ea7e44_0.conda
win-64::aws-sdk-cpp-1.10.39-he71221d_0.conda
win-64::wasmer-3.1.0-h4dd112c_0.conda
win-64::graphicsmagick-1.3.37-h0eae420_1.conda
win-64::pdal-2.4.3-h5458f8e_5.conda
win-64::postgresql-15.1-h09b8c1b_2.conda
win-64::qt6-3d-6.4.1-hef61a30_3.conda
win-64::tectonic-0.12.0-hcab5949_1.conda
win-64::arrow-cpp-8.0.1-py39h3ea1b9e_10_cuda.conda
win-64::postgresql-plpython-15.1-py39hbe02685_1.conda
win-64::arrow-cpp-6.0.2-py310hf2281a2_8_cpu.conda
win-64::arrow-cpp-6.0.2-py311hada0621_8_cpu.conda
win-64::libgdal-3.6.0-h74b97fb_12.conda
win-64::arrow-cpp-9.0.0-py38h3fbcbd5_15_cuda.conda
win-64::libopencv-4.6.0-py38h489e685_8.conda
win-64::pygame-2.1.3.dev8-py39h928c5e4_0.conda
win-64::arrow-cpp-6.0.2-py38h0647710_9_cpu.conda
win-64::imagecodecs-2022.9.26-py310hcad817f_5.conda
win-64::arrow-cpp-8.0.1-py38h5f63bb8_10_cpu.conda
win-64::ale-py-0.8.0-py310h2021ac3_3.conda
win-64::arrow-cpp-9.0.0-py310h0329283_13_cuda.conda
win-64::qt-main-5.15.6-hb9439ea_3.conda
win-64::arrow-cpp-8.0.1-py39hb8a7c1e_10_cpu.conda
win-64::wxwidgets-3.2.1-hc513c60_3.conda
win-64::openmeeg-2.5.5-py311h2eea1b1_2.conda
win-64::pytng-0.3.0-py38haa774df_0.conda
win-64::stir-5.0.2-py39h7e74d93_7.conda
win-64::pygame-2.1.3.dev8-py38h3ab908e_1.conda
win-64::libopencv-4.6.0-py38ha0fd5da_9.conda
win-64::arrow-cpp-9.0.0-py38hc846b74_13_cuda.conda
win-64::topologytoolkit-1.1.0-no_paraview_py38h1be4c9c_104.conda
win-64::tiledb-2.13.0-h5689973_0.conda
win-64::intel-cmplr-lib-rt-2023.0.0-h12be248_25922.conda
win-64::arrow-cpp-8.0.1-py39hc9c33e1_11_cuda.conda
win-64::qt6-datavis3d-6.4.1-h0ea7e44_0.conda
win-64::arrow-cpp-6.0.2-py311h672df56_7_cuda.conda
win-64::aws-sdk-cpp-1.10.42-h72dcc63_0.conda
win-64::arrow-cpp-8.0.1-py38h8c764ff_12_cpu.conda
win-64::gdstk-0.9.35-py39h6cd26d3_0.conda
win-64::arrow-cpp-8.0.1-py38hc846b74_12_cuda.conda
win-64::arrow-cpp-7.0.1-py39h19f0306_12_cuda.conda
win-64::gst-plugins-bad-1.21.2-h9ab1bbd_1.conda
win-64::libgdal-3.5.3-hc44c3d3_8.conda
win-64::gemmi-0.5.8-py39hd28a505_0.conda
win-64::arrow-cpp-6.0.2-py39h5b707d9_9_cuda.conda
win-64::arrow-cpp-8.0.1-py311hfd373be_9_cpu.conda
win-64::ale-py-0.8.0-py39hc6c698a_3.conda
win-64::libarrow-10.0.1-h226723c_3_cpu.conda
win-64::libcurl-7.86.0-h68f0423_2.conda
win-64::arrow-cpp-8.0.1-py38h602b2d6_13_cuda.conda
win-64::libgdal-arrow-parquet-3.6.1-hb46fc70_1.conda
win-64::tiledb-2.13.0-h3132609_0.conda
win-64::pytng-0.3.0-py311hcbca1fb_0.conda
win-64::qtwebkit-5.212-h992fabe_7.conda
win-64::arrow-cpp-9.0.0-py310h9497d45_13_cpu.conda
win-64::aws-sdk-cpp-1.10.37-he71221d_0.conda
win-64::arrow-cpp-8.0.1-py311hf6a8ae8_9_cuda.conda
win-64::gemmi-0.5.8-py311h5bc0dda_0.conda
win-64::scip-8.0.3-ha534786_0.conda
win-64::gdstk-0.9.35-py310h8f0d0a4_0.conda
win-64::postgresql-plpython-14.5-py39hc82172b_4.conda
win-64::arrow-cpp-8.0.1-py38h30bf176_12_cpu.conda
win-64::arrow-cpp-8.0.1-py310hc60980a_10_cuda.conda
win-64::postgresql-plpython-15.1-py38ha4d3e9f_2.conda
win-64::postgresql-plpython-14.5-py310hb7c6211_2.conda
win-64::msgpack-c-3.3.0-hd720695_5.conda
win-64::arrow-cpp-9.0.0-py39h6043d89_11_cuda.conda
win-64::postgresql-plpython-15.1-py38ha2f05b0_1.conda
win-64::arrow-cpp-9.0.0-py38h30bf176_15_cpu.conda
win-64::paraview-5.11.0-py311ha82b1cc_101_qt.conda
win-64::gmsh-4.11.0-h03e301d_1.conda
win-64::arrow-cpp-8.0.1-py39h19f0306_13_cuda.conda
win-64::postgresql-plpython-14.5-py311hdb0844a_3.conda
win-64::stir-5.0.2-py310h60465ec_8.conda
win-64::arrow-cpp-7.0.1-py311hfd373be_9_cpu.conda
win-64::arrow-cpp-6.0.2-py39h5b707d9_8_cuda.conda
win-64::intel-opencl-rt-2023.0.0-h78c0d30_25922.conda
win-64::postgresql-14.5-hd87cd2b_4.conda
win-64::gst-plugins-bad-1.21.2-h6350b2a_1.conda
win-64::ale-py-0.8.0-py38h246ea8d_3.conda
win-64::libgrpc-1.51.1-h6a6baca_0.conda
win-64::arrow-cpp-9.0.0-py310hf58943e_15_cuda.conda
win-64::arrow-cpp-7.0.1-py311h29796c4_12_cpu.conda
win-64::libarrow-10.0.1-h1309683_0_cpu.conda
win-64::aws-sdk-cpp-1.10.34-h2768dcf_0.conda
win-64::arrow-cpp-9.0.0-py310h9e8fea1_15_cuda.conda
win-64::coda-2.24.1-py311h0120304_0.conda
win-64::pdal-2.4.3-he844516_4.conda
win-64::stir-5.0.2-py39h7e74d93_8.conda
win-64::arrow-cpp-7.0.1-py310h501cca4_10_cpu.conda
win-64::arrow-cpp-9.0.0-py39h3de39ee_13_cuda.conda
win-64::arrow-cpp-6.0.2-py38h10bed8b_8_cpu.conda
win-64::qt-main-5.15.6-h068e40c_5.conda
win-64::arrow-cpp-9.0.0-py310h54c6eec_14_cuda.conda
win-64::libarrow-10.0.1-h226723c_2_cpu.conda
win-64::aws-sdk-cpp-1.10.34-h8422197_0.conda
win-64::gmt-5.4.5-hc7b4146_23.conda
win-64::hdf5-1.12.2-nompi_h2a0e4a3_101.conda
win-64::aws-sdk-cpp-1.10.41-h4d30238_0.conda
win-64::libpq-15.1-he840576_2.conda
win-64::arrow-cpp-8.0.1-py39hf5579cb_9_cpu.conda
win-64::qt-main-5.15.6-h9580fe5_5.conda
win-64::paraview-5.11.0-py38h2fe9e66_101_qt.conda
win-64::aws-sdk-cpp-1.10.39-h4d30238_0.conda
win-64::openmeeg-2.5.5-py39hbdce185_2.conda
win-64::libarrow-10.0.1-h22d0213_1_cuda.conda
win-64::arrow-cpp-6.0.2-py39h9c31614_8_cpu.conda
win-64::arrow-cpp-7.0.1-py38h602b2d6_12_cuda.conda
win-64::arrow-cpp-6.0.2-py310hf2281a2_9_cpu.conda
win-64::aws-sdk-cpp-1.10.23-h8422197_0.conda
win-64::libopencv-4.6.0-py310hb22e633_7.conda
win-64::heyoka-0.20.0-hdc464d3_0.conda
win-64::imagecodecs-2022.12.22-py39hbac47be_0.conda
win-64::arrow-cpp-7.0.1-py39hd6dadda_11_cpu.conda
win-64::postgresql-plpython-14.5-py311hf6a82bc_3.conda
win-64::qt6-datavis3d-6.4.1-hef61a30_1.conda
win-64::blosc-1.21.3-hdccc3a2_0.conda
win-64::libmlir-15.0.6-he744812_0.conda
win-64::gdstk-0.9.35-py311hc50246e_0.conda
win-64::qt-main-5.15.6-hb9439ea_4.conda
win-64::arrow-cpp-9.0.0-py39hd6dadda_14_cpu.conda
win-64::arrow-cpp-8.0.1-py38h8c764ff_13_cpu.conda
win-64::arrow-cpp-8.0.1-py38h3fbcbd5_13_cuda.conda
win-64::gemmi-0.5.8-py38hf225c54_0.conda
win-64::openjpeg-2.5.0-ha2aaf27_2.conda
win-64::topologytoolkit-1.1.0-no_paraview_py310hb06f9a3_104.conda
win-64::libgdal-arrow-parquet-3.6.0-hed821ca_12.conda
win-64::arrow-cpp-6.0.2-py39h6606fb2_9_cpu.conda
win-64::arrow-cpp-6.0.2-py310h918c54a_8_cuda.conda
win-64::libgdal-3.6.0-hc44c3d3_12.conda
win-64::lxml-4.9.2-py39h0942119_0.conda
win-64::libgdal-arrow-parquet-3.6.1-h6744213_0.conda
win-64::libtiff-4.4.0-hc4f729c_5.conda
win-64::libgdal-3.6.1-hffd0036_2.conda
win-64::vigra-1.11.1-py38hc1f152d_1037.conda
win-64::arrow-cpp-8.0.1-py39h958ad16_13_cuda.conda
win-64::arrow-cpp-7.0.1-py38h8c764ff_12_cpu.conda
win-64::libprotobuf-3.21.11-h12be248_0.conda
win-64::arrow-cpp-7.0.1-py311hbfcb821_11_cuda.conda
win-64::arrow-cpp-6.0.2-py38h43b1507_8_cuda.conda
win-64::pillow-9.2.0-py38h072e32c_4.conda
win-64::qt6-charts-6.4.1-hef61a30_1.conda
win-64::arrow-cpp-7.0.1-py310h9497d45_12_cpu.conda
win-64::paraview-5.11.0-py310hc8d15d2_101_qt.conda
win-64::aws-sdk-cpp-1.10.24-h8422197_0.conda
win-64::aws-sdk-cpp-1.10.21-h2768dcf_0.conda
win-64::arrow-cpp-6.0.2-py310h918c54a_9_cuda.conda
win-64::aws-sdk-cpp-1.10.27-h8422197_0.conda
win-64::arrow-cpp-8.0.1-py310h0329283_12_cuda.conda
win-64::arrow-cpp-8.0.1-py311h29796c4_11_cpu.conda
win-64::coda-2.24.1-py38hdd1a290_0.conda
win-64::aws-sdk-cpp-1.10.26-h8422197_0.conda
win-64::intel-opencl-rt-2023.0.0-hd72ace9_25922.conda
win-64::openmeeg-2.5.5-py38h1cd5e7a_2.conda
win-64::arrow-cpp-6.0.2-py311hd57b895_9_cpu.conda
win-64::tesseract-5.3.0-hcb5f61f_0.conda
win-64::libpq-14.5-hf15792c_2.conda
win-64::ale-py-0.8.0-py39h130f6a1_2.conda
win-64::arrow-cpp-6.0.2-py39h9c31614_9_cpu.conda
win-64::hugin-2022.0.0-pl5321h222e068_1.conda
win-64::postgresql-plpython-15.1-py310h8578712_2.conda
win-64::stir-5.0.2-py38h9224444_7.conda
win-64::vigra-1.11.1-py38h0f81844_1037.conda
win-64::arrow-cpp-6.0.2-py310hf90de3e_8_cuda.conda
win-64::imagecodecs-2022.12.24-py39h17e3817_0.conda
win-64::postgresql-plpython-14.5-py38ha4d3e9f_4.conda
win-64::arrow-cpp-6.0.2-py311hada0621_9_cpu.conda
win-64::aws-sdk-cpp-1.10.35-h4d30238_0.conda
win-64::topologytoolkit-1.1.0-no_paraview_py39hf84e3bd_104.conda
win-64::intel-opencl-rt-2023.0.0-h927a3ec_25922.conda
win-64::arrow-cpp-7.0.1-py39h19f0306_11_cuda.conda
win-64::arrow-cpp-9.0.0-py38he17c6ad_13_cuda.conda
win-64::ffmpeg-5.1.2-gpl_hfff1fce_104.conda
win-64::arrow-cpp-8.0.1-py311hd2e3e2b_12_cuda.conda
win-64::libgdal-3.6.1-hefe12b1_0.conda
win-64::libarrow-10.0.1-ha2559c1_1_cpu.conda
win-64::arrow-cpp-8.0.1-py38h30bf176_11_cpu.conda
win-64::arrow-cpp-7.0.1-py39hd6dadda_12_cpu.conda
win-64::arrow-cpp-9.0.0-py38h30bf176_14_cpu.conda
win-64::arrow-cpp-6.0.2-py310hf90de3e_9_cuda.conda
win-64::tectonic-0.12.0-ha65360a_1.conda
win-64::libopencv-4.6.0-py38h6c8a50e_8.conda
win-64::libopencv-4.6.0-py39h586db7a_8.conda
win-64::arrow-cpp-8.0.1-py310h9e8fea1_13_cuda.conda
win-64::poppler-22.12.0-ha6c1112_0.conda
win-64::pdal-2.4.3-h4bb809e_5.conda
win-64::arrow-cpp-6.0.2-py311h8b9abb6_8_cuda.conda
win-64::libopencv-4.6.0-py311hdcf7c22_8.conda
win-64::pytng-0.3.0-py310hff18152_0.conda
win-64::arrow-cpp-9.0.0-py310h54c6eec_13_cuda.conda
win-64::postgresql-plpython-15.1-py311hf773433_2.conda
win-64::arrow-cpp-8.0.1-py39hc9c33e1_12_cuda.conda
win-64::curl-7.87.0-h68f0423_0.conda
win-64::smesh-9.9.0.0-h9dbd24c_3.conda
win-64::libgdal-3.6.1-h1cb26dd_1.conda
win-64::aws-sdk-cpp-1.10.28-h2768dcf_0.conda
win-64::arrow-cpp-7.0.1-py38h602b2d6_11_cuda.conda
win-64::eccodes-2.27.1-hf38be0f_0.conda
win-64::libpq-14.5-hf15792c_3.conda
win-64::libgdal-3.6.1-h9364c56_1.conda
win-64::postgresql-14.5-h09b8c1b_4.conda
win-64::sdl2_image-2.6.2-h22b4670_2.conda
win-64::gemmi-0.5.8-py39h6848017_0.conda
win-64::arrow-cpp-6.0.2-py38h7469a17_7_cuda.conda
win-64::arrow-cpp-6.0.2-py38hc3a3766_8_cuda.conda
win-64::libopencv-4.6.0-py310h1921fa2_8.conda
win-64::pypy3.9-7.3.9-h994e1e7_7.conda
win-64::libprotobuf-static-3.21.11-h12be248_0.conda
win-64::ffmpeg-5.1.2-lgpl_h6a34b9d_4.conda
win-64::harp-1.17-py39r41h3d955e7_0.conda
win-64::hugin-base-2022.0.0-pl5321h1ca8264_0.conda
win-64::ale-py-0.8.0-py310h2021ac3_1.conda
win-64::libopencv-4.6.0-py311ha714b55_7.conda
win-64::arrow-cpp-7.0.1-py310hf58943e_12_cuda.conda
win-64::lxml-4.9.2-py310hc0e5b84_0.conda
win-64::libpq-15.1-ha9684e8_2.conda
win-64::freecad-0.20.2-py310h73a2bbb_0.conda
win-64::arrow-cpp-7.0.1-py38h30bf176_12_cpu.conda
win-64::arrow-cpp-9.0.0-py311hd4fa1f9_12_cuda.conda
win-64::postgresql-plpython-15.1-py39h60cde0d_2.conda
win-64::cpp-opentelemetry-sdk-1.8.1-h76468f2_1.conda
win-64::aws-sdk-cpp-1.10.22-h8422197_0.conda
win-64::arrow-cpp-9.0.0-py311h29796c4_13_cpu.conda
win-64::gdstk-0.9.35-py39h77acf15_0.conda
win-64::libprotobuf-3.21.12-h12be248_0.conda
win-64::arrow-cpp-8.0.1-py311hd4fa1f9_10_cuda.conda
win-64::libopencv-4.6.0-py38hafb13ef_7.conda
win-64::arrow-cpp-7.0.1-py311hf6a8ae8_9_cuda.conda
win-64::ale-py-0.8.0-py39hc6c698a_1.conda
win-64::arrow-cpp-7.0.1-py39h6043d89_9_cuda.conda
win-64::libarrow-10.0.1-h96d9594_3_cpu.conda
win-64::libarchive-3.6.2-h27c7867_0.conda
win-64::hdf5-1.12.2-nompi_h57737ce_101.conda
win-64::libgdal-3.5.3-hefe12b1_10.conda
win-64::libgdal-3.5.3-hcfac978_7.conda
win-64::ffmpeg-5.1.2-gpl_h5b1d025_105.conda
win-64::postgresql-plpython-14.5-py311hdb0844a_2.conda
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
================================================================================
================================================================================
osx-64
osx-64::postgresql-plpython-14.5-py310he875428_2.conda
osx-64::topologytoolkit-1.1.0-no_paraview_py38h07c2664_104.conda
osx-64::tesseract-5.3.0-h9177755_0.conda
osx-64::arrow-cpp-7.0.1-py311hb123e07_10_cpu.conda
osx-64::libcurl-7.87.0-haf73cf8_0.conda
osx-64::git-2.39.0-pl5321h0195497_0.conda
osx-64::pytng-0.3.0-py39h8828900_0.conda
osx-64::nco-5.1.3-h7eeb1a7_2.conda
osx-64::postgresql-15.1-h1482631_2.conda
osx-64::blosc-1.21.2-hebb52c4_0.conda
osx-64::gemmi-0.5.8-py311h4c819dc_0.conda
osx-64::libarrow-10.0.1-h6707bc3_3_cpu.conda
osx-64::sdl2_image-2.6.2-h20bcf9f_1.conda
osx-64::erlang-25.2-pl5321ha491908_0.conda
osx-64::jaxlib-0.3.25-cpu_py39hc0c80cf_1.conda
osx-64::postgresql-14.5-h7bc2cb3_2.conda
osx-64::arrow-cpp-7.0.1-py310h256c82d_12_cpu.conda
osx-64::folly-2022.12.12.00-h1234567_3_jemalloc.conda
osx-64::pytng-0.3.0-py39h3563917_0.conda
osx-64::arrow-cpp-7.0.1-py38h9990d12_10_cpu.conda
osx-64::jaxlib-0.4.1-cpu_py38h08dd9a7_1.conda
osx-64::arrow-cpp-9.0.0-py38h41169ae_11_cpu.conda
osx-64::ale-py-0.8.0-py39h7dffd8d_1.conda
osx-64::qt6-main-6.4.1-h81e6993_3.conda
osx-64::pdal-2.4.3-h4016543_5.conda
osx-64::aws-sdk-cpp-1.10.37-h6febe8c_0.conda
osx-64::imagecodecs-2022.9.26-py310hcb9387a_5.conda
osx-64::libspatialite-5.0.1-hd6e941a_23.conda
osx-64::netcdf4-1.6.0-mpi_mpich_py311h9b3df5f_3.conda
osx-64::arrow-cpp-9.0.0-py38hc9bd68f_13_cpu.conda
osx-64::xrootd-5.5.1-py38h20ef22e_3.conda
osx-64::pypy3.9-7.3.9-hed75a59_7.conda
osx-64::qt-main-5.15.6-hd1d9d18_4.conda
osx-64::arrow-cpp-8.0.1-py39hdb2bdca_13_cpu.conda
osx-64::imagecodecs-2022.12.24-py38he98a4d7_0.conda
osx-64::libcurl-static-7.87.0-h6df9250_0.conda
osx-64::lammps-2022.06.23-py39h9bd0131_mpich_5.conda
osx-64::postgresql-14.5-h7bc2cb3_3.conda
osx-64::imagemagick-7.1.0_54-pl5321h91100f7_0.conda
osx-64::arrow-cpp-8.0.1-py38h2197e5f_12_cpu.conda
osx-64::libtiff-4.4.0-h6268bbc_5.conda
osx-64::openmeeg-2.5.5-py311hba905de_2.conda
osx-64::xrootd-5.5.1-py39h4ac4d32_3.conda
osx-64::arrow-cpp-8.0.1-py38hc9bd68f_11_cpu.conda
osx-64::pdal-2.4.3-h95652d7_4.conda
osx-64::aws-sdk-cpp-1.10.22-hafd40d4_0.conda
osx-64::hdf5-1.12.2-nompi_h48135f9_101.conda
osx-64::libcurl-7.86.0-h6df9250_2.conda
osx-64::gdstk-0.9.35-py311h5d279ca_0.conda
osx-64::libopencv-4.6.0-py38haad26e0_7.conda
osx-64::qt-main-5.15.6-h23f3e19_3.conda
osx-64::gdk-pixbuf-2.42.8-h710d9fd_2.conda
osx-64::arrow-cpp-7.0.1-py310h256c82d_11_cpu.conda
osx-64::gst-plugins-good-1.21.3-ha8e55d2_0.conda
osx-64::lxml-4.9.2-py39hfbce9ca_0.conda
osx-64::mcpl-1.6.1-py39hf40e063_0.conda
osx-64::libgdal-3.6.0-h9b44252_12.conda
osx-64::arrow-cpp-6.0.2-py311h32a1cb3_7_cpu.conda
osx-64::liblal-7.2.4-mkl_h4a7761d_4.conda
osx-64::libgdal-arrow-parquet-3.6.1-h9287937_1.conda
osx-64::pillow-9.2.0-py38hc609523_4.conda
osx-64::pyinstaller-5.7.0-py39h4603615_0.conda
osx-64::arrow-cpp-7.0.1-py39h4b1d532_11_cpu.conda
osx-64::geotiff-1.7.1-hd690177_6.conda
osx-64::freecad-0.20.2-py39hd8426be_0.conda
osx-64::coda-2.24.1-py39hc709b36_0.conda
osx-64::sdl2_image-2.6.2-h20bcf9f_0.conda
osx-64::libgdal-3.6.1-hf2643b4_3.conda
osx-64::folly-2022.12.19.00-h1234567_3.conda
osx-64::aws-sdk-cpp-1.10.32-hafd40d4_0.conda
osx-64::heyoka-llvm-12-0.20.0-hd4a17fd_0.conda
osx-64::netcdf4-1.6.0-nompi_py310h6892ea4_103.conda
osx-64::arrow-cpp-7.0.1-py310hb95ee9c_9_cpu.conda
osx-64::folly-2022.12.26.00-h1234567_3_jemalloc.conda
osx-64::gemmi-0.5.8-py39had167e2_0.conda
osx-64::arrow-cpp-9.0.0-py38h7db5034_14_cpu.conda
osx-64::libopencv-4.6.0-py310h557c7f5_8.conda
osx-64::aws-sdk-cpp-1.10.34-h8c00297_1.conda
osx-64::libgdal-3.5.3-hb129600_9.conda
osx-64::aws-sdk-cpp-1.10.35-h8c00297_0.conda
osx-64::libgdal-arrow-parquet-3.6.0-hd57f5b5_12.conda
osx-64::soplex-6.0.3-h63f1887_0.conda
osx-64::magics-4.12.1-h0f55c2f_2.conda
osx-64::aws-sdk-cpp-1.10.28-h7e42394_0.conda
osx-64::pillow-9.2.0-py310h306a057_4.conda
osx-64::libgdal-3.6.0-h2a83306_11.conda
osx-64::heyoka-llvm-11-0.20.0-h35503db_0.conda
osx-64::paraview-5.11.0-py38h26c6d5d_101_qt.conda
osx-64::pypy3.8-7.3.9-h856ce2f_7.conda
osx-64::magics-metview-4.12.1-h1efa62c_2.conda
osx-64::xrootd-5.5.1-py310hbb2ba96_3.conda
osx-64::jaxlib-0.3.25-cpu_py38h08dd9a7_1.conda
osx-64::libopencv-4.6.0-py39hcf8aad3_9.conda
osx-64::openscenegraph-3.6.5-h7f03107_15.conda
osx-64::dcap-2.47.12-h2c404ec_6.conda
osx-64::sdl_image-1.2.12-h1bcb261_3.conda
osx-64::ale-py-0.8.0-py310hd4d3461_2.conda
osx-64::arrow-cpp-8.0.1-py38h41169ae_9_cpu.conda
osx-64::libopencv-4.6.0-py38h2d54489_9.conda
osx-64::pygame-2.1.3.dev8-py38h2a4dcd8_1.conda
osx-64::postgresql-plpython-15.1-py310he875428_1.conda
osx-64::postgresql-plpython-14.5-py310hbcaf779_4.conda
osx-64::postgresql-plpython-15.1-py38h54e53e2_2.conda
osx-64::arrow-cpp-7.0.1-py310h3566cb9_10_cpu.conda
osx-64::nd2-0.5.2-py311h8d48b40_0.conda
osx-64::heyoka-0.20.0-h9bbdcdc_0.conda
osx-64::arrow-cpp-8.0.1-py311hb123e07_10_cpu.conda
osx-64::poppler-qt-22.12.0-ha47c16f_0.conda
osx-64::harp-1.17-py39r41hc709b36_0.conda
osx-64::libitk-5.3.0-h10ab89a_1.conda
osx-64::aws-sdk-cpp-1.10.26-h7e42394_0.conda
osx-64::rstudio-desktop-2022.12.0-r42h6d7a641_353.conda
osx-64::lxml-4.9.2-py38h4724a1f_0.conda
osx-64::libgrpc-1.51.1-h834a566_0.conda
osx-64::topologytoolkit-1.1.0-with_paraview_py39h49aa448_4.conda
osx-64::libpq-15.1-h4aa9af9_1.conda
osx-64::yarp-cxx-3.7.2-he721ed9_6.conda
osx-64::libgdal-3.6.0-h9b44252_11.conda
osx-64::wxpython-4.2.0-py39h65650ff_3.conda
osx-64::arrow-cpp-9.0.0-py311h2e1e9f3_11_cpu.conda
osx-64::arrow-cpp-7.0.1-py39h41cc398_10_cpu.conda
osx-64::imagecodecs-2022.9.26-py38h6ecb730_5.conda
osx-64::arrow-cpp-8.0.1-py311h2e1e9f3_9_cpu.conda
osx-64::pillow-9.2.0-py38hf04c7c8_4.conda
osx-64::folly-2022.12.05.00-h1234567_3.conda
osx-64::arrow-cpp-9.0.0-py38h7db5034_15_cpu.conda
osx-64::imagecodecs-2022.9.26-py39h6914dba_5.conda
osx-64::aws-sdk-cpp-1.10.40-h6febe8c_0.conda
osx-64::arrow-cpp-7.0.1-py38h2197e5f_12_cpu.conda
osx-64::arrow-cpp-7.0.1-py39h3f536fd_9_cpu.conda
osx-64::folly-2022.12.05.00-h1234567_3_jemalloc.conda
osx-64::libgdal-3.6.1-h46da3b9_1.conda
osx-64::arrow-cpp-8.0.1-py38h7db5034_12_cpu.conda
osx-64::qt6-charts-6.4.1-h781abdd_0.conda
osx-64::aws-sdk-cpp-1.10.24-h7e42394_0.conda
osx-64::arrow-cpp-9.0.0-py39h7232b6e_15_cpu.conda
osx-64::libpq-15.1-hdbdeef1_2.conda
osx-64::imagemagick-7.1.0_55-pl5321ha4ef8ff_1.conda
osx-64::arrow-cpp-9.0.0-py310h226983c_14_cpu.conda
osx-64::arrow-cpp-7.0.1-py311hcd41e39_11_cpu.conda
osx-64::arrow-cpp-6.0.2-py311h08673b4_9_cpu.conda
osx-64::libgdal-arrow-parquet-3.6.1-h3adbde6_2.conda
osx-64::libopencv-4.6.0-py311h806b78a_9.conda
osx-64::tiledb-2.13.0-h3b7b576_1.conda
osx-64::dcap-2.47.12-h3f465b1_6.conda
osx-64::libgdal-arrow-parquet-3.6.0-hdb1d81b_12.conda
osx-64::subversion-1.14.2-pl5321hcea2a8b_3.conda
osx-64::r-base-4.1.3-hf7bdea0_5.conda
osx-64::gfortran_impl_osx-arm64-11.3.0-h05a1a03_27.conda
osx-64::arrow-cpp-9.0.0-py310h226983c_15_cpu.conda
osx-64::libarchive-3.6.2-h6d8d9f1_0.conda
osx-64::curl-7.86.0-haf73cf8_2.conda
osx-64::heyoka-llvm-14-0.20.0-h1328090_0.conda
osx-64::r-base-4.2.2-h6e3643f_2.conda
osx-64::libgdal-3.6.0-h2a83306_12.conda
osx-64::libssh-0.10.4-h5f94a08_3.conda
osx-64::r-gaston-1.5.8-r42h32f0767_0.conda
osx-64::arrow-cpp-7.0.1-py39hdb2bdca_12_cpu.conda
osx-64::astrometry-0.93-py38ha704502_0.conda
osx-64::aws-sdk-cpp-1.10.42-ha1f9507_0.conda
osx-64::curl-7.87.0-h6df9250_0.conda
osx-64::libgdal-3.5.3-hdf58b35_10.conda
osx-64::aws-sdk-cpp-1.10.39-h6febe8c_0.conda
osx-64::libgdal-3.5.3-h6cdfff9_12.conda
osx-64::aws-sdk-cpp-1.10.20-hafd40d4_0.conda
osx-64::arrow-cpp-9.0.0-py311h9834485_15_cpu.conda
osx-64::dcmtk-3.6.7-hc8a0e15_3.conda
osx-64::postgresql-plpython-15.1-py38h3ddcfb5_1.conda
osx-64::libgdal-3.4.3-h59434f6_1.conda
osx-64::libarrow-10.0.1-h7129002_3_cpu.conda
osx-64::wasmer-3.1.0-h4ccbb37_0.conda
osx-64::ffmpeg-5.1.2-gpl_h9733ccd_104.conda
osx-64::wxpython-4.2.0-py311hb6deb79_3.conda
osx-64::xrootd-5.5.1-py38he765bab_3.conda
osx-64::astrometry-0.93-py38hec85013_0.conda
osx-64::libgdal-3.6.0-h50dd3d1_13.conda
osx-64::poppler-qt-22.12.0-h98d8604_1.conda
osx-64::aws-sdk-cpp-1.10.30-h7e42394_0.conda
osx-64::heyoka-0.20.0-h85dd169_0.conda
osx-64::qt6-3d-6.4.1-h75f1121_2.conda
osx-64::yarp-cxx-3.7.2-he721ed9_7.conda
osx-64::openconnect-9.01-hfdf89e3_6.conda
osx-64::scip-8.0.3-h7e00b17_0.conda
osx-64::qt6-charts-6.4.1-h88e961d_1.conda
osx-64::vigra-1.11.1-py38hcc8f04e_1037.conda
osx-64::pytng-0.3.0-py38hadfd06d_0.conda
osx-64::arrow-cpp-8.0.1-py39h3f536fd_9_cpu.conda
osx-64::freecad-0.20.2-py310h04f1c1d_0.conda
osx-64::qt6-main-6.4.1-ha03ad3c_3.conda
osx-64::qt6-3d-6.4.1-h75f1121_3.conda
osx-64::ndcctools-7.4.16-py310h9c28b6c_0.conda
osx-64::gstlal-1.10.0-py310h8e3c859_3.conda
osx-64::arrow-cpp-6.0.2-py311h74cd466_8_cpu.conda
osx-64::arrow-cpp-7.0.1-py38h7db5034_12_cpu.conda
osx-64::octave-7.3.0-he36c18e_2.conda
osx-64::postgresql-plpython-15.1-py39h69d503d_2.conda
osx-64::libarchive-minimal-static-3.6.2-h1dd9cec_0.conda
osx-64::libssh-0.10.4-hcb2ccd1_3.conda
osx-64::arrow-cpp-9.0.0-py38h2197e5f_14_cpu.conda
osx-64::aws-sdk-cpp-1.10.29-h7e42394_0.conda
osx-64::arrow-cpp-7.0.1-py38h41169ae_9_cpu.conda
osx-64::libopencv-4.6.0-py311h85b2607_7.conda
osx-64::qt-main-5.15.6-h5b9e58d_3.conda
osx-64::gstlal-1.10.0-py38h527b813_2.conda
osx-64::nd2-0.5.2-py39hf61cd3b_0.conda
osx-64::arrow-cpp-8.0.1-py38h9990d12_10_cpu.conda
osx-64::libitk-5.3.0-h10ab89a_0.conda
osx-64::postgresql-plpython-14.5-py311h96b54f4_2.conda
osx-64::libgdal-arrow-parquet-3.6.1-h86b25ef_0.conda
osx-64::harp-1.17-py38r41had32a48_0.conda
osx-64::libgrpc-1.50.1-h966d1d5_0.conda
osx-64::netcdf4-1.6.0-nompi_py38hbdcf7ac_103.conda
osx-64::gfortran_impl_osx-64-11.3.0-h1f927f5_27.conda
osx-64::nco-5.1.3-h9bc8a9a_1.conda
osx-64::arrow-cpp-8.0.1-py38h2197e5f_11_cpu.conda
osx-64::qt-main-5.15.6-haeff654_5.conda
osx-64::aws-sdk-cpp-1.10.33-hafd40d4_0.conda
osx-64::libopencv-4.6.0-py38h84b54bd_9.conda
osx-64::hdf5-1.12.2-mpi_openmpi_h087476f_1.conda
osx-64::netcdf4-1.6.0-mpi_mpich_py38h022767a_3.conda
osx-64::gstlal-1.10.0-py310h8e3c859_2.conda
osx-64::rstudio-desktop-2022.07.2-r42h03e31a3_578.conda
osx-64::heyoka-llvm-13-0.20.0-h4bf0ae1_0.conda
osx-64::ale-py-0.8.0-py311h4168bf4_1.conda
osx-64::harp-1.17-py39r42hc709b36_0.conda
osx-64::libgdal-3.5.3-h8e46794_12.conda
osx-64::jaxlib-0.3.25-cpu_py311h30879f6_1.conda
osx-64::aws-sdk-cpp-1.10.27-h7e42394_0.conda
osx-64::postgresql-plpython-15.1-py38h54e53e2_1.conda
osx-64::rstudio-desktop-2022.12.0-r41h6d7a641_353.conda
osx-64::libpq-14.5-hb1ae2b1_2.conda
osx-64::mcpl-1.6.1-py310haafd797_0.conda
osx-64::vigra-1.11.1-py310h172a7d8_1037.conda
osx-64::aws-sdk-cpp-1.10.41-h8c00297_0.conda
osx-64::rstudio-desktop-2022.12.0-r41h4f96dbc_353.conda
osx-64::ndcctools-7.4.16-py39h7639174_0.conda
osx-64::arrow-cpp-6.0.2-py310hb9b707e_9_cpu.conda
osx-64::arrow-cpp-9.0.0-py311h17413f2_14_cpu.conda
osx-64::ffmpeg-5.1.2-lgpl_h16a42aa_5.conda
osx-64::aws-sdk-cpp-1.10.42-hdb1f066_0.conda
osx-64::libmediainfo-22.12-heb0c7ea_0.conda
osx-64::qt-main-5.15.6-h47f89c0_4.conda
osx-64::postgresql-plpython-14.5-py311hcf9f879_3.conda
osx-64::pypy3.8-7.3.9-hb40c2ac_7.conda
osx-64::jaxlib-0.4.1-cpu_py311h51b5b81_1.conda
osx-64::ale-py-0.8.0-py39h7dffd8d_2.conda
osx-64::xrootd-5.5.1-py311h28ae080_3.conda
osx-64::netcdf4-1.6.0-nompi_py311h41bc3eb_103.conda
osx-64::gfortran_impl_osx-64-9.5.0-he506f9a_27.conda
osx-64::ndcctools-7.4.16-py311h2f75ace_0.conda
osx-64::julia-1.8.4-h245b042_0.conda
osx-64::pygame-2.1.3.dev8-py311h99ee8cd_1.conda
osx-64::libarrow-10.0.1-haa1d530_1_cpu.conda
osx-64::postgresql-plpython-14.5-py39h69d503d_4.conda
osx-64::ffmpeg-4.4.2-gpl_h9733ccd_111.conda
osx-64::jaxlib-0.4.1-cpu_py311h30879f6_1.conda
osx-64::cpp-opentelemetry-sdk-1.8.1-h70cf688_0.conda
osx-64::hdf5-1.12.2-nompi_h70e9adf_101.conda
osx-64::aws-sdk-cpp-1.10.33-h7e42394_0.conda
osx-64::arrow-cpp-7.0.1-py39hee97212_11_cpu.conda
osx-64::imagecodecs-2022.12.22-py38h6ecb730_0.conda
osx-64::aws-sdk-cpp-1.9.379-h6febe8c_6.conda
osx-64::qt6-main-6.4.1-ha6a53a8_6.conda
osx-64::postgresql-plpython-14.5-py310he875428_4.conda
osx-64::libgdal-arrow-parquet-3.6.0-h12e2730_13.conda
osx-64::paraview-5.11.0-py310h142525f_101_qt.conda
osx-64::ale-py-0.8.0-py310hd4d3461_1.conda
osx-64::aws-sdk-cpp-1.10.28-hafd40d4_0.conda
osx-64::postgresql-plpython-14.5-py38h3ddcfb5_3.conda
osx-64::arrow-cpp-9.0.0-py311hc8cb9e8_15_cpu.conda
osx-64::tensorflow-base-2.11.0-cpu_py310h760b059_0.tar.bz2
osx-64::libtiff-4.5.0-h6268bbc_0.conda
osx-64::vigra-1.11.1-py38h49af131_1037.conda
osx-64::harp-1.17-py39r41h1ed1f25_0.conda
osx-64::qt-webengine-5.15.4-h1d4dd28_3.conda
osx-64::heyoka-0.20.0-haf2808b_0.conda
osx-64::ale-py-0.8.0-py38hc59edd4_2.conda
osx-64::ale-py-0.8.0-py311h4168bf4_2.conda
osx-64::libpq-14.5-h4aa9af9_2.conda
osx-64::sdl2_image-2.6.2-h20bcf9f_2.conda
osx-64::jaxlib-0.4.1-cpu_py38h24262bb_1.conda
osx-64::postgresql-plpython-15.1-py39h4f8c13b_1.conda
osx-64::coda-2.24.1-py311hd06703c_0.conda
osx-64::imagecodecs-2022.12.24-py38h6ecb730_0.conda
osx-64::arrow-cpp-6.0.2-py38h5c73b78_8_cpu.conda
osx-64::arrow-cpp-9.0.0-py39h41cc398_12_cpu.conda
osx-64::gstlal-1.10.0-py39hc0cf887_3.conda
osx-64::wxwidgets-3.2.1-h36d26ea_3.conda
osx-64::verilator-5.002-h07d71dc_0.conda
osx-64::rstudio-desktop-2022.07.2-r41h6d7a641_578.conda
osx-64::postgresql-plpython-15.1-py311hcf9f879_1.conda
osx-64::jaxlib-0.3.25-cpu_py310h2ffa0bb_1.conda
osx-64::libtensorflow-2.11.0-cpu_ha1346e6_0.tar.bz2
osx-64::folly-2022.12.19.00-h1234567_3_jemalloc.conda
osx-64::arrow-cpp-8.0.1-py311h17413f2_11_cpu.conda
osx-64::libgdal-arrow-parquet-3.6.0-h717f03c_14.conda
osx-64::imagecodecs-2022.12.22-py39h6914dba_0.conda
osx-64::ale-py-0.8.0-py38hbedcded_1.conda
osx-64::qt6-datavis3d-6.4.1-h88e961d_1.conda
osx-64::libopencv-4.6.0-py310h5962dd8_7.conda
osx-64::xrootd-5.5.1-py39he9f2228_3.conda
osx-64::libopencv-4.6.0-py38haeb76c4_8.conda
osx-64::katago-1.11.0-cpu_h78784b8_1.conda
osx-64::wxpython-4.2.0-py310h8b25810_3.conda
osx-64::libgdal-arrow-parquet-3.6.1-hc33deea_1.conda
osx-64::xrootd-5.5.1-py39hb389535_3.conda
osx-64::ndcctools-7.4.16-py311h35252aa_0.conda
osx-64::gemmi-0.5.8-py38h8c0d2ee_0.conda
osx-64::pypy3.9-7.3.9-h478034a_7.conda
osx-64::libgdal-arrow-parquet-3.6.0-hf3a6623_13.conda
osx-64::arrow-cpp-8.0.1-py39h7232b6e_13_cpu.conda
osx-64::qtwebkit-5.212-h11e631a_7.conda
osx-64::arrow-cpp-7.0.1-py311h17413f2_11_cpu.conda
osx-64::nd2-0.5.3-py311h8d48b40_0.conda
osx-64::ndcctools-7.4.16-py38h1bf433d_0.conda
osx-64::rpm-tools-4.17.1-lua54ha2235e4_2.conda
osx-64::graphicsmagick-1.3.39-hf0a6b54_0.conda
osx-64::libarrow-10.0.1-he297f60_0_cpu.conda
osx-64::heyoka-llvm-15-0.20.0-h31099df_0.conda
osx-64::harp-1.17-py311r41hd06703c_0.conda
osx-64::libgdal-arrow-parquet-3.6.1-h04237aa_2.conda
osx-64::jaxlib-0.4.1-cpu_py39hc0c80cf_1.conda
osx-64::tiledb-2.13.0-h8b9cbf0_1.conda
osx-64::netcdf4-1.6.0-mpi_openmpi_py311hcdb9f3e_3.conda
osx-64::libgrpc-1.51.1-h966d1d5_0.conda
osx-64::libgdal-3.4.3-hc09af11_1.conda
osx-64::arrow-cpp-6.0.2-py39hddc5d80_8_cpu.conda
osx-64::papilo-2.1.2-h9a2366d_0.conda
osx-64::ncl-6.6.2-haa333c0_42.conda
osx-64::libopencv-4.6.0-py38h03643a4_8.conda
osx-64::lxml-4.9.2-py310h0b20c97_0.conda
osx-64::arrow-cpp-8.0.1-py311hc8cb9e8_13_cpu.conda
osx-64::libarrow-10.0.1-hef0c04d_2_cpu.conda
osx-64::erlang-25.2-pl5321h12b42e0_0.conda
osx-64::pygame-2.1.3.dev8-py310h10396b0_1.conda
osx-64::openssh-9.1p1-hdbdeef1_1.conda
osx-64::rstudio-desktop-2022.12.0-r42h8f4c897_353.conda
osx-64::arrow-cpp-7.0.1-py39hee97212_12_cpu.conda
osx-64::arrow-cpp-9.0.0-py38h9990d12_12_cpu.conda
osx-64::texlive-core-20210325-h044ca44_7.conda
osx-64::verilator-5.004-h07d71dc_0.conda
osx-64::libgdal-3.5.3-h9c2770c_11.conda
osx-64::postgresql-plpython-15.1-py310hbcaf779_2.conda
osx-64::libitk-5.3.0-h9ea37ed_2.conda
osx-64::arrow-cpp-8.0.1-py39hee97212_11_cpu.conda
osx-64::libgd-2.3.3-h4685329_4.conda
osx-64::aws-sdk-cpp-1.10.22-h7e42394_0.conda
osx-64::arrow-cpp-6.0.2-py39hddc5d80_9_cpu.conda
osx-64::lxml-4.9.2-py39h2a9d282_0.conda
osx-64::libarrow-10.0.1-he5e7c54_1_cpu.conda
osx-64::nd2-0.5.3-py38hf703724_0.conda
osx-64::netcdf4-1.6.0-mpi_openmpi_py39h0377a20_3.conda
osx-64::qt6-3d-6.4.1-h781abdd_0.conda
osx-64::arrow-cpp-6.0.2-py310h8ba963e_8_cpu.conda
osx-64::arrow-cpp-6.0.2-py310hddd8add_8_cpu.conda
osx-64::arrow-cpp-8.0.1-py311hcd41e39_11_cpu.conda
osx-64::qt6-main-6.4.1-h87f51bd_4.conda
osx-64::paraview-5.11.0-py38h66086ce_101_qt.conda
osx-64::qt-main-5.15.6-h0916ed4_4.conda
osx-64::arrow-cpp-7.0.1-py38hc9bd68f_11_cpu.conda
osx-64::graphviz-7.0.5-hc51f7b9_0.conda
osx-64::aws-sdk-cpp-1.10.38-h8c00297_0.conda
osx-64::pdal-2.4.3-he374a05_5.conda
osx-64::libpq-15.1-hb1ae2b1_1.conda
osx-64::arrow-cpp-8.0.1-py311h17413f2_12_cpu.conda
osx-64::arrow-cpp-9.0.0-py310hb95ee9c_11_cpu.conda
osx-64::jaxlib-0.3.25-cpu_py310hcb8af8a_1.conda
osx-64::freeimage-3.18.0-h3263921_11.conda
osx-64::cmake-3.25.1-h4032537_0.conda
osx-64::aws-sdk-cpp-1.10.36-h6febe8c_0.conda
osx-64::arrow-cpp-9.0.0-py310h3566cb9_12_cpu.conda
osx-64::postgresql-14.5-h1482631_4.conda
osx-64::arrow-cpp-9.0.0-py39hee97212_14_cpu.conda
osx-64::harp-1.17-py38r41h20606e4_0.conda
osx-64::arrow-cpp-8.0.1-py310h226983c_13_cpu.conda
osx-64::magics-metview-batch-4.12.1-h0f55c2f_2.conda
osx-64::aws-sdk-cpp-1.10.31-hafd40d4_0.conda
osx-64::rstudio-desktop-2022.07.2-r41h8f4c897_578.conda
osx-64::tectonic-0.12.0-h3326baf_1.conda
osx-64::r-gaston-1.5.9-r41h32f0767_0.conda
osx-64::arrow-cpp-6.0.2-py38h5c73b78_9_cpu.conda
osx-64::rstudio-desktop-2022.12.0-r42h4f96dbc_353.conda
osx-64::ale-py-0.8.0-py39hdaf9168_3.conda
osx-64::nd2-0.5.3-py310h9c878d8_0.conda
osx-64::cpp-opentelemetry-sdk-1.8.0-h70cf688_0.conda
osx-64::topologytoolkit-1.1.0-no_paraview_py310heb2a32b_104.conda
osx-64::qt6-main-6.4.1-h87f51bd_5.conda
osx-64::arrow-cpp-9.0.0-py311hcd41e39_13_cpu.conda
osx-64::libgdal-3.6.1-hd24ca21_2.conda
osx-64::arrow-cpp-9.0.0-py39h3f536fd_11_cpu.conda
osx-64::harp-1.17-py311r42hd06703c_0.conda
osx-64::gmt-5.4.5-h091ea85_23.conda
osx-64::ale-py-0.8.0-py310h4d85b84_3.conda
osx-64::libpq-14.5-h3640bf0_4.conda
osx-64::openmpi-4.1.4-h4fe9131_102.conda
osx-64::wxpython-4.2.0-py38h153e219_3.conda
osx-64::aws-sdk-cpp-1.10.34-hafd40d4_0.conda
osx-64::coda-2.24.1-py39h1ed1f25_0.conda
osx-64::heyoka-0.20.0-h33f03d2_0.conda
osx-64::postgresql-plpython-14.5-py38h54e53e2_2.conda
osx-64::jaxlib-0.3.25-cpu_py38h24262bb_1.conda
osx-64::arrow-cpp-9.0.0-py310h2ba6c0d_15_cpu.conda
osx-64::libgdal-arrow-parquet-3.6.0-h86b25ef_14.conda
osx-64::postgresql-14.5-hae21482_3.conda
osx-64::qt6-3d-6.4.1-h75f1121_4.conda
osx-64::libopencv-4.6.0-py39h535b44a_8.conda
osx-64::mcpl-1.6.1-py39h4603615_0.conda
osx-64::nd2-0.5.2-py39hc39b4fa_0.conda
osx-64::openssh-9.1p1-h3640bf0_1.conda
osx-64::pytng-0.3.0-py310hb9ee061_0.conda
osx-64::imagecodecs-2022.9.26-py38he98a4d7_5.conda
osx-64::arrow-cpp-6.0.2-py38h64175c8_9_cpu.conda
osx-64::lammps-2022.06.23-py310hd2bfa26_mpich_5.conda
osx-64::openmeeg-2.5.5-py38h4407c70_2.conda
osx-64::pyinstaller-5.7.0-py310haafd797_0.conda
osx-64::curl-7.87.0-haf73cf8_0.conda
osx-64::rstudio-desktop-2022.07.2-r42h4f96dbc_578.conda
osx-64::arrow-cpp-8.0.1-py310h29ece76_11_cpu.conda
osx-64::libgdal-3.6.1-h03944e0_0.conda
osx-64::paraview-5.11.0-py311hbc32c54_101_qt.conda
osx-64::netpbm-10.73.42-pl5321hec83272_0.conda
osx-64::netcdf4-1.6.0-nompi_py39h0d363ce_103.conda
osx-64::tiledb-2.13.0-h8b9cbf0_0.conda
osx-64::ale-py-0.8.0-py38h610f833_3.conda
osx-64::libvips-8.13.3-h531776a_3.conda
osx-64::imagemagick-7.1.0_57-pl5321ha4ef8ff_0.conda
osx-64::mcpl-1.6.1-py38h85858c8_0.conda
osx-64::postgresql-plpython-15.1-py310he875428_2.conda
osx-64::coda-2.24.1-py310h2d8d718_0.conda
osx-64::rstudio-desktop-2022.12.0-r41h8f4c897_353.conda
osx-64::arrow-cpp-8.0.1-py311h9834485_12_cpu.conda
osx-64::nd2-0.5.3-py39hf61cd3b_0.conda
osx-64::nd2-0.5.2-py310h9c878d8_0.conda
osx-64::ale-py-0.8.0-py38hbedcded_2.conda
osx-64::libtensorflow_cc-2.11.0-cpu_ha1346e6_0.tar.bz2
osx-64::arrow-cpp-9.0.0-py311h9834485_14_cpu.conda
osx-64::xrootd-5.5.1-py39hd62cabe_3.conda
osx-64::jaxlib-0.4.1-cpu_py39h0e87717_1.conda
osx-64::lxml-4.9.2-py311h9f2bb26_0.conda
osx-64::ffmpeg-4.4.2-gpl_h8b4fe81_112.conda
osx-64::aws-sdk-cpp-1.9.379-h8c00297_6.conda
osx-64::libcurl-7.86.0-haf73cf8_2.conda
osx-64::postgresql-plpython-15.1-py311h96b54f4_2.conda
osx-64::postgresql-15.1-hbea33b9_2.conda
osx-64::openslide-3.4.1-h55ebaf2_6.conda
osx-64::imagemagick-7.1.0_56-pl5321ha4ef8ff_0.conda
osx-64::tiledb-2.13.0-h3b7b576_0.conda
osx-64::folly-2022.12.26.00-h1234567_3.conda
osx-64::rstudio-desktop-2022.12.0-r42hc211a60_353.conda
osx-64::aws-sdk-cpp-1.10.21-h7e42394_0.conda
osx-64::rstudio-desktop-2022.07.2-r42hc211a60_578.conda
osx-64::imagecodecs-2022.12.22-py39h2f6da2b_0.conda
osx-64::arrow-cpp-9.0.0-py39hee97212_13_cpu.conda
osx-64::fossil-2.20-hfc57bf9_1.conda
osx-64::arrow-cpp-8.0.1-py38h468a388_13_cpu.conda
osx-64::mlir-15.0.6-h07d71dc_0.conda
osx-64::libgdal-3.5.3-ha5e8b72_9.conda
osx-64::chemicalite-2022.04.1-h79e3693_6.conda
osx-64::openconnect-9.01-hb997174_5.conda
osx-64::aws-sdk-cpp-1.10.23-hafd40d4_0.conda
osx-64::aws-sdk-cpp-1.10.23-h7e42394_0.conda
osx-64::pillow-9.2.0-py39hd8d94df_4.conda
osx-64::lammps-2022.06.23-py38h9e84cc3_openmpi_5.conda
osx-64::rstudio-desktop-2022.07.2-r42h6d7a641_578.conda
osx-64::gdstk-0.9.35-py310hdb708e1_0.conda
osx-64::jaxlib-0.3.25-cpu_py39h0e87717_1.conda
osx-64::aws-sdk-cpp-1.10.20-h7e42394_0.conda
osx-64::lammps-2022.06.23-py310hddfdfda_openmpi_5.conda
osx-64::gdstk-0.9.35-py39h6d27d09_0.conda
osx-64::postgresql-plpython-15.1-py39h69d503d_1.conda
osx-64::orc-1.8.1-ha9d861c_0.conda
osx-64::jaxlib-0.4.1-cpu_py310hcb8af8a_1.conda
osx-64::tesseract-5.2.0-hf3aa071_2.conda
osx-64::ffmpeg-5.1.2-lgpl_hfb12b1b_4.conda
osx-64::gfortran_impl_osx-64-10.4.0-hb520ba8_27.conda
osx-64::postgresql-plpython-14.5-py39h69d503d_3.conda
osx-64::vigra-1.11.1-py311hf27ffd5_1037.conda
osx-64::poppler-22.12.0-hf2ff1a1_0.conda
osx-64::paraview-5.11.0-py39hb73a281_101_qt.conda
osx-64::aws-sdk-cpp-1.10.29-hafd40d4_0.conda
osx-64::ale-py-0.8.0-py310hd4d3461_0.conda
osx-64::libgdal-arrow-parquet-3.6.1-hfcc6562_3.conda
osx-64::aws-sdk-cpp-1.10.34-h6febe8c_1.conda
osx-64::rstudio-desktop-2022.07.2-r42h8f4c897_578.conda
osx-64::arrow-cpp-8.0.1-py39h41cc398_10_cpu.conda
osx-64::mcpl-1.6.1-py311hfb0ac31_0.conda
osx-64::libgdal-3.6.1-h44a409f_2.conda
osx-64::imagecodecs-2022.12.24-py39h2f6da2b_0.conda
osx-64::git-2.39.0-pl5321h00ebd2c_0.conda
osx-64::arrow-cpp-6.0.2-py38h90f9c0b_8_cpu.conda
osx-64::pillow-9.2.0-py311h5bae705_4.conda
osx-64::gemmi-0.5.8-py39h3d6f5fc_0.conda
osx-64::postgresql-15.1-hae21482_1.conda
osx-64::postgresql-plpython-14.5-py38h54e53e2_3.conda
osx-64::arrow-cpp-9.0.0-py39hdb2bdca_14_cpu.conda
osx-64::coda-2.24.1-py38had32a48_0.conda
osx-64::jaxlib-0.3.25-cpu_py311h51b5b81_1.conda
osx-64::netcdf4-1.6.0-mpi_mpich_py310h9f09b55_3.conda
osx-64::aws-sdk-cpp-1.9.379-hdb1f066_7.conda
osx-64::postgresql-plpython-15.1-py38h3ddcfb5_2.conda
osx-64::arrow-cpp-6.0.2-py311h72bb3f9_8_cpu.conda
osx-64::vigra-1.11.1-py39hd129338_1037.conda
osx-64::pdal-2.4.3-h2a8bfe5_4.conda
osx-64::postgresql-14.5-hae21482_2.conda
osx-64::wasmer-3.1.0-hca2dfb3_0.conda
osx-64::gdstk-0.9.35-py38hc2e84d9_0.conda
osx-64::pyinstaller-5.7.0-py38h01a1b83_0.conda
osx-64::arrow-cpp-6.0.2-py39hfab0811_9_cpu.conda
osx-64::gst-plugins-good-1.21.3-ha8e55d2_1.conda
osx-64::netcdf4-1.6.0-mpi_mpich_py39h99d9b56_3.conda
osx-64::openmeeg-2.5.5-py310he9bac87_2.conda
osx-64::libgdal-3.6.1-hd928027_1.conda
osx-64::ale-py-0.8.0-py39ha5af2ed_3.conda
osx-64::qt6-main-6.4.1-h7176462_5.conda
osx-64::libgdal-3.5.3-hdfaa372_11.conda
osx-64::cpp-opentelemetry-sdk-1.8.1-hb78b0ff_1.conda
osx-64::aws-sdk-cpp-1.10.27-hafd40d4_0.conda
osx-64::libgdal-3.6.0-hfce814a_13.conda
osx-64::pytng-0.3.0-py38h51293be_0.conda
osx-64::arrow-cpp-6.0.2-py39he4318e8_8_cpu.conda
osx-64::postgresql-plpython-15.1-py311hcf9f879_2.conda
osx-64::gemmi-0.5.8-py310h2bfb868_0.conda
osx-64::aws-sdk-cpp-1.10.38-h6febe8c_0.conda
osx-64::aws-sdk-cpp-1.10.40-h8c00297_0.conda
osx-64::imagecodecs-2022.12.24-py39h6914dba_0.conda
osx-64::netcdf4-1.6.0-mpi_openmpi_py310h8178e25_3.conda
osx-64::astrometry-0.93-py39hc57b64f_0.conda
osx-64::postgresql-plpython-14.5-py311h96b54f4_3.conda
osx-64::libpq-15.1-h3640bf0_2.conda
osx-64::arrow-cpp-6.0.2-py38h32d932e_7_cpu.conda
osx-64::libgdal-3.6.1-hb883ba3_0.conda
osx-64::xrootd-5.5.1-py311h9189708_3.conda
osx-64::libgrpc-1.50.1-h834a566_0.conda
osx-64::libpq-14.5-hdbdeef1_4.conda
osx-64::rstudio-desktop-2022.07.2-r41h4f96dbc_578.conda
osx-64::astrometry-0.93-py39h8d8ebea_0.conda
osx-64::astrometry-0.93-py310hf1f994c_0.conda
osx-64::arrow-cpp-8.0.1-py310h2ba6c0d_13_cpu.conda
osx-64::postgresql-plpython-14.5-py39h69d503d_2.conda
osx-64::nd2-0.5.2-py38h78b7a73_0.conda
osx-64::hdf5-1.12.2-mpi_openmpi_hf8ec552_1.conda
osx-64::arrow-cpp-7.0.1-py311h2e1e9f3_9_cpu.conda
osx-64::postgresql-plpython-14.5-py38h3ddcfb5_4.conda
osx-64::libpano13-2.9.20rc2-pl5321h40d062d_4.conda
osx-64::aws-sdk-cpp-1.10.24-hafd40d4_0.conda
osx-64::freecad-0.20.2-py37hb60f4f5_0.conda
osx-64::gdstk-0.9.35-py38hc22b7ae_0.conda
osx-64::graphicsmagick-1.3.37-h653b28e_0.conda
osx-64::postgresql-14.5-hbea33b9_4.conda
osx-64::subversion-1.14.2-pl5321h886d438_3.conda
osx-64::imagemagick-7.1.0_55-pl5321h55361aa_0.conda
osx-64::arrow-cpp-8.0.1-py311h9834485_13_cpu.conda
osx-64::harp-1.17-py310r42h2d8d718_0.conda
osx-64::nd2-0.5.3-py38h78b7a73_0.conda
osx-64::libarrow-10.0.1-h90981fa_2_cpu.conda
osx-64::xrootd-5.5.1-py310h5d74658_3.conda
osx-64::paraview-5.11.0-py39hc8b2986_101_qt.conda
osx-64::ale-py-0.8.0-py311h4f864f7_3.conda
osx-64::postgresql-plpython-14.5-py39h4f8c13b_3.conda
osx-64::libopencv-4.6.0-py39h45485f0_8.conda
osx-64::freecad-0.20.2-py38h08c05bb_0.conda
osx-64::arrow-cpp-7.0.1-py310h29ece76_11_cpu.conda
osx-64::postgresql-plpython-14.5-py311hcf9f879_4.conda
osx-64::ndcctools-7.4.16-py38h08c6ce4_0.conda
osx-64::arrow-cpp-8.0.1-py38h7db5034_13_cpu.conda
osx-64::pygame-2.1.3.dev8-py39h62f8cdd_1.conda
osx-64::rstudio-desktop-2022.07.2-r41h03e31a3_578.conda
osx-64::postgresql-plpython-15.1-py311h96b54f4_1.conda
osx-64::smesh-9.9.0.0-h6cf342c_3.conda
osx-64::lammps-2022.06.23-py39h5643e98_openmpi_5.conda
osx-64::r-gaston-1.5.8-r41h32f0767_0.conda
osx-64::gdstk-0.9.35-py39hf1f424a_0.conda
osx-64::topologytoolkit-1.1.0-with_paraview_py38ha100741_4.conda
osx-64::gemmi-0.5.8-py38hc86dbf9_0.conda
osx-64::folly-2022.12.12.00-h1234567_3.conda
osx-64::xrootd-5.5.1-py38h9afa794_3.conda
osx-64::nd2-0.5.3-py39hc39b4fa_0.conda
osx-64::libpq-14.5-h4aa9af9_3.conda
osx-64::arrow-cpp-6.0.2-py310hddd8add_9_cpu.conda
osx-64::imagecodecs-2022.9.26-py311hdaf324b_5.conda
osx-64::hugin-base-2022.0.0-pl5321hafe2a77_1.conda
osx-64::libopencv-4.6.0-py39hfa69ae4_7.conda
osx-64::arrow-cpp-7.0.1-py310h226983c_12_cpu.conda
osx-64::netpbm-10.73.41-pl5321hec83272_1.conda
osx-64::libvips-8.13.3-h48d7b61_4.conda
osx-64::curl-7.86.0-h6df9250_2.conda
osx-64::qt6-main-6.4.1-hb6a0f16_6.conda
osx-64::heyoka-0.20.0-h8478cee_0.conda
osx-64::libpq-14.5-hb1ae2b1_3.conda
osx-64::imagecodecs-2022.12.22-py38he98a4d7_0.conda
osx-64::libgdal-3.5.3-h64b5ae4_8.conda
osx-64::paraview-5.11.0-py310h629cbaf_101_qt.conda
osx-64::aws-sdk-cpp-1.10.25-h7e42394_0.conda
osx-64::arrow-cpp-8.0.1-py39hee97212_12_cpu.conda
osx-64::gfortran_impl_osx-arm64-10.3.0-h2f81028_27.conda
osx-64::imagecodecs-2022.9.26-py39h2f6da2b_5.conda
osx-64::arrow-cpp-8.0.1-py310h256c82d_11_cpu.conda
osx-64::aws-sdk-cpp-1.10.21-hafd40d4_0.conda
osx-64::postgresql-plpython-14.5-py38h54e53e2_4.conda
osx-64::arrow-cpp-6.0.2-py310ha1f65ac_7_cpu.conda
osx-64::lammps-2022.06.23-py38h3099bbc_mpich_5.conda
osx-64::postgresql-plpython-14.5-py310hbcaf779_2.conda
osx-64::libarrow-10.0.1-hba7c647_0_cpu.conda
osx-64::aws-sdk-cpp-1.10.39-h8c00297_0.conda
osx-64::aws-sdk-cpp-1.9.379-ha1f9507_7.conda
osx-64::imagemagick-7.1.0_53-pl5321h91100f7_0.conda
osx-64::arrow-cpp-7.0.1-py311h9834485_12_cpu.conda
osx-64::gstlal-1.10.0-py39hc0cf887_2.conda
osx-64::arrow-cpp-8.0.1-py310hb95ee9c_9_cpu.conda
osx-64::arrow-cpp-9.0.0-py39h4b1d532_13_cpu.conda
osx-64::libopencv-4.6.0-py38h28ed0f6_7.conda
osx-64::ale-py-0.8.0-py39hca6cdc9_2.conda
osx-64::ale-py-0.8.0-py39h7dffd8d_0.conda
osx-64::harp-1.17-py310r41h2d8d718_0.conda
osx-64::aws-sdk-cpp-1.10.41-h6febe8c_0.conda
osx-64::libgdal-3.5.3-h9c82b7a_8.conda
osx-64::postgresql-plpython-14.5-py310he875428_3.conda
osx-64::qt6-main-6.4.1-h7176462_4.conda
osx-64::aws-sdk-cpp-1.10.31-h7e42394_0.conda
osx-64::gmsh-4.11.0-hbe4ac96_1.conda
osx-64::rstudio-desktop-2022.07.2-r41hc211a60_578.conda
osx-64::libopencv-4.6.0-py39h007d6df_9.conda
osx-64::arrow-cpp-9.0.0-py311h17413f2_13_cpu.conda
osx-64::aws-sdk-cpp-1.10.41-ha1f9507_1.conda
osx-64::harp-1.17-py38r42h20606e4_0.conda
osx-64::postgresql-plpython-15.1-py310hbcaf779_1.conda
osx-64::libgdal-arrow-parquet-3.6.1-h717f03c_0.conda
osx-64::ffmpeg-5.1.2-gpl_h8b4fe81_105.conda
osx-64::postgresql-plpython-15.1-py39h4f8c13b_2.conda
osx-64::gstlal-1.10.0-py311h4cfbc18_3.conda
osx-64::libgdal-arrow-parquet-3.6.1-h42dfcc7_3.conda
osx-64::arrow-cpp-9.0.0-py38h2197e5f_13_cpu.conda
osx-64::postgresql-plpython-14.5-py310hbcaf779_3.conda
osx-64::dcmtk-3.6.7-hc996906_3.conda
osx-64::libcurl-7.87.0-h6df9250_0.conda
osx-64::libopencv-4.6.0-py310hcb4c670_9.conda
osx-64::aws-sdk-cpp-1.10.34-h7e42394_0.conda
osx-64::vigra-1.11.1-py39h70cada9_1037.conda
osx-64::libtiledb-sql-0.20.0-hd9b14cf_0.conda
osx-64::poppler-22.12.0-h6e9091c_1.conda
osx-64::postgresql-plpython-14.5-py39h4f8c13b_4.conda
osx-64::arrow-cpp-7.0.1-py38h2197e5f_11_cpu.conda
osx-64::ndcctools-7.4.16-py310h15278f1_0.conda
osx-64::pytng-0.3.0-py311h0108fbc_0.conda
osx-64::graphicsmagick-1.3.37-hf0a6b54_1.conda
osx-64::arrow-cpp-8.0.1-py39h4b1d532_11_cpu.conda
osx-64::imagecodecs-2022.12.22-py310hcb9387a_0.conda
osx-64::qt6-datavis3d-6.4.1-h781abdd_0.conda
osx-64::arrow-cpp-9.0.0-py310h256c82d_14_cpu.conda
osx-64::postgresql-plpython-14.5-py311h96b54f4_4.conda
osx-64::aws-sdk-cpp-1.10.41-hdb1f066_1.conda
osx-64::libcurl-static-7.86.0-h6df9250_2.conda
osx-64::pillow-9.2.0-py39h7f5cd59_4.conda
osx-64::ffmpeg-4.4.2-lgpl_hfb12b1b_11.conda
osx-64::libopencv-4.6.0-py311h35e0284_8.conda
osx-64::aws-sdk-cpp-1.10.25-hafd40d4_0.conda
osx-64::coda-2.24.1-py38h20606e4_0.conda
osx-64::rstudio-desktop-2022.12.0-r41hc211a60_353.conda
osx-64::hugin-base-2022.0.0-pl5321h659ba8e_0.conda
osx-64::libgdal-3.6.0-h03944e0_14.conda
osx-64::topologytoolkit-1.1.0-with_paraview_py310h8960b6d_4.conda
osx-64::octave-7.3.0-he36c18e_1.conda
osx-64::libarchive-3.6.2-h7181a6f_0.conda
osx-64::libgdal-3.5.3-hf9b1f87_10.conda
osx-64::netcdf4-1.6.0-mpi_openmpi_py38hfce56bd_3.conda
osx-64::octave-7.3.0-hea30b65_1.conda
osx-64::ovito-3.7.12-h3c6bf02_0.conda
osx-64::arrow-cpp-9.0.0-py310h29ece76_13_cpu.conda
osx-64::astrometry-0.93-py311h9d4b15d_0.conda
osx-64::sdl2_image-2.6.2-h3c9f506_3.conda
osx-64::mcpl-1.6.1-py38h01a1b83_0.conda
osx-64::xrootd-5.5.1-py38hf657636_3.conda
osx-64::harp-1.17-py38r42had32a48_0.conda
osx-64::libcurl-static-7.87.0-haf73cf8_0.conda
osx-64::geotiff-1.7.1-h2039a76_5.conda
osx-64::libcurl-static-7.86.0-haf73cf8_2.conda
osx-64::libgdal-3.6.0-hb883ba3_14.conda
osx-64::topologytoolkit-1.1.0-no_paraview_py39h9575245_104.conda
osx-64::fossil-2.20-h176df5f_1.conda
osx-64::openmeeg-2.5.5-py39hbc32ecc_2.conda
osx-64::arrow-cpp-6.0.2-py39h7aeb0eb_7_cpu.conda
osx-64::aws-sdk-cpp-1.10.30-hafd40d4_0.conda
osx-64::arrow-cpp-9.0.0-py39hdb2bdca_15_cpu.conda
osx-64::ale-py-0.8.0-py38hbedcded_0.conda
osx-64::arrow-cpp-7.0.1-py311h17413f2_12_cpu.conda
osx-64::katago-1.11.0-cpu_hfce7730_1.conda
osx-64::ffmpeg-4.4.2-lgpl_h16a42aa_12.conda
osx-64::libtiledb-sql-0.20.0-h1c15328_0.conda
osx-64::openmeeg-2.5.5-py39hb99fce2_2.conda
osx-64::arrow-cpp-8.0.1-py310h3566cb9_10_cpu.conda
osx-64::arrow-cpp-9.0.0-py310h256c82d_13_cpu.conda
osx-64::arrow-cpp-8.0.1-py310h256c82d_12_cpu.conda
osx-64::octave-7.3.0-hea30b65_2.conda
osx-64::aws-sdk-cpp-1.10.26-hafd40d4_0.conda
osx-64::r-gaston-1.5.9-r42h32f0767_0.conda
osx-64::arrow-cpp-9.0.0-py38h468a388_15_cpu.conda
osx-64::postgresql-plpython-14.5-py38h3ddcfb5_2.conda
osx-64::imagecodecs-2022.12.24-py310hcb9387a_0.conda
osx-64::libgdal-3.6.1-hcd3032b_3.conda
osx-64::gstlal-1.10.0-py38h527b813_3.conda
osx-64::jaxlib-0.4.1-cpu_py310h2ffa0bb_1.conda
osx-64::aws-sdk-cpp-1.10.32-h7e42394_0.conda
osx-64::paraview-5.11.0-py311h60cc20d_101_qt.conda
osx-64::arrow-cpp-9.0.0-py311hb123e07_12_cpu.conda
osx-64::tectonic-0.12.0-h58665ac_1.conda
osx-64::qt6-3d-6.4.1-h88e961d_1.conda
osx-64::arrow-cpp-8.0.1-py310h226983c_12_cpu.conda
osx-64::lxml-4.9.2-py38h64add32_0.conda
osx-64::aws-sdk-cpp-1.10.35-h6febe8c_0.conda
osx-64::imagecodecs-2022.12.22-py311hdaf324b_0.conda
osx-64::ale-py-0.8.0-py38h9646d6f_3.conda
osx-64::aws-sdk-cpp-1.10.36-h8c00297_0.conda
osx-64::openmeeg-2.5.5-py38hf58489f_2.conda
osx-64::postgresql-plpython-14.5-py39h4f8c13b_2.conda
osx-64::ndcctools-7.4.16-py39h1930336_0.conda
osx-64::postgresql-15.1-h7bc2cb3_1.conda
osx-64::arrow-cpp-8.0.1-py39hdb2bdca_12_cpu.conda
osx-64::libopencv-4.6.0-py39hc4816b1_7.conda
osx-64::arrow-cpp-6.0.2-py311h74cd466_9_cpu.conda
osx-64::nd2-0.5.2-py38hf703724_0.conda
osx-64::imagecodecs-2022.12.24-py311hdaf324b_0.conda
osx-64::aws-sdk-cpp-1.10.37-h8c00297_0.conda
osx-64::postgresql-plpython-14.5-py311hcf9f879_2.conda
osx-64::r-base-4.2.2-h841e2fe_3.conda
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
osx-64::gst-plugins-base-1.21.3-h37e1711_1.conda
osx-64::libmlir15-15.0.6-h07d71dc_0.conda
osx-64::msgpack-c-3.3.0-hd9e13b6_5.conda
osx-64::libprotobuf-static-3.21.11-hbc0c0cd_0.conda
osx-64::libsolv-0.7.23-hbc0c0cd_0.conda
osx-64::liblal-7.2.4-fftw_h6f3aaa0_104.conda
osx-64::libprotobuf-3.21.11-hbc0c0cd_0.conda
osx-64::gcab-1.5-h8ac4021_0.conda
osx-64::openjdk-17.0.3-hbc0c0cd_5.conda
osx-64::openjpeg-2.5.0-h13ac156_2.conda
osx-64::eccodes-2.27.1-hbf8a13b_0.conda
osx-64::libmlir-15.0.6-h07d71dc_0.conda
osx-64::libprotobuf-3.21.12-hbc0c0cd_0.conda
osx-64::libxmlpp-4.0-4.0.1-h1217ba6_0.conda
osx-64::gst-plugins-base-1.21.3-h37e1711_0.conda
osx-64::libsolv-static-0.7.23-hbc0c0cd_0.conda
osx-64::libprotobuf-static-3.21.12-hbc0c0cd_0.conda
osx-64::gds-base-3.0.0-hd662cfc_3.conda
osx-64::gds-base-3.0.0-hd662cfc_2.conda
-    "libzlib >=1.2.13,<1.3.0a0"
+    "libzlib >=1.2.13,<2.0.0a0"
================================================================================
================================================================================
linux-64
linux-64::folly-2022.12.19.00-h1234567_3.conda
linux-64::aws-sdk-cpp-1.10.34-hc894300_1.conda
linux-64::rstudio-desktop-2022.07.2-r42h1bbfd3c_578.conda
linux-64::netcdf4-1.6.0-nompi_py38h6b4b75c_103.conda
linux-64::xrootd-5.5.1-py39hc80556b_3.conda
linux-64::arrow-cpp-7.0.1-py38heace812_10_cuda.conda
linux-64::rstudio-desktop-2022.07.2-r41hd5ac50f_578.conda
linux-64::pypy3.8-7.3.9-h7febd65_7.conda
linux-64::libpq-14.5-hb675445_4.conda
linux-64::blosc-1.21.3-hafa529b_0.conda
linux-64::aws-sdk-cpp-1.9.379-h56135f1_7.conda
linux-64::postgresql-plpython-15.1-py311h62f2185_1.conda
linux-64::arrow-cpp-9.0.0-py310h21f88ba_14_cpu.conda
linux-64::linux-perf-6.0.11-py310h1c7d2e3_0.conda
linux-64::pyinstaller-5.7.0-py38hb5b1691_0.conda
linux-64::smesh-9.9.0.0-hb4b06b8_3.conda
linux-64::tensorflow-base-2.11.0-cpu_py310hc9b7e7f_0.conda
linux-64::arrow-cpp-9.0.0-py310he8f6ac5_14_cuda.conda
linux-64::arrow-cpp-8.0.1-py311h1ac16e0_13_cuda.conda
linux-64::arrow-cpp-7.0.1-py310h52b706f_10_cuda.conda
linux-64::aws-sdk-cpp-1.10.39-hc894300_0.conda
linux-64::arrow-cpp-7.0.1-py38ha5dbe27_12_cpu.conda
linux-64::libgd-2.3.3-h5aea950_4.conda
linux-64::imagecodecs-2022.9.26-py39h9bcf58b_5.conda
linux-64::harp-1.17-py38r41hc2fe1c0_0.conda
linux-64::arrow-cpp-7.0.1-py38h516eea7_10_cpu.conda
linux-64::arrow-cpp-9.0.0-py39h95e2317_15_cpu.conda
linux-64::postgresql-14.5-ha105346_2.conda
linux-64::postgresql-plpython-14.5-py311h62f2185_2.conda
linux-64::r-gaston-1.5.8-r42h58bca29_0.conda
linux-64::libgdal-3.4.3-hd4bcc23_1.conda
linux-64::aws-sdk-cpp-1.9.379-h33d5b13_6.conda
linux-64::aws-sdk-cpp-1.10.26-hb7d3cc7_0.conda
linux-64::arrow-cpp-7.0.1-py311hf763437_11_cpu.conda
linux-64::libpq-14.5-h72a31a5_3.conda
linux-64::ipe-7.2.24-lua54h3051f87_10.conda
linux-64::jaxlib-0.4.1-cuda112py38ha4d91bb_201.conda
linux-64::pytng-0.2.3-py311h48d25d0_1.conda
linux-64::pytng-0.2.3-py39hc42261d_1.conda
linux-64::ale-py-0.8.0-py39h0c2551f_3.conda
linux-64::paraview-5.11.0-py39h1858c34_1_egl.conda
linux-64::nd2-0.5.2-py38h9005721_0.conda
linux-64::aws-sdk-cpp-1.10.27-hb7d3cc7_0.conda
linux-64::hdf5-1.12.2-nompi_h2386368_101.conda
linux-64::aws-sdk-cpp-1.10.41-h32f6703_1.conda
linux-64::arrow-cpp-7.0.1-py311h1ac16e0_12_cuda.conda
linux-64::libarrow-10.0.1-h81e3e88_2_cuda.conda
linux-64::libgdal-3.5.3-h8cbb2de_12.conda
linux-64::arrow-cpp-6.0.2-py310h2ef4bb5_9_cuda.conda
linux-64::arrow-cpp-7.0.1-py310hd5873ae_11_cuda.conda
linux-64::aws-sdk-cpp-1.10.40-h33d5b13_0.conda
linux-64::jaxlib-0.3.25-cpu_py39hcceb00d_1.conda
linux-64::mapserver-8.0.0-py310hef5b17c_7.conda
linux-64::arrow-cpp-7.0.1-py310hbcc112b_9_cpu.conda
linux-64::gdstk-0.9.35-py311hcc32b3e_0.conda
linux-64::qt6-main-6.4.1-h12bba98_4.conda
linux-64::arrow-cpp-9.0.0-py39h9c31e50_15_cuda.conda
linux-64::aws-sdk-cpp-1.10.20-hdc6349a_0.conda
linux-64::arrow-cpp-7.0.1-py38hb24177d_11_cuda.conda
linux-64::coda-2.24.1-py38hc2fe1c0_0.conda
linux-64::pytng-0.3.0-py38hb5a4cc3_0.conda
linux-64::libopencv-4.6.0-py39hb375605_9.conda
linux-64::gstlal-1.10.0-py39h4cf9939_3.conda
linux-64::arrow-cpp-9.0.0-py310h74b2ba0_14_cuda.conda
linux-64::intel-opencl-rt-2023.0.0-h68971e6_25371.conda
linux-64::curl-7.86.0-hdc1c0ab_2.conda
linux-64::arrow-cpp-8.0.1-py38h9ebcd46_9_cuda.conda
linux-64::libgdal-3.4.3-hdfd6431_1.conda
linux-64::arrow-cpp-6.0.2-py311hd4a72f6_9_cuda.conda
linux-64::aws-sdk-cpp-1.10.42-h32f6703_0.conda
linux-64::imagecodecs-2022.12.24-py310h17758e3_0.conda
linux-64::linux-perf-6.0.12-py311h6353e60_0.conda
linux-64::subversion-1.14.2-pl5321h109cf7b_3.conda
linux-64::harp-1.17-py38r42hc2fe1c0_0.conda
linux-64::postgresql-plpython-15.1-py38hf875890_2.conda
linux-64::pytng-0.2.3-py39h0050040_1.conda
linux-64::gst-plugins-good-1.21.3-hbba150b_0.conda
linux-64::arrow-cpp-7.0.1-py39h06993d0_12_cpu.conda
linux-64::nd2-0.5.2-py38h3876440_0.conda
linux-64::ttyd-1.7.2-h821b6a9_1.conda
linux-64::libitk-5.3.0-hcedbc38_0.conda
linux-64::xrootd-5.5.1-py38he774a5e_3.conda
linux-64::libgdal-arrow-parquet-3.6.0-hba8e2df_12.conda
linux-64::ale-py-0.8.0-py39hcd51377_3.conda
linux-64::jaxlib-0.4.1-cpu_py38hfdd4148_1.conda
linux-64::wxpython-4.2.0-py311h7eaf305_3.conda
linux-64::arrow-cpp-9.0.0-py310h56e1d80_11_cuda.conda
linux-64::arrow-cpp-7.0.1-py310h42c066a_12_cuda.conda
linux-64::libgdal-arrow-parquet-3.6.0-hbbc48f0_13.conda
linux-64::qt-main-5.15.6-h25460bb_4.conda
linux-64::libarrow-10.0.1-h3871441_3_cpu.conda
linux-64::libgdal-3.6.0-hc956b1e_11.conda
linux-64::aws-sdk-cpp-1.10.30-hb7d3cc7_0.conda
linux-64::qt-main-5.15.6-he99da89_3.conda
linux-64::ale-py-0.8.0-py38h8f9f4eb_3.conda
linux-64::r-base-4.2.2-h6b4767f_2.conda
linux-64::netcdf4-1.6.0-mpi_openmpi_py311h7e23c81_3.conda
linux-64::octave-7.3.0-hbcd8a26_2.conda
linux-64::pillow-9.2.0-py39h2320bf1_4.conda
linux-64::curl-7.87.0-h6312ad2_0.conda
linux-64::tiledb-2.13.0-h3f4058f_0.conda
linux-64::nco-5.1.3-habcb6d4_2.conda
linux-64::arrow-cpp-8.0.1-py39h1010d6a_10_cpu.conda
linux-64::linux-perf-6.0.14-py310h533b2b3_0.conda
linux-64::qtwebkit-5.212-h3e5094c_7.conda
linux-64::arrow-cpp-6.0.2-py39hb4b83be_8_cpu.conda
linux-64::postgresql-plpython-14.5-py38h35e5630_2.conda
linux-64::netcdf4-1.6.0-mpi_openmpi_py310h9a227a8_3.conda
linux-64::lxml-4.9.2-py39h2679bbe_0.conda
linux-64::blosc-1.21.2-hafa529b_0.conda
linux-64::arrow-cpp-8.0.1-py310h21f88ba_11_cpu.conda
linux-64::tensorflow-base-2.11.0-cuda112py310hf77f70e_0.conda
linux-64::jaxlib-0.4.1-cpu_py38hdb3bdfc_1.conda
linux-64::postgresql-plpython-14.5-py39h9d02763_3.conda
linux-64::linux-perf-6.1.2-py38h74ecc8f_0.conda
linux-64::pygame-2.1.3.dev8-py38h4c52a55_1.conda
linux-64::wxpython-4.2.0-py39h4cf4d34_3.conda
linux-64::rstudio-desktop-2022.12.0-r41h1bbfd3c_353.conda
linux-64::ale-py-0.8.0-py311h0db04d4_3.conda
linux-64::libgdal-3.6.1-he31f7c0_2.conda
linux-64::arrow-cpp-8.0.1-py39h1b9ed61_9_cuda.conda
linux-64::liblal-7.2.4-mkl_hb5697f4_4.conda
linux-64::hugin-base-2022.0.0-pl5321ha4fc1d5_0.conda
linux-64::qt6-main-6.4.1-h96b0f0a_6.conda
linux-64::pypy3.8-7.3.9-h4185e50_7.conda
linux-64::postgresql-plpython-15.1-py39hd6779d9_1.conda
linux-64::libgdal-3.5.3-h2d23f43_10.conda
linux-64::tiledb-2.13.0-h1e4a385_0.conda
linux-64::mapserver-8.0.0-py38h38b8d11_7.conda
linux-64::git-credential-manager-2.0.886-hf1bc24a_0.conda
linux-64::linux-perf-6.0.14-py39h43fcbc4_0.conda
linux-64::libarrow-10.0.1-h7c19a5b_2_cpu.conda
linux-64::r-base-4.1.3-h2f963a2_5.conda
linux-64::astrometry-0.93-py39h57de281_0.conda
linux-64::imagecodecs-2022.9.26-py311h7f108a8_5.conda
linux-64::libtiff-4.4.0-h82bc61c_5.conda
linux-64::linux-perf-6.0.11-py310h56753f5_0.conda
linux-64::arrow-cpp-7.0.1-py311hf763437_12_cpu.conda
linux-64::mcpl-1.6.1-py39h0215ebd_0.conda
linux-64::aws-sdk-cpp-1.10.29-h4ccf91e_0.conda
linux-64::ale-py-0.8.0-py38hda4d45f_1.conda
linux-64::papilo-2.1.2-h9f89f54_0.conda
linux-64::arrow-cpp-7.0.1-py311h8a60d47_11_cuda.conda
linux-64::qt-main-5.15.6-hf6cd601_5.conda
linux-64::libssh-0.10.4-hc04a2de_3.conda
linux-64::jaxlib-0.3.25-cpu_py39h81af9c5_1.conda
linux-64::arrow-cpp-7.0.1-py39h7b5ecbe_11_cuda.conda
linux-64::folly-2022.12.12.00-h1234567_3.conda
linux-64::arrow-cpp-9.0.0-py38h46f5817_11_cpu.conda
linux-64::arrow-cpp-9.0.0-py39h1b9ed61_11_cuda.conda
linux-64::hdf5-1.12.2-nompi_h4df4325_101.conda
linux-64::rstudio-desktop-2022.07.2-r41h1bbfd3c_578.conda
linux-64::arrow-cpp-8.0.1-py38h3ffc01c_12_cpu.conda
linux-64::harp-1.17-py39r42h92210e6_0.conda
linux-64::rstudio-desktop-2022.07.2-r41h0f448d8_578.conda
linux-64::harp-1.17-py39r41hdb66b6c_0.conda
linux-64::linux-perf-6.0.13-py39h9993275_0.conda
linux-64::libitk-5.3.0-he3d6168_2.conda
linux-64::qt-main-5.15.6-h62441b5_5.conda
linux-64::libopencv-4.6.0-py38h2a969ba_7.conda
linux-64::mapserver-8.0.0-py310h8b6aa3a_5.conda
linux-64::texlive-core-20210325-hd43a2ed_7.conda
linux-64::folly-2022.12.12.00-h1234567_3_jemalloc.conda
linux-64::sdl2_ttf-2.0.18-h2eed4a9_0.conda
linux-64::libgdal-3.6.0-he5f2d09_13.conda
linux-64::mapserver-8.0.0-py39hba42550_7.conda
linux-64::linux-perf-6.0.13-py310h533b2b3_0.conda
linux-64::poppler-22.12.0-h92391eb_0.conda
linux-64::rstudio-desktop-2022.12.0-r42h1bbfd3c_353.conda
linux-64::pygame-2.1.3.dev8-py310h2a1bfa1_1.conda
linux-64::wasmer-3.1.0-h72b2c8f_0.conda
linux-64::pygame-2.1.3.dev8-py311he9dee14_1.conda
linux-64::libgrpc-1.51.1-h05bd8bd_0.conda
linux-64::netcdf4-1.6.0-nompi_py310h0a86a1f_103.conda
linux-64::libopencv-4.6.0-py39h596d152_7.conda
linux-64::linux-perf-6.0.11-py311h99b88e7_0.conda
linux-64::arrow-cpp-6.0.2-py39h2836962_8_cpu.conda
linux-64::arrow-cpp-8.0.1-py38h516eea7_10_cpu.conda
linux-64::gdk-pixbuf-2.42.8-h9fd3ed7_2.conda
linux-64::netcdf4-1.6.0-mpi_mpich_py39h977a9d2_3.conda
linux-64::ffmpeg-4.4.2-gpl_h8dda1f0_112.conda
linux-64::postgresql-15.1-h3248436_2.conda
linux-64::topologytoolkit-1.1.0-no_paraview_py38hd3b85ee_104.conda
linux-64::ndcctools-7.4.16-py39hdb74deb_0.conda
linux-64::sdl2_image-2.6.2-h7b3d2e9_3.conda
linux-64::folly-2022.12.19.00-h1234567_3_jemalloc.conda
linux-64::jaxlib-0.3.25-cuda112py38ha4d91bb_201.conda
linux-64::arrow-cpp-9.0.0-py310hbcc112b_11_cpu.conda
linux-64::netcdf4-1.6.0-mpi_mpich_py38h2410153_3.conda
linux-64::heyoka-llvm-14-0.20.0-h2270b41_0.conda
linux-64::folly-2022.12.26.00-h1234567_3.conda
linux-64::libcurl-7.87.0-h6312ad2_0.conda
linux-64::sdl2_image-2.6.2-h916e60d_0.conda
linux-64::arrow-cpp-8.0.1-py310h21f88ba_12_cpu.conda
linux-64::libarrow-10.0.1-ha344585_0_cuda.conda
linux-64::r-gaston-1.5.9-r41h58bca29_0.conda
linux-64::libgdal-3.6.0-h839a3bd_14.conda
linux-64::ale-py-0.8.0-py39hcd51377_1.conda
linux-64::arrow-cpp-6.0.2-py311h12593e4_8_cuda.conda
linux-64::lammps-2022.06.23-py310hedc66b7_mpich_5.conda
linux-64::arrow-cpp-7.0.1-py39h1b9ed61_9_cuda.conda
linux-64::arrow-cpp-7.0.1-py39h8c67656_12_cuda.conda
linux-64::arrow-cpp-6.0.2-py310hb81c6e1_7_cuda.conda
linux-64::arrow-cpp-7.0.1-py310h42c066a_11_cuda.conda
linux-64::netcdf4-1.6.0-mpi_mpich_py311h56f4aae_3.conda
linux-64::libitk-5.3.0-heda510a_1.conda
linux-64::postgresql-plpython-14.5-py38ha228084_3.conda
linux-64::arrow-cpp-6.0.2-py38hf8e4906_7_cuda.conda
linux-64::arrow-cpp-8.0.1-py310h2da3c2e_11_cpu.conda
linux-64::postgresql-plpython-15.1-py310h8c03797_2.conda
linux-64::erlang-25.2-pl5321h187a391_0.conda
linux-64::ndcctools-7.4.16-py38h2c126d3_0.conda
linux-64::graphicsmagick-1.3.37-hcb5e50b_1.conda
linux-64::imagecodecs-2022.12.24-py38hc91abf2_0.conda
linux-64::gemmi-0.5.8-py38h5c3b438_0.conda
linux-64::cpp-opentelemetry-sdk-1.8.1-hbf8ca65_1.conda
linux-64::poppler-qt-22.12.0-h693504a_0.conda
linux-64::libarrow-10.0.1-hbbec62c_1_cpu.conda
linux-64::gst-plugins-bad-1.21.2-h14a858b_1.conda
linux-64::libgdal-3.5.3-h46dac61_8.conda
linux-64::pdfmm-0.9.22-h29752d8_2.conda
linux-64::aws-sdk-cpp-1.10.33-hb7d3cc7_0.conda
linux-64::libarrow-10.0.1-h134e938_2_cuda.conda
linux-64::libcurl-static-7.87.0-h6312ad2_0.conda
linux-64::imagecodecs-2022.12.22-py39h24c8a72_0.conda
linux-64::postgresql-plpython-15.1-py38h4dde1d4_2.conda
linux-64::arrow-cpp-6.0.2-py39h6ea9bec_8_cuda.conda
linux-64::postgresql-plpython-15.1-py39hbf22de8_2.conda
linux-64::jaxlib-0.3.25-cpu_py310h09f4813_1.conda
linux-64::libcurl-7.87.0-hdc1c0ab_0.conda
linux-64::libgrpc-1.50.1-h30feacc_0.conda
linux-64::arrow-cpp-6.0.2-py310hde210ca_8_cpu.conda
linux-64::pyinstaller-5.7.0-py39hf95bbec_0.conda
linux-64::libgdal-arrow-parquet-3.6.0-hb68f653_14.conda
linux-64::pygame-2.1.3.dev8-py39ha038556_1.conda
linux-64::rstudio-desktop-2022.12.0-r41h90f8cb4_353.conda
linux-64::imagemagick-7.1.0_54-pl5321hbe46f5a_0.conda
linux-64::xrootd-5.5.1-py39h1434af6_3.conda
linux-64::arrow-cpp-8.0.1-py39hf8c098d_9_cpu.conda
linux-64::katago-1.11.0-cuda112h2d2ae80_1.conda
linux-64::qt6-main-6.4.1-hd3fa0b4_3.conda
linux-64::cpp-opentelemetry-sdk-1.8.1-h367e6c9_0.conda
linux-64::aws-sdk-cpp-1.10.32-h4ccf91e_0.conda
linux-64::magic-8.3.346-h66032b0_0.conda
linux-64::arrow-cpp-8.0.1-py311h94321e7_13_cuda.conda
linux-64::arrow-cpp-9.0.0-py311h9f71e43_15_cpu.conda
linux-64::arrow-cpp-9.0.0-py39h856a8b1_15_cuda.conda
linux-64::dcmtk-3.6.7-h63e84fa_3.conda
linux-64::scip-8.0.3-h13e48e5_0.conda
linux-64::actions-runner-2.300.0-h0cdce71_0.conda
linux-64::soplex-6.0.3-h4d60c50_0.conda
linux-64::julia-1.8.4-h783901f_0.conda
linux-64::arrow-cpp-7.0.1-py310h26e764d_12_cuda.conda
linux-64::arrow-cpp-9.0.0-py39hdbe7bc9_14_cpu.conda
linux-64::paraview-5.11.0-py38h69aa358_101_qt.conda
linux-64::aws-sdk-cpp-1.9.379-hc894300_6.conda
linux-64::aws-sdk-cpp-1.10.42-h56135f1_0.conda
linux-64::arrow-cpp-6.0.2-py39hffa70e8_8_cuda.conda
linux-64::arrow-cpp-9.0.0-py38h516eea7_12_cpu.conda
linux-64::postgresql-14.5-h3248436_4.conda
linux-64::curl-7.87.0-hdc1c0ab_0.conda
linux-64::nd2-0.5.3-py39hb8da52a_0.conda
linux-64::arrow-cpp-9.0.0-py311h1ac16e0_15_cuda.conda
linux-64::poppler-22.12.0-h091648b_1.conda
linux-64::netpbm-10.73.41-pl5321hacf8199_1.conda
linux-64::magic-8.3.348-h130c0f9_0.conda
linux-64::arrow-cpp-6.0.2-py39hb4b83be_9_cpu.conda
linux-64::astrometry-0.93-py311ha249530_0.conda
linux-64::paraview-5.11.0-py310hc4fda9b_101_qt.conda
linux-64::tiledb-2.13.0-hc2ae436_1.conda
linux-64::libtiff-4.5.0-h82bc61c_0.conda
linux-64::magic-8.3.349-h130c0f9_0.conda
linux-64::aws-sdk-cpp-1.10.21-hdc6349a_0.conda
linux-64::arrow-cpp-7.0.1-py39h06993d0_11_cpu.conda
linux-64::heyoka-0.20.0-he341774_0.conda
linux-64::arrow-cpp-8.0.1-py38ha5dbe27_11_cpu.conda
linux-64::libpano13-2.9.20rc2-pl5321h4a0979c_4.conda
linux-64::arrow-cpp-7.0.1-py38ha5dbe27_11_cpu.conda
linux-64::ffmpeg-5.1.2-lgpl_hd27bd3a_5.conda
linux-64::openmeeg-2.5.5-py310he251340_2.conda
linux-64::aws-sdk-cpp-1.10.24-hb7d3cc7_0.conda
linux-64::arrow-cpp-7.0.1-py311h72e8ef3_12_cpu.conda
linux-64::arrow-cpp-6.0.2-py311hb695f48_7_cpu.conda
linux-64::coda-2.24.1-py311h921a695_0.conda
linux-64::linux-perf-6.1.1-py38h74ecc8f_0.conda
linux-64::libpq-14.5-hf695f80_2.conda
linux-64::gemmi-0.5.8-py38h5a1f9f3_0.conda
linux-64::tesseract-5.2.0-hbc07a9d_2.conda
linux-64::linux-perf-6.1.1-py39h43fcbc4_0.conda
linux-64::rstudio-desktop-2022.07.2-r42h90f8cb4_578.conda
linux-64::arrow-cpp-9.0.0-py311h364b498_14_cuda.conda
linux-64::aws-sdk-cpp-1.10.34-h4ccf91e_0.conda
linux-64::paraview-5.11.0-py38h893293e_1_egl.conda
linux-64::xrootd-5.5.1-py311h9aa0daf_3.conda
linux-64::imagecodecs-2022.9.26-py38hc91abf2_5.conda
linux-64::nordugrid-arc-6.17.0-py311h86d6c4f_0.conda
linux-64::linux-perf-6.0.11-py39h34843c9_0.conda
linux-64::xrootd-5.5.1-py38h569187c_3.conda
linux-64::netpbm-10.73.42-pl5321hacf8199_0.conda
linux-64::openmeeg-2.5.5-py311hf2be580_2.conda
linux-64::jaxlib-0.3.25-cpu_py38hfdd4148_1.conda
linux-64::libcurl-static-7.87.0-hdc1c0ab_0.conda
linux-64::arrow-cpp-9.0.0-py39h439591b_12_cuda.conda
linux-64::mapserver-8.0.0-py39h3f92313_6.conda
linux-64::r-gaston-1.5.9-r42h58bca29_0.conda
linux-64::ncl-6.6.2-hd11d9a9_42.conda
linux-64::postgresql-plpython-14.5-py310hbcf67c7_3.conda
linux-64::tensorflow-base-2.11.0-cpu_py39h0b693b3_0.conda
linux-64::arrow-cpp-6.0.2-py38h86d596d_9_cpu.conda
linux-64::lammps-2022.06.23-py38h3b3622b_openmpi_5.conda
linux-64::arrow-cpp-9.0.0-py38h3ffc01c_13_cpu.conda
linux-64::libpq-14.5-h2baec63_4.conda
linux-64::libpq-15.1-hf695f80_1.conda
linux-64::libopencv-4.6.0-py39ha93bc41_8.conda
linux-64::arrow-cpp-7.0.1-py311h8c7f931_10_cpu.conda
linux-64::katago-1.11.0-cuda110h6f4c7f4_1.conda
linux-64::jaxlib-0.3.25-cuda112py39h17d59b0_201.conda
linux-64::poppler-qt-22.12.0-ha0c4cd6_1.conda
linux-64::aws-sdk-cpp-1.10.34-hb7d3cc7_0.conda
linux-64::libopencv-4.6.0-py310h8149549_8.conda
linux-64::xrootd-5.5.1-py310h1199695_3.conda
linux-64::jaxlib-0.4.1-cpu_py310hdc47304_1.conda
linux-64::libgdal-3.6.0-h4fca5ce_14.conda
linux-64::verilator-5.002-he0ac6c6_0.conda
linux-64::libtiledb-sql-0.20.0-h5e80f49_0.conda
linux-64::libssh-0.10.4-h108a366_3.conda
linux-64::gfortran_impl_osx-arm64-10.3.0-h784c0ce_27.conda
linux-64::aws-sdk-cpp-1.10.41-h33d5b13_0.conda
linux-64::libgdal-3.5.3-h2c497fb_10.conda
linux-64::libopencv-4.6.0-py311hb9031eb_8.conda
linux-64::pytng-0.3.0-py38hcf6129a_0.conda
linux-64::libopencv-4.6.0-py38h98be2c8_9.conda
linux-64::gemmi-0.5.8-py310h662bd17_0.conda
linux-64::dcap-2.47.12-h3e961eb_6.conda
linux-64::libpq-15.1-h2baec63_2.conda
linux-64::heyoka-llvm-15-0.20.0-h2ca537c_0.conda
linux-64::arrow-cpp-8.0.1-py311hf763437_12_cpu.conda
linux-64::qt6-3d-6.4.1-h9df2822_4.conda
linux-64::aws-sdk-cpp-1.10.38-hc894300_0.conda
linux-64::openmeeg-2.5.5-py38had6705e_2.conda
linux-64::hdf5-1.12.2-mpi_mpich_h5d83325_1.conda
linux-64::arrow-cpp-8.0.1-py310h56e1d80_9_cuda.conda
linux-64::mapserver-8.0.0-py310hda610a6_6.conda
linux-64::vigra-1.11.1-py310h1be6f1c_1037.conda
linux-64::arrow-cpp-8.0.1-py38hcf6f3fa_13_cuda.conda
linux-64::pdal-2.4.3-hdfc1b4a_5.conda
linux-64::freecad-0.20.2-py310h8dc7af3_0.conda
linux-64::slurm-22.05.4-hcee77ff_1.conda
linux-64::libarrow-10.0.1-h0cefc63_3_cuda.conda
linux-64::libtensorflow-2.11.0-cpu_h666fa03_0.conda
linux-64::aws-sdk-cpp-1.10.21-h54302c4_0.conda
linux-64::aws-sdk-cpp-1.10.25-hb7d3cc7_0.conda
linux-64::intel-cmplr-lib-rt-2023.0.0-h3eb15da_25370.conda
linux-64::openssh-9.1p1-h2baec63_1.conda
linux-64::jaxlib-0.4.1-cpu_py39h81af9c5_1.conda
linux-64::aws-sdk-cpp-1.10.35-h33d5b13_0.conda
linux-64::hdf5-1.12.2-mpi_openmpi_h41b9b70_1.conda
linux-64::jaxlib-0.3.25-cuda112py39h35fb927_201.conda
linux-64::arrow-cpp-9.0.0-py39h021ab0a_13_cuda.conda
linux-64::aws-sdk-cpp-1.10.39-h33d5b13_0.conda
linux-64::arrow-cpp-6.0.2-py38h0aa053a_8_cuda.conda
linux-64::lighttpd-1.4.64-lua54he374de0_2.conda
linux-64::netcdf4-1.6.0-nompi_py39h94a714e_103.conda
linux-64::katago-1.11.0-cuda102h3f64d6b_1.conda
linux-64::nd2-0.5.3-py39hff1726d_0.conda
linux-64::arrow-cpp-9.0.0-py310h11e707a_15_cpu.conda
linux-64::vigra-1.11.1-py38h08a9931_1037.conda
linux-64::arrow-cpp-9.0.0-py38h0949398_15_cuda.conda
linux-64::paraview-5.11.0-py39h77a4e5e_101_qt.conda
linux-64::postgresql-plpython-14.5-py39hd24e1a9_2.conda
linux-64::postgresql-plpython-15.1-py38h0354a93_1.conda
linux-64::libgdal-3.6.0-hedffb84_12.conda
linux-64::aws-sdk-cpp-1.10.23-hb7d3cc7_0.conda
linux-64::nordugrid-arc-6.17.0-py39h0b26024_0.conda
linux-64::libarrow-10.0.1-hdf71627_1_cuda.conda
linux-64::postgresql-plpython-14.5-py310hdedc773_3.conda
linux-64::pdal-2.4.3-h0ea1e05_5.conda
linux-64::postgresql-plpython-14.5-py39h29919a1_3.conda
linux-64::arrow-cpp-8.0.1-py311h8c7f931_10_cpu.conda
linux-64::libvips-8.13.3-h2c8b588_3.conda
linux-64::libtensorflow_cc-2.11.0-cpu_ha757fe5_0.conda
linux-64::libarrow-10.0.1-hd014966_3_cpu.conda
linux-64::libgdal-3.6.1-h19e2a31_3.conda
linux-64::ovito-3.7.12-hf4a16d5_0.conda
linux-64::magics-metview-batch-4.12.1-h2ccc01a_2.conda
linux-64::aws-sdk-cpp-1.10.37-hc894300_0.conda
linux-64::linux-perf-6.0.12-py39h43fcbc4_0.conda
linux-64::libgdal-arrow-parquet-3.6.0-hcd42968_13.conda
linux-64::arrow-cpp-6.0.2-py311h55719cd_8_cpu.conda
linux-64::linux-perf-6.0.12-py39h9993275_0.conda
linux-64::arrow-cpp-6.0.2-py311hd4a72f6_8_cuda.conda
linux-64::arrow-cpp-8.0.1-py310h11e707a_13_cpu.conda
linux-64::linux-perf-6.1.1-py38h458c6c9_0.conda
linux-64::postgresql-plpython-15.1-py39hd745751_2.conda
linux-64::xrootd-5.5.1-py310h8ff6cd0_3.conda
linux-64::mlir-15.0.6-he0ac6c6_0.conda
linux-64::libgdal-arrow-parquet-3.6.1-ha4b112a_2.conda
linux-64::linux-perf-6.1.2-py310hc7c4f61_0.conda
linux-64::tectonic-0.12.0-h9324c81_1.conda
linux-64::tensorflow-base-2.11.0-cpu_py38hbb27c95_0.conda
linux-64::arrow-cpp-8.0.1-py39h856a8b1_13_cuda.conda
linux-64::imagemagick-7.1.0_57-pl5321h0dc3a92_0.conda
linux-64::qt6-main-6.4.1-h12bba98_5.conda
linux-64::libpq-15.1-hb675445_2.conda
linux-64::aws-sdk-cpp-1.10.28-h4ccf91e_0.conda
linux-64::linux-perf-6.1.2-py39h9993275_0.conda
linux-64::rstudio-desktop-2022.12.0-r41hd5ac50f_353.conda
linux-64::aws-sdk-cpp-1.10.30-h4ccf91e_0.conda
linux-64::libopencv-4.6.0-py38h26aa303_8.conda
linux-64::xrootd-5.5.1-py39h765a0e5_3.conda
linux-64::folly-2022.12.26.00-h1234567_3_jemalloc.conda
linux-64::postgresql-14.5-h5bbe9e2_3.conda
linux-64::rstudio-desktop-2022.07.2-r42hed3354f_578.conda
linux-64::podofo-0.9.8-lua54hae2e964_1.conda
linux-64::heyoka-0.20.0-hac93ea9_0.conda
linux-64::vigra-1.11.1-py39heec5ef4_1037.conda
linux-64::arrow-cpp-9.0.0-py38hcf6f3fa_15_cuda.conda
linux-64::arrow-cpp-9.0.0-py39h55f0795_13_cuda.conda
linux-64::geotiff-1.7.1-h7157cca_5.conda
linux-64::ale-py-0.8.0-py38hda4d45f_3.conda
linux-64::wxpython-4.2.0-py310ha9c1c7c_3.conda
linux-64::pypy3.9-7.3.9-h72fc2f4_7.conda
linux-64::ffmpeg-4.4.2-lgpl_hd27bd3a_12.conda
linux-64::actions-runner-2.300.2-h0cdce71_0.conda
linux-64::chemicalite-2022.04.1-hf4f4d20_6.conda
linux-64::arrow-cpp-6.0.2-py39hcd1f045_7_cpu.conda
linux-64::libgdal-arrow-parquet-3.6.1-hb68f653_0.conda
linux-64::postgresql-15.1-hdeef612_1.conda
linux-64::pytng-0.3.0-py39hc42261d_0.conda
linux-64::jaxlib-0.4.1-cuda112py311hbbecf72_201.conda
linux-64::gstlal-1.10.0-py310hc1b84e2_2.conda
linux-64::arrow-cpp-8.0.1-py311h00f723b_10_cuda.conda
linux-64::postgresql-plpython-14.5-py311h7444109_2.conda
linux-64::libtensorflow_cc-2.11.0-cuda112h0b0778a_0.conda
linux-64::heavydb-6.2.0-h1234567_0_cpu.conda
linux-64::arrow-cpp-7.0.1-py38h3ffc01c_11_cpu.conda
linux-64::mcpl-1.6.1-py38hb5b1691_0.conda
linux-64::pdal-2.4.3-hc7876a8_4.conda
linux-64::tensorflow-base-2.11.0-cuda112py310h52da4a5_0.conda
linux-64::tensorflow-base-2.11.0-cuda112py38h7d4ee78_0.conda
linux-64::ffmpeg-5.1.2-lgpl_h35f4ce8_4.conda
linux-64::libgdal-3.6.0-hedffb84_11.conda
linux-64::linux-perf-6.0.11-py39hf2305ad_0.conda
linux-64::arrow-cpp-8.0.1-py39h021ab0a_11_cuda.conda
linux-64::pillow-9.2.0-py39ha1c7bba_4.conda
linux-64::postgresql-plpython-14.5-py310ha4fc38e_2.conda
linux-64::arrow-cpp-9.0.0-py311hf763437_13_cpu.conda
linux-64::libgdal-3.5.3-h7eed13e_9.conda
linux-64::imagecodecs-2022.12.24-py38h7f61701_0.conda
linux-64::ndcctools-7.4.16-py311h192dca1_0.conda
linux-64::arrow-cpp-9.0.0-py311h72e8ef3_14_cpu.conda
linux-64::arrow-cpp-8.0.1-py310h74b2ba0_12_cuda.conda
linux-64::vigra-1.11.1-py311h445603a_1037.conda
linux-64::arrow-cpp-7.0.1-py310h2da3c2e_12_cpu.conda
linux-64::imagecodecs-2022.12.22-py38hc91abf2_0.conda
linux-64::aws-sdk-cpp-1.10.31-hb7d3cc7_0.conda
linux-64::arrow-cpp-9.0.0-py311hf763437_14_cpu.conda
linux-64::gmt-5.4.5-h0e592c7_23.conda
linux-64::qt6-main-6.4.1-h300f4cc_5.conda
linux-64::arrow-cpp-8.0.1-py38ha5dbe27_12_cpu.conda
linux-64::mapserver-8.0.0-py311h96eb30a_6.conda
linux-64::arrow-cpp-7.0.1-py39hdbe7bc9_11_cpu.conda
linux-64::arrow-cpp-8.0.1-py39h439591b_10_cuda.conda
linux-64::mcpl-1.6.1-py39hf95bbec_0.conda
linux-64::ale-py-0.8.0-py38h8f9f4eb_2.conda
linux-64::netcdf4-1.6.0-mpi_openmpi_py38h1161fc6_3.conda
linux-64::xrootd-5.5.1-py311ha603955_3.conda
linux-64::arrow-cpp-8.0.1-py310h75b6941_10_cpu.conda
linux-64::topologytoolkit-1.1.0-no_paraview_py39h3704deb_104.conda
linux-64::libarrow-10.0.1-hcf5dfb8_1_cpu.conda
linux-64::arrow-cpp-6.0.2-py310h4268143_8_cuda.conda
linux-64::lxml-4.9.2-py38h9ced867_0.conda
linux-64::heyoka-llvm-13-0.20.0-h71b7762_0.conda
linux-64::imagemagick-7.1.0_56-pl5321h0dc3a92_0.conda
linux-64::paraview-5.11.0-py311h5c0d74d_101_qt.conda
linux-64::libgrpc-1.51.1-h30feacc_0.conda
linux-64::aws-sdk-cpp-1.10.29-hb7d3cc7_0.conda
linux-64::heavydb-6.2.0-h1234567_0_cuda.conda
linux-64::aws-sdk-cpp-1.10.32-hb7d3cc7_0.conda
linux-64::linux-perf-6.1.2-py310h533b2b3_0.conda
linux-64::libtensorflow_cc-2.11.0-cpu_h666fa03_0.conda
linux-64::arrow-cpp-6.0.2-py39hffa70e8_9_cuda.conda
linux-64::orc-1.8.1-hfdbbad2_0.conda
linux-64::aws-sdk-cpp-1.10.37-h33d5b13_0.conda
linux-64::openmpi-4.1.4-ha1ae619_102.conda
linux-64::arrow-cpp-8.0.1-py38hf3cccdb_13_cpu.conda
linux-64::arrow-cpp-9.0.0-py38h3ffc01c_14_cpu.conda
linux-64::arrow-cpp-8.0.1-py310he8f6ac5_12_cuda.conda
linux-64::arrow-cpp-7.0.1-py39h856a8b1_12_cuda.conda
linux-64::qt6-main-6.4.1-h4b992bb_3.conda
linux-64::elfutils-0.188-hde5d1a3_1.conda
linux-64::rstudio-desktop-2022.07.2-r42hd5ac50f_578.conda
linux-64::jaxlib-0.3.25-cpu_py38hdb3bdfc_1.conda
linux-64::arrow-cpp-7.0.1-py310h2da3c2e_11_cpu.conda
linux-64::linux-perf-6.0.13-py311h8f758d4_0.conda
linux-64::nordugrid-arc-6.17.0-py311h6017219_0.conda
linux-64::aws-sdk-cpp-1.9.379-h32f6703_7.conda
linux-64::yarp-cxx-3.7.2-ha0fc88e_6.conda
linux-64::libgdal-3.6.1-hdfbbfed_3.conda
linux-64::imagecodecs-2022.12.22-py311h7f108a8_0.conda
linux-64::libspatialite-5.0.1-h221c8f1_23.conda
linux-64::aws-sdk-cpp-1.10.22-h54302c4_0.conda
linux-64::rstudio-desktop-2022.12.0-r42h90f8cb4_353.conda
linux-64::sdl2_ttf-2.20.1-h44fa107_1.conda
linux-64::graphicsmagick-1.3.37-hace9984_0.conda
linux-64::aws-sdk-cpp-1.10.24-h4ccf91e_0.conda
linux-64::freeimage-3.18.0-h66f5774_11.conda
linux-64::rstudio-desktop-2022.07.2-r41hed3354f_578.conda
linux-64::harp-1.17-py311r42h921a695_0.conda
linux-64::libarchive-minimal-static-3.6.2-hdda6a36_0.conda
linux-64::openmeeg-2.5.5-py38h12d45fe_2.conda
linux-64::gstlal-1.10.0-py38hc059cbe_2.conda
linux-64::libgdal-arrow-parquet-3.6.1-h03859b5_2.conda
linux-64::ale-py-0.8.0-py39hcd51377_0.conda
linux-64::linux-perf-6.1.1-py39h9993275_0.conda
linux-64::rpm-tools-4.17.1-py39lua54ha117234_2.conda
linux-64::arrow-cpp-8.0.1-py38ha529e58_12_cuda.conda
linux-64::heyoka-llvm-12-0.20.0-h25571a0_0.conda
linux-64::arrow-cpp-9.0.0-py310h75b6941_12_cpu.conda
linux-64::folly-2022.12.05.00-h1234567_3_jemalloc.conda
linux-64::arrow-cpp-6.0.2-py310hae478e0_7_cpu.conda
linux-64::lxml-4.9.2-py39h14694de_0.conda
linux-64::linux-perf-6.0.11-py38he7f55c2_0.conda
linux-64::arrow-cpp-7.0.1-py39hf8c098d_9_cpu.conda
linux-64::qt6-main-6.4.1-h300f4cc_4.conda
linux-64::arrow-cpp-8.0.1-py39h7da1d83_12_cuda.conda
linux-64::libgdal-arrow-parquet-3.6.0-h7eb742c_12.conda
linux-64::arrow-cpp-9.0.0-py310h21f88ba_13_cpu.conda
linux-64::libgdal-3.5.3-h867e046_8.conda
linux-64::jaxlib-0.3.25-cuda112py310hf6b4f40_201.conda
linux-64::arrow-cpp-9.0.0-py38ha5dbe27_13_cpu.conda
linux-64::hdf5-1.12.2-mpi_mpich_h08b82f9_1.conda
linux-64::libgdal-3.6.1-h7d521fb_2.conda
linux-64::serf-1.3.9-hb3fec43_2.conda
linux-64::paraview-5.11.0-py311hae632ea_1_egl.conda
linux-64::serf-1.3.9-h4d54922_2.conda
linux-64::aws-sdk-cpp-1.10.34-h33d5b13_1.conda
linux-64::libopencv-4.6.0-py39h9757d25_7.conda
linux-64::rstudio-desktop-2022.12.0-r41hed3354f_353.conda
linux-64::aws-sdk-cpp-1.10.31-h4ccf91e_0.conda
linux-64::paraview-5.11.0-py310h7ff4cc6_1_egl.conda
linux-64::coda-2.24.1-py310h0a395da_0.conda
linux-64::jaxlib-0.4.1-cuda112py38hc807380_201.conda
linux-64::arrow-cpp-9.0.0-py38h9ebcd46_11_cuda.conda
linux-64::arrow-cpp-8.0.1-py311h9f71e43_13_cpu.conda
linux-64::pytng-0.3.0-py310hc908c09_0.conda
linux-64::postgresql-14.5-h84e8d4a_4.conda
linux-64::arrow-cpp-9.0.0-py38h66a2e17_13_cuda.conda
linux-64::pyinstaller-5.7.0-py310haffca24_0.conda
linux-64::openssh-9.1p1-hb675445_1.conda
linux-64::qt-main-5.15.6-hc2de0a7_3.conda
linux-64::arrow-cpp-9.0.0-py310h2da3c2e_13_cpu.conda
linux-64::ale-py-0.8.0-py310h2aa996b_3.conda
linux-64::libmediainfo-22.12-hca472f8_0.conda
linux-64::aws-sdk-cpp-1.10.36-h33d5b13_0.conda
linux-64::arrow-cpp-9.0.0-py311h8c7f931_12_cpu.conda
linux-64::linux-perf-6.0.14-py39h9993275_0.conda
linux-64::octave-7.3.0-h81a59c9_2.conda
linux-64::aws-sdk-cpp-1.10.27-h4ccf91e_0.conda
linux-64::arrow-cpp-8.0.1-py310h26e764d_13_cuda.conda
linux-64::topologytoolkit-1.1.0-with_paraview_py310h8cb066f_4.conda
linux-64::kitty-0.23.1-py38h75365bc_2.conda
linux-64::arrow-cpp-8.0.1-py39hdbe7bc9_11_cpu.conda
linux-64::arrow-cpp-6.0.2-py311h27e79e4_9_cpu.conda
linux-64::netcdf4-1.6.0-mpi_mpich_py310h2469d1f_3.conda
linux-64::qt6-main-6.4.1-h4013591_6.conda
linux-64::linux-perf-6.0.14-py311h8f758d4_0.conda
linux-64::arrow-cpp-8.0.1-py310h544389e_13_cuda.conda
linux-64::cpp-opentelemetry-sdk-1.8.0-he26330a_0.conda
linux-64::libtensorflow-2.11.0-cuda112h0b0778a_0.conda
linux-64::podofo-0.9.8-lua54h928d9b9_1.conda
linux-64::nordugrid-arc-6.17.0-py38h9a5c796_0.conda
linux-64::postgresql-plpython-14.5-py39hbf22de8_4.conda
linux-64::coda-2.24.1-py38hcb1ca6b_0.conda
linux-64::jaxlib-0.3.25-cuda112py311hfe5e4b5_201.conda
linux-64::sdl_image-1.2.12-h7c897af_3.conda
linux-64::openscenegraph-3.6.5-hf5f0c60_15.conda
linux-64::libtensorflow-2.11.0-cpu_ha757fe5_0.conda
linux-64::slurm-22.05.4-hbe0ef40_1.conda
linux-64::arrow-cpp-8.0.1-py310hbcc112b_9_cpu.conda
linux-64::linux-perf-6.0.11-py311ha9eb6e6_0.conda
linux-64::arrow-cpp-8.0.1-py39hdbe7bc9_12_cpu.conda
linux-64::arrow-cpp-8.0.1-py38hb531a40_11_cuda.conda
linux-64::aws-sdk-cpp-1.10.23-h4ccf91e_0.conda
linux-64::octave-7.3.0-h00970fe_1.conda
linux-64::libgdal-3.6.1-h4fca5ce_0.conda
linux-64::libpq-15.1-h67c24c5_1.conda
linux-64::paraview-5.11.0-py39h187cf68_101_qt.conda
linux-64::xrootd-5.5.1-py38h9a8e8ed_3.conda
linux-64::jaxlib-0.3.25-cuda112py38hc807380_201.conda
linux-64::harp-1.17-py310r41h0a395da_0.conda
linux-64::ale-py-0.8.0-py310h2aa996b_1.conda
linux-64::netcdf4-1.6.0-nompi_py311hc29c2f0_103.conda
linux-64::arrow-cpp-6.0.2-py38h9ad2fdf_7_cpu.conda
linux-64::libarrow-10.0.1-hac2d30e_3_cuda.conda
linux-64::postgresql-plpython-15.1-py311h35fdb49_2.conda
linux-64::arrow-cpp-8.0.1-py311h72e8ef3_11_cpu.conda
linux-64::ndcctools-7.4.16-py310he35441a_0.conda
linux-64::harp-1.17-py38r42hcb1ca6b_0.conda
linux-64::arrow-cpp-6.0.2-py310h7d39f80_9_cuda.conda
linux-64::lammps-2022.06.23-py39hd94cc11_openmpi_5.conda
linux-64::harp-1.17-py39r42hdb66b6c_0.conda
linux-64::gdstk-0.9.35-py38hea81f93_0.conda
linux-64::gst-plugins-bad-1.21.2-h36fd50f_1.conda
linux-64::arrow-cpp-7.0.1-py310h21f88ba_12_cpu.conda
linux-64::nd2-0.5.2-py310h9ca00e0_0.conda
linux-64::xrootd-5.5.1-py38hc25cc6b_3.conda
linux-64::postgresql-plpython-14.5-py310h8c03797_4.conda
linux-64::libgdal-3.5.3-h8b86210_9.conda
linux-64::arrow-cpp-6.0.2-py311h8c28006_7_cuda.conda
linux-64::arrow-cpp-8.0.1-py310h2da3c2e_12_cpu.conda
linux-64::pytng-0.3.0-py311h48d25d0_0.conda
linux-64::tensorflow-base-2.11.0-cpu_py310h8a70c67_0.conda
linux-64::arrow-cpp-9.0.0-py39h06993d0_13_cpu.conda
linux-64::imagecodecs-2022.12.22-py310h17758e3_0.conda
linux-64::paraview-5.11.0-py310hc9e8bab_1_egl.conda
linux-64::libarrow-10.0.1-h5523809_0_cpu.conda
linux-64::ffmpeg-5.1.2-gpl_h13415ed_104.conda
linux-64::topologytoolkit-1.1.0-no_paraview_py310h6768b79_104.conda
linux-64::sdl2_image-2.6.2-h916e60d_1.conda
linux-64::postgresql-plpython-14.5-py311hb3466cf_4.conda
linux-64::jaxlib-0.4.1-cuda112py310hf6b4f40_201.conda
linux-64::arrow-cpp-7.0.1-py311h00f723b_10_cuda.conda
linux-64::libpq-14.5-h52d0468_3.conda
linux-64::hugin-base-2022.0.0-pl5321hae931c2_1.conda
linux-64::heyoka-llvm-11-0.20.0-hd3d3276_0.conda
linux-64::arrow-cpp-8.0.1-py310h8cd3cd0_11_cuda.conda
linux-64::arrow-cpp-8.0.1-py310h3623fe0_13_cpu.conda
linux-64::arrow-cpp-7.0.1-py38hb24177d_12_cuda.conda
linux-64::libpq-14.5-h67c24c5_2.conda
linux-64::arrow-cpp-8.0.1-py311hf763437_11_cpu.conda
linux-64::hugin-2022.0.0-pl5321h3398141_0.conda
linux-64::pytng-0.2.3-py38hb5a4cc3_1.conda
linux-64::arrow-cpp-9.0.0-py310h52b706f_12_cuda.conda
linux-64::nordugrid-arc-6.17.0-py38hbd41f47_0.conda
linux-64::arrow-cpp-7.0.1-py38h46f5817_9_cpu.conda
linux-64::arrow-cpp-9.0.0-py311h43f3790_11_cpu.conda
linux-64::pytng-0.2.3-py310hc908c09_1.conda
linux-64::postgresql-14.5-hdeef612_2.conda
linux-64::arrow-cpp-7.0.1-py39hdbe7bc9_12_cpu.conda
linux-64::aws-sdk-cpp-1.10.40-hc894300_0.conda
linux-64::rstudio-desktop-2022.07.2-r41h90f8cb4_578.conda
linux-64::intel-cmplr-lib-rt-2023.0.0-h3eb15da_25371.conda
linux-64::libarrow-10.0.1-h2f45513_0_cpu.conda
linux-64::freecad-0.20.2-py37h6084e40_0.conda
linux-64::arrow-cpp-8.0.1-py39h06993d0_12_cpu.conda
linux-64::subversion-1.14.2-pl5321h7174519_3.conda
linux-64::ale-py-0.8.0-py310h2aa996b_0.conda
linux-64::coda-2.24.1-py39h92210e6_0.conda
linux-64::r-gaston-1.5.8-r41h58bca29_0.conda
linux-64::jaxlib-0.4.1-cuda112py310hf0bc174_201.conda
linux-64::qt6-3d-6.4.1-h9df2822_1.conda
linux-64::libgdal-arrow-parquet-3.6.1-h34c9f74_0.conda
linux-64::libgdal-3.6.1-h896b04b_1.conda
linux-64::linux-perf-6.1.2-py311h6353e60_0.conda
linux-64::ale-py-0.8.0-py39hcd51377_2.conda
linux-64::gdstk-0.9.35-py38h86d1459_0.conda
linux-64::libtensorflow-2.11.0-cuda112hf5ab516_0.conda
linux-64::git-2.39.0-pl5321ha3eba64_0.conda
linux-64::pillow-9.2.0-py310h023d228_4.conda
linux-64::aws-sdk-cpp-1.10.22-hdc6349a_0.conda
linux-64::ndcctools-7.4.16-py310h4a5a7b4_0.conda
linux-64::rpm-tools-4.17.1-py311lua54habb49eb_2.conda
linux-64::lammps-2022.06.23-py310ha1e3a4d_openmpi_5.conda
linux-64::arrow-cpp-9.0.0-py38heace812_12_cuda.conda
linux-64::ndcctools-7.4.16-py39hd5fd66b_0.conda
linux-64::openslide-3.4.1-h7773abc_6.conda
linux-64::arrow-cpp-9.0.0-py311h6f4b080_15_cpu.conda
linux-64::gemmi-0.5.8-py39h84b0cba_0.conda
linux-64::arrow-cpp-8.0.1-py39h06993d0_11_cpu.conda
linux-64::paraview-5.11.0-py39hf58b53e_1_egl.conda
linux-64::tiledb-2.13.0-hd532e3d_1.conda
linux-64::lxml-4.9.2-py311h14a6109_0.conda
linux-64::tensorflow-base-2.11.0-cuda112py39h1c230a5_0.conda
linux-64::postgresql-15.1-h84e8d4a_2.conda
linux-64::libopencv-4.6.0-py39hbc3ed98_8.conda
linux-64::linux-perf-6.0.13-py38h74ecc8f_0.conda
linux-64::arrow-cpp-7.0.1-py310h21f88ba_11_cpu.conda
linux-64::arrow-cpp-8.0.1-py38h44c1e35_13_cpu.conda
linux-64::paraview-5.11.0-py38hfcf4129_1_egl.conda
linux-64::aws-sdk-cpp-1.10.41-hc894300_0.conda
linux-64::tensorflow-base-2.11.0-cpu_py39h9b4020c_0.conda
linux-64::qt6-3d-6.4.1-h9df2822_2.conda
linux-64::linux-perf-6.0.12-py38h74ecc8f_0.conda
linux-64::gstlal-1.10.0-py310hc1b84e2_3.conda
linux-64::imagemagick-7.1.0_55-pl5321h0d24a18_0.conda
linux-64::openmeeg-2.5.5-py39h060fa36_2.conda
linux-64::magics-4.12.1-h2ccc01a_2.conda
linux-64::linux-perf-6.1.2-py38h458c6c9_0.conda
linux-64::ale-py-0.8.0-py310h2aa996b_2.conda
linux-64::postgresql-plpython-14.5-py311h35fdb49_4.conda
linux-64::arrow-cpp-9.0.0-py38h44c1e35_15_cpu.conda
linux-64::arrow-cpp-9.0.0-py38ha5dbe27_14_cpu.conda
linux-64::arrow-cpp-7.0.1-py311h72e8ef3_11_cpu.conda
linux-64::nordugrid-arc-6.17.0-py39hda4c732_0.conda
linux-64::ffmpeg-4.4.2-gpl_h13415ed_111.conda
linux-64::octave-7.3.0-hcbe002d_1.conda
linux-64::pillow-9.2.0-py38hde6dc18_4.conda
linux-64::heyoka-0.20.0-ha91564f_0.conda
linux-64::arrow-cpp-9.0.0-py39h7da1d83_14_cuda.conda
linux-64::vigra-1.11.1-py38h26df4ce_1037.conda
linux-64::katago-1.11.0-cuda110hf937dbe_1.conda
linux-64::gfortran_impl_osx-64-9.5.0-h2f1bdfb_27.conda
linux-64::arrow-cpp-8.0.1-py311h364b498_11_cuda.conda
linux-64::imagecodecs-2022.9.26-py38h7f61701_5.conda
linux-64::aws-sdk-cpp-1.10.41-h56135f1_1.conda
linux-64::jaxlib-0.4.1-cpu_py310h09f4813_1.conda
linux-64::arrow-cpp-6.0.2-py38hd546952_9_cuda.conda
linux-64::arrow-cpp-6.0.2-py310hde210ca_9_cpu.conda
linux-64::imagecodecs-2022.9.26-py310h17758e3_5.conda
linux-64::arrow-cpp-7.0.1-py311hc9bd083_11_cuda.conda
linux-64::arrow-cpp-9.0.0-py311h4688dfd_14_cuda.conda
linux-64::libgdal-3.5.3-h05f8703_11.conda
linux-64::jaxlib-0.4.1-cpu_py39hcceb00d_1.conda
linux-64::aws-sdk-cpp-1.10.33-h4ccf91e_0.conda
linux-64::heyoka-0.20.0-hbaf6dc7_0.conda
linux-64::linux-perf-6.0.13-py310hc7c4f61_0.conda
linux-64::arrow-cpp-8.0.1-py38hb531a40_12_cuda.conda
linux-64::arrow-cpp-8.0.1-py38h3ffc01c_11_cpu.conda
linux-64::libarrow-10.0.1-hba736f0_2_cpu.conda
linux-64::arrow-cpp-6.0.2-py39hf3b519b_7_cuda.conda
linux-64::postgresql-plpython-15.1-py39hd24e1a9_1.conda
linux-64::kitty-0.23.1-py39h4478c88_2.conda
linux-64::tesseract-5.3.0-he1868e8_0.conda
linux-64::wasmer-3.1.0-h88e59bd_0.conda
linux-64::heyoka-0.20.0-h921bcf6_0.conda
linux-64::nordugrid-arc-6.17.0-py310h64f0c9e_0.conda
linux-64::libopencv-4.6.0-py310h5bd1119_9.conda
linux-64::libgdal-arrow-parquet-3.6.1-ha740a2c_3.conda
linux-64::arrow-cpp-9.0.0-py310he8f6ac5_13_cuda.conda
linux-64::gemmi-0.5.8-py39ha6abdf1_0.conda
linux-64::katago-1.11.0-cpu_hec744e2_1.conda
linux-64::libopencv-4.6.0-py38h216e096_8.conda
linux-64::imagecodecs-2022.12.24-py39h24c8a72_0.conda
linux-64::mapserver-8.0.0-py39h5007fb7_5.conda
linux-64::arrow-cpp-9.0.0-py39hf8c098d_11_cpu.conda
linux-64::arrow-cpp-8.0.1-py311h43f3790_9_cpu.conda
linux-64::arrow-cpp-8.0.1-py39h8aa2ebb_13_cpu.conda
linux-64::jaxlib-0.3.25-cuda112py311hbbecf72_201.conda
linux-64::libgdal-arrow-parquet-3.6.1-hb72498f_1.conda
linux-64::paraview-5.11.0-py38h56af31a_101_qt.conda
linux-64::arrow-cpp-9.0.0-py311h364b498_13_cuda.conda
linux-64::topologytoolkit-1.1.0-with_paraview_py39hca7f37e_4.conda
linux-64::arrow-cpp-8.0.1-py310h52b706f_10_cuda.conda
linux-64::aws-sdk-cpp-1.10.36-hc894300_0.conda
linux-64::arrow-cpp-9.0.0-py38hf3cccdb_15_cpu.conda
linux-64::linux-perf-6.1.1-py310h533b2b3_0.conda
linux-64::arrow-cpp-6.0.2-py38h7acd393_8_cuda.conda
linux-64::postgresql-plpython-15.1-py310hd09b350_1.conda
linux-64::ale-py-0.8.0-py38hda4d45f_2.conda
linux-64::gst-plugins-good-1.21.3-hbba150b_1.conda
linux-64::postgresql-plpython-14.5-py310hd09b350_2.conda
linux-64::gstlal-1.10.0-py39h4cf9939_2.conda
linux-64::nd2-0.5.3-py38h9005721_0.conda
linux-64::harp-1.17-py38r41hcb1ca6b_0.conda
linux-64::rstudio-desktop-2022.12.0-r42hd5ac50f_353.conda
linux-64::imagecodecs-2022.12.22-py39h9bcf58b_0.conda
linux-64::graphviz-7.0.5-h2e5815a_0.conda
linux-64::postgresql-plpython-15.1-py38h35e5630_1.conda
linux-64::nordugrid-arc-6.17.0-py310h8c77e65_0.conda
linux-64::pillow-9.2.0-py38h335611b_4.conda
linux-64::katago-1.11.0-cuda111h68d30c0_1.conda
linux-64::freecad-0.20.2-py38h63dbee4_0.conda
linux-64::linux-perf-6.1.2-py39h43fcbc4_0.conda
linux-64::jaxlib-0.3.25-cpu_py311h40ce291_1.conda
linux-64::arrow-cpp-9.0.0-py311h72e8ef3_13_cpu.conda
linux-64::linux-perf-6.1.2-py311h8f758d4_0.conda
linux-64::ffmpeg-4.4.2-lgpl_h35f4ce8_11.conda
linux-64::libgdal-3.5.3-h5842160_12.conda
linux-64::libcurl-static-7.86.0-hdc1c0ab_2.conda
linux-64::arrow-cpp-6.0.2-py38h0aa053a_9_cuda.conda
linux-64::arrow-cpp-8.0.1-py311h364b498_12_cuda.conda
linux-64::libcurl-static-7.86.0-h6312ad2_2.conda
linux-64::dpcpp_impl_linux-64-2023.0.0-h7ce6118_25371.conda
linux-64::sdl2_ttf-2.0.15-h2eed4a9_2.conda
linux-64::linux-perf-6.0.14-py38h458c6c9_0.conda
linux-64::arrow-cpp-6.0.2-py311h8268191_9_cuda.conda
linux-64::mcpl-1.6.1-py38h5e7d216_0.conda
linux-64::gfortran_impl_osx-64-10.4.0-h2d6b85e_27.conda
linux-64::nd2-0.5.2-py39hff1726d_0.conda
linux-64::linux-perf-6.0.12-py38h458c6c9_0.conda
linux-64::arrow-cpp-6.0.2-py38h60ad849_9_cpu.conda
linux-64::arrow-cpp-9.0.0-py39h8aa2ebb_15_cpu.conda
linux-64::libarrow-10.0.1-h93bcc13_1_cuda.conda
linux-64::harp-1.17-py310r42h0a395da_0.conda
linux-64::arrow-cpp-8.0.1-py39h9c31e50_13_cuda.conda
linux-64::libgdal-3.6.0-h2f87c3e_13.conda
linux-64::arrow-cpp-8.0.1-py38h66a2e17_11_cuda.conda
linux-64::arrow-cpp-6.0.2-py38h86d596d_8_cpu.conda
linux-64::dcmtk-3.6.7-heca80e8_3.conda
linux-64::gmsh-4.11.0-h5c738d0_1.conda
linux-64::linux-perf-6.0.12-py311h8f758d4_0.conda
linux-64::coda-2.24.1-py39hdb66b6c_0.conda
linux-64::mapserver-8.0.0-py311h87f435f_5.conda
linux-64::paraview-5.11.0-py311hd52018a_101_qt.conda
linux-64::linux-perf-6.0.13-py311h6353e60_0.conda
linux-64::postgresql-plpython-14.5-py310h3a435b5_4.conda
linux-64::lighttpd-1.4.64-lua54h145e673_2.conda
linux-64::nd2-0.5.3-py310h9ca00e0_0.conda
linux-64::aws-sdk-cpp-1.10.35-hc894300_0.conda
linux-64::arrow-cpp-8.0.1-py39h95e2317_13_cpu.conda
linux-64::arrow-cpp-6.0.2-py310h7d39f80_8_cuda.conda
linux-64::mcpl-1.6.1-py311h4dca44d_0.conda
linux-64::git-2.39.0-pl5321h693f4a3_0.conda
linux-64::arrow-cpp-8.0.1-py39h55f0795_11_cuda.conda
linux-64::libopencv-4.6.0-py310h6214075_7.conda
linux-64::postgresql-plpython-14.5-py311h61d49a6_3.conda
linux-64::imagecodecs-2022.12.24-py311h7f108a8_0.conda
linux-64::linux-perf-6.0.14-py310hc7c4f61_0.conda
linux-64::postgresql-plpython-14.5-py39hd745751_4.conda
linux-64::pdfmm-0.9.22-h72fefdb_2.conda
linux-64::postgresql-plpython-14.5-py38h0354a93_2.conda
linux-64::gdstk-0.9.35-py310h6bf8744_0.conda
linux-64::folly-2022.12.05.00-h1234567_3.conda
linux-64::pytng-0.2.3-py38hcf6129a_1.conda
linux-64::aws-sdk-cpp-1.10.20-h54302c4_0.conda
linux-64::libgdal-arrow-parquet-3.6.1-hb2badfc_3.conda
linux-64::magic-8.3.351-h130c0f9_0.conda
linux-64::arrow-cpp-6.0.2-py310h8908805_9_cpu.conda
linux-64::libopencv-4.6.0-py311h8479920_7.conda
linux-64::katago-1.11.0-cuda111h817afab_1.conda
linux-64::ndcctools-7.4.16-py311h19978e3_0.conda
linux-64::linux-perf-6.0.14-py311h6353e60_0.conda
linux-64::arrow-cpp-8.0.1-py39h021ab0a_12_cuda.conda
linux-64::libgdal-arrow-parquet-3.6.1-ha37292b_1.conda
linux-64::katago-1.11.0-cuda112h43afb8f_1.conda
linux-64::nd2-0.5.2-py39hb8da52a_0.conda
linux-64::postgresql-14.5-h96c9388_3.conda
linux-64::xrootd-5.5.1-py39h473cfa2_3.conda
linux-64::katago-1.11.0-cuda102he49096f_1.conda
linux-64::gdstk-0.9.35-py39hafc1dc6_0.conda
linux-64::arrow-cpp-7.0.1-py39h439591b_10_cuda.conda
linux-64::arrow-cpp-6.0.2-py311h27e79e4_8_cpu.conda
linux-64::lxml-4.9.2-py310hbdc0903_0.conda
linux-64::arrow-cpp-9.0.0-py39hdbe7bc9_13_cpu.conda
linux-64::arrow-cpp-9.0.0-py39h021ab0a_14_cuda.conda
linux-64::rpm-tools-4.17.1-py310lua54h9fc2c10_2.conda
linux-64::libopencv-4.6.0-py38h3766f53_7.conda
linux-64::dpcpp_impl_linux-64-2023.0.0-h7ce6118_25370.conda
linux-64::imagecodecs-2022.12.24-py39h9bcf58b_0.conda
linux-64::arrow-cpp-8.0.1-py311hdb1b646_9_cuda.conda
linux-64::jaxlib-0.4.1-cpu_py311h5c1401b_1.conda
linux-64::arrow-cpp-7.0.1-py39h1010d6a_10_cpu.conda
linux-64::gemmi-0.5.8-py311h6844984_0.conda
linux-64::qt-main-5.15.6-hafeba50_4.conda
linux-64::jaxlib-0.4.1-cuda112py39h17d59b0_201.conda
linux-64::jaxlib-0.4.1-cuda112py39h35fb927_201.conda
linux-64::libarrow-10.0.1-h9ff0032_0_cuda.conda
linux-64::libtensorflow_cc-2.11.0-cuda112hf5ab516_0.conda
linux-64::mapserver-8.0.0-py38hcc76564_5.conda
linux-64::arrow-cpp-9.0.0-py310h3623fe0_15_cpu.conda
linux-64::jaxlib-0.3.25-cpu_py311h5c1401b_1.conda
linux-64::ffmpeg-5.1.2-gpl_h8dda1f0_105.conda
linux-64::rpm-tools-4.17.1-py38lua54h56b679e_2.conda
linux-64::intel-opencl-rt-2023.0.0-h68971e6_25370.conda
linux-64::aws-sdk-cpp-1.10.38-h33d5b13_0.conda
linux-64::jaxlib-0.4.1-cpu_py311h40ce291_1.conda
linux-64::arrow-cpp-7.0.1-py311hdb1b646_9_cuda.conda
linux-64::tectonic-0.12.0-hd632261_1.conda
linux-64::tensorflow-base-2.11.0-cpu_py38hb03d4c4_0.conda
linux-64::vigra-1.11.1-py39h362eba4_1037.conda
linux-64::libtiledb-sql-0.20.0-hd8d06ef_0.conda
linux-64::arrow-cpp-9.0.0-py310h26e764d_15_cuda.conda
linux-64::libgdal-arrow-parquet-3.6.0-h34c9f74_14.conda
linux-64::pypy3.9-7.3.9-hd671c94_7.conda
linux-64::arrow-cpp-9.0.0-py310h2da3c2e_14_cpu.conda
linux-64::arrow-cpp-6.0.2-py39h8288422_9_cuda.conda
linux-64::lammps-2022.06.23-py39h9dad821_mpich_5.conda
linux-64::gdstk-0.9.35-py39h919db21_0.conda
linux-64::imagecodecs-2022.9.26-py39h24c8a72_5.conda
linux-64::openconnect-9.01-h61f67eb_5.conda
linux-64::hugin-2022.0.0-pl5321h283b510_1.conda
linux-64::cmake-3.25.1-h816a3e0_0.conda
linux-64::libgdal-3.5.3-h9af8157_11.conda
linux-64::aws-sdk-cpp-1.10.25-h4ccf91e_0.conda
linux-64::arrow-cpp-9.0.0-py311h146e3d0_13_cuda.conda
linux-64::gstlal-1.10.0-py311h98bf79b_3.conda
linux-64::libgdal-3.6.1-hf2b5f72_1.conda
linux-64::linux-perf-6.1.1-py310hc7c4f61_0.conda
linux-64::rstudio-desktop-2022.07.2-r42h0f448d8_578.conda
linux-64::astrometry-0.93-py39ha999b03_0.conda
linux-64::imagecodecs-2022.12.22-py38h7f61701_0.conda
linux-64::qt6-3d-6.4.1-h9df2822_3.conda
linux-64::libgdal-3.6.1-h839a3bd_0.conda
linux-64::arrow-cpp-9.0.0-py311hdb1b646_11_cuda.conda
linux-64::arrow-cpp-6.0.2-py311h55719cd_9_cpu.conda
linux-64::arrow-cpp-7.0.1-py311h8a60d47_12_cuda.conda
linux-64::gfortran_impl_osx-64-11.3.0-hacec75c_27.conda
linux-64::magics-metview-4.12.1-h6b8281a_2.conda
linux-64::arrow-cpp-8.0.1-py310he8f6ac5_11_cuda.conda
linux-64::astrometry-0.93-py38h07be419_0.conda
linux-64::paraview-5.11.0-py311h1a5f0a1_1_egl.conda
linux-64::pdal-2.4.3-h4e029b3_4.conda
linux-64::postgresql-plpython-14.5-py38hf875890_4.conda
linux-64::arrow-cpp-7.0.1-py39h8c67656_11_cuda.conda
linux-64::postgresql-plpython-15.1-py311hb3466cf_2.conda
linux-64::topologytoolkit-1.1.0-with_paraview_py38h256a25b_4.conda
linux-64::ndcctools-7.4.16-py38hd31fdc1_0.conda
linux-64::arrow-cpp-9.0.0-py311h94321e7_15_cuda.conda
linux-64::kitty-0.23.1-py310hafada6c_2.conda
linux-64::arrow-cpp-7.0.1-py310h75b6941_10_cpu.conda
linux-64::magic-8.3.350-h130c0f9_0.conda
linux-64::ale-py-0.8.0-py311h0db04d4_1.conda
linux-64::wxwidgets-3.2.1-hafa1c0f_3.conda
linux-64::lxml-4.9.2-py38h215a2d7_0.conda
linux-64::libopencv-4.6.0-py311ha52ee4f_9.conda
linux-64::arrow-cpp-8.0.1-py311h146e3d0_11_cuda.conda
linux-64::libcurl-7.86.0-hdc1c0ab_2.conda
linux-64::nd2-0.5.3-py38h3876440_0.conda
linux-64::linux-perf-6.1.1-py311h6353e60_0.conda
linux-64::arrow-cpp-8.0.1-py311h6f4b080_13_cpu.conda
linux-64::ale-py-0.8.0-py39h0c2551f_2.conda
linux-64::gfortran_impl_osx-arm64-11.3.0-he99ca6a_27.conda
linux-64::katago-1.11.0-cpu_h66e20fa_1.conda
linux-64::arrow-cpp-7.0.1-py311h43f3790_9_cpu.conda
linux-64::jaxlib-0.3.25-cuda112py310hf0bc174_201.conda
linux-64::nd2-0.5.2-py311h3e0d2dd_0.conda
linux-64::lmod-8.7.15-lua54hd2ed8a0_0.conda
linux-64::hdf5-1.12.2-mpi_openmpi_hb3f3608_1.conda
linux-64::postgresql-15.1-ha105346_1.conda
linux-64::openmeeg-2.5.5-py39ha136a32_2.conda
linux-64::arrow-cpp-8.0.1-py311h4688dfd_12_cuda.conda
linux-64::curl-7.86.0-h6312ad2_2.conda
linux-64::linux-perf-6.1.1-py311h8f758d4_0.conda
linux-64::aws-sdk-cpp-1.10.26-h4ccf91e_0.conda
linux-64::ale-py-0.8.0-py311h0db04d4_2.conda
linux-64::libgdal-3.6.0-hc956b1e_12.conda
linux-64::arrow-cpp-8.0.1-py38h46f5817_9_cpu.conda
linux-64::arrow-cpp-6.0.2-py38h60ad849_8_cpu.conda
linux-64::linux-perf-6.0.14-py38h74ecc8f_0.conda
linux-64::postgresql-plpython-14.5-py39hd6779d9_2.conda
linux-64::fossil-2.20-hb6b37eb_1.conda
linux-64::rstudio-desktop-2022.12.0-r42hed3354f_353.conda
linux-64::nco-5.1.3-h3e2f719_1.conda
linux-64::astrometry-0.93-py310h22a6f72_0.conda
linux-64::linux-perf-6.0.11-py38h68d0b5d_0.conda
linux-64::yarp-cxx-3.7.2-h1fc458e_7.conda
linux-64::sdl2_ttf-2.20.1-h2eed4a9_0.conda
linux-64::netcdf4-1.6.0-mpi_openmpi_py39hdfb0d5a_3.conda
linux-64::pytng-0.3.0-py39h0050040_0.conda
linux-64::libopencv-4.6.0-py38h340f60e_9.conda
linux-64::ale-py-0.8.0-py38hda4d45f_0.conda
linux-64::libgrpc-1.50.1-h05bd8bd_0.conda
linux-64::imagemagick-7.1.0_53-pl5321hbe46f5a_0.conda
linux-64::harp-1.17-py311r41h921a695_0.conda
linux-64::verilator-5.004-h0cdce71_0.conda
linux-64::postgresql-plpython-15.1-py310ha4fc38e_1.conda
linux-64::harp-1.17-py39r41h92210e6_0.conda
linux-64::gstlal-1.10.0-py38hc059cbe_3.conda
linux-64::arrow-cpp-9.0.0-py39h06993d0_14_cpu.conda
linux-64::abinit-9.8.1-h7333e2c_0.conda
linux-64::sdl2_image-2.6.2-h916e60d_2.conda
linux-64::tensorflow-base-2.11.0-cuda112py39haa5674d_0.conda
linux-64::arrow-cpp-6.0.2-py310h8908805_8_cpu.conda
linux-64::arrow-cpp-8.0.1-py38heace812_10_cuda.conda
linux-64::lammps-2022.06.23-py38hfede4e1_mpich_5.conda
linux-64::libvips-8.13.3-hcb2d4e9_4.conda
linux-64::arrow-cpp-9.0.0-py38hb531a40_14_cuda.conda
linux-64::arrow-cpp-9.0.0-py310h544389e_15_cuda.conda
linux-64::astrometry-0.93-py38hd11d9ee_0.conda
linux-64::mapserver-8.0.0-py311h3dc1a9b_7.conda
linux-64::wxpython-4.2.0-py38h64e12a6_3.conda
linux-64::postgresql-plpython-14.5-py38h4dde1d4_4.conda
linux-64::imagemagick-7.1.0_55-pl5321h0dc3a92_1.conda
linux-64::arrow-cpp-7.0.1-py38hb0dbfff_11_cuda.conda
linux-64::geotiff-1.7.1-h7a142b4_6.conda
linux-64::jaxlib-0.3.25-cpu_py310hdc47304_1.conda
linux-64::arrow-cpp-8.0.1-py38h0949398_13_cuda.conda
linux-64::fossil-2.20-hb1d605b_1.conda
linux-64::libarchive-3.6.2-hc8874e4_0.conda
linux-64::graphicsmagick-1.3.39-hcb5e50b_0.conda
linux-64::qt6-datavis3d-6.4.1-h9df2822_1.conda
linux-64::postgresql-plpython-15.1-py311h7444109_1.conda
linux-64::dcap-2.47.12-h6ea09e9_6.conda
linux-64::ttyd-1.7.2-h5fd5823_1.conda
linux-64::linux-perf-6.0.13-py39h43fcbc4_0.conda
linux-64::libopencv-4.6.0-py39h7581794_9.conda
linux-64::arrow-cpp-9.0.0-py38hb531a40_13_cuda.conda
linux-64::mcpl-1.6.1-py310haffca24_0.conda
linux-64::qt6-charts-6.4.1-h9df2822_1.conda
linux-64::arrow-cpp-8.0.1-py311h72e8ef3_12_cpu.conda
linux-64::arrow-cpp-7.0.1-py38h0949398_12_cuda.conda
linux-64::linux-perf-6.0.12-py310hc7c4f61_0.conda
linux-64::arrow-cpp-9.0.0-py38ha529e58_14_cuda.conda
linux-64::linux-perf-6.0.12-py310h533b2b3_0.conda
linux-64::r-base-4.2.2-ha7d60f8_3.conda
linux-64::arrow-cpp-7.0.1-py38h9ebcd46_9_cuda.conda
linux-64::mapserver-8.0.0-py38h76271bb_6.conda
linux-64::pillow-9.2.0-py311h50def17_4.conda
linux-64::tensorflow-base-2.11.0-cuda112py38hed6a6ea_0.conda
linux-64::arrow-cpp-7.0.1-py310h56e1d80_9_cuda.conda
linux-64::openjdk-17.0.3-h58dac75_5.conda
linux-64::aws-sdk-cpp-1.10.28-hb7d3cc7_0.conda
linux-64::arrow-cpp-6.0.2-py39h2836962_9_cpu.conda
linux-64::arrow-cpp-7.0.1-py38h3ffc01c_12_cpu.conda
linux-64::linux-perf-6.0.13-py38h458c6c9_0.conda
linux-64::jaxlib-0.4.1-cuda112py311hfe5e4b5_201.conda
linux-64::qt-webengine-5.15.4-h325cec9_3.conda
linux-64::openconnect-9.01-hae0b61c_6.conda
linux-64::postgresql-plpython-14.5-py38h38f3aed_3.conda
linux-64::nd2-0.5.3-py311h3e0d2dd_0.conda
linux-64::paraview-5.11.0-py310hd7e7d62_101_qt.conda
linux-64::postgresql-plpython-14.5-py311h387a056_3.conda
linux-64::erlang-25.2-pl5321hd7804a7_0.conda
linux-64::libarchive-3.6.2-h3d51595_0.conda
linux-64::postgresql-plpython-15.1-py310h3a435b5_2.conda
linux-64::arrow-cpp-9.0.0-py311h00f723b_12_cuda.conda
linux-64::libcurl-7.86.0-h6312ad2_2.conda
linux-64::arrow-cpp-9.0.0-py310h8cd3cd0_13_cuda.conda
linux-64::arrow-cpp-9.0.0-py39h1010d6a_12_cpu.conda
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
linux-64::gst-plugins-base-1.21.3-h4243ec0_1.conda
linux-64::libprotobuf-3.21.12-h3eb15da_0.conda
linux-64::libsolv-static-0.7.23-h3eb15da_0.conda
linux-64::libmlir15-15.0.6-he0ac6c6_0.conda
linux-64::libmlir-15.0.6-he0ac6c6_0.conda
linux-64::msgpack-c-3.3.0-hf40c2ba_5.conda
linux-64::povray-3.7.0.8-h4a0979c_6.conda
linux-64::libprotobuf-3.21.11-h3eb15da_0.conda
linux-64::libcups-2.3.3-h36d4200_3.conda
linux-64::liblal-7.2.4-fftw_h818ca7a_104.conda
linux-64::libsolv-0.7.23-h3eb15da_0.conda
linux-64::gds-base-3.0.0-h19e07a9_3.conda
linux-64::gst-plugins-base-1.21.3-h4243ec0_0.conda
linux-64::openjpeg-2.5.0-hfec8fc6_2.conda
linux-64::eccodes-2.27.1-h7f7619e_0.conda
linux-64::libprotobuf-static-3.21.11-h3eb15da_0.conda
linux-64::zimpl-3.5.3-h302046c_0.conda
linux-64::libxmlpp-4.0-4.0.1-hd6487a6_0.conda
linux-64::libprotobuf-static-3.21.12-h3eb15da_0.conda
linux-64::gds-base-3.0.0-h36e703b_2.conda
linux-64::gcab-1.5-hb53fa53_0.conda
-    "libzlib >=1.2.13,<1.3.0a0"
+    "libzlib >=1.2.13,<2.0.0a0"
```

</details>