### PR TITLE
loosen zlib-pin to major level (21/N; September 2022)

### DIFF
--- a/recipe/patch_yaml/zlib.yaml
+++ b/recipe/patch_yaml/zlib.yaml
@@ -178,3 +178,12 @@ then:
   - loosen_depends:
       name: libzlib
       upper_bound: "2"
+---
+if:
+  has_depends: libzlib >=1.2*
+  timestamp_lt: 1664582400000  # 2022-10-01 00:00 UTC
+  timestamp_ge: 1661990400000  # 2022-09-01 00:00 UTC
+then:
+  - loosen_depends:
+      name: libzlib
+      upper_bound: "2"


### PR DESCRIPTION
Follow-up to https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/739, about 3200 artefacts affected.

### Result of `python show_diff.py`

<details>

```diff
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
osx-arm64::netcdf4-1.6.1-mpi_openmpi_py310h3b2823a_0.tar.bz2
osx-arm64::arrow-cpp-6.0.2-py39ha306277_3_cpu.tar.bz2
osx-arm64::assimp-5.2.4-h276577b_1.tar.bz2
osx-arm64::pdal-2.4.3-h48be3ce_2.tar.bz2
osx-arm64::aws-sdk-cpp-1.9.342-h28dd606_0.tar.bz2
osx-arm64::arrow-cpp-9.0.0-py310h8213172_3_cpu.tar.bz2
osx-arm64::ovito-3.7.8-h9edad43_1.tar.bz2
osx-arm64::aws-sdk-cpp-1.9.338-h0b4ba81_0.tar.bz2
osx-arm64::cppyy-cling-6.27.0-py310h59dd246_1.tar.bz2
osx-arm64::orc-1.8.0-hef0d403_0.tar.bz2
osx-arm64::grpc-cpp-1.48.1-h503f348_1.tar.bz2
osx-arm64::pyreadr-0.4.7-py38h5995db3_1.tar.bz2
osx-arm64::arrow-cpp-9.0.0-py310hd70906a_2_cpu.tar.bz2
osx-arm64::nodejs-16.17.1-haa6f3e8_0.tar.bz2
osx-arm64::python-igraph-0.10.0-py310hb3ce840_1.tar.bz2
osx-arm64::arrow-cpp-7.0.1-py310h5547a8d_1_cpu.tar.bz2
osx-arm64::imagecodecs-2022.9.26-py39h6bc43d6_0.tar.bz2
osx-arm64::grpc-cpp-1.46.4-h503f348_7.tar.bz2
osx-arm64::arrow-cpp-8.0.1-py310h9c2e107_3_cpu.tar.bz2
osx-arm64::arrow-cpp-9.0.0-py38he559872_3_cpu.tar.bz2
osx-arm64::libssh-0.10.2-h19e3c78_0.tar.bz2
osx-arm64::libtensorflow_cc-2.10.0-cpu_h52aa93f_0.tar.bz2
osx-arm64::magics-metview-4.12.1-h257d764_1.tar.bz2
osx-arm64::magics-4.12.1-h296c385_1.tar.bz2
osx-arm64::cpp-opentelemetry-sdk-1.6.1-h041a55c_0.tar.bz2
osx-arm64::arrow-cpp-9.0.0-py310h988b05a_2_cpu.tar.bz2
osx-arm64::indexed_gzip-1.7.0-py310h0292dfd_0.tar.bz2
osx-arm64::gemmi-0.5.7-py39h8ca5d33_0.tar.bz2
osx-arm64::openmpi-4.1.4-h4e676fc_101.tar.bz2
osx-arm64::ndcctools-7.4.14-py310hbaff3d7_1.tar.bz2
osx-arm64::vowpalwabbit-9.3.0-py39h6aa159f_2.tar.bz2
osx-arm64::nest-simulator-3.3-py38h8a9f503_2.tar.bz2
osx-arm64::libtensorflow-2.10.0-cpu_h52aa93f_0.tar.bz2
osx-arm64::grpc-cpp-1.48.1-h57f0ea7_1.tar.bz2
osx-arm64::mdtraj-1.9.7-py38hf9b85db_2.tar.bz2
osx-arm64::wxwidgets-3.2.0-py310hcddb3b7_2.tar.bz2
osx-arm64::libadios2-2.8.3-nompi_h2a7deb7_103.tar.bz2
osx-arm64::libadios2-2.8.3-mpi_mpich_hd98ca74_2.tar.bz2
osx-arm64::arrow-cpp-9.0.0-py310h38c6f73_6_cpu.tar.bz2
osx-arm64::arrow-cpp-6.0.2-py310hb113ec9_0_cpu.tar.bz2
osx-arm64::libsoup-3.2.0-h5a5772c_0.tar.bz2
osx-arm64::ndcctools-7.4.14-py38hc1332ea_1.tar.bz2
osx-arm64::arrow-cpp-6.0.2-py38h27a1824_1_cpu.tar.bz2
osx-arm64::aws-sdk-cpp-1.9.349-h28dd606_0.tar.bz2
osx-arm64::grpc-cpp-1.47.1-haeec53e_6.tar.bz2
osx-arm64::cppyy-cling-6.27.0-py38h9908e9a_1.tar.bz2
osx-arm64::aws-sdk-cpp-1.9.344-h28dd606_0.tar.bz2
osx-arm64::nodejs-18.9.0-h26a3f6d_0.tar.bz2
osx-arm64::vtk-9.1.0-qt_py38hadba9c1_215.tar.bz2
osx-arm64::tensorflow-base-2.10.0-cpu_py39h0d4f425_0.tar.bz2
osx-arm64::libadios2-2.8.3-nompi_h1a595cf_103.tar.bz2
osx-arm64::arrow-cpp-7.0.1-py310h1f9b56f_4_cpu.tar.bz2
osx-arm64::pyreadr-0.4.7-py310h7d40852_0.tar.bz2
osx-arm64::arrow-cpp-7.0.1-py310hd70906a_1_cpu.tar.bz2
osx-arm64::arrow-cpp-9.0.0-py39h2880af6_6_cpu.tar.bz2
osx-arm64::papilo-2.1.0-h2c0ef67_2.tar.bz2
osx-arm64::ffmpeg-5.1.1-gpl_h415c458_101.tar.bz2
osx-arm64::arrow-cpp-8.0.1-py39h744a0ab_2_cpu.tar.bz2
osx-arm64::arrow-cpp-9.0.0-py39h744a0ab_2_cpu.tar.bz2
osx-arm64::arrow-cpp-7.0.1-py38hd033ea8_1_cpu.tar.bz2
osx-arm64::ffmpeg-5.1.1-lgpl_h4c4a6e0_1.tar.bz2
osx-arm64::pdal-2.4.3-hc69dbcc_2.tar.bz2
osx-arm64::imagemagick-7.1.0_48-pl5321ha4981c7_0.tar.bz2
osx-arm64::nodejs-16.16.0-haa6f3e8_0.tar.bz2
osx-arm64::libssh-0.10.2-h2f81810_0.tar.bz2
osx-arm64::grpcio-1.48.1-py39h33439fd_0.tar.bz2
osx-arm64::libnetcdf-4.9.0-nompi_h996a5af_100.tar.bz2
osx-arm64::cpp-opentelemetry-sdk-1.6.0-h041a55c_1.tar.bz2
osx-arm64::gfal2-2.21.1-h0b9f163_0.tar.bz2
osx-arm64::nodejs-16.17.1-h26a3f6d_0.tar.bz2
osx-arm64::aws-sdk-cpp-1.9.353-hd024372_0.tar.bz2
osx-arm64::sagelib-9.6-py310h2478b59_3.tar.bz2
osx-arm64::sagelib-9.6-py39hdc4234c_3.tar.bz2
osx-arm64::aws-sdk-cpp-1.9.339-h0b4ba81_0.tar.bz2
osx-arm64::gemmi-0.5.7-py310h1e34944_0.tar.bz2
osx-arm64::arrow-cpp-7.0.1-py39h77e42b0_3_cpu.tar.bz2
osx-arm64::aws-sdk-cpp-1.9.347-h28dd606_0.tar.bz2
osx-arm64::pyreadstat-1.1.9-py39h019302e_1.tar.bz2
osx-arm64::aws-sdk-cpp-1.9.341-h28dd606_1.tar.bz2
osx-arm64::libadios2-2.8.3-nompi_hc3cbe00_103.tar.bz2
osx-arm64::aws-sdk-cpp-1.9.350-h16350d7_0.tar.bz2
osx-arm64::ndcctools-7.4.14-py39hfef7b1a_1.tar.bz2
osx-arm64::jaxlib-0.3.20-cpu_py310h18a4bca_0.tar.bz2
osx-arm64::libitk-5.2.1-h112da86_6.tar.bz2
osx-arm64::arrow-cpp-7.0.1-py38he559872_2_cpu.tar.bz2
osx-arm64::arrow-cpp-8.0.1-py38he559872_2_cpu.tar.bz2
osx-arm64::arrow-cpp-6.0.2-py38h2a94bf6_3_cpu.tar.bz2
osx-arm64::libadios2-2.8.3-nompi_h15f735f_103.tar.bz2
osx-arm64::nodejs-18.9.1-h26a3f6d_0.tar.bz2
osx-arm64::arrow-cpp-7.0.1-py310h7671348_0_cpu.tar.bz2
osx-arm64::wxwidgets-3.2.1-py310h70a066b_0.tar.bz2
osx-arm64::imagecodecs-2022.8.8-py310h1dfddb6_5.tar.bz2
osx-arm64::gsoap-2.8.123-hfb11b17_0.tar.bz2
osx-arm64::arrow-cpp-6.0.2-py310h70ad3bc_1_cpu.tar.bz2
osx-arm64::arrow-cpp-6.0.2-py39hd6a254d_0_cpu.tar.bz2
osx-arm64::imagemagick-7.1.0_48-pl5321h0a6f427_1.tar.bz2
osx-arm64::aws-sdk-cpp-1.9.343-h28dd606_0.tar.bz2
osx-arm64::nodejs-18.10.0-haa6f3e8_0.tar.bz2
osx-arm64::arrow-cpp-8.0.1-py310h8213172_2_cpu.tar.bz2
osx-arm64::llvmdev-15.0.0-h71e9575_0.tar.bz2
osx-arm64::libssh-0.10.1-h19e3c78_0.tar.bz2
osx-arm64::arrow-cpp-7.0.1-py38h92bc78b_0_cpu.tar.bz2
osx-arm64::arrow-cpp-6.0.2-py39h64e5d9a_1_cpu.tar.bz2
osx-arm64::libgdal-3.5.2-h889d05c_3.tar.bz2
osx-arm64::libnetcdf-4.9.0-mpi_mpich_h1ec8146_0.tar.bz2
osx-arm64::ffmpeg-5.1.2-gpl_h415c458_100.tar.bz2
osx-arm64::arrow-cpp-7.0.1-py38h7d92150_1_cpu.tar.bz2
osx-arm64::assimp-5.2.4-h276577b_2.tar.bz2
osx-arm64::gdk-pixbuf-2.42.8-h4f389bb_1.tar.bz2
osx-arm64::ovito-3.7.9-h9edad43_0.tar.bz2
osx-arm64::rsync-3.2.6-hff32518_0.tar.bz2
osx-arm64::tensorflow-base-2.10.0-cpu_py38h6c0f03e_0.tar.bz2
osx-arm64::libadios2-2.8.3-nompi_h44d955a_103.tar.bz2
osx-arm64::libssh-0.10.3-h2f81810_0.tar.bz2
osx-arm64::netcdf4-1.6.1-nompi_py38he52ce97_100.tar.bz2
osx-arm64::vowpalwabbit-9.3.0-py38hf78df78_2.tar.bz2
osx-arm64::ffmpeg-5.1.1-lgpl_hc0dd40f_1.tar.bz2
osx-arm64::indexed_gzip-1.7.0-py38hf2a5641_0.tar.bz2
osx-arm64::libgdal-3.5.2-h889d05c_0.tar.bz2
osx-arm64::nodejs-16.16.0-h26a3f6d_0.tar.bz2
osx-arm64::netcdf4-1.6.1-mpi_mpich_py310h9db3456_0.tar.bz2
osx-arm64::jaxlib-0.3.15-cpu_py38hdd4436d_4.tar.bz2
osx-arm64::arrow-cpp-9.0.0-py39hacf87b1_2_cpu.tar.bz2
osx-arm64::jaxlib-0.3.15-cpu_py38h8a320d7_4.tar.bz2
osx-arm64::libadios2-2.8.3-mpi_openmpi_h7f8a541_2.tar.bz2
osx-arm64::arrow-cpp-7.0.1-py39hacf87b1_0_cpu.tar.bz2
osx-arm64::arrow-cpp-8.0.1-py39hcabfb4f_2_cpu.tar.bz2
osx-arm64::arrow-cpp-9.0.0-py38h7d92150_2_cpu.tar.bz2
osx-arm64::grpc-cpp-1.46.4-haeec53e_7.tar.bz2
osx-arm64::gap-core-4.11.1-he8f4e70_4.tar.bz2
osx-arm64::libgdal-3.5.2-he1a18a7_1.tar.bz2
osx-arm64::libadios2-2.8.3-mpi_mpich_h06f0bc5_3.tar.bz2
osx-arm64::gazebo-11.11.0-h9dcfd48_13.tar.bz2
osx-arm64::magics-metview-batch-4.12.1-h296c385_1.tar.bz2
osx-arm64::python-igraph-0.9.11-py39h0645257_1.tar.bz2
osx-arm64::arrow-cpp-6.0.2-py38ha9d5168_0_cpu.tar.bz2
osx-arm64::ffmpeg-4.4.2-gpl_h415c458_108.tar.bz2
osx-arm64::libkml-1.3.0-h41464e4_1015.tar.bz2
osx-arm64::vigra-1.11.1-py38ha03ee47_1033.tar.bz2
osx-arm64::libitk-5.2.1-h0e669ce_5.tar.bz2
osx-arm64::arrow-cpp-9.0.0-py39h77e42b0_5_cpu.tar.bz2
osx-arm64::arrow-cpp-6.0.2-py39h7cdd81f_0_cpu.tar.bz2
osx-arm64::netcdf4-1.6.1-mpi_openmpi_py39h671b1b9_0.tar.bz2
osx-arm64::jaxlib-0.3.20-cpu_py310h48e4569_0.tar.bz2
osx-arm64::pyreadr-0.4.7-py39hdd982f8_0.tar.bz2
osx-arm64::libgdal-3.5.2-he1a18a7_0.tar.bz2
osx-arm64::tiledb-2.11.2-h9bd36d0_0.tar.bz2
osx-arm64::arrow-cpp-7.0.1-py310h9c2e107_3_cpu.tar.bz2
osx-arm64::nest-simulator-3.3-py39h1c397a2_2.tar.bz2
osx-arm64::pyreadr-0.4.7-py310h7d40852_1.tar.bz2
osx-arm64::arrow-cpp-9.0.0-py38h8f4b2ab_6_cpu.tar.bz2
osx-arm64::imagecodecs-2022.9.26-py38h7301a9e_0.tar.bz2
osx-arm64::libssh-0.10.4-he6c3a9c_2.tar.bz2
osx-arm64::aws-sdk-cpp-1.9.349-h16350d7_1.tar.bz2
osx-arm64::sqlite-3.39.3-h2229b38_0.tar.bz2
osx-arm64::libadios2-2.8.3-mpi_mpich_hd98ca74_3.tar.bz2
osx-arm64::arrow-cpp-8.0.1-py39h77e42b0_3_cpu.tar.bz2
osx-arm64::smesh-9.9.0.0-hff13646_1.tar.bz2
osx-arm64::imagecodecs-2022.9.26-py310hf6aa91f_0.tar.bz2
osx-arm64::llvmlite-0.39.1-py38he6bf707_0.tar.bz2
osx-arm64::libadios2-2.8.3-mpi_openmpi_h0557014_3.tar.bz2
osx-arm64::arrow-cpp-9.0.0-py38hd033ea8_2_cpu.tar.bz2
osx-arm64::libssh-0.10.4-h2f81810_0.tar.bz2
osx-arm64::imagecodecs-2022.8.8-py38hf7c3e48_5.tar.bz2
osx-arm64::ffmpeg-5.1.1-gpl_hfdc7bce_101.tar.bz2
osx-arm64::libadios2-2.8.3-mpi_mpich_h9b6efc4_3.tar.bz2
osx-arm64::soplex-6.0.1-h8acab5f_2.tar.bz2
osx-arm64::aws-sdk-cpp-1.9.340-h0b4ba81_0.tar.bz2
osx-arm64::arrow-cpp-6.0.2-py310h101e551_1_cpu.tar.bz2
osx-arm64::ndcctools-7.4.14-py38h05a9a42_1.tar.bz2
osx-arm64::jaxlib-0.3.15-cpu_py39ha8321c9_4.tar.bz2
osx-arm64::llvmdev-11.1.0-hfa12f05_4.tar.bz2
osx-arm64::jaxlib-0.3.15-cpu_py310h48e4569_4.tar.bz2
osx-arm64::jaxlib-0.3.20-cpu_py38hdd4436d_0.tar.bz2
osx-arm64::nodejs-16.15.1-h26a3f6d_0.tar.bz2
osx-arm64::pyreadstat-1.1.9-py38hc53b772_1.tar.bz2
osx-arm64::python-igraph-0.9.11-py38h8b745a7_1.tar.bz2
osx-arm64::pyreadstat-1.1.9-py310h5d88ba1_1.tar.bz2
osx-arm64::arrow-cpp-9.0.0-py310h9c2e107_4_cpu.tar.bz2
osx-arm64::python-igraph-0.9.11-py310hb3ce840_1.tar.bz2
osx-arm64::qt-main-5.15.6-h96bf0dc_0.tar.bz2
osx-arm64::thrift-compiler-0.16.0-h6635e49_2.tar.bz2
osx-arm64::arrow-cpp-6.0.2-py39hbda1e2e_1_cpu.tar.bz2
osx-arm64::aws-sdk-cpp-1.9.354-hd024372_0.tar.bz2
osx-arm64::grpc-cpp-1.48.1-h55edf5b_0.tar.bz2
osx-arm64::paraview-5.10.1-py310he503193_108_qt.tar.bz2
osx-arm64::libthrift-0.16.0-h1a74c4f_2.tar.bz2
osx-arm64::arrow-cpp-7.0.1-py38h3d7e031_0_cpu.tar.bz2
osx-arm64::libadios2-2.8.3-nompi_h2a7deb7_102.tar.bz2
osx-arm64::libssh-0.10.4-h2f81810_1.tar.bz2
osx-arm64::jaxlib-0.3.20-cpu_py38h8a320d7_0.tar.bz2
osx-arm64::arrow-cpp-9.0.0-py39hcabfb4f_3_cpu.tar.bz2
osx-arm64::ffmpeg-4.4.2-lgpl_hc0dd40f_8.tar.bz2
osx-arm64::libssh-0.10.3-h19e3c78_0.tar.bz2
osx-arm64::scip-8.0.1-hb8cc2fd_3.tar.bz2
osx-arm64::aws-sdk-cpp-1.9.345-h28dd606_0.tar.bz2
osx-arm64::ffmpeg-4.4.2-lgpl_hf2bc88c_8.tar.bz2
osx-arm64::cpp-opentelemetry-sdk-1.6.0-h146a497_1.tar.bz2
osx-arm64::ffmpeg-5.1.2-gpl_hcccd11d_101.tar.bz2
osx-arm64::arrow-cpp-6.0.2-py38hb80a442_1_cpu.tar.bz2
osx-arm64::python-igraph-0.10.0-py39h0645257_1.tar.bz2
osx-arm64::arrow-cpp-9.0.0-py310h5547a8d_2_cpu.tar.bz2
osx-arm64::arrow-cpp-6.0.2-py310h51b519a_0_cpu.tar.bz2
osx-arm64::arrow-cpp-8.0.1-py310hd70906a_2_cpu.tar.bz2
osx-arm64::llvmlite-0.39.1-py39h8ca5d33_0.tar.bz2
osx-arm64::libgdal-3.5.2-h889d05c_1.tar.bz2
osx-arm64::tensorflow-base-2.10.0-cpu_py310h4e07833_0.tar.bz2
osx-arm64::protozfits-2.0.1.post1-py310hf2b4c7d_9.tar.bz2
osx-arm64::arrow-cpp-9.0.0-py39h2271836_2_cpu.tar.bz2
osx-arm64::jaxlib-0.3.20-cpu_py39h100ce08_0.tar.bz2
osx-arm64::arrow-cpp-6.0.2-py310he35c4e1_2_cpu.tar.bz2
osx-arm64::arrow-cpp-8.0.1-py39h2271836_2_cpu.tar.bz2
osx-arm64::netcdf4-1.6.1-mpi_mpich_py39hd6d6928_0.tar.bz2
osx-arm64::emacs-28.2-h836aab7_0.tar.bz2
osx-arm64::libgdal-3.5.2-he1a18a7_3.tar.bz2
osx-arm64::grpc-cpp-1.48.1-haeec53e_1.tar.bz2
osx-arm64::graphviz-6.0.1-h37ddf74_0.tar.bz2
osx-arm64::ffmpeg-5.1.2-lgpl_hf2bc88c_1.tar.bz2
osx-arm64::nodejs-18.9.0-haa6f3e8_0.tar.bz2
osx-arm64::arrow-cpp-6.0.2-py38h5921dea_2_cpu.tar.bz2
osx-arm64::arrow-cpp-9.0.0-py310h9c2e107_5_cpu.tar.bz2
osx-arm64::libadios2-2.8.3-mpi_mpich_h4f585cb_2.tar.bz2
osx-arm64::arrow-cpp-9.0.0-py38h1ea89c0_4_cpu.tar.bz2
osx-arm64::libssh-0.10.1-h2f81810_0.tar.bz2
osx-arm64::coin-or-cgl-0.60.6-hf050ae7_2.tar.bz2
osx-arm64::grpc-cpp-1.46.4-h55edf5b_7.tar.bz2
osx-arm64::imagecodecs-2022.8.8-py39h6e7f272_5.tar.bz2
osx-arm64::tiledb-2.11.2-hc7ac4c9_0.tar.bz2
osx-arm64::libadios2-2.8.3-mpi_openmpi_h7f8a541_3.tar.bz2
osx-arm64::jaxlib-0.3.15-cpu_py39h100ce08_4.tar.bz2
osx-arm64::libadios2-2.8.3-mpi_openmpi_h46f72f7_2.tar.bz2
osx-arm64::vtk-9.1.0-qt_py310h3be5dd2_215.tar.bz2
osx-arm64::arrow-cpp-6.0.2-py39h5eed1d6_2_cpu.tar.bz2
osx-arm64::grpc-cpp-1.47.1-h503f348_6.tar.bz2
osx-arm64::poppler-22.04.0-h4f9e0c6_3.tar.bz2
osx-arm64::tesseract-5.2.0-h299fba5_1.tar.bz2
osx-arm64::libadios2-2.8.3-mpi_openmpi_he97a032_2.tar.bz2
osx-arm64::aws-sdk-cpp-1.9.356-hd024372_0.tar.bz2
osx-arm64::nodejs-18.9.1-haa6f3e8_0.tar.bz2
osx-arm64::arrow-cpp-6.0.2-py310h0ff1b70_3_cpu.tar.bz2
osx-arm64::collada-dom-2.5.0-h41ac093_5.tar.bz2
osx-arm64::arrow-cpp-7.0.1-py38h1ea89c0_3_cpu.tar.bz2
osx-arm64::libssh-0.10.4-hfb1f51c_2.tar.bz2
osx-arm64::llvmlite-0.39.1-py310h1e34944_0.tar.bz2
osx-arm64::arrow-cpp-9.0.0-py38h3d7e031_2_cpu.tar.bz2
osx-arm64::graphviz-6.0.0-h37ddf74_0.tar.bz2
osx-arm64::netcdf4-1.6.1-nompi_py39h8ded8ba_100.tar.bz2
osx-arm64::paraview-5.10.1-py38h33370e5_108_qt.tar.bz2
osx-arm64::aws-sdk-cpp-1.9.337-h0b4ba81_0.tar.bz2
osx-arm64::pyreadr-0.4.7-py39hdd982f8_1.tar.bz2
osx-arm64::grpc-cpp-1.47.1-h55edf5b_6.tar.bz2
osx-arm64::vigra-1.11.1-py39h43124a5_1034.tar.bz2
osx-arm64::grpcio-1.48.1-py310h71374d7_0.tar.bz2
osx-arm64::gst-plugins-good-1.20.3-hf411aef_2.tar.bz2
osx-arm64::libvips-8.13.1-h21e39f5_0.tar.bz2
osx-arm64::indexed_gzip-1.7.0-py39h76fbbf9_0.tar.bz2
osx-arm64::libvips-8.13.1-h7767637_1.tar.bz2
osx-arm64::soplex-6.0.1-h3da912a_3.tar.bz2
osx-arm64::libadios2-2.8.3-nompi_hc3cbe00_102.tar.bz2
osx-arm64::arrow-cpp-9.0.0-py39h77e42b0_4_cpu.tar.bz2
osx-arm64::libtiff-4.4.0-hfa0b094_4.tar.bz2
osx-arm64::vigra-1.11.1-py310hd1c930d_1033.tar.bz2
osx-arm64::libadios2-2.8.3-mpi_openmpi_h46f72f7_3.tar.bz2
osx-arm64::cairomm-1.0-1.14.4-h136753c_0.tar.bz2
osx-arm64::aws-sdk-cpp-1.9.351-hd024372_0.tar.bz2
osx-arm64::libadios2-2.8.3-mpi_openmpi_h4d55933_3.tar.bz2
osx-arm64::aws-sdk-cpp-1.9.346-h28dd606_0.tar.bz2
osx-arm64::arrow-cpp-7.0.1-py38h04e0e3b_4_cpu.tar.bz2
osx-arm64::libspatialite-5.0.1-h405e1be_20.tar.bz2
osx-arm64::nest-simulator-3.3-py310h0125578_2.tar.bz2
osx-arm64::arrow-cpp-8.0.1-py310h5547a8d_2_cpu.tar.bz2
osx-arm64::grpc-cpp-1.48.1-h55edf5b_1.tar.bz2
osx-arm64::giac-1.6.0.47-h8159021_6.tar.bz2
osx-arm64::arrow-cpp-8.0.1-py38h8f4b2ab_4_cpu.tar.bz2
osx-arm64::mysql-connector-cpp-8.0.29-h80e1b86_2.tar.bz2
osx-arm64::gazebo-11.12.0-h0e878e5_0.tar.bz2
osx-arm64::gemmi-0.5.7-py38he6bf707_0.tar.bz2
osx-arm64::arrow-cpp-9.0.0-py310h7671348_2_cpu.tar.bz2
osx-arm64::smesh-9.9.0.0-he6df951_0.tar.bz2
osx-arm64::gazebo-11.12.0-h55a68f1_0.tar.bz2
osx-arm64::arrow-cpp-8.0.1-py38h1ea89c0_3_cpu.tar.bz2
osx-arm64::nodejs-16.17.0-haa6f3e8_0.tar.bz2
osx-arm64::vowpalwabbit-9.3.0-py310hb174350_2.tar.bz2
osx-arm64::grpc-cpp-1.47.1-h57f0ea7_6.tar.bz2
osx-arm64::gazebo-11.11.0-h0e878e5_14.tar.bz2
osx-arm64::thrift-compiler-0.16.0-h1a74c4f_2.tar.bz2
osx-arm64::aws-sdk-cpp-1.9.350-hd024372_1.tar.bz2
osx-arm64::hugin-base-2021.0.0-pl5321hf48a77c_8.tar.bz2
osx-arm64::arrow-cpp-8.0.1-py38h7d92150_2_cpu.tar.bz2
osx-arm64::arrow-cpp-7.0.1-py39hcabfb4f_2_cpu.tar.bz2
osx-arm64::vigra-1.11.1-py310h693ab2c_1034.tar.bz2
osx-arm64::netcdf4-1.6.1-nompi_py310haaa361f_100.tar.bz2
osx-arm64::libspatialite-5.0.1-hca80f78_21.tar.bz2
osx-arm64::arrow-cpp-7.0.1-py39h2271836_1_cpu.tar.bz2
osx-arm64::arrow-cpp-6.0.2-py38h396e7e6_0_cpu.tar.bz2
osx-arm64::mdtraj-1.9.7-py310h1e75f39_2.tar.bz2
osx-arm64::libssh-0.10.4-h19e3c78_0.tar.bz2
osx-arm64::libadios2-2.8.3-mpi_mpich_hbc6cf1d_3.tar.bz2
osx-arm64::libxml2-2.10.2-ha9542bf_1.tar.bz2
osx-arm64::arrow-cpp-7.0.1-py310h988b05a_0_cpu.tar.bz2
osx-arm64::grpc-cpp-1.46.4-h57f0ea7_7.tar.bz2
osx-arm64::cppyy-cling-6.27.0-py39hd308395_1.tar.bz2
osx-arm64::nodejs-18.10.0-h26a3f6d_0.tar.bz2
osx-arm64::ndcctools-7.4.14-py310he1c76cb_1.tar.bz2
osx-arm64::glib-2.74.0-hb5ab8b9_0.tar.bz2
osx-arm64::ffmpeg-5.1.1-lgpl_hc0dd40f_2.tar.bz2
osx-arm64::rsync-3.2.6-hcdef6ba_0.tar.bz2
osx-arm64::libssh-0.10.4-h19e3c78_1.tar.bz2
osx-arm64::aws-sdk-cpp-1.9.352-hd024372_0.tar.bz2
osx-arm64::paraview-5.10.1-py39h0633422_108_qt.tar.bz2
osx-arm64::aws-sdk-cpp-1.9.341-h0b4ba81_0.tar.bz2
osx-arm64::arrow-cpp-7.0.1-py39h2217665_4_cpu.tar.bz2
osx-arm64::nodejs-16.15.1-haa6f3e8_0.tar.bz2
osx-arm64::arrow-cpp-8.0.1-py38hd033ea8_2_cpu.tar.bz2
osx-arm64::llvmdev-15.0.1-h71e9575_0.tar.bz2
osx-arm64::coin-or-clp-1.17.7-h65c2c7c_2.tar.bz2
osx-arm64::libthrift-0.16.0-h6635e49_2.tar.bz2
osx-arm64::gazebo-11.11.0-ha8b5a5e_12.tar.bz2
osx-arm64::gst-plugins-good-1.20.3-hf411aef_1.tar.bz2
osx-arm64::cairo-1.16.0-h73a0509_1014.tar.bz2
osx-arm64::mysql-connector-cpp-8.0.29-h15b38b3_2.tar.bz2
osx-arm64::jaxlib-0.3.15-cpu_py310h18a4bca_4.tar.bz2
osx-arm64::grpcio-1.48.1-py38h76f21f4_0.tar.bz2
osx-arm64::mdtraj-1.9.7-py39hefd17c3_2.tar.bz2
osx-arm64::ffmpeg-5.1.1-gpl_h415c458_102.tar.bz2
osx-arm64::arrow-cpp-7.0.1-py39h744a0ab_1_cpu.tar.bz2
osx-arm64::arrow-cpp-7.0.1-py310h8213172_2_cpu.tar.bz2
osx-arm64::cairomm-1.16-1.16.2-h136753c_0.tar.bz2
osx-arm64::pyreadr-0.4.7-py38h5995db3_0.tar.bz2
osx-arm64::aws-sdk-cpp-1.9.348-h28dd606_0.tar.bz2
osx-arm64::scip-8.0.1-hb8cc2fd_2.tar.bz2
osx-arm64::ffmpeg-5.1.2-lgpl_hc0dd40f_0.tar.bz2
osx-arm64::vtk-9.1.0-qt_py39h99f1238_215.tar.bz2
osx-arm64::geotiff-1.7.1-h90559a4_4.tar.bz2
osx-arm64::libadios2-2.8.3-mpi_mpich_h06f0bc5_2.tar.bz2
osx-arm64::arrow-cpp-9.0.0-py38h92bc78b_2_cpu.tar.bz2
osx-arm64::gazebo-11.11.0-h55a68f1_14.tar.bz2
osx-arm64::libadios2-2.8.3-mpi_mpich_h4f585cb_3.tar.bz2
osx-arm64::arrow-cpp-9.0.0-py39h4e21df5_2_cpu.tar.bz2
osx-arm64::arrow-cpp-7.0.1-py39h4e21df5_0_cpu.tar.bz2
osx-arm64::vigra-1.11.1-py38h28948af_1034.tar.bz2
osx-arm64::cmake-3.24.2-h967666c_0.tar.bz2
osx-arm64::ndcctools-7.4.14-py39h1c7e63e_1.tar.bz2
osx-arm64::libnetcdf-4.9.0-mpi_openmpi_h2fcbec1_0.tar.bz2
osx-arm64::libglib-2.74.0-h14ed1c1_0.tar.bz2
osx-arm64::netcdf4-1.6.1-mpi_mpich_py38h8a74167_0.tar.bz2
osx-arm64::mosh-1.3.2-pl5321hbe41834_1013.tar.bz2
osx-arm64::sagelib-9.6-py38h9ad5a0d_3.tar.bz2
osx-arm64::arrow-cpp-8.0.1-py39h2880af6_4_cpu.tar.bz2
osx-arm64::vigra-1.11.1-py39h0c1462f_1033.tar.bz2
osx-arm64::netcdf4-1.6.1-mpi_openmpi_py38h31dcd80_0.tar.bz2
osx-arm64::protozfits-2.0.1.post1-py39h3a42758_9.tar.bz2
osx-arm64::ffmpeg-4.4.2-gpl_hcccd11d_108.tar.bz2
osx-arm64::python-igraph-0.10.0-py38h8b745a7_1.tar.bz2
osx-arm64::gazebo-11.11.0-h98a8c5f_13.tar.bz2
osx-arm64::papilo-2.1.0-h9cc07e0_3.tar.bz2
osx-arm64::imagemagick-7.1.0_49-pl5321ha4612b8_0.tar.bz2
osx-arm64::jaxlib-0.3.20-cpu_py39ha8321c9_0.tar.bz2
osx-arm64::libadios2-2.8.3-nompi_h1a595cf_102.tar.bz2
osx-arm64::arrow-cpp-8.0.1-py310h38c6f73_4_cpu.tar.bz2
osx-arm64::nodejs-16.17.0-h26a3f6d_0.tar.bz2
osx-arm64::libadios2-2.8.3-mpi_openmpi_he97a032_3.tar.bz2
osx-arm64::gsoap-2.8.123-h6720f67_0.tar.bz2
-    "libzlib >=1.2.12,<1.3.0a0",
+    "libzlib >=1.2.12,<2.0.0a0",
osx-arm64::dotnet-aspnetcore-6.0.9-h674eb6b_0.tar.bz2
osx-arm64::libpng-1.6.38-h76d750c_0.tar.bz2
osx-arm64::libllvm11-11.1.0-hfa12f05_4.tar.bz2
osx-arm64::fontconfig-2.14.0-h82840c6_1.tar.bz2
osx-arm64::libprotobuf-static-3.21.6-hb5ab8b9_0.tar.bz2
osx-arm64::libprotobuf-3.20.1-hb5ab8b9_4.tar.bz2
osx-arm64::dotnet-sdk-6.0.401-h674eb6b_0.tar.bz2
osx-arm64::pocl-3.0-h422b2f1_1.tar.bz2
osx-arm64::libprotobuf-3.21.5-hb5ab8b9_2.tar.bz2
osx-arm64::llvm-tools-11.1.0-hfa12f05_4.tar.bz2
osx-arm64::llvm-tools-15.0.0-h71e9575_0.tar.bz2
osx-arm64::dotnet-runtime-6.0.9-h674eb6b_0.tar.bz2
osx-arm64::libprotobuf-static-3.21.5-hb5ab8b9_2.tar.bz2
osx-arm64::libllvm15-15.0.1-h71e9575_0.tar.bz2
osx-arm64::libprotobuf-static-3.21.6-hb5ab8b9_1.tar.bz2
osx-arm64::openjdk-11.0.15-hf913c23_1.tar.bz2
osx-arm64::llvm-15.0.0-h501a258_0.tar.bz2
osx-arm64::libprotobuf-static-3.20.1-hb5ab8b9_4.tar.bz2
osx-arm64::coin-or-osi-0.108.7-h19bcb3e_2.tar.bz2
osx-arm64::liblal-7.2.2-fftw_h6e50f36_100.tar.bz2
osx-arm64::libprotobuf-static-3.20.1-hb5ab8b9_2.tar.bz2
osx-arm64::libprotobuf-3.21.6-hb5ab8b9_1.tar.bz2
osx-arm64::libllvm15-15.0.0-h71e9575_0.tar.bz2
osx-arm64::llvm-11.1.0-h95d0606_4.tar.bz2
osx-arm64::libprotobuf-static-3.21.5-hb5ab8b9_1.tar.bz2
osx-arm64::gst-plugins-base-1.20.3-h8b7775e_2.tar.bz2
osx-arm64::glib-tools-2.74.0-hb5ab8b9_0.tar.bz2
osx-arm64::llvm-spirv-14.0.0-h25aad90_1.tar.bz2
osx-arm64::libprotobuf-static-3.20.1-hb5ab8b9_3.tar.bz2
osx-arm64::libprotobuf-3.20.1-hb5ab8b9_3.tar.bz2
osx-arm64::libprotobuf-static-3.21.5-hb5ab8b9_3.tar.bz2
osx-arm64::gst-plugins-base-1.20.3-h8b7775e_1.tar.bz2
osx-arm64::openjdk-17.0.3-hf913c23_2.tar.bz2
osx-arm64::openjdk-11.0.15-hf913c23_2.tar.bz2
osx-arm64::coin-or-utils-2.11.6-h8717b36_2.tar.bz2
osx-arm64::libprotobuf-3.21.5-hb5ab8b9_3.tar.bz2
osx-arm64::libprotobuf-3.21.6-hb5ab8b9_0.tar.bz2
osx-arm64::openjdk-17.0.3-hf913c23_1.tar.bz2
osx-arm64::llvm-15.0.1-h501a258_0.tar.bz2
osx-arm64::llvm-tools-15.0.1-h71e9575_0.tar.bz2
osx-arm64::libsqlite-3.39.3-h76d750c_0.tar.bz2
-    "libzlib >=1.2.12,<1.3.0a0"
+    "libzlib >=1.2.12,<2.0.0a0"
================================================================================
================================================================================
linux-ppc64le
linux-ppc64le::arrow-cpp-7.0.1-py310hbc713be_1_cpu.tar.bz2
linux-ppc64le::arrow-cpp-9.0.0-py39hd1dba26_4_cpu.tar.bz2
linux-ppc64le::grpc-cpp-1.48.1-hd4503be_1.tar.bz2
linux-ppc64le::openjdk-11.0.15-h5948ba2_2.tar.bz2
linux-ppc64le::arrow-cpp-8.0.1-py39h20edc30_2_cpu.tar.bz2
linux-ppc64le::nodejs-14.19.0-h9a3953a_0.tar.bz2
linux-ppc64le::cairo-1.16.0-h9ac834e_1014.tar.bz2
linux-ppc64le::libvips-8.13.1-h4df79fe_1.tar.bz2
linux-ppc64le::arrow-cpp-8.0.1-py37h32c5c48_3_cpu.tar.bz2
linux-ppc64le::arrow-cpp-6.0.2-py37h4f0e009_3_cpu.tar.bz2
linux-ppc64le::ffmpeg-5.1.1-lgpl_hb532579_2.tar.bz2
linux-ppc64le::aws-sdk-cpp-1.9.345-h1d7f1ac_0.tar.bz2
linux-ppc64le::libadios2-2.8.3-mpi_openmpi_h26eef5e_2.tar.bz2
linux-ppc64le::ffmpeg-5.1.2-lgpl_hb532579_0.tar.bz2
linux-ppc64le::arrow-cpp-7.0.1-py39hd363418_1_cpu.tar.bz2
linux-ppc64le::arrow-cpp-8.0.1-py39h7729523_2_cpu.tar.bz2
linux-ppc64le::arrow-cpp-8.0.1-py310h8b1cf4a_2_cpu.tar.bz2
linux-ppc64le::llvmlite-0.39.1-py38h8df0f6e_0.tar.bz2
linux-ppc64le::arrow-cpp-9.0.0-py37h32c5c48_4_cpu.tar.bz2
linux-ppc64le::grpc-cpp-1.48.1-h00557ac_1.tar.bz2
linux-ppc64le::libadios2-2.8.3-mpi_mpich_h9778faf_3.tar.bz2
linux-ppc64le::graphviz-6.0.1-h2dab0cd_0.tar.bz2
linux-ppc64le::arrow-cpp-8.0.1-py37hf952fd0_2_cpu.tar.bz2
linux-ppc64le::arrow-cpp-8.0.1-py38hc8db1b3_3_cpu.tar.bz2
linux-ppc64le::thrift-compiler-0.16.0-h484b8e3_2.tar.bz2
linux-ppc64le::imagecodecs-2022.8.8-py310h3483c11_5.tar.bz2
linux-ppc64le::arrow-cpp-6.0.2-py39h72d4f54_0_cpu.tar.bz2
linux-ppc64le::arrow-cpp-7.0.1-py37hab03e4d_0_cpu.tar.bz2
linux-ppc64le::aws-sdk-cpp-1.9.351-h93bb51c_0.tar.bz2
linux-ppc64le::arrow-cpp-6.0.2-py38h752b772_0_cpu.tar.bz2
linux-ppc64le::mapserver-8.0.0-py38h1445b8f_0.tar.bz2
linux-ppc64le::libadios2-2.8.3-mpi_mpich_h2610fa9_3.tar.bz2
linux-ppc64le::arrow-cpp-7.0.1-py37hd0e0174_1_cpu.tar.bz2
linux-ppc64le::arrow-cpp-9.0.0-py37hc350061_2_cpu.tar.bz2
linux-ppc64le::netcdf4-1.6.1-mpi_openmpi_py37h16a4bfb_0.tar.bz2
linux-ppc64le::libadios2-2.8.3-mpi_openmpi_h16f8d10_3.tar.bz2
linux-ppc64le::libadios2-2.8.3-mpi_openmpi_h43fd49f_3.tar.bz2
linux-ppc64le::llvmdev-15.0.0-hfe1df17_0.tar.bz2
linux-ppc64le::libssh-0.10.1-h262a72d_0.tar.bz2
linux-ppc64le::imagecodecs-2022.9.26-py310hf8c7ebb_0.tar.bz2
linux-ppc64le::arrow-cpp-7.0.1-py37h4ee62f7_0_cpu.tar.bz2
linux-ppc64le::libadios2-2.8.3-mpi_openmpi_h5390259_3.tar.bz2
linux-ppc64le::libgdal-3.5.2-h016ce9b_1.tar.bz2
linux-ppc64le::llvmlite-0.39.1-py39h11e4565_0.tar.bz2
linux-ppc64le::aws-sdk-cpp-1.9.350-hbd00276_0.tar.bz2
linux-ppc64le::arrow-cpp-8.0.1-py38h253fe00_2_cpu.tar.bz2
linux-ppc64le::libadios2-2.8.3-nompi_h013ccb2_103.tar.bz2
linux-ppc64le::arrow-cpp-7.0.1-py37h904c246_1_cpu.tar.bz2
linux-ppc64le::graphviz-6.0.0-h2dab0cd_0.tar.bz2
linux-ppc64le::libadios2-2.8.3-nompi_h699a37c_103.tar.bz2
linux-ppc64le::arrow-cpp-8.0.1-py39hd1dba26_3_cpu.tar.bz2
linux-ppc64le::cppyy-cling-6.27.0-py38hb6edf9e_1.tar.bz2
linux-ppc64le::ffmpeg-4.4.2-lgpl_he67232a_8.tar.bz2
linux-ppc64le::netcdf4-1.6.1-mpi_mpich_py38h607835c_0.tar.bz2
linux-ppc64le::grpcio-1.48.1-py38h73aa892_0.tar.bz2
linux-ppc64le::nodejs-16.16.0-h93803ed_0.tar.bz2
linux-ppc64le::ffmpeg-5.1.2-gpl_h54c1640_100.tar.bz2
linux-ppc64le::ffmpeg-4.4.2-gpl_h48e1702_108.tar.bz2
linux-ppc64le::libadios2-2.8.3-mpi_mpich_hd4932e6_2.tar.bz2
linux-ppc64le::libtiff-4.4.0-h74ce5ed_4.tar.bz2
linux-ppc64le::libadios2-2.8.3-nompi_h707d055_103.tar.bz2
linux-ppc64le::nodejs-14.19.2-h9a3953a_0.tar.bz2
linux-ppc64le::aws-sdk-cpp-1.9.343-h1d7f1ac_0.tar.bz2
linux-ppc64le::vtk-9.1.0-qt_py37he7118bf_215.tar.bz2
linux-ppc64le::libssh-0.10.2-h350ef5c_0.tar.bz2
linux-ppc64le::vowpalwabbit-9.3.0-py310h68263b2_2.tar.bz2
linux-ppc64le::rust-1.64.0-hf3e60ca_0.tar.bz2
linux-ppc64le::arrow-cpp-6.0.2-py310hda3048e_3_cpu.tar.bz2
linux-ppc64le::llvmlite-0.39.1-py310haa0efff_0.tar.bz2
linux-ppc64le::aws-sdk-cpp-1.9.349-hbd00276_1.tar.bz2
linux-ppc64le::rsync-3.2.6-h191f6af_0.tar.bz2
linux-ppc64le::nodejs-16.17.0-ha3ae8d5_0.tar.bz2
linux-ppc64le::thrift-compiler-0.16.0-h2fed408_2.tar.bz2
linux-ppc64le::arrow-cpp-7.0.1-py39h8b85b16_2_cpu.tar.bz2
linux-ppc64le::arrow-cpp-9.0.0-py37h5d1f9b8_2_cpu.tar.bz2
linux-ppc64le::arrow-cpp-6.0.2-py37hdcbd8f8_2_cpu.tar.bz2
linux-ppc64le::grpc-cpp-1.46.4-h210c47d_7.tar.bz2
linux-ppc64le::libadios2-2.8.3-mpi_openmpi_h492f1ec_3.tar.bz2
linux-ppc64le::arrow-cpp-9.0.0-py39h7729523_2_cpu.tar.bz2
linux-ppc64le::imagecodecs-2022.8.8-py39hd376dd6_5.tar.bz2
linux-ppc64le::aws-sdk-cpp-1.9.339-h5db4634_0.tar.bz2
linux-ppc64le::ffmpeg-5.1.2-gpl_h48e1702_101.tar.bz2
linux-ppc64le::arrow-cpp-6.0.2-py310hc735bd7_0_cpu.tar.bz2
linux-ppc64le::netcdf4-1.6.1-mpi_openmpi_py39h96aa2ae_0.tar.bz2
linux-ppc64le::mongodb-6.0.1-h592eddb_1.tar.bz2
linux-ppc64le::llvmdev-11.1.0-h6c99497_4.tar.bz2
linux-ppc64le::arrow-cpp-9.0.0-py39h3de4a70_2_cpu.tar.bz2
linux-ppc64le::arrow-cpp-8.0.1-py38hada690f_2_cpu.tar.bz2
linux-ppc64le::imagemagick-7.1.0_49-pl5321h2c2b468_0.tar.bz2
linux-ppc64le::arrow-cpp-7.0.1-py37h32c5c48_3_cpu.tar.bz2
linux-ppc64le::python-igraph-0.10.0-py39h69ef751_1.tar.bz2
linux-ppc64le::netcdf4-1.6.1-nompi_py37hfe3f5b7_100.tar.bz2
linux-ppc64le::arrow-cpp-9.0.0-py310h8b1cf4a_2_cpu.tar.bz2
linux-ppc64le::arrow-cpp-6.0.2-py39h9b75320_1_cpu.tar.bz2
linux-ppc64le::fenics-libdolfin-2019.1.0-hc0bc7f6_32.tar.bz2
linux-ppc64le::libadios2-2.8.3-mpi_mpich_h6d955e7_3.tar.bz2
linux-ppc64le::arrow-cpp-9.0.0-py310h2f899ee_5_cpu.tar.bz2
linux-ppc64le::aws-sdk-cpp-1.9.353-h93bb51c_0.tar.bz2
linux-ppc64le::arrow-cpp-7.0.1-py310hf0ac5a4_1_cpu.tar.bz2
linux-ppc64le::arrow-cpp-9.0.0-py38h197d660_3_cpu.tar.bz2
linux-ppc64le::smesh-9.9.0.0-h16cb099_1.tar.bz2
linux-ppc64le::arrow-cpp-7.0.1-py38hc8db1b3_3_cpu.tar.bz2
linux-ppc64le::arrow-cpp-7.0.1-py310hf5ea457_2_cpu.tar.bz2
linux-ppc64le::imagemagick-7.1.0_48-pl5321h378511c_1.tar.bz2
linux-ppc64le::python-igraph-0.10.0-py38hfa829bf_1.tar.bz2
linux-ppc64le::ffmpeg-4.4.2-lgpl_hb532579_8.tar.bz2
linux-ppc64le::netcdf4-1.6.1-mpi_mpich_py39h3b5de44_0.tar.bz2
linux-ppc64le::arrow-cpp-6.0.2-py38h00b8c44_3_cpu.tar.bz2
linux-ppc64le::python-igraph-0.9.11-py37h11f959f_1.tar.bz2
linux-ppc64le::cppyy-cling-6.27.0-py310hbbdc3b4_1.tar.bz2
linux-ppc64le::libssh-0.10.4-h3ab0c90_2.tar.bz2
linux-ppc64le::netcdf4-1.6.1-mpi_mpich_py37h5b1dc8e_0.tar.bz2
linux-ppc64le::arrow-cpp-7.0.1-py38hafb0a31_1_cpu.tar.bz2
linux-ppc64le::cmake-3.24.2-h4f7acd8_0.tar.bz2
linux-ppc64le::arrow-cpp-8.0.1-py310h52bb095_2_cpu.tar.bz2
linux-ppc64le::libadios2-2.8.3-nompi_hfc1dce4_103.tar.bz2
linux-ppc64le::netcdf4-1.6.1-mpi_openmpi_py310h9f2eeeb_0.tar.bz2
linux-ppc64le::grpc-cpp-1.48.1-h84ebf72_1.tar.bz2
linux-ppc64le::arrow-cpp-6.0.2-py39ha3dbf22_1_cpu.tar.bz2
linux-ppc64le::pdal-2.4.3-h8c20573_2.tar.bz2
linux-ppc64le::aws-sdk-cpp-1.9.341-h5db4634_0.tar.bz2
linux-ppc64le::libnetcdf-4.9.0-mpi_mpich_h31e3ad4_0.tar.bz2
linux-ppc64le::libadios2-2.8.3-mpi_openmpi_hdbe9cf0_3.tar.bz2
linux-ppc64le::arrow-cpp-9.0.0-py37hed7a0f6_2_cpu.tar.bz2
linux-ppc64le::arrow-cpp-6.0.2-py37hb7ff052_1_cpu.tar.bz2
linux-ppc64le::python-igraph-0.9.11-py310hfd235d9_1.tar.bz2
linux-ppc64le::tiledb-2.11.2-h11b1e19_0.tar.bz2
linux-ppc64le::libadios2-2.8.3-nompi_h65ebed0_103.tar.bz2
linux-ppc64le::pyreadstat-1.1.9-py310hc3fd98a_1.tar.bz2
linux-ppc64le::arrow-cpp-9.0.0-py310hd1e0834_6_cpu.tar.bz2
linux-ppc64le::ffmpeg-5.1.1-gpl_h54c1640_101.tar.bz2
linux-ppc64le::vtk-9.1.0-qt_py38h2b14034_215.tar.bz2
linux-ppc64le::smesh-9.9.0.0-h18d7a33_0.tar.bz2
linux-ppc64le::arrow-cpp-6.0.2-py310h0a2d00c_0_cpu.tar.bz2
linux-ppc64le::aws-sdk-cpp-1.9.346-h1d7f1ac_0.tar.bz2
linux-ppc64le::aws-sdk-cpp-1.9.356-h93bb51c_0.tar.bz2
linux-ppc64le::imagecodecs-2022.9.26-py39h140658a_0.tar.bz2
linux-ppc64le::libspatialite-5.0.1-ha617cc2_21.tar.bz2
linux-ppc64le::libadios2-2.8.3-mpi_openmpi_hf84decc_2.tar.bz2
linux-ppc64le::grpcio-1.48.1-py37hcae1be0_0.tar.bz2
linux-ppc64le::pyreadstat-1.1.9-py38h553f306_1.tar.bz2
linux-ppc64le::mapserver-8.0.0-py310h65b0d14_0.tar.bz2
linux-ppc64le::arrow-cpp-9.0.0-py310h49060af_2_cpu.tar.bz2
linux-ppc64le::giac-1.6.0.47-h091f942_6.tar.bz2
linux-ppc64le::arrow-cpp-9.0.0-py310hf5ea457_3_cpu.tar.bz2
linux-ppc64le::arrow-cpp-6.0.2-py37h1a11215_0_cpu.tar.bz2
linux-ppc64le::cpp-opentelemetry-sdk-1.6.0-h61a7937_1.tar.bz2
linux-ppc64le::python-igraph-0.10.0-py38h1274050_1.tar.bz2
linux-ppc64le::arrow-cpp-9.0.0-py38hc644cbd_2_cpu.tar.bz2
linux-ppc64le::netcdf4-1.6.1-mpi_openmpi_py38he1595ee_0.tar.bz2
linux-ppc64le::arrow-cpp-6.0.2-py38hccad32e_1_cpu.tar.bz2
linux-ppc64le::libthrift-0.16.0-h2fed408_2.tar.bz2
linux-ppc64le::libssh-0.10.3-h262a72d_0.tar.bz2
linux-ppc64le::aws-sdk-cpp-1.9.337-h5db4634_0.tar.bz2
linux-ppc64le::pyreadstat-1.1.9-py39h68499bf_1.tar.bz2
linux-ppc64le::grpc-cpp-1.48.1-h210c47d_1.tar.bz2
linux-ppc64le::libadios2-2.8.3-mpi_mpich_h6d955e7_2.tar.bz2
linux-ppc64le::clangdev-15.0.0-default_h1896e6d_0.tar.bz2
linux-ppc64le::libadios2-2.8.3-nompi_hfc1dce4_102.tar.bz2
linux-ppc64le::arrow-cpp-7.0.1-py310h661f4bb_0_cpu.tar.bz2
linux-ppc64le::libthrift-0.16.0-h484b8e3_2.tar.bz2
linux-ppc64le::gsoap-2.8.123-hfabde2d_0.tar.bz2
linux-ppc64le::grpc-cpp-1.46.4-h00557ac_7.tar.bz2
linux-ppc64le::libgdal-3.5.2-h016ce9b_3.tar.bz2
linux-ppc64le::arrow-cpp-7.0.1-py39hc3fadb8_0_cpu.tar.bz2
linux-ppc64le::mosh-1.3.2-pl5321h3f91b46_1013.tar.bz2
linux-ppc64le::nodejs-16.17.1-h93803ed_0.tar.bz2
linux-ppc64le::netcdf4-1.6.1-nompi_py38h08ad1e9_100.tar.bz2
linux-ppc64le::libssh-0.10.4-h262a72d_1.tar.bz2
linux-ppc64le::arrow-cpp-7.0.1-py38h60cb538_0_cpu.tar.bz2
linux-ppc64le::vtk-9.1.0-qt_py39h526f45c_215.tar.bz2
linux-ppc64le::grpcio-1.48.1-py38h9fbc671_0.tar.bz2
linux-ppc64le::arrow-cpp-8.0.1-py37ha7a09b5_4_cpu.tar.bz2
linux-ppc64le::imagecodecs-2022.9.26-py38h2f11562_0.tar.bz2
linux-ppc64le::vowpalwabbit-9.3.0-py38h64016eb_2.tar.bz2
linux-ppc64le::ffmpeg-5.1.1-lgpl_hb532579_1.tar.bz2
linux-ppc64le::arrow-cpp-7.0.1-py37h4950da8_2_cpu.tar.bz2
linux-ppc64le::arrow-cpp-8.0.1-py39he70a1da_4_cpu.tar.bz2
linux-ppc64le::arrow-cpp-7.0.1-py310h86a3873_0_cpu.tar.bz2
linux-ppc64le::libadios2-2.8.3-mpi_openmpi_h43fd49f_2.tar.bz2
linux-ppc64le::vowpalwabbit-9.3.0-py37h0381afc_2.tar.bz2
linux-ppc64le::llvmlite-0.39.1-py39hf8800fb_0.tar.bz2
linux-ppc64le::libxml2-2.10.2-h09c15aa_1.tar.bz2
linux-ppc64le::grpc-cpp-1.47.1-h210c47d_6.tar.bz2
linux-ppc64le::netcdf4-1.6.1-mpi_mpich_py310hb71598d_0.tar.bz2
linux-ppc64le::arrow-cpp-7.0.1-py39he70a1da_4_cpu.tar.bz2
linux-ppc64le::mosh-1.3.2-pl5321h0c158ac_1013.tar.bz2
linux-ppc64le::python-igraph-0.9.11-py38hfa829bf_1.tar.bz2
linux-ppc64le::aws-sdk-cpp-1.9.354-h93bb51c_0.tar.bz2
linux-ppc64le::arrow-cpp-7.0.1-py310hd1e0834_4_cpu.tar.bz2
linux-ppc64le::wxwidgets-3.2.1-py310h0631da6_0.tar.bz2
linux-ppc64le::libssh-0.10.1-h350ef5c_0.tar.bz2
linux-ppc64le::libkml-1.3.0-h8e7d1b7_1015.tar.bz2
linux-ppc64le::libadios2-2.8.3-nompi_h759ff96_103.tar.bz2
linux-ppc64le::libadios2-2.8.3-mpi_openmpi_h492f1ec_2.tar.bz2
linux-ppc64le::arrow-cpp-9.0.0-py39h20edc30_2_cpu.tar.bz2
linux-ppc64le::grpcio-1.48.1-py310hc0afa75_0.tar.bz2
linux-ppc64le::arrow-cpp-6.0.2-py39h0ca6399_0_cpu.tar.bz2
linux-ppc64le::arrow-cpp-9.0.0-py39he70a1da_6_cpu.tar.bz2
linux-ppc64le::arrow-cpp-9.0.0-py39hd1dba26_5_cpu.tar.bz2
linux-ppc64le::libadios2-2.8.3-mpi_openmpi_h26eef5e_3.tar.bz2
linux-ppc64le::arrow-cpp-7.0.1-py38h051e8e9_1_cpu.tar.bz2
linux-ppc64le::assimp-5.2.5-h968f3b7_0.tar.bz2
linux-ppc64le::wxwidgets-3.2.0-py310hede299b_2.tar.bz2
linux-ppc64le::nodejs-14.20.0-h9a3953a_0.tar.bz2
linux-ppc64le::arrow-cpp-8.0.1-py38hd74a482_4_cpu.tar.bz2
linux-ppc64le::libadios2-2.8.3-nompi_hffb98a7_102.tar.bz2
linux-ppc64le::libnetcdf-4.9.0-mpi_openmpi_h61ae36f_0.tar.bz2
linux-ppc64le::aws-sdk-cpp-1.9.340-h5db4634_0.tar.bz2
linux-ppc64le::arrow-cpp-6.0.2-py37h335bd52_1_cpu.tar.bz2
linux-ppc64le::arrow-cpp-7.0.1-py39h91182d0_0_cpu.tar.bz2
linux-ppc64le::vowpalwabbit-9.3.0-py39h8109dbe_2.tar.bz2
linux-ppc64le::arrow-cpp-9.0.0-py38hc8db1b3_5_cpu.tar.bz2
linux-ppc64le::python-igraph-0.10.0-py310hfd235d9_1.tar.bz2
linux-ppc64le::arrow-cpp-7.0.1-py38h7551f20_0_cpu.tar.bz2
linux-ppc64le::tesseract-5.2.0-h1312022_1.tar.bz2
linux-ppc64le::grpcio-1.48.1-py310h078cdaf_0.tar.bz2
linux-ppc64le::python-igraph-0.9.11-py38h1274050_1.tar.bz2
linux-ppc64le::arrow-cpp-6.0.2-py38h7a6a0cd_2_cpu.tar.bz2
linux-ppc64le::libssh-0.10.4-h712555d_2.tar.bz2
linux-ppc64le::arrow-cpp-6.0.2-py39h87231ec_3_cpu.tar.bz2
linux-ppc64le::clangdev-15.0.1-default_h1896e6d_0.tar.bz2
linux-ppc64le::cpp-opentelemetry-sdk-1.6.1-h61a7937_0.tar.bz2
linux-ppc64le::libvips-8.13.1-hd201370_0.tar.bz2
linux-ppc64le::arrow-cpp-8.0.1-py37hc350061_2_cpu.tar.bz2
linux-ppc64le::libadios2-2.8.3-nompi_h707d055_102.tar.bz2
linux-ppc64le::arrow-cpp-7.0.1-py38hd74a482_4_cpu.tar.bz2
linux-ppc64le::poppler-22.04.0-h107af26_3.tar.bz2
linux-ppc64le::libssh-0.10.4-h350ef5c_0.tar.bz2
linux-ppc64le::ffmpeg-5.1.1-lgpl_h08c3af9_1.tar.bz2
linux-ppc64le::geotiff-1.7.1-h57ef06e_4.tar.bz2
linux-ppc64le::gfal2-2.21.1-h1671a64_0.tar.bz2
linux-ppc64le::arrow-cpp-6.0.2-py310h2b45d22_1_cpu.tar.bz2
linux-ppc64le::libssh-0.10.2-h262a72d_0.tar.bz2
linux-ppc64le::cpp-opentelemetry-sdk-1.6.0-he011279_1.tar.bz2
linux-ppc64le::ffmpeg-5.1.2-lgpl_he67232a_1.tar.bz2
linux-ppc64le::ffmpeg-5.1.1-gpl_h54c1640_102.tar.bz2
linux-ppc64le::libsoup-3.2.0-he84dbf8_0.tar.bz2
linux-ppc64le::libadios2-2.8.3-mpi_mpich_h293900d_3.tar.bz2
linux-ppc64le::python-igraph-0.10.0-py39hbfe5ace_1.tar.bz2
linux-ppc64le::arrow-cpp-8.0.1-py38h197d660_2_cpu.tar.bz2
linux-ppc64le::arrow-cpp-7.0.1-py38h197d660_2_cpu.tar.bz2
linux-ppc64le::arrow-cpp-7.0.1-py39h0aa939d_1_cpu.tar.bz2
linux-ppc64le::arrow-cpp-9.0.0-py39h8b85b16_3_cpu.tar.bz2
linux-ppc64le::python-igraph-0.10.0-py37h11f959f_1.tar.bz2
linux-ppc64le::arrow-cpp-9.0.0-py38h253fe00_2_cpu.tar.bz2
linux-ppc64le::arrow-cpp-8.0.1-py310hd1e0834_4_cpu.tar.bz2
linux-ppc64le::libnetcdf-4.9.0-nompi_h7a936dc_100.tar.bz2
linux-ppc64le::libgdal-3.5.2-h016ce9b_0.tar.bz2
linux-ppc64le::tiledb-2.11.2-ha4bc364_0.tar.bz2
linux-ppc64le::sqlite-3.39.3-h3bd21b8_0.tar.bz2
linux-ppc64le::libssh-0.10.3-h350ef5c_0.tar.bz2
linux-ppc64le::nodejs-16.16.0-ha3ae8d5_0.tar.bz2
linux-ppc64le::libssh-0.10.4-h262a72d_0.tar.bz2
linux-ppc64le::arrow-cpp-6.0.2-py37hbd7ed71_0_cpu.tar.bz2
linux-ppc64le::arrow-cpp-8.0.1-py37h4950da8_2_cpu.tar.bz2
linux-ppc64le::nodejs-16.15.1-h93803ed_0.tar.bz2
linux-ppc64le::aws-sdk-cpp-1.9.350-h93bb51c_1.tar.bz2
linux-ppc64le::libadios2-2.8.3-mpi_mpich_hd4932e6_3.tar.bz2
linux-ppc64le::arrow-cpp-7.0.1-py37ha7a09b5_4_cpu.tar.bz2
linux-ppc64le::arrow-cpp-7.0.1-py39hd1dba26_3_cpu.tar.bz2
linux-ppc64le::gap-core-4.11.1-hdaa22ee_4.tar.bz2
linux-ppc64le::nodejs-16.17.1-ha3ae8d5_0.tar.bz2
linux-ppc64le::arrow-cpp-7.0.1-py310h2f899ee_3_cpu.tar.bz2
linux-ppc64le::llvmdev-15.0.1-hfe1df17_0.tar.bz2
linux-ppc64le::arrow-cpp-6.0.2-py38haf389b1_0_cpu.tar.bz2
linux-ppc64le::aws-sdk-cpp-1.9.349-h1d7f1ac_0.tar.bz2
linux-ppc64le::mapserver-8.0.0-py39h3fb7889_0.tar.bz2
linux-ppc64le::glib-2.74.0-ha72a2fa_0.tar.bz2
linux-ppc64le::aws-sdk-cpp-1.9.341-h1d7f1ac_1.tar.bz2
linux-ppc64le::vtk-9.1.0-qt_py310h9ffb71a_215.tar.bz2
linux-ppc64le::arrow-cpp-6.0.2-py38h27c978a_1_cpu.tar.bz2
linux-ppc64le::aws-sdk-cpp-1.9.344-h1d7f1ac_0.tar.bz2
linux-ppc64le::nodejs-14.20.1-h9a3953a_0.tar.bz2
linux-ppc64le::libssh-0.10.4-h350ef5c_1.tar.bz2
linux-ppc64le::arrow-cpp-6.0.2-py310hc49b95e_1_cpu.tar.bz2
linux-ppc64le::orc-1.8.0-h5c98c99_0.tar.bz2
linux-ppc64le::assimp-5.2.4-h968f3b7_1.tar.bz2
linux-ppc64le::arrow-cpp-9.0.0-py37ha7a09b5_6_cpu.tar.bz2
linux-ppc64le::arrow-cpp-9.0.0-py310h217ebb4_2_cpu.tar.bz2
linux-ppc64le::imagecodecs-2022.8.8-py38ha485224_5.tar.bz2
linux-ppc64le::arrow-cpp-9.0.0-py37h32c5c48_5_cpu.tar.bz2
linux-ppc64le::netcdf4-1.6.1-nompi_py310h4faa06a_100.tar.bz2
linux-ppc64le::grpc-cpp-1.46.4-hd4503be_7.tar.bz2
linux-ppc64le::libgdal-3.5.2-h779f1e7_0.tar.bz2
linux-ppc64le::aws-sdk-cpp-1.9.347-h1d7f1ac_0.tar.bz2
linux-ppc64le::llvmlite-0.39.1-py37h4f2946f_0.tar.bz2
linux-ppc64le::imagecodecs-2022.8.8-py38h4178227_5.tar.bz2
linux-ppc64le::pyreadstat-1.1.9-py37h0370d4e_1.tar.bz2
linux-ppc64le::arrow-cpp-9.0.0-py38hd74a482_6_cpu.tar.bz2
linux-ppc64le::arrow-cpp-8.0.1-py310h2f899ee_3_cpu.tar.bz2
linux-ppc64le::coin-or-cgl-0.60.6-h12b7cce_2.tar.bz2
linux-ppc64le::ffmpeg-5.1.1-gpl_h1fe4f10_101.tar.bz2
linux-ppc64le::cppyy-cling-6.27.0-py37hdd56643_1.tar.bz2
linux-ppc64le::nodejs-16.15.1-ha3ae8d5_0.tar.bz2
linux-ppc64le::libadios2-2.8.3-mpi_openmpi_hf84decc_3.tar.bz2
linux-ppc64le::assimp-5.2.4-h968f3b7_2.tar.bz2
linux-ppc64le::arrow-cpp-9.0.0-py39hb40b0d1_2_cpu.tar.bz2
linux-ppc64le::nodejs-14.19.1-h9a3953a_0.tar.bz2
linux-ppc64le::arrow-cpp-9.0.0-py38h5a359f2_2_cpu.tar.bz2
linux-ppc64le::aws-sdk-cpp-1.9.348-h1d7f1ac_0.tar.bz2
linux-ppc64le::libadios2-2.8.3-mpi_mpich_h2610fa9_2.tar.bz2
linux-ppc64le::grpc-cpp-1.47.1-h00557ac_6.tar.bz2
linux-ppc64le::openjdk-17.0.3-hef2f6bb_2.tar.bz2
linux-ppc64le::arrow-cpp-9.0.0-py310h52bb095_2_cpu.tar.bz2
linux-ppc64le::arrow-cpp-9.0.0-py37hf952fd0_2_cpu.tar.bz2
linux-ppc64le::libadios2-2.8.3-nompi_h699a37c_102.tar.bz2
linux-ppc64le::grpcio-1.48.1-py39h8ff3fa2_0.tar.bz2
linux-ppc64le::openmpi-4.1.4-ha6b021e_101.tar.bz2
linux-ppc64le::arrow-cpp-9.0.0-py310h2f899ee_4_cpu.tar.bz2
linux-ppc64le::pdal-2.4.3-had2805b_2.tar.bz2
linux-ppc64le::aws-sdk-cpp-1.9.342-h1d7f1ac_0.tar.bz2
linux-ppc64le::arrow-cpp-9.0.0-py38hc8db1b3_4_cpu.tar.bz2
linux-ppc64le::arrow-cpp-9.0.0-py38hada690f_2_cpu.tar.bz2
linux-ppc64le::grpc-cpp-1.46.4-h84ebf72_7.tar.bz2
linux-ppc64le::aws-sdk-cpp-1.9.352-h93bb51c_0.tar.bz2
linux-ppc64le::libadios2-2.8.3-nompi_hffb98a7_103.tar.bz2
linux-ppc64le::grpcio-1.48.1-py39h85899c9_0.tar.bz2
linux-ppc64le::grpc-cpp-1.47.1-h84ebf72_6.tar.bz2
linux-ppc64le::libglib-2.74.0-h1113824_0.tar.bz2
linux-ppc64le::libgdal-3.5.2-h779f1e7_1.tar.bz2
linux-ppc64le::nodejs-16.17.0-h93803ed_0.tar.bz2
linux-ppc64le::arrow-cpp-8.0.1-py310hf5ea457_2_cpu.tar.bz2
linux-ppc64le::libgdal-3.5.2-h779f1e7_3.tar.bz2
linux-ppc64le::arrow-cpp-6.0.2-py39h5392b14_2_cpu.tar.bz2
linux-ppc64le::gdk-pixbuf-2.42.8-hbeea2fb_1.tar.bz2
linux-ppc64le::rsync-3.2.6-h0c0bf12_0.tar.bz2
linux-ppc64le::imagecodecs-2022.8.8-py39h2e24cea_5.tar.bz2
linux-ppc64le::imagecodecs-2022.9.26-py38h1d3a935_0.tar.bz2
linux-ppc64le::arrow-cpp-6.0.2-py310h94f85ef_2_cpu.tar.bz2
linux-ppc64le::libspatialite-5.0.1-ha617cc2_20.tar.bz2
linux-ppc64le::nodejs-14.19.3-h9a3953a_0.tar.bz2
linux-ppc64le::python-igraph-0.9.11-py39h69ef751_1.tar.bz2
linux-ppc64le::arrow-cpp-8.0.1-py39h8b85b16_2_cpu.tar.bz2
linux-ppc64le::gsoap-2.8.123-ha019378_0.tar.bz2
linux-ppc64le::imagecodecs-2022.9.26-py39h74ea860_0.tar.bz2
linux-ppc64le::cppyy-cling-6.27.0-py39h51b9803_1.tar.bz2
linux-ppc64le::fenics-libdolfin-2019.1.0-h4194ae5_32.tar.bz2
linux-ppc64le::ffmpeg-4.4.2-gpl_h54c1640_108.tar.bz2
linux-ppc64le::grpcio-1.48.1-py37h9b76910_0.tar.bz2
linux-ppc64le::llvmlite-0.39.1-py38hd9056a4_0.tar.bz2
linux-ppc64le::mapserver-8.0.0-py37h76e684f_0.tar.bz2
linux-ppc64le::arrow-cpp-9.0.0-py37h4950da8_3_cpu.tar.bz2
linux-ppc64le::grpc-cpp-1.48.1-h84ebf72_0.tar.bz2
linux-ppc64le::libadios2-2.8.3-mpi_mpich_ha6c8fe8_3.tar.bz2
linux-ppc64le::coin-or-clp-1.17.7-h983ba35_2.tar.bz2
linux-ppc64le::libadios2-2.8.3-mpi_mpich_hc354810_3.tar.bz2
linux-ppc64le::grpc-cpp-1.48.1-h210c47d_0.tar.bz2
linux-ppc64le::netcdf4-1.6.1-nompi_py39h4b01eda_100.tar.bz2
linux-ppc64le::aws-sdk-cpp-1.9.338-h5db4634_0.tar.bz2
linux-ppc64le::imagemagick-7.1.0_48-pl5321h0a62cd9_0.tar.bz2
linux-ppc64le::python-igraph-0.9.11-py39hbfe5ace_1.tar.bz2
linux-ppc64le::grpc-cpp-1.47.1-hd4503be_6.tar.bz2
linux-ppc64le::libadios2-2.8.3-mpi_mpich_h9778faf_2.tar.bz2
-    "libzlib >=1.2.12,<1.3.0a0",
+    "libzlib >=1.2.12,<2.0.0a0",
linux-ppc64le::libclang-15.0.1-default_h1896e6d_0.tar.bz2
linux-ppc64le::libprotobuf-3.20.1-ha72a2fa_4.tar.bz2
linux-ppc64le::gst-plugins-base-1.20.3-h14ddb0e_1.tar.bz2
linux-ppc64le::libclang-cpp-15.0.1-default_h1896e6d_0.tar.bz2
linux-ppc64le::libprotobuf-static-3.20.1-ha72a2fa_2.tar.bz2
linux-ppc64le::libprotobuf-3.21.6-ha72a2fa_1.tar.bz2
linux-ppc64le::libclang-cpp15-15.0.0-default_h1896e6d_0.tar.bz2
linux-ppc64le::libprotobuf-static-3.21.5-ha72a2fa_3.tar.bz2
linux-ppc64le::libprotobuf-3.20.1-ha72a2fa_3.tar.bz2
linux-ppc64le::libclang13-15.0.1-default_ha49a280_0.tar.bz2
linux-ppc64le::libllvm15-15.0.0-hfe1df17_0.tar.bz2
linux-ppc64le::liblal-7.2.2-fftw_h8338b0a_100.tar.bz2
linux-ppc64le::clang-format-15-15.0.0-default_h1896e6d_0.tar.bz2
linux-ppc64le::clang-format-15-15.0.1-default_h1896e6d_0.tar.bz2
linux-ppc64le::libclang-cpp15-15.0.1-default_h1896e6d_0.tar.bz2
linux-ppc64le::gst-plugins-good-1.20.3-h3600cc6_2.tar.bz2
linux-ppc64le::libprotobuf-static-3.21.6-ha72a2fa_0.tar.bz2
linux-ppc64le::llvm-11.1.0-h12068cf_4.tar.bz2
linux-ppc64le::libclang13-15.0.0-default_ha49a280_0.tar.bz2
linux-ppc64le::clang-format-15.0.0-default_h1896e6d_0.tar.bz2
linux-ppc64le::llvm-15.0.1-h2b80cf0_0.tar.bz2
linux-ppc64le::libclang-15.0.0-default_h1896e6d_0.tar.bz2
linux-ppc64le::llvm-tools-15.0.1-hfe1df17_0.tar.bz2
linux-ppc64le::llvm-spirv-14.0.0-h3b69f5b_1.tar.bz2
linux-ppc64le::libllvm11-11.1.0-h6c99497_4.tar.bz2
linux-ppc64le::glib-tools-2.74.0-ha72a2fa_0.tar.bz2
linux-ppc64le::libprotobuf-3.21.6-ha72a2fa_0.tar.bz2
linux-ppc64le::libprotobuf-static-3.21.5-ha72a2fa_1.tar.bz2
linux-ppc64le::libprotobuf-3.21.5-ha72a2fa_2.tar.bz2
linux-ppc64le::fontconfig-2.14.0-hac4b4ab_1.tar.bz2
linux-ppc64le::clang-15-15.0.1-default_h1896e6d_0.tar.bz2
linux-ppc64le::libprotobuf-3.21.5-ha72a2fa_3.tar.bz2
linux-ppc64le::llvm-tools-15.0.0-hfe1df17_0.tar.bz2
linux-ppc64le::libpng-1.6.38-hcc10993_0.tar.bz2
linux-ppc64le::libprotobuf-static-3.20.1-ha72a2fa_3.tar.bz2
linux-ppc64le::libllvm15-15.0.1-hfe1df17_0.tar.bz2
linux-ppc64le::clang-15-15.0.0-default_h1896e6d_0.tar.bz2
linux-ppc64le::coin-or-osi-0.108.7-h34d7808_2.tar.bz2
linux-ppc64le::gst-plugins-base-1.20.3-h14ddb0e_2.tar.bz2
linux-ppc64le::clang-tools-15.0.0-default_h1896e6d_0.tar.bz2
linux-ppc64le::coin-or-utils-2.11.6-h2c085dd_2.tar.bz2
linux-ppc64le::libprotobuf-static-3.20.1-ha72a2fa_4.tar.bz2
linux-ppc64le::libclang-cpp-15.0.0-default_h1896e6d_0.tar.bz2
linux-ppc64le::libsqlite-3.39.3-hcc10993_0.tar.bz2
linux-ppc64le::gst-plugins-good-1.20.3-h3600cc6_1.tar.bz2
linux-ppc64le::libprotobuf-static-3.21.5-ha72a2fa_2.tar.bz2
linux-ppc64le::llvm-15.0.0-h2b80cf0_0.tar.bz2
linux-ppc64le::llvm-tools-11.1.0-h6c99497_4.tar.bz2
linux-ppc64le::clang-format-15.0.1-default_h1896e6d_0.tar.bz2
linux-ppc64le::libprotobuf-static-3.21.6-ha72a2fa_1.tar.bz2
linux-ppc64le::clang-tools-15.0.1-default_h1896e6d_0.tar.bz2
-    "libzlib >=1.2.12,<1.3.0a0"
+    "libzlib >=1.2.12,<2.0.0a0"
================================================================================
================================================================================
linux-aarch64
linux-aarch64::arrow-cpp-8.0.1-py310he1b2118_2_cuda.tar.bz2
linux-aarch64::nodejs-16.17.1-he850d6a_0.tar.bz2
linux-aarch64::vtk-9.1.0-qt_py38h05e3c73_215.tar.bz2
linux-aarch64::aws-sdk-cpp-1.9.341-hb7e8865_0.tar.bz2
linux-aarch64::libgdal-3.5.2-h8bc38f5_1.tar.bz2
linux-aarch64::arrow-cpp-8.0.1-py39hb4678b7_2_cpu.tar.bz2
linux-aarch64::grpc-cpp-1.47.1-hf1f2ea0_6.tar.bz2
linux-aarch64::arrow-cpp-8.0.1-py37hbcdea27_2_cuda.tar.bz2
linux-aarch64::arrow-cpp-6.0.2-py38h930048b_3_cpu.tar.bz2
linux-aarch64::arrow-cpp-8.0.1-py310h3db0423_2_cuda.tar.bz2
linux-aarch64::arrow-cpp-7.0.1-py37hba76c37_0_cpu.tar.bz2
linux-aarch64::arrow-cpp-7.0.1-py38h217d87b_3_cpu.tar.bz2
linux-aarch64::arrow-cpp-8.0.1-py39hbcfcb34_2_cuda.tar.bz2
linux-aarch64::libadios2-2.8.3-nompi_h886c990_102.tar.bz2
linux-aarch64::llvmlite-0.39.1-py38hd14ccfc_0.tar.bz2
linux-aarch64::graphviz-6.0.0-h856fde9_0.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py37h06a2d48_2_cuda.tar.bz2
linux-aarch64::orc-1.8.0-hf12ec96_0.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py310h957a929_4_cuda.tar.bz2
linux-aarch64::arrow-cpp-8.0.1-py310hb6a1642_2_cuda.tar.bz2
linux-aarch64::libnetcdf-4.9.0-nompi_h30b59ab_100.tar.bz2
linux-aarch64::grpc-cpp-1.46.4-h177ec6a_7.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py38ha2233e9_2_cuda.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py39h9ab9c9f_6_cuda.tar.bz2
linux-aarch64::ffmpeg-4.4.2-lgpl_he572d85_8.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py38h29d3b23_2_cuda.tar.bz2
linux-aarch64::python-igraph-0.9.11-py38h21fcf9e_1.tar.bz2
linux-aarch64::mapserver-8.0.0-py310h7f0e55d_0.tar.bz2
linux-aarch64::arrow-cpp-8.0.1-py39hd21bb2d_3_cuda.tar.bz2
linux-aarch64::libadios2-2.8.3-mpi_openmpi_ha715621_3.tar.bz2
linux-aarch64::arrow-cpp-7.0.1-py310h6eb07ec_0_cpu.tar.bz2
linux-aarch64::cppyy-cling-6.27.0-py37h21e75f5_1.tar.bz2
linux-aarch64::ffmpeg-5.1.1-gpl_h363b872_101.tar.bz2
linux-aarch64::arrow-cpp-6.0.2-py37hd641b2b_2_cpu.tar.bz2
linux-aarch64::libgdal-3.5.2-h3fa1e73_3.tar.bz2
linux-aarch64::aws-sdk-cpp-1.9.347-h6a52138_0.tar.bz2
linux-aarch64::nodejs-16.15.1-he850d6a_0.tar.bz2
linux-aarch64::arrow-cpp-6.0.2-py310hbf8a812_2_cpu.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py310h4c49b3c_5_cpu.tar.bz2
linux-aarch64::arrow-cpp-8.0.1-py38h00dbca3_3_cuda.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py39h6c488eb_3_cpu.tar.bz2
linux-aarch64::libadios2-2.8.3-mpi_mpich_h00c07c3_3.tar.bz2
linux-aarch64::libadios2-2.8.3-mpi_mpich_hcc7e981_3.tar.bz2
linux-aarch64::aws-sdk-cpp-1.9.346-h6a52138_0.tar.bz2
linux-aarch64::grpc-cpp-1.47.1-ha80fa33_6.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py39hb4678b7_2_cpu.tar.bz2
linux-aarch64::libssh-0.10.2-h2b6b862_0.tar.bz2
linux-aarch64::arrow-cpp-8.0.1-py38h462da0a_2_cuda.tar.bz2
linux-aarch64::sagelib-9.6-py38hf61f25c_3.tar.bz2
linux-aarch64::cmake-3.24.2-hcad14f8_0.tar.bz2
linux-aarch64::thrift-compiler-0.16.0-h81a1a33_2.tar.bz2
linux-aarch64::pyreadstat-1.1.9-py37ha3a0a47_1.tar.bz2
linux-aarch64::grpcio-1.48.1-py310he01d404_0.tar.bz2
linux-aarch64::thrift-compiler-0.16.0-h6e53a4e_2.tar.bz2
linux-aarch64::mongodb-6.0.1-h7d3f3b2_1.tar.bz2
linux-aarch64::sagelib-9.6-py39h30b59d6_3.tar.bz2
linux-aarch64::ffmpeg-5.1.1-lgpl_h71123b4_2.tar.bz2
linux-aarch64::gsoap-2.8.123-h6af4a7d_0.tar.bz2
linux-aarch64::grpc-cpp-1.46.4-ha80fa33_7.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py39ha1e6f38_2_cuda.tar.bz2
linux-aarch64::pyreadstat-1.1.9-py310hceb02de_1.tar.bz2
linux-aarch64::arrow-cpp-8.0.1-py37hbe838dc_4_cuda.tar.bz2
linux-aarch64::imagecodecs-2022.9.26-py39h43404c0_0.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py37he7d5681_2_cuda.tar.bz2
linux-aarch64::libssh-0.10.4-h2b6b862_1.tar.bz2
linux-aarch64::arrow-cpp-6.0.2-py310h441f12a_3_cpu.tar.bz2
linux-aarch64::libssh-0.10.1-h2b6b862_0.tar.bz2
linux-aarch64::arrow-cpp-7.0.1-py38h4ac0ed1_2_cpu.tar.bz2
linux-aarch64::imagecodecs-2022.9.26-py310he387205_0.tar.bz2
linux-aarch64::vtk-9.1.0-qt_py310h5b443d3_215.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py37h06be352_6_cpu.tar.bz2
linux-aarch64::netcdf4-1.6.1-mpi_mpich_py37hfbe6e91_0.tar.bz2
linux-aarch64::python-igraph-0.10.0-py310h7b07d77_1.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py39h0f42c21_2_cpu.tar.bz2
linux-aarch64::llvmlite-0.39.1-py38hb3e7a48_0.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py38hb2e2b04_2_cpu.tar.bz2
linux-aarch64::netcdf4-1.6.1-mpi_openmpi_py310h2eb597f_0.tar.bz2
linux-aarch64::mosh-1.3.2-pl5321h630b000_1013.tar.bz2
linux-aarch64::python-igraph-0.10.0-py38h21fcf9e_1.tar.bz2
linux-aarch64::mapserver-8.0.0-py39h2b9ce8a_0.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py38ha92025a_6_cpu.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py310h0c9a660_2_cpu.tar.bz2
linux-aarch64::arrow-cpp-7.0.1-py37hf1e001d_1_cpu.tar.bz2
linux-aarch64::sagelib-9.6-py310h4af1d41_3.tar.bz2
linux-aarch64::vowpalwabbit-9.3.0-py38h4ec28ea_2.tar.bz2
linux-aarch64::poppler-22.04.0-h6a1b0a8_3.tar.bz2
linux-aarch64::nodejs-16.17.1-h928fb59_0.tar.bz2
linux-aarch64::cppyy-cling-6.27.0-py38h986aded_1.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py310hb6a1642_3_cuda.tar.bz2
linux-aarch64::llvmlite-0.39.1-py310h773edab_0.tar.bz2
linux-aarch64::arrow-cpp-7.0.1-py310h2497870_2_cpu.tar.bz2
linux-aarch64::cpp-opentelemetry-sdk-1.6.1-h3d19de8_0.tar.bz2
linux-aarch64::arrow-cpp-6.0.2-py310hee4023a_1_cpu.tar.bz2
linux-aarch64::mosh-1.3.2-pl5321hcaad0cd_1013.tar.bz2
linux-aarch64::llvmdev-15.0.0-h71eeefc_0.tar.bz2
linux-aarch64::libadios2-2.8.3-nompi_hdf73317_103.tar.bz2
linux-aarch64::arrow-cpp-7.0.1-py37hf6737d1_4_cpu.tar.bz2
linux-aarch64::grpc-cpp-1.48.1-h2efb554_0.tar.bz2
linux-aarch64::nodejs-14.20.0-h4df20a3_0.tar.bz2
linux-aarch64::python-igraph-0.9.11-py37hf66d210_1.tar.bz2
linux-aarch64::arrow-cpp-8.0.1-py310h957a929_3_cuda.tar.bz2
linux-aarch64::libadios2-2.8.3-mpi_openmpi_hed0105c_3.tar.bz2
linux-aarch64::arrow-cpp-8.0.1-py38h8a8de8b_4_cuda.tar.bz2
linux-aarch64::arrow-cpp-7.0.1-py37h944df9a_2_cpu.tar.bz2
linux-aarch64::libadios2-2.8.3-mpi_mpich_h5f3687c_3.tar.bz2
linux-aarch64::arrow-cpp-6.0.2-py310h1a79730_1_cpu.tar.bz2
linux-aarch64::pyreadstat-1.1.9-py39hca51b09_1.tar.bz2
linux-aarch64::aws-sdk-cpp-1.9.353-hc317487_0.tar.bz2
linux-aarch64::aws-sdk-cpp-1.9.350-he0d2af6_0.tar.bz2
linux-aarch64::imagecodecs-2022.8.8-py310hf9888e6_5.tar.bz2
linux-aarch64::aws-sdk-cpp-1.9.343-h6a52138_0.tar.bz2
linux-aarch64::vowpalwabbit-9.3.0-py37hba274f4_2.tar.bz2
linux-aarch64::libadios2-2.8.3-mpi_openmpi_h3dbbb54_3.tar.bz2
linux-aarch64::nodejs-18.9.1-h928fb59_0.tar.bz2
linux-aarch64::python-igraph-0.9.11-py39hf062d6d_1.tar.bz2
linux-aarch64::mapserver-8.0.0-py38hb431584_0.tar.bz2
linux-aarch64::imagecodecs-2022.8.8-py39h2ac8a92_5.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py38h95b653f_2_cuda.tar.bz2
linux-aarch64::python-igraph-0.10.0-py37hf66d210_1.tar.bz2
linux-aarch64::arrow-cpp-8.0.1-py310h957a929_4_cuda.tar.bz2
linux-aarch64::libadios2-2.8.3-mpi_openmpi_hd7ef823_3.tar.bz2
linux-aarch64::llvmlite-0.39.1-py39hbbff7ca_0.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py37hbcdea27_2_cuda.tar.bz2
linux-aarch64::imagecodecs-2022.9.26-py38h8981edc_0.tar.bz2
linux-aarch64::arrow-cpp-6.0.2-py37h8ab1d56_1_cpu.tar.bz2
linux-aarch64::nodejs-14.19.1-h4df20a3_0.tar.bz2
linux-aarch64::imagecodecs-2022.8.8-py38hd8f0e02_5.tar.bz2
linux-aarch64::aws-sdk-cpp-1.9.340-hb7e8865_0.tar.bz2
linux-aarch64::aws-sdk-cpp-1.9.351-hc317487_0.tar.bz2
linux-aarch64::llvmdev-15.0.1-h71eeefc_0.tar.bz2
linux-aarch64::libgdal-3.5.2-h8bc38f5_0.tar.bz2
linux-aarch64::arrow-cpp-8.0.1-py39h7e0d52b_2_cuda.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py37h3444cda_4_cpu.tar.bz2
linux-aarch64::llvmlite-0.39.1-py39ha5d8a0d_0.tar.bz2
linux-aarch64::aws-sdk-cpp-1.9.345-h6a52138_0.tar.bz2
linux-aarch64::arrow-cpp-8.0.1-py37hd240594_2_cpu.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py37he524fe1_2_cuda.tar.bz2
linux-aarch64::libadios2-2.8.3-nompi_h47b3a90_102.tar.bz2
linux-aarch64::ffmpeg-5.1.1-gpl_h363b872_102.tar.bz2
linux-aarch64::nodejs-18.10.0-he850d6a_0.tar.bz2
linux-aarch64::ffmpeg-5.1.1-lgpl_h683d94b_1.tar.bz2
linux-aarch64::nodejs-14.19.3-h4df20a3_0.tar.bz2
linux-aarch64::llvmdev-11.1.0-hb2805f8_4.tar.bz2
linux-aarch64::arrow-cpp-8.0.1-py38h29d3b23_2_cuda.tar.bz2
linux-aarch64::aws-sdk-cpp-1.9.356-hc317487_0.tar.bz2
linux-aarch64::imagemagick-7.1.0_48-pl5321hf9c3441_0.tar.bz2
linux-aarch64::aws-sdk-cpp-1.9.337-hb7e8865_0.tar.bz2
linux-aarch64::arrow-cpp-8.0.1-py37he7d5681_2_cuda.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py39h7e0d52b_3_cuda.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py37ha00a694_2_cpu.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py39h90c5e57_4_cpu.tar.bz2
linux-aarch64::libadios2-2.8.3-mpi_mpich_hf18cf71_3.tar.bz2
linux-aarch64::grpc-cpp-1.46.4-h2efb554_7.tar.bz2
linux-aarch64::libadios2-2.8.3-nompi_h47b3a90_103.tar.bz2
linux-aarch64::arrow-cpp-6.0.2-py39hcdc0fe3_2_cpu.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py38h9a7a21c_2_cuda.tar.bz2
linux-aarch64::gfal2-2.21.1-he11e5a5_0.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py38hb4c0c01_4_cpu.tar.bz2
linux-aarch64::arrow-cpp-6.0.2-py310h88295ea_0_cpu.tar.bz2
linux-aarch64::rust-1.64.0-h26fb2b7_0.tar.bz2
linux-aarch64::arrow-cpp-6.0.2-py38h3a77053_0_cpu.tar.bz2
linux-aarch64::libnetcdf-4.9.0-mpi_openmpi_he59aa49_0.tar.bz2
linux-aarch64::netcdf4-1.6.1-mpi_openmpi_py39h41dcfb4_0.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py38h8a8de8b_6_cuda.tar.bz2
linux-aarch64::arrow-cpp-7.0.1-py39h20d839c_1_cpu.tar.bz2
linux-aarch64::arrow-cpp-7.0.1-py38hd8559c0_1_cpu.tar.bz2
linux-aarch64::clangdev-15.0.1-default_ha7bf5e6_0.tar.bz2
linux-aarch64::arrow-cpp-6.0.2-py39h8b3709c_1_cpu.tar.bz2
linux-aarch64::gsoap-2.8.123-hf52ca08_0.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py38hd24d122_2_cpu.tar.bz2
linux-aarch64::libvips-8.13.1-h595dfea_0.tar.bz2
linux-aarch64::grpc-cpp-1.47.1-h177ec6a_6.tar.bz2
linux-aarch64::imagemagick-7.1.0_48-pl5321h54dbd6f_1.tar.bz2
linux-aarch64::wxwidgets-3.2.1-py310h6cac4f0_0.tar.bz2
linux-aarch64::libkml-1.3.0-h068af62_1015.tar.bz2
linux-aarch64::ffmpeg-5.1.2-gpl_he6481ef_101.tar.bz2
linux-aarch64::python-igraph-0.9.11-py310h7b07d77_1.tar.bz2
linux-aarch64::netcdf4-1.6.1-mpi_openmpi_py38hc71dbc1_0.tar.bz2
linux-aarch64::imagecodecs-2022.9.26-py38he65dbe4_0.tar.bz2
linux-aarch64::libxml2-2.10.2-hd2439e0_1.tar.bz2
linux-aarch64::libssh-0.10.4-h75cb1c7_1.tar.bz2
linux-aarch64::arrow-cpp-6.0.2-py37h21f51f2_0_cpu.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py39h38c6507_2_cpu.tar.bz2
linux-aarch64::arrow-cpp-6.0.2-py38hf06f364_0_cpu.tar.bz2
linux-aarch64::cppyy-cling-6.27.0-py310h4eb0b0e_1.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py38h2329fbb_2_cpu.tar.bz2
linux-aarch64::arrow-cpp-6.0.2-py39h87c83bf_0_cpu.tar.bz2
linux-aarch64::netcdf4-1.6.1-nompi_py39h39d185c_100.tar.bz2
linux-aarch64::arrow-cpp-8.0.1-py38hb4c0c01_3_cpu.tar.bz2
linux-aarch64::arrow-cpp-6.0.2-py39hd9906cc_0_cpu.tar.bz2
linux-aarch64::grpcio-1.48.1-py38h58dd36c_0.tar.bz2
linux-aarch64::python-igraph-0.10.0-py39hf062d6d_1.tar.bz2
linux-aarch64::libadios2-2.8.3-nompi_h0e0b0ee_103.tar.bz2
linux-aarch64::libssh-0.10.1-h75cb1c7_0.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py37h40dfae7_4_cuda.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py310h952f992_2_cpu.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py38hf362318_3_cpu.tar.bz2
linux-aarch64::arrow-cpp-8.0.1-py38h538fbc5_2_cpu.tar.bz2
linux-aarch64::grpc-cpp-1.48.1-ha80fa33_1.tar.bz2
linux-aarch64::arrow-cpp-7.0.1-py39hf6a4d64_2_cpu.tar.bz2
linux-aarch64::arrow-cpp-7.0.1-py310hfd233e4_1_cpu.tar.bz2
linux-aarch64::libadios2-2.8.3-mpi_openmpi_hf1e1458_3.tar.bz2
linux-aarch64::sqlite-3.39.3-h69ca7e5_0.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py37hd240594_2_cpu.tar.bz2
linux-aarch64::arrow-cpp-8.0.1-py38ha92025a_4_cpu.tar.bz2
linux-aarch64::giac-1.6.0.47-h8f6a60c_6.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py310he1b2118_2_cuda.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py38h00dbca3_4_cuda.tar.bz2
linux-aarch64::ffmpeg-5.1.2-gpl_h363b872_100.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py310hfc45d82_3_cpu.tar.bz2
linux-aarch64::arrow-cpp-7.0.1-py39hca8eaee_4_cpu.tar.bz2
linux-aarch64::libssh-0.10.3-h75cb1c7_0.tar.bz2
linux-aarch64::arrow-cpp-7.0.1-py310hcf66207_1_cpu.tar.bz2
linux-aarch64::grpc-cpp-1.48.1-h177ec6a_0.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py310h7362c8e_2_cuda.tar.bz2
linux-aarch64::aws-sdk-cpp-1.9.344-h6a52138_0.tar.bz2
linux-aarch64::nodejs-18.9.1-he850d6a_0.tar.bz2
linux-aarch64::arrow-cpp-8.0.1-py37h3444cda_3_cpu.tar.bz2
linux-aarch64::python-igraph-0.9.11-py38h80ccd69_1.tar.bz2
linux-aarch64::libadios2-2.8.3-mpi_mpich_h4d57059_3.tar.bz2
linux-aarch64::tesseract-5.2.0-h21deb5d_1.tar.bz2
linux-aarch64::libadios2-2.8.3-mpi_mpich_h5f3687c_2.tar.bz2
linux-aarch64::openmpi-4.1.4-h34d0eb5_101.tar.bz2
linux-aarch64::arrow-cpp-8.0.1-py37haf4aebd_2_cpu.tar.bz2
linux-aarch64::libssh-0.10.4-h2b6b862_0.tar.bz2
linux-aarch64::arrow-cpp-6.0.2-py38h1e8370c_1_cpu.tar.bz2
linux-aarch64::arrow-cpp-7.0.1-py37hcc8694b_0_cpu.tar.bz2
linux-aarch64::libadios2-2.8.3-nompi_hcee1620_103.tar.bz2
linux-aarch64::grpcio-1.48.1-py39h4b3b29f_0.tar.bz2
linux-aarch64::ffmpeg-4.4.2-lgpl_h71123b4_8.tar.bz2
linux-aarch64::libgdal-3.5.2-h3fa1e73_0.tar.bz2
linux-aarch64::libadios2-2.8.3-mpi_openmpi_hdd0d253_2.tar.bz2
linux-aarch64::nodejs-16.15.1-h928fb59_0.tar.bz2
linux-aarch64::nodejs-16.17.0-h928fb59_0.tar.bz2
linux-aarch64::graphviz-6.0.1-h856fde9_0.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py39hbcfcb34_2_cuda.tar.bz2
linux-aarch64::fenics-libdolfin-2019.1.0-h21975ec_32.tar.bz2
linux-aarch64::cpp-opentelemetry-sdk-1.6.0-h0ffc852_1.tar.bz2
linux-aarch64::libssh-0.10.4-h75cb1c7_0.tar.bz2
linux-aarch64::nodejs-14.19.0-h4df20a3_0.tar.bz2
linux-aarch64::aws-sdk-cpp-1.9.348-h6a52138_0.tar.bz2
linux-aarch64::assimp-5.2.4-h3fd5656_2.tar.bz2
linux-aarch64::netcdf4-1.6.1-nompi_py37hd917056_100.tar.bz2
linux-aarch64::smesh-9.9.0.0-he96c191_0.tar.bz2
linux-aarch64::openjdk-17.0.3-hb502e91_2.tar.bz2
linux-aarch64::ffmpeg-5.1.2-lgpl_he572d85_1.tar.bz2
linux-aarch64::openjdk-11.0.15-h7583607_2.tar.bz2
linux-aarch64::arrow-cpp-7.0.1-py39hf458bcd_0_cpu.tar.bz2
linux-aarch64::netcdf4-1.6.1-mpi_openmpi_py37h65422f2_0.tar.bz2
linux-aarch64::arrow-cpp-7.0.1-py38h1f65645_0_cpu.tar.bz2
linux-aarch64::libspatialite-5.0.1-h728704c_21.tar.bz2
linux-aarch64::arrow-cpp-8.0.1-py310h0c9a660_2_cpu.tar.bz2
linux-aarch64::nodejs-14.19.2-h4df20a3_0.tar.bz2
linux-aarch64::tiledb-2.11.2-h354e0e1_0.tar.bz2
linux-aarch64::libadios2-2.8.3-mpi_openmpi_h3dbbb54_2.tar.bz2
linux-aarch64::vtk-9.1.0-qt_py39h0419119_215.tar.bz2
linux-aarch64::nodejs-16.16.0-h928fb59_0.tar.bz2
linux-aarch64::arrow-cpp-7.0.1-py39h31fafd8_0_cpu.tar.bz2
linux-aarch64::libtiff-4.4.0-hacef7f3_4.tar.bz2
linux-aarch64::imagemagick-7.1.0_49-pl5321h1b60c45_0.tar.bz2
linux-aarch64::assimp-5.2.4-h3fd5656_1.tar.bz2
linux-aarch64::grpcio-1.48.1-py39h5ccccc2_0.tar.bz2
linux-aarch64::clangdev-15.0.0-default_ha7bf5e6_0.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py37hfcc4152_2_cpu.tar.bz2
linux-aarch64::grpcio-1.48.1-py37h57bd0a3_0.tar.bz2
linux-aarch64::libadios2-2.8.3-mpi_mpich_h00c07c3_2.tar.bz2
linux-aarch64::arrow-cpp-8.0.1-py37h40dfae7_3_cuda.tar.bz2
linux-aarch64::libssh-0.10.4-h0787c01_2.tar.bz2
linux-aarch64::grpc-cpp-1.48.1-hf1f2ea0_1.tar.bz2
linux-aarch64::arrow-cpp-7.0.1-py310h2864484_0_cpu.tar.bz2
linux-aarch64::arrow-cpp-7.0.1-py38h5b6c785_0_cpu.tar.bz2
linux-aarch64::grpcio-1.48.1-py38h5474c30_0.tar.bz2
linux-aarch64::arrow-cpp-8.0.1-py37hc93b5a1_2_cpu.tar.bz2
linux-aarch64::libssh-0.10.3-h2b6b862_0.tar.bz2
linux-aarch64::libadios2-2.8.3-mpi_mpich_hcc7e981_2.tar.bz2
linux-aarch64::aws-sdk-cpp-1.9.342-h6a52138_0.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py37hc723a9a_3_cuda.tar.bz2
linux-aarch64::arrow-cpp-8.0.1-py39h8400e93_4_cpu.tar.bz2
linux-aarch64::python-igraph-0.10.0-py39h5f24fa8_1.tar.bz2
linux-aarch64::libadios2-2.8.3-mpi_openmpi_hdd0d253_3.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py310h38c8595_2_cpu.tar.bz2
linux-aarch64::llvmlite-0.39.1-py37h35d289f_0.tar.bz2
linux-aarch64::arrow-cpp-6.0.2-py39he7cfecc_3_cpu.tar.bz2
linux-aarch64::netcdf4-1.6.1-nompi_py38he0ac5db_100.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py310ha04e903_2_cuda.tar.bz2
linux-aarch64::gap-core-4.11.1-h7637c83_4.tar.bz2
linux-aarch64::vtk-9.1.0-qt_py37hf87f55a_215.tar.bz2
linux-aarch64::arrow-cpp-8.0.1-py37hc723a9a_2_cuda.tar.bz2
linux-aarch64::libgdal-3.5.2-h8bc38f5_3.tar.bz2
linux-aarch64::arrow-cpp-8.0.1-py310h4c49b3c_3_cpu.tar.bz2
linux-aarch64::libssh-0.10.4-h312c56c_2.tar.bz2
linux-aarch64::arrow-cpp-8.0.1-py38h95b653f_2_cuda.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py37haf4aebd_3_cpu.tar.bz2
linux-aarch64::libgdal-3.5.2-h3fa1e73_1.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py310h3db0423_2_cuda.tar.bz2
linux-aarch64::arrow-cpp-7.0.1-py310h16bd952_3_cpu.tar.bz2
linux-aarch64::aws-sdk-cpp-1.9.352-hc317487_0.tar.bz2
linux-aarch64::rsync-3.2.6-hc02733c_0.tar.bz2
linux-aarch64::python-igraph-0.10.0-py38h80ccd69_1.tar.bz2
linux-aarch64::pyreadstat-1.1.9-py38h1368025_1.tar.bz2
linux-aarch64::libadios2-2.8.3-nompi_hcee1620_102.tar.bz2
linux-aarch64::netcdf4-1.6.1-mpi_mpich_py38h2f7f385_0.tar.bz2
linux-aarch64::aws-sdk-cpp-1.9.341-h6a52138_1.tar.bz2
linux-aarch64::arrow-cpp-6.0.2-py37h174bb00_3_cpu.tar.bz2
linux-aarch64::pdal-2.4.3-h20700df_2.tar.bz2
linux-aarch64::grpc-cpp-1.46.4-hf1f2ea0_7.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py39hbb74ffb_2_cuda.tar.bz2
linux-aarch64::arrow-cpp-8.0.1-py38hf362318_2_cpu.tar.bz2
linux-aarch64::qt-main-5.15.6-hb0efc4c_0.tar.bz2
linux-aarch64::ffmpeg-4.4.2-gpl_h363b872_108.tar.bz2
linux-aarch64::libsoup-3.2.0-he354691_0.tar.bz2
linux-aarch64::arrow-cpp-7.0.1-py37h16d148d_3_cpu.tar.bz2
linux-aarch64::libadios2-2.8.3-mpi_mpich_h59636ad_3.tar.bz2
linux-aarch64::grpc-cpp-1.48.1-h177ec6a_1.tar.bz2
linux-aarch64::nodejs-18.9.0-he850d6a_0.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py310h4c49b3c_4_cpu.tar.bz2
linux-aarch64::arrow-cpp-6.0.2-py37h9d27eae_0_cpu.tar.bz2
linux-aarch64::nodejs-16.16.0-he850d6a_0.tar.bz2
linux-aarch64::libnetcdf-4.9.0-mpi_mpich_h792d7f8_0.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py39h60062d4_2_cpu.tar.bz2
linux-aarch64::grpc-cpp-1.48.1-h2efb554_1.tar.bz2
linux-aarch64::libthrift-0.16.0-h81a1a33_2.tar.bz2
linux-aarch64::aws-sdk-cpp-1.9.354-hc317487_0.tar.bz2
linux-aarch64::aws-sdk-cpp-1.9.349-he0d2af6_1.tar.bz2
linux-aarch64::arrow-cpp-7.0.1-py39h4199365_3_cpu.tar.bz2
linux-aarch64::netcdf4-1.6.1-mpi_mpich_py310h4e70317_0.tar.bz2
linux-aarch64::arrow-cpp-8.0.1-py310hfc45d82_2_cpu.tar.bz2
linux-aarch64::rsync-3.2.6-h6fa9c02_0.tar.bz2
linux-aarch64::nodejs-18.10.0-h928fb59_0.tar.bz2
linux-aarch64::geotiff-1.7.1-hb764940_4.tar.bz2
linux-aarch64::vowpalwabbit-9.3.0-py39hfb1ceef_2.tar.bz2
linux-aarch64::aws-sdk-cpp-1.9.350-hc317487_1.tar.bz2
linux-aarch64::glib-2.74.0-h7866ba4_0.tar.bz2
linux-aarch64::assimp-5.2.5-h3fd5656_0.tar.bz2
linux-aarch64::aws-sdk-cpp-1.9.349-h6a52138_0.tar.bz2
linux-aarch64::netcdf4-1.6.1-mpi_mpich_py39hd38e795_0.tar.bz2
linux-aarch64::python-igraph-0.9.11-py39h5f24fa8_1.tar.bz2
linux-aarch64::vowpalwabbit-9.3.0-py310had33819_2.tar.bz2
linux-aarch64::ffmpeg-5.1.2-lgpl_h71123b4_0.tar.bz2
linux-aarch64::arrow-cpp-7.0.1-py37hc7000b9_1_cpu.tar.bz2
linux-aarch64::coin-or-clp-1.17.7-h2398112_2.tar.bz2
linux-aarch64::wxwidgets-3.2.0-py310hc845f63_2.tar.bz2
linux-aarch64::cairo-1.16.0-hd19fb6e_1014.tar.bz2
linux-aarch64::coin-or-cgl-0.60.6-h1a03506_2.tar.bz2
linux-aarch64::imagecodecs-2022.8.8-py38h3a2a9c7_5.tar.bz2
linux-aarch64::grpcio-1.48.1-py37he2c8e39_0.tar.bz2
linux-aarch64::aws-sdk-cpp-1.9.338-hb7e8865_0.tar.bz2
linux-aarch64::nodejs-16.17.0-he850d6a_0.tar.bz2
linux-aarch64::nodejs-14.20.1-h4df20a3_0.tar.bz2
linux-aarch64::smesh-9.9.0.0-hb73e6ad_1.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py38h538fbc5_2_cpu.tar.bz2
linux-aarch64::arrow-cpp-8.0.1-py38hb2e2b04_2_cpu.tar.bz2
linux-aarch64::ffmpeg-4.4.2-gpl_he6481ef_108.tar.bz2
linux-aarch64::ffmpeg-5.1.1-lgpl_h71123b4_1.tar.bz2
linux-aarch64::grpc-cpp-1.47.1-h2efb554_6.tar.bz2
linux-aarch64::libadios2-2.8.3-mpi_openmpi_hed0105c_2.tar.bz2
linux-aarch64::arrow-cpp-8.0.1-py310h952f992_2_cpu.tar.bz2
linux-aarch64::sagelib-9.6-py37h8396c7f_3.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py310h957a929_6_cuda.tar.bz2
linux-aarch64::fenics-libdolfin-2019.1.0-hcc850cb_32.tar.bz2
linux-aarch64::grpcio-1.48.1-py310h11a0d58_0.tar.bz2
linux-aarch64::arrow-cpp-8.0.1-py39h90c5e57_3_cpu.tar.bz2
linux-aarch64::libadios2-2.8.3-nompi_he7a61a9_103.tar.bz2
linux-aarch64::ffmpeg-5.1.1-gpl_h4289b67_101.tar.bz2
linux-aarch64::libvips-8.13.1-hc79bdf0_1.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py39h11c5d33_2_cuda.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py39h90c5e57_5_cpu.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py310hc47cf85_2_cpu.tar.bz2
linux-aarch64::mongodb-6.0.1-hedbcfdd_1.tar.bz2
linux-aarch64::libadios2-2.8.3-mpi_openmpi_hda0f03a_2.tar.bz2
linux-aarch64::libspatialite-5.0.1-h728704c_20.tar.bz2
linux-aarch64::arrow-cpp-6.0.2-py37h000d998_1_cpu.tar.bz2
linux-aarch64::arrow-cpp-8.0.1-py39h0f42c21_2_cpu.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py310h4c49b3c_6_cpu.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py38h462da0a_3_cuda.tar.bz2
linux-aarch64::arrow-cpp-6.0.2-py39hbb0fd13_1_cpu.tar.bz2
linux-aarch64::arrow-cpp-8.0.1-py39h11c5d33_2_cuda.tar.bz2
linux-aarch64::tiledb-2.11.2-h6866cf4_0.tar.bz2
linux-aarch64::libthrift-0.16.0-h6e53a4e_2.tar.bz2
linux-aarch64::libadios2-2.8.3-nompi_he7a61a9_102.tar.bz2
linux-aarch64::arrow-cpp-6.0.2-py310h3695db0_0_cpu.tar.bz2
linux-aarch64::poppler-qt-22.04.0-h1b36eed_3.tar.bz2
linux-aarch64::pdal-2.4.3-hc364f71_2.tar.bz2
linux-aarch64::arrow-cpp-8.0.1-py39h6c488eb_2_cpu.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py37hc93b5a1_2_cpu.tar.bz2
linux-aarch64::libadios2-2.8.3-nompi_h6617583_103.tar.bz2
linux-aarch64::cppyy-cling-6.27.0-py39h20a37df_1.tar.bz2
linux-aarch64::arrow-cpp-7.0.1-py38h771cda8_4_cpu.tar.bz2
linux-aarch64::arrow-cpp-7.0.1-py38he0567b0_1_cpu.tar.bz2
linux-aarch64::imagecodecs-2022.9.26-py39h003a7a8_0.tar.bz2
linux-aarch64::imagecodecs-2022.8.8-py39h39b51ec_5.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py37hbe838dc_6_cuda.tar.bz2
linux-aarch64::arrow-cpp-9.0.0-py39hd21bb2d_4_cuda.tar.bz2
linux-aarch64::libadios2-2.8.3-nompi_h886c990_103.tar.bz2
linux-aarch64::libglib-2.74.0-h58953e2_0.tar.bz2
linux-aarch64::cpp-opentelemetry-sdk-1.6.0-h3d19de8_1.tar.bz2
linux-aarch64::arrow-cpp-6.0.2-py38hcecfc0a_2_cpu.tar.bz2
linux-aarch64::aws-sdk-cpp-1.9.339-hb7e8865_0.tar.bz2
linux-aarch64::libssh-0.10.2-h75cb1c7_0.tar.bz2
linux-aarch64::arrow-cpp-6.0.2-py38h26f3cc4_1_cpu.tar.bz2
linux-aarch64::netcdf4-1.6.1-nompi_py310hf0beae2_100.tar.bz2
linux-aarch64::libadios2-2.8.3-mpi_openmpi_hda0f03a_3.tar.bz2
linux-aarch64::nodejs-18.9.0-h928fb59_0.tar.bz2
linux-aarch64::mapserver-8.0.0-py37h39b1943_0.tar.bz2
linux-aarch64::arrow-cpp-7.0.1-py310h16bd952_4_cpu.tar.bz2
linux-aarch64::arrow-cpp-7.0.1-py39h58c699d_1_cpu.tar.bz2
linux-aarch64::libadios2-2.8.3-mpi_mpich_hcf2b225_3.tar.bz2
linux-aarch64::libadios2-2.8.3-mpi_mpich_h59636ad_2.tar.bz2
-    "libzlib >=1.2.12,<1.3.0a0",
+    "libzlib >=1.2.12,<2.0.0a0",
linux-aarch64::libprotobuf-3.21.5-h4dffa80_3.tar.bz2
linux-aarch64::coin-or-utils-2.11.6-h62e9a7e_2.tar.bz2
linux-aarch64::llvm-spirv-14.0.0-hb2805f8_1.tar.bz2
linux-aarch64::clang-format-15-15.0.1-default_ha7bf5e6_0.tar.bz2
linux-aarch64::llvm-15.0.0-h1426fca_0.tar.bz2
linux-aarch64::libllvm15-15.0.0-h71eeefc_0.tar.bz2
linux-aarch64::libclang-cpp15-15.0.0-default_ha7bf5e6_0.tar.bz2
linux-aarch64::dotnet-sdk-3.1.423-hb062e78_0.tar.bz2
linux-aarch64::libprotobuf-static-3.21.5-h7866ba4_3.tar.bz2
linux-aarch64::libclang-cpp15-15.0.1-default_ha7bf5e6_0.tar.bz2
linux-aarch64::libclang-cpp-15.0.0-default_ha7bf5e6_0.tar.bz2
linux-aarch64::dotnet-runtime-6.0.9-hb062e78_0.tar.bz2
linux-aarch64::libprotobuf-3.21.6-h4dffa80_0.tar.bz2
linux-aarch64::coin-or-osi-0.108.7-h9e9ff86_2.tar.bz2
linux-aarch64::libllvm11-11.1.0-hb2805f8_4.tar.bz2
linux-aarch64::llvm-tools-15.0.1-h71eeefc_0.tar.bz2
linux-aarch64::llvm-11.1.0-h40ce709_4.tar.bz2
linux-aarch64::llvm-15.0.1-h1426fca_0.tar.bz2
linux-aarch64::libprotobuf-static-3.21.5-h7866ba4_1.tar.bz2
linux-aarch64::glib-tools-2.74.0-h7866ba4_0.tar.bz2
linux-aarch64::gst-plugins-base-1.20.3-h9c4ba4c_2.tar.bz2
linux-aarch64::llvm-tools-11.1.0-hb2805f8_4.tar.bz2
linux-aarch64::clang-format-15-15.0.0-default_ha7bf5e6_0.tar.bz2
linux-aarch64::dotnet-sdk-6.0.401-hb062e78_0.tar.bz2
linux-aarch64::libprotobuf-3.20.1-h4dffa80_4.tar.bz2
linux-aarch64::gst-plugins-good-1.20.3-h660f13c_1.tar.bz2
linux-aarch64::llvm-tools-15.0.0-h71eeefc_0.tar.bz2
linux-aarch64::clang-15-15.0.1-default_ha7bf5e6_0.tar.bz2
linux-aarch64::libclang-15.0.1-default_ha7bf5e6_0.tar.bz2
linux-aarch64::libprotobuf-3.20.1-h4dffa80_3.tar.bz2
linux-aarch64::clang-tools-15.0.0-default_ha7bf5e6_0.tar.bz2
linux-aarch64::clang-15-15.0.0-default_ha7bf5e6_0.tar.bz2
linux-aarch64::libprotobuf-static-3.20.1-h7866ba4_3.tar.bz2
linux-aarch64::fontconfig-2.14.0-h77febde_1.tar.bz2
linux-aarch64::libsqlite-3.39.3-hf9034f9_0.tar.bz2
linux-aarch64::clang-tools-15.0.1-default_ha7bf5e6_0.tar.bz2
linux-aarch64::libprotobuf-3.21.5-h4dffa80_2.tar.bz2
linux-aarch64::gst-plugins-good-1.20.3-h660f13c_2.tar.bz2
linux-aarch64::libpng-1.6.38-hf9034f9_0.tar.bz2
linux-aarch64::libclang-cpp-15.0.1-default_ha7bf5e6_0.tar.bz2
linux-aarch64::libprotobuf-static-3.21.5-h7866ba4_2.tar.bz2
linux-aarch64::clang-format-15.0.0-default_ha7bf5e6_0.tar.bz2
linux-aarch64::libclang13-15.0.1-default_h3684801_0.tar.bz2
linux-aarch64::dotnet-runtime-3.1.29-hf32e593_0.tar.bz2
linux-aarch64::libprotobuf-static-3.20.1-h7866ba4_2.tar.bz2
linux-aarch64::libclang13-15.0.0-default_h3684801_0.tar.bz2
linux-aarch64::libprotobuf-static-3.21.6-h7866ba4_1.tar.bz2
linux-aarch64::liblal-7.2.2-fftw_he26ac06_100.tar.bz2
linux-aarch64::dotnet-aspnetcore-3.1.29-hb062e78_0.tar.bz2
linux-aarch64::libclang-15.0.0-default_ha7bf5e6_0.tar.bz2
linux-aarch64::clang-format-15.0.1-default_ha7bf5e6_0.tar.bz2
linux-aarch64::libprotobuf-static-3.21.6-h7866ba4_0.tar.bz2
linux-aarch64::gst-plugins-base-1.20.3-h9c4ba4c_1.tar.bz2
linux-aarch64::dotnet-aspnetcore-6.0.9-hb062e78_0.tar.bz2
linux-aarch64::libllvm15-15.0.1-h71eeefc_0.tar.bz2
linux-aarch64::libprotobuf-static-3.20.1-h7866ba4_4.tar.bz2
linux-aarch64::libprotobuf-3.21.6-h4dffa80_1.tar.bz2
-    "libzlib >=1.2.12,<1.3.0a0"
+    "libzlib >=1.2.12,<2.0.0a0"
================================================================================
================================================================================
noarch
================================================================================
================================================================================
win-64
win-64::imagecodecs-2022.9.26-py39h28bd840_0.tar.bz2
win-64::arrow-cpp-9.0.0-py39ha71ea14_2_cpu.tar.bz2
win-64::heyoka-0.19.0-h4266463_0.tar.bz2
win-64::arrow-cpp-7.0.1-py38h31dc3a2_3_cpu.tar.bz2
win-64::arrow-cpp-7.0.1-py39h0e732fe_1_cuda.tar.bz2
win-64::arrow-cpp-7.0.1-py37h20c8ba5_2_cpu.tar.bz2
win-64::grpc-cpp-1.48.1-h568aa7b_1.tar.bz2
win-64::topologytoolkit-1.1.0-no_paraview_py310h8feeedb_102.tar.bz2
win-64::arrow-cpp-7.0.1-py38hbb9d546_4_cuda.tar.bz2
win-64::libkml-1.3.0-hf2ab4e4_1015.tar.bz2
win-64::ffmpeg-5.1.2-gpl_hae392d0_100.tar.bz2
win-64::arrow-cpp-9.0.0-py38h12fc1e3_2_cuda.tar.bz2
win-64::llvm-tools-15.0.1-h0f93eaf_0.tar.bz2
win-64::cpp-opentelemetry-sdk-1.6.0-hf905de0_1.tar.bz2
win-64::python-igraph-0.10.0-py310he5bc916_1.tar.bz2
win-64::arrow-cpp-9.0.0-py310h2398ab9_2_cuda.tar.bz2
win-64::libprotobuf-static-3.20.1-h12be248_3.tar.bz2
win-64::vtk-9.1.0-qt_py37he11d85d_215.tar.bz2
win-64::grpc-cpp-1.47.1-h568aa7b_6.tar.bz2
win-64::arrow-cpp-7.0.1-py39h6e784f1_2_cpu.tar.bz2
win-64::pyreadr-0.4.7-py38heb50f4f_0.tar.bz2
win-64::arrow-cpp-6.0.2-py38hfc29e53_0_cuda.tar.bz2
win-64::libprotobuf-static-3.21.6-h12be248_0.tar.bz2
win-64::tiledb-2.11.2-h5689973_0.tar.bz2
win-64::arrow-cpp-8.0.1-py37h30001c3_3_cuda.tar.bz2
win-64::arrow-cpp-8.0.1-py310h8c4d3c6_2_cuda.tar.bz2
win-64::grpcio-1.48.1-py37h26ab029_0.tar.bz2
win-64::arrow-cpp-6.0.2-py38h290a048_0_cpu.tar.bz2
win-64::arrow-cpp-9.0.0-py310h8c4d3c6_2_cuda.tar.bz2
win-64::llvm-tools-11.1.0-hf00eed6_4.tar.bz2
win-64::arrow-cpp-6.0.2-py39h404436b_3_cuda.tar.bz2
win-64::stir-5.0.0-py38h99eca4e_3.tar.bz2
win-64::arrow-cpp-8.0.1-py310hdbaeaa9_3_cuda.tar.bz2
win-64::arrow-cpp-7.0.1-py37hd749cc5_4_cpu.tar.bz2
win-64::llvmlite-0.39.1-py39hd28a505_0.tar.bz2
win-64::arrow-cpp-9.0.0-py37hd64964d_6_cuda.tar.bz2
win-64::arrow-cpp-9.0.0-py39hf2f6362_5_cpu.tar.bz2
win-64::pyreadstat-1.1.9-py38h5c26c2e_1.tar.bz2
win-64::libclang13-15.0.1-default_h77d9078_0.tar.bz2
win-64::python-igraph-0.9.11-py39h5126385_1.tar.bz2
win-64::ovito-3.7.8-h19f58de_1.tar.bz2
win-64::arrow-cpp-9.0.0-py39h1e2f08e_2_cpu.tar.bz2
win-64::arrow-cpp-7.0.1-py310he75ff44_0_cuda.tar.bz2
win-64::qt-main-5.15.6-hf0cf448_0.tar.bz2
win-64::tiledb-2.11.2-h3132609_0.tar.bz2
win-64::pyreadr-0.4.7-py39h67dc9e1_0.tar.bz2
win-64::gemmi-0.5.7-py310hb84602e_0.tar.bz2
win-64::arrow-cpp-7.0.1-py310h67a9327_2_cpu.tar.bz2
win-64::cpp-opentelemetry-sdk-1.6.0-h684db20_1.tar.bz2
win-64::arrow-cpp-9.0.0-py38h0230ab1_2_cpu.tar.bz2
win-64::gst-plugins-base-1.20.3-h001b923_1.tar.bz2
win-64::grpcio-1.48.1-py37hb6b7e53_0.tar.bz2
win-64::clang-format-15.0.0-default_h66ee7f4_0.tar.bz2
win-64::mdtraj-1.9.7-py37hcef4199_2.tar.bz2
win-64::arrow-cpp-8.0.1-py310hdbaeaa9_4_cuda.tar.bz2
win-64::grpc-cpp-1.46.4-hcb02dd0_7.tar.bz2
win-64::vtk-9.1.0-qt_py310h01c2d33_215.tar.bz2
win-64::openexr-python-1.3.9-py39h7036e9b_0.tar.bz2
win-64::arrow-cpp-9.0.0-py310hdbaeaa9_4_cuda.tar.bz2
win-64::arrow-cpp-7.0.1-py38h12fc1e3_0_cuda.tar.bz2
win-64::libgdal-3.5.2-hc386656_1.tar.bz2
win-64::aws-sdk-cpp-1.9.340-h918cd17_0.tar.bz2
win-64::arrow-cpp-7.0.1-py310h2398ab9_0_cuda.tar.bz2
win-64::arrow-cpp-8.0.1-py38hd69dc15_2_cuda.tar.bz2
win-64::openexr-python-1.3.9-py39ha4c3308_0.tar.bz2
win-64::llvmdev-15.0.0-h0f93eaf_0.tar.bz2
win-64::arrow-cpp-9.0.0-py310h0b333a9_3_cuda.tar.bz2
win-64::clangdev-15.0.1-default_h66ee7f4_0.tar.bz2
win-64::gdk-pixbuf-2.42.8-h56bf1b2_1.tar.bz2
win-64::arrow-cpp-7.0.1-py39h1e2f08e_0_cpu.tar.bz2
win-64::arrow-cpp-8.0.1-py39hfdc3d9d_2_cuda.tar.bz2
win-64::arrow-cpp-9.0.0-py37h7fb22df_2_cpu.tar.bz2
win-64::topologytoolkit-1.1.0-no_paraview_py310hb06f9a3_103.tar.bz2
win-64::arrow-cpp-9.0.0-py37h20c8ba5_3_cpu.tar.bz2
win-64::arrow-cpp-6.0.2-py37h6a60a0a_2_cpu.tar.bz2
win-64::aws-sdk-cpp-1.9.349-h11ce4dd_0.tar.bz2
win-64::arrow-cpp-9.0.0-py37h987c7fe_5_cpu.tar.bz2
win-64::paraview-5.10.1-py37hb929789_108_qt.tar.bz2
win-64::arrow-cpp-7.0.1-py39hbca705c_1_cpu.tar.bz2
win-64::arrow-cpp-9.0.0-py39h07ee6b1_6_cpu.tar.bz2
win-64::aws-sdk-cpp-1.9.345-h11ce4dd_0.tar.bz2
win-64::arrow-cpp-8.0.1-py38hbab55ff_2_cpu.tar.bz2
win-64::aws-sdk-cpp-1.9.350-hd0556ea_1.tar.bz2
win-64::papilo-2.1.0-h45feaf2_2.tar.bz2
win-64::smesh-9.9.0.0-hae393ef_1.tar.bz2
win-64::arrow-cpp-7.0.1-py38h191bde2_1_cuda.tar.bz2
win-64::libprotobuf-3.21.5-h12be248_2.tar.bz2
win-64::arrow-cpp-6.0.2-py310h6b2ed25_3_cpu.tar.bz2
win-64::arrow-cpp-9.0.0-py38hbaa476a_4_cuda.tar.bz2
win-64::libprotobuf-static-3.21.5-h12be248_2.tar.bz2
win-64::arrow-cpp-9.0.0-py38h01359d8_2_cuda.tar.bz2
win-64::arrow-cpp-9.0.0-py39hf2f6362_4_cpu.tar.bz2
win-64::aws-sdk-cpp-1.9.342-h11ce4dd_0.tar.bz2
win-64::libprotobuf-static-3.20.1-h12be248_4.tar.bz2
win-64::arrow-cpp-9.0.0-py39h0a088b7_2_cuda.tar.bz2
win-64::topologytoolkit-1.1.0-no_paraview_py38h857fd83_102.tar.bz2
win-64::arrow-cpp-8.0.1-py37h7fb22df_2_cpu.tar.bz2
win-64::libadios2-2.8.3-nompi_h38ab939_102.tar.bz2
win-64::arrow-cpp-6.0.2-py310he2caa9f_1_cpu.tar.bz2
win-64::paraview-5.10.1-py39h36667f9_108_qt.tar.bz2
win-64::grpcio-1.48.1-py38h137c222_0.tar.bz2
win-64::arrow-cpp-7.0.1-py39h4f3435e_1_cpu.tar.bz2
win-64::grpc-cpp-1.46.4-h568aa7b_7.tar.bz2
win-64::libprotobuf-static-3.20.1-h12be248_2.tar.bz2
win-64::arrow-cpp-7.0.1-py39hdf17a4b_4_cuda.tar.bz2
win-64::osmium-tool-1.14.0-h8558f88_2.tar.bz2
win-64::pyreadr-0.4.7-py38h1fb7db9_0.tar.bz2
win-64::arrow-cpp-7.0.1-py39h0a088b7_0_cuda.tar.bz2
win-64::thrift-compiler-0.16.0-h9ce19ad_2.tar.bz2
win-64::libtiff-4.4.0-h8e97e67_4.tar.bz2
win-64::paraview-5.10.1-py310h0da12d5_108_qt.tar.bz2
win-64::arrow-cpp-9.0.0-py38h191bde2_2_cuda.tar.bz2
win-64::arrow-cpp-6.0.2-py310hfde5b3a_1_cpu.tar.bz2
win-64::arrow-cpp-6.0.2-py39h611e327_1_cuda.tar.bz2
win-64::arrow-cpp-8.0.1-py310h91fd97e_2_cpu.tar.bz2
win-64::arrow-cpp-6.0.2-py39h38a71b6_0_cuda.tar.bz2
win-64::heyoka-0.19.0-h595eaec_0.tar.bz2
win-64::libprotobuf-3.20.1-h12be248_2.tar.bz2
win-64::topologytoolkit-1.1.0-no_paraview_py37hbc32aed_103.tar.bz2
win-64::pyreadr-0.4.7-py310hdc45392_1.tar.bz2
win-64::arrow-cpp-8.0.1-py39hbca705c_2_cpu.tar.bz2
win-64::arrow-cpp-9.0.0-py39hdf17a4b_6_cuda.tar.bz2
win-64::arrow-cpp-9.0.0-py310h8b1cf1d_2_cpu.tar.bz2
win-64::libprotobuf-3.21.5-h12be248_3.tar.bz2
win-64::llvmlite-0.39.1-py310hb84602e_0.tar.bz2
win-64::mongodb-6.0.1-h5461356_1.tar.bz2
win-64::arrow-cpp-6.0.2-py310h9bcc0ba_0_cuda.tar.bz2
win-64::llvmlite-0.39.1-py37h0c9d48c_0.tar.bz2
win-64::websocketpp-0.8.2-h51fc605_0.tar.bz2
win-64::libgdal-3.5.2-hec59f66_3.tar.bz2
win-64::arrow-cpp-9.0.0-py37h987c7fe_4_cpu.tar.bz2
win-64::arrow-cpp-7.0.1-py38h277a788_2_cpu.tar.bz2
win-64::arrow-cpp-7.0.1-py37h30001c3_3_cuda.tar.bz2
win-64::arrow-cpp-7.0.1-py310h548f2ed_0_cpu.tar.bz2
win-64::arrow-cpp-9.0.0-py37h30001c3_5_cuda.tar.bz2
win-64::gst-plugins-good-1.20.3-h76f0265_1.tar.bz2
win-64::arrow-cpp-8.0.1-py310h1b77788_3_cpu.tar.bz2
win-64::arrow-cpp-7.0.1-py38h01359d8_0_cuda.tar.bz2
win-64::grpcio-1.48.1-py310hddc5390_0.tar.bz2
win-64::glib-2.74.0-h12be248_0.tar.bz2
win-64::libadios2-2.8.3-nompi_h38ab939_103.tar.bz2
win-64::vigra-1.11.1-py38h0c32289_1034.tar.bz2
win-64::arrow-cpp-7.0.1-py39hacff0a7_0_cuda.tar.bz2
win-64::grpc-cpp-1.46.4-h6a6baca_7.tar.bz2
win-64::arrow-cpp-9.0.0-py37h7affd69_2_cpu.tar.bz2
win-64::arrow-cpp-9.0.0-py39h6e784f1_3_cpu.tar.bz2
win-64::netcdf4-1.6.1-nompi_py39h34fa13a_100.tar.bz2
win-64::arrow-cpp-9.0.0-py38hbaa476a_5_cuda.tar.bz2
win-64::libadios2-2.8.3-nompi_h88241a3_103.tar.bz2
win-64::arrow-cpp-8.0.1-py310h1b77788_4_cpu.tar.bz2
win-64::indexed_gzip-1.7.0-py38ha935156_0.tar.bz2
win-64::arrow-cpp-8.0.1-py39h0e732fe_2_cuda.tar.bz2
win-64::arrow-cpp-6.0.2-py310hf119954_1_cuda.tar.bz2
win-64::arrow-cpp-8.0.1-py38hbb9d546_4_cuda.tar.bz2
win-64::arrow-cpp-9.0.0-py37h256b1c4_2_cpu.tar.bz2
win-64::smesh-9.9.0.0-h1dba484_0.tar.bz2
win-64::arrow-cpp-8.0.1-py39h6e784f1_2_cpu.tar.bz2
win-64::arrow-cpp-9.0.0-py310h1b77788_4_cpu.tar.bz2
win-64::arrow-cpp-7.0.1-py38h71f67b3_1_cuda.tar.bz2
win-64::grpc-cpp-1.48.1-hcb02dd0_1.tar.bz2
win-64::imagecodecs-2022.8.8-py39h4c42738_5.tar.bz2
win-64::arrow-cpp-7.0.1-py37h816ecd1_2_cuda.tar.bz2
win-64::ovito-3.7.9-h19f58de_0.tar.bz2
win-64::arrow-cpp-8.0.1-py310h67a9327_2_cpu.tar.bz2
win-64::vigra-1.11.1-py39h353c3ee_1034.tar.bz2
win-64::arrow-cpp-6.0.2-py38hafe912d_1_cpu.tar.bz2
win-64::pyreadr-0.4.7-py310hdc45392_0.tar.bz2
win-64::arrow-cpp-6.0.2-py39hffdd250_2_cpu.tar.bz2
win-64::arrow-cpp-9.0.0-py38hbb9d546_6_cuda.tar.bz2
win-64::libprotobuf-3.21.6-h12be248_0.tar.bz2
win-64::gemmi-0.5.7-py37h0c9d48c_0.tar.bz2
win-64::libllvm15-15.0.1-h0f93eaf_0.tar.bz2
win-64::clang-format-15.0.1-default_h66ee7f4_0.tar.bz2
win-64::mdtraj-1.9.7-py39h804b23a_2.tar.bz2
win-64::grpcio-1.48.1-py310hf56d9f5_0.tar.bz2
win-64::imagecodecs-2022.8.8-py39h08a830a_5.tar.bz2
win-64::indexed_gzip-1.7.0-py310hff18152_0.tar.bz2
win-64::arrow-cpp-9.0.0-py310hdbaeaa9_5_cuda.tar.bz2
win-64::pyreadr-0.4.7-py38heb50f4f_1.tar.bz2
win-64::arrow-cpp-6.0.2-py310h96cef69_3_cuda.tar.bz2
win-64::arrow-cpp-6.0.2-py37hd7bb45f_2_cuda.tar.bz2
win-64::netcdf4-1.6.1-nompi_py38h78680c8_100.tar.bz2
win-64::websocketpp-0.8.2-h4dcb625_1.tar.bz2
win-64::python-igraph-0.9.11-py39h16ec61d_1.tar.bz2
win-64::arrow-cpp-6.0.2-py39h7c64988_1_cpu.tar.bz2
win-64::nco-5.1.0-h343d473_2.tar.bz2
win-64::arrow-cpp-9.0.0-py39h7eda9d8_4_cuda.tar.bz2
win-64::intel-opencl-rt-2022.1.0-h0c8ddaa_3787.tar.bz2
win-64::llvmlite-0.39.1-py39h6848017_0.tar.bz2
win-64::libgdal-3.5.2-hc386656_0.tar.bz2
win-64::soplex-6.0.1-h949ae46_2.tar.bz2
win-64::arrow-cpp-8.0.1-py39h07ee6b1_4_cpu.tar.bz2
win-64::arrow-cpp-8.0.1-py37h84ffc76_2_cuda.tar.bz2
win-64::libnetcdf-4.9.0-nompi_h85765be_100.tar.bz2
win-64::wxwidgets-3.2.1-hd1f7ea3_0.tar.bz2
win-64::grpc-cpp-1.47.1-h535cfc9_6.tar.bz2
win-64::arrow-cpp-9.0.0-py38hd69dc15_3_cuda.tar.bz2
win-64::assimp-5.2.5-h4dcb625_0.tar.bz2
win-64::ffmpeg-5.1.1-gpl_hae392d0_102.tar.bz2
win-64::arrow-cpp-6.0.2-py37h1f605d3_0_cpu.tar.bz2
win-64::arrow-cpp-9.0.0-py37hd749cc5_6_cpu.tar.bz2
win-64::arrow-cpp-7.0.1-py310h8b1cf1d_1_cpu.tar.bz2
win-64::clang-15-15.0.0-default_h66ee7f4_0.tar.bz2
win-64::leptonica-1.78.0-h347fe67_1.tar.bz2
win-64::arrow-cpp-9.0.0-py37h30001c3_4_cuda.tar.bz2
win-64::ffmpeg-5.1.1-lgpl_h3b4b236_1.tar.bz2
win-64::arrow-cpp-6.0.2-py38h2cf7c35_1_cuda.tar.bz2
win-64::assimp-5.2.4-h4dcb625_2.tar.bz2
win-64::arrow-cpp-6.0.2-py310h2b544a8_0_cuda.tar.bz2
win-64::python-igraph-0.9.11-py38h1cea2b0_1.tar.bz2
win-64::pyreadr-0.4.7-py38h1fb7db9_1.tar.bz2
win-64::aws-sdk-cpp-1.9.351-hd0556ea_0.tar.bz2
win-64::libadios2-2.8.3-nompi_h88241a3_102.tar.bz2
win-64::arrow-cpp-8.0.1-py39hdf17a4b_4_cuda.tar.bz2
win-64::arrow-cpp-9.0.0-py39hacff0a7_2_cuda.tar.bz2
win-64::vtk-9.1.0-qt_py39hca7f291_215.tar.bz2
win-64::aws-sdk-cpp-1.9.343-h11ce4dd_0.tar.bz2
win-64::arrow-cpp-9.0.0-py38hdb32e4e_6_cpu.tar.bz2
win-64::arrow-cpp-9.0.0-py39h4f3435e_2_cpu.tar.bz2
win-64::aws-sdk-cpp-1.9.350-haceebd4_0.tar.bz2
win-64::ffmpeg-4.4.2-lgpl_h46f9d08_8.tar.bz2
win-64::arrow-cpp-9.0.0-py310ha85c99b_2_cuda.tar.bz2
win-64::tomviz-2.0.0rc1.post9-py37h5e52961_0.tar.bz2
win-64::pyreadr-0.4.7-py37h5b38b69_1.tar.bz2
win-64::cairo-1.16.0-hd694305_1014.tar.bz2
win-64::arrow-cpp-9.0.0-py38h8a50e48_2_cpu.tar.bz2
win-64::topologytoolkit-1.1.0-no_paraview_py39hc686df9_103.tar.bz2
win-64::arrow-cpp-6.0.2-py310h651c748_2_cuda.tar.bz2
win-64::arrow-cpp-8.0.1-py37h20c8ba5_2_cpu.tar.bz2
win-64::libxml2-2.10.2-h99b13fb_1.tar.bz2
win-64::arrow-cpp-9.0.0-py37h816ecd1_3_cuda.tar.bz2
win-64::arrow-cpp-9.0.0-py37hc2869ea_2_cuda.tar.bz2
win-64::paraview-5.10.1-py38hc358c29_108_qt.tar.bz2
win-64::arrow-cpp-6.0.2-py38had138b9_3_cpu.tar.bz2
win-64::arrow-cpp-7.0.1-py37h84ffc76_1_cuda.tar.bz2
win-64::mysql-connector-cpp-8.0.29-hf302a98_2.tar.bz2
win-64::arrow-cpp-9.0.0-py310h548f2ed_2_cpu.tar.bz2
win-64::arrow-cpp-6.0.2-py38h5d1cacb_1_cpu.tar.bz2
win-64::arrow-cpp-9.0.0-py38h71f67b3_2_cuda.tar.bz2
win-64::arrow-cpp-6.0.2-py37ha69392a_1_cuda.tar.bz2
win-64::arrow-cpp-8.0.1-py38h31dc3a2_3_cpu.tar.bz2
win-64::arrow-cpp-9.0.0-py38hbab55ff_2_cpu.tar.bz2
win-64::collada-dom-2.5.0-hcb3fdb8_5.tar.bz2
win-64::libprotobuf-3.21.6-h12be248_1.tar.bz2
win-64::gemmi-0.5.7-py38hf225c54_0.tar.bz2
win-64::aws-sdk-cpp-1.9.354-hd0556ea_0.tar.bz2
win-64::arrow-cpp-8.0.1-py310ha85c99b_2_cuda.tar.bz2
win-64::arrow-cpp-7.0.1-py39h07ee6b1_4_cpu.tar.bz2
win-64::arrow-cpp-6.0.2-py39hb8aa3f8_0_cpu.tar.bz2
win-64::pyreadstat-1.1.9-py37he22b0b1_1.tar.bz2
win-64::arrow-cpp-8.0.1-py39h801dfc1_2_cuda.tar.bz2
win-64::arrow-cpp-7.0.1-py38hbab55ff_1_cpu.tar.bz2
win-64::arrow-cpp-6.0.2-py39he238f48_1_cuda.tar.bz2
win-64::arrow-cpp-9.0.0-py310h91fd97e_2_cpu.tar.bz2
win-64::ffmpeg-4.4.2-gpl_hae392d0_108.tar.bz2
win-64::intel-cmplr-lib-rt-2022.1.0-h12be248_3787.tar.bz2
win-64::arrow-cpp-9.0.0-py310hdbaeaa9_6_cuda.tar.bz2
win-64::grpc-cpp-1.47.1-hcb02dd0_6.tar.bz2
win-64::arrow-cpp-8.0.1-py37hc2869ea_2_cuda.tar.bz2
win-64::heyoka-0.19.0-hb4083ac_0.tar.bz2
win-64::arrow-cpp-8.0.1-py37h7affd69_2_cpu.tar.bz2
win-64::netcdf4-1.6.1-nompi_py310h459bb5f_100.tar.bz2
win-64::libgdal-3.5.2-hc386656_3.tar.bz2
win-64::ffmpeg-4.4.2-lgpl_h8516bce_8.tar.bz2
win-64::wxwidgets-3.2.0-hd1f7ea3_2.tar.bz2
win-64::fontconfig-2.14.0-h720f74d_1.tar.bz2
win-64::arrow-cpp-9.0.0-py37h79b9725_2_cuda.tar.bz2
win-64::libclang-15.0.0-default_h77d9078_0.tar.bz2
win-64::stir-5.0.0-py310h63f273e_3.tar.bz2
win-64::arrow-cpp-9.0.0-py39h0e732fe_2_cuda.tar.bz2
win-64::libclang-15.0.1-default_h77d9078_0.tar.bz2
win-64::pdal-2.4.3-h9f74303_2.tar.bz2
win-64::libpng-1.6.38-h19919ed_0.tar.bz2
win-64::vigra-1.11.1-py310h96fe323_1034.tar.bz2
win-64::arrow-cpp-9.0.0-py38h31dc3a2_4_cpu.tar.bz2
win-64::libthrift-0.16.0-h9f558f2_2.tar.bz2
win-64::arrow-cpp-7.0.1-py37h7fb22df_1_cpu.tar.bz2
win-64::arrow-cpp-6.0.2-py39h4d144f7_0_cuda.tar.bz2
win-64::vigra-1.11.1-py37hb0efd5f_1034.tar.bz2
win-64::libllvm11-11.1.0-h97333cc_4.tar.bz2
win-64::libprotobuf-static-3.21.6-h12be248_1.tar.bz2
win-64::aws-sdk-cpp-1.9.347-h11ce4dd_0.tar.bz2
win-64::ffmpeg-5.1.2-gpl_h952562b_101.tar.bz2
win-64::grpc-cpp-1.46.4-h535cfc9_7.tar.bz2
win-64::arrow-cpp-9.0.0-py310h1b77788_6_cpu.tar.bz2
win-64::imagecodecs-2022.9.26-py310hd89ffe8_0.tar.bz2
win-64::indexed_gzip-1.7.0-py39h91d645b_0.tar.bz2
win-64::arrow-cpp-7.0.1-py38hdb32e4e_4_cpu.tar.bz2
win-64::arrow-cpp-9.0.0-py37h6fc2b47_2_cuda.tar.bz2
win-64::imagecodecs-2022.9.26-py38h1fa618c_0.tar.bz2
win-64::grpc-cpp-1.47.1-h6a6baca_6.tar.bz2
win-64::grpc-cpp-1.48.1-h6a6baca_1.tar.bz2
win-64::python-igraph-0.10.0-py37hb0a9f92_1.tar.bz2
win-64::pyreadr-0.4.7-py39h67dc9e1_1.tar.bz2
win-64::arrow-cpp-6.0.2-py38h0b79ff7_2_cuda.tar.bz2
win-64::arrow-cpp-8.0.1-py310h0b333a9_2_cuda.tar.bz2
win-64::arrow-cpp-6.0.2-py310hd879a9b_0_cpu.tar.bz2
win-64::python-igraph-0.9.11-py37hb0a9f92_1.tar.bz2
win-64::mdtraj-1.9.7-py38he55de21_2.tar.bz2
win-64::openexr-python-1.3.9-py38h36b40ce_0.tar.bz2
win-64::scip-8.0.1-hcb59a98_3.tar.bz2
win-64::python-igraph-0.9.11-py310he5bc916_1.tar.bz2
win-64::llvmlite-0.39.1-py38hf225c54_0.tar.bz2
win-64::libadios2-2.8.3-nompi_h56ba99c_102.tar.bz2
win-64::arrow-cpp-7.0.1-py310h0b333a9_2_cuda.tar.bz2
win-64::libadios2-2.8.3-nompi_hfe5be7e_103.tar.bz2
win-64::pyreadr-0.4.7-py39h94cc256_0.tar.bz2
win-64::arrow-cpp-6.0.2-py37h3b7a501_1_cuda.tar.bz2
win-64::llvmdev-15.0.1-h0f93eaf_0.tar.bz2
win-64::ffmpeg-5.1.1-gpl_hae392d0_101.tar.bz2
win-64::openexr-python-1.3.9-py37h080556b_0.tar.bz2
win-64::arrow-cpp-7.0.1-py39h801dfc1_1_cuda.tar.bz2
win-64::clang-tools-15.0.1-default_h66ee7f4_0.tar.bz2
win-64::arrow-cpp-6.0.2-py37h1f7bf4a_1_cpu.tar.bz2
win-64::arrow-cpp-6.0.2-py37h278c8eb_3_cuda.tar.bz2
win-64::heyoka-llvm-14-0.19.0-h72d92e8_0.tar.bz2
win-64::arrow-cpp-7.0.1-py310h8c4d3c6_1_cuda.tar.bz2
win-64::arrow-cpp-8.0.1-py37h816ecd1_2_cuda.tar.bz2
win-64::arrow-cpp-6.0.2-py38h5d448c8_1_cuda.tar.bz2
win-64::imagecodecs-2022.8.8-py38hd43ff21_5.tar.bz2
win-64::papilo-2.1.0-h45feaf2_3.tar.bz2
win-64::ffmpeg-5.1.2-lgpl_h8516bce_1.tar.bz2
win-64::heyoka-llvm-12-0.19.0-h85ea0ae_0.tar.bz2
win-64::llvmdev-11.1.0-h97333cc_4.tar.bz2
win-64::libthrift-0.16.0-h9ce19ad_2.tar.bz2
win-64::ffmpeg-5.1.2-lgpl_h46f9d08_0.tar.bz2
win-64::arrow-cpp-6.0.2-py38hc4c34d4_0_cuda.tar.bz2
win-64::arrow-cpp-9.0.0-py310h1b77788_5_cpu.tar.bz2
win-64::arrow-cpp-7.0.1-py39h7eda9d8_3_cuda.tar.bz2
win-64::arrow-cpp-8.0.1-py39h4f3435e_2_cpu.tar.bz2
win-64::arrow-cpp-7.0.1-py39hfdc3d9d_2_cuda.tar.bz2
win-64::libprotobuf-3.20.1-h12be248_3.tar.bz2
win-64::python-igraph-0.10.0-py39h5126385_1.tar.bz2
win-64::topologytoolkit-1.1.0-no_paraview_py39hbca7f05_102.tar.bz2
win-64::python-igraph-0.10.0-py38h1cea2b0_1.tar.bz2
win-64::arrow-cpp-9.0.0-py39hfdc3d9d_3_cuda.tar.bz2
win-64::arrow-cpp-7.0.1-py38h0230ab1_0_cpu.tar.bz2
win-64::arrow-cpp-7.0.1-py310hdbaeaa9_4_cuda.tar.bz2
win-64::arrow-cpp-9.0.0-py39h801dfc1_2_cuda.tar.bz2
win-64::imagecodecs-2022.8.8-py310hccb694b_5.tar.bz2
win-64::ffmpeg-5.1.1-lgpl_h46f9d08_2.tar.bz2
win-64::arrow-cpp-9.0.0-py39hbca705c_2_cpu.tar.bz2
win-64::arrow-cpp-9.0.0-py37h84ffc76_2_cuda.tar.bz2
win-64::libadios2-2.8.3-nompi_h56ba99c_103.tar.bz2
win-64::arrow-cpp-9.0.0-py38h31dc3a2_5_cpu.tar.bz2
win-64::ffmpeg-5.1.1-lgpl_h46f9d08_1.tar.bz2
win-64::ffmpeg-5.1.1-gpl_h7b28927_101.tar.bz2
win-64::arrow-cpp-8.0.1-py310h8b1cf1d_2_cpu.tar.bz2
win-64::indexed_gzip-1.7.0-py37hdbb065d_0.tar.bz2
win-64::hugin-2021.0.0-pl5321hb188226_8.tar.bz2
win-64::topologytoolkit-1.1.0-no_paraview_py37hcac6cf9_102.tar.bz2
win-64::arrow-cpp-7.0.1-py310h91fd97e_1_cpu.tar.bz2
win-64::arrow-cpp-6.0.2-py39hb0db571_1_cpu.tar.bz2
win-64::arrow-cpp-7.0.1-py37hc2869ea_1_cuda.tar.bz2
win-64::poppler-qt-22.04.0-h1a342ee_3.tar.bz2
win-64::aws-sdk-cpp-1.9.341-h11ce4dd_1.tar.bz2
win-64::aws-sdk-cpp-1.9.352-hd0556ea_0.tar.bz2
win-64::arrow-cpp-7.0.1-py37h5e28a35_0_cpu.tar.bz2
win-64::mdtraj-1.9.7-py310h1431f1b_2.tar.bz2
win-64::aws-sdk-cpp-1.9.337-h918cd17_0.tar.bz2
win-64::arrow-cpp-6.0.2-py37hdb08782_0_cpu.tar.bz2
win-64::arrow-cpp-7.0.1-py38h43240b4_0_cpu.tar.bz2
win-64::netcdf4-1.6.1-nompi_py37he734059_100.tar.bz2
win-64::gst-plugins-base-1.20.3-h001b923_2.tar.bz2
win-64::aws-sdk-cpp-1.9.341-h918cd17_0.tar.bz2
win-64::arrow-cpp-7.0.1-py37h6fc2b47_0_cuda.tar.bz2
win-64::arrow-cpp-6.0.2-py37h4ee6a08_1_cpu.tar.bz2
win-64::libllvm15-15.0.0-h0f93eaf_0.tar.bz2
win-64::arrow-cpp-8.0.1-py39h7eda9d8_3_cuda.tar.bz2
win-64::arrow-cpp-8.0.1-py37hd64964d_4_cuda.tar.bz2
win-64::gemmi-0.5.7-py39hd28a505_0.tar.bz2
win-64::libadios2-2.8.3-nompi_h93b69a6_103.tar.bz2
win-64::libadios2-2.8.3-nompi_h765cd8b_103.tar.bz2
win-64::libadios2-2.8.3-nompi_ha224372_103.tar.bz2
win-64::arrow-cpp-8.0.1-py39hf2f6362_3_cpu.tar.bz2
win-64::arrow-cpp-7.0.1-py37h79b9725_0_cuda.tar.bz2
win-64::stir-5.0.0-py39hbe385c1_3.tar.bz2
win-64::arrow-cpp-9.0.0-py310he75ff44_2_cuda.tar.bz2
win-64::arrow-cpp-6.0.2-py37h72a222d_0_cuda.tar.bz2
win-64::pdal-2.4.3-hf82e275_2.tar.bz2
win-64::freecad-0.20.1-py38h96d28ce_3.tar.bz2
win-64::llvm-15.0.0-hdfaf34f_0.tar.bz2
win-64::libprotobuf-3.20.1-h12be248_4.tar.bz2
win-64::freecad-0.20.1-py310h73a2bbb_3.tar.bz2
win-64::aws-sdk-cpp-1.9.356-hd0556ea_0.tar.bz2
win-64::python-igraph-0.9.11-py38hc27c15b_1.tar.bz2
win-64::hugin-base-2021.0.0-pl5321hf425189_8.tar.bz2
win-64::arrow-cpp-9.0.0-py39h7eda9d8_5_cuda.tar.bz2
win-64::imagecodecs-2022.8.8-py38h295afe2_5.tar.bz2
win-64::openexr-python-1.3.9-py38ha4d679c_0.tar.bz2
win-64::arrow-cpp-7.0.1-py39hf2f6362_3_cpu.tar.bz2
win-64::python-igraph-0.10.0-py39h16ec61d_1.tar.bz2
win-64::vtk-9.1.0-qt_py38h88190dd_215.tar.bz2
win-64::arrow-cpp-7.0.1-py37h7affd69_1_cpu.tar.bz2
win-64::clang-15-15.0.1-default_h66ee7f4_0.tar.bz2
win-64::arrow-cpp-7.0.1-py310h1b77788_3_cpu.tar.bz2
win-64::libprotobuf-3.21.5-h12be248_1.tar.bz2
win-64::gst-plugins-good-1.20.3-h76f0265_2.tar.bz2
win-64::topologytoolkit-1.1.0-no_paraview_py38ha32672e_103.tar.bz2
win-64::libgdal-3.5.2-hec59f66_1.tar.bz2
win-64::python-igraph-0.10.0-py38hc27c15b_1.tar.bz2
win-64::poppler-22.04.0-hb57f792_3.tar.bz2
win-64::soplex-6.0.1-h949ae46_3.tar.bz2
win-64::libadios2-2.8.3-nompi_ha224372_102.tar.bz2
win-64::cpp-opentelemetry-sdk-1.6.1-hf905de0_0.tar.bz2
win-64::ffmpeg-4.4.2-gpl_h952562b_108.tar.bz2
win-64::libclang13-15.0.0-default_h77d9078_0.tar.bz2
win-64::arrow-cpp-8.0.1-py37h987c7fe_3_cpu.tar.bz2
win-64::openexr-python-1.3.9-py310h40e972c_0.tar.bz2
win-64::arrow-cpp-8.0.1-py38h71f67b3_2_cuda.tar.bz2
win-64::aws-sdk-cpp-1.9.339-h918cd17_0.tar.bz2
win-64::arrow-cpp-7.0.1-py310h1b77788_4_cpu.tar.bz2
win-64::grpcio-1.48.1-py39h44c9872_0.tar.bz2
win-64::arrow-cpp-7.0.1-py39ha71ea14_0_cpu.tar.bz2
win-64::scip-8.0.1-hcb59a98_2.tar.bz2
win-64::cairomm-1.0-1.14.4-h580b552_0.tar.bz2
win-64::aws-sdk-cpp-1.9.338-h918cd17_0.tar.bz2
win-64::clangdev-15.0.0-default_h66ee7f4_0.tar.bz2
win-64::arrow-cpp-8.0.1-py38hdb32e4e_4_cpu.tar.bz2
win-64::arrow-cpp-6.0.2-py310heb09d2a_1_cuda.tar.bz2
win-64::arrow-cpp-7.0.1-py38hd69dc15_2_cuda.tar.bz2
win-64::pyreadr-0.4.7-py37h5b38b69_0.tar.bz2
win-64::arrow-cpp-6.0.2-py38h2c93598_3_cuda.tar.bz2
win-64::clang-tools-15.0.0-default_h66ee7f4_0.tar.bz2
win-64::arrow-cpp-6.0.2-py39hadc7ede_0_cpu.tar.bz2
win-64::gemmi-0.5.7-py38h19421c1_0.tar.bz2
win-64::arrow-cpp-9.0.0-py38h43240b4_2_cpu.tar.bz2
win-64::arrow-cpp-7.0.1-py37h987c7fe_3_cpu.tar.bz2
win-64::arrow-cpp-6.0.2-py37h3331a67_3_cpu.tar.bz2
win-64::arrow-cpp-8.0.1-py38h191bde2_2_cuda.tar.bz2
win-64::grpc-cpp-1.48.1-h535cfc9_1.tar.bz2
win-64::arrow-cpp-6.0.2-py310h98f066d_2_cpu.tar.bz2
win-64::arrow-cpp-7.0.1-py310ha85c99b_1_cuda.tar.bz2
win-64::arrow-cpp-7.0.1-py38hbaa476a_3_cuda.tar.bz2
win-64::grpcio-1.48.1-py38hb6f5816_0.tar.bz2
win-64::arrow-cpp-9.0.0-py310h67a9327_3_cpu.tar.bz2
win-64::aws-sdk-cpp-1.9.346-h11ce4dd_0.tar.bz2
win-64::geotiff-1.7.1-h4ffd875_4.tar.bz2
win-64::arrow-cpp-7.0.1-py310hdbaeaa9_3_cuda.tar.bz2
win-64::libspatialite-5.0.1-hd560d62_21.tar.bz2
win-64::llvm-tools-15.0.0-h0f93eaf_0.tar.bz2
win-64::arrow-cpp-9.0.0-py310h12b6346_2_cpu.tar.bz2
win-64::aws-sdk-cpp-1.9.348-h11ce4dd_0.tar.bz2
win-64::heyoka-llvm-13-0.19.0-he4b25c2_0.tar.bz2
win-64::imagecodecs-2022.9.26-py39h061ca8a_0.tar.bz2
win-64::libprotobuf-static-3.21.5-h12be248_1.tar.bz2
win-64::grpcio-1.48.1-py39hb4a3aa5_0.tar.bz2
win-64::pyreadr-0.4.7-py39h94cc256_1.tar.bz2
win-64::arrow-cpp-8.0.1-py38hbaa476a_3_cuda.tar.bz2
win-64::arrow-cpp-6.0.2-py37he622585_0_cuda.tar.bz2
win-64::libgdal-3.5.2-hec59f66_0.tar.bz2
win-64::arrow-cpp-7.0.1-py37hd64964d_4_cuda.tar.bz2
win-64::cairomm-1.16-1.16.2-h580b552_0.tar.bz2
win-64::tesseract-5.2.0-h7e066c4_1.tar.bz2
win-64::arrow-cpp-8.0.1-py38h8a50e48_2_cpu.tar.bz2
win-64::arrow-cpp-9.0.0-py38h277a788_3_cpu.tar.bz2
win-64::libglib-2.74.0-h79619a9_0.tar.bz2
win-64::arrow-cpp-7.0.1-py38h8a50e48_1_cpu.tar.bz2
win-64::freecad-0.20.1-py39hf545f7d_3.tar.bz2
win-64::llvmlite-0.39.1-py38h19421c1_0.tar.bz2
win-64::arrow-cpp-7.0.1-py310h12b6346_0_cpu.tar.bz2
win-64::llvm-15.0.1-hdfaf34f_0.tar.bz2
win-64::pyreadstat-1.1.9-py39h8339787_1.tar.bz2
win-64::aws-sdk-cpp-1.9.344-h11ce4dd_0.tar.bz2
win-64::pyreadstat-1.1.9-py310h652ad62_1.tar.bz2
win-64::arrow-cpp-6.0.2-py38h64ddf51_0_cpu.tar.bz2
win-64::gemmi-0.5.7-py39h6848017_0.tar.bz2
win-64::mysql-connector-cpp-8.0.29-hec19d3c_2.tar.bz2
win-64::arrow-cpp-6.0.2-py39he41c1b8_2_cuda.tar.bz2
win-64::libprotobuf-static-3.21.5-h12be248_3.tar.bz2
win-64::arrow-cpp-6.0.2-py38h0d874f7_2_cpu.tar.bz2
win-64::thrift-compiler-0.16.0-h9f558f2_2.tar.bz2
win-64::arrow-cpp-6.0.2-py39h341223e_3_cpu.tar.bz2
win-64::dpcpp_impl_win-64-2022.1.0-hbc6686b_3787.tar.bz2
win-64::arrow-cpp-6.0.2-py310h904f7ee_0_cpu.tar.bz2
win-64::arrow-cpp-8.0.1-py38h277a788_2_cpu.tar.bz2
win-64::aws-sdk-cpp-1.9.349-haceebd4_1.tar.bz2
win-64::arrow-cpp-8.0.1-py37hd749cc5_4_cpu.tar.bz2
win-64::glib-tools-2.74.0-h12be248_0.tar.bz2
win-64::freecad-0.20.1-py37h44010d8_3.tar.bz2
win-64::imagecodecs-2022.9.26-py38h3a4a28a_0.tar.bz2
win-64::libspatialite-5.0.1-hd560d62_20.tar.bz2
win-64::stir-5.0.0-py37h5bfd4b6_3.tar.bz2
win-64::aws-sdk-cpp-1.9.353-hd0556ea_0.tar.bz2
win-64::arrow-cpp-7.0.1-py37h256b1c4_0_cpu.tar.bz2
win-64::arrow-cpp-9.0.0-py37h5e28a35_2_cpu.tar.bz2
-    "libzlib >=1.2.12,<1.3.0a0",
+    "libzlib >=1.2.12,<2.0.0a0",
win-64::clang-15.0.1-h8e541a6_0.tar.bz2
win-64::clangxx-15.0.0-default_h66ee7f4_0.tar.bz2
win-64::llvm-11.1.0-h6fda50d_4.tar.bz2
win-64::clang-15.0.0-h8e541a6_0.tar.bz2
win-64::clangxx-15.0.1-default_h66ee7f4_0.tar.bz2
-    "libzlib >=1.2.12,<1.3.0a0"
+    "libzlib >=1.2.12,<2.0.0a0"
================================================================================
================================================================================
osx-64
osx-64::perl-net-ssleay-1.92-pl5321hb044416_1.tar.bz2
osx-64::libgdal-3.5.2-hc4f63bd_1.tar.bz2
osx-64::grpcio-1.48.1-py39h28eb122_0.tar.bz2
osx-64::imagecodecs-2022.8.8-py39hf968fa7_5.tar.bz2
osx-64::ovito-3.7.9-h43721e1_0.tar.bz2
osx-64::tiledb-2.11.2-h3b7b576_0.tar.bz2
osx-64::arrow-cpp-9.0.0-py38h807d612_2_cpu.tar.bz2
osx-64::python-igraph-0.9.11-py39h9a34910_1.tar.bz2
osx-64::pyreadstat-1.1.9-py37h1c981f0_1.tar.bz2
osx-64::ffmpeg-5.1.2-gpl_h758784a_101.tar.bz2
osx-64::arrow-cpp-9.0.0-py310h0687de5_2_cpu.tar.bz2
osx-64::libssh-0.10.2-h2e8ab23_0.tar.bz2
osx-64::aws-sdk-cpp-1.9.339-h7290728_0.tar.bz2
osx-64::arrow-cpp-6.0.2-py310h8d534b9_1_cpu.tar.bz2
osx-64::ffmpeg-5.1.2-gpl_h0fedfe4_100.tar.bz2
osx-64::llvmlite-0.39.1-py39had167e2_0.tar.bz2
osx-64::nodejs-14.20.0-h831259e_0.tar.bz2
osx-64::libadios2-2.8.3-nompi_h9c49b36_103.tar.bz2
osx-64::pyranha-0.11-py37h2325117_4.tar.bz2
osx-64::aws-sdk-cpp-1.9.351-h7440459_0.tar.bz2
osx-64::pdal-2.4.3-h4c19838_2.tar.bz2
osx-64::arrow-cpp-7.0.1-py39h920f9f4_4_cpu.tar.bz2
osx-64::aws-sdk-cpp-1.9.350-h4fcdf8c_0.tar.bz2
osx-64::coin-or-cgl-0.60.6-ha3c4b8c_2.tar.bz2
osx-64::triqs-3.1.1-py310hd72afe4_2.tar.bz2
osx-64::assimp-5.2.5-hd9e13b6_0.tar.bz2
osx-64::python-igraph-0.10.0-py39h0bfd786_1.tar.bz2
osx-64::pyreadr-0.4.7-py38h63175c7_1.tar.bz2
osx-64::arrow-cpp-9.0.0-py39h963c739_2_cpu.tar.bz2
osx-64::topologytoolkit-1.1.0-no_paraview_py37hf32cbc1_103.tar.bz2
osx-64::poppler-22.04.0-h9d9b264_3.tar.bz2
osx-64::python-igraph-0.9.11-py37h7aa6e88_1.tar.bz2
osx-64::nd2-0.4.3-py38he07af3e_0.tar.bz2
osx-64::arrow-cpp-6.0.2-py310hde3cff3_0_cpu.tar.bz2
osx-64::libadios2-2.8.3-mpi_mpich_h3746c7b_2.tar.bz2
osx-64::llvmlite-0.39.1-py310h2bfb868_0.tar.bz2
osx-64::python-igraph-0.9.11-py39h0bfd786_1.tar.bz2
osx-64::vowpalwabbit-9.3.0-py38h59b6f81_2.tar.bz2
osx-64::triqs-3.1.1-py38hbb3fb4a_2.tar.bz2
osx-64::paraview-5.10.1-py39h394e749_108_qt.tar.bz2
osx-64::gfal2-2.21.1-hb0ea081_0.tar.bz2
osx-64::topologytoolkit-1.1.0-no_paraview_py39h92f88d8_103.tar.bz2
osx-64::aws-sdk-cpp-1.9.348-he3588ee_0.tar.bz2
osx-64::netcdf4-1.6.1-mpi_openmpi_py37h9612ec2_0.tar.bz2
osx-64::lammps-2022.06.23-py310h274bf63_openmpi_2.tar.bz2
osx-64::arrow-cpp-7.0.1-py310h82205a3_1_cpu.tar.bz2
osx-64::ndcctools-7.4.14-py37hd9b0a61_0.tar.bz2
osx-64::jaxlib-0.3.15-cpu_py37h08c1716_4.tar.bz2
osx-64::jaxlib-0.3.15-cpu_py310hfe4bcb0_4.tar.bz2
osx-64::julia-1.8.0-hcb9ed81_3.tar.bz2
osx-64::pyreadr-0.4.7-py310h57dfd58_0.tar.bz2
osx-64::arrow-cpp-6.0.2-py310h32fa541_1_cpu.tar.bz2
osx-64::openexr-python-1.3.9-py39h7700608_0.tar.bz2
osx-64::pyreadr-0.4.7-py37hff8f8a3_0.tar.bz2
osx-64::libadios2-2.8.3-mpi_openmpi_heeb1211_3.tar.bz2
osx-64::giac-1.6.0.47-h6520c23_6.tar.bz2
osx-64::arrow-cpp-9.0.0-py310hdd8b2e5_2_cpu.tar.bz2
osx-64::octave-7.2.0-hf171fd9_5.tar.bz2
osx-64::arrow-cpp-9.0.0-py37h8ed0cd0_2_cpu.tar.bz2
osx-64::libtensorflow-2.10.0-cpu_h184dcb9_0.tar.bz2
osx-64::openexr-python-1.3.9-py37hbbf1df3_0.tar.bz2
osx-64::nodejs-18.9.1-h3591b89_0.tar.bz2
osx-64::nodejs-18.10.0-hd0c9b3c_0.tar.bz2
osx-64::smesh-9.9.0.0-he8082b2_0.tar.bz2
osx-64::osmium-tool-1.14.0-h3615b42_2.tar.bz2
osx-64::tensorflow-base-2.10.0-cpu_py37he4de7cd_0.tar.bz2
osx-64::grpcio-1.48.1-py38h1f0026d_0.tar.bz2
osx-64::grpc-cpp-1.46.4-h6579160_7.tar.bz2
osx-64::arrow-cpp-6.0.2-py38h24693e7_1_cpu.tar.bz2
osx-64::arrow-cpp-9.0.0-py38ha2c5550_4_cpu.tar.bz2
osx-64::triqs-3.1.1-py39h8ec010a_2.tar.bz2
osx-64::ndcctools-7.4.14-py39h1930336_0.tar.bz2
osx-64::libssh-0.10.1-h0108ac9_0.tar.bz2
osx-64::triqs-3.1.1-py37h99c35c1_2.tar.bz2
osx-64::vigra-1.11.1-py310h8d69f5c_1034.tar.bz2
osx-64::libthrift-0.16.0-h16802d8_2.tar.bz2
osx-64::nd2-0.4.3-py310h9c878d8_0.tar.bz2
osx-64::mandrake-1.2.2-py39h53d26a0_1.tar.bz2
osx-64::lammps-2022.06.23-py37h3cd0ab9_mpich_2.tar.bz2
osx-64::arrow-cpp-8.0.1-py310ha01b9ba_2_cpu.tar.bz2
osx-64::arrow-cpp-9.0.0-py310ha01b9ba_3_cpu.tar.bz2
osx-64::grpc-cpp-1.46.4-h966d1d5_7.tar.bz2
osx-64::arrow-cpp-7.0.1-py39hf9ad3a7_1_cpu.tar.bz2
osx-64::ndcctools-7.4.14-py39h7639174_0.tar.bz2
osx-64::arrow-cpp-7.0.1-py39h4e64083_3_cpu.tar.bz2
osx-64::pyreadr-0.4.7-py310h57dfd58_1.tar.bz2
osx-64::libadios2-2.8.3-mpi_mpich_h0e44d21_2.tar.bz2
osx-64::gazebo-11.11.0-h13453b0_13.tar.bz2
osx-64::libgdal-3.5.2-hc4f63bd_3.tar.bz2
osx-64::libadios2-2.8.3-nompi_hf3d07b1_103.tar.bz2
osx-64::protozfits-2.0.1.post1-py310h3e9fe93_9.tar.bz2
osx-64::nodejs-16.17.1-h3591b89_0.tar.bz2
osx-64::grpc-cpp-1.47.1-h966d1d5_6.tar.bz2
osx-64::aws-sdk-cpp-1.9.356-h7440459_0.tar.bz2
osx-64::arrow-cpp-6.0.2-py39hc6d4fec_1_cpu.tar.bz2
osx-64::assimp-5.2.4-hd9e13b6_1.tar.bz2
osx-64::lammps-2022.06.23-py37h33d2287_mpich_2.tar.bz2
osx-64::collada-dom-2.5.0-hd40f4c9_5.tar.bz2
osx-64::gsoap-2.8.123-h9d8cd7f_0.tar.bz2
osx-64::arrow-cpp-8.0.1-py310h82205a3_2_cpu.tar.bz2
osx-64::arrow-cpp-6.0.2-py37ha60e86b_0_cpu.tar.bz2
osx-64::soplex-6.0.1-h63f1887_3.tar.bz2
osx-64::libadios2-2.8.3-nompi_he3068f2_103.tar.bz2
osx-64::libadios2-2.8.3-nompi_he29e64f_103.tar.bz2
osx-64::triqs-3.1.1-py38h612ca9b_2.tar.bz2
osx-64::pyreadr-0.4.7-py37hff8f8a3_1.tar.bz2
osx-64::libadios2-2.8.3-mpi_openmpi_h1e48a16_2.tar.bz2
osx-64::libgdal-3.5.2-hc4f63bd_0.tar.bz2
osx-64::llvmlite-0.39.1-py39h3d6f5fc_0.tar.bz2
osx-64::arrow-cpp-7.0.1-py310h14c5125_0_cpu.tar.bz2
osx-64::hugin-base-2021.0.0-pl5321h7acfc35_8.tar.bz2
osx-64::arrow-cpp-7.0.1-py37h215398f_0_cpu.tar.bz2
osx-64::gazebo-11.12.0-h06cf0cd_0.tar.bz2
osx-64::llvmlite-0.39.1-py37h5d31d3a_0.tar.bz2
osx-64::netcdf4-1.6.1-mpi_openmpi_py38hfce56bd_0.tar.bz2
osx-64::libadios2-2.8.3-mpi_mpich_h8202dcb_2.tar.bz2
osx-64::ffmpeg-4.4.2-gpl_h758784a_108.tar.bz2
osx-64::pyreadstat-1.1.9-py310haafd797_1.tar.bz2
osx-64::aws-sdk-cpp-1.9.341-h7290728_0.tar.bz2
osx-64::fenics-libdolfin-2019.1.0-h117ead5_32.tar.bz2
osx-64::cppyy-cling-6.27.0-py310h71e7e49_1.tar.bz2
osx-64::arrow-cpp-7.0.1-py310hdd8b2e5_0_cpu.tar.bz2
osx-64::gazebo-11.12.0-hd983bee_0.tar.bz2
osx-64::libnetcdf-4.9.0-nompi_hebd45d5_100.tar.bz2
osx-64::arrow-cpp-8.0.1-py38h4dba66e_4_cpu.tar.bz2
osx-64::imagemagick-7.1.0_48-pl5321h90cda06_0.tar.bz2
osx-64::ndcctools-7.4.14-py38h08c6ce4_1.tar.bz2
osx-64::cppyy-cling-6.27.0-py38hd73a368_1.tar.bz2
osx-64::magics-metview-4.12.1-h9478ef2_1.tar.bz2
osx-64::libadios2-2.8.3-mpi_mpich_h09fd569_2.tar.bz2
osx-64::arrow-cpp-8.0.1-py39h920f9f4_4_cpu.tar.bz2
osx-64::arrow-cpp-7.0.1-py39h963c739_0_cpu.tar.bz2
osx-64::nd2-0.4.3-py39hc7862f6_0.tar.bz2
osx-64::triqs-3.1.1-py310h8bec689_2.tar.bz2
osx-64::libadios2-2.8.3-nompi_hf3d07b1_102.tar.bz2
osx-64::arrow-cpp-9.0.0-py37hb4f9682_3_cpu.tar.bz2
osx-64::vowpalwabbit-9.3.0-py37h5a891d2_2.tar.bz2
osx-64::libadios2-2.8.3-nompi_hea05c40_103.tar.bz2
osx-64::pyranha-0.11-py39hf8dff67_4.tar.bz2
osx-64::netcdf4-1.6.1-mpi_mpich_py38h022767a_0.tar.bz2
osx-64::openmpi-4.1.4-h4fe9131_101.tar.bz2
osx-64::netcdf4-1.6.1-nompi_py37h6cbace0_100.tar.bz2
osx-64::nd2-0.4.3-py39h076a754_0.tar.bz2
osx-64::rstudio-desktop-2022.07.1-r40h911b70e_554.tar.bz2
osx-64::rstudio-desktop-2022.07.1-r41h911b70e_554.tar.bz2
osx-64::grpc-cpp-1.48.1-h966d1d5_1.tar.bz2
osx-64::libadios2-2.8.3-mpi_openmpi_had2e348_2.tar.bz2
osx-64::arrow-cpp-6.0.2-py37h6449483_1_cpu.tar.bz2
osx-64::libitk-5.2.1-h10ab89a_6.tar.bz2
osx-64::imagecodecs-2022.8.8-py310h12e12fc_5.tar.bz2
osx-64::paraview-5.10.1-py38h29ea723_108_qt.tar.bz2
osx-64::protozfits-2.0.1.post1-py37hb5ddcc8_9.tar.bz2
osx-64::arrow-cpp-7.0.1-py37hce22cc2_0_cpu.tar.bz2
osx-64::mysql-connector-cpp-8.0.29-hc77c790_2.tar.bz2
osx-64::arrow-cpp-8.0.1-py37hc8c15f5_2_cpu.tar.bz2
osx-64::arrow-cpp-7.0.1-py39hf10b16c_2_cpu.tar.bz2
osx-64::libadios2-2.8.3-mpi_mpich_h09fd569_3.tar.bz2
osx-64::libnetcdf-4.9.0-mpi_mpich_h637882e_0.tar.bz2
osx-64::orc-1.8.0-ha9d861c_0.tar.bz2
osx-64::freecad-0.20.1-py38h08c05bb_3.tar.bz2
osx-64::aws-sdk-cpp-1.9.342-he3588ee_0.tar.bz2
osx-64::freecad-0.20.1-py310h04f1c1d_3.tar.bz2
osx-64::arrow-cpp-7.0.1-py37hb4f9682_2_cpu.tar.bz2
osx-64::vigra-1.11.1-py39hc92ba99_1034.tar.bz2
osx-64::nest-simulator-3.3-py38h314c1af_2.tar.bz2
osx-64::arrow-cpp-6.0.2-py310h9bdcb5e_0_cpu.tar.bz2
osx-64::arrow-cpp-9.0.0-py38h0f3aa89_2_cpu.tar.bz2
osx-64::gdk-pixbuf-2.42.8-h3648f77_1.tar.bz2
osx-64::netcdf4-1.6.1-nompi_py38hbdcf7ac_100.tar.bz2
osx-64::topologytoolkit-1.1.0-with_paraview_py310h2eaa296_2.tar.bz2
osx-64::nd2-0.4.3-py38hd1eed9b_0.tar.bz2
osx-64::jaxlib-0.3.20-cpu_py38h177ad0c_0.tar.bz2
osx-64::aws-sdk-cpp-1.9.338-h7290728_0.tar.bz2
osx-64::emacs-28.2-hc02544d_0.tar.bz2
osx-64::libadios2-2.8.3-mpi_openmpi_h45e0e9c_2.tar.bz2
osx-64::pyreadr-0.4.7-py39hf146cf2_1.tar.bz2
osx-64::netcdf4-1.6.1-nompi_py39h0d363ce_100.tar.bz2
osx-64::arrow-cpp-9.0.0-py39hf10b16c_3_cpu.tar.bz2
osx-64::pdal-2.4.3-h7e29d30_2.tar.bz2
osx-64::mandrake-1.2.2-py310heea2105_1.tar.bz2
osx-64::jaxlib-0.3.20-cpu_py310hc4ef77f_0.tar.bz2
osx-64::imagecodecs-2022.9.26-py310h8361cd4_0.tar.bz2
osx-64::nd2-0.4.3-py37h3555b31_0.tar.bz2
osx-64::arrow-cpp-9.0.0-py37hce22cc2_2_cpu.tar.bz2
osx-64::aws-sdk-cpp-1.9.349-he3588ee_0.tar.bz2
osx-64::arrow-cpp-6.0.2-py38h863f25a_3_cpu.tar.bz2
osx-64::arrow-cpp-8.0.1-py37hb4f9682_2_cpu.tar.bz2
osx-64::netcdf4-1.6.1-mpi_openmpi_py39h0377a20_0.tar.bz2
osx-64::rsync-3.2.6-ha1fed10_0.tar.bz2
osx-64::arrow-cpp-7.0.1-py310ha4e8f7c_4_cpu.tar.bz2
osx-64::arrow-cpp-7.0.1-py38h121cdac_2_cpu.tar.bz2
osx-64::libssh-0.10.1-h2e8ab23_0.tar.bz2
osx-64::llvm-15.0.1-hf86d651_0.tar.bz2
osx-64::cpp-opentelemetry-sdk-1.6.0-h299a416_1.tar.bz2
osx-64::libadios2-2.8.3-nompi_he3068f2_102.tar.bz2
osx-64::llvmlite-0.39.1-py38hc86dbf9_0.tar.bz2
osx-64::libllvm15-15.0.0-hb04caa8_0.tar.bz2
osx-64::python-igraph-0.10.0-py310h3f43f70_1.tar.bz2
osx-64::vtk-9.1.0-qt_py310h696756a_215.tar.bz2
osx-64::arrow-cpp-7.0.1-py39h3778106_1_cpu.tar.bz2
osx-64::nodejs-18.10.0-h3591b89_0.tar.bz2
osx-64::mdtraj-1.9.7-py39h5179a43_2.tar.bz2
osx-64::libtiff-4.4.0-hdb44e8a_4.tar.bz2
osx-64::arrow-cpp-6.0.2-py310h3dbccbf_2_cpu.tar.bz2
osx-64::python-igraph-0.10.0-py37h7aa6e88_1.tar.bz2
osx-64::aws-sdk-cpp-1.9.344-he3588ee_0.tar.bz2
osx-64::pyreadr-0.4.7-py39hf146cf2_0.tar.bz2
osx-64::mosh-1.3.2-pl5321he1daeac_1013.tar.bz2
osx-64::julia-1.8.1-hcb9ed81_0.tar.bz2
osx-64::netpbm-10.73.41-pl5321h74bfa32_0.tar.bz2
osx-64::grpc-cpp-1.48.1-h7df5b86_1.tar.bz2
osx-64::arrow-cpp-6.0.2-py39h8c67ad0_0_cpu.tar.bz2
osx-64::arrow-cpp-6.0.2-py39h66c3fa3_3_cpu.tar.bz2
osx-64::arrow-cpp-8.0.1-py39hf10b16c_2_cpu.tar.bz2
osx-64::subversion-1.14.2-pl5321hcea2a8b_2.tar.bz2
osx-64::ffmpeg-5.1.1-gpl_h5a1d76f_101.tar.bz2
osx-64::octave-7.2.0-h2800aca_2.tar.bz2
osx-64::arrow-cpp-6.0.2-py39he5ddf47_0_cpu.tar.bz2
osx-64::vigra-1.11.1-py38h1291863_1034.tar.bz2
osx-64::cpp-opentelemetry-sdk-1.6.0-h84c7b26_1.tar.bz2
osx-64::libllvm15-15.0.1-hb04caa8_0.tar.bz2
osx-64::arrow-cpp-7.0.1-py37hf93e634_4_cpu.tar.bz2
osx-64::libssh-0.10.4-h9e676c0_2.tar.bz2
osx-64::magics-4.12.1-h87efd57_1.tar.bz2
osx-64::gemmi-0.5.7-py39had167e2_0.tar.bz2
osx-64::julia-1.8.0-hcb9ed81_2.tar.bz2
osx-64::imagecodecs-2022.8.8-py39h0ee32b2_5.tar.bz2
osx-64::libadios2-2.8.3-mpi_openmpi_h45e0e9c_3.tar.bz2
osx-64::ffmpeg-4.4.2-lgpl_he907128_8.tar.bz2
osx-64::piranha-0.11-hee75850_1006.tar.bz2
osx-64::nodejs-16.16.0-hd0c9b3c_0.tar.bz2
osx-64::grpc-cpp-1.47.1-h834a566_6.tar.bz2
osx-64::liblal-7.2.2-mkl_h4a7761d_0.tar.bz2
osx-64::poppler-qt-22.04.0-h6a55204_3.tar.bz2
osx-64::arrow-cpp-9.0.0-py310ha4e8f7c_6_cpu.tar.bz2
osx-64::nodejs-14.19.3-h831259e_0.tar.bz2
osx-64::triqs-3.1.1-py39he7d28a4_2.tar.bz2
osx-64::imagecodecs-2022.8.8-py38hd1ac00e_5.tar.bz2
osx-64::lammps-2022.06.23-py39hda37b2d_mpich_2.tar.bz2
osx-64::arrow-cpp-9.0.0-py39h920f9f4_6_cpu.tar.bz2
osx-64::libspatialite-5.0.1-h778c766_21.tar.bz2
osx-64::python-igraph-0.10.0-py39h9a34910_1.tar.bz2
osx-64::arrow-cpp-9.0.0-py37h2d69998_4_cpu.tar.bz2
osx-64::libadios2-2.8.3-mpi_openmpi_h0a8b3f2_3.tar.bz2
osx-64::arrow-cpp-8.0.1-py37hf93e634_4_cpu.tar.bz2
osx-64::libadios2-2.8.3-mpi_openmpi_had2e348_3.tar.bz2
osx-64::lammps-2022.06.23-py37hf9414d1_openmpi_2.tar.bz2
osx-64::grpcio-1.48.1-py37h8ab485f_0.tar.bz2
osx-64::arrow-cpp-7.0.1-py38h807d612_1_cpu.tar.bz2
osx-64::ndcctools-7.4.14-py37h1ae3026_1.tar.bz2
osx-64::fenics-libdolfin-2019.1.0-h2bb9e8c_32.tar.bz2
osx-64::netcdf4-1.6.1-mpi_openmpi_py310h8178e25_0.tar.bz2
osx-64::tensorflow-base-2.10.0-cpu_py310h23d3fc9_0.tar.bz2
osx-64::topologytoolkit-1.1.0-no_paraview_py38hf10fcc3_102.tar.bz2
osx-64::arrow-cpp-6.0.2-py39h1d45b55_1_cpu.tar.bz2
osx-64::pyreadr-0.4.7-py38h63175c7_0.tar.bz2
osx-64::netcdf4-1.6.1-nompi_py310h6892ea4_100.tar.bz2
osx-64::arrow-cpp-8.0.1-py310h3c71577_3_cpu.tar.bz2
osx-64::ffmpeg-5.1.1-lgpl_h13201bc_1.tar.bz2
osx-64::jaxlib-0.3.15-cpu_py38h84efa26_4.tar.bz2
osx-64::ndcctools-7.4.14-py310h9c28b6c_0.tar.bz2
osx-64::gazebo-11.11.0-h3b5dc14_13.tar.bz2
osx-64::llvmdev-15.0.0-hb04caa8_0.tar.bz2
osx-64::jaxlib-0.3.20-cpu_py39hc031c27_0.tar.bz2
osx-64::libadios2-2.8.3-mpi_openmpi_h6b36135_2.tar.bz2
osx-64::llvmdev-15.0.1-hb04caa8_0.tar.bz2
osx-64::libadios2-2.8.3-mpi_mpich_h3746c7b_3.tar.bz2
osx-64::arrow-cpp-8.0.1-py37h2d69998_3_cpu.tar.bz2
osx-64::aws-sdk-cpp-1.9.353-h7440459_0.tar.bz2
osx-64::vigra-1.11.1-py38he5c83ed_1033.tar.bz2
osx-64::jaxlib-0.3.20-cpu_py39hc2d11b0_0.tar.bz2
osx-64::arrow-cpp-9.0.0-py38h121cdac_3_cpu.tar.bz2
osx-64::vigra-1.11.1-py37hcb56aa6_1033.tar.bz2
osx-64::tensorflow-base-2.10.0-cpu_py38h13e9d53_0.tar.bz2
osx-64::libssh-0.10.4-h0108ac9_0.tar.bz2
osx-64::thrift-compiler-0.16.0-h16802d8_2.tar.bz2
osx-64::topologytoolkit-1.1.0-with_paraview_py38h83f5df1_2.tar.bz2
osx-64::gemmi-0.5.7-py38hc86dbf9_0.tar.bz2
osx-64::octave-7.2.0-h41d233e_3.tar.bz2
osx-64::cppyy-cling-6.27.0-py39h0bb4e67_1.tar.bz2
osx-64::lammps-2022.06.23-py310h33d413e_mpich_2.tar.bz2
osx-64::mdtraj-1.9.7-py37h15d50fc_2.tar.bz2
osx-64::arrow-cpp-7.0.1-py38h14e59c2_1_cpu.tar.bz2
osx-64::arrow-cpp-9.0.0-py37h2d69998_5_cpu.tar.bz2
osx-64::arrow-cpp-7.0.1-py37hc8c15f5_1_cpu.tar.bz2
osx-64::perl-io-gzip-0.20-pl5321ha978bb4_0.tar.bz2
osx-64::imagecodecs-2022.9.26-py39h6ab02ec_0.tar.bz2
osx-64::grpcio-1.48.1-py310hb97b743_0.tar.bz2
osx-64::libssh-0.10.4-h2e8ab23_0.tar.bz2
osx-64::arrow-cpp-9.0.0-py39h4e64083_4_cpu.tar.bz2
osx-64::arrow-cpp-9.0.0-py38ha2c5550_5_cpu.tar.bz2
osx-64::jaxlib-0.3.15-cpu_py39hc031c27_4.tar.bz2
osx-64::sagelib-9.6-py37h3bc8bf5_3.tar.bz2
osx-64::grpc-cpp-1.48.1-h966d1d5_0.tar.bz2
osx-64::pyreadr-0.4.7-py38h0c3b4fe_0.tar.bz2
osx-64::arrow-cpp-7.0.1-py37h8ed0cd0_1_cpu.tar.bz2
osx-64::aws-sdk-cpp-1.9.350-h7440459_1.tar.bz2
osx-64::qt-main-5.15.6-he04cef1_0.tar.bz2
osx-64::ffmpeg-5.1.1-lgpl_he907128_1.tar.bz2
osx-64::lammps-2022.06.23-py39h97f36c9_openmpi_2.tar.bz2
osx-64::scip-8.0.1-hc8e8bba_3.tar.bz2
osx-64::gazebo-11.11.0-ha646a65_12.tar.bz2
osx-64::arrow-cpp-9.0.0-py310h3c71577_4_cpu.tar.bz2
osx-64::grpc-cpp-1.48.1-h6579160_1.tar.bz2
osx-64::llvmdev-11.1.0-h8fb7429_4.tar.bz2
osx-64::protozfits-2.0.1.post1-py38ha0b87c3_9.tar.bz2
osx-64::libgdal-3.5.2-hcf5fda6_3.tar.bz2
osx-64::llvmlite-0.39.1-py38h8c0d2ee_0.tar.bz2
osx-64::gazebo-11.11.0-h06cf0cd_14.tar.bz2
osx-64::arrow-cpp-6.0.2-py37h61d57d7_3_cpu.tar.bz2
osx-64::pyreadstat-1.1.9-py39h4603615_1.tar.bz2
osx-64::topologytoolkit-1.1.0-with_paraview_py38h7887525_3.tar.bz2
osx-64::grpc-cpp-1.48.1-h834a566_0.tar.bz2
osx-64::aws-sdk-cpp-1.9.352-h7440459_0.tar.bz2
osx-64::grpcio-1.48.1-py310hf87e1f3_0.tar.bz2
osx-64::arrow-cpp-9.0.0-py310h82205a3_2_cpu.tar.bz2
osx-64::libadios2-2.8.3-mpi_openmpi_h1e48a16_3.tar.bz2
osx-64::arrow-cpp-7.0.1-py38h0f3aa89_0_cpu.tar.bz2
osx-64::gazebo-11.11.0-h925ee93_12.tar.bz2
osx-64::vowpalwabbit-9.3.0-py310h630de0f_2.tar.bz2
osx-64::gemmi-0.5.7-py37h5d31d3a_0.tar.bz2
osx-64::tesseract-5.2.0-he1d5b4e_1.tar.bz2
osx-64::arrow-cpp-8.0.1-py39h3778106_2_cpu.tar.bz2
osx-64::perl-net-ssleay-1.92-pl5321hb044416_0.tar.bz2
osx-64::jaxlib-0.3.20-cpu_py310hfe4bcb0_0.tar.bz2
osx-64::libthrift-0.16.0-h08c06f4_2.tar.bz2
osx-64::grpc-cpp-1.46.4-h7df5b86_7.tar.bz2
osx-64::python-igraph-0.9.11-py38h5d3fc92_1.tar.bz2
osx-64::arrow-cpp-8.0.1-py38h14e59c2_2_cpu.tar.bz2
osx-64::arrow-cpp-9.0.0-py39h000cadc_2_cpu.tar.bz2
osx-64::openexr-python-1.3.9-py310hbfc34f8_0.tar.bz2
osx-64::wxwidgets-3.2.0-h80aa064_2.tar.bz2
osx-64::python-igraph-0.10.0-py38hc833c9c_1.tar.bz2
osx-64::grpc-cpp-1.46.4-h834a566_7.tar.bz2
osx-64::arrow-cpp-7.0.1-py310h0687de5_1_cpu.tar.bz2
osx-64::imagecodecs-2022.9.26-py38hf51cfe3_0.tar.bz2
osx-64::cairomm-1.16-1.16.2-h5b44118_0.tar.bz2
osx-64::ffmpeg-5.1.2-lgpl_he907128_0.tar.bz2
osx-64::ndcctools-7.4.14-py37hd9b0a61_1.tar.bz2
osx-64::libgdal-3.5.2-hcf5fda6_1.tar.bz2
osx-64::libssh-0.10.2-h0108ac9_0.tar.bz2
osx-64::grpc-cpp-1.47.1-h6579160_6.tar.bz2
osx-64::indexed_gzip-1.7.0-py39h5b66f39_0.tar.bz2
osx-64::libadios2-2.8.3-mpi_mpich_h8202dcb_3.tar.bz2
osx-64::freecad-0.20.1-py37hb60f4f5_3.tar.bz2
osx-64::arrow-cpp-7.0.1-py37h2d69998_3_cpu.tar.bz2
osx-64::netcdf4-1.6.1-mpi_mpich_py37h01260b0_0.tar.bz2
osx-64::gap-core-4.11.1-hc16eb5f_4.tar.bz2
osx-64::ffmpeg-4.4.2-lgpl_h4db8a5e_8.tar.bz2
osx-64::indexed_gzip-1.7.0-py38h91b5f70_0.tar.bz2
osx-64::arrow-cpp-6.0.2-py38h38b9900_2_cpu.tar.bz2
osx-64::openexr-python-1.3.9-py38h2dc3a58_0.tar.bz2
osx-64::nest-simulator-3.3-py310h56eb99a_2.tar.bz2
osx-64::ffmpeg-5.1.1-gpl_h0fedfe4_102.tar.bz2
osx-64::grpc-cpp-1.47.1-h7df5b86_6.tar.bz2
osx-64::aws-sdk-cpp-1.9.345-he3588ee_0.tar.bz2
osx-64::vigra-1.11.1-py37h1f001bc_1034.tar.bz2
osx-64::arrow-cpp-7.0.1-py39h000cadc_0_cpu.tar.bz2
osx-64::arrow-cpp-9.0.0-py38h4dba66e_6_cpu.tar.bz2
osx-64::nodejs-18.9.1-hd0c9b3c_0.tar.bz2
osx-64::jaxlib-0.3.15-cpu_py37hf12bf50_4.tar.bz2
osx-64::llvm-tools-15.0.1-hb04caa8_0.tar.bz2
osx-64::sqlite-3.39.3-h9ae0607_0.tar.bz2
osx-64::assimp-5.2.4-hd9e13b6_2.tar.bz2
osx-64::pyreadr-0.4.7-py38h0c3b4fe_1.tar.bz2
osx-64::ndcctools-7.4.14-py39h1930336_1.tar.bz2
osx-64::cmake-3.24.2-h5291bba_0.tar.bz2
osx-64::ndcctools-7.4.14-py310h15278f1_1.tar.bz2
osx-64::lammps-2022.06.23-py37hce628c2_openmpi_2.tar.bz2
osx-64::pyranha-0.11-py38hb22c48b_4.tar.bz2
osx-64::geotiff-1.7.1-he29fd1c_4.tar.bz2
osx-64::imagecodecs-2022.9.26-py39h2af7347_0.tar.bz2
osx-64::arrow-cpp-9.0.0-py39hf9ad3a7_2_cpu.tar.bz2
osx-64::libxml2-2.10.2-hba50db4_1.tar.bz2
osx-64::aws-sdk-cpp-1.9.337-h7290728_0.tar.bz2
osx-64::gemmi-0.5.7-py39h3d6f5fc_0.tar.bz2
osx-64::topologytoolkit-1.1.0-no_paraview_py38h4d87369_103.tar.bz2
osx-64::ndcctools-7.4.14-py310h15278f1_0.tar.bz2
osx-64::cpp-opentelemetry-sdk-1.6.1-h84c7b26_0.tar.bz2
osx-64::libnetcdf-4.9.0-mpi_openmpi_h142d788_0.tar.bz2
osx-64::openexr-python-1.3.9-py39h2346711_0.tar.bz2
osx-64::ffmpeg-5.1.2-lgpl_h4db8a5e_1.tar.bz2
osx-64::nest-simulator-3.3-py39hce61b93_2.tar.bz2
osx-64::papilo-2.1.0-h9a2366d_3.tar.bz2
osx-64::topologytoolkit-1.1.0-with_paraview_py39he21f6c4_2.tar.bz2
osx-64::jaxlib-0.3.15-cpu_py38h177ad0c_4.tar.bz2
osx-64::cppyy-cling-6.27.0-py39h78a5168_1.tar.bz2
osx-64::aws-sdk-cpp-1.9.347-he3588ee_0.tar.bz2
osx-64::nodejs-16.15.1-hd0c9b3c_0.tar.bz2
osx-64::smesh-9.9.0.0-h64faaed_1.tar.bz2
osx-64::perl-net-ssleay-1.92-pl5321h278ddf8_1.tar.bz2
osx-64::arrow-cpp-8.0.1-py310ha4e8f7c_4_cpu.tar.bz2
osx-64::libadios2-2.8.3-nompi_h94981c0_102.tar.bz2
osx-64::cairomm-1.0-1.14.4-h5b44118_0.tar.bz2
osx-64::openexr-python-1.3.9-py38h0400146_0.tar.bz2
osx-64::ndcctools-7.4.14-py37h1ae3026_0.tar.bz2
osx-64::papilo-2.1.0-h3533137_2.tar.bz2
osx-64::tomviz-2.0.0rc1.post9-py37h144ca29_0.tar.bz2
osx-64::magics-metview-batch-4.12.1-h87efd57_1.tar.bz2
osx-64::glib-2.74.0-hbc0c0cd_0.tar.bz2
osx-64::triqs-3.1.1-py37h097ca3f_2.tar.bz2
osx-64::sagelib-9.6-py310hbdee453_3.tar.bz2
osx-64::wxwidgets-3.2.1-hde9b9c7_0.tar.bz2
osx-64::arrow-cpp-9.0.0-py310h3c71577_5_cpu.tar.bz2
osx-64::libitk-5.2.1-hc003921_5.tar.bz2
osx-64::ndcctools-7.4.14-py38h08c6ce4_0.tar.bz2
osx-64::mongodb-6.0.1-h2b5a84f_1.tar.bz2
osx-64::nodejs-16.17.0-hd0c9b3c_0.tar.bz2
osx-64::octave-7.2.0-h41d233e_4.tar.bz2
osx-64::pyreadstat-1.1.9-py38h01a1b83_1.tar.bz2
osx-64::libssh-0.10.3-h2e8ab23_0.tar.bz2
osx-64::arrow-cpp-9.0.0-py37h215398f_2_cpu.tar.bz2
osx-64::llvm-tools-15.0.0-hb04caa8_0.tar.bz2
osx-64::arrow-cpp-8.0.1-py38h121cdac_2_cpu.tar.bz2
osx-64::jaxlib-0.3.20-cpu_py37hf12bf50_0.tar.bz2
osx-64::libssh-0.10.4-h2e8ab23_1.tar.bz2
osx-64::arrow-cpp-6.0.2-py37h686c0b0_1_cpu.tar.bz2
osx-64::verilator-4.226-h07d71dc_1.tar.bz2
osx-64::indexed_gzip-1.7.0-py310hb9ee061_0.tar.bz2
osx-64::cppyy-cling-6.27.0-py38hbcdfe3b_1.tar.bz2
osx-64::arrow-cpp-8.0.1-py39hf9ad3a7_2_cpu.tar.bz2
osx-64::topologytoolkit-1.1.0-no_paraview_py39hfc3c215_102.tar.bz2
osx-64::thrift-compiler-0.16.0-h08c06f4_2.tar.bz2
osx-64::nodejs-14.20.1-h831259e_0.tar.bz2
osx-64::llvm-15.0.0-hf86d651_0.tar.bz2
osx-64::arrow-cpp-6.0.2-py38h0382d2a_0_cpu.tar.bz2
osx-64::vtk-9.1.0-qt_py38h57742dd_215.tar.bz2
osx-64::netcdf4-1.6.1-mpi_mpich_py39h99d9b56_0.tar.bz2
osx-64::gazebo-11.11.0-hd983bee_14.tar.bz2
osx-64::ndcctools-7.4.14-py38h1bf433d_0.tar.bz2
osx-64::scip-8.0.1-hc8e8bba_2.tar.bz2
osx-64::mysql-connector-cpp-8.0.29-h4b5b3cf_2.tar.bz2
osx-64::libadios2-2.8.3-mpi_openmpi_h6b36135_3.tar.bz2
osx-64::arrow-cpp-6.0.2-py39h6c798e9_2_cpu.tar.bz2
osx-64::cairo-1.16.0-h904041c_1014.tar.bz2
osx-64::arrow-cpp-7.0.1-py38ha2c5550_3_cpu.tar.bz2
osx-64::arrow-cpp-8.0.1-py39h4e64083_3_cpu.tar.bz2
osx-64::topologytoolkit-1.1.0-with_paraview_py310h8960b6d_3.tar.bz2
osx-64::nodejs-16.17.1-hd0c9b3c_0.tar.bz2
osx-64::libadios2-2.8.3-mpi_mpich_h690d333_3.tar.bz2
osx-64::topologytoolkit-1.1.0-no_paraview_py37he7e6a2e_102.tar.bz2
osx-64::aws-sdk-cpp-1.9.341-he3588ee_1.tar.bz2
osx-64::rstudio-desktop-2022.07.2-r41h911b70e_576.tar.bz2
osx-64::imagecodecs-2022.8.8-py38h7f92502_5.tar.bz2
osx-64::grpcio-1.48.1-py38hec8a11a_0.tar.bz2
osx-64::nco-5.1.0-h9bc8a9a_2.tar.bz2
osx-64::ndcctools-7.4.14-py39h7639174_1.tar.bz2
osx-64::arrow-cpp-6.0.2-py37hdba827c_0_cpu.tar.bz2
osx-64::nodejs-18.9.0-h3591b89_0.tar.bz2
osx-64::freecad-0.20.1-py39hd8426be_3.tar.bz2
osx-64::arrow-cpp-8.0.1-py38ha2c5550_3_cpu.tar.bz2
osx-64::imagemagick-7.1.0_49-pl5321h39c443d_0.tar.bz2
osx-64::nodejs-18.9.0-hd0c9b3c_0.tar.bz2
osx-64::paraview-5.10.1-py310h0a73c1e_108_qt.tar.bz2
osx-64::tensorflow-base-2.10.0-cpu_py39h4341d28_0.tar.bz2
osx-64::topologytoolkit-1.1.0-no_paraview_py310h45d0650_102.tar.bz2
osx-64::python-igraph-0.9.11-py38hc833c9c_1.tar.bz2
osx-64::libadios2-2.8.3-nompi_hc4686d9_103.tar.bz2
osx-64::arrow-cpp-9.0.0-py39h3778106_2_cpu.tar.bz2
osx-64::vtk-9.1.0-qt_py37h1bf964c_215.tar.bz2
osx-64::jaxlib-0.3.20-cpu_py37h08c1716_0.tar.bz2
osx-64::arrow-cpp-9.0.0-py37hf93e634_6_cpu.tar.bz2
osx-64::sagelib-9.6-py39h2b5d681_3.tar.bz2
osx-64::lammps-2022.06.23-py38ha6b19d1_mpich_2.tar.bz2
osx-64::graphviz-6.0.1-ha8464fc_0.tar.bz2
osx-64::libadios2-2.8.3-nompi_he29e64f_102.tar.bz2
osx-64::indexed_gzip-1.7.0-py37h5e14895_0.tar.bz2
osx-64::libvips-8.13.1-h38b8c2c_0.tar.bz2
osx-64::nodejs-16.17.0-h3591b89_0.tar.bz2
osx-64::nodejs-14.19.2-h831259e_0.tar.bz2
osx-64::netcdf4-1.6.1-mpi_mpich_py310h9f09b55_0.tar.bz2
osx-64::libvips-8.13.1-h95d21a1_1.tar.bz2
osx-64::arrow-cpp-9.0.0-py310h14c5125_2_cpu.tar.bz2
osx-64::vigra-1.11.1-py310ha12e591_1033.tar.bz2
osx-64::soplex-6.0.1-h5233140_2.tar.bz2
osx-64::pyreadr-0.4.7-py39h9dad49b_1.tar.bz2
osx-64::pyranha-0.11-py310h9c44c43_4.tar.bz2
osx-64::arrow-cpp-6.0.2-py38h493b07b_1_cpu.tar.bz2
osx-64::libadios2-2.8.3-nompi_h94981c0_103.tar.bz2
osx-64::nodejs-14.19.0-h831259e_0.tar.bz2
osx-64::rstudio-desktop-2022.07.2-r40h911b70e_576.tar.bz2
osx-64::erlang-25.1-pl5321ha491908_0.tar.bz2
osx-64::libadios2-2.8.3-mpi_mpich_h4667290_3.tar.bz2
osx-64::libkml-1.3.0-haeb80ef_1015.tar.bz2
osx-64::arrow-cpp-7.0.1-py310h3c71577_3_cpu.tar.bz2
osx-64::ndcctools-7.4.14-py310h9c28b6c_1.tar.bz2
osx-64::lammps-2022.06.23-py38h47ea5b8_openmpi_2.tar.bz2
osx-64::imagecodecs-2022.9.26-py38hca54095_0.tar.bz2
osx-64::arrow-cpp-9.0.0-py39h4e64083_5_cpu.tar.bz2
osx-64::grpc-cpp-1.48.1-h834a566_1.tar.bz2
osx-64::coin-or-clp-1.17.7-hf0ee74e_2.tar.bz2
osx-64::aws-sdk-cpp-1.9.343-he3588ee_0.tar.bz2
osx-64::arrow-cpp-9.0.0-py37hc8c15f5_2_cpu.tar.bz2
osx-64::gemmi-0.5.7-py38h8c0d2ee_0.tar.bz2
osx-64::aws-sdk-cpp-1.9.346-he3588ee_0.tar.bz2
osx-64::pyreadr-0.4.7-py39h9dad49b_0.tar.bz2
osx-64::libssh-0.10.4-haca8a89_2.tar.bz2
osx-64::topologytoolkit-1.1.0-with_paraview_py39h286030b_3.tar.bz2
osx-64::arrow-cpp-7.0.1-py38h8d22721_0_cpu.tar.bz2
osx-64::mdtraj-1.9.7-py310h1b5c016_2.tar.bz2
osx-64::vtk-9.1.0-qt_py39hb4ae040_215.tar.bz2
osx-64::arrow-cpp-8.0.1-py310h0687de5_2_cpu.tar.bz2
osx-64::nodejs-16.15.1-h3591b89_0.tar.bz2
osx-64::jaxlib-0.3.15-cpu_py310hc4ef77f_4.tar.bz2
osx-64::libadios2-2.8.3-mpi_mpich_hdf34f2e_3.tar.bz2
osx-64::nodejs-16.16.0-h3591b89_0.tar.bz2
osx-64::rsync-3.2.6-h30d983d_0.tar.bz2
osx-64::arrow-cpp-8.0.1-py38h807d612_2_cpu.tar.bz2
osx-64::libssh-0.10.4-h0108ac9_1.tar.bz2
osx-64::python-igraph-0.10.0-py38h5d3fc92_1.tar.bz2
osx-64::libtensorflow_cc-2.10.0-cpu_h184dcb9_0.tar.bz2
osx-64::arrow-cpp-6.0.2-py38h4d165b6_0_cpu.tar.bz2
osx-64::mdtraj-1.9.7-py38h011acc5_2.tar.bz2
osx-64::arrow-cpp-9.0.0-py38h14e59c2_2_cpu.tar.bz2
osx-64::ovito-3.7.8-h43721e1_1.tar.bz2
osx-64::topologytoolkit-1.1.0-no_paraview_py310heb2a32b_103.tar.bz2
osx-64::jaxlib-0.3.15-cpu_py39hc2d11b0_4.tar.bz2
osx-64::arrow-cpp-7.0.1-py38h4dba66e_4_cpu.tar.bz2
osx-64::grpcio-1.48.1-py39h5179f2f_0.tar.bz2
osx-64::ffmpeg-4.4.2-gpl_h0fedfe4_108.tar.bz2
osx-64::cppyy-cling-6.27.0-py37hc63106f_1.tar.bz2
osx-64::ffmpeg-5.1.1-lgpl_he907128_2.tar.bz2
osx-64::aws-sdk-cpp-1.9.354-h7440459_0.tar.bz2
osx-64::ndcctools-7.4.14-py38h1bf433d_1.tar.bz2
osx-64::arrow-cpp-6.0.2-py37hba1304f_2_cpu.tar.bz2
osx-64::grpcio-1.48.1-py37hb59364e_0.tar.bz2
osx-64::libglib-2.74.0-h3ba3332_0.tar.bz2
osx-64::libssh-0.10.3-h0108ac9_0.tar.bz2
osx-64::julia-1.8.0-hcb9ed81_1.tar.bz2
osx-64::nodejs-14.19.1-h831259e_0.tar.bz2
osx-64::protozfits-2.0.1.post1-py39he6d14f9_9.tar.bz2
osx-64::python-igraph-0.9.11-py310h3f43f70_1.tar.bz2
osx-64::gsoap-2.8.123-h21ae599_0.tar.bz2
osx-64::arrow-cpp-6.0.2-py310hd6219f6_3_cpu.tar.bz2
osx-64::libadios2-2.8.3-mpi_openmpi_h1f27214_3.tar.bz2
osx-64::arrow-cpp-8.0.1-py37h8ed0cd0_2_cpu.tar.bz2
osx-64::ffmpeg-5.1.1-gpl_h0fedfe4_101.tar.bz2
osx-64::tiledb-2.11.2-h8b9cbf0_0.tar.bz2
osx-64::graphviz-6.0.0-ha8464fc_0.tar.bz2
osx-64::arrow-cpp-7.0.1-py310ha01b9ba_2_cpu.tar.bz2
osx-64::mosh-1.3.2-pl5321he4b5906_1013.tar.bz2
osx-64::libgdal-3.5.2-hcf5fda6_0.tar.bz2
osx-64::sagelib-9.6-py38hb79c7c8_3.tar.bz2
osx-64::libadios2-2.8.3-mpi_mpich_h0e44d21_3.tar.bz2
osx-64::libsoup-3.2.0-h9cf3a4b_0.tar.bz2
osx-64::vowpalwabbit-9.3.0-py39h431b345_2.tar.bz2
osx-64::imagemagick-7.1.0_48-pl5321h6a6422e_1.tar.bz2
osx-64::verilator-4.226-h07d71dc_0.tar.bz2
osx-64::gemmi-0.5.7-py310h2bfb868_0.tar.bz2
osx-64::vigra-1.11.1-py39h83cdd11_1033.tar.bz2
osx-64::arrow-cpp-9.0.0-py38h8d22721_2_cpu.tar.bz2
osx-64::jaxlib-0.3.20-cpu_py38h84efa26_0.tar.bz2
osx-64::aws-sdk-cpp-1.9.349-h4fcdf8c_1.tar.bz2
osx-64::mandrake-1.2.2-py38hce1d78d_1.tar.bz2
osx-64::aws-sdk-cpp-1.9.340-h7290728_0.tar.bz2
-    "libzlib >=1.2.12,<1.3.0a0",
+    "libzlib >=1.2.12,<2.0.0a0",
osx-64::libpng-1.6.38-ha978bb4_0.tar.bz2
osx-64::llvm-spirv-14.0.0-h07d71dc_1.tar.bz2
osx-64::readstat-1.1.8-he48a508_1.tar.bz2
osx-64::libprotobuf-static-3.20.1-hbc0c0cd_4.tar.bz2
osx-64::gst-plugins-base-1.20.3-h37e1711_2.tar.bz2
osx-64::gst-plugins-good-1.20.3-h9c2bda7_1.tar.bz2
osx-64::libprotobuf-static-3.20.1-hbc0c0cd_2.tar.bz2
osx-64::libprotobuf-3.21.6-hbc0c0cd_1.tar.bz2
osx-64::libsqlite-3.39.3-ha978bb4_0.tar.bz2
osx-64::coin-or-utils-2.11.6-h7a46149_2.tar.bz2
osx-64::zimpl-3.5.2-h38610d6_2.tar.bz2
osx-64::websocketpp-0.8.2-hd9e13b6_1.tar.bz2
osx-64::libprotobuf-static-3.20.1-hbc0c0cd_3.tar.bz2
osx-64::dotnet-runtime-3.1.29-h86e9ca2_0.tar.bz2
osx-64::libprotobuf-static-3.21.5-hbc0c0cd_3.tar.bz2
osx-64::gst-plugins-base-1.20.3-h37e1711_1.tar.bz2
osx-64::libllvm11-11.1.0-h8fb7429_4.tar.bz2
osx-64::zimpl-3.5.2-h38610d6_3.tar.bz2
osx-64::openjdk-17.0.3-hbc0c0cd_2.tar.bz2
osx-64::websocketpp-0.8.2-h32d65fa_0.tar.bz2
osx-64::coin-or-osi-0.108.7-hfef9e4d_2.tar.bz2
osx-64::pocl-3.0-h8b4fca9_1.tar.bz2
osx-64::libprotobuf-3.21.5-hbc0c0cd_2.tar.bz2
osx-64::fontconfig-2.14.0-h5bb23bf_1.tar.bz2
osx-64::llvm-11.1.0-h9d075a6_4.tar.bz2
osx-64::openjdk-11.0.15-hbc0c0cd_2.tar.bz2
osx-64::libprotobuf-static-3.21.6-hbc0c0cd_1.tar.bz2
osx-64::openjdk-17.0.3-hbc0c0cd_1.tar.bz2
osx-64::libprotobuf-3.20.1-hbc0c0cd_4.tar.bz2
osx-64::dotnet-runtime-6.0.9-h86e9ca2_0.tar.bz2
osx-64::libprotobuf-static-3.21.6-hbc0c0cd_0.tar.bz2
osx-64::libprotobuf-3.20.1-hbc0c0cd_3.tar.bz2
osx-64::libprotobuf-static-3.21.5-hbc0c0cd_2.tar.bz2
osx-64::dotnet-sdk-3.1.423-h86e9ca2_0.tar.bz2
osx-64::libprotobuf-3.21.5-hbc0c0cd_3.tar.bz2
osx-64::openjdk-11.0.15-hbc0c0cd_1.tar.bz2
osx-64::liblal-7.2.2-fftw_h6f3aaa0_100.tar.bz2
osx-64::glib-tools-2.74.0-hbc0c0cd_0.tar.bz2
osx-64::dotnet-aspnetcore-3.1.29-h86e9ca2_0.tar.bz2
osx-64::pocl-3.0-h5552be4_1.tar.bz2
osx-64::gst-plugins-good-1.20.3-h9c2bda7_2.tar.bz2
osx-64::dotnet-aspnetcore-6.0.9-h86e9ca2_0.tar.bz2
osx-64::libprotobuf-3.21.6-hbc0c0cd_0.tar.bz2
osx-64::libprotobuf-static-3.21.5-hbc0c0cd_1.tar.bz2
osx-64::dotnet-sdk-6.0.401-h86e9ca2_0.tar.bz2
osx-64::llvm-tools-11.1.0-h8fb7429_4.tar.bz2
-    "libzlib >=1.2.12,<1.3.0a0"
+    "libzlib >=1.2.12,<2.0.0a0"
================================================================================
================================================================================
linux-64
linux-64::arrow-cpp-7.0.1-py37h646f429_0_cuda.tar.bz2
linux-64::jaxlib-0.3.20-cpu_py39h2420ce0_0.tar.bz2
linux-64::jaxlib-0.3.20-cuda112py39h5d93514_200.tar.bz2
linux-64::cppyy-cling-6.27.0-py37had014c9_1.tar.bz2
linux-64::smesh-9.9.0.0-h4ac60e7_1.tar.bz2
linux-64::libspatialite-5.0.1-hfbd986c_21.tar.bz2
linux-64::topologytoolkit-1.1.0-no_paraview_py39ha5603a3_103.tar.bz2
linux-64::nodejs-16.17.0-h8839609_0.tar.bz2
linux-64::arrow-cpp-7.0.1-py38hd411b42_0_cuda.tar.bz2
linux-64::arrow-cpp-9.0.0-py37h5914fcc_2_cuda.tar.bz2
linux-64::jaxlib-0.3.15-cuda112py310hfa36681_204.tar.bz2
linux-64::libadios2-2.8.3-mpi_openmpi_hf054031_3.tar.bz2
linux-64::tensorflow-base-2.10.0-cpu_py39h16601f7_0.tar.bz2
linux-64::arrow-cpp-6.0.2-py38haf787f0_1_cuda.tar.bz2
linux-64::libssh-0.10.4-he49606f_0.tar.bz2
linux-64::libllvm15-15.0.1-h503ea73_0.tar.bz2
linux-64::libadios2-2.8.3-mpi_openmpi_hab6374b_3.tar.bz2
linux-64::jaxlib-0.3.15-cuda112py39h1e4da38_204.tar.bz2
linux-64::arrow-cpp-7.0.1-py310he7aa4d3_1_cpu.tar.bz2
linux-64::arrow-cpp-9.0.0-py310hc498ad1_5_cuda.tar.bz2
linux-64::arrow-cpp-9.0.0-py39hb952132_2_cpu.tar.bz2
linux-64::gemmi-0.5.7-py38hb85eefc_0.tar.bz2
linux-64::libkml-1.3.0-h37653c0_1015.tar.bz2
linux-64::arrow-cpp-6.0.2-py39hb9fa733_2_cuda.tar.bz2
linux-64::tiledb-2.11.2-h3f4058f_0.tar.bz2
linux-64::libssh-0.10.1-he49606f_0.tar.bz2
linux-64::libvips-8.13.1-h4a8a4d3_0.tar.bz2
linux-64::ndcctools-7.4.14-py38h1aa6533_1.tar.bz2
linux-64::python-igraph-0.9.11-py39h000617a_1.tar.bz2
linux-64::aws-sdk-cpp-1.9.341-hb288c42_0.tar.bz2
linux-64::arrow-cpp-9.0.0-py39h763f843_2_cpu.tar.bz2
linux-64::poppler-qt-22.04.0-hda5adef_3.tar.bz2
linux-64::liblal-7.2.2-mkl_hb5697f4_0.tar.bz2
linux-64::vtk-9.1.0-qt_py310h343fe84_215.tar.bz2
linux-64::libtensorflow-2.10.0-cuda112h443c560_0.tar.bz2
linux-64::cpp-opentelemetry-sdk-1.6.1-h48a8ea9_0.tar.bz2
linux-64::topologytoolkit-1.1.0-no_paraview_py38h45f70bf_102.tar.bz2
linux-64::arrow-cpp-9.0.0-py37h4e182ac_2_cuda.tar.bz2
linux-64::arrow-cpp-6.0.2-py310haf21572_1_cuda.tar.bz2
linux-64::vigra-1.11.1-py38hda5223c_1034.tar.bz2
linux-64::libadios2-2.8.3-mpi_openmpi_h6776c36_3.tar.bz2
linux-64::arrow-cpp-9.0.0-py37h646f429_2_cuda.tar.bz2
linux-64::arrow-cpp-6.0.2-py39h4ab9694_2_cpu.tar.bz2
linux-64::arrow-cpp-8.0.1-py310he7aa4d3_2_cpu.tar.bz2
linux-64::mosh-1.3.2-pl5321h9ed9655_1013.tar.bz2
linux-64::jaxlib-0.3.20-cuda112py37heebddfd_200.tar.bz2
linux-64::arrow-cpp-7.0.1-py38hfcf6a12_4_cuda.tar.bz2
linux-64::magics-metview-batch-4.12.1-h6972fcc_1.tar.bz2
linux-64::thrift-compiler-0.16.0-h491838f_2.tar.bz2
linux-64::pyreadstat-1.1.9-py38he5536e0_1.tar.bz2
linux-64::gemmi-0.5.7-py39h7d9a04d_0.tar.bz2
linux-64::libadios2-2.8.3-nompi_hc18e13d_102.tar.bz2
linux-64::arrow-cpp-9.0.0-py39hd3ccb9b_2_cpu.tar.bz2
linux-64::arrow-cpp-6.0.2-py38h3eb4240_1_cpu.tar.bz2
linux-64::arrow-cpp-6.0.2-py38ha96e256_1_cuda.tar.bz2
linux-64::pyranha-0.11-py38he403d7c_4.tar.bz2
linux-64::paraview-5.10.1-py38hb10153d_108_qt.tar.bz2
linux-64::arrow-cpp-6.0.2-py38h2c68f52_2_cuda.tar.bz2
linux-64::ndcctools-7.4.14-py38h1aa6533_0.tar.bz2
linux-64::arrow-cpp-9.0.0-py310hc498ad1_4_cuda.tar.bz2
linux-64::arrow-cpp-7.0.1-py37hf320bec_3_cpu.tar.bz2
linux-64::gemmi-0.5.7-py310h58363a5_0.tar.bz2
linux-64::arrow-cpp-7.0.1-py39hcada0b4_0_cuda.tar.bz2
linux-64::jaxlib-0.3.15-cpu_py39h2420ce0_4.tar.bz2
linux-64::arrow-cpp-7.0.1-py39hd75b5e9_4_cpu.tar.bz2
linux-64::grpc-cpp-1.48.1-hbad87ad_1.tar.bz2
linux-64::aws-sdk-cpp-1.9.338-hb288c42_0.tar.bz2
linux-64::jaxlib-0.3.20-cuda112py310hfa36681_200.tar.bz2
linux-64::indexed_gzip-1.7.0-py39hc217eb8_0.tar.bz2
linux-64::arrow-cpp-9.0.0-py310h51b11f0_3_cuda.tar.bz2
linux-64::arrow-cpp-9.0.0-py310h028ac91_4_cpu.tar.bz2
linux-64::arrow-cpp-6.0.2-py37h9e2a758_1_cpu.tar.bz2
linux-64::arrow-cpp-9.0.0-py38h8cbe7a1_2_cuda.tar.bz2
linux-64::arrow-cpp-9.0.0-py37he84a226_2_cpu.tar.bz2
linux-64::libadios2-2.8.3-nompi_hf44c66e_102.tar.bz2
linux-64::python-igraph-0.10.0-py38h64ef804_1.tar.bz2
linux-64::jaxlib-0.3.15-cuda112py38hb8bfbf9_204.tar.bz2
linux-64::netcdf4-1.6.1-mpi_mpich_py37h8f9d21e_0.tar.bz2
linux-64::netcdf4-1.6.1-mpi_openmpi_py37heb77dd2_0.tar.bz2
linux-64::imagecodecs-2022.9.26-py38h3872b58_0.tar.bz2
linux-64::jaxlib-0.3.20-cuda112py37h5087797_200.tar.bz2
linux-64::grpc-cpp-1.46.4-hc2bec63_7.tar.bz2
linux-64::papilo-2.1.0-h828dae8_3.tar.bz2
linux-64::ndcctools-7.4.14-py38h782bae8_1.tar.bz2
linux-64::ffmpeg-5.1.2-gpl_he10e716_101.tar.bz2
linux-64::nodejs-18.9.1-h96d913c_0.tar.bz2
linux-64::arrow-cpp-9.0.0-py38h8aae47f_3_cuda.tar.bz2
linux-64::libgdal-3.5.2-hc23bfc3_0.tar.bz2
linux-64::gst-plugins-good-1.20.3-h20dca43_2.tar.bz2
linux-64::arrow-cpp-9.0.0-py38h0bdc179_2_cuda.tar.bz2
linux-64::arrow-cpp-9.0.0-py38h929c095_4_cuda.tar.bz2
linux-64::imagecodecs-2022.9.26-py39hf586f7a_0.tar.bz2
linux-64::sagelib-9.6-py38hc949e4e_3.tar.bz2
linux-64::topologytoolkit-1.1.0-no_paraview_py39hc2f06e9_102.tar.bz2
linux-64::opentype-sanitizer-9.0.0-py39hf939315_0.tar.bz2
linux-64::arrow-cpp-9.0.0-py37h36fbf88_4_cuda.tar.bz2
linux-64::topologytoolkit-1.1.0-with_paraview_py310h5bff7ac_2.tar.bz2
linux-64::jaxlib-0.3.20-cpu_py310h59da3f0_0.tar.bz2
linux-64::arrow-cpp-9.0.0-py37h2c258d9_2_cpu.tar.bz2
linux-64::llvmlite-0.39.1-py39h6b9fe7f_0.tar.bz2
linux-64::topologytoolkit-1.1.0-with_paraview_py38h64df43c_3.tar.bz2
linux-64::arrow-cpp-7.0.1-py310h3d6efb2_0_cpu.tar.bz2
linux-64::arrow-cpp-8.0.1-py37hd377246_4_cuda.tar.bz2
linux-64::arrow-cpp-6.0.2-py310hb0d094b_2_cpu.tar.bz2
linux-64::netcdf4-1.6.1-mpi_mpich_py38h6baeaa4_0.tar.bz2
linux-64::libadios2-2.8.3-mpi_openmpi_hf054031_2.tar.bz2
linux-64::arrow-cpp-7.0.1-py38h8aae47f_2_cuda.tar.bz2
linux-64::folly-2022.09.26.00-h1234567_1.tar.bz2
linux-64::dotnet-sdk-3.1.423-h751d214_0.tar.bz2
linux-64::arrow-cpp-6.0.2-py38he0e374a_2_cpu.tar.bz2
linux-64::arrow-cpp-9.0.0-py39h4b9716b_2_cuda.tar.bz2
linux-64::topologytoolkit-1.1.0-with_paraview_py37hfaf4921_3.tar.bz2
linux-64::grpcio-1.48.1-py310h2fbdd6c_0.tar.bz2
linux-64::freecad-0.20.1-py39h650ad5b_3.tar.bz2
linux-64::arrow-cpp-6.0.2-py38h4320e0e_0_cuda.tar.bz2
linux-64::aws-sdk-cpp-1.9.353-h41e575e_0.tar.bz2
linux-64::grpc-cpp-1.48.1-h05bd8bd_0.tar.bz2
linux-64::jaxlib-0.3.15-cpu_py37hb467de3_4.tar.bz2
linux-64::vtk-9.1.0-osmesa_py39hd96a68f_115.tar.bz2
linux-64::arrow-cpp-6.0.2-py38h5688e29_0_cpu.tar.bz2
linux-64::arrow-cpp-8.0.1-py39h555f12d_2_cpu.tar.bz2
linux-64::arrow-cpp-7.0.1-py38h2a1c311_0_cpu.tar.bz2
linux-64::arrow-cpp-8.0.1-py310hc498ad1_3_cuda.tar.bz2
linux-64::libssh-0.10.2-he49606f_0.tar.bz2
linux-64::mdtraj-1.9.7-py310h902c554_2.tar.bz2
linux-64::arrow-cpp-8.0.1-py37h36fbf88_3_cuda.tar.bz2
linux-64::arrow-cpp-9.0.0-py38h6933191_6_cpu.tar.bz2
linux-64::arrow-cpp-6.0.2-py37h719e882_0_cpu.tar.bz2
linux-64::julia-1.8.1-h6f5dd7c_0.tar.bz2
linux-64::arrow-cpp-7.0.1-py39hb14a856_4_cuda.tar.bz2
linux-64::netcdf4-1.6.1-mpi_openmpi_py310h7739a52_0.tar.bz2
linux-64::grpcio-1.48.1-py38h61810cd_0.tar.bz2
linux-64::topologytoolkit-1.1.0-with_paraview_py39h2188323_2.tar.bz2
linux-64::arrow-cpp-7.0.1-py38h929c095_3_cuda.tar.bz2
linux-64::mapserver-8.0.0-py38h4472e1c_0.tar.bz2
linux-64::vigra-1.11.1-py37ha9db1f0_1034.tar.bz2
linux-64::clangdev-15.0.0-default_h2e3cab8_0.tar.bz2
linux-64::arrow-cpp-7.0.1-py39h1ae1b14_2_cuda.tar.bz2
linux-64::arrow-cpp-8.0.1-py310h4f1c134_2_cpu.tar.bz2
linux-64::arrow-cpp-7.0.1-py39h763f843_0_cpu.tar.bz2
linux-64::nodejs-14.20.0-h96d913c_0.tar.bz2
linux-64::arrow-cpp-9.0.0-py39hcada0b4_2_cuda.tar.bz2
linux-64::arrow-cpp-6.0.2-py37hfb2e28a_1_cuda.tar.bz2
linux-64::arrow-cpp-7.0.1-py37h5914fcc_1_cuda.tar.bz2
linux-64::grpc-cpp-1.48.1-h30feacc_0.tar.bz2
linux-64::libssh-0.10.4-he49606f_1.tar.bz2
linux-64::pdal-2.4.3-hbecf0f4_2.tar.bz2
linux-64::mdtraj-1.9.7-py38h4b5026a_2.tar.bz2
linux-64::ffmpeg-5.1.2-gpl_hffa7cc2_100.tar.bz2
linux-64::arrow-cpp-8.0.1-py310h028ac91_4_cpu.tar.bz2
linux-64::tensorflow-base-2.10.0-cpu_py38h67fe383_0.tar.bz2
linux-64::arrow-cpp-8.0.1-py38h998ac4b_2_cpu.tar.bz2
linux-64::arrow-cpp-8.0.1-py310ha432434_2_cuda.tar.bz2
linux-64::pyreadr-0.4.7-py39h7c3d64d_0.tar.bz2
linux-64::assimp-5.2.4-hf40c2ba_2.tar.bz2
linux-64::python-igraph-0.9.11-py38h3805f6d_1.tar.bz2
linux-64::opentype-sanitizer-9.0.0-py38h43d8883_0.tar.bz2
linux-64::arrow-cpp-8.0.1-py310h51b11f0_2_cuda.tar.bz2
linux-64::libssh-0.10.4-hefc96ee_2.tar.bz2
linux-64::arrow-cpp-8.0.1-py38ha31b012_2_cuda.tar.bz2
linux-64::nd2-0.4.3-py38hd7afe33_0.tar.bz2
linux-64::arrow-cpp-8.0.1-py38h8aae47f_2_cuda.tar.bz2
linux-64::rstudio-desktop-2022.07.2-r41hfd48464_576.tar.bz2
linux-64::arrow-cpp-7.0.1-py37h2c258d9_1_cpu.tar.bz2
linux-64::python-igraph-0.9.11-py38h64ef804_1.tar.bz2
linux-64::arrow-cpp-8.0.1-py38hfcf6a12_4_cuda.tar.bz2
linux-64::libadios2-2.8.3-mpi_openmpi_he39c393_3.tar.bz2
linux-64::jaxlib-0.3.20-cuda112py39h1e4da38_200.tar.bz2
linux-64::pyranha-0.11-py37h1147a6e_4.tar.bz2
linux-64::pyreadr-0.4.7-py38h78f8500_0.tar.bz2
linux-64::tensorflow-base-2.10.0-cuda112py39h2957820_0.tar.bz2
linux-64::openexr-python-1.3.9-py37h01ff5f8_0.tar.bz2
linux-64::folly-2022.09.05.00-h1234567_1.tar.bz2
linux-64::clangdev-15.0.1-default_h2e3cab8_0.tar.bz2
linux-64::ndcctools-7.4.14-py39hbe13330_1.tar.bz2
linux-64::llvmlite-0.39.1-py37h0761922_0.tar.bz2
linux-64::libglib-2.74.0-h7a41b64_0.tar.bz2
linux-64::libadios2-2.8.3-mpi_openmpi_h3072b55_3.tar.bz2
linux-64::arrow-cpp-7.0.1-py37he84a226_1_cpu.tar.bz2
linux-64::hugin-2021.0.0-pl5321hb327bc7_8.tar.bz2
linux-64::soplex-6.0.1-h49ca5c0_3.tar.bz2
linux-64::glib-2.74.0-h6239696_0.tar.bz2
linux-64::grpc-cpp-1.47.1-h30feacc_6.tar.bz2
linux-64::llvmdev-11.1.0-he0ac6c6_4.tar.bz2
linux-64::arrow-cpp-6.0.2-py39hd382bdf_3_cuda.tar.bz2
linux-64::arrow-cpp-9.0.0-py37hbea53b0_6_cpu.tar.bz2
linux-64::arrow-cpp-9.0.0-py37hedc27d3_3_cpu.tar.bz2
linux-64::openjdk-11.0.15-h1e1ecb3_2.tar.bz2
linux-64::python-igraph-0.10.0-py37h24ddbbb_1.tar.bz2
linux-64::python-igraph-0.9.11-py37h24ddbbb_1.tar.bz2
linux-64::octave-7.2.0-h3839a39_2.tar.bz2
linux-64::arrow-cpp-6.0.2-py310h8f3c351_0_cpu.tar.bz2
linux-64::ndcctools-7.4.14-py37hecb152a_0.tar.bz2
linux-64::imagecodecs-2022.8.8-py39h1bf5304_5.tar.bz2
linux-64::arrow-cpp-9.0.0-py37hf320bec_4_cpu.tar.bz2
linux-64::arrow-cpp-9.0.0-py37h4ae2626_3_cuda.tar.bz2
linux-64::netcdf4-1.6.1-nompi_py39hfaa66c4_100.tar.bz2
linux-64::cppyy-cling-6.27.0-py39h3d66fe8_1.tar.bz2
linux-64::jaxlib-0.3.20-cuda112py310h0f6dfd5_200.tar.bz2
linux-64::libadios2-2.8.3-mpi_openmpi_h3adf480_3.tar.bz2
linux-64::arrow-cpp-7.0.1-py310he5e3186_0_cuda.tar.bz2
linux-64::arrow-cpp-8.0.1-py37he84a226_2_cpu.tar.bz2
linux-64::aws-sdk-cpp-1.9.348-h824300c_0.tar.bz2
linux-64::fenics-libdolfin-2019.1.0-h1c8bd2e_32.tar.bz2
linux-64::libtensorflow_cc-2.10.0-cuda112h443c560_0.tar.bz2
linux-64::wxwidgets-3.2.0-h12dd593_2.tar.bz2
linux-64::arrow-cpp-8.0.1-py39h7971003_2_cuda.tar.bz2
linux-64::paraview-5.10.1-py39hd50f33d_8_egl.tar.bz2
linux-64::libadios2-2.8.3-mpi_mpich_h02bc99a_3.tar.bz2
linux-64::triqs-3.1.1-py37h00e6d33_2.tar.bz2
linux-64::gst-plugins-good-1.20.3-h20dca43_1.tar.bz2
linux-64::python-igraph-0.10.0-py38h3805f6d_1.tar.bz2
linux-64::arrow-cpp-9.0.0-py38h2a1c311_2_cpu.tar.bz2
linux-64::opentype-sanitizer-8.2.2-py39hf939315_0.tar.bz2
linux-64::arrow-cpp-7.0.1-py37h505edeb_0_cpu.tar.bz2
linux-64::sagelib-9.6-py37h280181f_3.tar.bz2
linux-64::topologytoolkit-1.1.0-no_paraview_py38h0b67021_103.tar.bz2
linux-64::protozfits-2.0.1.post1-py39h2dcfbf5_9.tar.bz2
linux-64::arrow-cpp-8.0.1-py39ha525f37_2_cuda.tar.bz2
linux-64::jaxlib-0.3.20-cpu_py39h7e0d102_0.tar.bz2
linux-64::opentype-sanitizer-9.0.0-py310hbf28c38_0.tar.bz2
linux-64::arrow-cpp-6.0.2-py37h1d7fd9e_3_cuda.tar.bz2
linux-64::lammps-2022.06.23-py310h7ddc592_mpich_2.tar.bz2
linux-64::arrow-cpp-9.0.0-py310he5e3186_2_cuda.tar.bz2
linux-64::libssh-0.10.4-h727a467_0.tar.bz2
linux-64::opentype-sanitizer-8.2.2-py39h2865249_0.tar.bz2
linux-64::rstudio-desktop-2022.07.1-r40hfd48464_554.tar.bz2
linux-64::emacs-28.2-h0bd1994_0.tar.bz2
linux-64::arrow-cpp-8.0.1-py39h1ae1b14_2_cuda.tar.bz2
linux-64::arrow-cpp-7.0.1-py39hb952132_1_cpu.tar.bz2
linux-64::netcdf4-1.6.1-nompi_py38h2250339_100.tar.bz2
linux-64::arrow-cpp-8.0.1-py37hbea53b0_4_cpu.tar.bz2
linux-64::topologytoolkit-1.1.0-no_paraview_py310h66b888d_103.tar.bz2
linux-64::arrow-cpp-7.0.1-py38h709d5f2_0_cpu.tar.bz2
linux-64::imagecodecs-2022.9.26-py39hf9ac8f0_0.tar.bz2
linux-64::libtensorflow_cc-2.10.0-cpu_he30adf4_0.tar.bz2
linux-64::triqs-3.1.1-py39hb1325ff_2.tar.bz2
linux-64::verilator-4.226-he0ac6c6_0.tar.bz2
linux-64::orc-1.8.0-h09e0d61_0.tar.bz2
linux-64::libadios2-2.8.3-nompi_h0e55c60_102.tar.bz2
linux-64::arrow-cpp-6.0.2-py310hfba0d38_0_cpu.tar.bz2
linux-64::rstudio-desktop-2022.07.1-r41hfd48464_554.tar.bz2
linux-64::arrow-cpp-9.0.0-py39h7971003_2_cuda.tar.bz2
linux-64::vowpalwabbit-9.3.0-py310h604a8ea_2.tar.bz2
linux-64::opentype-sanitizer-8.2.2-py37h7cecad7_0.tar.bz2
linux-64::cairomm-1.16-1.16.2-h09cb3b9_0.tar.bz2
linux-64::aws-sdk-cpp-1.9.343-h824300c_0.tar.bz2
linux-64::mongodb-6.0.1-h9e3d2f7_1.tar.bz2
linux-64::graphviz-6.0.1-h5abf519_0.tar.bz2
linux-64::protozfits-2.0.1.post1-py37h43f504f_9.tar.bz2
linux-64::arrow-cpp-6.0.2-py39h7036dc2_3_cpu.tar.bz2
linux-64::netcdf4-1.6.1-mpi_openmpi_py38h040c551_0.tar.bz2
linux-64::ffmpeg-5.1.1-lgpl_h3dd3725_1.tar.bz2
linux-64::jaxlib-0.3.15-cpu_py39h7e0d102_4.tar.bz2
linux-64::cmake-3.24.2-h5432695_0.tar.bz2
linux-64::ndcctools-7.4.14-py310ha616101_1.tar.bz2
linux-64::ndcctools-7.4.14-py310h5deebde_1.tar.bz2
linux-64::pyreadr-0.4.7-py39h7c3d64d_1.tar.bz2
linux-64::arrow-cpp-8.0.1-py37hf320bec_3_cpu.tar.bz2
linux-64::pyreadr-0.4.7-py37h881f09f_1.tar.bz2
linux-64::intel-opencl-rt-2022.1.0-hce74451_3768.tar.bz2
linux-64::libllvm15-15.0.0-h503ea73_0.tar.bz2
linux-64::arrow-cpp-9.0.0-py310h22cf7ed_2_cpu.tar.bz2
linux-64::ffmpeg-4.4.2-lgpl_h3dd3725_8.tar.bz2
linux-64::nco-5.1.0-h81bb2a3_2.tar.bz2
linux-64::arrow-cpp-6.0.2-py39he271535_1_cuda.tar.bz2
linux-64::tensorflow-base-2.10.0-cuda112py310hf679b68_0.tar.bz2
linux-64::nodejs-14.19.0-h96d913c_0.tar.bz2
linux-64::nest-simulator-3.3-py39h69e065a_2.tar.bz2
linux-64::cpp-opentelemetry-sdk-1.6.0-h48a8ea9_1.tar.bz2
linux-64::nodejs-14.19.2-h96d913c_0.tar.bz2
linux-64::arrow-cpp-9.0.0-py310h4f1c134_2_cpu.tar.bz2
linux-64::nodejs-18.9.1-h8839609_0.tar.bz2
linux-64::arrow-cpp-9.0.0-py38h929c095_5_cuda.tar.bz2
linux-64::folly-2022.09.26.00-h1234567_1_jemalloc.tar.bz2
linux-64::openmpi-4.1.4-ha1ae619_101.tar.bz2
linux-64::arrow-cpp-6.0.2-py38hd1cba64_3_cpu.tar.bz2
linux-64::arrow-cpp-9.0.0-py310hc498ad1_6_cuda.tar.bz2
linux-64::arrow-cpp-6.0.2-py310h4f49b75_3_cuda.tar.bz2
linux-64::ffmpeg-5.1.1-gpl_hfe78399_101.tar.bz2
linux-64::nd2-0.4.3-py39hd4323c9_0.tar.bz2
linux-64::arrow-cpp-9.0.0-py38hdd638c3_5_cpu.tar.bz2
linux-64::nodejs-16.17.1-h96d913c_0.tar.bz2
linux-64::arrow-cpp-7.0.1-py38he270906_1_cpu.tar.bz2
linux-64::arrow-cpp-7.0.1-py310h2595e56_0_cuda.tar.bz2
linux-64::actions-runner-2.296.1-he0ac6c6_0.tar.bz2
linux-64::arrow-cpp-8.0.1-py39hb952132_2_cpu.tar.bz2
linux-64::nest-simulator-3.3-py38hece92b8_2.tar.bz2
linux-64::aws-sdk-cpp-1.9.350-h1b8e81a_0.tar.bz2
linux-64::tomviz-2.0.0rc1.post9-py37h3444f97_0.tar.bz2
linux-64::netcdf4-1.6.1-mpi_mpich_py39h6149389_0.tar.bz2
linux-64::arrow-cpp-8.0.1-py38he270906_2_cpu.tar.bz2
linux-64::tensorflow-base-2.10.0-cpu_py310hc537a0e_0.tar.bz2
linux-64::giac-1.6.0.47-he9ede01_6.tar.bz2
linux-64::nodejs-16.16.0-h8839609_0.tar.bz2
linux-64::nodejs-14.19.1-h96d913c_0.tar.bz2
linux-64::openexr-python-1.3.9-py38h094547f_0.tar.bz2
linux-64::arrow-cpp-8.0.1-py310h028ac91_3_cpu.tar.bz2
linux-64::grpcio-1.48.1-py37hc2f46f4_0.tar.bz2
linux-64::arrow-cpp-7.0.1-py310hc498ad1_3_cuda.tar.bz2
linux-64::arrow-cpp-6.0.2-py310h13d1497_1_cpu.tar.bz2
linux-64::aws-sdk-cpp-1.9.345-h824300c_0.tar.bz2
linux-64::mapserver-8.0.0-py310he8241b0_0.tar.bz2
linux-64::arrow-cpp-7.0.1-py37h36fbf88_3_cuda.tar.bz2
linux-64::libadios2-2.8.3-mpi_mpich_h8e71b1c_3.tar.bz2
linux-64::opentype-sanitizer-8.2.2-py38h43d8883_0.tar.bz2
linux-64::assimp-5.2.5-hf40c2ba_0.tar.bz2
linux-64::pdal-2.4.3-hbf0e37d_2.tar.bz2
linux-64::libadios2-2.8.3-nompi_h3757cd0_103.tar.bz2
linux-64::pyreadr-0.4.7-py38hf5ddb21_1.tar.bz2
linux-64::libadios2-2.8.3-nompi_h0e55c60_103.tar.bz2
linux-64::arrow-cpp-6.0.2-py37h5251846_2_cpu.tar.bz2
linux-64::opentype-sanitizer-8.2.2-py310hbf28c38_0.tar.bz2
linux-64::protozfits-2.0.1.post1-py310h29f6ed9_9.tar.bz2
linux-64::imagecodecs-2022.8.8-py310h112de15_5.tar.bz2
linux-64::grpc-cpp-1.48.1-h05bd8bd_1.tar.bz2
linux-64::llvm-tools-15.0.0-h503ea73_0.tar.bz2
linux-64::arrow-cpp-9.0.0-py37h36fbf88_5_cuda.tar.bz2
linux-64::grpc-cpp-1.46.4-h05bd8bd_7.tar.bz2
linux-64::aws-sdk-cpp-1.9.340-hb288c42_0.tar.bz2
linux-64::dotnet-sdk-6.0.401-h751d214_0.tar.bz2
linux-64::arrow-cpp-6.0.2-py310hc17d24d_0_cuda.tar.bz2
linux-64::libadios2-2.8.3-mpi_mpich_h499f3aa_3.tar.bz2
linux-64::jaxlib-0.3.15-cuda112py38h6ea58e9_204.tar.bz2
linux-64::sqlite-3.39.3-h4ff8645_0.tar.bz2
linux-64::grpcio-1.48.1-py38h81467c6_0.tar.bz2
linux-64::scip-8.0.1-h1d3a576_3.tar.bz2
linux-64::ffmpeg-4.4.2-lgpl_hd1a2dd7_8.tar.bz2
linux-64::mandrake-1.2.2-py38hd866c6d_1.tar.bz2
linux-64::python-igraph-0.10.0-py310hf05fc85_1.tar.bz2
linux-64::netcdf4-1.6.1-nompi_py37hb61e06c_100.tar.bz2
linux-64::paraview-5.10.1-py37h55a54d3_8_egl.tar.bz2
linux-64::mysql-connector-cpp-8.0.29-hced9a49_2.tar.bz2
linux-64::arrow-cpp-8.0.1-py37h1a5f661_2_cuda.tar.bz2
linux-64::verilator-4.226-he0ac6c6_1.tar.bz2
linux-64::vowpalwabbit-9.3.0-py39hadcec2c_2.tar.bz2
linux-64::ndcctools-7.4.14-py37hecb152a_1.tar.bz2
linux-64::arrow-cpp-9.0.0-py38he270906_2_cpu.tar.bz2
linux-64::nd2-0.4.3-py37h1425b33_0.tar.bz2
linux-64::mandrake-1.2.2-py310h7dbff7e_1.tar.bz2
linux-64::git-annex-10.20220927-alldep_h2ca4687_100.tar.bz2
linux-64::aws-sdk-cpp-1.9.350-h41e575e_1.tar.bz2
linux-64::freecad-0.20.1-py38h63dbee4_3.tar.bz2
linux-64::arrow-cpp-6.0.2-py310h07276a2_3_cpu.tar.bz2
linux-64::arrow-cpp-7.0.1-py38hdd638c3_3_cpu.tar.bz2
linux-64::arrow-cpp-7.0.1-py39heb27936_3_cuda.tar.bz2
linux-64::jaxlib-0.3.15-cuda112py37h5087797_204.tar.bz2
linux-64::libxml2-2.10.2-h4c7fe37_1.tar.bz2
linux-64::jaxlib-0.3.20-cuda112py38h6ea58e9_200.tar.bz2
linux-64::vtk-9.1.0-egl_py39h146abd9_15.tar.bz2
linux-64::folly-2022.09.12.00-h1234567_1_jemalloc.tar.bz2
linux-64::gemmi-0.5.7-py38h38d86a4_0.tar.bz2
linux-64::arrow-cpp-7.0.1-py310ha432434_1_cuda.tar.bz2
linux-64::libadios2-2.8.3-nompi_hf1a624a_103.tar.bz2
linux-64::imagemagick-7.1.0_48-pl5321hae1b4c2_0.tar.bz2
linux-64::dotnet-aspnetcore-6.0.9-h751d214_0.tar.bz2
linux-64::gdk-pixbuf-2.42.8-hff1cb4f_1.tar.bz2
linux-64::imagemagick-7.1.0_49-pl5321hbb10140_0.tar.bz2
linux-64::arrow-cpp-6.0.2-py38h581a82e_0_cuda.tar.bz2
linux-64::mandrake-1.2.2-py310hafac34d_1.tar.bz2
linux-64::libgdal-3.5.2-hc23bfc3_3.tar.bz2
linux-64::magics-4.12.1-h6972fcc_1.tar.bz2
linux-64::ovito-3.7.9-h4572772_0.tar.bz2
linux-64::arrow-cpp-9.0.0-py310he794579_3_cpu.tar.bz2
linux-64::arrow-cpp-7.0.1-py310he794579_2_cpu.tar.bz2
linux-64::vtk-9.1.0-egl_py38he163af0_15.tar.bz2
linux-64::aws-sdk-cpp-1.9.346-h824300c_0.tar.bz2
linux-64::mandrake-1.2.2-py39hbd8570d_1.tar.bz2
linux-64::lammps-2022.06.23-py38h4296d50_mpich_2.tar.bz2
linux-64::arrow-cpp-9.0.0-py310h3d6efb2_2_cpu.tar.bz2
linux-64::arrow-cpp-9.0.0-py38hdd638c3_4_cpu.tar.bz2
linux-64::grpcio-1.48.1-py39h161891f_0.tar.bz2
linux-64::julia-1.8.0-h6f5dd7c_1.tar.bz2
linux-64::hugin-base-2021.0.0-pl5321hfdd3619_8.tar.bz2
linux-64::ndcctools-7.4.14-py37h8b51a51_1.tar.bz2
linux-64::arrow-cpp-9.0.0-py310hda5e8db_2_cuda.tar.bz2
linux-64::pyreadstat-1.1.9-py310ha400145_1.tar.bz2
linux-64::ovito-3.7.8-h4572772_1.tar.bz2
linux-64::vowpalwabbit-9.3.0-py37h8cf013c_2.tar.bz2
linux-64::llvm-15.0.0-h4553d2b_0.tar.bz2
linux-64::grpc-cpp-1.48.1-hc2bec63_1.tar.bz2
linux-64::netcdf4-1.6.1-nompi_py310h55e1e36_100.tar.bz2
linux-64::arrow-cpp-8.0.1-py310hda5e8db_2_cuda.tar.bz2
linux-64::arrow-cpp-6.0.2-py310h4ebd0c7_0_cuda.tar.bz2
linux-64::actions-runner-2.297.0-he0ac6c6_0.tar.bz2
linux-64::perl-net-ssleay-1.92-pl5321hf14f497_1.tar.bz2
linux-64::libsoup-3.2.0-had0b2b9_0.tar.bz2
linux-64::thrift-compiler-0.16.0-he500d00_2.tar.bz2
linux-64::grpcio-1.48.1-py39h6c2b787_0.tar.bz2
linux-64::pyreadr-0.4.7-py39hcf4def5_0.tar.bz2
linux-64::gfal2-2.21.1-h1edf11a_0.tar.bz2
linux-64::libadios2-2.8.3-mpi_openmpi_he39c393_2.tar.bz2
linux-64::nodejs-18.9.0-h96d913c_0.tar.bz2
linux-64::ffmpeg-4.4.2-gpl_he10e716_108.tar.bz2
linux-64::arrow-cpp-6.0.2-py37ha616881_2_cuda.tar.bz2
linux-64::julia-1.8.0-h6f5dd7c_3.tar.bz2
linux-64::arrow-cpp-6.0.2-py38h0b64dcc_0_cpu.tar.bz2
linux-64::pyreadr-0.4.7-py39hcf4def5_1.tar.bz2
linux-64::openexr-python-1.3.9-py39hbd9bb45_0.tar.bz2
linux-64::libitk-5.2.1-hcedbc38_6.tar.bz2
linux-64::arrow-cpp-6.0.2-py37h8b163c9_1_cuda.tar.bz2
linux-64::pyreadr-0.4.7-py310h957f721_0.tar.bz2
linux-64::ffmpeg-5.1.2-lgpl_hd1a2dd7_1.tar.bz2
linux-64::pyranha-0.11-py39hd64c34f_4.tar.bz2
linux-64::libgdal-3.5.2-h84f2e82_0.tar.bz2
linux-64::arrow-cpp-9.0.0-py37hd377246_6_cuda.tar.bz2
linux-64::opentype-sanitizer-9.0.0-py38h875ae46_0.tar.bz2
linux-64::topologytoolkit-1.1.0-with_paraview_py310h7b98c7d_3.tar.bz2
linux-64::arrow-cpp-6.0.2-py37h10699ad_1_cpu.tar.bz2
linux-64::rsync-3.2.6-h220164a_0.tar.bz2
linux-64::arrow-cpp-8.0.1-py38hdd638c3_3_cpu.tar.bz2
linux-64::arrow-cpp-9.0.0-py37hce38596_2_cpu.tar.bz2
linux-64::lammps-2022.06.23-py37h7a1a7bf_mpich_2.tar.bz2
linux-64::arrow-cpp-8.0.1-py38h9cb1f5c_2_cpu.tar.bz2
linux-64::opentype-sanitizer-9.0.0-py39h2865249_0.tar.bz2
linux-64::jaxlib-0.3.15-cpu_py38h7aae4ce_4.tar.bz2
linux-64::cppyy-cling-6.27.0-py38h8225899_1.tar.bz2
linux-64::nd2-0.4.3-py38h28b09c2_0.tar.bz2
linux-64::assimp-5.2.4-hf40c2ba_1.tar.bz2
linux-64::arrow-cpp-7.0.1-py38h9cb1f5c_2_cpu.tar.bz2
linux-64::arrow-cpp-8.0.1-py37h4ae2626_2_cuda.tar.bz2
linux-64::aws-sdk-cpp-1.9.349-h824300c_0.tar.bz2
linux-64::openexr-python-1.3.9-py310hac5ffb1_0.tar.bz2
linux-64::ndcctools-7.4.14-py39hbe13330_0.tar.bz2
linux-64::grpc-cpp-1.47.1-h05bd8bd_6.tar.bz2
linux-64::perl-io-gzip-0.20-pl5321h753d276_0.tar.bz2
linux-64::triqs-3.1.1-py38h3e53aaa_2.tar.bz2
linux-64::arrow-cpp-7.0.1-py38h0bdc179_0_cuda.tar.bz2
linux-64::libtensorflow-2.10.0-cpu_he30adf4_0.tar.bz2
linux-64::vtk-9.1.0-egl_py37haf37319_15.tar.bz2
linux-64::topologytoolkit-1.1.0-no_paraview_py310h30fdf1e_102.tar.bz2
linux-64::jaxlib-0.3.15-cuda112py39h5d93514_204.tar.bz2
linux-64::triqs-3.1.1-py39ha502f63_2.tar.bz2
linux-64::dpcpp_impl_linux-64-2022.1.0-hb01953d_3768.tar.bz2
linux-64::lammps-2022.06.23-py37h6ea83e3_mpich_2.tar.bz2
linux-64::libnetcdf-4.9.0-mpi_mpich_h06c54e2_0.tar.bz2
linux-64::arrow-cpp-7.0.1-py37hce38596_0_cpu.tar.bz2
linux-64::octave-7.2.0-hfb59817_3.tar.bz2
linux-64::libthrift-0.16.0-h491838f_2.tar.bz2
linux-64::python-igraph-0.9.11-py39h8e58fdc_1.tar.bz2
linux-64::tesseract-5.2.0-h2ac6c52_1.tar.bz2
linux-64::vtk-9.1.0-osmesa_py37h4fefe72_115.tar.bz2
linux-64::grpcio-1.48.1-py310h3b97f14_0.tar.bz2
linux-64::imagecodecs-2022.8.8-py38hb64448d_5.tar.bz2
linux-64::nodejs-16.15.1-h8839609_0.tar.bz2
linux-64::cpp-opentelemetry-sdk-1.6.0-hb354d1b_1.tar.bz2
linux-64::mandrake-1.2.2-py38h94c7e02_1.tar.bz2
linux-64::arrow-cpp-9.0.0-py39h9016804_4_cpu.tar.bz2
linux-64::arrow-cpp-9.0.0-py39heb27936_4_cuda.tar.bz2
linux-64::opentype-sanitizer-8.2.2-py38h875ae46_0.tar.bz2
linux-64::triqs-3.1.1-py37h457f65a_2.tar.bz2
linux-64::mysql-connector-cpp-8.0.29-h38d9289_2.tar.bz2
linux-64::fenics-libdolfin-2019.1.0-h0f808bc_32.tar.bz2
linux-64::openexr-python-1.3.9-py39heb3e085_0.tar.bz2
linux-64::imagecodecs-2022.8.8-py39h090f8d4_5.tar.bz2
linux-64::libssh-0.10.2-h727a467_0.tar.bz2
linux-64::mdtraj-1.9.7-py39hc79b4f4_2.tar.bz2
linux-64::jaxlib-0.3.15-cuda112py310h0f6dfd5_204.tar.bz2
linux-64::folly-2022.09.05.00-h1234567_1_jemalloc.tar.bz2
linux-64::gemmi-0.5.7-py39h6b9fe7f_0.tar.bz2
linux-64::arrow-cpp-7.0.1-py39hfd629c7_0_cpu.tar.bz2
linux-64::arrow-cpp-9.0.0-py37h505edeb_2_cpu.tar.bz2
linux-64::grpc-cpp-1.46.4-hbad87ad_7.tar.bz2
linux-64::arrow-cpp-9.0.0-py39ha525f37_2_cuda.tar.bz2
linux-64::arrow-cpp-9.0.0-py38h9cb1f5c_3_cpu.tar.bz2
linux-64::arrow-cpp-7.0.1-py37h1a5f661_1_cuda.tar.bz2
linux-64::geotiff-1.7.1-ha76d385_4.tar.bz2
linux-64::ffmpeg-4.4.2-gpl_hffa7cc2_108.tar.bz2
linux-64::ndcctools-7.4.14-py310h5deebde_0.tar.bz2
linux-64::arrow-cpp-8.0.1-py39heb27936_3_cuda.tar.bz2
linux-64::imagemagick-7.1.0_48-pl5321h2a53dc9_1.tar.bz2
linux-64::arrow-cpp-7.0.1-py38h8cbe7a1_1_cuda.tar.bz2
linux-64::dotnet-runtime-3.1.29-h751d214_0.tar.bz2
linux-64::jaxlib-0.3.20-cuda112py38hb8bfbf9_200.tar.bz2
linux-64::mandrake-1.2.2-py39h51b886f_1.tar.bz2
linux-64::llvmlite-0.39.1-py39h7d9a04d_0.tar.bz2
linux-64::intel-cmplr-lib-rt-2022.1.0-h6239696_3768.tar.bz2
linux-64::ndcctools-7.4.14-py37h8b51a51_0.tar.bz2
linux-64::pyranha-0.11-py310hdd422b6_4.tar.bz2
linux-64::libadios2-2.8.3-nompi_hf4f8f70_103.tar.bz2
linux-64::triqs-3.1.1-py310hdcd0525_2.tar.bz2
linux-64::arrow-cpp-7.0.1-py37h4ae2626_2_cuda.tar.bz2
linux-64::arrow-cpp-9.0.0-py38hfcf6a12_6_cuda.tar.bz2
linux-64::erlang-25.1-pl5321h5001644_0.tar.bz2
linux-64::arrow-cpp-8.0.1-py37hedc27d3_2_cpu.tar.bz2
linux-64::nodejs-16.17.0-h96d913c_0.tar.bz2
linux-64::vtk-9.1.0-egl_py310h9838174_15.tar.bz2
linux-64::arrow-cpp-6.0.2-py39hc2dd5f6_0_cpu.tar.bz2
linux-64::freecad-0.20.1-py310h8dc7af3_3.tar.bz2
linux-64::topologytoolkit-1.1.0-no_paraview_py37ha36b5ba_103.tar.bz2
linux-64::jaxlib-0.3.20-cpu_py310hb359a59_0.tar.bz2
linux-64::arrow-cpp-9.0.0-py310he7aa4d3_2_cpu.tar.bz2
linux-64::imagecodecs-2022.9.26-py310h1689d63_0.tar.bz2
linux-64::arrow-cpp-7.0.1-py37hedc27d3_2_cpu.tar.bz2
linux-64::arrow-cpp-6.0.2-py39h8b5430b_0_cuda.tar.bz2
linux-64::llvmlite-0.39.1-py38h38d86a4_0.tar.bz2
linux-64::grpc-cpp-1.47.1-hbad87ad_6.tar.bz2
linux-64::cppyy-cling-6.27.0-py39h13b352c_1.tar.bz2
linux-64::jaxlib-0.3.20-cpu_py38h7aae4ce_0.tar.bz2
linux-64::arrow-cpp-8.0.1-py38h929c095_3_cuda.tar.bz2
linux-64::arrow-cpp-7.0.1-py310h22cf7ed_0_cpu.tar.bz2
linux-64::libvips-8.13.1-h90b0b56_1.tar.bz2
linux-64::nodejs-16.16.0-h96d913c_0.tar.bz2
linux-64::lmod-8.7.13-lua54h71fc533_0.tar.bz2
linux-64::pdfmm-0.9.22-hff8fc8e_0.tar.bz2
linux-64::rust-1.64.0-h30be4a0_0.tar.bz2
linux-64::netcdf4-1.6.1-mpi_openmpi_py39ha5e07e6_0.tar.bz2
linux-64::aws-sdk-cpp-1.9.341-h824300c_1.tar.bz2
linux-64::arrow-cpp-8.0.1-py39hd75b5e9_4_cpu.tar.bz2
linux-64::imagecodecs-2022.8.8-py38hf09e3b1_5.tar.bz2
linux-64::smesh-9.9.0.0-hf3572f8_0.tar.bz2
linux-64::gemmi-0.5.7-py37h0761922_0.tar.bz2
linux-64::arrow-cpp-9.0.0-py38h998ac4b_2_cpu.tar.bz2
linux-64::grpc-cpp-1.47.1-hc2bec63_6.tar.bz2
linux-64::nodejs-14.20.1-h96d913c_0.tar.bz2
linux-64::libitk-5.2.1-hd8cd2f9_5.tar.bz2
linux-64::sagelib-9.6-py310h5b61bae_3.tar.bz2
linux-64::libssh-0.10.4-h727a467_1.tar.bz2
linux-64::rstudio-desktop-2022.07.2-r40hfd48464_576.tar.bz2
linux-64::aws-sdk-cpp-1.9.352-h41e575e_0.tar.bz2
linux-64::topologytoolkit-1.1.0-no_paraview_py37h89008d2_102.tar.bz2
linux-64::arrow-cpp-6.0.2-py39he9fa2f1_1_cuda.tar.bz2
linux-64::libadios2-2.8.3-mpi_mpich_h02bc99a_2.tar.bz2
linux-64::sagelib-9.6-py39h42ccf77_3.tar.bz2
linux-64::topologytoolkit-1.1.0-with_paraview_py37h78d74ce_2.tar.bz2
linux-64::libadios2-2.8.3-mpi_openmpi_h3072b55_2.tar.bz2
linux-64::folly-2022.09.19.00-h1234567_1_jemalloc.tar.bz2
linux-64::arrow-cpp-8.0.1-py37h2c258d9_2_cpu.tar.bz2
linux-64::mapserver-8.0.0-py37h32ba603_0.tar.bz2
linux-64::lammps-2022.06.23-py37h27773f8_openmpi_2.tar.bz2
linux-64::vowpalwabbit-9.3.0-py38h7030a49_2.tar.bz2
linux-64::collada-dom-2.5.0-h9e5ae81_5.tar.bz2
linux-64::pyreadr-0.4.7-py310h957f721_1.tar.bz2
linux-64::paraview-5.10.1-py310h75451c9_108_qt.tar.bz2
linux-64::mapserver-8.0.0-py39h702e41e_0.tar.bz2
linux-64::pyreadr-0.4.7-py38h78f8500_1.tar.bz2
linux-64::jaxlib-0.3.15-cpu_py38hfbcf518_4.tar.bz2
linux-64::jaxlib-0.3.20-cpu_py38hfbcf518_0.tar.bz2
linux-64::aws-sdk-cpp-1.9.339-hb288c42_0.tar.bz2
linux-64::ndcctools-7.4.14-py39h084f619_0.tar.bz2
linux-64::topologytoolkit-1.1.0-with_paraview_py38hf398c0f_2.tar.bz2
linux-64::llvm-15.0.1-h4553d2b_0.tar.bz2
linux-64::libtiff-4.4.0-h55922b4_4.tar.bz2
linux-64::opentype-sanitizer-9.0.0-py37h7cecad7_0.tar.bz2
linux-64::nodejs-18.10.0-h8839609_0.tar.bz2
linux-64::libadios2-2.8.3-mpi_mpich_hfcd9c48_2.tar.bz2
linux-64::arrow-cpp-9.0.0-py310h028ac91_6_cpu.tar.bz2
linux-64::aws-sdk-cpp-1.9.356-h41e575e_0.tar.bz2
linux-64::ffmpeg-5.1.1-gpl_hffa7cc2_102.tar.bz2
linux-64::subversion-1.14.2-pl5321h5000d4a_2.tar.bz2
linux-64::indexed_gzip-1.7.0-py38h3b715e4_0.tar.bz2
linux-64::llvm-tools-15.0.1-h503ea73_0.tar.bz2
linux-64::arrow-cpp-6.0.2-py37hb8c6bdb_3_cpu.tar.bz2
linux-64::imagecodecs-2022.9.26-py38h0e951e9_0.tar.bz2
linux-64::lammps-2022.06.23-py39h69e9cdf_mpich_2.tar.bz2
linux-64::llvmdev-15.0.1-h503ea73_0.tar.bz2
linux-64::lammps-2022.06.23-py37hddd25e3_openmpi_2.tar.bz2
linux-64::arrow-cpp-7.0.1-py38h998ac4b_1_cpu.tar.bz2
linux-64::aws-sdk-cpp-1.9.344-h824300c_0.tar.bz2
linux-64::arrow-cpp-6.0.2-py38h6d37a1d_1_cpu.tar.bz2
linux-64::jaxlib-0.3.20-cpu_py37hb467de3_0.tar.bz2
linux-64::triqs-3.1.1-py38h21d07bd_2.tar.bz2
linux-64::soplex-6.0.1-h9561d1b_2.tar.bz2
linux-64::wxwidgets-3.2.1-h7e98adb_0.tar.bz2
linux-64::jaxlib-0.3.15-cpu_py310h59da3f0_4.tar.bz2
linux-64::aws-sdk-cpp-1.9.351-h41e575e_0.tar.bz2
linux-64::libssh-0.10.4-h965dfa5_2.tar.bz2
linux-64::nest-simulator-3.3-py310hf1800e2_2.tar.bz2
linux-64::arrow-cpp-7.0.1-py310hc498ad1_4_cuda.tar.bz2
linux-64::papilo-2.1.0-hc9d876a_2.tar.bz2
linux-64::lammps-2022.06.23-py310h392c10f_openmpi_2.tar.bz2
linux-64::indexed_gzip-1.7.0-py37h7dba1dc_0.tar.bz2
linux-64::libspatialite-5.0.1-hfbd986c_20.tar.bz2
linux-64::nodejs-18.9.0-h8839609_0.tar.bz2
linux-64::arrow-cpp-7.0.1-py310h028ac91_3_cpu.tar.bz2
linux-64::libssh-0.10.3-he49606f_0.tar.bz2
linux-64::arrow-cpp-7.0.1-py310h51b11f0_2_cuda.tar.bz2
linux-64::aws-sdk-cpp-1.9.342-h824300c_0.tar.bz2
linux-64::cppyy-cling-6.27.0-py310hd64a29c_1.tar.bz2
linux-64::topologytoolkit-1.1.0-with_paraview_py39h8cf0053_3.tar.bz2
linux-64::arrow-cpp-9.0.0-py310h028ac91_5_cpu.tar.bz2
linux-64::ndcctools-7.4.14-py38h782bae8_0.tar.bz2
linux-64::arrow-cpp-8.0.1-py310hc498ad1_4_cuda.tar.bz2
linux-64::arrow-cpp-9.0.0-py39h555f12d_3_cpu.tar.bz2
linux-64::tensorflow-base-2.10.0-cuda112py37ha0c8746_0.tar.bz2
linux-64::arrow-cpp-7.0.1-py39h7971003_1_cuda.tar.bz2
linux-64::arrow-cpp-7.0.1-py310h028ac91_4_cpu.tar.bz2
linux-64::arrow-cpp-7.0.1-py37h4e182ac_0_cuda.tar.bz2
linux-64::arrow-cpp-9.0.0-py38ha31b012_2_cuda.tar.bz2
linux-64::arrow-cpp-9.0.0-py38hd411b42_2_cuda.tar.bz2
linux-64::arrow-cpp-6.0.2-py37h7aaf90f_0_cpu.tar.bz2
linux-64::arrow-cpp-9.0.0-py310h2595e56_2_cuda.tar.bz2
linux-64::folly-2022.09.19.00-h1234567_1.tar.bz2
linux-64::qt-main-5.15.6-hc525480_0.tar.bz2
linux-64::arrow-cpp-7.0.1-py39hd3ccb9b_1_cpu.tar.bz2
linux-64::netcdf4-1.6.1-mpi_mpich_py310h19e27b4_0.tar.bz2
linux-64::nodejs-14.19.3-h96d913c_0.tar.bz2
linux-64::coin-or-cgl-0.60.6-h6f57e76_2.tar.bz2
linux-64::arrow-cpp-6.0.2-py37h54b7a15_0_cuda.tar.bz2
linux-64::cairo-1.16.0-ha61ee94_1014.tar.bz2
linux-64::libadios2-2.8.3-mpi_mpich_h419f6b7_3.tar.bz2
linux-64::tensorflow-base-2.10.0-cuda112py38h6b2b66c_0.tar.bz2
linux-64::aws-sdk-cpp-1.9.337-hb288c42_0.tar.bz2
linux-64::arrow-cpp-9.0.0-py39hfd629c7_2_cpu.tar.bz2
linux-64::grpcio-1.48.1-py37hd557365_0.tar.bz2
linux-64::ffmpeg-5.1.1-lgpl_h3dd3725_2.tar.bz2
linux-64::libadios2-2.8.3-nompi_he5c561d_103.tar.bz2
linux-64::aws-sdk-cpp-1.9.347-h824300c_0.tar.bz2
linux-64::arrow-cpp-8.0.1-py39hd3ccb9b_2_cpu.tar.bz2
linux-64::arrow-cpp-9.0.0-py37h1a5f661_2_cuda.tar.bz2
linux-64::vtk-9.1.0-osmesa_py38h68dc7f3_115.tar.bz2
linux-64::dotnet-runtime-6.0.9-h751d214_0.tar.bz2
linux-64::gap-core-4.11.1-hd225dc4_4.tar.bz2
linux-64::llvmlite-0.39.1-py38hb85eefc_0.tar.bz2
linux-64::lammps-2022.06.23-py39h2f3b62e_openmpi_2.tar.bz2
linux-64::arrow-cpp-7.0.1-py38h6933191_4_cpu.tar.bz2
linux-64::gsoap-2.8.123-h8dc497d_0.tar.bz2
linux-64::libadios2-2.8.3-mpi_openmpi_hab6374b_2.tar.bz2
linux-64::arrow-cpp-7.0.1-py39h4b9716b_0_cuda.tar.bz2
linux-64::lammps-2022.06.23-py38h6ea0623_openmpi_2.tar.bz2
linux-64::pyreadr-0.4.7-py37h881f09f_0.tar.bz2
linux-64::osmium-tool-1.14.0-h193e024_2.tar.bz2
linux-64::cairomm-1.0-1.14.4-h09cb3b9_0.tar.bz2
linux-64::mandrake-1.2.2-py310ha656d29_1.tar.bz2
linux-64::arrow-cpp-6.0.2-py37hcab7bb7_0_cuda.tar.bz2
linux-64::arrow-cpp-8.0.1-py39hb14a856_4_cuda.tar.bz2
linux-64::libnetcdf-4.9.0-nompi_h21705cb_100.tar.bz2
linux-64::openexr-python-1.3.9-py38h9fb9928_0.tar.bz2
linux-64::arrow-cpp-9.0.0-py39h9016804_5_cpu.tar.bz2
linux-64::indexed_gzip-1.7.0-py310hd25046b_0.tar.bz2
linux-64::magics-metview-4.12.1-hb4944b1_1.tar.bz2
linux-64::erlang-25.1-pl5321hb9e9383_0.tar.bz2
linux-64::poppler-22.04.0-h0733791_3.tar.bz2
linux-64::ffmpeg-5.1.2-lgpl_h3dd3725_0.tar.bz2
linux-64::jaxlib-0.3.20-cpu_py37h82df9ab_0.tar.bz2
linux-64::jaxlib-0.3.15-cpu_py37h82df9ab_4.tar.bz2
linux-64::vtk-9.1.0-qt_py39h6797c2b_215.tar.bz2
linux-64::libssh-0.10.1-h727a467_0.tar.bz2
linux-64::aws-sdk-cpp-1.9.349-h1b8e81a_1.tar.bz2
linux-64::actions-runner-2.296.2-he0ac6c6_0.tar.bz2
linux-64::julia-1.8.0-h6f5dd7c_2.tar.bz2
linux-64::mandrake-1.2.2-py39h09c4ef8_1.tar.bz2
linux-64::vigra-1.11.1-py310h2c75445_1034.tar.bz2
linux-64::arrow-cpp-6.0.2-py310h1558904_1_cpu.tar.bz2
linux-64::gsoap-2.8.123-h598caef_0.tar.bz2
linux-64::arrow-cpp-9.0.0-py310ha432434_2_cuda.tar.bz2
linux-64::tiledb-2.11.2-h1e4a385_0.tar.bz2
linux-64::libssh-0.10.3-h727a467_0.tar.bz2
linux-64::libadios2-2.8.3-mpi_mpich_hfcd9c48_3.tar.bz2
linux-64::llvmdev-15.0.0-h503ea73_0.tar.bz2
linux-64::arrow-cpp-7.0.1-py38ha31b012_1_cuda.tar.bz2
linux-64::arrow-cpp-8.0.1-py310he794579_2_cpu.tar.bz2
linux-64::lyx-2.3.6.1-py310h3e3d406_5.tar.bz2
linux-64::pyreadstat-1.1.9-py37he2f7bc2_1.tar.bz2
linux-64::paraview-5.10.1-py37h764ff70_108_qt.tar.bz2
linux-64::dotnet-aspnetcore-3.1.29-h751d214_0.tar.bz2
linux-64::jaxlib-0.3.15-cuda112py37heebddfd_204.tar.bz2
linux-64::libadios2-2.8.3-mpi_mpich_hd302066_3.tar.bz2
linux-64::pyreadr-0.4.7-py38hf5ddb21_0.tar.bz2
linux-64::vtk-9.1.0-osmesa_py310h8faa513_115.tar.bz2
linux-64::paraview-5.10.1-py310h409d647_8_egl.tar.bz2
linux-64::libadios2-2.8.3-nompi_hf44c66e_103.tar.bz2
linux-64::grpc-cpp-1.48.1-h30feacc_1.tar.bz2
linux-64::libadios2-2.8.3-nompi_he5c561d_102.tar.bz2
linux-64::paraview-5.10.1-py38h2fb4be8_8_egl.tar.bz2
linux-64::graphviz-6.0.0-h5abf519_0.tar.bz2
linux-64::tensorflow-base-2.10.0-cpu_py37h50bd216_0.tar.bz2
linux-64::piranha-0.11-hf501b25_1006.tar.bz2
linux-64::openjdk-17.0.3-h85293d2_2.tar.bz2
linux-64::libadios2-2.8.3-mpi_mpich_h499f3aa_2.tar.bz2
linux-64::libadios2-2.8.3-mpi_mpich_h78362ea_3.tar.bz2
linux-64::arrow-cpp-7.0.1-py310h4f1c134_1_cpu.tar.bz2
linux-64::mosh-1.3.2-pl5321h4981305_1013.tar.bz2
linux-64::arrow-cpp-9.0.0-py39hb14a856_6_cuda.tar.bz2
linux-64::mdtraj-1.9.7-py37hcc56668_2.tar.bz2
linux-64::nd2-0.4.3-py310h062fc0b_0.tar.bz2
linux-64::arrow-cpp-7.0.1-py39h555f12d_2_cpu.tar.bz2
linux-64::aws-sdk-cpp-1.9.354-h41e575e_0.tar.bz2
linux-64::llvmlite-0.39.1-py310h58363a5_0.tar.bz2
linux-64::arrow-cpp-7.0.1-py37hd377246_4_cuda.tar.bz2
linux-64::libadios2-2.8.3-mpi_openmpi_h886ef3a_3.tar.bz2
linux-64::triqs-3.1.1-py310h13fdf25_2.tar.bz2
linux-64::vtk-9.1.0-qt_py37he4e22c4_215.tar.bz2
linux-64::ndcctools-7.4.14-py39h084f619_1.tar.bz2
linux-64::octave-7.2.0-hfb59817_4.tar.bz2
linux-64::arrow-cpp-6.0.2-py39h26e972f_1_cpu.tar.bz2
linux-64::cppyy-cling-6.27.0-py38h2a4c724_1.tar.bz2
linux-64::arrow-cpp-6.0.2-py39hb6d143b_0_cuda.tar.bz2
linux-64::libgdal-3.5.2-h84f2e82_3.tar.bz2
linux-64::arrow-cpp-9.0.0-py39heb27936_5_cuda.tar.bz2
linux-64::arrow-cpp-8.0.1-py38h8cbe7a1_2_cuda.tar.bz2
linux-64::arrow-cpp-7.0.1-py39h9016804_3_cpu.tar.bz2
linux-64::arrow-cpp-8.0.1-py37h5914fcc_2_cuda.tar.bz2
linux-64::grpc-cpp-1.46.4-h30feacc_7.tar.bz2
linux-64::arrow-cpp-7.0.1-py37hbea53b0_4_cpu.tar.bz2
linux-64::nd2-0.4.3-py39h155c9d3_0.tar.bz2
linux-64::nodejs-16.15.1-h96d913c_0.tar.bz2
linux-64::arrow-cpp-8.0.1-py39h9016804_3_cpu.tar.bz2
linux-64::arrow-cpp-9.0.0-py37hf320bec_5_cpu.tar.bz2
linux-64::arrow-cpp-6.0.2-py39h2cff001_1_cpu.tar.bz2
linux-64::jaxlib-0.3.15-cpu_py310hb359a59_4.tar.bz2
linux-64::ffmpeg-5.1.1-lgpl_h5c13f96_1.tar.bz2
linux-64::scip-8.0.1-h1d3a576_2.tar.bz2
linux-64::arrow-cpp-6.0.2-py310h25a5722_2_cuda.tar.bz2
linux-64::ffmpeg-5.1.1-gpl_hffa7cc2_101.tar.bz2
linux-64::nodejs-16.17.1-h8839609_0.tar.bz2
linux-64::arrow-cpp-9.0.0-py39hd75b5e9_6_cpu.tar.bz2
linux-64::coin-or-clp-1.17.7-hc56784d_2.tar.bz2
linux-64::octave-7.2.0-h72f21b2_5.tar.bz2
linux-64::freecad-0.20.1-py37h6084e40_3.tar.bz2
linux-64::libthrift-0.16.0-he500d00_2.tar.bz2
linux-64::mandrake-1.2.2-py38h2c480b1_1.tar.bz2
linux-64::perl-net-ssleay-1.92-pl5321haa6b8db_1.tar.bz2
linux-64::paraview-5.10.1-py39ha1207ff_108_qt.tar.bz2
linux-64::vigra-1.11.1-py39h23d1435_1034.tar.bz2
linux-64::arrow-cpp-9.0.0-py38h709d5f2_2_cpu.tar.bz2
linux-64::ndcctools-7.4.14-py310ha616101_0.tar.bz2
linux-64::netpbm-10.73.41-pl5321h79e5dd2_0.tar.bz2
linux-64::libadios2-2.8.3-mpi_mpich_h8e71b1c_2.tar.bz2
linux-64::arrow-cpp-6.0.2-py38hf04e27b_3_cuda.tar.bz2
linux-64::libadios2-2.8.3-nompi_hc18e13d_103.tar.bz2
linux-64::arrow-cpp-8.0.1-py38h6933191_4_cpu.tar.bz2
linux-64::arrow-cpp-7.0.1-py310hda5e8db_1_cuda.tar.bz2
linux-64::protozfits-2.0.1.post1-py38hdae5b66_9.tar.bz2
linux-64::mongodb-6.0.1-h024d9bb_1.tar.bz2
linux-64::perl-net-ssleay-1.92-pl5321haa6b8db_0.tar.bz2
linux-64::arrow-cpp-9.0.0-py39h1ae1b14_3_cuda.tar.bz2
linux-64::arrow-cpp-6.0.2-py310h836ab38_1_cuda.tar.bz2
linux-64::libgdal-3.5.2-h84f2e82_1.tar.bz2
linux-64::nodejs-18.10.0-h96d913c_0.tar.bz2
linux-64::vtk-9.1.0-qt_py38hc2a4946_215.tar.bz2
linux-64::arrow-cpp-6.0.2-py39h8dba964_0_cpu.tar.bz2
linux-64::arrow-cpp-7.0.1-py39ha525f37_1_cuda.tar.bz2
linux-64::folly-2022.09.12.00-h1234567_1.tar.bz2
linux-64::pyreadstat-1.1.9-py39hd08d98e_1.tar.bz2
linux-64::python-igraph-0.9.11-py310hf05fc85_1.tar.bz2
linux-64::rsync-3.2.6-h70740c4_0.tar.bz2
linux-64::libgdal-3.5.2-hc23bfc3_1.tar.bz2
-    "libzlib >=1.2.12,<1.3.0a0",
+    "libzlib >=1.2.12,<2.0.0a0",
linux-64::liblal-7.2.2-fftw_h818ca7a_100.tar.bz2
linux-64::libclang-cpp-15.0.1-default_h2e3cab8_0.tar.bz2
linux-64::povray-3.7.0.8-h7376ae0_5.tar.bz2
linux-64::gst-plugins-base-1.20.3-h57caac4_2.tar.bz2
linux-64::websocketpp-0.8.2-h4c92fa2_0.tar.bz2
linux-64::libprotobuf-static-3.20.1-h6239696_2.tar.bz2
linux-64::clang-format-15-15.0.1-default_h2e3cab8_0.tar.bz2
linux-64::zimpl-3.5.2-hb4bb7ca_3.tar.bz2
linux-64::libprotobuf-3.21.6-h6239696_1.tar.bz2
linux-64::libclang13-15.0.1-default_h3a83d3e_0.tar.bz2
linux-64::libllvm11-11.1.0-he0ac6c6_4.tar.bz2
linux-64::clang-format-15-15.0.0-default_h2e3cab8_0.tar.bz2
linux-64::coin-or-osi-0.108.7-h2720bb7_2.tar.bz2
linux-64::libprotobuf-static-3.21.5-h6239696_1.tar.bz2
linux-64::readstat-1.1.8-h5e2004d_1.tar.bz2
linux-64::clang-15-15.0.1-default_h2e3cab8_0.tar.bz2
linux-64::clang-format-15.0.0-default_h2e3cab8_0.tar.bz2
linux-64::libclang-cpp-15.0.0-default_h2e3cab8_0.tar.bz2
linux-64::llvm-spirv-14.0.0-he0ac6c6_1.tar.bz2
linux-64::libprotobuf-static-3.21.5-h6239696_2.tar.bz2
linux-64::libclang-cpp15-15.0.1-default_h2e3cab8_0.tar.bz2
linux-64::libsqlite-3.39.3-h753d276_0.tar.bz2
linux-64::zimpl-3.5.2-hb4bb7ca_2.tar.bz2
linux-64::libpng-1.6.38-h753d276_0.tar.bz2
linux-64::websocketpp-0.8.2-hf40c2ba_1.tar.bz2
linux-64::libprotobuf-3.20.1-h6239696_3.tar.bz2
linux-64::gst-plugins-base-1.20.3-h57caac4_1.tar.bz2
linux-64::libprotobuf-3.21.5-h6239696_2.tar.bz2
linux-64::libclang-15.0.1-default_h2e3cab8_0.tar.bz2
linux-64::glib-tools-2.74.0-h6239696_0.tar.bz2
linux-64::libprotobuf-3.20.1-h6239696_4.tar.bz2
linux-64::clang-tools-15.0.0-default_h2e3cab8_0.tar.bz2
linux-64::libprotobuf-3.21.5-h6239696_3.tar.bz2
linux-64::libprotobuf-static-3.20.1-h6239696_3.tar.bz2
linux-64::libprotobuf-static-3.21.6-h6239696_1.tar.bz2
linux-64::clang-tools-15.0.1-default_h2e3cab8_0.tar.bz2
linux-64::clang-15-15.0.0-default_h2e3cab8_0.tar.bz2
linux-64::llvm-tools-11.1.0-he0ac6c6_4.tar.bz2
linux-64::libprotobuf-3.21.6-h6239696_0.tar.bz2
linux-64::clang-format-15.0.1-default_h2e3cab8_0.tar.bz2
linux-64::coin-or-utils-2.11.6-h202d8b1_2.tar.bz2
linux-64::libprotobuf-static-3.21.6-h6239696_0.tar.bz2
linux-64::fontconfig-2.14.0-hc2a2eb6_1.tar.bz2
linux-64::libprotobuf-static-3.21.5-h6239696_3.tar.bz2
linux-64::llvm-11.1.0-h32600fe_4.tar.bz2
linux-64::libclang-15.0.0-default_h2e3cab8_0.tar.bz2
linux-64::libclang-cpp15-15.0.0-default_h2e3cab8_0.tar.bz2
linux-64::libclang13-15.0.0-default_h3a83d3e_0.tar.bz2
linux-64::libprotobuf-static-3.20.1-h6239696_4.tar.bz2
-    "libzlib >=1.2.12,<1.3.0a0"
+    "libzlib >=1.2.12,<2.0.0a0"
```

</details>