### PR TITLE
loosen zlib-pin to major level (20/N; October 2022)

### DIFF
--- a/recipe/patch_yaml/zlib.yaml
+++ b/recipe/patch_yaml/zlib.yaml
@@ -169,3 +169,12 @@ then:
   - loosen_depends:
       name: libzlib
       upper_bound: "2"
+---
+if:
+  has_depends: libzlib >=1.2*
+  timestamp_lt: 1667260800000  # 2022-11-01 00:00 UTC
+  timestamp_ge: 1664582400000  # 2022-10-01 00:00 UTC
+then:
+  - loosen_depends:
+      name: libzlib
+      upper_bound: "2"


### PR DESCRIPTION
Follow-up to https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/739, about 4300 artefacts affected.

### Result of `python show_diff.py`

<details>

```diff
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
linux-ppc64le
linux-ppc64le::mapserver-8.0.0-py37h8a3ce74_1.tar.bz2
linux-ppc64le::python-igraph-0.10.2-py38h1274050_0.tar.bz2
linux-ppc64le::vtk-9.2.2-qt_py39h94ec0b3_202.tar.bz2
linux-ppc64le::ogre-13.4.4-h942a854_1.tar.bz2
linux-ppc64le::vtk-9.2.2-qt_py310h0956c3a_202.tar.bz2
linux-ppc64le::xrootd-5.5.1-py310h188cf94_0.tar.bz2
linux-ppc64le::postgresql-plpython-13.8-py39ha412058_0.tar.bz2
linux-ppc64le::imagecodecs-2022.9.26-py38hbd10eb4_1.tar.bz2
linux-ppc64le::pypy3.8-7.3.9-ha1569c4_5.tar.bz2
linux-ppc64le::grpc-cpp-1.47.1-h84ebf72_7.tar.bz2
linux-ppc64le::arrow-cpp-6.0.2-py38h929087b_6_cpu.tar.bz2
linux-ppc64le::libadios2-2.8.3-mpi_openmpi_h16f8d10_4.tar.bz2
linux-ppc64le::arrow-cpp-7.0.1-py311h655fc89_7_cpu.tar.bz2
linux-ppc64le::pygrib-2.1.4-py310h69eb5f8_6.tar.bz2
linux-ppc64le::xrootd-5.5.1-py39h1057d82_1.tar.bz2
linux-ppc64le::vtk-9.2.2-qt_py310h0956c3a_201.tar.bz2
linux-ppc64le::rsync-3.2.7-h0c0bf12_0.tar.bz2
linux-ppc64le::netcdf4-1.6.1-mpi_openmpi_py38he1595ee_1.tar.bz2
linux-ppc64le::tiledb-2.12.0-ha4bc364_1.tar.bz2
linux-ppc64le::libadios2-2.8.3-mpi_openmpi_h5390259_4.tar.bz2
linux-ppc64le::pygrib-2.1.4-py311hb2334d2_6.tar.bz2
linux-ppc64le::xrootd-5.5.0-py310h375a5b4_0.tar.bz2
linux-ppc64le::curl-7.86.0-h1ac174b_0.tar.bz2
linux-ppc64le::libxmlsec1-1.2.35-h7e73a18_1.tar.bz2
linux-ppc64le::aws-sdk-cpp-1.9.371-hb39a729_0.tar.bz2
linux-ppc64le::imagecodecs-2022.9.26-py39ha3a8205_3.tar.bz2
linux-ppc64le::xrootd-5.5.1-py39h1d115ad_0.tar.bz2
linux-ppc64le::root_base-6.26.8-py38hec0cb87_1.tar.bz2
linux-ppc64le::imagecodecs-2022.9.26-py38hecd7b2b_2.tar.bz2
linux-ppc64le::xrootd-5.5.1-py39h2a7d73d_0.tar.bz2
linux-ppc64le::aws-sdk-cpp-1.9.373-hb39a729_0.tar.bz2
linux-ppc64le::imagecodecs-2022.9.26-py310h4b8669b_2.tar.bz2
linux-ppc64le::llvmdev-15.0.3-h66d2248_1.tar.bz2
linux-ppc64le::openjdk-11.0.15-h488ab5f_3.tar.bz2
linux-ppc64le::libpq-13.8-h8203483_0.tar.bz2
linux-ppc64le::xrootd-5.5.0-py310h188cf94_0.tar.bz2
linux-ppc64le::postgresql-plpython-14.5-py310hdb0ae67_1.tar.bz2
linux-ppc64le::aws-sdk-cpp-1.9.372-hb39a729_0.tar.bz2
linux-ppc64le::nordugrid-arc-6.16.1-py39h359556e_1.tar.bz2
linux-ppc64le::vtk-9.2.2-qt_py37h9b39636_203.tar.bz2
linux-ppc64le::aws-sdk-cpp-1.9.373-hcfe3a7f_0.tar.bz2
linux-ppc64le::pyreadstat-1.2.0-py38h553f306_0.tar.bz2
linux-ppc64le::libopencv-4.6.0-py38h6c11ed8_5.tar.bz2
linux-ppc64le::aws-sdk-cpp-1.9.370-hcfe3a7f_2.tar.bz2
linux-ppc64le::arrow-cpp-6.0.2-py39h1a58804_5_cpu.tar.bz2
linux-ppc64le::libcurl-static-7.86.0-h1ac174b_0.tar.bz2
linux-ppc64le::netcdf4-1.6.1-mpi_mpich_py311hfc3dc8d_1.tar.bz2
linux-ppc64le::python-igraph-0.10.2-py310hfd235d9_0.tar.bz2
linux-ppc64le::texlive-core-20210325-h05d9418_5.tar.bz2
linux-ppc64le::libopencv-4.6.0-py37h98c6e63_5.tar.bz2
linux-ppc64le::netcdf4-1.6.1-mpi_openmpi_py311hba19386_1.tar.bz2
linux-ppc64le::nordugrid-arc-6.16.0-py37hac5bd09_0.tar.bz2
linux-ppc64le::arrow-cpp-9.0.0-py39hea16cab_10_cpu.tar.bz2
linux-ppc64le::ogre-1.12.13-h0d958df_3.tar.bz2
linux-ppc64le::vtk-9.2.2-qt_py38h60ec57a_202.tar.bz2
linux-ppc64le::xrootd-5.5.1-py38ha73a20f_1.tar.bz2
linux-ppc64le::pillow-9.2.0-py39hb068481_3.tar.bz2
linux-ppc64le::voms-2.1.0rc2-h61d541a_7.tar.bz2
linux-ppc64le::libgdal-3.5.2-he487669_4.tar.bz2
linux-ppc64le::libgrpc-1.49.1-h84ebf72_1.tar.bz2
linux-ppc64le::openbabel-3.1.1-py38h927c623_5.tar.bz2
linux-ppc64le::libgdal-3.5.2-h0d4c0f0_4.tar.bz2
linux-ppc64le::arrow-cpp-6.0.2-py38h8e022ea_5_cpu.tar.bz2
linux-ppc64le::xrootd-5.5.1-py38h3e2b69e_2.tar.bz2
linux-ppc64le::omniorb-4.2.5-py38h8129e00_3.tar.bz2
linux-ppc64le::xrootd-5.5.1-py38h4503399_2.tar.bz2
linux-ppc64le::postgresql-plpython-13.8-py310hdb0ae67_0.tar.bz2
linux-ppc64le::postgresql-plpython-13.8-py39h06a10bf_0.tar.bz2
linux-ppc64le::arrow-cpp-6.0.2-py39h173b337_6_cpu.tar.bz2
linux-ppc64le::xrootd-5.5.1-py39h910a105_0.tar.bz2
linux-ppc64le::netcdf4-1.6.1-nompi_py310h4faa06a_101.tar.bz2
linux-ppc64le::pygrib-2.1.4-py39hbb5c0bb_6.tar.bz2
linux-ppc64le::postgresql-14.5-h2c861b0_1.tar.bz2
linux-ppc64le::imagecodecs-2022.9.26-py39hc2a2a03_1.tar.bz2
linux-ppc64le::omniorb-4.2.5-py38h064c1e6_4.tar.bz2
linux-ppc64le::grpc-cpp-1.47.1-h210c47d_7.tar.bz2
linux-ppc64le::xrootd-5.5.0-py39h910a105_0.tar.bz2
linux-ppc64le::aws-sdk-cpp-1.9.374-hcfe3a7f_0.tar.bz2
linux-ppc64le::pypy3.9-7.3.9-h47d63c8_5.tar.bz2
linux-ppc64le::root_base-6.26.8-py38h14c60f1_0.tar.bz2
linux-ppc64le::xrootd-5.5.1-py38ha73a20f_0.tar.bz2
linux-ppc64le::mlir-15.0.2-h96f6aa1_0.tar.bz2
linux-ppc64le::postgresql-plpython-13.8-py310hd4ca3ae_0.tar.bz2
linux-ppc64le::xrootd-5.5.1-py37hd27a18c_1.tar.bz2
linux-ppc64le::arrow-cpp-7.0.1-py38hb76e381_7_cpu.tar.bz2
linux-ppc64le::aws-sdk-cpp-1.9.365-h877c6b3_0.tar.bz2
linux-ppc64le::cpp-opentelemetry-sdk-1.6.1-hb4ca5fa_1.tar.bz2
linux-ppc64le::vtk-9.2.2-qt_py38hac8647b_203.tar.bz2
linux-ppc64le::root_base-6.26.8-py37hfbbd038_0.tar.bz2
linux-ppc64le::nordugrid-arc-6.16.1-py39hbc0878f_1.tar.bz2
linux-ppc64le::xrootd-5.5.0-py37h590fc74_0.tar.bz2
linux-ppc64le::mlir-15.0.1-h96f6aa1_0.tar.bz2
linux-ppc64le::nordugrid-arc-6.16.1-py39h359556e_0.tar.bz2
linux-ppc64le::glib-2.74.1-ha72a2fa_0.tar.bz2
linux-ppc64le::omniorb-4.2.5-py39h002269c_4.tar.bz2
linux-ppc64le::omniorb-4.2.5-py310h790102e_3.tar.bz2
linux-ppc64le::pytables-3.7.0-py39h7a72d32_3.tar.bz2
linux-ppc64le::arrow-cpp-9.0.0-py311h655fc89_9_cpu.tar.bz2
linux-ppc64le::imagecodecs-2022.9.26-py38hecd7b2b_1.tar.bz2
linux-ppc64le::netcdf4-1.6.1-nompi_py39h4b01eda_101.tar.bz2
linux-ppc64le::arrow-cpp-9.0.0-py38hb76e381_9_cpu.tar.bz2
linux-ppc64le::omniorb-4.2.5-py39headc9c4_3.tar.bz2
linux-ppc64le::imagecodecs-2022.9.26-py38h35bf377_2.tar.bz2
linux-ppc64le::xrootd-5.5.1-py38hfc413fe_0.tar.bz2
linux-ppc64le::aws-sdk-cpp-1.9.370-hd9c7a56_0.tar.bz2
linux-ppc64le::xrootd-5.5.1-py39h6c58388_0.tar.bz2
linux-ppc64le::imagecodecs-2022.9.26-py310h8a18d38_1.tar.bz2
linux-ppc64le::aws-sdk-cpp-1.9.369-hd9c7a56_1.tar.bz2
linux-ppc64le::postgresql-plpython-13.8-py311h423c013_0.tar.bz2
linux-ppc64le::grpc-cpp-1.46.4-h84ebf72_8.tar.bz2
linux-ppc64le::git-2.38.1-pl5321h24cd7a7_0.tar.bz2
linux-ppc64le::libadios2-2.8.3-mpi_openmpi_h26eef5e_4.tar.bz2
linux-ppc64le::xrootd-5.5.1-py37h590fc74_0.tar.bz2
linux-ppc64le::xrootd-5.5.0-py39hd0d693e_0.tar.bz2
linux-ppc64le::xrootd-5.5.0-py39h8f32654_0.tar.bz2
linux-ppc64le::davix-0.8.3-h2b29436_0.tar.bz2
linux-ppc64le::libvips-8.13.2-h9b2df70_0.tar.bz2
linux-ppc64le::arrow-cpp-7.0.1-py310h3f2c8e5_6_cpu.tar.bz2
linux-ppc64le::omniorb-4.2.5-py311h1600098_3.tar.bz2
linux-ppc64le::vowpalwabbit-9.5.0-py310h68263b2_1.tar.bz2
linux-ppc64le::libadios2-2.8.3-nompi_hccdf1fb_104.tar.bz2
linux-ppc64le::postgresql-14.5-h62d6b9d_1.tar.bz2
linux-ppc64le::postgresql-plpython-14.5-py38he899557_1.tar.bz2
linux-ppc64le::libnetcdf-4.9.0-nompi_h398e007_102.tar.bz2
linux-ppc64le::nordugrid-arc-6.16.1-py38he417ea4_0.tar.bz2
linux-ppc64le::xrootd-5.5.1-py38ha73a20f_2.tar.bz2
linux-ppc64le::xrootd-5.5.1-py39h1d115ad_1.tar.bz2
linux-ppc64le::python-igraph-0.10.2-py38hb0971a3_1.tar.bz2
linux-ppc64le::ffmpeg-5.1.2-lgpl_h4c34dea_3.tar.bz2
linux-ppc64le::pytables-3.7.0-py38h9921f94_3.tar.bz2
linux-ppc64le::imagecodecs-2022.9.26-py311h5ee1aad_3.tar.bz2
linux-ppc64le::arrow-cpp-8.0.1-py38hb76e381_7_cpu.tar.bz2
linux-ppc64le::netcdf4-1.6.1-mpi_mpich_py310hb71598d_1.tar.bz2
linux-ppc64le::plumed-2.8.1-mpi_openmpi_h85be092_0.tar.bz2
linux-ppc64le::ffmpeg-4.4.2-lgpl_h4c34dea_10.tar.bz2
linux-ppc64le::xrootd-5.5.1-py38hf25a345_0.tar.bz2
linux-ppc64le::xrootd-5.5.1-py38h3687d79_0.tar.bz2
linux-ppc64le::xrootd-5.5.1-py38ha5d5151_0.tar.bz2
linux-ppc64le::pyinstaller-5.1-py39h9919470_1.tar.bz2
linux-ppc64le::voms-2.1.0rc0-h450b4e0_7.tar.bz2
linux-ppc64le::vtk-9.2.2-qt_py311h28cacd5_204.tar.bz2
linux-ppc64le::ffmpeg-4.4.2-gpl_ha2a9cf3_109.tar.bz2
linux-ppc64le::omniorb-4.2.5-py38h8129e00_4.tar.bz2
linux-ppc64le::nordugrid-arc-6.16.0-py38ha87dbe8_0.tar.bz2
linux-ppc64le::xrootd-5.5.1-py37h0d0d2e1_0.tar.bz2
linux-ppc64le::xrootd-5.5.1-py37hfd9b5d9_1.tar.bz2
linux-ppc64le::lxml-4.9.1-py310hfae34cf_1.tar.bz2
linux-ppc64le::omniorb-libs-4.2.5-h350ef5c_3.tar.bz2
linux-ppc64le::pyreadstat-1.2.0-py310hc3fd98a_0.tar.bz2
linux-ppc64le::pyhdf-0.10.5-py38h95e82d7_1.tar.bz2
linux-ppc64le::postgresql-13.8-h62d6b9d_0.tar.bz2
linux-ppc64le::lxml-4.9.1-py38h4e02ca2_1.tar.bz2
linux-ppc64le::xrootd-5.5.0-py38h638ae86_0.tar.bz2
linux-ppc64le::libcurl-static-7.86.0-h2ae36b4_0.tar.bz2
linux-ppc64le::libpq-14.5-h9fbd2da_1.tar.bz2
linux-ppc64le::tiledb-2.12.0-h11b1e19_1.tar.bz2
linux-ppc64le::xrootd-5.5.1-py39h6c58388_1.tar.bz2
linux-ppc64le::postgresql-plpython-14.5-py38h5709af1_1.tar.bz2
linux-ppc64le::libadios2-2.8.3-mpi_openmpi_h4829f4c_4.tar.bz2
linux-ppc64le::xrootd-5.5.1-py38h4503399_1.tar.bz2
linux-ppc64le::arrow-cpp-8.0.1-py310h3f2c8e5_6_cpu.tar.bz2
linux-ppc64le::imagecodecs-2022.9.26-py38hecd7b2b_3.tar.bz2
linux-ppc64le::clangdev-15.0.3-default_h1896e6d_0.tar.bz2
linux-ppc64le::libglib-2.74.1-h1113824_0.tar.bz2
linux-ppc64le::pillow-9.2.0-py38hc506947_3.tar.bz2
linux-ppc64le::omniorb-4.2.5-py311h48e4f2a_4.tar.bz2
linux-ppc64le::libxmlsec1-1.2.35-h5ac4bf1_0.tar.bz2
linux-ppc64le::imagecodecs-2022.9.26-py39he7c5792_1.tar.bz2
linux-ppc64le::llvmdev-15.0.3-hfe1df17_0.tar.bz2
linux-ppc64le::pyreadstat-1.2.0-py38h553f306_1.tar.bz2
linux-ppc64le::arrow-cpp-7.0.1-py39h1c97b1d_7_cpu.tar.bz2
linux-ppc64le::llvmlite-0.39.1-py310haa0efff_1.tar.bz2
linux-ppc64le::libadios2-2.8.3-mpi_mpich_ha6c8fe8_4.tar.bz2
linux-ppc64le::libgrpc-1.49.1-h210c47d_1.tar.bz2
linux-ppc64le::pillow-9.2.0-py38h64f4d0a_3.tar.bz2
linux-ppc64le::xrootd-5.5.1-py39hd0d693e_0.tar.bz2
linux-ppc64le::vtk-9.2.2-qt_py38h60ec57a_201.tar.bz2
linux-ppc64le::openbabel-3.1.1-py311h44353c9_5.tar.bz2
linux-ppc64le::aws-sdk-cpp-1.9.372-hcfe3a7f_0.tar.bz2
linux-ppc64le::pyinstaller-5.1-py310hd84c83a_1.tar.bz2
linux-ppc64le::imagecodecs-2022.9.26-py39hfa95422_1.tar.bz2
linux-ppc64le::imagecodecs-2022.9.26-py39ha3a8205_2.tar.bz2
linux-ppc64le::imagecodecs-2022.9.26-py310h4b8669b_1.tar.bz2
linux-ppc64le::arrow-cpp-9.0.0-py310h3103fcf_10_cpu.tar.bz2
linux-ppc64le::ffmpeg-5.1.2-gpl_h688f0ca_103.tar.bz2
linux-ppc64le::pyhdf-0.10.5-py39h14ba49b_1.tar.bz2
linux-ppc64le::imagecodecs-2022.9.26-py38h35bf377_3.tar.bz2
linux-ppc64le::arrow-cpp-8.0.1-py39h1c97b1d_7_cpu.tar.bz2
linux-ppc64le::vowpalwabbit-9.5.0-py39h8101073_1.tar.bz2
linux-ppc64le::arrow-cpp-9.0.0-py39h1c97b1d_9_cpu.tar.bz2
linux-ppc64le::pypy3.8-7.3.9-hc3e29ba_5.tar.bz2
linux-ppc64le::libadios2-2.8.3-mpi_mpich_h293900d_4.tar.bz2
linux-ppc64le::netcdf4-1.6.1-nompi_py311h6d1fdca_101.tar.bz2
linux-ppc64le::gct-6.2.1629922860-h72880b3_2.tar.bz2
linux-ppc64le::libopencv-4.6.0-py311h529770c_6.tar.bz2
linux-ppc64le::mapserver-8.0.0-py38he38b663_1.tar.bz2
linux-ppc64le::leptonica-1.82.0-hfea9911_1.tar.bz2
linux-ppc64le::arrow-cpp-9.0.0-py38h16dbfa5_8_cpu.tar.bz2
linux-ppc64le::nordugrid-arc-6.16.0-py310hced2eda_0.tar.bz2
linux-ppc64le::pyhdf-0.10.5-py311h3d4f588_1.tar.bz2
linux-ppc64le::arrow-cpp-8.0.1-py39hebd12ad_6_cpu.tar.bz2
linux-ppc64le::arrow-cpp-9.0.0-py311hcc70f59_8_cpu.tar.bz2
linux-ppc64le::pygrib-2.1.4-py38h2f44c66_6.tar.bz2
linux-ppc64le::aws-sdk-cpp-1.9.370-hb39a729_2.tar.bz2
linux-ppc64le::postgresql-13.8-h2c861b0_0.tar.bz2
linux-ppc64le::libadios2-2.8.3-nompi_h65ebed0_104.tar.bz2
linux-ppc64le::llvmlite-0.39.1-py39h11e4565_1.tar.bz2
linux-ppc64le::xrootd-5.5.1-py38h3e2b69e_1.tar.bz2
linux-ppc64le::glibmm-2.4-2.66.3-h23db2ad_0.tar.bz2
linux-ppc64le::cppyy-cling-6.27.0-py311h2d1ec74_2.tar.bz2
linux-ppc64le::xrootd-5.5.1-py39h0c29a2f_0.tar.bz2
linux-ppc64le::aws-sdk-cpp-1.9.369-h877c6b3_0.tar.bz2
linux-ppc64le::aws-sdk-cpp-1.9.374-hb39a729_0.tar.bz2
linux-ppc64le::libcurl-7.86.0-h2ae36b4_0.tar.bz2
linux-ppc64le::root_base-6.26.8-py310h85efebc_0.tar.bz2
linux-ppc64le::arrow-cpp-8.0.1-py311hcc70f59_6_cpu.tar.bz2
linux-ppc64le::python-igraph-0.10.2-py39hbfe5ace_0.tar.bz2
linux-ppc64le::xrootd-5.5.1-py38hfc413fe_1.tar.bz2
linux-ppc64le::davix-0.8.3-h48da8a0_1.tar.bz2
linux-ppc64le::vtk-9.2.2-qt_py38hac8647b_204.tar.bz2
linux-ppc64le::python-3.11.0-h0cb8861_0_cpython.tar.bz2
linux-ppc64le::arrow-cpp-9.0.0-py311he04a1bf_10_cpu.tar.bz2
linux-ppc64le::pyreadstat-1.2.0-py39h68499bf_0.tar.bz2
linux-ppc64le::root_base-6.26.8-py39h43b5674_1.tar.bz2
linux-ppc64le::arrow-cpp-8.0.1-py311h655fc89_7_cpu.tar.bz2
linux-ppc64le::poppler-22.10.0-hc3169ea_0.tar.bz2
linux-ppc64le::nordugrid-arc-6.16.1-py310h6f86a99_1.tar.bz2
linux-ppc64le::ffmpeg-4.4.2-gpl_h688f0ca_110.tar.bz2
linux-ppc64le::pygrib-2.1.4-py38h2379645_6.tar.bz2
linux-ppc64le::omniorb-4.2.5-py39headc9c4_4.tar.bz2
linux-ppc64le::arrow-cpp-9.0.0-py38h7c5b217_10_cpu.tar.bz2
linux-ppc64le::libadios2-2.8.3-nompi_h013ccb2_104.tar.bz2
linux-ppc64le::ldas-tools-framecpp-2.9.1-h40196d7_1.tar.bz2
linux-ppc64le::pillow-9.2.0-py39h195213c_3.tar.bz2
linux-ppc64le::omniorb-libs-4.2.5-h262a72d_3.tar.bz2
linux-ppc64le::netcdf4-1.6.1-mpi_mpich_py39h3b5de44_1.tar.bz2
linux-ppc64le::grpc-cpp-1.45.2-h8073a9a_7.tar.bz2
linux-ppc64le::llvmlite-0.39.1-py38hd9056a4_1.tar.bz2
linux-ppc64le::libopencv-4.6.0-py38hf3f5ee6_5.tar.bz2
linux-ppc64le::nordugrid-arc-6.16.0-py39hc32c019_0.tar.bz2
linux-ppc64le::xrootd-5.5.0-py38h3687d79_0.tar.bz2
linux-ppc64le::postgresql-plpython-13.8-py311h6e8de2e_0.tar.bz2
linux-ppc64le::davix-0.8.3-hde1c088_0.tar.bz2
linux-ppc64le::ogre-13.4.4-ha1545c2_1.tar.bz2
linux-ppc64le::imagecodecs-2022.9.26-py38h35bf377_1.tar.bz2
linux-ppc64le::openjdk-17.0.3-hb9bd398_4.tar.bz2
linux-ppc64le::omniorb-4.2.5-py311h1600098_4.tar.bz2
linux-ppc64le::vtk-9.2.2-qt_py39h94ec0b3_201.tar.bz2
linux-ppc64le::postgresql-plpython-13.8-py38he899557_0.tar.bz2
linux-ppc64le::arrow-cpp-6.0.2-py311h6e60a4c_5_cpu.tar.bz2
linux-ppc64le::curl-7.86.0-h2ae36b4_0.tar.bz2
linux-ppc64le::xrootd-5.5.1-py39h8f32654_0.tar.bz2
linux-ppc64le::nordugrid-arc-6.16.1-py38he3e1f9c_1.tar.bz2
linux-ppc64le::ffmpeg-5.1.2-lgpl_h4cf48f2_2.tar.bz2
linux-ppc64le::netcdf4-1.6.1-nompi_py38h08ad1e9_101.tar.bz2
linux-ppc64le::python-igraph-0.10.2-py310h7fc68f8_1.tar.bz2
linux-ppc64le::netcdf4-1.6.1-mpi_mpich_py38h607835c_1.tar.bz2
linux-ppc64le::xrootd-5.5.0-py38ha5d5151_0.tar.bz2
linux-ppc64le::arrow-cpp-7.0.1-py39hea16cab_8_cpu.tar.bz2
linux-ppc64le::libnetcdf-4.8.1-mpi_mpich_h40f996b_6.tar.bz2
linux-ppc64le::xrootd-5.5.1-py37hfd9b5d9_0.tar.bz2
linux-ppc64le::vowpalwabbit-9.5.0-py38h26e7900_0.tar.bz2
linux-ppc64le::plumed-2.8.1-mpi_mpich_hbf374c0_0.tar.bz2
linux-ppc64le::pyhdf-0.10.5-py39h850dbce_1.tar.bz2
linux-ppc64le::mlir-15.0.3-h96f6aa1_0.tar.bz2
linux-ppc64le::root_base-6.26.8-py310hf18b595_1.tar.bz2
linux-ppc64le::libvips-8.13.1-h9b2df70_2.tar.bz2
linux-ppc64le::root_base-6.26.8-py310hcc4aa47_1.tar.bz2
linux-ppc64le::aws-sdk-cpp-1.9.368-h877c6b3_0.tar.bz2
linux-ppc64le::pillow-9.2.0-py311h4f53988_3.tar.bz2
linux-ppc64le::vowpalwabbit-9.5.0-py39h8101073_0.tar.bz2
linux-ppc64le::pyreadstat-1.2.0-py311h596718e_1.tar.bz2
linux-ppc64le::python-igraph-0.10.2-py37h11f959f_0.tar.bz2
linux-ppc64le::openbabel-3.1.1-py39hce6b6a7_5.tar.bz2
linux-ppc64le::netcdf4-1.6.1-mpi_openmpi_py310h9f2eeeb_1.tar.bz2
linux-ppc64le::libnetcdf-4.9.0-mpi_mpich_h7493731_2.tar.bz2
linux-ppc64le::xrootd-5.5.1-py38h3e2b69e_0.tar.bz2
linux-ppc64le::vtk-9.2.2-qt_py310ha231aca_204.tar.bz2
linux-ppc64le::libopencv-4.6.0-py39h52bd70e_5.tar.bz2
linux-ppc64le::postgresql-plpython-14.5-py311h423c013_1.tar.bz2
linux-ppc64le::postgresql-plpython-14.5-py39ha412058_1.tar.bz2
linux-ppc64le::xrootd-5.5.1-py310h68432b6_0.tar.bz2
linux-ppc64le::imagecodecs-2022.9.26-py39hc2a2a03_3.tar.bz2
linux-ppc64le::llvmdev-11.1.0-h6c99497_5.tar.bz2
linux-ppc64le::libopencv-4.6.0-py39h3ac104e_6.tar.bz2
linux-ppc64le::postgresql-plpython-14.5-py39h06a10bf_1.tar.bz2
linux-ppc64le::root_base-6.26.8-py38hdbeb33b_1.tar.bz2
linux-ppc64le::nodejs-14.20.1-h9a3953a_1.tar.bz2
linux-ppc64le::pygrib-2.1.4-py39h81c5ecc_6.tar.bz2
linux-ppc64le::libopencv-4.6.0-py310h2e052fa_5.tar.bz2
linux-ppc64le::python-igraph-0.10.2-py38hfa829bf_0.tar.bz2
linux-ppc64le::lxml-4.9.1-py39h803173d_1.tar.bz2
linux-ppc64le::libgdal-3.5.2-h00300af_6.tar.bz2
linux-ppc64le::root_base-6.26.8-py39habbbe83_0.tar.bz2
linux-ppc64le::hdf4-4.2.15-h9c637a8_5.tar.bz2
linux-ppc64le::pyhdf-0.10.5-py38hc8e8714_1.tar.bz2
linux-ppc64le::libgdal-3.5.2-ha71a698_5.tar.bz2
linux-ppc64le::arrow-cpp-7.0.1-py38h16dbfa5_6_cpu.tar.bz2
linux-ppc64le::xrootd-5.5.1-py39h1057d82_2.tar.bz2
linux-ppc64le::netcdf4-1.6.1-mpi_openmpi_py39h96aa2ae_1.tar.bz2
linux-ppc64le::python-igraph-0.10.2-py39h2d0b246_1.tar.bz2
linux-ppc64le::libnetcdf-4.9.0-nompi_h398e007_101.tar.bz2
linux-ppc64le::postgresql-plpython-13.8-py38h5709af1_0.tar.bz2
linux-ppc64le::xrootd-5.5.1-py39h1057d82_0.tar.bz2
linux-ppc64le::aws-sdk-cpp-1.9.367-h877c6b3_0.tar.bz2
linux-ppc64le::davix-0.8.3-h8f2c560_1.tar.bz2
linux-ppc64le::libxslt-1.1.35-hba2f9f1_1.tar.bz2
linux-ppc64le::libopencv-4.6.0-py310h2e052fa_6.tar.bz2
linux-ppc64le::xrootd-5.5.1-py38hfc413fe_2.tar.bz2
linux-ppc64le::omniorb-libs-4.2.5-h350ef5c_4.tar.bz2
linux-ppc64le::llvmlite-0.39.1-py39hf8800fb_1.tar.bz2
linux-ppc64le::arrow-cpp-7.0.1-py311hcc70f59_6_cpu.tar.bz2
linux-ppc64le::libpq-14.5-h8203483_1.tar.bz2
linux-ppc64le::xrootd-5.5.0-py38hf25a345_0.tar.bz2
linux-ppc64le::xrootd-5.5.1-py39h6c58388_2.tar.bz2
linux-ppc64le::llvmlite-0.39.1-py38h8df0f6e_1.tar.bz2
linux-ppc64le::python-igraph-0.10.2-py39hedd54f5_1.tar.bz2
linux-ppc64le::imagecodecs-2022.9.26-py310h4b8669b_3.tar.bz2
linux-ppc64le::imagecodecs-2022.9.26-py39hc2a2a03_2.tar.bz2
linux-ppc64le::ogre-1.12.13-h65f45c8_3.tar.bz2
linux-ppc64le::vowpalwabbit-9.5.0-py311h4bf9e70_1.tar.bz2
linux-ppc64le::vtk-9.2.2-qt_py39h18227cf_203.tar.bz2
linux-ppc64le::python-igraph-0.10.2-py311h90d1fdf_1.tar.bz2
linux-ppc64le::xrootd-5.5.0-py37h0d0d2e1_0.tar.bz2
linux-ppc64le::tiledb-2.11.3-ha4bc364_1.tar.bz2
linux-ppc64le::grpc-cpp-1.45.2-h6e98d61_7.tar.bz2
linux-ppc64le::pypy3.9-7.3.9-h9158500_5.tar.bz2
linux-ppc64le::pyreadstat-1.2.0-py39h68499bf_1.tar.bz2
linux-ppc64le::xrootd-5.5.1-py310he187cb7_1.tar.bz2
linux-ppc64le::lxml-4.9.1-py39h9725500_1.tar.bz2
linux-ppc64le::nordugrid-arc-6.16.1-py38he417ea4_1.tar.bz2
linux-ppc64le::ffmpeg-4.4.2-lgpl_h4cf48f2_9.tar.bz2
linux-ppc64le::arrow-cpp-7.0.1-py38h7c5b217_8_cpu.tar.bz2
linux-ppc64le::libopencv-4.6.0-py38h6c11ed8_6.tar.bz2
linux-ppc64le::openbabel-3.1.1-py310h0570645_5.tar.bz2
linux-ppc64le::libgdal-3.5.2-h00300af_5.tar.bz2
linux-ppc64le::cppyy-cling-6.27.0-py39h51b9803_2.tar.bz2
linux-ppc64le::root_base-6.26.8-py39h23831e2_1.tar.bz2
linux-ppc64le::libnetcdf-4.9.0-mpi_openmpi_he7f00c8_1.tar.bz2
linux-ppc64le::imagecodecs-2022.9.26-py39ha3a8205_1.tar.bz2
linux-ppc64le::ffmpeg-5.1.2-gpl_ha2a9cf3_102.tar.bz2
linux-ppc64le::vowpalwabbit-9.5.0-py38h26e7900_1.tar.bz2
linux-ppc64le::xrootd-5.5.1-py38h4503399_0.tar.bz2
linux-ppc64le::root_base-6.26.8-py37h3322438_1.tar.bz2
linux-ppc64le::ldas-tools-framecpp-2.9.1-hceb85a4_1.tar.bz2
linux-ppc64le::omniorb-4.2.5-py38h064c1e6_3.tar.bz2
linux-ppc64le::aws-sdk-cpp-1.9.370-hb39a729_1.tar.bz2
linux-ppc64le::arrow-cpp-9.0.0-py310h3f2c8e5_8_cpu.tar.bz2
linux-ppc64le::xrootd-5.5.1-py38h638ae86_0.tar.bz2
linux-ppc64le::vtk-9.2.2-qt_py310ha231aca_203.tar.bz2
linux-ppc64le::libcurl-7.86.0-h1ac174b_0.tar.bz2
linux-ppc64le::rsync-3.2.7-h191f6af_0.tar.bz2
linux-ppc64le::omniorb-4.2.5-py310hef85685_3.tar.bz2
linux-ppc64le::xrootd-5.5.1-py311h0e9a25a_2.tar.bz2
linux-ppc64le::libadios2-2.8.3-mpi_mpich_h9778faf_4.tar.bz2
linux-ppc64le::omniorb-4.2.5-py311h48e4f2a_3.tar.bz2
linux-ppc64le::omniorb-4.2.5-py310h790102e_4.tar.bz2
linux-ppc64le::imagecodecs-2022.9.26-py38h6b985eb_1.tar.bz2
linux-ppc64le::python-igraph-0.10.2-py38h3965ca5_1.tar.bz2
linux-ppc64le::vtk-9.2.2-qt_py37ha536c0e_202.tar.bz2
linux-ppc64le::xrootd-5.5.1-py310he187cb7_2.tar.bz2
linux-ppc64le::pillow-9.2.0-py310hdaf9dc9_3.tar.bz2
linux-ppc64le::arrow-cpp-9.0.0-py310hf91300a_9_cpu.tar.bz2
linux-ppc64le::xrootd-5.5.1-py310h375a5b4_0.tar.bz2
linux-ppc64le::postgresql-plpython-14.5-py310hd4ca3ae_1.tar.bz2
linux-ppc64le::pytables-3.7.0-py311h667feee_3.tar.bz2
linux-ppc64le::omniorb-4.2.5-py39h002269c_3.tar.bz2
linux-ppc64le::cppyy-cling-6.27.0-py310hbbdc3b4_2.tar.bz2
linux-ppc64le::libnetcdf-4.8.1-mpi_mpich_h40f996b_5.tar.bz2
linux-ppc64le::xrootd-5.5.1-py310h68432b6_2.tar.bz2
linux-ppc64le::voms-2.1.0rc2-h450b4e0_7.tar.bz2
linux-ppc64le::gct-6.2.1629922860-h635f956_2.tar.bz2
linux-ppc64le::pyreadstat-1.2.0-py37h0370d4e_0.tar.bz2
linux-ppc64le::lxml-4.9.1-py311h7d1ddbe_1.tar.bz2
linux-ppc64le::mapserver-8.0.0-py39hdeeca3e_1.tar.bz2
linux-ppc64le::arrow-cpp-6.0.2-py311h7341b26_6_cpu.tar.bz2
linux-ppc64le::aws-sdk-cpp-1.9.371-hcfe3a7f_0.tar.bz2
linux-ppc64le::libgdal-3.5.2-ha71a698_6.tar.bz2
linux-ppc64le::arrow-cpp-7.0.1-py39hebd12ad_6_cpu.tar.bz2
linux-ppc64le::cpp-opentelemetry-sdk-1.7.0-h648540d_0.tar.bz2
linux-ppc64le::libadios2-2.8.3-nompi_h707d055_104.tar.bz2
linux-ppc64le::omniorb-4.2.5-py310hef85685_4.tar.bz2
linux-ppc64le::ogre-1.10.12-h112db1c_10.tar.bz2
linux-ppc64le::nodejs-14.20.1-hc72f780_1.tar.bz2
linux-ppc64le::python-3.11.0-h2c4edbf_0_cpython.tar.bz2
linux-ppc64le::pyinstaller-5.1-py38hfa13636_1.tar.bz2
linux-ppc64le::cppyy-cling-6.27.0-py38hb6edf9e_2.tar.bz2
linux-ppc64le::aws-sdk-cpp-1.8.186-h23c7f7d_4.tar.bz2
linux-ppc64le::aws-sdk-cpp-1.9.366-h877c6b3_0.tar.bz2
linux-ppc64le::wxwidgets-3.2.1-py311hd03dcfa_1.tar.bz2
linux-ppc64le::libxml2-2.10.3-h3010393_0.tar.bz2
linux-ppc64le::pyreadstat-1.2.0-py310hc3fd98a_1.tar.bz2
linux-ppc64le::cpp-opentelemetry-sdk-1.6.1-h648540d_2.tar.bz2
linux-ppc64le::libnetcdf-4.8.1-mpi_openmpi_hc977d7c_6.tar.bz2
linux-ppc64le::vtk-9.2.2-qt_py39h18227cf_204.tar.bz2
linux-ppc64le::leptonica-1.82.0-hfea9911_2.tar.bz2
linux-ppc64le::postgresql-plpython-14.5-py311h6e8de2e_1.tar.bz2
linux-ppc64le::xrootd-5.5.1-py39h2a7d73d_2.tar.bz2
linux-ppc64le::python-igraph-0.10.2-py39h69ef751_0.tar.bz2
linux-ppc64le::xrootd-5.5.0-py39h0c29a2f_0.tar.bz2
linux-ppc64le::libopencv-4.6.0-py38hf3f5ee6_6.tar.bz2
linux-ppc64le::libnetcdf-4.9.0-mpi_openmpi_he7f00c8_2.tar.bz2
linux-ppc64le::mapserver-8.0.0-py310hd83988b_1.tar.bz2
linux-ppc64le::arrow-cpp-7.0.1-py310hf91300a_7_cpu.tar.bz2
linux-ppc64le::libopencv-4.6.0-py39h52bd70e_6.tar.bz2
linux-ppc64le::vowpalwabbit-9.5.0-py310h68263b2_0.tar.bz2
linux-ppc64le::xrootd-5.5.1-py39h1d115ad_2.tar.bz2
linux-ppc64le::libadios2-2.8.3-mpi_mpich_hf01b766_4.tar.bz2
linux-ppc64le::grpc-cpp-1.48.1-h84ebf72_2.tar.bz2
linux-ppc64le::grpc-cpp-1.48.1-h210c47d_2.tar.bz2
linux-ppc64le::libxmlsec1-1.2.35-h5ac4bf1_1.tar.bz2
linux-ppc64le::grpc-cpp-1.46.4-h210c47d_8.tar.bz2
linux-ppc64le::vowpalwabbit-9.5.0-py37h95c992b_0.tar.bz2
linux-ppc64le::vtk-9.2.2-qt_py37ha536c0e_201.tar.bz2
linux-ppc64le::libnetcdf-4.9.0-mpi_mpich_h7493731_1.tar.bz2
linux-ppc64le::aws-sdk-cpp-1.9.364-h877c6b3_0.tar.bz2
linux-ppc64le::xrootd-5.5.1-py39h2a7d73d_1.tar.bz2
linux-ppc64le::libopencv-4.6.0-py39h3ac104e_5.tar.bz2
linux-ppc64le::arrow-cpp-8.0.1-py38h16dbfa5_6_cpu.tar.bz2
linux-ppc64le::libnetcdf-4.8.1-mpi_openmpi_hc977d7c_5.tar.bz2
linux-ppc64le::arrow-cpp-7.0.1-py310h3103fcf_8_cpu.tar.bz2
linux-ppc64le::pytables-3.7.0-py310ha99dac2_3.tar.bz2
linux-ppc64le::omniorb-libs-4.2.5-h262a72d_4.tar.bz2
linux-ppc64le::root_base-6.26.8-py37h237b938_1.tar.bz2
linux-ppc64le::nordugrid-arc-6.16.1-py310h1f1b4b3_1.tar.bz2
linux-ppc64le::git-2.38.1-pl5321hecdd0d8_0.tar.bz2
linux-ppc64le::xrootd-5.5.1-py37hd27a18c_0.tar.bz2
linux-ppc64le::nordugrid-arc-6.16.1-py310h1f1b4b3_0.tar.bz2
linux-ppc64le::arrow-cpp-9.0.0-py39hebd12ad_8_cpu.tar.bz2
linux-ppc64le::arrow-cpp-8.0.1-py310hf91300a_7_cpu.tar.bz2
linux-ppc64le::arrow-cpp-6.0.2-py310h7696910_5_cpu.tar.bz2
linux-ppc64le::xrootd-5.5.1-py311h0731d6b_2.tar.bz2
linux-ppc64le::libpq-13.8-h9fbd2da_0.tar.bz2
linux-ppc64le::pytables-3.7.0-py39h5c94e3b_3.tar.bz2
linux-ppc64le::arrow-cpp-6.0.2-py310h2c0d761_6_cpu.tar.bz2
linux-ppc64le::arrow-cpp-7.0.1-py311he04a1bf_8_cpu.tar.bz2
linux-ppc64le::tiledb-2.11.3-h11b1e19_1.tar.bz2
linux-ppc64le::pyhdf-0.10.5-py310h1cda928_1.tar.bz2
linux-ppc64le::pytables-3.7.0-py38h093a711_3.tar.bz2
linux-ppc64le::openjdk-17.0.3-h488ab5f_3.tar.bz2
linux-ppc64le::xrootd-5.5.1-py310h68432b6_1.tar.bz2
linux-ppc64le::lxml-4.9.1-py38h964199b_1.tar.bz2
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
linux-ppc64le::librdkafka-1.9.2-h07ed76a_1.tar.bz2
linux-ppc64le::aws-sdk-cpp-1.9.362-h877c6b3_1.tar.bz2
linux-ppc64le::r-git2r-0.30.1-r42h1fc590f_1.tar.bz2
linux-ppc64le::arrow-cpp-7.0.1-py39hebd12ad_5_cpu.tar.bz2
linux-ppc64le::r-git2r-0.30.1-r41h1fc590f_1.tar.bz2
linux-ppc64le::arrow-cpp-8.0.1-py37he86989c_5_cpu.tar.bz2
linux-ppc64le::mysql-client-8.0.31-ha7fd285_0.tar.bz2
linux-ppc64le::aws-sdk-cpp-1.9.356-hb78e2fb_1.tar.bz2
linux-ppc64le::mongodb-6.0.2-hcdc689c_0.tar.bz2
linux-ppc64le::sqlite-3.39.4-h3bd21b8_0.tar.bz2
linux-ppc64le::vtk-9.2.2-qt_py37he7118bf_200.tar.bz2
linux-ppc64le::vowpalwabbit-9.4.0-py39h8101073_0.tar.bz2
linux-ppc64le::python-igraph-0.10.1-py38h1274050_1.tar.bz2
linux-ppc64le::python-igraph-0.10.1-py39hbfe5ace_1.tar.bz2
linux-ppc64le::arrow-cpp-6.0.2-py310h7696910_4_cpu.tar.bz2
linux-ppc64le::giac-1.9.0.21-h091f942_0.tar.bz2
linux-ppc64le::arrow-cpp-6.0.2-py39h1a58804_4_cpu.tar.bz2
linux-ppc64le::mysql-router-8.0.31-he4ccf2b_0.tar.bz2
linux-ppc64le::arrow-cpp-9.0.0-py39hebd12ad_7_cpu.tar.bz2
linux-ppc64le::libxml2-2.10.2-h3010393_2.tar.bz2
linux-ppc64le::r-base-4.1.3-h77e1141_3.tar.bz2
linux-ppc64le::aws-sdk-cpp-1.9.358-h4ffab0f_1.tar.bz2
linux-ppc64le::arrow-cpp-6.0.2-py38h8e022ea_4_cpu.tar.bz2
linux-ppc64le::arrow-cpp-9.0.0-py37he86989c_7_cpu.tar.bz2
linux-ppc64le::symengine-0.9.0-ha59e709_1.tar.bz2
linux-ppc64le::r-git2r-0.30.1-r41h525679c_1.tar.bz2
linux-ppc64le::python-igraph-0.10.1-py39h69ef751_1.tar.bz2
linux-ppc64le::arrow-cpp-8.0.1-py310h3f2c8e5_5_cpu.tar.bz2
linux-ppc64le::git-2.38.0-pl5321hecdd0d8_0.tar.bz2
linux-ppc64le::git-2.38.0-pl5321h24cd7a7_0.tar.bz2
linux-ppc64le::mysql-connector-odbc-8.0.31-ha72a2fa_0.tar.bz2
linux-ppc64le::vowpalwabbit-9.4.0-py38h26e7900_0.tar.bz2
linux-ppc64le::imagemagick-7.1.0_50-pl5321h2c2b468_0.tar.bz2
linux-ppc64le::libcurl-7.85.0-h2ae36b4_0.tar.bz2
linux-ppc64le::vowpalwabbit-9.4.0-py310h68263b2_0.tar.bz2
linux-ppc64le::pcre2-static-10.40-h02375f6_0.tar.bz2
linux-ppc64le::openssh-9.1p1-hbe330f9_0.tar.bz2
linux-ppc64le::arrow-cpp-8.0.1-py39hebd12ad_5_cpu.tar.bz2
linux-ppc64le::mysql-server-8.0.31-hbb5bbcf_0.tar.bz2
linux-ppc64le::libsoup-3.2.1-he84dbf8_0.tar.bz2
linux-ppc64le::mysql-libs-8.0.31-ha23194b_0.tar.bz2
linux-ppc64le::mysql-router-8.0.31-h61ed4ab_0.tar.bz2
linux-ppc64le::libcurl-static-7.85.0-h1ac174b_0.tar.bz2
linux-ppc64le::vtk-9.2.2-qt_py38h2b14034_200.tar.bz2
linux-ppc64le::python-igraph-0.10.1-py38hfa829bf_1.tar.bz2
linux-ppc64le::arrow-cpp-8.0.1-py38h16dbfa5_5_cpu.tar.bz2
linux-ppc64le::mysql-server-8.0.31-he2bdd7d_0.tar.bz2
linux-ppc64le::arrow-cpp-7.0.1-py38h16dbfa5_5_cpu.tar.bz2
linux-ppc64le::arrow-cpp-6.0.2-py37heef148b_4_cpu.tar.bz2
linux-ppc64le::aws-sdk-cpp-1.9.361-h8406d9c_0.tar.bz2
linux-ppc64le::python-igraph-0.10.1-py310hfd235d9_1.tar.bz2
linux-ppc64le::r-git2r-0.30.1-r42h525679c_1.tar.bz2
linux-ppc64le::curl-7.85.0-h1ac174b_0.tar.bz2
linux-ppc64le::aws-sdk-cpp-1.9.358-h8406d9c_2.tar.bz2
linux-ppc64le::arrow-cpp-9.0.0-py38h16dbfa5_7_cpu.tar.bz2
linux-ppc64le::curl-7.85.0-h2ae36b4_0.tar.bz2
linux-ppc64le::vtk-9.2.2-qt_py39h526f45c_200.tar.bz2
linux-ppc64le::r-base-4.2.1-h73f44a3_2.tar.bz2
linux-ppc64le::aws-sdk-cpp-1.9.359-h8406d9c_0.tar.bz2
linux-ppc64le::aws-sdk-cpp-1.9.358-hb78e2fb_0.tar.bz2
linux-ppc64le::mysql-client-8.0.31-hfff87ee_0.tar.bz2
linux-ppc64le::librdkafka-1.9.2-h18f86e8_1.tar.bz2
linux-ppc64le::clangdev-15.0.2-default_h1896e6d_0.tar.bz2
linux-ppc64le::mysql-libs-8.0.31-h3ac40eb_0.tar.bz2
linux-ppc64le::aws-sdk-cpp-1.9.357-hb78e2fb_0.tar.bz2
linux-ppc64le::mongodb-6.0.2-h592eddb_0.tar.bz2
linux-ppc64le::arrow-cpp-9.0.0-py310h3f2c8e5_7_cpu.tar.bz2
linux-ppc64le::libcurl-7.85.0-h1ac174b_0.tar.bz2
linux-ppc64le::arrow-cpp-7.0.1-py310h3f2c8e5_5_cpu.tar.bz2
linux-ppc64le::llvmdev-15.0.2-hfe1df17_0.tar.bz2
linux-ppc64le::arrow-cpp-7.0.1-py37he86989c_5_cpu.tar.bz2
linux-ppc64le::glibmm-2.68-2.74.0-h8d71e2f_0.tar.bz2
linux-ppc64le::openssh-9.1p1-h41524dc_0.tar.bz2
linux-ppc64le::aws-sdk-cpp-1.9.362-h8406d9c_0.tar.bz2
linux-ppc64le::aws-sdk-cpp-1.9.363-h877c6b3_0.tar.bz2
linux-ppc64le::libcurl-static-7.85.0-h2ae36b4_0.tar.bz2
linux-ppc64le::vowpalwabbit-9.4.0-py37h95c992b_0.tar.bz2
linux-ppc64le::vtk-9.2.2-qt_py310h9ffb71a_200.tar.bz2
linux-ppc64le::python-igraph-0.10.1-py37h11f959f_1.tar.bz2
-    "libzlib >=1.2.12,<1.3.0a0",
+    "libzlib >=1.2.12,<2.0.0a0",
linux-ppc64le::liblal-7.2.4-fftw_h8338b0a_100.tar.bz2
linux-ppc64le::libclang13-15.0.2-default_ha49a280_0.tar.bz2
linux-ppc64le::libllvm15-15.0.2-hfe1df17_0.tar.bz2
linux-ppc64le::pcre2-10.40-h02375f6_0.tar.bz2
linux-ppc64le::libclang-cpp-15.0.2-default_h1896e6d_0.tar.bz2
linux-ppc64le::llvm-15.0.2-h2b80cf0_0.tar.bz2
linux-ppc64le::llvm-tools-15.0.2-hfe1df17_0.tar.bz2
linux-ppc64le::clang-format-15-15.0.2-default_h1896e6d_0.tar.bz2
linux-ppc64le::gst-plugins-good-1.21.1-h3600cc6_0.tar.bz2
linux-ppc64le::gst-plugins-base-1.21.1-h14ddb0e_0.tar.bz2
linux-ppc64le::libprotobuf-static-3.21.7-ha72a2fa_0.tar.bz2
linux-ppc64le::libclang-15.0.2-default_h1896e6d_0.tar.bz2
linux-ppc64le::clang-15-15.0.2-default_h1896e6d_0.tar.bz2
linux-ppc64le::clang-format-15.0.2-default_h1896e6d_0.tar.bz2
linux-ppc64le::clang-tools-15.0.2-default_h1896e6d_0.tar.bz2
linux-ppc64le::libsqlite-3.39.4-hcc10993_0.tar.bz2
linux-ppc64le::libclang-cpp15-15.0.2-default_h1896e6d_0.tar.bz2
linux-ppc64le::libprotobuf-3.21.7-ha72a2fa_0.tar.bz2
-    "libzlib >=1.2.12,<1.3.0a0"
+    "libzlib >=1.2.12,<2.0.0a0"
linux-ppc64le::gst-plugins-good-1.21.1-h3600cc6_1.tar.bz2
linux-ppc64le::gst-libav-1.20.3-hc4c9807_2.tar.bz2
linux-ppc64le::libprotobuf-static-3.21.9-ha72a2fa_0.tar.bz2
linux-ppc64le::llvm-11.1.0-h12068cf_5.tar.bz2
linux-ppc64le::libnetcdf-4.8.1-nompi_h73ee791_105.tar.bz2
linux-ppc64le::gst-plugins-base-1.21.1-h3213b09_1.tar.bz2
linux-ppc64le::libprotobuf-3.21.9-ha72a2fa_0.tar.bz2
linux-ppc64le::llvm-15.0.3-hb49d0ea_1.tar.bz2
linux-ppc64le::plumed-2.8.1-nompi_hd710000_100.tar.bz2
linux-ppc64le::libmlir-15.0.3-h96f6aa1_0.tar.bz2
linux-ppc64le::clang-format-15.0.3-default_h1896e6d_0.tar.bz2
linux-ppc64le::clang-format-15-15.0.3-default_h1896e6d_0.tar.bz2
linux-ppc64le::liblal-7.2.4-fftw_h8338b0a_101.tar.bz2
linux-ppc64le::libmlir-15.0.1-h96f6aa1_0.tar.bz2
linux-ppc64le::libprotobuf-3.21.8-ha72a2fa_0.tar.bz2
linux-ppc64le::libllvm11-11.1.0-h6c99497_5.tar.bz2
linux-ppc64le::libclang13-15.0.3-default_ha49a280_0.tar.bz2
linux-ppc64le::liblal-7.2.4-fftw_h8338b0a_102.tar.bz2
linux-ppc64le::glib-tools-2.74.1-ha72a2fa_0.tar.bz2
linux-ppc64le::llvm-15.0.3-h2b80cf0_0.tar.bz2
linux-ppc64le::libmlir15-15.0.2-h96f6aa1_0.tar.bz2
linux-ppc64le::llvm-tools-15.0.3-hfe1df17_0.tar.bz2
linux-ppc64le::libclang-cpp15-15.0.3-default_h1896e6d_0.tar.bz2
linux-ppc64le::libllvm15-15.0.3-hfe1df17_0.tar.bz2
linux-ppc64le::libllvm15-15.0.3-h66d2248_1.tar.bz2
linux-ppc64le::libmlir15-15.0.1-h96f6aa1_0.tar.bz2
linux-ppc64le::libmlir-15.0.2-h96f6aa1_0.tar.bz2
linux-ppc64le::llvm-tools-11.1.0-h6c99497_5.tar.bz2
linux-ppc64le::clang-tools-15.0.3-default_h1896e6d_0.tar.bz2
linux-ppc64le::libprotobuf-static-3.21.8-ha72a2fa_0.tar.bz2
linux-ppc64le::libclang-15.0.3-default_h1896e6d_0.tar.bz2
linux-ppc64le::libnetcdf-4.8.1-nompi_h73ee791_106.tar.bz2
linux-ppc64le::libclang-cpp-15.0.3-default_h1896e6d_0.tar.bz2
linux-ppc64le::llvm-tools-15.0.3-h66d2248_1.tar.bz2
linux-ppc64le::fontconfig-2.14.1-hac4b4ab_0.tar.bz2
linux-ppc64le::libmlir15-15.0.3-h96f6aa1_0.tar.bz2
linux-ppc64le::clang-15-15.0.3-default_h1896e6d_0.tar.bz2
-    "libzlib >=1.2.13,<1.3.0a0"
+    "libzlib >=1.2.13,<2.0.0a0"
================================================================================
================================================================================
osx-arm64
osx-arm64::aws-sdk-cpp-1.9.369-h9b8a9c0_0.tar.bz2
osx-arm64::grpc-cpp-1.47.1-h55edf5b_7.tar.bz2
osx-arm64::pyreadr-0.4.7-py38hb13658c_2.tar.bz2
osx-arm64::arrow-cpp-7.0.1-py38h2d18913_7_cpu.tar.bz2
osx-arm64::wxpython-4.1.1-py38heac51d8_8.tar.bz2
osx-arm64::postgresql-plpython-13.8-py38h6299952_0.tar.bz2
osx-arm64::vtk-9.2.2-qt_py310h032bd38_204.tar.bz2
osx-arm64::aws-sdk-cpp-1.9.374-h6a5d661_0.tar.bz2
osx-arm64::netcdf4-1.6.1-mpi_openmpi_py311h157bc16_1.tar.bz2
osx-arm64::arrow-cpp-7.0.1-py310h856654d_6_cpu.tar.bz2
osx-arm64::vtk-9.2.2-qt_py39h5d03555_204.tar.bz2
osx-arm64::aws-sdk-cpp-1.9.370-h6a5d661_2.tar.bz2
osx-arm64::arrow-cpp-9.0.0-py311h7cbe25e_10_cpu.tar.bz2
osx-arm64::pygrib-2.1.4-py38h0ef7f3f_6.tar.bz2
osx-arm64::openmeeg-2.5.5-py38hc04c32e_1.tar.bz2
osx-arm64::pyhdf-0.10.5-py310ha3a438a_1.tar.bz2
osx-arm64::cpp-opentelemetry-sdk-1.7.0-h40dc6d1_0.tar.bz2
osx-arm64::arrow-cpp-8.0.1-py310h3feeac8_7_cpu.tar.bz2
osx-arm64::aws-sdk-cpp-1.9.373-h6a5d661_0.tar.bz2
osx-arm64::omniorb-4.2.5-py38hc1f8488_4.tar.bz2
osx-arm64::vtk-9.2.2-qt_py38he16d68f_203.tar.bz2
osx-arm64::arrow-cpp-7.0.1-py39h274948c_6_cpu.tar.bz2
osx-arm64::python-igraph-0.10.2-py39h1d1a559_1.tar.bz2
osx-arm64::gemmi-0.5.7-py38he6bf707_1.tar.bz2
osx-arm64::libadios2-2.8.3-mpi_openmpi_h0557014_4.tar.bz2
osx-arm64::libopencv-4.6.0-py38h6e4ee2f_5.tar.bz2
osx-arm64::mysql-connector-python-8.0.31-py39hb48e62b_2.tar.bz2
osx-arm64::pyreadstat-1.2.0-py310h5d88ba1_0.tar.bz2
osx-arm64::rsync-3.2.7-hff32518_0.tar.bz2
osx-arm64::git-2.38.1-pl5321h8b0ea5f_0.tar.bz2
osx-arm64::glib-2.74.1-hb5ab8b9_0.tar.bz2
osx-arm64::postgresql-plpython-13.8-py39h9637372_0.tar.bz2
osx-arm64::cppyy-cling-6.27.0-py39hd308395_2.tar.bz2
osx-arm64::netcdf4-1.6.1-mpi_mpich_py39hd6d6928_1.tar.bz2
osx-arm64::grpc-cpp-1.47.1-h503f348_7.tar.bz2
osx-arm64::llvmdev-15.0.3-h62b9111_1.tar.bz2
osx-arm64::omniorb-libs-4.2.5-h2f81810_3.tar.bz2
osx-arm64::pillow-9.2.0-py39h139752e_3.tar.bz2
osx-arm64::libadios2-2.8.3-mpi_mpich_h9b6efc4_4.tar.bz2
osx-arm64::libglib-2.74.1-h14ed1c1_0.tar.bz2
osx-arm64::root_base-6.26.8-py310he39f453_1.tar.bz2
osx-arm64::postgresql-plpython-13.8-py311ha3c0150_0.tar.bz2
osx-arm64::vigra-1.11.1-py39heb72264_1036.tar.bz2
osx-arm64::xrootd-5.5.1-py310h40f616e_1.tar.bz2
osx-arm64::postgresql-14.5-ha48369c_1.tar.bz2
osx-arm64::libopencv-4.6.0-py310h5ab14b7_5.tar.bz2
osx-arm64::xrootd-5.5.1-py310h40f616e_0.tar.bz2
osx-arm64::root_base-6.26.8-py38hce1135a_1.tar.bz2
osx-arm64::aws-sdk-cpp-1.9.374-h75b112a_0.tar.bz2
osx-arm64::libadios2-2.8.3-mpi_mpich_hbc6cf1d_4.tar.bz2
osx-arm64::pyreadstat-1.2.0-py39h019302e_0.tar.bz2
osx-arm64::arrow-cpp-9.0.0-py310h3feeac8_9_cpu.tar.bz2
osx-arm64::libpq-14.5-h3f71257_1.tar.bz2
osx-arm64::omniorb-4.2.5-py310h7dcfcf1_4.tar.bz2
osx-arm64::python-3.11.0-h403fd4c_0_cpython.tar.bz2
osx-arm64::gst-plugins-good-1.21.1-hf411aef_1.tar.bz2
osx-arm64::root_base-6.26.8-py39h1847e19_1.tar.bz2
osx-arm64::aws-sdk-cpp-1.9.373-h75b112a_0.tar.bz2
osx-arm64::arrow-cpp-8.0.1-py311hf12f70d_7_cpu.tar.bz2
osx-arm64::libadios2-2.8.3-mpi_openmpi_h4d55933_4.tar.bz2
osx-arm64::ffmpeg-5.1.2-lgpl_h75e0260_2.tar.bz2
osx-arm64::harp-1.15.1-py39hb72c553_3.tar.bz2
osx-arm64::harp-1.15.1-py310hb1b509d_3.tar.bz2
osx-arm64::omniorb-4.2.5-py310hc6b4ac9_3.tar.bz2
osx-arm64::omniorb-4.2.5-py39h717bbcb_3.tar.bz2
osx-arm64::tiledb-2.12.0-h9bd36d0_1.tar.bz2
osx-arm64::ndcctools-7.4.14-py310he1c76cb_2.tar.bz2
osx-arm64::vtk-9.2.2-qt_py39hf9a2a13_202.tar.bz2
osx-arm64::netcdf4-1.6.1-mpi_mpich_py311h991e30d_1.tar.bz2
osx-arm64::libadios2-2.8.3-mpi_mpich_h38d9516_4.tar.bz2
osx-arm64::curl-7.86.0-hd538317_0.tar.bz2
osx-arm64::llvmlite-0.39.1-py310h1e34944_1.tar.bz2
osx-arm64::pyreadr-0.4.7-py310hdad74a6_2.tar.bz2
osx-arm64::postgresql-plpython-13.8-py310hd96cdda_0.tar.bz2
osx-arm64::xrootd-5.5.1-py310h8171e25_0.tar.bz2
osx-arm64::libpq-13.8-h2af30dc_0.tar.bz2
osx-arm64::coda-2.24-py310hb1b509d_2.tar.bz2
osx-arm64::omniorb-libs-4.2.5-h19e3c78_4.tar.bz2
osx-arm64::arrow-cpp-9.0.0-py38hf1066ac_9_cpu.tar.bz2
osx-arm64::libadios2-2.8.3-mpi_openmpi_habde895_4.tar.bz2
osx-arm64::ffmpeg-4.4.2-gpl_hf4c414c_110.tar.bz2
osx-arm64::aws-sdk-cpp-1.9.365-h9b8a9c0_0.tar.bz2
osx-arm64::vtk-9.2.2-qt_py310h032bd38_203.tar.bz2
osx-arm64::grpc-cpp-1.48.1-h55edf5b_2.tar.bz2
osx-arm64::voms-2.1.0rc2-ha39e5ef_7.tar.bz2
osx-arm64::aws-sdk-cpp-1.9.371-h6a5d661_0.tar.bz2
osx-arm64::ffmpeg-4.4.2-lgpl_h75e0260_9.tar.bz2
osx-arm64::xrootd-5.5.1-py38h87fa3d5_1.tar.bz2
osx-arm64::libgdal-3.5.2-ha8fd3ac_5.tar.bz2
osx-arm64::arrow-cpp-9.0.0-py38h1e45027_10_cpu.tar.bz2
osx-arm64::qt6-main-6.4.0-h95acb26_4.tar.bz2
osx-arm64::jaxlib-0.3.22-cpu_py311he7b5d2c_0.tar.bz2
osx-arm64::arrow-cpp-8.0.1-py39h3e392ae_6_cpu.tar.bz2
osx-arm64::libopencv-4.6.0-py39h9ebde8a_5.tar.bz2
osx-arm64::xrootd-5.5.1-py39h2a8ee0f_0.tar.bz2
osx-arm64::mysql-connector-python-8.0.30-py38hc447c08_1.tar.bz2
osx-arm64::xrootd-5.5.1-py311hdffa972_2.tar.bz2
osx-arm64::ldas-tools-framecpp-2.9.1-hcae2a22_1.tar.bz2
osx-arm64::tectonic-0.12.0-hdb7a312_0.tar.bz2
osx-arm64::libgrpc-1.49.1-h503f348_1.tar.bz2
osx-arm64::netcdf4-1.6.1-mpi_openmpi_py39h671b1b9_1.tar.bz2
osx-arm64::wxpython-4.1.1-py39h2d7ee21_8.tar.bz2
osx-arm64::imagecodecs-2022.9.26-py38h4fe6f40_2.tar.bz2
osx-arm64::omniorb-4.2.5-py311h0918f0e_3.tar.bz2
osx-arm64::xrootd-5.5.0-py310h6743cc5_0.tar.bz2
osx-arm64::libadios2-2.8.3-nompi_h15f735f_104.tar.bz2
osx-arm64::vtk-9.2.2-qt_py38hf5b51b3_201.tar.bz2
osx-arm64::gemmi-0.5.7-py310h1e34944_1.tar.bz2
osx-arm64::aws-sdk-cpp-1.9.370-h75b112a_2.tar.bz2
osx-arm64::cppyy-cling-6.27.0-py38h9908e9a_2.tar.bz2
osx-arm64::wxpython-4.1.1-py310h5d6131b_8.tar.bz2
osx-arm64::arrow-cpp-6.0.2-py38hf771be7_6_cpu.tar.bz2
osx-arm64::ffmpeg-5.1.2-lgpl_hfe03f9f_3.tar.bz2
osx-arm64::grpc-cpp-1.45.2-hdb1f5ff_7.tar.bz2
osx-arm64::arrow-cpp-8.0.1-py38hf1066ac_7_cpu.tar.bz2
osx-arm64::xrootd-5.5.0-py39h2a8ee0f_0.tar.bz2
osx-arm64::aws-sdk-cpp-1.8.186-h392f50b_4.tar.bz2
osx-arm64::xrootd-5.5.1-py310h12cb314_0.tar.bz2
osx-arm64::imagecodecs-2022.9.26-py38h0c6dbed_1.tar.bz2
osx-arm64::omniorb-4.2.5-py311h4238351_4.tar.bz2
osx-arm64::omniorb-libs-4.2.5-h19e3c78_3.tar.bz2
osx-arm64::aws-sdk-cpp-1.9.372-h6a5d661_0.tar.bz2
osx-arm64::pygrib-2.1.4-py311h5159c23_6.tar.bz2
osx-arm64::omniorb-4.2.5-py311h4238351_3.tar.bz2
osx-arm64::openbabel-3.1.1-py38hb51ff8d_5.tar.bz2
osx-arm64::libcurl-7.86.0-hd538317_0.tar.bz2
osx-arm64::arrow-cpp-9.0.0-py39h9235a69_9_cpu.tar.bz2
osx-arm64::libpq-13.8-h3f71257_0.tar.bz2
osx-arm64::omniorb-4.2.5-py38hc1f8488_3.tar.bz2
osx-arm64::pyreadstat-1.2.0-py38hc53b772_1.tar.bz2
osx-arm64::pytables-3.7.0-py310h838cff0_3.tar.bz2
osx-arm64::vigra-1.11.1-py38h32dc123_1036.tar.bz2
osx-arm64::ovito-3.7.10-h24bc78c_1.tar.bz2
osx-arm64::postgresql-plpython-14.5-py311h3fc7eca_1.tar.bz2
osx-arm64::mysql-connector-python-8.0.30-py310he49648e_1.tar.bz2
osx-arm64::arrow-cpp-9.0.0-py39h7ad6bcf_10_cpu.tar.bz2
osx-arm64::root_base-6.26.8-py38hfaf977f_1.tar.bz2
osx-arm64::arrow-cpp-9.0.0-py311hf12f70d_9_cpu.tar.bz2
osx-arm64::xrootd-5.5.1-py39h09ae174_0.tar.bz2
osx-arm64::coda-2.24-py311h4489670_2.tar.bz2
osx-arm64::pytables-3.7.0-py39h8abd629_3.tar.bz2
osx-arm64::grpc-cpp-1.46.4-h55edf5b_8.tar.bz2
osx-arm64::harp-1.15.1-py311h4489670_4.tar.bz2
osx-arm64::xrootd-5.5.0-py38h9289208_0.tar.bz2
osx-arm64::netcdf4-1.6.1-mpi_openmpi_py38h31dcd80_1.tar.bz2
osx-arm64::gazebo-11.12.0-h4478ad8_2.tar.bz2
osx-arm64::lxml-4.9.1-py311h246f609_1.tar.bz2
osx-arm64::imagecodecs-2022.9.26-py38h4fe6f40_3.tar.bz2
osx-arm64::root_base-6.26.8-py310h62bb4df_1.tar.bz2
osx-arm64::netcdf4-1.6.1-nompi_py39h8ded8ba_101.tar.bz2
osx-arm64::libgdal-3.5.2-hdf189a9_4.tar.bz2
osx-arm64::mysql-connector-python-8.0.31-py39hb48e62b_1.tar.bz2
osx-arm64::arrow-cpp-7.0.1-py310hf07fb4d_7_cpu.tar.bz2
osx-arm64::imagecodecs-2022.9.26-py310h24fba19_2.tar.bz2
osx-arm64::libopencv-4.6.0-py310h5ab14b7_6.tar.bz2
osx-arm64::llvmdev-15.0.3-h71e9575_0.tar.bz2
osx-arm64::arrow-cpp-9.0.0-py39h3e392ae_8_cpu.tar.bz2
osx-arm64::arrow-cpp-6.0.2-py310h01f6158_6_cpu.tar.bz2
osx-arm64::davix-0.8.3-hd45f7fa_0.tar.bz2
osx-arm64::mysql-connector-python-8.0.31-py311hf0e4097_2.tar.bz2
osx-arm64::imagecodecs-2022.9.26-py39hca81624_1.tar.bz2
osx-arm64::xrootd-5.5.1-py38h9f330ff_0.tar.bz2
osx-arm64::libnetcdf-4.9.0-mpi_openmpi_h6b085dc_1.tar.bz2
osx-arm64::postgresql-13.8-ha48369c_0.tar.bz2
osx-arm64::gct-6.2.1629922860-h31843b3_2.tar.bz2
osx-arm64::harp-1.15.1-py39hb72c553_4.tar.bz2
osx-arm64::mysql-connector-python-8.0.31-py38hc447c08_2.tar.bz2
osx-arm64::arrow-cpp-7.0.1-py39h2b080cb_7_cpu.tar.bz2
osx-arm64::python-3.11.0-h93c2e33_0_cpython.tar.bz2
osx-arm64::cpp-opentelemetry-sdk-1.6.1-h7ddeac2_1.tar.bz2
osx-arm64::grpc-cpp-1.48.1-h503f348_2.tar.bz2
osx-arm64::plumed-2.8.1-nompi_hd508e74_100.tar.bz2
osx-arm64::pyreadr-0.4.7-py39h6c4633b_2.tar.bz2
osx-arm64::aws-sdk-cpp-1.9.371-h75b112a_0.tar.bz2
osx-arm64::xrootd-5.5.1-py39hc651197_2.tar.bz2
osx-arm64::omniorb-4.2.5-py38h91a4336_3.tar.bz2
osx-arm64::libgrpc-1.49.1-h55edf5b_1.tar.bz2
osx-arm64::hdf4-4.2.15-h1a38d6a_5.tar.bz2
osx-arm64::arrow-cpp-6.0.2-py310h86b352b_5_cpu.tar.bz2
osx-arm64::arrow-cpp-8.0.1-py310he7ddf0e_6_cpu.tar.bz2
osx-arm64::xrootd-5.5.0-py39h09ae174_0.tar.bz2
osx-arm64::libpq-14.5-h2af30dc_1.tar.bz2
osx-arm64::xrootd-5.5.1-py39h70a1725_0.tar.bz2
osx-arm64::libnetcdf-4.9.0-mpi_openmpi_h6b085dc_2.tar.bz2
osx-arm64::llvmlite-0.39.1-py39h8ca5d33_1.tar.bz2
osx-arm64::xrootd-5.5.1-py38h1e155e7_0.tar.bz2
osx-arm64::libadios2-2.8.3-nompi_h44d955a_104.tar.bz2
osx-arm64::omniorb-4.2.5-py311h0918f0e_4.tar.bz2
osx-arm64::xrootd-5.5.1-py39h70a1725_2.tar.bz2
osx-arm64::curl-7.86.0-h1c293e1_0.tar.bz2
osx-arm64::arrow-cpp-8.0.1-py311he8e28c7_6_cpu.tar.bz2
osx-arm64::openbabel-3.1.1-py39h9bbd472_5.tar.bz2
osx-arm64::coda-2.24-py38h8b41f1f_2.tar.bz2
osx-arm64::xrootd-5.5.1-py310h40f616e_2.tar.bz2
osx-arm64::aws-sdk-cpp-1.9.368-h9b8a9c0_0.tar.bz2
osx-arm64::qt-main-5.15.6-hf3dd84c_1.tar.bz2
osx-arm64::imagecodecs-2022.9.26-py311hc032047_3.tar.bz2
osx-arm64::omniorb-4.2.5-py310hc6b4ac9_4.tar.bz2
osx-arm64::aws-sdk-cpp-1.9.364-h9b8a9c0_0.tar.bz2
osx-arm64::mysql-connector-python-8.0.31-py38hc447c08_1.tar.bz2
osx-arm64::python-igraph-0.10.2-py311h6f1cfba_1.tar.bz2
osx-arm64::aws-sdk-cpp-1.9.369-h645e6ee_1.tar.bz2
osx-arm64::pyinstaller-5.1-py38hc53b772_1.tar.bz2
osx-arm64::pyinstaller-5.1-py39h019302e_1.tar.bz2
osx-arm64::jaxlib-0.3.22-cpu_py311h8c890d0_0.tar.bz2
osx-arm64::libxmlsec1-1.2.35-hf4532c6_0.tar.bz2
osx-arm64::gst-plugins-base-1.21.1-h8b7775e_1.tar.bz2
osx-arm64::arrow-cpp-7.0.1-py39hdb2f099_8_cpu.tar.bz2
osx-arm64::pillow-9.2.0-py38hf86a106_3.tar.bz2
osx-arm64::rsync-3.2.7-hcdef6ba_0.tar.bz2
osx-arm64::vigra-1.11.1-py310h693ab2c_1036.tar.bz2
osx-arm64::omniorb-4.2.5-py39h7740d13_3.tar.bz2
osx-arm64::ndcctools-7.4.14-py39h1c7e63e_2.tar.bz2
osx-arm64::pygrib-2.1.4-py310he4ee976_6.tar.bz2
osx-arm64::tectonic-0.12.0-h53ee156_0.tar.bz2
osx-arm64::imagecodecs-2022.9.26-py310hf9f14f2_1.tar.bz2
osx-arm64::postgresql-plpython-13.8-py311h3fc7eca_0.tar.bz2
osx-arm64::vtk-9.2.2-qt_py310h771f6f5_201.tar.bz2
osx-arm64::yoda-1.9.6-py39h345bc73_2.tar.bz2
osx-arm64::vtk-9.2.2-qt_py310h771f6f5_202.tar.bz2
osx-arm64::arrow-cpp-9.0.0-py38h628faa2_8_cpu.tar.bz2
osx-arm64::libnetcdf-4.9.0-nompi_h66d6d65_101.tar.bz2
osx-arm64::ffmpeg-4.4.2-lgpl_hfe03f9f_10.tar.bz2
osx-arm64::arrow-cpp-9.0.0-py310heae1359_10_cpu.tar.bz2
osx-arm64::pyreadstat-1.2.0-py39h019302e_1.tar.bz2
osx-arm64::aws-sdk-cpp-1.9.372-h75b112a_0.tar.bz2
osx-arm64::mlir-15.0.1-hcb86549_0.tar.bz2
osx-arm64::libxslt-1.1.35-h7598e6e_1.tar.bz2
osx-arm64::pytables-3.7.0-py311h887c5ef_3.tar.bz2
osx-arm64::qt6-main-6.4.0-h0633097_5.tar.bz2
osx-arm64::coda-2.24-py39hb72c553_2.tar.bz2
osx-arm64::libadios2-2.8.3-mpi_mpich_h4f585cb_4.tar.bz2
osx-arm64::omniorb-4.2.5-py39h7740d13_4.tar.bz2
osx-arm64::imagecodecs-2022.9.26-py38h4fe6f40_1.tar.bz2
osx-arm64::netcdf4-1.6.1-mpi_mpich_py38h8a74167_1.tar.bz2
osx-arm64::mysql-connector-python-8.0.31-py310he49648e_2.tar.bz2
osx-arm64::git-2.38.1-pl5321hbc4f155_0.tar.bz2
osx-arm64::vtk-9.2.2-qt_py38he16d68f_204.tar.bz2
osx-arm64::libcurl-7.86.0-h1c293e1_0.tar.bz2
osx-arm64::davix-0.8.3-h727ee82_1.tar.bz2
osx-arm64::arrow-cpp-6.0.2-py311h3be50e2_5_cpu.tar.bz2
osx-arm64::openmeeg-2.5.5-py311h04bcfaa_1.tar.bz2
osx-arm64::libopencv-4.6.0-py39h9ebde8a_6.tar.bz2
osx-arm64::xrootd-5.5.1-py38h87fa3d5_2.tar.bz2
osx-arm64::sox-14.4.2-hdf4f08f_1016.tar.bz2
osx-arm64::libcurl-static-7.86.0-hd538317_0.tar.bz2
osx-arm64::postgresql-plpython-13.8-py310h0fcec4b_0.tar.bz2
osx-arm64::vowpalwabbit-9.5.0-py39hba3fb6c_1.tar.bz2
osx-arm64::libvips-8.13.2-h238e3fe_0.tar.bz2
osx-arm64::arrow-cpp-7.0.1-py310h951ed3f_8_cpu.tar.bz2
osx-arm64::xrootd-5.5.1-py310h6743cc5_0.tar.bz2
osx-arm64::davix-0.8.3-h5075106_0.tar.bz2
osx-arm64::arrow-cpp-7.0.1-py38h4840ada_8_cpu.tar.bz2
osx-arm64::libadios2-2.8.3-nompi_hc3cbe00_104.tar.bz2
osx-arm64::libnetcdf-4.8.1-mpi_mpich_h8e475c3_6.tar.bz2
osx-arm64::ogre-1.10.12-h04145a7_10.tar.bz2
osx-arm64::postgresql-14.5-hf80b784_1.tar.bz2
osx-arm64::arrow-cpp-8.0.1-py39h9235a69_7_cpu.tar.bz2
osx-arm64::python-igraph-0.10.2-py38h0504639_1.tar.bz2
osx-arm64::libopencv-4.6.0-py311h8f65ed9_6.tar.bz2
osx-arm64::libnetcdf-4.8.1-mpi_openmpi_h245372f_6.tar.bz2
osx-arm64::leptonica-1.82.0-h2ec74d5_1.tar.bz2
osx-arm64::netcdf4-1.6.1-mpi_mpich_py310h9db3456_1.tar.bz2
osx-arm64::omniorb-libs-4.2.5-h2f81810_4.tar.bz2
osx-arm64::ffmpeg-5.1.2-gpl_hc92e51b_102.tar.bz2
osx-arm64::xrootd-5.5.1-py39h70a1725_1.tar.bz2
osx-arm64::pyreadstat-1.2.0-py38hc53b772_0.tar.bz2
osx-arm64::cpp-opentelemetry-sdk-1.6.1-h40dc6d1_2.tar.bz2
osx-arm64::postgresql-plpython-13.8-py38hf47d0ba_0.tar.bz2
osx-arm64::cppyy-cling-6.27.0-py310h59dd246_2.tar.bz2
osx-arm64::vtk-9.2.2-qt_py38hf5b51b3_202.tar.bz2
osx-arm64::imagecodecs-2022.9.26-py39hefd8678_1.tar.bz2
osx-arm64::libnetcdf-4.9.0-nompi_h66d6d65_102.tar.bz2
osx-arm64::xrootd-5.5.0-py310h12cb314_0.tar.bz2
osx-arm64::tiledb-2.11.3-h9bd36d0_1.tar.bz2
osx-arm64::openbabel-3.1.1-py311h6cc52c5_5.tar.bz2
osx-arm64::pyreadstat-1.2.0-py311h5d36e46_1.tar.bz2
osx-arm64::postgresql-plpython-13.8-py39h9dcd10c_0.tar.bz2
osx-arm64::postgresql-plpython-14.5-py38hf47d0ba_1.tar.bz2
osx-arm64::xrootd-5.5.1-py39hc651197_1.tar.bz2
osx-arm64::netcdf4-1.6.1-nompi_py310haaa361f_101.tar.bz2
osx-arm64::postgresql-13.8-hf80b784_0.tar.bz2
osx-arm64::arrow-cpp-6.0.2-py38h36dc208_5_cpu.tar.bz2
osx-arm64::ogre-1.12.13-h9144a23_3.tar.bz2
osx-arm64::vtk-9.2.2-qt_py39hf9a2a13_201.tar.bz2
osx-arm64::gemmi-0.5.7-py311h7b25133_1.tar.bz2
osx-arm64::ndcctools-7.4.14-py39hfef7b1a_2.tar.bz2
osx-arm64::ffmpeg-5.1.2-gpl_hf4c414c_103.tar.bz2
osx-arm64::libxmlsec1-1.2.35-h967a3f3_1.tar.bz2
osx-arm64::netcdf4-1.6.1-nompi_py311hf175f78_101.tar.bz2
osx-arm64::pytables-3.7.0-py38h1919196_3.tar.bz2
osx-arm64::ldas-tools-framecpp-2.9.1-h509ff9f_1.tar.bz2
osx-arm64::harp-1.15.1-py38h8b41f1f_3.tar.bz2
osx-arm64::yoda-1.9.6-py310h536ff04_2.tar.bz2
osx-arm64::imagecodecs-2022.9.26-py39hefd8678_3.tar.bz2
osx-arm64::pillow-9.2.0-py310h9337a76_3.tar.bz2
osx-arm64::libadios2-2.8.3-mpi_openmpi_h7f8a541_4.tar.bz2
osx-arm64::libgdal-3.5.2-h1ecf2db_4.tar.bz2
osx-arm64::postgresql-plpython-14.5-py311ha3c0150_1.tar.bz2
osx-arm64::pillow-9.2.0-py311h09de4a2_3.tar.bz2
osx-arm64::libadios2-2.8.3-nompi_h72b4c4b_104.tar.bz2
osx-arm64::tiledb-2.12.0-hc7ac4c9_1.tar.bz2
osx-arm64::libxml2-2.10.3-h87b0503_0.tar.bz2
osx-arm64::python-igraph-0.10.2-py39h0645257_0.tar.bz2
osx-arm64::pyhdf-0.10.5-py311h8e30659_1.tar.bz2
osx-arm64::vigra-1.11.1-py311hf4b3484_1036.tar.bz2
osx-arm64::openmeeg-2.5.5-py310h5aed94e_1.tar.bz2
osx-arm64::omniorb-4.2.5-py38h91a4336_4.tar.bz2
osx-arm64::gemmi-0.5.7-py39h8ca5d33_1.tar.bz2
osx-arm64::harp-1.15.1-py310hb1b509d_4.tar.bz2
osx-arm64::arrow-cpp-6.0.2-py39hccce914_5_cpu.tar.bz2
osx-arm64::leptonica-1.82.0-h2ec74d5_2.tar.bz2
osx-arm64::arrow-cpp-9.0.0-py310he7ddf0e_8_cpu.tar.bz2
osx-arm64::openbabel-3.1.1-py310he084157_5.tar.bz2
osx-arm64::omniorb-4.2.5-py39h717bbcb_4.tar.bz2
osx-arm64::pygrib-2.1.4-py39h3a1e438_6.tar.bz2
osx-arm64::pyreadr-0.4.7-py311h6447b9f_2.tar.bz2
osx-arm64::pyhdf-0.10.5-py38h960ae97_1.tar.bz2
osx-arm64::libvips-8.13.1-h238e3fe_2.tar.bz2
osx-arm64::root_base-6.26.8-py39h611b57b_1.tar.bz2
osx-arm64::imagecodecs-2022.9.26-py310h24fba19_1.tar.bz2
osx-arm64::libnetcdf-4.8.1-mpi_openmpi_h245372f_5.tar.bz2
osx-arm64::vowpalwabbit-9.5.0-py310hb174350_1.tar.bz2
osx-arm64::lxml-4.9.1-py38h43d3e64_1.tar.bz2
osx-arm64::ogre-13.4.4-h8e6f18c_1.tar.bz2
osx-arm64::xrootd-5.5.1-py38h87fa3d5_0.tar.bz2
osx-arm64::netcdf4-1.6.1-nompi_py38he52ce97_101.tar.bz2
osx-arm64::imagecodecs-2022.9.26-py310h24fba19_3.tar.bz2
osx-arm64::xrootd-5.5.1-py310h8171e25_1.tar.bz2
osx-arm64::ndcctools-7.4.14-py311hf06ad48_2.tar.bz2
osx-arm64::davix-0.8.3-hd6f5c42_1.tar.bz2
osx-arm64::libnetcdf-4.9.0-mpi_mpich_h1dec8b6_2.tar.bz2
osx-arm64::llvmdev-11.1.0-hfa12f05_5.tar.bz2
osx-arm64::libnetcdf-4.8.1-mpi_mpich_h8e475c3_5.tar.bz2
osx-arm64::libopencv-4.6.0-py38h6e4ee2f_6.tar.bz2
osx-arm64::ogre-1.12.13-hd8c844f_3.tar.bz2
osx-arm64::vowpalwabbit-9.5.0-py311hc357fe2_1.tar.bz2
osx-arm64::aws-sdk-cpp-1.9.367-h9b8a9c0_0.tar.bz2
osx-arm64::openmeeg-2.5.5-py39hc1b817c_1.tar.bz2
osx-arm64::poppler-22.10.0-hae7f5f0_0.tar.bz2
osx-arm64::mysql-connector-python-8.0.30-py39hb48e62b_1.tar.bz2
osx-arm64::ndcctools-7.4.14-py38h05a9a42_2.tar.bz2
osx-arm64::ogre-13.4.4-ha856a38_1.tar.bz2
osx-arm64::gct-6.2.1629922860-heeab788_2.tar.bz2
osx-arm64::wxwidgets-3.2.1-py311h06d64fb_1.tar.bz2
osx-arm64::python-igraph-0.10.2-py38h8b745a7_0.tar.bz2
osx-arm64::vtk-9.2.2-qt_py311h90bcdb8_204.tar.bz2
osx-arm64::aws-sdk-cpp-1.9.366-h9b8a9c0_0.tar.bz2
osx-arm64::assimp-5.2.5-h276577b_0.tar.bz2
osx-arm64::ffmpeg-4.4.2-gpl_hc92e51b_109.tar.bz2
osx-arm64::libxmlsec1-1.2.35-hf4532c6_1.tar.bz2
osx-arm64::voms-2.1.0rc0-h7a71a8a_7.tar.bz2
osx-arm64::grpc-cpp-1.46.4-h503f348_8.tar.bz2
osx-arm64::arrow-cpp-8.0.1-py38h628faa2_6_cpu.tar.bz2
osx-arm64::postgresql-plpython-14.5-py310h0fcec4b_1.tar.bz2
osx-arm64::mlir-15.0.3-hcb86549_0.tar.bz2
osx-arm64::postgresql-plpython-14.5-py38h6299952_1.tar.bz2
osx-arm64::vigra-1.11.1-py39heb72264_1035.tar.bz2
osx-arm64::libcurl-static-7.86.0-h1c293e1_0.tar.bz2
osx-arm64::ndcctools-7.4.14-py310hbaff3d7_2.tar.bz2
osx-arm64::llvmlite-0.39.1-py38he6bf707_1.tar.bz2
osx-arm64::arrow-cpp-7.0.1-py311h4624d4f_7_cpu.tar.bz2
osx-arm64::aws-sdk-cpp-1.9.370-h645e6ee_0.tar.bz2
osx-arm64::arrow-cpp-7.0.1-py38h0d0288b_6_cpu.tar.bz2
osx-arm64::grpc-cpp-1.45.2-hfdb7c5c_7.tar.bz2
osx-arm64::gazebo-11.12.0-h5491266_2.tar.bz2
osx-arm64::xrootd-5.5.0-py38h1e155e7_0.tar.bz2
osx-arm64::libnetcdf-4.9.0-mpi_mpich_h1dec8b6_1.tar.bz2
osx-arm64::tiledb-2.11.3-hc7ac4c9_1.tar.bz2
osx-arm64::xrootd-5.5.1-py39hc651197_0.tar.bz2
osx-arm64::netcdf4-1.6.1-mpi_openmpi_py310h3b2823a_1.tar.bz2
osx-arm64::lxml-4.9.1-py39h0520ce3_1.tar.bz2
osx-arm64::omniorb-4.2.5-py310h7dcfcf1_3.tar.bz2
osx-arm64::arrow-cpp-9.0.0-py311he8e28c7_8_cpu.tar.bz2
osx-arm64::mysql-connector-python-8.0.31-py310he49648e_1.tar.bz2
osx-arm64::yoda-1.9.6-py38hbcd6ec7_2.tar.bz2
osx-arm64::lfortran-0.18.0-hf913c23_0.tar.bz2
osx-arm64::harp-1.15.1-py38h8b41f1f_4.tar.bz2
osx-arm64::xrootd-5.5.1-py38h9f330ff_1.tar.bz2
osx-arm64::vigra-1.11.1-py38h32dc123_1035.tar.bz2
osx-arm64::mlir-15.0.2-hcb86549_0.tar.bz2
osx-arm64::xrootd-5.5.1-py311h7b439ff_2.tar.bz2
osx-arm64::postgresql-plpython-14.5-py39h9637372_1.tar.bz2
osx-arm64::xrootd-5.5.1-py38h9f330ff_2.tar.bz2
osx-arm64::voms-2.1.0rc2-h7a71a8a_7.tar.bz2
osx-arm64::arrow-cpp-7.0.1-py311h58d7cf6_8_cpu.tar.bz2
osx-arm64::cppyy-cling-6.27.0-py311h4ca21db_2.tar.bz2
osx-arm64::ndcctools-7.4.14-py311hc81a0f4_2.tar.bz2
osx-arm64::arrow-cpp-6.0.2-py39hdfe124f_6_cpu.tar.bz2
osx-arm64::postgresql-plpython-14.5-py39h9dcd10c_1.tar.bz2
osx-arm64::vigra-1.11.1-py310h693ab2c_1035.tar.bz2
osx-arm64::vtk-9.2.2-qt_py39h5d03555_203.tar.bz2
osx-arm64::arrow-cpp-6.0.2-py311h8970c68_6_cpu.tar.bz2
osx-arm64::vowpalwabbit-9.5.0-py38h9b29d42_1.tar.bz2
osx-arm64::pyreadstat-1.2.0-py310h5d88ba1_1.tar.bz2
osx-arm64::postgresql-plpython-14.5-py310hd96cdda_1.tar.bz2
osx-arm64::aws-sdk-cpp-1.9.370-h6a5d661_1.tar.bz2
osx-arm64::qt6-main-6.4.0-h4be6a9e_3.tar.bz2
osx-arm64::arrow-cpp-7.0.1-py311h693a41b_6_cpu.tar.bz2
osx-arm64::xrootd-5.5.1-py38h9289208_0.tar.bz2
osx-arm64::pyhdf-0.10.5-py39h3826115_1.tar.bz2
osx-arm64::python-igraph-0.10.2-py310he372fcf_1.tar.bz2
osx-arm64::pyinstaller-5.1-py310h5d88ba1_1.tar.bz2
osx-arm64::python-igraph-0.10.2-py310hb3ce840_0.tar.bz2
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
osx-arm64::z5py-2.0.16-py310h8acfa5e_0.tar.bz2
osx-arm64::giac-1.9.0.21-h8159021_0.tar.bz2
osx-arm64::mysql-server-8.0.31-ha1fd688_0.tar.bz2
osx-arm64::ovito-3.7.10-h9edad43_0.tar.bz2
osx-arm64::openssh-9.1p1-h998ac43_0.tar.bz2
osx-arm64::openssh-9.1p1-hb650857_0.tar.bz2
osx-arm64::pcre2-static-10.40-hb34f9b4_0.tar.bz2
osx-arm64::vowpalwabbit-9.4.0-py310hb174350_0.tar.bz2
osx-arm64::nodejs-18.11.0-h26a3f6d_0.tar.bz2
osx-arm64::nodejs-18.11.0-haa6f3e8_0.tar.bz2
osx-arm64::arrow-cpp-8.0.1-py39h3e392ae_5_cpu.tar.bz2
osx-arm64::libcurl-7.85.0-h1c293e1_0.tar.bz2
osx-arm64::vowpalwabbit-9.5.0-py310hb174350_0.tar.bz2
osx-arm64::sagelib-9.7-py38he55e7ee_1.tar.bz2
osx-arm64::aws-sdk-cpp-1.9.358-h53ec0b3_1.tar.bz2
osx-arm64::jaxlib-0.3.22-cpu_py310h48e4569_0.tar.bz2
osx-arm64::vowpalwabbit-9.4.0-py39hba3fb6c_0.tar.bz2
osx-arm64::aws-sdk-cpp-1.9.361-h8d7a4d8_0.tar.bz2
osx-arm64::tectonic-0.11.0-hdb7a312_0.tar.bz2
osx-arm64::qt6-main-6.4.0-h4be6a9e_2.tar.bz2
osx-arm64::vowpalwabbit-9.5.0-py39hba3fb6c_0.tar.bz2
osx-arm64::sagelib-9.7-py39h0f1d45d_1.tar.bz2
osx-arm64::llvmdev-15.0.2-h71e9575_0.tar.bz2
osx-arm64::git-2.38.0-pl5321h8b0ea5f_0.tar.bz2
osx-arm64::soplex-6.0.2-h3da912a_1.tar.bz2
osx-arm64::r-git2r-0.30.1-r41h8f8f29b_1.tar.bz2
osx-arm64::sqlite-3.39.4-h2229b38_0.tar.bz2
osx-arm64::aws-sdk-cpp-1.9.356-hfc72c24_1.tar.bz2
osx-arm64::scip-8.0.2-h0b19ae7_1.tar.bz2
osx-arm64::aws-sdk-cpp-1.9.359-h8d7a4d8_0.tar.bz2
osx-arm64::librdkafka-1.9.2-h067ffc7_1.tar.bz2
osx-arm64::qt6-main-6.4.0-h4be6a9e_0.tar.bz2
osx-arm64::scip-8.0.2-hb7915e4_0.tar.bz2
osx-arm64::jaxlib-0.3.22-cpu_py38h8a320d7_0.tar.bz2
osx-arm64::sagelib-9.7-py39h0f1d45d_0.tar.bz2
osx-arm64::libcurl-7.85.0-hd538317_0.tar.bz2
osx-arm64::gazebo-11.12.0-h0e878e5_1.tar.bz2
osx-arm64::arrow-cpp-9.0.0-py38h628faa2_7_cpu.tar.bz2
osx-arm64::mongodb-6.0.2-ha89ae16_0.tar.bz2
osx-arm64::libcurl-static-7.85.0-h1c293e1_0.tar.bz2
osx-arm64::glibmm-2.68-2.74.0-had0cb2f_0.tar.bz2
osx-arm64::git-2.38.0-pl5321hbc4f155_0.tar.bz2
osx-arm64::curl-7.85.0-h1c293e1_0.tar.bz2
osx-arm64::vowpalwabbit-9.4.0-py38h9b29d42_0.tar.bz2
osx-arm64::mysql-libs-8.0.31-hcb599eb_0.tar.bz2
osx-arm64::arrow-cpp-9.0.0-py39h3e392ae_7_cpu.tar.bz2
osx-arm64::aws-sdk-cpp-1.9.357-hfc72c24_0.tar.bz2
osx-arm64::papilo-2.1.1-h9cc07e0_0.tar.bz2
osx-arm64::mysql-client-8.0.31-hf4a1620_0.tar.bz2
osx-arm64::lammps-2022.06.23-py38h0225e28_openmpi_3.tar.bz2
osx-arm64::r-git2r-0.30.1-r41he530e86_1.tar.bz2
osx-arm64::sagelib-9.6-py39h0f1d45d_4.tar.bz2
osx-arm64::arrow-cpp-8.0.1-py38h628faa2_5_cpu.tar.bz2
osx-arm64::r-git2r-0.30.1-r42h8f8f29b_1.tar.bz2
osx-arm64::sagelib-9.6-py38he55e7ee_4.tar.bz2
osx-arm64::gdstk-0.9.1-py38hf6acb95_0.tar.bz2
osx-arm64::imagemagick-7.1.0_50-pl5321ha4612b8_0.tar.bz2
osx-arm64::r-base-4.1.3-hab92f3e_3.tar.bz2
osx-arm64::arrow-cpp-7.0.1-py39h274948c_5_cpu.tar.bz2
osx-arm64::soplex-6.0.2-h3da912a_0.tar.bz2
osx-arm64::jaxlib-0.3.22-cpu_py39ha8321c9_0.tar.bz2
osx-arm64::gdstk-0.9.1-py310h1408f53_0.tar.bz2
osx-arm64::mysql-libs-8.0.31-hea58576_0.tar.bz2
osx-arm64::gst-plugins-good-1.21.1-hf411aef_0.tar.bz2
osx-arm64::lammps-2022.06.23-py310h7f81c99_mpich_3.tar.bz2
osx-arm64::vowpalwabbit-9.5.0-py38h9b29d42_0.tar.bz2
osx-arm64::arrow-cpp-8.0.1-py310he7ddf0e_5_cpu.tar.bz2
osx-arm64::ogre-next-2.3.1-h642b98f_3.tar.bz2
osx-arm64::aws-sdk-cpp-1.9.363-h9b8a9c0_0.tar.bz2
osx-arm64::arrow-cpp-7.0.1-py310h856654d_5_cpu.tar.bz2
osx-arm64::sagelib-9.7-py310haef829e_1.tar.bz2
osx-arm64::arrow-cpp-6.0.2-py310h86b352b_4_cpu.tar.bz2
osx-arm64::libcurl-static-7.85.0-hd538317_0.tar.bz2
osx-arm64::lammps-2022.06.23-py39h44150e4_mpich_3.tar.bz2
osx-arm64::jaxlib-0.3.22-cpu_py38hdd4436d_0.tar.bz2
osx-arm64::python-igraph-0.10.1-py310hb3ce840_1.tar.bz2
osx-arm64::z5py-2.0.16-py38h603d7ca_0.tar.bz2
osx-arm64::z5py-2.0.16-py39h5f92137_0.tar.bz2
osx-arm64::curl-7.85.0-hd538317_0.tar.bz2
osx-arm64::vtk-9.2.2-qt_py310h3be5dd2_200.tar.bz2
osx-arm64::libxml2-2.10.2-h87b0503_2.tar.bz2
osx-arm64::aws-sdk-cpp-1.9.362-h9b8a9c0_1.tar.bz2
osx-arm64::jaxlib-0.3.22-cpu_py310h18a4bca_0.tar.bz2
osx-arm64::sagelib-9.7-py38he55e7ee_0.tar.bz2
osx-arm64::vtk-9.2.2-qt_py38hadba9c1_200.tar.bz2
osx-arm64::arrow-cpp-9.0.0-py310he7ddf0e_7_cpu.tar.bz2
osx-arm64::aws-sdk-cpp-1.9.362-h8d7a4d8_0.tar.bz2
osx-arm64::papilo-2.1.1-h9cc07e0_1.tar.bz2
osx-arm64::mysql-client-8.0.31-h382bae0_0.tar.bz2
osx-arm64::libsoup-3.2.1-h5a5772c_0.tar.bz2
osx-arm64::gdstk-0.9.1-py39hacb9366_0.tar.bz2
osx-arm64::sagelib-9.6-py310haef829e_4.tar.bz2
osx-arm64::r-base-4.2.1-hab92f3e_2.tar.bz2
osx-arm64::r-git2r-0.30.1-r42he530e86_1.tar.bz2
osx-arm64::arrow-cpp-6.0.2-py39hccce914_4_cpu.tar.bz2
osx-arm64::lammps-2022.06.23-py38hc96dc77_mpich_3.tar.bz2
osx-arm64::jaxlib-0.3.22-cpu_py39h100ce08_0.tar.bz2
osx-arm64::python-igraph-0.10.1-py39h0645257_1.tar.bz2
osx-arm64::tectonic-0.11.0-h53ee156_0.tar.bz2
osx-arm64::librdkafka-1.9.2-haa81777_1.tar.bz2
osx-arm64::sagelib-9.7-py310haef829e_0.tar.bz2
osx-arm64::libmediainfo-22.09-h94a21ce_0.tar.bz2
osx-arm64::lammps-2022.06.23-py39h146d5b3_openmpi_3.tar.bz2
osx-arm64::lammps-2022.06.23-py310ha3f3991_openmpi_3.tar.bz2
osx-arm64::arrow-cpp-6.0.2-py38h36dc208_4_cpu.tar.bz2
osx-arm64::python-igraph-0.10.1-py38h8b745a7_1.tar.bz2
osx-arm64::gazebo-11.12.0-h55a68f1_1.tar.bz2
osx-arm64::vtk-9.2.2-qt_py39h99f1238_200.tar.bz2
osx-arm64::mysql-server-8.0.31-h17425c9_0.tar.bz2
-    "libzlib >=1.2.12,<1.3.0a0",
+    "libzlib >=1.2.12,<2.0.0a0",
osx-arm64::libllvm15-15.0.2-h71e9575_0.tar.bz2
osx-arm64::liblal-7.2.4-fftw_h6e50f36_100.tar.bz2
osx-arm64::pcre2-10.40-hb34f9b4_0.tar.bz2
osx-arm64::pocl-3.0-h422b2f1_2.tar.bz2
osx-arm64::llvm-15.0.2-h501a258_0.tar.bz2
osx-arm64::gst-plugins-base-1.21.1-h8b7775e_0.tar.bz2
osx-arm64::libsqlite-3.39.4-h76d750c_0.tar.bz2
osx-arm64::libprotobuf-static-3.21.7-hb5ab8b9_0.tar.bz2
osx-arm64::llvm-tools-15.0.2-h71e9575_0.tar.bz2
osx-arm64::cgns-4.3.0-h801ce26_2.tar.bz2
osx-arm64::libprotobuf-3.21.7-hb5ab8b9_0.tar.bz2
-    "libzlib >=1.2.12,<1.3.0a0"
+    "libzlib >=1.2.12,<2.0.0a0"
osx-arm64::liblal-7.2.4-fftw_h6e50f36_102.tar.bz2
osx-arm64::libllvm15-15.0.3-h62b9111_1.tar.bz2
osx-arm64::libnetcdf-4.8.1-nompi_h2510be2_105.tar.bz2
osx-arm64::liblal-7.2.4-fftw_h6e50f36_101.tar.bz2
osx-arm64::llvm-15.0.3-h90c9d4e_1.tar.bz2
osx-arm64::libv8-8.9.83-ha3ef9b2_2.tar.bz2
osx-arm64::libprotobuf-static-3.21.8-hb5ab8b9_0.tar.bz2
osx-arm64::libmlir15-15.0.2-hcb86549_0.tar.bz2
osx-arm64::libllvm15-15.0.3-h71e9575_0.tar.bz2
osx-arm64::libprotobuf-static-3.21.9-hb5ab8b9_0.tar.bz2
osx-arm64::openjdk-17.0.3-hf913c23_4.tar.bz2
osx-arm64::llvm-tools-15.0.3-h62b9111_1.tar.bz2
osx-arm64::llvm-tools-11.1.0-hfa12f05_5.tar.bz2
osx-arm64::fontconfig-2.14.1-h82840c6_0.tar.bz2
osx-arm64::glib-tools-2.74.1-hb5ab8b9_0.tar.bz2
osx-arm64::llvm-15.0.3-h501a258_0.tar.bz2
osx-arm64::libprotobuf-3.21.8-hb5ab8b9_0.tar.bz2
osx-arm64::libnetcdf-4.8.1-nompi_h2510be2_106.tar.bz2
osx-arm64::openjdk-11.0.15-hf913c23_3.tar.bz2
osx-arm64::llvm-11.1.0-h95d0606_5.tar.bz2
osx-arm64::llvm-tools-15.0.3-h71e9575_0.tar.bz2
osx-arm64::libmlir15-15.0.3-hcb86549_0.tar.bz2
osx-arm64::libllvm11-11.1.0-hfa12f05_5.tar.bz2
osx-arm64::libmlir-15.0.1-hcb86549_0.tar.bz2
osx-arm64::libprotobuf-3.21.9-hb5ab8b9_0.tar.bz2
osx-arm64::libmlir-15.0.3-hcb86549_0.tar.bz2
osx-arm64::openjdk-17.0.3-hf913c23_3.tar.bz2
osx-arm64::libmlir15-15.0.1-hcb86549_0.tar.bz2
osx-arm64::libmlir-15.0.2-hcb86549_0.tar.bz2
-    "libzlib >=1.2.13,<1.3.0a0"
+    "libzlib >=1.2.13,<2.0.0a0"
================================================================================
================================================================================
linux-aarch64
linux-aarch64::aws-sdk-cpp-1.9.357-h51e1be9_0.tar.bz2
linux-aarch64::mysql-client-8.0.31-h546d73d_0.tar.bz2
linux-aarch64::aws-sdk-cpp-1.9.356-h51e1be9_1.tar.bz2
linux-aarch64::mysql-router-8.0.31-h859e3e3_0.tar.bz2
linux-aarch64::sagelib-9.7-py310h04a57a7_1.tar.bz2
linux-aarch64::python-igraph-0.10.1-py38h80ccd69_1.tar.bz2
linux-aarch64::vtk-9.2.2-qt_py310h5b443d3_200.tar.bz2
linux-aarch64::mysql-client-8.0.31-h1208568_0.tar.bz2
linux-aarch64::curl-7.85.0-h22f3f83_0.tar.bz2
linux-aarch64::arrow-cpp-8.0.1-py39h9bfba9e_5_cpu.tar.bz2
linux-aarch64::mysql-server-8.0.31-h6ab4b8c_0.tar.bz2
linux-aarch64::vowpalwabbit-9.4.0-py39h9c61910_0.tar.bz2
linux-aarch64::sqlite-3.39.4-h69ca7e5_0.tar.bz2
linux-aarch64::librdkafka-1.9.2-hcd1f046_1.tar.bz2
linux-aarch64::r-git2r-0.30.1-r41he9c2a78_1.tar.bz2
linux-aarch64::symengine-0.9.0-h4e13e85_1.tar.bz2
linux-aarch64::qt6-main-6.4.0-h7a20051_1.tar.bz2
linux-aarch64::clangdev-15.0.2-default_ha7bf5e6_0.tar.bz2
linux-aarch64::sagelib-9.6-py38h7c2cf87_4.tar.bz2
linux-aarch64::aws-sdk-cpp-1.9.362-h3bddac7_0.tar.bz2
linux-aarch64::imagemagick-7.1.0_50-pl5321h1b60c45_0.tar.bz2
linux-aarch64::python-igraph-0.10.1-py38h21fcf9e_1.tar.bz2
linux-aarch64::openssh-9.1p1-h68e116c_0.tar.bz2
linux-aarch64::aws-sdk-cpp-1.9.359-h3bddac7_0.tar.bz2
linux-aarch64::libcurl-7.85.0-h8fd98b7_0.tar.bz2
linux-aarch64::ogre-next-2.3.1-hbad1a05_3.tar.bz2
linux-aarch64::nodejs-18.11.0-h928fb59_0.tar.bz2
linux-aarch64::python-igraph-0.10.1-py37hf66d210_1.tar.bz2
linux-aarch64::qt6-main-6.4.0-h7a20051_2.tar.bz2
linux-aarch64::aws-sdk-cpp-1.9.363-hf4a00b0_0.tar.bz2
linux-aarch64::sagelib-9.6-py39h82eec59_4.tar.bz2
linux-aarch64::libxml2-2.10.2-h249b6dd_2.tar.bz2
linux-aarch64::arrow-cpp-8.0.1-py39h46a8690_5_cuda.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py38h9326a07_7_cuda.tar.bz2
linux-aarch64::vowpalwabbit-9.4.0-py38hadc8d8a_0.tar.bz2
linux-aarch64::mongodb-6.0.2-h7d3f3b2_0.tar.bz2
linux-aarch64::aws-sdk-cpp-1.9.358-h2186c49_1.tar.bz2
linux-aarch64::glibmm-2.68-2.74.0-hf46034d_0.tar.bz2
linux-aarch64::librdkafka-1.9.2-h6fe9ebe_1.tar.bz2
linux-aarch64::vtk-9.2.2-qt_py38h05e3c73_200.tar.bz2
linux-aarch64::qt6-main-6.4.0-h7a20051_0.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py37h4656362_7_cpu.tar.bz2
linux-aarch64::openssh-9.1p1-h0f47c37_0.tar.bz2
linux-aarch64::vtk-9.2.2-qt_py37hf87f55a_200.tar.bz2
linux-aarch64::sagelib-9.7-py39h82eec59_0.tar.bz2
linux-aarch64::python-igraph-0.10.1-py39h5f24fa8_1.tar.bz2
linux-aarch64::mysql-connector-odbc-8.0.31-h7866ba4_0.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py38ha9aaf46_7_cpu.tar.bz2
linux-aarch64::arrow-cpp-8.0.1-py38h9326a07_5_cuda.tar.bz2
linux-aarch64::git-2.38.0-pl5321hbb15e16_0.tar.bz2
linux-aarch64::libsoup-3.2.1-he354691_0.tar.bz2
linux-aarch64::sagelib-9.6-py37hcc5023c_4.tar.bz2
linux-aarch64::arrow-cpp-7.0.1-py37h035fc10_5_cpu.tar.bz2
linux-aarch64::sagelib-9.7-py38h7c2cf87_1.tar.bz2
linux-aarch64::vtk-9.2.2-qt_py39h0419119_200.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py37h68fff1d_7_cuda.tar.bz2
linux-aarch64::arrow-cpp-7.0.1-py39h88819a2_5_cpu.tar.bz2
linux-aarch64::r-git2r-0.30.1-r42he9c2a78_1.tar.bz2
linux-aarch64::mysql-libs-8.0.31-h913e832_0.tar.bz2
linux-aarch64::git-2.38.0-pl5321h6429092_0.tar.bz2
linux-aarch64::mysql-router-8.0.31-h75ef108_0.tar.bz2
linux-aarch64::arrow-cpp-6.0.2-py39h0b94853_4_cpu.tar.bz2
linux-aarch64::arrow-cpp-8.0.1-py310h0768ad5_5_cpu.tar.bz2
linux-aarch64::r-base-4.2.1-ha0ad6db_2.tar.bz2
linux-aarch64::arrow-cpp-6.0.2-py38h1928210_4_cpu.tar.bz2
linux-aarch64::arrow-cpp-6.0.2-py37ha148d62_4_cpu.tar.bz2
linux-aarch64::arrow-cpp-8.0.1-py38ha9aaf46_5_cpu.tar.bz2
linux-aarch64::libcurl-static-7.85.0-h8fd98b7_0.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py310h32d1995_7_cuda.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py310h0768ad5_7_cpu.tar.bz2
linux-aarch64::mongodb-6.0.2-hedbcfdd_0.tar.bz2
linux-aarch64::pcre2-static-10.40-he7b27c6_0.tar.bz2
linux-aarch64::sagelib-9.6-py310h04a57a7_4.tar.bz2
linux-aarch64::aws-sdk-cpp-1.9.358-h51e1be9_0.tar.bz2
linux-aarch64::llvmdev-15.0.2-h71eeefc_0.tar.bz2
linux-aarch64::aws-sdk-cpp-1.9.358-h3bddac7_2.tar.bz2
linux-aarch64::r-base-4.1.3-h6c2366f_3.tar.bz2
linux-aarch64::mysql-server-8.0.31-h400928d_0.tar.bz2
linux-aarch64::aws-sdk-cpp-1.9.361-h3bddac7_0.tar.bz2
linux-aarch64::curl-7.85.0-h8fd98b7_0.tar.bz2
linux-aarch64::aws-sdk-cpp-1.9.362-hf4a00b0_1.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py39h46a8690_7_cuda.tar.bz2
linux-aarch64::arrow-cpp-7.0.1-py38h1ba7452_5_cpu.tar.bz2
linux-aarch64::arrow-cpp-6.0.2-py310ha1b8013_4_cpu.tar.bz2
linux-aarch64::arrow-cpp-7.0.1-py310h5b76d4b_5_cpu.tar.bz2
linux-aarch64::python-igraph-0.10.1-py310h7b07d77_1.tar.bz2
linux-aarch64::mysql-libs-8.0.31-h8735f6a_0.tar.bz2
linux-aarch64::giac-1.9.0.21-h8f6a60c_0.tar.bz2
linux-aarch64::sagelib-9.7-py38h7c2cf87_0.tar.bz2
linux-aarch64::python-igraph-0.10.1-py39hf062d6d_1.tar.bz2
linux-aarch64::libcurl-7.85.0-h22f3f83_0.tar.bz2
linux-aarch64::r-git2r-0.30.1-r41he0eff8e_1.tar.bz2
linux-aarch64::vowpalwabbit-9.4.0-py37h92919c0_0.tar.bz2
linux-aarch64::sagelib-9.7-py39h82eec59_1.tar.bz2
linux-aarch64::nodejs-18.11.0-he850d6a_0.tar.bz2
linux-aarch64::vowpalwabbit-9.4.0-py310had33819_0.tar.bz2
linux-aarch64::r-git2r-0.30.1-r42he0eff8e_1.tar.bz2
linux-aarch64::libcurl-static-7.85.0-h22f3f83_0.tar.bz2
linux-aarch64::sagelib-9.7-py310h04a57a7_0.tar.bz2
-    "libzlib >=1.2.12,<1.3.0a0",
+    "libzlib >=1.2.12,<2.0.0a0",
linux-aarch64::imagecodecs-2022.9.26-py38h66b80f2_2.tar.bz2
linux-aarch64::arrow-cpp-6.0.2-py311hec3634c_6_cpu.tar.bz2
linux-aarch64::qt6-main-6.4.0-h7ab754d_5.tar.bz2
linux-aarch64::libadios2-2.8.3-mpi_openmpi_hdd0d253_4.tar.bz2
linux-aarch64::libxmlsec1-1.2.35-h5b443b6_0.tar.bz2
linux-aarch64::xrootd-5.5.1-py39hdffd329_1.tar.bz2
linux-aarch64::wxwidgets-3.2.1-py311hb505eec_1.tar.bz2
linux-aarch64::xrootd-5.5.1-py37he64f28a_0.tar.bz2
linux-aarch64::cpp-opentelemetry-sdk-1.6.1-h728f511_1.tar.bz2
linux-aarch64::root_base-6.26.8-py39h6929db7_1.tar.bz2
linux-aarch64::netcdf4-1.6.1-mpi_openmpi_py38hc71dbc1_1.tar.bz2
linux-aarch64::xrootd-5.5.1-py310h2ab1d73_1.tar.bz2
linux-aarch64::clangdev-15.0.3-default_ha7bf5e6_0.tar.bz2
linux-aarch64::aws-sdk-cpp-1.9.364-hf4a00b0_0.tar.bz2
linux-aarch64::curl-7.86.0-h8fd98b7_0.tar.bz2
linux-aarch64::pyhdf-0.10.5-py39h0479546_1.tar.bz2
linux-aarch64::arrow-cpp-8.0.1-py39ha4f4325_7_cuda.tar.bz2
linux-aarch64::nordugrid-arc-6.16.1-py38h60333e4_1.tar.bz2
linux-aarch64::xrootd-5.5.1-py39hcc239b0_0.tar.bz2
linux-aarch64::pillow-9.2.0-py38h29cb35a_3.tar.bz2
linux-aarch64::xrootd-5.5.1-py38h14220bf_0.tar.bz2
linux-aarch64::xrootd-5.5.0-py310h286b669_0.tar.bz2
linux-aarch64::arrow-cpp-6.0.2-py38h058a7fb_6_cpu.tar.bz2
linux-aarch64::aws-sdk-cpp-1.9.371-he5a3c52_0.tar.bz2
linux-aarch64::postgresql-plpython-14.5-py39hce544f0_1.tar.bz2
linux-aarch64::root_base-6.26.8-py39h377c755_1.tar.bz2
linux-aarch64::libcurl-7.86.0-h22f3f83_0.tar.bz2
linux-aarch64::arrow-cpp-8.0.1-py38h18143df_7_cuda.tar.bz2
linux-aarch64::openjdk-17.0.3-h5ee6981_4.tar.bz2
linux-aarch64::xrootd-5.5.1-py39h6b94427_0.tar.bz2
linux-aarch64::vtk-9.2.2-qt_py37hcb58371_203.tar.bz2
linux-aarch64::xrootd-5.5.1-py37hff6604c_0.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py38h9326a07_8_cuda.tar.bz2
linux-aarch64::libcurl-static-7.86.0-h22f3f83_0.tar.bz2
linux-aarch64::vtk-9.2.2-qt_py37h7bade05_201.tar.bz2
linux-aarch64::aws-sdk-cpp-1.8.186-h69c4eb0_4.tar.bz2
linux-aarch64::xrootd-5.5.1-py38h2e6e18d_0.tar.bz2
linux-aarch64::aws-sdk-cpp-1.9.373-he5a3c52_0.tar.bz2
linux-aarch64::pyhdf-0.10.5-py310h1036232_1.tar.bz2
linux-aarch64::ffmpeg-4.4.2-lgpl_hfb0143a_10.tar.bz2
linux-aarch64::xrootd-5.5.0-py38hbcbad04_0.tar.bz2
linux-aarch64::python-igraph-0.10.2-py39h5f24fa8_0.tar.bz2
linux-aarch64::libxslt-1.1.35-ha895ef9_1.tar.bz2
linux-aarch64::nordugrid-arc-6.16.1-py39hb0bd8df_1.tar.bz2
linux-aarch64::xrootd-5.5.1-py38h7ead08f_1.tar.bz2
linux-aarch64::poppler-22.10.0-h054b39a_0.tar.bz2
linux-aarch64::nodejs-14.20.1-h63f6986_1.tar.bz2
linux-aarch64::gct-6.2.1629922860-h19ae8ab_2.tar.bz2
linux-aarch64::vowpalwabbit-9.5.0-py38hadc8d8a_1.tar.bz2
linux-aarch64::glib-2.74.1-h7866ba4_0.tar.bz2
linux-aarch64::aws-sdk-cpp-1.9.370-h4cbfff6_2.tar.bz2
linux-aarch64::mysql-connector-python-8.0.31-py39he97ccc9_1.tar.bz2
linux-aarch64::postgresql-plpython-14.5-py310h729c7dc_1.tar.bz2
linux-aarch64::libopencv-4.6.0-py39h911383a_6.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py311h373dd21_9_cuda.tar.bz2
linux-aarch64::xrootd-5.5.0-py38h2e6e18d_0.tar.bz2
linux-aarch64::git-2.38.1-pl5321h6429092_0.tar.bz2
linux-aarch64::aws-sdk-cpp-1.9.370-he5a3c52_2.tar.bz2
linux-aarch64::libadios2-2.8.3-nompi_he861502_104.tar.bz2
linux-aarch64::libglib-2.74.1-h58953e2_0.tar.bz2
linux-aarch64::libnetcdf-4.9.0-mpi_mpich_h57f4698_2.tar.bz2
linux-aarch64::mysql-connector-python-8.0.30-py39h340ce64_1.tar.bz2
linux-aarch64::arrow-cpp-8.0.1-py39hd844c3b_7_cpu.tar.bz2
linux-aarch64::pypy3.9-7.3.9-hd21bb22_5.tar.bz2
linux-aarch64::root_base-6.26.8-py310hfbd43d7_1.tar.bz2
linux-aarch64::libxml2-2.10.3-h249b6dd_0.tar.bz2
linux-aarch64::libnetcdf-4.9.0-nompi_h3c184e0_101.tar.bz2
linux-aarch64::pyhdf-0.10.5-py38h382523e_1.tar.bz2
linux-aarch64::vtk-9.2.2-qt_py39hc62e5ed_201.tar.bz2
linux-aarch64::libpq-14.5-h9bd3da0_1.tar.bz2
linux-aarch64::mysql-connector-python-8.0.31-py310hf40e0e8_1.tar.bz2
linux-aarch64::ogre-13.4.4-hfd22afb_1.tar.bz2
linux-aarch64::vtk-9.2.2-qt_py310h5d60328_201.tar.bz2
linux-aarch64::lxml-4.9.1-py38hb3d293b_1.tar.bz2
linux-aarch64::aws-sdk-cpp-1.9.374-h4cbfff6_0.tar.bz2
linux-aarch64::imagecodecs-2022.9.26-py39hd0e7d1a_2.tar.bz2
linux-aarch64::arrow-cpp-8.0.1-py311h61979a1_6_cuda.tar.bz2
linux-aarch64::libadios2-2.8.3-mpi_openmpi_hd7ef823_4.tar.bz2
linux-aarch64::postgresql-13.8-h8376ac0_0.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py39ha4f4325_9_cuda.tar.bz2
linux-aarch64::llvmdev-15.0.3-hd950eb9_1.tar.bz2
linux-aarch64::python-igraph-0.10.2-py310h11ca2a4_1.tar.bz2
linux-aarch64::python-igraph-0.10.2-py38h0137088_1.tar.bz2
linux-aarch64::libnetcdf-4.8.1-mpi_openmpi_h318df00_5.tar.bz2
linux-aarch64::leptonica-1.82.0-hfacd571_2.tar.bz2
linux-aarch64::davix-0.8.3-he1a556a_0.tar.bz2
linux-aarch64::pyreadstat-1.2.0-py39hca51b09_0.tar.bz2
linux-aarch64::xrootd-5.5.1-py38h9b932bc_2.tar.bz2
linux-aarch64::voms-2.1.0rc0-h5bc9c79_7.tar.bz2
linux-aarch64::vowpalwabbit-9.5.0-py39h9c61910_0.tar.bz2
linux-aarch64::libadios2-2.8.3-nompi_h6617583_104.tar.bz2
linux-aarch64::ffmpeg-5.1.2-gpl_h43c0eeb_102.tar.bz2
linux-aarch64::yoda-1.9.6-py38h53e7d53_2.tar.bz2
linux-aarch64::mysql-connector-python-8.0.31-py310hf40e0e8_2.tar.bz2
linux-aarch64::libpq-13.8-h9bd3da0_0.tar.bz2
linux-aarch64::ffmpeg-4.4.2-lgpl_h16ca9de_9.tar.bz2
linux-aarch64::libopencv-4.6.0-py38h58c7249_5.tar.bz2
linux-aarch64::pygrib-2.1.4-py310h19f8b5f_6.tar.bz2
linux-aarch64::root_base-6.26.8-py311h4fb8e53_1.tar.bz2
linux-aarch64::nordugrid-arc-6.16.0-py310h5791aa7_0.tar.bz2
linux-aarch64::vtk-9.2.2-qt_py38h8ac3a4e_204.tar.bz2
linux-aarch64::libopencv-4.6.0-py38h58c7249_6.tar.bz2
linux-aarch64::rsync-3.2.7-hc02733c_0.tar.bz2
linux-aarch64::arrow-cpp-8.0.1-py311h50142af_6_cpu.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py311hba36607_10_cpu.tar.bz2
linux-aarch64::xrootd-5.5.1-py39ha3660a7_2.tar.bz2
linux-aarch64::postgresql-plpython-13.8-py311h9aad48d_0.tar.bz2
linux-aarch64::libadios2-2.8.3-mpi_mpich_h4d57059_4.tar.bz2
linux-aarch64::vtk-9.2.2-qt_py38h556b559_201.tar.bz2
linux-aarch64::vtk-9.2.2-qt_py310h77917dc_203.tar.bz2
linux-aarch64::aws-sdk-cpp-1.9.370-hbca3711_0.tar.bz2
linux-aarch64::ldas-tools-framecpp-2.9.1-h8946d71_1.tar.bz2
linux-aarch64::pygrib-2.1.4-py38h2ab8e5a_6.tar.bz2
linux-aarch64::libnetcdf-4.9.0-nompi_h3c184e0_102.tar.bz2
linux-aarch64::mapserver-8.0.0-py38haaab9ec_1.tar.bz2
linux-aarch64::pygrib-2.1.4-py311h18780b5_6.tar.bz2
linux-aarch64::libpq-13.8-h2856e3f_0.tar.bz2
linux-aarch64::imagecodecs-2022.9.26-py39hcfdcb4a_2.tar.bz2
linux-aarch64::openjdk-17.0.3-h44ed822_3.tar.bz2
linux-aarch64::imagecodecs-2022.9.26-py38hefe985b_1.tar.bz2
linux-aarch64::libopencv-4.6.0-py310h7b04e73_5.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py39h46a8690_8_cuda.tar.bz2
linux-aarch64::pygrib-2.1.4-py39hbcd7896_6.tar.bz2
linux-aarch64::imagecodecs-2022.9.26-py38h95be06f_1.tar.bz2
linux-aarch64::nordugrid-arc-6.16.0-py37hb8eaef1_0.tar.bz2
linux-aarch64::nordugrid-arc-6.16.1-py310h07a9f05_0.tar.bz2
linux-aarch64::xrootd-5.5.1-py38hbcbad04_0.tar.bz2
linux-aarch64::arrow-cpp-8.0.1-py310h7cd4428_7_cpu.tar.bz2
linux-aarch64::pytables-3.7.0-py39h1e0361d_3.tar.bz2
linux-aarch64::nordugrid-arc-6.16.1-py39hb0bd8df_0.tar.bz2
linux-aarch64::nordugrid-arc-6.16.1-py38hd36240b_0.tar.bz2
linux-aarch64::xrootd-5.5.1-py39h40fcea2_0.tar.bz2
linux-aarch64::libadios2-2.8.3-mpi_openmpi_hb0811bc_4.tar.bz2
linux-aarch64::libadios2-2.8.3-mpi_mpich_h00c07c3_4.tar.bz2
linux-aarch64::vowpalwabbit-9.5.0-py38hadc8d8a_0.tar.bz2
linux-aarch64::libopencv-4.6.0-py311h270816b_6.tar.bz2
linux-aarch64::arrow-cpp-7.0.1-py310h5b76d4b_6_cpu.tar.bz2
linux-aarch64::mysql-connector-python-8.0.31-py39h340ce64_2.tar.bz2
linux-aarch64::xrootd-5.5.1-py39haf604e9_0.tar.bz2
linux-aarch64::pypy3.9-7.3.9-h58ba33a_5.tar.bz2
linux-aarch64::netcdf4-1.6.1-mpi_openmpi_py311heb9d168_1.tar.bz2
linux-aarch64::pyinstaller-5.1-py39h1a16a0b_1.tar.bz2
linux-aarch64::pyreadstat-1.2.0-py311hce9d1d9_1.tar.bz2
linux-aarch64::xrootd-5.5.1-py310hd9143e0_2.tar.bz2
linux-aarch64::davix-0.8.3-h8c3218f_1.tar.bz2
linux-aarch64::qt6-main-6.4.0-h7a20051_3.tar.bz2
linux-aarch64::qt-main-5.15.6-h77580c3_1.tar.bz2
linux-aarch64::python-igraph-0.10.2-py310h7b07d77_0.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py38h18143df_9_cuda.tar.bz2
linux-aarch64::postgresql-plpython-13.8-py311h68c29d4_0.tar.bz2
linux-aarch64::pillow-9.2.0-py310hd6d4ca1_3.tar.bz2
linux-aarch64::libopencv-4.6.0-py310h7b04e73_6.tar.bz2
linux-aarch64::xrootd-5.5.1-py310h286b669_0.tar.bz2
linux-aarch64::mlir-15.0.2-h5ca471e_0.tar.bz2
linux-aarch64::mysql-connector-python-8.0.31-py39he97ccc9_2.tar.bz2
linux-aarch64::xrootd-5.5.1-py39h6b94427_1.tar.bz2
linux-aarch64::python-igraph-0.10.2-py37hf66d210_0.tar.bz2
linux-aarch64::ogre-1.10.12-h3ade7c8_10.tar.bz2
linux-aarch64::aws-sdk-cpp-1.9.372-h4cbfff6_0.tar.bz2
linux-aarch64::tiledb-2.11.3-h6866cf4_1.tar.bz2
linux-aarch64::postgresql-plpython-14.5-py39habe12e2_1.tar.bz2
linux-aarch64::grpc-cpp-1.45.2-hcc7b95b_7.tar.bz2
linux-aarch64::xrootd-5.5.1-py38h9b932bc_0.tar.bz2
linux-aarch64::openbabel-3.1.1-py310h47cfdb9_5.tar.bz2
linux-aarch64::grpc-cpp-1.46.4-h177ec6a_8.tar.bz2
linux-aarch64::xrootd-5.5.1-py39h9a6de4d_0.tar.bz2
linux-aarch64::pypy3.8-7.3.9-hde6385c_5.tar.bz2
linux-aarch64::arrow-cpp-8.0.1-py38ha9aaf46_6_cpu.tar.bz2
linux-aarch64::openjdk-11.0.15-h44ed822_3.tar.bz2
linux-aarch64::libgdal-3.5.2-he0bab8c_4.tar.bz2
linux-aarch64::libnetcdf-4.9.0-mpi_mpich_h57f4698_1.tar.bz2
linux-aarch64::root_base-6.26.8-py37h3c36b75_1.tar.bz2
linux-aarch64::libnetcdf-4.9.0-mpi_openmpi_h9d9cef3_2.tar.bz2
linux-aarch64::vtk-9.2.2-qt_py39hb0fc2ed_204.tar.bz2
linux-aarch64::llvmlite-0.39.1-py310h773edab_1.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py311hf795ac8_10_cuda.tar.bz2
linux-aarch64::python-igraph-0.10.2-py39h9a26dc9_1.tar.bz2
linux-aarch64::gct-6.2.1629922860-haa01bc1_2.tar.bz2
linux-aarch64::curl-7.86.0-h22f3f83_0.tar.bz2
linux-aarch64::postgresql-plpython-13.8-py310h913e3d5_0.tar.bz2
linux-aarch64::arrow-cpp-7.0.1-py39h875ca75_8_cpu.tar.bz2
linux-aarch64::root_base-6.26.8-py311h9007e07_1.tar.bz2
linux-aarch64::root_base-6.26.8-py38h1848f7a_1.tar.bz2
linux-aarch64::xrootd-5.5.1-py38h9b932bc_1.tar.bz2
linux-aarch64::llvmlite-0.39.1-py39hbbff7ca_1.tar.bz2
linux-aarch64::postgresql-plpython-14.5-py310h913e3d5_1.tar.bz2
linux-aarch64::arrow-cpp-8.0.1-py39h9bfba9e_6_cpu.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py39h80fe8dd_10_cpu.tar.bz2
linux-aarch64::mysql-connector-python-8.0.31-py37h97b4959_1.tar.bz2
linux-aarch64::qt6-main-6.4.0-h7a82f11_4.tar.bz2
linux-aarch64::postgresql-plpython-14.5-py311h68c29d4_1.tar.bz2
linux-aarch64::postgresql-13.8-hc0ee1c8_0.tar.bz2
linux-aarch64::arrow-cpp-7.0.1-py39h88819a2_6_cpu.tar.bz2
linux-aarch64::grpc-cpp-1.48.1-h2efb554_2.tar.bz2
linux-aarch64::llvmlite-0.39.1-py38hd14ccfc_1.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py311h61979a1_8_cuda.tar.bz2
linux-aarch64::ffmpeg-4.4.2-gpl_h43c0eeb_109.tar.bz2
linux-aarch64::mysql-connector-python-8.0.31-py38h961032d_1.tar.bz2
linux-aarch64::mysql-connector-python-8.0.31-py311hbb75c3c_2.tar.bz2
linux-aarch64::aws-sdk-cpp-1.9.366-hf4a00b0_0.tar.bz2
linux-aarch64::netcdf4-1.6.1-mpi_mpich_py310h4e70317_1.tar.bz2
linux-aarch64::libadios2-2.8.3-mpi_mpich_h88cd251_4.tar.bz2
linux-aarch64::postgresql-14.5-h8376ac0_1.tar.bz2
linux-aarch64::imagecodecs-2022.9.26-py39hcfdcb4a_3.tar.bz2
linux-aarch64::pyinstaller-5.1-py38hbe4f9ff_1.tar.bz2
linux-aarch64::vtk-9.2.2-qt_py310h77917dc_204.tar.bz2
linux-aarch64::pytables-3.7.0-py39h0c94539_3.tar.bz2
linux-aarch64::imagecodecs-2022.9.26-py39hd0e7d1a_3.tar.bz2
linux-aarch64::xrootd-5.5.1-py37hb7847dc_1.tar.bz2
linux-aarch64::root_base-6.26.8-py37h91c2578_1.tar.bz2
linux-aarch64::libopencv-4.6.0-py38h04a8b0f_5.tar.bz2
linux-aarch64::nordugrid-arc-6.16.0-py39hc305b87_0.tar.bz2
linux-aarch64::grpc-cpp-1.46.4-h2efb554_8.tar.bz2
linux-aarch64::xrootd-5.5.1-py38h14220bf_2.tar.bz2
linux-aarch64::libopencv-4.6.0-py39h911383a_5.tar.bz2
linux-aarch64::arrow-cpp-7.0.1-py311heed03a5_7_cpu.tar.bz2
linux-aarch64::python-3.11.0-h023d47c_0_cpython.tar.bz2
linux-aarch64::imagecodecs-2022.9.26-py310h4acf4a0_1.tar.bz2
linux-aarch64::pillow-9.2.0-py311hce299d0_3.tar.bz2
linux-aarch64::llvmdev-11.1.0-hb2805f8_5.tar.bz2
linux-aarch64::pyreadstat-1.2.0-py310hceb02de_0.tar.bz2
linux-aarch64::yoda-1.9.6-py310he9b6ae9_2.tar.bz2
linux-aarch64::aws-sdk-cpp-1.9.371-h4cbfff6_0.tar.bz2
linux-aarch64::rsync-3.2.7-h6fa9c02_0.tar.bz2
linux-aarch64::mysql-connector-python-8.0.31-py39h340ce64_1.tar.bz2
linux-aarch64::pyreadstat-1.2.0-py310hceb02de_1.tar.bz2
linux-aarch64::xrootd-5.5.1-py38h14220bf_1.tar.bz2
linux-aarch64::cpp-opentelemetry-sdk-1.7.0-h9206765_0.tar.bz2
linux-aarch64::imagecodecs-2022.9.26-py310hd246ef8_2.tar.bz2
linux-aarch64::davix-0.8.3-hba07a7e_1.tar.bz2
linux-aarch64::poppler-qt-22.10.0-haf01173_0.tar.bz2
linux-aarch64::arrow-cpp-7.0.1-py311hb5cd4ee_8_cpu.tar.bz2
linux-aarch64::pytables-3.7.0-py38h2d20418_3.tar.bz2
linux-aarch64::python-igraph-0.10.2-py311h8f13d06_1.tar.bz2
linux-aarch64::netcdf4-1.6.1-nompi_py39h39d185c_101.tar.bz2
linux-aarch64::imagecodecs-2022.9.26-py39hf671d82_1.tar.bz2
linux-aarch64::arrow-cpp-8.0.1-py39h46a8690_6_cuda.tar.bz2
linux-aarch64::netcdf4-1.6.1-mpi_mpich_py38h2f7f385_1.tar.bz2
linux-aarch64::postgresql-plpython-13.8-py310h729c7dc_0.tar.bz2
linux-aarch64::libtiledb-sql-0.19.0-hf7c5151_0.tar.bz2
linux-aarch64::mysql-connector-python-8.0.30-py310hf40e0e8_1.tar.bz2
linux-aarch64::python-igraph-0.10.2-py39hf062d6d_0.tar.bz2
linux-aarch64::root_base-6.26.8-py38h60827db_1.tar.bz2
linux-aarch64::arrow-cpp-6.0.2-py311hf2883d4_5_cpu.tar.bz2
linux-aarch64::xrootd-5.5.1-py38h7ead08f_2.tar.bz2
linux-aarch64::vtk-9.2.2-qt_py39hc62e5ed_202.tar.bz2
linux-aarch64::arrow-cpp-7.0.1-py310hd5d2859_8_cpu.tar.bz2
linux-aarch64::nordugrid-arc-6.16.1-py38hd36240b_1.tar.bz2
linux-aarch64::netcdf4-1.6.1-nompi_py310hf0beae2_101.tar.bz2
linux-aarch64::libnetcdf-4.8.1-mpi_mpich_hffd9398_5.tar.bz2
linux-aarch64::arrow-cpp-7.0.1-py39h711406c_7_cpu.tar.bz2
linux-aarch64::llvmlite-0.39.1-py39ha5d8a0d_1.tar.bz2
linux-aarch64::mapserver-8.0.0-py310h070e036_1.tar.bz2
linux-aarch64::pillow-9.2.0-py39hd8e725c_3.tar.bz2
linux-aarch64::pyinstaller-5.1-py310h9164b14_1.tar.bz2
linux-aarch64::libgdal-3.5.2-hb4c7a9f_4.tar.bz2
linux-aarch64::tiledb-2.12.0-h354e0e1_1.tar.bz2
linux-aarch64::imagecodecs-2022.9.26-py311h10da06c_3.tar.bz2
linux-aarch64::xrootd-5.5.0-py37he64f28a_0.tar.bz2
linux-aarch64::libadios2-2.8.3-nompi_hdf73317_104.tar.bz2
linux-aarch64::pygrib-2.1.4-py39hd578c3f_6.tar.bz2
linux-aarch64::aws-sdk-cpp-1.9.374-he5a3c52_0.tar.bz2
linux-aarch64::lxml-4.9.1-py310h141c14b_1.tar.bz2
linux-aarch64::imagecodecs-2022.9.26-py310hd246ef8_1.tar.bz2
linux-aarch64::voms-2.1.0rc2-h5bc9c79_7.tar.bz2
linux-aarch64::arrow-cpp-6.0.2-py38h1928210_5_cpu.tar.bz2
linux-aarch64::vtk-9.2.2-qt_py38h556b559_202.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py39h9bfba9e_8_cpu.tar.bz2
linux-aarch64::libvips-8.13.2-h3876494_0.tar.bz2
linux-aarch64::vtk-9.2.2-qt_py38h8ac3a4e_203.tar.bz2
linux-aarch64::xrootd-5.5.1-py39h40fcea2_1.tar.bz2
linux-aarch64::mlir-15.0.1-h5ca471e_0.tar.bz2
linux-aarch64::xrootd-5.5.1-py39h40fcea2_2.tar.bz2
linux-aarch64::libnetcdf-4.8.1-mpi_openmpi_h318df00_6.tar.bz2
linux-aarch64::vtk-9.2.2-qt_py311h76a9c4b_204.tar.bz2
linux-aarch64::libnetcdf-4.9.0-mpi_openmpi_h9d9cef3_1.tar.bz2
linux-aarch64::ffmpeg-4.4.2-gpl_hdfc3963_110.tar.bz2
linux-aarch64::llvmdev-15.0.3-h71eeefc_0.tar.bz2
linux-aarch64::xrootd-5.5.0-py37hff6604c_0.tar.bz2
linux-aarch64::aws-sdk-cpp-1.9.368-hf4a00b0_0.tar.bz2
linux-aarch64::arrow-cpp-7.0.1-py38h1ba7452_6_cpu.tar.bz2
linux-aarch64::vowpalwabbit-9.5.0-py311h3e7a247_1.tar.bz2
linux-aarch64::netcdf4-1.6.1-nompi_py38he0ac5db_101.tar.bz2
linux-aarch64::plumed-2.8.1-mpi_mpich_h4eea40a_0.tar.bz2
linux-aarch64::imagecodecs-2022.9.26-py39h36aa2f6_1.tar.bz2
linux-aarch64::root_base-6.26.8-py38hacd3f1f_0.tar.bz2
linux-aarch64::libadios2-2.8.3-mpi_openmpi_hf1e1458_4.tar.bz2
linux-aarch64::arrow-cpp-8.0.1-py38h9326a07_6_cuda.tar.bz2
linux-aarch64::pyhdf-0.10.5-py39h5001059_1.tar.bz2
linux-aarch64::xrootd-5.5.0-py38hb5711a5_0.tar.bz2
linux-aarch64::aws-sdk-cpp-1.9.365-hf4a00b0_0.tar.bz2
linux-aarch64::arrow-cpp-6.0.2-py310ha1b8013_5_cpu.tar.bz2
linux-aarch64::netcdf4-1.6.1-mpi_mpich_py39hd38e795_1.tar.bz2
linux-aarch64::mapserver-8.0.0-py37hfbe13a1_1.tar.bz2
linux-aarch64::xrootd-5.5.0-py39h1d44ce8_0.tar.bz2
linux-aarch64::grpc-cpp-1.47.1-h177ec6a_7.tar.bz2
linux-aarch64::xrootd-5.5.1-py310h9cd7803_0.tar.bz2
linux-aarch64::libgrpc-1.49.1-h177ec6a_1.tar.bz2
linux-aarch64::libcurl-static-7.86.0-h8fd98b7_0.tar.bz2
linux-aarch64::mysql-connector-python-8.0.31-py38h961032d_2.tar.bz2
linux-aarch64::xrootd-5.5.1-py38hdc7c1d9_1.tar.bz2
linux-aarch64::postgresql-plpython-13.8-py39habe12e2_0.tar.bz2
linux-aarch64::libadios2-2.8.3-mpi_mpich_hcf2b225_4.tar.bz2
linux-aarch64::xrootd-5.5.1-py39hdffd329_0.tar.bz2
linux-aarch64::grpc-cpp-1.45.2-h19938a8_7.tar.bz2
linux-aarch64::postgresql-plpython-13.8-py38h9b0c8fe_0.tar.bz2
linux-aarch64::pyreadstat-1.2.0-py38h1368025_1.tar.bz2
linux-aarch64::postgresql-plpython-14.5-py38hf732e25_1.tar.bz2
linux-aarch64::libopencv-4.6.0-py39h739b805_5.tar.bz2
linux-aarch64::netcdf4-1.6.1-mpi_mpich_py311h3377fe7_1.tar.bz2
linux-aarch64::arrow-cpp-8.0.1-py310hfd5d9b5_7_cuda.tar.bz2
linux-aarch64::libgdal-3.5.2-hd05fd4e_5.tar.bz2
linux-aarch64::xrootd-5.5.1-py37hf280c88_0.tar.bz2
linux-aarch64::ffmpeg-5.1.2-lgpl_hfb0143a_3.tar.bz2
linux-aarch64::postgresql-plpython-14.5-py38h9b0c8fe_1.tar.bz2
linux-aarch64::postgresql-plpython-13.8-py39hce544f0_0.tar.bz2
linux-aarch64::git-2.38.1-pl5321hbb15e16_0.tar.bz2
linux-aarch64::xrootd-5.5.1-py310hd9143e0_1.tar.bz2
linux-aarch64::libgrpc-1.49.1-h2efb554_1.tar.bz2
linux-aarch64::xrootd-5.5.1-py39h6b94427_2.tar.bz2
linux-aarch64::cppyy-cling-6.27.0-py310h4eb0b0e_2.tar.bz2
linux-aarch64::imagecodecs-2022.9.26-py38h66b80f2_3.tar.bz2
linux-aarch64::arrow-cpp-6.0.2-py310hfa61d2d_6_cpu.tar.bz2
linux-aarch64::mysql-connector-python-8.0.31-py38h3409c5b_1.tar.bz2
linux-aarch64::llvmlite-0.39.1-py38hb3e7a48_1.tar.bz2
linux-aarch64::pytables-3.7.0-py310h70c8ff7_3.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py310h0768ad5_8_cpu.tar.bz2
linux-aarch64::pyreadstat-1.2.0-py37ha3a0a47_0.tar.bz2
linux-aarch64::xrootd-5.5.0-py39h9a6de4d_0.tar.bz2
linux-aarch64::libadios2-2.8.3-nompi_hcee1620_104.tar.bz2
linux-aarch64::nordugrid-arc-6.16.1-py310ha5aa5c6_1.tar.bz2
linux-aarch64::imagecodecs-2022.9.26-py310hd246ef8_3.tar.bz2
linux-aarch64::libgdal-3.5.2-h284fc38_5.tar.bz2
linux-aarch64::cppyy-cling-6.27.0-py311h142830e_2.tar.bz2
linux-aarch64::imagecodecs-2022.9.26-py38h66b80f2_1.tar.bz2
linux-aarch64::ogre-1.12.13-he6accff_3.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py38ha9aaf46_8_cpu.tar.bz2
linux-aarch64::pygrib-2.1.4-py38h127fb92_6.tar.bz2
linux-aarch64::nordugrid-arc-6.16.1-py310h07a9f05_1.tar.bz2
linux-aarch64::pyhdf-0.10.5-py311h05b6ecb_1.tar.bz2
linux-aarch64::arrow-cpp-8.0.1-py310h32d1995_6_cuda.tar.bz2
linux-aarch64::libpq-14.5-h2856e3f_1.tar.bz2
linux-aarch64::xrootd-5.5.0-py38hc1158d8_0.tar.bz2
linux-aarch64::arrow-cpp-6.0.2-py39h0b94853_5_cpu.tar.bz2
linux-aarch64::xrootd-5.5.1-py38h7ead08f_0.tar.bz2
linux-aarch64::xrootd-5.5.1-py310h2ab1d73_2.tar.bz2
linux-aarch64::xrootd-5.5.0-py39haf604e9_0.tar.bz2
linux-aarch64::xrootd-5.5.1-py311h6454be2_2.tar.bz2
linux-aarch64::libxmlsec1-1.2.35-ha4f8685_1.tar.bz2
linux-aarch64::lxml-4.9.1-py311h81ddf15_1.tar.bz2
linux-aarch64::vtk-9.2.2-qt_py39hb0fc2ed_203.tar.bz2
linux-aarch64::pillow-9.2.0-py39h9711517_3.tar.bz2
linux-aarch64::root_base-6.26.8-py37he40313f_0.tar.bz2
linux-aarch64::ldas-tools-framecpp-2.9.1-hfef4142_1.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py310hfd5d9b5_9_cuda.tar.bz2
linux-aarch64::pyhdf-0.10.5-py38hdfe3ba0_1.tar.bz2
linux-aarch64::postgresql-plpython-14.5-py311h9aad48d_1.tar.bz2
linux-aarch64::lxml-4.9.1-py38hf0737e2_1.tar.bz2
linux-aarch64::mapserver-8.0.0-py39hb26e84c_1.tar.bz2
linux-aarch64::libxmlsec1-1.2.35-h5b443b6_1.tar.bz2
linux-aarch64::postgresql-plpython-13.8-py38hf732e25_0.tar.bz2
linux-aarch64::openbabel-3.1.1-py39h14f0dd9_5.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py310h32d1995_8_cuda.tar.bz2
linux-aarch64::xrootd-5.5.1-py310h2ab1d73_0.tar.bz2
linux-aarch64::openbabel-3.1.1-py38hf422781_5.tar.bz2
linux-aarch64::imagecodecs-2022.9.26-py39hcfdcb4a_1.tar.bz2
linux-aarch64::netcdf4-1.6.1-nompi_py311h44c63aa_101.tar.bz2
linux-aarch64::ffmpeg-5.1.2-lgpl_h16ca9de_2.tar.bz2
linux-aarch64::aws-sdk-cpp-1.9.369-hf4a00b0_0.tar.bz2
linux-aarch64::xrootd-5.5.1-py39ha3660a7_1.tar.bz2
linux-aarch64::root_base-6.26.8-py39hc9ad19f_0.tar.bz2
linux-aarch64::xrootd-5.5.1-py38hdc7c1d9_2.tar.bz2
linux-aarch64::arrow-cpp-7.0.1-py310hbf595e2_7_cpu.tar.bz2
linux-aarch64::xrootd-5.5.1-py38hc1158d8_0.tar.bz2
linux-aarch64::lxml-4.9.1-py39hac69777_1.tar.bz2
linux-aarch64::root_base-6.26.8-py310h57f7b6d_1.tar.bz2
linux-aarch64::xrootd-5.5.1-py310hd9143e0_0.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py38hf2b73b7_9_cpu.tar.bz2
linux-aarch64::netcdf4-1.6.1-mpi_openmpi_py310h2eb597f_1.tar.bz2
linux-aarch64::libopencv-4.6.0-py38h04a8b0f_6.tar.bz2
linux-aarch64::yoda-1.9.6-py37h924a801_2.tar.bz2
linux-aarch64::xrootd-5.5.1-py39hdffd329_2.tar.bz2
linux-aarch64::vtk-9.2.2-qt_py310h5d60328_202.tar.bz2
linux-aarch64::cpp-opentelemetry-sdk-1.6.1-h9206765_2.tar.bz2
linux-aarch64::python-igraph-0.10.2-py39h9b6ca12_1.tar.bz2
linux-aarch64::vowpalwabbit-9.5.0-py39h9c61910_1.tar.bz2
linux-aarch64::yoda-1.9.6-py39hda3eeda_2.tar.bz2
linux-aarch64::qt-main-5.15.6-hbd5891e_2.tar.bz2
linux-aarch64::imagecodecs-2022.9.26-py38hefe985b_3.tar.bz2
linux-aarch64::python-igraph-0.10.2-py38h80ccd69_0.tar.bz2
linux-aarch64::cppyy-cling-6.27.0-py38h986aded_2.tar.bz2
linux-aarch64::xrootd-5.5.1-py39ha3660a7_0.tar.bz2
linux-aarch64::tiledb-2.12.0-h6866cf4_1.tar.bz2
linux-aarch64::mysql-connector-python-8.0.31-py38h3409c5b_2.tar.bz2
linux-aarch64::xrootd-5.5.1-py38hb5711a5_0.tar.bz2
linux-aarch64::xrootd-5.5.1-py37hb7847dc_0.tar.bz2
linux-aarch64::aws-sdk-cpp-1.9.367-hf4a00b0_0.tar.bz2
linux-aarch64::libopencv-4.6.0-py37h50d0c34_5.tar.bz2
linux-aarch64::ogre-1.12.13-h646418b_3.tar.bz2
linux-aarch64::mysql-connector-python-8.0.30-py38h3409c5b_1.tar.bz2
linux-aarch64::davix-0.8.3-hb7decff_0.tar.bz2
linux-aarch64::aws-sdk-cpp-1.9.370-he5a3c52_1.tar.bz2
linux-aarch64::xrootd-5.5.1-py39h1d44ce8_0.tar.bz2
linux-aarch64::imagecodecs-2022.9.26-py38h7dd9533_1.tar.bz2
linux-aarch64::python-3.11.0-h92ab765_0_cpython.tar.bz2
linux-aarch64::ffmpeg-5.1.2-gpl_hdfc3963_103.tar.bz2
linux-aarch64::xrootd-5.5.0-py310h9cd7803_0.tar.bz2
linux-aarch64::grpc-cpp-1.48.1-h177ec6a_2.tar.bz2
linux-aarch64::aws-sdk-cpp-1.9.369-hbca3711_1.tar.bz2
linux-aarch64::imagecodecs-2022.9.26-py39hd0e7d1a_1.tar.bz2
linux-aarch64::python-igraph-0.10.2-py38h166df3f_1.tar.bz2
linux-aarch64::libvips-8.13.1-h3876494_2.tar.bz2
linux-aarch64::plumed-2.8.1-mpi_openmpi_hcd80bc1_0.tar.bz2
linux-aarch64::vowpalwabbit-9.5.0-py310had33819_1.tar.bz2
linux-aarch64::arrow-cpp-7.0.1-py311hd1af3b9_6_cpu.tar.bz2
linux-aarch64::lxml-4.9.1-py39he7129ea_1.tar.bz2
linux-aarch64::nordugrid-arc-6.16.0-py38h251a840_0.tar.bz2
linux-aarch64::mlir-15.0.3-h5ca471e_0.tar.bz2
linux-aarch64::vowpalwabbit-9.5.0-py310had33819_0.tar.bz2
linux-aarch64::libcurl-7.86.0-h8fd98b7_0.tar.bz2
linux-aarch64::xrootd-5.5.1-py38hdc7c1d9_0.tar.bz2
linux-aarch64::pyreadstat-1.2.0-py38h1368025_0.tar.bz2
linux-aarch64::pillow-9.2.0-py38h95f636a_3.tar.bz2
linux-aarch64::netcdf4-1.6.1-mpi_openmpi_py39h41dcfb4_1.tar.bz2
linux-aarch64::xrootd-5.5.0-py39hcc239b0_0.tar.bz2
linux-aarch64::python-igraph-0.10.2-py38h21fcf9e_0.tar.bz2
linux-aarch64::arrow-cpp-7.0.1-py38h502e7a9_8_cpu.tar.bz2
linux-aarch64::aws-sdk-cpp-1.9.372-he5a3c52_0.tar.bz2
linux-aarch64::libopencv-4.6.0-py39h739b805_6.tar.bz2
linux-aarch64::hdf4-4.2.15-hb6731fe_5.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py311h50142af_8_cpu.tar.bz2
linux-aarch64::mysql-connector-python-8.0.30-py37h97b4959_1.tar.bz2
linux-aarch64::cppyy-cling-6.27.0-py39h20a37df_2.tar.bz2
linux-aarch64::pyreadstat-1.2.0-py39hca51b09_1.tar.bz2
linux-aarch64::root_base-6.26.8-py310hede064e_0.tar.bz2
linux-aarch64::pytables-3.7.0-py311h45d2fe7_3.tar.bz2
linux-aarch64::postgresql-14.5-hc0ee1c8_1.tar.bz2
linux-aarch64::vowpalwabbit-9.5.0-py37h92919c0_0.tar.bz2
linux-aarch64::arrow-cpp-6.0.2-py39h52ce7eb_6_cpu.tar.bz2
linux-aarch64::xrootd-5.5.1-py311hd021f51_2.tar.bz2
linux-aarch64::pypy3.8-7.3.9-h2623490_5.tar.bz2
linux-aarch64::libgdal-3.5.2-hd05fd4e_6.tar.bz2
linux-aarch64::grpc-cpp-1.47.1-h2efb554_7.tar.bz2
linux-aarch64::libtiledb-sql-0.19.0-h4327567_0.tar.bz2
linux-aarch64::aws-sdk-cpp-1.9.373-h4cbfff6_0.tar.bz2
linux-aarch64::xrootd-5.5.1-py37hf280c88_1.tar.bz2
linux-aarch64::ogre-13.4.4-hf4613d7_1.tar.bz2
linux-aarch64::libnetcdf-4.8.1-mpi_mpich_hffd9398_6.tar.bz2
linux-aarch64::voms-2.1.0rc2-hc93ca27_7.tar.bz2
linux-aarch64::arrow-cpp-7.0.1-py38h67cc968_7_cpu.tar.bz2
linux-aarch64::nodejs-14.20.1-h4df20a3_1.tar.bz2
linux-aarch64::leptonica-1.82.0-hfacd571_1.tar.bz2
linux-aarch64::imagecodecs-2022.9.26-py38hefe985b_2.tar.bz2
linux-aarch64::nordugrid-arc-6.16.1-py39h7a95e08_1.tar.bz2
linux-aarch64::tiledb-2.11.3-h354e0e1_1.tar.bz2
linux-aarch64::texlive-core-20210325-hafe3a60_5.tar.bz2
linux-aarch64::pytables-3.7.0-py38haa232e4_3.tar.bz2
linux-aarch64::openbabel-3.1.1-py311h4473814_5.tar.bz2
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
linux-aarch64::llvm-tools-15.0.2-h71eeefc_0.tar.bz2
linux-aarch64::libclang-15.0.2-default_ha7bf5e6_0.tar.bz2
linux-aarch64::libclang-cpp15-15.0.2-default_ha7bf5e6_0.tar.bz2
linux-aarch64::libprotobuf-static-3.21.7-h7866ba4_0.tar.bz2
linux-aarch64::libclang13-15.0.2-default_h3684801_0.tar.bz2
linux-aarch64::libprotobuf-3.21.7-h4dffa80_0.tar.bz2
linux-aarch64::llvm-15.0.2-h1426fca_0.tar.bz2
linux-aarch64::clang-format-15-15.0.2-default_ha7bf5e6_0.tar.bz2
linux-aarch64::gst-plugins-base-1.21.1-h9c4ba4c_0.tar.bz2
linux-aarch64::gst-plugins-good-1.21.1-h660f13c_0.tar.bz2
linux-aarch64::clang-format-15.0.2-default_ha7bf5e6_0.tar.bz2
linux-aarch64::libclang-cpp-15.0.2-default_ha7bf5e6_0.tar.bz2
linux-aarch64::libllvm15-15.0.2-h71eeefc_0.tar.bz2
linux-aarch64::pcre2-10.40-he7b27c6_0.tar.bz2
linux-aarch64::clang-tools-15.0.2-default_ha7bf5e6_0.tar.bz2
linux-aarch64::libsqlite-3.39.4-hf9034f9_0.tar.bz2
linux-aarch64::clang-15-15.0.2-default_ha7bf5e6_0.tar.bz2
linux-aarch64::liblal-7.2.4-fftw_he26ac06_100.tar.bz2
-    "libzlib >=1.2.12,<1.3.0a0"
+    "libzlib >=1.2.12,<2.0.0a0"
linux-aarch64::libclang13-15.0.3-default_h3684801_0.tar.bz2
linux-aarch64::libllvm11-11.1.0-hb2805f8_5.tar.bz2
linux-aarch64::libclang-cpp15-15.0.3-default_ha7bf5e6_0.tar.bz2
linux-aarch64::libmlir-15.0.3-h5ca471e_0.tar.bz2
linux-aarch64::libprotobuf-static-3.21.8-h7866ba4_0.tar.bz2
linux-aarch64::fontconfig-2.14.1-h77febde_0.tar.bz2
linux-aarch64::libnetcdf-4.8.1-nompi_h88e613c_106.tar.bz2
linux-aarch64::llvm-15.0.3-h1d0b1a5_1.tar.bz2
linux-aarch64::libprotobuf-3.21.8-h4dffa80_0.tar.bz2
linux-aarch64::libmlir15-15.0.3-h5ca471e_0.tar.bz2
linux-aarch64::gst-plugins-base-1.21.1-h044bd2c_1.tar.bz2
linux-aarch64::gst-libav-1.20.3-hcb8f52c_2.tar.bz2
linux-aarch64::liblal-7.2.4-fftw_he26ac06_102.tar.bz2
linux-aarch64::glib-tools-2.74.1-h7866ba4_0.tar.bz2
linux-aarch64::llvm-tools-11.1.0-hb2805f8_5.tar.bz2
linux-aarch64::gst-plugins-good-1.21.1-h660f13c_1.tar.bz2
linux-aarch64::clang-15-15.0.3-default_ha7bf5e6_0.tar.bz2
linux-aarch64::libmlir15-15.0.1-h5ca471e_0.tar.bz2
linux-aarch64::libnetcdf-4.8.1-nompi_h88e613c_105.tar.bz2
linux-aarch64::llvm-tools-15.0.3-hd950eb9_1.tar.bz2
linux-aarch64::llvm-tools-15.0.3-h71eeefc_0.tar.bz2
linux-aarch64::libprotobuf-3.21.9-h4dffa80_0.tar.bz2
linux-aarch64::libllvm15-15.0.3-hd950eb9_1.tar.bz2
linux-aarch64::plumed-2.8.1-nompi_h1debfa0_100.tar.bz2
linux-aarch64::libclang-cpp-15.0.3-default_ha7bf5e6_0.tar.bz2
linux-aarch64::libprotobuf-static-3.21.9-h7866ba4_0.tar.bz2
linux-aarch64::libmlir-15.0.2-h5ca471e_0.tar.bz2
linux-aarch64::clang-format-15-15.0.3-default_ha7bf5e6_0.tar.bz2
linux-aarch64::clang-format-15.0.3-default_ha7bf5e6_0.tar.bz2
linux-aarch64::llvm-15.0.3-h1426fca_0.tar.bz2
linux-aarch64::llvm-11.1.0-h40ce709_5.tar.bz2
linux-aarch64::clang-tools-15.0.3-default_ha7bf5e6_0.tar.bz2
linux-aarch64::liblal-7.2.4-fftw_he26ac06_101.tar.bz2
linux-aarch64::libllvm15-15.0.3-h71eeefc_0.tar.bz2
linux-aarch64::libclang-15.0.3-default_ha7bf5e6_0.tar.bz2
linux-aarch64::libmlir15-15.0.2-h5ca471e_0.tar.bz2
linux-aarch64::libmlir-15.0.1-h5ca471e_0.tar.bz2
-    "libzlib >=1.2.13,<1.3.0a0"
+    "libzlib >=1.2.13,<2.0.0a0"
================================================================================
================================================================================
noarch
================================================================================
================================================================================
win-64
win-64::glibmm-2.68-2.74.0-h94f358d_0.tar.bz2
win-64::arrow-cpp-8.0.1-py38hdb32e4e_5_cpu.tar.bz2
win-64::arrow-cpp-8.0.1-py310hdbaeaa9_5_cuda.tar.bz2
win-64::qt6-main-6.4.0-he608ae7_0.tar.bz2
win-64::gdstk-0.9.1-py38h2029624_0.tar.bz2
win-64::aws-sdk-cpp-1.9.356-hefbdf23_1.tar.bz2
win-64::libmediainfo-22.09-h0650ae2_0.tar.bz2
win-64::librdkafka-1.9.2-h1fcf997_1.tar.bz2
win-64::scip-8.0.2-ha534786_1.tar.bz2
win-64::aws-sdk-cpp-1.9.362-hf6283e5_1.tar.bz2
win-64::arrow-cpp-6.0.2-py39h404436b_4_cuda.tar.bz2
win-64::gdstk-0.9.1-py38hf76a6cb_0.tar.bz2
win-64::arrow-cpp-8.0.1-py310h1b77788_5_cpu.tar.bz2
win-64::arrow-cpp-9.0.0-py310hdbaeaa9_7_cuda.tar.bz2
win-64::arrow-cpp-6.0.2-py38h2c93598_4_cuda.tar.bz2
win-64::gst-plugins-base-1.21.1-h001b923_0.tar.bz2
win-64::arrow-cpp-6.0.2-py310h96cef69_4_cuda.tar.bz2
win-64::z5py-2.0.16-py38hf6cfc17_0.tar.bz2
win-64::papilo-2.1.1-h45feaf2_0.tar.bz2
win-64::aws-sdk-cpp-1.9.357-hefbdf23_0.tar.bz2
win-64::r-strawr-0.0.9-r41h39ac6ef_1.tar.bz2
win-64::llvmdev-15.0.2-h0f93eaf_0.tar.bz2
win-64::gdstk-0.9.1-py310h8f0d0a4_0.tar.bz2
win-64::gdstk-0.9.1-py39h6cd26d3_0.tar.bz2
win-64::aws-sdk-cpp-1.9.358-h86bbcab_1.tar.bz2
win-64::arrow-cpp-9.0.0-py310h1b77788_7_cpu.tar.bz2
win-64::clang-format-15.0.2-default_h66ee7f4_0.tar.bz2
win-64::ogre-next-2.3.1-h606bb5d_3.tar.bz2
win-64::clang-15-15.0.2-default_h66ee7f4_0.tar.bz2
win-64::mysql-client-8.0.31-hf8b63c5_0.tar.bz2
win-64::z5py-2.0.16-py39hd3dd819_0.tar.bz2
win-64::r-gaston-1.5.7-r41h67098fc_1.tar.bz2
win-64::gst-plugins-good-1.21.1-h76f0265_0.tar.bz2
win-64::arrow-cpp-7.0.1-py37hd64964d_5_cuda.tar.bz2
win-64::llvm-tools-15.0.2-h0f93eaf_0.tar.bz2
win-64::arrow-cpp-9.0.0-py37hd749cc5_7_cpu.tar.bz2
win-64::arrow-cpp-8.0.1-py39h07ee6b1_5_cpu.tar.bz2
win-64::pypy3.9-7.3.9-h994e1e7_5.tar.bz2
win-64::aws-sdk-cpp-1.9.358-h26cf332_2.tar.bz2
win-64::libcurl-7.85.0-heaf79c2_0.tar.bz2
win-64::intel-cmplr-lib-rt-2022.2.0-h12be248_9553.tar.bz2
win-64::arrow-cpp-6.0.2-py37h3331a67_4_cpu.tar.bz2
win-64::tectonic-0.11.0-h42e402a_0.tar.bz2
win-64::arrow-cpp-9.0.0-py37hd64964d_7_cuda.tar.bz2
win-64::pypy3.8-7.3.9-h577050a_5.tar.bz2
win-64::r-git2r-0.30.1-r41h007cf7e_1.tar.bz2
win-64::mysql-server-8.0.31-h3549bd1_0.tar.bz2
win-64::r-seqminer-8.4-r41h5bfd6cc_1.tar.bz2
win-64::arrow-cpp-8.0.1-py39hdf17a4b_5_cuda.tar.bz2
win-64::arrow-cpp-6.0.2-py39h341223e_4_cpu.tar.bz2
win-64::arrow-cpp-9.0.0-py38hbb9d546_7_cuda.tar.bz2
win-64::aws-sdk-cpp-1.9.363-hf6283e5_0.tar.bz2
win-64::vtk-9.2.2-qt_py310h01c2d33_200.tar.bz2
win-64::soplex-6.0.2-h949ae46_1.tar.bz2
win-64::python-igraph-0.10.1-py39h16ec61d_1.tar.bz2
win-64::gdstk-0.9.1-py39h77acf15_0.tar.bz2
win-64::qt6-main-6.4.0-he608ae7_1.tar.bz2
win-64::curl-7.85.0-heaf79c2_0.tar.bz2
win-64::dpcpp_impl_win-64-2022.2.0-hbc6686b_9553.tar.bz2
win-64::soplex-6.0.2-h949ae46_0.tar.bz2
win-64::aws-sdk-cpp-1.9.362-h26cf332_0.tar.bz2
win-64::libllvm15-15.0.2-h0f93eaf_0.tar.bz2
win-64::arrow-cpp-7.0.1-py310h1b77788_5_cpu.tar.bz2
win-64::arrow-cpp-9.0.0-py38hdb32e4e_7_cpu.tar.bz2
win-64::vtk-9.2.2-qt_py37he11d85d_200.tar.bz2
win-64::llvm-15.0.2-hdfaf34f_0.tar.bz2
win-64::vtk-9.2.2-qt_py38h88190dd_200.tar.bz2
win-64::arrow-cpp-6.0.2-py37h278c8eb_4_cuda.tar.bz2
win-64::python-igraph-0.10.1-py38hc27c15b_1.tar.bz2
win-64::arrow-cpp-6.0.2-py38had138b9_4_cpu.tar.bz2
win-64::libclang-15.0.2-default_h77d9078_0.tar.bz2
win-64::clang-tools-15.0.2-default_h66ee7f4_0.tar.bz2
win-64::pypy3.8-7.3.9-hd438790_5.tar.bz2
win-64::python-igraph-0.10.1-py37hb0a9f92_1.tar.bz2
win-64::tectonic-0.11.0-he0972dc_0.tar.bz2
win-64::qt6-main-6.4.0-he608ae7_2.tar.bz2
win-64::pcre2-10.40-h17e33f8_0.tar.bz2
win-64::mysql-libs-8.0.31-h4d1747d_0.tar.bz2
win-64::python-igraph-0.10.1-py38h1cea2b0_1.tar.bz2
win-64::intel-opencl-rt-2022.2.0-h0c8ddaa_9553.tar.bz2
win-64::papilo-2.1.1-h45feaf2_1.tar.bz2
win-64::mysql-router-8.0.31-h1a65749_0.tar.bz2
win-64::symengine-0.9.0-h0f8d4b3_1.tar.bz2
win-64::pypy3.9-7.3.9-h4bd5010_5.tar.bz2
win-64::python-igraph-0.10.1-py310he5bc916_1.tar.bz2
win-64::mysql-router-8.0.31-h8f1a885_0.tar.bz2
win-64::z5py-2.0.16-py310h51f9496_0.tar.bz2
win-64::aws-sdk-cpp-1.9.359-h26cf332_0.tar.bz2
win-64::libclang13-15.0.2-default_h77d9078_0.tar.bz2
win-64::clangdev-15.0.2-default_h66ee7f4_0.tar.bz2
win-64::r-git2r-0.30.1-r41h7c54dad_1.tar.bz2
win-64::vtk-9.2.2-qt_py39hca7f291_200.tar.bz2
win-64::mysql-client-8.0.31-hed9f4ee_0.tar.bz2
win-64::arrow-cpp-7.0.1-py38hdb32e4e_5_cpu.tar.bz2
win-64::libcurl-static-7.85.0-heaf79c2_0.tar.bz2
win-64::arrow-cpp-7.0.1-py37hd749cc5_5_cpu.tar.bz2
win-64::cgns-4.3.0-hcfbc7b6_2.tar.bz2
win-64::mysql-server-8.0.31-hd6e9830_0.tar.bz2
win-64::libprotobuf-static-3.21.7-h12be248_0.tar.bz2
win-64::arrow-cpp-8.0.1-py38hbb9d546_5_cuda.tar.bz2
win-64::python-igraph-0.10.1-py39h5126385_1.tar.bz2
win-64::arrow-cpp-8.0.1-py37hd749cc5_5_cpu.tar.bz2
win-64::arrow-cpp-7.0.1-py310hdbaeaa9_5_cuda.tar.bz2
win-64::arrow-cpp-7.0.1-py39h07ee6b1_5_cpu.tar.bz2
win-64::arrow-cpp-8.0.1-py37hd64964d_5_cuda.tar.bz2
win-64::gdstk-0.9.1-py37h3b82d10_0.tar.bz2
win-64::mongodb-6.0.2-h5461356_0.tar.bz2
win-64::libprotobuf-3.21.7-h12be248_0.tar.bz2
win-64::libxml2-2.10.2-hc3477c8_2.tar.bz2
win-64::z5py-2.0.16-py37h50a9241_0.tar.bz2
win-64::arrow-cpp-6.0.2-py310h6b2ed25_4_cpu.tar.bz2
win-64::aws-sdk-cpp-1.9.361-h26cf332_0.tar.bz2
win-64::mysql-libs-8.0.31-h8b0d2c3_0.tar.bz2
win-64::ovito-3.7.10-h19f58de_0.tar.bz2
win-64::pcre2-static-10.40-h17e33f8_0.tar.bz2
win-64::arrow-cpp-9.0.0-py39hdf17a4b_7_cuda.tar.bz2
win-64::librdkafka-1.9.2-h9d84117_1.tar.bz2
win-64::scip-8.0.2-hcae2003_0.tar.bz2
win-64::arrow-cpp-7.0.1-py39hdf17a4b_5_cuda.tar.bz2
win-64::aws-sdk-cpp-1.9.358-hefbdf23_0.tar.bz2
win-64::arrow-cpp-7.0.1-py38hbb9d546_5_cuda.tar.bz2
win-64::arrow-cpp-9.0.0-py39h07ee6b1_7_cpu.tar.bz2
-    "libzlib >=1.2.12,<1.3.0a0",
+    "libzlib >=1.2.12,<2.0.0a0",
win-64::qt6-main-6.4.0-h7a4ecde_4.tar.bz2
win-64::pypy3.9-7.3.9-h4bd5010_6.tar.bz2
win-64::python-igraph-0.10.2-py38h9df9d4c_1.tar.bz2
win-64::mysql-connector-python-8.0.31-py39hf7d6b5c_1.tar.bz2
win-64::arrow-cpp-8.0.1-py39hd774c44_7_cuda.tar.bz2
win-64::pypy3.9-7.3.9-h994e1e7_6.tar.bz2
win-64::gst-libav-1.20.3-hee343dc_2.tar.bz2
win-64::glib-tools-2.74.1-h12be248_0.tar.bz2
win-64::grpc-cpp-1.46.4-h535cfc9_8.tar.bz2
win-64::r-popgenome-2.7.5-r41h67098fc_2.tar.bz2
win-64::ffmpeg-4.4.2-gpl_h6a9407d_110.tar.bz2
win-64::python-igraph-0.10.2-py39h16ec61d_0.tar.bz2
win-64::ogre-13.4.4-haf1463a_1.tar.bz2
win-64::omniorb-4.2.5-py311haf4ec1b_3.tar.bz2
win-64::python-igraph-0.10.2-py310h4d9ddb3_1.tar.bz2
win-64::python-3.11.0-hcf16a7b_0_cpython.tar.bz2
win-64::py-bgzip-0.4.0-py39h78ffc47_3.tar.bz2
win-64::imagecodecs-2022.9.26-py39h414dd1e_2.tar.bz2
win-64::arrow-cpp-7.0.1-py311h736ecbe_7_cpu.tar.bz2
win-64::clang-format-15.0.3-default_h66ee7f4_0.tar.bz2
win-64::arrow-cpp-8.0.1-py38h6f30ff9_8_cuda.tar.bz2
win-64::ffmpeg-5.1.2-gpl_h02edd2a_102.tar.bz2
win-64::llvmdev-15.0.3-h2c25772_1.tar.bz2
win-64::arrow-cpp-8.0.1-py310h16f3d1e_8_cuda.tar.bz2
win-64::pillow-9.2.0-py310hd4fb230_3.tar.bz2
win-64::arrow-cpp-9.0.0-py311hb9719d8_8_cuda.tar.bz2
win-64::pyinstaller-5.1-py38ha959d8a_1.tar.bz2
win-64::arrow-cpp-9.0.0-py38hdb32e4e_8_cpu.tar.bz2
win-64::arrow-cpp-7.0.1-py310h1b77788_6_cpu.tar.bz2
win-64::omniorb-4.2.5-py311haf4ec1b_4.tar.bz2
win-64::libpq-14.5-h04fd8be_1.tar.bz2
win-64::imagecodecs-2022.9.26-py311h861ed29_3.tar.bz2
win-64::arrow-cpp-6.0.2-py39h341223e_5_cpu.tar.bz2
win-64::mysql-connector-python-8.0.30-py38h3bb5535_1.tar.bz2
win-64::arrow-cpp-7.0.1-py311hb9719d8_6_cuda.tar.bz2
win-64::clangdev-15.0.3-default_h66ee7f4_0.tar.bz2
win-64::arrow-cpp-9.0.0-py310hc022373_9_cpu.tar.bz2
win-64::vtk-9.2.2-qt_py38hc1024be_202.tar.bz2
win-64::imagecodecs-2022.9.26-py38h8bd6efd_2.tar.bz2
win-64::tectonic-0.12.0-he0972dc_0.tar.bz2
win-64::arrow-cpp-9.0.0-py39h19363dd_10_cuda.tar.bz2
win-64::openbabel-3.1.1-py311h15ef7a7_5.tar.bz2
win-64::pytables-3.7.0-py38h5096371_3.tar.bz2
win-64::pillow-9.2.0-py38h3cd753b_3.tar.bz2
win-64::libadios2-2.8.3-nompi_hfe5be7e_104.tar.bz2
win-64::yarp-cxx-3.7.2-ha672ae2_4.tar.bz2
win-64::openmeeg-2.5.5-py311hcd9c1d5_1.tar.bz2
win-64::ffmpeg-5.1.2-lgpl_he8de668_2.tar.bz2
win-64::imagecodecs-2022.9.26-py38h4198fce_2.tar.bz2
win-64::arrow-cpp-8.0.1-py310hc022373_7_cpu.tar.bz2
win-64::clang-tools-15.0.3-default_h66ee7f4_0.tar.bz2
win-64::aws-sdk-cpp-1.9.369-h63c059d_1.tar.bz2
win-64::pyhdf-0.10.5-py311h702c2b7_1.tar.bz2
win-64::arrow-cpp-6.0.2-py38had138b9_5_cpu.tar.bz2
win-64::openexr-python-1.3.9-py38ha4d679c_1.tar.bz2
win-64::vtk-9.2.2-qt_py37h2749e25_203.tar.bz2
win-64::arrow-cpp-8.0.1-py311hf3afb5c_7_cuda.tar.bz2
win-64::omniorb-libs-4.2.5-hb04206d_4.tar.bz2
win-64::arrow-cpp-9.0.0-py310h16f3d1e_10_cuda.tar.bz2
win-64::leptonica-1.82.0-h822e431_2.tar.bz2
win-64::arrow-cpp-6.0.2-py39hedc96d6_6_cuda.tar.bz2
win-64::gemmi-0.5.7-py311h5bc0dda_1.tar.bz2
win-64::imagecodecs-2022.9.26-py38h72f9683_1.tar.bz2
win-64::llvm-tools-15.0.3-h2c25772_1.tar.bz2
win-64::aws-sdk-cpp-1.9.372-hf1e1e5e_0.tar.bz2
win-64::libopencv-4.6.0-py310hb22e633_6.tar.bz2
win-64::vigra-1.11.1-py39h7fe724b_1035.tar.bz2
win-64::pyreadstat-1.2.0-py37h5f30cb9_0.tar.bz2
win-64::libopencv-4.6.0-py38hafb13ef_5.tar.bz2
win-64::aws-sdk-cpp-1.9.369-hf6283e5_0.tar.bz2
win-64::llvmlite-0.39.1-py39h6848017_1.tar.bz2
win-64::cpp-opentelemetry-sdk-1.6.1-hf92dd61_1.tar.bz2
win-64::openbabel-3.1.1-py38h62647bb_5.tar.bz2
win-64::arrow-cpp-6.0.2-py39h8965eb0_6_cpu.tar.bz2
win-64::aws-sdk-cpp-1.9.370-hf1e1e5e_2.tar.bz2
win-64::gemmi-0.5.7-py38hf225c54_1.tar.bz2
win-64::py-bgzip-0.4.0-py38hed8690e_3.tar.bz2
win-64::curl-7.86.0-heaf79c2_0.tar.bz2
win-64::omniorb-4.2.5-py39ha00b111_3.tar.bz2
win-64::pillow-9.2.0-py39h2247d3f_3.tar.bz2
win-64::python-igraph-0.10.2-py38h1cea2b0_0.tar.bz2
win-64::pyhdf-0.10.5-py39h1ab0bd0_1.tar.bz2
win-64::libadios2-2.8.3-nompi_h765cd8b_104.tar.bz2
win-64::arrow-cpp-9.0.0-py39hd774c44_9_cuda.tar.bz2
win-64::arrow-cpp-9.0.0-py38h6f30ff9_10_cuda.tar.bz2
win-64::arrow-cpp-8.0.1-py310h1b77788_6_cpu.tar.bz2
win-64::pygrib-2.1.4-py39h4b778c7_6.tar.bz2
win-64::llvm-15.0.3-hdfaf34f_0.tar.bz2
win-64::coda-2.24-py39h3d955e7_2.tar.bz2
win-64::libnetcdf-4.9.0-nompi_hc41bf00_102.tar.bz2
win-64::cpp-opentelemetry-sdk-1.6.1-ha55d2dd_2.tar.bz2
win-64::cling-0.9-h97333cc_0.tar.bz2
win-64::stir-5.0.2-py38h00d5545_4.tar.bz2
win-64::tiledb-2.11.3-h3132609_1.tar.bz2
win-64::python-igraph-0.10.2-py311h8db4363_1.tar.bz2
win-64::aws-sdk-cpp-1.9.373-h4a58fab_0.tar.bz2
win-64::cling-0.9-h97333cc_1.tar.bz2
win-64::mysql-connector-python-8.0.31-py38h3bb5535_1.tar.bz2
win-64::nco-5.1.1-h343d473_0.tar.bz2
win-64::arrow-cpp-9.0.0-py310h9f4c3e6_10_cpu.tar.bz2
win-64::omniorb-4.2.5-py38ha1d5d2c_3.tar.bz2
win-64::harp-1.15.1-py38r41h2706d8f_4.tar.bz2
win-64::gemmi-0.5.7-py39h6848017_1.tar.bz2
win-64::libpq-13.8-h04fd8be_0.tar.bz2
win-64::arrow-cpp-8.0.1-py38h2d85969_7_cpu.tar.bz2
win-64::llvmlite-0.39.1-py39hd28a505_1.tar.bz2
win-64::pyreadstat-1.2.0-py39h585ecb4_0.tar.bz2
win-64::openmeeg-2.5.5-py310h38669e5_1.tar.bz2
win-64::pillow-9.2.0-py39h595c93f_3.tar.bz2
win-64::libgdal-3.5.2-h2477998_4.tar.bz2
win-64::ffmpeg-5.1.2-gpl_h6a9407d_103.tar.bz2
win-64::postgresql-13.8-h58a5ca5_0.tar.bz2
win-64::mysql-connector-python-8.0.31-py39hf7d6b5c_2.tar.bz2
win-64::llvmlite-0.39.1-py310hb84602e_1.tar.bz2
win-64::postgresql-plpython-14.5-py38ha2f05b0_1.tar.bz2
win-64::vigra-1.11.1-py38h654e1e2_1036.tar.bz2
win-64::arrow-cpp-9.0.0-py39hdf17a4b_8_cuda.tar.bz2
win-64::vtk-9.2.2-qt_py38hc31031b_204.tar.bz2
win-64::mysql-connector-python-8.0.30-py39hf7d6b5c_1.tar.bz2
win-64::vtk-9.2.2-qt_py39h397e45c_204.tar.bz2
win-64::arrow-cpp-6.0.2-py38h2c93598_5_cuda.tar.bz2
win-64::libprotobuf-3.21.9-h12be248_0.tar.bz2
win-64::imagecodecs-2022.9.26-py38h4198fce_3.tar.bz2
win-64::pytng-0.2.3-py39had03f03_1.tar.bz2
win-64::arrow-cpp-6.0.2-py310h96cef69_5_cuda.tar.bz2
win-64::libprotobuf-3.21.8-h12be248_0.tar.bz2
win-64::postgresql-plpython-13.8-py311hdb0844a_0.tar.bz2
win-64::libopencv-4.6.0-py39h0c67194_6.tar.bz2
win-64::yarp-cxx-3.7.2-ha672ae2_3.tar.bz2
win-64::py-bgzip-0.4.0-py311h12e69fa_3.tar.bz2
win-64::libpq-13.8-hf15792c_0.tar.bz2
win-64::arrow-cpp-7.0.1-py310hc022373_7_cpu.tar.bz2
win-64::arrow-cpp-7.0.1-py39h07ee6b1_6_cpu.tar.bz2
win-64::libopencv-4.6.0-py38h671439d_6.tar.bz2
win-64::imagecodecs-2022.9.26-py38ha7e2d65_1.tar.bz2
win-64::libgdal-3.5.2-h042b378_4.tar.bz2
win-64::grpc-cpp-1.45.2-hcb496ee_7.tar.bz2
win-64::arrow-cpp-8.0.1-py311h736ecbe_7_cpu.tar.bz2
win-64::postgresql-plpython-13.8-py38hcf00bc8_0.tar.bz2
win-64::stir-5.0.2-py39h4b893ef_4.tar.bz2
win-64::arrow-cpp-7.0.1-py39hf9a4b71_7_cpu.tar.bz2
win-64::sdl2_image-2.6.1-h4fd72c5_1.tar.bz2
win-64::katago-1.11.0-cpu_hf79927b_0.tar.bz2
win-64::libopencv-4.6.0-py311ha714b55_6.tar.bz2
win-64::mysql-connector-python-8.0.31-py311hc774530_2.tar.bz2
win-64::python-igraph-0.10.2-py39hf582c05_1.tar.bz2
win-64::libclang-15.0.3-default_h77d9078_0.tar.bz2
win-64::openmeeg-2.5.5-py39h6fb49ae_1.tar.bz2
win-64::arrow-cpp-7.0.1-py310hdbaeaa9_6_cuda.tar.bz2
win-64::clang-15-15.0.3-default_h66ee7f4_0.tar.bz2
win-64::pytables-3.7.0-py39hde744ac_3.tar.bz2
win-64::vtk-9.2.2-qt_py310ha56cc52_204.tar.bz2
win-64::vigra-1.11.1-py38hf4bf0fc_1035.tar.bz2
win-64::libopencv-4.6.0-py39hedeca96_6.tar.bz2
win-64::libmlir-15.0.2-he744812_0.tar.bz2
win-64::pyhdf-0.10.5-py38hca9b550_1.tar.bz2
win-64::mysql-connector-python-8.0.31-py38h3bb5535_2.tar.bz2
win-64::pyreadstat-1.2.0-py38h84023d3_1.tar.bz2
win-64::arrow-cpp-7.0.1-py311hbf3624f_8_cuda.tar.bz2
win-64::postgresql-plpython-14.5-py39hbe02685_1.tar.bz2
win-64::vigra-1.11.1-py39ha24bc5c_1036.tar.bz2
win-64::postgresql-14.5-h392df6f_1.tar.bz2
win-64::harp-1.15.1-py38r41h2706d8f_3.tar.bz2
win-64::lxml-4.9.1-py39h0942119_1.tar.bz2
win-64::libgrpc-1.49.1-h6a6baca_1.tar.bz2
win-64::coda-2.24-py311h0120304_2.tar.bz2
win-64::stir-5.0.2-py38h00d5545_1.tar.bz2
win-64::python-igraph-0.10.2-py39h5126385_0.tar.bz2
win-64::python-igraph-0.10.2-py38hc27c15b_0.tar.bz2
win-64::postgresql-plpython-14.5-py311hf6a82bc_1.tar.bz2
win-64::grpc-cpp-1.47.1-h6a6baca_7.tar.bz2
win-64::postgresql-plpython-14.5-py310hb7c6211_1.tar.bz2
win-64::aws-sdk-cpp-1.9.365-hf6283e5_0.tar.bz2
win-64::cling-0.8-h97333cc_2.tar.bz2
win-64::stir-5.0.2-py38h00d5545_3.tar.bz2
win-64::vtk-9.2.2-qt_py38hc31031b_203.tar.bz2
win-64::arrow-cpp-7.0.1-py38hdb32e4e_6_cpu.tar.bz2
win-64::arrow-cpp-9.0.0-py310hab0adef_9_cuda.tar.bz2
win-64::libopencv-4.6.0-py38h671439d_5.tar.bz2
win-64::imagecodecs-2022.9.26-py38h8bd6efd_3.tar.bz2
win-64::pyhdf-0.10.5-py39h4036ffb_1.tar.bz2
win-64::aws-sdk-cpp-1.9.370-h4a58fab_2.tar.bz2
win-64::stir-5.0.2-py38h99eca4e_0.tar.bz2
win-64::py-bgzip-0.4.0-py39h84a0465_3.tar.bz2
win-64::harp-1.15.1-py39r41h3d955e7_4.tar.bz2
win-64::arrow-cpp-7.0.1-py38h1813ad1_8_cpu.tar.bz2
win-64::mysql-connector-python-8.0.31-py38h2426d48_1.tar.bz2
win-64::mysql-connector-python-8.0.30-py37he4f8dd4_1.tar.bz2
win-64::arrow-cpp-9.0.0-py310hdbaeaa9_8_cuda.tar.bz2
win-64::harp-1.15.1-py311r41h0120304_4.tar.bz2
win-64::ogre-1.12.13-h282e550_3.tar.bz2
win-64::mysql-connector-python-8.0.31-py38h2426d48_2.tar.bz2
win-64::arrow-cpp-6.0.2-py311h8491090_6_cpu.tar.bz2
win-64::imagecodecs-2022.9.26-py310h5cb8b0e_1.tar.bz2
win-64::coda-2.24-py310h40b6f39_2.tar.bz2
win-64::lxml-4.9.1-py39h5462cdd_1.tar.bz2
win-64::aws-sdk-cpp-1.9.368-hf6283e5_0.tar.bz2
win-64::libadios2-2.8.3-nompi_h38ab939_104.tar.bz2
win-64::libopencv-4.6.0-py37hefdbd86_5.tar.bz2
win-64::netcdf4-1.6.1-nompi_py311h45b207f_101.tar.bz2
win-64::libnetcdf-4.8.1-nompi_h8c042bf_106.tar.bz2
win-64::wxwidgets-3.2.1-ha494159_1.tar.bz2
win-64::imagecodecs-2022.9.26-py39h4413bcf_2.tar.bz2
win-64::gemmi-0.5.7-py310hb84602e_1.tar.bz2
win-64::pyreadr-0.4.7-py38hd5e6679_2.tar.bz2
win-64::vtk-9.2.2-qt_py39h808efec_202.tar.bz2
win-64::grpc-cpp-1.45.2-h509c0ec_7.tar.bz2
win-64::arrow-cpp-7.0.1-py310h9f4c3e6_8_cpu.tar.bz2
win-64::stir-5.0.2-py310h418b276_5.tar.bz2
win-64::libxslt-1.1.35-h2f02f80_1.tar.bz2
win-64::harp-1.15.1-py39r41h3d955e7_3.tar.bz2
win-64::omniorb-4.2.5-py38ha1d5d2c_4.tar.bz2
win-64::imagecodecs-2022.9.26-py39h414dd1e_1.tar.bz2
win-64::postgresql-plpython-13.8-py39hbe02685_0.tar.bz2
win-64::pyreadr-0.4.7-py39h39b8732_2.tar.bz2
win-64::pyreadstat-1.2.0-py311hd8f7e58_1.tar.bz2
win-64::leptonica-1.82.0-h822e431_1.tar.bz2
win-64::stir-5.0.2-py310h63f273e_0.tar.bz2
win-64::pyreadstat-1.2.0-py310h51ee7fe_1.tar.bz2
win-64::libllvm15-15.0.3-h0f93eaf_0.tar.bz2
win-64::openmeeg-2.5.5-py39h2405fd1_1.tar.bz2
win-64::harp-1.15.1-py39r41h763b820_3.tar.bz2
win-64::arrow-cpp-9.0.0-py38hbb9d546_8_cuda.tar.bz2
win-64::libclang13-15.0.3-default_h77d9078_0.tar.bz2
win-64::lxml-4.9.1-py38h8e95c58_1.tar.bz2
win-64::pyinstaller-5.1-py310h35269f2_1.tar.bz2
win-64::omniorb-libs-4.2.5-h27dd91c_4.tar.bz2
win-64::python-igraph-0.10.2-py310he5bc916_0.tar.bz2
win-64::aws-sdk-cpp-1.9.373-hf1e1e5e_0.tar.bz2
win-64::arrow-cpp-8.0.1-py310hdbaeaa9_6_cuda.tar.bz2
win-64::vtk-9.2.2-qt_py39h397e45c_203.tar.bz2
win-64::openexr-python-1.3.9-py38h36b40ce_1.tar.bz2
win-64::libcurl-static-7.86.0-heaf79c2_0.tar.bz2
win-64::mysql-connector-python-8.0.30-py310h9b4d4ad_1.tar.bz2
win-64::vtk-9.2.2-qt_py37hdaf77b0_201.tar.bz2
win-64::arrow-cpp-9.0.0-py311h949603d_10_cpu.tar.bz2
win-64::arrow-cpp-8.0.1-py39hf9a4b71_7_cpu.tar.bz2
win-64::llvmdev-15.0.3-h0f93eaf_0.tar.bz2
win-64::stir-5.0.2-py310h418b276_1.tar.bz2
win-64::postgresql-13.8-h392df6f_0.tar.bz2
win-64::imagecodecs-2022.9.26-py310h68994fe_2.tar.bz2
win-64::harp-1.15.1-py37r41hf8622d2_3.tar.bz2
win-64::coda-2.24-py38h2706d8f_2.tar.bz2
win-64::pillow-9.2.0-py38h486af0e_3.tar.bz2
win-64::grpc-cpp-1.47.1-h535cfc9_7.tar.bz2
win-64::arrow-cpp-7.0.1-py39h93fcf85_8_cpu.tar.bz2
win-64::omniorb-4.2.5-py38h78b27f5_4.tar.bz2
win-64::libnetcdf-4.9.0-nompi_hc41bf00_101.tar.bz2
win-64::omniorb-4.2.5-py38h78b27f5_3.tar.bz2
win-64::llvmlite-0.39.1-py38hf225c54_1.tar.bz2
win-64::postgresql-plpython-14.5-py38hcf00bc8_1.tar.bz2
win-64::llvm-tools-15.0.3-h0f93eaf_0.tar.bz2
win-64::pyreadstat-1.2.0-py39h585ecb4_1.tar.bz2
win-64::openexr-python-1.3.9-py310h40e972c_1.tar.bz2
win-64::harp-1.15.1-py38r41hdd1a290_3.tar.bz2
win-64::libmlir-15.0.1-he744812_0.tar.bz2
win-64::ogre-1.10.12-h7604e60_10.tar.bz2
win-64::libprotobuf-static-3.21.8-h12be248_0.tar.bz2
win-64::libgdal-3.5.2-h263b2b1_5.tar.bz2
win-64::libglib-2.74.1-h79619a9_0.tar.bz2
win-64::postgresql-plpython-14.5-py39h15dfc06_1.tar.bz2
win-64::libcurl-7.86.0-heaf79c2_0.tar.bz2
win-64::gst-plugins-good-1.21.1-h76f0265_1.tar.bz2
win-64::sox-14.4.2-h6e28ce0_1016.tar.bz2
win-64::stir-5.0.2-py39h4b893ef_2.tar.bz2
win-64::pyinstaller-5.1-py39h84a0465_1.tar.bz2
win-64::gemmi-0.5.7-py38h19421c1_1.tar.bz2
win-64::pygrib-2.1.4-py38h71c1bbe_6.tar.bz2
win-64::yarp-cxx-3.7.2-h6208eec_2.tar.bz2
win-64::arrow-cpp-9.0.0-py311hf3afb5c_9_cuda.tar.bz2
win-64::llvm-tools-11.1.0-h4bb6d4f_5.tar.bz2
win-64::arrow-cpp-7.0.1-py38hbb9d546_6_cuda.tar.bz2
win-64::stir-5.0.2-py310h418b276_2.tar.bz2
win-64::arrow-cpp-6.0.2-py311h6e3bc62_5_cuda.tar.bz2
win-64::arrow-cpp-8.0.1-py311hbf3624f_8_cuda.tar.bz2
win-64::netcdf4-1.6.1-nompi_py310h459bb5f_101.tar.bz2
win-64::r-vcfr-1.13.0-r41h67098fc_1.tar.bz2
win-64::stir-5.0.2-py39h4b893ef_3.tar.bz2
win-64::ogre-1.12.13-h66fabce_3.tar.bz2
win-64::pypy3.8-7.3.9-h577050a_6.tar.bz2
win-64::pytables-3.7.0-py38hd4c1824_3.tar.bz2
win-64::aws-sdk-cpp-1.9.370-h63c059d_0.tar.bz2
win-64::llvm-15.0.3-h38bddbe_1.tar.bz2
win-64::arrow-cpp-7.0.1-py310h16f3d1e_8_cuda.tar.bz2
win-64::vigra-1.11.1-py39h7fe724b_1036.tar.bz2
win-64::arrow-cpp-9.0.0-py39h93fcf85_10_cpu.tar.bz2
win-64::pytng-0.2.3-py311hcbca1fb_1.tar.bz2
win-64::imagecodecs-2022.9.26-py39h4413bcf_1.tar.bz2
win-64::omniorb-4.2.5-py310h281aaab_4.tar.bz2
win-64::poppler-qt-22.10.0-hf8b1922_0.tar.bz2
win-64::vtk-9.2.2-qt_py310hafc99e1_201.tar.bz2
win-64::arrow-cpp-8.0.1-py38hdbef18b_7_cuda.tar.bz2
win-64::vigra-1.11.1-py38hf4bf0fc_1036.tar.bz2
win-64::poppler-22.10.0-ha6c1112_0.tar.bz2
win-64::grpc-cpp-1.48.1-h535cfc9_2.tar.bz2
win-64::stir-5.0.2-py39hbe385c1_0.tar.bz2
win-64::pygrib-2.1.4-py39hb97199f_6.tar.bz2
win-64::vtk-9.2.2-qt_py311h2c833bd_204.tar.bz2
win-64::omniorb-libs-4.2.5-hb04206d_3.tar.bz2
win-64::mysql-connector-python-8.0.30-py39h25a42f0_1.tar.bz2
win-64::cpp-opentelemetry-sdk-1.7.0-ha55d2dd_0.tar.bz2
win-64::omniorb-libs-4.2.5-h27dd91c_3.tar.bz2
win-64::arrow-cpp-6.0.2-py38h9775a1b_6_cpu.tar.bz2
win-64::aws-sdk-cpp-1.9.372-h4a58fab_0.tar.bz2
win-64::omniorb-4.2.5-py311h40cf3c0_3.tar.bz2
win-64::pytables-3.7.0-py39hc4d0b1b_3.tar.bz2
win-64::harp-1.15.1-py310r41h40b6f39_4.tar.bz2
win-64::py-bgzip-0.4.0-py38ha959d8a_3.tar.bz2
win-64::python-3.11.0-h9a09f29_0_cpython.tar.bz2
win-64::yarp-cxx-3.7.2-ha672ae2_5.tar.bz2
win-64::imagecodecs-2022.9.26-py310h68994fe_1.tar.bz2
win-64::arrow-cpp-6.0.2-py311h746923b_5_cpu.tar.bz2
win-64::openbabel-3.1.1-py39h5784a3d_5.tar.bz2
win-64::stir-5.0.2-py310h418b276_4.tar.bz2
win-64::netcdf4-1.6.1-nompi_py38h78680c8_101.tar.bz2
win-64::arrow-cpp-6.0.2-py310h8ad9450_6_cpu.tar.bz2
win-64::postgresql-14.5-h58a5ca5_1.tar.bz2
win-64::arrow-cpp-6.0.2-py311h112e6c3_6_cuda.tar.bz2
win-64::arrow-cpp-7.0.1-py39hd774c44_7_cuda.tar.bz2
win-64::vigra-1.11.1-py310h96fe323_1036.tar.bz2
win-64::vigra-1.11.1-py38h654e1e2_1035.tar.bz2
win-64::libllvm11-11.1.0-h97333cc_5.tar.bz2
win-64::lxml-4.9.1-py310hc0e5b84_1.tar.bz2
win-64::arrow-cpp-8.0.1-py39h07ee6b1_6_cpu.tar.bz2
win-64::arrow-cpp-9.0.0-py310h1b77788_8_cpu.tar.bz2
win-64::pyreadstat-1.2.0-py310h51ee7fe_0.tar.bz2
win-64::lxml-4.9.1-py311h5942461_1.tar.bz2
win-64::pygrib-2.1.4-py310h3a12092_6.tar.bz2
win-64::mysql-connector-python-8.0.31-py310h9b4d4ad_1.tar.bz2
win-64::tiledb-2.12.0-h3132609_1.tar.bz2
win-64::python-igraph-0.10.2-py39h16f159a_1.tar.bz2
win-64::arrow-cpp-9.0.0-py311hbf3624f_10_cuda.tar.bz2
win-64::arrow-cpp-7.0.1-py38h6f30ff9_8_cuda.tar.bz2
win-64::mlir-15.0.2-he744812_0.tar.bz2
win-64::pypy3.8-7.3.9-hd438790_6.tar.bz2
win-64::arrow-cpp-6.0.2-py310hd527717_6_cuda.tar.bz2
win-64::mysql-connector-python-8.0.31-py310h9b4d4ad_2.tar.bz2
win-64::ovito-3.7.10-habef550_1.tar.bz2
win-64::arrow-cpp-7.0.1-py39h19363dd_8_cuda.tar.bz2
win-64::lxml-4.9.1-py38h9b876ae_1.tar.bz2
win-64::mysql-connector-python-8.0.31-py37he4f8dd4_1.tar.bz2
win-64::pyreadr-0.4.7-py310hfdea923_2.tar.bz2
win-64::pyhdf-0.10.5-py310h9480a18_1.tar.bz2
win-64::postgresql-plpython-13.8-py311hf6a82bc_0.tar.bz2
win-64::postgresql-plpython-13.8-py310h25eba5b_0.tar.bz2
win-64::stir-5.0.2-py38h00d5545_2.tar.bz2
win-64::arrow-cpp-7.0.1-py38hdbef18b_7_cuda.tar.bz2
win-64::pygrib-2.1.4-py38h06b6c13_6.tar.bz2
win-64::pytables-3.7.0-py310haee3a42_3.tar.bz2
win-64::mlir-15.0.3-he744812_0.tar.bz2
win-64::libllvm15-15.0.3-h2c25772_1.tar.bz2
win-64::pygrib-2.1.4-py311h9efd4c3_6.tar.bz2
win-64::python-igraph-0.10.2-py37hb0a9f92_0.tar.bz2
win-64::openexr-python-1.3.9-py311h8f0bb5e_1.tar.bz2
win-64::mysql-connector-python-8.0.31-py39h25a42f0_2.tar.bz2
win-64::omniorb-4.2.5-py310h281aaab_3.tar.bz2
win-64::grpc-cpp-1.48.1-h6a6baca_2.tar.bz2
win-64::arrow-cpp-8.0.1-py311h16474ae_6_cpu.tar.bz2
win-64::imagecodecs-2022.9.26-py39h414dd1e_3.tar.bz2
win-64::arrow-cpp-6.0.2-py39h404436b_5_cuda.tar.bz2
win-64::omniorb-4.2.5-py310he97f525_4.tar.bz2
win-64::netcdf4-1.6.1-nompi_py39h34fa13a_101.tar.bz2
win-64::python-igraph-0.10.2-py38h595c5dd_1.tar.bz2
win-64::mlir-15.0.1-he744812_0.tar.bz2
win-64::arrow-cpp-9.0.0-py38h1813ad1_10_cpu.tar.bz2
win-64::openmeeg-2.5.5-py38hadb4aeb_1.tar.bz2
win-64::arrow-cpp-7.0.1-py310hab0adef_7_cuda.tar.bz2
win-64::aws-sdk-cpp-1.9.366-hf6283e5_0.tar.bz2
win-64::aws-sdk-cpp-1.9.371-hf1e1e5e_0.tar.bz2
win-64::aws-sdk-cpp-1.9.374-h4a58fab_0.tar.bz2
win-64::arrow-cpp-7.0.1-py311hf3afb5c_7_cuda.tar.bz2
win-64::libopencv-4.6.0-py38hafb13ef_6.tar.bz2
win-64::tiledb-2.12.0-h5689973_1.tar.bz2
win-64::omniorb-4.2.5-py39ha00b111_4.tar.bz2
win-64::pyreadr-0.4.7-py38hda8ff42_2.tar.bz2
win-64::openexr-python-1.3.9-py39h7036e9b_1.tar.bz2
win-64::vtk-9.2.2-qt_py310ha56cc52_203.tar.bz2
win-64::libnetcdf-4.8.1-nompi_h8c042bf_105.tar.bz2
win-64::arrow-cpp-6.0.2-py310h6b2ed25_5_cpu.tar.bz2
win-64::aws-sdk-cpp-1.9.370-h4a58fab_1.tar.bz2
win-64::arrow-cpp-7.0.1-py311h949603d_8_cpu.tar.bz2
win-64::aws-sdk-cpp-1.9.364-hf6283e5_0.tar.bz2
win-64::ogre-13.4.4-h8b644b4_1.tar.bz2
win-64::libgrpc-1.49.1-h535cfc9_1.tar.bz2
win-64::arrow-cpp-8.0.1-py38hbb9d546_6_cuda.tar.bz2
win-64::arrow-cpp-7.0.1-py311h16474ae_6_cpu.tar.bz2
win-64::postgresql-plpython-13.8-py38ha2f05b0_0.tar.bz2
win-64::arrow-cpp-7.0.1-py39hdf17a4b_6_cuda.tar.bz2
win-64::pytng-0.2.3-py39hcb05468_1.tar.bz2
win-64::vtk-9.2.2-qt_py37hdaf77b0_202.tar.bz2
win-64::stir-5.0.2-py39h4b893ef_5.tar.bz2
win-64::arrow-cpp-8.0.1-py39h19363dd_8_cuda.tar.bz2
win-64::imagecodecs-2022.9.26-py38h4198fce_1.tar.bz2
win-64::qt6-main-6.4.0-he608ae7_3.tar.bz2
win-64::arrow-cpp-9.0.0-py38hdbef18b_9_cuda.tar.bz2
win-64::libprotobuf-static-3.21.9-h12be248_0.tar.bz2
win-64::pillow-9.2.0-py311h97bb24d_3.tar.bz2
win-64::pytng-0.2.3-py38haa774df_1.tar.bz2
win-64::coda-2.24-py38hdd1a290_2.tar.bz2
win-64::gemmi-0.5.7-py39hd28a505_1.tar.bz2
win-64::harp-1.15.1-py310r41h40b6f39_3.tar.bz2
win-64::tectonic-0.12.0-h42e402a_0.tar.bz2
win-64::pytng-0.2.3-py310hff18152_1.tar.bz2
win-64::libmlir-15.0.3-he744812_0.tar.bz2
win-64::aws-sdk-cpp-1.9.371-h4a58fab_0.tar.bz2
win-64::vigra-1.11.1-py311h8dccad1_1036.tar.bz2
win-64::qt6-main-6.4.0-he867631_5.tar.bz2
win-64::arrow-cpp-9.0.0-py311h736ecbe_9_cpu.tar.bz2
win-64::vigra-1.11.1-py39ha24bc5c_1035.tar.bz2
win-64::postgresql-plpython-13.8-py39h15dfc06_0.tar.bz2
win-64::aws-sdk-cpp-1.9.374-hf1e1e5e_0.tar.bz2
win-64::libopencv-4.6.0-py39hedeca96_5.tar.bz2
win-64::sdl2_image-2.6.1-h22b4670_1.tar.bz2
win-64::lfortran-0.18.0-h12be248_0.tar.bz2
win-64::aws-sdk-cpp-1.9.367-hf6283e5_0.tar.bz2
win-64::vtk-9.2.2-qt_py39h808efec_201.tar.bz2
win-64::imagecodecs-2022.9.26-py39h8697103_1.tar.bz2
win-64::ffmpeg-4.4.2-lgpl_h396e71c_10.tar.bz2
win-64::stir-5.0.2-py38h00d5545_5.tar.bz2
win-64::pyhdf-0.10.5-py38h66e28d5_1.tar.bz2
win-64::pytng-0.2.3-py38hde45749_1.tar.bz2
win-64::arrow-cpp-9.0.0-py39h07ee6b1_8_cpu.tar.bz2
win-64::arrow-cpp-9.0.0-py39hf9a4b71_9_cpu.tar.bz2
win-64::omniorb-4.2.5-py311h40cf3c0_4.tar.bz2
win-64::omniorb-4.2.5-py310he97f525_3.tar.bz2
win-64::fontconfig-2.14.1-hbde0cde_0.tar.bz2
win-64::harp-1.15.1-py38r41hdd1a290_4.tar.bz2
win-64::postgresql-plpython-14.5-py311hdb0844a_1.tar.bz2
win-64::llvmdev-11.1.0-h97333cc_5.tar.bz2
win-64::pytables-3.7.0-py311h360bcb6_3.tar.bz2
win-64::tiledb-2.11.3-h5689973_1.tar.bz2
win-64::pyreadstat-1.2.0-py38h84023d3_0.tar.bz2
win-64::arrow-cpp-7.0.1-py38h2d85969_7_cpu.tar.bz2
win-64::vtk-9.2.2-qt_py38hc1024be_201.tar.bz2
win-64::mysql-connector-python-8.0.31-py39h25a42f0_1.tar.bz2
win-64::openbabel-3.1.1-py310hf5b7db0_5.tar.bz2
win-64::arrow-cpp-9.0.0-py38h2d85969_9_cpu.tar.bz2
win-64::imagecodecs-2022.9.26-py39h4413bcf_3.tar.bz2
win-64::arrow-cpp-9.0.0-py311h16474ae_8_cpu.tar.bz2
win-64::ffmpeg-5.1.2-lgpl_h396e71c_3.tar.bz2
win-64::omniorb-4.2.5-py39h0a8b3da_3.tar.bz2
win-64::grpc-cpp-1.46.4-h6a6baca_8.tar.bz2
win-64::openexr-python-1.3.9-py39ha4c3308_1.tar.bz2
win-64::imagecodecs-2022.9.26-py38h8bd6efd_1.tar.bz2
win-64::aws-sdk-cpp-1.8.186-h93d3aa3_4.tar.bz2
win-64::stir-5.0.2-py37h5bfd4b6_0.tar.bz2
win-64::ffmpeg-4.4.2-gpl_h02edd2a_109.tar.bz2
win-64::vigra-1.11.1-py310h96fe323_1035.tar.bz2
win-64::arrow-cpp-8.0.1-py311hb9719d8_6_cuda.tar.bz2
win-64::coda-2.24-py39h763b820_2.tar.bz2
win-64::harp-1.15.1-py39r41h763b820_4.tar.bz2
win-64::mysql-connector-python-8.0.30-py38h2426d48_1.tar.bz2
win-64::pyreadr-0.4.7-py39hd0dc6f3_2.tar.bz2
win-64::stir-5.0.2-py310h418b276_3.tar.bz2
win-64::py-bgzip-0.4.0-py310h35269f2_3.tar.bz2
win-64::libadios2-2.8.3-nompi_h1dbfd04_104.tar.bz2
win-64::hdf4-4.2.15-h1b1b6ef_5.tar.bz2
win-64::pyreadr-0.4.7-py311ha5690a0_2.tar.bz2
win-64::arrow-cpp-8.0.1-py310hab0adef_7_cuda.tar.bz2
win-64::llvmlite-0.39.1-py38h19421c1_1.tar.bz2
win-64::postgresql-plpython-13.8-py310hb7c6211_0.tar.bz2
win-64::omniorb-4.2.5-py39h0a8b3da_4.tar.bz2
win-64::arrow-cpp-8.0.1-py39hdf17a4b_6_cuda.tar.bz2
win-64::stir-5.0.2-py39h4b893ef_1.tar.bz2
win-64::qt-main-5.15.6-h9c3277a_1.tar.bz2
win-64::gst-plugins-base-1.21.1-h001b923_1.tar.bz2
win-64::arrow-cpp-6.0.2-py38hbbe9e87_6_cuda.tar.bz2
win-64::libpq-14.5-hf15792c_1.tar.bz2
win-64::imagecodecs-2022.9.26-py39h97fc6f5_1.tar.bz2
win-64::libopencv-4.6.0-py310hb22e633_5.tar.bz2
win-64::libxml2-2.10.3-hc3477c8_0.tar.bz2
win-64::libopencv-4.6.0-py39h0c67194_5.tar.bz2
win-64::arrow-cpp-8.0.1-py38hdb32e4e_6_cpu.tar.bz2
win-64::ffmpeg-4.4.2-lgpl_he8de668_9.tar.bz2
win-64::glib-2.74.1-h12be248_0.tar.bz2
win-64::postgresql-plpython-14.5-py310h25eba5b_1.tar.bz2
win-64::libgdal-3.5.2-h283e77c_5.tar.bz2
win-64::imagecodecs-2022.9.26-py310h68994fe_3.tar.bz2
win-64::openmeeg-2.5.5-py38hd51e9d6_1.tar.bz2
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
win-64::clang-15.0.2-h8e541a6_0.tar.bz2
win-64::clangxx-15.0.2-default_h66ee7f4_0.tar.bz2
-    "libzlib >=1.2.12,<1.3.0a0"
+    "libzlib >=1.2.12,<2.0.0a0"
win-64::clangxx-15.0.3-default_h66ee7f4_0.tar.bz2
win-64::clang-15.0.3-h8e541a6_0.tar.bz2
win-64::llvm-11.1.0-h6fda50d_5.tar.bz2
-    "libzlib >=1.2.13,<1.3.0a0"
+    "libzlib >=1.2.13,<2.0.0a0"
================================================================================
================================================================================
osx-64
osx-64::aws-sdk-cpp-1.9.358-he70de9a_0.tar.bz2
osx-64::scip-8.0.2-h7e00b17_1.tar.bz2
osx-64::aws-sdk-cpp-1.9.358-h6386e9f_1.tar.bz2
osx-64::mysql-client-8.0.31-h81e0a63_0.tar.bz2
osx-64::vtk-9.2.2-qt_py39hb4ae040_200.tar.bz2
osx-64::gdstk-0.9.1-py39hf1f424a_0.tar.bz2
osx-64::gazebo-11.12.0-h063ddd6_1.tar.bz2
osx-64::ovito-3.7.10-h43721e1_0.tar.bz2
osx-64::aws-sdk-cpp-1.9.361-h07b5f36_0.tar.bz2
osx-64::mysql-server-8.0.31-h0c5184f_0.tar.bz2
osx-64::sqlite-3.39.4-h9ae0607_0.tar.bz2
osx-64::jaxlib-0.3.22-cpu_py39hc2d11b0_0.tar.bz2
osx-64::lammps-2022.06.23-py38h3099bbc_mpich_3.tar.bz2
osx-64::mysql-libs-8.0.31-hc37e033_0.tar.bz2
osx-64::jaxlib-0.3.22-cpu_py310hfe4bcb0_0.tar.bz2
osx-64::arrow-cpp-7.0.1-py310hc9ce90b_5_cpu.tar.bz2
osx-64::nd2-0.4.5-py38hf703724_0.tar.bz2
osx-64::sagelib-9.7-py38h030ff5c_0.tar.bz2
osx-64::python-igraph-0.10.1-py38h5d3fc92_1.tar.bz2
osx-64::r-git2r-0.30.1-r42ha808ce5_1.tar.bz2
osx-64::arrow-cpp-6.0.2-py38h2ee4cb9_4_cpu.tar.bz2
osx-64::panda3d-1.10.12-py38hcca270f_0.tar.bz2
osx-64::nd2-0.4.6-py38h78b7a73_0.tar.bz2
osx-64::libcurl-7.85.0-h57eb407_0.tar.bz2
osx-64::gdstk-0.9.1-py39h6d27d09_0.tar.bz2
osx-64::lammps-2022.06.23-py37h7504ed2_openmpi_3.tar.bz2
osx-64::papilo-2.1.1-h9a2366d_1.tar.bz2
osx-64::tectonic-0.11.0-hcb82130_0.tar.bz2
osx-64::arrow-cpp-9.0.0-py38h6173236_7_cpu.tar.bz2
osx-64::verilator-4.228-h07d71dc_0.tar.bz2
osx-64::nd2-0.4.6-py310h9c878d8_0.tar.bz2
osx-64::nd2-0.4.6-py39hf61cd3b_0.tar.bz2
osx-64::z5py-2.0.16-py37hdfbb191_0.tar.bz2
osx-64::soplex-6.0.2-h63f1887_1.tar.bz2
osx-64::gdstk-0.9.1-py38hc22b7ae_0.tar.bz2
osx-64::mcpl-1.5.0-py37h5d31d3a_0.tar.bz2
osx-64::lammps-2022.06.23-py310hd2bfa26_mpich_3.tar.bz2
osx-64::mongodb-6.0.2-h2b5a84f_0.tar.bz2
osx-64::sagelib-9.7-py310h6c9b66d_0.tar.bz2
osx-64::nd2-0.4.5-py37h454128a_0.tar.bz2
osx-64::pypy3.9-7.3.9-hed75a59_5.tar.bz2
osx-64::pcre2-static-10.40-h1c4e4bc_0.tar.bz2
osx-64::python-igraph-0.10.1-py38hc833c9c_1.tar.bz2
osx-64::r-base-4.2.1-he54549f_2.tar.bz2
osx-64::r-strawr-0.0.9-r41h9c57f51_1.tar.bz2
osx-64::nodejs-18.11.0-hd0c9b3c_0.tar.bz2
osx-64::sagelib-9.6-py39hf8a2b27_4.tar.bz2
osx-64::librdkafka-1.9.2-h7571dfd_1.tar.bz2
osx-64::gdstk-0.9.1-py38hc2e84d9_0.tar.bz2
osx-64::jaxlib-0.3.22-cpu_py37h08c1716_0.tar.bz2
osx-64::llvmdev-15.0.2-hb04caa8_0.tar.bz2
osx-64::gdstk-0.9.1-py310hdb708e1_0.tar.bz2
osx-64::qt6-main-6.4.0-h353ae22_2.tar.bz2
osx-64::panda3d-1.10.12-py39h66cfac1_0.tar.bz2
osx-64::arrow-cpp-9.0.0-py37h7943f50_7_cpu.tar.bz2
osx-64::imagemagick-7.1.0_50-pl5321h39c443d_0.tar.bz2
osx-64::r-strawr-0.0.9-r42h9c57f51_1.tar.bz2
osx-64::nodejs-18.11.0-h3591b89_0.tar.bz2
osx-64::arrow-cpp-8.0.1-py38h6173236_5_cpu.tar.bz2
osx-64::mysql-connector-odbc-8.0.31-hbc0c0cd_0.tar.bz2
osx-64::r-git2r-0.30.1-r41ha808ce5_1.tar.bz2
osx-64::mcpl-1.5.0-py310h2bfb868_0.tar.bz2
osx-64::vtk-9.2.2-qt_py310h696756a_200.tar.bz2
osx-64::libxml2-2.10.2-hb9e07b5_2.tar.bz2
osx-64::lammps-2022.06.23-py39h9bd0131_mpich_3.tar.bz2
osx-64::r-git2r-0.30.1-r41ha599b27_1.tar.bz2
osx-64::pypy3.8-7.3.9-hb40c2ac_5.tar.bz2
osx-64::sagelib-9.6-py38h030ff5c_4.tar.bz2
osx-64::aws-sdk-cpp-1.9.357-he70de9a_0.tar.bz2
osx-64::nd2-0.4.6-py39hc39b4fa_0.tar.bz2
osx-64::sagelib-9.7-py310h6c9b66d_1.tar.bz2
osx-64::rstudio-desktop-2022.07.2-r42h911b70e_577.tar.bz2
osx-64::arrow-cpp-6.0.2-py310h33c4a6f_4_cpu.tar.bz2
osx-64::r-base-4.1.3-he54549f_3.tar.bz2
osx-64::libllvm15-15.0.2-hb04caa8_0.tar.bz2
osx-64::aws-sdk-cpp-1.9.362-h07b5f36_0.tar.bz2
osx-64::librdkafka-1.9.2-h7246ccc_1.tar.bz2
osx-64::libcurl-static-7.85.0-h57eb407_0.tar.bz2
osx-64::nd2-0.4.5-py38h78b7a73_0.tar.bz2
osx-64::lammps-2022.06.23-py37h0d80f39_mpich_3.tar.bz2
osx-64::sagelib-9.6-py37h02e0cb4_4.tar.bz2
osx-64::jaxlib-0.3.22-cpu_py39hc031c27_0.tar.bz2
osx-64::nd2-0.4.6-py37h454128a_0.tar.bz2
osx-64::libsoup-3.2.1-h9cf3a4b_0.tar.bz2
osx-64::curl-7.85.0-h57eb407_0.tar.bz2
osx-64::git-2.38.0-pl5321he9137ab_0.tar.bz2
osx-64::liblal-7.2.4-mkl_h4a7761d_0.tar.bz2
osx-64::python-igraph-0.10.1-py39h0bfd786_1.tar.bz2
osx-64::r-rmatio-0.16.0-r41h815d134_1.tar.bz2
osx-64::jaxlib-0.3.22-cpu_py310hc4ef77f_0.tar.bz2
osx-64::vowpalwabbit-9.4.0-py310h630de0f_0.tar.bz2
osx-64::arrow-cpp-8.0.1-py37h7943f50_5_cpu.tar.bz2
osx-64::aws-sdk-cpp-1.9.362-hab2004f_1.tar.bz2
osx-64::jaxlib-0.3.22-cpu_py38h177ad0c_0.tar.bz2
osx-64::git-2.38.0-pl5321h17f406e_0.tar.bz2
osx-64::giac-1.9.0.21-h6520c23_0.tar.bz2
osx-64::python-igraph-0.10.1-py37h7aa6e88_1.tar.bz2
osx-64::jaxlib-0.3.22-cpu_py37hf12bf50_0.tar.bz2
osx-64::sagelib-9.7-py38h030ff5c_1.tar.bz2
osx-64::erlang-25.1.1-pl5321ha491908_0.tar.bz2
osx-64::curl-7.85.0-h581aaea_0.tar.bz2
osx-64::qt6-main-6.4.0-h353ae22_1.tar.bz2
osx-64::arrow-cpp-8.0.1-py310hc9ce90b_5_cpu.tar.bz2
osx-64::arrow-cpp-9.0.0-py39h04a14be_7_cpu.tar.bz2
osx-64::gdstk-0.9.1-py37h90ea96d_0.tar.bz2
osx-64::lammps-2022.06.23-py310hddfdfda_openmpi_3.tar.bz2
osx-64::panda3d-1.10.12-py310hc72d090_0.tar.bz2
osx-64::arrow-cpp-7.0.1-py38h6173236_5_cpu.tar.bz2
osx-64::nd2-0.4.5-py39hc39b4fa_0.tar.bz2
osx-64::panda3d-1.10.12-py37h1097cb5_0.tar.bz2
osx-64::libmediainfo-22.09-heb0c7ea_0.tar.bz2
osx-64::r-rmatio-0.16.0-r42h815d134_1.tar.bz2
osx-64::z5py-2.0.16-py310hfade586_0.tar.bz2
osx-64::qt6-main-6.4.0-h353ae22_0.tar.bz2
osx-64::vowpalwabbit-9.4.0-py37h6833aad_0.tar.bz2
osx-64::arrow-cpp-6.0.2-py39ha94e4ea_4_cpu.tar.bz2
osx-64::vowpalwabbit-9.4.0-py39h20fc92d_0.tar.bz2
osx-64::symengine-0.9.0-h754f8cb_1.tar.bz2
osx-64::vowpalwabbit-9.4.0-py38h9361c75_0.tar.bz2
osx-64::r-gaston-1.5.7-r42h32f0767_1.tar.bz2
osx-64::panda3d-1.10.12-py37h60c8147_0.tar.bz2
osx-64::scip-8.0.2-ha844535_0.tar.bz2
osx-64::z5py-2.0.16-py38hf5b887e_0.tar.bz2
osx-64::aws-sdk-cpp-1.9.356-he70de9a_1.tar.bz2
osx-64::nd2-0.4.5-py310h9c878d8_0.tar.bz2
osx-64::r-seqminer-8.4-r41h773cbae_1.tar.bz2
osx-64::erlang-25.1.1-pl5321h12b42e0_0.tar.bz2
osx-64::vtk-9.2.2-qt_py38h57742dd_200.tar.bz2
osx-64::arrow-cpp-7.0.1-py37h7943f50_5_cpu.tar.bz2
osx-64::tectonic-0.11.0-h9ef1e01_0.tar.bz2
osx-64::mysql-client-8.0.31-hbbbc359_0.tar.bz2
osx-64::r-git2r-0.30.1-r42ha599b27_1.tar.bz2
osx-64::r-seqminer-8.4-r42h773cbae_1.tar.bz2
osx-64::vtk-9.2.2-qt_py37h1bf964c_200.tar.bz2
osx-64::soplex-6.0.2-h63f1887_0.tar.bz2
osx-64::arrow-cpp-8.0.1-py39h04a14be_5_cpu.tar.bz2
osx-64::lammps-2022.06.23-py38h9e84cc3_openmpi_3.tar.bz2
osx-64::aws-sdk-cpp-1.9.363-hab2004f_0.tar.bz2
osx-64::pypy3.9-7.3.9-h478034a_5.tar.bz2
osx-64::pypy3.8-7.3.9-h856ce2f_5.tar.bz2
osx-64::gazebo-11.12.0-hb03ebe4_1.tar.bz2
osx-64::arrow-cpp-9.0.0-py310hc9ce90b_7_cpu.tar.bz2
osx-64::nd2-0.4.6-py38hf703724_0.tar.bz2
osx-64::sagelib-9.7-py39hf8a2b27_1.tar.bz2
osx-64::z5py-2.0.16-py39hfeb0836_0.tar.bz2
osx-64::libcurl-7.85.0-h581aaea_0.tar.bz2
osx-64::lammps-2022.06.23-py39h5643e98_openmpi_3.tar.bz2
osx-64::mysql-server-8.0.31-ha134c4c_0.tar.bz2
osx-64::libcurl-static-7.85.0-h581aaea_0.tar.bz2
osx-64::panda3d-1.10.12-py310hba575f8_0.tar.bz2
osx-64::python-igraph-0.10.1-py39h9a34910_1.tar.bz2
osx-64::papilo-2.1.1-h9a2366d_0.tar.bz2
osx-64::panda3d-1.10.12-py39h4fa6eb9_0.tar.bz2
osx-64::llvm-15.0.2-hf86d651_0.tar.bz2
osx-64::rstudio-desktop-2022.07.2-r41h911b70e_577.tar.bz2
osx-64::sagelib-9.6-py310h6c9b66d_4.tar.bz2
osx-64::mcpl-1.5.0-py39had167e2_0.tar.bz2
osx-64::gst-plugins-good-1.21.1-h9c2bda7_0.tar.bz2
osx-64::sagelib-9.7-py39hf8a2b27_0.tar.bz2
osx-64::ogre-next-2.3.1-h4ebc42d_3.tar.bz2
osx-64::openssh-9.1p1-h4aa9af9_0.tar.bz2
osx-64::arrow-cpp-6.0.2-py37hebff73e_4_cpu.tar.bz2
osx-64::mysql-libs-8.0.31-h8658499_0.tar.bz2
osx-64::julia-1.8.2-hcb9ed81_0.tar.bz2
osx-64::jaxlib-0.3.22-cpu_py38h84efa26_0.tar.bz2
osx-64::r-gaston-1.5.7-r41h32f0767_1.tar.bz2
osx-64::mcpl-1.5.0-py38hc86dbf9_0.tar.bz2
osx-64::python-igraph-0.10.1-py310h3f43f70_1.tar.bz2
osx-64::aws-sdk-cpp-1.9.358-h07b5f36_2.tar.bz2
osx-64::glibmm-2.68-2.74.0-h2aa9358_0.tar.bz2
osx-64::llvm-tools-15.0.2-hb04caa8_0.tar.bz2
-    "libzlib >=1.2.12,<1.3.0a0",
+    "libzlib >=1.2.12,<2.0.0a0",
osx-64::lxml-4.9.1-py39h2a9d282_1.tar.bz2
osx-64::xrootd-5.5.0-py39h8fbd737_0.tar.bz2
osx-64::harp-1.15.1-py39r41h1ed1f25_4.tar.bz2
osx-64::arrow-cpp-9.0.0-py311hfb3f5be_9_cpu.tar.bz2
osx-64::panda3d-1.10.12-py310h28144e0_1.tar.bz2
osx-64::postgresql-13.8-hae21482_0.tar.bz2
osx-64::vigra-1.11.1-py310h8d69f5c_1036.tar.bz2
osx-64::postgresql-plpython-14.5-py311h4897fa8_1.tar.bz2
osx-64::netcdf4-1.6.1-nompi_py310h6892ea4_101.tar.bz2
osx-64::xrootd-5.5.1-py38h09ef9fa_1.tar.bz2
osx-64::libopencv-4.6.0-py38haad26e0_5.tar.bz2
osx-64::cppyy-cling-6.27.0-py39h0bb4e67_2.tar.bz2
osx-64::libgrpc-1.49.1-h834a566_1.tar.bz2
osx-64::vowpalwabbit-9.5.0-py39h20fc92d_1.tar.bz2
osx-64::openmeeg-2.5.5-py38h873d8ab_1.tar.bz2
osx-64::xrootd-5.5.1-py38h7d0fd33_1.tar.bz2
osx-64::imagecodecs-2022.9.26-py310h79a1b8a_2.tar.bz2
osx-64::harp-1.15.1-py38r42h20606e4_3.tar.bz2
osx-64::pillow-9.2.0-py38h9890993_3.tar.bz2
osx-64::vigra-1.11.1-py39h20cf4fd_1036.tar.bz2
osx-64::libadios2-2.8.3-nompi_h73467be_104.tar.bz2
osx-64::libllvm15-15.0.3-hb04caa8_0.tar.bz2
osx-64::xrootd-5.5.1-py38h42e509c_2.tar.bz2
osx-64::cppyy-cling-6.27.0-py38hbcdfe3b_2.tar.bz2
osx-64::lxml-4.9.1-py38h64add32_1.tar.bz2
osx-64::ffmpeg-5.1.2-gpl_hff0bab5_102.tar.bz2
osx-64::arrow-cpp-8.0.1-py38ha1acfac_8_cpu.tar.bz2
osx-64::openbabel-3.1.1-py311hb8587a6_5.tar.bz2
osx-64::xrootd-5.5.1-py38h42e509c_1.tar.bz2
osx-64::vigra-1.11.1-py38h357bd86_1035.tar.bz2
osx-64::aws-sdk-cpp-1.9.370-h36efd74_2.tar.bz2
osx-64::postgresql-plpython-13.8-py38hd4d7870_0.tar.bz2
osx-64::voms-2.1.0rc2-h62d1148_7.tar.bz2
osx-64::libcurl-static-7.86.0-h57eb407_0.tar.bz2
osx-64::pytables-3.7.0-py39hc15ac9a_3.tar.bz2
osx-64::ogre-1.10.12-hd9b3965_10.tar.bz2
osx-64::harp-1.15.1-py310r42h2d8d718_4.tar.bz2
osx-64::py-bgzip-0.4.0-py39h6bb596b_3.tar.bz2
osx-64::arrow-cpp-8.0.1-py311hd48e9fc_8_cpu.tar.bz2
osx-64::llvmlite-0.39.1-py38h8c0d2ee_1.tar.bz2
osx-64::libnetcdf-4.8.1-mpi_mpich_hc6a5375_6.tar.bz2
osx-64::panda3d-1.10.12-py37h52c098d_1.tar.bz2
osx-64::gemmi-0.5.7-py39h3d6f5fc_1.tar.bz2
osx-64::pytng-0.2.3-py38h51293be_1.tar.bz2
osx-64::openmeeg-2.5.5-py39h22dda8a_1.tar.bz2
osx-64::mysql-connector-python-8.0.31-py38h6bc455e_2.tar.bz2
osx-64::aws-sdk-cpp-1.9.372-h32e7509_0.tar.bz2
osx-64::pytables-3.7.0-py310h90ba602_3.tar.bz2
osx-64::arrow-cpp-8.0.1-py310hbce6b4f_8_cpu.tar.bz2
osx-64::vowpalwabbit-9.5.0-py310h630de0f_0.tar.bz2
osx-64::arrow-cpp-6.0.2-py39h661c45e_6_cpu.tar.bz2
osx-64::libvips-8.13.2-h2fcb8b9_0.tar.bz2
osx-64::libadios2-2.8.3-mpi_openmpi_h8c6559c_4.tar.bz2
osx-64::xrootd-5.5.1-py310h53be6d9_2.tar.bz2
osx-64::llvmlite-0.39.1-py39h3d6f5fc_1.tar.bz2
osx-64::python-3.11.0-ha621ccb_0_cpython.tar.bz2
osx-64::imagecodecs-2022.9.26-py38h868acd9_2.tar.bz2
osx-64::root_base-6.26.8-py311hf8fe3e7_1.tar.bz2
osx-64::coda-2.24-py38h20606e4_2.tar.bz2
osx-64::imagecodecs-2022.9.26-py310he2d74c2_1.tar.bz2
osx-64::vtk-9.2.2-qt_py38h965549f_204.tar.bz2
osx-64::vtk-9.2.2-qt_py311h4d5bf31_204.tar.bz2
osx-64::python-igraph-0.10.2-py38hc833c9c_0.tar.bz2
osx-64::mcpl-1.5.0-py38h8c0d2ee_2.tar.bz2
osx-64::harp-1.15.1-py39r41h1ed1f25_3.tar.bz2
osx-64::arrow-cpp-9.0.0-py311hd48e9fc_10_cpu.tar.bz2
osx-64::imagecodecs-2022.9.26-py39h263a9f6_3.tar.bz2
osx-64::libadios2-2.8.3-nompi_h94981c0_104.tar.bz2
osx-64::python-rocksdb-0.7.0-py310h1cd6d85_7.tar.bz2
osx-64::vtk-9.2.2-qt_py38hcea346a_201.tar.bz2
osx-64::imagecodecs-2022.9.26-py38h868acd9_3.tar.bz2
osx-64::xrootd-5.5.1-py39h6fc80d7_2.tar.bz2
osx-64::gazebo-11.12.0-h8bc65b3_2.tar.bz2
osx-64::imagecodecs-2022.9.26-py38h11726d4_1.tar.bz2
osx-64::pytng-0.2.3-py310hb9ee061_1.tar.bz2
osx-64::grpc-cpp-1.48.1-h966d1d5_2.tar.bz2
osx-64::mcpl-1.5.0-py38hc86dbf9_1.tar.bz2
osx-64::netcdf4-1.6.1-nompi_py38hbdcf7ac_101.tar.bz2
osx-64::libcurl-static-7.86.0-h581aaea_0.tar.bz2
osx-64::ogre-13.4.4-h04e0adc_1.tar.bz2
osx-64::libnetcdf-4.9.0-mpi_openmpi_hd01fa53_1.tar.bz2
osx-64::mysql-connector-python-8.0.30-py38h6bc455e_1.tar.bz2
osx-64::poppler-qt-22.10.0-ha47c16f_0.tar.bz2
osx-64::python-igraph-0.10.2-py38h5d3fc92_0.tar.bz2
osx-64::arrow-cpp-9.0.0-py39h7d8c460_10_cpu.tar.bz2
osx-64::grpc-cpp-1.45.2-h128934e_7.tar.bz2
osx-64::mysql-connector-python-8.0.31-py310h1ced1e2_1.tar.bz2
osx-64::pytng-0.2.3-py38hadfd06d_1.tar.bz2
osx-64::r-httpgd-1.3.0-r42h3a056c8_1.tar.bz2
osx-64::libopencv-4.6.0-py38h28ed0f6_5.tar.bz2
osx-64::plumed-2.8.1-nompi_h514ca54_100.tar.bz2
osx-64::harp-1.15.1-py311r42hd06703c_4.tar.bz2
osx-64::omniorb-4.2.5-py38h732d4a6_3.tar.bz2
osx-64::vigra-1.11.1-py310h8d69f5c_1035.tar.bz2
osx-64::xrootd-5.5.0-py37h813fa76_0.tar.bz2
osx-64::omniorb-4.2.5-py38h46655f2_4.tar.bz2
osx-64::pyreadstat-1.2.0-py310haafd797_0.tar.bz2
osx-64::netcdf4-1.6.1-nompi_py311h41bc3eb_101.tar.bz2
osx-64::pillow-9.2.0-py310hffcf78b_3.tar.bz2
osx-64::vtk-9.2.2-qt_py37he90502e_202.tar.bz2
osx-64::imagecodecs-2022.9.26-py38hcb80ccf_1.tar.bz2
osx-64::xrootd-5.5.1-py310h74df8f0_1.tar.bz2
osx-64::hdf4-4.2.15-h7aa5921_5.tar.bz2
osx-64::pytng-0.2.3-py311h0108fbc_1.tar.bz2
osx-64::libopencv-4.6.0-py39hfa69ae4_5.tar.bz2
osx-64::aws-sdk-cpp-1.9.371-h32e7509_0.tar.bz2
osx-64::harp-1.15.1-py39r42hc709b36_4.tar.bz2
osx-64::root_base-6.26.8-py37h0015d16_1.tar.bz2
osx-64::arrow-cpp-8.0.1-py39h04a14be_6_cpu.tar.bz2
osx-64::harp-1.15.1-py39r41hc709b36_4.tar.bz2
osx-64::gst-plugins-good-1.21.1-h9c2bda7_1.tar.bz2
osx-64::gazebo-11.12.0-h5c7d138_2.tar.bz2
osx-64::xrootd-5.5.0-py39he05f790_0.tar.bz2
osx-64::pillow-9.2.0-py39h35d4919_3.tar.bz2
osx-64::xrootd-5.5.1-py39hd098475_2.tar.bz2
osx-64::panda3d-1.10.12-py39h25d9565_1.tar.bz2
osx-64::aws-sdk-cpp-1.8.186-h7c85d8e_4.tar.bz2
osx-64::aws-sdk-cpp-1.9.370-h32e7509_2.tar.bz2
osx-64::coda-2.24-py39hc709b36_2.tar.bz2
osx-64::arrow-cpp-7.0.1-py311hfb3f5be_7_cpu.tar.bz2
osx-64::vigra-1.11.1-py311h48a3cf6_1036.tar.bz2
osx-64::pyhdf-0.10.5-py39hcc41ca7_1.tar.bz2
osx-64::yarp-cxx-3.7.2-h59af4d3_2.tar.bz2
osx-64::pp-sketchlib-2.0.1-py39hb779d6e_1.tar.bz2
osx-64::pyreadr-0.4.7-py38hf8e802a_2.tar.bz2
osx-64::root_base-6.26.8-py39hcedc2be_1.tar.bz2
osx-64::vtk-9.2.2-qt_py39h5e22e60_201.tar.bz2
osx-64::mcpl-1.5.0-py38h8c0d2ee_1.tar.bz2
osx-64::xrootd-5.5.1-py37h4029b84_0.tar.bz2
osx-64::curl-7.86.0-h57eb407_0.tar.bz2
osx-64::vowpalwabbit-9.5.0-py38h9361c75_1.tar.bz2
osx-64::xrootd-5.5.1-py37h813fa76_0.tar.bz2
osx-64::omniorb-4.2.5-py310hb9993f7_3.tar.bz2
osx-64::omniorb-4.2.5-py39h8bad868_4.tar.bz2
osx-64::aws-sdk-cpp-1.9.369-h4157a37_1.tar.bz2
osx-64::voms-2.1.0rc0-he0d4868_7.tar.bz2
osx-64::netcdf4-1.6.1-mpi_openmpi_py39h0377a20_1.tar.bz2
osx-64::aws-sdk-cpp-1.9.374-h36efd74_0.tar.bz2
osx-64::arrow-cpp-8.0.1-py310h01f5732_7_cpu.tar.bz2
osx-64::cppyy-cling-6.27.0-py38hd73a368_2.tar.bz2
osx-64::xrootd-5.5.1-py38h7d0fd33_2.tar.bz2
osx-64::ndcctools-7.4.14-py310h15278f1_2.tar.bz2
osx-64::pyhdf-0.10.5-py38ha1f4b08_1.tar.bz2
osx-64::pylibmc-1.6.3-py310haafd797_1.tar.bz2
osx-64::harp-1.15.1-py311r41hd06703c_4.tar.bz2
osx-64::nginx-1.23.2-ha931d61_0.tar.bz2
osx-64::arrow-cpp-6.0.2-py311h9f3306f_5_cpu.tar.bz2
osx-64::root_base-6.26.8-py310h811f337_1.tar.bz2
osx-64::panda3d-1.10.12-py38h42bce6b_1.tar.bz2
osx-64::vowpalwabbit-9.5.0-py311hf41b962_1.tar.bz2
osx-64::xrootd-5.5.1-py38h4785fdb_1.tar.bz2
osx-64::panda3d-1.10.12-py37h5e5e747_1.tar.bz2
osx-64::postgresql-plpython-13.8-py39h7138289_0.tar.bz2
osx-64::pillow-9.2.0-py39hc5443f6_3.tar.bz2
osx-64::pyinstaller-5.1-py38h01a1b83_1.tar.bz2
osx-64::libopencv-4.6.0-py37h0e7fadd_5.tar.bz2
osx-64::postgresql-plpython-14.5-py310h2452bfe_1.tar.bz2
osx-64::openbabel-3.1.1-py39h3edb9d3_5.tar.bz2
osx-64::pillow-9.2.0-py311he7df5c9_3.tar.bz2
osx-64::poppler-22.10.0-hf2ff1a1_0.tar.bz2
osx-64::vigra-1.11.1-py39h20cf4fd_1035.tar.bz2
osx-64::vtk-9.2.2-qt_py310h3be1ae4_201.tar.bz2
osx-64::arrow-cpp-6.0.2-py39ha94e4ea_5_cpu.tar.bz2
osx-64::yarp-cxx-3.7.2-he721ed9_4.tar.bz2
osx-64::arrow-cpp-9.0.0-py38ha1acfac_10_cpu.tar.bz2
osx-64::imagecodecs-2022.9.26-py39h1e0cc1c_2.tar.bz2
osx-64::pygrib-2.1.4-py39h9def944_6.tar.bz2
osx-64::yarp-cxx-3.7.2-he721ed9_3.tar.bz2
osx-64::arrow-cpp-7.0.1-py311hd48e9fc_8_cpu.tar.bz2
osx-64::xrootd-5.5.0-py39h83e33c3_0.tar.bz2
osx-64::ffmpeg-5.1.2-lgpl_hc2ce967_3.tar.bz2
osx-64::panda3d-1.10.12-py310h194a88a_1.tar.bz2
osx-64::aws-sdk-cpp-1.9.370-h36efd74_1.tar.bz2
osx-64::tiledb-2.12.0-h8b9cbf0_1.tar.bz2
osx-64::tiledb-2.11.3-h8b9cbf0_1.tar.bz2
osx-64::postgresql-plpython-14.5-py39ha872ce3_1.tar.bz2
osx-64::mcpl-1.5.0-py38hc86dbf9_2.tar.bz2
osx-64::mysql-connector-python-8.0.30-py38hffbffe8_1.tar.bz2
osx-64::plumed-2.8.1-mpi_openmpi_h3bb7d58_0.tar.bz2
osx-64::pp-sketchlib-2.0.1-py38h60b3f94_0.tar.bz2
osx-64::coda-2.24-py39h1ed1f25_2.tar.bz2
osx-64::libopencv-4.6.0-py39hc4816b1_6.tar.bz2
osx-64::xrootd-5.5.1-py39he73330d_1.tar.bz2
osx-64::vowpalwabbit-9.5.0-py39h20fc92d_0.tar.bz2
osx-64::voms-2.1.0rc2-he0d4868_7.tar.bz2
osx-64::python-3.11.0-h559f36b_0_cpython.tar.bz2
osx-64::nginx-1.23.2-he2ecc56_0.tar.bz2
osx-64::imagecodecs-2022.9.26-py39h263a9f6_1.tar.bz2
osx-64::tectonic-0.12.0-h9ef1e01_0.tar.bz2
osx-64::pp-sketchlib-2.0.1-py311hec5560a_1.tar.bz2
osx-64::imagecodecs-2022.9.26-py39h263a9f6_2.tar.bz2
osx-64::arrow-cpp-8.0.1-py38hf6a008a_7_cpu.tar.bz2
osx-64::grpc-cpp-1.48.1-h834a566_2.tar.bz2
osx-64::nco-5.1.1-h9bc8a9a_0.tar.bz2
osx-64::python-igraph-0.10.2-py38h719606e_1.tar.bz2
osx-64::omniorb-4.2.5-py39h7e79b73_3.tar.bz2
osx-64::xrootd-5.5.0-py38h82437db_0.tar.bz2
osx-64::panda3d-1.10.12-py38hf742e6a_1.tar.bz2
osx-64::openexr-python-1.3.9-py38h0400146_1.tar.bz2
osx-64::wxpython-4.1.1-py38h1ca7a7d_8.tar.bz2
osx-64::harp-1.15.1-py38r41h20606e4_4.tar.bz2
osx-64::r-popgenome-2.7.5-r41h32f0767_2.tar.bz2
osx-64::ldas-tools-framecpp-2.9.1-h7221f53_1.tar.bz2
osx-64::curl-7.86.0-h581aaea_0.tar.bz2
osx-64::xrootd-5.5.1-py38h2b04da7_0.tar.bz2
osx-64::mcpl-1.5.0-py310h2bfb868_2.tar.bz2
osx-64::aws-sdk-cpp-1.9.374-h32e7509_0.tar.bz2
osx-64::libpq-13.8-h50fae06_0.tar.bz2
osx-64::rsync-3.2.7-ha1fed10_0.tar.bz2
osx-64::llvmlite-0.39.1-py38hc86dbf9_1.tar.bz2
osx-64::pytng-0.2.3-py39h3563917_1.tar.bz2
osx-64::gemmi-0.5.7-py38hc86dbf9_1.tar.bz2
osx-64::plumed-2.8.1-mpi_mpich_hda57ff0_0.tar.bz2
osx-64::xrootd-5.5.1-py311h130c050_2.tar.bz2
osx-64::pp-sketchlib-2.0.1-py310hef20f8f_1.tar.bz2
osx-64::xrootd-5.5.1-py310h74df8f0_2.tar.bz2
osx-64::xrootd-5.5.1-py39h99ac593_2.tar.bz2
osx-64::liblal-7.2.4-mkl_h4a7761d_1.tar.bz2
osx-64::yoda-1.9.6-py37h9da7802_2.tar.bz2
osx-64::pyhdf-0.10.5-py311h5d2f87f_1.tar.bz2
osx-64::xrootd-5.5.1-py38hd1c7eff_0.tar.bz2
osx-64::libcurl-7.86.0-h581aaea_0.tar.bz2
osx-64::xrootd-5.5.1-py39he73330d_0.tar.bz2
osx-64::harp-1.15.1-py38r41had32a48_4.tar.bz2
osx-64::xrootd-5.5.1-py39h6fc80d7_0.tar.bz2
osx-64::davix-0.8.3-hf249a6f_0.tar.bz2
osx-64::netcdf4-1.6.1-mpi_mpich_py38h022767a_1.tar.bz2
osx-64::pyinstaller-5.1-py39h4603615_1.tar.bz2
osx-64::imagecodecs-2022.9.26-py38hc93c41e_1.tar.bz2
osx-64::davix-0.8.3-he554864_0.tar.bz2
osx-64::xrootd-5.5.1-py38h82437db_0.tar.bz2
osx-64::ffmpeg-5.1.2-lgpl_h134ff56_2.tar.bz2
osx-64::libnetcdf-4.8.1-mpi_openmpi_hb9a5949_5.tar.bz2
osx-64::xrootd-5.5.1-py38h09ef9fa_0.tar.bz2
osx-64::omniorb-4.2.5-py311hdd2c131_3.tar.bz2
osx-64::arrow-cpp-7.0.1-py310h01f5732_7_cpu.tar.bz2
osx-64::leptonica-1.82.0-hdfcea66_1.tar.bz2
osx-64::pytables-3.7.0-py39hb2d75a1_3.tar.bz2
osx-64::yoda-1.9.6-py39h4cdd271_2.tar.bz2
osx-64::libpq-13.8-hd79e848_0.tar.bz2
osx-64::pygrib-2.1.4-py38h41fcb08_6.tar.bz2
osx-64::libopencv-4.6.0-py310h5962dd8_6.tar.bz2
osx-64::mcpl-1.5.0-py39h3d6f5fc_2.tar.bz2
osx-64::pyreadstat-1.2.0-py38h01a1b83_0.tar.bz2
osx-64::cppyy-cling-6.27.0-py39h78a5168_2.tar.bz2
osx-64::git-2.38.1-pl5321he9137ab_0.tar.bz2
osx-64::xrootd-5.5.1-py39h99ac593_0.tar.bz2
osx-64::python-rocksdb-0.7.0-py38hcf18f0a_7.tar.bz2
osx-64::xrootd-5.5.1-py311h9ce162d_2.tar.bz2
osx-64::py-bgzip-0.4.0-py311h2047dbb_3.tar.bz2
osx-64::rsync-3.2.7-h30d983d_0.tar.bz2
osx-64::leptonica-1.82.0-hdfcea66_2.tar.bz2
osx-64::mcpl-1.5.0-py311h4c819dc_2.tar.bz2
osx-64::pygrib-2.1.4-py38h6cc88e1_6.tar.bz2
osx-64::xrootd-5.5.1-py39hd098475_0.tar.bz2
osx-64::xrootd-5.5.1-py39h83e33c3_0.tar.bz2
osx-64::root_base-6.26.8-py310h660d7e6_0.tar.bz2
osx-64::pylibmc-1.6.3-py38h85858c8_1.tar.bz2
osx-64::arrow-cpp-7.0.1-py310hc9ce90b_6_cpu.tar.bz2
osx-64::root_base-6.26.8-py310h1c6a0d5_1.tar.bz2
osx-64::omniorb-4.2.5-py310hb9993f7_4.tar.bz2
osx-64::vigra-1.11.1-py39h1e020cb_1035.tar.bz2
osx-64::mcpl-1.5.0-py310h2bfb868_1.tar.bz2
osx-64::pyreadr-0.4.7-py310h458ce67_2.tar.bz2
osx-64::r-httpgd-1.3.0-r41h3a056c8_1.tar.bz2
osx-64::ffmpeg-5.1.2-gpl_h1c50e5d_103.tar.bz2
osx-64::libglib-2.74.1-h3ba3332_0.tar.bz2
osx-64::libnetcdf-4.9.0-nompi_h5456b97_102.tar.bz2
osx-64::ffmpeg-4.4.2-gpl_hff0bab5_109.tar.bz2
osx-64::omniorb-4.2.5-py39h8bad868_3.tar.bz2
osx-64::vtk-9.2.2-qt_py38h965549f_203.tar.bz2
osx-64::vigra-1.11.1-py38h4a9ea6e_1036.tar.bz2
osx-64::python-igraph-0.10.2-py38heed66c0_1.tar.bz2
osx-64::xrootd-5.5.1-py310heffd4c4_0.tar.bz2
osx-64::harp-1.15.1-py38r42had32a48_4.tar.bz2
osx-64::libxml2-2.10.3-hb9e07b5_0.tar.bz2
osx-64::arrow-cpp-7.0.1-py311h15d7f3f_6_cpu.tar.bz2
osx-64::xrootd-5.5.1-py37h83ba209_1.tar.bz2
osx-64::yoda-1.9.6-py310he14f491_2.tar.bz2
osx-64::pyhdf-0.10.5-py310h8ceabd9_1.tar.bz2
osx-64::pylibmc-1.6.3-py38h01a1b83_1.tar.bz2
osx-64::imagecodecs-2022.9.26-py38h868acd9_1.tar.bz2
osx-64::pygrib-2.1.4-py311h9d56dc7_6.tar.bz2
osx-64::pp-sketchlib-2.0.1-py310hef20f8f_0.tar.bz2
osx-64::ogre-1.12.13-h3b2412a_3.tar.bz2
osx-64::openmeeg-2.5.5-py38hc4750b3_1.tar.bz2
osx-64::vtk-9.2.2-qt_py38hcea346a_202.tar.bz2
osx-64::erlang-25.1.2-pl5321ha491908_0.tar.bz2
osx-64::python-rocksdb-0.7.0-py39h98fd093_7.tar.bz2
osx-64::cpp-opentelemetry-sdk-1.6.1-ha0fd4f6_1.tar.bz2
osx-64::libxmlsec1-1.2.35-he0797f1_1.tar.bz2
osx-64::panda3d-1.10.12-py37h3525ba4_1.tar.bz2
osx-64::mysql-connector-python-8.0.31-py39hb4b9d65_1.tar.bz2
osx-64::libxmlsec1-1.2.35-he0797f1_0.tar.bz2
osx-64::xrootd-5.5.1-py310h53be6d9_0.tar.bz2
osx-64::tiledb-2.11.3-h3b7b576_1.tar.bz2
osx-64::libllvm15-15.0.3-h7001e86_1.tar.bz2
osx-64::liblal-7.2.4-mkl_h4a7761d_2.tar.bz2
osx-64::aws-sdk-cpp-1.9.371-h36efd74_0.tar.bz2
osx-64::vowpalwabbit-9.5.0-py38h9361c75_0.tar.bz2
osx-64::xrootd-5.5.0-py37h4029b84_0.tar.bz2
osx-64::panda3d-1.10.12-py37h8d38891_1.tar.bz2
osx-64::libgdal-3.5.2-h02359ec_4.tar.bz2
osx-64::arrow-cpp-9.0.0-py39h04a14be_8_cpu.tar.bz2
osx-64::libopencv-4.6.0-py38h28ed0f6_6.tar.bz2
osx-64::aws-sdk-cpp-1.9.369-hab2004f_0.tar.bz2
osx-64::aws-sdk-cpp-1.9.370-h4157a37_0.tar.bz2
osx-64::ffmpeg-4.4.2-gpl_h1c50e5d_110.tar.bz2
osx-64::openexr-python-1.3.9-py39h7700608_1.tar.bz2
osx-64::pytables-3.7.0-py38h75a17bf_3.tar.bz2
osx-64::ndcctools-7.4.14-py39h7639174_2.tar.bz2
osx-64::panda3d-1.10.12-py310h682b620_1.tar.bz2
osx-64::libtiledb-sql-0.19.0-h134b83a_0.tar.bz2
osx-64::ffmpeg-4.4.2-lgpl_h134ff56_9.tar.bz2
osx-64::pyreadr-0.4.7-py39h47e4aa0_2.tar.bz2
osx-64::omniorb-4.2.5-py310h601326b_3.tar.bz2
osx-64::netcdf4-1.6.1-mpi_mpich_py39h99d9b56_1.tar.bz2
osx-64::gct-6.2.1629922860-h0108ac9_2.tar.bz2
osx-64::lxml-4.9.1-py310h0b20c97_1.tar.bz2
osx-64::gemmi-0.5.7-py311h4c819dc_1.tar.bz2
osx-64::vtk-9.2.2-qt_py37he90502e_201.tar.bz2
osx-64::xrootd-5.5.0-py38hd1c7eff_0.tar.bz2
osx-64::libnetcdf-4.9.0-mpi_openmpi_hd01fa53_2.tar.bz2
osx-64::xrootd-5.5.0-py38h00a85de_0.tar.bz2
osx-64::python-rocksdb-0.7.0-py39h18193aa_7.tar.bz2
osx-64::xrootd-5.5.0-py38h2b04da7_0.tar.bz2
osx-64::imagecodecs-2022.9.26-py39h1e0cc1c_3.tar.bz2
osx-64::python-igraph-0.10.2-py39h9a34910_0.tar.bz2
osx-64::vigra-1.11.1-py38h357bd86_1036.tar.bz2
osx-64::libgdal-3.5.2-h9ab8fee_5.tar.bz2
osx-64::arrow-cpp-7.0.1-py38h6173236_6_cpu.tar.bz2
osx-64::pyreadstat-1.2.0-py39h4603615_0.tar.bz2
osx-64::openexr-python-1.3.9-py38h2dc3a58_1.tar.bz2
osx-64::arrow-cpp-9.0.0-py38h6173236_8_cpu.tar.bz2
osx-64::pypy3.8-7.3.9-hb40c2ac_6.tar.bz2
osx-64::mysql-connector-python-8.0.31-py39h492002b_2.tar.bz2
osx-64::mcpl-1.5.0-py39had167e2_2.tar.bz2
osx-64::mysql-connector-python-8.0.31-py311h8378485_2.tar.bz2
osx-64::postgresql-14.5-h7bc2cb3_1.tar.bz2
osx-64::davix-0.8.3-h9de8d55_1.tar.bz2
osx-64::libadios2-2.8.3-mpi_mpich_hdf34f2e_4.tar.bz2
osx-64::arrow-cpp-8.0.1-py39h7d8c460_8_cpu.tar.bz2
osx-64::imagecodecs-2022.9.26-py38hc93c41e_2.tar.bz2
osx-64::netcdf4-1.6.1-nompi_py39h0d363ce_101.tar.bz2
osx-64::postgresql-plpython-13.8-py38ha51b9f7_0.tar.bz2
osx-64::omniorb-libs-4.2.5-h0108ac9_3.tar.bz2
osx-64::libadios2-2.8.3-mpi_mpich_h690d333_4.tar.bz2
osx-64::libgdal-3.5.2-h7c33f7c_4.tar.bz2
osx-64::ffmpeg-4.4.2-lgpl_hc2ce967_10.tar.bz2
osx-64::libopencv-4.6.0-py38haad26e0_6.tar.bz2
osx-64::arrow-cpp-6.0.2-py311h2b7377d_6_cpu.tar.bz2
osx-64::ndcctools-7.4.14-py39h1930336_2.tar.bz2
osx-64::grpc-cpp-1.47.1-h966d1d5_7.tar.bz2
osx-64::imagecodecs-2022.9.26-py311ha2e84aa_3.tar.bz2
osx-64::omniorb-4.2.5-py310h601326b_4.tar.bz2
osx-64::openexr-python-1.3.9-py39h2346711_1.tar.bz2
osx-64::arrow-cpp-9.0.0-py39h0b5e700_9_cpu.tar.bz2
osx-64::pytng-0.2.3-py39h8828900_1.tar.bz2
osx-64::root_base-6.26.8-py311h985b37a_1.tar.bz2
osx-64::vigra-1.11.1-py38h4a9ea6e_1035.tar.bz2
osx-64::arrow-cpp-7.0.1-py39h04a14be_6_cpu.tar.bz2
osx-64::harp-1.15.1-py38r42had32a48_3.tar.bz2
osx-64::pypy3.8-7.3.9-h856ce2f_6.tar.bz2
osx-64::arrow-cpp-9.0.0-py310hbce6b4f_10_cpu.tar.bz2
osx-64::postgresql-plpython-14.5-py38hd4d7870_1.tar.bz2
osx-64::panda3d-1.10.12-py39h386ef6b_1.tar.bz2
osx-64::openexr-python-1.3.9-py310hbfc34f8_1.tar.bz2
osx-64::openexr-python-1.3.9-py311h2ab3080_1.tar.bz2
osx-64::tiledb-2.12.0-h3b7b576_1.tar.bz2
osx-64::ndcctools-7.4.14-py311h35252aa_2.tar.bz2
osx-64::xrootd-5.5.0-py310hfc8ebee_0.tar.bz2
osx-64::imagecodecs-2022.9.26-py39h1e0cc1c_1.tar.bz2
osx-64::aws-sdk-cpp-1.9.367-hab2004f_0.tar.bz2
osx-64::rpm-tools-4.17.1-lua54h600b768_1.tar.bz2
osx-64::ldas-tools-framecpp-2.9.1-h03df003_1.tar.bz2
osx-64::llvmlite-0.39.1-py310h2bfb868_1.tar.bz2
osx-64::lxml-4.9.1-py311h9f2bb26_1.tar.bz2
osx-64::xrootd-5.5.1-py37h0ae514b_0.tar.bz2
osx-64::pylibmc-1.6.3-py39hf40e063_1.tar.bz2
osx-64::libnetcdf-4.9.0-mpi_mpich_h5b1d61c_1.tar.bz2
osx-64::mysql-connector-python-8.0.31-py39hb4b9d65_2.tar.bz2
osx-64::r-vcfr-1.13.0-r41h32f0767_1.tar.bz2
osx-64::llvmdev-15.0.3-hb04caa8_0.tar.bz2
osx-64::libadios2-2.8.3-nompi_h9c49b36_104.tar.bz2
osx-64::harp-1.15.1-py310r41h2d8d718_3.tar.bz2
osx-64::r-popgenome-2.7.5-r42h32f0767_2.tar.bz2
osx-64::pyreadstat-1.2.0-py310haafd797_1.tar.bz2
osx-64::xrootd-5.5.0-py39h0629304_0.tar.bz2
osx-64::gdcm-2.8.9-py310heaa167f_7.tar.bz2
osx-64::libvips-8.13.1-h2fcb8b9_2.tar.bz2
osx-64::harp-1.15.1-py38r41h20606e4_3.tar.bz2
osx-64::libadios2-2.8.3-mpi_openmpi_had2e348_4.tar.bz2
osx-64::gstlal-1.9.0-py38h68c3ce3_6.tar.bz2
osx-64::mysql-connector-python-8.0.30-py39h492002b_1.tar.bz2
osx-64::sdl2_image-2.6.1-h20bcf9f_1.tar.bz2
osx-64::davix-0.8.3-he32a841_1.tar.bz2
osx-64::vtk-9.2.2-qt_py310h668b6fc_203.tar.bz2
osx-64::llvmlite-0.39.1-py39had167e2_1.tar.bz2
osx-64::llvm-tools-15.0.3-h7001e86_1.tar.bz2
osx-64::arrow-cpp-9.0.0-py38hf6a008a_9_cpu.tar.bz2
osx-64::wxpython-4.1.1-py310h789e990_8.tar.bz2
osx-64::postgresql-plpython-13.8-py311h4897fa8_0.tar.bz2
osx-64::r-vcfr-1.13.0-r42h32f0767_1.tar.bz2
osx-64::ogre-13.4.4-h64a6803_1.tar.bz2
osx-64::gstlal-1.9.0-py310hfcb27a6_6.tar.bz2
osx-64::omniorb-4.2.5-py311hdd2c131_4.tar.bz2
osx-64::tectonic-0.12.0-hcb82130_0.tar.bz2
osx-64::omniorb-4.2.5-py38h46655f2_3.tar.bz2
osx-64::postgresql-plpython-14.5-py310h86189c4_1.tar.bz2
osx-64::mysql-connector-python-8.0.31-py37h0ef5ddd_1.tar.bz2
osx-64::llvmdev-15.0.3-h7001e86_1.tar.bz2
osx-64::libopencv-4.6.0-py311h85b2607_6.tar.bz2
osx-64::netcdf4-1.6.1-mpi_mpich_py310h9f09b55_1.tar.bz2
osx-64::harp-1.15.1-py39r41hc709b36_3.tar.bz2
osx-64::erlang-25.1.2-pl5321h12b42e0_0.tar.bz2
osx-64::pylibmc-1.6.3-py311hfb0ac31_1.tar.bz2
osx-64::imagecodecs-2022.9.26-py39hdd7619a_1.tar.bz2
osx-64::xrootd-5.5.1-py37h83ba209_0.tar.bz2
osx-64::libcurl-7.86.0-h57eb407_0.tar.bz2
osx-64::py-bgzip-0.4.0-py39he0cb5ab_3.tar.bz2
osx-64::python-rocksdb-0.7.0-py311h322dbc0_7.tar.bz2
osx-64::jaxlib-0.3.22-cpu_py311hb03ad3a_0.tar.bz2
osx-64::py-bgzip-0.4.0-py38h59e6411_3.tar.bz2
osx-64::libadios2-2.8.3-mpi_mpich_h8202dcb_4.tar.bz2
osx-64::py-bgzip-0.4.0-py310h0aff0b5_3.tar.bz2
osx-64::python-igraph-0.10.2-py39hb1cde5b_1.tar.bz2
osx-64::vtk-9.2.2-qt_py39h5e22e60_202.tar.bz2
osx-64::root_base-6.26.8-py38h8b42de2_1.tar.bz2
osx-64::panda3d-1.10.12-py310ha3cd400_1.tar.bz2
osx-64::pygrib-2.1.4-py39h34c24b5_6.tar.bz2
osx-64::libxmlsec1-1.2.35-h4dfa09a_1.tar.bz2
osx-64::arrow-cpp-8.0.1-py311hfb3f5be_7_cpu.tar.bz2
osx-64::arrow-cpp-6.0.2-py310hfdcd00b_6_cpu.tar.bz2
osx-64::wxpython-4.1.1-py39h04bff8f_8.tar.bz2
osx-64::ndcctools-7.4.14-py38h1bf433d_2.tar.bz2
osx-64::gdcm-2.8.9-py38h1da2ff8_7.tar.bz2
osx-64::vtk-9.2.2-qt_py39h7c0bfd1_204.tar.bz2
osx-64::pygrib-2.1.4-py310hda14e83_6.tar.bz2
osx-64::libpq-14.5-h50fae06_1.tar.bz2
osx-64::qt6-main-6.4.0-h024db75_4.tar.bz2
osx-64::mysql-connector-python-8.0.31-py310h1ced1e2_2.tar.bz2
osx-64::libnetcdf-4.8.1-mpi_mpich_hc6a5375_5.tar.bz2
osx-64::omniorb-4.2.5-py311hda15e10_3.tar.bz2
osx-64::xrootd-5.5.1-py39h0629304_0.tar.bz2
osx-64::panda3d-1.10.12-py38hef92140_1.tar.bz2
osx-64::grpc-cpp-1.46.4-h966d1d5_8.tar.bz2
osx-64::vtk-9.2.2-qt_py310h668b6fc_204.tar.bz2
osx-64::xrootd-5.5.1-py39h8fbd737_0.tar.bz2
osx-64::python-igraph-0.10.2-py39h0bfd786_0.tar.bz2
osx-64::xrootd-5.5.1-py310h53be6d9_1.tar.bz2
osx-64::libnetcdf-4.9.0-mpi_mpich_h5b1d61c_2.tar.bz2
osx-64::vowpalwabbit-9.5.0-py310h630de0f_1.tar.bz2
osx-64::libnetcdf-4.8.1-mpi_openmpi_hb9a5949_6.tar.bz2
osx-64::libopencv-4.6.0-py310h5962dd8_5.tar.bz2
osx-64::aws-sdk-cpp-1.9.365-hab2004f_0.tar.bz2
osx-64::lfortran-0.18.0-hbc0c0cd_0.tar.bz2
osx-64::xrootd-5.5.1-py38h4785fdb_2.tar.bz2
osx-64::xrootd-5.5.1-py39h6fc80d7_1.tar.bz2
osx-64::vtk-9.2.2-qt_py310h3be1ae4_202.tar.bz2
osx-64::mcpl-1.5.0-py37h5d31d3a_1.tar.bz2
osx-64::omniorb-4.2.5-py38h732d4a6_4.tar.bz2
osx-64::aws-sdk-cpp-1.9.364-hab2004f_0.tar.bz2
osx-64::arrow-cpp-7.0.1-py39h7d8c460_8_cpu.tar.bz2
osx-64::yoda-1.9.6-py38hd735938_2.tar.bz2
osx-64::root_base-6.26.8-py38hcc2afa0_1.tar.bz2
osx-64::aws-sdk-cpp-1.9.373-h32e7509_0.tar.bz2
osx-64::python-igraph-0.10.2-py39hd599802_1.tar.bz2
osx-64::xrootd-5.5.1-py38h09ef9fa_2.tar.bz2
osx-64::vtk-9.2.2-qt_py37h0432e3b_203.tar.bz2
osx-64::llvm-15.0.3-hf86d651_0.tar.bz2
osx-64::coda-2.24-py310h2d8d718_2.tar.bz2
osx-64::libxslt-1.1.35-hb2dc1ff_1.tar.bz2
osx-64::python-rocksdb-0.7.0-py38h9e97f86_7.tar.bz2
osx-64::mysql-connector-python-8.0.31-py38hffbffe8_1.tar.bz2
osx-64::aws-sdk-cpp-1.9.368-hab2004f_0.tar.bz2
osx-64::cppyy-cling-6.27.0-py311h0102fb6_2.tar.bz2
osx-64::root_base-6.26.8-py37h6776343_1.tar.bz2
osx-64::qt-main-5.15.6-he0d2461_1.tar.bz2
osx-64::katago-1.11.0-cpu_hfce7730_0.tar.bz2
osx-64::harp-1.15.1-py310r42h2d8d718_3.tar.bz2
osx-64::nodejs-14.20.1-h0c1c029_1.tar.bz2
osx-64::pypy3.9-7.3.9-h478034a_6.tar.bz2
osx-64::imagecodecs-2022.9.26-py310h79a1b8a_1.tar.bz2
osx-64::coda-2.24-py311hd06703c_2.tar.bz2
osx-64::lxml-4.9.1-py38h4724a1f_1.tar.bz2
osx-64::arrow-cpp-7.0.1-py310hbce6b4f_8_cpu.tar.bz2
osx-64::root_base-6.26.8-py38haeb9d46_0.tar.bz2
osx-64::netcdf4-1.6.1-mpi_openmpi_py38hfce56bd_1.tar.bz2
osx-64::libadios2-2.8.3-nompi_hc4686d9_104.tar.bz2
osx-64::pyreadstat-1.2.0-py39h4603615_1.tar.bz2
osx-64::arrow-cpp-6.0.2-py38h44ef5c2_6_cpu.tar.bz2
osx-64::imagecodecs-2022.9.26-py38hc93c41e_3.tar.bz2
osx-64::gemmi-0.5.7-py38h8c0d2ee_1.tar.bz2
osx-64::mysql-connector-python-8.0.30-py310h1ced1e2_1.tar.bz2
osx-64::openbabel-3.1.1-py310h04a54f5_5.tar.bz2
osx-64::lxml-4.9.1-py39hfbce9ca_1.tar.bz2
osx-64::cppyy-cling-6.27.0-py310h71e7e49_2.tar.bz2
osx-64::octave-7.2.0-hea30b65_7.tar.bz2
osx-64::xrootd-5.5.1-py38h4785fdb_0.tar.bz2
osx-64::imagecodecs-2022.9.26-py39h7a4b07d_1.tar.bz2
osx-64::openmeeg-2.5.5-py39h1c43b02_1.tar.bz2
osx-64::ogre-1.12.13-hcf9016f_3.tar.bz2
osx-64::gemmi-0.5.7-py39had167e2_1.tar.bz2
osx-64::mysql-connector-python-8.0.31-py38hffbffe8_2.tar.bz2
osx-64::openmeeg-2.5.5-py310h8684da9_1.tar.bz2
osx-64::glib-2.74.1-hbc0c0cd_0.tar.bz2
osx-64::xrootd-5.5.1-py310hfc8ebee_0.tar.bz2
osx-64::root_base-6.26.8-py39hbf644bc_1.tar.bz2
osx-64::xrootd-5.5.1-py37h0ae514b_1.tar.bz2
osx-64::git-2.38.1-pl5321h17f406e_0.tar.bz2
osx-64::mlir-15.0.3-h07d71dc_0.tar.bz2
osx-64::libadios2-2.8.3-mpi_openmpi_heeb1211_4.tar.bz2
osx-64::pillow-9.2.0-py38h85595ef_3.tar.bz2
osx-64::xrootd-5.5.1-py38h7d0fd33_0.tar.bz2
osx-64::pyreadstat-1.2.0-py38h01a1b83_1.tar.bz2
osx-64::postgresql-plpython-14.5-py39h7138289_1.tar.bz2
osx-64::python-igraph-0.10.2-py310h3f43f70_0.tar.bz2
osx-64::panda3d-1.10.12-py38haf5663b_1.tar.bz2
osx-64::arrow-cpp-8.0.1-py39h0b5e700_7_cpu.tar.bz2
osx-64::gstlal-1.9.0-py37ha7c0b47_6.tar.bz2
osx-64::postgresql-13.8-h7bc2cb3_0.tar.bz2
osx-64::xrootd-5.5.1-py310h74df8f0_0.tar.bz2
osx-64::netcdf4-1.6.1-mpi_mpich_py311h9b3df5f_1.tar.bz2
osx-64::libnetcdf-4.9.0-nompi_h5456b97_101.tar.bz2
osx-64::pyreadr-0.4.7-py39ha85e7bc_2.tar.bz2
osx-64::pyreadstat-1.2.0-py37h1c981f0_0.tar.bz2
osx-64::harp-1.15.1-py38r42h20606e4_4.tar.bz2
osx-64::ndcctools-7.4.14-py311h2f75ace_2.tar.bz2
osx-64::arrow-cpp-6.0.2-py310h33c4a6f_5_cpu.tar.bz2
osx-64::mysql-connector-python-8.0.30-py39hb4b9d65_1.tar.bz2
osx-64::root_base-6.26.8-py37hdc94c67_0.tar.bz2
osx-64::pyinstaller-5.1-py310haafd797_1.tar.bz2
osx-64::arrow-cpp-9.0.0-py311h15d7f3f_8_cpu.tar.bz2
osx-64::arrow-cpp-6.0.2-py38h2ee4cb9_5_cpu.tar.bz2
osx-64::harp-1.15.1-py39r42h1ed1f25_4.tar.bz2
osx-64::arrow-cpp-7.0.1-py39h0b5e700_7_cpu.tar.bz2
osx-64::harp-1.15.1-py37r42h6ea2a66_3.tar.bz2
osx-64::libopencv-4.6.0-py39hfa69ae4_6.tar.bz2
osx-64::harp-1.15.1-py310r41h2d8d718_4.tar.bz2
osx-64::postgresql-plpython-14.5-py311heac9572_1.tar.bz2
osx-64::arrow-cpp-9.0.0-py310h01f5732_9_cpu.tar.bz2
osx-64::pp-sketchlib-2.0.1-py38h60b3f94_1.tar.bz2
osx-64::arrow-cpp-7.0.1-py38ha1acfac_8_cpu.tar.bz2
osx-64::octave-7.2.0-h8ad2f50_6.tar.bz2
osx-64::openmeeg-2.5.5-py311h87bed55_1.tar.bz2
osx-64::root_base-6.26.8-py39hd040bd6_0.tar.bz2
osx-64::qt6-main-6.4.0-hfa477c3_5.tar.bz2
osx-64::postgresql-plpython-13.8-py39ha872ce3_0.tar.bz2
osx-64::nodejs-14.20.1-h831259e_1.tar.bz2
osx-64::xrootd-5.5.1-py39hd098475_1.tar.bz2
osx-64::sox-14.4.2-h507d050_1016.tar.bz2
osx-64::postgresql-plpython-13.8-py310h86189c4_0.tar.bz2
osx-64::qt6-main-6.4.0-h353ae22_3.tar.bz2
osx-64::python-igraph-0.10.2-py37h7aa6e88_0.tar.bz2
osx-64::gct-6.2.1629922860-h2e8ab23_2.tar.bz2
osx-64::arrow-cpp-8.0.1-py310hc9ce90b_6_cpu.tar.bz2
osx-64::xrootd-5.5.1-py39he73330d_2.tar.bz2
osx-64::mlir-15.0.1-h07d71dc_0.tar.bz2
osx-64::aws-sdk-cpp-1.9.372-h36efd74_0.tar.bz2
osx-64::libgrpc-1.49.1-h966d1d5_1.tar.bz2
osx-64::pyhdf-0.10.5-py38h029235e_1.tar.bz2
osx-64::xrootd-5.5.1-py38h42e509c_0.tar.bz2
osx-64::aws-sdk-cpp-1.9.373-h36efd74_0.tar.bz2
osx-64::yarp-cxx-3.7.2-he721ed9_5.tar.bz2
osx-64::mlir-15.0.2-h07d71dc_0.tar.bz2
osx-64::omniorb-libs-4.2.5-h0108ac9_4.tar.bz2
osx-64::arrow-cpp-8.0.1-py311h15d7f3f_6_cpu.tar.bz2
osx-64::python-igraph-0.10.2-py310hedfac68_1.tar.bz2
osx-64::harp-1.15.1-py39r42hc709b36_3.tar.bz2
osx-64::vigra-1.11.1-py39h1e020cb_1036.tar.bz2
osx-64::cpp-opentelemetry-sdk-1.6.1-h70cf688_2.tar.bz2
osx-64::grpc-cpp-1.46.4-h834a566_8.tar.bz2
osx-64::xrootd-5.5.1-py39he05f790_0.tar.bz2
osx-64::grpc-cpp-1.45.2-hb852853_7.tar.bz2
osx-64::ndcctools-7.4.14-py38h08c6ce4_2.tar.bz2
osx-64::pyreadstat-1.2.0-py311hfb0ac31_1.tar.bz2
osx-64::xrootd-5.5.1-py39h99ac593_1.tar.bz2
osx-64::py-bgzip-0.4.0-py38h5d8cb2c_3.tar.bz2
osx-64::netcdf4-1.6.1-mpi_openmpi_py311hcdb9f3e_1.tar.bz2
osx-64::harp-1.15.1-py38r41had32a48_3.tar.bz2
osx-64::pyreadr-0.4.7-py311h2f174a2_2.tar.bz2
osx-64::pyreadr-0.4.7-py38h748759a_2.tar.bz2
osx-64::sdl2_image-2.6.1-hb438505_1.tar.bz2
osx-64::libadios2-2.8.3-mpi_mpich_h2f1679d_4.tar.bz2
osx-64::coda-2.24-py38had32a48_2.tar.bz2
osx-64::grpc-cpp-1.47.1-h834a566_7.tar.bz2
osx-64::pp-sketchlib-2.0.1-py39hb779d6e_0.tar.bz2
osx-64::postgresql-plpython-14.5-py38ha51b9f7_1.tar.bz2
osx-64::gdcm-2.8.9-py39h379776f_7.tar.bz2
osx-64::postgresql-plpython-13.8-py310h2452bfe_0.tar.bz2
osx-64::arrow-cpp-8.0.1-py38h6173236_6_cpu.tar.bz2
osx-64::texlive-core-20210325-h044ca44_5.tar.bz2
osx-64::omniorb-libs-4.2.5-h2e8ab23_3.tar.bz2
osx-64::pyhdf-0.10.5-py39hd150a72_1.tar.bz2
osx-64::pypy3.9-7.3.9-hed75a59_6.tar.bz2
osx-64::vowpalwabbit-9.5.0-py37h6833aad_0.tar.bz2
osx-64::openbabel-3.1.1-py38heac13bf_5.tar.bz2
osx-64::llvmdev-11.1.0-h8fb7429_5.tar.bz2
osx-64::libgdal-3.5.2-h10e6fb2_5.tar.bz2
osx-64::pytables-3.7.0-py38h9f12aa8_3.tar.bz2
osx-64::netcdf4-1.6.1-mpi_openmpi_py310h8178e25_1.tar.bz2
osx-64::panda3d-1.10.12-py39hdbc6ad0_1.tar.bz2
osx-64::mysql-connector-python-8.0.31-py39h492002b_1.tar.bz2
osx-64::imagecodecs-2022.9.26-py310h79a1b8a_3.tar.bz2
osx-64::gemmi-0.5.7-py310h2bfb868_1.tar.bz2
osx-64::ovito-3.7.10-h3c6bf02_1.tar.bz2
osx-64::omniorb-libs-4.2.5-h2e8ab23_4.tar.bz2
osx-64::llvm-15.0.3-hbf068ea_1.tar.bz2
osx-64::jaxlib-0.3.22-cpu_py311hbe0fda5_0.tar.bz2
osx-64::omniorb-4.2.5-py311hda15e10_4.tar.bz2
osx-64::pytables-3.7.0-py311ha9b306f_3.tar.bz2
osx-64::omniorb-4.2.5-py39h7e79b73_4.tar.bz2
osx-64::mysql-connector-python-8.0.31-py38h6bc455e_1.tar.bz2
osx-64::cpp-opentelemetry-sdk-1.7.0-h70cf688_0.tar.bz2
osx-64::vtk-9.2.2-qt_py39h7c0bfd1_203.tar.bz2
osx-64::mcpl-1.5.0-py39h3d6f5fc_1.tar.bz2
osx-64::llvm-tools-15.0.3-hb04caa8_0.tar.bz2
osx-64::libtiledb-sql-0.19.0-hae4a274_0.tar.bz2
osx-64::wxwidgets-3.2.1-h96daef2_1.tar.bz2
osx-64::xrootd-5.5.0-py310heffd4c4_0.tar.bz2
osx-64::libpq-14.5-hd79e848_1.tar.bz2
osx-64::mysql-connector-python-8.0.30-py37h0ef5ddd_1.tar.bz2
osx-64::postgresql-14.5-hae21482_1.tar.bz2
osx-64::postgresql-plpython-13.8-py311heac9572_0.tar.bz2
osx-64::libadios2-2.8.3-mpi_openmpi_h0a8b3f2_4.tar.bz2
osx-64::arrow-cpp-7.0.1-py38hf6a008a_7_cpu.tar.bz2
osx-64::harp-1.15.1-py37r41h6ea2a66_3.tar.bz2
osx-64::arrow-cpp-9.0.0-py310hc9ce90b_8_cpu.tar.bz2
osx-64::gstlal-1.9.0-py39h9ab0693_6.tar.bz2
osx-64::scilab-6.1.1-hcecc103_1.tar.bz2
osx-64::xrootd-5.5.1-py38h00a85de_0.tar.bz2
osx-64::gdcm-2.8.9-py311hc859c6e_7.tar.bz2
osx-64::python-igraph-0.10.2-py311h19c8b50_1.tar.bz2
osx-64::panda3d-1.10.12-py39hdd5f18d_1.tar.bz2
osx-64::mcpl-1.5.0-py39had167e2_1.tar.bz2
osx-64::pylibmc-1.6.3-py39h4603615_1.tar.bz2
osx-64::harp-1.15.1-py39r42h1ed1f25_3.tar.bz2
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
osx-64::pocl-3.0-h5552be4_2.tar.bz2
osx-64::pcre2-10.40-h1c4e4bc_0.tar.bz2
osx-64::liblal-7.2.4-fftw_h6f3aaa0_100.tar.bz2
osx-64::zimpl-3.5.3-h38610d6_0.tar.bz2
osx-64::libsqlite-3.39.4-ha978bb4_0.tar.bz2
osx-64::libprotobuf-static-3.21.7-hbc0c0cd_0.tar.bz2
osx-64::cgns-4.3.0-h2f48961_2.tar.bz2
osx-64::zimpl-3.5.3-h38610d6_1.tar.bz2
osx-64::libprotobuf-3.21.7-hbc0c0cd_0.tar.bz2
osx-64::pocl-3.0-h8b4fca9_2.tar.bz2
osx-64::gst-plugins-base-1.21.1-h37e1711_0.tar.bz2
-    "libzlib >=1.2.12,<1.3.0a0"
+    "libzlib >=1.2.12,<2.0.0a0"
osx-64::libmlir-15.0.2-h07d71dc_0.tar.bz2
osx-64::gst-plugins-base-1.21.1-h37e1711_1.tar.bz2
osx-64::cling-0.8-h07d71dc_2.tar.bz2
osx-64::openjdk-17.0.3-hbc0c0cd_4.tar.bz2
osx-64::llvm-tools-11.1.0-h8fb7429_5.tar.bz2
osx-64::libmlir15-15.0.3-h07d71dc_0.tar.bz2
osx-64::openjdk-17.0.3-hbc0c0cd_3.tar.bz2
osx-64::libmlir15-15.0.2-h07d71dc_0.tar.bz2
osx-64::libv8-8.9.83-h20b7c8e_2.tar.bz2
osx-64::libprotobuf-3.21.9-hbc0c0cd_0.tar.bz2
osx-64::libnetcdf-4.8.1-nompi_hc61b76e_105.tar.bz2
osx-64::libprotobuf-static-3.21.8-hbc0c0cd_0.tar.bz2
osx-64::libprotobuf-static-3.21.9-hbc0c0cd_0.tar.bz2
osx-64::libmlir-15.0.3-h07d71dc_0.tar.bz2
osx-64::libnetcdf-4.8.1-nompi_hc61b76e_106.tar.bz2
osx-64::fontconfig-2.14.1-h5bb23bf_0.tar.bz2
osx-64::llvm-11.1.0-h9d075a6_5.tar.bz2
osx-64::liblal-7.2.4-fftw_h6f3aaa0_102.tar.bz2
osx-64::cling-0.9-h07d71dc_1.tar.bz2
osx-64::glib-tools-2.74.1-hbc0c0cd_0.tar.bz2
osx-64::libmlir15-15.0.1-h07d71dc_0.tar.bz2
osx-64::libllvm11-11.1.0-h8fb7429_5.tar.bz2
osx-64::libprotobuf-3.21.8-hbc0c0cd_0.tar.bz2
osx-64::libmlir-15.0.1-h07d71dc_0.tar.bz2
osx-64::liblal-7.2.4-fftw_h6f3aaa0_101.tar.bz2
osx-64::cling-0.9-h07d71dc_0.tar.bz2
osx-64::openjdk-11.0.15-hbc0c0cd_3.tar.bz2
-    "libzlib >=1.2.13,<1.3.0a0"
+    "libzlib >=1.2.13,<2.0.0a0"
================================================================================
================================================================================
linux-64
linux-64::arrow-cpp-6.0.2-py310h7376438_4_cpu.tar.bz2
linux-64::jaxlib-0.3.22-cpu_py37h82df9ab_0.tar.bz2
linux-64::arrow-cpp-7.0.1-py39hb3b17c4_5_cpu.tar.bz2
linux-64::arrow-cpp-8.0.1-py310h9c91e85_5_cpu.tar.bz2
linux-64::r-seqminer-8.4-r42h16263c7_1.tar.bz2
linux-64::llvm-15.0.2-h4553d2b_0.tar.bz2
linux-64::papilo-2.1.1-h828dae8_1.tar.bz2
linux-64::actions-runner-2.298.2-he0ac6c6_0.tar.bz2
linux-64::nd2-0.4.6-py38hc7f61b9_0.tar.bz2
linux-64::lammps-2022.06.23-py310h28067f8_mpich_3.tar.bz2
linux-64::panda3d-1.10.12-py37h6a32cad_0.tar.bz2
linux-64::tectonic-0.11.0-hc538360_0.tar.bz2
linux-64::folly-2022.10.03.00-h1234567_1.tar.bz2
linux-64::python-igraph-0.10.1-py38h64ef804_1.tar.bz2
linux-64::mongodb-6.0.2-h9e3d2f7_0.tar.bz2
linux-64::mysql-server-8.0.31-hb01f15f_0.tar.bz2
linux-64::symengine-0.9.0-h39fa5e7_1.tar.bz2
linux-64::r-rmatio-0.16.0-r41h06615bd_1.tar.bz2
linux-64::gdstk-0.9.1-py37h5781da2_0.tar.bz2
linux-64::nd2-0.4.5-py310h062fc0b_0.tar.bz2
linux-64::panda3d-1.10.12-py310hb82616e_0.tar.bz2
linux-64::jaxlib-0.3.22-cuda112py310h0f6dfd5_200.tar.bz2
linux-64::mysql-client-8.0.31-hf89ab62_0.tar.bz2
linux-64::panda3d-1.10.12-py310h7116425_0.tar.bz2
linux-64::arrow-cpp-7.0.1-py39hb7ffd1f_5_cuda.tar.bz2
linux-64::vowpalwabbit-9.4.0-py38hd67f247_0.tar.bz2
linux-64::arrow-cpp-8.0.1-py310h8f2da51_5_cuda.tar.bz2
linux-64::pypy3.9-7.3.9-hd671c94_5.tar.bz2
linux-64::vtk-9.2.2-osmesa_py39hd96a68f_100.tar.bz2
linux-64::arrow-cpp-8.0.1-py39hb3b17c4_5_cpu.tar.bz2
linux-64::libcurl-static-7.85.0-h2283fc2_0.tar.bz2
linux-64::gdstk-0.9.1-py39h7e93476_0.tar.bz2
linux-64::python-igraph-0.10.1-py37h24ddbbb_1.tar.bz2
linux-64::ortools-cpp-9.2-h1b53c3f_8.tar.bz2
linux-64::panda3d-1.10.12-py39h5ee1c2f_0.tar.bz2
linux-64::aws-sdk-cpp-1.9.357-he1d2be2_0.tar.bz2
linux-64::lammps-2022.06.23-py37h8978f3d_openmpi_3.tar.bz2
linux-64::ortools-python-9.2-py310h7737593_6.tar.bz2
linux-64::aws-sdk-cpp-1.9.359-h3656c63_0.tar.bz2
linux-64::sagelib-9.7-py310h28be7dd_0.tar.bz2
linux-64::llvmdev-15.0.2-h503ea73_0.tar.bz2
linux-64::pypy3.8-7.3.9-h4185e50_5.tar.bz2
linux-64::z5py-2.0.16-py37hdea7b8e_0.tar.bz2
linux-64::aws-sdk-cpp-1.9.356-he1d2be2_1.tar.bz2
linux-64::arrow-cpp-7.0.1-py310h9c91e85_5_cpu.tar.bz2
linux-64::ortools-cpp-9.2-h50423b7_7.tar.bz2
linux-64::sagelib-9.6-py37h42061e7_4.tar.bz2
linux-64::sagelib-9.7-py310h28be7dd_1.tar.bz2
linux-64::vtk-9.2.2-osmesa_py37h4fefe72_100.tar.bz2
linux-64::mysql-libs-8.0.31-hbc51c84_0.tar.bz2
linux-64::aws-sdk-cpp-1.9.362-heccfd1e_1.tar.bz2
linux-64::glibmm-2.68-2.74.0-hc273901_0.tar.bz2
linux-64::ortools-python-9.2-py39hf7849ec_6.tar.bz2
linux-64::librdkafka-1.9.2-h832f386_1.tar.bz2
linux-64::libcurl-static-7.85.0-h7bff187_0.tar.bz2
linux-64::sagelib-9.7-py38h5017592_0.tar.bz2
linux-64::aws-sdk-cpp-1.9.358-h3656c63_2.tar.bz2
linux-64::ortools-cpp-9.2-h0e484a6_6.tar.bz2
linux-64::mcpl-1.5.0-py37h0761922_0.tar.bz2
linux-64::z5py-2.0.16-py310h5005252_0.tar.bz2
linux-64::ovito-3.7.10-h4572772_0.tar.bz2
linux-64::vtk-9.2.2-egl_py38he163af0_0.tar.bz2
linux-64::z5py-2.0.16-py38h112d6be_0.tar.bz2
linux-64::aws-sdk-cpp-1.9.358-he1d2be2_0.tar.bz2
linux-64::imagemagick-7.1.0_50-pl5321hbb10140_0.tar.bz2
linux-64::python-igraph-0.10.0-py39h8e58fdc_1.tar.bz2
linux-64::git-2.38.0-pl5321h5fbbf19_0.tar.bz2
linux-64::erlang-25.1.1-pl5321hb9e9383_0.tar.bz2
linux-64::ortools-cpp-9.2-h06e27a4_6.tar.bz2
linux-64::clangdev-15.0.2-default_h2e3cab8_0.tar.bz2
linux-64::soplex-6.0.2-h49ca5c0_1.tar.bz2
linux-64::lammps-2022.06.23-py38h69ac4ac_openmpi_3.tar.bz2
linux-64::arrow-cpp-7.0.1-py37hb04813e_5_cpu.tar.bz2
linux-64::ortools-python-9.2-py39hfa683b7_6.tar.bz2
linux-64::ortools-python-9.2-py310hd4c1952_6.tar.bz2
linux-64::erlang-25.1.1-pl5321h5001644_0.tar.bz2
linux-64::scip-8.0.2-h666ace5_1.tar.bz2
linux-64::r-strawr-0.0.9-r41h495f63e_1.tar.bz2
linux-64::libxml2-2.10.2-h7463322_2.tar.bz2
linux-64::dpcpp_impl_linux-64-2022.2.0-hb01953d_8734.tar.bz2
linux-64::ortools-cpp-9.2-h9dd34ca_7.tar.bz2
linux-64::panda3d-1.10.12-py37hdd0d46f_0.tar.bz2
linux-64::mysql-router-8.0.31-h0358a0e_0.tar.bz2
linux-64::pcre2-static-10.40-hc3806b6_0.tar.bz2
linux-64::arrow-cpp-8.0.1-py37hb04813e_5_cpu.tar.bz2
linux-64::jaxlib-0.3.22-cpu_py310hb359a59_0.tar.bz2
linux-64::qt6-main-6.4.0-h83b3a27_2.tar.bz2
linux-64::arrow-cpp-9.0.0-py39hb7ffd1f_7_cuda.tar.bz2
linux-64::libcurl-7.85.0-h2283fc2_0.tar.bz2
linux-64::nodejs-18.11.0-h8839609_0.tar.bz2
linux-64::git-2.38.0-pl5321had83b7b_0.tar.bz2
linux-64::jaxlib-0.3.22-cuda112py39h5d93514_200.tar.bz2
linux-64::vtk-9.2.2-qt_py37he4e22c4_200.tar.bz2
linux-64::nd2-0.4.5-py38h0295db2_0.tar.bz2
linux-64::mysql-router-8.0.31-ha33f3f5_0.tar.bz2
linux-64::liblal-7.2.4-mkl_hb5697f4_0.tar.bz2
linux-64::ortools-cpp-9.2-h06e27a4_7.tar.bz2
linux-64::lammps-2022.06.23-py38h8329d17_mpich_3.tar.bz2
linux-64::vtk-9.2.2-qt_py38hc2a4946_200.tar.bz2
linux-64::giac-1.9.0.21-he9ede01_0.tar.bz2
linux-64::llvm-tools-15.0.2-h503ea73_0.tar.bz2
linux-64::jaxlib-0.3.22-cuda112py37h5087797_200.tar.bz2
linux-64::mcpl-1.5.0-py310h58363a5_0.tar.bz2
linux-64::openssh-9.1p1-hf695f80_0.tar.bz2
linux-64::vtk-9.2.2-egl_py39h146abd9_0.tar.bz2
linux-64::sagelib-9.7-py38h5017592_1.tar.bz2
linux-64::arrow-cpp-8.0.1-py38h4a4dda9_5_cuda.tar.bz2
linux-64::arrow-cpp-9.0.0-py310h9c91e85_7_cpu.tar.bz2
linux-64::arrow-cpp-6.0.2-py39heda4e9d_4_cpu.tar.bz2
linux-64::ortools-python-9.2-py310hccad116_8.tar.bz2
linux-64::jaxlib-0.3.22-cpu_py310h59da3f0_0.tar.bz2
linux-64::nd2-0.4.5-py37h08392c7_0.tar.bz2
linux-64::gdstk-0.9.1-py310h1b6b022_0.tar.bz2
linux-64::nd2-0.4.6-py310h062fc0b_0.tar.bz2
linux-64::ortools-cpp-9.2-h50423b7_6.tar.bz2
linux-64::rstudio-desktop-2022.07.2-r42hfd48464_577.tar.bz2
linux-64::jaxlib-0.3.22-cpu_py38h7aae4ce_0.tar.bz2
linux-64::r-git2r-0.30.1-r42h96773ce_1.tar.bz2
linux-64::arrow-cpp-8.0.1-py38h06d3c50_5_cpu.tar.bz2
linux-64::arrow-cpp-7.0.1-py310h8f2da51_5_cuda.tar.bz2
linux-64::lammps-2022.06.23-py37hf41abd6_mpich_3.tar.bz2
linux-64::nd2-0.4.6-py37h08392c7_0.tar.bz2
linux-64::curl-7.85.0-h2283fc2_0.tar.bz2
linux-64::julia-1.8.2-h6f5dd7c_0.tar.bz2
linux-64::sagelib-9.6-py310h28be7dd_4.tar.bz2
linux-64::r-git2r-0.30.1-r41h96773ce_1.tar.bz2
linux-64::jaxlib-0.3.22-cuda112py39h1e4da38_200.tar.bz2
linux-64::r-base-4.2.1-h7880091_2.tar.bz2
linux-64::nd2-0.4.5-py38hc7f61b9_0.tar.bz2
linux-64::python-igraph-0.10.1-py310hf05fc85_1.tar.bz2
linux-64::ortools-cpp-9.2-hfa76038_6.tar.bz2
linux-64::nodejs-18.11.0-h96d913c_0.tar.bz2
linux-64::ortools-cpp-9.2-hd3093bc_7.tar.bz2
linux-64::vtk-9.2.2-egl_py310h9838174_0.tar.bz2
linux-64::arrow-cpp-8.0.1-py39hb7ffd1f_5_cuda.tar.bz2
linux-64::ortools-cpp-9.2-h75c2bb6_6.tar.bz2
linux-64::ortools-cpp-9.2-h0343aa2_6.tar.bz2
linux-64::jaxlib-0.3.22-cpu_py37hb467de3_0.tar.bz2
linux-64::gst-plugins-good-1.21.1-h20dca43_0.tar.bz2
linux-64::r-seqminer-8.4-r41h16263c7_1.tar.bz2
linux-64::lammps-2022.06.23-py39h18ede88_mpich_3.tar.bz2
linux-64::r-strawr-0.0.9-r42h495f63e_1.tar.bz2
linux-64::vtk-9.2.2-egl_py37haf37319_0.tar.bz2
linux-64::mcpl-1.5.0-py39h7d9a04d_0.tar.bz2
linux-64::r-git2r-0.30.1-r42hf72769b_1.tar.bz2
linux-64::arrow-cpp-9.0.0-py38h06d3c50_7_cpu.tar.bz2
linux-64::arrow-cpp-7.0.1-py37h4eca2ee_5_cuda.tar.bz2
linux-64::rstudio-desktop-2022.07.2-r41hfd48464_577.tar.bz2
linux-64::gdstk-0.9.1-py39hb43805a_0.tar.bz2
linux-64::jaxlib-0.3.22-cpu_py39h7e0d102_0.tar.bz2
linux-64::arrow-cpp-7.0.1-py38h06d3c50_5_cpu.tar.bz2
linux-64::slurm-22.05.4-hc3eeb58_0.tar.bz2
linux-64::ortools-cpp-9.2-hbf53673_6.tar.bz2
linux-64::mysql-libs-8.0.31-h28c427c_0.tar.bz2
linux-64::vowpalwabbit-9.4.0-py310h604a8ea_0.tar.bz2
linux-64::z5py-2.0.16-py39he490e96_0.tar.bz2
linux-64::arrow-cpp-9.0.0-py37hb04813e_7_cpu.tar.bz2
linux-64::aws-sdk-cpp-1.9.358-h728d186_1.tar.bz2
linux-64::mysql-connector-odbc-8.0.31-h6239696_0.tar.bz2
linux-64::sqlite-3.39.4-h4ff8645_0.tar.bz2
linux-64::gdstk-0.9.1-py38h32e6147_0.tar.bz2
linux-64::ortools-cpp-9.2-h6d9bd8e_6.tar.bz2
linux-64::ortools-python-9.2-py310h7737593_7.tar.bz2
linux-64::nd2-0.4.6-py39h691759d_0.tar.bz2
linux-64::aws-sdk-cpp-1.9.363-heccfd1e_0.tar.bz2
linux-64::pypy3.9-7.3.9-h72fc2f4_5.tar.bz2
linux-64::tectonic-0.11.0-hab7175f_0.tar.bz2
linux-64::r-gaston-1.5.7-r41h690469d_1.tar.bz2
linux-64::gdstk-0.9.1-py38h1cdf9e6_0.tar.bz2
linux-64::libsoup-3.2.1-had0b2b9_0.tar.bz2
linux-64::python-igraph-0.10.1-py39h000617a_1.tar.bz2
linux-64::intel-cmplr-lib-rt-2022.2.0-h6239696_8734.tar.bz2
linux-64::ogre-next-2.3.1-hd9d6a18_3.tar.bz2
linux-64::mysql-server-8.0.31-h3b92772_0.tar.bz2
linux-64::sagelib-9.6-py38h5017592_4.tar.bz2
linux-64::python-igraph-0.10.1-py38h3805f6d_1.tar.bz2
linux-64::ortools-cpp-9.2-h619498d_8.tar.bz2
linux-64::vtk-9.2.2-qt_py39h6797c2b_200.tar.bz2
linux-64::panda3d-1.10.12-py39hb67345b_0.tar.bz2
linux-64::ortools-cpp-9.2-hef36b91_8.tar.bz2
linux-64::folly-2022.10.03.00-h1234567_1_jemalloc.tar.bz2
linux-64::aws-sdk-cpp-1.9.362-h3656c63_0.tar.bz2
linux-64::ortools-python-9.2-py39h443fdaf_7.tar.bz2
linux-64::nd2-0.4.5-py39h691759d_0.tar.bz2
linux-64::openssh-9.1p1-h67c24c5_0.tar.bz2
linux-64::panda3d-1.10.12-py38h3382573_0.tar.bz2
linux-64::curl-7.85.0-h7bff187_0.tar.bz2
linux-64::ortools-cpp-9.2-h6fd80a2_6.tar.bz2
linux-64::r-base-4.1.3-h7880091_3.tar.bz2
linux-64::libcurl-7.85.0-h7bff187_0.tar.bz2
linux-64::jaxlib-0.3.22-cuda112py37heebddfd_200.tar.bz2
linux-64::pypy3.8-7.3.9-h7febd65_5.tar.bz2
linux-64::lammps-2022.06.23-py39h6cdd95e_openmpi_3.tar.bz2
linux-64::sagelib-9.6-py39hd3413e4_4.tar.bz2
linux-64::papilo-2.1.1-h828dae8_0.tar.bz2
linux-64::ortools-cpp-9.2-h369b2a8_8.tar.bz2
linux-64::aws-sdk-cpp-1.9.361-h3656c63_0.tar.bz2
linux-64::arrow-cpp-6.0.2-py38h7569f40_4_cuda.tar.bz2
linux-64::folly-2022.10.10.00-h1234567_1_jemalloc.tar.bz2
linux-64::mongodb-6.0.2-h024d9bb_0.tar.bz2
linux-64::libllvm15-15.0.2-h503ea73_0.tar.bz2
linux-64::ortools-cpp-9.2-h9dd34ca_6.tar.bz2
linux-64::jaxlib-0.3.22-cpu_py39h2420ce0_0.tar.bz2
linux-64::vtk-9.2.2-osmesa_py310h8faa513_100.tar.bz2
linux-64::nd2-0.4.6-py38h0295db2_0.tar.bz2
linux-64::ortools-cpp-9.2-hc446982_6.tar.bz2
linux-64::panda3d-1.10.12-py38h09e752a_0.tar.bz2
linux-64::mysql-client-8.0.31-h92c5bc7_0.tar.bz2
linux-64::ortools-cpp-9.2-h2b5e516_8.tar.bz2
linux-64::vtk-9.2.2-osmesa_py38h68dc7f3_100.tar.bz2
linux-64::jaxlib-0.3.22-cuda112py38h6ea58e9_200.tar.bz2
linux-64::arrow-cpp-7.0.1-py38h4a4dda9_5_cuda.tar.bz2
linux-64::sagelib-9.7-py39hd3413e4_0.tar.bz2
linux-64::arrow-cpp-9.0.0-py38h4a4dda9_7_cuda.tar.bz2
linux-64::jaxlib-0.3.22-cpu_py38hfbcf518_0.tar.bz2
linux-64::vowpalwabbit-9.4.0-py39he26cc25_0.tar.bz2
linux-64::python-igraph-0.10.0-py39h000617a_1.tar.bz2
linux-64::r-git2r-0.30.1-r41hf72769b_1.tar.bz2
linux-64::libmediainfo-22.09-ha998575_0.tar.bz2
linux-64::r-gaston-1.5.7-r42h690469d_1.tar.bz2
linux-64::arrow-cpp-8.0.1-py37h4eca2ee_5_cuda.tar.bz2
linux-64::arrow-cpp-9.0.0-py39hb3b17c4_7_cpu.tar.bz2
linux-64::arrow-cpp-9.0.0-py310h8f2da51_7_cuda.tar.bz2
linux-64::qt6-main-6.4.0-h83b3a27_0.tar.bz2
linux-64::jaxlib-0.3.22-cuda112py310hfa36681_200.tar.bz2
linux-64::arrow-cpp-6.0.2-py37h991c0b6_4_cuda.tar.bz2
linux-64::ortools-cpp-9.2-hfa76038_7.tar.bz2
linux-64::nd2-0.4.5-py39h73af93f_0.tar.bz2
linux-64::nd2-0.4.6-py39h73af93f_0.tar.bz2
linux-64::arrow-cpp-6.0.2-py37h2481f7a_4_cpu.tar.bz2
linux-64::pdfmm-0.9.22-hff8fc8e_1.tar.bz2
linux-64::ortools-cpp-9.2-h0343aa2_7.tar.bz2
linux-64::librdkafka-1.9.2-hd5ad11f_1.tar.bz2
linux-64::arrow-cpp-6.0.2-py310hfca9b73_4_cuda.tar.bz2
linux-64::vowpalwabbit-9.4.0-py37hbe185e3_0.tar.bz2
linux-64::arrow-cpp-6.0.2-py38h2bc6329_4_cpu.tar.bz2
linux-64::arrow-cpp-6.0.2-py39h7d22c74_4_cuda.tar.bz2
linux-64::ortools-python-9.2-py39h17fb082_8.tar.bz2
linux-64::lammps-2022.06.23-py310h9dcc103_openmpi_3.tar.bz2
linux-64::sagelib-9.7-py39hd3413e4_1.tar.bz2
linux-64::folly-2022.10.10.00-h1234567_1.tar.bz2
linux-64::mcpl-1.5.0-py38h38d86a4_0.tar.bz2
linux-64::ortools-cpp-9.2-hd3093bc_6.tar.bz2
linux-64::verilator-4.228-he0ac6c6_0.tar.bz2
linux-64::vtk-9.2.2-qt_py310h343fe84_200.tar.bz2
linux-64::r-rmatio-0.16.0-r42h06615bd_1.tar.bz2
linux-64::ortools-cpp-9.2-h8af9c52_8.tar.bz2
linux-64::qt6-main-6.4.0-h83b3a27_1.tar.bz2
linux-64::soplex-6.0.2-h49ca5c0_0.tar.bz2
linux-64::arrow-cpp-9.0.0-py37h4eca2ee_7_cuda.tar.bz2
linux-64::jaxlib-0.3.22-cuda112py38hb8bfbf9_200.tar.bz2
linux-64::pdfmm-0.9.22-h82f0948_1.tar.bz2
linux-64::intel-opencl-rt-2022.2.0-hce74451_8734.tar.bz2
linux-64::scip-8.0.2-hd6ea22a_0.tar.bz2
-    "libzlib >=1.2.12,<1.3.0a0",
+    "libzlib >=1.2.12,<2.0.0a0",
linux-64::imagecodecs-2022.9.26-py39h87d88b1_2.tar.bz2
linux-64::libnetcdf-4.9.0-mpi_openmpi_h1cecd2a_0.tar.bz2
linux-64::py-bgzip-0.4.0-py39h197971b_3.tar.bz2
linux-64::coda-2.24-py39hec2c022_2.tar.bz2
linux-64::pp-sketchlib-2.0.1-py39h9ba2027_0.tar.bz2
linux-64::nordugrid-arc-6.16.1-py38hbd41f47_2.tar.bz2
linux-64::omniorb-libs-4.2.5-he49606f_4.tar.bz2
linux-64::nordugrid-arc-6.16.1-py310h64f0c9e_1.tar.bz2
linux-64::r-popgenome-2.7.5-r41h690469d_2.tar.bz2
linux-64::mysql-connector-python-8.0.31-py39h3b2be4b_2.tar.bz2
linux-64::nordugrid-arc-6.16.1-py310h8c77e65_0.tar.bz2
linux-64::openmeeg-2.5.5-py39hc0c20cf_1.tar.bz2
linux-64::xrootd-5.5.0-py39h2e4a97b_0.tar.bz2
linux-64::xrootd-5.5.1-py39hf2fec6d_2.tar.bz2
linux-64::pillow-9.2.0-py311h9461556_3.tar.bz2
linux-64::vtk-9.2.2-qt_py37h89e4133_201.tar.bz2
linux-64::ndcctools-7.4.14-py38h782bae8_2.tar.bz2
linux-64::vtk-9.2.2-egl_py39h581f868_2.tar.bz2
linux-64::aws-sdk-cpp-1.9.370-h719178a_0.tar.bz2
linux-64::pygrib-2.1.4-py39h828a7e6_6.tar.bz2
linux-64::imagecodecs-2022.9.26-py310h90cd304_2.tar.bz2
linux-64::pp-sketchlib-2.0.1-py38h3e4b5bf_1.tar.bz2
linux-64::panda3d-1.10.12-py310h65a2ab1_1.tar.bz2
linux-64::pyhdf-0.10.5-py38h34d691e_1.tar.bz2
linux-64::texlive-core-20210325-ha9dafaf_5.tar.bz2
linux-64::yarp-cxx-3.7.2-h3fbe9e5_2.tar.bz2
linux-64::pypy3.9-7.3.9-h72fc2f4_6.tar.bz2
linux-64::postgresql-plpython-14.5-py310ha34cd62_1.tar.bz2
linux-64::clangdev-15.0.3-default_h2e3cab8_0.tar.bz2
linux-64::pillow-9.2.0-py39hf3a2cdf_3.tar.bz2
linux-64::xrootd-5.5.1-py38hd1bb81f_0.tar.bz2
linux-64::xrootd-5.5.1-py311h6df6daf_2.tar.bz2
linux-64::omniorb-4.2.5-py38h2e9ca35_3.tar.bz2
linux-64::root_base-6.26.8-py39hd8fdd9e_1.tar.bz2
linux-64::rpm-tools-4.17.1-py38lua54h0780255_1.tar.bz2
linux-64::arrow-cpp-8.0.1-py38hc370d79_8_cpu.tar.bz2
linux-64::python-3.11.0-h582c2e5_0_cpython.tar.bz2
linux-64::xrootd-5.5.1-py310h81387bc_0.tar.bz2
linux-64::pp-sketchlib-2.0.1-py39hb5dc4b4_0.tar.bz2
linux-64::xrootd-5.5.0-py38h3b6881a_0.tar.bz2
linux-64::vtk-9.2.2-osmesa_py310h47209f7_101.tar.bz2
linux-64::vigra-1.11.1-py39h70025df_1036.tar.bz2
linux-64::root_base-6.26.8-py311hd69c50d_1.tar.bz2
linux-64::panda3d-1.10.12-py37h9b98efb_1.tar.bz2
linux-64::omniorb-4.2.5-py38ha0cdfde_3.tar.bz2
linux-64::pyreadr-0.4.7-py311hc24ef6a_2.tar.bz2
linux-64::hdf4-4.2.15-h9772cbc_5.tar.bz2
linux-64::arrow-cpp-7.0.1-py311h667e89b_7_cpu.tar.bz2
linux-64::vigra-1.11.1-py311hb73ee5b_1036.tar.bz2
linux-64::arrow-cpp-9.0.0-py39h36aaa54_9_cuda.tar.bz2
linux-64::ndcctools-7.4.14-py311hb8a3657_2.tar.bz2
linux-64::aws-sdk-cpp-1.9.370-h4e1ddfe_2.tar.bz2
linux-64::vtk-9.2.2-osmesa_py39h18be1fb_103.tar.bz2
linux-64::nodejs-14.20.1-h96d913c_1.tar.bz2
linux-64::nordugrid-arc-6.16.1-py310h64f0c9e_2.tar.bz2
linux-64::arrow-cpp-6.0.2-py39h7d22c74_5_cuda.tar.bz2
linux-64::folly-2022.10.17.00-h1234567_1.tar.bz2
linux-64::xrootd-5.5.1-py310hb00e688_2.tar.bz2
linux-64::openexr-python-1.3.9-py38h094547f_1.tar.bz2
linux-64::molgrid-0.5.2-cuda111py39h7c4f309_0.tar.bz2
linux-64::plumed-2.8.1-mpi_mpich_ha3f8260_0.tar.bz2
linux-64::libgdal-3.5.2-h27ae5c1_5.tar.bz2
linux-64::ogre-1.12.13-h4f9a257_3.tar.bz2
linux-64::panda3d-1.10.12-py39h9672020_1.tar.bz2
linux-64::libnetcdf-4.8.1-mpi_openmpi_h8cd3663_5.tar.bz2
linux-64::pyreadstat-1.2.0-py37he2f7bc2_0.tar.bz2
linux-64::netcdf4-1.6.1-mpi_mpich_py310h19e27b4_1.tar.bz2
linux-64::arrow-cpp-7.0.1-py39h7664fac_8_cuda.tar.bz2
linux-64::arrow-cpp-8.0.1-py38h6dbbd90_7_cuda.tar.bz2
linux-64::xrootd-5.5.1-py37h62c5c55_0.tar.bz2
linux-64::llvmlite-0.39.1-py39h6b9fe7f_1.tar.bz2
linux-64::gemmi-0.5.7-py39h6b9fe7f_1.tar.bz2
linux-64::xrootd-5.5.1-py38h7473b47_1.tar.bz2
linux-64::arrow-cpp-9.0.0-py311hbb8d1fa_8_cpu.tar.bz2
linux-64::folly-2022.10.24.00-h1234567_1_jemalloc.tar.bz2
linux-64::arrow-cpp-7.0.1-py310h8f2da51_6_cuda.tar.bz2
linux-64::pytables-3.7.0-py311ha8a2728_3.tar.bz2
linux-64::wxpython-4.1.1-py39h433f99e_8.tar.bz2
linux-64::imagecodecs-2022.9.26-py38h8c870ac_1.tar.bz2
linux-64::vtk-9.2.2-osmesa_py311hf567cde_104.tar.bz2
linux-64::pyreadr-0.4.7-py38h80bbbdc_2.tar.bz2
linux-64::xrootd-5.5.1-py39hbfe9b54_0.tar.bz2
linux-64::libtiledb-sql-0.19.0-h0fb7025_0.tar.bz2
linux-64::arrow-cpp-6.0.2-py311h659f3cb_5_cpu.tar.bz2
linux-64::openjdk-17.0.3-hafdced1_4.tar.bz2
linux-64::grpc-cpp-1.46.4-h05bd8bd_8.tar.bz2
linux-64::vtk-9.2.2-osmesa_py310h5c08693_103.tar.bz2
linux-64::openjdk-11.0.15-hea3dc9f_3.tar.bz2
linux-64::mysql-connector-python-8.0.31-py310h3a1307d_1.tar.bz2
linux-64::harp-1.15.1-py310r41h001d289_3.tar.bz2
linux-64::python-rocksdb-0.7.0-py38hfd94845_7.tar.bz2
linux-64::sox-14.4.2-h5ea8058_1016.tar.bz2
linux-64::vtk-9.2.2-qt_py37h8d6a135_203.tar.bz2
linux-64::pp-sketchlib-2.0.1-py38h3e4b5bf_0.tar.bz2
linux-64::ogre-13.4.4-hc1d0498_1.tar.bz2
linux-64::coda-2.24-py310h001d289_2.tar.bz2
linux-64::folly-2022.10.24.00-h1234567_1.tar.bz2
linux-64::libtiledb-sql-0.19.0-he54ea11_0.tar.bz2
linux-64::nodejs-14.20.1-hb42c98f_1.tar.bz2
linux-64::harp-1.15.1-py39r41hec2c022_4.tar.bz2
linux-64::vowpalwabbit-9.5.0-py310h604a8ea_1.tar.bz2
linux-64::python-rocksdb-0.7.0-py39he438597_7.tar.bz2
linux-64::glib-2.74.1-h6239696_0.tar.bz2
linux-64::ffmpeg-4.4.2-lgpl_h5fea1fa_10.tar.bz2
linux-64::arrow-cpp-8.0.1-py310ha2b2c41_7_cuda.tar.bz2
linux-64::harp-1.15.1-py39r41h78b9e46_3.tar.bz2
linux-64::grpc-cpp-1.45.2-hf8be90a_7.tar.bz2
linux-64::libpq-14.5-hd77ab85_1.tar.bz2
linux-64::arrow-cpp-7.0.1-py311h5fd143a_8_cpu.tar.bz2
linux-64::arrow-cpp-6.0.2-py311hbfcec64_6_cuda.tar.bz2
linux-64::gdcm-2.8.9-py39hc696704_7.tar.bz2
linux-64::lxml-4.9.1-py38ha9ef780_1.tar.bz2
linux-64::nginx-1.23.2-h27a1cb2_0.tar.bz2
linux-64::python-3.11.0-ha86cf86_0_cpython.tar.bz2
linux-64::aws-sdk-cpp-1.9.367-heccfd1e_0.tar.bz2
linux-64::nordugrid-arc-6.16.1-py39hda4c732_2.tar.bz2
linux-64::nordugrid-arc-6.16.1-py38h9a5c796_0.tar.bz2
linux-64::libcurl-static-7.86.0-h7bff187_0.tar.bz2
linux-64::harp-1.15.1-py39r41hec2c022_3.tar.bz2
linux-64::pyreadstat-1.2.0-py311h1866167_1.tar.bz2
linux-64::nordugrid-arc-6.16.0-py38hd473ef2_0.tar.bz2
linux-64::aws-sdk-cpp-1.9.374-h4e1ddfe_0.tar.bz2
linux-64::coda-2.24-py311h3871e23_2.tar.bz2
linux-64::jasp-0.14.3-r42h2fc320d_4.tar.bz2
linux-64::arrow-cpp-7.0.1-py311h9aa9700_7_cuda.tar.bz2
linux-64::libadios2-2.8.3-nompi_he5c561d_104.tar.bz2
linux-64::omniorb-libs-4.2.5-h727a467_3.tar.bz2
linux-64::llvmlite-0.39.1-py39h7d9a04d_1.tar.bz2
linux-64::yarp-cxx-3.7.2-ha0fc88e_4.tar.bz2
linux-64::arrow-cpp-8.0.1-py310h9c91e85_6_cpu.tar.bz2
linux-64::libllvm15-15.0.3-h503ea73_0.tar.bz2
linux-64::omniorb-4.2.5-py311h70693a8_4.tar.bz2
linux-64::imagecodecs-2022.9.26-py39h702eeef_1.tar.bz2
linux-64::xrootd-5.5.1-py38hd1bb81f_1.tar.bz2
linux-64::vigra-1.11.1-py38h2de9cd0_1035.tar.bz2
linux-64::arrow-cpp-8.0.1-py39h99e103b_8_cpu.tar.bz2
linux-64::postgresql-13.8-ha105346_0.tar.bz2
linux-64::tiledb-2.12.0-h3f4058f_1.tar.bz2
linux-64::panda3d-1.10.12-py37h1d2a449_1.tar.bz2
linux-64::ffmpeg-4.4.2-gpl_hc51e5dc_110.tar.bz2
linux-64::panda3d-1.10.12-py38hff2d2b6_1.tar.bz2
linux-64::mysql-connector-python-8.0.30-py37h25a2e48_1.tar.bz2
linux-64::root_base-6.26.8-py310h8caf089_1.tar.bz2
linux-64::llvmlite-0.39.1-py38h38d86a4_1.tar.bz2
linux-64::libopencv-4.6.0-py311h8479920_6.tar.bz2
linux-64::python-igraph-0.10.2-py310h18f4e01_1.tar.bz2
linux-64::ogre-1.12.13-h1bf46e3_3.tar.bz2
linux-64::vigra-1.11.1-py39h07a257d_1036.tar.bz2
linux-64::libnetcdf-4.9.0-nompi_h20fbbf5_102.tar.bz2
linux-64::python-igraph-0.10.2-py39h000617a_0.tar.bz2
linux-64::ndcctools-7.4.14-py38h1aa6533_2.tar.bz2
linux-64::curl-7.86.0-h2283fc2_0.tar.bz2
linux-64::llvm-tools-15.0.3-h503ea73_0.tar.bz2
linux-64::imagecodecs-2022.9.26-py38h839e5d1_3.tar.bz2
linux-64::molgrid-0.5.2-cuda110py310hb97f616_0.tar.bz2
linux-64::aws-sdk-cpp-1.8.186-hecaee15_4.tar.bz2
linux-64::libgdal-3.5.2-h91cfbaa_4.tar.bz2
linux-64::gdcm-2.8.9-py311hcf8723a_7.tar.bz2
linux-64::arrow-cpp-8.0.1-py38h06d3c50_6_cpu.tar.bz2
linux-64::pygrib-2.1.4-py310h815554b_6.tar.bz2
linux-64::xrootd-5.5.1-py38h3b6881a_0.tar.bz2
linux-64::omniorb-libs-4.2.5-he49606f_3.tar.bz2
linux-64::vtk-9.2.2-egl_py39h2ab29b9_4.tar.bz2
linux-64::root_base-6.26.8-py38h5756bc8_0.tar.bz2
linux-64::opentype-sanitizer-9.0.0-py39h2865249_1.tar.bz2
linux-64::vigra-1.11.1-py310h2c75445_1036.tar.bz2
linux-64::mcpl-1.5.0-py37h0761922_1.tar.bz2
linux-64::opentype-sanitizer-9.0.0-py311h4dd048b_1.tar.bz2
linux-64::mcpl-1.5.0-py39h6b9fe7f_1.tar.bz2
linux-64::xrootd-5.5.1-py39h2e4a97b_0.tar.bz2
linux-64::vowpalwabbit-9.5.0-py310h604a8ea_0.tar.bz2
linux-64::vigra-1.11.1-py39h07a257d_1035.tar.bz2
linux-64::pyreadstat-1.2.0-py310ha400145_0.tar.bz2
linux-64::aws-sdk-cpp-1.9.368-heccfd1e_0.tar.bz2
linux-64::xrootd-5.5.1-py39h522448e_2.tar.bz2
linux-64::omniorb-4.2.5-py39h0f497a6_3.tar.bz2
linux-64::root_base-6.26.8-py39hadefe9e_0.tar.bz2
linux-64::libopencv-4.6.0-py37h7b66c90_5.tar.bz2
linux-64::xrootd-5.5.1-py38h1fe64f4_1.tar.bz2
linux-64::molgrid-0.5.2-cuda110py39h0de7145_1.tar.bz2
linux-64::molgrid-0.5.2-cuda111py310h9a375a2_1.tar.bz2
linux-64::gdcm-2.8.9-py38h0f356bb_7.tar.bz2
linux-64::libpq-13.8-he2d8382_0.tar.bz2
linux-64::pytng-0.2.3-py311h6beadde_1.tar.bz2
linux-64::valgrind-3.20.0-he0ac6c6_0.tar.bz2
linux-64::postgresql-plpython-14.5-py38h8f65108_1.tar.bz2
linux-64::arrow-cpp-9.0.0-py311h667e89b_9_cpu.tar.bz2
linux-64::qt6-main-6.4.0-h187b99b_5.tar.bz2
linux-64::panda3d-1.10.12-py37he651a51_1.tar.bz2
linux-64::arrow-cpp-8.0.1-py39h78fddc2_7_cpu.tar.bz2
linux-64::coda-2.24-py38hb673e2a_2.tar.bz2
linux-64::netcdf4-1.6.1-mpi_openmpi_py39ha5e07e6_1.tar.bz2
linux-64::llvmdev-15.0.3-h63197d8_1.tar.bz2
linux-64::mysql-connector-python-8.0.30-py310h3a1307d_1.tar.bz2
linux-64::vtk-9.2.2-osmesa_py39h18be1fb_104.tar.bz2
linux-64::mysql-connector-python-8.0.31-py39hfa0bd35_2.tar.bz2
linux-64::mcpl-1.5.0-py311h9ac72c8_2.tar.bz2
linux-64::libcurl-7.86.0-h7bff187_0.tar.bz2
linux-64::poppler-22.10.0-h92391eb_0.tar.bz2
linux-64::imagecodecs-2022.9.26-py311h9f3c88e_3.tar.bz2
linux-64::grpc-cpp-1.47.1-h30feacc_7.tar.bz2
linux-64::leptonica-1.82.0-h74f16a4_1.tar.bz2
linux-64::qt6-main-6.4.0-h83b3a27_3.tar.bz2
linux-64::xrootd-5.5.1-py38h1fe64f4_0.tar.bz2
linux-64::arrow-cpp-7.0.1-py38h3931927_8_cuda.tar.bz2
linux-64::libvips-8.13.1-h1d81026_2.tar.bz2
linux-64::opentype-sanitizer-9.0.0-py38h43d8883_1.tar.bz2
linux-64::grpc-cpp-1.48.1-h05bd8bd_2.tar.bz2
linux-64::vtk-9.2.2-osmesa_py37h9f072b0_101.tar.bz2
linux-64::jasp-0.14.3-r41h2fc320d_4.tar.bz2
linux-64::pyreadstat-1.2.0-py38he5536e0_1.tar.bz2
linux-64::vtk-9.2.2-qt_py38he961636_204.tar.bz2
linux-64::pyreadstat-1.2.0-py310ha400145_1.tar.bz2
linux-64::cppyy-cling-6.27.0-py39h3d66fe8_2.tar.bz2
linux-64::arrow-cpp-7.0.1-py38hc370d79_8_cpu.tar.bz2
linux-64::arrow-cpp-6.0.2-py311h7b7b74b_6_cpu.tar.bz2
linux-64::xrootd-5.5.1-py38h5806b66_1.tar.bz2
linux-64::aws-sdk-cpp-1.9.365-heccfd1e_0.tar.bz2
linux-64::vtk-9.2.2-osmesa_py38h2fc8eb8_102.tar.bz2
linux-64::vtk-9.2.2-qt_py310haf2e316_201.tar.bz2
linux-64::libpq-14.5-he2d8382_1.tar.bz2
linux-64::libxslt-1.1.35-h1116d7b_1.tar.bz2
linux-64::katago-1.11.0-cuda111h68d30c0_0.tar.bz2
linux-64::postgresql-13.8-hdeef612_0.tar.bz2
linux-64::postgresql-14.5-hdeef612_1.tar.bz2
linux-64::root_base-6.26.8-py310h3e5cd03_1.tar.bz2
linux-64::omniorb-4.2.5-py39h0f497a6_4.tar.bz2
linux-64::libopencv-4.6.0-py38h2a969ba_5.tar.bz2
linux-64::panda3d-1.10.12-py37h082dd87_1.tar.bz2
linux-64::mcpl-1.5.0-py39h7d9a04d_2.tar.bz2
linux-64::vtk-9.2.2-osmesa_py310h5c08693_104.tar.bz2
linux-64::aws-sdk-cpp-1.9.373-hb2dfdac_0.tar.bz2
linux-64::harp-1.15.1-py311r42h3871e23_4.tar.bz2
linux-64::xrootd-5.5.0-py37h9855270_0.tar.bz2
linux-64::postgresql-plpython-13.8-py38h8f65108_0.tar.bz2
linux-64::ffmpeg-5.1.2-lgpl_h8db3f10_2.tar.bz2
linux-64::xrootd-5.5.1-py310hb00e688_1.tar.bz2
linux-64::opentype-sanitizer-9.0.0-py38h875ae46_1.tar.bz2
linux-64::ffmpeg-4.4.2-lgpl_h8db3f10_9.tar.bz2
linux-64::xrootd-5.5.1-py38h1fe64f4_2.tar.bz2
linux-64::xrootd-5.5.1-py38h9a35ce2_0.tar.bz2
linux-64::root_base-6.26.8-py38h69c3293_1.tar.bz2
linux-64::pytng-0.2.3-py310hd25046b_1.tar.bz2
linux-64::ffmpeg-4.4.2-gpl_hbd009f3_109.tar.bz2
linux-64::vtk-9.2.2-egl_py37hc7e07be_3.tar.bz2
linux-64::libvips-8.13.2-h1d81026_0.tar.bz2
linux-64::ndcctools-7.4.14-py39hbe13330_2.tar.bz2
linux-64::imagecodecs-2022.9.26-py38h60ac18d_1.tar.bz2
linux-64::vtk-9.2.2-qt_py38hc4fb426_202.tar.bz2
linux-64::cpp-opentelemetry-sdk-1.6.1-he26330a_2.tar.bz2
linux-64::nordugrid-arc-6.16.1-py39h0b26024_0.tar.bz2
linux-64::libpq-13.8-hd77ab85_0.tar.bz2
linux-64::pylibmc-1.6.3-py310ha400145_1.tar.bz2
linux-64::python-igraph-0.10.2-py310hf05fc85_0.tar.bz2
linux-64::arrow-cpp-8.0.1-py39h36aaa54_7_cuda.tar.bz2
linux-64::arrow-cpp-6.0.2-py310heaa4ad9_6_cuda.tar.bz2
linux-64::nordugrid-arc-6.16.1-py38hbd41f47_1.tar.bz2
linux-64::gst-plugins-good-1.21.1-h20dca43_1.tar.bz2
linux-64::pygrib-2.1.4-py311h0acc61a_6.tar.bz2
linux-64::panda3d-1.10.12-py310hf204812_1.tar.bz2
linux-64::lxml-4.9.1-py39h6137ad7_1.tar.bz2
linux-64::wxpython-4.1.1-py38h87c136f_8.tar.bz2
linux-64::imagecodecs-2022.9.26-py39h4a19bbd_1.tar.bz2
linux-64::openexr-python-1.3.9-py39hbd9bb45_1.tar.bz2
linux-64::netcdf4-1.6.1-mpi_mpich_py311h46d6f48_1.tar.bz2
linux-64::mapserver-8.0.0-py39h1939626_1.tar.bz2
linux-64::libgdal-3.5.2-h6e88209_4.tar.bz2
linux-64::llvm-15.0.3-h110208f_1.tar.bz2
linux-64::imagecodecs-2022.9.26-py310hd8daff2_1.tar.bz2
linux-64::gemmi-0.5.7-py38h38d86a4_1.tar.bz2
linux-64::arrow-cpp-9.0.0-py310h9d6e05a_10_cpu.tar.bz2
linux-64::libadios2-2.8.3-nompi_h5445a86_104.tar.bz2
linux-64::molgrid-0.5.2-cuda112py38h4b67a9c_0.tar.bz2
linux-64::libopencv-4.6.0-py38h3766f53_6.tar.bz2
linux-64::pp-sketchlib-2.0.1-py310h5a37817_1.tar.bz2
linux-64::arrow-cpp-8.0.1-py39hb7ffd1f_6_cuda.tar.bz2
linux-64::aws-sdk-cpp-1.9.366-heccfd1e_0.tar.bz2
linux-64::cppyy-cling-6.27.0-py39h13b352c_2.tar.bz2
linux-64::davix-0.8.3-h4190ea8_0.tar.bz2
linux-64::jaxlib-0.3.22-cpu_py311hc3c0860_0.tar.bz2
linux-64::arrow-cpp-9.0.0-py38h4a4dda9_8_cuda.tar.bz2
linux-64::vowpalwabbit-9.5.0-py38hd67f247_1.tar.bz2
linux-64::arrow-cpp-7.0.1-py310hf972f07_7_cpu.tar.bz2
linux-64::mapserver-8.0.0-py37h4183152_1.tar.bz2
linux-64::grpc-cpp-1.46.4-h30feacc_8.tar.bz2
linux-64::libcurl-7.86.0-h2283fc2_0.tar.bz2
linux-64::harp-1.15.1-py310r42h001d289_3.tar.bz2
linux-64::root_base-6.26.8-py310hb120405_0.tar.bz2
linux-64::mysql-connector-python-8.0.31-py39h3b2be4b_1.tar.bz2
linux-64::yarp-cxx-3.7.2-ha0fc88e_3.tar.bz2
linux-64::yarp-cxx-3.7.2-ha0fc88e_5.tar.bz2
linux-64::arrow-cpp-6.0.2-py38h7569f40_5_cuda.tar.bz2
linux-64::leptonica-1.82.0-h74f16a4_2.tar.bz2
linux-64::cppyy-cling-6.27.0-py38h8225899_2.tar.bz2
linux-64::llvm-tools-15.0.3-h63197d8_1.tar.bz2
linux-64::vtk-9.2.2-osmesa_py38h1221fe5_103.tar.bz2
linux-64::arrow-cpp-6.0.2-py311hb64b279_5_cuda.tar.bz2
linux-64::postgresql-plpython-13.8-py310h77fb44f_0.tar.bz2
linux-64::erlang-25.1.2-pl5321h5001644_0.tar.bz2
linux-64::postgresql-14.5-ha105346_1.tar.bz2
linux-64::xrootd-5.5.1-py310hf716355_0.tar.bz2
linux-64::imagecodecs-2022.9.26-py38h60ac18d_2.tar.bz2
linux-64::xrootd-5.5.1-py310h81387bc_1.tar.bz2
linux-64::python-igraph-0.10.2-py38hd23ad9b_1.tar.bz2
linux-64::pytng-0.2.3-py38h06cb870_1.tar.bz2
linux-64::arrow-cpp-7.0.1-py38h06d3c50_6_cpu.tar.bz2
linux-64::netcdf4-1.6.1-mpi_openmpi_py38h040c551_1.tar.bz2
linux-64::xrootd-5.5.1-py38hf2e46ea_0.tar.bz2
linux-64::gstlal-1.9.0-py37h3dd9757_6.tar.bz2
linux-64::molgrid-0.5.2-cuda110py39h0de7145_0.tar.bz2
linux-64::liblal-7.2.4-mkl_hb5697f4_2.tar.bz2
linux-64::harp-1.15.1-py39r42h78b9e46_4.tar.bz2
linux-64::openmeeg-2.5.5-py38h3debe3d_1.tar.bz2
linux-64::pp-sketchlib-2.0.1-py38hf8e212d_0.tar.bz2
linux-64::davix-0.8.3-hcf804e0_0.tar.bz2
linux-64::imagecodecs-2022.9.26-py38h839e5d1_2.tar.bz2
linux-64::py-bgzip-0.4.0-py39hd08d98e_3.tar.bz2
linux-64::xrootd-5.5.1-py311hee63fb2_2.tar.bz2
linux-64::grpc-cpp-1.45.2-h3716539_7.tar.bz2
linux-64::libxmlsec1-1.2.35-h927ea9a_1.tar.bz2
linux-64::pp-sketchlib-2.0.1-py39hb5dc4b4_1.tar.bz2
linux-64::arrow-cpp-9.0.0-py38h3931927_10_cuda.tar.bz2
linux-64::aws-sdk-cpp-1.9.364-heccfd1e_0.tar.bz2
linux-64::pp-sketchlib-2.0.1-py310h5a37817_0.tar.bz2
linux-64::pygrib-2.1.4-py39h4a743ac_6.tar.bz2
linux-64::gemmi-0.5.7-py38hb85eefc_1.tar.bz2
linux-64::lxml-4.9.1-py38h439c854_1.tar.bz2
linux-64::cppyy-cling-6.27.0-py311hd0be90f_2.tar.bz2
linux-64::arrow-cpp-9.0.0-py39h99e103b_10_cpu.tar.bz2
linux-64::gemmi-0.5.7-py310h58363a5_1.tar.bz2
linux-64::pyhdf-0.10.5-py310heb19e17_1.tar.bz2
linux-64::pyinstaller-5.1-py39hd08d98e_1.tar.bz2
linux-64::omniorb-4.2.5-py310h44b9e0c_4.tar.bz2
linux-64::molgrid-0.5.2-cuda112py39h276c839_0.tar.bz2
linux-64::vtk-9.2.2-egl_py310h80bd0e4_4.tar.bz2
linux-64::libopencv-4.6.0-py39h9757d25_6.tar.bz2
linux-64::gct-6.2.1629922860-h727a467_2.tar.bz2
linux-64::panda3d-1.10.12-py38h7992a75_1.tar.bz2
linux-64::vtk-9.2.2-qt_py310haf2e316_202.tar.bz2
linux-64::libadios2-2.8.3-mpi_openmpi_h886ef3a_4.tar.bz2
linux-64::openmeeg-2.5.5-py310h1bac95a_1.tar.bz2
linux-64::omniorb-4.2.5-py39h7fbbf82_3.tar.bz2
linux-64::netcdf4-1.6.1-nompi_py310h55e1e36_101.tar.bz2
linux-64::jaxlib-0.3.22-cuda112py311h8f5a486_200.tar.bz2
linux-64::libopencv-4.6.0-py39h596d152_6.tar.bz2
linux-64::ldas-tools-framecpp-2.9.1-he3f5635_1.tar.bz2
linux-64::pylibmc-1.6.3-py38h1795236_1.tar.bz2
linux-64::lfortran-0.18.0-h6239696_0.tar.bz2
linux-64::vtk-9.2.2-egl_py38h6ab77d2_4.tar.bz2
linux-64::xrootd-5.5.1-py310h81387bc_2.tar.bz2
linux-64::vtk-9.2.2-egl_py37h0be628b_1.tar.bz2
linux-64::nordugrid-arc-6.16.1-py311h6017219_2.tar.bz2
linux-64::gdcm-2.8.9-py310hdfb500c_7.tar.bz2
linux-64::aws-sdk-cpp-1.9.371-hb2dfdac_0.tar.bz2
linux-64::arrow-cpp-6.0.2-py38hf3a5f43_6_cuda.tar.bz2
linux-64::libglib-2.74.1-h7a41b64_0.tar.bz2
linux-64::arrow-cpp-7.0.1-py39h99e103b_8_cpu.tar.bz2
linux-64::mapserver-8.0.0-py310h099a405_1.tar.bz2
linux-64::mysql-connector-python-8.0.31-py310h3a1307d_2.tar.bz2
linux-64::curl-7.86.0-h7bff187_0.tar.bz2
linux-64::vtk-9.2.2-osmesa_py37h9f072b0_102.tar.bz2
linux-64::ffmpeg-5.1.2-gpl_hc51e5dc_103.tar.bz2
linux-64::pytng-0.2.3-py38h85c5c26_1.tar.bz2
linux-64::ogre-1.10.12-h7cc4a1d_10.tar.bz2
linux-64::mcpl-1.5.0-py38hb85eefc_2.tar.bz2
linux-64::molgrid-0.5.2-cuda110py38heb8b639_1.tar.bz2
linux-64::root_base-6.26.8-py37he0d95f5_1.tar.bz2
linux-64::vigra-1.11.1-py38h9782624_1036.tar.bz2
linux-64::r-popgenome-2.7.5-r42h690469d_2.tar.bz2
linux-64::r-httpgd-1.3.0-r41he46e8b9_1.tar.bz2
linux-64::aws-sdk-cpp-1.9.369-h719178a_1.tar.bz2
linux-64::xrootd-5.5.0-py39hbfe9b54_0.tar.bz2
linux-64::pp-sketchlib-2.0.1-py310hfbcd943_1.tar.bz2
linux-64::mlir-15.0.1-he0ac6c6_0.tar.bz2
linux-64::mysql-connector-python-8.0.31-py37h25a2e48_1.tar.bz2
linux-64::harp-1.15.1-py38r42hb673e2a_4.tar.bz2
linux-64::arrow-cpp-8.0.1-py38h3931927_8_cuda.tar.bz2
linux-64::libadios2-2.8.3-nompi_h3757cd0_104.tar.bz2
linux-64::openmeeg-2.5.5-py311h54c5fe3_1.tar.bz2
linux-64::harp-1.15.1-py310r41h001d289_4.tar.bz2
linux-64::imagecodecs-2022.9.26-py310h90cd304_1.tar.bz2
linux-64::folly-2022.10.17.00-h1234567_1_jemalloc.tar.bz2
linux-64::netcdf4-1.6.1-mpi_openmpi_py310h7739a52_1.tar.bz2
linux-64::pylibmc-1.6.3-py39h197971b_1.tar.bz2
linux-64::panda3d-1.10.12-py39h0b4349c_1.tar.bz2
linux-64::arrow-cpp-6.0.2-py310h7376438_5_cpu.tar.bz2
linux-64::omniorb-4.2.5-py310h44b9e0c_3.tar.bz2
linux-64::ndcctools-7.4.14-py310ha616101_2.tar.bz2
linux-64::mcpl-1.5.0-py310h58363a5_2.tar.bz2
linux-64::voms-2.1.0rc0-h4fe81f9_7.tar.bz2
linux-64::mysql-connector-python-8.0.30-py39hfa0bd35_1.tar.bz2
linux-64::libadios2-2.8.3-nompi_hf4f8f70_104.tar.bz2
linux-64::libgdal-3.5.2-h27ae5c1_6.tar.bz2
linux-64::openbabel-3.1.1-py311h7c3e0e0_5.tar.bz2
linux-64::root_base-6.26.8-py39h7695a35_1.tar.bz2
linux-64::wxpython-4.1.1-py310h3828ac4_8.tar.bz2
linux-64::mcpl-1.5.0-py38h38d86a4_2.tar.bz2
linux-64::ipe-7.2.24-lua54hae7312c_8.tar.bz2
linux-64::pygrib-2.1.4-py38h60c67e5_6.tar.bz2
linux-64::python-rocksdb-0.7.0-py38h92e01d7_7.tar.bz2
linux-64::xrootd-5.5.1-py38h5806b66_2.tar.bz2
linux-64::vtk-9.2.2-qt_py39h3967a4b_201.tar.bz2
linux-64::openbabel-3.1.1-py310heaf86c6_5.tar.bz2
linux-64::gstlal-1.9.0-py39hd9f177b_6.tar.bz2
linux-64::arrow-cpp-6.0.2-py38h2bc6329_5_cpu.tar.bz2
linux-64::arrow-cpp-9.0.0-py310h9c91e85_8_cpu.tar.bz2
linux-64::molgrid-0.5.2-cuda111py310h9a375a2_0.tar.bz2
linux-64::harp-1.15.1-py39r42hec2c022_4.tar.bz2
linux-64::pp-sketchlib-2.0.1-py311hc5fc9ec_1.tar.bz2
linux-64::vtk-9.2.2-egl_py310h80bd0e4_3.tar.bz2
linux-64::octave-7.2.0-h00970fe_7.tar.bz2
linux-64::aws-sdk-cpp-1.9.369-heccfd1e_0.tar.bz2
linux-64::arrow-cpp-9.0.0-py311h5fd143a_10_cpu.tar.bz2
linux-64::harp-1.15.1-py39r42h78b9e46_3.tar.bz2
linux-64::openexr-python-1.3.9-py310hac5ffb1_1.tar.bz2
linux-64::arrow-cpp-7.0.1-py310h3bc141c_8_cuda.tar.bz2
linux-64::arrow-cpp-9.0.0-py310h8f2da51_8_cuda.tar.bz2
linux-64::rpm-tools-4.17.1-py311lua54h4e08ac5_1.tar.bz2
linux-64::llvmdev-11.1.0-he0ac6c6_5.tar.bz2
linux-64::mysql-connector-python-8.0.30-py38h94c5afe_1.tar.bz2
linux-64::arrow-cpp-8.0.1-py39h7664fac_8_cuda.tar.bz2
linux-64::harp-1.15.1-py38r42h459ef46_3.tar.bz2
linux-64::ogre-13.4.4-hd5ec235_1.tar.bz2
linux-64::pp-sketchlib-2.0.1-py39h951e4a6_1.tar.bz2
linux-64::tectonic-0.12.0-hc538360_0.tar.bz2
linux-64::nordugrid-arc-6.16.1-py39hda4c732_1.tar.bz2
linux-64::libadios2-2.8.3-mpi_mpich_h2ccd16c_4.tar.bz2
linux-64::cpp-opentelemetry-sdk-1.7.0-he26330a_0.tar.bz2
linux-64::pytng-0.2.3-py39he77f0ae_1.tar.bz2
linux-64::arrow-cpp-7.0.1-py311h6e7b9a6_8_cuda.tar.bz2
linux-64::arrow-cpp-7.0.1-py38h6dbbd90_7_cuda.tar.bz2
linux-64::grpc-cpp-1.47.1-h05bd8bd_7.tar.bz2
linux-64::pp-sketchlib-2.0.1-py38h6b22f3b_0.tar.bz2
linux-64::postgresql-plpython-14.5-py38hefce9d6_1.tar.bz2
linux-64::netcdf4-1.6.1-mpi_mpich_py38h6baeaa4_1.tar.bz2
linux-64::pyreadr-0.4.7-py310hd869da0_2.tar.bz2
linux-64::voms-2.1.0rc2-h4fe81f9_7.tar.bz2
linux-64::postgresql-plpython-14.5-py39h15d2a43_1.tar.bz2
linux-64::r-vcfr-1.13.0-r41h690469d_1.tar.bz2
linux-64::vtk-9.2.2-egl_py39h581f868_1.tar.bz2
linux-64::libxml2-2.10.3-h7463322_0.tar.bz2
linux-64::vowpalwabbit-9.5.0-py37hbe185e3_0.tar.bz2
linux-64::jaxlib-0.3.22-cuda112py311hd9f7b2a_200.tar.bz2
linux-64::arrow-cpp-6.0.2-py310hfca9b73_5_cuda.tar.bz2
linux-64::pyreadr-0.4.7-py39hcb9185c_2.tar.bz2
linux-64::pp-sketchlib-2.0.1-py311hba4f777_1.tar.bz2
linux-64::arrow-cpp-9.0.0-py38h7e05405_9_cpu.tar.bz2
linux-64::vtk-9.2.2-egl_py38h02412aa_2.tar.bz2
linux-64::pp-sketchlib-2.0.1-py310hfbcd943_0.tar.bz2
linux-64::vtk-9.2.2-qt_py37h89e4133_202.tar.bz2
linux-64::libopencv-4.6.0-py39h9757d25_5.tar.bz2
linux-64::cppyy-cling-6.27.0-py310hd64a29c_2.tar.bz2
linux-64::pyreadstat-1.2.0-py39hd08d98e_1.tar.bz2
linux-64::mysql-connector-python-8.0.30-py39h3b2be4b_1.tar.bz2
linux-64::py-bgzip-0.4.0-py38h1795236_3.tar.bz2
linux-64::vtk-9.2.2-egl_py39h2ab29b9_3.tar.bz2
linux-64::harp-1.15.1-py38r42hb673e2a_3.tar.bz2
linux-64::postgresql-plpython-13.8-py310ha34cd62_0.tar.bz2
linux-64::pillow-9.2.0-py38h17663d1_3.tar.bz2
linux-64::arrow-cpp-8.0.1-py310h8f2da51_6_cuda.tar.bz2
linux-64::yoda-1.9.6-py39hda36f15_2.tar.bz2
linux-64::ffmpeg-5.1.2-lgpl_h5fea1fa_3.tar.bz2
linux-64::postgresql-plpython-13.8-py38hefce9d6_0.tar.bz2
linux-64::vtk-9.2.2-egl_py310h5bfb0bf_2.tar.bz2
linux-64::harp-1.15.1-py38r41h459ef46_4.tar.bz2
linux-64::molgrid-0.5.2-cuda111py39h7c4f309_1.tar.bz2
linux-64::postgresql-plpython-13.8-py39h9d33b8a_0.tar.bz2
linux-64::arrow-cpp-8.0.1-py310h9d6e05a_8_cpu.tar.bz2
linux-64::pillow-9.2.0-py310h454ad03_3.tar.bz2
linux-64::nordugrid-arc-6.16.1-py38h9a5c796_1.tar.bz2
linux-64::pytng-0.2.3-py39h383e350_1.tar.bz2
linux-64::imagecodecs-2022.9.26-py39h5a039c7_1.tar.bz2
linux-64::gstlal-1.9.0-py310h16a9ee0_6.tar.bz2
linux-64::arrow-cpp-6.0.2-py38h001ee12_6_cpu.tar.bz2
linux-64::nordugrid-arc-6.16.0-py310h484b64e_0.tar.bz2
linux-64::xrootd-5.5.0-py39h85ad3ca_0.tar.bz2
linux-64::libgrpc-1.49.1-h05bd8bd_1.tar.bz2
linux-64::xrootd-5.5.0-py38h9a35ce2_0.tar.bz2
linux-64::arrow-cpp-9.0.0-py39hb3b17c4_8_cpu.tar.bz2
linux-64::molgrid-0.5.2-cuda112py38h4b67a9c_1.tar.bz2
linux-64::pygrib-2.1.4-py38h6f3e8fa_6.tar.bz2
linux-64::mcpl-1.5.0-py39h7d9a04d_1.tar.bz2
linux-64::vigra-1.11.1-py38h9782624_1035.tar.bz2
linux-64::tectonic-0.12.0-hab7175f_0.tar.bz2
linux-64::scilab-6.1.1-he84a06f_1.tar.bz2
linux-64::python-rocksdb-0.7.0-py310h110d2a3_7.tar.bz2
linux-64::harp-1.15.1-py311r41h3871e23_4.tar.bz2
linux-64::arrow-cpp-7.0.1-py310h9c91e85_6_cpu.tar.bz2
linux-64::netcdf4-1.6.1-nompi_py39hfaa66c4_101.tar.bz2
linux-64::vtk-9.2.2-osmesa_py310h47209f7_102.tar.bz2
linux-64::ldas-tools-framecpp-2.9.1-h26dcea8_1.tar.bz2
linux-64::arrow-cpp-8.0.1-py311h667e89b_7_cpu.tar.bz2
linux-64::libopencv-4.6.0-py310h6214075_6.tar.bz2
linux-64::octave-7.2.0-h4faf725_6.tar.bz2
linux-64::omniorb-4.2.5-py38h2e9ca35_4.tar.bz2
linux-64::gemmi-0.5.7-py311h9ac72c8_1.tar.bz2
linux-64::imagecodecs-2022.9.26-py39h702eeef_2.tar.bz2
linux-64::katago-1.11.0-cuda110hf937dbe_0.tar.bz2
linux-64::ffmpeg-5.1.2-gpl_hbd009f3_102.tar.bz2
linux-64::plumed-2.8.1-mpi_openmpi_h1e5d6aa_0.tar.bz2
linux-64::openexr-python-1.3.9-py38h9fb9928_1.tar.bz2
linux-64::coda-2.24-py38h459ef46_2.tar.bz2
linux-64::python-igraph-0.10.2-py39h441ba2a_1.tar.bz2
linux-64::vtk-9.2.2-osmesa_py39hc07d7d9_101.tar.bz2
linux-64::vtk-9.2.2-egl_py38h6ab77d2_3.tar.bz2
linux-64::pypy3.9-7.3.9-hd671c94_6.tar.bz2
linux-64::mcpl-1.5.0-py38hb85eefc_1.tar.bz2
linux-64::arrow-cpp-9.0.0-py38hc370d79_10_cpu.tar.bz2
linux-64::libnetcdf-4.9.0-mpi_openmpi_h1ce8e08_1.tar.bz2
linux-64::xrootd-5.5.1-py39h85ad3ca_0.tar.bz2
linux-64::qt6-main-6.4.0-h65d1b16_4.tar.bz2
linux-64::vtk-9.2.2-osmesa_py38h2fc8eb8_101.tar.bz2
linux-64::panda3d-1.10.12-py39hfa1161c_1.tar.bz2
linux-64::xrootd-5.5.0-py310hf716355_0.tar.bz2
linux-64::imagecodecs-2022.9.26-py39h87d88b1_3.tar.bz2
linux-64::mcpl-1.5.0-py38h38d86a4_1.tar.bz2
linux-64::r-vcfr-1.13.0-r42h690469d_1.tar.bz2
linux-64::ttyd-1.7.2-hc5eb070_0.tar.bz2
linux-64::gct-6.2.1629922860-he49606f_2.tar.bz2
linux-64::imagecodecs-2022.9.26-py39h87d88b1_1.tar.bz2
linux-64::arrow-cpp-8.0.1-py38h7e05405_7_cpu.tar.bz2
linux-64::nordugrid-arc-6.16.1-py310h8c77e65_1.tar.bz2
linux-64::molgrid-0.5.2-cuda112py39h276c839_1.tar.bz2
linux-64::xrootd-5.5.1-py38h7473b47_0.tar.bz2
linux-64::xrootd-5.5.1-py39hf2fec6d_0.tar.bz2
linux-64::arrow-cpp-9.0.0-py310h3bc141c_10_cuda.tar.bz2
linux-64::vtk-9.2.2-osmesa_py39hc07d7d9_102.tar.bz2
linux-64::vigra-1.11.1-py310h2c75445_1035.tar.bz2
linux-64::arrow-cpp-7.0.1-py311hde57637_6_cuda.tar.bz2
linux-64::vowpalwabbit-9.5.0-py39he26cc25_1.tar.bz2
linux-64::xrootd-5.5.1-py39hc3296fd_2.tar.bz2
linux-64::arrow-cpp-9.0.0-py311hde57637_8_cuda.tar.bz2
linux-64::llvm-15.0.3-h4553d2b_0.tar.bz2
linux-64::molgrid-0.5.2-cuda112py310h824e6a0_1.tar.bz2
linux-64::pp-sketchlib-2.0.1-py38h6b22f3b_1.tar.bz2
linux-64::molgrid-0.5.2-cuda111py38h0e4c272_1.tar.bz2
linux-64::vowpalwabbit-9.5.0-py39he26cc25_0.tar.bz2
linux-64::mlir-15.0.3-he0ac6c6_0.tar.bz2
linux-64::nginx-1.23.2-hf2e6093_0.tar.bz2
linux-64::xrootd-5.5.1-py39hc649c4b_2.tar.bz2
linux-64::arrow-cpp-8.0.1-py311h6e7b9a6_8_cuda.tar.bz2
linux-64::libopencv-4.6.0-py39h596d152_5.tar.bz2
linux-64::llvmlite-0.39.1-py310h58363a5_1.tar.bz2
linux-64::nordugrid-arc-6.16.0-py37ha2ac109_0.tar.bz2
linux-64::git-2.38.1-pl5321had83b7b_0.tar.bz2
linux-64::postgresql-plpython-13.8-py311h17985b3_0.tar.bz2
linux-64::vtk-9.2.2-qt_py310h180de18_204.tar.bz2
linux-64::pyreadr-0.4.7-py39hbd47d1b_2.tar.bz2
linux-64::harp-1.15.1-py38r41h459ef46_3.tar.bz2
linux-64::pytables-3.7.0-py38h54ec15f_3.tar.bz2
linux-64::omniorb-libs-4.2.5-h727a467_4.tar.bz2
linux-64::rsync-3.2.7-h220164a_0.tar.bz2
linux-64::mysql-connector-python-8.0.31-py38h94c5afe_2.tar.bz2
linux-64::omniorb-4.2.5-py38ha0cdfde_4.tar.bz2
linux-64::xrootd-5.5.1-py38h5806b66_0.tar.bz2
linux-64::yoda-1.9.6-py310he43b193_2.tar.bz2
linux-64::arrow-cpp-7.0.1-py39hb3b17c4_6_cpu.tar.bz2
linux-64::pyinstaller-5.1-py310ha400145_1.tar.bz2
linux-64::pypy3.8-7.3.9-h4185e50_6.tar.bz2
linux-64::openexr-python-1.3.9-py311h626f6d5_1.tar.bz2
linux-64::libnetcdf-4.9.0-mpi_mpich_h9de0870_2.tar.bz2
linux-64::omniorb-4.2.5-py310hba10ccf_3.tar.bz2
linux-64::opentype-sanitizer-9.0.0-py39hf939315_1.tar.bz2
linux-64::davix-0.8.3-h7666a67_1.tar.bz2
linux-64::arrow-cpp-8.0.1-py311h9aa9700_7_cuda.tar.bz2
linux-64::vigra-1.11.1-py39h70025df_1035.tar.bz2
linux-64::lxml-4.9.1-py310ha00c094_1.tar.bz2
linux-64::harp-1.15.1-py39r41h78b9e46_4.tar.bz2
linux-64::vtk-9.2.2-egl_py310h5bfb0bf_1.tar.bz2
linux-64::xrootd-5.5.1-py37h9855270_0.tar.bz2
linux-64::nordugrid-arc-6.16.1-py38h9a5c796_2.tar.bz2
linux-64::arrow-cpp-7.0.1-py311hbb8d1fa_6_cpu.tar.bz2
linux-64::arrow-cpp-6.0.2-py310hc962973_6_cpu.tar.bz2
linux-64::arrow-cpp-9.0.0-py39h7664fac_10_cuda.tar.bz2
linux-64::git-2.38.1-pl5321h5fbbf19_0.tar.bz2
linux-64::xrootd-5.5.1-py39hc3296fd_0.tar.bz2
linux-64::mysql-connector-python-8.0.31-py38h94c5afe_1.tar.bz2
linux-64::harp-1.15.1-py39r42hec2c022_3.tar.bz2
linux-64::libopencv-4.6.0-py38h3766f53_5.tar.bz2
linux-64::openjdk-17.0.3-hea3dc9f_3.tar.bz2
linux-64::libadios2-2.8.3-mpi_openmpi_h59a7dd3_4.tar.bz2
linux-64::katago-1.11.0-cuda112h43afb8f_0.tar.bz2
linux-64::postgresql-plpython-13.8-py311h8669bae_0.tar.bz2
linux-64::libxmlsec1-1.2.35-ha60910c_0.tar.bz2
linux-64::openmeeg-2.5.5-py38h125c3ac_1.tar.bz2
linux-64::pypy3.8-7.3.9-h7febd65_6.tar.bz2
linux-64::pp-sketchlib-2.0.1-py39h9ba2027_1.tar.bz2
linux-64::mysql-connector-python-8.0.31-py38hec49fd2_1.tar.bz2
linux-64::root_base-6.26.8-py38hac900ee_1.tar.bz2
linux-64::vtk-9.2.2-qt_py38hc4fb426_201.tar.bz2
linux-64::xrootd-5.5.1-py39hc3296fd_1.tar.bz2
linux-64::panda3d-1.10.12-py310hcc94ea2_1.tar.bz2
linux-64::pyhdf-0.10.5-py38h21fd9e1_1.tar.bz2
linux-64::xrootd-5.5.1-py39hc649c4b_0.tar.bz2
linux-64::libadios2-2.8.3-mpi_openmpi_hab6374b_4.tar.bz2
linux-64::libnetcdf-4.8.1-mpi_mpich_hcd871d9_6.tar.bz2
linux-64::postgresql-plpython-14.5-py310h77fb44f_1.tar.bz2
linux-64::nordugrid-arc-6.16.1-py311h86d6c4f_2.tar.bz2
linux-64::pylibmc-1.6.3-py311h1866167_1.tar.bz2
linux-64::libgrpc-1.49.1-h30feacc_1.tar.bz2
linux-64::aws-sdk-cpp-1.9.370-hb2dfdac_1.tar.bz2
linux-64::ndcctools-7.4.14-py310h5deebde_2.tar.bz2
linux-64::lxml-4.9.1-py39h91f8133_1.tar.bz2
linux-64::harp-1.15.1-py38r42h459ef46_4.tar.bz2
linux-64::pyhdf-0.10.5-py39h98358c6_1.tar.bz2
linux-64::postgresql-plpython-13.8-py39h15d2a43_0.tar.bz2
linux-64::nordugrid-arc-6.16.1-py39h0b26024_1.tar.bz2
linux-64::mcpl-1.5.0-py39h6b9fe7f_2.tar.bz2
linux-64::pyreadstat-1.2.0-py38he5536e0_0.tar.bz2
linux-64::gstlal-1.9.0-py38h1f95574_6.tar.bz2
linux-64::tiledb-2.11.3-h3f4058f_1.tar.bz2
linux-64::aws-sdk-cpp-1.9.373-h4e1ddfe_0.tar.bz2
linux-64::poppler-qt-22.10.0-h693504a_0.tar.bz2
linux-64::mysql-connector-python-8.0.31-py311h0cf059c_2.tar.bz2
linux-64::vowpalwabbit-9.5.0-py311h397179a_1.tar.bz2
linux-64::rpm-tools-4.17.1-py310lua54h32295db_1.tar.bz2
linux-64::nordugrid-arc-6.16.1-py39h0b26024_2.tar.bz2
linux-64::arrow-cpp-9.0.0-py38h6dbbd90_9_cuda.tar.bz2
linux-64::panda3d-1.10.12-py38h9db6964_1.tar.bz2
linux-64::openbabel-3.1.1-py39h80c93ca_5.tar.bz2
linux-64::arrow-cpp-7.0.1-py39hb7ffd1f_6_cuda.tar.bz2
linux-64::xrootd-5.5.1-py39hc7bb5bc_0.tar.bz2
linux-64::katago-1.11.0-cuda102he49096f_0.tar.bz2
linux-64::molgrid-0.5.2-cuda111py38h0e4c272_0.tar.bz2
linux-64::xrootd-5.5.1-py38h92bdfd5_0.tar.bz2
linux-64::mysql-connector-python-8.0.31-py39hfa0bd35_1.tar.bz2
linux-64::libadios2-2.8.3-mpi_mpich_h78362ea_4.tar.bz2
linux-64::aws-sdk-cpp-1.9.370-hb2dfdac_2.tar.bz2
linux-64::pytables-3.7.0-py39h761063b_3.tar.bz2
linux-64::netcdf4-1.6.1-nompi_py311hc6fcf29_101.tar.bz2
linux-64::arrow-cpp-9.0.0-py310hf972f07_9_cpu.tar.bz2
linux-64::arrow-cpp-6.0.2-py39h3902eb2_6_cpu.tar.bz2
linux-64::tiledb-2.12.0-h1e4a385_1.tar.bz2
linux-64::xrootd-5.5.1-py39h522448e_1.tar.bz2
linux-64::grpc-cpp-1.48.1-h30feacc_2.tar.bz2
linux-64::omniorb-4.2.5-py311hfbf1579_4.tar.bz2
linux-64::omniorb-4.2.5-py39h7fbbf82_4.tar.bz2
linux-64::xrootd-5.5.1-py37hbf1ac35_1.tar.bz2
linux-64::panda3d-1.10.12-py38ha559ac0_1.tar.bz2
linux-64::yoda-1.9.6-py37h41a8cb8_2.tar.bz2
linux-64::nco-5.1.1-h81bb2a3_0.tar.bz2
linux-64::libadios2-2.8.3-mpi_mpich_h02bc99a_4.tar.bz2
linux-64::vigra-1.11.1-py38h2de9cd0_1036.tar.bz2
linux-64::davix-0.8.3-h0ea7790_1.tar.bz2
linux-64::vtk-9.2.2-osmesa_py37hb962a43_103.tar.bz2
linux-64::py-bgzip-0.4.0-py38he5536e0_3.tar.bz2
linux-64::pyreadstat-1.2.0-py39hd08d98e_0.tar.bz2
linux-64::r-httpgd-1.3.0-r42he46e8b9_1.tar.bz2
linux-64::vtk-9.2.2-osmesa_py38h1221fe5_104.tar.bz2
linux-64::xrootd-5.5.0-py39hc7bb5bc_0.tar.bz2
linux-64::pytables-3.7.0-py38hf134f34_3.tar.bz2
linux-64::xrootd-5.5.1-py38h7473b47_2.tar.bz2
linux-64::python-rocksdb-0.7.0-py39hea5d01e_7.tar.bz2
linux-64::libnetcdf-4.9.0-nompi_h20fbbf5_101.tar.bz2
linux-64::arrow-cpp-8.0.1-py311hde57637_6_cuda.tar.bz2
linux-64::netcdf4-1.6.1-mpi_mpich_py39h6149389_1.tar.bz2
linux-64::mapserver-8.0.0-py38h6f5dc24_1.tar.bz2
linux-64::gemmi-0.5.7-py39h7d9a04d_1.tar.bz2
linux-64::arrow-cpp-7.0.1-py38h7e05405_7_cpu.tar.bz2
linux-64::netcdf4-1.6.1-nompi_py38h2250339_101.tar.bz2
linux-64::xrootd-5.5.1-py39hf2fec6d_1.tar.bz2
linux-64::pp-sketchlib-2.0.1-py311h2418af3_1.tar.bz2
linux-64::mcpl-1.5.0-py310h58363a5_1.tar.bz2
linux-64::libxmlsec1-1.2.35-ha60910c_1.tar.bz2
linux-64::pylibmc-1.6.3-py38he5536e0_1.tar.bz2
linux-64::nordugrid-arc-6.16.1-py310h8c77e65_2.tar.bz2
linux-64::netcdf4-1.6.1-mpi_openmpi_py311h9c61bb6_1.tar.bz2
linux-64::panda3d-1.10.12-py310he60e020_1.tar.bz2
linux-64::imagecodecs-2022.9.26-py39h702eeef_3.tar.bz2
linux-64::vtk-9.2.2-qt_py39hfcd09ca_203.tar.bz2
linux-64::liblal-7.2.4-mkl_hb5697f4_1.tar.bz2
linux-64::libgdal-3.5.2-hf663712_5.tar.bz2
linux-64::xrootd-5.5.1-py38hd1bb81f_2.tar.bz2
linux-64::arrow-cpp-7.0.1-py38h4a4dda9_6_cuda.tar.bz2
linux-64::pyhdf-0.10.5-py39heaf8357_1.tar.bz2
linux-64::katago-1.11.0-cpu_h8f048fa_0.tar.bz2
linux-64::python-rocksdb-0.7.0-py311hb1a4989_7.tar.bz2
linux-64::root_base-6.26.8-py37hd977ad3_0.tar.bz2
linux-64::arrow-cpp-8.0.1-py38h4a4dda9_6_cuda.tar.bz2
linux-64::libnetcdf-4.8.1-mpi_mpich_hcd871d9_5.tar.bz2
linux-64::arrow-cpp-9.0.0-py39h78fddc2_9_cpu.tar.bz2
linux-64::vtk-9.2.2-qt_py311h4f2dc85_204.tar.bz2
linux-64::omniorb-4.2.5-py311h70693a8_3.tar.bz2
linux-64::pyhdf-0.10.5-py311hfcec568_1.tar.bz2
linux-64::libnetcdf-4.9.0-mpi_openmpi_h1ce8e08_2.tar.bz2
linux-64::pylibmc-1.6.3-py39hd08d98e_1.tar.bz2
linux-64::openexr-python-1.3.9-py39heb3e085_1.tar.bz2
linux-64::libnetcdf-4.8.1-mpi_openmpi_h8cd3663_6.tar.bz2
linux-64::sdl2_image-2.6.1-hd32519b_1.tar.bz2
linux-64::arrow-cpp-9.0.0-py39hb7ffd1f_8_cuda.tar.bz2
linux-64::rsync-3.2.7-h70740c4_0.tar.bz2
linux-64::xrootd-5.5.0-py38h92bdfd5_0.tar.bz2
linux-64::aws-sdk-cpp-1.9.372-hb2dfdac_0.tar.bz2
linux-64::nordugrid-arc-6.16.0-py39h264062b_0.tar.bz2
linux-64::harp-1.15.1-py38r41hb673e2a_3.tar.bz2
linux-64::python-igraph-0.10.2-py311hd9247fc_1.tar.bz2
linux-64::xrootd-5.5.1-py37h654ae84_0.tar.bz2
linux-64::erlang-25.1.2-pl5321hb9e9383_0.tar.bz2
linux-64::harp-1.15.1-py38r41hb673e2a_4.tar.bz2
linux-64::vtk-9.2.2-egl_py38h02412aa_1.tar.bz2
linux-64::libadios2-2.8.3-mpi_mpich_h419f6b7_4.tar.bz2
linux-64::harp-1.15.1-py310r42h001d289_4.tar.bz2
linux-64::ovito-3.7.10-hf05a35b_1.tar.bz2
linux-64::voms-2.1.0rc2-h36cfb3a_7.tar.bz2
linux-64::pillow-9.2.0-py39hc6341f6_3.tar.bz2
linux-64::openmeeg-2.5.5-py39h88b1108_1.tar.bz2
linux-64::pillow-9.2.0-py38h9eb91d8_3.tar.bz2
linux-64::llvmlite-0.39.1-py38hb85eefc_1.tar.bz2
linux-64::imagecodecs-2022.9.26-py310h90cd304_3.tar.bz2
linux-64::opentype-sanitizer-9.0.0-py310hbf28c38_1.tar.bz2
linux-64::vtk-9.2.2-egl_py311h7a2c178_4.tar.bz2
linux-64::sdl2_image-2.6.1-hb919cc5_1.tar.bz2
linux-64::aws-sdk-cpp-1.9.371-h4e1ddfe_0.tar.bz2
linux-64::jaxlib-0.3.22-cpu_py311h15f5515_0.tar.bz2
linux-64::arrow-cpp-7.0.1-py310h9d6e05a_8_cpu.tar.bz2
linux-64::arrow-cpp-8.0.1-py311h5fd143a_8_cpu.tar.bz2
linux-64::arrow-cpp-8.0.1-py310h3bc141c_8_cuda.tar.bz2
linux-64::arrow-cpp-8.0.1-py310hf972f07_7_cpu.tar.bz2
linux-64::wxwidgets-3.2.1-h0113fe8_1.tar.bz2
linux-64::aws-sdk-cpp-1.9.372-h4e1ddfe_0.tar.bz2
linux-64::pytables-3.7.0-py310hb60b9b2_3.tar.bz2
linux-64::root_base-6.26.8-py311h8bbac24_1.tar.bz2
linux-64::rpm-tools-4.17.1-py39lua54h9efa183_1.tar.bz2
linux-64::pp-sketchlib-2.0.1-py39h951e4a6_0.tar.bz2
linux-64::cppyy-cling-6.27.0-py38h2a4c724_2.tar.bz2
linux-64::pyreadr-0.4.7-py38he057510_2.tar.bz2
linux-64::pytables-3.7.0-py39h6a7961f_3.tar.bz2
linux-64::pp-sketchlib-2.0.1-py38hf8e212d_1.tar.bz2
linux-64::yoda-1.9.6-py38h696bc5a_2.tar.bz2
linux-64::arrow-cpp-6.0.2-py39heda4e9d_5_cpu.tar.bz2
linux-64::postgresql-plpython-14.5-py311h17985b3_1.tar.bz2
linux-64::libnetcdf-4.9.0-mpi_mpich_h9de0870_1.tar.bz2
linux-64::vtk-9.2.2-qt_py38he961636_203.tar.bz2
linux-64::coda-2.24-py39h78b9e46_2.tar.bz2
linux-64::libcurl-static-7.86.0-h2283fc2_0.tar.bz2
linux-64::python-igraph-0.10.2-py38h3805f6d_0.tar.bz2
linux-64::libopencv-4.6.0-py38h2a969ba_6.tar.bz2
linux-64::mysql-connector-python-8.0.30-py38hec49fd2_1.tar.bz2
linux-64::ndcctools-7.4.14-py39h084f619_2.tar.bz2
linux-64::vtk-9.2.2-qt_py39hfcd09ca_204.tar.bz2
linux-64::omniorb-4.2.5-py311hfbf1579_3.tar.bz2
linux-64::panda3d-1.10.12-py39h55e2dd0_1.tar.bz2
linux-64::vtk-9.2.2-qt_py310h180de18_203.tar.bz2
linux-64::openbabel-3.1.1-py38h3c5e4c7_5.tar.bz2
linux-64::libllvm15-15.0.3-h63197d8_1.tar.bz2
linux-64::llvmdev-15.0.3-h503ea73_0.tar.bz2
linux-64::mysql-connector-python-8.0.31-py38hec49fd2_2.tar.bz2
linux-64::arrow-cpp-9.0.0-py310ha2b2c41_9_cuda.tar.bz2
linux-64::python-igraph-0.10.2-py38h64ef804_0.tar.bz2
linux-64::imagecodecs-2022.9.26-py38h60ac18d_3.tar.bz2
linux-64::mlir-15.0.2-he0ac6c6_0.tar.bz2
linux-64::pp-sketchlib-2.0.1-py310hf069bf9_0.tar.bz2
linux-64::python-igraph-0.10.2-py38h092921c_1.tar.bz2
linux-64::tiledb-2.11.3-h1e4a385_1.tar.bz2
linux-64::cpp-opentelemetry-sdk-1.6.1-h43b9883_1.tar.bz2
linux-64::python-igraph-0.10.2-py39h8e58fdc_0.tar.bz2
linux-64::xrootd-5.5.1-py39hc649c4b_1.tar.bz2
linux-64::xrootd-5.5.0-py310he953489_0.tar.bz2
linux-64::arrow-cpp-9.0.0-py38h06d3c50_8_cpu.tar.bz2
linux-64::arrow-cpp-7.0.1-py39h36aaa54_7_cuda.tar.bz2
linux-64::xrootd-5.5.0-py37h62c5c55_0.tar.bz2
linux-64::postgresql-plpython-14.5-py311h8669bae_1.tar.bz2
linux-64::libadios2-2.8.3-mpi_openmpi_h6776c36_4.tar.bz2
linux-64::xrootd-5.5.1-py310hb00e688_0.tar.bz2
linux-64::molgrid-0.5.2-cuda110py310hb97f616_1.tar.bz2
linux-64::root_base-6.26.8-py37hcbbcdc8_1.tar.bz2
linux-64::arrow-cpp-8.0.1-py311hbb8d1fa_6_cpu.tar.bz2
linux-64::molgrid-0.5.2-cuda112py310h824e6a0_0.tar.bz2
linux-64::python-igraph-0.10.2-py39h7fbefcb_1.tar.bz2
linux-64::aws-sdk-cpp-1.9.374-hb2dfdac_0.tar.bz2
linux-64::imagecodecs-2022.9.26-py38h839e5d1_1.tar.bz2
linux-64::pp-sketchlib-2.0.1-py310hf069bf9_1.tar.bz2
linux-64::arrow-cpp-8.0.1-py39hb3b17c4_6_cpu.tar.bz2
linux-64::harp-1.15.1-py37r41hc69f9df_3.tar.bz2
linux-64::xrootd-5.5.0-py38hf2e46ea_0.tar.bz2
linux-64::libopencv-4.6.0-py310h6214075_5.tar.bz2
linux-64::arrow-cpp-9.0.0-py311h9aa9700_9_cuda.tar.bz2
linux-64::arrow-cpp-9.0.0-py311h6e7b9a6_10_cuda.tar.bz2
linux-64::lxml-4.9.1-py311hc4dbab1_1.tar.bz2
linux-64::pyinstaller-5.1-py38he5536e0_1.tar.bz2
linux-64::omniorb-4.2.5-py310hba10ccf_4.tar.bz2
linux-64::xrootd-5.5.1-py37hbf1ac35_0.tar.bz2
linux-64::arrow-cpp-6.0.2-py39h797150d_6_cuda.tar.bz2
linux-64::ndcctools-7.4.14-py311hd4b0366_2.tar.bz2
linux-64::arrow-cpp-7.0.1-py310ha2b2c41_7_cuda.tar.bz2
linux-64::xrootd-5.5.1-py39h522448e_0.tar.bz2
linux-64::imagecodecs-2022.9.26-py38h67e265d_1.tar.bz2
linux-64::qt-main-5.15.6-hd477bba_1.tar.bz2
linux-64::harp-1.15.1-py37r42hc69f9df_3.tar.bz2
linux-64::molgrid-0.5.2-cuda110py38heb8b639_0.tar.bz2
linux-64::vowpalwabbit-9.5.0-py38hd67f247_0.tar.bz2
linux-64::py-bgzip-0.4.0-py310ha400145_3.tar.bz2
linux-64::arrow-cpp-7.0.1-py39h78fddc2_7_cpu.tar.bz2
linux-64::postgresql-plpython-14.5-py39h9d33b8a_1.tar.bz2
linux-64::py-bgzip-0.4.0-py311h1866167_3.tar.bz2
linux-64::xrootd-5.5.1-py37h654ae84_1.tar.bz2
linux-64::xrootd-5.5.1-py310he953489_0.tar.bz2
-    "libzlib >=1.2.13,<1.3.0a0",
+    "libzlib >=1.2.13,<2.0.0a0",
linux-64::liblal-7.2.4-fftw_h818ca7a_100.tar.bz2
linux-64::clang-format-15.0.2-default_h2e3cab8_0.tar.bz2
linux-64::libsqlite-3.39.4-h753d276_0.tar.bz2
linux-64::libprotobuf-3.21.7-h6239696_0.tar.bz2
linux-64::libclang-15.0.2-default_h2e3cab8_0.tar.bz2
linux-64::clang-15-15.0.2-default_h2e3cab8_0.tar.bz2
linux-64::clang-tools-15.0.2-default_h2e3cab8_0.tar.bz2
linux-64::libclang-cpp-15.0.2-default_h2e3cab8_0.tar.bz2
linux-64::libprotobuf-static-3.21.7-h6239696_0.tar.bz2
linux-64::libclang-cpp15-15.0.2-default_h2e3cab8_0.tar.bz2
linux-64::zimpl-3.5.3-hb4bb7ca_1.tar.bz2
linux-64::clang-format-15-15.0.2-default_h2e3cab8_0.tar.bz2
linux-64::pcre2-10.40-hc3806b6_0.tar.bz2
linux-64::zimpl-3.5.3-hb4bb7ca_0.tar.bz2
linux-64::libclang13-15.0.2-default_h3a83d3e_0.tar.bz2
linux-64::cgns-4.3.0-hcb04c3e_2.tar.bz2
linux-64::gst-plugins-base-1.21.1-h57caac4_0.tar.bz2
-    "libzlib >=1.2.12,<1.3.0a0"
+    "libzlib >=1.2.12,<2.0.0a0"
linux-64::clang-tools-15.0.3-default_h2e3cab8_0.tar.bz2
linux-64::libclang-15.0.3-default_h2e3cab8_0.tar.bz2
linux-64::libmlir-15.0.2-he0ac6c6_0.tar.bz2
linux-64::libprotobuf-static-3.21.8-h6239696_0.tar.bz2
linux-64::clang-format-15.0.3-default_h2e3cab8_0.tar.bz2
linux-64::cling-0.9-he0ac6c6_0.tar.bz2
linux-64::libprotobuf-3.21.9-h6239696_0.tar.bz2
linux-64::fontconfig-2.14.1-hc2a2eb6_0.tar.bz2
linux-64::llvm-tools-11.1.0-he0ac6c6_5.tar.bz2
linux-64::clang-format-15-15.0.3-default_h2e3cab8_0.tar.bz2
linux-64::libprotobuf-static-3.21.9-h6239696_0.tar.bz2
linux-64::libmlir15-15.0.2-he0ac6c6_0.tar.bz2
linux-64::cling-0.8-he0ac6c6_2.tar.bz2
linux-64::clang-15-15.0.3-default_h2e3cab8_0.tar.bz2
linux-64::libclang-cpp15-15.0.3-default_h2e3cab8_0.tar.bz2
linux-64::llvm-11.1.0-h32600fe_5.tar.bz2
linux-64::libllvm11-11.1.0-he0ac6c6_5.tar.bz2
linux-64::libv8-8.9.83-h7465d70_2.tar.bz2
linux-64::libmlir-15.0.3-he0ac6c6_0.tar.bz2
linux-64::glib-tools-2.74.1-h6239696_0.tar.bz2
linux-64::libnetcdf-4.8.1-nompi_h261ec11_106.tar.bz2
linux-64::libprotobuf-3.21.8-h6239696_0.tar.bz2
linux-64::liblal-7.2.4-fftw_h818ca7a_101.tar.bz2
linux-64::pandoc-2.19.2-h32600fe_1.tar.bz2
linux-64::libmlir-15.0.1-he0ac6c6_0.tar.bz2
linux-64::libclang13-15.0.3-default_h3a83d3e_0.tar.bz2
linux-64::libmlir15-15.0.1-he0ac6c6_0.tar.bz2
linux-64::plumed-2.8.1-nompi_hd7db5c2_100.tar.bz2
linux-64::gst-libav-1.20.3-h6d1a0e6_2.tar.bz2
linux-64::libclang-cpp-15.0.3-default_h2e3cab8_0.tar.bz2
linux-64::cling-0.9-he0ac6c6_1.tar.bz2
linux-64::libnetcdf-4.8.1-nompi_h261ec11_105.tar.bz2
linux-64::liblal-7.2.4-fftw_h818ca7a_102.tar.bz2
linux-64::libmlir15-15.0.3-he0ac6c6_0.tar.bz2
linux-64::gst-plugins-base-1.21.1-h3e40eee_1.tar.bz2
-    "libzlib >=1.2.13,<1.3.0a0"
+    "libzlib >=1.2.13,<2.0.0a0"
```

</details>