### PR TITLE
loosen zlib-pin to major level (22/N; August 2022)

### DIFF
--- a/recipe/patch_yaml/zlib.yaml
+++ b/recipe/patch_yaml/zlib.yaml
@@ -187,3 +187,12 @@ then:
   - loosen_depends:
       name: libzlib
       upper_bound: "2"
+---
+if:
+  has_depends: libzlib >=1.2*
+  timestamp_lt: 1661990400000  # 2022-09-01 00:00 UTC
+  timestamp_ge: 1659312000000  # 2022-08-01 00:00 UTC
+then:
+  - loosen_depends:
+      name: libzlib
+      upper_bound: "2"


### PR DESCRIPTION
Follow-up to https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/739, about X artefacts affected.

### Result of `python show_diff.py`

<details>

```diff
```

</details>