### PR TITLE
loosen zlib-pin to major level (23/N; June & July 2022)

### DIFF
--- a/recipe/patch_yaml/zlib.yaml
+++ b/recipe/patch_yaml/zlib.yaml
@@ -205,3 +205,12 @@ then:
   - loosen_depends:
       name: libzlib
       upper_bound: "2"
+---
+if:
+  has_depends: libzlib >=1.2*
+  timestamp_lt: 1656633600000  # 2022-07-01 00:00 UTC
+  timestamp_ge: 1654041600000  # 2022-06-01 00:00 UTC
+then:
+  - loosen_depends:
+      name: libzlib
+      upper_bound: "2"

--- a/recipe/patch_yaml/zlib.yaml
+++ b/recipe/patch_yaml/zlib.yaml
@@ -196,3 +196,12 @@ then:
   - loosen_depends:
       name: libzlib
       upper_bound: "2"
+---
+if:
+  has_depends: libzlib >=1.2*
+  timestamp_lt: 1659312000000  # 2022-08-01 00:00 UTC
+  timestamp_ge: 1656633600000  # 2022-07-01 00:00 UTC
+then:
+  - loosen_depends:
+      name: libzlib
+      upper_bound: "2"


### PR DESCRIPTION
Follow-up to https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/739, about 4400 artefacts affected.

### Result of `python show_diff.py`

<details>

```diff
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
linux-ppc64le
linux-ppc64le::arrow-cpp-5.0.0-py37h9ac9d18_35_cpu.tar.bz2
linux-ppc64le::libopencv-4.6.0-py310h6a6f48e_3.tar.bz2
linux-ppc64le::libopencv-4.6.0-py38h9bcac7c_0.tar.bz2
linux-ppc64le::arrow-cpp-8.0.0-py38h9190bb6_1_cpu.tar.bz2
linux-ppc64le::libpq-14.4-h8203483_0.tar.bz2
linux-ppc64le::vtk-9.1.0-qt_py39h237216a_209.tar.bz2
linux-ppc64le::pyreadstat-1.1.9-py39h68499bf_0.tar.bz2
linux-ppc64le::imagemagick-7.1.0.43-pl5321h44e7865_0.tar.bz2
linux-ppc64le::arrow-cpp-8.0.0-py37hf1e70c6_3_cpu.tar.bz2
linux-ppc64le::libpq-14.4-h9fbd2da_0.tar.bz2
linux-ppc64le::libopencv-4.6.0-py37h86a0027_3.tar.bz2
linux-ppc64le::libopencv-4.6.0-py38h59a0e08_1.tar.bz2
linux-ppc64le::libopencv-4.5.5-py39h2943183_12.tar.bz2
linux-ppc64le::grpc-cpp-1.45.2-h072c3dd_4.tar.bz2
linux-ppc64le::libopencv-4.6.0-py38h9bcac7c_1.tar.bz2
linux-ppc64le::postgresql-14.4-h5c1f22d_0.tar.bz2
linux-ppc64le::arrow-cpp-8.0.0-py310ha380b6c_4_cpu.tar.bz2
linux-ppc64le::pyreadstat-1.1.9-py38h553f306_0.tar.bz2
linux-ppc64le::cpp-opentelemetry-sdk-1.4.1-h61a7937_2.tar.bz2
linux-ppc64le::libglib-2.72.1-h4be9a15_0.tar.bz2
linux-ppc64le::mapserver-7.6.4-py310h6632c96_8.tar.bz2
linux-ppc64le::grpc-cpp-1.43.2-h314028f_6.tar.bz2
linux-ppc64le::postgresql-plpython-14.4-py39hbdddc40_0.tar.bz2
linux-ppc64le::libgdal-3.5.0-he86754f_2.tar.bz2
linux-ppc64le::arrow-cpp-7.0.0-py310h77b293d_8_cpu.tar.bz2
linux-ppc64le::vtk-9.1.0-qt_py38h0752e76_210.tar.bz2
linux-ppc64le::arrow-cpp-8.0.0-py38h1059231_5_cpu.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py39h36c6969_54_cpu.tar.bz2
linux-ppc64le::pillow-9.2.0-py38hdb37dd1_0.tar.bz2
linux-ppc64le::pdal-2.4.2-hdadeff6_3.tar.bz2
linux-ppc64le::arrow-cpp-7.0.0-py39h8beac7c_8_cpu.tar.bz2
linux-ppc64le::arrow-cpp-8.0.0-py39h12ffbfc_3_cpu.tar.bz2
linux-ppc64le::cpp-opentelemetry-sdk-1.4.1-h61a7937_1.tar.bz2
linux-ppc64le::openmpi-4.1.4-ha6b021e_100.tar.bz2
linux-ppc64le::pyreadstat-1.1.9-py37h5dbe327_0.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py37ha152ca9_20_cpu.tar.bz2
linux-ppc64le::librdkafka-1.9.1-h5ac515a_0.tar.bz2
linux-ppc64le::arrow-cpp-8.0.0-py39h8b7b185_5_cpu.tar.bz2
linux-ppc64le::libcurl-7.83.1-h1ac174b_0.tar.bz2
linux-ppc64le::libgdal-3.5.0-h8a6728d_1.tar.bz2
linux-ppc64le::arrow-cpp-8.0.0-py38h00c75bb_4_cpu.tar.bz2
linux-ppc64le::arrow-cpp-8.0.0-py37h2b9a8d7_4_cpu.tar.bz2
linux-ppc64le::libopencv-4.6.0-py37h80964a6_1.tar.bz2
linux-ppc64le::arrow-cpp-7.0.0-py38h2f27c36_8_cpu.tar.bz2
linux-ppc64le::arrow-cpp-7.0.0-py37hab2c54d_8_cpu.tar.bz2
linux-ppc64le::llvmdev-14.0.6-h3b69f5b_0.tar.bz2
linux-ppc64le::fenics-libdolfin-2019.1.0-h145bc16_31.tar.bz2
linux-ppc64le::grpc-cpp-1.46.3-h7ea06b5_2.tar.bz2
linux-ppc64le::mapserver-7.6.4-py37had1c113_10.tar.bz2
linux-ppc64le::libgdal-3.5.0-h5380aa6_3.tar.bz2
linux-ppc64le::tiledb-2.10.2-h11b1e19_0.tar.bz2
linux-ppc64le::sqlite-3.39.1-h3bd21b8_0.tar.bz2
linux-ppc64le::mongodb-5.2.1-h41936a2_0.tar.bz2
linux-ppc64le::coin-or-cgl-0.60.6-h12b7cce_1.tar.bz2
linux-ppc64le::arrow-cpp-8.0.0-py37hf594269_1_cpu.tar.bz2
linux-ppc64le::grpc-cpp-1.46.3-hd5d0d5a_1.tar.bz2
linux-ppc64le::geotiff-1.7.1-h679f354_3.tar.bz2
linux-ppc64le::libarchive-3.5.2-h7ab535a_3.tar.bz2
linux-ppc64le::openmpi-4.1.3-hb1f5ef7_104.tar.bz2
linux-ppc64le::glib-2.72.1-ha72a2fa_0.tar.bz2
linux-ppc64le::xrootd-5.4.3-py310h375a5b4_0.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py310h53c0ef3_54_cpu.tar.bz2
linux-ppc64le::tiledb-2.10.1-h11b1e19_0.tar.bz2
linux-ppc64le::ffmpeg-5.0.1-gpl_h6f2bf8a_105.tar.bz2
linux-ppc64le::ffmpeg-4.4.2-h2e5205d_0.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py37h9ac9d18_54_cpu.tar.bz2
linux-ppc64le::libspatialite-5.0.1-he442c0e_18.tar.bz2
linux-ppc64le::libopencv-4.6.0-py310hea84e48_1.tar.bz2
linux-ppc64le::ffmpeg-5.0.1-lgpl_h245c98b_7.tar.bz2
linux-ppc64le::arrow-cpp-8.0.0-py310h1129cf2_3_cpu.tar.bz2
linux-ppc64le::openbabel-3.1.1-py38h3ac9ee2_4.tar.bz2
linux-ppc64le::mongodb-6.0.0-hce3fca1_0.tar.bz2
linux-ppc64le::libopencv-4.6.0-py39h2943183_0.tar.bz2
linux-ppc64le::libgdal-3.5.1-hc9db435_2.tar.bz2
linux-ppc64le::libgdal-3.5.0-h1f1dbb9_2.tar.bz2
linux-ppc64le::vtk-9.1.0-qt_py38hfa66816_209.tar.bz2
linux-ppc64le::tiledb-2.9.5-h11b1e19_0.tar.bz2
linux-ppc64le::arrow-cpp-7.0.0-py37h22231d3_8_cpu.tar.bz2
linux-ppc64le::ffmpeg-4.4.2-lgpl_he3c2e0e_1.tar.bz2
linux-ppc64le::libopencv-4.6.0-py310hff4065b_2.tar.bz2
linux-ppc64le::hdf5-1.12.2-mpi_mpich_hdcbb436_0.tar.bz2
linux-ppc64le::mapserver-7.6.4-py39h0ece968_8.tar.bz2
linux-ppc64le::xrootd-5.4.3-py38ha5d5151_0.tar.bz2
linux-ppc64le::cpp-opentelemetry-sdk-1.4.1-he011279_2.tar.bz2
linux-ppc64le::mapserver-7.6.4-py39habecccc_11.tar.bz2
linux-ppc64le::pyreadstat-1.1.7-py37h0370d4e_0.tar.bz2
linux-ppc64le::ffmpeg-4.4.2-gpl_h8159a51_103.tar.bz2
linux-ppc64le::llvmdev-14.0.5-h3b69f5b_0.tar.bz2
linux-ppc64le::libopencv-4.6.0-py39hace93a5_0.tar.bz2
linux-ppc64le::grpc-cpp-1.43.2-h072c3dd_6.tar.bz2
linux-ppc64le::pillow-9.2.0-py37h5061cd4_0.tar.bz2
linux-ppc64le::arrow-cpp-8.0.1-py310ha380b6c_0_cpu.tar.bz2
linux-ppc64le::pdal-2.4.1-h60b858d_2.tar.bz2
linux-ppc64le::curl-7.83.1-h1ac174b_0.tar.bz2
linux-ppc64le::arrow-cpp-8.0.0-py310h3b0e6ca_1_cpu.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py39h32d69a7_54_cpu.tar.bz2
linux-ppc64le::mongodb-5.3.2-hce3fca1_0.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py310h53c0ef3_20_cpu.tar.bz2
linux-ppc64le::libopencv-4.6.0-py38h23e4b54_2.tar.bz2
linux-ppc64le::xrootd-5.4.3-py38h3687d79_1.tar.bz2
linux-ppc64le::grpc-cpp-1.47.1-hf61bd5b_0.tar.bz2
linux-ppc64le::graphviz-2.50.0-h2dab0cd_3.tar.bz2
linux-ppc64le::openmpi-4.1.3-ha6b021e_105.tar.bz2
linux-ppc64le::xrootd-5.4.3-py39hd0d693e_1.tar.bz2
linux-ppc64le::libpng-1.6.37-hcc10993_3.tar.bz2
linux-ppc64le::vtk-9.1.0-qt_py39h380161a_210.tar.bz2
linux-ppc64le::tesseract-5.2.0-hf10cad7_0.tar.bz2
linux-ppc64le::vtk-9.1.0-qt_py310h201117f_209.tar.bz2
linux-ppc64le::pdal-2.4.2-hbba2935_0.tar.bz2
linux-ppc64le::openjdk-11.0.15-h65c716e_0.tar.bz2
linux-ppc64le::ffmpeg-5.0.1-gpl_h6f2bf8a_104.tar.bz2
linux-ppc64le::cppyy-cling-6.27.0-py38hb6edf9e_0.tar.bz2
linux-ppc64le::pdal-2.4.1-hb08791a_1.tar.bz2
linux-ppc64le::cmake-3.23.3-h4f7acd8_0.tar.bz2
linux-ppc64le::imagecodecs-2022.7.27-py310h5461375_1.tar.bz2
linux-ppc64le::pdal-2.4.1-hbba2935_2.tar.bz2
linux-ppc64le::ffmpeg-4.4.2-lgpl_h99aa470_6.tar.bz2
linux-ppc64le::glib-networking-2.72.1-h66abc5c_1.tar.bz2
linux-ppc64le::libgdal-3.5.1-h065ea7f_2.tar.bz2
linux-ppc64le::libmongoc-1.22.0-h38ffc6b_0.tar.bz2
linux-ppc64le::arrow-cpp-8.0.0-py39hb37cde5_1_cpu.tar.bz2
linux-ppc64le::glib-networking-2.72.1-hb1ff470_1.tar.bz2
linux-ppc64le::libopencv-4.5.5-py39hace93a5_11.tar.bz2
linux-ppc64le::sqlite-3.39.0-h3bd21b8_0.tar.bz2
linux-ppc64le::git-2.37.0-pl5321hbceff91_0.tar.bz2
linux-ppc64le::tiledb-2.9.5-ha4bc364_0.tar.bz2
linux-ppc64le::wxwidgets-3.2.0-py310hede299b_1.tar.bz2
linux-ppc64le::cpp-opentelemetry-sdk-1.4.1-hbf4d76c_3.tar.bz2
linux-ppc64le::ldas-tools-framecpp-2.9.0-hf7f3998_0.tar.bz2
linux-ppc64le::libopencv-4.5.5-py37h80964a6_12.tar.bz2
linux-ppc64le::wxwidgets-3.2.0-h059a3f2_0.tar.bz2
linux-ppc64le::arrow-cpp-8.0.0-py310h33b7674_5_cpu.tar.bz2
linux-ppc64le::mongodb-5.2.0-hce3fca1_0.tar.bz2
linux-ppc64le::mongodb-5.3.2-h41936a2_0.tar.bz2
linux-ppc64le::arrow-cpp-8.0.0-py39hf77e9c6_1_cpu.tar.bz2
linux-ppc64le::vtk-9.1.0-qt_py37h99c95d9_210.tar.bz2
linux-ppc64le::librdkafka-1.9.1-h36f433a_0.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py38h4490bee_20_cpu.tar.bz2
linux-ppc64le::hdf5-1.12.2-mpi_mpich_h3c62663_0.tar.bz2
linux-ppc64le::xrootd-5.4.3-py38h638ae86_0.tar.bz2
linux-ppc64le::libtiff-4.4.0-hc9fb2ee_1.tar.bz2
linux-ppc64le::ogre-13.4.1-hd428ee4_1.tar.bz2
linux-ppc64le::mongodb-5.2.0-hd2e7532_0.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py38h4490bee_54_cpu.tar.bz2
linux-ppc64le::arrow-cpp-8.0.0-py37h2b81c1b_5_cpu.tar.bz2
linux-ppc64le::ogre-13.4.1-h137c098_0.tar.bz2
linux-ppc64le::arrow-cpp-8.0.0-py310hdad923b_1_cpu.tar.bz2
linux-ppc64le::cmake-3.23.2-h4f7acd8_0.tar.bz2
linux-ppc64le::arrow-cpp-8.0.0-py38h7f36183_2_cpu.tar.bz2
linux-ppc64le::mapserver-7.6.4-py39h59f0381_7.tar.bz2
linux-ppc64le::libopencv-4.6.0-py39hd097360_2.tar.bz2
linux-ppc64le::arrow-cpp-8.0.1-py37h2b9a8d7_0_cpu.tar.bz2
linux-ppc64le::hdf5-1.12.2-nompi_he7b1174_100.tar.bz2
linux-ppc64le::ffmpeg-5.0.1-gpl_h8159a51_106.tar.bz2
linux-ppc64le::libopencv-4.5.5-py39hace93a5_12.tar.bz2
linux-ppc64le::fish-3.5.1-h28d1537_0.tar.bz2
linux-ppc64le::libopencv-4.5.5-py39hace93a5_10.tar.bz2
linux-ppc64le::libgit2-1.5.0-heee76ec_0.tar.bz2
linux-ppc64le::arrow-cpp-8.0.0-py310ha380b6c_5_cpu.tar.bz2
linux-ppc64le::cpp-opentelemetry-sdk-1.4.1-hb6a04ad_0.tar.bz2
linux-ppc64le::arrow-cpp-8.0.0-py38h9190bb6_2_cpu.tar.bz2
linux-ppc64le::libxml2-2.9.14-hc8bd4e3_2.tar.bz2
linux-ppc64le::libgsf-1.14.50-h74189ae_0.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py39h32d69a7_35_cpu.tar.bz2
linux-ppc64le::xrootd-5.4.3-py37h0d0d2e1_1.tar.bz2
linux-ppc64le::libgdal-3.5.1-h1e9f507_1.tar.bz2
linux-ppc64le::libopencv-4.5.5-py37h80964a6_11.tar.bz2
linux-ppc64le::arrow-cpp-8.0.1-py39h6121070_0_cpu.tar.bz2
linux-ppc64le::libgdal-3.5.1-h51dae8c_1.tar.bz2
linux-ppc64le::mongodb-6.0.0-hd2e7532_0.tar.bz2
linux-ppc64le::cppyy-cling-6.27.0-py37hdd56643_0.tar.bz2
linux-ppc64le::ogre-1.12.13-h5f75287_2.tar.bz2
linux-ppc64le::libzip-1.9.2-hd1f1b4c_0.tar.bz2
linux-ppc64le::vtk-9.1.0-qt_py39h32c7f2c_212.tar.bz2
linux-ppc64le::gmsh-4.10.5-h23cd722_0.tar.bz2
linux-ppc64le::mongodb-5.2.1-heb9217d_0.tar.bz2
linux-ppc64le::vtk-9.1.0-qt_py37hec8ee9b_212.tar.bz2
linux-ppc64le::ldas-tools-framecpp-2.9.1-h915b827_0.tar.bz2
linux-ppc64le::mapserver-7.6.4-py37hfe2d367_7.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py38h0ea5ac4_35_cpu.tar.bz2
linux-ppc64le::libgdal-3.5.0-h51dae8c_5.tar.bz2
linux-ppc64le::xrootd-5.4.3-py39h910a105_0.tar.bz2
linux-ppc64le::libopencv-4.5.5-py310hea84e48_13.tar.bz2
linux-ppc64le::arrow-cpp-8.0.0-py310h7e35253_3_cpu.tar.bz2
linux-ppc64le::postgresql-plpython-14.4-py37hec40d7e_0.tar.bz2
linux-ppc64le::pdal-2.4.2-hbba2935_2.tar.bz2
linux-ppc64le::fenics-libdolfin-2019.1.0-h4c0f4d5_31.tar.bz2
linux-ppc64le::libprotobuf-static-21.4-ha72a2fa_0.tar.bz2
linux-ppc64le::libopencv-4.6.0-py39h5f98151_3.tar.bz2
linux-ppc64le::pillow-9.2.0-py38hcb1119a_0.tar.bz2
linux-ppc64le::mapserver-7.6.4-py38h460480e_8.tar.bz2
linux-ppc64le::ffmpeg-5.0.1-gpl_h3d3d4d4_107.tar.bz2
linux-ppc64le::ffmpeg-4.4.2-gpl_h3d3d4d4_104.tar.bz2
linux-ppc64le::libopencv-4.5.5-py38h59a0e08_11.tar.bz2
linux-ppc64le::vtk-9.1.0-qt_py38h1ca8281_212.tar.bz2
linux-ppc64le::postgresql-plpython-14.4-py38h777a03b_0.tar.bz2
linux-ppc64le::pyreadstat-1.1.7-py39h68499bf_0.tar.bz2
linux-ppc64le::sqlite-3.39.2-h3bd21b8_0.tar.bz2
linux-ppc64le::arrow-cpp-8.0.1-py310h33b7674_0_cpu.tar.bz2
linux-ppc64le::libopencv-4.5.5-py310hea84e48_10.tar.bz2
linux-ppc64le::grpc-cpp-1.45.2-hd71d159_4.tar.bz2
linux-ppc64le::git-2.37.0-pl5321h131946c_0.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py39h36c6969_20_cpu.tar.bz2
linux-ppc64le::libmongoc-1.22.0-h8e0dd54_0.tar.bz2
linux-ppc64le::rust-1.62.0-hf3e60ca_0.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py310h53c0ef3_35_cpu.tar.bz2
linux-ppc64le::libopencv-4.6.0-py39h879b1c5_2.tar.bz2
linux-ppc64le::xrootd-5.4.3-py310h375a5b4_1.tar.bz2
linux-ppc64le::arrow-cpp-8.0.0-py310hdad923b_2_cpu.tar.bz2
linux-ppc64le::libopencv-4.6.0-py38ha13be96_3.tar.bz2
linux-ppc64le::xrootd-5.4.3-py39h8f32654_0.tar.bz2
linux-ppc64le::imagemagick-7.1.0_41-pl5321h2621fa6_0.tar.bz2
linux-ppc64le::libxml2-2.9.14-hc8bd4e3_1.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py38h0ea5ac4_54_cpu.tar.bz2
linux-ppc64le::pdal-2.4.2-h60b858d_0.tar.bz2
linux-ppc64le::postgresql-plpython-14.4-py310h8fb64e9_0.tar.bz2
linux-ppc64le::libarchive-3.5.2-h01158bd_3.tar.bz2
linux-ppc64le::tiledb-2.9.3-h11b1e19_0.tar.bz2
linux-ppc64le::libopencv-4.5.5-py310hea84e48_12.tar.bz2
linux-ppc64le::tiledb-2.9.4-h11b1e19_0.tar.bz2
linux-ppc64le::mapserver-7.6.4-py39hf7ebe6d_9.tar.bz2
linux-ppc64le::xrootd-5.4.3-py37h590fc74_1.tar.bz2
linux-ppc64le::xrootd-5.4.3-py38h638ae86_1.tar.bz2
linux-ppc64le::ffmpeg-4.4.2-gpl_h3d3d4d4_105.tar.bz2
linux-ppc64le::arrow-cpp-8.0.1-py38h1059231_0_cpu.tar.bz2
linux-ppc64le::pyreadstat-1.1.9-py37h0370d4e_0.tar.bz2
linux-ppc64le::libspatialite-5.0.1-h3e16286_17.tar.bz2
linux-ppc64le::tesseract-5.1.0-hf10cad7_0.tar.bz2
linux-ppc64le::grpc-cpp-1.46.3-ha483e86_1.tar.bz2
linux-ppc64le::vowpalwabbit-9.2.0-py37h4efa2fe_0.tar.bz2
linux-ppc64le::prometheus-cpp-1.0.1-h66f153c_0.tar.bz2
linux-ppc64le::imagemagick-7.1.0_40-pl5321h2621fa6_0.tar.bz2
linux-ppc64le::hdf5-1.12.2-nompi_h85f07b9_100.tar.bz2
linux-ppc64le::mongodb-5.2.0-heb9217d_0.tar.bz2
linux-ppc64le::libzip-1.9.2-h7a13181_0.tar.bz2
linux-ppc64le::libtiff-4.4.0-hf3ce6f2_2.tar.bz2
linux-ppc64le::postgresql-plpython-14.4-py38h4f5da63_0.tar.bz2
linux-ppc64le::ffmpeg-5.1.0-lgpl_h99aa470_0.tar.bz2
linux-ppc64le::arrow-cpp-8.0.0-py38h32f4183_3_cpu.tar.bz2
linux-ppc64le::postgresql-plpython-14.4-py39hf36d1c2_0.tar.bz2
linux-ppc64le::libprotobuf-static-21.2-ha72a2fa_0.tar.bz2
linux-ppc64le::arrow-cpp-8.0.0-py39h6121070_4_cpu.tar.bz2
linux-ppc64le::clangdev-14.0.5-default_h1896e6d_0.tar.bz2
linux-ppc64le::grpc-cpp-1.44.0-hd71d159_5.tar.bz2
linux-ppc64le::postgresql-plpython-14.4-py310h318e24f_0.tar.bz2
linux-ppc64le::libopencv-4.5.5-py39hace93a5_13.tar.bz2
linux-ppc64le::geotiff-1.7.1-h679f354_2.tar.bz2
linux-ppc64le::openbabel-3.1.1-py37hce52177_4.tar.bz2
linux-ppc64le::imagecodecs-2022.7.27-py38h1fcfd79_0.tar.bz2
linux-ppc64le::libopencv-4.6.0-py39h6bd5d01_3.tar.bz2
linux-ppc64le::arrow-cpp-8.0.0-py39hb37cde5_2_cpu.tar.bz2
linux-ppc64le::mapserver-7.6.4-py310h09a3cd2_7.tar.bz2
linux-ppc64le::grpc-cpp-1.43.2-hd71d159_6.tar.bz2
linux-ppc64le::vowpalwabbit-9.2.0-py38ha23c9fd_0.tar.bz2
linux-ppc64le::mapserver-7.6.4-py39h7912193_10.tar.bz2
linux-ppc64le::libgdal-3.5.1-h51dae8c_0.tar.bz2
linux-ppc64le::mlir-14.0.3-h96f6aa1_0.tar.bz2
linux-ppc64le::libopencv-4.5.5-py38h9bcac7c_11.tar.bz2
linux-ppc64le::libgit2-1.4.4-heee76ec_0.tar.bz2
linux-ppc64le::mapserver-7.6.4-py37hcc62d73_9.tar.bz2
linux-ppc64le::libopencv-4.6.0-py38h0e15c88_3.tar.bz2
linux-ppc64le::gmsh-4.10.4-h23cd722_0.tar.bz2
linux-ppc64le::ffmpeg-5.0.1-lgpl_h99aa470_8.tar.bz2
linux-ppc64le::grpc-cpp-1.43.2-h40ec86f_6.tar.bz2
linux-ppc64le::grpc-cpp-1.45.2-h40ec86f_4.tar.bz2
linux-ppc64le::librdkafka-1.9.0-h76d1442_0.tar.bz2
linux-ppc64le::coin-or-clp-1.17.7-h983ba35_1.tar.bz2
linux-ppc64le::mlir-14.0.5-h96f6aa1_0.tar.bz2
linux-ppc64le::mapserver-7.6.4-py310haf4f95d_9.tar.bz2
linux-ppc64le::ldas-tools-framecpp-2.9.1-h13c1508_0.tar.bz2
linux-ppc64le::arrow-cpp-8.0.0-py310h33b7674_4_cpu.tar.bz2
linux-ppc64le::openbabel-3.1.1-py310ha1f192d_4.tar.bz2
linux-ppc64le::ogre-13.4.2-hd428ee4_0.tar.bz2
linux-ppc64le::libcurl-static-7.83.1-h1ac174b_0.tar.bz2
linux-ppc64le::libopencv-4.5.5-py39h2943183_10.tar.bz2
linux-ppc64le::vtk-9.1.0-qt_py38h27cab94_211.tar.bz2
linux-ppc64le::arrow-cpp-8.0.0-py38h1059231_4_cpu.tar.bz2
linux-ppc64le::postgresql-plpython-14.4-py37h5ff7a43_0.tar.bz2
linux-ppc64le::arrow-cpp-8.0.0-py39h8b7b185_4_cpu.tar.bz2
linux-ppc64le::tiledb-2.10.1-ha4bc364_0.tar.bz2
linux-ppc64le::glib-networking-2.72.1-h77685a4_0.tar.bz2
linux-ppc64le::libnetcdf-4.8.1-mpi_openmpi_h61ae36f_3.tar.bz2
linux-ppc64le::libopencv-4.5.5-py37h80964a6_10.tar.bz2
linux-ppc64le::xrootd-5.4.3-py37h0d0d2e1_0.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py38h0ea5ac4_20_cpu.tar.bz2
linux-ppc64le::hdf5-1.12.2-mpi_openmpi_hd7df8e7_0.tar.bz2
linux-ppc64le::vtk-9.1.0-qt_py310hcf62b44_211.tar.bz2
linux-ppc64le::python-3.10.5-h0cb8861_0_cpython.tar.bz2
linux-ppc64le::pyreadstat-1.1.7-py38h553f306_0.tar.bz2
linux-ppc64le::arrow-cpp-8.0.0-py37h1ba6b11_2_cpu.tar.bz2
linux-ppc64le::texlive-core-20210325-he94f91b_4.tar.bz2
linux-ppc64le::imagemagick-7.1.0_44-pl5321h44e7865_0.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py37h9ac9d18_20_cpu.tar.bz2
linux-ppc64le::root_base-6.26.4-py38h4c6bb4a_3.tar.bz2
linux-ppc64le::libopencv-4.6.0-py310hea84e48_0.tar.bz2
linux-ppc64le::ffmpeg-5.0.1-gpl_hf56ae17_108.tar.bz2
linux-ppc64le::librdkafka-1.9.0-h3992f39_0.tar.bz2
linux-ppc64le::libsoup-2.74.2-h7ee6442_0.tar.bz2
linux-ppc64le::git-2.37.1-pl5321hbceff91_0.tar.bz2
linux-ppc64le::libopencv-4.6.0-py39hace93a5_1.tar.bz2
linux-ppc64le::mapserver-7.6.4-py38h3197c22_11.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py39h32d69a7_20_cpu.tar.bz2
linux-ppc64le::imagecodecs-2022.2.22-py38hef43db0_6.tar.bz2
linux-ppc64le::ffmpeg-5.0.1-lgpl_he3c2e0e_5.tar.bz2
linux-ppc64le::tiledb-2.10.2-ha4bc364_0.tar.bz2
linux-ppc64le::vtk-9.1.0-qt_py310h5bfa8fc_212.tar.bz2
linux-ppc64le::cppyy-cling-6.27.0-py39h51b9803_0.tar.bz2
linux-ppc64le::fenics-libdolfin-2019.1.0-h3183372_30.tar.bz2
linux-ppc64le::grpc-cpp-1.47.0-h7ea06b5_1.tar.bz2
linux-ppc64le::imagecodecs-2022.7.27-py38h51d7eb3_1.tar.bz2
linux-ppc64le::postgresql-14.4-he6b6aa5_0.tar.bz2
linux-ppc64le::mongodb-5.2.1-hce3fca1_0.tar.bz2
linux-ppc64le::grpc-cpp-1.44.0-h072c3dd_5.tar.bz2
linux-ppc64le::mapserver-7.6.4-py38h1d30b9d_10.tar.bz2
linux-ppc64le::libopencv-4.6.0-py38h0bd3c0e_2.tar.bz2
linux-ppc64le::libopencv-4.5.5-py310hea84e48_11.tar.bz2
linux-ppc64le::libopencv-4.5.5-py38h59a0e08_12.tar.bz2
linux-ppc64le::grpc-cpp-1.48.0-hf61bd5b_0.tar.bz2
linux-ppc64le::cpp-opentelemetry-sdk-1.4.1-he011279_3.tar.bz2
linux-ppc64le::arrow-cpp-8.0.0-py37h2b81c1b_4_cpu.tar.bz2
linux-ppc64le::imagemagick-7.1.0_39-pl5321h2621fa6_0.tar.bz2
linux-ppc64le::gfal2-2.21.0-h1671a64_0.tar.bz2
linux-ppc64le::imagecodecs-2022.7.27-py39h11357df_0.tar.bz2
linux-ppc64le::arrow-cpp-7.0.0-py38hfd14ca2_8_cpu.tar.bz2
linux-ppc64le::grpc-cpp-1.48.0-h7ea06b5_0.tar.bz2
linux-ppc64le::mapserver-7.6.4-py37hb46384c_11.tar.bz2
linux-ppc64le::grpc-cpp-1.47.0-ha483e86_0.tar.bz2
linux-ppc64le::libopencv-4.5.5-py38h59a0e08_13.tar.bz2
linux-ppc64le::ffmpeg-4.4.2-gpl_h6f2bf8a_101.tar.bz2
linux-ppc64le::imagecodecs-2022.2.22-py310h2e61ef2_6.tar.bz2
linux-ppc64le::xrootd-5.4.3-py38hf25a345_1.tar.bz2
linux-ppc64le::vowpalwabbit-9.2.0-py310h579531b_0.tar.bz2
linux-ppc64le::tiledb-2.10.0-h11b1e19_0.tar.bz2
linux-ppc64le::wxwidgets-3.1.7-h059a3f2_0.tar.bz2
linux-ppc64le::cpp-opentelemetry-sdk-1.4.1-he011279_1.tar.bz2
linux-ppc64le::libsoup-3.0.7-h7ee6442_0.tar.bz2
linux-ppc64le::pdal-2.4.2-hbba2935_1.tar.bz2
linux-ppc64le::git-2.37.1-pl5321h131946c_0.tar.bz2
linux-ppc64le::mongodb-6.0.0-h41936a2_0.tar.bz2
linux-ppc64le::vtk-9.1.0-qt_py37h96ef7a9_209.tar.bz2
linux-ppc64le::clangdev-14.0.6-default_h1896e6d_0.tar.bz2
linux-ppc64le::arrow-cpp-8.0.0-py39hf77e9c6_2_cpu.tar.bz2
linux-ppc64le::root_base-6.26.4-py37h8986ac2_3.tar.bz2
linux-ppc64le::graphviz-4.0.0-h2dab0cd_1.tar.bz2
linux-ppc64le::imagecodecs-2022.2.22-py39h564eeac_6.tar.bz2
linux-ppc64le::graphviz-5.0.0-h2dab0cd_0.tar.bz2
linux-ppc64le::grpc-cpp-1.44.0-h40ec86f_5.tar.bz2
linux-ppc64le::arrow-cpp-8.0.1-py37h2b81c1b_0_cpu.tar.bz2
linux-ppc64le::arrow-cpp-8.0.0-py39hef4c8f1_3_cpu.tar.bz2
linux-ppc64le::arrow-cpp-8.0.0-py38h00c75bb_5_cpu.tar.bz2
linux-ppc64le::libgdal-3.5.0-h1e9f507_5.tar.bz2
linux-ppc64le::mongodb-5.3.2-hd2e7532_0.tar.bz2
linux-ppc64le::tiledb-2.10.0-ha4bc364_0.tar.bz2
linux-ppc64le::mapserver-7.6.4-py37hd419690_8.tar.bz2
linux-ppc64le::ffmpeg-4.4.2-gpl_h6f2bf8a_102.tar.bz2
linux-ppc64le::libopencv-4.6.0-py38h59a0e08_0.tar.bz2
linux-ppc64le::mongodb-6.0.0-heb9217d_0.tar.bz2
linux-ppc64le::libopencv-4.6.0-py39h2943183_1.tar.bz2
linux-ppc64le::librdkafka-1.9.1-h36f433a_1.tar.bz2
linux-ppc64le::mongodb-5.2.1-hd2e7532_0.tar.bz2
linux-ppc64le::xrootd-5.4.3-py39h910a105_1.tar.bz2
linux-ppc64le::zstd-1.5.2-h8ac4a70_2.tar.bz2
linux-ppc64le::vowpalwabbit-9.2.0-py39h1e80273_0.tar.bz2
linux-ppc64le::grpc-cpp-1.47.1-h7ea06b5_0.tar.bz2
linux-ppc64le::cpp-opentelemetry-sdk-1.4.1-h61a7937_4.tar.bz2
linux-ppc64le::smesh-9.8.0.2-h18d7a33_1.tar.bz2
linux-ppc64le::pillow-9.2.0-py39he47bc6b_0.tar.bz2
linux-ppc64le::fenics-libdolfin-2019.1.0-h8a3d221_30.tar.bz2
linux-ppc64le::ffmpeg-4.4.2-lgpl_hc247ca6_3.tar.bz2
linux-ppc64le::root_base-6.26.4-py39h0777a9b_3.tar.bz2
linux-ppc64le::libopencv-4.5.5-py37h80964a6_13.tar.bz2
linux-ppc64le::libxml2-2.9.14-hc8bd4e3_3.tar.bz2
linux-ppc64le::prometheus-cpp-1.0.0-h66f153c_0.tar.bz2
linux-ppc64le::librdkafka-1.9.1-h5ac515a_1.tar.bz2
linux-ppc64le::libgdal-3.5.0-h5b1aec5_3.tar.bz2
linux-ppc64le::pdal-2.4.2-h60b858d_2.tar.bz2
linux-ppc64le::libopencv-4.5.5-py38h9bcac7c_10.tar.bz2
linux-ppc64le::libgdal-3.5.0-h3ea25b2_1.tar.bz2
linux-ppc64le::mongodb-5.2.0-h41936a2_0.tar.bz2
linux-ppc64le::ffmpeg-4.4.2-lgpl_he3c2e0e_2.tar.bz2
linux-ppc64le::arrow-cpp-8.0.0-py37h2b9a8d7_5_cpu.tar.bz2
linux-ppc64le::arrow-cpp-8.0.0-py37hf594269_2_cpu.tar.bz2
linux-ppc64le::libspatialite-5.0.1-h4bdde78_16.tar.bz2
linux-ppc64le::mapserver-7.6.4-py38hb5c96e8_7.tar.bz2
linux-ppc64le::ffmpeg-4.4.2-lgpl_h245c98b_5.tar.bz2
linux-ppc64le::arrow-cpp-8.0.0-py38h7f36183_1_cpu.tar.bz2
linux-ppc64le::ogre-1.10.12-h112db1c_9.tar.bz2
linux-ppc64le::cppyy-cling-6.27.0-py310hbbdc3b4_0.tar.bz2
linux-ppc64le::xrootd-5.4.3-py310h188cf94_1.tar.bz2
linux-ppc64le::vtk-9.1.0-qt_py37h9df6470_211.tar.bz2
linux-ppc64le::vowpalwabbit-9.2.0-py37h26a726e_0.tar.bz2
linux-ppc64le::orc-1.7.5-he018b29_0.tar.bz2
linux-ppc64le::tiledb-2.9.4-ha4bc364_0.tar.bz2
linux-ppc64le::grpc-cpp-1.47.0-hd5d0d5a_0.tar.bz2
linux-ppc64le::arrow-cpp-8.0.1-py39h8b7b185_0_cpu.tar.bz2
linux-ppc64le::grpc-cpp-1.46.3-hf61bd5b_2.tar.bz2
linux-ppc64le::libopencv-4.5.5-py39h2943183_13.tar.bz2
linux-ppc64le::ffmpeg-5.0.1-lgpl_hc247ca6_6.tar.bz2
linux-ppc64le::libopencv-4.5.5-py38h9bcac7c_12.tar.bz2
linux-ppc64le::arrow-cpp-8.0.0-py37hf464883_3_cpu.tar.bz2
linux-ppc64le::libopencv-4.6.0-py37h922fc7f_2.tar.bz2
linux-ppc64le::pillow-9.2.0-py39h6cd6960_0.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py37ha152ca9_54_cpu.tar.bz2
linux-ppc64le::xrootd-5.4.3-py38ha5d5151_1.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py310h80ea60f_20_cpu.tar.bz2
linux-ppc64le::arrow-cpp-7.0.0-py310h8068b49_8_cpu.tar.bz2
linux-ppc64le::cpp-opentelemetry-sdk-1.4.1-he011279_4.tar.bz2
linux-ppc64le::libnetcdf-4.8.1-mpi_mpich_h31e3ad4_3.tar.bz2
linux-ppc64le::libgdal-3.5.0-h46644de_4.tar.bz2
linux-ppc64le::poppler-22.04.0-ha15b90a_1.tar.bz2
linux-ppc64le::ffmpeg-4.4.2-gpl_hf56ae17_106.tar.bz2
linux-ppc64le::hdf5-1.12.2-mpi_openmpi_h31519e4_0.tar.bz2
linux-ppc64le::libvips-8.13.0-hd201370_0.tar.bz2
linux-ppc64le::cpp-opentelemetry-sdk-1.4.1-he011279_0.tar.bz2
linux-ppc64le::pdal-2.4.1-he6b4ad1_1.tar.bz2
linux-ppc64le::imagemagick-7.1.0_41-pl5321h44e7865_1.tar.bz2
linux-ppc64le::ffmpeg-5.0.1-h2e5205d_3.tar.bz2
linux-ppc64le::libgit2-1.4.4-h5f335ab_0.tar.bz2
linux-ppc64le::imagemagick-7.1.0_38-pl5321h2621fa6_0.tar.bz2
linux-ppc64le::pyreadstat-1.1.7-py310hc3fd98a_0.tar.bz2
linux-ppc64le::graphviz-3.0.0-h2dab0cd_2.tar.bz2
linux-ppc64le::grpc-cpp-1.44.0-h314028f_5.tar.bz2
linux-ppc64le::imagecodecs-2022.7.27-py310h52f07d8_0.tar.bz2
linux-ppc64le::libmatio-1.5.23-h9e95a4b_1.tar.bz2
linux-ppc64le::ffmpeg-4.4.2-lgpl_h245c98b_4.tar.bz2
linux-ppc64le::root_base-6.26.4-py310hc73340b_3.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py310h80ea60f_54_cpu.tar.bz2
linux-ppc64le::libopencv-4.5.5-py38h9bcac7c_13.tar.bz2
linux-ppc64le::vtk-9.1.0-qt_py310h790534d_210.tar.bz2
linux-ppc64le::ffmpeg-5.0.1-lgpl_he3c2e0e_4.tar.bz2
linux-ppc64le::arrow-cpp-8.0.0-py37h1ba6b11_1_cpu.tar.bz2
linux-ppc64le::arrow-cpp-8.0.0-py39h6121070_5_cpu.tar.bz2
linux-ppc64le::arrow-cpp-7.0.0-py39h7c28260_8_cpu.tar.bz2
linux-ppc64le::grpc-cpp-1.45.2-h314028f_4.tar.bz2
linux-ppc64le::libgdal-3.5.0-h5daf618_4.tar.bz2
linux-ppc64le::pdal-2.4.2-h60b858d_1.tar.bz2
linux-ppc64le::pdal-2.4.2-h3988d54_3.tar.bz2
linux-ppc64le::openbabel-3.1.1-py39h02902a7_4.tar.bz2
linux-ppc64le::libitk-5.2.1-hdcc3714_4.tar.bz2
linux-ppc64le::pyreadstat-1.1.7-py37h5dbe327_0.tar.bz2
linux-ppc64le::arrow-cpp-8.0.0-py38h2f1f5e7_3_cpu.tar.bz2
linux-ppc64le::libopencv-4.5.5-py39h2943183_11.tar.bz2
linux-ppc64le::mapserver-7.6.4-py310h2ac12e8_10.tar.bz2
linux-ppc64le::vtk-9.1.0-qt_py39hf64d6bf_211.tar.bz2
linux-ppc64le::xrootd-5.4.3-py39h8f32654_1.tar.bz2
linux-ppc64le::tiledb-2.9.3-ha4bc364_0.tar.bz2
linux-ppc64le::mongodb-5.3.2-heb9217d_0.tar.bz2
linux-ppc64le::ffmpeg-5.1.0-gpl_hf56ae17_100.tar.bz2
linux-ppc64le::pyreadstat-1.1.9-py310hc3fd98a_0.tar.bz2
linux-ppc64le::libopencv-4.5.5-py38h59a0e08_10.tar.bz2
linux-ppc64le::ffmpeg-4.4.1-h2e5205d_5.tar.bz2
linux-ppc64le::mapserver-7.6.4-py38hc94ce07_9.tar.bz2
linux-ppc64le::libnetcdf-4.8.1-nompi_h7a936dc_103.tar.bz2
linux-ppc64le::mapserver-7.6.4-py310hb827185_11.tar.bz2
linux-ppc64le::xrootd-5.4.3-py39h0c29a2f_1.tar.bz2
linux-ppc64le::arrow-cpp-8.0.1-py38h00c75bb_0_cpu.tar.bz2
linux-ppc64le::pillow-9.2.0-py310hc96afb3_0.tar.bz2
linux-ppc64le::fish-3.5.0-h28d1537_0.tar.bz2
linux-ppc64le::arrow-cpp-8.0.0-py310h3b0e6ca_2_cpu.tar.bz2
linux-ppc64le::libopencv-4.6.0-py37h80964a6_0.tar.bz2
linux-ppc64le::libgit2-1.5.0-h5f335ab_0.tar.bz2
linux-ppc64le::ldas-tools-framecpp-2.9.0-h2ba7fcd_0.tar.bz2
linux-ppc64le::libprotobuf-static-21.3-ha72a2fa_0.tar.bz2
linux-ppc64le::imagemagick-7.1.0_37-pl5321h2621fa6_0.tar.bz2
linux-ppc64le::grpc-cpp-1.47.0-hf61bd5b_1.tar.bz2
linux-ppc64le::libgdal-3.5.1-h1e9f507_0.tar.bz2
-    "libzlib >=1.2.12,<1.3.0a0",
+    "libzlib >=1.2.12,<2.0.0a0",
linux-ppc64le::clang-format-14.0.5-default_h1896e6d_0.tar.bz2
linux-ppc64le::libclang13-14.0.6-default_ha49a280_0.tar.bz2
linux-ppc64le::coin-or-utils-2.11.6-h2c085dd_1.tar.bz2
linux-ppc64le::cudnn-8.3.2.44-h321de51_0.tar.bz2
linux-ppc64le::libllvm14-14.0.5-h3b69f5b_0.tar.bz2
linux-ppc64le::libclang-cpp14-14.0.5-default_h1896e6d_0.tar.bz2
linux-ppc64le::libclang-cpp14-14.0.6-default_h1896e6d_0.tar.bz2
linux-ppc64le::llvm-tools-14.0.5-h3b69f5b_0.tar.bz2
linux-ppc64le::llvm-14.0.5-h12068cf_0.tar.bz2
linux-ppc64le::clang-format-14-14.0.6-default_h1896e6d_0.tar.bz2
linux-ppc64le::openh264-2.2.0-ha72a2fa_1.tar.bz2
linux-ppc64le::coin-or-osi-0.108.7-h34d7808_1.tar.bz2
linux-ppc64le::libclang13-14.0.5-default_ha49a280_0.tar.bz2
linux-ppc64le::libmlir14-14.0.5-h96f6aa1_0.tar.bz2
linux-ppc64le::libclang-cpp-14.0.6-default_h1896e6d_0.tar.bz2
linux-ppc64le::gst-plugins-base-1.20.2-h6512beb_2.tar.bz2
linux-ppc64le::cudnn-8.4.0.27-h321de51_0.tar.bz2
linux-ppc64le::llvm-tools-14.0.6-h3b69f5b_0.tar.bz2
linux-ppc64le::clang-14-14.0.6-default_h1896e6d_0.tar.bz2
linux-ppc64le::libmagic-5.39-hcc10993_1.tar.bz2
linux-ppc64le::clang-format-14-14.0.5-default_h1896e6d_0.tar.bz2
linux-ppc64le::libclang-cpp-14.0.5-default_h1896e6d_0.tar.bz2
linux-ppc64le::libmlir14-14.0.3-h96f6aa1_0.tar.bz2
linux-ppc64le::cudnn-8.4.0.27-h321de51_1.tar.bz2
linux-ppc64le::gst-plugins-base-1.20.3-h6512beb_0.tar.bz2
linux-ppc64le::libllvm14-14.0.6-h3b69f5b_0.tar.bz2
linux-ppc64le::clang-tools-14.0.6-default_h1896e6d_0.tar.bz2
linux-ppc64le::glib-tools-2.72.1-ha72a2fa_0.tar.bz2
linux-ppc64le::clang-14-14.0.5-default_h1896e6d_0.tar.bz2
linux-ppc64le::libmlir-14.0.3-h96f6aa1_0.tar.bz2
linux-ppc64le::libclang-14.0.6-default_h1896e6d_0.tar.bz2
linux-ppc64le::libclang-14.0.5-default_h1896e6d_0.tar.bz2
linux-ppc64le::cudnn-8.3.2.44-h321de51_1.tar.bz2
linux-ppc64le::clang-format-14.0.6-default_h1896e6d_0.tar.bz2
linux-ppc64le::clang-tools-14.0.5-default_h1896e6d_0.tar.bz2
linux-ppc64le::libmlir-14.0.5-h96f6aa1_0.tar.bz2
linux-ppc64le::openh264-2.2.0-ha72a2fa_0.tar.bz2
linux-ppc64le::file-5.39-hcc10993_1.tar.bz2
linux-ppc64le::llvm-14.0.6-h12068cf_0.tar.bz2
-    "libzlib >=1.2.12,<1.3.0a0"
+    "libzlib >=1.2.12,<2.0.0a0"
================================================================================
================================================================================
linux-aarch64
linux-aarch64::mongodb-5.2.1-hcbb7fc8_0.tar.bz2
linux-aarch64::vtk-9.1.0-qt_py38h5f83dd5_211.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py37hdaa88b2_2_cpu.tar.bz2
linux-aarch64::libopencv-4.6.0-py37hc1bbaf2_0.tar.bz2
linux-aarch64::postgresql-plpython-14.4-py39hb3217f8_0.tar.bz2
linux-aarch64::libopencv-4.6.0-py38ha83d297_0.tar.bz2
linux-aarch64::qt-main-5.15.4-h09093bf_2.tar.bz2
linux-aarch64::libgdal-3.5.1-h72b7976_0.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py310hf57a544_1_cpu.tar.bz2
linux-aarch64::cpp-opentelemetry-sdk-1.4.1-h3d19de8_4.tar.bz2
linux-aarch64::ffmpeg-5.0.1-lgpl_hbab375f_7.tar.bz2
linux-aarch64::grpc-cpp-1.47.0-h19c0212_1.tar.bz2
linux-aarch64::root_base-6.26.4-py310hb46ab8d_3.tar.bz2
linux-aarch64::libopencv-4.5.5-py38hb0a0df1_12.tar.bz2
linux-aarch64::libgdal-3.5.1-h72b7976_1.tar.bz2
linux-aarch64::imagemagick-7.1.0_41-pl5321hde91a41_0.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py39hbe2f326_20_cpu.tar.bz2
linux-aarch64::qt-main-5.15.4-h09093bf_1.tar.bz2
linux-aarch64::sqlite-3.39.2-hc74f5b8_0.tar.bz2
linux-aarch64::ffmpeg-5.0.1-gpl_h1275b40_108.tar.bz2
linux-aarch64::nodejs-18.7.0-h928fb59_0.tar.bz2
linux-aarch64::orc-1.7.5-h016ce0c_0.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py39h932b275_4_cuda.tar.bz2
linux-aarch64::libmatio-1.5.23-hef60de1_1.tar.bz2
linux-aarch64::vowpalwabbit-9.2.0-py310h5ffbc89_0.tar.bz2
linux-aarch64::vtk-9.1.0-qt_py37h6e02971_212.tar.bz2
linux-aarch64::librdkafka-1.9.1-h70a263e_0.tar.bz2
linux-aarch64::libnetcdf-4.8.1-mpi_mpich_h792d7f8_3.tar.bz2
linux-aarch64::prometheus-cpp-1.0.1-hf32e593_0.tar.bz2
linux-aarch64::ffmpeg-5.0.1-gpl_hc6fb87e_105.tar.bz2
linux-aarch64::clangdev-14.0.6-default_ha7bf5e6_0.tar.bz2
linux-aarch64::grpc-cpp-1.48.0-h13cea6e_0.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py310h8b89866_4_cpu.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py38hc717704_5_cpu.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py39ha383ec2_5_cpu.tar.bz2
linux-aarch64::pyreadstat-1.1.7-py39hca51b09_0.tar.bz2
linux-aarch64::libopencv-4.6.0-py38h8304266_2.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py39h9dcb8f6_5_cpu.tar.bz2
linux-aarch64::libopencv-4.5.5-py39hdadc393_12.tar.bz2
linux-aarch64::postgresql-14.4-hd89e3e7_0.tar.bz2
linux-aarch64::libopencv-4.6.0-py39he74db38_1.tar.bz2
linux-aarch64::libopencv-4.5.5-py39hce51a2a_10.tar.bz2
linux-aarch64::libgdal-3.5.0-hbb572ce_1.tar.bz2
linux-aarch64::pdal-2.4.2-h3ab9495_0.tar.bz2
linux-aarch64::yoda-1.9.5-py310h54384be_1.tar.bz2
linux-aarch64::ogre-1.12.13-h7d42a4d_2.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py37hc3d30d7_2_cpu.tar.bz2
linux-aarch64::libgit2-1.5.0-he9ce915_0.tar.bz2
linux-aarch64::mapserver-7.6.4-py38hd277df4_8.tar.bz2
linux-aarch64::tiledb-2.9.3-h354e0e1_0.tar.bz2
linux-aarch64::openmpi-4.1.4-h34d0eb5_100.tar.bz2
linux-aarch64::arrow-cpp-7.0.0-py310hbe5fc41_8_cpu.tar.bz2
linux-aarch64::imagecodecs-2022.7.27-py310h8edf51d_1.tar.bz2
linux-aarch64::nodejs-18.3.0-h928fb59_0.tar.bz2
linux-aarch64::arrow-cpp-7.0.0-py310h8646389_8_cpu.tar.bz2
linux-aarch64::openmpi-4.1.3-h34d0eb5_105.tar.bz2
linux-aarch64::imagemagick-7.1.0_38-pl5321hde91a41_0.tar.bz2
linux-aarch64::mapserver-7.6.4-py38hdc58882_10.tar.bz2
linux-aarch64::libopencv-4.6.0-py38hb0a0df1_0.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py38hf766fd9_3_cuda.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py39hbe2f326_54_cpu.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py310hb330c1d_4_cuda.tar.bz2
linux-aarch64::vtk-9.1.0-qt_py39hde95ea2_211.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py37hca0bd1b_3_cuda.tar.bz2
linux-aarch64::arrow-cpp-8.0.1-py38h7c7ad16_0_cuda.tar.bz2
linux-aarch64::ogre-next-2.3.0-hbad1a05_1.tar.bz2
linux-aarch64::root_base-6.26.4-py38h9a81444_3.tar.bz2
linux-aarch64::pyreadstat-1.1.9-py37ha3a0a47_0.tar.bz2
linux-aarch64::librdkafka-1.9.1-h5eb4358_0.tar.bz2
linux-aarch64::xrootd-5.4.3-py39hcc239b0_1.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py38h2e4623d_1_cuda.tar.bz2
linux-aarch64::libgdal-3.5.0-hed33a98_5.tar.bz2
linux-aarch64::openbabel-3.1.1-py38h6f4d32d_4.tar.bz2
linux-aarch64::ffmpeg-4.4.2-h618b8be_0.tar.bz2
linux-aarch64::libopencv-4.6.0-py39hdadc393_1.tar.bz2
linux-aarch64::vtk-9.1.0-qt_py37hdba57f2_209.tar.bz2
linux-aarch64::ffmpeg-4.4.1-h618b8be_5.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py37h0f6a5ea_1_cuda.tar.bz2
linux-aarch64::libtiledb-sql-0.15.1-heaa659b_0.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py37h04e1d34_20_cpu.tar.bz2
linux-aarch64::postgresql-plpython-14.4-py38h1cbd339_0.tar.bz2
linux-aarch64::vtk-9.1.0-qt_py310he27233f_211.tar.bz2
linux-aarch64::libspatialite-5.0.1-hf334495_16.tar.bz2
linux-aarch64::clangdev-14.0.5-default_ha7bf5e6_0.tar.bz2
linux-aarch64::mapserver-7.6.4-py39h99dda6f_11.tar.bz2
linux-aarch64::mongodb-5.3.2-h436986b_0.tar.bz2
linux-aarch64::ffmpeg-5.1.0-lgpl_hbbaf1ae_0.tar.bz2
linux-aarch64::ogre-13.4.2-h1b5173e_0.tar.bz2
linux-aarch64::cmake-3.23.3-hcad14f8_0.tar.bz2
linux-aarch64::yoda-1.9.6-py38h74aa218_0.tar.bz2
linux-aarch64::libgdal-3.5.1-hed33a98_1.tar.bz2
linux-aarch64::yoda-1.9.5-py39h709ab80_1.tar.bz2
linux-aarch64::libopencv-4.5.5-py39hdadc393_11.tar.bz2
linux-aarch64::root_base-6.26.4-py37h924202b_3.tar.bz2
linux-aarch64::vtk-9.1.0-qt_py310h299774f_210.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py39h8b23a4f_20_cpu.tar.bz2
linux-aarch64::arrow-cpp-7.0.0-py39h1defcb6_8_cpu.tar.bz2
linux-aarch64::graphviz-5.0.0-h856fde9_0.tar.bz2
linux-aarch64::vtk-9.1.0-qt_py39h929c197_209.tar.bz2
linux-aarch64::mongodb-5.2.1-h854de11_0.tar.bz2
linux-aarch64::ffmpeg-5.0.1-lgpl_h7826265_6.tar.bz2
linux-aarch64::mapserver-7.6.4-py310hb957e10_8.tar.bz2
linux-aarch64::libopencv-4.5.5-py37hcbcc096_10.tar.bz2
linux-aarch64::mapserver-7.6.4-py37hbd78fb1_9.tar.bz2
linux-aarch64::ldas-tools-framecpp-2.9.1-h99eb3dd_0.tar.bz2
linux-aarch64::libpq-14.4-h2856e3f_0.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py38h57670ea_2_cpu.tar.bz2
linux-aarch64::mongodb-5.2.0-hcbb7fc8_0.tar.bz2
linux-aarch64::ffmpeg-4.4.2-lgpl_he9eefc0_2.tar.bz2
linux-aarch64::grpc-cpp-1.44.0-h560b3e1_5.tar.bz2
linux-aarch64::libprotobuf-static-21.2-h7866ba4_0.tar.bz2
linux-aarch64::fenics-libdolfin-2019.1.0-h8c601e4_31.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py38hc717704_4_cpu.tar.bz2
linux-aarch64::graphviz-4.0.0-h856fde9_1.tar.bz2
linux-aarch64::pdal-2.4.2-h3ab9495_2.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py39ha01fecf_3_cuda.tar.bz2
linux-aarch64::libgdal-3.5.0-h4f0f843_2.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py37he26ae0b_2_cuda.tar.bz2
linux-aarch64::libopencv-4.6.0-py39hdadc393_0.tar.bz2
linux-aarch64::mapserver-7.6.4-py37hafeb17b_11.tar.bz2
linux-aarch64::imagecodecs-2022.7.27-py38hf250464_1.tar.bz2
linux-aarch64::libopencv-4.5.5-py39he74db38_11.tar.bz2
linux-aarch64::libopencv-4.5.5-py310h97fa367_13.tar.bz2
linux-aarch64::mongodb-6.0.0-h07e2754_0.tar.bz2
linux-aarch64::libopencv-4.5.5-py39h3ac2588_10.tar.bz2
linux-aarch64::xrootd-5.4.3-py39h9a6de4d_1.tar.bz2
linux-aarch64::ffmpeg-5.0.1-h618b8be_3.tar.bz2
linux-aarch64::pdal-2.4.2-h3ab9495_1.tar.bz2
linux-aarch64::libopencv-4.6.0-py38hd443a6d_3.tar.bz2
linux-aarch64::tiledb-2.9.3-h6866cf4_0.tar.bz2
linux-aarch64::tiledb-2.9.5-h6866cf4_0.tar.bz2
linux-aarch64::libgdal-3.5.0-h629d3a5_4.tar.bz2
linux-aarch64::imagecodecs-2022.7.27-py39h9e16af1_1.tar.bz2
linux-aarch64::libtiff-4.4.0-hd185ee5_2.tar.bz2
linux-aarch64::hdf5-1.12.2-mpi_openmpi_h4189069_0.tar.bz2
linux-aarch64::arrow-cpp-8.0.1-py310hb330c1d_0_cuda.tar.bz2
linux-aarch64::ffmpeg-5.0.1-lgpl_he9eefc0_4.tar.bz2
linux-aarch64::hdf5-1.12.2-mpi_mpich_hdab57eb_0.tar.bz2
linux-aarch64::libopencv-4.5.5-py39hdadc393_13.tar.bz2
linux-aarch64::libopencv-4.5.5-py39he74db38_12.tar.bz2
linux-aarch64::mongodb-5.2.0-h07e2754_0.tar.bz2
linux-aarch64::mongodb-5.2.1-h07e2754_0.tar.bz2
linux-aarch64::cppyy-cling-6.27.0-py310h4eb0b0e_0.tar.bz2
linux-aarch64::mlir-14.0.5-h5ca471e_0.tar.bz2
linux-aarch64::yoda-1.9.5-py37hcb59d8a_1.tar.bz2
linux-aarch64::cppyy-cling-6.27.0-py37h21e75f5_0.tar.bz2
linux-aarch64::nodejs-18.6.0-h928fb59_0.tar.bz2
linux-aarch64::ffmpeg-4.4.2-lgpl_hbbaf1ae_6.tar.bz2
linux-aarch64::mapserver-7.6.4-py39h1277226_7.tar.bz2
linux-aarch64::libtiff-4.4.0-hacb60eb_1.tar.bz2
linux-aarch64::libpq-14.4-h9bd3da0_0.tar.bz2
linux-aarch64::grpc-cpp-1.47.1-h19c0212_0.tar.bz2
linux-aarch64::ffmpeg-4.4.2-gpl_had1e225_103.tar.bz2
linux-aarch64::ffmpeg-4.4.2-gpl_hd5d6480_105.tar.bz2
linux-aarch64::glib-networking-2.72.1-he35a61d_1.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py38h91d0c52_3_cpu.tar.bz2
linux-aarch64::libgdal-3.5.0-h09c07ac_3.tar.bz2
linux-aarch64::grpc-cpp-1.43.2-h92cd71b_6.tar.bz2
linux-aarch64::fenics-libdolfin-2019.1.0-ha4fe10e_31.tar.bz2
linux-aarch64::mongodb-5.3.2-h854de11_0.tar.bz2
linux-aarch64::libmongoc-1.22.0-h0863bf3_0.tar.bz2
linux-aarch64::libopencv-4.6.0-py39hf660ac5_2.tar.bz2
linux-aarch64::pillow-9.2.0-py37h2dc4c6d_0.tar.bz2
linux-aarch64::libsoup-2.74.2-h867a169_0.tar.bz2
linux-aarch64::libgdal-3.5.1-hed33a98_0.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py37hb9b6455_4_cpu.tar.bz2
linux-aarch64::tesseract-5.1.0-h4705a96_0.tar.bz2
linux-aarch64::libopencv-4.5.5-py38hbcbb465_10.tar.bz2
linux-aarch64::ffmpeg-4.4.2-gpl_hc6fb87e_102.tar.bz2
linux-aarch64::prometheus-cpp-1.0.0-hf32e593_0.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py37h836fcc0_4_cuda.tar.bz2
linux-aarch64::llvmdev-14.0.6-hb2805f8_0.tar.bz2
linux-aarch64::imagemagick-7.1.0_37-pl5321hde91a41_0.tar.bz2
linux-aarch64::mapserver-7.6.4-py310hd5eaf4f_9.tar.bz2
linux-aarch64::libopencv-4.6.0-py38hb0a0df1_1.tar.bz2
linux-aarch64::mapserver-7.6.4-py37h3d8f776_7.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py39h055097c_2_cuda.tar.bz2
linux-aarch64::vtk-9.1.0-qt_py37h49414dc_210.tar.bz2
linux-aarch64::coin-or-cgl-0.60.6-h1a03506_1.tar.bz2
linux-aarch64::mapserver-7.6.4-py38h34bf75a_7.tar.bz2
linux-aarch64::libtiledb-sql-0.17.0-h2f14679_0.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py39ha383ec2_4_cpu.tar.bz2
linux-aarch64::mongodb-5.2.0-h436986b_0.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py310h13ff0fa_1_cpu.tar.bz2
linux-aarch64::qt-main-5.15.3-hfaa85a3_2.tar.bz2
linux-aarch64::tiledb-2.10.1-h354e0e1_0.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py37h04e1d34_54_cpu.tar.bz2
linux-aarch64::texlive-core-20210325-h7feb347_4.tar.bz2
linux-aarch64::arrow-cpp-8.0.1-py37h873ad94_0_cuda.tar.bz2
linux-aarch64::openjdk-11.0.15-h47f71a8_0.tar.bz2
linux-aarch64::pdal-2.4.1-h3ab9495_2.tar.bz2
linux-aarch64::arrow-cpp-7.0.0-py37hefb6d7a_8_cpu.tar.bz2
linux-aarch64::libopencv-4.6.0-py38h8b4a014_2.tar.bz2
linux-aarch64::pdal-2.4.2-h91e6477_0.tar.bz2
linux-aarch64::xrootd-5.4.3-py310h9cd7803_1.tar.bz2
linux-aarch64::pyreadstat-1.1.9-py38h1368025_0.tar.bz2
linux-aarch64::sqlite-3.39.1-hc74f5b8_0.tar.bz2
linux-aarch64::vowpalwabbit-9.2.0-py37hc73f551_0.tar.bz2
linux-aarch64::postgresql-14.4-h6a5f0b7_0.tar.bz2
linux-aarch64::arrow-cpp-8.0.1-py37hb9b6455_0_cpu.tar.bz2
linux-aarch64::libtiledb-sql-0.16.1-h2f14679_0.tar.bz2
linux-aarch64::pyreadstat-1.1.7-py37h8236fb0_0.tar.bz2
linux-aarch64::mapserver-7.6.4-py39h70ecbb4_10.tar.bz2
linux-aarch64::xrootd-5.4.3-py39haf604e9_0.tar.bz2
linux-aarch64::graphviz-2.50.0-h856fde9_3.tar.bz2
linux-aarch64::tiledb-2.10.0-h354e0e1_0.tar.bz2
linux-aarch64::vtk-9.1.0-qt_py39h4eebc41_212.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py310hd46ca40_1_cuda.tar.bz2
linux-aarch64::libopencv-4.5.5-py38hb0a0df1_13.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py39h9dcb8f6_4_cpu.tar.bz2
linux-aarch64::mapserver-7.6.4-py310h6b5c05a_7.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py37h025a996_3_cpu.tar.bz2
linux-aarch64::mapserver-7.6.4-py310he81acaf_11.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py37ha6fea4d_3_cuda.tar.bz2
linux-aarch64::grpc-cpp-1.44.0-hd7503c7_5.tar.bz2
linux-aarch64::hdf5-1.12.2-nompi_h3900512_100.tar.bz2
linux-aarch64::gfal2-2.21.0-he11e5a5_0.tar.bz2
linux-aarch64::cpp-opentelemetry-sdk-1.4.1-h0ffc852_4.tar.bz2
linux-aarch64::libgdal-3.5.1-h0ee2c91_2.tar.bz2
linux-aarch64::rust-1.62.0-h26fb2b7_0.tar.bz2
linux-aarch64::glib-networking-2.72.1-hc02c9a3_1.tar.bz2
linux-aarch64::libspatialite-5.0.1-h07d089a_18.tar.bz2
linux-aarch64::xrootd-5.4.3-py37he64f28a_0.tar.bz2
linux-aarch64::pyreadstat-1.1.7-py37ha3a0a47_0.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py38h20757d6_3_cuda.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py39h716c1f6_2_cpu.tar.bz2
linux-aarch64::mapserver-7.6.4-py37h236c1df_8.tar.bz2
linux-aarch64::arrow-cpp-8.0.1-py310h6ee2cd6_0_cpu.tar.bz2
linux-aarch64::python-3.10.5-h92ab765_0_cpython.tar.bz2
linux-aarch64::arrow-cpp-8.0.1-py39ha383ec2_0_cpu.tar.bz2
linux-aarch64::imagemagick-7.1.0_44-pl5321h8e4ea60_0.tar.bz2
linux-aarch64::cppyy-cling-6.27.0-py38h986aded_0.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py310hd46ca40_2_cuda.tar.bz2
linux-aarch64::vtk-9.1.0-qt_py38hf484a68_212.tar.bz2
linux-aarch64::libzip-1.9.2-ha107f47_0.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py310h9de12a2_20_cpu.tar.bz2
linux-aarch64::xrootd-5.4.3-py39h1d44ce8_1.tar.bz2
linux-aarch64::python-3.10.5-h023d47c_0_cpython.tar.bz2
linux-aarch64::libpng-1.6.37-hf9034f9_3.tar.bz2
linux-aarch64::grpc-cpp-1.45.2-h92cd71b_4.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py37h873ad94_4_cuda.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py38hbdc3c6e_5_cuda.tar.bz2
linux-aarch64::pyreadstat-1.1.9-py310hceb02de_0.tar.bz2
linux-aarch64::libopencv-4.5.5-py38ha83d297_13.tar.bz2
linux-aarch64::cpp-opentelemetry-sdk-1.4.1-h0ffc852_0.tar.bz2
linux-aarch64::hdf5-1.12.2-mpi_mpich_h7253f08_0.tar.bz2
linux-aarch64::mongodb-5.2.0-h854de11_0.tar.bz2
linux-aarch64::git-2.37.0-pl5321haf30559_0.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py39h716c1f6_1_cpu.tar.bz2
linux-aarch64::libnetcdf-4.8.1-nompi_h30b59ab_103.tar.bz2
linux-aarch64::xrootd-5.4.3-py310h286b669_1.tar.bz2
linux-aarch64::geotiff-1.7.1-h17a4d75_2.tar.bz2
linux-aarch64::postgresql-plpython-14.4-py37hf413ee8_0.tar.bz2
linux-aarch64::arrow-cpp-7.0.0-py38hc63db81_8_cpu.tar.bz2
linux-aarch64::libarchive-3.5.2-h610d84a_3.tar.bz2
linux-aarch64::libxml2-2.9.14-h370961a_3.tar.bz2
linux-aarch64::mongodb-6.0.0-h436986b_0.tar.bz2
linux-aarch64::postgresql-plpython-14.4-py310h0b21c4e_0.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py37hb63e26e_5_cpu.tar.bz2
linux-aarch64::git-2.37.0-pl5321hd6c143b_0.tar.bz2
linux-aarch64::yoda-1.9.6-py37hcb59d8a_0.tar.bz2
linux-aarch64::libopencv-4.6.0-py310h97fa367_1.tar.bz2
linux-aarch64::mongodb-5.2.1-h436986b_0.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py310h9efa0a8_20_cpu.tar.bz2
linux-aarch64::postgresql-plpython-14.4-py38h7359617_0.tar.bz2
linux-aarch64::ffmpeg-4.4.2-lgpl_he9eefc0_1.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py38hbdc3c6e_4_cuda.tar.bz2
linux-aarch64::cpp-opentelemetry-sdk-1.4.1-h3d19de8_1.tar.bz2
linux-aarch64::librdkafka-1.9.1-h5eb4358_1.tar.bz2
linux-aarch64::libprotobuf-static-21.3-h7866ba4_0.tar.bz2
linux-aarch64::ldas-tools-framecpp-2.9.1-h093f4ce_0.tar.bz2
linux-aarch64::vowpalwabbit-9.2.0-py37h7e71088_0.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py38h3436e02_20_cpu.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py39h932b275_5_cuda.tar.bz2
linux-aarch64::ffmpeg-4.4.2-lgpl_h7826265_3.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py38h7950b60_2_cpu.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py310hd017b88_2_cuda.tar.bz2
linux-aarch64::llvmdev-14.0.5-hb2805f8_0.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py39h4f8bf2b_3_cpu.tar.bz2
linux-aarch64::gmsh-4.10.4-h6bb50e3_0.tar.bz2
linux-aarch64::glib-2.72.1-h7866ba4_0.tar.bz2
linux-aarch64::pyreadstat-1.1.9-py37h8236fb0_0.tar.bz2
linux-aarch64::ogre-next-2.2.6-hbad1a05_0.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py38hf25dac4_20_cpu.tar.bz2
linux-aarch64::grpc-cpp-1.48.0-h19c0212_0.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py310h6ee2cd6_4_cpu.tar.bz2
linux-aarch64::libopencv-4.6.0-py37h53aed50_3.tar.bz2
linux-aarch64::fenics-libdolfin-2019.1.0-h2857c1c_30.tar.bz2
linux-aarch64::tiledb-2.10.2-h354e0e1_0.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py37hb9b6455_5_cpu.tar.bz2
linux-aarch64::libglib-2.72.1-hd4f7528_0.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py39h8e6cf6a_1_cuda.tar.bz2
linux-aarch64::pyreadstat-1.1.9-py39hca51b09_0.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py37he5ee4ee_35_cpu.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py310h2224936_3_cuda.tar.bz2
linux-aarch64::mlir-14.0.3-h5ca471e_0.tar.bz2
linux-aarch64::openmpi-4.1.3-h26b3c96_104.tar.bz2
linux-aarch64::nodejs-18.7.0-he850d6a_0.tar.bz2
linux-aarch64::imagemagick-7.1.0_39-pl5321hde91a41_0.tar.bz2
linux-aarch64::ffmpeg-5.0.1-lgpl_he9eefc0_5.tar.bz2
linux-aarch64::arrow-cpp-8.0.1-py37h836fcc0_0_cuda.tar.bz2
linux-aarch64::ffmpeg-4.4.2-gpl_h1275b40_106.tar.bz2
linux-aarch64::arrow-cpp-8.0.1-py39h9dcb8f6_0_cpu.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py38h5d35cfd_2_cuda.tar.bz2
linux-aarch64::vtk-9.1.0-qt_py38h210a2ba_209.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py310h773ee66_3_cpu.tar.bz2
linux-aarch64::libtiledb-sql-0.16.0-heaa659b_0.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py38h2e4623d_2_cuda.tar.bz2
linux-aarch64::ffmpeg-5.1.0-gpl_h1275b40_100.tar.bz2
linux-aarch64::libopencv-4.6.0-py310h8cf9992_2.tar.bz2
linux-aarch64::libtiledb-sql-0.16.1-heaa659b_0.tar.bz2
linux-aarch64::libopencv-4.6.0-py39he74db38_0.tar.bz2
linux-aarch64::pillow-9.2.0-py39h2a8e185_0.tar.bz2
linux-aarch64::librdkafka-1.9.0-h9e317bd_0.tar.bz2
linux-aarch64::arrow-cpp-8.0.1-py39ha966787_0_cuda.tar.bz2
linux-aarch64::xrootd-5.4.3-py38hc1158d8_1.tar.bz2
linux-aarch64::libvips-8.13.0-h595dfea_0.tar.bz2
linux-aarch64::libmongoc-1.22.0-h99c7dba_0.tar.bz2
linux-aarch64::libsoup-3.0.7-h867a169_0.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py37he5ee4ee_54_cpu.tar.bz2
linux-aarch64::nodejs-18.6.0-he850d6a_0.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py38h7950b60_1_cpu.tar.bz2
linux-aarch64::mongodb-5.3.2-hcbb7fc8_0.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py310h9a095f5_4_cuda.tar.bz2
linux-aarch64::pdal-2.4.1-he9b1c87_1.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py38h7c7ad16_5_cuda.tar.bz2
linux-aarch64::pyreadstat-1.1.7-py38h1368025_0.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py310h7ecc3cf_3_cuda.tar.bz2
linux-aarch64::ffmpeg-4.4.2-lgpl_hbab375f_4.tar.bz2
linux-aarch64::openbabel-3.1.1-py310h3c07419_4.tar.bz2
linux-aarch64::pdal-2.4.2-h91e6477_2.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py39hac6f81d_2_cpu.tar.bz2
linux-aarch64::tiledb-2.9.4-h6866cf4_0.tar.bz2
linux-aarch64::libopencv-4.6.0-py37h7ed40ad_2.tar.bz2
linux-aarch64::libopencv-4.5.5-py310hc2e78f4_10.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py39hac6f81d_1_cpu.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py39h239b2a5_3_cuda.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py39h8e6cf6a_2_cuda.tar.bz2
linux-aarch64::grpc-cpp-1.45.2-h09a3db2_4.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py38h7c7ad16_4_cuda.tar.bz2
linux-aarch64::xrootd-5.4.3-py39haf604e9_1.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py38h2eca7ea_5_cpu.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py310h9de12a2_54_cpu.tar.bz2
linux-aarch64::libtiledb-sql-0.17.0-heaa659b_0.tar.bz2
linux-aarch64::grpc-cpp-1.44.0-h92cd71b_5.tar.bz2
linux-aarch64::libopencv-4.5.5-py37hc1bbaf2_13.tar.bz2
linux-aarch64::libtiledb-sql-0.16.0-h2f14679_0.tar.bz2
linux-aarch64::imagecodecs-2022.7.27-py310h749bac2_0.tar.bz2
linux-aarch64::git-2.37.1-pl5321hd6c143b_0.tar.bz2
linux-aarch64::xrootd-5.4.3-py38hbcbad04_1.tar.bz2
linux-aarch64::fenics-libdolfin-2019.1.0-h8325675_30.tar.bz2
linux-aarch64::libopencv-4.6.0-py39hed75996_2.tar.bz2
linux-aarch64::libgdal-3.5.0-hef23136_1.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py310h9efa0a8_35_cpu.tar.bz2
linux-aarch64::libgdal-3.5.1-hb04d4e0_2.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py38h3436e02_54_cpu.tar.bz2
linux-aarch64::libopencv-4.5.5-py38ha83d297_12.tar.bz2
linux-aarch64::pdal-2.4.2-h9dd7f16_3.tar.bz2
linux-aarch64::libopencv-4.5.5-py39he74db38_13.tar.bz2
linux-aarch64::xrootd-5.4.3-py310h286b669_0.tar.bz2
linux-aarch64::ogre-1.10.12-h3ade7c8_9.tar.bz2
linux-aarch64::arrow-cpp-8.0.1-py38hc717704_0_cpu.tar.bz2
linux-aarch64::imagemagick-7.1.0_40-pl5321hde91a41_0.tar.bz2
linux-aarch64::ffmpeg-5.0.1-lgpl_hbbaf1ae_8.tar.bz2
linux-aarch64::nodejs-18.5.0-h928fb59_0.tar.bz2
linux-aarch64::libgit2-1.4.4-ha9a0767_0.tar.bz2
linux-aarch64::mapserver-7.6.4-py38h364860e_9.tar.bz2
linux-aarch64::nodejs-18.5.0-he850d6a_0.tar.bz2
linux-aarch64::wxwidgets-3.2.0-py310hc845f63_1.tar.bz2
linux-aarch64::pillow-9.2.0-py38h96fe0d2_0.tar.bz2
linux-aarch64::ogre-next-2.3.1-hbad1a05_0.tar.bz2
linux-aarch64::mapserver-7.6.4-py38hfceb311_11.tar.bz2
linux-aarch64::grpc-cpp-1.45.2-h560b3e1_4.tar.bz2
linux-aarch64::xrootd-5.4.3-py38hb5711a5_0.tar.bz2
linux-aarch64::libgit2-1.4.4-he9ce915_0.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py39ha966787_5_cuda.tar.bz2
linux-aarch64::smesh-9.8.0.2-he96c191_1.tar.bz2
linux-aarch64::vtk-9.1.0-qt_py310h9f8d884_209.tar.bz2
linux-aarch64::tiledb-2.10.2-h6866cf4_0.tar.bz2
linux-aarch64::imagecodecs-2022.2.22-py38hbfc07d9_6.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py37he26ae0b_1_cuda.tar.bz2
linux-aarch64::arrow-cpp-8.0.1-py310h8b89866_0_cpu.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py310h6ee2cd6_5_cpu.tar.bz2
linux-aarch64::libxml2-2.9.14-h370961a_1.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py38h57670ea_1_cpu.tar.bz2
linux-aarch64::arrow-cpp-8.0.1-py39h932b275_0_cuda.tar.bz2
linux-aarch64::ffmpeg-5.0.1-gpl_had1e225_106.tar.bz2
linux-aarch64::cpp-opentelemetry-sdk-1.4.1-h0ffc852_1.tar.bz2
linux-aarch64::glib-networking-2.72.1-hc02c9a3_0.tar.bz2
linux-aarch64::pillow-9.2.0-py38h3870bda_0.tar.bz2
linux-aarch64::arrow-cpp-7.0.0-py38h6013a35_8_cpu.tar.bz2
linux-aarch64::vtk-9.1.0-qt_py38hecb46c1_210.tar.bz2
linux-aarch64::vowpalwabbit-9.2.0-py39h480f993_0.tar.bz2
linux-aarch64::postgresql-plpython-14.4-py39hc61fba2_0.tar.bz2
linux-aarch64::pdal-2.4.1-h5f71da2_1.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py310h13ff0fa_2_cpu.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py39hf0da6d2_3_cpu.tar.bz2
linux-aarch64::libarchive-3.5.2-hc5648f3_3.tar.bz2
linux-aarch64::zstd-1.5.2-haad177d_2.tar.bz2
linux-aarch64::vtk-9.1.0-qt_py37heab8c5a_211.tar.bz2
linux-aarch64::libtiledb-sql-0.17.1-h2f14679_0.tar.bz2
linux-aarch64::tiledb-2.9.4-h354e0e1_0.tar.bz2
linux-aarch64::pillow-9.2.0-py310h31078c8_0.tar.bz2
linux-aarch64::openbabel-3.1.1-py39h117be11_4.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py37h836fcc0_5_cuda.tar.bz2
linux-aarch64::ogre-next-2.3.1-hbad1a05_1.tar.bz2
linux-aarch64::pyreadstat-1.1.7-py310hceb02de_0.tar.bz2
linux-aarch64::grpc-cpp-1.46.3-h13cea6e_2.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py37hb63e26e_4_cpu.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py37hdaa88b2_1_cpu.tar.bz2
linux-aarch64::wxwidgets-3.2.0-h9e57b98_0.tar.bz2
linux-aarch64::imagemagick-7.1.0_41-pl5321h8e4ea60_1.tar.bz2
linux-aarch64::fish-3.5.1-hfba443e_0.tar.bz2
linux-aarch64::mongodb-6.0.0-h854de11_0.tar.bz2
linux-aarch64::libgsf-1.14.50-h11073c9_0.tar.bz2
linux-aarch64::hdf5-1.12.2-nompi_h7bde11e_100.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py39h8b23a4f_54_cpu.tar.bz2
linux-aarch64::libopencv-4.5.5-py38hb0a0df1_11.tar.bz2
linux-aarch64::ffmpeg-5.0.1-gpl_hd5d6480_107.tar.bz2
linux-aarch64::hdf5-1.12.2-mpi_openmpi_hf150c17_0.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py38h3436e02_35_cpu.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py310h9efa0a8_54_cpu.tar.bz2
linux-aarch64::ffmpeg-4.4.2-gpl_hd5d6480_104.tar.bz2
linux-aarch64::libgdal-3.5.0-h1fc9814_4.tar.bz2
linux-aarch64::postgresql-plpython-14.4-py37h71fe8e9_0.tar.bz2
linux-aarch64::libopencv-4.6.0-py39h5b9290d_3.tar.bz2
linux-aarch64::tiledb-2.10.1-h6866cf4_0.tar.bz2
linux-aarch64::grpc-cpp-1.47.0-h46ce4ae_0.tar.bz2
linux-aarch64::libopencv-4.6.0-py38hab26dd8_3.tar.bz2
linux-aarch64::yoda-1.9.5-py38h74aa218_1.tar.bz2
linux-aarch64::xrootd-5.4.3-py37he64f28a_1.tar.bz2
linux-aarch64::xrootd-5.4.3-py38hb5711a5_1.tar.bz2
linux-aarch64::ffmpeg-4.4.2-lgpl_hbab375f_5.tar.bz2
linux-aarch64::root_base-6.26.4-py39h380c2de_3.tar.bz2
linux-aarch64::arrow-cpp-7.0.0-py37hbd15e14_8_cpu.tar.bz2
linux-aarch64::graphviz-3.0.0-h856fde9_2.tar.bz2
linux-aarch64::grpc-cpp-1.45.2-hd7503c7_4.tar.bz2
linux-aarch64::arrow-cpp-8.0.1-py38hbdc3c6e_0_cuda.tar.bz2
linux-aarch64::mongodb-6.0.0-hcbb7fc8_0.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py38hf25dac4_54_cpu.tar.bz2
linux-aarch64::libzip-1.9.2-heb2ba21_0.tar.bz2
linux-aarch64::libopencv-4.6.0-py310h97fa367_0.tar.bz2
linux-aarch64::arrow-cpp-7.0.0-py39h4aaf10d_8_cpu.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py37h0f6a5ea_2_cuda.tar.bz2
linux-aarch64::cpp-opentelemetry-sdk-1.4.1-h0ffc852_2.tar.bz2
linux-aarch64::xrootd-5.4.3-py37hff6604c_1.tar.bz2
linux-aarch64::cppyy-cling-6.27.0-py39h20a37df_0.tar.bz2
linux-aarch64::libxml2-2.9.14-h370961a_2.tar.bz2
linux-aarch64::grpc-cpp-1.47.0-h13cea6e_1.tar.bz2
linux-aarch64::ldas-tools-framecpp-2.9.0-h0148cf3_0.tar.bz2
linux-aarch64::wxwidgets-3.1.7-h9e57b98_0.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py310h9a095f5_5_cuda.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py38h5d35cfd_1_cuda.tar.bz2
linux-aarch64::vowpalwabbit-9.2.0-py38hdb23cb2_0.tar.bz2
linux-aarch64::geotiff-1.7.1-h17a4d75_3.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py38h2eca7ea_4_cpu.tar.bz2
linux-aarch64::imagecodecs-2022.7.27-py38h0b59aa9_0.tar.bz2
linux-aarch64::tiledb-2.10.0-h6866cf4_0.tar.bz2
linux-aarch64::fish-3.5.0-hfba443e_0.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py310h4e60bef_3_cpu.tar.bz2
linux-aarch64::pillow-9.2.0-py39h55c8a1a_0.tar.bz2
linux-aarch64::cpp-opentelemetry-sdk-1.4.1-h0ada592_0.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py37hc3d30d7_1_cpu.tar.bz2
linux-aarch64::poppler-22.04.0-h27ad1b0_1.tar.bz2
linux-aarch64::libopencv-4.5.5-py310h97fa367_12.tar.bz2
linux-aarch64::rust-1.62.1-h26fb2b7_0.tar.bz2
linux-aarch64::imagemagick-7.1.0.43-pl5321h8e4ea60_0.tar.bz2
linux-aarch64::librdkafka-1.9.0-h8bc9935_0.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py37h873ad94_5_cuda.tar.bz2
linux-aarch64::imagecodecs-2022.2.22-py39h89890a1_6.tar.bz2
linux-aarch64::libopencv-4.5.5-py310h97fa367_11.tar.bz2
linux-aarch64::mapserver-7.6.4-py39h89d623b_9.tar.bz2
linux-aarch64::grpc-cpp-1.43.2-h09a3db2_6.tar.bz2
linux-aarch64::imagecodecs-2022.2.22-py310hf52949c_6.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py37h61ad8f6_3_cpu.tar.bz2
linux-aarch64::ogre-13.4.1-h1b5173e_1.tar.bz2
linux-aarch64::postgresql-plpython-14.4-py310h357d6aa_0.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py310hb330c1d_5_cuda.tar.bz2
linux-aarch64::nodejs-18.3.0-he850d6a_0.tar.bz2
linux-aarch64::openbabel-3.1.1-py37h1039381_4.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py310h8b89866_5_cpu.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py310hf57a544_2_cpu.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py38hf023481_3_cpu.tar.bz2
linux-aarch64::ogre-13.4.1-hddf42ac_0.tar.bz2
linux-aarch64::libtiledb-sql-0.15.1-h2f14679_0.tar.bz2
linux-aarch64::grpc-cpp-1.47.1-h13cea6e_0.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py39ha966787_4_cuda.tar.bz2
linux-aarch64::yoda-1.9.6-py39h709ab80_0.tar.bz2
linux-aarch64::pdal-2.4.1-h91e6477_2.tar.bz2
linux-aarch64::cpp-opentelemetry-sdk-1.4.1-h326b58d_3.tar.bz2
linux-aarch64::xrootd-5.4.3-py39h9a6de4d_0.tar.bz2
linux-aarch64::vtk-9.1.0-qt_py310h6a179f1_212.tar.bz2
linux-aarch64::mapserver-7.6.4-py310h4f43b35_10.tar.bz2
linux-aarch64::libopencv-4.5.5-py38ha83d297_11.tar.bz2
linux-aarch64::libtiledb-sql-0.17.1-heaa659b_0.tar.bz2
linux-aarch64::arrow-cpp-8.0.1-py37hb63e26e_0_cpu.tar.bz2
linux-aarch64::libgit2-1.5.0-ha9a0767_0.tar.bz2
linux-aarch64::libopencv-4.6.0-py39hbceaec8_3.tar.bz2
linux-aarch64::libopencv-4.5.5-py38h5082584_10.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py39hbe2f326_35_cpu.tar.bz2
linux-aarch64::grpc-cpp-1.43.2-h560b3e1_6.tar.bz2
linux-aarch64::libopencv-4.6.0-py38ha83d297_1.tar.bz2
linux-aarch64::grpc-cpp-1.46.3-h46ce4ae_1.tar.bz2
linux-aarch64::cpp-opentelemetry-sdk-1.4.1-h3d19de8_2.tar.bz2
linux-aarch64::mapserver-7.6.4-py39h227a6e5_8.tar.bz2
linux-aarch64::arrow-cpp-8.0.1-py38h2eca7ea_0_cpu.tar.bz2
linux-aarch64::cpp-opentelemetry-sdk-1.4.1-h0ffc852_3.tar.bz2
linux-aarch64::libopencv-4.5.5-py37hc1bbaf2_11.tar.bz2
linux-aarch64::libopencv-4.5.5-py37hc1bbaf2_12.tar.bz2
linux-aarch64::libgdal-3.5.0-h72b7976_5.tar.bz2
linux-aarch64::git-2.37.1-pl5321haf30559_0.tar.bz2
linux-aarch64::libspatialite-5.0.1-h8085923_17.tar.bz2
linux-aarch64::pdal-2.4.2-h91e6477_1.tar.bz2
linux-aarch64::librdkafka-1.9.1-h70a263e_1.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py310hd017b88_1_cuda.tar.bz2
linux-aarch64::pdal-2.4.2-h668a379_3.tar.bz2
linux-aarch64::mapserver-7.6.4-py37h46354cb_10.tar.bz2
linux-aarch64::graphicsmagick-1.3.37-hb4937b2_0.tar.bz2
linux-aarch64::gmsh-4.10.5-h6bb50e3_0.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py37he5ee4ee_20_cpu.tar.bz2
linux-aarch64::libopencv-4.6.0-py310hca2d9ae_3.tar.bz2
linux-aarch64::imagecodecs-2022.7.27-py39he5227f0_0.tar.bz2
linux-aarch64::libgdal-3.5.0-hfe30d5c_3.tar.bz2
linux-aarch64::grpc-cpp-1.46.3-h19c0212_2.tar.bz2
linux-aarch64::ffmpeg-5.0.1-gpl_hc6fb87e_104.tar.bz2
linux-aarch64::tesseract-5.2.0-h4705a96_0.tar.bz2
linux-aarch64::yoda-1.9.6-py310h54384be_0.tar.bz2
linux-aarch64::libopencv-4.6.0-py37hc1bbaf2_1.tar.bz2
linux-aarch64::sqlite-3.39.0-hc74f5b8_0.tar.bz2
linux-aarch64::xrootd-5.4.3-py38h2e6e18d_1.tar.bz2
linux-aarch64::ldas-tools-framecpp-2.9.0-he0383cc_0.tar.bz2
linux-aarch64::grpc-cpp-1.43.2-hd7503c7_6.tar.bz2
linux-aarch64::libitk-5.2.1-haa79bb1_4.tar.bz2
linux-aarch64::libgdal-3.5.0-h1bf4674_2.tar.bz2
linux-aarch64::mongodb-5.3.2-h07e2754_0.tar.bz2
linux-aarch64::poppler-qt-22.04.0-he00d887_1.tar.bz2
linux-aarch64::libprotobuf-static-21.4-h7866ba4_0.tar.bz2
linux-aarch64::grpc-cpp-1.46.3-h7f5ef31_1.tar.bz2
linux-aarch64::libnetcdf-4.8.1-mpi_openmpi_he59aa49_3.tar.bz2
linux-aarch64::qt-main-5.15.4-hfaa85a3_0.tar.bz2
linux-aarch64::arrow-cpp-8.0.1-py310h9a095f5_0_cuda.tar.bz2
linux-aarch64::xrootd-5.4.3-py38hbcbad04_0.tar.bz2
linux-aarch64::coin-or-clp-1.17.7-h2398112_1.tar.bz2
linux-aarch64::tiledb-2.9.5-h354e0e1_0.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py39h055097c_1_cuda.tar.bz2
linux-aarch64::vtk-9.1.0-qt_py39h5e378f6_210.tar.bz2
linux-aarch64::ffmpeg-4.4.2-gpl_hc6fb87e_101.tar.bz2
linux-aarch64::grpc-cpp-1.47.0-h7f5ef31_0.tar.bz2
-    "libzlib >=1.2.12,<1.3.0a0",
+    "libzlib >=1.2.12,<2.0.0a0",
linux-aarch64::clang-tools-14.0.5-default_ha7bf5e6_0.tar.bz2
linux-aarch64::dotnet-sdk-3.1.420-hb062e78_0.tar.bz2
linux-aarch64::file-5.39-h259bafa_1.tar.bz2
linux-aarch64::cudnn-8.3.2.44-h66ab864_0.tar.bz2
linux-aarch64::coin-or-utils-2.11.6-h62e9a7e_1.tar.bz2
linux-aarch64::dotnet-aspnetcore-6.0.6-hb062e78_0.tar.bz2
linux-aarch64::libclang-cpp-14.0.6-default_ha7bf5e6_0.tar.bz2
linux-aarch64::dotnet-runtime-6.0.5-hb062e78_0.tar.bz2
linux-aarch64::dotnet-runtime-5.0.17-hb062e78_0.tar.bz2
linux-aarch64::libclang13-14.0.5-default_h3684801_0.tar.bz2
linux-aarch64::gst-plugins-good-1.20.3-h660f13c_0.tar.bz2
linux-aarch64::clang-14-14.0.5-default_ha7bf5e6_0.tar.bz2
linux-aarch64::clang-format-14.0.6-default_ha7bf5e6_0.tar.bz2
linux-aarch64::llvm-tools-14.0.6-hb2805f8_0.tar.bz2
linux-aarch64::llvm-tools-14.0.5-hb2805f8_0.tar.bz2
linux-aarch64::gst-plugins-good-1.20.2-h660f13c_2.tar.bz2
linux-aarch64::llvm-14.0.5-h40ce709_0.tar.bz2
linux-aarch64::openh264-2.2.0-h7866ba4_0.tar.bz2
linux-aarch64::llvm-14.0.6-h40ce709_0.tar.bz2
linux-aarch64::libclang-cpp-14.0.5-default_ha7bf5e6_0.tar.bz2
linux-aarch64::libmlir14-14.0.3-h5ca471e_0.tar.bz2
linux-aarch64::libclang13-14.0.6-default_h3684801_0.tar.bz2
linux-aarch64::clang-format-14-14.0.5-default_ha7bf5e6_0.tar.bz2
linux-aarch64::gst-plugins-base-1.20.2-hfe44c80_2.tar.bz2
linux-aarch64::clang-tools-14.0.6-default_ha7bf5e6_0.tar.bz2
linux-aarch64::dotnet-sdk-6.0.301-hb062e78_0.tar.bz2
linux-aarch64::libclang-14.0.6-default_ha7bf5e6_0.tar.bz2
linux-aarch64::dotnet-aspnetcore-5.0.17-hb062e78_0.tar.bz2
linux-aarch64::libmlir-14.0.3-h5ca471e_0.tar.bz2
linux-aarch64::libclang-cpp14-14.0.5-default_ha7bf5e6_0.tar.bz2
linux-aarch64::libmlir14-14.0.5-h5ca471e_0.tar.bz2
linux-aarch64::coin-or-osi-0.108.7-h9e9ff86_1.tar.bz2
linux-aarch64::dotnet-runtime-6.0.6-hb062e78_0.tar.bz2
linux-aarch64::libmagic-5.39-hf9034f9_1.tar.bz2
linux-aarch64::dotnet-aspnetcore-3.1.25-hb062e78_0.tar.bz2
linux-aarch64::glib-tools-2.72.1-h7866ba4_0.tar.bz2
linux-aarch64::openh264-2.2.0-h7866ba4_1.tar.bz2
linux-aarch64::clang-format-14.0.5-default_ha7bf5e6_0.tar.bz2
linux-aarch64::dotnet-sdk-3.1.419-hb062e78_0.tar.bz2
linux-aarch64::dotnet-aspnetcore-3.1.26-hb062e78_0.tar.bz2
linux-aarch64::libllvm14-14.0.6-hb2805f8_0.tar.bz2
linux-aarch64::cudnn-8.4.0.27-h66ab864_1.tar.bz2
linux-aarch64::dotnet-sdk-5.0.408-hb062e78_0.tar.bz2
linux-aarch64::clang-format-14-14.0.6-default_ha7bf5e6_0.tar.bz2
linux-aarch64::dotnet-aspnetcore-6.0.5-hb062e78_0.tar.bz2
linux-aarch64::gst-plugins-base-1.20.3-hfe44c80_0.tar.bz2
linux-aarch64::dotnet-runtime-3.1.26-hf32e593_0.tar.bz2
linux-aarch64::dotnet-runtime-3.1.25-hf32e593_0.tar.bz2
linux-aarch64::libclang-14.0.5-default_ha7bf5e6_0.tar.bz2
linux-aarch64::libllvm14-14.0.5-hb2805f8_0.tar.bz2
linux-aarch64::cudnn-8.3.2.44-h66ab864_1.tar.bz2
linux-aarch64::cudnn-8.4.1.50-h66ab864_0.tar.bz2
linux-aarch64::libmlir-14.0.5-h5ca471e_0.tar.bz2
linux-aarch64::libclang-cpp14-14.0.6-default_ha7bf5e6_0.tar.bz2
linux-aarch64::dotnet-sdk-6.0.300-hb062e78_0.tar.bz2
linux-aarch64::clang-14-14.0.6-default_ha7bf5e6_0.tar.bz2
-    "libzlib >=1.2.12,<1.3.0a0"
+    "libzlib >=1.2.12,<2.0.0a0"
================================================================================
================================================================================
osx-arm64
osx-arm64::postgresql-14.4-h99efecd_0.tar.bz2
osx-arm64::ffmpeg-4.4.2-gpl_h27c9728_104.tar.bz2
osx-arm64::xrootd-5.4.3-py39h7a7f79a_0.tar.bz2
osx-arm64::fish-3.5.1-hc5976cb_0.tar.bz2
osx-arm64::magics-metview-4.12.0-hf7923e3_1.tar.bz2
osx-arm64::librdkafka-1.9.0-h5db051d_0.tar.bz2
osx-arm64::jaxlib-0.3.14-cpu_py39h293c5b4_3.tar.bz2
osx-arm64::sqlite-3.39.0-h40dfcc0_0.tar.bz2
osx-arm64::ffmpeg-5.0.1-lgpl_hca39864_7.tar.bz2
osx-arm64::libvips-8.13.0-h4a543b2_0.tar.bz2
osx-arm64::arrow-cpp-8.0.0-py310h4fee3f5_5_cpu.tar.bz2
osx-arm64::ldas-tools-framecpp-2.9.1-h5e00029_0.tar.bz2
osx-arm64::arrow-cpp-7.0.0-py38h2f9e2c6_8_cpu.tar.bz2
osx-arm64::openmeeg-2.4.4-py38hbab9506_0.tar.bz2
osx-arm64::pdal-2.4.1-h46b78e2_2.tar.bz2
osx-arm64::cppyy-cling-6.27.0-py39h9dd4a2c_0.tar.bz2
osx-arm64::vowpalwabbit-9.2.0-py39hd90c785_0.tar.bz2
osx-arm64::root_base-6.26.4-py39h2ec9a04_3.tar.bz2
osx-arm64::pyreadstat-1.1.9-py38ha509820_0.tar.bz2
osx-arm64::grpc-cpp-1.47.0-h6666856_0.tar.bz2
osx-arm64::gfal2-2.21.0-heb7f5a1_0.tar.bz2
osx-arm64::vtk-9.1.0-qt_py39h7262794_210.tar.bz2
osx-arm64::magics-metview-4.12.0-h7d07fd2_3.tar.bz2
osx-arm64::libxml2-2.9.14-h035c1df_2.tar.bz2
osx-arm64::papilo-2.1.0-hce67156_1.tar.bz2
osx-arm64::libxml2-2.9.14-h035c1df_1.tar.bz2
osx-arm64::imagecodecs-2022.7.27-py38h7bccbae_1.tar.bz2
osx-arm64::imagecodecs-2022.7.27-py310h06ba816_1.tar.bz2
osx-arm64::yoda-1.9.5-py39hf846450_1.tar.bz2
osx-arm64::arrow-cpp-3.0.0-py38hcc5bc27_54_cpu.tar.bz2
osx-arm64::libopencv-4.5.5-py39h86e1ac9_11.tar.bz2
osx-arm64::arrow-cpp-7.0.0-py310h460715f_8_cpu.tar.bz2
osx-arm64::tiledb-2.9.3-h824fbfd_0.tar.bz2
osx-arm64::postgresql-plpython-14.4-py39h032559e_0.tar.bz2
osx-arm64::vtk-9.1.0-qt_py310hce58b2a_209.tar.bz2
osx-arm64::arrow-cpp-7.0.0-py39h8a997f0_8_cpu.tar.bz2
osx-arm64::libopencv-4.6.0-py38he52a0c8_1.tar.bz2
osx-arm64::cpp-opentelemetry-sdk-1.4.1-h1276eba_1.tar.bz2
osx-arm64::arrow-cpp-8.0.0-py310h662495a_3_cpu.tar.bz2
osx-arm64::graphicsmagick-1.3.37-h98435ee_0.tar.bz2
osx-arm64::arrow-cpp-6.0.1-py38hcc5bc27_20_cpu.tar.bz2
osx-arm64::arrow-cpp-8.0.1-py310hef82f62_0_cpu.tar.bz2
osx-arm64::arrow-cpp-8.0.0-py39h148c617_4_cpu.tar.bz2
osx-arm64::libtiff-4.4.0-hcbbed22_1.tar.bz2
osx-arm64::grpc-cpp-1.46.3-h6666856_1.tar.bz2
osx-arm64::libpq-14.4-h8ab49ba_0.tar.bz2
osx-arm64::mlir-14.0.3-h2e2d6ab_0.tar.bz2
osx-arm64::ffmpeg-4.4.2-lgpl_hf88b213_1.tar.bz2
osx-arm64::ogre-1.12.13-h148629e_2.tar.bz2
osx-arm64::arrow-cpp-3.0.0-py38haaa68d7_54_cpu.tar.bz2
osx-arm64::arrow-cpp-6.0.1-py39h0fb3614_20_cpu.tar.bz2
osx-arm64::graphviz-5.0.0-hc7d6d94_0.tar.bz2
osx-arm64::imagecodecs-2022.2.22-py38hc8fddaf_6.tar.bz2
osx-arm64::cpp-opentelemetry-sdk-1.4.1-hedd8126_4.tar.bz2
osx-arm64::cpp-opentelemetry-sdk-1.4.1-h54bd388_3.tar.bz2
osx-arm64::gmsh-4.10.4-h8f86c64_0.tar.bz2
osx-arm64::glib-networking-2.72.1-hb1e1873_1.tar.bz2
osx-arm64::libopencv-4.6.0-py310he340bd1_1.tar.bz2
osx-arm64::imagemagick-7.1.0_41-pl5321hc4c6cfc_1.tar.bz2
osx-arm64::ogre-next-2.3.1-h8eed35d_0.tar.bz2
osx-arm64::ffmpeg-5.1.0-lgpl_hcece248_0.tar.bz2
osx-arm64::libopencv-4.6.0-py39h86e1ac9_0.tar.bz2
osx-arm64::libitk-5.2.1-h502eeef_4.tar.bz2
osx-arm64::jaxlib-0.3.14-cpu_py39h963f08e_1.tar.bz2
osx-arm64::coin-or-cgl-0.60.6-h7897f42_1.tar.bz2
osx-arm64::gmsh-4.10.5-h8f86c64_0.tar.bz2
osx-arm64::pdal-2.4.1-hd451bfc_1.tar.bz2
osx-arm64::libgit2-1.4.4-h50dc06c_0.tar.bz2
osx-arm64::nodejs-18.5.0-h181ad7c_0.tar.bz2
osx-arm64::arrow-cpp-3.0.0-py310h7f6059a_54_cpu.tar.bz2
osx-arm64::pyreadstat-1.1.9-py39h854b70c_0.tar.bz2
osx-arm64::arrow-cpp-8.0.0-py310h460715f_3_cpu.tar.bz2
osx-arm64::tiledb-2.9.4-h824fbfd_0.tar.bz2
osx-arm64::libopencv-4.6.0-py38hed35a8a_3.tar.bz2
osx-arm64::soplex-6.0.1-h00e1a30_1.tar.bz2
osx-arm64::libglib-2.72.1-ha1047ec_0.tar.bz2
osx-arm64::libmediainfo-22.06-hbc06cea_0.tar.bz2
osx-arm64::arrow-cpp-8.0.0-py310hef82f62_4_cpu.tar.bz2
osx-arm64::ffmpeg-5.0.1-gpl_h27c9728_107.tar.bz2
osx-arm64::arrow-cpp-5.0.0-py39h0fb3614_35_cpu.tar.bz2
osx-arm64::gazebo-11.11.0-h46f2ba0_9.tar.bz2
osx-arm64::hugin-base-2021.0.0-pl5321h1f0edaa_7.tar.bz2
osx-arm64::paraview-5.10.1-py38hcf09b12_107_qt.tar.bz2
osx-arm64::harp-1.15.1-py38h17370f9_2.tar.bz2
osx-arm64::postgresql-plpython-14.4-py39h22af90f_0.tar.bz2
osx-arm64::gazebo-11.11.0-h53f2fae_2.tar.bz2
osx-arm64::librdkafka-1.9.1-h06520fc_0.tar.bz2
osx-arm64::jaxlib-0.3.14-cpu_py39h963f08e_0.tar.bz2
osx-arm64::jaxlib-0.3.14-cpu_py38h189b518_3.tar.bz2
osx-arm64::glib-networking-2.72.1-h969aa61_1.tar.bz2
osx-arm64::grpc-cpp-1.44.0-he5d1839_5.tar.bz2
osx-arm64::jaxlib-0.3.14-cpu_py310hc8f61c1_0.tar.bz2
osx-arm64::nodejs-18.6.0-h181ad7c_0.tar.bz2
osx-arm64::arrow-cpp-5.0.0-py310h45feaed_35_cpu.tar.bz2
osx-arm64::paraview-5.10.1-py38hd17ad18_107_qt.tar.bz2
osx-arm64::ffmpeg-4.4.2-gpl_h27c9728_105.tar.bz2
osx-arm64::poppler-22.04.0-hadf1f10_1.tar.bz2
osx-arm64::pdal-2.4.1-hc36b3b7_2.tar.bz2
osx-arm64::arrow-cpp-8.0.0-py310hef82f62_5_cpu.tar.bz2
osx-arm64::gazebo-11.11.0-h8dffdd9_7.tar.bz2
osx-arm64::libgdal-3.5.0-hbb787c8_2.tar.bz2
osx-arm64::libzip-1.9.2-h8caee39_0.tar.bz2
osx-arm64::grpc-cpp-1.43.2-h7a23adf_6.tar.bz2
osx-arm64::libarchive-3.5.2-hdd7f49f_3.tar.bz2
osx-arm64::wxwidgets-3.2.0-py310hc9af680_1.tar.bz2
osx-arm64::libtensorflow-2.9.1-cpu_h7e4e388_0.tar.bz2
osx-arm64::openbabel-3.1.1-py310hd29cb64_4.tar.bz2
osx-arm64::vowpalwabbit-9.2.0-py310h903ca5e_0.tar.bz2
osx-arm64::arrow-cpp-7.0.0-py38h0321cd0_8_cpu.tar.bz2
osx-arm64::grpcio-1.46.3-py310h10ad472_1.tar.bz2
osx-arm64::xrootd-5.4.3-py39h7a7f79a_1.tar.bz2
osx-arm64::openmeeg-2.4.2-py38hab352dd_1.tar.bz2
osx-arm64::openconnect-9.01-h1894f03_1.tar.bz2
osx-arm64::nodejs-18.3.0-h3712f7e_0.tar.bz2
osx-arm64::jaxlib-0.3.14-cpu_py310h9f98a3b_0.tar.bz2
osx-arm64::openmeeg-2.4.2-py310haddacac_3.tar.bz2
osx-arm64::arrow-cpp-8.0.0-py39h53b7727_2_cpu.tar.bz2
osx-arm64::harp-1.15.1-py38h56a2ace_1.tar.bz2
osx-arm64::arrow-cpp-8.0.0-py38h7d4df96_5_cpu.tar.bz2
osx-arm64::libopencv-4.6.0-py310hcfd521e_3.tar.bz2
osx-arm64::ogre-13.4.1-h55d775c_0.tar.bz2
osx-arm64::gazebo-11.11.0-hd5ded3a_4.tar.bz2
osx-arm64::imagemagick-7.1.0_40-pl5321h8f75910_0.tar.bz2
osx-arm64::cpp-opentelemetry-sdk-1.4.1-h1276eba_0.tar.bz2
osx-arm64::graphviz-4.0.0-hc7d6d94_1.tar.bz2
osx-arm64::arrow-cpp-8.0.0-py39h5805033_4_cpu.tar.bz2
osx-arm64::vtk-9.1.0-qt_py38he8f5a5f_212.tar.bz2
osx-arm64::arrow-cpp-8.0.0-py39h148c617_5_cpu.tar.bz2
osx-arm64::ffmpeg-5.0.1-gpl_h0b00469_108.tar.bz2
osx-arm64::llvmdev-14.0.6-h37c5ba8_0.tar.bz2
osx-arm64::graphviz-3.0.0-hc7d6d94_2.tar.bz2
osx-arm64::paraview-5.10.1-py310hb28e967_107_qt.tar.bz2
osx-arm64::jaxlib-0.3.14-cpu_py39ha1df067_1.tar.bz2
osx-arm64::gazebo-11.11.0-h46f2ba0_7.tar.bz2
osx-arm64::grpc-cpp-1.44.0-h6e39ad6_5.tar.bz2
osx-arm64::pdal-2.4.2-hc36b3b7_2.tar.bz2
osx-arm64::pillow-9.2.0-py39h1b8be2f_0.tar.bz2
osx-arm64::openmeeg-2.4.2-py38hbab9506_4.tar.bz2
osx-arm64::scip-8.0.1-h7158e95_0.tar.bz2
osx-arm64::libopencv-4.5.5-py38he52a0c8_11.tar.bz2
osx-arm64::libtiff-4.4.0-h57e8767_2.tar.bz2
osx-arm64::root_base-6.26.4-py38he532589_3.tar.bz2
osx-arm64::libnetcdf-4.8.1-mpi_openmpi_h4e51680_3.tar.bz2
osx-arm64::coda-2.24-py310ha3d3d99_0.tar.bz2
osx-arm64::jaxlib-0.3.14-cpu_py39h1faf19b_0.tar.bz2
osx-arm64::openmeeg-2.4.2-py38hab352dd_2.tar.bz2
osx-arm64::arrow-cpp-7.0.0-py39h0fcfa69_8_cpu.tar.bz2
osx-arm64::imagecodecs-2022.7.27-py39h4fd65cd_0.tar.bz2
osx-arm64::cppyy-cling-6.27.0-py310he0c1fe7_0.tar.bz2
osx-arm64::smesh-9.8.0.2-hb205d28_1.tar.bz2
osx-arm64::geant4-11.0.2-py310he6f6967_1.tar.bz2
osx-arm64::grpc-cpp-1.46.3-h7d90225_2.tar.bz2
osx-arm64::cpp-opentelemetry-sdk-1.4.1-hedd8126_2.tar.bz2
osx-arm64::ffmpeg-4.4.1-h4556347_5.tar.bz2
osx-arm64::yoda-1.9.5-py38h71b7416_1.tar.bz2
osx-arm64::libopencv-4.6.0-py39he1c1adf_3.tar.bz2
osx-arm64::ffmpeg-5.0.1-h4556347_3.tar.bz2
osx-arm64::libopencv-4.6.0-py38hdd274b2_2.tar.bz2
osx-arm64::gazebo-11.11.0-h256b86c_2.tar.bz2
osx-arm64::ffmpeg-5.0.1-lgpl_hcece248_8.tar.bz2
osx-arm64::ffmpeg-5.0.1-lgpl_h1e762cc_6.tar.bz2
osx-arm64::libgit2-1.5.0-hf86504d_0.tar.bz2
osx-arm64::libopencv-4.6.0-py39hb16ced2_2.tar.bz2
osx-arm64::tectonic-0.9.0-h8c1c61b_1.tar.bz2
osx-arm64::ffmpeg-4.4.2-lgpl_hca39864_5.tar.bz2
osx-arm64::xrootd-5.4.3-py38h9c8604b_1.tar.bz2
osx-arm64::gazebo-11.11.0-ha5c0ef3_1.tar.bz2
osx-arm64::pillow-9.2.0-py310hc9df86f_0.tar.bz2
osx-arm64::libprotobuf-static-21.4-h332123e_0.tar.bz2
osx-arm64::imagemagick-7.1.0_39-pl5321h8f75910_0.tar.bz2
osx-arm64::tiledb-2.9.4-hdd33e7b_0.tar.bz2
osx-arm64::libprotobuf-static-21.3-h332123e_0.tar.bz2
osx-arm64::jaxlib-0.3.14-cpu_py310h006dc33_0.tar.bz2
osx-arm64::libpng-1.6.37-h2c9beb0_3.tar.bz2
osx-arm64::libopencv-4.5.5-py39h86e1ac9_10.tar.bz2
osx-arm64::hdf5-1.12.2-mpi_openmpi_hfe3cbcd_0.tar.bz2
osx-arm64::openmeeg-2.4.7-py39h6db3175_0.tar.bz2
osx-arm64::pyreadstat-1.1.7-py38ha509820_0.tar.bz2
osx-arm64::vtk-9.1.0-qt_py38h2f633e3_210.tar.bz2
osx-arm64::ffmpeg-4.4.2-lgpl_hca39864_4.tar.bz2
osx-arm64::coda-2.24-py39ha872ab9_1.tar.bz2
osx-arm64::pdal-2.4.2-hc36b3b7_0.tar.bz2
osx-arm64::openmeeg-2.4.2-py39h51061df_1.tar.bz2
osx-arm64::mongodb-6.0.0-hdbfeab2_0.tar.bz2
osx-arm64::openmeeg-2.4.2-py39h51061df_2.tar.bz2
osx-arm64::libgdal-3.5.1-hc0c25a4_2.tar.bz2
osx-arm64::openmeeg-2.4.4-py310h6e1f347_0.tar.bz2
osx-arm64::root_base-6.26.4-py310h31ace29_3.tar.bz2
osx-arm64::arrow-cpp-6.0.1-py38haaa68d7_20_cpu.tar.bz2
osx-arm64::openmeeg-2.4.2-py310hceebde6_2.tar.bz2
osx-arm64::tesseract-5.1.0-hd002dc4_0.tar.bz2
osx-arm64::mongodb-6.0.0-h92782e7_0.tar.bz2
osx-arm64::ffmpeg-4.4.2-lgpl_h1e762cc_3.tar.bz2
osx-arm64::gazebo-11.11.0-h50b4561_3.tar.bz2
osx-arm64::libopencv-4.5.5-py310he340bd1_12.tar.bz2
osx-arm64::tiledb-2.9.3-hdd33e7b_0.tar.bz2
osx-arm64::hdf5-1.12.2-nompi_h8968d4b_100.tar.bz2
osx-arm64::openmpi-4.1.3-hd4b5bf3_104.tar.bz2
osx-arm64::libtensorflow_cc-2.9.1-cpu_h7e4e388_0.tar.bz2
osx-arm64::arrow-cpp-8.0.0-py38h7d4df96_4_cpu.tar.bz2
osx-arm64::openmeeg-2.4.4-py39h6db3175_0.tar.bz2
osx-arm64::grpc-cpp-1.45.2-h7a23adf_4.tar.bz2
osx-arm64::libopencv-4.5.5-py310he340bd1_11.tar.bz2
osx-arm64::grpc-cpp-1.48.0-h7d90225_0.tar.bz2
osx-arm64::libgdal-3.5.1-h125b1ee_1.tar.bz2
osx-arm64::vtk-9.1.0-qt_py39h4e51a77_212.tar.bz2
osx-arm64::jaxlib-0.3.14-cpu_py38h78c0d4f_0.tar.bz2
osx-arm64::cpp-opentelemetry-sdk-1.4.1-h1276eba_4.tar.bz2
osx-arm64::grpc-cpp-1.46.3-h65cd93d_1.tar.bz2
osx-arm64::librdkafka-1.9.1-h8e44059_1.tar.bz2
osx-arm64::postgresql-plpython-14.4-py310h501847f_0.tar.bz2
osx-arm64::ogre-next-2.3.0-h8eed35d_1.tar.bz2
osx-arm64::nodejs-18.6.0-h3712f7e_0.tar.bz2
osx-arm64::vtk-9.1.0-qt_py310hb373bb4_211.tar.bz2
osx-arm64::nodejs-18.7.0-h181ad7c_0.tar.bz2
osx-arm64::vigra-1.11.1-py310h36966a0_1033.tar.bz2
osx-arm64::jaxlib-0.3.14-cpu_py39h9833c27_3.tar.bz2
osx-arm64::imagecodecs-2022.7.27-py39h221b581_1.tar.bz2
osx-arm64::pdal-2.4.2-haca32e1_3.tar.bz2
osx-arm64::libgdal-3.5.1-h125b1ee_0.tar.bz2
osx-arm64::ldas-tools-framecpp-2.9.0-h6120fb8_0.tar.bz2
osx-arm64::nodejs-18.5.0-h3712f7e_0.tar.bz2
osx-arm64::ovito-3.7.8-hfc1e6e5_0.tar.bz2
osx-arm64::imagemagick-7.1.0_38-pl5321h8f75910_0.tar.bz2
osx-arm64::arrow-cpp-8.0.0-py39h2436d35_2_cpu.tar.bz2
osx-arm64::geotiff-1.7.1-hc898e3f_2.tar.bz2
osx-arm64::ogre-13.4.2-h847e3f4_0.tar.bz2
osx-arm64::openmeeg-2.4.6-py38hbab9506_0.tar.bz2
osx-arm64::grpc-cpp-1.44.0-h7a23adf_5.tar.bz2
osx-arm64::libspatialite-5.0.1-hc8eb19a_16.tar.bz2
osx-arm64::vigra-1.11.1-py39hdabd6fd_1033.tar.bz2
osx-arm64::qt-main-5.15.4-haf604a7_1.tar.bz2
osx-arm64::postgresql-14.4-heaa1073_0.tar.bz2
osx-arm64::grpcio-1.46.3-py38h1ef021a_1.tar.bz2
osx-arm64::jaxlib-0.3.14-cpu_py310h7f2b7ff_0.tar.bz2
osx-arm64::paraview-5.10.1-py310h1ab78dc_107_qt.tar.bz2
osx-arm64::vtk-9.1.0-qt_py38h17df82a_211.tar.bz2
osx-arm64::vowpalwabbit-9.2.0-py38h63e6dac_0.tar.bz2
osx-arm64::libgdal-3.5.0-h62702d4_3.tar.bz2
osx-arm64::ogre-1.10.12-h5654cb5_9.tar.bz2
osx-arm64::xrootd-5.4.3-py38hc274ea7_1.tar.bz2
osx-arm64::grpcio-1.46.3-py38hd51562d_1.tar.bz2
osx-arm64::glib-2.72.1-h332123e_0.tar.bz2
osx-arm64::openconnect-9.01-h31d2978_2.tar.bz2
osx-arm64::vtk-9.1.0-qt_py310hafcb908_212.tar.bz2
osx-arm64::pillow-9.2.0-py38h3852883_0.tar.bz2
osx-arm64::magics-metview-4.12.0-hf7923e3_2.tar.bz2
osx-arm64::git-2.37.0-pl5321h824b0f5_0.tar.bz2
osx-arm64::git-2.37.1-pl5321h824b0f5_0.tar.bz2
osx-arm64::ogre-13.4.1-h847e3f4_1.tar.bz2
osx-arm64::ovito-3.7.5-hfc1e6e5_1.tar.bz2
osx-arm64::papilo-2.1.0-hce67156_0.tar.bz2
osx-arm64::vtk-9.1.0-qt_py38hf5e40fb_209.tar.bz2
osx-arm64::postgresql-plpython-14.4-py38haa447b5_0.tar.bz2
osx-arm64::ogre-next-2.3.1-h8eed35d_1.tar.bz2
osx-arm64::librdkafka-1.9.1-h06520fc_1.tar.bz2
osx-arm64::libnetcdf-4.8.1-mpi_mpich_hd45b26b_3.tar.bz2
osx-arm64::qt-main-5.15.4-haf604a7_2.tar.bz2
osx-arm64::arrow-cpp-8.0.0-py310h46ba588_2_cpu.tar.bz2
osx-arm64::libopencv-4.6.0-py38he52a0c8_0.tar.bz2
osx-arm64::yoda-1.9.6-py39hf846450_0.tar.bz2
osx-arm64::arrow-cpp-5.0.0-py38hcc5bc27_35_cpu.tar.bz2
osx-arm64::grpcio-1.46.3-py39h518bade_1.tar.bz2
osx-arm64::yoda-1.9.5-py310h17d258d_1.tar.bz2
osx-arm64::arrow-cpp-8.0.1-py310h4fee3f5_0_cpu.tar.bz2
osx-arm64::imagemagick-7.1.0_41-pl5321h8f75910_0.tar.bz2
osx-arm64::coda-2.24-py310h79a65ec_1.tar.bz2
osx-arm64::openmeeg-2.4.6-py39h6db3175_0.tar.bz2
osx-arm64::arrow-cpp-8.0.0-py38h7fd58b1_2_cpu.tar.bz2
osx-arm64::arrow-cpp-3.0.0-py310h45feaed_54_cpu.tar.bz2
osx-arm64::gazebo-11.11.0-h8dffdd9_9.tar.bz2
osx-arm64::mlir-14.0.5-h2e2d6ab_0.tar.bz2
osx-arm64::git-2.37.1-pl5321h3ff7a5b_0.tar.bz2
osx-arm64::grpc-cpp-1.47.0-hd7338e0_1.tar.bz2
osx-arm64::qt-main-5.15.4-haf604a7_0.tar.bz2
osx-arm64::gmt-6.3.0-hc1430c3_6.tar.bz2
osx-arm64::libgdal-3.5.0-hb972c36_5.tar.bz2
osx-arm64::jaxlib-0.3.14-cpu_py38h87657f7_1.tar.bz2
osx-arm64::libgdal-3.5.0-h042cc3e_3.tar.bz2
osx-arm64::connectorx-0.3.0-py38h8fef32a_1.tar.bz2
osx-arm64::harp-1.15.1-py310ha3d3d99_1.tar.bz2
osx-arm64::libopencv-4.6.0-py39h86e1ac9_1.tar.bz2
osx-arm64::libopencv-4.5.5-py38he52a0c8_10.tar.bz2
osx-arm64::ffmpeg-5.0.1-lgpl_hf88b213_5.tar.bz2
osx-arm64::libnetcdf-4.8.1-nompi_hc076e8b_103.tar.bz2
osx-arm64::libmatio-1.5.23-h85dfe62_1.tar.bz2
osx-arm64::arrow-cpp-8.0.1-py39h148c617_0_cpu.tar.bz2
osx-arm64::librdkafka-1.9.1-h8e44059_0.tar.bz2
osx-arm64::ovito-3.7.7-hfc1e6e5_0.tar.bz2
osx-arm64::paraview-5.10.1-py39hf421057_107_qt.tar.bz2
osx-arm64::grpc-cpp-1.44.0-he0aa8a8_5.tar.bz2
osx-arm64::magics-metview-batch-4.12.0-heeaf687_1.tar.bz2
osx-arm64::openbabel-3.1.1-py39h0e0ec99_4.tar.bz2
osx-arm64::python-3.10.5-h71ab1a4_0_cpython.tar.bz2
osx-arm64::hdf5-1.12.2-nompi_h33dac16_100.tar.bz2
osx-arm64::openmpi-4.1.3-h63a3ee9_105.tar.bz2
osx-arm64::sqlite-3.39.1-h40dfcc0_0.tar.bz2
osx-arm64::arrow-cpp-8.0.0-py310h4fee3f5_4_cpu.tar.bz2
osx-arm64::hdf5-1.12.2-mpi_openmpi_h7f82a92_0.tar.bz2
osx-arm64::jaxlib-0.3.14-cpu_py38hfaea817_0.tar.bz2
osx-arm64::openmeeg-2.4.2-py310h6e1f347_4.tar.bz2
osx-arm64::arrow-cpp-8.0.0-py38hc445ed8_2_cpu.tar.bz2
osx-arm64::arrow-cpp-8.0.0-py39h0fcfa69_3_cpu.tar.bz2
osx-arm64::ovito-3.7.7-hfc1e6e5_1.tar.bz2
osx-arm64::grpc-cpp-1.47.1-h7d90225_0.tar.bz2
osx-arm64::ffmpeg-4.4.2-lgpl_hf88b213_2.tar.bz2
osx-arm64::librdkafka-1.9.0-hf1269b9_0.tar.bz2
osx-arm64::arrow-cpp-8.0.0-py38h2f9e2c6_3_cpu.tar.bz2
osx-arm64::ldas-tools-framecpp-2.9.0-h5e00029_0.tar.bz2
osx-arm64::harp-1.15.1-py39ha872ab9_2.tar.bz2
osx-arm64::gdstk-0.8.3-py38hd7239c2_0.tar.bz2
osx-arm64::jaxlib-0.3.14-cpu_py38hfaea817_1.tar.bz2
osx-arm64::imagecodecs-2022.7.27-py38h25bbd06_0.tar.bz2
osx-arm64::pyreadstat-1.1.9-py310h75fa04e_0.tar.bz2
osx-arm64::tensorflow-base-2.9.1-cpu_py39ha1ad4ae_0.tar.bz2
osx-arm64::arrow-cpp-7.0.0-py310h662495a_8_cpu.tar.bz2
osx-arm64::coda-2.24-py39h8ba6c9f_0.tar.bz2
osx-arm64::jaxlib-0.3.14-cpu_py310h006dc33_1.tar.bz2
osx-arm64::libgit2-1.5.0-h50dc06c_0.tar.bz2
osx-arm64::pdal-2.4.2-hc36b3b7_1.tar.bz2
osx-arm64::libopencv-4.5.5-py39h86e1ac9_12.tar.bz2
osx-arm64::libarchive-3.5.2-h69ec738_3.tar.bz2
osx-arm64::arrow-cpp-8.0.1-py38h7d4df96_0_cpu.tar.bz2
osx-arm64::prometheus-cpp-1.0.1-h7ebaf7f_0.tar.bz2
osx-arm64::grpc-cpp-1.43.2-h6e39ad6_6.tar.bz2
osx-arm64::arrow-cpp-8.0.0-py39h5805033_5_cpu.tar.bz2
osx-arm64::libsoup-2.74.2-ha8663b0_0.tar.bz2
osx-arm64::tectonic-0.9.0-hadb1766_1.tar.bz2
osx-arm64::ffmpeg-4.4.2-lgpl_hcece248_6.tar.bz2
osx-arm64::jaxlib-0.3.14-cpu_py38h78c0d4f_1.tar.bz2
osx-arm64::jaxlib-0.3.14-cpu_py310h43dc086_3.tar.bz2
osx-arm64::ogre-next-2.2.6-h8eed35d_0.tar.bz2
osx-arm64::arrow-cpp-8.0.0-py310h06d4556_2_cpu.tar.bz2
osx-arm64::vtk-9.1.0-qt_py310h5ad20fb_210.tar.bz2
osx-arm64::openmeeg-2.4.2-py39h6db3175_4.tar.bz2
osx-arm64::pdal-2.4.2-h46b78e2_1.tar.bz2
osx-arm64::jaxlib-0.3.14-cpu_py38hade8c37_1.tar.bz2
osx-arm64::libzip-1.9.2-h57b78ed_0.tar.bz2
osx-arm64::xrootd-5.4.3-py310h73e20e7_1.tar.bz2
osx-arm64::gazebo-11.11.0-h6eea99a_1.tar.bz2
osx-arm64::openmpi-4.1.4-h63a3ee9_100.tar.bz2
osx-arm64::hdf5-1.12.2-mpi_mpich_h1901e0a_0.tar.bz2
osx-arm64::ldas-tools-framecpp-2.9.1-h6120fb8_0.tar.bz2
osx-arm64::vigra-1.11.1-py38h98b3e9e_1033.tar.bz2
osx-arm64::geant4-11.0.2-py39h518e00d_1.tar.bz2
osx-arm64::magics-4.12.0-heeaf687_1.tar.bz2
osx-arm64::ffmpeg-5.0.1-lgpl_hf88b213_4.tar.bz2
osx-arm64::arrow-cpp-3.0.0-py39h0fb3614_54_cpu.tar.bz2
osx-arm64::cppyy-cling-6.27.0-py38h4d7b76e_0.tar.bz2
osx-arm64::gdstk-0.8.3-py310h7da48d1_0.tar.bz2
osx-arm64::openmeeg-2.4.2-py310hceebde6_1.tar.bz2
osx-arm64::cpp-opentelemetry-sdk-1.4.1-h1276eba_3.tar.bz2
osx-arm64::xrootd-5.4.3-py310ha736343_1.tar.bz2
osx-arm64::geant4-11.0.2-py38h9d60207_1.tar.bz2
osx-arm64::imagemagick-7.1.0_44-pl5321hc4c6cfc_0.tar.bz2
osx-arm64::libgdal-3.5.1-hb972c36_1.tar.bz2
osx-arm64::openmeeg-2.4.2-py39h54c461b_3.tar.bz2
osx-arm64::jaxlib-0.3.14-cpu_py310h9f98a3b_1.tar.bz2
osx-arm64::cpp-opentelemetry-sdk-1.4.1-h1276eba_2.tar.bz2
osx-arm64::gazebo-11.11.0-h177735c_6.tar.bz2
osx-arm64::gdstk-0.8.3-py39h234819f_0.tar.bz2
osx-arm64::libopencv-4.5.5-py310he340bd1_10.tar.bz2
osx-arm64::jaxlib-0.3.14-cpu_py310h82d31ad_3.tar.bz2
osx-arm64::connectorx-0.3.0-py310h57e002c_1.tar.bz2
osx-arm64::pyreadstat-1.1.7-py310h75fa04e_0.tar.bz2
osx-arm64::imagecodecs-2022.2.22-py39h661bc3f_6.tar.bz2
osx-arm64::git-2.37.0-pl5321h3ff7a5b_0.tar.bz2
osx-arm64::harp-1.15.1-py39h8ba6c9f_1.tar.bz2
osx-arm64::gazebo-11.11.0-h46f2ba0_8.tar.bz2
osx-arm64::jaxlib-0.3.14-cpu_py39hdebe834_1.tar.bz2
osx-arm64::pdal-2.4.2-h670929e_3.tar.bz2
osx-arm64::arrow-cpp-8.0.0-py39h8a997f0_3_cpu.tar.bz2
osx-arm64::postgresql-plpython-14.4-py310h1e3b118_0.tar.bz2
osx-arm64::arrow-cpp-8.0.0-py38h0321cd0_3_cpu.tar.bz2
osx-arm64::grpc-cpp-1.47.0-h65cd93d_0.tar.bz2
osx-arm64::xrootd-5.4.3-py39hc1c9732_1.tar.bz2
osx-arm64::pyreadstat-1.1.7-py39h854b70c_0.tar.bz2
osx-arm64::gemmi-0.5.5-py38h8a5a59d_0.tar.bz2
osx-arm64::ffmpeg-5.0.1-gpl_h263e9c8_104.tar.bz2
osx-arm64::ffmpeg-4.4.2-gpl_h263e9c8_102.tar.bz2
osx-arm64::openbabel-3.1.1-py38h028a5c4_4.tar.bz2
osx-arm64::grpc-cpp-1.43.2-he0aa8a8_6.tar.bz2
osx-arm64::libsoup-3.0.7-ha8663b0_0.tar.bz2
osx-arm64::libgit2-1.4.4-hf86504d_0.tar.bz2
osx-arm64::glib-networking-2.72.1-h969aa61_0.tar.bz2
osx-arm64::gmt-6.4.0-h216c163_2.tar.bz2
osx-arm64::libgdal-3.5.0-h125b1ee_5.tar.bz2
osx-arm64::libgdal-3.5.1-h97effd8_2.tar.bz2
osx-arm64::jaxlib-0.3.14-cpu_py39h1faf19b_1.tar.bz2
osx-arm64::libgdal-3.5.0-h3fabfaf_4.tar.bz2
osx-arm64::ffmpeg-4.4.2-gpl_h263e9c8_101.tar.bz2
osx-arm64::grpc-cpp-1.48.0-hd7338e0_0.tar.bz2
osx-arm64::prometheus-cpp-1.0.0-h7ebaf7f_0.tar.bz2
osx-arm64::gazebo-11.11.0-h7e4f8a5_4.tar.bz2
osx-arm64::pdal-2.4.1-h73c9c92_1.tar.bz2
osx-arm64::cmake-3.23.3-h52850c7_0.tar.bz2
osx-arm64::libopencv-4.6.0-py310he340bd1_0.tar.bz2
osx-arm64::imagemagick-7.1.0.43-pl5321hc4c6cfc_0.tar.bz2
osx-arm64::pdal-2.4.2-h46b78e2_2.tar.bz2
osx-arm64::libopencv-4.5.5-py310he340bd1_13.tar.bz2
osx-arm64::libgdal-3.5.0-hebcfd5c_4.tar.bz2
osx-arm64::libgsf-1.14.50-h93658a1_0.tar.bz2
osx-arm64::libspatialite-5.0.1-h47b1232_18.tar.bz2
osx-arm64::jaxlib-0.3.14-cpu_py310h7f2b7ff_1.tar.bz2
osx-arm64::arrow-cpp-8.0.0-py38hf3a2c03_4_cpu.tar.bz2
osx-arm64::coda-2.24-py38h17370f9_1.tar.bz2
osx-arm64::gazebo-11.11.0-hc5f9815_3.tar.bz2
osx-arm64::gazebo-11.11.0-h8dffdd9_8.tar.bz2
osx-arm64::jaxlib-0.3.14-cpu_py39ha1df067_0.tar.bz2
osx-arm64::nodejs-18.7.0-h3712f7e_0.tar.bz2
osx-arm64::openmeeg-2.4.7-py310h6e1f347_0.tar.bz2
osx-arm64::grpc-cpp-1.47.0-h7d90225_1.tar.bz2
osx-arm64::libopencv-4.5.5-py38he52a0c8_13.tar.bz2
osx-arm64::openmeeg-2.4.2-py38h2ce8bab_3.tar.bz2
osx-arm64::sqlite-3.39.2-h40dfcc0_0.tar.bz2
osx-arm64::cpp-opentelemetry-sdk-1.4.1-h094c233_0.tar.bz2
osx-arm64::openscenegraph-3.6.5-h5a15a81_14.tar.bz2
osx-arm64::jaxlib-0.3.14-cpu_py310hc8f61c1_1.tar.bz2
osx-arm64::libgdal-3.5.0-he6ec110_1.tar.bz2
osx-arm64::connectorx-0.3.0-py39hd43f6ff_1.tar.bz2
osx-arm64::gazebo-11.11.0-hd5ded3a_5.tar.bz2
osx-arm64::grpc-cpp-1.45.2-he0aa8a8_4.tar.bz2
osx-arm64::yoda-1.9.6-py310h17d258d_0.tar.bz2
osx-arm64::imagecodecs-2022.7.27-py310h0a5c56b_0.tar.bz2
osx-arm64::imagecodecs-2022.2.22-py310hd4be40a_6.tar.bz2
osx-arm64::xrootd-5.4.3-py38h9c8604b_0.tar.bz2
osx-arm64::ffmpeg-4.4.2-h4556347_0.tar.bz2
osx-arm64::yoda-1.9.6-py38h71b7416_0.tar.bz2
osx-arm64::llvmdev-14.0.5-h37c5ba8_0.tar.bz2
osx-arm64::pdal-2.4.2-h46b78e2_0.tar.bz2
osx-arm64::ffmpeg-5.0.1-gpl_h263e9c8_105.tar.bz2
osx-arm64::libopencv-4.5.5-py39h86e1ac9_13.tar.bz2
osx-arm64::postgresql-plpython-14.4-py38hf5dda18_0.tar.bz2
osx-arm64::scip-8.0.1-hc348fcc_1.tar.bz2
osx-arm64::paraview-5.10.1-py39h74135c3_107_qt.tar.bz2
osx-arm64::grpc-cpp-1.46.3-hd7338e0_2.tar.bz2
osx-arm64::jaxlib-0.3.14-cpu_py38ha1a958d_3.tar.bz2
osx-arm64::ffmpeg-4.4.2-gpl_h544b4b4_103.tar.bz2
osx-arm64::libgdal-3.5.1-hb972c36_0.tar.bz2
osx-arm64::openmeeg-2.4.6-py310h6e1f347_0.tar.bz2
osx-arm64::ffmpeg-5.1.0-gpl_h0b00469_100.tar.bz2
osx-arm64::libxml2-2.9.14-h035c1df_3.tar.bz2
osx-arm64::gmt-6.4.0-h81c286a_1.tar.bz2
osx-arm64::zstd-1.5.2-hd705a24_2.tar.bz2
osx-arm64::libpq-14.4-hd0d3353_0.tar.bz2
osx-arm64::coda-2.24-py38h56a2ace_0.tar.bz2
osx-arm64::arrow-cpp-3.0.0-py39h1602ef9_54_cpu.tar.bz2
osx-arm64::gazebo-11.11.0-h31d55a5_6.tar.bz2
osx-arm64::jaxlib-0.3.14-cpu_py39hdebe834_0.tar.bz2
osx-arm64::graphviz-2.50.0-hc7d6d94_3.tar.bz2
osx-arm64::grpc-cpp-1.45.2-he5d1839_4.tar.bz2
osx-arm64::libgdal-3.5.0-h80d3286_2.tar.bz2
osx-arm64::fish-3.5.0-hc5976cb_0.tar.bz2
osx-arm64::gazebo-11.11.0-h7e4f8a5_5.tar.bz2
osx-arm64::openmeeg-2.4.7-py38hbab9506_0.tar.bz2
osx-arm64::openconnect-9.01-h757da47_0.tar.bz2
osx-arm64::arrow-cpp-6.0.1-py310h45feaed_20_cpu.tar.bz2
osx-arm64::libgdal-3.5.0-hf7d4b80_1.tar.bz2
osx-arm64::arrow-cpp-6.0.1-py310h7f6059a_20_cpu.tar.bz2
osx-arm64::jaxlib-0.3.14-cpu_py38hade8c37_0.tar.bz2
osx-arm64::gmt-6.4.0-hc1430c3_0.tar.bz2
osx-arm64::arrow-cpp-6.0.1-py39h1602ef9_20_cpu.tar.bz2
osx-arm64::ffmpeg-4.4.2-gpl_h0b00469_106.tar.bz2
osx-arm64::cpp-opentelemetry-sdk-1.4.1-hedd8126_1.tar.bz2
osx-arm64::python-3.10.5-h4eee789_0_cpython.tar.bz2
osx-arm64::hdf5-1.12.2-mpi_mpich_h16e63df_0.tar.bz2
osx-arm64::openconnect-9.01-h1775154_3.tar.bz2
osx-arm64::grpc-cpp-1.45.2-h6e39ad6_4.tar.bz2
osx-arm64::gmt-6.3.0-he0a14ed_5.tar.bz2
osx-arm64::tensorflow-base-2.9.1-cpu_py310h048a3e3_0.tar.bz2
osx-arm64::libopencv-4.6.0-py310ha0bc457_2.tar.bz2
osx-arm64::xrootd-5.4.3-py310h73e20e7_0.tar.bz2
osx-arm64::jaxlib-0.3.14-cpu_py38h87657f7_0.tar.bz2
osx-arm64::libspatialite-5.0.1-h8ed0826_17.tar.bz2
osx-arm64::gemmi-0.5.5-py39h88d5170_0.tar.bz2
osx-arm64::arrow-cpp-8.0.1-py39h5805033_0_cpu.tar.bz2
osx-arm64::grpc-cpp-1.47.1-hd7338e0_0.tar.bz2
osx-arm64::arrow-cpp-8.0.0-py38hf3a2c03_5_cpu.tar.bz2
osx-arm64::vtk-9.1.0-qt_py39hd7f8fe9_209.tar.bz2
osx-arm64::libprotobuf-static-21.2-h332123e_0.tar.bz2
osx-arm64::tensorflow-base-2.9.1-cpu_py38hc9b23b7_0.tar.bz2
osx-arm64::nodejs-18.3.0-h181ad7c_0.tar.bz2
osx-arm64::soplex-6.0.1-h00e1a30_0.tar.bz2
osx-arm64::grpc-cpp-1.43.2-he5d1839_6.tar.bz2
osx-arm64::tesseract-5.2.0-hd002dc4_0.tar.bz2
osx-arm64::arrow-cpp-8.0.1-py38hf3a2c03_0_cpu.tar.bz2
osx-arm64::libopencv-4.5.5-py38he52a0c8_12.tar.bz2
osx-arm64::imagemagick-7.1.0_37-pl5321h8f75910_0.tar.bz2
osx-arm64::gemmi-0.5.5-py310hbf292a2_0.tar.bz2
osx-arm64::coin-or-clp-1.17.7-h96423db_1.tar.bz2
osx-arm64::geotiff-1.7.1-hc898e3f_3.tar.bz2
osx-arm64::harp-1.15.1-py310h79a65ec_2.tar.bz2
osx-arm64::ffmpeg-5.0.1-gpl_h544b4b4_106.tar.bz2
osx-arm64::orc-1.7.5-h96f55be_0.tar.bz2
osx-arm64::vtk-9.1.0-qt_py39h927f1b2_211.tar.bz2
-    "libzlib >=1.2.12,<1.3.0a0",
+    "libzlib >=1.2.12,<2.0.0a0",
osx-arm64::coin-or-osi-0.108.7-h180e9d1_1.tar.bz2
osx-arm64::llvm-14.0.6-h95d0606_0.tar.bz2
osx-arm64::openh264-2.2.0-h332123e_0.tar.bz2
osx-arm64::dotnet-runtime-6.0.6-h7a16aba_0.tar.bz2
osx-arm64::llvm-tools-14.0.5-h37c5ba8_0.tar.bz2
osx-arm64::dotnet-sdk-6.0.301-h7a16aba_0.tar.bz2
osx-arm64::libllvm14-14.0.5-h37c5ba8_0.tar.bz2
osx-arm64::dotnet-runtime-6.0.5-h7a16aba_0.tar.bz2
osx-arm64::dotnet-aspnetcore-6.0.6-h7a16aba_0.tar.bz2
osx-arm64::cgns-4.3.0-h01d85df_1.tar.bz2
osx-arm64::gst-plugins-good-1.20.3-h0ed40fb_0.tar.bz2
osx-arm64::libmlir14-14.0.5-h2e2d6ab_0.tar.bz2
osx-arm64::coin-or-utils-2.11.6-h80e3032_1.tar.bz2
osx-arm64::exiv2-0.27.5-hcd57150_0.tar.bz2
osx-arm64::dotnet-sdk-6.0.300-h7a16aba_0.tar.bz2
osx-arm64::openh264-2.2.0-h332123e_1.tar.bz2
osx-arm64::libmlir-14.0.5-h2e2d6ab_0.tar.bz2
osx-arm64::gst-plugins-good-1.20.2-h0ed40fb_2.tar.bz2
osx-arm64::libmlir-14.0.3-h2e2d6ab_0.tar.bz2
osx-arm64::exiv2-v0.27.3-hcd57150_3.tar.bz2
osx-arm64::llvm-tools-14.0.6-h37c5ba8_0.tar.bz2
osx-arm64::exiv2-0.27.3-hcd57150_3.tar.bz2
osx-arm64::llvm-14.0.5-h95d0606_0.tar.bz2
osx-arm64::openjdk-17.0.3-he8acd94_0.tar.bz2
osx-arm64::libmagic-5.39-h2c9beb0_1.tar.bz2
osx-arm64::glib-tools-2.72.1-h332123e_0.tar.bz2
osx-arm64::file-5.39-h2c9beb0_1.tar.bz2
osx-arm64::libllvm14-14.0.6-h37c5ba8_0.tar.bz2
osx-arm64::pocl-3.0-h422b2f1_0.tar.bz2
osx-arm64::dotnet-aspnetcore-6.0.5-h7a16aba_0.tar.bz2
osx-arm64::gst-plugins-base-1.20.3-hbf05cfb_0.tar.bz2
osx-arm64::gst-plugins-base-1.20.2-hbf05cfb_2.tar.bz2
osx-arm64::openjdk-11.0.15-he8acd94_0.tar.bz2
osx-arm64::libmlir14-14.0.3-h2e2d6ab_0.tar.bz2
-    "libzlib >=1.2.12,<1.3.0a0"
+    "libzlib >=1.2.12,<2.0.0a0"
================================================================================
================================================================================
noarch
================================================================================
================================================================================
win-64
win-64::openmeeg-2.4.4-py39h14c149a_0.tar.bz2
win-64::arrow-cpp-7.0.0-py37hbb161b1_8_cpu.tar.bz2
win-64::vtk-9.1.0-qt_py39hb02976f_211.tar.bz2
win-64::gmt-6.4.0-h5e50918_1.tar.bz2
win-64::libmatio-1.5.23-h505fb7e_1.tar.bz2
win-64::paraview-5.10.1-py310hcb9d7ea_107_qt.tar.bz2
win-64::topologytoolkit-1.0.0-no_paraview_py310hb7e702b_107.tar.bz2
win-64::harp-1.15.1-py38r41hef63295_2.tar.bz2
win-64::qt-main-5.15.4-h467ea89_1.tar.bz2
win-64::tiledb-2.9.4-h5689973_0.tar.bz2
win-64::arrow-cpp-7.0.0-py39h9297170_8_cuda.tar.bz2
win-64::libgdal-3.5.0-hb5137b4_3.tar.bz2
win-64::zstd-1.5.2-h6255e5f_2.tar.bz2
win-64::pypy3.9-7.3.9-h1738a25_3.tar.bz2
win-64::libopencv-4.5.5-py37h542666b_10.tar.bz2
win-64::grpc-cpp-1.48.0-hbb1c445_0.tar.bz2
win-64::libgdal-3.5.1-h9e25771_1.tar.bz2
win-64::clang-14-14.0.5-default_h66ee7f4_0.tar.bz2
win-64::arrow-cpp-3.0.0-py39hf372ac5_54_cuda.tar.bz2
win-64::libopencv-4.5.5-py38h238d745_10.tar.bz2
win-64::tiledb-2.10.0-h5689973_0.tar.bz2
win-64::topologytoolkit-1.0.0-no_paraview_py37h7ec9e76_107.tar.bz2
win-64::libopencv-4.6.0-py39hbfd931d_1.tar.bz2
win-64::pdal-2.4.2-h4f05cd5_1.tar.bz2
win-64::gemmi-0.5.5-py310h2c03ce5_0.tar.bz2
win-64::arrow-cpp-3.0.0-py37h92c0b90_54_cpu.tar.bz2
win-64::arrow-cpp-3.0.0-py38h0c97e59_54_cpu.tar.bz2
win-64::gmt-5.4.5-he39315c_19.tar.bz2
win-64::grpc-cpp-1.46.3-h95a78a2_2.tar.bz2
win-64::arrow-cpp-8.0.0-py38h8c433ac_2_cuda.tar.bz2
win-64::glib-2.72.1-h7755175_0.tar.bz2
win-64::harp-1.15.1-py37r41hca80f52_1.tar.bz2
win-64::freecad-0.20.0-py37h98f6a88_0.tar.bz2
win-64::arrow-cpp-8.0.0-py310h13f3e17_2_cpu.tar.bz2
win-64::arrow-cpp-6.0.1-py37hd943af9_20_cpu.tar.bz2
win-64::arrow-cpp-8.0.0-py38h3760864_5_cpu.tar.bz2
win-64::harp-1.15.1-py39r41h9e66478_2.tar.bz2
win-64::grpc-cpp-1.47.1-h95a78a2_0.tar.bz2
win-64::libopencv-4.6.0-py39h6dcd0cd_2.tar.bz2
win-64::libopencv-4.6.0-py38h5bb5612_3.tar.bz2
win-64::harp-1.15.1-py38r41h9644311_1.tar.bz2
win-64::r-vcfr-1.13.0-r41h67098fc_0.tar.bz2
win-64::tesseract-5.1.0-h17c68af_0.tar.bz2
win-64::postgresql-14.4-he353ca9_0.tar.bz2
win-64::pyreadstat-1.1.9-py37hcc03f2d_0.tar.bz2
win-64::coda-2.24-py38h0c67891_1.tar.bz2
win-64::coda-2.24-py39h9e66478_1.tar.bz2
win-64::libgdal-3.5.0-ha3bfaf0_2.tar.bz2
win-64::pillow-9.1.1-py39h4bd82c8_1.tar.bz2
win-64::libopencv-4.6.0-py38h3d2d820_0.tar.bz2
win-64::cpp-opentelemetry-sdk-1.4.1-h3060df4_1.tar.bz2
win-64::arrow-cpp-7.0.0-py38hd88d0cb_8_cpu.tar.bz2
win-64::arrow-cpp-8.0.0-py37h56a155d_4_cpu.tar.bz2
win-64::mongodb-6.0.0-h3875601_0.tar.bz2
win-64::libspatialite-5.0.1-h8f4c726_16.tar.bz2
win-64::grpc-cpp-1.47.0-h60e7cd9_0.tar.bz2
win-64::libopencv-4.6.0-py39h6dcd0cd_3.tar.bz2
win-64::libmongoc-1.21.2-hf697a22_0.tar.bz2
win-64::openmeeg-2.4.4-py38h022cf48_0.tar.bz2
win-64::harp-1.15.1-py37r41h98ee94f_2.tar.bz2
win-64::vtk-9.1.0-qt_py39h5fee18d_212.tar.bz2
win-64::libopencv-4.6.0-py39hbfd931d_2.tar.bz2
win-64::tiledb-2.9.3-h5689973_0.tar.bz2
win-64::libpng-1.6.37-h1d00b33_3.tar.bz2
win-64::gemmi-0.5.5-py38h57a6900_0.tar.bz2
win-64::llvmdev-14.0.6-h97333cc_0.tar.bz2
win-64::libopencv-4.6.0-py310h913f68d_1.tar.bz2
win-64::yarp-cxx-3.7.0-h31a2f7f_0.tar.bz2
win-64::arrow-cpp-3.0.0-py310h5ae816d_54_cuda.tar.bz2
win-64::libopencv-4.5.5-py39h1d41392_10.tar.bz2
win-64::harp-1.15.1-py37r40hca80f52_1.tar.bz2
win-64::grpc-cpp-1.45.2-hcd87e55_4.tar.bz2
win-64::python-3.10.5-hcf16a7b_0_cpython.tar.bz2
win-64::arrow-cpp-8.0.1-py310h7122012_0_cuda.tar.bz2
win-64::grpc-cpp-1.46.3-h60e7cd9_1.tar.bz2
win-64::papilo-2.1.0-h8113af5_1.tar.bz2
win-64::harp-1.15.1-py38r40hef63295_2.tar.bz2
win-64::libopencv-4.6.0-py37had86beb_2.tar.bz2
win-64::grpc-cpp-1.47.1-hbb1c445_0.tar.bz2
win-64::harp-1.15.1-py39r40h9e66478_2.tar.bz2
win-64::arrow-cpp-5.0.0-py38h0c97e59_35_cpu.tar.bz2
win-64::gdstk-0.8.3-py38ha2a9628_0.tar.bz2
win-64::arrow-cpp-8.0.0-py39h1a96d6e_5_cpu.tar.bz2
win-64::arrow-cpp-7.0.0-py310h9019dcf_8_cuda.tar.bz2
win-64::tiledb-2.10.1-h3132609_0.tar.bz2
win-64::libopencv-4.5.5-py37hbae3f13_12.tar.bz2
win-64::arrow-cpp-8.0.0-py37h19be435_3_cuda.tar.bz2
win-64::arrow-cpp-5.0.0-py39hf372ac5_35_cuda.tar.bz2
win-64::libclang13-14.0.5-default_h77d9078_0.tar.bz2
win-64::arrow-cpp-3.0.0-py37h09cac41_54_cuda.tar.bz2
win-64::arrow-cpp-8.0.0-py38he4c2617_5_cpu.tar.bz2
win-64::arrow-cpp-8.0.0-py37hfa81a3a_4_cpu.tar.bz2
win-64::arrow-cpp-8.0.0-py310h054aeab_3_cuda.tar.bz2
win-64::scip-8.0.1-hcb2e73d_0.tar.bz2
win-64::paraview-5.10.1-py39hfed1ecd_107_qt.tar.bz2
win-64::gmt-5.4.5-he39315c_20.tar.bz2
win-64::clang-tools-14.0.6-default_h66ee7f4_0.tar.bz2
win-64::harp-1.15.1-py39r41hed3fa83_1.tar.bz2
win-64::arrow-cpp-8.0.0-py310h9019dcf_2_cuda.tar.bz2
win-64::arrow-cpp-8.0.0-py39h3bf93ba_4_cpu.tar.bz2
win-64::libopencv-4.5.5-py310hc96b821_11.tar.bz2
win-64::arrow-cpp-8.0.0-py39h9297170_3_cuda.tar.bz2
win-64::arrow-cpp-5.0.0-py39h1a1e958_35_cpu.tar.bz2
win-64::pillow-9.2.0-py38hd8e0db4_0.tar.bz2
win-64::pyreadstat-1.1.9-py39hb82d6ee_0.tar.bz2
win-64::arrow-cpp-6.0.1-py37h09cac41_20_cuda.tar.bz2
win-64::arrow-cpp-8.0.0-py310h6cee11b_4_cpu.tar.bz2
win-64::topologytoolkit-1.0.0-no_paraview_py39h93b7088_105.tar.bz2
win-64::pillow-9.1.1-py38hb2b9be2_1.tar.bz2
win-64::grpc-cpp-1.43.2-h895c7f8_6.tar.bz2
win-64::heavydb-6.1.0-h1234567_0_cpu.tar.bz2
win-64::tesseract-5.2.0-h17c68af_0.tar.bz2
win-64::openmeeg-2.4.7-py310h6ae1cfc_0.tar.bz2
win-64::libopencv-4.5.5-py38h792a168_10.tar.bz2
win-64::tiledb-2.10.2-h5689973_0.tar.bz2
win-64::topologytoolkit-1.0.0-no_paraview_py37h77eaa21_104.tar.bz2
win-64::ogre-13.4.1-hde5e6e4_0.tar.bz2
win-64::arrow-cpp-8.0.0-py37h5f18eb7_2_cuda.tar.bz2
win-64::arrow-cpp-7.0.0-py38h8c433ac_8_cuda.tar.bz2
win-64::harp-1.15.1-py38r41h0c67891_2.tar.bz2
win-64::arrow-cpp-8.0.0-py37h56a155d_5_cpu.tar.bz2
win-64::arrow-cpp-8.0.0-py39h9297170_2_cuda.tar.bz2
win-64::pypy3.8-7.3.9-h4acdc65_3.tar.bz2
win-64::wxwidgets-3.2.0-h8e1ed31_0.tar.bz2
win-64::coda-2.24-py310h43ac6bf_1.tar.bz2
win-64::gemmi-0.5.5-py37habb0c8c_0.tar.bz2
win-64::pdal-2.4.2-h4667b23_0.tar.bz2
win-64::paraview-5.10.1-py39habdcd31_107_qt.tar.bz2
win-64::libclang-14.0.5-default_h77d9078_0.tar.bz2
win-64::scip-8.0.1-hc78b598_1.tar.bz2
win-64::soplex-6.0.1-hac97764_0.tar.bz2
win-64::ogre-next-2.3.1-hdef13af_1.tar.bz2
win-64::harp-1.15.1-py37r40h98ee94f_2.tar.bz2
win-64::ffmpeg-5.0.1-gpl_hc2492c1_107.tar.bz2
win-64::pillow-9.1.1-py310h767b3fd_1.tar.bz2
win-64::tiledb-2.10.1-h5689973_0.tar.bz2
win-64::libmongoc-1.21.2-he3419e8_0.tar.bz2
win-64::vtk-9.1.0-qt_py38h933a7ce_209.tar.bz2
win-64::libopencv-4.6.0-py37had86beb_1.tar.bz2
win-64::libgdal-3.5.0-h7a07f3b_1.tar.bz2
win-64::libopencv-4.6.0-py39h242a94c_0.tar.bz2
win-64::arrow-cpp-8.0.0-py37h19be435_2_cuda.tar.bz2
win-64::arrow-cpp-8.0.0-py39h34ef9b7_4_cuda.tar.bz2
win-64::openmeeg-2.4.4-py310h6ae1cfc_0.tar.bz2
win-64::libopencv-4.5.5-py38hcca9be0_11.tar.bz2
win-64::pdal-2.4.1-hd3deecb_1.tar.bz2
win-64::pyreadstat-1.1.9-py310he2412df_0.tar.bz2
win-64::arrow-cpp-7.0.0-py39hae7b3f5_8_cpu.tar.bz2
win-64::r-vcfr-1.13.0-r40h67098fc_0.tar.bz2
win-64::clang-format-14.0.5-default_h66ee7f4_0.tar.bz2
win-64::harp-1.15.1-py38r41h8975372_1.tar.bz2
win-64::pillow-9.2.0-py39h4bd82c8_0.tar.bz2
win-64::arrow-cpp-3.0.0-py39h1a1e958_54_cpu.tar.bz2
win-64::arrow-cpp-8.0.1-py38h3760864_0_cpu.tar.bz2
win-64::openmeeg-2.4.4-py38h1896c9c_0.tar.bz2
win-64::mongodb-5.3.2-h3875601_0.tar.bz2
win-64::pdal-2.4.2-h4f05cd5_2.tar.bz2
win-64::arrow-cpp-8.0.0-py38h70e5797_2_cuda.tar.bz2
win-64::openmeeg-2.4.6-py37h8baa966_0.tar.bz2
win-64::libllvm14-14.0.6-h97333cc_0.tar.bz2
win-64::arrow-cpp-6.0.1-py310ha1d70bf_20_cuda.tar.bz2
win-64::hugin-2021.0.0-pl5321hda8ff79_7.tar.bz2
win-64::libopencv-4.6.0-py38hdb1d9b2_0.tar.bz2
win-64::pillow-9.2.0-py39ha53f419_0.tar.bz2
win-64::vtk-9.1.0-qt_py37h4277bd9_212.tar.bz2
win-64::arrow-cpp-8.0.0-py310h6cee11b_5_cpu.tar.bz2
win-64::harp-1.15.1-py39r41h0989d49_1.tar.bz2
win-64::libtiff-4.4.0-h2ed3b44_1.tar.bz2
win-64::libopencv-4.5.5-py310h3ffe08b_10.tar.bz2
win-64::ffmpeg-4.4.2-gpl_hc2492c1_105.tar.bz2
win-64::libclang13-14.0.6-default_h77d9078_0.tar.bz2
win-64::hugin-2021.0.0-pl5321hc3197c4_6.tar.bz2
win-64::arrow-cpp-7.0.0-py37h5f18eb7_8_cuda.tar.bz2
win-64::openmeeg-2.4.7-py37h8baa966_0.tar.bz2
win-64::arrow-cpp-7.0.0-py39h444f20b_8_cuda.tar.bz2
win-64::exiv2-0.27.5-h02b4549_0.tar.bz2
win-64::gst-plugins-base-1.20.2-he07aa86_2.tar.bz2
win-64::gdstk-0.8.3-py310h903a3d8_0.tar.bz2
win-64::arrow-cpp-7.0.0-py37h19be435_8_cuda.tar.bz2
win-64::ffmpeg-5.0.1-lgpl_h907f4eb_7.tar.bz2
win-64::libopencv-4.5.5-py39h7b909df_11.tar.bz2
win-64::topologytoolkit-1.0.0-no_paraview_py37h7ec9e76_106.tar.bz2
win-64::openmeeg-2.4.4-py39he9171ab_0.tar.bz2
win-64::libpq-14.4-h1ea2d34_0.tar.bz2
win-64::libopencv-4.6.0-py38h1d24239_1.tar.bz2
win-64::gemmi-0.5.5-py38h20167b6_0.tar.bz2
win-64::gmt-5.4.5-ha7378e2_21.tar.bz2
win-64::arrow-cpp-7.0.0-py39h4f6b0cd_8_cpu.tar.bz2
win-64::yarp-cxx-3.7.1-hc157652_0.tar.bz2
win-64::libgdal-3.5.1-h472ea22_2.tar.bz2
win-64::paraview-5.10.1-py37h9d85ad6_107_qt.tar.bz2
win-64::vigra-1.11.1-py37hc3ed208_1033.tar.bz2
win-64::paraview-5.10.1-py37hfa53afc_107_qt.tar.bz2
win-64::arrow-cpp-8.0.0-py310h054aeab_2_cuda.tar.bz2
win-64::yarp-cxx-3.7.0-hc157652_3.tar.bz2
win-64::libtiff-4.4.0-ha17eb64_2.tar.bz2
win-64::ovito-3.7.8-h2983c6a_0.tar.bz2
win-64::soplex-6.0.1-hac97764_1.tar.bz2
win-64::tiledb-2.10.0-h3132609_0.tar.bz2
win-64::arrow-cpp-8.0.0-py37h5f2e85a_2_cpu.tar.bz2
win-64::imagecodecs-2022.7.27-py38h50adbfd_1.tar.bz2
win-64::openmeeg-2.4.7-py38h022cf48_0.tar.bz2
win-64::arrow-cpp-5.0.0-py310hd72be80_35_cpu.tar.bz2
win-64::grpc-cpp-1.43.2-h7bf95e0_6.tar.bz2
win-64::ffmpeg-4.4.2-gpl_hc2492c1_104.tar.bz2
win-64::arrow-cpp-8.0.1-py37hfa81a3a_0_cpu.tar.bz2
win-64::topologytoolkit-1.1.0-no_paraview_py38h027f3f7_100.tar.bz2
win-64::gst-plugins-good-1.20.3-h69687a5_0.tar.bz2
win-64::nco-5.1.0-hd50321f_0.tar.bz2
win-64::hugin-base-2021.0.0-py37pl5321hc488a2b_6.tar.bz2
win-64::ogre-13.4.2-haef3d18_0.tar.bz2
win-64::openbabel-3.1.1-py310h925f80e_4.tar.bz2
win-64::paraview-5.10.1-py38h371fdc9_107_qt.tar.bz2
win-64::paraview-5.10.1-py38h084b821_107_qt.tar.bz2
win-64::openscenegraph-3.6.5-hf2fc117_14.tar.bz2
win-64::arrow-cpp-8.0.0-py38he4c2617_4_cpu.tar.bz2
win-64::openbabel-3.1.1-py37h4690490_4.tar.bz2
win-64::glib-networking-2.72.1-h083f0a8_1.tar.bz2
win-64::libgdal-3.5.0-hc4fa9d1_2.tar.bz2
win-64::poppler-qt-22.04.0-hd5bfec7_1.tar.bz2
win-64::arrow-cpp-3.0.0-py37hd943af9_54_cpu.tar.bz2
win-64::paraview-5.10.1-py38h7ab2beb_106_qt.tar.bz2
win-64::prometheus-cpp-1.0.1-h8680213_0.tar.bz2
win-64::harp-1.15.1-py39r40h0989d49_1.tar.bz2
win-64::arrow-cpp-6.0.1-py38hcbef6f9_20_cuda.tar.bz2
win-64::arrow-cpp-6.0.1-py38h9c0e68c_20_cpu.tar.bz2
win-64::paraview-5.10.1-py37he1b430f_106_qt.tar.bz2
win-64::arrow-cpp-6.0.1-py39h738f269_20_cuda.tar.bz2
win-64::arrow-cpp-5.0.0-py37h09cac41_35_cuda.tar.bz2
win-64::ogre-next-2.3.1-hdef13af_0.tar.bz2
win-64::capnproto-0.10.0-h7755175_0.tar.bz2
win-64::imagecodecs-2022.7.27-py39h8730835_1.tar.bz2
win-64::arrow-cpp-6.0.1-py310h4c953eb_20_cpu.tar.bz2
win-64::arrow-cpp-6.0.1-py310h5ae816d_20_cuda.tar.bz2
win-64::exiv2-0.27.3-h02b4549_3.tar.bz2
win-64::libopencv-4.6.0-py39hbfd931d_3.tar.bz2
win-64::vtk-9.1.0-qt_py38hdbe69e9_210.tar.bz2
win-64::gmt-6.3.0-hadc9982_6.tar.bz2
win-64::coda-2.24-py38hef63295_1.tar.bz2
win-64::libopencv-4.5.5-py38h3d2d820_12.tar.bz2
win-64::libarchive-3.5.2-hb45042f_3.tar.bz2
win-64::topologytoolkit-1.1.0-no_paraview_py39h93b7088_100.tar.bz2
win-64::arrow-cpp-8.0.0-py310h7122012_4_cuda.tar.bz2
win-64::tectonic-0.9.0-hec613bb_1.tar.bz2
win-64::ovito-3.7.7-h2983c6a_1.tar.bz2
win-64::arrow-cpp-5.0.0-py310h5ae816d_35_cuda.tar.bz2
win-64::libopencv-4.5.5-py39h34a9f72_11.tar.bz2
win-64::harp-1.15.1-py310r40h43ac6bf_2.tar.bz2
win-64::libgdal-3.5.0-hb55b917_4.tar.bz2
win-64::yarp-cxx-3.7.0-hf2cc95b_1.tar.bz2
win-64::arrow-cpp-8.0.0-py310hf269ffb_3_cpu.tar.bz2
win-64::mongodb-5.2.1-h3875601_0.tar.bz2
win-64::openmeeg-2.4.4-py37h8baa966_0.tar.bz2
win-64::arrow-cpp-8.0.0-py38hd88d0cb_2_cpu.tar.bz2
win-64::arrow-cpp-3.0.0-py310hd72be80_54_cpu.tar.bz2
win-64::arrow-cpp-7.0.0-py37h5f2e85a_8_cpu.tar.bz2
win-64::arrow-cpp-8.0.0-py310h9019dcf_3_cuda.tar.bz2
win-64::hugin-base-2021.0.0-py39pl5321hf00cc8b_6.tar.bz2
win-64::grpc-cpp-1.48.0-h95a78a2_0.tar.bz2
win-64::topologytoolkit-1.0.0-no_paraview_py38h027f3f7_106.tar.bz2
win-64::harp-1.15.1-py38r40h0c67891_2.tar.bz2
win-64::postgresql-plpython-14.4-py39he868e5a_0.tar.bz2
win-64::openmeeg-2.4.6-py38h022cf48_0.tar.bz2
win-64::postgresql-14.4-h1c22c4f_0.tar.bz2
win-64::librdkafka-1.9.1-hc0a2ac9_1.tar.bz2
win-64::pypy3.9-7.3.9-hc3b0203_3.tar.bz2
win-64::vtk-9.1.0-qt_py37h5c529e1_210.tar.bz2
win-64::arrow-cpp-3.0.0-py38h24768a2_54_cuda.tar.bz2
win-64::vtk-9.1.0-qt_py38hefa7cc6_211.tar.bz2
win-64::paraview-5.10.1-py38h2744749_107_qt.tar.bz2
win-64::imagecodecs-2022.2.22-py39h43fe4e9_6.tar.bz2
win-64::postgresql-plpython-14.4-py38h98422bd_0.tar.bz2
win-64::hugin-2021.0.0-pl5321h7bafedf_6.tar.bz2
win-64::cpp-opentelemetry-sdk-1.4.1-h3060df4_2.tar.bz2
win-64::libopencv-4.5.5-py38h3d2d820_13.tar.bz2
win-64::tiledb-2.9.5-h5689973_0.tar.bz2
win-64::cpp-opentelemetry-sdk-1.4.1-h27294ca_4.tar.bz2
win-64::arrow-cpp-8.0.0-py39h4f6b0cd_2_cpu.tar.bz2
win-64::libopencv-4.5.5-py38hdb1d9b2_12.tar.bz2
win-64::arrow-cpp-8.0.0-py37hbb161b1_2_cpu.tar.bz2
win-64::clang-14-14.0.6-default_h66ee7f4_0.tar.bz2
win-64::openmeeg-2.4.7-py39h14c149a_0.tar.bz2
win-64::hugin-base-2021.0.0-pl5321h9e2f497_7.tar.bz2
win-64::postgresql-plpython-14.4-py38hda22b0a_0.tar.bz2
win-64::grpc-cpp-1.43.2-hb30e31e_6.tar.bz2
win-64::libmlir-14.0.5-he744812_0.tar.bz2
win-64::grpc-cpp-1.46.3-h4b97d95_1.tar.bz2
win-64::arrow-cpp-3.0.0-py310ha1d70bf_54_cuda.tar.bz2
win-64::ogre-next-2.2.6-hdef13af_0.tar.bz2
win-64::librdkafka-1.9.0-h57a60f6_0.tar.bz2
win-64::openmeeg-2.4.7-py38h1896c9c_0.tar.bz2
win-64::geotiff-1.7.1-h714bc5f_2.tar.bz2
win-64::arrow-cpp-5.0.0-py38hcbef6f9_35_cuda.tar.bz2
win-64::libopencv-4.6.0-py39he11e404_0.tar.bz2
win-64::gmt-6.4.0-hace14ca_2.tar.bz2
win-64::pdal-2.4.2-h4667b23_1.tar.bz2
win-64::arrow-cpp-3.0.0-py38hcbef6f9_54_cuda.tar.bz2
win-64::arrow-cpp-3.0.0-py38h9c0e68c_54_cpu.tar.bz2
win-64::ogre-1.10.12-hab73eff_9.tar.bz2
win-64::freecad-0.20.0-py38h8c32871_0.tar.bz2
win-64::gdstk-0.8.3-py37h5487f94_0.tar.bz2
win-64::imagecodecs-2022.2.22-py38hbd87eac_6.tar.bz2
win-64::arrow-cpp-5.0.0-py37hd943af9_35_cpu.tar.bz2
win-64::libopencv-4.5.5-py37hd23903f_11.tar.bz2
win-64::gst-plugins-good-1.20.2-h69687a5_2.tar.bz2
win-64::arrow-cpp-8.0.0-py310h057835a_4_cpu.tar.bz2
win-64::wasmer-2.3.0-hf725046_0.tar.bz2
win-64::arrow-cpp-8.0.0-py39h1a96d6e_4_cpu.tar.bz2
win-64::glib-tools-2.72.1-h7755175_0.tar.bz2
win-64::tiledb-2.9.3-h3132609_0.tar.bz2
win-64::arrow-cpp-6.0.1-py39h78f48c9_20_cpu.tar.bz2
win-64::arrow-cpp-8.0.0-py38h8c433ac_3_cuda.tar.bz2
win-64::libgdal-3.5.0-hafd188d_3.tar.bz2
win-64::grpc-cpp-1.46.3-hbb1c445_2.tar.bz2
win-64::harp-1.15.1-py38r40h9644311_1.tar.bz2
win-64::arrow-cpp-8.0.0-py39h3bf93ba_5_cpu.tar.bz2
win-64::arrow-cpp-8.0.1-py38h298bac7_0_cuda.tar.bz2
win-64::coda-2.24-py39h823a5e9_1.tar.bz2
win-64::openmeeg-2.4.6-py39he9171ab_0.tar.bz2
win-64::qt-main-5.15.4-h467ea89_2.tar.bz2
win-64::arrow-cpp-8.0.1-py38hc41c06b_0_cuda.tar.bz2
win-64::llvm-tools-14.0.6-hf00eed6_0.tar.bz2
win-64::tiledb-2.10.2-h3132609_0.tar.bz2
win-64::topologytoolkit-1.0.0-no_paraview_py38h027f3f7_105.tar.bz2
win-64::harp-1.15.1-py39r40hed3fa83_1.tar.bz2
win-64::topologytoolkit-1.0.0-no_paraview_py39h93b7088_107.tar.bz2
win-64::libgdal-3.5.1-h87661d9_2.tar.bz2
win-64::arrow-cpp-8.0.1-py37h0f12e23_0_cuda.tar.bz2
win-64::mongodb-5.2.0-h3875601_0.tar.bz2
win-64::arrow-cpp-7.0.0-py310hf269ffb_8_cpu.tar.bz2
win-64::pdal-2.4.2-h4667b23_2.tar.bz2
win-64::arrow-cpp-6.0.1-py37h92c0b90_20_cpu.tar.bz2
win-64::libopencv-4.6.0-py38h1d24239_2.tar.bz2
win-64::yarp-cxx-3.7.0-hc157652_2.tar.bz2
win-64::topologytoolkit-1.0.0-no_paraview_py38h027f3f7_107.tar.bz2
win-64::vigra-1.11.1-py38hd053477_1033.tar.bz2
win-64::libglib-2.72.1-h3be07f2_0.tar.bz2
win-64::arrow-cpp-8.0.1-py37h16f4a4a_0_cuda.tar.bz2
win-64::vigra-1.11.1-py310h76547e3_1033.tar.bz2
win-64::openbabel-3.1.1-py38h0443e6b_4.tar.bz2
win-64::arrow-cpp-3.0.0-py39h78f48c9_54_cpu.tar.bz2
win-64::gmt-6.4.0-hadc9982_0.tar.bz2
win-64::libopencv-4.5.5-py38hdb1d9b2_13.tar.bz2
win-64::hdf5-1.12.2-nompi_h2a0e4a3_100.tar.bz2
win-64::libgdal-3.5.0-h40a1202_4.tar.bz2
win-64::libopencv-4.5.5-py38h2254afa_11.tar.bz2
win-64::arrow-cpp-6.0.1-py37ha37a849_20_cuda.tar.bz2
win-64::topologytoolkit-1.1.0-no_paraview_py37h7ec9e76_100.tar.bz2
win-64::libpq-14.4-hfcc5ef8_0.tar.bz2
win-64::openmeeg-2.4.6-py310h6ae1cfc_0.tar.bz2
win-64::paraview-5.10.1-py37hdde311b_107_qt.tar.bz2
win-64::harp-1.15.1-py310r40heba9ebb_1.tar.bz2
win-64::arrow-cpp-7.0.0-py310h13f3e17_8_cpu.tar.bz2
win-64::cgns-4.3.0-ha798546_1.tar.bz2
win-64::cpp-opentelemetry-sdk-1.4.1-h3060df4_4.tar.bz2
win-64::tomviz-1.10.0.post266-py37h71896b8_2.tar.bz2
win-64::ogre-next-2.3.0-hdef13af_0.tar.bz2
win-64::arrow-cpp-8.0.0-py39h444f20b_3_cuda.tar.bz2
win-64::vtk-9.1.0-qt_py39h95da234_209.tar.bz2
win-64::mlir-14.0.3-he744812_0.tar.bz2
win-64::grpc-cpp-1.47.0-hbb1c445_1.tar.bz2
win-64::heavydb-6.1.1-h1234567_0_cpu.tar.bz2
win-64::libmongoc-1.22.0-hf697a22_0.tar.bz2
win-64::libopencv-4.5.5-py39h242a94c_13.tar.bz2
win-64::ovito-3.7.5-h240815b_1.tar.bz2
win-64::arrow-cpp-8.0.0-py39hae6a196_4_cuda.tar.bz2
win-64::hugin-base-2021.0.0-py38pl5321hb895f83_6.tar.bz2
win-64::arrow-cpp-8.0.0-py38h61ae8a5_3_cpu.tar.bz2
win-64::grpc-cpp-1.44.0-h7bf95e0_5.tar.bz2
win-64::arrow-cpp-8.0.0-py37hfa81a3a_5_cpu.tar.bz2
win-64::libopencv-4.5.5-py39h3ee7fbc_10.tar.bz2
win-64::harp-1.15.1-py310r41h43ac6bf_2.tar.bz2
win-64::arrow-cpp-8.0.0-py310hf269ffb_2_cpu.tar.bz2
win-64::paraview-5.10.1-py310ha73759f_107_qt.tar.bz2
win-64::hdf5-1.12.2-nompi_h57737ce_100.tar.bz2
win-64::libmlir-14.0.3-he744812_0.tar.bz2
win-64::arrow-cpp-8.0.0-py37hbb161b1_3_cpu.tar.bz2
win-64::arrow-cpp-6.0.1-py39hf372ac5_20_cuda.tar.bz2
win-64::tomviz-1.10.0.post259-py37h71896b8_2.tar.bz2
win-64::paraview-5.10.1-py39h6d5414c_105_qt.tar.bz2
win-64::pillow-9.2.0-py37h8675073_0.tar.bz2
win-64::ffmpeg-4.4.2-lgpl_h9fc484d_6.tar.bz2
win-64::grpc-cpp-1.47.0-h4b97d95_0.tar.bz2
win-64::tiledb-2.9.4-h3132609_0.tar.bz2
win-64::capnproto-0.10.2-h7755175_0.tar.bz2
win-64::libopencv-4.5.5-py37hbae3f13_13.tar.bz2
win-64::libgdal-3.5.0-h7a56975_5.tar.bz2
win-64::libprotobuf-static-21.3-h7755175_0.tar.bz2
win-64::arrow-cpp-6.0.1-py38h24768a2_20_cuda.tar.bz2
win-64::libprotobuf-static-21.4-h7755175_0.tar.bz2
win-64::pypy3.8-7.3.9-hd58c836_3.tar.bz2
win-64::libclang-14.0.6-default_h77d9078_0.tar.bz2
win-64::postgresql-plpython-14.4-py310ha83e0bf_0.tar.bz2
win-64::libspatialite-5.0.1-h39690df_17.tar.bz2
win-64::arrow-cpp-8.0.0-py38hd88d0cb_3_cpu.tar.bz2
win-64::arrow-cpp-8.0.0-py310h0036a59_5_cuda.tar.bz2
win-64::arrow-cpp-8.0.0-py39hae7b3f5_2_cpu.tar.bz2
win-64::libopencv-4.5.5-py39h242a94c_12.tar.bz2
win-64::arrow-cpp-7.0.0-py38h70e5797_8_cuda.tar.bz2
win-64::arrow-cpp-8.0.0-py38h3760864_4_cpu.tar.bz2
win-64::arrow-cpp-3.0.0-py310h4c953eb_54_cpu.tar.bz2
win-64::arrow-cpp-8.0.0-py310h0036a59_4_cuda.tar.bz2
win-64::paraview-5.10.1-py37he1b430f_105_qt.tar.bz2
win-64::libllvm14-14.0.5-h97333cc_0.tar.bz2
win-64::imagecodecs-2022.7.27-py310he690c7e_0.tar.bz2
win-64::libmongoc-1.22.0-he3419e8_0.tar.bz2
win-64::wxwidgets-3.2.0-hef4063f_1.tar.bz2
win-64::ffmpeg-5.1.0-lgpl_h9fc484d_0.tar.bz2
win-64::vtk-9.1.0-qt_py39hf2c8a5a_210.tar.bz2
win-64::imagecodecs-2022.2.22-py310he06a552_6.tar.bz2
win-64::librdkafka-1.9.0-he4d9d34_0.tar.bz2
win-64::arrow-cpp-8.0.0-py310h7122012_5_cuda.tar.bz2
win-64::arrow-cpp-6.0.1-py38h0c97e59_20_cpu.tar.bz2
win-64::mongodb-5.2.0-h9fd7119_0.tar.bz2
win-64::ogre-13.4.1-haef3d18_1.tar.bz2
win-64::clang-tools-14.0.5-default_h66ee7f4_0.tar.bz2
win-64::libmediainfo-22.06-hbabe409_0.tar.bz2
win-64::arrow-cpp-8.0.1-py39h3bf93ba_0_cpu.tar.bz2
win-64::ffmpeg-4.4.2-gpl_ha0349d7_106.tar.bz2
win-64::sdl2_image-2.6.0-hb27fea3_0.tar.bz2
win-64::llvm-tools-14.0.5-hf00eed6_0.tar.bz2
win-64::postgresql-plpython-14.4-py310hb974fb4_0.tar.bz2
win-64::libsoup-2.74.2-h309951b_0.tar.bz2
win-64::libopencv-4.5.5-py39he11e404_12.tar.bz2
win-64::arrow-cpp-8.0.0-py38hc41c06b_5_cuda.tar.bz2
win-64::gst-libav-1.20.3-h4b3502a_0.tar.bz2
win-64::libnetcdf-4.8.1-nompi_h85765be_103.tar.bz2
win-64::libgdal-3.5.1-h7a56975_1.tar.bz2
win-64::arrow-cpp-8.0.0-py38h298bac7_5_cuda.tar.bz2
win-64::hugin-2021.0.0-pl5321h47f7af9_6.tar.bz2
win-64::topologytoolkit-1.0.0-no_paraview_py39h93b7088_106.tar.bz2
win-64::paraview-5.10.1-py39h6d5414c_106_qt.tar.bz2
win-64::arrow-cpp-8.0.0-py38h61ae8a5_2_cpu.tar.bz2
win-64::librdkafka-1.9.1-he4d9d34_0.tar.bz2
win-64::gdstk-0.8.3-py39h48ffc68_0.tar.bz2
win-64::vtk-9.1.0-qt_py37h1f83640_211.tar.bz2
win-64::gemmi-0.5.5-py39h7bb736d_0.tar.bz2
win-64::wxwidgets-3.1.7-h8e1ed31_0.tar.bz2
win-64::imagecodecs-2022.7.27-py38hf6bdc0d_0.tar.bz2
win-64::libgdal-3.5.0-h9e25771_5.tar.bz2
win-64::prometheus-cpp-1.0.0-h8680213_0.tar.bz2
win-64::cpp-opentelemetry-sdk-1.4.1-h8f560b3_3.tar.bz2
win-64::arrow-cpp-8.0.0-py38h298bac7_4_cuda.tar.bz2
win-64::cpp-opentelemetry-sdk-1.4.1-h3060df4_3.tar.bz2
win-64::gmsh-4.10.5-hec9a65b_0.tar.bz2
win-64::ffmpeg-5.0.1-gpl_ha0349d7_108.tar.bz2
win-64::vigra-1.11.1-py39h7a35149_1033.tar.bz2
win-64::postgresql-plpython-14.4-py39h2d4c99b_0.tar.bz2
win-64::libopencv-4.5.5-py310he958ad5_13.tar.bz2
win-64::qt-main-5.15.4-h467ea89_0.tar.bz2
win-64::arrow-cpp-8.0.1-py37h56a155d_0_cpu.tar.bz2
win-64::llvmdev-14.0.5-h97333cc_0.tar.bz2
win-64::arrow-cpp-8.0.0-py38hc41c06b_4_cuda.tar.bz2
win-64::pillow-9.1.1-py37h8675073_1.tar.bz2
win-64::hugin-2021.0.0-pl5321h8206767_6.tar.bz2
win-64::freecad-0.20.0-py310h4f389b4_0.tar.bz2
win-64::mongodb-5.2.1-h9fd7119_0.tar.bz2
win-64::arrow-cpp-3.0.0-py37ha37a849_54_cuda.tar.bz2
win-64::imagecodecs-2022.7.27-py310h084c1a7_1.tar.bz2
win-64::libspatialite-5.0.1-ha17912d_18.tar.bz2
win-64::harp-1.15.1-py39r41h823a5e9_2.tar.bz2
win-64::libopencv-4.6.0-py38h5bb5612_1.tar.bz2
win-64::librdkafka-1.9.1-h6e08003_1.tar.bz2
win-64::libopencv-4.6.0-py37had86beb_3.tar.bz2
win-64::openmeeg-2.4.6-py39h14c149a_0.tar.bz2
win-64::hugin-base-2021.0.0-py310pl5321h617fbd8_6.tar.bz2
win-64::papilo-2.1.0-h8113af5_0.tar.bz2
win-64::libgdal-3.5.0-hba1fd4b_1.tar.bz2
win-64::arrow-cpp-8.0.0-py37h16f4a4a_5_cuda.tar.bz2
win-64::paraview-5.10.1-py39h4379d63_107_qt.tar.bz2
win-64::arrow-cpp-8.0.0-py37h5f2e85a_3_cpu.tar.bz2
win-64::paraview-5.10.1-py38h7ab2beb_105_qt.tar.bz2
win-64::arrow-cpp-8.0.0-py37h0f12e23_4_cuda.tar.bz2
win-64::grpc-cpp-1.44.0-hcd87e55_5.tar.bz2
win-64::arrow-cpp-8.0.0-py39hae6a196_5_cuda.tar.bz2
win-64::libopencv-4.6.0-py310he958ad5_0.tar.bz2
win-64::vtk-9.1.0-qt_py38hecdbd01_212.tar.bz2
win-64::arrow-cpp-6.0.1-py310hd72be80_20_cpu.tar.bz2
win-64::pdal-2.4.1-h34f5e4d_1.tar.bz2
win-64::ffmpeg-5.0.1-lgpl_h9fc484d_8.tar.bz2
win-64::ffmpeg-4.4.2-lgpl_h907f4eb_4.tar.bz2
win-64::libgdal-3.5.1-h9e25771_0.tar.bz2
win-64::gdstk-0.8.3-py38hc6971d9_0.tar.bz2
win-64::openbabel-3.1.1-py39hfc62d72_4.tar.bz2
win-64::arrow-cpp-8.0.1-py310h0036a59_0_cuda.tar.bz2
win-64::glib-networking-2.72.1-h72722a3_1.tar.bz2
win-64::ffmpeg-4.4.2-lgpl_h907f4eb_5.tar.bz2
win-64::grpc-cpp-1.44.0-h895c7f8_5.tar.bz2
win-64::geotiff-1.7.1-h714bc5f_3.tar.bz2
win-64::libopencv-4.6.0-py38h1d24239_3.tar.bz2
win-64::libopencv-4.6.0-py310h913f68d_3.tar.bz2
win-64::yarp-cxx-3.7.0-hc157652_4.tar.bz2
win-64::gmsh-4.10.4-hec9a65b_0.tar.bz2
win-64::gdstk-0.8.3-py39hcb63d39_0.tar.bz2
win-64::arrow-cpp-8.0.1-py39h34ef9b7_0_cuda.tar.bz2
win-64::gst-plugins-base-1.20.3-he07aa86_0.tar.bz2
win-64::poppler-22.04.0-h24fffdf_1.tar.bz2
win-64::grpc-cpp-1.45.2-h895c7f8_4.tar.bz2
win-64::coda-2.24-py37h98ee94f_1.tar.bz2
win-64::arrow-cpp-8.0.0-py37h0f12e23_5_cuda.tar.bz2
win-64::libgit2-1.4.4-h8648793_0.tar.bz2
win-64::mlir-14.0.5-he744812_0.tar.bz2
win-64::arrow-cpp-8.0.1-py38he4c2617_0_cpu.tar.bz2
win-64::gmt-6.3.0-h37748ca_5.tar.bz2
win-64::arrow-cpp-8.0.1-py310h057835a_0_cpu.tar.bz2
win-64::cpp-opentelemetry-sdk-1.4.1-h3060df4_0.tar.bz2
win-64::pdal-2.4.2-h4f05cd5_0.tar.bz2
win-64::cpp-opentelemetry-sdk-1.4.1-h27294ca_2.tar.bz2
win-64::arrow-cpp-8.0.0-py39h444f20b_2_cuda.tar.bz2
win-64::libopencv-4.6.0-py39h6dcd0cd_1.tar.bz2
win-64::pillow-9.1.1-py38hd8e0db4_1.tar.bz2
win-64::libopencv-4.6.0-py37hbae3f13_0.tar.bz2
win-64::vtk-9.1.0-qt_py310hbebbbde_212.tar.bz2
win-64::ovito-3.7.5-h6f389ac_0.tar.bz2
win-64::postgresql-plpython-14.4-py37h44f2ed4_0.tar.bz2
win-64::capnproto-0.10.1-h7755175_0.tar.bz2
win-64::ogre-1.12.13-h4187535_2.tar.bz2
win-64::arrow-cpp-8.0.0-py310h057835a_5_cpu.tar.bz2
win-64::librdkafka-1.9.1-h57a60f6_0.tar.bz2
win-64::exiv2-v0.27.3-h02b4549_3.tar.bz2
win-64::pillow-9.1.1-py39ha53f419_1.tar.bz2
win-64::libzip-1.9.2-hfed4ece_0.tar.bz2
win-64::mongodb-5.3.2-h9fd7119_0.tar.bz2
win-64::harp-1.15.1-py38r40h8975372_1.tar.bz2
win-64::cpp-opentelemetry-sdk-1.4.1-h728dffb_0.tar.bz2
win-64::paraview-5.10.1-py310h2b9138f_106_qt.tar.bz2
win-64::arrow-cpp-8.0.0-py39h34ef9b7_5_cuda.tar.bz2
win-64::pdal-2.4.1-h4f05cd5_2.tar.bz2
win-64::grpc-cpp-1.45.2-h7bf95e0_4.tar.bz2
win-64::mongodb-6.0.0-h9fd7119_0.tar.bz2
win-64::python-3.10.5-h9a09f29_0_cpython.tar.bz2
win-64::libopencv-4.6.0-py38h5bb5612_2.tar.bz2
win-64::arrow-cpp-6.0.1-py39h1a1e958_20_cpu.tar.bz2
win-64::pillow-9.2.0-py38hb2b9be2_0.tar.bz2
win-64::tectonic-0.9.0-h1efc63e_1.tar.bz2
win-64::postgresql-plpython-14.4-py37h547e9a6_0.tar.bz2
win-64::libgit2-1.5.0-h8648793_0.tar.bz2
win-64::libzip-1.9.2-h519de47_0.tar.bz2
win-64::arrow-cpp-3.0.0-py39h738f269_54_cuda.tar.bz2
win-64::libarchive-3.5.2-habf0b7a_3.tar.bz2
win-64::grpc-cpp-1.47.0-h95a78a2_1.tar.bz2
win-64::pillow-9.2.0-py310h767b3fd_0.tar.bz2
win-64::harp-1.15.1-py39r40h823a5e9_2.tar.bz2
win-64::ogre-next-2.3.0-hdef13af_1.tar.bz2
win-64::pdal-2.4.1-h4667b23_2.tar.bz2
win-64::smesh-9.8.0.2-h1dba484_1.tar.bz2
win-64::cpp-opentelemetry-sdk-1.4.1-h27294ca_1.tar.bz2
win-64::libopencv-4.5.5-py310he958ad5_12.tar.bz2
win-64::yarp-cxx-3.7.2-hc157652_0.tar.bz2
win-64::arrow-cpp-7.0.0-py38h61ae8a5_8_cpu.tar.bz2
win-64::openmeeg-2.4.7-py39he9171ab_0.tar.bz2
win-64::clang-format-14.0.6-default_h66ee7f4_0.tar.bz2
win-64::gemmi-0.5.5-py39ha0cd8c8_0.tar.bz2
win-64::paraview-5.10.1-py310h284284c_107_qt.tar.bz2
win-64::vtk-9.1.0-qt_py37h3a9b253_209.tar.bz2
win-64::harp-1.15.1-py310r41heba9ebb_1.tar.bz2
win-64::vtk-9.1.0-qt_py310h3533bfe_211.tar.bz2
win-64::gst-libav-1.20.3-he215ef2_1.tar.bz2
win-64::topologytoolkit-1.0.0-no_paraview_py38ha8c3cf2_104.tar.bz2
win-64::imagecodecs-2022.7.27-py39h1c15bc2_0.tar.bz2
win-64::libgdal-3.5.1-h7a56975_0.tar.bz2
win-64::arrow-cpp-8.0.0-py310h13f3e17_3_cpu.tar.bz2
win-64::grpc-cpp-1.44.0-hb30e31e_5.tar.bz2
win-64::tomviz-1.10.0.post249-py37h71896b8_2.tar.bz2
win-64::ovito-3.7.7-h240815b_0.tar.bz2
win-64::libopencv-4.6.0-py310h913f68d_2.tar.bz2
win-64::nco-5.1.0-h8531d33_1.tar.bz2
win-64::arrow-cpp-8.0.0-py39h4f6b0cd_3_cpu.tar.bz2
win-64::wasmer-2.3.0-hc9dcdca_0.tar.bz2
win-64::libopencv-4.5.5-py39he11e404_13.tar.bz2
win-64::topologytoolkit-1.1.0-no_paraview_py310hb7e702b_100.tar.bz2
win-64::vtk-9.1.0-qt_py310h68bede9_210.tar.bz2
win-64::ffmpeg-5.1.0-gpl_ha0349d7_100.tar.bz2
win-64::topologytoolkit-1.0.0-no_paraview_py310hb7e702b_106.tar.bz2
win-64::grpc-cpp-1.43.2-hcd87e55_6.tar.bz2
win-64::libxml2-2.9.14-hf5bbc77_3.tar.bz2
win-64::pdal-2.4.2-h1db056c_3.tar.bz2
win-64::arrow-cpp-8.0.1-py39h1a96d6e_0_cpu.tar.bz2
win-64::gmt-5.4.5-he39315c_18.tar.bz2
win-64::pyreadstat-1.1.9-py38h294d835_0.tar.bz2
win-64::tiledb-2.9.5-h3132609_0.tar.bz2
win-64::arrow-cpp-8.0.0-py38h70e5797_3_cuda.tar.bz2
win-64::pdal-2.4.2-h9b73ead_3.tar.bz2
win-64::arrow-cpp-8.0.1-py39hae6a196_0_cuda.tar.bz2
win-64::openmeeg-2.4.6-py38h1896c9c_0.tar.bz2
win-64::libprotobuf-static-21.2-h7755175_0.tar.bz2
win-64::arrow-cpp-7.0.0-py310h054aeab_8_cuda.tar.bz2
win-64::freecad-0.20.0-py39h234b588_0.tar.bz2
win-64::arrow-cpp-8.0.0-py37h5f18eb7_3_cuda.tar.bz2
win-64::vtk-9.1.0-qt_py310h09a3b9d_209.tar.bz2
win-64::topologytoolkit-1.0.0-no_paraview_py39hbf07cb6_104.tar.bz2
win-64::topologytoolkit-1.0.0-no_paraview_py37h7ec9e76_105.tar.bz2
win-64::arrow-cpp-8.0.0-py39hae7b3f5_3_cpu.tar.bz2
win-64::arrow-cpp-8.0.0-py37h16f4a4a_4_cuda.tar.bz2
win-64::arrow-cpp-8.0.1-py310h6cee11b_0_cpu.tar.bz2
win-64::grpc-cpp-1.45.2-hb30e31e_4.tar.bz2
win-64::glib-networking-2.72.1-h083f0a8_0.tar.bz2
-    "libzlib >=1.2.12,<1.3.0a0",
+    "libzlib >=1.2.12,<2.0.0a0",
win-64::llvm-14.0.5-h6fda50d_0.tar.bz2
win-64::clangxx-14.0.5-default_h66ee7f4_0.tar.bz2
win-64::clang-14.0.5-h8e541a6_0.tar.bz2
win-64::clang-14.0.6-h8e541a6_0.tar.bz2
win-64::clangxx-14.0.6-default_h66ee7f4_0.tar.bz2
win-64::llvm-14.0.6-h6fda50d_0.tar.bz2
-    "libzlib >=1.2.12,<1.3.0a0"
+    "libzlib >=1.2.12,<2.0.0a0"
================================================================================
================================================================================
osx-64
osx-64::astrometry-0.90-py37h3c2cab7_2.tar.bz2
osx-64::sdl2_image-2.6.0-hcfbcb78_0.tar.bz2
osx-64::gmt-5.4.5-h32ba6b3_21.tar.bz2
osx-64::harp-1.15.1-py37r41h4e666a4_1.tar.bz2
osx-64::pyreadstat-1.1.9-py310h5f16a0e_0.tar.bz2
osx-64::pypy3.8-7.3.9-ha6d791a_3.tar.bz2
osx-64::libopencv-4.5.5-py310h9d304e4_11.tar.bz2
osx-64::ffmpeg-4.4.2-lgpl_ha649829_5.tar.bz2
osx-64::vtk-9.1.0-qt_py38hf4ddb89_211.tar.bz2
osx-64::openmeeg-2.4.2-py38h273c31f_0.tar.bz2
osx-64::rstudio-desktop-2022.02.3-r40h2514ccb_493.tar.bz2
osx-64::harp-1.15.1-py39r41h95401f7_1.tar.bz2
osx-64::libtiledb-sql-0.17.0-hc318ded_0.tar.bz2
osx-64::connectorx-0.3.0-py39h970db14_1.tar.bz2
osx-64::lammps-2021.09.29-py39hcb92f58_mpich_4.tar.bz2
osx-64::pdal-2.4.2-h2e47583_1.tar.bz2
osx-64::jaxlib-0.3.14-cpu_py310h5891f1b_0.tar.bz2
osx-64::paraview-5.10.1-py37h91102e4_107_qt.tar.bz2
osx-64::arrow-cpp-6.0.1-py37h9576b21_20_cpu.tar.bz2
osx-64::libopencv-4.5.5-py38hb1cac05_12.tar.bz2
osx-64::xrootd-5.4.3-py39h995a777_1.tar.bz2
osx-64::librdkafka-1.9.0-hef2a209_0.tar.bz2
osx-64::topologytoolkit-1.0.0-with_paraview_py310h8fac747_6.tar.bz2
osx-64::vtk-9.1.0-qt_py310h3678531_210.tar.bz2
osx-64::ffmpeg-4.4.2-lgpl_h418d387_1.tar.bz2
osx-64::capnproto-0.10.2-h40906a8_0.tar.bz2
osx-64::topologytoolkit-1.0.0-with_paraview_py38h5fede53_6.tar.bz2
osx-64::grpc-cpp-1.44.0-h360b188_5.tar.bz2
osx-64::pdal-2.4.2-h2e47583_2.tar.bz2
osx-64::gmt-6.4.0-h81e1e63_2.tar.bz2
osx-64::openmeeg-2.4.2-py38hb5a4852_3.tar.bz2
osx-64::cppyy-cling-6.27.0-py37h60e553d_0.tar.bz2
osx-64::vigra-1.11.1-py37h6210daa_1033.tar.bz2
osx-64::sqlite-3.39.2-hd9f0692_0.tar.bz2
osx-64::freecad-0.20.0-py38h9a06716_0.tar.bz2
osx-64::jaxlib-0.3.14-cpu_py310h52bc2dc_0.tar.bz2
osx-64::arrow-cpp-8.0.0-py39h7f3cede_3_cpu.tar.bz2
osx-64::pdal-2.4.1-h58bacbd_2.tar.bz2
osx-64::jaxlib-0.3.14-cpu_py38h7c3ec13_1.tar.bz2
osx-64::tiledb-2.9.4-h86bd37b_0.tar.bz2
osx-64::postgresql-14.4-h600828a_0.tar.bz2
osx-64::libmongoc-1.21.2-h7416738_0.tar.bz2
osx-64::pypy3.9-7.3.9-h2f59b4d_3.tar.bz2
osx-64::libopencv-4.5.5-py39h08827a9_10.tar.bz2
osx-64::harp-1.15.1-py310r40h64be719_2.tar.bz2
osx-64::libxml2-2.9.14-h08a9926_1.tar.bz2
osx-64::grpc-cpp-1.46.3-h6f0e29b_2.tar.bz2
osx-64::ldas-tools-framecpp-2.9.1-hc4ca5b1_0.tar.bz2
osx-64::ndcctools-7.4.6-py37hbf02f29_0.tar.bz2
osx-64::harp-1.15.1-py38r40hac333f3_1.tar.bz2
osx-64::arrow-cpp-8.0.0-py39h90233d3_5_cpu.tar.bz2
osx-64::topologytoolkit-1.0.0-no_paraview_py39h0e29549_104.tar.bz2
osx-64::xrootd-5.4.3-py38h355803d_0.tar.bz2
osx-64::harp-1.15.1-py39r40he0ec8f2_2.tar.bz2
osx-64::ndcctools-7.4.10-py39h936c88a_0.tar.bz2
osx-64::ldas-tools-framecpp-2.9.1-h4456899_0.tar.bz2
osx-64::cpp-opentelemetry-sdk-1.4.1-hd702da9_0.tar.bz2
osx-64::arrow-cpp-8.0.0-py310hcd44676_2_cpu.tar.bz2
osx-64::gazebo-11.11.0-hf659f47_4.tar.bz2
osx-64::root_base-6.26.4-py38h6cf95d1_3.tar.bz2
osx-64::cpp-opentelemetry-sdk-1.4.1-hd702da9_2.tar.bz2
osx-64::coda-2.24-py37hdca3185_1.tar.bz2
osx-64::imagecodecs-2022.7.27-py310h012e3b2_0.tar.bz2
osx-64::libtiledb-sql-0.16.1-hc318ded_0.tar.bz2
osx-64::ndcctools-7.4.9-py37hbf02f29_0.tar.bz2
osx-64::arrow-cpp-3.0.0-py39h8463452_54_cpu.tar.bz2
osx-64::openmeeg-2.4.7-py37h2620256_0.tar.bz2
osx-64::ndcctools-7.4.10-py37haddda99_0.tar.bz2
osx-64::connectorx-0.3.0-py37hc00be2a_0.tar.bz2
osx-64::arrow-cpp-8.0.1-py39h7a817bb_0_cpu.tar.bz2
osx-64::pyreadstat-1.1.7-py37hbb35929_0.tar.bz2
osx-64::vowpalwabbit-9.2.0-py38hb0defc8_0.tar.bz2
osx-64::libgit2-1.4.4-he9088d2_0.tar.bz2
osx-64::libgit2-1.5.0-hf44dd67_0.tar.bz2
osx-64::jaxlib-0.3.14-cpu_py310h5891f1b_1.tar.bz2
osx-64::jaxlib-0.3.14-cpu_py310h70f0fad_3.tar.bz2
osx-64::librdkafka-1.9.0-h5f2db2f_0.tar.bz2
osx-64::libvips-8.13.0-he70d912_0.tar.bz2
osx-64::libitk-5.2.1-h45a1ef1_4.tar.bz2
osx-64::topologytoolkit-1.0.0-no_paraview_py38h77ef75a_106.tar.bz2
osx-64::glib-networking-2.72.1-hff4773f_0.tar.bz2
osx-64::arrow-cpp-7.0.0-py310hf221cfc_8_cpu.tar.bz2
osx-64::ffmpeg-5.0.1-gpl_hc501bf3_108.tar.bz2
osx-64::zstd-1.5.2-ha9df2e0_2.tar.bz2
osx-64::postgresql-14.4-hd3ec586_0.tar.bz2
osx-64::libprotobuf-static-21.3-h2292cb8_0.tar.bz2
osx-64::fish-3.5.0-h8d25b39_0.tar.bz2
osx-64::fenics-libdolfin-2019.1.0-hf78deb0_31.tar.bz2
osx-64::libopencv-4.6.0-py38hb1cac05_1.tar.bz2
osx-64::libpq-14.4-h2b7167c_0.tar.bz2
osx-64::ndcctools-7.4.9-py310h3114b78_0.tar.bz2
osx-64::ndcctools-7.4.10-py310h3114b78_0.tar.bz2
osx-64::vowpalwabbit-9.2.0-py310h6e4bd56_0.tar.bz2
osx-64::ndcctools-7.4.10-py39h4c84a47_1.tar.bz2
osx-64::gazebo-11.11.0-h3f1d0e5_9.tar.bz2
osx-64::ndcctools-7.4.6-py310h22e835d_0.tar.bz2
osx-64::jaxlib-0.3.14-cpu_py37he413125_3.tar.bz2
osx-64::arrow-cpp-8.0.0-py38hc53480e_4_cpu.tar.bz2
osx-64::coda-2.24-py38h12bdf3d_1.tar.bz2
osx-64::arrow-cpp-8.0.0-py37h306261b_3_cpu.tar.bz2
osx-64::jaxlib-0.3.14-cpu_py37h6b066c9_0.tar.bz2
osx-64::lammps-2021.09.29-py310h983d345_mpich_4.tar.bz2
osx-64::imagecodecs-2022.2.22-py310h7843972_6.tar.bz2
osx-64::tesseract-5.2.0-h1226324_0.tar.bz2
osx-64::xrootd-5.4.3-py37h912ad72_1.tar.bz2
osx-64::python-rocksdb-0.7.0-py310hbb0fdae_6.tar.bz2
osx-64::libgdal-3.5.0-h7aefe33_4.tar.bz2
osx-64::magics-metview-batch-4.12.0-h395abf9_1.tar.bz2
osx-64::wasmer-2.3.0-hb0e307f_0.tar.bz2
osx-64::sqlite-3.39.1-hd9f0692_0.tar.bz2
osx-64::jaxlib-0.3.14-cpu_py38h7c3ec13_0.tar.bz2
osx-64::tensorflow-base-2.9.1-cpu_py39hdd40284_0.tar.bz2
osx-64::tiledb-2.10.1-h86bd37b_0.tar.bz2
osx-64::libarchive-3.5.2-hde4784d_3.tar.bz2
osx-64::gmt-6.4.0-hde71ec8_0.tar.bz2
osx-64::r-vcfr-1.13.0-r41h3b3474e_0.tar.bz2
osx-64::libnetcdf-4.8.1-nompi_h3f14d1f_103.tar.bz2
osx-64::root_base-6.26.4-py39he408945_3.tar.bz2
osx-64::libopencv-4.5.5-py38hb1cac05_10.tar.bz2
osx-64::ffmpeg-4.4.2-gpl_h75cd845_103.tar.bz2
osx-64::ndcctools-7.4.9-py39h4c84a47_0.tar.bz2
osx-64::libpq-14.4-hf6bb32a_0.tar.bz2
osx-64::jaxlib-0.3.14-cpu_py37ha8dabb0_0.tar.bz2
osx-64::topologytoolkit-1.0.0-no_paraview_py39h34a8614_107.tar.bz2
osx-64::grpc-cpp-1.45.2-h360b188_4.tar.bz2
osx-64::lammps-2021.09.29-py310h3bed0f2_mpich_5.tar.bz2
osx-64::erlang-25.0.3-pl5321hbad8640_0.tar.bz2
osx-64::harp-1.15.1-py39r41he0ec8f2_2.tar.bz2
osx-64::ffmpeg-5.0.1-gpl_h0bbc480_105.tar.bz2
osx-64::openmeeg-2.4.6-py39h5303b8a_0.tar.bz2
osx-64::postgresql-plpython-14.4-py38h26df6d1_0.tar.bz2
osx-64::yoda-1.9.5-py38h4581af5_1.tar.bz2
osx-64::ndcctools-7.4.6-py38hf4dbdb2_0.tar.bz2
osx-64::libopencv-4.6.0-py39h93c2317_3.tar.bz2
osx-64::jaxlib-0.3.14-cpu_py38hfc92d86_1.tar.bz2
osx-64::grpc-cpp-1.45.2-h781f40e_4.tar.bz2
osx-64::openmeeg-2.4.2-py39hbc5d26d_0.tar.bz2
osx-64::openmeeg-2.4.2-py39hbc5d26d_2.tar.bz2
osx-64::libtiledb-sql-0.17.1-hc318ded_0.tar.bz2
osx-64::libopencv-4.6.0-py39h6ed1040_1.tar.bz2
osx-64::openmeeg-2.4.2-py39h6e9aa2e_3.tar.bz2
osx-64::python-rocksdb-0.7.0-py37he1d8efb_6.tar.bz2
osx-64::triqs-3.1.1-py38he474a60_0.tar.bz2
osx-64::erlang-25.0.2-pl5321hbad8640_0.tar.bz2
osx-64::arrow-cpp-3.0.0-py310h6a19e43_54_cpu.tar.bz2
osx-64::libtiledb-sql-0.17.1-hd314c81_0.tar.bz2
osx-64::tiledb-2.10.0-h86bd37b_0.tar.bz2
osx-64::openmeeg-2.4.2-py37h2620256_4.tar.bz2
osx-64::arrow-cpp-8.0.1-py37hc8acea9_0_cpu.tar.bz2
osx-64::paraview-5.10.1-py39h2e0819b_107_qt.tar.bz2
osx-64::vigra-1.11.1-py310h0ed4ab4_1033.tar.bz2
osx-64::openmeeg-2.4.7-py39h5303b8a_0.tar.bz2
osx-64::arrow-cpp-8.0.0-py38h63aa197_3_cpu.tar.bz2
osx-64::harp-1.15.1-py38r41h5dbed13_1.tar.bz2
osx-64::octave-7.1.0-h7e1aef8_1.tar.bz2
osx-64::gmt-5.4.5-h3094832_19.tar.bz2
osx-64::libtiledb-sql-0.15.1-hc318ded_0.tar.bz2
osx-64::tiledb-2.10.2-hb1ce2c0_0.tar.bz2
osx-64::grpc-cpp-1.46.3-h39bda65_1.tar.bz2
osx-64::arrow-cpp-8.0.1-py39h90233d3_0_cpu.tar.bz2
osx-64::openconnect-9.01-ha68b674_3.tar.bz2
osx-64::libopencv-4.6.0-py39h9203ec9_2.tar.bz2
osx-64::jaxlib-0.3.14-cpu_py310hb11a045_3.tar.bz2
osx-64::soplex-6.0.1-he521b3d_1.tar.bz2
osx-64::geant4-11.0.2-py39h20eae99_1.tar.bz2
osx-64::triqs-3.1.1-py37hdda2e0e_1.tar.bz2
osx-64::imagecodecs-2022.7.27-py38he2d6b2d_0.tar.bz2
osx-64::astrometry-0.90-py39h0777b8e_2.tar.bz2
osx-64::harp-1.15.1-py38r40h12bdf3d_2.tar.bz2
osx-64::libgdal-3.5.0-h2acc0c7_4.tar.bz2
osx-64::topologytoolkit-1.1.0-with_paraview_py310h3dd7647_0.tar.bz2
osx-64::arrow-cpp-8.0.0-py310hd2b853e_3_cpu.tar.bz2
osx-64::openbabel-3.1.1-py37h0fef594_4.tar.bz2
osx-64::libspatialite-5.0.1-ha6ecd9f_17.tar.bz2
osx-64::triqs-3.1.1-py310hdecceab_1.tar.bz2
osx-64::libgit2-1.5.0-he9088d2_0.tar.bz2
osx-64::paraview-5.10.1-py38h75ca095_107_qt.tar.bz2
osx-64::ndcctools-7.4.10-py310h3114b78_1.tar.bz2
osx-64::imagecodecs-2022.2.22-py39h7c839d0_6.tar.bz2
osx-64::mongodb-5.2.1-h281f97d_0.tar.bz2
osx-64::harp-1.15.1-py37r40hdca3185_2.tar.bz2
osx-64::grpc-cpp-1.43.2-h781f40e_6.tar.bz2
osx-64::libopencv-4.5.5-py39h6ed1040_11.tar.bz2
osx-64::jaxlib-0.3.14-cpu_py39ha19811c_1.tar.bz2
osx-64::lammps-2021.09.29-py310h3bdb10c_openmpi_5.tar.bz2
osx-64::openmeeg-2.4.2-py37hf5465f1_1.tar.bz2
osx-64::libopencv-4.5.5-py37h134b0dc_13.tar.bz2
osx-64::vtk-9.1.0-qt_py310h6479ab7_209.tar.bz2
osx-64::quazip-1.3-h246edc1_1.tar.bz2
osx-64::gemmi-0.5.5-py310h8fbb61a_0.tar.bz2
osx-64::yoda-1.9.5-py37h469e82c_1.tar.bz2
osx-64::harp-1.15.1-py310r40h778f2a2_1.tar.bz2
osx-64::postgresql-plpython-14.4-py37h6e22b94_0.tar.bz2
osx-64::geant4-11.0.2-py310h0314e81_1.tar.bz2
osx-64::arrow-cpp-8.0.1-py38hc53480e_0_cpu.tar.bz2
osx-64::arrow-cpp-8.0.0-py37h21a7035_5_cpu.tar.bz2
osx-64::vtk-9.1.0-qt_py39he514436_211.tar.bz2
osx-64::hdfeos5-5.1.16-hb7c390e_10.tar.bz2
osx-64::arrow-cpp-8.0.0-py37hf8a2639_2_cpu.tar.bz2
osx-64::python-3.10.5-hdd68b96_0_cpython.tar.bz2
osx-64::verilator-4.224-h2292cb8_0.tar.bz2
osx-64::vtk-9.1.0-qt_py39h235f978_209.tar.bz2
osx-64::qt-main-5.15.4-h938c29d_1.tar.bz2
osx-64::mongodb-5.3.2-h207facf_0.tar.bz2
osx-64::cppyy-cling-6.27.0-py38hcb412f5_0.tar.bz2
osx-64::libgdal-3.5.1-h242d4e5_0.tar.bz2
osx-64::yarp-cxx-3.7.0-h247d3f9_3.tar.bz2
osx-64::xrootd-5.4.3-py39h1811ca7_1.tar.bz2
osx-64::ndcctools-7.4.7-py310h22e835d_0.tar.bz2
osx-64::paraview-5.10.1-py39he91d88f_105_qt.tar.bz2
osx-64::topologytoolkit-1.0.0-with_paraview_py39hebd0eb5_4.tar.bz2
osx-64::qt-main-5.15.4-h938c29d_2.tar.bz2
osx-64::nd2-0.3.0-py39h79df2d4_0.tar.bz2
osx-64::tensorflow-base-2.9.1-cpu_py38hb7d77cb_0.tar.bz2
osx-64::ndcctools-7.4.8-py37hbf02f29_0.tar.bz2
osx-64::scip-8.0.1-h8316f79_1.tar.bz2
osx-64::harp-1.15.1-py39r41h96e5b50_2.tar.bz2
osx-64::xrootd-5.4.3-py38h355803d_1.tar.bz2
osx-64::openmeeg-2.4.2-py310h8221bc5_1.tar.bz2
osx-64::paraview-5.10.1-py38h72effbf_107_qt.tar.bz2
osx-64::texlive-core-20210325-he1746da_4.tar.bz2
osx-64::harp-1.15.1-py38r41h12bdf3d_2.tar.bz2
osx-64::yarp-cxx-3.7.0-h247d3f9_2.tar.bz2
osx-64::gdstk-0.8.3-py38h1ad6bf9_0.tar.bz2
osx-64::topologytoolkit-1.0.0-no_paraview_py38hf92426d_104.tar.bz2
osx-64::imagecodecs-2022.7.27-py39hddb54e8_0.tar.bz2
osx-64::imagemagick-7.1.0_38-pl5321h1a6ef8d_0.tar.bz2
osx-64::librdkafka-1.9.1-hd1fd568_1.tar.bz2
osx-64::vowpalwabbit-9.2.0-py37h903ef41_0.tar.bz2
osx-64::yoda-1.9.6-py38h4581af5_0.tar.bz2
osx-64::grpc-cpp-1.48.0-h6f0e29b_0.tar.bz2
osx-64::gmt-5.4.5-h3094832_18.tar.bz2
osx-64::jaxlib-0.3.14-cpu_py39hbe3403f_3.tar.bz2
osx-64::libopencv-4.6.0-py38he6c0e75_0.tar.bz2
osx-64::ffmpeg-5.1.0-gpl_hc501bf3_100.tar.bz2
osx-64::ogre-1.12.13-hb9c3ade_2.tar.bz2
osx-64::triqs-3.1.1-py39h66f4bee_0.tar.bz2
osx-64::openconnect-9.01-h792f6ef_0.tar.bz2
osx-64::ndcctools-7.4.8-py310h3114b78_0.tar.bz2
osx-64::triqs-3.1.1-py37hd9c1538_0.tar.bz2
osx-64::coda-2.24-py39h96e5b50_1.tar.bz2
osx-64::gemmi-0.5.5-py38h13516e3_0.tar.bz2
osx-64::ffmpeg-4.4.2-gpl_h96dde7a_105.tar.bz2
osx-64::yarp-cxx-3.7.2-h247d3f9_0.tar.bz2
osx-64::harp-1.15.1-py38r40h5dbed13_1.tar.bz2
osx-64::pypy3.8-7.3.9-h56a3d24_3.tar.bz2
osx-64::ndcctools-7.4.7-py37haddda99_0.tar.bz2
osx-64::libsoup-3.0.7-he214f22_0.tar.bz2
osx-64::poppler-qt-22.04.0-h4b3eab7_1.tar.bz2
osx-64::triqs-3.1.1-py310h689d16a_0.tar.bz2
osx-64::arrow-cpp-8.0.0-py38h7d042e8_3_cpu.tar.bz2
osx-64::vtk-9.1.0-qt_py38h92e7090_210.tar.bz2
osx-64::openbabel-3.1.1-py38h83d495d_4.tar.bz2
osx-64::hugin-base-2021.0.0-py39pl5321hcc9ec88_6.tar.bz2
osx-64::libopencv-4.6.0-py310h9d304e4_1.tar.bz2
osx-64::libopencv-4.5.5-py37h134b0dc_12.tar.bz2
osx-64::lammps-2021.09.29-py39hd6843ed_mpich_5.tar.bz2
osx-64::mongodb-5.2.1-h207facf_0.tar.bz2
osx-64::ndcctools-7.4.10-py310h22e835d_0.tar.bz2
osx-64::mongodb-5.2.0-h207facf_0.tar.bz2
osx-64::pdal-2.4.2-h58bacbd_2.tar.bz2
osx-64::hdf5-1.12.2-nompi_hc782337_100.tar.bz2
osx-64::arrow-cpp-8.0.0-py39h90233d3_4_cpu.tar.bz2
osx-64::jaxlib-0.3.14-cpu_py37he7ed797_3.tar.bz2
osx-64::graphviz-2.50.0-ha5baa68_3.tar.bz2
osx-64::soplex-6.0.1-he521b3d_0.tar.bz2
osx-64::libopencv-4.5.5-py39h08827a9_11.tar.bz2
osx-64::gazebo-11.11.0-h3598761_6.tar.bz2
osx-64::pdal-2.4.2-hcf4a4e9_3.tar.bz2
osx-64::libarchive-3.5.2-hbf7dfe4_3.tar.bz2
osx-64::sqlite-3.39.0-hd9f0692_0.tar.bz2
osx-64::openmeeg-2.4.2-py37h1963f51_3.tar.bz2
osx-64::mongodb-5.2.0-h281f97d_0.tar.bz2
osx-64::quazip-1.3-h0f80edd_0.tar.bz2
osx-64::libopencv-4.6.0-py39hebb012e_3.tar.bz2
osx-64::jaxlib-0.3.14-cpu_py38h0c18534_3.tar.bz2
osx-64::gdstk-0.8.3-py39h37c8bac_0.tar.bz2
osx-64::libopencv-4.6.0-py39h5f1b8ba_2.tar.bz2
osx-64::lammps-2021.09.29-py37h5a5743e_openmpi_5.tar.bz2
osx-64::libopencv-4.5.5-py38he6c0e75_11.tar.bz2
osx-64::paraview-5.10.1-py38h0660885_105_qt.tar.bz2
osx-64::pypy3.9-7.3.9-h70a7e04_3.tar.bz2
osx-64::readdy-2.0.12-py38hfb48978_0.tar.bz2
osx-64::gemmi-0.5.5-py39hb75758d_0.tar.bz2
osx-64::pdal-2.4.2-h58bacbd_1.tar.bz2
osx-64::libopencv-4.5.5-py37h134b0dc_11.tar.bz2
osx-64::lammps-2021.09.29-py38h6377f0c_openmpi_4.tar.bz2
osx-64::paraview-5.10.1-py310h1d821bb_106_qt.tar.bz2
osx-64::grpc-cpp-1.46.3-h0d31105_2.tar.bz2
osx-64::jaxlib-0.3.14-cpu_py39h552bf4e_1.tar.bz2
osx-64::gazebo-11.11.0-h01c0446_4.tar.bz2
osx-64::vigra-1.11.1-py37hf7fa1f8_1033.tar.bz2
osx-64::xrootd-5.4.3-py310hbf8f24b_1.tar.bz2
osx-64::geant4-11.0.2-py310ha063418_0.tar.bz2
osx-64::arrow-cpp-8.0.0-py37hf7096f7_2_cpu.tar.bz2
osx-64::arrow-cpp-5.0.0-py38h430e7ab_35_cpu.tar.bz2
osx-64::ndcctools-7.4.10-py37haddda99_1.tar.bz2
osx-64::ffmpeg-5.0.1-h8454a6e_3.tar.bz2
osx-64::libgdal-3.5.0-h231da96_1.tar.bz2
osx-64::yoda-1.9.6-py37h469e82c_0.tar.bz2
osx-64::prometheus-cpp-1.0.1-h8daca28_0.tar.bz2
osx-64::openmeeg-2.4.2-py39hb5b5238_3.tar.bz2
osx-64::pillow-9.2.0-py39h579eac4_0.tar.bz2
osx-64::libopencv-4.5.5-py38he6c0e75_10.tar.bz2
osx-64::ffmpeg-4.4.2-lgpl_ha649829_4.tar.bz2
osx-64::ndcctools-7.4.9-py38hf4dbdb2_0.tar.bz2
osx-64::ncl-6.6.2-hd121c43_40.tar.bz2
osx-64::coda-2.24-py38h616c10b_1.tar.bz2
osx-64::ffmpeg-5.0.1-gpl_h75cd845_106.tar.bz2
osx-64::grpc-cpp-1.47.0-h0d31105_1.tar.bz2
osx-64::topologytoolkit-1.0.0-with_paraview_py38h5fede53_5.tar.bz2
osx-64::llvmdev-14.0.6-h41df66c_0.tar.bz2
osx-64::ticcutils-0.29-he4f4f6d_0.tar.bz2
osx-64::ndcctools-7.4.6-py310h3114b78_0.tar.bz2
osx-64::jaxlib-0.3.14-cpu_py39h552bf4e_0.tar.bz2
osx-64::hdf5-1.12.2-mpi_mpich_h9807619_0.tar.bz2
osx-64::xrootd-5.4.3-py39ha77102f_1.tar.bz2
osx-64::gfal2-2.21.0-hb108ef6_0.tar.bz2
osx-64::tiledb-2.10.2-h86bd37b_0.tar.bz2
osx-64::openmeeg-2.4.7-py38h3d5a339_0.tar.bz2
osx-64::git-2.37.0-pl5321h7190d3f_0.tar.bz2
osx-64::nodejs-18.7.0-haa867d2_0.tar.bz2
osx-64::libopencv-4.6.0-py310h9d304e4_0.tar.bz2
osx-64::arrow-cpp-6.0.1-py310h6a19e43_20_cpu.tar.bz2
osx-64::ffmpeg-5.0.1-lgpl_h418d387_5.tar.bz2
osx-64::pdal-2.4.2-h2e47583_0.tar.bz2
osx-64::cpp-opentelemetry-sdk-1.4.1-h8969fb7_0.tar.bz2
osx-64::magics-metview-4.12.0-h1029bc6_2.tar.bz2
osx-64::libtiledb-sql-0.16.0-hc318ded_0.tar.bz2
osx-64::yarp-cxx-3.7.0-hafc17dd_0.tar.bz2
osx-64::libgdal-3.5.0-h50ae38e_2.tar.bz2
osx-64::python-rocksdb-0.7.0-py39hc396da8_6.tar.bz2
osx-64::grpc-cpp-1.43.2-hf4cdc08_6.tar.bz2
osx-64::cppyy-cling-6.27.0-py39h23ee7eb_0.tar.bz2
osx-64::hugin-base-2021.0.0-py310pl5321h22d20d6_6.tar.bz2
osx-64::triqs-3.1.1-py38h847572d_1.tar.bz2
osx-64::ffmpeg-5.1.0-lgpl_hb35dd3b_0.tar.bz2
osx-64::pdal-2.4.2-h986b353_3.tar.bz2
osx-64::vtk-9.1.0-qt_py310ha3f681f_211.tar.bz2
osx-64::ndcctools-7.4.10-py37hbf02f29_0.tar.bz2
osx-64::cpp-opentelemetry-sdk-1.4.1-hd702da9_4.tar.bz2
osx-64::tiledb-2.9.5-h86bd37b_0.tar.bz2
osx-64::openmeeg-2.4.4-py310h4d3c5e4_0.tar.bz2
osx-64::arrow-cpp-8.0.0-py37h21a7035_4_cpu.tar.bz2
osx-64::glib-2.72.1-h2292cb8_0.tar.bz2
osx-64::environment-modules-5.1.1-hf3baf74_0.tar.bz2
osx-64::arrow-cpp-7.0.0-py37h306261b_8_cpu.tar.bz2
osx-64::gmsh-4.10.4-he204d90_0.tar.bz2
osx-64::gemmi-0.5.5-py38h1e1b051_0.tar.bz2
osx-64::openmeeg-2.4.6-py39h048cf10_0.tar.bz2
osx-64::postgresql-plpython-14.4-py37hecf6b4e_0.tar.bz2
osx-64::gdstk-0.8.3-py38hc895574_0.tar.bz2
osx-64::tensorflow-base-2.9.1-cpu_py37h5a6ca87_0.tar.bz2
osx-64::ndcctools-7.4.9-py310h22e835d_0.tar.bz2
osx-64::openmeeg-2.4.6-py38h1a7c08e_0.tar.bz2
osx-64::vowpalwabbit-9.2.0-py39ha8b9020_0.tar.bz2
osx-64::nodejs-18.6.0-haa867d2_0.tar.bz2
osx-64::harp-1.15.1-py37r41hdca3185_2.tar.bz2
osx-64::lammps-2021.09.29-py37hd2e647d_openmpi_5.tar.bz2
osx-64::topologytoolkit-1.0.0-no_paraview_py39h4aab467_106.tar.bz2
osx-64::libopencv-4.6.0-py310hdaa94e3_2.tar.bz2
osx-64::lammps-2021.09.29-py39h33af542_openmpi_4.tar.bz2
osx-64::jaxlib-0.3.14-cpu_py310h265b3eb_1.tar.bz2
osx-64::ovito-3.7.5-h6ac1d47_0.tar.bz2
osx-64::libtensorflow_cc-2.9.1-cpu_h6b62bad_0.tar.bz2
osx-64::nodejs-18.6.0-h0a5f95b_0.tar.bz2
osx-64::ogre-13.4.2-h75e84fb_0.tar.bz2
osx-64::openbabel-3.1.1-py310he467037_4.tar.bz2
osx-64::libopencv-4.5.5-py38hb1cac05_11.tar.bz2
osx-64::yoda-1.9.5-py310h578265e_1.tar.bz2
osx-64::grpc-cpp-1.43.2-h379cd86_6.tar.bz2
osx-64::ndcctools-7.4.10-py39h4c84a47_0.tar.bz2
osx-64::jaxlib-0.3.14-cpu_py310h52bc2dc_1.tar.bz2
osx-64::ndcctools-7.4.10-py37hbf02f29_1.tar.bz2
osx-64::gdstk-0.8.3-py37haf330b5_0.tar.bz2
osx-64::ndcctools-7.4.7-py37hbf02f29_0.tar.bz2
osx-64::vtk-9.1.0-qt_py39h23d95d6_210.tar.bz2
osx-64::imagemagick-7.1.0.43-pl5321h4335fd5_0.tar.bz2
osx-64::arrow-cpp-8.0.0-py39h5cd9efb_3_cpu.tar.bz2
osx-64::freecad-0.20.0-py39h06b78ca_0.tar.bz2
osx-64::ogre-13.4.1-h75e84fb_1.tar.bz2
osx-64::imagemagick-7.1.0_41-pl5321h1a6ef8d_0.tar.bz2
osx-64::tiledb-2.9.5-hb1ce2c0_0.tar.bz2
osx-64::triqs-3.1.1-py310h682fc19_0.tar.bz2
osx-64::tomviz-1.10.0.post249-py37h5abe756_2.tar.bz2
osx-64::libopencv-4.5.5-py39h6ed1040_13.tar.bz2
osx-64::tiledb-2.9.3-h86bd37b_0.tar.bz2
osx-64::arrow-cpp-8.0.0-py38h751a74a_4_cpu.tar.bz2
osx-64::arrow-cpp-3.0.0-py310h060cdaa_54_cpu.tar.bz2
osx-64::grpc-cpp-1.44.0-h781f40e_5.tar.bz2
osx-64::gazebo-11.11.0-hb2664c6_9.tar.bz2
osx-64::libopencv-4.6.0-py37h134b0dc_0.tar.bz2
osx-64::pillow-9.2.0-py39hbf29c74_0.tar.bz2
osx-64::pyreadstat-1.1.7-py310h5f16a0e_0.tar.bz2
osx-64::imagecodecs-2022.2.22-py38hc57772a_6.tar.bz2
osx-64::harp-1.15.1-py39r40h1da5fad_1.tar.bz2
osx-64::libtiff-4.4.0-h4aaeabe_2.tar.bz2
osx-64::postgresql-plpython-14.4-py39h10f0d74_0.tar.bz2
osx-64::gazebo-11.11.0-h01c0446_5.tar.bz2
osx-64::libgdal-3.5.0-h242d4e5_5.tar.bz2
osx-64::gazebo-11.11.0-h3f1d0e5_8.tar.bz2
osx-64::grpc-cpp-1.47.1-h6f0e29b_0.tar.bz2
osx-64::triqs-3.1.1-py37hb5f9b74_0.tar.bz2
osx-64::grpc-cpp-1.44.0-h379cd86_5.tar.bz2
osx-64::ffmpeg-4.4.2-gpl_h0bbc480_101.tar.bz2
osx-64::openmeeg-2.4.2-py38h273c31f_1.tar.bz2
osx-64::topologytoolkit-1.0.0-with_paraview_py38h8e4bc32_4.tar.bz2
osx-64::arrow-cpp-6.0.1-py39h8463452_20_cpu.tar.bz2
osx-64::octave-7.1.0-h193ef59_1.tar.bz2
osx-64::libgsf-1.14.50-h2f6ec70_0.tar.bz2
osx-64::openmpi-4.1.4-h8589876_100.tar.bz2
osx-64::freecad-0.20.0-py310h5699401_0.tar.bz2
osx-64::arrow-cpp-8.0.0-py39h7a817bb_5_cpu.tar.bz2
osx-64::imagemagick-7.1.0_40-pl5321h1a6ef8d_0.tar.bz2
osx-64::imagemagick-7.1.0_44-pl5321h4335fd5_0.tar.bz2
osx-64::libzip-1.9.2-hedeed6f_0.tar.bz2
osx-64::libopencv-4.6.0-py38h2bd0f6c_2.tar.bz2
osx-64::topologytoolkit-1.1.0-no_paraview_py37hfda8ea9_100.tar.bz2
osx-64::mongodb-6.0.0-h281f97d_0.tar.bz2
osx-64::libmongoc-1.22.0-h7416738_0.tar.bz2
osx-64::openmeeg-2.4.2-py39h5303b8a_4.tar.bz2
osx-64::grpc-cpp-1.44.0-hf4cdc08_5.tar.bz2
osx-64::nd2-0.3.0-py310hfb80a91_0.tar.bz2
osx-64::postgresql-plpython-14.4-py38h52e5b9a_0.tar.bz2
osx-64::arrow-cpp-8.0.0-py37hd7410c4_3_cpu.tar.bz2
osx-64::octave-7.1.0-h9b29aa9_3.tar.bz2
osx-64::cpp-opentelemetry-sdk-1.4.1-h2940032_4.tar.bz2
osx-64::libopencv-4.6.0-py310h9c6a2ff_3.tar.bz2
osx-64::orc-1.7.5-h4856350_0.tar.bz2
osx-64::poppler-22.04.0-hed6754a_1.tar.bz2
osx-64::root_base-6.26.4-py37h289815d_3.tar.bz2
osx-64::openmeeg-2.4.6-py38h3d5a339_0.tar.bz2
osx-64::jaxlib-0.3.14-cpu_py310h265b3eb_0.tar.bz2
osx-64::gazebo-11.11.0-hb2664c6_7.tar.bz2
osx-64::gmsh-4.10.5-he204d90_0.tar.bz2
osx-64::nd2-0.3.0-py37hadc9cfe_0.tar.bz2
osx-64::ndcctools-7.4.10-py310h22e835d_1.tar.bz2
osx-64::arrow-cpp-5.0.0-py310h060cdaa_35_cpu.tar.bz2
osx-64::arrow-cpp-8.0.0-py38hc53480e_5_cpu.tar.bz2
osx-64::paraview-5.10.1-py39h5d2565c_107_qt.tar.bz2
osx-64::libopencv-4.6.0-py38ha0ff2e0_2.tar.bz2
osx-64::glib-networking-2.72.1-h3ae9fd1_1.tar.bz2
osx-64::libprotobuf-static-21.4-h2292cb8_0.tar.bz2
osx-64::hdf5-1.12.2-mpi_openmpi_ha84660b_0.tar.bz2
osx-64::harp-1.15.1-py39r40h96e5b50_2.tar.bz2
osx-64::openbabel-3.1.1-py39hb4f85b1_4.tar.bz2
osx-64::openmeeg-2.4.7-py38h1a7c08e_0.tar.bz2
osx-64::yarp-cxx-3.7.0-h247d3f9_4.tar.bz2
osx-64::readdy-2.0.12-py39h6bf280b_0.tar.bz2
osx-64::ogre-13.4.1-h3ecc1be_0.tar.bz2
osx-64::python-rocksdb-0.7.0-py39h2d04b5b_6.tar.bz2
osx-64::cppyy-cling-6.27.0-py38hc2dbfde_0.tar.bz2
osx-64::ndcctools-7.4.6-py37haddda99_0.tar.bz2
osx-64::cpp-opentelemetry-sdk-1.4.1-h2940032_1.tar.bz2
osx-64::tectonic-0.9.0-h8a3aa6c_1.tar.bz2
osx-64::pyreadstat-1.1.9-py39h26d836a_0.tar.bz2
osx-64::triqs-3.1.1-py38h859aff4_0.tar.bz2
osx-64::pillow-9.2.0-py38h8ad2bec_0.tar.bz2
osx-64::pdal-2.4.2-h58bacbd_0.tar.bz2
osx-64::hdf5-1.12.2-mpi_openmpi_hb4707a0_0.tar.bz2
osx-64::libtensorflow-2.9.1-cpu_h6b62bad_0.tar.bz2
osx-64::arrow-cpp-8.0.0-py310h8d1dac6_4_cpu.tar.bz2
osx-64::geant4-11.0.2-py37h72b5c7c_0.tar.bz2
osx-64::libopencv-4.6.0-py38he6c0e75_1.tar.bz2
osx-64::libopencv-4.5.5-py38he6c0e75_13.tar.bz2
osx-64::pillow-9.2.0-py37h1eb1bbc_0.tar.bz2
osx-64::ovito-3.7.8-haeff761_0.tar.bz2
osx-64::vtk-9.1.0-qt_py38h8b6b089_209.tar.bz2
osx-64::ndcctools-7.4.8-py38hcac5eec_0.tar.bz2
osx-64::imagemagick-7.1.0_37-pl5321h1a6ef8d_0.tar.bz2
osx-64::grpc-cpp-1.48.0-h0d31105_0.tar.bz2
osx-64::nodejs-18.5.0-h0a5f95b_0.tar.bz2
osx-64::ffmpeg-4.4.2-h8454a6e_0.tar.bz2
osx-64::fenics-libdolfin-2019.1.0-hfb08b87_30.tar.bz2
osx-64::openmpi-4.1.3-hd33e60e_104.tar.bz2
osx-64::ncl-6.6.2-hfaaff42_39.tar.bz2
osx-64::nd2-0.3.0-py38h4586019_0.tar.bz2
osx-64::jaxlib-0.3.14-cpu_py37h008d09a_1.tar.bz2
osx-64::ffmpeg-4.4.2-gpl_h96dde7a_104.tar.bz2
osx-64::jaxlib-0.3.14-cpu_py38h227fd48_1.tar.bz2
osx-64::triqs-3.1.1-py39hb88faee_0.tar.bz2
osx-64::papilo-2.1.0-hed58181_0.tar.bz2
osx-64::connectorx-0.3.0-py37hc00be2a_1.tar.bz2
osx-64::openmeeg-2.4.2-py38h1a7c08e_4.tar.bz2
osx-64::libopencv-4.5.5-py38he6c0e75_12.tar.bz2
osx-64::r-rmatio-0.16.0-r41h67d6963_0.tar.bz2
osx-64::nco-5.1.0-h1bf0434_0.tar.bz2
osx-64::lammps-2021.09.29-py37ha6ca0c3_openmpi_4.tar.bz2
osx-64::tomviz-1.10.0.post266-py37h5abe756_2.tar.bz2
osx-64::jaxlib-0.3.14-cpu_py38h227fd48_0.tar.bz2
osx-64::nd2-0.2.5-py37hadc9cfe_0.tar.bz2
osx-64::ndcctools-7.4.8-py39h936c88a_0.tar.bz2
osx-64::yoda-1.9.5-py39he667c16_1.tar.bz2
osx-64::postgresql-plpython-14.4-py310h692a392_0.tar.bz2
osx-64::gmt-6.3.0-hfad453a_5.tar.bz2
osx-64::ndcctools-7.4.9-py37haddda99_0.tar.bz2
osx-64::openmeeg-2.4.2-py38h1b1f42c_2.tar.bz2
osx-64::gemmi-0.5.5-py39hdfe08e5_0.tar.bz2
osx-64::ndcctools-7.4.7-py38hf4dbdb2_0.tar.bz2
osx-64::ogre-next-2.2.6-hd51ceb8_0.tar.bz2
osx-64::codes-ui-1.5.2-h2292cb8_1.tar.bz2
osx-64::openmeeg-2.4.2-py310he16ee25_3.tar.bz2
osx-64::ogre-next-2.3.0-hd51ceb8_0.tar.bz2
osx-64::pyreadstat-1.1.9-py37hca69792_0.tar.bz2
osx-64::geant4-11.0.2-py37h6939c6c_1.tar.bz2
osx-64::prometheus-cpp-1.0.0-h8daca28_0.tar.bz2
osx-64::gazebo-11.11.0-h3f1d0e5_7.tar.bz2
osx-64::erlang-25.0.3-pl5321hbd0f5b5_0.tar.bz2
osx-64::triqs-3.1.1-py310h46cab94_1.tar.bz2
osx-64::vtk-9.1.0-qt_py37h0131ba1_209.tar.bz2
osx-64::yarp-cxx-3.7.1-h247d3f9_0.tar.bz2
osx-64::nd2-0.2.5-py310hfb80a91_0.tar.bz2
osx-64::libnetcdf-4.8.1-mpi_mpich_h5e8bdaf_3.tar.bz2
osx-64::gmt-5.4.5-h3094832_20.tar.bz2
osx-64::ogre-next-2.3.1-hd51ceb8_1.tar.bz2
osx-64::cppyy-cling-6.27.0-py39h0219df7_0.tar.bz2
osx-64::libopencv-4.5.5-py37h134b0dc_10.tar.bz2
osx-64::cpp-opentelemetry-sdk-1.4.1-h7224fd3_3.tar.bz2
osx-64::paraview-5.10.1-py39h83ba6af_107_qt.tar.bz2
osx-64::jaxlib-0.3.14-cpu_py38hfc92d86_0.tar.bz2
osx-64::arrow-cpp-7.0.0-py39h5cd9efb_8_cpu.tar.bz2
osx-64::xrootd-5.4.3-py38h4a303dc_1.tar.bz2
osx-64::wxwidgets-3.2.0-hfb22cc3_1.tar.bz2
osx-64::paraview-5.10.1-py38h20e6886_107_qt.tar.bz2
osx-64::libopencv-4.5.5-py39h08827a9_13.tar.bz2
osx-64::libopencv-4.5.5-py310h9d304e4_12.tar.bz2
osx-64::gdstk-0.8.3-py310h8a15a4a_0.tar.bz2
osx-64::libgdal-3.5.1-hf82897d_2.tar.bz2
osx-64::ndcctools-7.4.8-py39h4c84a47_0.tar.bz2
osx-64::magics-4.12.0-h395abf9_1.tar.bz2
osx-64::ffmpeg-4.4.2-gpl_hc501bf3_106.tar.bz2
osx-64::gazebo-11.11.0-hc166254_3.tar.bz2
osx-64::astrometry-0.90-py37h0860050_2.tar.bz2
osx-64::git-2.37.0-pl5321h4c4e27f_0.tar.bz2
osx-64::hdf5-1.12.2-mpi_mpich_hc154f39_0.tar.bz2
osx-64::libgdal-3.5.1-h3a44f2c_0.tar.bz2
osx-64::ffmpeg-5.0.1-lgpl_h418d387_4.tar.bz2
osx-64::coda-2.24-py310h64be719_1.tar.bz2
osx-64::libgdal-3.5.1-h242d4e5_1.tar.bz2
osx-64::tectonic-0.9.0-h831ce2b_1.tar.bz2
osx-64::libmongoc-1.21.2-h9e5b77c_0.tar.bz2
osx-64::paraview-5.10.1-py38h0660885_106_qt.tar.bz2
osx-64::nco-5.1.0-hc95a56f_1.tar.bz2
osx-64::ndcctools-7.4.7-py39h936c88a_0.tar.bz2
osx-64::topologytoolkit-1.0.0-with_paraview_py39h7a0765c_5.tar.bz2
osx-64::arrow-cpp-8.0.0-py310h8d1dac6_5_cpu.tar.bz2
osx-64::openmeeg-2.4.2-py39h048cf10_4.tar.bz2
osx-64::grpc-cpp-1.47.0-haf5484d_0.tar.bz2
osx-64::graphviz-4.0.0-ha5baa68_1.tar.bz2
osx-64::jaxlib-0.3.14-cpu_py310h0e7486c_1.tar.bz2
osx-64::libopencv-4.6.0-py39h08827a9_1.tar.bz2
osx-64::arrow-cpp-8.0.0-py39h3bd5d96_2_cpu.tar.bz2
osx-64::libopencv-4.6.0-py37h0b74fb2_3.tar.bz2
osx-64::yoda-1.9.6-py310h578265e_0.tar.bz2
osx-64::ndcctools-7.4.8-py310h22e835d_0.tar.bz2
osx-64::libopencv-4.6.0-py37h9505f4c_2.tar.bz2
osx-64::arrow-cpp-6.0.1-py38h430e7ab_20_cpu.tar.bz2
osx-64::harp-1.15.1-py38r40h616c10b_2.tar.bz2
osx-64::gazebo-11.11.0-h3d3b4b5_2.tar.bz2
osx-64::pdal-2.4.1-h2e47583_2.tar.bz2
osx-64::libsoup-2.74.2-he214f22_0.tar.bz2
osx-64::topologytoolkit-1.1.0-no_paraview_py38hc8f0334_100.tar.bz2
osx-64::pyreadstat-1.1.7-py37hca69792_0.tar.bz2
osx-64::ffmpeg-5.0.1-lgpl_ha649829_7.tar.bz2
osx-64::ndcctools-7.4.7-py38hcac5eec_0.tar.bz2
osx-64::jaxlib-0.3.14-cpu_py39h797cc16_0.tar.bz2
osx-64::imagecodecs-2022.7.27-py39h75584d7_1.tar.bz2
osx-64::cpp-opentelemetry-sdk-1.4.1-h2940032_2.tar.bz2
osx-64::hugin-base-2021.0.0-pl5321hcd574a5_7.tar.bz2
osx-64::arrow-cpp-7.0.0-py38h7d042e8_8_cpu.tar.bz2
osx-64::jaxlib-0.3.14-cpu_py37h008d09a_0.tar.bz2
osx-64::connectorx-0.3.0-py38he959c03_1.tar.bz2
osx-64::ndcctools-7.4.10-py38hcac5eec_0.tar.bz2
osx-64::glib-networking-2.72.1-hff4773f_1.tar.bz2
osx-64::topologytoolkit-1.0.0-no_paraview_py37hcc7e34b_106.tar.bz2
osx-64::cmake-3.23.3-hf2c7296_0.tar.bz2
osx-64::arrow-cpp-8.0.1-py37h21a7035_0_cpu.tar.bz2
osx-64::ogre-next-2.3.1-hd51ceb8_0.tar.bz2
osx-64::topologytoolkit-1.1.0-with_paraview_py38h2769ddb_0.tar.bz2
osx-64::imagecodecs-2022.7.27-py310h4208eff_1.tar.bz2
osx-64::triqs-3.1.1-py37h1167a88_1.tar.bz2
osx-64::gmt-6.4.0-h7f1b9d3_1.tar.bz2
osx-64::arrow-cpp-3.0.0-py38h430e7ab_54_cpu.tar.bz2
osx-64::libopencv-4.6.0-py37h134b0dc_1.tar.bz2
osx-64::xrootd-5.4.3-py38h836df29_1.tar.bz2
osx-64::hugin-base-2021.0.0-py37pl5321h1c22a85_6.tar.bz2
osx-64::geotiff-1.7.1-ha1a2aeb_3.tar.bz2
osx-64::lammps-2021.09.29-py39h0ecbc93_openmpi_5.tar.bz2
osx-64::arrow-cpp-8.0.0-py310h6846212_5_cpu.tar.bz2
osx-64::topologytoolkit-1.0.0-no_paraview_py39h4aab467_105.tar.bz2
osx-64::pyreadstat-1.1.7-py38h66216d4_0.tar.bz2
osx-64::readdy-2.0.12-py37h7007407_0.tar.bz2
osx-64::gazebo-11.11.0-hf659f47_5.tar.bz2
osx-64::fish-3.5.1-h8d25b39_0.tar.bz2
osx-64::erlang-25.0.1-pl5321hbad8640_0.tar.bz2
osx-64::vigra-1.11.1-py39he3c0770_1033.tar.bz2
osx-64::rstudio-desktop-2022.02.3-r41h2514ccb_493.tar.bz2
osx-64::ndcctools-7.4.8-py38hf4dbdb2_0.tar.bz2
osx-64::gazebo-11.11.0-h91438aa_2.tar.bz2
osx-64::xrootd-5.4.3-py310hbf8f24b_0.tar.bz2
osx-64::libgdal-3.5.1-h3a44f2c_1.tar.bz2
osx-64::jaxlib-0.3.14-cpu_py39ha0a6ba6_0.tar.bz2
osx-64::gmt-6.3.0-hde71ec8_6.tar.bz2
osx-64::jaxlib-0.3.14-cpu_py37ha8dabb0_1.tar.bz2
osx-64::arrow-cpp-6.0.1-py38h32d64d2_20_cpu.tar.bz2
osx-64::libopencv-4.5.5-py310h9d304e4_10.tar.bz2
osx-64::openscenegraph-3.6.5-hbf6ad10_14.tar.bz2
osx-64::ffmpeg-4.4.2-lgpl_hb35dd3b_6.tar.bz2
osx-64::jaxlib-0.3.14-cpu_py310h0e7486c_0.tar.bz2
osx-64::ffmpeg-4.4.2-gpl_h0bbc480_102.tar.bz2
osx-64::coda-2.24-py39he0ec8f2_1.tar.bz2
osx-64::libxml2-2.9.14-h08a9926_3.tar.bz2
osx-64::openmeeg-2.4.2-py38h273c31f_2.tar.bz2
osx-64::openmeeg-2.4.2-py38h06f17e3_3.tar.bz2
osx-64::topologytoolkit-1.0.0-no_paraview_py37hcc7e34b_105.tar.bz2
osx-64::grpc-cpp-1.43.2-h360b188_6.tar.bz2
osx-64::r-rmatio-0.16.0-r40h67d6963_0.tar.bz2
osx-64::rstudio-desktop-2022.02.3-r40h6e504f6_492.tar.bz2
osx-64::yoda-1.9.6-py39he667c16_0.tar.bz2
osx-64::ovito-3.7.5-haeff761_1.tar.bz2
osx-64::libopencv-4.6.0-py39h08827a9_0.tar.bz2
osx-64::topologytoolkit-1.1.0-with_paraview_py39hdf6581e_0.tar.bz2
osx-64::python-rocksdb-0.7.0-py38h39c9159_6.tar.bz2
osx-64::topologytoolkit-1.0.0-no_paraview_py38hc8f0334_107.tar.bz2
osx-64::paraview-5.10.1-py39he91d88f_106_qt.tar.bz2
osx-64::topologytoolkit-1.0.0-with_paraview_py38h2769ddb_7.tar.bz2
osx-64::lammps-2021.09.29-py310h121345e_openmpi_4.tar.bz2
osx-64::pdal-2.4.1-ha4e371a_1.tar.bz2
osx-64::pyreadstat-1.1.9-py37hbb35929_0.tar.bz2
osx-64::lammps-2021.09.29-py37hee20b2b_mpich_4.tar.bz2
osx-64::openmeeg-2.4.4-py38h3d5a339_0.tar.bz2
osx-64::tiledb-2.9.3-hb1ce2c0_0.tar.bz2
osx-64::jaxlib-0.3.14-cpu_py39ha0a6ba6_1.tar.bz2
osx-64::openmeeg-2.4.4-py39h048cf10_0.tar.bz2
osx-64::geotiff-1.7.1-ha1a2aeb_2.tar.bz2
osx-64::tiledb-2.10.1-hb1ce2c0_0.tar.bz2
osx-64::ogre-1.10.12-hf9dbd05_9.tar.bz2
osx-64::libgdal-3.5.1-h49e027b_2.tar.bz2
osx-64::gemmi-0.5.5-py37h4db3d30_0.tar.bz2
osx-64::openmeeg-2.4.4-py39h5303b8a_0.tar.bz2
osx-64::arrow-cpp-7.0.0-py38h63aa197_8_cpu.tar.bz2
osx-64::openconnect-9.01-h7d47fae_1.tar.bz2
osx-64::geant4-11.0.2-py38h54de395_1.tar.bz2
osx-64::ffmpeg-4.4.2-lgpl_h34cfc4d_3.tar.bz2
osx-64::openmeeg-2.4.2-py37hf5465f1_0.tar.bz2
osx-64::arrow-cpp-3.0.0-py38h32d64d2_54_cpu.tar.bz2
osx-64::topologytoolkit-1.0.0-with_paraview_py39hdf6581e_7.tar.bz2
osx-64::hugin-base-2021.0.0-py38pl5321h39cc8ff_6.tar.bz2
osx-64::vigra-1.11.1-py38h804152e_1033.tar.bz2
osx-64::lammps-2021.09.29-py38hf082f69_openmpi_5.tar.bz2
osx-64::mongodb-6.0.0-h207facf_0.tar.bz2
osx-64::libopencv-4.5.5-py39h6ed1040_10.tar.bz2
osx-64::libgdal-3.5.0-h13ce871_1.tar.bz2
osx-64::geant4-11.0.2-py39h8564560_0.tar.bz2
osx-64::libopencv-4.6.0-py38hb1cac05_0.tar.bz2
osx-64::arrow-cpp-3.0.0-py37h2905a43_54_cpu.tar.bz2
osx-64::gazebo-11.11.0-h047f548_1.tar.bz2
osx-64::vtk-9.1.0-qt_py37h1693e1f_211.tar.bz2
osx-64::ndcctools-7.4.7-py310h3114b78_0.tar.bz2
osx-64::cppyy-cling-6.27.0-py310h9ba57a8_0.tar.bz2
osx-64::topologytoolkit-1.0.0-no_paraview_py37h611e27c_104.tar.bz2
osx-64::libnetcdf-4.8.1-mpi_openmpi_h3354a58_3.tar.bz2
osx-64::openmeeg-2.4.7-py310h4d3c5e4_0.tar.bz2
osx-64::ffmpeg-4.4.1-h8454a6e_5.tar.bz2
osx-64::libgdal-3.5.0-h0a9d91c_3.tar.bz2
osx-64::vtk-9.1.0-qt_py37h15d47a3_210.tar.bz2
osx-64::openmeeg-2.4.2-py310h8221bc5_0.tar.bz2
osx-64::arrow-cpp-8.0.0-py39h7a817bb_4_cpu.tar.bz2
osx-64::llvmdev-14.0.5-h41df66c_0.tar.bz2
osx-64::arrow-cpp-8.0.0-py310h6846212_4_cpu.tar.bz2
osx-64::arrow-cpp-8.0.0-py38h2548bce_2_cpu.tar.bz2
osx-64::jaxlib-0.3.14-cpu_py38h59da463_3.tar.bz2
osx-64::grpc-cpp-1.45.2-hf4cdc08_4.tar.bz2
osx-64::ndcctools-7.4.6-py38hcac5eec_0.tar.bz2
osx-64::freecad-0.20.0-py37h805be43_0.tar.bz2
osx-64::libmediainfo-22.06-hc570d3c_0.tar.bz2
osx-64::arrow-cpp-8.0.1-py310h8d1dac6_0_cpu.tar.bz2
osx-64::ndcctools-7.4.9-py38hcac5eec_0.tar.bz2
osx-64::julia-1.7.3-hd571496_1.tar.bz2
osx-64::python-rocksdb-0.7.0-py38h5b5547e_6.tar.bz2
osx-64::librdkafka-1.9.1-hd1fd568_0.tar.bz2
osx-64::magics-metview-4.12.0-h5cb1739_3.tar.bz2
osx-64::topologytoolkit-1.0.0-with_paraview_py39h7a0765c_6.tar.bz2
osx-64::openmpi-4.1.3-h8589876_105.tar.bz2
osx-64::paraview-5.10.1-py37h10d1521_107_qt.tar.bz2
osx-64::paraview-5.10.1-py310h1d821bb_105_qt.tar.bz2
osx-64::geant4-11.0.2-py38h1f0edaf_0.tar.bz2
osx-64::arrow-cpp-8.0.1-py310h6846212_0_cpu.tar.bz2
osx-64::ldas-tools-framecpp-2.9.0-h4456899_0.tar.bz2
osx-64::git-2.37.1-pl5321h4c4e27f_0.tar.bz2
osx-64::verilator-4.222-h2292cb8_0.tar.bz2
osx-64::jaxlib-0.3.14-cpu_py37h24447ef_0.tar.bz2
osx-64::arrow-cpp-6.0.1-py39hee4d004_20_cpu.tar.bz2
osx-64::libgdal-3.5.0-he1bea4f_3.tar.bz2
osx-64::topologytoolkit-1.0.0-no_paraview_py310hf1c8e2a_107.tar.bz2
osx-64::arrow-cpp-8.0.0-py37hc8acea9_5_cpu.tar.bz2
osx-64::ffmpeg-5.0.1-gpl_h0bbc480_104.tar.bz2
osx-64::lammps-2021.09.29-py37h9e51265_mpich_5.tar.bz2
osx-64::triqs-3.1.1-py39hb3f2caa_1.tar.bz2
osx-64::rpm-tools-4.17.1-lua54h0b86cf6_0.tar.bz2
osx-64::libspatialite-5.0.1-hc4f8150_16.tar.bz2
osx-64::jaxlib-0.3.14-cpu_py39ha19811c_0.tar.bz2
osx-64::libgit2-1.4.4-hf44dd67_0.tar.bz2
osx-64::coin-or-clp-1.17.7-h947a6f2_1.tar.bz2
osx-64::ffmpeg-4.4.2-lgpl_h418d387_2.tar.bz2
osx-64::xrootd-5.4.3-py310h4a5d345_1.tar.bz2
osx-64::harp-1.15.1-py39r40h95401f7_1.tar.bz2
osx-64::librdkafka-1.9.1-h0e9ebe8_1.tar.bz2
osx-64::arrow-cpp-5.0.0-py39hee4d004_35_cpu.tar.bz2
osx-64::grpc-cpp-1.46.3-haf5484d_1.tar.bz2
osx-64::qt-main-5.15.4-h938c29d_0.tar.bz2
osx-64::nd2-0.2.5-py38h4586019_0.tar.bz2
osx-64::arrow-cpp-6.0.1-py310h060cdaa_20_cpu.tar.bz2
osx-64::xrootd-5.4.3-py37h10b0ff1_1.tar.bz2
osx-64::libglib-2.72.1-hfbcb929_0.tar.bz2
osx-64::libprotobuf-static-21.2-h2292cb8_0.tar.bz2
osx-64::arrow-cpp-8.0.0-py38h4076a70_2_cpu.tar.bz2
osx-64::postgresql-plpython-14.4-py39h36e506d_0.tar.bz2
osx-64::librdkafka-1.9.1-h0e9ebe8_0.tar.bz2
osx-64::lammps-2021.09.29-py37h39cad76_openmpi_4.tar.bz2
osx-64::arrow-cpp-8.0.0-py37hc8acea9_4_cpu.tar.bz2
osx-64::xrootd-5.4.3-py37h10b0ff1_0.tar.bz2
osx-64::xrootd-5.4.3-py38h71cc043_1.tar.bz2
osx-64::libopencv-4.6.0-py39h6ed1040_0.tar.bz2
osx-64::ndcctools-7.4.7-py39h4c84a47_0.tar.bz2
osx-64::hugin-base-2021.0.0-py37pl5321h86b4d04_6.tar.bz2
osx-64::jaxlib-0.3.14-cpu_py37h24447ef_1.tar.bz2
osx-64::capnproto-0.10.0-h40906a8_0.tar.bz2
osx-64::imagemagick-7.1.0_39-pl5321h1a6ef8d_0.tar.bz2
osx-64::lammps-2021.09.29-py38h4a5d01f_mpich_5.tar.bz2
osx-64::arrow-cpp-8.0.0-py38h751a74a_5_cpu.tar.bz2
osx-64::paraview-5.10.1-py37he396043_105_qt.tar.bz2
osx-64::magics-metview-4.12.0-h1029bc6_1.tar.bz2
osx-64::ndcctools-7.4.10-py38hcac5eec_1.tar.bz2
osx-64::openmeeg-2.4.2-py37hf5465f1_2.tar.bz2
osx-64::triqs-3.1.1-py39h6a46d9b_1.tar.bz2
osx-64::jaxlib-0.3.14-cpu_py39h797cc16_1.tar.bz2
osx-64::graphviz-5.0.0-ha5baa68_0.tar.bz2
osx-64::openmeeg-2.4.2-py39hc2f03f6_2.tar.bz2
osx-64::libtiledb-sql-0.15.1-hd314c81_0.tar.bz2
osx-64::coin-or-cgl-0.60.6-hd1832e5_1.tar.bz2
osx-64::imagecodecs-2022.7.27-py38h5e7db42_1.tar.bz2
osx-64::arrow-cpp-6.0.1-py37h2905a43_20_cpu.tar.bz2
osx-64::scip-8.0.1-hcfc4cfd_0.tar.bz2
osx-64::libopencv-4.6.0-py38h7876362_3.tar.bz2
osx-64::ndcctools-7.4.10-py38hf4dbdb2_0.tar.bz2
osx-64::pyreadstat-1.1.7-py39h26d836a_0.tar.bz2
osx-64::libxml2-2.9.14-h08a9926_2.tar.bz2
osx-64::smesh-9.8.0.2-hf066c19_1.tar.bz2
osx-64::topologytoolkit-1.1.0-no_paraview_py39h34a8614_100.tar.bz2
osx-64::topologytoolkit-1.1.0-no_paraview_py310hf1c8e2a_100.tar.bz2
osx-64::ndcctools-7.4.6-py39h4c84a47_0.tar.bz2
osx-64::grpc-cpp-1.45.2-h379cd86_4.tar.bz2
osx-64::openmeeg-2.4.2-py310h4d3c5e4_4.tar.bz2
osx-64::lammps-2021.09.29-py38hc2678fa_mpich_4.tar.bz2
osx-64::tiledb-2.10.0-hb1ce2c0_0.tar.bz2
osx-64::yarp-cxx-3.7.0-hd3b0b34_1.tar.bz2
osx-64::mongodb-5.3.2-h281f97d_0.tar.bz2
osx-64::hdf5-1.12.2-nompi_h1f71328_100.tar.bz2
osx-64::grpc-cpp-1.47.1-h0d31105_0.tar.bz2
osx-64::arrow-cpp-5.0.0-py37h9576b21_35_cpu.tar.bz2
osx-64::arrow-cpp-7.0.0-py37hd7410c4_8_cpu.tar.bz2
osx-64::libtiledb-sql-0.16.1-hd314c81_0.tar.bz2
osx-64::libopencv-4.5.5-py38hb1cac05_13.tar.bz2
osx-64::libspatialite-5.0.1-hdbf6ee6_18.tar.bz2
osx-64::arrow-cpp-3.0.0-py39hee4d004_54_cpu.tar.bz2
osx-64::paraview-5.10.1-py310ha8fd3bf_107_qt.tar.bz2
osx-64::ndcctools-7.4.8-py37haddda99_0.tar.bz2
osx-64::arrow-cpp-8.0.1-py38h751a74a_0_cpu.tar.bz2
osx-64::libmongoc-1.22.0-h9e5b77c_0.tar.bz2
osx-64::tiledb-2.9.4-hb1ce2c0_0.tar.bz2
osx-64::libopencv-4.5.5-py39h6ed1040_12.tar.bz2
osx-64::openmeeg-2.4.2-py38h3d5a339_4.tar.bz2
osx-64::libgdal-3.5.0-he601c66_2.tar.bz2
osx-64::arrow-cpp-7.0.0-py310hd2b853e_8_cpu.tar.bz2
osx-64::ffmpeg-5.0.1-lgpl_hb35dd3b_8.tar.bz2
osx-64::nodejs-18.3.0-haa867d2_0.tar.bz2
osx-64::cpp-opentelemetry-sdk-1.4.1-hd702da9_1.tar.bz2
osx-64::jaxlib-0.3.14-cpu_py38hf114e49_1.tar.bz2
osx-64::gazebo-11.11.0-h9de88cd_3.tar.bz2
osx-64::openmeeg-2.4.6-py310h4d3c5e4_0.tar.bz2
osx-64::harp-1.15.1-py38r41h616c10b_2.tar.bz2
osx-64::nodejs-18.5.0-haa867d2_0.tar.bz2
osx-64::harp-1.15.1-py38r41hac333f3_1.tar.bz2
osx-64::tomviz-1.10.0.post259-py37h5abe756_2.tar.bz2
osx-64::gdstk-0.8.3-py39h329cc2e_0.tar.bz2
osx-64::gazebo-11.11.0-hb1775de_1.tar.bz2
osx-64::ndcctools-7.4.6-py39h936c88a_0.tar.bz2
osx-64::openmeeg-2.4.7-py39h048cf10_0.tar.bz2
osx-64::xrootd-5.4.3-py39ha77102f_0.tar.bz2
osx-64::harp-1.15.1-py310r41h778f2a2_1.tar.bz2
osx-64::graphicsmagick-1.3.37-h14b4ad5_0.tar.bz2
osx-64::pillow-9.2.0-py310hb3240ae_0.tar.bz2
osx-64::libtiledb-sql-0.17.0-hd314c81_0.tar.bz2
osx-64::ndcctools-7.4.10-py39h936c88a_1.tar.bz2
osx-64::vowpalwabbit-9.2.0-py37h58e0897_0.tar.bz2
osx-64::triqs-3.1.1-py38h9f8a780_1.tar.bz2
osx-64::cpp-opentelemetry-sdk-1.4.1-hd702da9_3.tar.bz2
osx-64::postgresql-plpython-14.4-py310h6331131_0.tar.bz2
osx-64::jaxlib-0.3.14-cpu_py39h081fe41_3.tar.bz2
osx-64::arrow-cpp-8.0.0-py310ha2d0369_2_cpu.tar.bz2
osx-64::git-2.37.1-pl5321h7190d3f_0.tar.bz2
osx-64::openmeeg-2.4.2-py310h8221bc5_2.tar.bz2
osx-64::tensorflow-base-2.9.1-cpu_py310h157eb30_0.tar.bz2
osx-64::ndcctools-7.4.10-py38hf4dbdb2_1.tar.bz2
osx-64::lammps-2021.09.29-py37h761ec40_mpich_4.tar.bz2
osx-64::ovito-3.7.7-haeff761_0.tar.bz2
osx-64::libopencv-4.5.5-py39h08827a9_12.tar.bz2
osx-64::xrootd-5.4.3-py39h05797ea_1.tar.bz2
osx-64::libopencv-4.6.0-py38h129d1c4_3.tar.bz2
osx-64::ovito-3.7.7-haeff761_1.tar.bz2
osx-64::coda-2.24-py38h5dbed13_0.tar.bz2
osx-64::topologytoolkit-1.0.0-no_paraview_py37hfda8ea9_107.tar.bz2
osx-64::ffmpeg-5.0.1-gpl_h96dde7a_107.tar.bz2
osx-64::openmeeg-2.4.4-py38h1a7c08e_0.tar.bz2
osx-64::nd2-0.2.5-py39h79df2d4_0.tar.bz2
osx-64::astrometry-0.90-py310h88e4311_2.tar.bz2
osx-64::paraview-5.10.1-py310h34a187e_107_qt.tar.bz2
osx-64::topologytoolkit-1.0.0-with_paraview_py310h3dd7647_7.tar.bz2
osx-64::connectorx-0.3.0-py310h100fe93_1.tar.bz2
osx-64::pdal-2.4.1-h596ddcf_1.tar.bz2
osx-64::libopencv-4.5.5-py310h9d304e4_13.tar.bz2
osx-64::gazebo-11.11.0-hb2664c6_8.tar.bz2
osx-64::octave-7.2.0-h9b29aa9_0.tar.bz2
osx-64::ffmpeg-5.0.1-lgpl_h34cfc4d_6.tar.bz2
osx-64::imagemagick-7.1.0_41-pl5321h4335fd5_1.tar.bz2
osx-64::graphviz-3.0.0-ha5baa68_2.tar.bz2
osx-64::harp-1.15.1-py37r40h4e666a4_1.tar.bz2
osx-64::libgdal-3.5.0-h3a44f2c_5.tar.bz2
osx-64::capnproto-0.10.1-h40906a8_0.tar.bz2
osx-64::papilo-2.1.0-hed58181_1.tar.bz2
osx-64::topologytoolkit-1.0.0-no_paraview_py38h77ef75a_105.tar.bz2
osx-64::harp-1.15.1-py39r41h1da5fad_1.tar.bz2
osx-64::wasmer-2.3.0-h489082d_0.tar.bz2
osx-64::arrow-cpp-8.0.0-py310hf221cfc_3_cpu.tar.bz2
osx-64::nodejs-18.3.0-h0a5f95b_0.tar.bz2
osx-64::arrow-cpp-3.0.0-py37h9576b21_54_cpu.tar.bz2
osx-64::pillow-9.2.0-py38h21af888_0.tar.bz2
osx-64::libtiff-4.4.0-h9847915_1.tar.bz2
osx-64::readdy-2.0.12-py310hfc64f75_0.tar.bz2
osx-64::topologytoolkit-1.0.0-no_paraview_py310h189d49a_106.tar.bz2
osx-64::fenics-libdolfin-2019.1.0-h38b2049_30.tar.bz2
osx-64::libpng-1.6.37-h5a3d3bf_3.tar.bz2
osx-64::connectorx-0.3.0-py38he959c03_0.tar.bz2
osx-64::openmeeg-2.4.6-py37h2620256_0.tar.bz2
osx-64::ldas-tools-framecpp-2.9.0-hc4ca5b1_0.tar.bz2
osx-64::fenics-libdolfin-2019.1.0-hd8ce7f8_31.tar.bz2
osx-64::erlang-25.0.1-pl5321hbd0f5b5_0.tar.bz2
osx-64::arrow-cpp-7.0.0-py39h7f3cede_8_cpu.tar.bz2
osx-64::connectorx-0.3.0-py39h970db14_0.tar.bz2
osx-64::libzip-1.9.2-hab082e8_0.tar.bz2
osx-64::arrow-cpp-8.0.0-py39h2da71d5_2_cpu.tar.bz2
osx-64::jaxlib-0.3.14-cpu_py37h6b066c9_1.tar.bz2
osx-64::lammps-2021.09.29-py37h839fc57_mpich_5.tar.bz2
osx-64::r-vcfr-1.13.0-r40h3b3474e_0.tar.bz2
osx-64::jaxlib-0.3.14-cpu_py38hf114e49_0.tar.bz2
osx-64::astrometry-0.90-py38ha96221d_2.tar.bz2
osx-64::paraview-5.10.1-py37he396043_106_qt.tar.bz2
osx-64::mlir-14.0.3-h0f80edd_0.tar.bz2
osx-64::openconnect-9.01-hcd8cb70_2.tar.bz2
osx-64::erlang-25.0.2-pl5321hbd0f5b5_0.tar.bz2
osx-64::root_base-6.26.4-py310hff5c893_3.tar.bz2
osx-64::harp-1.15.1-py310r41h64be719_2.tar.bz2
osx-64::pyreadstat-1.1.9-py38h66216d4_0.tar.bz2
osx-64::xrootd-5.4.3-py38h4a303dc_0.tar.bz2
osx-64::libmatio-1.5.23-h9be9bca_1.tar.bz2
osx-64::grpc-cpp-1.47.0-h6f0e29b_1.tar.bz2
osx-64::tesseract-5.1.0-h1226324_0.tar.bz2
osx-64::ogre-next-2.3.0-hd51ceb8_1.tar.bz2
osx-64::julia-1.7.3-hd571496_0.tar.bz2
osx-64::openmeeg-2.4.2-py39hbc5d26d_1.tar.bz2
osx-64::octave-7.1.0-h59f3447_2.tar.bz2
osx-64::xrootd-5.4.3-py39h995a777_0.tar.bz2
osx-64::openmeeg-2.4.4-py37h2620256_0.tar.bz2
osx-64::netpbm-10.73.40-pl5321hff30709_0.tar.bz2
osx-64::python-3.10.5-hdaaf3db_0_cpython.tar.bz2
osx-64::rstudio-desktop-2022.02.3-r41h6e504f6_492.tar.bz2
osx-64::grpc-cpp-1.47.0-h39bda65_0.tar.bz2
osx-64::ndcctools-7.4.9-py39h936c88a_0.tar.bz2
-    "libzlib >=1.2.12,<1.3.0a0",
+    "libzlib >=1.2.12,<2.0.0a0",
osx-64::dotnet-sdk-6.0.301-h8daca28_0.tar.bz2
osx-64::exiv2-0.27.3-hecb95e5_3.tar.bz2
osx-64::libics-1.6.5-h2292cb8_0.tar.bz2
osx-64::cgns-4.3.0-ha4aa92f_1.tar.bz2
osx-64::libmlir-14.0.3-h0f80edd_0.tar.bz2
osx-64::dotnet-runtime-6.0.6-h8daca28_0.tar.bz2
osx-64::pocl-3.0-h5552be4_0.tar.bz2
osx-64::dotnet-sdk-3.1.420-h8daca28_0.tar.bz2
osx-64::coin-or-osi-0.108.7-h263dbfc_1.tar.bz2
osx-64::exiv2-0.27.5-hecb95e5_0.tar.bz2
osx-64::llvm-14.0.5-h9d075a6_0.tar.bz2
osx-64::spidermonkey-91.11.0-hb8cc226_0.tar.bz2
osx-64::llvm-tools-14.0.5-h41df66c_0.tar.bz2
osx-64::dotnet-runtime-3.1.25-h8daca28_0.tar.bz2
osx-64::exiv2-v0.27.3-hecb95e5_3.tar.bz2
osx-64::libmlir14-14.0.3-h0f80edd_0.tar.bz2
osx-64::pocl-3.0-h8b4fca9_0.tar.bz2
osx-64::glib-tools-2.72.1-h2292cb8_0.tar.bz2
osx-64::spidermonkey-91.12.0-hb8cc226_0.tar.bz2
osx-64::llvm-14.0.6-h9d075a6_0.tar.bz2
osx-64::dotnet-sdk-6.0.300-h8daca28_0.tar.bz2
osx-64::openjdk-17.0.3-h2292cb8_0.tar.bz2
osx-64::dotnet-runtime-6.0.5-h8daca28_0.tar.bz2
osx-64::spidermonkey-bin-91.11.0-h1154517_0.tar.bz2
osx-64::spidermonkey-bin-91.12.0-h1154517_0.tar.bz2
osx-64::dotnet-aspnetcore-3.1.26-h8daca28_0.tar.bz2
osx-64::openjdk-11.0.15-h2292cb8_0.tar.bz2
osx-64::dotnet-aspnetcore-3.1.25-h8daca28_0.tar.bz2
osx-64::openh264-2.2.0-h2292cb8_1.tar.bz2
osx-64::zimpl-3.5.2-hff3dd85_0.tar.bz2
osx-64::libllvm14-14.0.5-h41df66c_0.tar.bz2
osx-64::coin-or-utils-2.11.6-h4a88296_1.tar.bz2
osx-64::llvm-tools-14.0.6-h41df66c_0.tar.bz2
osx-64::dotnet-runtime-3.1.26-h8daca28_0.tar.bz2
osx-64::gst-plugins-good-1.20.2-h50d9aa0_2.tar.bz2
osx-64::libllvm14-14.0.6-h41df66c_0.tar.bz2
osx-64::gst-plugins-good-1.20.3-h50d9aa0_0.tar.bz2
osx-64::dotnet-aspnetcore-6.0.6-h8daca28_0.tar.bz2
osx-64::gst-plugins-base-1.20.2-hda0ba4b_2.tar.bz2
osx-64::dotnet-aspnetcore-6.0.5-h8daca28_0.tar.bz2
osx-64::openh264-2.2.0-h2292cb8_0.tar.bz2
osx-64::dotnet-sdk-3.1.419-h8daca28_0.tar.bz2
osx-64::gst-plugins-base-1.20.3-hda0ba4b_0.tar.bz2
osx-64::zimpl-3.5.2-hff3dd85_1.tar.bz2
-    "libzlib >=1.2.12,<1.3.0a0"
+    "libzlib >=1.2.12,<2.0.0a0"
osx-64::r-santoku-1.0.0-r42h25d921d_0.conda
-{
-  "build": "r42h25d921d_0",
-  "build_number": 0,
-  "depends": [
-    "__osx >=10.13",
-    "libcxx >=16",
-    "r-assertthat",
-    "r-base >=4.2,<4.3.0a0",
-    "r-glue",
-    "r-lifecycle",
-    "r-rcpp",
-    "r-rlang",
-    "r-vctrs"
-  ],
-  "license": "MIT",
-  "md5": "ed8e99c3eab4506d3b86e7218ebcf6a5",
-  "name": "r-santoku",
-  "sha256": "6f662014f2fed92e39c8c778f217d6ff17a57364385ebf31a1250a91e6fd4a34",
-  "size": 385455,
-  "subdir": "osx-64",
-  "timestamp": 1717557223513,
-  "version": "1.0.0"
-}
+{}
osx-64::r-santoku-1.0.0-r43h25d921d_0.conda
-{
-  "build": "r43h25d921d_0",
-  "build_number": 0,
-  "depends": [
-    "__osx >=10.13",
-    "libcxx >=16",
-    "r-assertthat",
-    "r-base >=4.3,<4.4.0a0",
-    "r-glue",
-    "r-lifecycle",
-    "r-rcpp",
-    "r-rlang",
-    "r-vctrs"
-  ],
-  "license": "MIT",
-  "md5": "d553e3a78089f5767e8d55b41750e44e",
-  "name": "r-santoku",
-  "sha256": "e3d4308d8a42f4d2cc914f55bdb953c184d0b50a24c094e569e1e53250b10155",
-  "size": 385710,
-  "subdir": "osx-64",
-  "timestamp": 1717557168508,
-  "version": "1.0.0"
-}
+{}
================================================================================
================================================================================
linux-64
linux-64::astrometry-0.90-py39hd54e90f_2.tar.bz2
linux-64::pdal-2.4.1-he35911a_2.tar.bz2
linux-64::cppyy-cling-6.27.0-py310hd64a29c_0.tar.bz2
linux-64::dotnet-runtime-6.0.6-h751d214_0.tar.bz2
linux-64::arrow-cpp-6.0.1-py38h91fe7ba_20_cpu.tar.bz2
linux-64::lammps-2021.09.29-py37h7a1a7bf_mpich_5.tar.bz2
linux-64::libgdal-3.5.0-hd131f80_2.tar.bz2
linux-64::libopencv-4.6.0-py38hcc5f2f6_1.tar.bz2
linux-64::libgit2-1.5.0-h6529ace_0.tar.bz2
linux-64::python-rocksdb-0.7.0-py38h92e01d7_6.tar.bz2
linux-64::arrow-cpp-8.0.0-py37ha08e9a0_2_cuda.tar.bz2
linux-64::triqs-3.1.1-py310hdfe8425_0.tar.bz2
linux-64::postgresql-plpython-14.4-py310h8a5a08d_0.tar.bz2
linux-64::xrootd-5.4.3-py310hf716355_1.tar.bz2
linux-64::gdstk-0.8.3-py310h1b6b022_0.tar.bz2
linux-64::hugin-2021.0.0-pl5321h7f7609f_6.tar.bz2
linux-64::harp-1.15.1-py37r40hcb5871f_1.tar.bz2
linux-64::postgresql-plpython-14.4-py38he5fc2dc_0.tar.bz2
linux-64::jaxlib-0.3.14-cuda112py310h637716b_0.tar.bz2
linux-64::octave-7.1.0-h920c6b5_1.tar.bz2
linux-64::libmongoc-1.21.2-h0506597_0.tar.bz2
linux-64::libopencv-4.5.5-py37h4a49c2f_11.tar.bz2
linux-64::vtk-9.1.0-osmesa_py37h29869c8_109.tar.bz2
linux-64::ndcctools-7.4.6-py38h1aa6533_0.tar.bz2
linux-64::yarp-cxx-3.7.1-hfee3fe3_0.tar.bz2
linux-64::vowpalwabbit-9.2.0-py37h9adbab3_0.tar.bz2
linux-64::arrow-cpp-6.0.1-py37h846d386_20_cuda.tar.bz2
linux-64::pyreadstat-1.1.9-py38he5536e0_0.tar.bz2
linux-64::magics-metview-4.12.0-hd8afd86_1.tar.bz2
linux-64::libopencv-4.5.5-py310hcb97b83_11.tar.bz2
linux-64::nd2-0.2.5-py37h1425b33_0.tar.bz2
linux-64::vtk-9.1.0-qt_py38hdc146df_210.tar.bz2
linux-64::vowpalwabbit-9.2.0-py37h22dc011_0.tar.bz2
linux-64::hugin-base-2021.0.0-py37pl5321h110199d_6.tar.bz2
linux-64::paraview-5.10.1-py310h8b3e420_7_egl.tar.bz2
linux-64::ndcctools-7.4.10-py310h5deebde_1.tar.bz2
linux-64::openmeeg-2.4.7-py37h43168b8_0.tar.bz2
linux-64::arrow-cpp-8.0.0-py37h81c5bf6_5_cpu.tar.bz2
linux-64::coda-2.24-py38hb673e2a_1.tar.bz2
linux-64::dotnet-sdk-5.0.408-h751d214_0.tar.bz2
linux-64::gmt-6.3.0-he424f55_6.tar.bz2
linux-64::vtk-9.1.0-qt_py38h3d30439_211.tar.bz2
linux-64::arrow-cpp-7.0.0-py310hb9c72a6_8_cuda.tar.bz2
linux-64::arrow-cpp-7.0.0-py37he618775_8_cuda.tar.bz2
linux-64::libopencv-4.5.5-py310hcb97b83_12.tar.bz2
linux-64::cppyy-cling-6.27.0-py39h3d66fe8_0.tar.bz2
linux-64::mapserver-7.6.4-py39h6ed9385_10.tar.bz2
linux-64::arrow-cpp-6.0.1-py38h97bb493_20_cuda.tar.bz2
linux-64::arrow-cpp-3.0.0-py39h461039b_54_cpu.tar.bz2
linux-64::librdkafka-1.9.0-h35f46da_0.tar.bz2
linux-64::openmeeg-2.4.6-py39hf1d92c7_0.tar.bz2
linux-64::jaxlib-0.3.14-cpu_py310h0f9bb56_0.tar.bz2
linux-64::ndcctools-7.4.10-py37hecb152a_1.tar.bz2
linux-64::topologytoolkit-1.0.0-with_paraview_py39h0e04872_6.tar.bz2
linux-64::mongodb-5.3.2-h0a4f5e4_0.tar.bz2
linux-64::ffmpeg-5.0.1-lgpl_h46cd745_4.tar.bz2
linux-64::vtk-9.1.0-qt_py37h0cfe764_212.tar.bz2
linux-64::ndcctools-7.4.9-py39hbe13330_0.tar.bz2
linux-64::harp-1.15.1-py310r40h2b6cc9b_1.tar.bz2
linux-64::libtiff-4.4.0-hc85c160_1.tar.bz2
linux-64::yoda-1.9.6-py38hf06b66b_0.tar.bz2
linux-64::rpm-tools-4.17.1-py39lua54h7f235df_0.tar.bz2
linux-64::mapserver-7.6.4-py38hd41210b_9.tar.bz2
linux-64::libtensorflow-2.9.1-cuda111h7ff4470_0.tar.bz2
linux-64::coin-or-cgl-0.60.6-h6f57e76_1.tar.bz2
linux-64::libopencv-4.5.5-py39hd011c1b_11.tar.bz2
linux-64::harp-1.15.1-py38r41h234bf9d_1.tar.bz2
linux-64::arrow-cpp-7.0.0-py310h1f609fe_8_cuda.tar.bz2
linux-64::jaxlib-0.3.14-cuda112py38h6e6c269_0.tar.bz2
linux-64::geant4-11.0.2-py310he4e8f5b_1.tar.bz2
linux-64::jaxlib-0.3.14-cpu_py37ha701b26_0.tar.bz2
linux-64::lammps-2021.09.29-py37h6ea83e3_mpich_5.tar.bz2
linux-64::geant4-11.0.2-py37h43c807b_1.tar.bz2
linux-64::topologytoolkit-1.1.0-with_paraview_py39h21d363e_0.tar.bz2
linux-64::arrow-cpp-8.0.0-py38h3ad7428_2_cpu.tar.bz2
linux-64::wasmer-2.3.0-h542c21f_0.tar.bz2
linux-64::nco-5.1.0-h81bb2a3_1.tar.bz2
linux-64::lyx-2.3.6.1-py310hc35973f_4.tar.bz2
linux-64::pdal-2.4.2-hf59c231_3.tar.bz2
linux-64::ncl-6.6.2-hfc90af8_40.tar.bz2
linux-64::paraview-5.10.1-py37h0a14479_106_qt.tar.bz2
linux-64::triqs-3.1.1-py38h569377a_1.tar.bz2
linux-64::cppyy-cling-6.27.0-py38h2a4c724_0.tar.bz2
linux-64::mongodb-5.2.0-h0e13805_0.tar.bz2
linux-64::libprotobuf-static-21.3-h6239696_0.tar.bz2
linux-64::nd2-0.3.0-py39h155c9d3_0.tar.bz2
linux-64::r-vcfr-1.13.0-r41h690469d_0.tar.bz2
linux-64::jaxlib-0.3.14-cuda112py37h4498987_1.tar.bz2
linux-64::arrow-cpp-8.0.0-py38ha7276ea_4_cpu.tar.bz2
linux-64::arrow-cpp-8.0.1-py39h2f48f8a_0_cuda.tar.bz2
linux-64::arrow-cpp-8.0.1-py37hd9ae0f0_0_cuda.tar.bz2
linux-64::tiledb-2.9.4-h1e4a385_0.tar.bz2
linux-64::libopencv-4.6.0-py38h2a2a1be_3.tar.bz2
linux-64::pillow-9.2.0-py38h0ee0e06_0.tar.bz2
linux-64::ldas-tools-framecpp-2.9.1-hdf7349a_0.tar.bz2
linux-64::libopencv-4.6.0-py39ha3d0060_0.tar.bz2
linux-64::lmod-8.7.5-lua54h71fc533_0.tar.bz2
linux-64::jaxlib-0.3.14-cpu_py37h115581e_1.tar.bz2
linux-64::postgresql-14.4-ha7cec9f_0.tar.bz2
linux-64::tensorflow-base-2.9.1-cuda111py39hc0859d9_0.tar.bz2
linux-64::libopencv-4.6.0-py37h4a49c2f_0.tar.bz2
linux-64::openmeeg-2.4.2-py310hae38141_4.tar.bz2
linux-64::gdstk-0.8.3-py39hac9c483_0.tar.bz2
linux-64::heavydb-6.1.0-h1234567_0_cuda.tar.bz2
linux-64::arrow-cpp-8.0.0-py39h0f417f0_3_cuda.tar.bz2
linux-64::topologytoolkit-1.0.0-no_paraview_py38ha4a19b8_104.tar.bz2
linux-64::triqs-3.1.1-py38he59ff7d_0.tar.bz2
linux-64::capnproto-0.10.1-h6239696_0.tar.bz2
linux-64::openjdk-11.0.15-hc6918da_0.tar.bz2
linux-64::xrootd-5.4.3-py39hc7bb5bc_0.tar.bz2
linux-64::ndcctools-7.4.6-py39hbe13330_0.tar.bz2
linux-64::xrootd-5.4.3-py310he953489_1.tar.bz2
linux-64::poppler-22.04.0-h1434ded_1.tar.bz2
linux-64::geant4-11.0.2-py310he864562_0.tar.bz2
linux-64::libopencv-4.6.0-py38h3504efa_3.tar.bz2
linux-64::jaxlib-0.3.14-cpu_py38heba6e0f_0.tar.bz2
linux-64::arrow-cpp-8.0.0-py310h78b1107_2_cpu.tar.bz2
linux-64::nd2-0.2.5-py310h062fc0b_0.tar.bz2
linux-64::arrow-cpp-6.0.1-py37h7ae9e3b_20_cpu.tar.bz2
linux-64::gemmi-0.5.5-py38h38d86a4_0.tar.bz2
linux-64::createrepo_c-0.20.1-py38h9030dcd_0.tar.bz2
linux-64::libtiledb-sql-0.16.0-h0993566_0.tar.bz2
linux-64::tensorflow-base-2.9.1-cuda110py310h31c0a5d_0.tar.bz2
linux-64::libmongoc-1.21.2-h15e390e_0.tar.bz2
linux-64::connectorx-0.3.0-py37h13c547b_1.tar.bz2
linux-64::libnetcdf-4.8.1-nompi_h21705cb_103.tar.bz2
linux-64::cpp-opentelemetry-sdk-1.4.1-hb354d1b_4.tar.bz2
linux-64::vtk-9.1.0-qt_py37h045eca2_209.tar.bz2
linux-64::ogre-next-2.3.0-hd9d6a18_0.tar.bz2
linux-64::gfal2-2.21.0-h1edf11a_0.tar.bz2
linux-64::triqs-3.1.1-py310h9130fde_1.tar.bz2
linux-64::lammps-2021.09.29-py39h8d583fb_mpich_4.tar.bz2
linux-64::libopencv-4.6.0-py38hcc5f2f6_0.tar.bz2
linux-64::ovito-3.7.7-h21620c5_1.tar.bz2
linux-64::yarp-cxx-3.7.2-hfee3fe3_0.tar.bz2
linux-64::mongodb-5.3.2-h0e13805_0.tar.bz2
linux-64::pypy3.8-7.3.9-h5001382_3.tar.bz2
linux-64::vigra-1.11.1-py37h6492f6a_1033.tar.bz2
linux-64::arrow-cpp-6.0.1-py39h461039b_20_cpu.tar.bz2
linux-64::arrow-cpp-6.0.1-py39hf56cb2e_20_cuda.tar.bz2
linux-64::libgdal-3.5.1-h0c20829_1.tar.bz2
linux-64::yarp-cxx-3.7.0-h6301288_0.tar.bz2
linux-64::arrow-cpp-8.0.0-py37hd9ae0f0_4_cuda.tar.bz2
linux-64::paraview-5.10.1-py38h07e563c_7_egl.tar.bz2
linux-64::jaxlib-0.3.14-cpu_py39h320bf12_1.tar.bz2
linux-64::openmeeg-2.4.2-py310hf8ee683_2.tar.bz2
linux-64::pyreadstat-1.1.9-py39hd08d98e_0.tar.bz2
linux-64::vtk-9.1.0-egl_py39h8b8423f_10.tar.bz2
linux-64::pdal-2.4.2-h68a0bdf_1.tar.bz2
linux-64::arrow-cpp-3.0.0-py310he6da3e4_54_cpu.tar.bz2
linux-64::jaxlib-0.3.14-cuda112py39h4d6bb82_1.tar.bz2
linux-64::arrow-cpp-8.0.1-py310h025e8b3_0_cuda.tar.bz2
linux-64::imagemagick-7.1.0_44-pl5321h2098167_0.tar.bz2
linux-64::ldas-tools-framecpp-2.9.1-hf5a2e36_0.tar.bz2
linux-64::jaxlib-0.3.14-cuda112py38h8754b44_203.tar.bz2
linux-64::harp-1.15.1-py38r40hb673e2a_2.tar.bz2
linux-64::readdy-2.0.12-py39h8d5ab89_0.tar.bz2
linux-64::jaxlib-0.3.14-cpu_py310heb27631_0.tar.bz2
linux-64::paraview-5.10.1-py39h6852f71_7_egl.tar.bz2
linux-64::glib-2.72.1-h6239696_0.tar.bz2
linux-64::papilo-2.1.0-hc9d876a_1.tar.bz2
linux-64::libxml2-2.9.14-h22db469_1.tar.bz2
linux-64::triqs-3.1.1-py37h3bb641e_0.tar.bz2
linux-64::arrow-cpp-8.0.0-py37hcc8ad85_2_cpu.tar.bz2
linux-64::libopencv-4.6.0-py37hdd4fae6_2.tar.bz2
linux-64::topologytoolkit-1.0.0-with_paraview_py38h2f62d9a_4.tar.bz2
linux-64::jaxlib-0.3.14-cpu_py310h0f9bb56_1.tar.bz2
linux-64::ndcctools-7.4.10-py37h8b51a51_1.tar.bz2
linux-64::jaxlib-0.3.14-cuda112py37h964a14d_0.tar.bz2
linux-64::arrow-cpp-8.0.0-py38h8abf307_4_cuda.tar.bz2
linux-64::jaxlib-0.3.14-cuda112py37heb223d1_203.tar.bz2
linux-64::arrow-cpp-8.0.0-py39h2531139_4_cpu.tar.bz2
linux-64::postgresql-14.4-hfdbbde3_0.tar.bz2
linux-64::libspatialite-5.0.1-h38b5f51_18.tar.bz2
linux-64::yoda-1.9.6-py37h3bd29a6_0.tar.bz2
linux-64::erlang-25.0.2-pl5321h5001644_0.tar.bz2
linux-64::cpp-opentelemetry-sdk-1.4.1-hb354d1b_3.tar.bz2
linux-64::dotnet-aspnetcore-3.1.26-h751d214_0.tar.bz2
linux-64::xrootd-5.4.3-py39hc7bb5bc_1.tar.bz2
linux-64::libopencv-4.5.5-py39ha3d0060_12.tar.bz2
linux-64::yoda-1.9.6-py310h2c11959_0.tar.bz2
linux-64::clangdev-14.0.6-default_h2e3cab8_0.tar.bz2
linux-64::vtk-9.1.0-egl_py310ha29738a_11.tar.bz2
linux-64::pyreadstat-1.1.7-py37h7faf3f8_0.tar.bz2
linux-64::openmeeg-2.4.2-py39h2ca0e0f_3.tar.bz2
linux-64::jaxlib-0.3.14-cpu_py39h79d7c74_1.tar.bz2
linux-64::arrow-cpp-8.0.0-py39h2f48f8a_4_cuda.tar.bz2
linux-64::connectorx-0.3.0-py39h87ee89f_1.tar.bz2
linux-64::libmatio-1.5.23-h63e3022_1.tar.bz2
linux-64::yoda-1.9.5-py39hd1fba03_1.tar.bz2
linux-64::triqs-3.1.1-py37hb05999a_1.tar.bz2
linux-64::rpm-tools-4.17.1-py37lua54h778795a_0.tar.bz2
linux-64::openmeeg-2.4.7-py38h3a1a314_0.tar.bz2
linux-64::tiledb-2.9.5-h3f4058f_0.tar.bz2
linux-64::jaxlib-0.3.14-cuda112py38h6e6c269_1.tar.bz2
linux-64::ldas-tools-framecpp-2.9.0-hf5a2e36_0.tar.bz2
linux-64::arrow-cpp-5.0.0-py39h5dd0ea6_35_cpu.tar.bz2
linux-64::vtk-9.1.0-osmesa_py38h17bbde3_111.tar.bz2
linux-64::nodejs-18.3.0-h96d913c_0.tar.bz2
linux-64::createrepo_c-0.20.1-py38hcb80abe_0.tar.bz2
linux-64::hdf5-1.12.2-nompi_h2386368_100.tar.bz2
linux-64::ndcctools-7.4.6-py37h8b51a51_0.tar.bz2
linux-64::arrow-cpp-8.0.0-py37ha0737cd_3_cpu.tar.bz2
linux-64::graphviz-4.0.0-h5abf519_1.tar.bz2
linux-64::arrow-cpp-8.0.0-py310h47fda4d_5_cuda.tar.bz2
linux-64::ndcctools-7.4.10-py310ha616101_0.tar.bz2
linux-64::nodejs-18.5.0-h8839609_0.tar.bz2
linux-64::jaxlib-0.3.14-cpu_py38h3c20414_0.tar.bz2
linux-64::mlir-14.0.5-he0ac6c6_0.tar.bz2
linux-64::readdy-2.0.12-py37haad0c6c_0.tar.bz2
linux-64::dotnet-runtime-3.1.25-h751d214_0.tar.bz2
linux-64::vtk-9.1.0-osmesa_py37h55b34c0_110.tar.bz2
linux-64::libopencv-4.6.0-py310hcb97b83_0.tar.bz2
linux-64::cpp-opentelemetry-sdk-1.4.1-hb354d1b_2.tar.bz2
linux-64::jaxlib-0.3.14-cpu_py38h95f6c42_1.tar.bz2
linux-64::grpc-cpp-1.47.0-hbd84cd8_1.tar.bz2
linux-64::git-annex-10.20220624-alldep_hc98582e_100.tar.bz2
linux-64::paraview-5.10.1-py38h955742f_6_egl.tar.bz2
linux-64::ffmpeg-5.1.0-gpl_h2b602b6_100.tar.bz2
linux-64::arrow-cpp-8.0.0-py37he618775_3_cuda.tar.bz2
linux-64::triqs-3.1.1-py39h13edd48_1.tar.bz2
linux-64::paraview-5.10.1-py37h08f2f7e_6_egl.tar.bz2
linux-64::arrow-cpp-6.0.1-py37h41c12fa_20_cpu.tar.bz2
linux-64::harp-1.15.1-py39r40h665c6b1_1.tar.bz2
linux-64::ffmpeg-5.0.1-gpl_h8733cef_106.tar.bz2
linux-64::mongodb-5.2.0-h0a4f5e4_0.tar.bz2
linux-64::coda-2.24-py37hc69f9df_1.tar.bz2
linux-64::jaxlib-0.3.14-cpu_py37h85ad4aa_3.tar.bz2
linux-64::ffmpeg-4.4.2-gpl_ha70255f_101.tar.bz2
linux-64::imagecodecs-2022.2.22-py39hfcd4fa2_6.tar.bz2
linux-64::vtk-9.1.0-osmesa_py37h0d3fb4b_111.tar.bz2
linux-64::tensorflow-base-2.9.1-cpu_py37hb97876d_0.tar.bz2
linux-64::geant4-11.0.2-py39h79c2f6a_1.tar.bz2
linux-64::libopencv-4.6.0-py39hd011c1b_0.tar.bz2
linux-64::libnetcdf-4.8.1-mpi_openmpi_h1cecd2a_3.tar.bz2
linux-64::nodejs-18.3.0-h8839609_0.tar.bz2
linux-64::lammps-2021.09.29-py37h6e29b28_mpich_4.tar.bz2
linux-64::arrow-cpp-7.0.0-py38hd8d37cc_8_cpu.tar.bz2
linux-64::ndcctools-7.4.10-py39h084f619_1.tar.bz2
linux-64::arrow-cpp-5.0.0-py37h7ae9e3b_35_cpu.tar.bz2
linux-64::triqs-3.1.1-py39h214adfa_0.tar.bz2
linux-64::openconnect-9.01-hd38230a_2.tar.bz2
linux-64::jaxlib-0.3.14-cuda112py310hc9977b2_1.tar.bz2
linux-64::pyreadstat-1.1.7-py37he2f7bc2_0.tar.bz2
linux-64::pyreadstat-1.1.9-py37h7faf3f8_0.tar.bz2
linux-64::arrow-cpp-3.0.0-py39hf56cb2e_54_cuda.tar.bz2
linux-64::nodejs-18.7.0-h8839609_0.tar.bz2
linux-64::paraview-5.10.1-py38ha2429de_107_qt.tar.bz2
linux-64::gdstk-0.8.3-py39h31e9908_0.tar.bz2
linux-64::openmeeg-2.4.2-py39hf74c8ea_4.tar.bz2
linux-64::rust-1.62.0-h30be4a0_0.tar.bz2
linux-64::libtiledb-sql-0.16.1-h204bf05_0.tar.bz2
linux-64::pdal-2.4.1-h47bd493_1.tar.bz2
linux-64::arrow-cpp-7.0.0-py39h0f417f0_8_cuda.tar.bz2
linux-64::libgdal-3.5.1-h32640fd_0.tar.bz2
linux-64::mapserver-7.6.4-py37hffaef0e_9.tar.bz2
linux-64::lmod-8.7.4-lua54h71fc533_0.tar.bz2
linux-64::arrow-cpp-3.0.0-py37h7ae9e3b_54_cpu.tar.bz2
linux-64::topologytoolkit-1.1.0-with_paraview_py37h3242364_0.tar.bz2
linux-64::nd2-0.3.0-py38h28b09c2_0.tar.bz2
linux-64::ndcctools-7.4.7-py310h5deebde_0.tar.bz2
linux-64::cppyy-cling-6.27.0-py38h8225899_0.tar.bz2
linux-64::pdal-2.4.1-h68a0bdf_2.tar.bz2
linux-64::mapserver-7.6.4-py310hf5bd655_10.tar.bz2
linux-64::ttyd-1.6.3-hc5eb070_2.tar.bz2
linux-64::imagecodecs-2022.7.27-py310h2708a72_1.tar.bz2
linux-64::mapserver-7.6.4-py38h1778987_10.tar.bz2
linux-64::jaxlib-0.3.14-cpu_py310hacd7525_1.tar.bz2
linux-64::ipe-7.2.24-lua54h69b3f0b_7.tar.bz2
linux-64::vtk-9.1.0-qt_py39he4fa311_210.tar.bz2
linux-64::arrow-cpp-8.0.0-py37h1277737_4_cpu.tar.bz2
linux-64::arrow-cpp-8.0.1-py39h2531139_0_cpu.tar.bz2
linux-64::dotnet-aspnetcore-3.1.25-h751d214_0.tar.bz2
linux-64::lammps-2021.09.29-py37hddd25e3_openmpi_5.tar.bz2
linux-64::mapserver-7.6.4-py39h5054734_8.tar.bz2
linux-64::mongodb-5.3.2-h6f82f1e_0.tar.bz2
linux-64::jaxlib-0.3.14-cpu_py310heb27631_1.tar.bz2
linux-64::triqs-3.1.1-py39h70b405f_1.tar.bz2
linux-64::ndcctools-7.4.7-py38h1aa6533_0.tar.bz2
linux-64::libsoup-2.74.2-h5aab1f2_0.tar.bz2
linux-64::lammps-2021.09.29-py39h2f3b62e_openmpi_5.tar.bz2
linux-64::arrow-cpp-8.0.0-py37h6c59e74_2_cpu.tar.bz2
linux-64::libgdal-3.5.0-h31d7bda_3.tar.bz2
linux-64::magics-metview-4.12.0-hd8afd86_2.tar.bz2
linux-64::topologytoolkit-1.0.0-with_paraview_py37hb045075_5.tar.bz2
linux-64::pdal-2.4.2-he35911a_2.tar.bz2
linux-64::libgsf-1.14.50-he99f2b3_0.tar.bz2
linux-64::grpc-cpp-1.47.0-hc275302_0.tar.bz2
linux-64::paraview-5.10.1-py38ha58563f_7_egl.tar.bz2
linux-64::jaxlib-0.3.14-cuda112py37h13d6ec4_0.tar.bz2
linux-64::libgdal-3.5.1-hd6149ef_2.tar.bz2
linux-64::openmpi-4.1.3-ha1ae619_105.tar.bz2
linux-64::jaxlib-0.3.14-cpu_py310h0283394_0.tar.bz2
linux-64::pyreadstat-1.1.9-py37he2f7bc2_0.tar.bz2
linux-64::hugin-base-2021.0.0-py310pl5321hc7f0858_6.tar.bz2
linux-64::vtk-9.1.0-osmesa_py310h7f05e95_111.tar.bz2
linux-64::arrow-cpp-8.0.1-py37h1277737_0_cpu.tar.bz2
linux-64::paraview-5.10.1-py38ha84b46e_7_egl.tar.bz2
linux-64::libgdal-3.5.0-hd0aedcd_1.tar.bz2
linux-64::grpc-cpp-1.47.1-hbd84cd8_0.tar.bz2
linux-64::openmeeg-2.4.2-py310hf8ee683_0.tar.bz2
linux-64::harp-1.15.1-py38r41hb673e2a_2.tar.bz2
linux-64::libxml2-2.9.14-h22db469_3.tar.bz2
linux-64::paraview-5.10.1-py38h955742f_5_egl.tar.bz2
linux-64::r-rmatio-0.16.0-r40h06615bd_0.tar.bz2
linux-64::createrepo_c-0.20.1-py39h3c599e5_0.tar.bz2
linux-64::arrow-cpp-7.0.0-py39h3f731f7_8_cpu.tar.bz2
linux-64::openmeeg-2.4.7-py310hae38141_0.tar.bz2
linux-64::openmeeg-2.4.2-py38hdd05e23_4.tar.bz2
linux-64::libtiledb-sql-0.15.1-h204bf05_0.tar.bz2
linux-64::yarp-cxx-3.7.0-hfee3fe3_2.tar.bz2
linux-64::ldas-tools-framecpp-2.9.0-hdf7349a_0.tar.bz2
linux-64::openmeeg-2.4.4-py38hdd05e23_0.tar.bz2
linux-64::mapserver-7.6.4-py37he52bdc3_8.tar.bz2
linux-64::dotnet-aspnetcore-6.0.6-h751d214_0.tar.bz2
linux-64::lammps-2021.09.29-py37h27773f8_openmpi_5.tar.bz2
linux-64::git-2.37.1-pl5321h04cb727_0.tar.bz2
linux-64::mongodb-6.0.0-h6f82f1e_0.tar.bz2
linux-64::ndcctools-7.4.10-py38h782bae8_1.tar.bz2
linux-64::ndcctools-7.4.7-py310ha616101_0.tar.bz2
linux-64::openmeeg-2.4.6-py310hae38141_0.tar.bz2
linux-64::readdy-2.0.12-py38hb764eaf_0.tar.bz2
linux-64::jaxlib-0.3.14-cuda112py39h2d0c158_1.tar.bz2
linux-64::ffmpeg-4.4.2-gpl_ha70255f_102.tar.bz2
linux-64::ogre-next-2.3.1-hd9d6a18_1.tar.bz2
linux-64::vtk-9.1.0-osmesa_py310h9b2d59d_109.tar.bz2
linux-64::libgit2-1.4.4-h6529ace_0.tar.bz2
linux-64::mapserver-7.6.4-py37h0c1be87_7.tar.bz2
linux-64::gmt-5.4.5-h328af0a_21.tar.bz2
linux-64::ndcctools-7.4.8-py37h8b51a51_0.tar.bz2
linux-64::libtensorflow-2.9.1-cuda102he204bbd_0.tar.bz2
linux-64::jaxlib-0.3.14-cuda112py37had983bc_0.tar.bz2
linux-64::tiledb-2.10.1-h3f4058f_0.tar.bz2
linux-64::tiledb-2.9.3-h1e4a385_0.tar.bz2
linux-64::ndcctools-7.4.7-py37hecb152a_0.tar.bz2
linux-64::lammps-2021.09.29-py37h73adce4_openmpi_4.tar.bz2
linux-64::orc-1.7.5-h6c59b99_0.tar.bz2
linux-64::lammps-2021.09.29-py310h392c10f_openmpi_5.tar.bz2
linux-64::erlang-25.0.2-pl5321hb9e9383_0.tar.bz2
linux-64::arrow-cpp-3.0.0-py38h97bb493_54_cuda.tar.bz2
linux-64::libopencv-4.6.0-py310hcb97b83_1.tar.bz2
linux-64::ffmpeg-5.0.1-lgpl_he28c0fb_8.tar.bz2
linux-64::openmeeg-2.4.2-py38hc755a88_0.tar.bz2
linux-64::vigra-1.11.1-py310hf6240fa_1033.tar.bz2
linux-64::rpm-tools-4.17.1-py37lua54h8725385_0.tar.bz2
linux-64::rpm-tools-4.17.1-py310lua54hdd49c18_0.tar.bz2
linux-64::librdkafka-1.9.1-ha384dbd_0.tar.bz2
linux-64::lmod-8.7.6-lua54h71fc533_0.tar.bz2
linux-64::vtk-9.1.0-egl_py38hf444112_12.tar.bz2
linux-64::createrepo_c-0.20.1-py37h0332789_0.tar.bz2
linux-64::wxwidgets-3.1.7-h645ee20_0.tar.bz2
linux-64::arrow-cpp-6.0.1-py38h4dc91b6_20_cuda.tar.bz2
linux-64::sdl2_image-2.6.0-hf8d5f1c_0.tar.bz2
linux-64::paraview-5.10.1-py37h08f2f7e_5_egl.tar.bz2
linux-64::openmeeg-2.4.7-py38hdd05e23_0.tar.bz2
linux-64::openbabel-3.1.1-py39h71cce9b_4.tar.bz2
linux-64::octave-7.2.0-h3839a39_0.tar.bz2
linux-64::paraview-5.10.1-py38h6d50a87_105_qt.tar.bz2
linux-64::jaxlib-0.3.14-cpu_py38ha013065_3.tar.bz2
linux-64::triqs-3.1.1-py310h663fc7b_1.tar.bz2
linux-64::scip-8.0.1-h920c4ec_0.tar.bz2
linux-64::arrow-cpp-8.0.0-py39h811ffd7_5_cpu.tar.bz2
linux-64::libtensorflow-2.9.1-cuda112h02da4e0_0.tar.bz2
linux-64::rstudio-desktop-2022.02.3-r41h2a89545_493.tar.bz2
linux-64::clangdev-14.0.5-default_h2e3cab8_0.tar.bz2
linux-64::tiledb-2.10.0-h1e4a385_0.tar.bz2
linux-64::nodejs-18.6.0-h96d913c_0.tar.bz2
linux-64::ffmpeg-4.4.2-lgpl_hd24bc48_4.tar.bz2
linux-64::paraview-5.10.1-py310h990bd95_7_egl.tar.bz2
linux-64::paraview-5.10.1-py310h9a76674_5_egl.tar.bz2
linux-64::arrow-cpp-8.0.1-py310h47fda4d_0_cuda.tar.bz2
linux-64::topologytoolkit-1.0.0-no_paraview_py38h3b9b033_106.tar.bz2
linux-64::tomviz-1.10.0.post249-py37h3444f97_2.tar.bz2
linux-64::hugin-base-2021.0.0-py38pl5321h28aceeb_6.tar.bz2
linux-64::paraview-5.10.1-py38h20aba1e_107_qt.tar.bz2
linux-64::python-rocksdb-0.7.0-py38hfd94845_6.tar.bz2
linux-64::arrow-cpp-6.0.1-py310h3a96f94_20_cuda.tar.bz2
linux-64::harp-1.15.1-py38r41h378a090_1.tar.bz2
linux-64::openmeeg-2.4.6-py38h3a1a314_0.tar.bz2
linux-64::quazip-1.3-hd88dc07_1.tar.bz2
linux-64::arrow-cpp-8.0.0-py39h0ae2fab_2_cuda.tar.bz2
linux-64::mongodb-6.0.0-h64e8455_0.tar.bz2
linux-64::gemmi-0.5.5-py310h58363a5_0.tar.bz2
linux-64::libgdal-3.5.0-h32640fd_5.tar.bz2
linux-64::arrow-cpp-8.0.0-py37h41ad185_5_cuda.tar.bz2
linux-64::connectorx-0.3.0-py39h87ee89f_0.tar.bz2
linux-64::heavydb-6.1.1-h1234567_0_cuda.tar.bz2
linux-64::jaxlib-0.3.14-cuda112py39h4d6bb82_0.tar.bz2
linux-64::nodejs-18.7.0-h96d913c_0.tar.bz2
linux-64::pypy3.8-7.3.9-h5bd2d06_3.tar.bz2
linux-64::vtk-9.1.0-egl_py37hc3f521b_9.tar.bz2
linux-64::arrow-cpp-6.0.1-py310he6da3e4_20_cpu.tar.bz2
linux-64::harp-1.15.1-py310r41h001d289_2.tar.bz2
linux-64::libtiledb-sql-0.17.0-h0993566_0.tar.bz2
linux-64::ndcctools-7.4.6-py37hecb152a_0.tar.bz2
linux-64::libopencv-4.5.5-py38hc65905f_11.tar.bz2
linux-64::librdkafka-1.9.1-ha384dbd_1.tar.bz2
linux-64::grpc-cpp-1.46.3-hc275302_1.tar.bz2
linux-64::jaxlib-0.3.14-cuda112py310h637716b_1.tar.bz2
linux-64::tensorflow-base-2.9.1-cuda111py38h346ca62_0.tar.bz2
linux-64::glib-networking-2.72.1-hf605b43_1.tar.bz2
linux-64::jaxlib-0.3.14-cpu_py37ha701b26_1.tar.bz2
linux-64::papilo-2.1.0-hc9d876a_0.tar.bz2
linux-64::jasp-0.14.3-r41h2fc320d_3.tar.bz2
linux-64::libopencv-4.5.5-py38hdaef270_10.tar.bz2
linux-64::jaxlib-0.3.14-cpu_py38h95f6c42_0.tar.bz2
linux-64::ogre-13.4.1-hf901267_0.tar.bz2
linux-64::ffmpeg-4.4.2-lgpl_h46cd745_2.tar.bz2
linux-64::ndcctools-7.4.10-py38h782bae8_0.tar.bz2
linux-64::rstudio-desktop-2022.02.3-r40haf5249e_492.tar.bz2
linux-64::arrow-cpp-8.0.0-py38he106920_2_cuda.tar.bz2
linux-64::libopencv-4.6.0-py310he663ad9_2.tar.bz2
linux-64::arrow-cpp-7.0.0-py38h913b37a_8_cuda.tar.bz2
linux-64::yarp-cxx-3.7.0-h70892ea_1.tar.bz2
linux-64::jaxlib-0.3.14-cuda112py310h0a0fd6d_203.tar.bz2
linux-64::fenics-libdolfin-2019.1.0-h721e7d7_30.tar.bz2
linux-64::libgdal-3.5.1-h32640fd_1.tar.bz2
linux-64::jaxlib-0.3.14-cpu_py39h320bf12_0.tar.bz2
linux-64::tensorflow-base-2.9.1-cpu_py39hfe2e05e_0.tar.bz2
linux-64::vtk-9.1.0-qt_py310h6cf6e75_212.tar.bz2
linux-64::paraview-5.10.1-py39h0db8aaa_107_qt.tar.bz2
linux-64::wxwidgets-3.2.0-h645ee20_0.tar.bz2
linux-64::postgresql-plpython-14.4-py39hde6a39c_0.tar.bz2
linux-64::arrow-cpp-7.0.0-py310hc7d0c5d_8_cpu.tar.bz2
linux-64::vowpalwabbit-9.2.0-py39h65e83d8_0.tar.bz2
linux-64::paraview-5.10.1-py37h1efbd42_107_qt.tar.bz2
linux-64::ogre-1.12.13-h4b045b0_2.tar.bz2
linux-64::harp-1.15.1-py310r40h001d289_2.tar.bz2
linux-64::tesseract-5.1.0-h7bf7e52_0.tar.bz2
linux-64::nd2-0.2.5-py38h28b09c2_0.tar.bz2
linux-64::openmeeg-2.4.6-py39hf74c8ea_0.tar.bz2
linux-64::openmeeg-2.4.2-py38hc755a88_2.tar.bz2
linux-64::arrow-cpp-8.0.0-py310hbe01597_4_cpu.tar.bz2
linux-64::openmeeg-2.4.2-py39hfaa7730_2.tar.bz2
linux-64::gmt-5.4.5-haecc3ae_20.tar.bz2
linux-64::postgresql-plpython-14.4-py37h7d20ccc_0.tar.bz2
linux-64::topologytoolkit-1.0.0-no_paraview_py37h5ac0a63_106.tar.bz2
linux-64::jaxlib-0.3.14-cuda112py38hc2be4d7_1.tar.bz2
linux-64::vtk-9.1.0-qt_py39h105b9e9_211.tar.bz2
linux-64::xrootd-5.4.3-py38h3b6881a_1.tar.bz2
linux-64::connectorx-0.3.0-py37h13c547b_0.tar.bz2
linux-64::lammps-2021.09.29-py38h6ea0623_openmpi_5.tar.bz2
linux-64::arrow-cpp-3.0.0-py39ha743040_54_cuda.tar.bz2
linux-64::ffmpeg-4.4.2-lgpl_hd24bc48_5.tar.bz2
linux-64::arrow-cpp-8.0.0-py39h7490d1d_2_cpu.tar.bz2
linux-64::vtk-9.1.0-osmesa_py310ha192733_112.tar.bz2
linux-64::vtk-9.1.0-egl_py39h9238f29_11.tar.bz2
linux-64::arrow-cpp-3.0.0-py38hd499e97_54_cpu.tar.bz2
linux-64::createrepo_c-0.20.1-py39hb908eda_0.tar.bz2
linux-64::scip-8.0.1-hd6ea22a_1.tar.bz2
linux-64::grpc-cpp-1.43.2-hbe52ea8_6.tar.bz2
linux-64::pdal-2.4.1-h3c5d96b_1.tar.bz2
linux-64::gmt-6.4.0-h97aba1e_1.tar.bz2
linux-64::vtk-9.1.0-qt_py310h639fe90_209.tar.bz2
linux-64::yoda-1.9.5-py38hf06b66b_1.tar.bz2
linux-64::lammps-2021.09.29-py38h4296d50_mpich_5.tar.bz2
linux-64::vtk-9.1.0-egl_py39h3374e66_9.tar.bz2
linux-64::paraview-5.10.1-py310hf78973a_107_qt.tar.bz2
linux-64::mongodb-5.2.1-h0a4f5e4_0.tar.bz2
linux-64::ffmpeg-5.0.1-gpl_ha70255f_104.tar.bz2
linux-64::arrow-cpp-7.0.0-py38h1f0c88a_8_cpu.tar.bz2
linux-64::jaxlib-0.3.14-cpu_py39he2c30a8_3.tar.bz2
linux-64::python-rocksdb-0.7.0-py37h3027098_6.tar.bz2
linux-64::nd2-0.2.5-py39h155c9d3_0.tar.bz2
linux-64::topologytoolkit-1.0.0-with_paraview_py38h1be178e_5.tar.bz2
linux-64::arrow-cpp-6.0.1-py310h5b2b108_20_cpu.tar.bz2
linux-64::libopencv-4.5.5-py38hc65905f_12.tar.bz2
linux-64::arrow-cpp-8.0.1-py39hced362b_0_cuda.tar.bz2
linux-64::vtk-9.1.0-qt_py37hd87f963_211.tar.bz2
linux-64::gmsh-4.10.4-hc719622_0.tar.bz2
linux-64::postgresql-plpython-14.4-py310he4beaea_0.tar.bz2
linux-64::imagecodecs-2022.2.22-py310h3ac3b6e_6.tar.bz2
linux-64::harp-1.15.1-py39r40h78b9e46_2.tar.bz2
linux-64::vtk-9.1.0-egl_py37hdca10a4_12.tar.bz2
linux-64::verilator-4.222-h6239696_0.tar.bz2
linux-64::jaxlib-0.3.14-cuda112py39h867d1ad_203.tar.bz2
linux-64::arrow-cpp-8.0.0-py310h178c6ae_2_cpu.tar.bz2
linux-64::libtensorflow_cc-2.9.1-cuda111h7ff4470_0.tar.bz2
linux-64::topologytoolkit-1.0.0-with_paraview_py39h0e04872_5.tar.bz2
linux-64::ndcctools-7.4.7-py37h8b51a51_0.tar.bz2
linux-64::zstd-1.5.2-h8a70e8d_2.tar.bz2
linux-64::soplex-6.0.1-h9561d1b_1.tar.bz2
linux-64::topologytoolkit-1.0.0-no_paraview_py38h5e64707_107.tar.bz2
linux-64::grpc-cpp-1.48.0-hbd84cd8_0.tar.bz2
linux-64::pdal-2.4.2-h14a1b45_3.tar.bz2
linux-64::hugin-base-2021.0.0-py37pl5321hf27b994_6.tar.bz2
linux-64::openmeeg-2.4.2-py39h56a3a9a_0.tar.bz2
linux-64::xrootd-5.4.3-py37h9855270_1.tar.bz2
linux-64::lammps-2021.09.29-py310hcd1f8ba_openmpi_4.tar.bz2
linux-64::ndcctools-7.4.10-py38h1aa6533_1.tar.bz2
linux-64::imagemagick-7.1.0_41-pl5321heb7c40d_0.tar.bz2
linux-64::jaxlib-0.3.14-cpu_py38hcb1c0b8_0.tar.bz2
linux-64::graphicsmagick-1.3.37-ha30789c_0.tar.bz2
linux-64::openmeeg-2.4.2-py37h64e15ff_1.tar.bz2
linux-64::topologytoolkit-1.1.0-no_paraview_py39ha7956d7_100.tar.bz2
linux-64::libopencv-4.6.0-py39h5ca1638_3.tar.bz2
linux-64::arrow-cpp-8.0.0-py310hbe01597_5_cpu.tar.bz2
linux-64::rpm-tools-4.17.1-py38lua54h10574bd_0.tar.bz2
linux-64::ffmpeg-5.0.1-gpl_ha70255f_105.tar.bz2
linux-64::paraview-5.10.1-py310h7078951_107_qt.tar.bz2
linux-64::erlang-25.0.3-pl5321h5001644_0.tar.bz2
linux-64::cmake-3.23.3-h5432695_0.tar.bz2
linux-64::vtk-9.1.0-egl_py310h7dde85f_10.tar.bz2
linux-64::ogre-next-2.3.0-hd9d6a18_1.tar.bz2
linux-64::arrow-cpp-8.0.0-py310h47fda4d_4_cuda.tar.bz2
linux-64::lammps-2021.09.29-py37h48e969a_openmpi_4.tar.bz2
linux-64::openmpi-4.1.4-ha1ae619_100.tar.bz2
linux-64::connectorx-0.3.0-py310hfd47932_1.tar.bz2
linux-64::harp-1.15.1-py38r40h234bf9d_1.tar.bz2
linux-64::gmt-6.4.0-h78e8b95_2.tar.bz2
linux-64::arrow-cpp-8.0.1-py38h8abf307_0_cuda.tar.bz2
linux-64::jaxlib-0.3.14-cpu_py37h86b75d4_0.tar.bz2
linux-64::libopencv-4.6.0-py38hc65905f_0.tar.bz2
linux-64::geant4-11.0.2-py38hbec1966_1.tar.bz2
linux-64::arrow-cpp-8.0.0-py310h1f609fe_3_cuda.tar.bz2
linux-64::jaxlib-0.3.14-cpu_py39hcc5685a_0.tar.bz2
linux-64::vtk-9.1.0-qt_py39ha8c27c6_209.tar.bz2
linux-64::codes-ui-1.5.2-h6239696_1.tar.bz2
linux-64::r-rmatio-0.16.0-r41h06615bd_0.tar.bz2
linux-64::geotiff-1.7.1-h4fc65e6_3.tar.bz2
linux-64::ndcctools-7.4.8-py38h782bae8_0.tar.bz2
linux-64::openbabel-3.1.1-py310h4b1c3e3_4.tar.bz2
linux-64::pillow-9.2.0-py38h9267336_0.tar.bz2
linux-64::root_base-6.26.4-py39hc027151_3.tar.bz2
linux-64::jaxlib-0.3.14-cpu_py310he634034_3.tar.bz2
linux-64::jaxlib-0.3.14-cuda112py37had983bc_1.tar.bz2
linux-64::openconnect-9.01-hcb9dc17_1.tar.bz2
linux-64::arrow-cpp-8.0.0-py39h2531139_5_cpu.tar.bz2
linux-64::paraview-5.10.1-py39h0666e00_5_egl.tar.bz2
linux-64::openconnect-9.01-h53f2a81_3.tar.bz2
linux-64::julia-1.7.3-h35b96e5_0.tar.bz2
linux-64::jaxlib-0.3.14-cpu_py39hc536ea5_0.tar.bz2
linux-64::tensorflow-base-2.9.1-cuda112py38h47a61a2_0.tar.bz2
linux-64::yoda-1.9.5-py310h2c11959_1.tar.bz2
linux-64::magics-metview-batch-4.12.0-hb2107fa_1.tar.bz2
linux-64::gmt-5.4.5-haecc3ae_18.tar.bz2
linux-64::imagecodecs-2022.7.27-py39hf49355c_0.tar.bz2
linux-64::triqs-3.1.1-py38h29fc550_0.tar.bz2
linux-64::quazip-1.3-he0ac6c6_0.tar.bz2
linux-64::arrow-cpp-8.0.0-py39hced362b_4_cuda.tar.bz2
linux-64::mapserver-7.6.4-py39he83d6d3_7.tar.bz2
linux-64::arrow-cpp-7.0.0-py39h395f399_8_cpu.tar.bz2
linux-64::libopencv-4.6.0-py37hfe11ba8_3.tar.bz2
linux-64::gemmi-0.5.5-py39h6b9fe7f_0.tar.bz2
linux-64::harp-1.15.1-py39r40hec2c022_2.tar.bz2
linux-64::jaxlib-0.3.14-cuda112py310h3b68594_203.tar.bz2
linux-64::libspatialite-5.0.1-hc16130b_17.tar.bz2
linux-64::capnproto-0.10.2-h6239696_0.tar.bz2
linux-64::nd2-0.3.0-py37h1425b33_0.tar.bz2
linux-64::libopencv-4.5.5-py38hcc5f2f6_13.tar.bz2
linux-64::jasp-0.14.3-r40h2fc320d_3.tar.bz2
linux-64::grpc-cpp-1.47.1-h00ec82a_0.tar.bz2
linux-64::arrow-cpp-3.0.0-py37h846d386_54_cuda.tar.bz2
linux-64::tensorflow-base-2.9.1-cuda102py37h0d2b0d7_0.tar.bz2
linux-64::jaxlib-0.3.14-cpu_py37h86b75d4_1.tar.bz2
linux-64::ffmpeg-5.1.0-lgpl_he28c0fb_0.tar.bz2
linux-64::tensorflow-base-2.9.1-cuda110py37h5235c7d_0.tar.bz2
linux-64::ffmpeg-4.4.2-gpl_h8733cef_103.tar.bz2
linux-64::ndcctools-7.4.10-py39h084f619_0.tar.bz2
linux-64::jaxlib-0.3.14-cpu_py37hb660f38_3.tar.bz2
linux-64::paraview-5.10.1-py37h0a14479_105_qt.tar.bz2
linux-64::ndcctools-7.4.6-py310ha616101_0.tar.bz2
linux-64::arrow-cpp-8.0.0-py39h74dfcfe_2_cpu.tar.bz2
linux-64::fenics-libdolfin-2019.1.0-h07a031a_31.tar.bz2
linux-64::openmeeg-2.4.2-py37h64e15ff_2.tar.bz2
linux-64::arrow-cpp-5.0.0-py38h91fe7ba_35_cpu.tar.bz2
linux-64::vtk-9.1.0-egl_py37hbf74a02_11.tar.bz2
linux-64::ovito-3.7.5-h21620c5_1.tar.bz2
linux-64::libglib-2.72.1-h2d90d5f_0.tar.bz2
linux-64::jaxlib-0.3.14-cpu_py310h0283394_1.tar.bz2
linux-64::gemmi-0.5.5-py38hb85eefc_0.tar.bz2
linux-64::mongodb-6.0.0-h0a4f5e4_0.tar.bz2
linux-64::jaxlib-0.3.14-cpu_py39h79d7c74_0.tar.bz2
linux-64::triqs-3.1.1-py39hf92be6d_0.tar.bz2
linux-64::arrow-cpp-3.0.0-py310h4b55f4d_54_cuda.tar.bz2
linux-64::xrootd-5.4.3-py37h62c5c55_0.tar.bz2
linux-64::qt-main-5.15.4-ha5833f6_1.tar.bz2
linux-64::ffmpeg-4.4.2-lgpl_he28c0fb_6.tar.bz2
linux-64::tensorflow-base-2.9.1-cuda102py38hba23241_0.tar.bz2
linux-64::arrow-cpp-8.0.0-py38hc4756d1_3_cuda.tar.bz2
linux-64::tensorflow-base-2.9.1-cpu_py310h8df3ab6_0.tar.bz2
linux-64::libgit2-1.4.4-h4c07d5c_0.tar.bz2
linux-64::openmeeg-2.4.2-py38h745038f_2.tar.bz2
linux-64::arrow-cpp-8.0.0-py38hd8d37cc_3_cpu.tar.bz2
linux-64::libopencv-4.5.5-py39h1acfb62_10.tar.bz2
linux-64::arrow-cpp-8.0.0-py37hd9ae0f0_5_cuda.tar.bz2
linux-64::graphviz-5.0.0-h5abf519_0.tar.bz2
linux-64::openmeeg-2.4.2-py38hc755a88_1.tar.bz2
linux-64::openmeeg-2.4.4-py38h3a1a314_0.tar.bz2
linux-64::topologytoolkit-1.0.0-with_paraview_py37hb045075_6.tar.bz2
linux-64::paraview-5.10.1-py38h6d50a87_106_qt.tar.bz2
linux-64::connectorx-0.3.0-py38h3fe3e3e_0.tar.bz2
linux-64::jaxlib-0.3.14-cuda112py37h964a14d_1.tar.bz2
linux-64::libsoup-3.0.7-h5aab1f2_0.tar.bz2
linux-64::openmeeg-2.4.4-py37h43168b8_0.tar.bz2
linux-64::openmeeg-2.4.4-py39hf1d92c7_0.tar.bz2
linux-64::topologytoolkit-1.0.0-with_paraview_py310hf82f9bf_7.tar.bz2
linux-64::vtk-9.1.0-qt_py38heb06ca6_209.tar.bz2
linux-64::arrow-cpp-8.0.0-py310hf92bf32_3_cpu.tar.bz2
linux-64::libtiledb-sql-0.17.1-h0993566_0.tar.bz2
linux-64::libzip-1.9.2-hc929e4a_0.tar.bz2
linux-64::ovito-3.7.5-hbb7e7d1_0.tar.bz2
linux-64::gmsh-4.10.5-hc719622_0.tar.bz2
linux-64::imagecodecs-2022.2.22-py38hd0f120e_6.tar.bz2
linux-64::lammps-2021.09.29-py38h125bc6e_openmpi_4.tar.bz2
linux-64::ndcctools-7.4.8-py38h1aa6533_0.tar.bz2
linux-64::heavydb-6.1.1-h1234567_0_cpu.tar.bz2
linux-64::tiledb-2.9.5-h1e4a385_0.tar.bz2
linux-64::git-2.37.0-pl5321h04cb727_0.tar.bz2
linux-64::ndcctools-7.4.9-py310ha616101_0.tar.bz2
linux-64::mongodb-5.3.2-h64e8455_0.tar.bz2
linux-64::libopencv-4.6.0-py38hc65905f_1.tar.bz2
linux-64::grpc-cpp-1.44.0-hbe52ea8_5.tar.bz2
linux-64::jaxlib-0.3.14-cuda112py38h40808eb_0.tar.bz2
linux-64::arrow-cpp-5.0.0-py39hf56cb2e_35_cuda.tar.bz2
linux-64::pdal-2.4.2-he35911a_1.tar.bz2
linux-64::xrootd-5.4.3-py39h2e4a97b_1.tar.bz2
linux-64::vtk-9.1.0-osmesa_py310h975217f_110.tar.bz2
linux-64::fenics-libdolfin-2019.1.0-ha924701_30.tar.bz2
linux-64::tiledb-2.9.4-h3f4058f_0.tar.bz2
linux-64::vtk-9.1.0-osmesa_py39hb065a2d_110.tar.bz2
linux-64::libpq-14.4-hd77ab85_0.tar.bz2
linux-64::hugin-2021.0.0-pl5321h0b0a715_6.tar.bz2
linux-64::ffmpeg-4.4.2-gpl_h2b602b6_106.tar.bz2
linux-64::imagemagick-7.1.0_37-pl5321heb7c40d_0.tar.bz2
linux-64::graphviz-3.0.0-h5abf519_2.tar.bz2
linux-64::grpc-cpp-1.46.3-hbd84cd8_2.tar.bz2
linux-64::grpc-cpp-1.44.0-h3b8df00_5.tar.bz2
linux-64::arrow-cpp-8.0.0-py310h025e8b3_5_cuda.tar.bz2
linux-64::arrow-cpp-8.0.0-py310h893e394_5_cpu.tar.bz2
linux-64::xrootd-5.4.3-py39hbfe9b54_1.tar.bz2
linux-64::topologytoolkit-1.1.0-no_paraview_py37h5c10003_100.tar.bz2
linux-64::mapserver-7.6.4-py310h50e9b79_7.tar.bz2
linux-64::ffmpeg-5.0.1-lgpl_h63c43cc_6.tar.bz2
linux-64::lammps-2021.09.29-py310h6856c86_mpich_4.tar.bz2
linux-64::pyreadstat-1.1.7-py38he5536e0_0.tar.bz2
linux-64::xrootd-5.4.3-py38h9a35ce2_1.tar.bz2
linux-64::libopencv-4.6.0-py37h4a49c2f_1.tar.bz2
linux-64::tiledb-2.10.1-h1e4a385_0.tar.bz2
linux-64::libpq-14.4-he2d8382_0.tar.bz2
linux-64::libopencv-4.5.5-py310hc83fb77_10.tar.bz2
linux-64::paraview-5.10.1-py310hf61c2f2_107_qt.tar.bz2
linux-64::git-annex-10.20220724-alldep_hc98582e_100.tar.bz2
linux-64::vigra-1.11.1-py39h067b64b_1033.tar.bz2
linux-64::topologytoolkit-1.0.0-no_paraview_py37h5c10003_107.tar.bz2
linux-64::mapserver-7.6.4-py37h47896c0_10.tar.bz2
linux-64::tiledb-2.10.0-h3f4058f_0.tar.bz2
linux-64::imagemagick-7.1.0.43-pl5321h2098167_0.tar.bz2
linux-64::arrow-cpp-8.0.0-py38h21af1cf_4_cuda.tar.bz2
linux-64::jaxlib-0.3.14-cuda112py38h195edf8_0.tar.bz2
linux-64::ndcctools-7.4.8-py310ha616101_0.tar.bz2
linux-64::ffmpeg-4.4.1-habc3f16_5.tar.bz2
linux-64::mongodb-5.2.0-h6f82f1e_0.tar.bz2
linux-64::paraview-5.10.1-py39h69086b3_105_qt.tar.bz2
linux-64::openmeeg-2.4.2-py37h43168b8_4.tar.bz2
linux-64::dotnet-aspnetcore-6.0.5-h751d214_0.tar.bz2
linux-64::arrow-cpp-7.0.0-py37ha0737cd_8_cpu.tar.bz2
linux-64::openmeeg-2.4.7-py39hf1d92c7_0.tar.bz2
linux-64::tensorflow-base-2.9.1-cuda111py37ha9dc7ab_0.tar.bz2
linux-64::imagemagick-7.1.0_40-pl5321heb7c40d_0.tar.bz2
linux-64::createrepo_c-0.20.1-py37h85cd5c2_0.tar.bz2
linux-64::ovito-3.7.8-h21620c5_0.tar.bz2
linux-64::topologytoolkit-1.0.0-with_paraview_py38hff668bf_7.tar.bz2
linux-64::graphviz-2.50.0-h5abf519_3.tar.bz2
linux-64::jaxlib-0.3.14-cpu_py37h115581e_0.tar.bz2
linux-64::python-rocksdb-0.7.0-py310h110d2a3_6.tar.bz2
linux-64::jaxlib-0.3.14-cpu_py38h3c20414_1.tar.bz2
linux-64::arrow-cpp-8.0.0-py310h025e8b3_4_cuda.tar.bz2
linux-64::postgresql-plpython-14.4-py39h4325d1c_0.tar.bz2
linux-64::sqlite-3.39.1-h4ff8645_0.tar.bz2
linux-64::libgdal-3.5.0-hc0ebe42_4.tar.bz2
linux-64::mongodb-5.2.0-h64e8455_0.tar.bz2
linux-64::topologytoolkit-1.1.0-no_paraview_py38h5e64707_100.tar.bz2
linux-64::arrow-cpp-8.0.1-py38ha7276ea_0_cpu.tar.bz2
linux-64::harp-1.15.1-py38r40h378a090_1.tar.bz2
linux-64::abinit-9.6.2-he9f11b1_1.tar.bz2
linux-64::git-2.37.0-pl5321h36853c3_0.tar.bz2
linux-64::dotnet-runtime-6.0.5-h751d214_0.tar.bz2
linux-64::ffmpeg-4.4.2-gpl_h512afef_104.tar.bz2
linux-64::libopencv-4.5.5-py38hcc5f2f6_11.tar.bz2
linux-64::harp-1.15.1-py37r40hc69f9df_2.tar.bz2
linux-64::rstudio-desktop-2022.02.3-r40h2a89545_493.tar.bz2
linux-64::libgdal-3.5.0-h0c20829_5.tar.bz2
linux-64::openmeeg-2.4.2-py310hf8ee683_1.tar.bz2
linux-64::libpng-1.6.37-h753d276_3.tar.bz2
linux-64::xrootd-5.4.3-py38h92bdfd5_0.tar.bz2
linux-64::cpp-opentelemetry-sdk-1.4.1-h48a8ea9_4.tar.bz2
linux-64::librdkafka-1.9.1-ha6af7cb_1.tar.bz2
linux-64::ffmpeg-4.4.2-lgpl_h63c43cc_3.tar.bz2
linux-64::arrow-cpp-6.0.1-py39ha743040_20_cuda.tar.bz2
linux-64::libopencv-4.6.0-py39hc7f7d4a_3.tar.bz2
linux-64::arrow-cpp-5.0.0-py310h3a96f94_35_cuda.tar.bz2
linux-64::pyreadstat-1.1.7-py39hd08d98e_0.tar.bz2
linux-64::jaxlib-0.3.14-cuda112py39h8d07533_1.tar.bz2
linux-64::grpc-cpp-1.43.2-h60c3337_6.tar.bz2
linux-64::ogre-13.4.1-h9cbfa6b_1.tar.bz2
linux-64::ndcctools-7.4.8-py39hbe13330_0.tar.bz2
linux-64::dotnet-sdk-3.1.420-h751d214_0.tar.bz2
linux-64::libgdal-3.5.0-h1f7a3f3_2.tar.bz2
linux-64::libgdal-3.5.0-h59d0e54_4.tar.bz2
linux-64::dotnet-sdk-3.1.419-h751d214_0.tar.bz2
linux-64::pyreadstat-1.1.9-py310ha400145_0.tar.bz2
linux-64::fish-3.5.0-h682823d_0.tar.bz2
linux-64::openscenegraph-3.6.5-h6e0f175_14.tar.bz2
linux-64::createrepo_c-0.20.1-py310h7ca2958_0.tar.bz2
linux-64::root_base-6.26.4-py37h897d9a3_3.tar.bz2
linux-64::paraview-5.10.1-py39h9d6b33f_7_egl.tar.bz2
linux-64::postgresql-plpython-14.4-py37h44beeb2_0.tar.bz2
linux-64::openmeeg-2.4.4-py39hf74c8ea_0.tar.bz2
linux-64::arrow-cpp-8.0.0-py38h1f0c88a_3_cpu.tar.bz2
linux-64::libtiledb-sql-0.16.1-h0993566_0.tar.bz2
linux-64::topologytoolkit-1.0.0-with_paraview_py37h3242364_7.tar.bz2
linux-64::rust-1.62.1-h30be4a0_0.tar.bz2
linux-64::jaxlib-0.3.14-cuda112py37h13d6ec4_1.tar.bz2
linux-64::capnproto-0.10.0-h6239696_0.tar.bz2
linux-64::qt-main-5.15.4-ha5833f6_2.tar.bz2
linux-64::openmeeg-2.4.4-py310hae38141_0.tar.bz2
linux-64::arrow-cpp-7.0.0-py39h77f26dc_8_cuda.tar.bz2
linux-64::libgdal-3.5.1-h53011df_2.tar.bz2
linux-64::lammps-2021.09.29-py39h69e9cdf_mpich_5.tar.bz2
linux-64::ndcctools-7.4.9-py310h5deebde_0.tar.bz2
linux-64::mlir-14.0.3-he0ac6c6_0.tar.bz2
linux-64::mongodb-5.2.1-h64e8455_0.tar.bz2
linux-64::jaxlib-0.3.14-cuda112py38h7fda4ea_203.tar.bz2
linux-64::libopencv-4.5.5-py39ha3d0060_13.tar.bz2
linux-64::openmeeg-2.4.2-py310h7c24d38_3.tar.bz2
linux-64::mapserver-7.6.4-py310hf2108eb_8.tar.bz2
linux-64::jaxlib-0.3.14-cuda112py310hc9977b2_0.tar.bz2
linux-64::ogre-1.10.12-h7cc4a1d_9.tar.bz2
linux-64::readdy-2.0.12-py310hdfe83f4_0.tar.bz2
linux-64::tensorflow-base-2.9.1-cuda112py37h83f6acc_0.tar.bz2
linux-64::arrow-cpp-3.0.0-py37h9ba88d0_54_cuda.tar.bz2
linux-64::xrootd-5.4.3-py38hf2e46ea_1.tar.bz2
linux-64::libtensorflow_cc-2.9.1-cpu_h0c3d7b9_0.tar.bz2
linux-64::jaxlib-0.3.14-cuda112py310h9def920_0.tar.bz2
linux-64::openconnect-9.01-hb4ddca0_0.tar.bz2
linux-64::yarp-cxx-3.7.0-hfee3fe3_4.tar.bz2
linux-64::yoda-1.9.5-py37h3bd29a6_1.tar.bz2
linux-64::connectorx-0.3.0-py38h3fe3e3e_1.tar.bz2
linux-64::libgdal-3.5.0-he21a14a_3.tar.bz2
linux-64::jaxlib-0.3.14-cpu_py39hc536ea5_1.tar.bz2
linux-64::arrow-cpp-8.0.0-py38h21af1cf_5_cuda.tar.bz2
linux-64::libopencv-4.5.5-py310hcb97b83_13.tar.bz2
linux-64::pdal-2.4.2-he35911a_0.tar.bz2
linux-64::hdf5-1.12.2-mpi_openmpi_h41b9b70_0.tar.bz2
linux-64::paraview-5.10.1-py39h0666e00_6_egl.tar.bz2
linux-64::libopencv-4.6.0-py39hf4bb9d8_2.tar.bz2
linux-64::julia-1.7.3-h6f5dd7c_1.tar.bz2
linux-64::librdkafka-1.9.1-ha6af7cb_0.tar.bz2
linux-64::mapserver-7.6.4-py310h1830c35_9.tar.bz2
linux-64::triqs-3.1.1-py37hdc384cb_1.tar.bz2
linux-64::prometheus-cpp-1.0.1-h751d214_0.tar.bz2
linux-64::cpp-opentelemetry-sdk-1.4.1-h8e9fcac_0.tar.bz2
linux-64::mongodb-5.2.1-h6f82f1e_0.tar.bz2
linux-64::tensorflow-base-2.9.1-cuda110py38hd7529fe_0.tar.bz2
linux-64::topologytoolkit-1.0.0-with_paraview_py39hb629964_4.tar.bz2
linux-64::dotnet-sdk-6.0.301-h751d214_0.tar.bz2
linux-64::libgdal-3.5.1-h0c20829_0.tar.bz2
linux-64::arrow-cpp-8.0.0-py310hb9c72a6_3_cuda.tar.bz2
linux-64::grpc-cpp-1.44.0-ha96aa4b_5.tar.bz2
linux-64::tensorflow-base-2.9.1-cuda112py39h81abfd3_0.tar.bz2
linux-64::paraview-5.10.1-py37hcd5bbaf_7_egl.tar.bz2
linux-64::vtk-9.1.0-egl_py37ha060784_10.tar.bz2
linux-64::magics-metview-4.12.0-h58bb426_3.tar.bz2
linux-64::ndcctools-7.4.9-py39h084f619_0.tar.bz2
linux-64::vtk-9.1.0-osmesa_py39h4086a4b_112.tar.bz2
linux-64::glib-networking-2.72.1-hf605b43_0.tar.bz2
linux-64::harp-1.15.1-py38r41h459ef46_2.tar.bz2
linux-64::ogre-next-2.3.1-hd9d6a18_0.tar.bz2
linux-64::libopencv-4.6.0-py39hd011c1b_1.tar.bz2
linux-64::arrow-cpp-8.0.0-py38h69b25f9_2_cpu.tar.bz2
linux-64::pdal-2.4.2-h68a0bdf_0.tar.bz2
linux-64::jaxlib-0.3.14-cpu_py310hacd7525_0.tar.bz2
linux-64::arrow-cpp-6.0.1-py37h9ba88d0_20_cuda.tar.bz2
linux-64::tiledb-2.9.3-h3f4058f_0.tar.bz2
linux-64::libtiff-4.4.0-h0d92c0b_2.tar.bz2
linux-64::paraview-5.10.1-py39h1692c64_7_egl.tar.bz2
linux-64::topologytoolkit-1.1.0-with_paraview_py38hff668bf_0.tar.bz2
linux-64::poppler-qt-22.04.0-h0efdd12_1.tar.bz2
linux-64::jaxlib-0.3.14-cpu_py39hcc5685a_1.tar.bz2
linux-64::jaxlib-0.3.14-cuda112py39ha5e9d1c_203.tar.bz2
linux-64::harp-1.15.1-py310r41h2b6cc9b_1.tar.bz2
linux-64::verilator-4.224-h6239696_0.tar.bz2
linux-64::mongodb-5.2.1-h0e13805_0.tar.bz2
linux-64::geant4-11.0.2-py39h0aa766a_0.tar.bz2
linux-64::fenics-libdolfin-2019.1.0-hc94edae_31.tar.bz2
linux-64::triqs-3.1.1-py37ha35320a_0.tar.bz2
linux-64::qt-main-5.15.4-hf97cb25_0.tar.bz2
linux-64::dotnet-runtime-3.1.26-h751d214_0.tar.bz2
linux-64::openmeeg-2.4.2-py38hf4dd868_3.tar.bz2
linux-64::libopencv-4.6.0-py38hadd57a7_2.tar.bz2
linux-64::xrootd-5.4.3-py39h85ad3ca_1.tar.bz2
linux-64::folly-2022.07.25.00-h1234567_1_jemalloc.tar.bz2
linux-64::hugin-2021.0.0-pl5321h0537b6a_6.tar.bz2
linux-64::arrow-cpp-3.0.0-py310h3a96f94_54_cuda.tar.bz2
linux-64::nodejs-18.6.0-h8839609_0.tar.bz2
linux-64::pillow-9.2.0-py37h44f0d7a_0.tar.bz2
linux-64::dotnet-aspnetcore-5.0.17-h751d214_0.tar.bz2
linux-64::vtk-9.1.0-egl_py310hddf0bb7_12.tar.bz2
linux-64::paraview-5.10.1-py310hef6551b_106_qt.tar.bz2
linux-64::openmeeg-2.4.6-py37h43168b8_0.tar.bz2
linux-64::openmeeg-2.4.2-py37ha4bb9a9_3.tar.bz2
linux-64::xrootd-5.4.3-py310hf716355_0.tar.bz2
linux-64::arrow-cpp-8.0.1-py310h893e394_0_cpu.tar.bz2
linux-64::hugin-2021.0.0-pl5321hd8fc026_7.tar.bz2
linux-64::libnetcdf-4.8.1-mpi_mpich_h06c54e2_3.tar.bz2
linux-64::ndcctools-7.4.7-py39h084f619_0.tar.bz2
linux-64::tomviz-1.10.0.post259-py37h3444f97_2.tar.bz2
linux-64::ndcctools-7.4.7-py38h782bae8_0.tar.bz2
linux-64::arrow-cpp-8.0.0-py38hd09f243_5_cpu.tar.bz2
linux-64::arrow-cpp-8.0.0-py39h3f731f7_3_cpu.tar.bz2
linux-64::ogre-13.4.2-h9cbfa6b_0.tar.bz2
linux-64::topologytoolkit-1.0.0-no_paraview_py39ha7956d7_107.tar.bz2
linux-64::gemmi-0.5.5-py37h0761922_0.tar.bz2
linux-64::jaxlib-0.3.14-cpu_py37hf0fc7ea_1.tar.bz2
linux-64::openmeeg-2.4.2-py38h8a6fca0_3.tar.bz2
linux-64::grpc-cpp-1.43.2-h3b8df00_6.tar.bz2
linux-64::topologytoolkit-1.0.0-no_paraview_py39h27f2d4b_104.tar.bz2
linux-64::pillow-9.2.0-py39habab96e_0.tar.bz2
linux-64::vowpalwabbit-9.2.0-py38hc7e5c7f_0.tar.bz2
linux-64::hdf5-1.12.2-nompi_h4df4325_100.tar.bz2
linux-64::vtk-9.1.0-egl_py38hb2f2b2c_10.tar.bz2
linux-64::ffmpeg-5.0.1-lgpl_h46cd745_5.tar.bz2
linux-64::yoda-1.9.6-py39hd1fba03_0.tar.bz2
linux-64::freecad-0.20.0-py39h2d0cb5e_0.tar.bz2
linux-64::tomviz-1.10.0.post266-py37h3444f97_2.tar.bz2
linux-64::openmeeg-2.4.2-py39h56a3a9a_2.tar.bz2
linux-64::texlive-core-20210325-h5b4e33e_4.tar.bz2
linux-64::arrow-cpp-6.0.1-py310h4b55f4d_20_cuda.tar.bz2
linux-64::arrow-cpp-7.0.0-py37h4a94403_8_cuda.tar.bz2
linux-64::jaxlib-0.3.14-cuda112py38h195edf8_1.tar.bz2
linux-64::harp-1.15.1-py37r41hcb5871f_1.tar.bz2
linux-64::llvmdev-14.0.5-he0ac6c6_0.tar.bz2
linux-64::cppyy-cling-6.27.0-py39h13b352c_0.tar.bz2
linux-64::cpp-opentelemetry-sdk-1.4.1-h48a8ea9_1.tar.bz2
linux-64::git-2.37.1-pl5321h36853c3_0.tar.bz2
linux-64::ffmpeg-5.0.1-lgpl_hd24bc48_7.tar.bz2
linux-64::arrow-cpp-8.0.0-py38h8abf307_5_cuda.tar.bz2
linux-64::libtensorflow-2.9.1-cuda110ha3f6c36_0.tar.bz2
linux-64::soplex-6.0.1-h9561d1b_0.tar.bz2
linux-64::python-rocksdb-0.7.0-py39hea5d01e_6.tar.bz2
linux-64::vtk-9.1.0-egl_py310hb16941e_9.tar.bz2
linux-64::libspatialite-5.0.1-h3baac0b_16.tar.bz2
linux-64::harp-1.15.1-py39r40he2a1b48_1.tar.bz2
linux-64::topologytoolkit-1.0.0-with_paraview_py310h8b99dbf_6.tar.bz2
linux-64::vtk-9.1.0-osmesa_py38hc616f7f_112.tar.bz2
linux-64::arrow-cpp-8.0.0-py37h1277737_5_cpu.tar.bz2
linux-64::paraview-5.10.1-py37hdd3c924_107_qt.tar.bz2
linux-64::ndcctools-7.4.10-py39hbe13330_0.tar.bz2
linux-64::sqlite-3.39.2-h4ff8645_0.tar.bz2
linux-64::mapserver-7.6.4-py38hb972beb_11.tar.bz2
linux-64::openmpi-4.1.3-h846660c_104.tar.bz2
linux-64::arrow-cpp-8.0.0-py39h2f48f8a_5_cuda.tar.bz2
linux-64::jaxlib-0.3.14-cpu_py37hf0fc7ea_0.tar.bz2
linux-64::openmeeg-2.4.2-py39h56a3a9a_1.tar.bz2
linux-64::arrow-cpp-8.0.0-py310hdc7e031_2_cuda.tar.bz2
linux-64::grpc-cpp-1.46.3-h00ec82a_2.tar.bz2
linux-64::topologytoolkit-1.0.0-no_paraview_py310h4298bc0_106.tar.bz2
linux-64::arrow-cpp-8.0.0-py37he172e40_2_cuda.tar.bz2
linux-64::ovito-3.7.7-h21620c5_0.tar.bz2
linux-64::postgresql-plpython-14.4-py38h70534a9_0.tar.bz2
linux-64::ndcctools-7.4.9-py38h1aa6533_0.tar.bz2
linux-64::topologytoolkit-1.0.0-with_paraview_py39h21d363e_7.tar.bz2
linux-64::dotnet-runtime-5.0.17-h751d214_0.tar.bz2
linux-64::tensorflow-base-2.9.1-cpu_py38hca74540_0.tar.bz2
linux-64::libarchive-3.5.2-hb890918_3.tar.bz2
linux-64::pypy3.9-7.3.9-h56abe6f_3.tar.bz2
linux-64::topologytoolkit-1.0.0-no_paraview_py37h8bbbb37_104.tar.bz2
linux-64::harp-1.15.1-py37r41hc69f9df_2.tar.bz2
linux-64::jaxlib-0.3.14-cuda112py39h2d0c158_0.tar.bz2
linux-64::vigra-1.11.1-py38h0c9775c_1033.tar.bz2
linux-64::cpp-opentelemetry-sdk-1.4.1-he95c404_3.tar.bz2
linux-64::ndcctools-7.4.8-py39h084f619_0.tar.bz2
linux-64::mapserver-7.6.4-py37h457a928_11.tar.bz2
linux-64::ndcctools-7.4.10-py38h1aa6533_0.tar.bz2
linux-64::ndcctools-7.4.10-py37h8b51a51_0.tar.bz2
linux-64::arrow-cpp-8.0.1-py37h81c5bf6_0_cpu.tar.bz2
linux-64::imagecodecs-2022.7.27-py39he992b3b_1.tar.bz2
linux-64::arrow-cpp-3.0.0-py39h5dd0ea6_54_cpu.tar.bz2
linux-64::arrow-cpp-8.0.0-py39h811ffd7_4_cpu.tar.bz2
linux-64::freecad-0.20.0-py37h9db6d3a_0.tar.bz2
linux-64::pypy3.9-7.3.9-h986b250_3.tar.bz2
linux-64::topologytoolkit-1.0.0-with_paraview_py37h45f106a_4.tar.bz2
linux-64::hdfeos5-5.1.16-hc2f950b_10.tar.bz2
linux-64::libtensorflow_cc-2.9.1-cuda102he204bbd_0.tar.bz2
linux-64::triqs-3.1.1-py38hd156762_1.tar.bz2
linux-64::astrometry-0.90-py38h487418f_2.tar.bz2
linux-64::topologytoolkit-1.0.0-with_paraview_py38h1be178e_6.tar.bz2
linux-64::librdkafka-1.9.0-hcf600c6_0.tar.bz2
linux-64::harp-1.15.1-py38r40h459ef46_2.tar.bz2
linux-64::lammps-2021.09.29-py38he8d70b0_mpich_4.tar.bz2
linux-64::mapserver-7.6.4-py38h25442ac_7.tar.bz2
linux-64::geant4-11.0.2-py37hc0c0af5_0.tar.bz2
linux-64::libtiledb-sql-0.16.0-h204bf05_0.tar.bz2
linux-64::libprotobuf-static-21.2-h6239696_0.tar.bz2
linux-64::octave-7.1.0-h3839a39_3.tar.bz2
linux-64::ndcctools-7.4.9-py37h8b51a51_0.tar.bz2
linux-64::smesh-9.8.0.2-hf3572f8_1.tar.bz2
linux-64::coda-2.24-py39h78b9e46_1.tar.bz2
linux-64::openmeeg-2.4.2-py38h3a1a314_4.tar.bz2
linux-64::arrow-cpp-8.0.0-py39hced362b_5_cuda.tar.bz2
linux-64::ndcctools-7.4.9-py38h782bae8_0.tar.bz2
linux-64::python-rocksdb-0.7.0-py39he438597_6.tar.bz2
linux-64::python-3.10.5-ha86cf86_0_cpython.tar.bz2
linux-64::rstudio-desktop-2022.02.3-r41haf5249e_492.tar.bz2
linux-64::openmeeg-2.4.2-py39h8c33eef_3.tar.bz2
linux-64::lammps-2021.09.29-py39h9cf58a2_openmpi_4.tar.bz2
linux-64::paraview-5.10.1-py38h0b799cd_107_qt.tar.bz2
linux-64::grpc-cpp-1.43.2-ha96aa4b_6.tar.bz2
linux-64::ffmpeg-4.4.2-gpl_h512afef_105.tar.bz2
linux-64::octave-7.1.0-h8cb3778_1.tar.bz2
linux-64::folly-2022.07.25.00-h1234567_1.tar.bz2
linux-64::hugin-base-2021.0.0-pl5321hb494a84_7.tar.bz2
linux-64::astrometry-0.90-py37hfbcb4a1_2.tar.bz2
linux-64::dotnet-sdk-6.0.300-h751d214_0.tar.bz2
linux-64::octave-7.1.0-h2299be1_2.tar.bz2
linux-64::libopencv-4.5.5-py38h3d8de8b_10.tar.bz2
linux-64::libtiledb-sql-0.17.0-h204bf05_0.tar.bz2
linux-64::libtensorflow_cc-2.9.1-cuda112h02da4e0_0.tar.bz2
linux-64::harp-1.15.1-py39r41hec2c022_2.tar.bz2
linux-64::createrepo_c-0.20.1-py310hb52ebc5_0.tar.bz2
linux-64::environment-modules-5.1.1-h71fc533_0.tar.bz2
linux-64::arrow-cpp-8.0.1-py310hbe01597_0_cpu.tar.bz2
linux-64::r-vcfr-1.13.0-r40h690469d_0.tar.bz2
linux-64::ticcutils-0.29-h45a0d52_0.tar.bz2
linux-64::arrow-cpp-8.0.0-py39h77f26dc_3_cuda.tar.bz2
linux-64::jaxlib-0.3.14-cpu_py38heba6e0f_1.tar.bz2
linux-64::libmediainfo-22.06-ha998575_0.tar.bz2
linux-64::topologytoolkit-1.0.0-no_paraview_py310h3d7b1a7_107.tar.bz2
linux-64::openmeeg-2.4.2-py39hf1d92c7_4.tar.bz2
linux-64::nodejs-18.5.0-h96d913c_0.tar.bz2
linux-64::mapserver-7.6.4-py38hb4d328d_8.tar.bz2
linux-64::pillow-9.2.0-py310he619898_0.tar.bz2
linux-64::libopencv-4.6.0-py310hedba25b_3.tar.bz2
linux-64::ndcctools-7.4.9-py37hecb152a_0.tar.bz2
linux-64::libtiledb-sql-0.17.1-h204bf05_0.tar.bz2
linux-64::grpc-cpp-1.44.0-h60c3337_5.tar.bz2
linux-64::wxwidgets-3.2.0-h12dd593_1.tar.bz2
linux-64::gdstk-0.8.3-py38h1082054_0.tar.bz2
linux-64::openmeeg-2.4.7-py39hf74c8ea_0.tar.bz2
linux-64::libgdal-3.5.0-h844f3f6_1.tar.bz2
linux-64::imagemagick-7.1.0_38-pl5321heb7c40d_0.tar.bz2
linux-64::ndcctools-7.4.10-py39hbe13330_1.tar.bz2
linux-64::grpc-cpp-1.45.2-ha96aa4b_4.tar.bz2
linux-64::xrootd-5.4.3-py38h3b6881a_0.tar.bz2
linux-64::libgit2-1.5.0-h4c07d5c_0.tar.bz2
linux-64::paraview-5.10.1-py39hd2e9ed8_107_qt.tar.bz2
linux-64::grpc-cpp-1.47.0-h00ec82a_1.tar.bz2
linux-64::arrow-cpp-3.0.0-py310h5b2b108_54_cpu.tar.bz2
linux-64::ffmpeg-4.4.2-habc3f16_0.tar.bz2
linux-64::paraview-5.10.1-py310hef6551b_105_qt.tar.bz2
linux-64::netpbm-10.73.40-pl5321h79e5dd2_0.tar.bz2
linux-64::openbabel-3.1.1-py37ha011765_4.tar.bz2
linux-64::grpc-cpp-1.46.3-h0b91f02_1.tar.bz2
linux-64::xrootd-5.4.3-py38h92bdfd5_1.tar.bz2
linux-64::libzip-1.9.2-hc869a4a_0.tar.bz2
linux-64::libopencv-4.5.5-py37h4a49c2f_12.tar.bz2
linux-64::gmt-5.4.5-haecc3ae_19.tar.bz2
linux-64::heavydb-6.1.0-h1234567_0_cpu.tar.bz2
linux-64::paraview-5.10.1-py37h658e5b5_7_egl.tar.bz2
linux-64::ndcctools-7.4.6-py310h5deebde_0.tar.bz2
linux-64::erlang-25.0.1-pl5321h5001644_0.tar.bz2
linux-64::hdf5-1.12.2-mpi_mpich_h5d83325_0.tar.bz2
linux-64::libopencv-4.6.0-py38h2ff0a41_2.tar.bz2
linux-64::harp-1.15.1-py39r41h78b9e46_2.tar.bz2
linux-64::pyreadstat-1.1.7-py310ha400145_0.tar.bz2
linux-64::arrow-cpp-7.0.0-py37h399d738_8_cpu.tar.bz2
linux-64::arrow-cpp-7.0.0-py310hf92bf32_8_cpu.tar.bz2
linux-64::jaxlib-0.3.14-cuda112py310h59d0295_1.tar.bz2
linux-64::python-3.10.5-h582c2e5_0_cpython.tar.bz2
linux-64::tiledb-2.10.2-h3f4058f_0.tar.bz2
linux-64::jaxlib-0.3.14-cpu_py39h60ef58f_3.tar.bz2
linux-64::libitk-5.2.1-hd8cd2f9_4.tar.bz2
linux-64::ogre-next-2.2.6-hd9d6a18_0.tar.bz2
linux-64::libprotobuf-static-21.4-h6239696_0.tar.bz2
linux-64::arrow-cpp-5.0.0-py37h846d386_35_cuda.tar.bz2
linux-64::paraview-5.10.1-py37he0f13b8_107_qt.tar.bz2
linux-64::cppyy-cling-6.27.0-py37had014c9_0.tar.bz2
linux-64::geotiff-1.7.1-h4fc65e6_2.tar.bz2
linux-64::jaxlib-0.3.14-cuda112py39h8b761d8_0.tar.bz2
linux-64::jaxlib-0.3.14-cpu_py38hcb1c0b8_1.tar.bz2
linux-64::astrometry-0.90-py37h274e8da_2.tar.bz2
linux-64::nco-5.1.0-hdef2bbc_0.tar.bz2
linux-64::libopencv-4.5.5-py37h780a5f5_10.tar.bz2
linux-64::arrow-cpp-7.0.0-py38hc4756d1_8_cuda.tar.bz2
linux-64::ndcctools-7.4.10-py310h5deebde_0.tar.bz2
linux-64::arrow-cpp-8.0.0-py310hc7d0c5d_3_cpu.tar.bz2
linux-64::hugin-2021.0.0-pl5321h8a2d1fa_6.tar.bz2
linux-64::jaxlib-0.3.14-cuda112py38hc2be4d7_0.tar.bz2
linux-64::imagecodecs-2022.7.27-py38hd335c26_0.tar.bz2
linux-64::lammps-2021.09.29-py310h7ddc592_mpich_5.tar.bz2
linux-64::arrow-cpp-8.0.0-py37h4a94403_3_cuda.tar.bz2
linux-64::vtk-9.1.0-qt_py39h3b1a52d_212.tar.bz2
linux-64::imagecodecs-2022.7.27-py310h1281eb2_0.tar.bz2
linux-64::jaxlib-0.3.14-cuda112py38h40808eb_1.tar.bz2
linux-64::topologytoolkit-1.1.0-with_paraview_py310hf82f9bf_0.tar.bz2
linux-64::ffmpeg-5.0.1-habc3f16_3.tar.bz2
linux-64::ncl-6.6.2-h71be550_39.tar.bz2
linux-64::arrow-cpp-8.0.1-py38hd09f243_0_cpu.tar.bz2
linux-64::libmongoc-1.22.0-h0506597_0.tar.bz2
linux-64::xrootd-5.4.3-py39hbfe9b54_0.tar.bz2
linux-64::freecad-0.20.0-py38h1e741d0_0.tar.bz2
linux-64::libtensorflow-2.9.1-cpu_h0c3d7b9_0.tar.bz2
linux-64::vtk-9.1.0-osmesa_py39h185a7a0_111.tar.bz2
linux-64::tensorflow-base-2.9.1-cuda102py39h4f2f7b8_0.tar.bz2
linux-64::lammps-2021.09.29-py37h2dbc777_mpich_4.tar.bz2
linux-64::libvips-8.13.0-h4a8a4d3_0.tar.bz2
linux-64::grpc-cpp-1.45.2-h3b8df00_4.tar.bz2
linux-64::magics-4.12.0-hb2107fa_1.tar.bz2
linux-64::grpc-cpp-1.48.0-h00ec82a_0.tar.bz2
linux-64::erlang-25.0.3-pl5321hb9e9383_0.tar.bz2
linux-64::paraview-5.10.1-py39h69086b3_106_qt.tar.bz2
linux-64::hugin-base-2021.0.0-py39pl5321h725b965_6.tar.bz2
linux-64::paraview-5.10.1-py310h9a76674_6_egl.tar.bz2
linux-64::ndcctools-7.4.7-py39hbe13330_0.tar.bz2
linux-64::vtk-9.1.0-qt_py310hb71b3df_211.tar.bz2
linux-64::geant4-11.0.2-py38had2d439_0.tar.bz2
linux-64::coin-or-clp-1.17.7-hc56784d_1.tar.bz2
linux-64::gmt-6.3.0-h9c93da3_5.tar.bz2
linux-64::libxml2-2.9.14-h22db469_2.tar.bz2
linux-64::pillow-9.2.0-py39hae2aec6_0.tar.bz2
linux-64::pdal-2.4.2-h68a0bdf_2.tar.bz2
linux-64::gdstk-0.8.3-py37hcceba20_0.tar.bz2
linux-64::arrow-cpp-8.0.0-py310h893e394_4_cpu.tar.bz2
linux-64::mapserver-7.6.4-py39h72a77e4_9.tar.bz2
linux-64::yarp-cxx-3.7.0-hfee3fe3_3.tar.bz2
linux-64::arrow-cpp-8.0.0-py39h395f399_3_cpu.tar.bz2
linux-64::tensorflow-base-2.9.1-cuda111py310h12abe6f_0.tar.bz2
linux-64::libarchive-3.5.2-hada088e_3.tar.bz2
linux-64::hdf5-1.12.2-mpi_openmpi_hb3f3608_0.tar.bz2
linux-64::arrow-cpp-8.0.1-py37h41ad185_0_cuda.tar.bz2
linux-64::triqs-3.1.1-py310h02d43f6_0.tar.bz2
linux-64::mapserver-7.6.4-py39h6d6df6e_11.tar.bz2
linux-64::arrow-cpp-8.0.1-py39h811ffd7_0_cpu.tar.bz2
linux-64::vtk-9.1.0-egl_py39h5435a3f_12.tar.bz2
linux-64::libopencv-4.5.5-py39hd011c1b_12.tar.bz2
linux-64::libopencv-4.5.5-py39he64e9e9_10.tar.bz2
linux-64::ffmpeg-5.0.1-gpl_h2b602b6_108.tar.bz2
linux-64::cpp-opentelemetry-sdk-1.4.1-hb354d1b_1.tar.bz2
linux-64::hdf5-1.12.2-mpi_mpich_h08b82f9_0.tar.bz2
linux-64::hugin-2021.0.0-pl5321hb4e0585_6.tar.bz2
linux-64::vtk-9.1.0-egl_py38h3346cfb_9.tar.bz2
linux-64::libtensorflow_cc-2.9.1-cuda110ha3f6c36_0.tar.bz2
linux-64::topologytoolkit-1.1.0-no_paraview_py310h3d7b1a7_100.tar.bz2
linux-64::grpc-cpp-1.47.0-h0b91f02_0.tar.bz2
linux-64::libopencv-4.6.0-py39ha3d0060_1.tar.bz2
linux-64::gemmi-0.5.5-py39h7d9a04d_0.tar.bz2
linux-64::ffmpeg-5.0.1-gpl_h512afef_107.tar.bz2
linux-64::ndcctools-7.4.6-py38h782bae8_0.tar.bz2
linux-64::arrow-cpp-8.0.0-py310h8cf3212_2_cuda.tar.bz2
linux-64::tiledb-2.10.2-h1e4a385_0.tar.bz2
linux-64::libopencv-4.5.5-py39ha3d0060_11.tar.bz2
linux-64::arrow-cpp-8.0.0-py38ha7276ea_5_cpu.tar.bz2
linux-64::grpc-cpp-1.45.2-hbe52ea8_4.tar.bz2
linux-64::arrow-cpp-8.0.0-py39he577829_2_cuda.tar.bz2
linux-64::paraview-5.10.1-py310h4f67b28_7_egl.tar.bz2
linux-64::tectonic-0.9.0-h77108f9_1.tar.bz2
linux-64::vtk-9.1.0-egl_py38h21ea40a_11.tar.bz2
linux-64::libopencv-4.6.0-py39he08f5c2_2.tar.bz2
linux-64::openbabel-3.1.1-py38h3d1cf2f_4.tar.bz2
linux-64::nd2-0.3.0-py310h062fc0b_0.tar.bz2
linux-64::vtk-9.1.0-qt_py310h6363799_210.tar.bz2
linux-64::root_base-6.26.4-py310hcbef177_3.tar.bz2
linux-64::tensorflow-base-2.9.1-cuda112py310hc65a3b4_0.tar.bz2
linux-64::arrow-cpp-5.0.0-py38h97bb493_35_cuda.tar.bz2
linux-64::ndcctools-7.4.8-py37hecb152a_0.tar.bz2
linux-64::lmod-8.7.7-lua54h71fc533_0.tar.bz2
linux-64::libmongoc-1.22.0-h15e390e_0.tar.bz2
linux-64::jaxlib-0.3.14-cpu_py38h8465198_3.tar.bz2
linux-64::arrow-cpp-3.0.0-py38h91fe7ba_54_cpu.tar.bz2
linux-64::vtk-9.1.0-osmesa_py38h2712717_110.tar.bz2
linux-64::arrow-cpp-8.0.0-py38hd09f243_4_cpu.tar.bz2
linux-64::tectonic-0.9.0-h20e8f85_1.tar.bz2
linux-64::coda-2.24-py39hec2c022_1.tar.bz2
linux-64::harp-1.15.1-py39r41h665c6b1_1.tar.bz2
linux-64::arrow-cpp-8.0.0-py38h3915496_2_cuda.tar.bz2
linux-64::vtk-9.1.0-osmesa_py38hfe2dfd5_109.tar.bz2
linux-64::jaxlib-0.3.14-cuda112py37h4498987_0.tar.bz2
linux-64::openmeeg-2.4.6-py38hdd05e23_0.tar.bz2
linux-64::vtk-9.1.0-osmesa_py39h8ab48e2_109.tar.bz2
linux-64::llvmdev-14.0.6-he0ac6c6_0.tar.bz2
linux-64::jaxlib-0.3.14-cuda112py39h8b761d8_1.tar.bz2
linux-64::imagemagick-7.1.0_41-pl5321h2098167_1.tar.bz2
linux-64::vtk-9.1.0-qt_py38h5d0067c_212.tar.bz2
linux-64::libopencv-4.5.5-py37h4a49c2f_13.tar.bz2
linux-64::fish-3.5.1-h682823d_0.tar.bz2
linux-64::ffmpeg-4.4.2-lgpl_h46cd745_1.tar.bz2
linux-64::astrometry-0.90-py310h47ba2b7_2.tar.bz2
linux-64::erlang-25.0.1-pl5321hb9e9383_0.tar.bz2
linux-64::paraview-5.10.1-py37hebc95f2_7_egl.tar.bz2
linux-64::xrootd-5.4.3-py37h62c5c55_1.tar.bz2
linux-64::ndcctools-7.4.6-py39h084f619_0.tar.bz2
linux-64::mapserver-7.6.4-py310hfa931c3_11.tar.bz2
linux-64::jaxlib-0.3.14-cuda112py39h8d07533_0.tar.bz2
linux-64::arrow-cpp-3.0.0-py38h4dc91b6_54_cuda.tar.bz2
linux-64::harp-1.15.1-py39r41he2a1b48_1.tar.bz2
linux-64::grpc-cpp-1.45.2-h60c3337_4.tar.bz2
linux-64::wasmer-2.3.0-h2af65a9_0.tar.bz2
linux-64::gdstk-0.8.3-py38h0048722_0.tar.bz2
linux-64::paraview-5.10.1-py39hb74cda6_107_qt.tar.bz2
linux-64::arrow-cpp-8.0.0-py37h41ad185_4_cuda.tar.bz2
linux-64::arrow-cpp-3.0.0-py37h41c12fa_54_cpu.tar.bz2
linux-64::ndcctools-7.4.10-py310ha616101_1.tar.bz2
linux-64::cpp-opentelemetry-sdk-1.4.1-h48a8ea9_2.tar.bz2
linux-64::arrow-cpp-6.0.1-py38hd499e97_20_cpu.tar.bz2
linux-64::ndcctools-7.4.10-py37hecb152a_0.tar.bz2
linux-64::coda-2.24-py310h001d289_1.tar.bz2
linux-64::topologytoolkit-1.0.0-no_paraview_py39h356bce5_105.tar.bz2
linux-64::ndcctools-7.4.8-py310h5deebde_0.tar.bz2
linux-64::tensorflow-base-2.9.1-cuda102py310h282d6da_0.tar.bz2
linux-64::libopencv-4.5.5-py38hcc5f2f6_12.tar.bz2
linux-64::tesseract-5.2.0-h7bf7e52_0.tar.bz2
linux-64::arrow-cpp-8.0.0-py37h399d738_3_cpu.tar.bz2
linux-64::vigra-1.11.1-py37hc2f5209_1033.tar.bz2
linux-64::topologytoolkit-1.0.0-no_paraview_py38h3b9b033_105.tar.bz2
linux-64::topologytoolkit-1.0.0-no_paraview_py39h356bce5_106.tar.bz2
linux-64::jaxlib-0.3.14-cuda112py310h59d0295_0.tar.bz2
linux-64::libtiledb-sql-0.15.1-h0993566_0.tar.bz2
linux-64::cpp-opentelemetry-sdk-1.4.1-hb354d1b_0.tar.bz2
linux-64::openmeeg-2.4.2-py37h64e15ff_0.tar.bz2
linux-64::root_base-6.26.4-py38h9550cab_3.tar.bz2
linux-64::vtk-9.1.0-qt_py37h238fe64_210.tar.bz2
linux-64::glib-networking-2.72.1-h6605ff3_1.tar.bz2
linux-64::tensorflow-base-2.9.1-cuda110py39h2c4febc_0.tar.bz2
linux-64::vowpalwabbit-9.2.0-py310h6db030a_0.tar.bz2
linux-64::libopencv-4.5.5-py39hd011c1b_13.tar.bz2
linux-64::jaxlib-0.3.14-cpu_py310h3dca822_3.tar.bz2
linux-64::arrow-cpp-8.0.0-py38h913b37a_3_cuda.tar.bz2
linux-64::jaxlib-0.3.14-cuda112py37h2291b5a_203.tar.bz2
linux-64::prometheus-cpp-1.0.0-h751d214_0.tar.bz2
linux-64::arrow-cpp-8.0.1-py38h21af1cf_0_cuda.tar.bz2
linux-64::coda-2.24-py38h459ef46_1.tar.bz2
linux-64::arrow-cpp-5.0.0-py310he6da3e4_35_cpu.tar.bz2
linux-64::freecad-0.20.0-py310hb49a254_0.tar.bz2
linux-64::sqlite-3.39.0-h4ff8645_0.tar.bz2
linux-64::libopencv-4.5.5-py38hc65905f_13.tar.bz2
linux-64::arrow-cpp-6.0.1-py39h5dd0ea6_20_cpu.tar.bz2
linux-64::mongodb-6.0.0-h0e13805_0.tar.bz2
linux-64::arrow-cpp-8.0.0-py37h81c5bf6_4_cpu.tar.bz2
linux-64::gmt-6.4.0-he424f55_0.tar.bz2
linux-64::jaxlib-0.3.14-cuda112py310h9def920_1.tar.bz2
linux-64::imagecodecs-2022.7.27-py38hb244211_1.tar.bz2
linux-64::vtk-9.1.0-osmesa_py37h3e2d351_112.tar.bz2
linux-64::topologytoolkit-1.0.0-no_paraview_py37h5ac0a63_105.tar.bz2
linux-64::imagemagick-7.1.0_39-pl5321heb7c40d_0.tar.bz2
-    "libzlib >=1.2.12,<1.3.0a0",
+    "libzlib >=1.2.12,<2.0.0a0",
linux-64::clang-format-14.0.6-default_h2e3cab8_0.tar.bz2
linux-64::coin-or-utils-2.11.6-h202d8b1_1.tar.bz2
linux-64::zimpl-3.5.2-hb4bb7ca_0.tar.bz2
linux-64::clang-14-14.0.6-default_h2e3cab8_0.tar.bz2
linux-64::libclang-cpp14-14.0.6-default_h2e3cab8_0.tar.bz2
linux-64::llvm-14.0.5-h32600fe_0.tar.bz2
linux-64::cudnn-8.4.0.27-hed8a83a_1.tar.bz2
linux-64::libclang13-14.0.5-default_h3a83d3e_0.tar.bz2
linux-64::spidermonkey-bin-91.11.0-hc8fd5ad_0.tar.bz2
linux-64::spidermonkey-bin-91.12.0-hc8fd5ad_0.tar.bz2
linux-64::openh264-2.2.0-h6239696_1.tar.bz2
linux-64::libclang-cpp14-14.0.5-default_h2e3cab8_0.tar.bz2
linux-64::libmlir-14.0.5-he0ac6c6_0.tar.bz2
linux-64::clang-14-14.0.5-default_h2e3cab8_0.tar.bz2
linux-64::gst-plugins-good-1.20.2-h20dca43_2.tar.bz2
linux-64::gst-plugins-base-1.20.3-hf6a322e_0.tar.bz2
linux-64::file-5.39-h753d276_1.tar.bz2
linux-64::clang-format-14-14.0.5-default_h2e3cab8_0.tar.bz2
linux-64::libmlir14-14.0.5-he0ac6c6_0.tar.bz2
linux-64::llvm-14.0.6-h32600fe_0.tar.bz2
linux-64::libllvm14-14.0.6-he0ac6c6_0.tar.bz2
linux-64::spidermonkey-91.11.0-hba313d4_0.tar.bz2
linux-64::clang-format-14-14.0.6-default_h2e3cab8_0.tar.bz2
linux-64::cudnn-8.3.2.44-hed8a83a_1.tar.bz2
linux-64::libclang-cpp-14.0.6-default_h2e3cab8_0.tar.bz2
linux-64::libclang-14.0.5-default_h2e3cab8_0.tar.bz2
linux-64::exiv2-v0.27.3-h848de5d_3.tar.bz2
linux-64::cgns-4.3.0-hcb04c3e_1.tar.bz2
linux-64::clang-tools-14.0.5-default_h2e3cab8_0.tar.bz2
linux-64::llvm-tools-14.0.5-he0ac6c6_0.tar.bz2
linux-64::glib-tools-2.72.1-h6239696_0.tar.bz2
linux-64::openh264-2.2.0-h6239696_0.tar.bz2
linux-64::exiv2-0.27.3-h848de5d_3.tar.bz2
linux-64::coin-or-osi-0.108.7-h2720bb7_1.tar.bz2
linux-64::cudnn-8.3.2.44-hed8a83a_0.tar.bz2
linux-64::clang-tools-14.0.6-default_h2e3cab8_0.tar.bz2
linux-64::libclang-cpp-14.0.5-default_h2e3cab8_0.tar.bz2
linux-64::libllvm14-14.0.5-he0ac6c6_0.tar.bz2
linux-64::zimpl-3.5.2-hb4bb7ca_1.tar.bz2
linux-64::libmlir14-14.0.3-he0ac6c6_0.tar.bz2
linux-64::gst-plugins-base-1.20.2-hf6a322e_2.tar.bz2
linux-64::libmlir-14.0.3-he0ac6c6_0.tar.bz2
linux-64::llvm-tools-14.0.6-he0ac6c6_0.tar.bz2
linux-64::libclang-14.0.6-default_h2e3cab8_0.tar.bz2
linux-64::cudnn-8.4.1.50-hed8a83a_0.tar.bz2
linux-64::gst-plugins-good-1.20.3-h20dca43_0.tar.bz2
linux-64::libclang13-14.0.6-default_h3a83d3e_0.tar.bz2
linux-64::exiv2-0.27.5-h848de5d_0.tar.bz2
linux-64::cudnn-8.4.0.27-hed8a83a_0.tar.bz2
linux-64::libics-1.6.5-h6239696_0.tar.bz2
linux-64::clang-format-14.0.5-default_h2e3cab8_0.tar.bz2
linux-64::libmagic-5.39-h753d276_1.tar.bz2
linux-64::spidermonkey-91.12.0-hba313d4_0.tar.bz2
-    "libzlib >=1.2.12,<1.3.0a0"
+    "libzlib >=1.2.12,<2.0.0a0"
```

</details>