### PR TITLE
loosen zlib-pin to major level (24/N; April & May 2022)

### DIFF
--- a/recipe/patch_yaml/zlib.yaml
+++ b/recipe/patch_yaml/zlib.yaml
@@ -223,3 +223,12 @@ then:
   - loosen_depends:
       name: libzlib
       upper_bound: "2"
+---
+if:
+  has_depends: libzlib >=1.2*
+  timestamp_lt: 1651363200000  # 2022-05-01 00:00 UTC
+  timestamp_ge: 1648771200000  # 2022-04-01 00:00 UTC
+then:
+  - loosen_depends:
+      name: libzlib
+      upper_bound: "2"

--- a/recipe/patch_yaml/zlib.yaml
+++ b/recipe/patch_yaml/zlib.yaml
@@ -214,3 +214,12 @@ then:
   - loosen_depends:
       name: libzlib
       upper_bound: "2"
+---
+if:
+  has_depends: libzlib >=1.2*
+  timestamp_lt: 1654041600000  # 2022-06-01 00:00 UTC
+  timestamp_ge: 1651363200000  # 2022-05-01 00:00 UTC
+then:
+  - loosen_depends:
+      name: libzlib
+      upper_bound: "2"


### PR DESCRIPTION
Follow-up to https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/739, about 5000 artefacts affected.

### Result of `python show_diff.py`

<details>

```diff
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
osx-arm64::pyinstaller-5.1-py38ha509820_0.tar.bz2
osx-arm64::libfido2-1.11.0-h6b14776_0.tar.bz2
osx-arm64::libgdal-3.4.2-hbfa40f0_5.tar.bz2
osx-arm64::yoda-1.9.5-py310h5452d61_0.tar.bz2
osx-arm64::tensorflow-base-2.7.1-cpu_py38he912e9c_0.tar.bz2
osx-arm64::git-2.35.3-pl5321hdb569e8_0.tar.bz2
osx-arm64::cctools_osx-64-973.0.1-h844ac8f_10.tar.bz2
osx-arm64::imagemagick-7.1.0_30-pl5321h7fa8d43_0.tar.bz2
osx-arm64::mysql-libs-8.0.28-h39b7a3a_3.tar.bz2
osx-arm64::gazebo-11.10.2-h2a4c5de_1.tar.bz2
osx-arm64::cmake-3.23.1-he7c8c24_0.tar.bz2
osx-arm64::jaxlib-0.3.10-cpu_py310h9f98a3b_0.tar.bz2
osx-arm64::orc-1.7.3-h53399b4_1.tar.bz2
osx-arm64::pdal-2.4.0-h3643eae_4.tar.bz2
osx-arm64::jaxlib-0.3.0-py39h9871300_4.tar.bz2
osx-arm64::arrow-cpp-3.0.0-py38ha825487_53_cpu.tar.bz2
osx-arm64::root_base-6.26.2-py39h1f657f7_1.tar.bz2
osx-arm64::grpc-cpp-1.43.2-ha558326_3.tar.bz2
osx-arm64::vtk-9.1.0-qt_py38hf5e40fb_208.tar.bz2
osx-arm64::pillow-9.1.0-py39hd72dd6b_1.tar.bz2
osx-arm64::grpc-cpp-1.43.2-h42cd831_5.tar.bz2
osx-arm64::arrow-cpp-5.0.0-py38h0a94c3e_32_cpu.tar.bz2
osx-arm64::pyinstaller-5.0.1-py39h854b70c_0.tar.bz2
osx-arm64::grpcio-1.46.1-py38hd51562d_0.tar.bz2
osx-arm64::mysql-libs-8.0.29-h13128d0_0.tar.bz2
osx-arm64::imagemagick-7.1.0_35-pl5321h8f75910_0.tar.bz2
osx-arm64::root_base-6.24.6-py310h6d57595_2.tar.bz2
osx-arm64::jaxlib-0.3.7-py310hc91f26d_0.tar.bz2
osx-arm64::grpc-cpp-1.46.3-h65cd93d_0.tar.bz2
osx-arm64::pyreadstat-1.1.5-py39h854b70c_0.tar.bz2
osx-arm64::libnetcdf-4.8.1-nompi_h96a3436_102.tar.bz2
osx-arm64::ogre-13.3.4-hcb396c5_0.tar.bz2
osx-arm64::ffmpeg-5.0.1-h254c7df_2.tar.bz2
osx-arm64::arrow-cpp-7.0.0-py38h0c586e9_4_cpu.tar.bz2
osx-arm64::tiledb-2.8.0-h29b8279_1.tar.bz2
osx-arm64::pillow-9.1.0-py38h7ff1586_2.tar.bz2
osx-arm64::jaxlib-0.3.2-py39h4979227_0.tar.bz2
osx-arm64::libmatio-1.5.23-h5c1be75_0.tar.bz2
osx-arm64::sqlite-3.38.5-h40dfcc0_0.tar.bz2
osx-arm64::imagemagick-7.1.0_33-pl5321h8f75910_0.tar.bz2
osx-arm64::tiledb-2.8.3-h824fbfd_0.tar.bz2
osx-arm64::libcurl-static-7.83.1-h2fcd78c_0.tar.bz2
osx-arm64::jaxlib-0.3.10-cpu_py38h87657f7_0.tar.bz2
osx-arm64::mysql-client-8.0.29-h5be83e2_0.tar.bz2
osx-arm64::llvmlite-0.38.0-py39hd599773_1.tar.bz2
osx-arm64::arrow-cpp-5.0.0-py310ha01ccb6_29_cpu.tar.bz2
osx-arm64::jaxlib-0.3.0-py310h5f9fef9_4.tar.bz2
osx-arm64::arrow-cpp-6.0.1-py38he319883_15_cpu.tar.bz2
osx-arm64::arrow-cpp-6.0.1-py39h79013d2_15_cpu.tar.bz2
osx-arm64::arrow-cpp-6.0.1-py39h60eade1_19_cpu.tar.bz2
osx-arm64::jaxlib-0.3.0-py38h42d6cd8_4.tar.bz2
osx-arm64::imagecodecs-2022.2.22-py39hfa2e616_4.tar.bz2
osx-arm64::python-3.9.13-h96fcbfb_0_cpython.tar.bz2
osx-arm64::coin-or-cgl-0.60.6-h7897f42_0.tar.bz2
osx-arm64::jaxlib-0.3.10-cpu_py38h78c0d4f_0.tar.bz2
osx-arm64::arrow-cpp-5.0.0-py38he319883_30_cpu.tar.bz2
osx-arm64::arrow-cpp-3.0.0-py38h0a94c3e_53_cpu.tar.bz2
osx-arm64::wxpython-4.1.1-py310h548dc07_7.tar.bz2
osx-arm64::indexed_gzip-1.6.13-py38h16e6c9d_1.tar.bz2
osx-arm64::tiledb-2.8.2-hdd33e7b_0.tar.bz2
osx-arm64::arrow-cpp-8.0.0-py310h46ba588_1_cpu.tar.bz2
osx-arm64::arrow-cpp-6.0.1-py310h50e0c3d_16_cpu.tar.bz2
osx-arm64::arrow-cpp-6.0.1-py38ha825487_19_cpu.tar.bz2
osx-arm64::arrow-cpp-6.0.1-py310ha01ccb6_14_cpu.tar.bz2
osx-arm64::sqlite-3.38.2-h7e3ccbd_0.tar.bz2
osx-arm64::grpcio-1.46.0-py39h365d37b_0.tar.bz2
osx-arm64::tectonic-0.9.0-h1eadb92_0.tar.bz2
osx-arm64::libarchive-3.5.2-hdd7f49f_2.tar.bz2
osx-arm64::arrow-cpp-8.0.0-py38hacdd530_1_cpu.tar.bz2
osx-arm64::coin-or-clp-1.17.7-h5f94771_0.tar.bz2
osx-arm64::arrow-cpp-5.0.0-py39h032a6c7_29_cpu.tar.bz2
osx-arm64::jaxlib-0.3.7-py39h9389d93_0.tar.bz2
osx-arm64::pyinstaller-5.1-py310h75fa04e_0.tar.bz2
osx-arm64::arrow-cpp-8.0.0-py310h06d4556_1_cpu.tar.bz2
osx-arm64::vigra-1.11.1-py310hb7246df_1031.tar.bz2
osx-arm64::llvmlite-0.38.1-py39h88d5170_0.tar.bz2
osx-arm64::arrow-cpp-3.0.0-py39h032a6c7_48_cpu.tar.bz2
osx-arm64::indexed_gzip-1.6.13-py39he150c34_1.tar.bz2
osx-arm64::cmake-3.23.2-h52850c7_0.tar.bz2
osx-arm64::mysql-server-8.0.28-hd9f5b67_4.tar.bz2
osx-arm64::arrow-cpp-5.0.0-py38h0a94c3e_34_cpu.tar.bz2
osx-arm64::grpc-cpp-1.46.0-ha5a88ed_0.tar.bz2
osx-arm64::pdal-2.4.0-h71c66b6_3.tar.bz2
osx-arm64::pygrib-2.1.4-py39h962a9b5_5.tar.bz2
osx-arm64::pyinstaller-5.0-py39hd623912_0.tar.bz2
osx-arm64::grpcio-1.46.1-py310h10ad472_0.tar.bz2
osx-arm64::gsoap-2.8.121-h4b682c6_0.tar.bz2
osx-arm64::root_base-6.24.6-py39h1f657f7_2.tar.bz2
osx-arm64::libopencv-4.5.5-py38he52a0c8_9.tar.bz2
osx-arm64::postgresql-14.3-heaa1073_0.tar.bz2
osx-arm64::grpc-cpp-1.43.2-h875ad3d_3.tar.bz2
osx-arm64::vowpalwabbit-9.1.0-py39h4c40599_0.tar.bz2
osx-arm64::pillow-9.1.0-py38h7ff1586_0.tar.bz2
osx-arm64::mysql-client-8.0.29-hd044a26_1.tar.bz2
osx-arm64::tectonic-0.9.0-h9906442_0.tar.bz2
osx-arm64::arrow-cpp-6.0.1-py39h60eade1_18_cpu.tar.bz2
osx-arm64::mysql-libs-8.0.28-hb723b2b_4.tar.bz2
osx-arm64::xrootd-5.4.2-py38h5789955_0.tar.bz2
osx-arm64::arrow-cpp-5.0.0-py310h50e0c3d_34_cpu.tar.bz2
osx-arm64::freeimage-3.18.0-h6393344_8.tar.bz2
osx-arm64::jaxlib-0.3.7-py38h05704ff_0.tar.bz2
osx-arm64::grpcio-1.46.0-py38h1ef021a_0.tar.bz2
osx-arm64::arrow-cpp-5.0.0-py310h50e0c3d_32_cpu.tar.bz2
osx-arm64::gemmi-0.5.4-py39hd599773_0.tar.bz2
osx-arm64::arrow-cpp-7.0.0-py38hc445ed8_7_cpu.tar.bz2
osx-arm64::vigra-1.11.1-py38h2d219e2_1032.tar.bz2
osx-arm64::libgdal-3.4.3-hf042c4b_0.tar.bz2
osx-arm64::magics-metview-batch-4.12.0-h555a53f_0.tar.bz2
osx-arm64::libcurl-7.83.0-h2fcd78c_0.tar.bz2
osx-arm64::arrow-cpp-5.0.0-py310h4f63f05_30_cpu.tar.bz2
osx-arm64::arrow-cpp-6.0.1-py39h440626a_14_cpu.tar.bz2
osx-arm64::gct-6.2.1629922860-h5de80d7_1.tar.bz2
osx-arm64::scip-8.0.0-h7158e95_1.tar.bz2
osx-arm64::grpc-cpp-1.43.2-h250b2ad_4.tar.bz2
osx-arm64::tiledb-2.9.0-h824fbfd_1.tar.bz2
osx-arm64::grpc-cpp-1.45.2-ha5a88ed_3.tar.bz2
osx-arm64::libxmlsec1-1.2.33-hcaf8fcb_1.tar.bz2
osx-arm64::pyinstaller-5.0.1-py38ha509820_0.tar.bz2
osx-arm64::pyreadstat-1.1.4-py38h95a778e_1.tar.bz2
osx-arm64::tensorflow-base-2.8.1-cpu_py39h84f6f83_0.tar.bz2
osx-arm64::ffmpeg-5.0.1-he648476_0.tar.bz2
osx-arm64::ogre-1.12.13-he6f17a6_1.tar.bz2
osx-arm64::grpc-cpp-1.46.3-h6666856_0.tar.bz2
osx-arm64::omniorb-libs-4.2.5-haeec458_2.tar.bz2
osx-arm64::librdkafka-1.8.2.post2-h5db051d_1.tar.bz2
osx-arm64::libtensorflow-2.8.1-cpu_h4a37cde_0.tar.bz2
osx-arm64::arrow-cpp-6.0.1-py39ha0ddcc3_19_cpu.tar.bz2
osx-arm64::tensorflow-base-2.8.0-cpu_py39hcf13c84_0.tar.bz2
osx-arm64::libxml2-2.9.13-h97d9dda_0.tar.bz2
osx-arm64::gsoap-2.8.122-h4ebd778_0.tar.bz2
osx-arm64::cpp-opentelemetry-sdk-1.3.0-hc73a0e7_0.tar.bz2
osx-arm64::arrow-cpp-8.0.0-py39h53b7727_1_cpu.tar.bz2
osx-arm64::openjpeg-2.5.0-hd370e0e_0.tar.bz2
osx-arm64::omniorb-libs-4.2.5-h6b14776_2.tar.bz2
osx-arm64::collada-dom-2.5.0-h19855e2_4.tar.bz2
osx-arm64::mysql-server-8.0.28-h6984ec0_3.tar.bz2
osx-arm64::sqlite-3.38.3-h40dfcc0_0.tar.bz2
osx-arm64::grpc-cpp-1.45.2-h8ea39b2_3.tar.bz2
osx-arm64::smesh-9.7.0.1-hee3001f_1.tar.bz2
osx-arm64::curl-7.83.1-h2fcd78c_0.tar.bz2
osx-arm64::arrow-cpp-7.0.0-py39h2176349_4_cpu.tar.bz2
osx-arm64::grpc-cpp-1.45.2-hdac892a_0.tar.bz2
osx-arm64::boost-cpp-1.78.0-h1cb353e_1.tar.bz2
osx-arm64::ffmpeg-5.0.1-heb85afd_1.tar.bz2
osx-arm64::libtensorflow-2.8.0-cpu_hb019c61_0.tar.bz2
osx-arm64::mysql-server-8.0.28-h7bb88c2_4.tar.bz2
osx-arm64::arrow-cpp-6.0.1-py39h032a6c7_14_cpu.tar.bz2
osx-arm64::arrow-cpp-7.0.0-py38hacdd530_5_cpu.tar.bz2
osx-arm64::jaxlib-0.3.7-py38hb6f2dd7_0.tar.bz2
osx-arm64::gemmi-0.5.3-py310hc7cf0d3_1.tar.bz2
osx-arm64::jaxlib-0.3.10-cpu_py38hfaea817_0.tar.bz2
osx-arm64::imagecodecs-2022.2.22-py39h2be30d5_3.tar.bz2
osx-arm64::imagecodecs-2022.2.22-py310h5c6ed18_2.tar.bz2
osx-arm64::pyreadstat-1.1.6-py38ha509820_0.tar.bz2
osx-arm64::libtiff-4.3.0-h2810ee2_4.tar.bz2
osx-arm64::tiledb-2.8.0-h9fb27ea_1.tar.bz2
osx-arm64::gemmi-0.5.3-py38hd1051fe_1.tar.bz2
osx-arm64::arrow-cpp-6.0.1-py38h93d1ccb_14_cpu.tar.bz2
osx-arm64::pillow-9.1.0-py38h7ff1586_1.tar.bz2
osx-arm64::pygrib-2.1.4-py310h5b8a0c6_5.tar.bz2
osx-arm64::libcurl-static-7.83.0-h7965298_0.tar.bz2
osx-arm64::root_base-6.24.6-py39haccfeaf_3.tar.bz2
osx-arm64::jaxlib-0.3.0-py39h4979227_4.tar.bz2
osx-arm64::grpc-cpp-1.45.2-he55ebb4_1.tar.bz2
osx-arm64::libgdal-3.4.3-h5cd83ce_0.tar.bz2
osx-arm64::libgdal-3.5.0-hf042c4b_0.tar.bz2
osx-arm64::cppyy-cling-6.25.3-py310h5297d37_1.tar.bz2
osx-arm64::arrow-cpp-6.0.1-py310hed2bb84_19_cpu.tar.bz2
osx-arm64::pyinstaller-5.0-py310h5e5bb13_0.tar.bz2
osx-arm64::omniorb-4.2.5-py38h1ef021a_2.tar.bz2
osx-arm64::mysql-client-8.0.29-h5be83e2_1.tar.bz2
osx-arm64::ogre-13.3.4-he6f17a6_1.tar.bz2
osx-arm64::nodejs-17.9.0-hf46ff2d_0.tar.bz2
osx-arm64::poppler-22.04.0-hb0e405e_0.tar.bz2
osx-arm64::arrow-cpp-3.0.0-py310h50e0c3d_51_cpu.tar.bz2
osx-arm64::gmsh-4.10.2-h8f86c64_0.tar.bz2
osx-arm64::curl-7.83.0-h7965298_0.tar.bz2
osx-arm64::libopencv-4.5.5-py39h8810e4f_8.tar.bz2
osx-arm64::arrow-cpp-8.0.0-py38h7fd58b1_1_cpu.tar.bz2
osx-arm64::mysql-client-8.0.29-hd044a26_0.tar.bz2
osx-arm64::mysql-libs-8.0.29-h0a1dba2_1.tar.bz2
osx-arm64::openmpi-4.1.3-h8490d8b_0.tar.bz2
osx-arm64::jaxlib-0.3.10-cpu_py39ha1df067_0.tar.bz2
osx-arm64::libcurl-7.83.1-h7965298_0.tar.bz2
osx-arm64::mosh-1.3.2-pl5321h3d44535_1012.tar.bz2
osx-arm64::openscenegraph-3.6.5-ha0111ab_13.tar.bz2
osx-arm64::llvmlite-0.38.0-py310hc7cf0d3_1.tar.bz2
osx-arm64::tensorflow-base-2.8.0-cpu_py310h7f11b9b_0.tar.bz2
osx-arm64::cctools_osx-64-973.0.1-he3d0e6b_10.tar.bz2
osx-arm64::arrow-cpp-8.0.0-py310h0f2c11a_0_cpu.tar.bz2
osx-arm64::grpc-cpp-1.43.2-h7d3d786_3.tar.bz2
osx-arm64::arrow-cpp-7.0.0-py310h46ba588_7_cpu.tar.bz2
osx-arm64::grpc-cpp-1.43.2-h9f4a6bb_4.tar.bz2
osx-arm64::cpp-opentelemetry-sdk-1.3.0-h1276eba_1.tar.bz2
osx-arm64::grpcio-1.46.0-py38hd51562d_0.tar.bz2
osx-arm64::arrow-cpp-6.0.1-py310h50e0c3d_19_cpu.tar.bz2
osx-arm64::libssh-0.8.9-h6b14776_2.tar.bz2
osx-arm64::xrootd-5.4.2-py310hd2c8f92_0.tar.bz2
osx-arm64::grpc-cpp-1.46.0-h98c3ada_0.tar.bz2
osx-arm64::tiledb-2.8.1-h29b8279_0.tar.bz2
osx-arm64::git-2.35.2-pl5321h8b11ce0_0.tar.bz2
osx-arm64::gfal2-2.20.5-h78819f7_1.tar.bz2
osx-arm64::llvmdev-14.0.2-h37c5ba8_0.tar.bz2
osx-arm64::grpcio-1.46.3-py38h1ef021a_0.tar.bz2
osx-arm64::grpc-cpp-1.44.0-h250b2ad_3.tar.bz2
osx-arm64::mosh-1.3.2-pl5321hef450a1_1012.tar.bz2
osx-arm64::vigra-1.11.1-py38hf8bd7f9_1031.tar.bz2
osx-arm64::libcurl-static-7.83.1-h7965298_0.tar.bz2
osx-arm64::tiledb-2.7.2-h29b8279_0.tar.bz2
osx-arm64::arrow-cpp-3.0.0-py310h3a4abcd_48_cpu.tar.bz2
osx-arm64::grpcio-1.46.1-py39h518bade_0.tar.bz2
osx-arm64::imagecodecs-2022.2.22-py38h5a0705f_4.tar.bz2
osx-arm64::tiledb-2.8.0-h29b8279_0.tar.bz2
osx-arm64::jaxlib-0.3.7-py38hea720f3_0.tar.bz2
osx-arm64::git-2.35.2-pl5321hdb569e8_0.tar.bz2
osx-arm64::root_base-6.26.2-py310h6d57595_1.tar.bz2
osx-arm64::grpc-cpp-1.43.2-h98c3ada_5.tar.bz2
osx-arm64::indexed_gzip-1.6.13-py310h00f8794_1.tar.bz2
osx-arm64::arrow-cpp-3.0.0-py38hb11185f_48_cpu.tar.bz2
osx-arm64::imagemagick-7.1.0_32-pl5321h8f75910_0.tar.bz2
osx-arm64::gdstk-0.8.2-py39h698fb12_1.tar.bz2
osx-arm64::libpq-14.3-h8ab49ba_0.tar.bz2
osx-arm64::libfido2-1.11.0-haeec458_0.tar.bz2
osx-arm64::omniorb-4.2.5-py310h10ad472_2.tar.bz2
osx-arm64::sqlite-3.38.4-h40dfcc0_0.tar.bz2
osx-arm64::gazebo-11.10.2-h5979ed2_2.tar.bz2
osx-arm64::fish-3.4.1-hc4ce0c0_0.tar.bz2
osx-arm64::grpcio-1.46.0-py38h1ef021a_1.tar.bz2
osx-arm64::blosc-1.21.1-hd0d9a2c_1.tar.bz2
osx-arm64::grpc-cpp-1.44.0-h6a0e032_3.tar.bz2
osx-arm64::pdal-2.4.0-hc55c685_3.tar.bz2
osx-arm64::wxpython-4.1.1-py39h2f097a1_6.tar.bz2
osx-arm64::mysql-client-8.0.28-hee60060_3.tar.bz2
osx-arm64::arrow-cpp-5.0.0-py39h60eade1_34_cpu.tar.bz2
osx-arm64::vigra-1.11.1-py39h9b26c2d_1031.tar.bz2
osx-arm64::papilo-2.0.0-hce67156_1.tar.bz2
osx-arm64::arrow-cpp-3.0.0-py310h50e0c3d_53_cpu.tar.bz2
osx-arm64::libssh-0.8.9-haeec458_2.tar.bz2
osx-arm64::openmpi-4.1.3-hd4b5bf3_103.tar.bz2
osx-arm64::llvmdev-14.0.3-h37c5ba8_0.tar.bz2
osx-arm64::gmsh-4.10.3-h8f86c64_0.tar.bz2
osx-arm64::arrow-cpp-7.0.0-py310ha5cac74_4_cpu.tar.bz2
osx-arm64::gazebo-11.10.2-h8303677_1.tar.bz2
osx-arm64::arrow-cpp-7.0.0-py39h2436d35_7_cpu.tar.bz2
osx-arm64::curl-7.83.1-h7965298_0.tar.bz2
osx-arm64::grpcio-1.46.0-py310ha26ec5d_0.tar.bz2
osx-arm64::vowpalwabbit-9.1.0-py38h470d07a_0.tar.bz2
osx-arm64::grpc-cpp-1.43.2-hb50c3d6_3.tar.bz2
osx-arm64::pillow-9.1.0-py310hade9107_1.tar.bz2
osx-arm64::nss-3.78-h1483a63_0.tar.bz2
osx-arm64::imagecodecs-2022.2.22-py310h1d9b92d_4.tar.bz2
osx-arm64::vowpalwabbit-9.1.0-py310h6e295bf_0.tar.bz2
osx-arm64::mysql-connector-cpp-8.0.29-hf47c702_0.tar.bz2
osx-arm64::gazebo-11.10.2-ha85a7c6_1.tar.bz2
osx-arm64::arrow-cpp-3.0.0-py39h79013d2_49_cpu.tar.bz2
osx-arm64::pdal-2.4.1-h80c1ad8_0.tar.bz2
osx-arm64::arrow-cpp-5.0.0-py39h79013d2_30_cpu.tar.bz2
osx-arm64::grpc-cpp-1.45.2-he6ee347_0.tar.bz2
osx-arm64::pillow-9.1.1-py38h3852883_0.tar.bz2
osx-arm64::rsync-3.2.3-hddcd259_4.tar.bz2
osx-arm64::grpcio-1.46.1-py39h365d37b_0.tar.bz2
osx-arm64::nodejs-17.9.0-h941bd55_0.tar.bz2
osx-arm64::mysql-server-8.0.29-h671362a_0.tar.bz2
osx-arm64::root_base-6.26.2-py39h2ec9a04_2.tar.bz2
osx-arm64::gemmi-0.5.3-py39hd599773_1.tar.bz2
osx-arm64::vtk-9.1.0-qt_py310hce58b2a_208.tar.bz2
osx-arm64::llvmdev-14.0.1-hfd59cb2_0.tar.bz2
osx-arm64::grpc-cpp-1.45.2-heb93ea6_1.tar.bz2
osx-arm64::jaxlib-0.3.10-cpu_py310h7f2b7ff_0.tar.bz2
osx-arm64::pyreadstat-1.1.6-py39h854b70c_0.tar.bz2
osx-arm64::imagecodecs-2022.2.22-py38hb8d0f52_3.tar.bz2
osx-arm64::libprotobuf-3.20.1-h332123e_0.tar.bz2
osx-arm64::llvmdev-14.0.4-h37c5ba8_0.tar.bz2
osx-arm64::arrow-cpp-3.0.0-py310h50e0c3d_52_cpu.tar.bz2
osx-arm64::libarchive-3.5.2-h69ec738_2.tar.bz2
osx-arm64::grpc-cpp-1.44.0-hb50c3d6_2.tar.bz2
osx-arm64::arrow-cpp-7.0.0-py39hfe9f825_6_cpu.tar.bz2
osx-arm64::tiledb-2.8.3-hdd33e7b_0.tar.bz2
osx-arm64::grpc-cpp-1.45.2-h98c3ada_2.tar.bz2
osx-arm64::jaxlib-0.3.10-cpu_py38hade8c37_0.tar.bz2
osx-arm64::libpq-14.3-hd0d3353_0.tar.bz2
osx-arm64::pdal-2.4.0-h5989eb2_4.tar.bz2
osx-arm64::grpcio-1.46.0-py39h518bade_1.tar.bz2
osx-arm64::assimp-5.2.4-h3287542_0.tar.bz2
osx-arm64::gsoap-2.8.121-h0bb0491_0.tar.bz2
osx-arm64::libmediainfo-22.03-hfbb8764_1.tar.bz2
osx-arm64::tiledb-2.8.1-h9fb27ea_0.tar.bz2
osx-arm64::msgpack-c-3.3.0-h3287542_4.tar.bz2
osx-arm64::jaxlib-0.3.7-py38hb9ddc9d_0.tar.bz2
osx-arm64::arrow-cpp-8.0.0-py38hc445ed8_1_cpu.tar.bz2
osx-arm64::openssh-9.0p1-h1704389_0.tar.bz2
osx-arm64::imagecodecs-2022.2.22-py38h9575e3c_2.tar.bz2
osx-arm64::arrow-cpp-8.0.0-py39hfe9f825_0_cpu.tar.bz2
osx-arm64::tiledb-2.9.0-hdd33e7b_1.tar.bz2
osx-arm64::yoda-1.9.4-py39h657c83b_2.tar.bz2
osx-arm64::jaxlib-0.3.7-py39h1ae40a9_0.tar.bz2
osx-arm64::pyreadstat-1.1.4-py39h3753aae_1.tar.bz2
osx-arm64::root_base-6.24.6-py38h3e22404_3.tar.bz2
osx-arm64::postgresql-plpython-14.3-py310h1e3b118_0.tar.bz2
osx-arm64::xrootd-5.4.2-py39h18e9571_0.tar.bz2
osx-arm64::squashfs-tools-4.4-hc87c5f6_3.tar.bz2
osx-arm64::protozfits-2.0.1.post1-py39h2fb97d7_8.tar.bz2
osx-arm64::grpc-cpp-1.45.2-h98c3ada_3.tar.bz2
osx-arm64::tensorflow-base-2.8.1-cpu_py310hbd06b1c_0.tar.bz2
osx-arm64::boost-cpp-1.79.0-h1cb353e_0.tar.bz2
osx-arm64::grpc-cpp-1.45.1-h1b780c8_0.tar.bz2
osx-arm64::mysql-server-8.0.28-h9a6ce2f_3.tar.bz2
osx-arm64::pyreadstat-1.1.5-py38ha509820_0.tar.bz2
osx-arm64::libopencv-4.5.5-py31h9ab9639_8.tar.bz2
osx-arm64::grpc-cpp-1.44.0-ha5a88ed_4.tar.bz2
osx-arm64::cppyy-cling-6.25.3-py39ha71e53e_1.tar.bz2
osx-arm64::jaxlib-0.3.2-py38h42d6cd8_0.tar.bz2
osx-arm64::pyreadstat-1.1.4-py310h5363a0e_1.tar.bz2
osx-arm64::libcurl-7.83.0-h7965298_0.tar.bz2
osx-arm64::jaxlib-0.3.2-py38haca7f1a_0.tar.bz2
osx-arm64::arrow-cpp-7.0.0-py310h0f2c11a_5_cpu.tar.bz2
osx-arm64::orc-1.7.4-h96f55be_1.tar.bz2
osx-arm64::grpc-cpp-1.44.0-h9f4a6bb_3.tar.bz2
osx-arm64::tiledb-2.8.3-h824fbfd_1.tar.bz2
osx-arm64::tensorflow-base-2.8.0-cpu_py38h0aa0dbe_0.tar.bz2
osx-arm64::arrow-cpp-3.0.0-py38he319883_49_cpu.tar.bz2
osx-arm64::libcurl-7.83.1-h2fcd78c_0.tar.bz2
osx-arm64::tensorflow-base-2.7.1-cpu_py310h512fbbd_0.tar.bz2
osx-arm64::arrow-cpp-6.0.1-py39h60eade1_17_cpu.tar.bz2
osx-arm64::arrow-cpp-5.0.0-py310h3a4abcd_29_cpu.tar.bz2
osx-arm64::arrow-cpp-3.0.0-py38h93d1ccb_48_cpu.tar.bz2
osx-arm64::tiledb-2.8.2-h824fbfd_0.tar.bz2
osx-arm64::libvips-8.12.2-h4a543b2_4.tar.bz2
osx-arm64::smesh-9.8.0.2-hb205d28_0.tar.bz2
osx-arm64::gmsh-4.10.0-h8f86c64_0.tar.bz2
osx-arm64::arrow-cpp-6.0.1-py38hb11185f_14_cpu.tar.bz2
osx-arm64::postgresql-plpython-14.3-py310h501847f_0.tar.bz2
osx-arm64::jaxlib-0.3.7-py310hc886dfc_0.tar.bz2
osx-arm64::mysql-server-8.0.29-hb9ef4e7_1.tar.bz2
osx-arm64::vigra-1.11.1-py310hee2f8cb_1032.tar.bz2
osx-arm64::grpc-cpp-1.44.0-h8ea39b2_4.tar.bz2
osx-arm64::ffmpeg-4.4.1-h254c7df_4.tar.bz2
osx-arm64::pillow-9.1.0-py310hade9107_2.tar.bz2
osx-arm64::grpcio-1.46.1-py38h1ef021a_0.tar.bz2
osx-arm64::openmpi-4.1.3-hd4b5bf3_102.tar.bz2
osx-arm64::root_base-6.24.6-py38h377e93d_2.tar.bz2
osx-arm64::arrow-cpp-5.0.0-py39h440626a_29_cpu.tar.bz2
osx-arm64::grpcio-1.46.0-py39h518bade_0.tar.bz2
osx-arm64::grpcio-1.46.3-py39h365d37b_0.tar.bz2
osx-arm64::arrow-cpp-6.0.1-py310h4f63f05_15_cpu.tar.bz2
osx-arm64::emacs-28.1-hcba963b_0.tar.bz2
osx-arm64::libcurl-static-7.83.0-h2fcd78c_0.tar.bz2
osx-arm64::grpcio-1.46.0-py310h10ad472_1.tar.bz2
osx-arm64::wxpython-4.1.1-py39hc5d20e2_7.tar.bz2
osx-arm64::wxpython-4.1.1-py310h88f142e_6.tar.bz2
osx-arm64::root_base-6.26.2-py38he532589_2.tar.bz2
osx-arm64::cppyy-cling-6.25.3-py38h2ad942f_1.tar.bz2
osx-arm64::gdstk-0.8.2-py310h4ae449b_1.tar.bz2
osx-arm64::grpc-cpp-1.44.0-h42cd831_4.tar.bz2
osx-arm64::ogre-1.10.12-h8e6b19e_8.tar.bz2
osx-arm64::curl-7.83.0-h2fcd78c_0.tar.bz2
osx-arm64::mysql-libs-8.0.29-h13128d0_1.tar.bz2
osx-arm64::libprotobuf-static-3.20.1-h332123e_0.tar.bz2
osx-arm64::pillow-9.1.0-py39hd72dd6b_2.tar.bz2
osx-arm64::jaxlib-0.3.10-cpu_py39h963f08e_0.tar.bz2
osx-arm64::libgdal-3.4.2-hf042c4b_7.tar.bz2
osx-arm64::postgresql-plpython-14.3-py38haa447b5_0.tar.bz2
osx-arm64::grpcio-1.46.0-py310ha26ec5d_1.tar.bz2
osx-arm64::grpc-cpp-1.44.0-h98c3ada_4.tar.bz2
osx-arm64::arrow-cpp-3.0.0-py39h60eade1_52_cpu.tar.bz2
osx-arm64::grpc-cpp-1.45.1-hdac892a_1.tar.bz2
osx-arm64::mysql-client-8.0.28-h039e5bf_4.tar.bz2
osx-arm64::libopencv-4.5.5-py310he340bd1_9.tar.bz2
osx-arm64::jaxlib-0.3.7-py38hc99afcb_0.tar.bz2
osx-arm64::grpcio-1.46.3-py38hd51562d_0.tar.bz2
osx-arm64::libgdal-3.4.2-h1833ab8_6.tar.bz2
osx-arm64::yoda-1.9.5-py39h657c83b_0.tar.bz2
osx-arm64::root_base-6.24.6-py310h186c2fd_3.tar.bz2
osx-arm64::arrow-cpp-7.0.0-py38hacdd530_6_cpu.tar.bz2
osx-arm64::yoda-1.9.5-py38h286503d_0.tar.bz2
osx-arm64::libxmlsec1-1.2.34-haab97fc_0.tar.bz2
osx-arm64::jaxlib-0.3.2-py310hb25b340_0.tar.bz2
osx-arm64::arrow-cpp-7.0.0-py310h0f2c11a_6_cpu.tar.bz2
osx-arm64::grpc-cpp-1.44.0-h7d3d786_2.tar.bz2
osx-arm64::arrow-cpp-8.0.0-py310h0f2c11a_1_cpu.tar.bz2
osx-arm64::arrow-cpp-7.0.0-py39hfe9f825_5_cpu.tar.bz2
osx-arm64::llvmlite-0.38.1-py310hbf292a2_0.tar.bz2
osx-arm64::qt-main-5.15.3-haf604a7_0.tar.bz2
osx-arm64::arrow-cpp-8.0.0-py38hacdd530_0_cpu.tar.bz2
osx-arm64::arrow-cpp-5.0.0-py310hed2bb84_34_cpu.tar.bz2
osx-arm64::python-3.9.13-hc596b02_0_cpython.tar.bz2
osx-arm64::llvmlite-0.38.1-py38h8a5a59d_0.tar.bz2
osx-arm64::gdstk-0.8.2-py38habd9e6c_1.tar.bz2
osx-arm64::tiledb-2.8.0-h9fb27ea_0.tar.bz2
osx-arm64::grpc-cpp-1.45.2-ha5a88ed_2.tar.bz2
osx-arm64::arrow-cpp-5.0.0-py310h50e0c3d_31_cpu.tar.bz2
osx-arm64::libopencv-4.5.5-py38hdb209fb_8.tar.bz2
osx-arm64::ffmpeg-4.4.1-heb85afd_3.tar.bz2
osx-arm64::arrow-cpp-5.0.0-py38ha825487_34_cpu.tar.bz2
osx-arm64::mysql-client-8.0.28-hee60060_4.tar.bz2
osx-arm64::orc-1.7.4-h53399b4_0.tar.bz2
osx-arm64::vtk-9.1.0-qt_py39hd7f8fe9_208.tar.bz2
osx-arm64::grpc-cpp-1.45.2-h42cd831_2.tar.bz2
osx-arm64::arrow-cpp-5.0.0-py38h0a94c3e_33_cpu.tar.bz2
osx-arm64::grpcio-1.46.1-py310ha26ec5d_0.tar.bz2
osx-arm64::arrow-cpp-5.0.0-py39ha0ddcc3_34_cpu.tar.bz2
osx-arm64::arrow-cpp-5.0.0-py38h0a94c3e_31_cpu.tar.bz2
osx-arm64::postgresql-plpython-14.3-py39h22af90f_0.tar.bz2
osx-arm64::openssh-9.0p1-h00f9d85_0.tar.bz2
osx-arm64::gazebo-11.10.2-hff9ed98_1.tar.bz2
osx-arm64::blosc-1.21.1-hd414afc_2.tar.bz2
osx-arm64::protozfits-2.0.1.post1-py38h3567512_8.tar.bz2
osx-arm64::pyreadstat-1.1.6-py310h75fa04e_0.tar.bz2
osx-arm64::omniorb-4.2.5-py39h365d37b_2.tar.bz2
osx-arm64::root_base-6.26.2-py38he532589_3.tar.bz2
osx-arm64::libgdal-3.4.2-hf2b0853_5.tar.bz2
osx-arm64::jaxlib-0.3.2-py39h9871300_0.tar.bz2
osx-arm64::arrow-cpp-5.0.0-py39h60eade1_33_cpu.tar.bz2
osx-arm64::tensorflow-base-2.8.1-cpu_py38hd48fb59_0.tar.bz2
osx-arm64::mysql-libs-8.0.28-hb723b2b_3.tar.bz2
osx-arm64::grpc-cpp-1.44.0-h60856fd_3.tar.bz2
osx-arm64::blosc-1.21.1-hd414afc_3.tar.bz2
osx-arm64::jaxlib-0.3.7-py310h50585ab_0.tar.bz2
osx-arm64::cpp-opentelemetry-sdk-1.4.0-h1276eba_0.tar.bz2
osx-arm64::grpcio-1.46.0-py310h10ad472_0.tar.bz2
osx-arm64::gsoap-2.8.122-h9e21110_0.tar.bz2
osx-arm64::grpc-cpp-1.45.2-h42cd831_3.tar.bz2
osx-arm64::mysql-libs-8.0.28-h39b7a3a_4.tar.bz2
osx-arm64::magics-4.12.0-h555a53f_0.tar.bz2
osx-arm64::pillow-9.1.0-py310hade9107_0.tar.bz2
osx-arm64::arrow-cpp-6.0.1-py310h3a4abcd_14_cpu.tar.bz2
osx-arm64::cctools_osx-arm64-973.0.1-h8e51184_10.tar.bz2
osx-arm64::jaxlib-0.3.7-py39hfe616cd_0.tar.bz2
osx-arm64::tiledb-2.9.1-h824fbfd_0.tar.bz2
osx-arm64::jaxlib-0.3.7-py39h4c365d3_0.tar.bz2
osx-arm64::pygrib-2.1.4-py38hfb3bc3b_5.tar.bz2
osx-arm64::grpcio-1.46.3-py310ha26ec5d_0.tar.bz2
osx-arm64::yoda-1.9.4-py38h286503d_2.tar.bz2
osx-arm64::boost-cpp-1.74.0-h1cb353e_8.tar.bz2
osx-arm64::root_base-6.26.2-py39h2ec9a04_3.tar.bz2
osx-arm64::mysql-libs-8.0.29-h0a1dba2_0.tar.bz2
osx-arm64::ruby-3.1.2-h0bd3743_0.tar.bz2
osx-arm64::jaxlib-0.3.0-py310hb25b340_4.tar.bz2
osx-arm64::llvmlite-0.38.0-py38hd1051fe_1.tar.bz2
osx-arm64::jaxlib-0.3.7-py310hf8295f5_0.tar.bz2
osx-arm64::arrow-cpp-3.0.0-py39h60eade1_50_cpu.tar.bz2
osx-arm64::libmediainfo-22.03-hfbb8764_0.tar.bz2
osx-arm64::pyinstaller-5.0-py38h2495b5b_0.tar.bz2
osx-arm64::git-2.35.3-pl5321h8b11ce0_0.tar.bz2
osx-arm64::omniorb-4.2.5-py38hd51562d_2.tar.bz2
osx-arm64::protozfits-2.0.1.post1-py310h9c5f33f_8.tar.bz2
osx-arm64::wxpython-4.1.1-py38h2e3edf3_7.tar.bz2
osx-arm64::gemmi-0.5.4-py38hd1051fe_0.tar.bz2
osx-arm64::libtensorflow_cc-2.8.1-cpu_h4a37cde_0.tar.bz2
osx-arm64::arrow-cpp-3.0.0-py39h440626a_48_cpu.tar.bz2
osx-arm64::libxml2-2.9.14-h035c1df_0.tar.bz2
osx-arm64::libnetcdf-4.8.1-mpi_mpich_hcc2321e_2.tar.bz2
osx-arm64::grpcio-1.46.3-py310h10ad472_0.tar.bz2
osx-arm64::mysql-server-8.0.29-h671362a_1.tar.bz2
osx-arm64::jaxlib-0.3.7-py310h037146a_0.tar.bz2
osx-arm64::arrow-cpp-5.0.0-py38h93d1ccb_29_cpu.tar.bz2
osx-arm64::tectonic-0.8.2-ha125bc1_3.tar.bz2
osx-arm64::arrow-cpp-3.0.0-py310ha01ccb6_48_cpu.tar.bz2
osx-arm64::tiledb-2.8.3-hdd33e7b_1.tar.bz2
osx-arm64::arrow-cpp-6.0.1-py38h0a94c3e_17_cpu.tar.bz2
osx-arm64::postgresql-plpython-14.3-py39h032559e_0.tar.bz2
osx-arm64::cctools_osx-arm64-973.0.1-he930820_10.tar.bz2
osx-arm64::libgdal-3.5.0-h5cd83ce_0.tar.bz2
osx-arm64::grpc-cpp-1.45.1-h21168a7_0.tar.bz2
osx-arm64::arrow-cpp-7.0.0-py38h7fd58b1_7_cpu.tar.bz2
osx-arm64::arrow-cpp-6.0.1-py38h0a94c3e_19_cpu.tar.bz2
osx-arm64::jaxlib-0.3.7-py310hf6a320f_0.tar.bz2
osx-arm64::arrow-cpp-7.0.0-py310h06d4556_7_cpu.tar.bz2
osx-arm64::gct-6.2.1629922860-h0efd88a_1.tar.bz2
osx-arm64::tiledb-2.9.1-hdd33e7b_0.tar.bz2
osx-arm64::emacs-27.2-hcba963b_3.tar.bz2
osx-arm64::jaxlib-0.3.10-cpu_py39h1faf19b_0.tar.bz2
osx-arm64::jaxlib-0.3.2-py310h5f9fef9_0.tar.bz2
osx-arm64::grpc-cpp-1.43.2-ha5a88ed_5.tar.bz2
osx-arm64::arrow-cpp-5.0.0-py38hb11185f_29_cpu.tar.bz2
osx-arm64::imagemagick-7.1.0_31-pl5321h8f75910_0.tar.bz2
osx-arm64::arrow-cpp-3.0.0-py39ha0ddcc3_53_cpu.tar.bz2
osx-arm64::qt-webengine-5.15.4-h43c6231_3.tar.bz2
osx-arm64::libgit2-1.4.3-h6407d7d_0.tar.bz2
osx-arm64::librdkafka-1.8.2.post2-hf1269b9_1.tar.bz2
osx-arm64::grpcio-1.46.0-py39h365d37b_1.tar.bz2
osx-arm64::arrow-cpp-5.0.0-py310h50e0c3d_33_cpu.tar.bz2
osx-arm64::arrow-cpp-3.0.0-py39h60eade1_53_cpu.tar.bz2
osx-arm64::root_base-6.26.2-py310h31ace29_3.tar.bz2
osx-arm64::arrow-cpp-3.0.0-py310hed2bb84_53_cpu.tar.bz2
osx-arm64::grpc-cpp-1.45.1-he6ee347_1.tar.bz2
osx-arm64::pillow-9.1.1-py39h1b8be2f_0.tar.bz2
osx-arm64::gmsh-4.10.1-h8f86c64_0.tar.bz2
osx-arm64::arrow-cpp-3.0.0-py38h0a94c3e_52_cpu.tar.bz2
osx-arm64::jaxlib-0.3.0-py38haca7f1a_4.tar.bz2
osx-arm64::soplex-6.0.0-h00e1a30_1.tar.bz2
osx-arm64::pillow-9.1.0-py39hd72dd6b_0.tar.bz2
osx-arm64::pdal-2.4.1-h9224bf6_0.tar.bz2
osx-arm64::mysql-server-8.0.29-hb9ef4e7_0.tar.bz2
osx-arm64::tiledb-2.7.2-h9fb27ea_0.tar.bz2
osx-arm64::omniorb-4.2.5-py39h518bade_2.tar.bz2
osx-arm64::libopencv-4.5.5-py39h86e1ac9_9.tar.bz2
osx-arm64::imagemagick-7.1.0_34-pl5321h8f75910_0.tar.bz2
osx-arm64::openmpi-4.1.3-h23c1900_101.tar.bz2
osx-arm64::arrow-cpp-5.0.0-py39h60eade1_32_cpu.tar.bz2
osx-arm64::pyinstaller-5.0.1-py310h75fa04e_0.tar.bz2
osx-arm64::gazebo-11.10.2-hd637351_2.tar.bz2
osx-arm64::tensorflow-base-2.7.1-cpu_py39h0053dd5_0.tar.bz2
osx-arm64::pillow-9.1.1-py310hc9df86f_0.tar.bz2
osx-arm64::llvmdev-14.0.2-h37c5ba8_1.tar.bz2
osx-arm64::postgresql-14.3-h99efecd_0.tar.bz2
osx-arm64::root_base-6.26.2-py38h377e93d_1.tar.bz2
osx-arm64::libgdal-3.4.2-h5cd83ce_7.tar.bz2
osx-arm64::vigra-1.11.1-py39hf83ad93_1032.tar.bz2
osx-arm64::imagecodecs-2022.2.22-py310hb25cb81_3.tar.bz2
osx-arm64::imagecodecs-2022.2.22-py39h2fa623e_5.tar.bz2
osx-arm64::jaxlib-0.3.10-cpu_py310hc8f61c1_0.tar.bz2
osx-arm64::grpcio-1.46.3-py39h518bade_0.tar.bz2
osx-arm64::qt-main-5.15.3-haf604a7_1.tar.bz2
osx-arm64::arrow-cpp-8.0.0-py39h2436d35_1_cpu.tar.bz2
osx-arm64::wxpython-4.1.1-py38hb97f6a1_6.tar.bz2
osx-arm64::jaxlib-0.3.10-cpu_py39hdebe834_0.tar.bz2
osx-arm64::jaxlib-0.3.7-py39h4d16dac_0.tar.bz2
osx-arm64::grpc-cpp-1.43.2-h6a0e032_4.tar.bz2
osx-arm64::mysql-client-8.0.28-h039e5bf_3.tar.bz2
osx-arm64::libtensorflow_cc-2.8.0-cpu_hb019c61_0.tar.bz2
osx-arm64::arrow-cpp-6.0.1-py39h60eade1_16_cpu.tar.bz2
osx-arm64::grpc-cpp-1.44.0-ha558326_2.tar.bz2
osx-arm64::ruby-3.1.2-h462d72a_0.tar.bz2
osx-arm64::libgit2-1.4.3-he56d1ff_0.tar.bz2
osx-arm64::imagecodecs-2022.2.22-py310h1589e16_5.tar.bz2
osx-arm64::arrow-cpp-8.0.0-py39hfe9f825_1_cpu.tar.bz2
osx-arm64::imagecodecs-2022.2.22-py39hd9178f8_2.tar.bz2
osx-arm64::jaxlib-0.3.7-py39h0fb43af_0.tar.bz2
osx-arm64::jaxlib-0.3.7-py38hfb348c2_0.tar.bz2
osx-arm64::pyinstaller-5.1-py39h854b70c_0.tar.bz2
osx-arm64::grpc-cpp-1.45.2-h8ea39b2_2.tar.bz2
osx-arm64::yoda-1.9.4-py310h5452d61_2.tar.bz2
osx-arm64::omniorb-4.2.5-py310ha26ec5d_2.tar.bz2
osx-arm64::rsync-3.2.3-h9619fcd_4.tar.bz2
osx-arm64::gemmi-0.5.4-py310hc7cf0d3_0.tar.bz2
osx-arm64::grpc-cpp-1.44.0-h875ad3d_2.tar.bz2
osx-arm64::arrow-cpp-5.0.0-py39h60eade1_31_cpu.tar.bz2
osx-arm64::imagecodecs-2022.2.22-py38h29dc463_5.tar.bz2
osx-arm64::jaxlib-0.3.10-cpu_py310h006dc33_0.tar.bz2
osx-arm64::grpc-cpp-1.43.2-h8ea39b2_5.tar.bz2
osx-arm64::grpc-cpp-1.43.2-h60856fd_4.tar.bz2
osx-arm64::zstd-1.5.2-hd705a24_1.tar.bz2
osx-arm64::libnetcdf-4.8.1-mpi_openmpi_hb732ec9_2.tar.bz2
osx-arm64::root_base-6.26.2-py310h31ace29_2.tar.bz2
osx-arm64::postgresql-plpython-14.3-py38hf5dda18_0.tar.bz2
osx-arm64::grpcio-1.46.0-py38hd51562d_1.tar.bz2
osx-arm64::libgdal-3.4.2-h3df7942_6.tar.bz2
osx-arm64::pyreadstat-1.1.5-py310h75fa04e_0.tar.bz2
-    "libzlib >=1.2.11,<1.3.0a0",
+    "libzlib >=1.2.11,<2.0.0a0",
osx-arm64::llvm-14.0.2-h95d0606_0.tar.bz2
osx-arm64::gst-plugins-base-1.20.2-hbf05cfb_1.tar.bz2
osx-arm64::libclang-cpp-9.0.1-default_h2c105f5_5.tar.bz2
osx-arm64::lld-14.0.4-h70e0dcb_0.tar.bz2
osx-arm64::dotnet-runtime-6.0.4-h35bb5c4_0.tar.bz2
osx-arm64::niftyreg-1.5.69.6-h72ed088_1.tar.bz2
osx-arm64::pocl-1.8-h422b2f1_4.tar.bz2
osx-arm64::libclang-cpp9-9.0.1-default_h2c105f5_5.tar.bz2
osx-arm64::libllvm14-14.0.3-h37c5ba8_0.tar.bz2
osx-arm64::libllvm14-14.0.2-h37c5ba8_0.tar.bz2
osx-arm64::gst-plugins-base-1.20.2-hbf05cfb_0.tar.bz2
osx-arm64::openexr-3.1.5-h264c651_0.tar.bz2
osx-arm64::gst-plugins-good-1.20.2-h0ed40fb_0.tar.bz2
osx-arm64::libsolv-0.7.22-h1280f1d_0.tar.bz2
osx-arm64::kaldi-5.5.1016-cpu_h7b7618d_1.tar.bz2
osx-arm64::lld-14.0.2-h70e0dcb_0.tar.bz2
osx-arm64::dotnet-sdk-6.0.202-h35bb5c4_0.tar.bz2
osx-arm64::libllvm14-14.0.4-h37c5ba8_0.tar.bz2
osx-arm64::libclang-cpp9-9.0.1-root_62600_hc092715_5.tar.bz2
osx-arm64::clang-9-9.0.1-root_62600_hc092715_5.tar.bz2
osx-arm64::coin-or-osi-0.108.7-hbb6b098_0.tar.bz2
osx-arm64::openjdk-11.0.9.1-he8acd94_3.tar.bz2
osx-arm64::libclang-cpp-9.0.1-cling_v0.9_h7a49ca7_5.tar.bz2
osx-arm64::llvm-tools-14.0.2-h37c5ba8_1.tar.bz2
osx-arm64::libsolv-static-0.7.22-h1280f1d_0.tar.bz2
osx-arm64::openjdk-11.0.9.1-he8acd94_2.tar.bz2
osx-arm64::llvm-14.0.1-h95d0606_0.tar.bz2
osx-arm64::libclang-cpp-9.0.1-root_62600_hc092715_5.tar.bz2
osx-arm64::llvm-tools-14.0.3-h37c5ba8_0.tar.bz2
osx-arm64::libllvm14-14.0.1-hfd59cb2_0.tar.bz2
osx-arm64::llvm-tools-14.0.2-h37c5ba8_0.tar.bz2
osx-arm64::kaldi-5.5.1016-cpu_h1234567_0.tar.bz2
osx-arm64::clang-9-9.0.1-cling_v0.9_h7a49ca7_5.tar.bz2
osx-arm64::kaldi-5.5.1016-cpu_h4c2b7eb_2.tar.bz2
osx-arm64::clang-9-9.0.1-default_h2c105f5_5.tar.bz2
osx-arm64::lld-14.0.3-h70e0dcb_0.tar.bz2
osx-arm64::llvm-tools-14.0.1-hfd59cb2_0.tar.bz2
osx-arm64::llvm-14.0.2-h95d0606_1.tar.bz2
osx-arm64::libclang-cpp9-9.0.1-cling_v0.9_h7a49ca7_5.tar.bz2
osx-arm64::libllvm14-14.0.2-h37c5ba8_1.tar.bz2
osx-arm64::gst-plugins-good-1.20.2-h0ed40fb_1.tar.bz2
osx-arm64::llvm-14.0.4-h95d0606_0.tar.bz2
osx-arm64::llvm-tools-14.0.4-h37c5ba8_0.tar.bz2
osx-arm64::lld-14.0.0-h70e0dcb_0.tar.bz2
osx-arm64::llvm-14.0.3-h95d0606_0.tar.bz2
osx-arm64::dotnet-aspnetcore-6.0.4-h35bb5c4_0.tar.bz2
-    "libzlib >=1.2.11,<1.3.0a0"
+    "libzlib >=1.2.11,<2.0.0a0"
osx-arm64::gazebo-11.11.0-hc654bec_0.tar.bz2
osx-arm64::tiledb-2.9.2-h824fbfd_0.tar.bz2
osx-arm64::sagelib-9.6-py38h2e7102d_0.tar.bz2
osx-arm64::tiledb-2.9.2-hdd33e7b_0.tar.bz2
osx-arm64::sagelib-9.6-py310h5f53620_0.tar.bz2
osx-arm64::libtiff-4.4.0-h2810ee2_0.tar.bz2
osx-arm64::pillow-9.1.1-py310hc9df86f_1.tar.bz2
osx-arm64::graphviz-4.0.0-hc7d6d94_0.tar.bz2
osx-arm64::pillow-9.1.1-py39h1b8be2f_1.tar.bz2
osx-arm64::emacs-28.1-h1d13f01_1.tar.bz2
osx-arm64::mysql-connector-cpp-8.0.29-hf47c702_1.tar.bz2
osx-arm64::sagelib-9.6-py39h375837f_0.tar.bz2
osx-arm64::freeimage-3.18.0-h78c0cbe_9.tar.bz2
osx-arm64::imagemagick-7.1.0_36-pl5321h8f75910_0.tar.bz2
osx-arm64::libprotobuf-static-21.1-h332123e_0.tar.bz2
osx-arm64::gazebo-11.11.0-h54ffdfc_0.tar.bz2
osx-arm64::mysql-connector-cpp-8.0.29-h872864d_1.tar.bz2
osx-arm64::qt-main-5.15.3-haf604a7_2.tar.bz2
osx-arm64::libxslt-1.1.35-ha8fb468_0.tar.bz2
osx-arm64::libprotobuf-3.21.1-h332123e_0.tar.bz2
osx-arm64::pillow-9.1.1-py38h3852883_1.tar.bz2
osx-arm64::libprotobuf-static-3.21.1-h332123e_0.tar.bz2
-    "libzlib >=1.2.12,<1.3.0a0",
+    "libzlib >=1.2.12,<2.0.0a0",
================================================================================
================================================================================
linux-ppc64le
linux-ppc64le::vowpalwabbit-9.1.0-py37h6d64f5a_0.tar.bz2
linux-ppc64le::smesh-9.8.0.2-h18d7a33_0.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py38h8c99fcf_14_cpu.tar.bz2
linux-ppc64le::arrow-cpp-8.0.0-py37h5207e0b_1_cpu.tar.bz2
linux-ppc64le::libgdal-3.4.3-h16fb583_0.tar.bz2
linux-ppc64le::arrow-cpp-7.0.0-py310hd1a4fef_4_cpu.tar.bz2
linux-ppc64le::libcurl-7.83.0-h1ac174b_0.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py310h4b04f48_32_cpu.tar.bz2
linux-ppc64le::imagemagick-7.1.0_31-pl5321h2621fa6_0.tar.bz2
linux-ppc64le::root_base-6.26.2-py310ha22a33f_3.tar.bz2
linux-ppc64le::mysql-router-8.0.28-hf17d03d_3.tar.bz2
linux-ppc64le::mysql-libs-8.0.28-h3ac40eb_4.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py38h8c99fcf_48_cpu.tar.bz2
linux-ppc64le::curl-7.83.1-h2ae36b4_0.tar.bz2
linux-ppc64le::grpcio-1.46.1-py310h8623af6_0.tar.bz2
linux-ppc64le::grpcio-1.46.0-py310hef85685_0.tar.bz2
linux-ppc64le::ogre-13.3.4-h4fe95a5_0.tar.bz2
linux-ppc64le::pillow-9.1.0-py38hdb37dd1_1.tar.bz2
linux-ppc64le::grpcio-1.46.0-py37hc6dff39_1.tar.bz2
linux-ppc64le::nodejs-17.9.0-ha3ae8d5_0.tar.bz2
linux-ppc64le::grpc-cpp-1.45.2-h7108e4b_2.tar.bz2
linux-ppc64le::gmsh-4.10.0-hdf1b8cf_0.tar.bz2
linux-ppc64le::libssh-0.8.9-h350ef5c_2.tar.bz2
linux-ppc64le::imagecodecs-2022.2.22-py39hc100fd9_3.tar.bz2
linux-ppc64le::nordugrid-arc-6.15.1-py39h3f4f55c_0.tar.bz2
linux-ppc64le::pyinstaller-5.1-py37h1bfa0ba_0.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py39h798d310_34_cpu.tar.bz2
linux-ppc64le::grpcio-1.46.1-py38ha57aa52_0.tar.bz2
linux-ppc64le::pillow-9.1.0-py37h5061cd4_1.tar.bz2
linux-ppc64le::libgdal-3.4.2-h16fb583_7.tar.bz2
linux-ppc64le::pillow-9.1.0-py39h6cd6960_2.tar.bz2
linux-ppc64le::libxml2-2.9.13-hc8bd4e3_0.tar.bz2
linux-ppc64le::grpc-cpp-1.46.0-h62e3d64_0.tar.bz2
linux-ppc64le::postgresql-plpython-14.3-py310h8fb64e9_0.tar.bz2
linux-ppc64le::mongodb-5.1.1-hd2e7532_3.tar.bz2
linux-ppc64le::coin-or-clp-1.17.7-h138b220_0.tar.bz2
linux-ppc64le::grpcio-1.46.0-py39headc9c4_0.tar.bz2
linux-ppc64le::libtiff-4.3.0-hfb97ac2_4.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py37hba910f7_19_cpu.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py37h5138860_49_cpu.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py310h4b04f48_52_cpu.tar.bz2
linux-ppc64le::libnetcdf-4.8.1-mpi_mpich_h0f637b0_2.tar.bz2
linux-ppc64le::pyinstaller-5.1-py310hd84c83a_0.tar.bz2
linux-ppc64le::grpcio-1.46.3-py38hc636529_0.tar.bz2
linux-ppc64le::mosh-1.3.2-pl5321h67dd1e5_1012.tar.bz2
linux-ppc64le::pillow-9.1.0-py310hc96afb3_0.tar.bz2
linux-ppc64le::mysql-client-8.0.28-ha7fd285_4.tar.bz2
linux-ppc64le::grpcio-1.46.3-py37hc6dff39_0.tar.bz2
linux-ppc64le::pillow-9.1.0-py39he47bc6b_2.tar.bz2
linux-ppc64le::arrow-cpp-7.0.0-py38h4acbd31_7_cpu.tar.bz2
linux-ppc64le::arrow-cpp-7.0.0-py39h4eb72c0_4_cpu.tar.bz2
linux-ppc64le::grpc-cpp-1.45.2-h26af672_2.tar.bz2
linux-ppc64le::imagecodecs-2022.2.22-py310h406ef43_4.tar.bz2
linux-ppc64le::grpc-cpp-1.45.2-h62e3d64_3.tar.bz2
linux-ppc64le::gct-6.2.1629922860-h635f956_1.tar.bz2
linux-ppc64le::libcurl-static-7.83.0-h1ac174b_0.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py37he75da11_50_cpu.tar.bz2
linux-ppc64le::cppyy-cling-6.25.3-py39h51b9803_1.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py38h0a25458_16_cpu.tar.bz2
linux-ppc64le::ruby-3.1.2-hf3f6e89_0.tar.bz2
linux-ppc64le::grpc-cpp-1.44.0-h26af672_4.tar.bz2
linux-ppc64le::pillow-9.1.1-py38hdb37dd1_0.tar.bz2
linux-ppc64le::grpc-cpp-1.43.2-hdd124a7_3.tar.bz2
linux-ppc64le::nordugrid-arc-6.15.1-py38h7b2d203_0.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py310h1b703b9_48_cpu.tar.bz2
linux-ppc64le::arrow-cpp-8.0.0-py38h99de980_1_cpu.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py38h0a25458_50_cpu.tar.bz2
linux-ppc64le::llvmlite-0.38.0-py39hf8800fb_1.tar.bz2
linux-ppc64le::nordugrid-arc-6.15.1-py310h02e3743_0.tar.bz2
linux-ppc64le::grpc-cpp-1.45.1-hf25c54d_1.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py310h4b04f48_19_cpu.tar.bz2
linux-ppc64le::grpcio-1.46.3-py38ha57aa52_0.tar.bz2
linux-ppc64le::libvips-8.12.2-hd201370_4.tar.bz2
linux-ppc64le::imagecodecs-2022.2.22-py39h8a103c8_5.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py310hf812e0e_34_cpu.tar.bz2
linux-ppc64le::root_base-6.26.2-py39heb08fc1_3.tar.bz2
linux-ppc64le::cppyy-cling-6.25.3-py38hb6edf9e_1.tar.bz2
linux-ppc64le::pypy3.8-7.3.9-h50729ec_1.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py310h4b04f48_53_cpu.tar.bz2
linux-ppc64le::libopencv-4.5.5-py37h76598dc_9.tar.bz2
linux-ppc64le::libxmlsec1-1.2.33-hd22dce2_1.tar.bz2
linux-ppc64le::arrow-cpp-8.0.0-py38h99de980_0_cpu.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py37he75da11_31_cpu.tar.bz2
linux-ppc64le::grpc-cpp-1.45.2-hd2f16f1_0.tar.bz2
linux-ppc64le::texlive-core-20210325-he94f91b_3.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py39h1384dbd_52_cpu.tar.bz2
linux-ppc64le::mysql-libs-8.0.28-ha23194b_3.tar.bz2
linux-ppc64le::llvmlite-0.38.0-py38hd9056a4_1.tar.bz2
linux-ppc64le::grpc-cpp-1.45.2-hf25c54d_0.tar.bz2
linux-ppc64le::cpp-opentelemetry-sdk-1.3.0-hb6a04ad_0.tar.bz2
linux-ppc64le::root_base-6.26.2-py310ha22a33f_1.tar.bz2
linux-ppc64le::mysql-libs-8.0.28-h3ac40eb_3.tar.bz2
linux-ppc64le::coin-or-cgl-0.60.6-h05022b0_0.tar.bz2
linux-ppc64le::grpcio-1.46.0-py37h8c7194f_0.tar.bz2
linux-ppc64le::root_base-6.24.6-py37hc4fb544_2.tar.bz2
linux-ppc64le::mysql-client-8.0.29-ha7fd285_0.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py310h4b04f48_33_cpu.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py37h3889f5a_48_cpu.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py39hc89bb6d_29_cpu.tar.bz2
linux-ppc64le::arrow-cpp-8.0.0-py310he62f98e_1_cpu.tar.bz2
linux-ppc64le::tiledb-2.9.1-ha4bc364_0.tar.bz2
linux-ppc64le::pdal-2.4.0-h0218297_3.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py39h5c28195_30_cpu.tar.bz2
linux-ppc64le::imagemagick-7.1.0_34-pl5321h2621fa6_0.tar.bz2
linux-ppc64le::pillow-9.1.0-py310hc96afb3_1.tar.bz2
linux-ppc64le::grpc-cpp-1.43.2-h62e3d64_5.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py39h1384dbd_17_cpu.tar.bz2
linux-ppc64le::smesh-9.7.0.1-hb7acfeb_1.tar.bz2
linux-ppc64le::tiledb-2.9.0-ha4bc364_1.tar.bz2
linux-ppc64le::grpc-cpp-1.44.0-hdd124a7_2.tar.bz2
linux-ppc64le::arrow-cpp-8.0.0-py39hf52d5e1_0_cpu.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py37he75da11_53_cpu.tar.bz2
linux-ppc64le::pypy3.9-7.3.9-hf38bb15_1.tar.bz2
linux-ppc64le::root_base-6.24.6-py310ha22a33f_2.tar.bz2
linux-ppc64le::arrow-cpp-7.0.0-py310h3cb9e4f_7_cpu.tar.bz2
linux-ppc64le::arrow-cpp-7.0.0-py39hf52d5e1_5_cpu.tar.bz2
linux-ppc64le::pdal-2.4.0-hd8953a8_4.tar.bz2
linux-ppc64le::imagecodecs-2022.2.22-py310h4bcd9b1_3.tar.bz2
linux-ppc64le::libpq-14.3-h9fbd2da_0.tar.bz2
linux-ppc64le::root_base-6.24.6-py39heb08fc1_2.tar.bz2
linux-ppc64le::pygrib-2.1.4-py37h56aa5c9_5.tar.bz2
linux-ppc64le::root_base-6.26.2-py38h6b45a44_2.tar.bz2
linux-ppc64le::grpc-cpp-1.45.1-hd2f16f1_1.tar.bz2
linux-ppc64le::grpcio-1.46.0-py39h6a055fd_1.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py37hba910f7_53_cpu.tar.bz2
linux-ppc64le::mongodb-5.1.1-heb9217d_3.tar.bz2
linux-ppc64le::grpc-cpp-1.44.0-h2dc1fd2_4.tar.bz2
linux-ppc64le::imagemagick-7.1.0_33-pl5321h2621fa6_0.tar.bz2
linux-ppc64le::postgresql-plpython-14.3-py37h5ff7a43_0.tar.bz2
linux-ppc64le::grpc-cpp-1.45.1-hb435f04_0.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py39h5f703b4_29_cpu.tar.bz2
linux-ppc64le::libcurl-7.83.1-h2ae36b4_0.tar.bz2
linux-ppc64le::tiledb-2.8.3-h11b1e19_0.tar.bz2
linux-ppc64le::grpcio-1.46.0-py37h0d21115_0.tar.bz2
linux-ppc64le::libgit2-1.4.3-h5f335ab_0.tar.bz2
linux-ppc64le::cppyy-cling-6.25.3-py37hdd56643_1.tar.bz2
linux-ppc64le::assimp-5.2.4-h52ce049_0.tar.bz2
linux-ppc64le::arrow-cpp-8.0.0-py38hba41418_1_cpu.tar.bz2
linux-ppc64le::clangdev-14.0.4-default_h1896e6d_0.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py310hf812e0e_53_cpu.tar.bz2
linux-ppc64le::pillow-9.1.0-py39he47bc6b_1.tar.bz2
linux-ppc64le::cppyy-cling-6.25.3-py310hbbdc3b4_1.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py37he75da11_18_cpu.tar.bz2
linux-ppc64le::arrow-cpp-7.0.0-py39he2d0a57_7_cpu.tar.bz2
linux-ppc64le::arrow-cpp-7.0.0-py37hfd90f1c_5_cpu.tar.bz2
linux-ppc64le::mysql-router-8.0.28-h1cb365c_4.tar.bz2
linux-ppc64le::llvmdev-14.0.3-h3b69f5b_0.tar.bz2
linux-ppc64le::rsync-3.2.3-h380b542_4.tar.bz2
linux-ppc64le::llvmdev-14.0.2-h3b69f5b_1.tar.bz2
linux-ppc64le::mysql-server-8.0.29-h023ef85_0.tar.bz2
linux-ppc64le::mysql-client-8.0.28-hfff87ee_3.tar.bz2
linux-ppc64le::root_base-6.26.2-py39heb08fc1_2.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py38h0a25458_31_cpu.tar.bz2
linux-ppc64le::gmsh-4.10.2-hdf1b8cf_0.tar.bz2
linux-ppc64le::ruby-3.1.2-h41c096d_0.tar.bz2
linux-ppc64le::mysql-server-8.0.28-h46112bc_4.tar.bz2
linux-ppc64le::arrow-cpp-7.0.0-py37hfd90f1c_6_cpu.tar.bz2
linux-ppc64le::blosc-1.21.1-ha8860b1_1.tar.bz2
linux-ppc64le::grpc-cpp-1.46.3-hd5d0d5a_0.tar.bz2
linux-ppc64le::libopencv-4.5.5-py38h6bea156_8.tar.bz2
linux-ppc64le::openssh-9.0p1-hbe330f9_0.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py39h1384dbd_32_cpu.tar.bz2
linux-ppc64le::imagemagick-7.1.0_32-pl5321h2621fa6_0.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py310h0ac32be_29_cpu.tar.bz2
linux-ppc64le::grpc-cpp-1.43.2-h36087fb_4.tar.bz2
linux-ppc64le::arrow-cpp-8.0.0-py39he2d0a57_1_cpu.tar.bz2
linux-ppc64le::grpc-cpp-1.43.2-h448807a_3.tar.bz2
linux-ppc64le::fish-3.4.1-h28d1537_0.tar.bz2
linux-ppc64le::xrootd-5.4.2-py37h0d0d2e1_0.tar.bz2
linux-ppc64le::tiledb-2.8.2-h11b1e19_0.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py38h8f58732_14_cpu.tar.bz2
linux-ppc64le::orc-1.7.3-he018b29_1.tar.bz2
linux-ppc64le::grpc-cpp-1.43.2-h5cc0a07_4.tar.bz2
linux-ppc64le::libopencv-4.5.5-py39h9466907_9.tar.bz2
linux-ppc64le::postgresql-plpython-14.3-py38h4f5da63_0.tar.bz2
linux-ppc64le::libgdal-3.4.3-h292809a_0.tar.bz2
linux-ppc64le::postgresql-plpython-14.3-py310h318e24f_0.tar.bz2
linux-ppc64le::imagecodecs-2022.2.22-py39h8a103c8_4.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py39h1384dbd_53_cpu.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py37h3889f5a_29_cpu.tar.bz2
linux-ppc64le::grpc-cpp-1.45.2-h62e3d64_2.tar.bz2
linux-ppc64le::grpc-cpp-1.45.2-h2dc1fd2_3.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py38h8f58732_48_cpu.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py38h0a25458_51_cpu.tar.bz2
linux-ppc64le::arrow-cpp-8.0.0-py310h3cb9e4f_1_cpu.tar.bz2
linux-ppc64le::grpcio-1.46.1-py310h0a32414_0.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py38h0a25458_34_cpu.tar.bz2
linux-ppc64le::libopencv-4.5.5-py310he90d21e_9.tar.bz2
linux-ppc64le::tiledb-2.8.0-h11b1e19_1.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py37h6c177ce_48_cpu.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py39h5c28195_49_cpu.tar.bz2
linux-ppc64le::pillow-9.1.0-py37h5061cd4_2.tar.bz2
linux-ppc64le::arrow-cpp-7.0.0-py39hf52d5e1_6_cpu.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py37hba910f7_34_cpu.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py38h57cf402_19_cpu.tar.bz2
linux-ppc64le::grpcio-1.46.1-py37h9d49ee5_0.tar.bz2
linux-ppc64le::rust-1.60.0-hf3e60ca_0.tar.bz2
linux-ppc64le::ffmpeg-5.0.1-h85a9e51_2.tar.bz2
linux-ppc64le::libgdal-3.4.2-h1b561e9_6.tar.bz2
linux-ppc64le::arrow-cpp-8.0.0-py310hd982366_0_cpu.tar.bz2
linux-ppc64le::sqlite-3.38.3-h3bd21b8_0.tar.bz2
linux-ppc64le::pdal-2.4.0-h626f0fb_3.tar.bz2
linux-ppc64le::imagecodecs-2022.2.22-py38hba2883d_3.tar.bz2
linux-ppc64le::tiledb-2.8.2-ha4bc364_0.tar.bz2
linux-ppc64le::pillow-9.1.0-py310hc96afb3_2.tar.bz2
linux-ppc64le::llvmlite-0.38.0-py37h4f2946f_1.tar.bz2
linux-ppc64le::llvmlite-0.38.1-py39h11e4565_0.tar.bz2
linux-ppc64le::mysql-libs-8.0.29-h3ac40eb_1.tar.bz2
linux-ppc64le::arrow-cpp-7.0.0-py310hd982366_5_cpu.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py39h1384dbd_50_cpu.tar.bz2
linux-ppc64le::grpc-cpp-1.44.0-h71885d5_3.tar.bz2
linux-ppc64le::git-2.35.2-pl5321h131946c_0.tar.bz2
linux-ppc64le::grpc-cpp-1.46.3-ha483e86_0.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py37h3889f5a_14_cpu.tar.bz2
linux-ppc64le::mysql-client-8.0.29-ha7fd285_1.tar.bz2
linux-ppc64le::ogre-13.3.4-h5f75287_1.tar.bz2
linux-ppc64le::tiledb-2.8.3-h11b1e19_1.tar.bz2
linux-ppc64le::pillow-9.1.1-py37h5061cd4_0.tar.bz2
linux-ppc64le::grpc-cpp-1.45.2-h2dc1fd2_2.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py310h4b04f48_18_cpu.tar.bz2
linux-ppc64le::libfido2-1.11.0-h262a72d_0.tar.bz2
linux-ppc64le::grpc-cpp-1.43.2-h71885d5_4.tar.bz2
linux-ppc64le::grpcio-1.46.0-py310h790102e_0.tar.bz2
linux-ppc64le::gsoap-2.8.121-hfabde2d_0.tar.bz2
linux-ppc64le::llvmdev-14.0.1-h3b69f5b_0.tar.bz2
linux-ppc64le::ogre-1.10.12-h112db1c_8.tar.bz2
linux-ppc64le::pillow-9.1.1-py39he47bc6b_0.tar.bz2
linux-ppc64le::grpcio-1.46.0-py37h9d49ee5_1.tar.bz2
linux-ppc64le::curl-7.83.0-h1ac174b_0.tar.bz2
linux-ppc64le::orc-1.7.4-he018b29_1.tar.bz2
linux-ppc64le::pygrib-2.1.4-py38ha6e08ff_5.tar.bz2
linux-ppc64le::postgresql-14.3-he6b6aa5_0.tar.bz2
linux-ppc64le::arrow-cpp-7.0.0-py37hdb4cc56_4_cpu.tar.bz2
linux-ppc64le::pillow-9.1.1-py310hc96afb3_0.tar.bz2
linux-ppc64le::blosc-1.21.1-hd7f9d97_2.tar.bz2
linux-ppc64le::tiledb-2.7.2-h11b1e19_0.tar.bz2
linux-ppc64le::root_base-6.26.2-py38h6b45a44_1.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py37he75da11_52_cpu.tar.bz2
linux-ppc64le::pillow-9.1.0-py37h5061cd4_0.tar.bz2
linux-ppc64le::openssh-9.0p1-h41524dc_0.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py310h1b703b9_14_cpu.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py39h1384dbd_18_cpu.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py37he75da11_51_cpu.tar.bz2
linux-ppc64le::root_base-6.24.6-py37hc4fb544_3.tar.bz2
linux-ppc64le::arrow-cpp-8.0.0-py39hf52d5e1_1_cpu.tar.bz2
linux-ppc64le::arrow-cpp-7.0.0-py38hba41418_7_cpu.tar.bz2
linux-ppc64le::xrootd-5.4.2-py39h910a105_0.tar.bz2
linux-ppc64le::pillow-9.1.0-py38hcb1119a_2.tar.bz2
linux-ppc64le::mysql-client-8.0.29-hfff87ee_0.tar.bz2
linux-ppc64le::elfutils-0.187-h7f4d49c_0.tar.bz2
linux-ppc64le::mongodb-5.1.1-h41936a2_3.tar.bz2
linux-ppc64le::orc-1.7.4-he018b29_0.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py310h4b04f48_34_cpu.tar.bz2
linux-ppc64le::libgdal-3.5.0-h292809a_0.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py37h6c177ce_29_cpu.tar.bz2
linux-ppc64le::pyinstaller-5.0-py38hfa13636_0.tar.bz2
linux-ppc64le::grpcio-1.46.0-py310h8623af6_1.tar.bz2
linux-ppc64le::pillow-9.1.0-py38hcb1119a_1.tar.bz2
linux-ppc64le::grpcio-1.46.3-py37h9d49ee5_0.tar.bz2
linux-ppc64le::pyinstaller-5.0-py37h1bfa0ba_0.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py38h8f58732_29_cpu.tar.bz2
linux-ppc64le::pypy3.8-7.3.9-h7e6389c_1.tar.bz2
linux-ppc64le::mongodb-5.1.1-hd2e7532_2.tar.bz2
linux-ppc64le::openjpeg-2.5.0-h9ebd272_0.tar.bz2
linux-ppc64le::mysql-client-8.0.29-hfff87ee_1.tar.bz2
linux-ppc64le::imagecodecs-2022.2.22-py38h5e16ba4_4.tar.bz2
linux-ppc64le::pyinstaller-5.0-py310hd84c83a_0.tar.bz2
linux-ppc64le::grpcio-1.46.0-py39h002269c_0.tar.bz2
linux-ppc64le::imagecodecs-2022.2.22-py310h6675503_2.tar.bz2
linux-ppc64le::librdkafka-1.8.2.post2-h3992f39_1.tar.bz2
linux-ppc64le::tiledb-2.9.1-h11b1e19_0.tar.bz2
linux-ppc64le::grpc-cpp-1.43.2-h2dc1fd2_5.tar.bz2
linux-ppc64le::cpp-opentelemetry-sdk-1.3.0-he011279_1.tar.bz2
linux-ppc64le::sqlite-3.38.4-h3bd21b8_0.tar.bz2
linux-ppc64le::root_base-6.26.2-py39heb08fc1_1.tar.bz2
linux-ppc64le::pyreadstat-1.1.6-py310hc3fd98a_0.tar.bz2
linux-ppc64le::vtk-9.1.0-qt_py37h96ef7a9_208.tar.bz2
linux-ppc64le::grpcio-1.46.0-py38h8129e00_0.tar.bz2
linux-ppc64le::tiledb-2.7.2-ha4bc364_0.tar.bz2
linux-ppc64le::tiledb-2.8.1-ha4bc364_0.tar.bz2
linux-ppc64le::python-3.9.13-h08a33c2_0_cpython.tar.bz2
linux-ppc64le::mysql-client-8.0.28-hfff87ee_4.tar.bz2
linux-ppc64le::vtk-9.1.0-qt_py38hfa66816_208.tar.bz2
linux-ppc64le::root_base-6.26.2-py37hc4fb544_2.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py39h1384dbd_34_cpu.tar.bz2
linux-ppc64le::openmpi-4.1.3-he12334d_101.tar.bz2
linux-ppc64le::grpcio-1.46.0-py38ha57aa52_1.tar.bz2
linux-ppc64le::pdal-2.4.0-h4ea81e5_4.tar.bz2
linux-ppc64le::libcurl-static-7.83.1-h2ae36b4_0.tar.bz2
linux-ppc64le::nodejs-17.9.0-h93803ed_0.tar.bz2
linux-ppc64le::libgdal-3.4.2-h49e4226_5.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py37he75da11_34_cpu.tar.bz2
linux-ppc64le::grpc-cpp-1.45.2-h26af672_1.tar.bz2
linux-ppc64le::postgresql-plpython-14.3-py39hbdddc40_0.tar.bz2
linux-ppc64le::llvmlite-0.38.1-py39hf8800fb_0.tar.bz2
linux-ppc64le::root_base-6.26.2-py310ha22a33f_2.tar.bz2
linux-ppc64le::grpc-cpp-1.46.0-h26af672_0.tar.bz2
linux-ppc64le::grpcio-1.46.3-py39h8d13958_0.tar.bz2
linux-ppc64le::grpc-cpp-1.44.0-h7108e4b_4.tar.bz2
linux-ppc64le::pyinstaller-5.1-py38hfa13636_0.tar.bz2
linux-ppc64le::git-2.35.3-pl5321hbceff91_0.tar.bz2
linux-ppc64le::libopencv-4.5.5-py37h76598dc_8.tar.bz2
linux-ppc64le::mysql-server-8.0.28-h76a05c6_3.tar.bz2
linux-ppc64le::grpcio-1.46.0-py38h064c1e6_0.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py37he75da11_16_cpu.tar.bz2
linux-ppc64le::mysql-server-8.0.29-h023ef85_1.tar.bz2
linux-ppc64le::libcurl-7.83.0-h2ae36b4_0.tar.bz2
linux-ppc64le::mysql-libs-8.0.29-ha23194b_0.tar.bz2
linux-ppc64le::grpc-cpp-1.44.0-h8e12c62_2.tar.bz2
linux-ppc64le::freeimage-3.18.0-hdbda078_8.tar.bz2
linux-ppc64le::grpc-cpp-1.43.2-h7108e4b_5.tar.bz2
linux-ppc64le::mysql-client-8.0.28-ha7fd285_3.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py39h5c28195_15_cpu.tar.bz2
linux-ppc64le::llvmlite-0.38.0-py38h8df0f6e_1.tar.bz2
linux-ppc64le::libopencv-4.5.5-py38h6bea156_9.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py39h1384dbd_33_cpu.tar.bz2
linux-ppc64le::libgdal-3.5.0-h16fb583_0.tar.bz2
linux-ppc64le::tiledb-2.8.0-ha4bc364_1.tar.bz2
linux-ppc64le::mysql-server-8.0.28-hb13dc30_3.tar.bz2
linux-ppc64le::curl-7.83.0-h2ae36b4_0.tar.bz2
linux-ppc64le::pdal-2.4.1-hd8953a8_0.tar.bz2
linux-ppc64le::imagecodecs-2022.2.22-py310h406ef43_5.tar.bz2
linux-ppc64le::arrow-cpp-7.0.0-py310he62f98e_7_cpu.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py310h1b703b9_29_cpu.tar.bz2
linux-ppc64le::librdkafka-1.8.2.post2-h76d1442_1.tar.bz2
linux-ppc64le::libfido2-1.11.0-h350ef5c_0.tar.bz2
linux-ppc64le::libgdal-3.4.2-h292809a_7.tar.bz2
linux-ppc64le::libarchive-3.5.2-h01158bd_2.tar.bz2
linux-ppc64le::llvmdev-14.0.4-h3b69f5b_0.tar.bz2
linux-ppc64le::pillow-9.1.0-py39h6cd6960_1.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py39h5f703b4_14_cpu.tar.bz2
linux-ppc64le::vtk-9.1.0-qt_py39h237216a_208.tar.bz2
linux-ppc64le::tiledb-2.8.3-ha4bc364_1.tar.bz2
linux-ppc64le::squashfuse-0.1.104-h929b313_2.tar.bz2
linux-ppc64le::mysql-server-8.0.29-h46112bc_0.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py38h8c99fcf_29_cpu.tar.bz2
linux-ppc64le::ffmpeg-5.0.1-h9bc31b5_0.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py310hc2a255f_15_cpu.tar.bz2
linux-ppc64le::arrow-cpp-8.0.0-py37hb36d697_1_cpu.tar.bz2
linux-ppc64le::grpc-cpp-1.44.0-h448807a_2.tar.bz2
linux-ppc64le::imagecodecs-2022.2.22-py38h5e16ba4_5.tar.bz2
linux-ppc64le::grpc-cpp-1.45.2-h62e3d64_1.tar.bz2
linux-ppc64le::grpc-cpp-1.43.2-hb81e5fe_4.tar.bz2
linux-ppc64le::grpcio-1.46.1-py39h6a055fd_0.tar.bz2
linux-ppc64le::zstd-1.5.2-h8ac4a70_1.tar.bz2
linux-ppc64le::grpc-cpp-1.44.0-hb81e5fe_3.tar.bz2
linux-ppc64le::openjdk-11.0.9.1-h8d623da_2.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py38h40cb1f2_30_cpu.tar.bz2
linux-ppc64le::rust-1.61.0-hf3e60ca_0.tar.bz2
linux-ppc64le::mysql-libs-8.0.29-ha23194b_1.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py310h0ac32be_14_cpu.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py39h5f703b4_48_cpu.tar.bz2
linux-ppc64le::postgresql-plpython-14.3-py39hf36d1c2_0.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py310h4b04f48_31_cpu.tar.bz2
linux-ppc64le::libpq-14.3-h8203483_0.tar.bz2
linux-ppc64le::pyreadstat-1.1.6-py37h5dbe327_0.tar.bz2
linux-ppc64le::grpc-cpp-1.44.0-h5cc0a07_3.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py310hc2a255f_49_cpu.tar.bz2
linux-ppc64le::rsync-3.2.3-h45c244a_4.tar.bz2
linux-ppc64le::libprotobuf-3.20.1-ha72a2fa_0.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py39h1384dbd_51_cpu.tar.bz2
linux-ppc64le::mysql-router-8.0.29-h1cb365c_0.tar.bz2
linux-ppc64le::libopencv-4.5.5-py39h9466907_8.tar.bz2
linux-ppc64le::grpcio-1.46.1-py39h8d13958_0.tar.bz2
linux-ppc64le::pdal-2.4.1-h4ea81e5_0.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py39h798d310_19_cpu.tar.bz2
linux-ppc64le::libnetcdf-4.8.1-nompi_h3da7563_102.tar.bz2
linux-ppc64le::gsoap-2.8.121-ha019378_0.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py310hf812e0e_19_cpu.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py38h0a25458_33_cpu.tar.bz2
linux-ppc64le::openjdk-11.0.9.1-h65c716e_3.tar.bz2
linux-ppc64le::grpc-cpp-1.43.2-h26af672_5.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py38h0a25458_19_cpu.tar.bz2
linux-ppc64le::sqlite-3.38.2-h3bd21b8_0.tar.bz2
linux-ppc64le::ffmpeg-5.0.1-h9bc31b5_1.tar.bz2
linux-ppc64le::mysql-server-8.0.29-h46112bc_1.tar.bz2
linux-ppc64le::gfal2-2.20.5-h1671a64_1.tar.bz2
linux-ppc64le::mongodb-5.1.1-hce3fca1_2.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py39h798d310_53_cpu.tar.bz2
linux-ppc64le::openmpi-4.1.3-hb1f5ef7_103.tar.bz2
linux-ppc64le::pygrib-2.1.4-py310h69eb5f8_5.tar.bz2
linux-ppc64le::pyinstaller-5.1-py39h9919470_0.tar.bz2
linux-ppc64le::arrow-cpp-7.0.0-py38h99de980_5_cpu.tar.bz2
linux-ppc64le::pyreadstat-1.1.6-py39h68499bf_0.tar.bz2
linux-ppc64le::libprotobuf-static-3.20.1-ha72a2fa_0.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py310h4b04f48_50_cpu.tar.bz2
linux-ppc64le::libgit2-1.4.3-heee76ec_0.tar.bz2
linux-ppc64le::llvmdev-14.0.2-h3b69f5b_0.tar.bz2
linux-ppc64le::imagemagick-7.1.0_30-pl5321h2621fa6_0.tar.bz2
linux-ppc64le::vowpalwabbit-9.1.0-py39h44d3861_0.tar.bz2
linux-ppc64le::arrow-cpp-7.0.0-py310hd982366_6_cpu.tar.bz2
linux-ppc64le::libgdal-3.4.2-hfc30fd4_6.tar.bz2
linux-ppc64le::arrow-cpp-7.0.0-py38h79d0beb_4_cpu.tar.bz2
linux-ppc64le::imagemagick-7.1.0_35-pl5321h2621fa6_0.tar.bz2
linux-ppc64le::libxml2-2.9.14-hc8bd4e3_0.tar.bz2
linux-ppc64le::mysql-router-8.0.28-hdc8fe54_4.tar.bz2
linux-ppc64le::gct-6.2.1629922860-h72880b3_1.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py38h0a25458_32_cpu.tar.bz2
linux-ppc64le::libnetcdf-4.8.1-mpi_openmpi_h7c1e06c_2.tar.bz2
linux-ppc64le::libarchive-3.5.2-h7ab535a_2.tar.bz2
linux-ppc64le::pillow-9.1.1-py38hcb1119a_0.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py310h4b04f48_17_cpu.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py38h0a25458_53_cpu.tar.bz2
linux-ppc64le::gmsh-4.10.1-hdf1b8cf_0.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py37h6c177ce_14_cpu.tar.bz2
linux-ppc64le::mysql-libs-8.0.28-ha23194b_4.tar.bz2
linux-ppc64le::openmpi-4.1.3-hb1f5ef7_102.tar.bz2
linux-ppc64le::grpcio-1.46.0-py310h0a32414_1.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py310h0ac32be_48_cpu.tar.bz2
linux-ppc64le::imagecodecs-2022.2.22-py39h3ae6d17_2.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py37h5138860_30_cpu.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py39hc89bb6d_48_cpu.tar.bz2
linux-ppc64le::pygrib-2.1.4-py38hd65cc54_5.tar.bz2
linux-ppc64le::vowpalwabbit-9.1.0-py310h57a3bd3_0.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py39h1384dbd_31_cpu.tar.bz2
linux-ppc64le::root_base-6.24.6-py38h6b45a44_2.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py38h40cb1f2_49_cpu.tar.bz2
linux-ppc64le::root_base-6.26.2-py37hc4fb544_3.tar.bz2
linux-ppc64le::grpc-cpp-1.43.2-hb435f04_3.tar.bz2
linux-ppc64le::postgresql-14.3-h5c1f22d_0.tar.bz2
linux-ppc64le::grpcio-1.46.3-py310h0a32414_0.tar.bz2
linux-ppc64le::llvmlite-0.38.1-py310haa0efff_0.tar.bz2
linux-ppc64le::grpc-cpp-1.44.0-h36087fb_3.tar.bz2
linux-ppc64le::pyinstaller-5.0-py39h9919470_0.tar.bz2
linux-ppc64le::pyreadstat-1.1.6-py38h553f306_0.tar.bz2
linux-ppc64le::imagecodecs-2022.2.22-py38he981936_2.tar.bz2
linux-ppc64le::grpcio-1.46.0-py39h8d13958_1.tar.bz2
linux-ppc64le::sqlite-3.38.5-h3bd21b8_0.tar.bz2
linux-ppc64le::libssh-0.8.9-h262a72d_2.tar.bz2
linux-ppc64le::poppler-22.04.0-ha15b90a_0.tar.bz2
linux-ppc64le::vowpalwabbit-9.1.0-py38h732686b_0.tar.bz2
linux-ppc64le::arrow-cpp-8.0.0-py39h444fb91_1_cpu.tar.bz2
linux-ppc64le::root_base-6.26.2-py38h6b45a44_3.tar.bz2
linux-ppc64le::ambertools-22.0-py37h3d708b0_0.tar.bz2
linux-ppc64le::llvmlite-0.38.1-py37h4f2946f_0.tar.bz2
linux-ppc64le::grpcio-1.46.3-py39h6a055fd_0.tar.bz2
linux-ppc64le::pillow-9.1.0-py37h9d9d421_0.tar.bz2
linux-ppc64le::tiledb-2.9.0-h11b1e19_1.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py37he75da11_33_cpu.tar.bz2
linux-ppc64le::pillow-9.1.0-py38hdb37dd1_2.tar.bz2
linux-ppc64le::grpc-cpp-1.45.2-h7108e4b_3.tar.bz2
linux-ppc64le::vtk-9.1.0-qt_py310h201117f_208.tar.bz2
linux-ppc64le::xrootd-5.4.2-py310h375a5b4_0.tar.bz2
linux-ppc64le::mysql-router-8.0.28-hdfabd79_3.tar.bz2
linux-ppc64le::git-2.35.3-pl5321h131946c_0.tar.bz2
linux-ppc64le::gdb-11.2-py39h8cc400a_0.tar.bz2
linux-ppc64le::grpc-cpp-1.45.1-h448807a_0.tar.bz2
linux-ppc64le::mysql-router-8.0.29-hdc8fe54_1.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py39h1384dbd_19_cpu.tar.bz2
linux-ppc64le::nordugrid-arc-6.15.1-py37hc76ad04_0.tar.bz2
linux-ppc64le::ffmpeg-4.4.1-h9bc31b5_3.tar.bz2
linux-ppc64le::mysql-libs-8.0.29-h3ac40eb_0.tar.bz2
linux-ppc64le::pypy3.9-7.3.9-h80351e3_1.tar.bz2
linux-ppc64le::gmsh-4.10.3-h23cd722_0.tar.bz2
linux-ppc64le::libgdal-3.4.2-hc8fbd3a_5.tar.bz2
linux-ppc64le::grpc-cpp-1.44.0-h62e3d64_4.tar.bz2
linux-ppc64le::mosh-1.3.2-pl5321h1fb2832_1012.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py38h57cf402_53_cpu.tar.bz2
linux-ppc64le::arrow-cpp-8.0.0-py310hd982366_1_cpu.tar.bz2
linux-ppc64le::xrootd-5.4.2-py38h638ae86_0.tar.bz2
linux-ppc64le::grpcio-1.46.1-py38hc636529_0.tar.bz2
linux-ppc64le::libopencv-4.5.5-py31he90d21e_8.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py38h0a25458_17_cpu.tar.bz2
linux-ppc64le::pygrib-2.1.4-py39h52ed568_5.tar.bz2
linux-ppc64le::arrow-cpp-7.0.0-py37hb36d697_7_cpu.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py37he75da11_17_cpu.tar.bz2
linux-ppc64le::vowpalwabbit-9.1.0-py37h01e47c8_0.tar.bz2
linux-ppc64le::grpcio-1.46.0-py38hc636529_1.tar.bz2
linux-ppc64le::ffmpeg-4.4.1-h85a9e51_4.tar.bz2
linux-ppc64le::arrow-cpp-8.0.0-py37hfd90f1c_1_cpu.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py310hc2a255f_30_cpu.tar.bz2
linux-ppc64le::grpcio-1.46.1-py37hc6dff39_0.tar.bz2
linux-ppc64le::libxmlsec1-1.2.34-hd22dce2_0.tar.bz2
linux-ppc64le::postgresql-plpython-14.3-py38h777a03b_0.tar.bz2
linux-ppc64le::libcurl-static-7.83.0-h2ae36b4_0.tar.bz2
linux-ppc64le::pillow-9.1.0-py39he47bc6b_0.tar.bz2
linux-ppc64le::llvmlite-0.38.1-py38h8df0f6e_0.tar.bz2
linux-ppc64le::tiledb-2.8.1-h11b1e19_0.tar.bz2
linux-ppc64le::root_base-6.26.2-py37hc4fb544_1.tar.bz2
linux-ppc64le::openmpi-4.1.3-h6dec02d_0.tar.bz2
linux-ppc64le::ogre-1.12.13-h5f75287_1.tar.bz2
linux-ppc64le::boost-cpp-1.74.0-hcdee1be_8.tar.bz2
linux-ppc64le::pygrib-2.1.4-py39h67524c8_5.tar.bz2
linux-ppc64le::git-2.35.2-pl5321hbceff91_0.tar.bz2
linux-ppc64le::llvmlite-0.38.1-py38hd9056a4_0.tar.bz2
linux-ppc64le::cmake-3.23.1-h4f7acd8_0.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py37h5138860_15_cpu.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py39hc89bb6d_14_cpu.tar.bz2
linux-ppc64le::ambertools-22.0-py310h8043e95_1.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py310h4b04f48_16_cpu.tar.bz2
linux-ppc64le::arrow-cpp-7.0.0-py38h99de980_6_cpu.tar.bz2
linux-ppc64le::arrow-cpp-7.0.0-py39h444fb91_7_cpu.tar.bz2
linux-ppc64le::clangdev-14.0.3-default_h1896e6d_0.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py38h40cb1f2_15_cpu.tar.bz2
linux-ppc64le::arrow-cpp-8.0.0-py38h4acbd31_1_cpu.tar.bz2
linux-ppc64le::grpc-cpp-1.43.2-h8e12c62_3.tar.bz2
linux-ppc64le::mysql-server-8.0.28-h023ef85_4.tar.bz2
linux-ppc64le::grpc-cpp-1.44.0-hb435f04_2.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py38h0a25458_52_cpu.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py310h4b04f48_51_cpu.tar.bz2
linux-ppc64le::blosc-1.21.1-hd7f9d97_3.tar.bz2
linux-ppc64le::boost-cpp-1.78.0-hcdee1be_1.tar.bz2
linux-ppc64le::xrootd-5.4.2-py38ha5d5151_0.tar.bz2
linux-ppc64le::mysql-router-8.0.29-hdc8fe54_0.tar.bz2
linux-ppc64le::llvmlite-0.38.0-py310haa0efff_1.tar.bz2
linux-ppc64le::mongodb-5.1.1-hce3fca1_3.tar.bz2
linux-ppc64le::postgresql-plpython-14.3-py37hec40d7e_0.tar.bz2
linux-ppc64le::pyreadstat-1.1.6-py37h0370d4e_0.tar.bz2
linux-ppc64le::grpcio-1.46.3-py310h8623af6_0.tar.bz2
linux-ppc64le::wxwidgets-3.1.6-h059a3f2_0.tar.bz2
linux-ppc64le::cpp-opentelemetry-sdk-1.4.0-he011279_0.tar.bz2
linux-ppc64le::boost-cpp-1.79.0-hcdee1be_0.tar.bz2
linux-ppc64le::grpc-cpp-1.45.2-h26af672_3.tar.bz2
linux-ppc64le::nordugrid-arc-6.15.1-py37hfecfb3a_0.tar.bz2
linux-ppc64le::clangdev-14.0.0-default_h1896e6d_0.tar.bz2
linux-ppc64le::squashfs-tools-4.4-h929b313_3.tar.bz2
linux-ppc64le::pillow-9.1.0-py38hdb37dd1_0.tar.bz2
linux-ppc64le::arrow-cpp-7.0.0-py37h5207e0b_7_cpu.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py39h1384dbd_16_cpu.tar.bz2
linux-ppc64le::mysql-router-8.0.29-h1cb365c_1.tar.bz2
linux-ppc64le::gsoap-2.8.122-ha019378_0.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py37he75da11_32_cpu.tar.bz2
linux-ppc64le::xrootd-5.4.2-py39h8f32654_0.tar.bz2
linux-ppc64le::pillow-9.1.1-py39h6cd6960_0.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py38h0a25458_18_cpu.tar.bz2
linux-ppc64le::arrow-cpp-8.0.0-py37hfd90f1c_0_cpu.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py37he75da11_19_cpu.tar.bz2
linux-ppc64le::llvmlite-0.38.0-py39h11e4565_1.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py38h57cf402_34_cpu.tar.bz2
-    "libzlib >=1.2.11,<1.3.0a0",
+    "libzlib >=1.2.11,<2.0.0a0",
linux-ppc64le::clang-tools-14.0.0-default_h1896e6d_0.tar.bz2
linux-ppc64le::libclang-cpp-9.0.1-cling_v0.9_h8d17fa5_5.tar.bz2
linux-ppc64le::libclang-cpp9-9.0.1-root_62600_hfe130f6_5.tar.bz2
linux-ppc64le::libclang-cpp9-9.0.1-hcc_h7fea5d2_5.tar.bz2
linux-ppc64le::llvm-openmp-14.0.2-h3b69f5b_0.tar.bz2
linux-ppc64le::clang-tools-14.0.3-default_h1896e6d_0.tar.bz2
linux-ppc64le::libllvm14-14.0.1-h3b69f5b_0.tar.bz2
linux-ppc64le::llvm-openmp-14.0.3-h3b69f5b_0.tar.bz2
linux-ppc64le::libclang-cpp-9.0.1-hcc_h7fea5d2_5.tar.bz2
linux-ppc64le::libclang-14.0.0-default_h1896e6d_0.tar.bz2
linux-ppc64le::libclang-14.0.3-default_h1896e6d_0.tar.bz2
linux-ppc64le::lld-14.0.2-he90465d_0.tar.bz2
linux-ppc64le::lld-14.0.3-he90465d_0.tar.bz2
linux-ppc64le::libsolv-static-0.7.22-ha72a2fa_0.tar.bz2
linux-ppc64le::clang-9-9.0.1-cling_v0.9_h8d17fa5_5.tar.bz2
linux-ppc64le::llvm-14.0.2-h12068cf_1.tar.bz2
linux-ppc64le::libclang-cpp-14.0.4-default_h1896e6d_0.tar.bz2
linux-ppc64le::clang-format-14-14.0.3-default_h1896e6d_0.tar.bz2
linux-ppc64le::lld-14.0.0-he90465d_0.tar.bz2
linux-ppc64le::libclang-cpp-9.0.1-default_h6b7f2a5_5.tar.bz2
linux-ppc64le::libclang-cpp9-9.0.1-cling_v0.9_h8d17fa5_5.tar.bz2
linux-ppc64le::llvm-tools-14.0.3-h3b69f5b_0.tar.bz2
linux-ppc64le::llvm-tools-14.0.2-h3b69f5b_1.tar.bz2
linux-ppc64le::clang-14-14.0.3-default_h1896e6d_0.tar.bz2
linux-ppc64le::llvm-tools-14.0.1-h3b69f5b_0.tar.bz2
linux-ppc64le::libclang13-14.0.4-default_ha49a280_0.tar.bz2
linux-ppc64le::clang-9-9.0.1-hcc_h7fea5d2_5.tar.bz2
linux-ppc64le::clang-format-14-14.0.4-default_h1896e6d_0.tar.bz2
linux-ppc64le::llvm-openmp-14.0.4-h3b69f5b_0.tar.bz2
linux-ppc64le::libllvm14-14.0.4-h3b69f5b_0.tar.bz2
linux-ppc64le::coin-or-osi-0.108.7-h8fdeaf0_0.tar.bz2
linux-ppc64le::llvm-14.0.4-h12068cf_0.tar.bz2
linux-ppc64le::clang-tools-14.0.4-default_h1896e6d_0.tar.bz2
linux-ppc64le::clang-format-14.0.0-default_h1896e6d_0.tar.bz2
linux-ppc64le::libclang13-14.0.3-default_ha49a280_0.tar.bz2
linux-ppc64le::libclang-14.0.4-default_h1896e6d_0.tar.bz2
linux-ppc64le::libllvm14-14.0.3-h3b69f5b_0.tar.bz2
linux-ppc64le::libclang-cpp14-14.0.4-default_h1896e6d_0.tar.bz2
linux-ppc64le::libclang-cpp14-14.0.0-default_h1896e6d_0.tar.bz2
linux-ppc64le::llvm-14.0.2-h12068cf_0.tar.bz2
linux-ppc64le::libclang-cpp-14.0.3-default_h1896e6d_0.tar.bz2
linux-ppc64le::llvm-tools-14.0.2-h3b69f5b_0.tar.bz2
linux-ppc64le::libclang-cpp-14.0.0-default_h1896e6d_0.tar.bz2
linux-ppc64le::llvm-14.0.3-h12068cf_0.tar.bz2
linux-ppc64le::clang-format-14.0.4-default_h1896e6d_0.tar.bz2
linux-ppc64le::clang-14-14.0.4-default_h1896e6d_0.tar.bz2
linux-ppc64le::libclang13-14.0.0-default_ha49a280_0.tar.bz2
linux-ppc64le::llvm-14.0.1-h12068cf_0.tar.bz2
linux-ppc64le::libclang-cpp14-14.0.3-default_h1896e6d_0.tar.bz2
linux-ppc64le::clang-format-14.0.3-default_h1896e6d_0.tar.bz2
linux-ppc64le::lld-14.0.4-he90465d_0.tar.bz2
linux-ppc64le::clang-9-9.0.1-default_h6b7f2a5_5.tar.bz2
linux-ppc64le::gst-plugins-base-1.20.2-h6512beb_1.tar.bz2
linux-ppc64le::clang-9-9.0.1-root_62600_hfe130f6_5.tar.bz2
linux-ppc64le::libllvm14-14.0.2-h3b69f5b_1.tar.bz2
linux-ppc64le::gst-plugins-base-1.20.2-hf9bd150_0.tar.bz2
linux-ppc64le::libllvm14-14.0.2-h3b69f5b_0.tar.bz2
linux-ppc64le::libclang-cpp-9.0.1-root_62600_hfe130f6_5.tar.bz2
linux-ppc64le::llvm-tools-14.0.4-h3b69f5b_0.tar.bz2
linux-ppc64le::clang-format-14-14.0.0-default_h1896e6d_0.tar.bz2
linux-ppc64le::libsolv-0.7.22-ha72a2fa_0.tar.bz2
linux-ppc64le::libclang-cpp9-9.0.1-default_h6b7f2a5_5.tar.bz2
linux-ppc64le::clang-14-14.0.0-default_h1896e6d_0.tar.bz2
linux-ppc64le::llvm-openmp-14.0.0-h3b69f5b_0.tar.bz2
linux-ppc64le::openexr-3.1.5-h3b69f5b_0.tar.bz2
-    "libzlib >=1.2.11,<1.3.0a0"
+    "libzlib >=1.2.11,<2.0.0a0"
linux-ppc64le::pillow-9.1.1-py38hcb1119a_1.tar.bz2
linux-ppc64le::freeimage-3.18.0-hdbda078_9.tar.bz2
linux-ppc64le::graphviz-4.0.0-h2dab0cd_0.tar.bz2
linux-ppc64le::libprotobuf-3.21.1-ha72a2fa_0.tar.bz2
linux-ppc64le::libprotobuf-static-3.21.1-ha72a2fa_0.tar.bz2
linux-ppc64le::pillow-9.1.1-py39he47bc6b_1.tar.bz2
linux-ppc64le::libxslt-1.1.35-h7dda857_0.tar.bz2
linux-ppc64le::libprotobuf-static-21.1-ha72a2fa_0.tar.bz2
linux-ppc64le::tiledb-2.9.2-h11b1e19_0.tar.bz2
linux-ppc64le::libtiff-4.4.0-hfb97ac2_0.tar.bz2
linux-ppc64le::pillow-9.1.1-py38hdb37dd1_1.tar.bz2
linux-ppc64le::pillow-9.1.1-py37h5061cd4_1.tar.bz2
linux-ppc64le::pillow-9.1.1-py310hc96afb3_1.tar.bz2
linux-ppc64le::tiledb-2.9.2-ha4bc364_0.tar.bz2
linux-ppc64le::pillow-9.1.1-py39h6cd6960_1.tar.bz2
-    "libzlib >=1.2.12,<1.3.0a0",
+    "libzlib >=1.2.12,<2.0.0a0",
================================================================================
================================================================================
linux-aarch64
linux-aarch64::tiledb-2.9.1-h6866cf4_0.tar.bz2
linux-aarch64::pillow-9.1.0-py37h6ad5fca_0.tar.bz2
linux-aarch64::llvmlite-0.38.0-py310h773edab_1.tar.bz2
linux-aarch64::pillow-9.1.1-py38h96fe0d2_0.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py37h649bee8_49_cpu.tar.bz2
linux-aarch64::tiledb-2.7.2-h6866cf4_0.tar.bz2
linux-aarch64::libtiledb-sql-0.14.2-h2f14679_0.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py310h38efe08_1_cpu.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py39h6f00710_16_cpu.tar.bz2
linux-aarch64::libopencv-4.5.5-py310hee64ec2_9.tar.bz2
linux-aarch64::blosc-1.21.1-h497fdc0_1.tar.bz2
linux-aarch64::libgdal-3.4.2-hea5bd89_5.tar.bz2
linux-aarch64::mosh-1.3.2-pl5321h32df868_1012.tar.bz2
linux-aarch64::vowpalwabbit-9.1.0-py37h764a833_0.tar.bz2
linux-aarch64::yoda-1.9.5-py310h6f30888_0.tar.bz2
linux-aarch64::arrow-cpp-7.0.0-py310h231626f_7_cpu.tar.bz2
linux-aarch64::grpcio-1.46.0-py38h7d9ddd4_1.tar.bz2
linux-aarch64::libgdal-3.5.0-h7a4ffd3_0.tar.bz2
linux-aarch64::pillow-9.1.0-py310h31078c8_2.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py310hd5afd2e_53_cpu.tar.bz2
linux-aarch64::cpp-opentelemetry-sdk-1.3.0-h0ada592_0.tar.bz2
linux-aarch64::llvmlite-0.38.1-py38hd14ccfc_0.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py39h6f00710_52_cpu.tar.bz2
linux-aarch64::squashfs-tools-4.4-h7c3462f_3.tar.bz2
linux-aarch64::arrow-cpp-7.0.0-py310h70a1840_6_cpu.tar.bz2
linux-aarch64::grpcio-1.46.0-py310h64fc9e5_1.tar.bz2
linux-aarch64::imagecodecs-2022.2.22-py38h93eb347_2.tar.bz2
linux-aarch64::root_base-6.26.2-py310hafdc390_3.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py310hd5afd2e_34_cpu.tar.bz2
linux-aarch64::grpc-cpp-1.43.2-h8183a91_4.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py39h1aae454_48_cpu.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py38h20463b3_53_cpu.tar.bz2
linux-aarch64::arrow-cpp-7.0.0-py39h202adf9_6_cpu.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py38h20463b3_17_cpu.tar.bz2
linux-aarch64::pyreadstat-1.1.6-py37ha3a0a47_0.tar.bz2
linux-aarch64::grpcio-1.46.3-py39h8a0731a_0.tar.bz2
linux-aarch64::tiledb-2.8.3-h354e0e1_1.tar.bz2
linux-aarch64::openssh-9.0p1-h0f47c37_0.tar.bz2
linux-aarch64::grpcio-1.46.1-py39h8a0731a_0.tar.bz2
linux-aarch64::cppyy-cling-6.25.3-py39h20a37df_1.tar.bz2
linux-aarch64::mysql-client-8.0.28-h1208568_3.tar.bz2
linux-aarch64::llvmlite-0.38.1-py39ha5d8a0d_0.tar.bz2
linux-aarch64::libarchive-3.5.2-hc5648f3_2.tar.bz2
linux-aarch64::grpcio-1.46.0-py39h8a0731a_1.tar.bz2
linux-aarch64::mysql-client-8.0.29-h546d73d_0.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py37hbba9808_32_cpu.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py39h1aae454_29_cpu.tar.bz2
linux-aarch64::pyinstaller-5.0.1-py39h1a16a0b_0.tar.bz2
linux-aarch64::libvips-8.12.2-h595dfea_4.tar.bz2
linux-aarch64::tiledb-2.9.0-h6866cf4_1.tar.bz2
linux-aarch64::pdal-2.4.0-h2029a75_3.tar.bz2
linux-aarch64::imagemagick-7.1.0_33-pl5321hde91a41_0.tar.bz2
linux-aarch64::boost-cpp-1.74.0-ha1c1135_8.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py310h676c81e_53_cpu.tar.bz2
linux-aarch64::llvmdev-14.0.2-hb2805f8_1.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py39h3051451_48_cpu.tar.bz2
linux-aarch64::yoda-1.9.4-py39h87c0d69_2.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py310h3c7708d_14_cpu.tar.bz2
linux-aarch64::pyreadstat-1.1.6-py38h1368025_0.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py39h3051451_14_cpu.tar.bz2
linux-aarch64::libcurl-static-7.83.0-h8fd98b7_0.tar.bz2
linux-aarch64::imagecodecs-2022.2.22-py310hc699a9d_3.tar.bz2
linux-aarch64::curl-7.83.0-h22f3f83_0.tar.bz2
linux-aarch64::pillow-9.1.0-py38h3870bda_1.tar.bz2
linux-aarch64::root_base-6.26.2-py39h0728cd7_3.tar.bz2
linux-aarch64::sqlite-3.38.5-hc74f5b8_0.tar.bz2
linux-aarch64::grpcio-1.46.0-py37h781dd95_0.tar.bz2
linux-aarch64::gmsh-4.10.3-h6bb50e3_0.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py37h649bee8_15_cpu.tar.bz2
linux-aarch64::librdkafka-1.8.2.post2-h8bc9935_1.tar.bz2
linux-aarch64::grpc-cpp-1.44.0-h540e336_4.tar.bz2
linux-aarch64::openmpi-4.1.3-h26b3c96_102.tar.bz2
linux-aarch64::root_base-6.24.6-py38h9d9f28d_2.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py37hbba9808_53_cpu.tar.bz2
linux-aarch64::elfutils-0.187-h8f16a99_0.tar.bz2
linux-aarch64::pdal-2.4.0-hc6b58a3_4.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py310h3c7708d_29_cpu.tar.bz2
linux-aarch64::libcurl-static-7.83.1-h8fd98b7_0.tar.bz2
linux-aarch64::mysql-server-8.0.29-h34d02de_0.tar.bz2
linux-aarch64::llvmdev-14.0.1-hb2805f8_0.tar.bz2
linux-aarch64::nss-3.78-h1b46d77_0.tar.bz2
linux-aarch64::pyinstaller-5.0-py38hbe4f9ff_0.tar.bz2
linux-aarch64::pyinstaller-5.0.1-py38hbe4f9ff_0.tar.bz2
linux-aarch64::grpc-cpp-1.45.1-h0ee89e4_1.tar.bz2
linux-aarch64::libgdal-3.4.2-h9735432_5.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py310h70a1840_1_cpu.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py39h6f00710_18_cpu.tar.bz2
linux-aarch64::pyinstaller-5.1-py39h1a16a0b_0.tar.bz2
linux-aarch64::grpc-cpp-1.45.1-h1e9c3c8_1.tar.bz2
linux-aarch64::rust-1.61.0-h26fb2b7_0.tar.bz2
linux-aarch64::xrootd-5.4.2-py310h286b669_0.tar.bz2
linux-aarch64::openjdk-11.0.9.1-h484f8f1_2.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py310h56adcac_29_cpu.tar.bz2
linux-aarch64::xrootd-5.4.2-py39haf604e9_0.tar.bz2
linux-aarch64::mysql-server-8.0.28-hbe0b11a_3.tar.bz2
linux-aarch64::grpc-cpp-1.43.2-hda7c937_5.tar.bz2
linux-aarch64::libcurl-7.83.0-h22f3f83_0.tar.bz2
linux-aarch64::libopencv-4.5.5-py31hee64ec2_8.tar.bz2
linux-aarch64::sqlite-3.38.3-hc74f5b8_0.tar.bz2
linux-aarch64::libfido2-1.11.0-h75cb1c7_0.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py38hdf2861c_0_cpu.tar.bz2
linux-aarch64::mysql-router-8.0.29-hd5c2098_1.tar.bz2
linux-aarch64::arrow-cpp-7.0.0-py310h38efe08_7_cpu.tar.bz2
linux-aarch64::grpcio-1.46.0-py37h1fda7f6_0.tar.bz2
linux-aarch64::libmatio-1.5.23-hfc325d1_0.tar.bz2
linux-aarch64::grpcio-1.46.0-py310hab61ab1_1.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py39h6f00710_51_cpu.tar.bz2
linux-aarch64::boost-cpp-1.78.0-ha1c1135_1.tar.bz2
linux-aarch64::arrow-cpp-7.0.0-py39h6ca0213_7_cpu.tar.bz2
linux-aarch64::gct-6.2.1629922860-h19ae8ab_1.tar.bz2
linux-aarch64::rsync-3.2.3-h87a674a_4.tar.bz2
linux-aarch64::grpc-cpp-1.43.2-h6befb7c_3.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py39h6f00710_53_cpu.tar.bz2
linux-aarch64::mongodb-5.1.1-h436986b_3.tar.bz2
linux-aarch64::libarchive-3.5.2-h610d84a_2.tar.bz2
linux-aarch64::python-3.9.13-h2eada40_0_cpython.tar.bz2
linux-aarch64::grpcio-1.46.0-py310h64fc9e5_0.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py38h20463b3_52_cpu.tar.bz2
linux-aarch64::libgdal-3.4.2-hc8e6538_6.tar.bz2
linux-aarch64::llvmlite-0.38.1-py37h35d289f_0.tar.bz2
linux-aarch64::grpcio-1.46.3-py39h535dcc4_0.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py37h8dddf3c_53_cpu.tar.bz2
linux-aarch64::libgdal-3.4.2-hb85e2da_7.tar.bz2
linux-aarch64::pyinstaller-5.1-py38hbe4f9ff_0.tar.bz2
linux-aarch64::pygrib-2.1.4-py38hda5af9a_5.tar.bz2
linux-aarch64::llvmlite-0.38.1-py310h773edab_0.tar.bz2
linux-aarch64::grpc-cpp-1.45.2-hda7c937_2.tar.bz2
linux-aarch64::libtiff-4.3.0-h8ba47be_4.tar.bz2
linux-aarch64::grpcio-1.46.0-py37h781dd95_1.tar.bz2
linux-aarch64::pillow-9.1.0-py39h55c8a1a_2.tar.bz2
linux-aarch64::mysql-libs-8.0.29-h913e832_0.tar.bz2
linux-aarch64::grpcio-1.46.1-py310h64fc9e5_0.tar.bz2
linux-aarch64::grpcio-1.46.1-py37h1fda7f6_0.tar.bz2
linux-aarch64::grpc-cpp-1.44.0-h8183a91_3.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py39h6f00710_32_cpu.tar.bz2
linux-aarch64::grpcio-1.46.0-py39h535dcc4_1.tar.bz2
linux-aarch64::git-2.35.3-pl5321hd6c143b_0.tar.bz2
linux-aarch64::arrow-cpp-7.0.0-py37h7768c7b_6_cpu.tar.bz2
linux-aarch64::tiledb-2.8.0-h354e0e1_0.tar.bz2
linux-aarch64::smesh-9.8.0.2-he96c191_0.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py310h676c81e_19_cpu.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py39h6f00710_19_cpu.tar.bz2
linux-aarch64::root_base-6.26.2-py310hafdc390_2.tar.bz2
linux-aarch64::sqlite-3.38.2-hc74f5b8_0.tar.bz2
linux-aarch64::grpc-cpp-1.45.1-h9af5783_0.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py38h20463b3_34_cpu.tar.bz2
linux-aarch64::openmpi-4.1.3-h7728b8d_0.tar.bz2
linux-aarch64::grpcio-1.46.0-py39h8a0731a_0.tar.bz2
linux-aarch64::pygrib-2.1.4-py37h302dd12_5.tar.bz2
linux-aarch64::postgresql-plpython-14.3-py38h7359617_0.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py37hbba9808_34_cpu.tar.bz2
linux-aarch64::grpc-cpp-1.45.2-hb66c5c5_3.tar.bz2
linux-aarch64::libtiledb-sql-0.14.1-heaa659b_0.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py39h6f00710_34_cpu.tar.bz2
linux-aarch64::grpc-cpp-1.46.0-h4b4b5b4_0.tar.bz2
linux-aarch64::libxmlsec1-1.2.33-h840a424_1.tar.bz2
linux-aarch64::pygrib-2.1.4-py38h9734403_5.tar.bz2
linux-aarch64::poppler-qt-22.04.0-hbd36401_0.tar.bz2
linux-aarch64::tiledb-2.8.1-h6866cf4_0.tar.bz2
linux-aarch64::root_base-6.26.2-py37h1d7e146_1.tar.bz2
linux-aarch64::git-2.35.2-pl5321haf30559_0.tar.bz2
linux-aarch64::mosh-1.3.2-pl5321hcf8e85e_1012.tar.bz2
linux-aarch64::grpc-cpp-1.44.0-hda7c937_4.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py39h3051451_29_cpu.tar.bz2
linux-aarch64::pyreadstat-1.1.6-py310hceb02de_0.tar.bz2
linux-aarch64::fish-3.4.1-hfba443e_0.tar.bz2
linux-aarch64::tiledb-2.8.0-h354e0e1_1.tar.bz2
linux-aarch64::mysql-client-8.0.28-h546d73d_3.tar.bz2
linux-aarch64::grpcio-1.46.1-py38hff8890e_0.tar.bz2
linux-aarch64::pdal-2.4.1-h9cc8db8_0.tar.bz2
linux-aarch64::pypy3.8-7.3.9-hfb6fae5_1.tar.bz2
linux-aarch64::openmpi-4.1.3-hfeb99b9_101.tar.bz2
linux-aarch64::pyinstaller-5.0-py37h132cd36_0.tar.bz2
linux-aarch64::pyinstaller-5.1-py37h132cd36_0.tar.bz2
linux-aarch64::pdal-2.4.1-hc6b58a3_0.tar.bz2
linux-aarch64::mysql-router-8.0.29-h9a575f8_1.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py310h56adcac_48_cpu.tar.bz2
linux-aarch64::grpcio-1.46.1-py39h535dcc4_0.tar.bz2
linux-aarch64::libtiledb-sql-0.14.1-h2f14679_0.tar.bz2
linux-aarch64::libcurl-7.83.0-h8fd98b7_0.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py38h5fce45e_48_cpu.tar.bz2
linux-aarch64::libgdal-3.4.2-h8603a83_6.tar.bz2
linux-aarch64::wxwidgets-3.1.6-h9e57b98_0.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py39h1aae454_14_cpu.tar.bz2
linux-aarch64::llvmlite-0.38.1-py39hbbff7ca_0.tar.bz2
linux-aarch64::libopencv-4.5.5-py39hfb951e7_8.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py38h20463b3_33_cpu.tar.bz2
linux-aarch64::arrow-cpp-7.0.0-py310haca3654_4_cpu.tar.bz2
linux-aarch64::grpc-cpp-1.46.3-h46ce4ae_0.tar.bz2
linux-aarch64::ruby-3.1.2-hd1861fb_0.tar.bz2
linux-aarch64::pillow-9.1.1-py38h3870bda_0.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py37hbba9808_33_cpu.tar.bz2
linux-aarch64::texlive-core-20210325-h7feb347_3.tar.bz2
linux-aarch64::pyreadstat-1.1.6-py37h8236fb0_0.tar.bz2
linux-aarch64::grpc-cpp-1.45.2-h0ee89e4_0.tar.bz2
linux-aarch64::vtk-9.1.0-qt_py39hbef8b53_208.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py39h6f00710_33_cpu.tar.bz2
linux-aarch64::mongodb-5.1.1-h854de11_3.tar.bz2
linux-aarch64::curl-7.83.1-h22f3f83_0.tar.bz2
linux-aarch64::xrootd-5.4.2-py37he64f28a_0.tar.bz2
linux-aarch64::pillow-9.1.0-py310h31078c8_0.tar.bz2
linux-aarch64::nordugrid-arc-6.15.1-py39h0a375b4_0.tar.bz2
linux-aarch64::yoda-1.9.4-py310h6f30888_2.tar.bz2
linux-aarch64::imagemagick-7.1.0_31-pl5321hde91a41_0.tar.bz2
linux-aarch64::zstd-1.5.2-haad177d_1.tar.bz2
linux-aarch64::ogre-1.10.12-h3ade7c8_8.tar.bz2
linux-aarch64::llvmdev-14.0.2-hb2805f8_0.tar.bz2
linux-aarch64::nordugrid-arc-6.15.1-py37h6350fa1_0.tar.bz2
linux-aarch64::libopencv-4.5.5-py37h8f034d2_9.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py37h7768c7b_0_cpu.tar.bz2
linux-aarch64::pillow-9.1.0-py38h96fe0d2_2.tar.bz2
linux-aarch64::llvmlite-0.38.0-py38hd14ccfc_1.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py310hd5afd2e_33_cpu.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py310h676c81e_34_cpu.tar.bz2
linux-aarch64::freeimage-3.18.0-h8929e4b_8.tar.bz2
linux-aarch64::gmsh-4.10.1-ha086f09_0.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py37hbba9808_18_cpu.tar.bz2
linux-aarch64::grpcio-1.46.0-py39h535dcc4_0.tar.bz2
linux-aarch64::imagecodecs-2022.2.22-py39ha27213c_5.tar.bz2
linux-aarch64::root_base-6.26.2-py38h9d9f28d_1.tar.bz2
linux-aarch64::postgresql-plpython-14.3-py310h0b21c4e_0.tar.bz2
linux-aarch64::root_base-6.24.6-py39h0728cd7_2.tar.bz2
linux-aarch64::root_base-6.24.6-py37h1d7e146_2.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py310hd5afd2e_17_cpu.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py310hd5afd2e_31_cpu.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py39h6f00710_50_cpu.tar.bz2
linux-aarch64::mysql-router-8.0.29-hd5c2098_0.tar.bz2
linux-aarch64::ogre-13.3.4-h42ef9eb_0.tar.bz2
linux-aarch64::pygrib-2.1.4-py39hb874b96_5.tar.bz2
linux-aarch64::imagemagick-7.1.0_34-pl5321hde91a41_0.tar.bz2
linux-aarch64::mongodb-5.1.1-h07e2754_2.tar.bz2
linux-aarch64::arrow-cpp-7.0.0-py37h80e4e19_7_cpu.tar.bz2
linux-aarch64::orc-1.7.3-h016ce0c_1.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py39h661a48c_15_cpu.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py310hd5afd2e_52_cpu.tar.bz2
linux-aarch64::grpc-cpp-1.43.2-h4e595cf_3.tar.bz2
linux-aarch64::libprotobuf-static-3.20.1-h7866ba4_0.tar.bz2
linux-aarch64::yoda-1.9.5-py37h171ca18_0.tar.bz2
linux-aarch64::grpc-cpp-1.43.2-h4b4b5b4_5.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py38h20463b3_51_cpu.tar.bz2
linux-aarch64::yoda-1.9.4-py37h171ca18_2.tar.bz2
linux-aarch64::mysql-libs-8.0.29-h913e832_1.tar.bz2
linux-aarch64::grpcio-1.46.0-py37h1fda7f6_1.tar.bz2
linux-aarch64::mysql-libs-8.0.29-h8735f6a_0.tar.bz2
linux-aarch64::llvmdev-14.0.3-hb2805f8_0.tar.bz2
linux-aarch64::imagemagick-7.1.0_30-pl5321hde91a41_0.tar.bz2
linux-aarch64::cppyy-cling-6.25.3-py310h4eb0b0e_1.tar.bz2
linux-aarch64::smesh-9.7.0.1-h16eb388_1.tar.bz2
linux-aarch64::ffmpeg-4.4.1-h5c3c644_4.tar.bz2
linux-aarch64::mysql-router-8.0.28-h9e0b997_3.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py39h661a48c_49_cpu.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py37h7768c7b_1_cpu.tar.bz2
linux-aarch64::libtiledb-sql-0.14.2-heaa659b_1.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py38h20463b3_31_cpu.tar.bz2
linux-aarch64::libtiledb-sql-0.13.0-h2f14679_0.tar.bz2
linux-aarch64::arrow-cpp-7.0.0-py38hcbb976d_7_cpu.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py38h1bcab90_15_cpu.tar.bz2
linux-aarch64::yoda-1.9.4-py38h586b997_2.tar.bz2
linux-aarch64::orc-1.7.4-h016ce0c_1.tar.bz2
linux-aarch64::libtiledb-sql-0.14.2-h2f14679_1.tar.bz2
linux-aarch64::mysql-server-8.0.29-h4754e1b_1.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py310hd5afd2e_51_cpu.tar.bz2
linux-aarch64::postgresql-plpython-14.3-py310h357d6aa_0.tar.bz2
linux-aarch64::tiledb-2.8.2-h6866cf4_0.tar.bz2
linux-aarch64::grpcio-1.46.3-py38h7d9ddd4_0.tar.bz2
linux-aarch64::arrow-cpp-7.0.0-py39hb4a9b89_4_cpu.tar.bz2
linux-aarch64::tiledb-2.8.3-h6866cf4_1.tar.bz2
linux-aarch64::arrow-cpp-7.0.0-py38hdf2861c_5_cpu.tar.bz2
linux-aarch64::libopencv-4.5.5-py38hae708ee_9.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py310h3c7708d_48_cpu.tar.bz2
linux-aarch64::rsync-3.2.3-h39f2bdd_4.tar.bz2
linux-aarch64::libtiledb-sql-0.14.0-h2f14679_0.tar.bz2
linux-aarch64::grpc-cpp-1.44.0-h2e01d81_3.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py37hbba9808_31_cpu.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py37h1f7e134_1_cpu.tar.bz2
linux-aarch64::ruby-3.1.2-h53e0626_0.tar.bz2
linux-aarch64::postgresql-plpython-14.3-py38h1cbd339_0.tar.bz2
linux-aarch64::libgdal-3.4.3-hb85e2da_0.tar.bz2
linux-aarch64::libprotobuf-3.20.1-h7866ba4_0.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py38hdf2861c_1_cpu.tar.bz2
linux-aarch64::libpq-14.3-h2856e3f_0.tar.bz2
linux-aarch64::libssh-0.8.9-h2b6b862_2.tar.bz2
linux-aarch64::arrow-cpp-7.0.0-py37h1f7e134_7_cpu.tar.bz2
linux-aarch64::arrow-cpp-7.0.0-py310h70a1840_5_cpu.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py39h62432c7_53_cpu.tar.bz2
linux-aarch64::llvmlite-0.38.1-py38hb3e7a48_0.tar.bz2
linux-aarch64::libnetcdf-4.8.1-nompi_h9b46fb9_102.tar.bz2
linux-aarch64::git-2.35.3-pl5321haf30559_0.tar.bz2
linux-aarch64::tiledb-2.9.0-h354e0e1_1.tar.bz2
linux-aarch64::grpcio-1.46.0-py38h7d9ddd4_0.tar.bz2
linux-aarch64::mysql-server-8.0.29-h4754e1b_0.tar.bz2
linux-aarch64::mysql-router-8.0.28-h06fb26e_3.tar.bz2
linux-aarch64::imagemagick-7.1.0_32-pl5321hde91a41_0.tar.bz2
linux-aarch64::rust-1.60.0-h26fb2b7_0.tar.bz2
linux-aarch64::libopencv-4.5.5-py39hfb951e7_9.tar.bz2
linux-aarch64::pypy3.9-7.3.9-h57c6639_1.tar.bz2
linux-aarch64::qt-main-5.15.3-hfaa85a3_1.tar.bz2
linux-aarch64::blosc-1.21.1-hdfcada4_3.tar.bz2
linux-aarch64::ffmpeg-4.4.1-h3bda925_3.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py37hbba9808_17_cpu.tar.bz2
linux-aarch64::grpc-cpp-1.45.2-h540e336_3.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py310hd5afd2e_18_cpu.tar.bz2
linux-aarch64::imagecodecs-2022.2.22-py38h6f5bafd_5.tar.bz2
linux-aarch64::xrootd-5.4.2-py38hb5711a5_0.tar.bz2
linux-aarch64::grpcio-1.46.3-py37h1fda7f6_0.tar.bz2
linux-aarch64::mysql-server-8.0.29-h34d02de_1.tar.bz2
linux-aarch64::yoda-1.9.4-py39h865afa5_2.tar.bz2
linux-aarch64::tiledb-2.8.0-h6866cf4_1.tar.bz2
linux-aarch64::mysql-client-8.0.29-h1208568_0.tar.bz2
linux-aarch64::imagecodecs-2022.2.22-py38h44bed0a_3.tar.bz2
linux-aarch64::cpp-opentelemetry-sdk-1.3.0-h0ffc852_1.tar.bz2
linux-aarch64::mysql-libs-8.0.28-h8735f6a_3.tar.bz2
linux-aarch64::openjpeg-2.5.0-h9b6de37_0.tar.bz2
linux-aarch64::root_base-6.26.2-py38h9d9f28d_3.tar.bz2
linux-aarch64::pillow-9.1.0-py37h2dc4c6d_2.tar.bz2
linux-aarch64::mongodb-5.1.1-h07e2754_3.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py39h202adf9_0_cpu.tar.bz2
linux-aarch64::postgresql-plpython-14.3-py37h71fe8e9_0.tar.bz2
linux-aarch64::yoda-1.9.4-py37h19cc558_2.tar.bz2
linux-aarch64::postgresql-plpython-14.3-py39hc61fba2_0.tar.bz2
linux-aarch64::grpc-cpp-1.45.2-hda7c937_3.tar.bz2
linux-aarch64::postgresql-14.3-h6a5f0b7_0.tar.bz2
linux-aarch64::cmake-3.23.1-hcad14f8_0.tar.bz2
linux-aarch64::root_base-6.24.6-py310hafdc390_2.tar.bz2
linux-aarch64::mongodb-5.1.1-h436986b_2.tar.bz2
linux-aarch64::root_base-6.26.2-py37h1d7e146_3.tar.bz2
linux-aarch64::vowpalwabbit-9.1.0-py37hf697780_0.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py39h62432c7_19_cpu.tar.bz2
linux-aarch64::grpcio-1.46.1-py310hab61ab1_0.tar.bz2
linux-aarch64::gmsh-4.10.0-ha086f09_0.tar.bz2
linux-aarch64::imagecodecs-2022.2.22-py39h8beacc9_3.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py37h0840a33_14_cpu.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py37hbba9808_19_cpu.tar.bz2
linux-aarch64::root_base-6.26.2-py39h0728cd7_2.tar.bz2
linux-aarch64::libtiledb-sql-0.14.2-heaa659b_0.tar.bz2
linux-aarch64::grpc-cpp-1.43.2-h768e200_4.tar.bz2
linux-aarch64::mysql-client-8.0.29-h1208568_1.tar.bz2
linux-aarch64::pdal-2.4.0-h9cc8db8_4.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py38h20463b3_16_cpu.tar.bz2
linux-aarch64::boost-cpp-1.79.0-ha1c1135_0.tar.bz2
linux-aarch64::grpc-cpp-1.43.2-h4e6d506_4.tar.bz2
linux-aarch64::imagemagick-7.1.0_35-pl5321hde91a41_0.tar.bz2
linux-aarch64::vtk-9.1.0-qt_py310h2169390_208.tar.bz2
linux-aarch64::grpcio-1.46.3-py310hab61ab1_0.tar.bz2
linux-aarch64::imagecodecs-2022.2.22-py310h0c3244d_4.tar.bz2
linux-aarch64::pygrib-2.1.4-py39hc269215_5.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py310h56adcac_14_cpu.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py38h701efe5_48_cpu.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py39h6f00710_17_cpu.tar.bz2
linux-aarch64::libxmlsec1-1.2.34-h840a424_0.tar.bz2
linux-aarch64::libtiledb-sql-0.14.0-heaa659b_0.tar.bz2
linux-aarch64::grpcio-1.46.3-py38hff8890e_0.tar.bz2
linux-aarch64::grpc-cpp-1.45.2-h4b4b5b4_1.tar.bz2
linux-aarch64::pyinstaller-5.0.1-py310h9164b14_0.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py38h701efe5_29_cpu.tar.bz2
linux-aarch64::mysql-client-8.0.28-h1208568_4.tar.bz2
linux-aarch64::pyinstaller-5.0-py39h1a16a0b_0.tar.bz2
linux-aarch64::grpcio-1.46.3-py37h781dd95_0.tar.bz2
linux-aarch64::vowpalwabbit-9.1.0-py39h34fe1c9_0.tar.bz2
linux-aarch64::grpc-cpp-1.43.2-h540e336_5.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py38h48a040f_34_cpu.tar.bz2
linux-aarch64::pillow-9.1.0-py39h2a8e185_1.tar.bz2
linux-aarch64::mysql-server-8.0.28-hc3d1dca_3.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py37he395cf6_14_cpu.tar.bz2
linux-aarch64::cppyy-cling-6.25.3-py37h21e75f5_1.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py39h6f00710_31_cpu.tar.bz2
linux-aarch64::gmsh-4.10.2-ha086f09_0.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py38h48a040f_53_cpu.tar.bz2
linux-aarch64::yoda-1.9.4-py38hedfad09_2.tar.bz2
linux-aarch64::gsoap-2.8.121-h6af4a7d_0.tar.bz2
linux-aarch64::pillow-9.1.1-py310h31078c8_0.tar.bz2
linux-aarch64::libnetcdf-4.8.1-mpi_mpich_h3a93c69_2.tar.bz2
linux-aarch64::grpc-cpp-1.44.0-hb66c5c5_4.tar.bz2
linux-aarch64::llvmlite-0.38.0-py39ha5d8a0d_1.tar.bz2
linux-aarch64::arrow-cpp-7.0.0-py38h866527c_4_cpu.tar.bz2
linux-aarch64::ogre-13.3.4-h7d42a4d_1.tar.bz2
linux-aarch64::coin-or-clp-1.17.7-he47f482_0.tar.bz2
linux-aarch64::tiledb-2.8.3-h6866cf4_0.tar.bz2
linux-aarch64::grpc-cpp-1.45.2-hb66c5c5_2.tar.bz2
linux-aarch64::grpcio-1.46.3-py310h64fc9e5_0.tar.bz2
linux-aarch64::grpc-cpp-1.44.0-h9af5783_2.tar.bz2
linux-aarch64::libgit2-1.4.3-ha9a0767_0.tar.bz2
linux-aarch64::qt-main-5.15.3-hfaa85a3_0.tar.bz2
linux-aarch64::pillow-9.1.0-py37h2dc4c6d_0.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py310h85965dc_30_cpu.tar.bz2
linux-aarch64::curl-7.83.1-h8fd98b7_0.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py38h20463b3_18_cpu.tar.bz2
linux-aarch64::nordugrid-arc-6.15.1-py37hc6c70b4_0.tar.bz2
linux-aarch64::grpc-cpp-1.45.1-h6befb7c_0.tar.bz2
linux-aarch64::cpp-opentelemetry-sdk-1.4.0-h0ffc852_0.tar.bz2
linux-aarch64::libxml2-2.9.13-h370961a_0.tar.bz2
linux-aarch64::git-2.35.2-pl5321hd6c143b_0.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py39h8d7a521_1_cpu.tar.bz2
linux-aarch64::libgdal-3.4.3-h7a4ffd3_0.tar.bz2
linux-aarch64::grpc-cpp-1.43.2-h9af5783_3.tar.bz2
linux-aarch64::tiledb-2.8.2-h354e0e1_0.tar.bz2
linux-aarch64::grpc-cpp-1.46.3-h7f5ef31_0.tar.bz2
linux-aarch64::grpcio-1.46.1-py37h781dd95_0.tar.bz2
linux-aarch64::nodejs-17.9.0-he850d6a_0.tar.bz2
linux-aarch64::qt-webengine-5.15.4-hb91c699_3.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py310hd5afd2e_16_cpu.tar.bz2
linux-aarch64::libnetcdf-4.8.1-mpi_openmpi_h3a47db1_2.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py38h0ff6dd9_1_cpu.tar.bz2
linux-aarch64::imagecodecs-2022.2.22-py39h3968835_2.tar.bz2
linux-aarch64::openjdk-11.0.9.1-h47f71a8_3.tar.bz2
linux-aarch64::squashfuse-0.1.104-h7c3462f_2.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py37h8dddf3c_19_cpu.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py310hd5afd2e_32_cpu.tar.bz2
linux-aarch64::arrow-cpp-7.0.0-py37ha4092ea_4_cpu.tar.bz2
linux-aarch64::pyinstaller-5.0.1-py37h132cd36_0.tar.bz2
linux-aarch64::librdkafka-1.8.2.post2-h9e317bd_1.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py39h661a48c_30_cpu.tar.bz2
linux-aarch64::vowpalwabbit-9.1.0-py38h7a54b30_0.tar.bz2
linux-aarch64::llvmlite-0.38.0-py39hbbff7ca_1.tar.bz2
linux-aarch64::grpc-cpp-1.43.2-hbb61a01_3.tar.bz2
linux-aarch64::poppler-22.04.0-h27ad1b0_0.tar.bz2
linux-aarch64::pyreadstat-1.1.6-py39hca51b09_0.tar.bz2
linux-aarch64::libgdal-3.4.2-h7a4ffd3_7.tar.bz2
linux-aarch64::yoda-1.9.5-py38hedfad09_0.tar.bz2
linux-aarch64::mysql-libs-8.0.28-h913e832_4.tar.bz2
linux-aarch64::arrow-cpp-7.0.0-py37h7768c7b_5_cpu.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py37hbba9808_51_cpu.tar.bz2
linux-aarch64::pillow-9.1.0-py39h2a8e185_2.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py310hd5afd2e_50_cpu.tar.bz2
linux-aarch64::pillow-9.1.0-py310h31078c8_1.tar.bz2
linux-aarch64::pillow-9.1.0-py38h3870bda_0.tar.bz2
linux-aarch64::xrootd-5.4.2-py39h9a6de4d_0.tar.bz2
linux-aarch64::pillow-9.1.1-py39h2a8e185_0.tar.bz2
linux-aarch64::openssh-9.0p1-h68e116c_0.tar.bz2
linux-aarch64::libgit2-1.4.3-he9ce915_0.tar.bz2
linux-aarch64::orc-1.7.4-h016ce0c_0.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py310h85965dc_49_cpu.tar.bz2
linux-aarch64::gfal2-2.20.5-he11e5a5_1.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py38h20463b3_19_cpu.tar.bz2
linux-aarch64::mysql-libs-8.0.28-h8735f6a_4.tar.bz2
linux-aarch64::pyinstaller-5.1-py310h9164b14_0.tar.bz2
linux-aarch64::pypy3.9-7.3.9-h6058f72_1.tar.bz2
linux-aarch64::libcurl-static-7.83.0-h22f3f83_0.tar.bz2
linux-aarch64::arrow-cpp-7.0.0-py39h8d7a521_7_cpu.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py310h70a1840_0_cpu.tar.bz2
linux-aarch64::root_base-6.26.2-py37h1d7e146_2.tar.bz2
linux-aarch64::mongodb-5.1.1-hcbb7fc8_3.tar.bz2
linux-aarch64::clangdev-14.0.3-default_ha7bf5e6_0.tar.bz2
linux-aarch64::gsoap-2.8.121-hf52ca08_0.tar.bz2
linux-aarch64::mysql-libs-8.0.29-h8735f6a_1.tar.bz2
linux-aarch64::imagecodecs-2022.2.22-py310h2837582_2.tar.bz2
linux-aarch64::tiledb-2.8.0-h6866cf4_0.tar.bz2
linux-aarch64::pillow-9.1.0-py38h3870bda_2.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py37h8dddf3c_34_cpu.tar.bz2
linux-aarch64::grpcio-1.46.0-py38hff8890e_1.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py39h6ca0213_1_cpu.tar.bz2
linux-aarch64::cmake-3.23.2-hcad14f8_0.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py37h80e4e19_1_cpu.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py38h5fce45e_14_cpu.tar.bz2
linux-aarch64::ogre-1.12.13-h7d42a4d_1.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py37h649bee8_30_cpu.tar.bz2
linux-aarch64::grpc-cpp-1.44.0-hbb61a01_2.tar.bz2
linux-aarch64::pillow-9.1.1-py37h2dc4c6d_0.tar.bz2
linux-aarch64::nordugrid-arc-6.15.1-py310h4a6bc45_0.tar.bz2
linux-aarch64::libopencv-4.5.5-py38hae708ee_8.tar.bz2
linux-aarch64::libpq-14.3-h9bd3da0_0.tar.bz2
linux-aarch64::grpc-cpp-1.45.2-hda7c937_1.tar.bz2
linux-aarch64::pillow-9.1.0-py39h55c8a1a_1.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py38h20463b3_50_cpu.tar.bz2
linux-aarch64::gsoap-2.8.122-hf52ca08_0.tar.bz2
linux-aarch64::tiledb-2.7.2-h354e0e1_0.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py310hd5afd2e_19_cpu.tar.bz2
linux-aarch64::postgresql-plpython-14.3-py37hf413ee8_0.tar.bz2
linux-aarch64::arrow-cpp-7.0.0-py39h202adf9_5_cpu.tar.bz2
linux-aarch64::libtiledb-sql-0.13.0-heaa659b_0.tar.bz2
linux-aarch64::yoda-1.9.5-py39h87c0d69_0.tar.bz2
linux-aarch64::libfido2-1.11.0-h2b6b862_0.tar.bz2
linux-aarch64::libcurl-7.83.1-h22f3f83_0.tar.bz2
linux-aarch64::postgresql-14.3-hd89e3e7_0.tar.bz2
linux-aarch64::openmpi-4.1.3-h26b3c96_103.tar.bz2
linux-aarch64::tiledb-2.8.1-h354e0e1_0.tar.bz2
linux-aarch64::curl-7.83.0-h8fd98b7_0.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py38h1bcab90_49_cpu.tar.bz2
linux-aarch64::mysql-router-8.0.29-h9a575f8_0.tar.bz2
linux-aarch64::coin-or-cgl-0.60.6-h564ed3d_0.tar.bz2
linux-aarch64::llvmdev-14.0.4-hb2805f8_0.tar.bz2
linux-aarch64::grpc-cpp-1.45.2-h540e336_2.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py37h0840a33_29_cpu.tar.bz2
linux-aarch64::imagecodecs-2022.2.22-py38h6f5bafd_4.tar.bz2
linux-aarch64::pillow-9.1.0-py39h2a8e185_0.tar.bz2
linux-aarch64::libcurl-7.83.1-h8fd98b7_0.tar.bz2
linux-aarch64::clangdev-14.0.0-default_ha7bf5e6_0.tar.bz2
linux-aarch64::root_base-6.26.2-py38h9d9f28d_2.tar.bz2
linux-aarch64::grpc-cpp-1.43.2-hb66c5c5_5.tar.bz2
linux-aarch64::sqlite-3.38.4-hc74f5b8_0.tar.bz2
linux-aarch64::mysql-router-8.0.28-hd5c2098_4.tar.bz2
linux-aarch64::pyinstaller-5.0-py310h9164b14_0.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py37he395cf6_29_cpu.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py38h1bcab90_30_cpu.tar.bz2
linux-aarch64::blosc-1.21.1-hdfcada4_2.tar.bz2
linux-aarch64::pygrib-2.1.4-py310h19f8b5f_5.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py38h701efe5_14_cpu.tar.bz2
linux-aarch64::mysql-libs-8.0.28-h913e832_3.tar.bz2
linux-aarch64::grpc-cpp-1.45.2-h1e9c3c8_0.tar.bz2
linux-aarch64::grpcio-1.46.0-py38hff8890e_0.tar.bz2
linux-aarch64::llvmlite-0.38.0-py38hb3e7a48_1.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py310h231626f_1_cpu.tar.bz2
linux-aarch64::grpcio-1.46.0-py310hab61ab1_0.tar.bz2
linux-aarch64::vtk-9.1.0-qt_py38h57b2951_208.tar.bz2
linux-aarch64::root_base-6.26.2-py310hafdc390_1.tar.bz2
linux-aarch64::grpc-cpp-1.44.0-h4b4b5b4_4.tar.bz2
linux-aarch64::python-3.9.13-h5016f1d_0_cpython.tar.bz2
linux-aarch64::qt-webengine-5.15.4-h7d4f763_2.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py38h20463b3_32_cpu.tar.bz2
linux-aarch64::tiledb-2.9.1-h354e0e1_0.tar.bz2
linux-aarch64::cppyy-cling-6.25.3-py38h986aded_1.tar.bz2
linux-aarch64::imagecodecs-2022.2.22-py39ha27213c_4.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py37he395cf6_48_cpu.tar.bz2
linux-aarch64::gct-6.2.1629922860-haa01bc1_1.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py39h62432c7_34_cpu.tar.bz2
linux-aarch64::nordugrid-arc-6.15.1-py38he97988b_0.tar.bz2
linux-aarch64::tiledb-2.8.3-h354e0e1_0.tar.bz2
linux-aarch64::pdal-2.4.0-h46a4021_3.tar.bz2
linux-aarch64::nodejs-17.9.0-h928fb59_0.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py37hbba9808_50_cpu.tar.bz2
linux-aarch64::xrootd-5.4.2-py38hbcbad04_0.tar.bz2
linux-aarch64::mysql-server-8.0.28-h4754e1b_4.tar.bz2
linux-aarch64::libxml2-2.9.14-h370961a_0.tar.bz2
linux-aarch64::grpc-cpp-1.46.0-hda7c937_0.tar.bz2
linux-aarch64::libopencv-4.5.5-py37h8f034d2_8.tar.bz2
linux-aarch64::grpc-cpp-1.45.2-h4b4b5b4_3.tar.bz2
linux-aarch64::imagecodecs-2022.2.22-py310h0c3244d_5.tar.bz2
linux-aarch64::pillow-9.1.0-py37h2dc4c6d_1.tar.bz2
linux-aarch64::postgresql-plpython-14.3-py39hb3217f8_0.tar.bz2
linux-aarch64::grpc-cpp-1.44.0-h4e595cf_2.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py37h0840a33_48_cpu.tar.bz2
linux-aarch64::ffmpeg-5.0.1-h3bda925_0.tar.bz2
linux-aarch64::gsoap-2.8.122-h6af4a7d_0.tar.bz2
linux-aarch64::clangdev-14.0.4-default_ha7bf5e6_0.tar.bz2
linux-aarch64::vtk-9.1.0-qt_py37hac61793_208.tar.bz2
linux-aarch64::arrow-cpp-7.0.0-py38h0ff6dd9_7_cpu.tar.bz2
linux-aarch64::grpc-cpp-1.44.0-h6befb7c_2.tar.bz2
linux-aarch64::mysql-router-8.0.28-h9a575f8_4.tar.bz2
linux-aarch64::grpc-cpp-1.45.2-h4b4b5b4_2.tar.bz2
linux-aarch64::libgdal-3.5.0-hb85e2da_0.tar.bz2
linux-aarch64::grpc-cpp-1.44.0-h4e6d506_3.tar.bz2
linux-aarch64::libssh-0.8.9-h75cb1c7_2.tar.bz2
linux-aarch64::grpcio-1.46.1-py38h7d9ddd4_0.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py37hbba9808_16_cpu.tar.bz2
linux-aarch64::ffmpeg-5.0.1-h5c3c644_2.tar.bz2
linux-aarch64::arrow-cpp-7.0.0-py38hdf2861c_6_cpu.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py310h85965dc_15_cpu.tar.bz2
linux-aarch64::pillow-9.1.0-py38h96fe0d2_1.tar.bz2
linux-aarch64::pillow-9.1.1-py39h55c8a1a_0.tar.bz2
linux-aarch64::grpc-cpp-1.44.0-h768e200_3.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py38h5fce45e_29_cpu.tar.bz2
linux-aarch64::mysql-client-8.0.28-h546d73d_4.tar.bz2
linux-aarch64::root_base-6.26.2-py39h0728cd7_1.tar.bz2
linux-aarch64::libcurl-static-7.83.1-h22f3f83_0.tar.bz2
linux-aarch64::mysql-client-8.0.29-h546d73d_1.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py38hcbb976d_1_cpu.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py37hbba9808_52_cpu.tar.bz2
linux-aarch64::pypy3.8-7.3.9-h4c41721_1.tar.bz2
linux-aarch64::mysql-server-8.0.28-h34d02de_4.tar.bz2
linux-aarch64::assimp-5.2.4-hf7258a5_0.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py38h48a040f_19_cpu.tar.bz2
linux-aarch64::ffmpeg-5.0.1-h3bda925_1.tar.bz2
linux-aarch64::grpc-cpp-1.43.2-h2e01d81_4.tar.bz2
linux-aarch64::llvmlite-0.38.0-py37h35d289f_1.tar.bz2
linux-aarch64::vowpalwabbit-9.1.0-py310h2d01fb6_0.tar.bz2
linux-aarch64::arrow-cpp-8.0.0-py39h202adf9_1_cpu.tar.bz2
-    "libzlib >=1.2.11,<1.3.0a0",
+    "libzlib >=1.2.11,<2.0.0a0",
linux-aarch64::llvm-14.0.4-h40ce709_0.tar.bz2
linux-aarch64::coin-or-osi-0.108.7-hdfab8da_0.tar.bz2
linux-aarch64::dotnet-aspnetcore-6.0.4-hb062e78_0.tar.bz2
linux-aarch64::clang-format-14.0.0-default_ha7bf5e6_0.tar.bz2
linux-aarch64::dotnet-sdk-3.1.418-hb062e78_0.tar.bz2
linux-aarch64::libclang-cpp-14.0.4-default_ha7bf5e6_0.tar.bz2
linux-aarch64::gst-plugins-good-1.20.2-h660f13c_1.tar.bz2
linux-aarch64::libllvm14-14.0.4-hb2805f8_0.tar.bz2
linux-aarch64::llvm-tools-14.0.2-hb2805f8_0.tar.bz2
linux-aarch64::llvm-14.0.1-h40ce709_0.tar.bz2
linux-aarch64::gst-plugins-base-1.20.2-hbea7648_0.tar.bz2
linux-aarch64::libclang-14.0.4-default_ha7bf5e6_0.tar.bz2
linux-aarch64::clang-format-14-14.0.3-default_ha7bf5e6_0.tar.bz2
linux-aarch64::lld-14.0.4-h58cdf4e_0.tar.bz2
linux-aarch64::libclang-cpp9-9.0.1-cling_v0.9_h27cd1b6_5.tar.bz2
linux-aarch64::dotnet-aspnetcore-3.1.24-hb062e78_0.tar.bz2
linux-aarch64::libclang13-14.0.4-default_h3684801_0.tar.bz2
linux-aarch64::llvm-14.0.2-h40ce709_1.tar.bz2
linux-aarch64::dotnet-aspnetcore-5.0.16-hb062e78_0.tar.bz2
linux-aarch64::libllvm14-14.0.1-hb2805f8_0.tar.bz2
linux-aarch64::libclang-cpp-9.0.1-hcc_hfb8c119_5.tar.bz2
linux-aarch64::llvm-tools-14.0.1-hb2805f8_0.tar.bz2
linux-aarch64::libsolv-0.7.22-h7866ba4_0.tar.bz2
linux-aarch64::clang-14-14.0.4-default_ha7bf5e6_0.tar.bz2
linux-aarch64::llvm-tools-14.0.4-hb2805f8_0.tar.bz2
linux-aarch64::clang-14-14.0.3-default_ha7bf5e6_0.tar.bz2
linux-aarch64::llvm-openmp-14.0.0-hb2805f8_0.tar.bz2
linux-aarch64::dotnet-runtime-3.1.24-hf32e593_0.tar.bz2
linux-aarch64::libclang-cpp-9.0.1-default_h2caf41e_5.tar.bz2
linux-aarch64::clang-9-9.0.1-cling_v0.9_h27cd1b6_5.tar.bz2
linux-aarch64::clang-tools-14.0.4-default_ha7bf5e6_0.tar.bz2
linux-aarch64::libclang-cpp9-9.0.1-hcc_hfb8c119_5.tar.bz2
linux-aarch64::dotnet-sdk-5.0.407-hb062e78_0.tar.bz2
linux-aarch64::clang-9-9.0.1-root_62600_h487e30a_5.tar.bz2
linux-aarch64::clang-tools-14.0.3-default_ha7bf5e6_0.tar.bz2
linux-aarch64::lld-14.0.2-h58cdf4e_0.tar.bz2
linux-aarch64::clang-tools-14.0.0-default_ha7bf5e6_0.tar.bz2
linux-aarch64::llvm-14.0.2-h40ce709_0.tar.bz2
linux-aarch64::libsolv-static-0.7.22-h7866ba4_0.tar.bz2
linux-aarch64::clang-9-9.0.1-hcc_hfb8c119_5.tar.bz2
linux-aarch64::dotnet-runtime-6.0.4-hb062e78_0.tar.bz2
linux-aarch64::clang-format-14-14.0.4-default_ha7bf5e6_0.tar.bz2
linux-aarch64::openexr-3.1.5-hb2805f8_0.tar.bz2
linux-aarch64::llvm-openmp-14.0.4-hb2805f8_0.tar.bz2
linux-aarch64::libllvm14-14.0.3-hb2805f8_0.tar.bz2
linux-aarch64::clang-9-9.0.1-default_h2caf41e_5.tar.bz2
linux-aarch64::libllvm14-14.0.2-hb2805f8_0.tar.bz2
linux-aarch64::libclang-cpp9-9.0.1-default_h2caf41e_5.tar.bz2
linux-aarch64::libclang-14.0.0-default_ha7bf5e6_0.tar.bz2
linux-aarch64::libllvm14-14.0.2-hb2805f8_1.tar.bz2
linux-aarch64::clang-format-14.0.4-default_ha7bf5e6_0.tar.bz2
linux-aarch64::clang-format-14.0.3-default_ha7bf5e6_0.tar.bz2
linux-aarch64::libclang-cpp-14.0.3-default_ha7bf5e6_0.tar.bz2
linux-aarch64::libclang-14.0.3-default_ha7bf5e6_0.tar.bz2
linux-aarch64::dotnet-sdk-6.0.202-hb062e78_0.tar.bz2
linux-aarch64::libclang-cpp-14.0.0-default_ha7bf5e6_0.tar.bz2
linux-aarch64::clang-14-14.0.0-default_ha7bf5e6_0.tar.bz2
linux-aarch64::gst-plugins-good-1.20.2-h660f13c_0.tar.bz2
linux-aarch64::libclang-cpp9-9.0.1-root_62600_h487e30a_5.tar.bz2
linux-aarch64::libclang-cpp-9.0.1-root_62600_h487e30a_5.tar.bz2
linux-aarch64::lld-14.0.3-h58cdf4e_0.tar.bz2
linux-aarch64::libclang-cpp14-14.0.3-default_ha7bf5e6_0.tar.bz2
linux-aarch64::lld-14.0.0-h58cdf4e_0.tar.bz2
linux-aarch64::llvm-openmp-14.0.2-hb2805f8_0.tar.bz2
linux-aarch64::libclang13-14.0.3-default_h3684801_0.tar.bz2
linux-aarch64::gst-plugins-base-1.20.2-hfe44c80_1.tar.bz2
linux-aarch64::dotnet-runtime-5.0.16-hb062e78_0.tar.bz2
linux-aarch64::llvm-openmp-14.0.3-hb2805f8_0.tar.bz2
linux-aarch64::libclang-cpp14-14.0.4-default_ha7bf5e6_0.tar.bz2
linux-aarch64::libclang-cpp14-14.0.0-default_ha7bf5e6_0.tar.bz2
linux-aarch64::libclang-cpp-9.0.1-cling_v0.9_h27cd1b6_5.tar.bz2
linux-aarch64::llvm-tools-14.0.3-hb2805f8_0.tar.bz2
linux-aarch64::libclang13-14.0.0-default_h3684801_0.tar.bz2
linux-aarch64::llvm-tools-14.0.2-hb2805f8_1.tar.bz2
linux-aarch64::clang-format-14-14.0.0-default_ha7bf5e6_0.tar.bz2
linux-aarch64::llvm-14.0.3-h40ce709_0.tar.bz2
-    "libzlib >=1.2.11,<1.3.0a0"
+    "libzlib >=1.2.11,<2.0.0a0"
linux-aarch64::graphviz-4.0.0-h856fde9_0.tar.bz2
linux-aarch64::pillow-9.1.1-py37h2dc4c6d_1.tar.bz2
linux-aarch64::libprotobuf-3.21.1-h7866ba4_0.tar.bz2
linux-aarch64::libprotobuf-static-3.21.1-h7866ba4_0.tar.bz2
linux-aarch64::sagelib-9.6-py310hcc22e18_0.tar.bz2
linux-aarch64::pillow-9.1.1-py38h3870bda_1.tar.bz2
linux-aarch64::sagelib-9.6-py39h0b0774c_0.tar.bz2
linux-aarch64::imagemagick-7.1.0_36-pl5321hde91a41_0.tar.bz2
linux-aarch64::pillow-9.1.1-py310h31078c8_1.tar.bz2
linux-aarch64::sagelib-9.6-py37h6c375de_0.tar.bz2
linux-aarch64::pillow-9.1.1-py39h2a8e185_1.tar.bz2
linux-aarch64::tiledb-2.9.2-h354e0e1_0.tar.bz2
linux-aarch64::pillow-9.1.1-py38h96fe0d2_1.tar.bz2
linux-aarch64::pillow-9.1.1-py39h55c8a1a_1.tar.bz2
linux-aarch64::libtiff-4.4.0-h8ba47be_0.tar.bz2
linux-aarch64::libtiledb-sql-0.15.0-heaa659b_0.tar.bz2
linux-aarch64::libxslt-1.1.35-h55d2cec_0.tar.bz2
linux-aarch64::libprotobuf-static-21.1-h7866ba4_0.tar.bz2
linux-aarch64::freeimage-3.18.0-h8929e4b_9.tar.bz2
linux-aarch64::sagelib-9.6-py38hb0d89e6_0.tar.bz2
linux-aarch64::libtiledb-sql-0.15.0-h2f14679_0.tar.bz2
linux-aarch64::tiledb-2.9.2-h6866cf4_0.tar.bz2
-    "libzlib >=1.2.12,<1.3.0a0",
+    "libzlib >=1.2.12,<2.0.0a0",
================================================================================
================================================================================
noarch
================================================================================
================================================================================
win-64
win-64::grpc-cpp-1.43.2-hcf7c36f_3.tar.bz2
win-64::pillow-9.1.0-py37h8675073_0.tar.bz2
win-64::arrow-cpp-5.0.0-py310he4b5c8f_29_cpu.tar.bz2
win-64::arrow-cpp-7.0.0-py39hae7b3f5_7_cpu.tar.bz2
win-64::grpcio-1.46.0-py39hb76b349_1.tar.bz2
win-64::libclang13-14.0.3-default_h77d9078_0.tar.bz2
win-64::libclang13-14.0.4-default_h77d9078_0.tar.bz2
win-64::grpcio-1.46.3-py39hb76b349_0.tar.bz2
win-64::mongodb-5.1.1-he619f2b_3.tar.bz2
win-64::pypy3.9-7.3.9-hc3b0203_1.tar.bz2
win-64::coda-2.24-py39h0989d49_0.tar.bz2
win-64::coda-2.24-py38h9644311_0.tar.bz2
win-64::tiledb-2.9.1-h5689973_0.tar.bz2
win-64::harp-1.15.1-py39r40h0989d49_0.tar.bz2
win-64::harp-1.15-py38r41h9644311_1.tar.bz2
win-64::imagecodecs-2022.2.22-py310h4c2b206_2.tar.bz2
win-64::llvmlite-0.38.0-py39h7bb736d_1.tar.bz2
win-64::llvm-tools-14.0.1-hf00eed6_0.tar.bz2
win-64::arrow-cpp-5.0.0-py37hd943af9_31_cpu.tar.bz2
win-64::harp-1.15-py39r40hed3fa83_1.tar.bz2
win-64::coda-2.24-py37hca80f52_0.tar.bz2
win-64::arrow-cpp-6.0.1-py310hd72be80_15_cpu.tar.bz2
win-64::nco-5.0.7-h5be7ecf_0.tar.bz2
win-64::pillow-9.1.1-py39h4bd82c8_0.tar.bz2
win-64::openexr-python-1.3.8-py37h0cc0ffa_0.tar.bz2
win-64::libllvm14-14.0.4-h97333cc_0.tar.bz2
win-64::harp-1.15-py38r41h8975372_1.tar.bz2
win-64::arrow-cpp-3.0.0-py37hd943af9_51_cpu.tar.bz2
win-64::mysql-libs-8.0.29-h8b0d2c3_1.tar.bz2
win-64::arrow-cpp-6.0.1-py310h5ae816d_19_cuda.tar.bz2
win-64::arrow-cpp-6.0.1-py38hcbef6f9_16_cuda.tar.bz2
win-64::python-3.9.13-h9a09f29_0_cpython.tar.bz2
win-64::pypy3.8-7.3.8-h4acdc65_2.tar.bz2
win-64::harp-1.15.1-py37r41hca80f52_0.tar.bz2
win-64::llvmlite-0.38.0-py37habb0c8c_1.tar.bz2
win-64::arrow-cpp-6.0.1-py39hf372ac5_18_cuda.tar.bz2
win-64::pyinstaller-5.0-py38hd0d6af5_0.tar.bz2
win-64::arrow-cpp-8.0.0-py310h43be0d3_0_cpu.tar.bz2
win-64::harp-1.15.1-py38r40h9644311_0.tar.bz2
win-64::pillow-9.1.1-py38hb2b9be2_0.tar.bz2
win-64::grpc-cpp-1.44.0-hddde413_3.tar.bz2
win-64::grpc-cpp-1.43.2-he33f7c1_3.tar.bz2
win-64::tectonic-0.9.0-hb5e0120_0.tar.bz2
win-64::postgresql-plpython-14.3-py37h44f2ed4_0.tar.bz2
win-64::libarchive-3.5.2-hb45042f_2.tar.bz2
win-64::grpc-cpp-1.46.0-hb22af2e_0.tar.bz2
win-64::libopencv-4.5.5-py37h5f7ba43_9.tar.bz2
win-64::hugin-2021.0.0-pl5321h903e67e_5.tar.bz2
win-64::arrow-cpp-6.0.1-py37h09cac41_19_cuda.tar.bz2
win-64::harp-1.15-py39r41h0989d49_1.tar.bz2
win-64::arrow-cpp-5.0.0-py38h0c97e59_31_cpu.tar.bz2
win-64::mysql-client-8.0.28-hed9f4ee_4.tar.bz2
win-64::gemmi-0.5.3-py39h7bb736d_1.tar.bz2
win-64::grpc-cpp-1.45.2-h8a32aac_0.tar.bz2
win-64::libarchive-3.5.2-habf0b7a_2.tar.bz2
win-64::arrow-cpp-7.0.0-py37h19be435_7_cuda.tar.bz2
win-64::arrow-cpp-6.0.1-py39h1a1e958_15_cpu.tar.bz2
win-64::arrow-cpp-7.0.0-py39h4f6b0cd_7_cpu.tar.bz2
win-64::hugin-2021.0.0-pl5321hc4af2df_5.tar.bz2
win-64::pypy3.8-7.3.9-h4acdc65_2.tar.bz2
win-64::grpcio-1.46.0-py310h694bffd_1.tar.bz2
win-64::arrow-cpp-7.0.0-py38hb8deb2c_4_cpu.tar.bz2
win-64::grpcio-1.46.0-py37h04d2302_1.tar.bz2
win-64::pillow-9.1.0-py37h8675073_2.tar.bz2
win-64::blosc-1.21.1-h74325e0_2.tar.bz2
win-64::arrow-cpp-6.0.1-py37hd943af9_18_cpu.tar.bz2
win-64::llvmlite-0.38.0-py38h20167b6_1.tar.bz2
win-64::grpc-cpp-1.43.2-hc952ed8_5.tar.bz2
win-64::grpc-cpp-1.43.2-h7b4b439_3.tar.bz2
win-64::arrow-cpp-8.0.0-py39hae7b3f5_1_cpu.tar.bz2
win-64::clang-tools-14.0.3-default_h66ee7f4_0.tar.bz2
win-64::harp-1.15-py39r41hed3fa83_1.tar.bz2
win-64::arrow-cpp-5.0.0-py39h1a1e958_30_cpu.tar.bz2
win-64::arrow-cpp-7.0.0-py37hcb9b886_5_cuda.tar.bz2
win-64::grpc-cpp-1.45.2-hc952ed8_2.tar.bz2
win-64::indexed_gzip-1.6.13-py38h4289a13_1.tar.bz2
win-64::ogre-1.10.12-hab73eff_8.tar.bz2
win-64::py-bgzip-0.4.0-py38h7939008_2.tar.bz2
win-64::gmsh-4.10.3-hec9a65b_0.tar.bz2
win-64::arrow-cpp-6.0.1-py37h8d5c36c_14_cpu.tar.bz2
win-64::arrow-cpp-3.0.0-py37hd943af9_53_cpu.tar.bz2
win-64::grpcio-1.46.0-py39hf7b6eba_0.tar.bz2
win-64::libgdal-3.5.0-h2040a12_0.tar.bz2
win-64::qtwebkit-5.212-h0db62b3_6.tar.bz2
win-64::mysql-connector-cpp-8.0.29-h4b8edf9_0.tar.bz2
win-64::lld-14.0.3-h61e91c3_0.tar.bz2
win-64::libgdal-3.4.2-hb47f0b7_7.tar.bz2
win-64::grpc-cpp-1.45.2-hfe5f411_1.tar.bz2
win-64::grpcio-1.46.1-py38he5377a8_0.tar.bz2
win-64::arrow-cpp-8.0.0-py310h054aeab_1_cuda.tar.bz2
win-64::coda-2.23.1-py37hca80f52_1.tar.bz2
win-64::arrow-cpp-5.0.0-py38h0c97e59_33_cpu.tar.bz2
win-64::arrow-cpp-3.0.0-py38h2f89446_48_cuda.tar.bz2
win-64::harp-1.15-py39r40h0989d49_1.tar.bz2
win-64::arrow-cpp-6.0.1-py310ha1d70bf_19_cuda.tar.bz2
win-64::harp-1.15.1-py38r41h9644311_0.tar.bz2
win-64::coda-2.23.1-py38h8975372_1.tar.bz2
win-64::py-bgzip-0.4.0-py39ha4c3b15_2.tar.bz2
win-64::mysql-router-8.0.29-h8d31c3a_0.tar.bz2
win-64::mysql-client-8.0.29-hf8b63c5_0.tar.bz2
win-64::arrow-cpp-3.0.0-py38h0bc4d77_48_cuda.tar.bz2
win-64::py-bgzip-0.4.0-py310h3cefddf_2.tar.bz2
win-64::osmium-tool-1.14.0-hc6c9c6a_0.tar.bz2
win-64::grpc-cpp-1.45.2-hf0c0030_0.tar.bz2
win-64::harp-1.15-py310r41heba9ebb_1.tar.bz2
win-64::arrow-cpp-6.0.1-py37hd943af9_15_cpu.tar.bz2
win-64::ruby-3.1.2-h1d9c0f5_0.tar.bz2
win-64::postgresql-plpython-14.3-py38hda22b0a_0.tar.bz2
win-64::libclang13-14.0.0-default_h77d9078_0.tar.bz2
win-64::arrow-cpp-3.0.0-py37h09cac41_51_cuda.tar.bz2
win-64::arrow-cpp-8.0.0-py37hcb9b886_1_cuda.tar.bz2
win-64::arrow-cpp-8.0.0-py310hf269ffb_1_cpu.tar.bz2
win-64::grpcio-1.46.1-py310h694bffd_0.tar.bz2
win-64::llvmdev-14.0.2-h97333cc_0.tar.bz2
win-64::arrow-cpp-3.0.0-py38hcbef6f9_50_cuda.tar.bz2
win-64::libclang-cpp-9.0.1-cling_v0.9_h913594f_5.tar.bz2
win-64::arrow-cpp-3.0.0-py38h0c97e59_51_cpu.tar.bz2
win-64::vigra-1.11.1-py37haa9f8d0_1031.tar.bz2
win-64::mysql-libs-8.0.29-h4d1747d_0.tar.bz2
win-64::arrow-cpp-3.0.0-py38hcbef6f9_52_cuda.tar.bz2
win-64::kaldi-5.5.1016-cpu_h0345967_2.tar.bz2
win-64::mysql-server-8.0.29-h7e086dd_0.tar.bz2
win-64::arrow-cpp-7.0.0-py37h5f2e85a_7_cpu.tar.bz2
win-64::libgdal-3.4.2-h0bdba65_5.tar.bz2
win-64::arrow-cpp-5.0.0-py37h09cac41_33_cuda.tar.bz2
win-64::arrow-cpp-6.0.1-py38hcbef6f9_18_cuda.tar.bz2
win-64::grpc-cpp-1.44.0-hd599c1a_2.tar.bz2
win-64::pypy3.9-7.3.8-hc3b0203_2.tar.bz2
win-64::arrow-cpp-3.0.0-py310h5ae816d_52_cuda.tar.bz2
win-64::gemmi-0.5.4-py39ha0cd8c8_0.tar.bz2
win-64::pyinstaller-5.0.1-py310h3cefddf_0.tar.bz2
win-64::arrow-cpp-3.0.0-py310h5ae816d_53_cuda.tar.bz2
win-64::arrow-cpp-6.0.1-py38haf55456_14_cpu.tar.bz2
win-64::gemmi-0.5.3-py38h20167b6_1.tar.bz2
win-64::paraview-5.10.1-py37h8376483_105_qt.tar.bz2
win-64::arrow-cpp-6.0.1-py38h0c97e59_19_cpu.tar.bz2
win-64::libopencv-4.5.5-py38h541d912_9.tar.bz2
win-64::grpc-cpp-1.45.2-hc952ed8_3.tar.bz2
win-64::arrow-cpp-5.0.0-py310hd72be80_30_cpu.tar.bz2
win-64::mysql-router-8.0.28-h2885b7f_3.tar.bz2
win-64::arrow-cpp-6.0.1-py310hebc3e9d_14_cuda.tar.bz2
win-64::grpc-cpp-1.45.2-hfe5f411_2.tar.bz2
win-64::pillow-9.1.0-py39ha53f419_1.tar.bz2
win-64::grpc-cpp-1.43.2-h6219408_5.tar.bz2
win-64::harp-1.15.1-py37r40hca80f52_0.tar.bz2
win-64::pygrib-2.1.4-py39h13045f2_5.tar.bz2
win-64::pygrib-2.1.4-py38h00f4b73_5.tar.bz2
win-64::niftyreg-1.5.69.6-he9b7a49_1.tar.bz2
win-64::arrow-cpp-3.0.0-py39hf372ac5_52_cuda.tar.bz2
win-64::arrow-cpp-3.0.0-py310hd72be80_52_cpu.tar.bz2
win-64::arrow-cpp-8.0.0-py38h7423697_1_cuda.tar.bz2
win-64::arrow-cpp-8.0.0-py310h43be0d3_1_cpu.tar.bz2
win-64::kaldi-5.5.1016-cuda110hd885332_2.tar.bz2
win-64::pypy3.8-7.3.9-hd58c836_2.tar.bz2
win-64::arrow-cpp-5.0.0-py38h24768a2_34_cuda.tar.bz2
win-64::harp-1.15-py310r40heba9ebb_1.tar.bz2
win-64::grpcio-1.46.0-py38ha65041e_0.tar.bz2
win-64::gst-plugins-good-1.20.2-h69687a5_1.tar.bz2
win-64::libgdal-3.4.2-hb0e98dc_6.tar.bz2
win-64::pdal-2.4.0-h34d9053_4.tar.bz2
win-64::clang-14-14.0.3-default_h66ee7f4_0.tar.bz2
win-64::paraview-5.10.1-py39h581a1fe_105_qt.tar.bz2
win-64::pyinstaller-5.1-py39h4dafc3f_0.tar.bz2
win-64::postgresql-plpython-14.3-py310ha83e0bf_0.tar.bz2
win-64::grpcio-1.46.0-py310ha05212b_1.tar.bz2
win-64::pyinstaller-5.0.1-py39h4dafc3f_0.tar.bz2
win-64::smesh-9.7.0.1-he851e0b_1.tar.bz2
win-64::grpc-cpp-1.45.1-h8a32aac_1.tar.bz2
win-64::pytng-0.2.2-py37hce53aab_2.tar.bz2
win-64::arrow-cpp-8.0.0-py37h341c593_0_cpu.tar.bz2
win-64::arrow-cpp-3.0.0-py39hf372ac5_53_cuda.tar.bz2
win-64::arrow-cpp-7.0.0-py38h92f4a14_5_cpu.tar.bz2
win-64::grpc-cpp-1.44.0-h2913ec3_3.tar.bz2
win-64::arrow-cpp-5.0.0-py39hb2e54e8_29_cuda.tar.bz2
win-64::arrow-cpp-3.0.0-py310h2d0eef5_48_cpu.tar.bz2
win-64::llvm-tools-14.0.2-hf00eed6_0.tar.bz2
win-64::libgdal-3.4.3-hb47f0b7_0.tar.bz2
win-64::tiledb-2.9.1-h3132609_0.tar.bz2
win-64::harp-1.15.1-py310r40heba9ebb_0.tar.bz2
win-64::arrow-cpp-5.0.0-py310hd72be80_32_cpu.tar.bz2
win-64::postgresql-plpython-14.3-py37h547e9a6_0.tar.bz2
win-64::grpc-cpp-1.45.1-hcf7c36f_0.tar.bz2
win-64::coda-2.23.1-py39hed3fa83_1.tar.bz2
win-64::arrow-cpp-8.0.0-py39habf1b7f_0_cuda.tar.bz2
win-64::clang-14-14.0.0-default_h66ee7f4_0.tar.bz2
win-64::qt-main-5.15.3-h467ea89_0.tar.bz2
win-64::arrow-cpp-6.0.1-py310hd72be80_18_cpu.tar.bz2
win-64::arrow-cpp-3.0.0-py37hd943af9_50_cpu.tar.bz2
win-64::arrow-cpp-3.0.0-py38h9c0e68c_53_cpu.tar.bz2
win-64::arrow-cpp-7.0.0-py38h9900cf7_4_cuda.tar.bz2
win-64::arrow-cpp-7.0.0-py37ha9e6e5b_4_cuda.tar.bz2
win-64::arrow-cpp-5.0.0-py37h617d867_29_cpu.tar.bz2
win-64::hugin-base-2021.0.0-py310pl5321h617fbd8_5.tar.bz2
win-64::harp-1.15-py37r41hca80f52_1.tar.bz2
win-64::vigra-1.11.1-py39hf198278_1031.tar.bz2
win-64::arrow-cpp-6.0.1-py39hfc49773_14_cpu.tar.bz2
win-64::gmsh-4.10.0-ha4c064c_0.tar.bz2
win-64::arrow-cpp-6.0.1-py39h738f269_19_cuda.tar.bz2
win-64::pillow-9.1.0-py310h767b3fd_1.tar.bz2
win-64::arrow-cpp-3.0.0-py38h0c97e59_50_cpu.tar.bz2
win-64::grpc-cpp-1.45.1-hf0c0030_1.tar.bz2
win-64::mysql-client-8.0.29-hed9f4ee_1.tar.bz2
win-64::arrow-cpp-6.0.1-py37h617d867_14_cpu.tar.bz2
win-64::imagecodecs-2022.2.22-py310h5fef71e_4.tar.bz2
win-64::arrow-cpp-6.0.1-py37h09cac41_16_cuda.tar.bz2
win-64::imagecodecs-2022.2.22-py310h5fef71e_5.tar.bz2
win-64::qt-webengine-5.15.4-h94572ca_2.tar.bz2
win-64::arrow-cpp-3.0.0-py39h78f48c9_53_cpu.tar.bz2
win-64::pdal-2.4.1-h8c2eea7_0.tar.bz2
win-64::grpc-cpp-1.43.2-h2d464df_4.tar.bz2
win-64::arrow-cpp-5.0.0-py310h4c953eb_34_cpu.tar.bz2
win-64::arrow-cpp-5.0.0-py310h5ae816d_33_cuda.tar.bz2
win-64::arrow-cpp-5.0.0-py39h78f48c9_34_cpu.tar.bz2
win-64::tiledb-2.8.3-h5689973_0.tar.bz2
win-64::kaldi-5.5.1016-cuda110hccdfe78_1.tar.bz2
win-64::arrow-cpp-8.0.0-py37h5f18eb7_1_cuda.tar.bz2
win-64::arrow-cpp-7.0.0-py38h7423697_5_cuda.tar.bz2
win-64::tiledb-2.8.3-h3132609_1.tar.bz2
win-64::arrow-cpp-3.0.0-py310h5ae816d_49_cuda.tar.bz2
win-64::pillow-9.1.0-py310h767b3fd_0.tar.bz2
win-64::zstd-1.5.2-h6255e5f_1.tar.bz2
win-64::arrow-cpp-8.0.0-py39habf1b7f_1_cuda.tar.bz2
win-64::tiledb-2.9.0-h3132609_1.tar.bz2
win-64::llvmdev-14.0.2-h97333cc_1.tar.bz2
win-64::arrow-cpp-6.0.1-py310he4b5c8f_14_cpu.tar.bz2
win-64::arrow-cpp-8.0.0-py38h7423697_0_cuda.tar.bz2
win-64::pillow-9.1.0-py38hb2b9be2_2.tar.bz2
win-64::grpc-cpp-1.44.0-h2d464df_3.tar.bz2
win-64::hugin-base-2021.0.0-py38pl5321hb895f83_5.tar.bz2
win-64::vtk-9.1.0-qt_py37h04430da_208.tar.bz2
win-64::grpcio-1.46.3-py310h694bffd_0.tar.bz2
win-64::arrow-cpp-5.0.0-py39hf372ac5_31_cuda.tar.bz2
win-64::arrow-cpp-5.0.0-py310h5ae816d_32_cuda.tar.bz2
win-64::mysql-libs-8.0.29-h4d1747d_1.tar.bz2
win-64::arrow-cpp-5.0.0-py39h1a1e958_32_cpu.tar.bz2
win-64::grpcio-1.46.3-py38he5377a8_0.tar.bz2
win-64::gdstk-0.8.2-py39h48ffc68_1.tar.bz2
win-64::libsolv-0.7.22-h7755175_0.tar.bz2
win-64::libnetcdf-4.8.1-nompi_h1cc8e9d_102.tar.bz2
win-64::arrow-cpp-5.0.0-py38hcbef6f9_32_cuda.tar.bz2
win-64::grpcio-1.46.1-py37h04d2302_0.tar.bz2
win-64::llvmlite-0.38.1-py38h20167b6_0.tar.bz2
win-64::arrow-cpp-5.0.0-py310hd72be80_33_cpu.tar.bz2
win-64::vigra-1.11.1-py38hc8e63ce_1031.tar.bz2
win-64::kaldi-5.5.1016-cuda112hf26e681_1.tar.bz2
win-64::imagecodecs-2022.2.22-py38h6acac19_4.tar.bz2
win-64::kaldi-5.5.1016-cuda112h5333976_2.tar.bz2
win-64::arrow-cpp-3.0.0-py37h617d867_48_cpu.tar.bz2
win-64::libllvm14-14.0.2-h97333cc_1.tar.bz2
win-64::openexr-python-1.3.7-py38h0a49c8c_1.tar.bz2
win-64::arrow-cpp-5.0.0-py37h92c0b90_34_cpu.tar.bz2
win-64::harp-1.15.1-py310r41heba9ebb_0.tar.bz2
win-64::llvm-tools-14.0.3-hf00eed6_0.tar.bz2
win-64::arrow-cpp-6.0.1-py38h9c0e68c_19_cpu.tar.bz2
win-64::grpc-cpp-1.43.2-hb22af2e_5.tar.bz2
win-64::grpcio-1.46.0-py37h265e445_0.tar.bz2
win-64::boost-cpp-1.78.0-h9f4b32c_1.tar.bz2
win-64::openjpeg-2.5.0-hb211442_0.tar.bz2
win-64::vigra-1.11.1-py38h86d9ac2_1032.tar.bz2
win-64::paraview-5.10.1-py310h2a28801_105_qt.tar.bz2
win-64::arrow-cpp-7.0.0-py37hcb9b886_6_cuda.tar.bz2
win-64::grpcio-1.46.3-py37h04d2302_0.tar.bz2
win-64::lld-14.0.4-h61e91c3_0.tar.bz2
win-64::arrow-cpp-6.0.1-py310h5ae816d_18_cuda.tar.bz2
win-64::arrow-cpp-7.0.0-py37h341c593_6_cpu.tar.bz2
win-64::pillow-9.1.1-py37h8675073_0.tar.bz2
win-64::arrow-cpp-3.0.0-py39h1a1e958_52_cpu.tar.bz2
win-64::libprotobuf-static-3.20.1-h7755175_0.tar.bz2
win-64::pdal-2.4.0-h66e1c42_3.tar.bz2
win-64::arrow-cpp-7.0.0-py310hf53fc53_5_cuda.tar.bz2
win-64::tiledb-2.8.2-h3132609_0.tar.bz2
win-64::mysql-router-8.0.28-h8d31c3a_4.tar.bz2
win-64::pytng-0.2.2-py39h6778c38_2.tar.bz2
win-64::assimp-5.2.4-hc2aa0de_0.tar.bz2
win-64::pyinstaller-5.0-py37hd4a9ce8_0.tar.bz2
win-64::gst-libav-1.20.2-h4b3502a_0.tar.bz2
win-64::pillow-9.1.0-py39ha53f419_0.tar.bz2
win-64::libclang-cpp-9.0.1-default_h4233bec_5.tar.bz2
win-64::arrow-cpp-3.0.0-py38h24768a2_53_cuda.tar.bz2
win-64::pillow-9.1.1-py310h767b3fd_0.tar.bz2
win-64::pyinstaller-5.0-py39h4dafc3f_0.tar.bz2
win-64::tomviz-1.10.0.post230-py37h71896b8_1.tar.bz2
win-64::mysql-server-8.0.28-h0fe0749_3.tar.bz2
win-64::grpcio-1.46.3-py310ha05212b_0.tar.bz2
win-64::python-3.9.13-hcf16a7b_0_cpython.tar.bz2
win-64::pytng-0.2.2-py39h5c95031_2.tar.bz2
win-64::arrow-cpp-8.0.0-py39h03a2cc7_0_cpu.tar.bz2
win-64::libopencv-4.5.5-py310hdc13464_9.tar.bz2
win-64::indexed_gzip-1.6.13-py310hcdd6db8_1.tar.bz2
win-64::grpc-cpp-1.43.2-h2913ec3_4.tar.bz2
win-64::arrow-cpp-7.0.0-py310hcc62f79_4_cuda.tar.bz2
win-64::arrow-cpp-5.0.0-py38haf55456_29_cpu.tar.bz2
win-64::arrow-cpp-6.0.1-py310h5ae816d_16_cuda.tar.bz2
win-64::grpc-cpp-1.44.0-h7b4b439_2.tar.bz2
win-64::blosc-1.21.1-h74325e0_3.tar.bz2
win-64::kaldi-5.5.1016-cpu_h1234567_0.tar.bz2
win-64::pypy3.8-7.3.9-hd58c836_1.tar.bz2
win-64::vtk-9.1.0-qt_py38h1df8eee_208.tar.bz2
win-64::arrow-cpp-3.0.0-py37h92c0b90_53_cpu.tar.bz2
win-64::arrow-cpp-7.0.0-py310h054aeab_7_cuda.tar.bz2
win-64::imagecodecs-2022.2.22-py39ha957cf4_2.tar.bz2
win-64::arrow-cpp-7.0.0-py39h444f20b_7_cuda.tar.bz2
win-64::arrow-cpp-6.0.1-py39h06b715d_14_cpu.tar.bz2
win-64::grpcio-1.46.0-py38he5377a8_1.tar.bz2
win-64::arrow-cpp-6.0.1-py38hcbef6f9_15_cuda.tar.bz2
win-64::pdal-2.4.0-h7f2b936_3.tar.bz2
win-64::freeimage-3.18.0-h6676e37_8.tar.bz2
win-64::postgresql-plpython-14.3-py39h2d4c99b_0.tar.bz2
win-64::py-bgzip-0.4.0-py37hd4a9ce8_2.tar.bz2
win-64::arrow-cpp-6.0.1-py38h2f89446_14_cuda.tar.bz2
win-64::arrow-cpp-6.0.1-py310h5ae816d_17_cuda.tar.bz2
win-64::wxwidgets-3.1.6-h8e1ed31_0.tar.bz2
win-64::arrow-cpp-5.0.0-py38h0c97e59_32_cpu.tar.bz2
win-64::pypy3.9-7.3.9-hc3b0203_0.tar.bz2
win-64::llvmlite-0.38.1-py39ha0cd8c8_0.tar.bz2
win-64::clang-9-9.0.1-cling_v0.9_h913594f_5.tar.bz2
win-64::gmsh-4.10.1-ha4c064c_0.tar.bz2
win-64::hugin-2021.0.0-pl5321h3138ae8_5.tar.bz2
win-64::openexr-3.1.5-hab3b255_0.tar.bz2
win-64::libpq-14.3-h1ea2d34_0.tar.bz2
win-64::pygrib-2.1.4-py39h417709b_5.tar.bz2
win-64::arrow-cpp-5.0.0-py38hcbef6f9_33_cuda.tar.bz2
win-64::grpcio-1.46.1-py39hf7b6eba_0.tar.bz2
win-64::arrow-cpp-3.0.0-py37h8d5c36c_48_cpu.tar.bz2
win-64::arrow-cpp-7.0.0-py39habf1b7f_5_cuda.tar.bz2
win-64::mysql-client-8.0.29-hed9f4ee_0.tar.bz2
win-64::tectonic-0.8.2-hb5e0120_3.tar.bz2
win-64::arrow-cpp-5.0.0-py39h06b715d_29_cpu.tar.bz2
win-64::arrow-cpp-3.0.0-py310hd72be80_51_cpu.tar.bz2
win-64::arrow-cpp-3.0.0-py310hd72be80_53_cpu.tar.bz2
win-64::mysql-libs-8.0.28-h4d1747d_3.tar.bz2
win-64::mysql-libs-8.0.28-h4d1747d_4.tar.bz2
win-64::grpcio-1.46.0-py37h04d2302_0.tar.bz2
win-64::arrow-cpp-5.0.0-py310hd72be80_34_cpu.tar.bz2
win-64::arrow-cpp-3.0.0-py37h09cac41_52_cuda.tar.bz2
win-64::arrow-cpp-3.0.0-py39h1a1e958_53_cpu.tar.bz2
win-64::arrow-cpp-6.0.1-py38h0c97e59_15_cpu.tar.bz2
win-64::indexed_gzip-1.6.13-py37hce53aab_0.tar.bz2
win-64::pillow-9.1.0-py39h4bd82c8_2.tar.bz2
win-64::mysql-client-8.0.28-hed9f4ee_3.tar.bz2
win-64::arrow-cpp-3.0.0-py39h1a1e958_50_cpu.tar.bz2
win-64::pyinstaller-5.0.1-py38hd0d6af5_0.tar.bz2
win-64::arrow-cpp-6.0.1-py37h09cac41_17_cuda.tar.bz2
win-64::libgdal-3.4.2-hc2921ad_5.tar.bz2
win-64::grpc-cpp-1.46.0-hfe5f411_0.tar.bz2
win-64::ovito-3.7.2-h6f389ac_2.tar.bz2
win-64::kaldi-5.5.1016-cuda111ha7451c4_1.tar.bz2
win-64::arrow-cpp-5.0.0-py310h5ae816d_34_cuda.tar.bz2
win-64::arrow-cpp-6.0.1-py38h0c97e59_18_cpu.tar.bz2
win-64::librdkafka-1.8.2.post2-he4d9d34_1.tar.bz2
win-64::arrow-cpp-8.0.0-py39h9297170_1_cuda.tar.bz2
win-64::tiledb-2.8.1-h5689973_0.tar.bz2
win-64::arrow-cpp-6.0.1-py37h09cac41_18_cuda.tar.bz2
win-64::pytng-0.2.2-py38hb9b89dc_2.tar.bz2
win-64::grpcio-1.46.1-py39hb76b349_0.tar.bz2
win-64::arrow-cpp-6.0.1-py38h3797c26_14_cpu.tar.bz2
win-64::vigra-1.11.1-py37h791734a_1032.tar.bz2
win-64::clang-14-14.0.4-default_h66ee7f4_0.tar.bz2
win-64::libmatio-1.5.23-hc273f65_0.tar.bz2
win-64::mysql-server-8.0.28-h7e086dd_4.tar.bz2
win-64::pyinstaller-5.1-py310h3cefddf_0.tar.bz2
win-64::pillow-9.1.0-py38hd8e0db4_1.tar.bz2
win-64::arrow-cpp-6.0.1-py37hd943af9_16_cpu.tar.bz2
win-64::arrow-cpp-3.0.0-py38hcbef6f9_49_cuda.tar.bz2
win-64::arrow-cpp-7.0.0-py39h38522ff_4_cpu.tar.bz2
win-64::arrow-cpp-8.0.0-py38h70e5797_1_cuda.tar.bz2
win-64::paraview-5.10.1-hfcba856_104_qt.tar.bz2
win-64::arrow-cpp-8.0.0-py37h5f2e85a_1_cpu.tar.bz2
win-64::pdal-2.4.0-h8c2eea7_4.tar.bz2
win-64::paraview-5.10.1-h8376483_104_qt.tar.bz2
win-64::mysql-client-8.0.29-hf8b63c5_1.tar.bz2
win-64::arrow-cpp-6.0.1-py39h1a1e958_16_cpu.tar.bz2
win-64::pypy3.9-7.3.9-h1738a25_2.tar.bz2
win-64::gst-plugins-base-1.20.2-he07aa86_1.tar.bz2
win-64::arrow-cpp-5.0.0-py37h09cac41_30_cuda.tar.bz2
win-64::libgdal-3.4.2-hd0657f4_6.tar.bz2
win-64::hugin-2021.0.0-pl5321h6a180d1_5.tar.bz2
win-64::imagecodecs-2022.2.22-py39hc1e9cd8_5.tar.bz2
win-64::arrow-cpp-7.0.0-py39h9297170_7_cuda.tar.bz2
win-64::conduit-0.8.3-py37hf90027e_0.tar.bz2
win-64::vtk-9.1.0-qt_py39h1ab545e_208.tar.bz2
win-64::libclang-14.0.4-default_h77d9078_0.tar.bz2
win-64::arrow-cpp-6.0.1-py39hf372ac5_16_cuda.tar.bz2
win-64::arrow-cpp-7.0.0-py37hbb161b1_7_cpu.tar.bz2
win-64::arrow-cpp-6.0.1-py37h43ae4a3_14_cuda.tar.bz2
win-64::harp-1.15.1-py39r40hed3fa83_0.tar.bz2
win-64::tiledb-2.7.2-h47404fa_0.tar.bz2
win-64::harp-1.15-py38r40h8975372_1.tar.bz2
win-64::qt-webengine-5.15.4-h7325c83_3.tar.bz2
win-64::clang-format-14.0.4-default_h66ee7f4_0.tar.bz2
win-64::conduit-0.8.3-py39h53d6734_0.tar.bz2
win-64::arrow-cpp-6.0.1-py39hf372ac5_19_cuda.tar.bz2
win-64::indexed_gzip-1.6.13-py39h6778c38_0.tar.bz2
win-64::arrow-cpp-5.0.0-py37hd943af9_34_cpu.tar.bz2
win-64::arrow-cpp-3.0.0-py37hb22ef53_48_cuda.tar.bz2
win-64::ogre-13.3.4-h4187535_1.tar.bz2
win-64::vtk-9.1.0-qt_py310h99a8838_208.tar.bz2
win-64::pillow-9.1.1-py38hd8e0db4_0.tar.bz2
win-64::msgpack-c-3.3.0-h6d63774_4.tar.bz2
win-64::arrow-cpp-5.0.0-py310h2d0eef5_29_cpu.tar.bz2
win-64::clang-9-9.0.1-default_h4233bec_5.tar.bz2
win-64::arrow-cpp-8.0.0-py39h4f6b0cd_1_cpu.tar.bz2
win-64::arrow-cpp-3.0.0-py39h1a1e958_51_cpu.tar.bz2
win-64::paraview-5.10.1-h2a28801_104_qt.tar.bz2
win-64::arrow-cpp-5.0.0-py37h09cac41_32_cuda.tar.bz2
win-64::libpq-14.3-hfcc5ef8_0.tar.bz2
win-64::arrow-cpp-5.0.0-py310hebc3e9d_29_cuda.tar.bz2
win-64::libmediainfo-22.03-hbabe409_0.tar.bz2
win-64::arrow-cpp-3.0.0-py38h3797c26_48_cpu.tar.bz2
win-64::conduit-0.8.3-py38hf5d0979_0.tar.bz2
win-64::openexr-python-1.3.8-py39h22367b9_0.tar.bz2
win-64::openexr-python-1.3.7-py39h22367b9_1.tar.bz2
win-64::arrow-cpp-6.0.1-py37h09cac41_15_cuda.tar.bz2
win-64::gdstk-0.8.2-py38hc6971d9_1.tar.bz2
win-64::grpcio-1.46.1-py310ha05212b_0.tar.bz2
win-64::grpc-cpp-1.44.0-he33f7c1_2.tar.bz2
win-64::pygrib-2.1.4-py37hee75c48_5.tar.bz2
win-64::curl-7.83.1-h789b8ee_0.tar.bz2
win-64::arrow-cpp-5.0.0-py37hd943af9_32_cpu.tar.bz2
win-64::gdstk-0.8.2-py38ha2a9628_1.tar.bz2
win-64::tiledb-2.9.0-h5689973_1.tar.bz2
win-64::arrow-cpp-3.0.0-py39hca98053_48_cuda.tar.bz2
win-64::kaldi-5.5.1016-cpu_h8528178_1.tar.bz2
win-64::arrow-cpp-8.0.0-py37h19be435_1_cuda.tar.bz2
win-64::gemmi-0.5.4-py310h2c03ce5_0.tar.bz2
win-64::arrow-cpp-6.0.1-py37hd943af9_19_cpu.tar.bz2
win-64::mysql-router-8.0.28-ha5f2955_3.tar.bz2
win-64::gemmi-0.5.4-py37habb0c8c_0.tar.bz2
win-64::grpc-cpp-1.44.0-hb22af2e_4.tar.bz2
win-64::pyinstaller-5.0-py310h3cefddf_0.tar.bz2
win-64::vigra-1.11.1-py310he75b342_1032.tar.bz2
win-64::arrow-cpp-8.0.0-py38h92f4a14_1_cpu.tar.bz2
win-64::arrow-cpp-7.0.0-py37h5f18eb7_7_cuda.tar.bz2
win-64::arrow-cpp-5.0.0-py39h738f269_34_cuda.tar.bz2
win-64::arrow-cpp-5.0.0-py38hcbef6f9_34_cuda.tar.bz2
win-64::harp-1.15.1-py38r40h8975372_0.tar.bz2
win-64::arrow-cpp-7.0.0-py38h8c433ac_7_cuda.tar.bz2
win-64::arrow-cpp-6.0.1-py39hb2e54e8_14_cuda.tar.bz2
win-64::gemmi-0.5.4-py38h57a6900_0.tar.bz2
win-64::pillow-9.1.0-py37h8675073_1.tar.bz2
win-64::arrow-cpp-3.0.0-py37h09cac41_53_cuda.tar.bz2
win-64::mysql-libs-8.0.29-h8b0d2c3_0.tar.bz2
win-64::arrow-cpp-6.0.1-py38h0bc4d77_14_cuda.tar.bz2
win-64::clang-tools-14.0.0-default_h66ee7f4_0.tar.bz2
win-64::grpcio-1.46.0-py38ha65041e_1.tar.bz2
win-64::arrow-cpp-3.0.0-py310h5ae816d_51_cuda.tar.bz2
win-64::tiledb-2.8.0-h3132609_1.tar.bz2
win-64::imagecodecs-2022.2.22-py38h6acac19_5.tar.bz2
win-64::arrow-cpp-7.0.0-py310h13f3e17_7_cpu.tar.bz2
win-64::openexr-python-1.3.8-py38h5738ade_0.tar.bz2
win-64::libxml2-2.9.14-hf5bbc77_0.tar.bz2
win-64::grpcio-1.46.0-py39hb76b349_0.tar.bz2
win-64::arrow-cpp-8.0.0-py310h13f3e17_1_cpu.tar.bz2
win-64::coda-2.24-py310heba9ebb_0.tar.bz2
win-64::grpc-cpp-1.44.0-hc952ed8_4.tar.bz2
win-64::arrow-cpp-7.0.0-py38hd88d0cb_7_cpu.tar.bz2
win-64::llvm-tools-14.0.2-hf00eed6_1.tar.bz2
win-64::arrow-cpp-7.0.0-py310hf269ffb_7_cpu.tar.bz2
win-64::grpcio-1.46.0-py310ha05212b_0.tar.bz2
win-64::arrow-cpp-6.0.1-py310hd72be80_19_cpu.tar.bz2
win-64::arrow-cpp-3.0.0-py310hebc3e9d_48_cuda.tar.bz2
win-64::tiledb-2.8.2-h5689973_0.tar.bz2
win-64::imagecodecs-2022.2.22-py39hc1e9cd8_4.tar.bz2
win-64::tectonic-0.8.2-hb102b78_3.tar.bz2
win-64::harp-1.15.1-py39r41hed3fa83_0.tar.bz2
win-64::imagecodecs-2022.2.22-py310h7653d06_3.tar.bz2
win-64::gdstk-0.8.2-py39hcb63d39_1.tar.bz2
win-64::arrow-cpp-3.0.0-py39hfc49773_48_cpu.tar.bz2
win-64::libtiff-4.3.0-hc4061b1_4.tar.bz2
win-64::pillow-9.1.0-py38hb2b9be2_1.tar.bz2
win-64::arrow-cpp-5.0.0-py38hcbef6f9_30_cuda.tar.bz2
win-64::cpp-opentelemetry-sdk-1.3.0-h3060df4_1.tar.bz2
win-64::arrow-cpp-5.0.0-py38h0c97e59_30_cpu.tar.bz2
win-64::indexed_gzip-1.6.13-py310hcdd6db8_0.tar.bz2
win-64::arrow-cpp-8.0.0-py37hcb9b886_0_cuda.tar.bz2
win-64::grpc-cpp-1.45.2-hb22af2e_3.tar.bz2
win-64::pypy3.8-7.3.9-hd58c836_0.tar.bz2
win-64::pdal-2.4.1-h34d9053_0.tar.bz2
win-64::coda-2.23.1-py38h9644311_1.tar.bz2
win-64::arrow-cpp-6.0.1-py38h0c97e59_17_cpu.tar.bz2
win-64::arrow-cpp-5.0.0-py38hcbef6f9_31_cuda.tar.bz2
win-64::openexr-python-1.3.7-py310hd60ded4_1.tar.bz2
win-64::postgresql-plpython-14.3-py310hb974fb4_0.tar.bz2
win-64::arrow-cpp-7.0.0-py39h1ef22c9_4_cuda.tar.bz2
win-64::gemmi-0.5.3-py39ha0cd8c8_1.tar.bz2
win-64::arrow-cpp-3.0.0-py38hcbef6f9_51_cuda.tar.bz2
win-64::arrow-cpp-5.0.0-py37ha37a849_34_cuda.tar.bz2
win-64::pypy3.8-7.3.8-hd58c836_2.tar.bz2
win-64::libopencv-4.5.5-py31hdc13464_8.tar.bz2
win-64::vigra-1.11.1-py310h19cbd51_1031.tar.bz2
win-64::grpc-cpp-1.45.2-h6219408_3.tar.bz2
win-64::pyinstaller-5.0.1-py37hd4a9ce8_0.tar.bz2
win-64::libopencv-4.5.5-py38h541d912_8.tar.bz2
win-64::arrow-cpp-3.0.0-py310h2cfba5c_48_cuda.tar.bz2
win-64::arrow-cpp-3.0.0-py310he4b5c8f_48_cpu.tar.bz2
win-64::arrow-cpp-6.0.1-py38hcbef6f9_19_cuda.tar.bz2
win-64::tectonic-0.9.0-hb102b78_0.tar.bz2
win-64::arrow-cpp-3.0.0-py39h738f269_53_cuda.tar.bz2
win-64::arrow-cpp-7.0.0-py38h70e5797_7_cuda.tar.bz2
win-64::grpc-cpp-1.44.0-hfe5f411_4.tar.bz2
win-64::qtwebkit-5.212-ha446f65_5.tar.bz2
win-64::gst-plugins-good-1.20.2-h69687a5_0.tar.bz2
win-64::arrow-cpp-5.0.0-py39hf372ac5_30_cuda.tar.bz2
win-64::arrow-cpp-5.0.0-py310hd72be80_31_cpu.tar.bz2
win-64::pillow-9.1.1-py39ha53f419_0.tar.bz2
win-64::arrow-cpp-5.0.0-py37hd943af9_30_cpu.tar.bz2
win-64::arrow-cpp-5.0.0-py310h5ae816d_31_cuda.tar.bz2
win-64::tomviz-1.10.0.post230-py37h71896b8_2.tar.bz2
win-64::arrow-cpp-7.0.0-py39h03a2cc7_5_cpu.tar.bz2
win-64::tiledb-2.8.1-h3132609_0.tar.bz2
win-64::grpc-cpp-1.45.2-hfe5f411_3.tar.bz2
win-64::niftyreg-1.5.69.6-he9b7a49_0.tar.bz2
win-64::paraview-5.10.1-h581a1fe_104_qt.tar.bz2
win-64::arrow-cpp-7.0.0-py38h7423697_6_cuda.tar.bz2
win-64::arrow-cpp-5.0.0-py39h1a1e958_34_cpu.tar.bz2
win-64::arrow-cpp-6.0.1-py310h2d0eef5_14_cpu.tar.bz2
win-64::mongodb-5.1.1-hfb6e20b_3.tar.bz2
win-64::arrow-cpp-8.0.0-py38h8c433ac_1_cuda.tar.bz2
win-64::arrow-cpp-3.0.0-py39hf372ac5_51_cuda.tar.bz2
win-64::arrow-cpp-5.0.0-py39hf372ac5_34_cuda.tar.bz2
win-64::arrow-cpp-5.0.0-py38h9c0e68c_34_cpu.tar.bz2
win-64::libcurl-7.83.1-h789b8ee_0.tar.bz2
win-64::clang-tools-14.0.4-default_h66ee7f4_0.tar.bz2
win-64::grpcio-1.46.3-py39hf7b6eba_0.tar.bz2
win-64::pypy3.8-7.3.9-h4acdc65_0.tar.bz2
win-64::arrow-cpp-5.0.0-py39hca98053_29_cuda.tar.bz2
win-64::arrow-cpp-3.0.0-py38h0c97e59_52_cpu.tar.bz2
win-64::clang-format-14.0.3-default_h66ee7f4_0.tar.bz2
win-64::grpc-cpp-1.44.0-h286a2bd_3.tar.bz2
win-64::pillow-9.1.0-py39h4bd82c8_1.tar.bz2
win-64::arrow-cpp-6.0.1-py310hd72be80_16_cpu.tar.bz2
win-64::grpc-cpp-1.44.0-hcf7c36f_2.tar.bz2
win-64::py-bgzip-0.4.0-py39h4dafc3f_2.tar.bz2
win-64::arrow-cpp-5.0.0-py37h43ae4a3_29_cuda.tar.bz2
win-64::imagecodecs-2022.2.22-py38hebefbeb_3.tar.bz2
win-64::arrow-cpp-8.0.0-py310hf53fc53_1_cuda.tar.bz2
win-64::pypy3.9-7.3.9-h1738a25_0.tar.bz2
win-64::vigra-1.11.1-py39h21fcd1c_1032.tar.bz2
win-64::pyinstaller-5.1-py37hd4a9ce8_0.tar.bz2
win-64::kaldi-5.5.1016-cuda111h4b32e78_2.tar.bz2
win-64::arrow-cpp-3.0.0-py39h06b715d_48_cpu.tar.bz2
win-64::grpcio-1.46.0-py37h265e445_1.tar.bz2
win-64::arrow-cpp-5.0.0-py37h09cac41_34_cuda.tar.bz2
win-64::arrow-cpp-6.0.1-py39h78f48c9_19_cpu.tar.bz2
win-64::arrow-cpp-6.0.1-py310hd72be80_17_cpu.tar.bz2
win-64::arrow-cpp-3.0.0-py38h0c97e59_53_cpu.tar.bz2
win-64::arrow-cpp-3.0.0-py39hf372ac5_49_cuda.tar.bz2
win-64::arrow-cpp-5.0.0-py39h1a1e958_31_cpu.tar.bz2
win-64::gemmi-0.5.3-py37habb0c8c_1.tar.bz2
win-64::boost-cpp-1.79.0-h9f4b32c_0.tar.bz2
win-64::libgdal-3.4.3-h2040a12_0.tar.bz2
win-64::arrow-cpp-7.0.0-py310h9019dcf_7_cuda.tar.bz2
win-64::arrow-cpp-3.0.0-py310h4c953eb_53_cpu.tar.bz2
win-64::arrow-cpp-8.0.0-py39h03a2cc7_1_cpu.tar.bz2
win-64::arrow-cpp-3.0.0-py39h1a1e958_49_cpu.tar.bz2
win-64::coda-2.24-py39hed3fa83_0.tar.bz2
win-64::arrow-cpp-6.0.1-py39h1a1e958_17_cpu.tar.bz2
win-64::pillow-9.1.0-py39ha53f419_2.tar.bz2
win-64::hugin-base-2021.0.0-py39pl5321hf00cc8b_5.tar.bz2
win-64::arrow-cpp-3.0.0-py39hb2e54e8_48_cuda.tar.bz2
win-64::arrow-cpp-6.0.1-py310h2cfba5c_14_cuda.tar.bz2
win-64::libxml2-2.9.13-hf5bbc77_0.tar.bz2
win-64::llvmdev-14.0.4-h97333cc_0.tar.bz2
win-64::gemmi-0.5.3-py310h2c03ce5_1.tar.bz2
win-64::libllvm14-14.0.2-h97333cc_0.tar.bz2
win-64::arrow-cpp-8.0.0-py38hd88d0cb_1_cpu.tar.bz2
win-64::pypy3.9-7.3.9-hc3b0203_2.tar.bz2
win-64::arrow-cpp-5.0.0-py37h8d5c36c_29_cpu.tar.bz2
win-64::osmium-tool-1.14.0-hc6c9c6a_1.tar.bz2
win-64::openexr-python-1.3.8-py310hd60ded4_0.tar.bz2
win-64::arrow-cpp-5.0.0-py39hf372ac5_33_cuda.tar.bz2
win-64::cpp-opentelemetry-sdk-1.3.0-h728dffb_0.tar.bz2
win-64::poppler-qt-22.04.0-h332a8cf_0.tar.bz2
win-64::grpcio-1.46.0-py39hf7b6eba_1.tar.bz2
win-64::lld-14.0.2-h61e91c3_0.tar.bz2
win-64::arrow-cpp-5.0.0-py37hb22ef53_29_cuda.tar.bz2
win-64::paraview-5.10.1-py38hfcba856_105_qt.tar.bz2
win-64::arrow-cpp-7.0.0-py310h43be0d3_6_cpu.tar.bz2
win-64::mysql-client-8.0.28-hf8b63c5_3.tar.bz2
win-64::llvmlite-0.38.1-py38h57a6900_0.tar.bz2
win-64::blosc-1.21.1-hf5c711b_1.tar.bz2
win-64::arrow-cpp-3.0.0-py38haf55456_48_cpu.tar.bz2
win-64::arrow-cpp-8.0.0-py38h61ae8a5_1_cpu.tar.bz2
win-64::arrow-cpp-8.0.0-py37hbb161b1_1_cpu.tar.bz2
win-64::mysql-libs-8.0.28-h8b0d2c3_4.tar.bz2
win-64::pyinstaller-5.1-py38hd0d6af5_0.tar.bz2
win-64::arrow-cpp-7.0.0-py310h43be0d3_5_cpu.tar.bz2
win-64::mysql-router-8.0.29-h8d31c3a_1.tar.bz2
win-64::arrow-cpp-7.0.0-py38h92f4a14_6_cpu.tar.bz2
win-64::cpp-opentelemetry-sdk-1.4.0-h3060df4_0.tar.bz2
win-64::imagecodecs-2022.2.22-py38h7400a1e_2.tar.bz2
win-64::arrow-cpp-7.0.0-py38h61ae8a5_7_cpu.tar.bz2
win-64::libllvm14-14.0.1-h97333cc_0.tar.bz2
win-64::llvmlite-0.38.1-py37habb0c8c_0.tar.bz2
win-64::grpc-cpp-1.43.2-hd599c1a_3.tar.bz2
win-64::harp-1.15.1-py38r41h8975372_0.tar.bz2
win-64::pytng-0.2.2-py38h4289a13_2.tar.bz2
win-64::arrow-cpp-5.0.0-py39hf372ac5_32_cuda.tar.bz2
win-64::hugin-base-2021.0.0-py37pl5321hc488a2b_5.tar.bz2
win-64::smesh-9.8.0.2-h1dba484_0.tar.bz2
win-64::libcurl-7.83.0-h789b8ee_0.tar.bz2
win-64::grpc-cpp-1.43.2-hddde413_4.tar.bz2
win-64::arrow-cpp-5.0.0-py39hfc49773_29_cpu.tar.bz2
win-64::libgdal-3.5.0-hb47f0b7_0.tar.bz2
win-64::mysql-server-8.0.29-h0065552_1.tar.bz2
win-64::arrow-cpp-3.0.0-py38h0c97e59_49_cpu.tar.bz2
win-64::grpcio-1.46.3-py38ha65041e_0.tar.bz2
win-64::pillow-9.1.0-py37h57c0a70_0.tar.bz2
win-64::tiledb-2.8.0-h5689973_1.tar.bz2
win-64::arrow-cpp-8.0.0-py310hf53fc53_0_cuda.tar.bz2
win-64::arrow-cpp-5.0.0-py37hd943af9_33_cpu.tar.bz2
win-64::libcurl-static-7.83.1-h789b8ee_0.tar.bz2
win-64::arrow-cpp-3.0.0-py37h43ae4a3_48_cuda.tar.bz2
win-64::arrow-cpp-5.0.0-py38h0bc4d77_29_cuda.tar.bz2
win-64::llvmlite-0.38.1-py39h7bb736d_0.tar.bz2
win-64::mysql-server-8.0.28-h593b645_3.tar.bz2
win-64::arrow-cpp-7.0.0-py37h3d3514b_4_cpu.tar.bz2
win-64::arrow-cpp-3.0.0-py310hd72be80_50_cpu.tar.bz2
win-64::mysql-router-8.0.29-h9e1cf62_1.tar.bz2
win-64::arrow-cpp-3.0.0-py37hd943af9_52_cpu.tar.bz2
win-64::arrow-cpp-5.0.0-py38h3797c26_29_cpu.tar.bz2
win-64::arrow-cpp-5.0.0-py310h2cfba5c_29_cuda.tar.bz2
win-64::arrow-cpp-3.0.0-py310hd72be80_49_cpu.tar.bz2
win-64::arrow-cpp-7.0.0-py39habf1b7f_6_cuda.tar.bz2
win-64::llvmlite-0.38.1-py310h2c03ce5_0.tar.bz2
win-64::arrow-cpp-3.0.0-py310ha1d70bf_53_cuda.tar.bz2
win-64::arrow-cpp-7.0.0-py310hf53fc53_6_cuda.tar.bz2
win-64::clang-format-14.0.0-default_h66ee7f4_0.tar.bz2
win-64::openexr-python-1.3.7-py37h0cc0ffa_1.tar.bz2
win-64::curl-7.83.0-h789b8ee_0.tar.bz2
win-64::py-bgzip-0.4.0-py38hd0d6af5_2.tar.bz2
win-64::librdkafka-1.8.2.post2-h57a60f6_1.tar.bz2
win-64::llvmdev-14.0.3-h97333cc_0.tar.bz2
win-64::libllvm14-14.0.3-h97333cc_0.tar.bz2
win-64::harp-1.15-py37r40hca80f52_1.tar.bz2
win-64::llvmlite-0.38.0-py38h57a6900_1.tar.bz2
win-64::arrow-cpp-6.0.1-py39h1a1e958_18_cpu.tar.bz2
win-64::grpcio-1.46.0-py38he5377a8_0.tar.bz2
win-64::ogre-13.3.4-h0650132_0.tar.bz2
win-64::libopencv-4.5.5-py39hb20b4e8_9.tar.bz2
win-64::grpc-cpp-1.43.2-hfe5f411_5.tar.bz2
win-64::grpcio-1.46.1-py38ha65041e_0.tar.bz2
win-64::arrow-cpp-5.0.0-py37h09cac41_31_cuda.tar.bz2
win-64::arrow-cpp-5.0.0-py310ha1d70bf_34_cuda.tar.bz2
win-64::arrow-cpp-6.0.1-py310h5ae816d_15_cuda.tar.bz2
win-64::arrow-cpp-8.0.0-py38h92f4a14_0_cpu.tar.bz2
win-64::mysql-client-8.0.28-hf8b63c5_4.tar.bz2
win-64::arrow-cpp-6.0.1-py310h4c953eb_19_cpu.tar.bz2
win-64::pillow-9.1.0-py38hd8e0db4_0.tar.bz2
win-64::gmsh-4.10.2-ha4c064c_0.tar.bz2
win-64::llvm-tools-14.0.4-hf00eed6_0.tar.bz2
win-64::gdstk-0.8.2-py310h903a3d8_1.tar.bz2
win-64::lld-14.0.0-h61e91c3_0.tar.bz2
win-64::coda-2.24-py38h8975372_0.tar.bz2
win-64::grpcio-1.46.0-py310h694bffd_0.tar.bz2
win-64::grpc-cpp-1.44.0-h6219408_4.tar.bz2
win-64::imagecodecs-2022.2.22-py39h279a0da_3.tar.bz2
win-64::arrow-cpp-8.0.0-py310h9019dcf_1_cuda.tar.bz2
win-64::tiledb-2.7.2-h95dad36_0.tar.bz2
win-64::libclang-14.0.0-default_h77d9078_0.tar.bz2
win-64::grpc-cpp-1.46.3-h60e7cd9_0.tar.bz2
win-64::arrow-cpp-6.0.1-py39hf372ac5_15_cuda.tar.bz2
win-64::gemmi-0.5.4-py38h20167b6_0.tar.bz2
win-64::pillow-9.1.0-py38hd8e0db4_2.tar.bz2
win-64::coda-2.23.1-py39h0989d49_1.tar.bz2
win-64::ogre-1.12.13-h4187535_1.tar.bz2
win-64::grpc-cpp-1.45.2-hb22af2e_1.tar.bz2
win-64::libprotobuf-3.20.1-h7755175_0.tar.bz2
win-64::indexed_gzip-1.6.13-py38h4289a13_0.tar.bz2
win-64::pillow-9.1.0-py310h767b3fd_2.tar.bz2
win-64::libsolv-static-0.7.22-h7755175_0.tar.bz2
win-64::grpcio-1.46.1-py37h265e445_0.tar.bz2
win-64::libopencv-4.5.5-py37h5f7ba43_8.tar.bz2
win-64::harp-1.15-py38r40h9644311_1.tar.bz2
win-64::mysql-router-8.0.28-h9e1cf62_4.tar.bz2
win-64::openexr-python-1.3.8-py38h0a49c8c_0.tar.bz2
win-64::grpc-cpp-1.45.2-hb22af2e_2.tar.bz2
win-64::harp-1.15.1-py39r41h0989d49_0.tar.bz2
win-64::pypy3.9-7.3.9-h1738a25_1.tar.bz2
win-64::tiledb-2.8.3-h5689973_1.tar.bz2
win-64::llvmlite-0.38.0-py310h2c03ce5_1.tar.bz2
win-64::arrow-cpp-3.0.0-py38hcbef6f9_53_cuda.tar.bz2
win-64::boost-cpp-1.74.0-h9f4b32c_8.tar.bz2
win-64::arrow-cpp-5.0.0-py38h2f89446_29_cuda.tar.bz2
win-64::arrow-cpp-3.0.0-py310h5ae816d_50_cuda.tar.bz2
win-64::grpc-cpp-1.45.2-h6219408_2.tar.bz2
win-64::arrow-cpp-7.0.0-py37h341c593_5_cpu.tar.bz2
win-64::arrow-cpp-7.0.0-py39h03a2cc7_6_cpu.tar.bz2
win-64::gst-plugins-base-1.20.2-he07aa86_0.tar.bz2
win-64::llvmdev-14.0.1-h97333cc_0.tar.bz2
win-64::libclang-14.0.3-default_h77d9078_0.tar.bz2
win-64::mysql-libs-8.0.28-h8b0d2c3_3.tar.bz2
win-64::arrow-cpp-5.0.0-py39h1a1e958_33_cpu.tar.bz2
win-64::postgresql-plpython-14.3-py39he868e5a_0.tar.bz2
win-64::papilo-2.0.0-h8955bf1_1.tar.bz2
win-64::arrow-cpp-3.0.0-py37hd943af9_49_cpu.tar.bz2
win-64::arrow-cpp-3.0.0-py37h09cac41_50_cuda.tar.bz2
win-64::libopencv-4.5.5-py39hb20b4e8_8.tar.bz2
win-64::postgresql-plpython-14.3-py38h98422bd_0.tar.bz2
win-64::grpcio-1.46.3-py37h265e445_0.tar.bz2
win-64::scip-8.0.0-h6aab56e_1.tar.bz2
win-64::arrow-cpp-6.0.1-py37ha37a849_19_cuda.tar.bz2
win-64::gemmi-0.5.4-py39h7bb736d_0.tar.bz2
win-64::pytng-0.2.2-py310hcdd6db8_2.tar.bz2
win-64::arrow-cpp-5.0.0-py310h5ae816d_30_cuda.tar.bz2
win-64::mysql-server-8.0.28-h0065552_4.tar.bz2
win-64::qt-main-5.15.3-h467ea89_1.tar.bz2
win-64::arrow-cpp-8.0.0-py37h341c593_1_cpu.tar.bz2
win-64::grpc-cpp-1.43.2-h286a2bd_4.tar.bz2
win-64::indexed_gzip-1.6.13-py39h6778c38_1.tar.bz2
win-64::grpc-cpp-1.46.3-h4b97d95_0.tar.bz2
win-64::coda-2.23.1-py310heba9ebb_1.tar.bz2
win-64::openexr-python-1.3.7-py38h5738ade_1.tar.bz2
win-64::mysql-server-8.0.29-h7e086dd_1.tar.bz2
win-64::gemmi-0.5.3-py38h57a6900_1.tar.bz2
win-64::arrow-cpp-6.0.1-py39hca98053_14_cuda.tar.bz2
win-64::arrow-cpp-6.0.1-py37hb22ef53_14_cuda.tar.bz2
win-64::libgdal-3.4.2-h2040a12_7.tar.bz2
win-64::arrow-cpp-8.0.0-py39h444f20b_1_cuda.tar.bz2
win-64::postgresql-14.3-he353ca9_0.tar.bz2
win-64::postgresql-14.3-h1c22c4f_0.tar.bz2
win-64::arrow-cpp-6.0.1-py39h1a1e958_19_cpu.tar.bz2
win-64::mysql-router-8.0.29-h9e1cf62_0.tar.bz2
win-64::arrow-cpp-6.0.1-py37hd943af9_17_cpu.tar.bz2
win-64::grpc-cpp-1.45.1-h7b4b439_0.tar.bz2
win-64::gdstk-0.8.2-py37h5487f94_1.tar.bz2
win-64::arrow-cpp-6.0.1-py38h0c97e59_16_cpu.tar.bz2
win-64::arrow-cpp-6.0.1-py38hcbef6f9_17_cuda.tar.bz2
win-64::arrow-cpp-7.0.0-py310he67c4b2_4_cpu.tar.bz2
win-64::tiledb-2.8.3-h3132609_0.tar.bz2
win-64::osmium-tool-1.13.2-hc6c9c6a_0.tar.bz2
win-64::arrow-cpp-3.0.0-py37ha37a849_53_cuda.tar.bz2
win-64::libcurl-static-7.83.0-h789b8ee_0.tar.bz2
win-64::arrow-cpp-3.0.0-py37h09cac41_49_cuda.tar.bz2
win-64::soplex-6.0.0-h1f26b8a_1.tar.bz2
win-64::poppler-22.04.0-h24fffdf_0.tar.bz2
win-64::arrow-cpp-3.0.0-py39hf372ac5_50_cuda.tar.bz2
win-64::libgit2-1.4.3-h8648793_0.tar.bz2
win-64::ruby-3.1.2-h8ed59c0_0.tar.bz2
win-64::arrow-cpp-6.0.1-py38h24768a2_19_cuda.tar.bz2
win-64::openexr-python-1.3.8-py39h61b3435_0.tar.bz2
win-64::mysql-server-8.0.29-h0065552_0.tar.bz2
win-64::arrow-cpp-5.0.0-py38h0c97e59_34_cpu.tar.bz2
win-64::arrow-cpp-6.0.1-py39hf372ac5_17_cuda.tar.bz2
win-64::libmediainfo-22.03-hbabe409_1.tar.bz2
win-64::pypy3.8-7.3.9-h4acdc65_1.tar.bz2
win-64::llvmlite-0.38.0-py39ha0cd8c8_1.tar.bz2
win-64::indexed_gzip-1.6.13-py37hce53aab_1.tar.bz2
win-64::pygrib-2.1.4-py38h62851ba_5.tar.bz2
win-64::pypy3.9-7.3.8-h1738a25_2.tar.bz2
win-64::pygrib-2.1.4-py310hba9c684_5.tar.bz2
win-64::arrow-cpp-6.0.1-py37h92c0b90_19_cpu.tar.bz2
win-64::openexr-python-1.3.7-py39h61b3435_1.tar.bz2
-    "libzlib >=1.2.11,<1.3.0a0",
+    "libzlib >=1.2.11,<2.0.0a0",
win-64::clang-14.0.3-h8e541a6_0.tar.bz2
win-64::clangxx-14.0.3-default_h66ee7f4_0.tar.bz2
win-64::llvm-14.0.2-h6fda50d_1.tar.bz2
win-64::llvm-14.0.3-h6fda50d_0.tar.bz2
win-64::clang-14.0.4-h8e541a6_0.tar.bz2
win-64::llvm-14.0.4-h6fda50d_0.tar.bz2
win-64::llvm-14.0.2-h6fda50d_0.tar.bz2
win-64::clang-14.0.0-h8e541a6_0.tar.bz2
win-64::clangxx-14.0.4-default_h66ee7f4_0.tar.bz2
win-64::clangxx-14.0.0-default_h66ee7f4_0.tar.bz2
win-64::llvm-14.0.1-h6fda50d_0.tar.bz2
-    "libzlib >=1.2.11,<1.3.0a0"
+    "libzlib >=1.2.11,<2.0.0a0"
win-64::mysql-connector-cpp-8.0.29-h4b8edf9_1.tar.bz2
win-64::libprotobuf-3.21.1-h7755175_0.tar.bz2
win-64::tiledb-2.9.2-h3132609_0.tar.bz2
win-64::tiledb-2.9.2-h5689973_0.tar.bz2
win-64::libtiff-4.4.0-hc4061b1_0.tar.bz2
win-64::libprotobuf-static-3.21.1-h7755175_0.tar.bz2
win-64::freeimage-3.18.0-h6676e37_9.tar.bz2
win-64::libxslt-1.1.35-h34f844d_0.tar.bz2
win-64::mysql-connector-cpp-8.0.29-h526ecb7_1.tar.bz2
win-64::libprotobuf-static-21.1-h7755175_0.tar.bz2
win-64::qt-main-5.15.3-h467ea89_2.tar.bz2
-    "libzlib >=1.2.12,<1.3.0a0",
+    "libzlib >=1.2.12,<2.0.0a0",
================================================================================
================================================================================
osx-64
osx-64::vtk-9.1.0-qt_py310h7b8c64f_208.tar.bz2
osx-64::jaxlib-0.3.10-cpu_py310h0e7486c_0.tar.bz2
osx-64::llvmlite-0.38.0-py39ha9d9895_1.tar.bz2
osx-64::cpp-opentelemetry-sdk-1.4.0-hd702da9_0.tar.bz2
osx-64::yoda-1.9.5-py39h8fbbf90_0.tar.bz2
osx-64::grpcio-1.46.0-py38hf25cc3e_0.tar.bz2
osx-64::llvmlite-0.38.0-py37h464c7a5_1.tar.bz2
osx-64::gazebo-11.10.2-h76980ee_2.tar.bz2
osx-64::sqlite-3.38.3-hd9f0692_0.tar.bz2
osx-64::grpcio-1.46.0-py38hf25cc3e_1.tar.bz2
osx-64::tiledb-2.8.3-h349c43f_1.tar.bz2
osx-64::yoda-1.9.4-py38h5ecb58d_2.tar.bz2
osx-64::grpc-cpp-1.43.2-hcc48474_3.tar.bz2
osx-64::grpc-cpp-1.45.2-h671dcb9_1.tar.bz2
osx-64::coda-2.23.1-py38h0664e9e_1.tar.bz2
osx-64::grpc-cpp-1.43.2-h5dcc0b3_5.tar.bz2
osx-64::libtiledb-sql-0.14.2-hc318ded_0.tar.bz2
osx-64::conduit-0.8.3-py38hccdcc68_0.tar.bz2
osx-64::gdstk-0.8.2-py38ha250e75_1.tar.bz2
osx-64::arrow-cpp-6.0.1-py37ha46e8df_18_cpu.tar.bz2
osx-64::arrow-cpp-7.0.0-py310ha2d0369_7_cpu.tar.bz2
osx-64::arrow-cpp-8.0.0-py37hf8a2639_1_cpu.tar.bz2
osx-64::imagecodecs-2022.2.22-py39he079fe0_2.tar.bz2
osx-64::postgresql-plpython-14.3-py37h6e22b94_0.tar.bz2
osx-64::arrow-cpp-5.0.0-py37h77c286d_30_cpu.tar.bz2
osx-64::grpc-cpp-1.43.2-h7e3b474_4.tar.bz2
osx-64::grpcio-1.46.3-py38hf25cc3e_0.tar.bz2
osx-64::jaxlib-0.3.10-cpu_py39h797cc16_0.tar.bz2
osx-64::conduit-0.8.3-py38h95cf32c_0.tar.bz2
osx-64::pillow-9.1.0-py310h382dc3b_1.tar.bz2
osx-64::jaxlib-0.3.10-cpu_py37h008d09a_0.tar.bz2
osx-64::mysql-libs-8.0.28-h2a44bf5_3.tar.bz2
osx-64::blosc-1.21.1-h97e831e_2.tar.bz2
osx-64::pillow-9.1.0-py37h0fe8677_0.tar.bz2
osx-64::grpc-cpp-1.45.1-h62077fd_0.tar.bz2
osx-64::gemmi-0.5.4-py38hbfc0824_0.tar.bz2
osx-64::libpq-14.3-h2b7167c_0.tar.bz2
osx-64::grpc-cpp-1.44.0-h76973e4_2.tar.bz2
osx-64::mysql-client-8.0.29-h756fca8_0.tar.bz2
osx-64::mysql-client-8.0.28-h7ddd48c_3.tar.bz2
osx-64::openmpi-4.1.3-hd33e60e_103.tar.bz2
osx-64::tiledb-2.9.1-h86bd37b_0.tar.bz2
osx-64::libtiledb-sql-0.13.0-hf429a70_0.tar.bz2
osx-64::vowpalwabbit-9.1.0-py37hc8ffe2d_0.tar.bz2
osx-64::arrow-cpp-5.0.0-py39h3e37d58_32_cpu.tar.bz2
osx-64::librdkafka-1.8.2.post2-hef2a209_1.tar.bz2
osx-64::libtiledb-sql-0.14.1-hc318ded_0.tar.bz2
osx-64::nd2-0.2.4-py39h79df2d4_0.tar.bz2
osx-64::grpcio-1.46.0-py310h9983da3_0.tar.bz2
osx-64::conduit-0.8.3-py37h12b09a5_0.tar.bz2
osx-64::erlang-24.3.4-pl5321hbad8640_0.tar.bz2
osx-64::postgresql-plpython-14.3-py39h36e506d_0.tar.bz2
osx-64::astrometry-0.90-py38h0848f27_0.tar.bz2
osx-64::openjpeg-2.5.0-h69f46e4_0.tar.bz2
osx-64::libgdal-3.4.2-h6474519_7.tar.bz2
osx-64::grpcio-1.46.1-py310h23d8e5b_0.tar.bz2
osx-64::grpc-cpp-1.45.2-hd522a8a_0.tar.bz2
osx-64::gazebo-11.10.2-hf45d158_1.tar.bz2
osx-64::gemmi-0.5.3-py310hc82e721_1.tar.bz2
osx-64::grpcio-1.46.0-py310h9983da3_1.tar.bz2
osx-64::grpcio-1.46.3-py38h0fbd9b5_0.tar.bz2
osx-64::pyreadstat-1.1.5-py310h5f16a0e_0.tar.bz2
osx-64::llvmdev-14.0.2-h41df66c_0.tar.bz2
osx-64::libgdal-3.4.2-h1d5b9b0_6.tar.bz2
osx-64::ruby-3.1.2-h586acb3_0.tar.bz2
osx-64::pillow-9.1.0-py310h382dc3b_0.tar.bz2
osx-64::vtk-9.1.0-qt_py38hd04c270_208.tar.bz2
osx-64::libpq-14.3-hf6bb32a_0.tar.bz2
osx-64::wxpython-4.1.1-py39h9e23b40_7.tar.bz2
osx-64::grpc-cpp-1.44.0-hb472a99_4.tar.bz2
osx-64::vowpalwabbit-9.1.0-py39h84a0b8d_0.tar.bz2
osx-64::qt-webengine-5.15.4-h72ca1e5_3.tar.bz2
osx-64::gfal2-2.20.5-h446a942_1.tar.bz2
osx-64::arrow-cpp-5.0.0-py39h3e37d58_31_cpu.tar.bz2
osx-64::pytng-0.2.2-py310h01ad4ef_2.tar.bz2
osx-64::llvmlite-0.38.0-py38hbfc0824_1.tar.bz2
osx-64::tensorflow-base-2.7.1-cpu_py310h4211812_0.tar.bz2
osx-64::arrow-cpp-6.0.1-py39h4993cbe_14_cpu.tar.bz2
osx-64::py-bgzip-0.4.0-py310h169abc5_2.tar.bz2
osx-64::cpp-opentelemetry-sdk-1.3.0-hf4b11f9_0.tar.bz2
osx-64::tensorflow-base-2.8.0-cpu_py310hc10d694_0.tar.bz2
osx-64::tiledb-2.8.3-h349c43f_0.tar.bz2
osx-64::fenics-libdolfin-2019.1.0-h8b70391_28.tar.bz2
osx-64::lammps-2021.09.29-py37ha6ca0c3_openmpi_3.tar.bz2
osx-64::jaxlib-0.3.10-cpu_py39ha0a6ba6_0.tar.bz2
osx-64::arrow-cpp-7.0.0-py38h2d04a99_4_cpu.tar.bz2
osx-64::yoda-1.9.4-py38h5323faa_2.tar.bz2
osx-64::libtiledb-sql-0.14.2-hc318ded_1.tar.bz2
osx-64::jaxlib-0.3.2-py310hec45b66_0.tar.bz2
osx-64::ndcctools-7.4.4-py39h0d687a8_0.tar.bz2
osx-64::openmpi-4.1.3-hd33e60e_102.tar.bz2
osx-64::cmake-3.23.1-h35a7dd9_0.tar.bz2
osx-64::arrow-cpp-8.0.0-py37hf7096f7_1_cpu.tar.bz2
osx-64::cctools_osx-arm64-973.0.1-had23a73_10.tar.bz2
osx-64::harp-1.15.1-py38r41hac333f3_0.tar.bz2
osx-64::conduit-0.8.3-py39h2496e8b_0.tar.bz2
osx-64::gdstk-0.8.2-py39h269e0f6_1.tar.bz2
osx-64::ambertools-22.0-py38hd6424c8_0.tar.bz2
osx-64::arrow-cpp-7.0.0-py39h3bd5d96_7_cpu.tar.bz2
osx-64::poppler-22.04.0-h39497b0_0.tar.bz2
osx-64::cctools_osx-64-973.0.1-h3eff9a4_10.tar.bz2
osx-64::tensorflow-base-2.8.1-cpu_py37hde0f349_0.tar.bz2
osx-64::mysql-client-8.0.29-h859e134_0.tar.bz2
osx-64::astrometry-0.90-py37he47b6c8_0.tar.bz2
osx-64::kaldi-5.5.1016-cpu_hbb203b2_1.tar.bz2
osx-64::orc-1.7.4-h5ac28ee_0.tar.bz2
osx-64::grpc-cpp-1.44.0-h3e9e271_4.tar.bz2
osx-64::boost-cpp-1.79.0-h8b082ac_0.tar.bz2
osx-64::pytng-0.2.2-py38h9b23094_2.tar.bz2
osx-64::llvmlite-0.38.0-py310hc82e721_1.tar.bz2
osx-64::libarchive-3.5.2-hde4784d_2.tar.bz2
osx-64::astrometry-0.90-py37h3c2cab7_1.tar.bz2
osx-64::arrow-cpp-7.0.0-py39hfe23411_5_cpu.tar.bz2
osx-64::arrow-cpp-3.0.0-py37hc17bbe7_53_cpu.tar.bz2
osx-64::conduit-0.8.3-py39hcb29030_0.tar.bz2
osx-64::arrow-cpp-3.0.0-py37ha46e8df_51_cpu.tar.bz2
osx-64::py-bgzip-0.4.0-py39h6f7375a_2.tar.bz2
osx-64::grpc-cpp-1.43.2-h6abb781_4.tar.bz2
osx-64::pillow-9.1.0-py38hf1b508f_1.tar.bz2
osx-64::libcurl-static-7.83.1-h23f1065_0.tar.bz2
osx-64::grpcio-1.46.1-py37h7ec71ce_0.tar.bz2
osx-64::tiledb-2.9.0-hb1ce2c0_1.tar.bz2
osx-64::arrow-cpp-8.0.0-py38h2548bce_1_cpu.tar.bz2
osx-64::libtensorflow_cc-2.8.1-cpu_h5b67d77_0.tar.bz2
osx-64::pillow-9.1.0-py310h382dc3b_2.tar.bz2
osx-64::mysql-client-8.0.29-h859e134_1.tar.bz2
osx-64::jaxlib-0.3.7-py38he9bd310_0.tar.bz2
osx-64::grpcio-1.46.3-py39h02843a8_0.tar.bz2
osx-64::coda-2.23.1-py310he448329_1.tar.bz2
osx-64::boost-cpp-1.74.0-h8b082ac_8.tar.bz2
osx-64::gdb-11.2-py39h159cfd2_0.tar.bz2
osx-64::arrow-cpp-3.0.0-py37h981337d_48_cpu.tar.bz2
osx-64::cppyy-cling-6.25.3-py39hda0e682_1.tar.bz2
osx-64::pytng-0.2.2-py37hb6c0c2a_2.tar.bz2
osx-64::libarchive-3.5.2-hbf7dfe4_2.tar.bz2
osx-64::lammps-2021.09.29-py37h761ec40_mpich_3.tar.bz2
osx-64::jaxlib-0.3.2-py38he16bdd2_0.tar.bz2
osx-64::ambertools-22.0-py310h94426a9_1.tar.bz2
osx-64::arrow-cpp-5.0.0-py37h669e0fe_29_cpu.tar.bz2
osx-64::tectonic-0.9.0-h224c532_0.tar.bz2
osx-64::grpc-cpp-1.43.2-h9067f4e_5.tar.bz2
osx-64::arrow-cpp-5.0.0-py37hc17bbe7_34_cpu.tar.bz2
osx-64::jaxlib-0.3.10-cpu_py37h6b066c9_0.tar.bz2
osx-64::libgdal-3.5.0-h12b3c45_0.tar.bz2
osx-64::xrootd-5.4.2-py39h4006b3f_0.tar.bz2
osx-64::tomviz-1.10.0.post230-py37h5abe756_2.tar.bz2
osx-64::coda-2.24-py39h1da5fad_0.tar.bz2
osx-64::vigra-1.11.1-py310h61a7a60_1032.tar.bz2
osx-64::astrometry-0.90-py39hedc8ae1_0.tar.bz2
osx-64::gdstk-0.8.2-py39h8bd3d57_1.tar.bz2
osx-64::libgdal-3.4.2-hc16c69e_5.tar.bz2
osx-64::astrometry-0.90-py310h88e4311_1.tar.bz2
osx-64::git-2.35.2-pl5321h9a94999_0.tar.bz2
osx-64::nd2-0.2.3-py310hfb80a91_0.tar.bz2
osx-64::gazebo-11.10.2-h3a32a6f_1.tar.bz2
osx-64::indexed_gzip-1.6.13-py310h01ad4ef_0.tar.bz2
osx-64::jaxlib-0.3.0-py38he16bdd2_4.tar.bz2
osx-64::pytng-0.2.2-py38he3e1023_2.tar.bz2
osx-64::root_base-6.24.6-py38h33e1717_3.tar.bz2
osx-64::arrow-cpp-6.0.1-py39h3e37d58_19_cpu.tar.bz2
osx-64::grpc-cpp-1.44.0-hf8f7871_3.tar.bz2
osx-64::mysql-server-8.0.29-ha7b25ec_0.tar.bz2
osx-64::arrow-cpp-3.0.0-py39h4993cbe_48_cpu.tar.bz2
osx-64::rstudio-desktop-2022.02.2-r41h10945f1_0.tar.bz2
osx-64::pyreadstat-1.1.6-py39h26d836a_0.tar.bz2
osx-64::lammps-2021.09.29-py310h983d345_mpich_3.tar.bz2
osx-64::arrow-cpp-8.0.0-py39h3bd5d96_1_cpu.tar.bz2
osx-64::orc-1.7.3-h5ac28ee_1.tar.bz2
osx-64::xrootd-5.4.2-py37he6b4dc7_0.tar.bz2
osx-64::llvmlite-0.38.1-py38h13516e3_0.tar.bz2
osx-64::nd2-0.2.4-py38h4586019_0.tar.bz2
osx-64::arrow-cpp-7.0.0-py37hf9b8a82_4_cpu.tar.bz2
osx-64::postgresql-14.3-h600828a_0.tar.bz2
osx-64::arrow-cpp-3.0.0-py38h57c148b_48_cpu.tar.bz2
osx-64::rstudio-desktop-2022.02.2-r40h10945f1_0.tar.bz2
osx-64::arrow-cpp-6.0.1-py310h77d0c5c_19_cpu.tar.bz2
osx-64::jaxlib-0.3.7-py38h123bfba_0.tar.bz2
osx-64::paraview-5.10.1-hf6cf536_104_qt.tar.bz2
osx-64::gdcm-2.8.9-py37he1d26a1_5.tar.bz2
osx-64::pyinstaller-5.0-py39h0e58486_0.tar.bz2
osx-64::arrow-cpp-6.0.1-py39h1defeeb_19_cpu.tar.bz2
osx-64::omniorb-4.2.5-py37h17e3b07_2.tar.bz2
osx-64::arrow-cpp-3.0.0-py310h77d0c5c_51_cpu.tar.bz2
osx-64::ogre-13.3.4-h188a5dd_0.tar.bz2
osx-64::arrow-cpp-5.0.0-py37h981337d_29_cpu.tar.bz2
osx-64::arrow-cpp-6.0.1-py39h3e37d58_17_cpu.tar.bz2
osx-64::grpcio-1.46.1-py39h02843a8_0.tar.bz2
osx-64::grpcio-1.46.0-py39h02843a8_1.tar.bz2
osx-64::arrow-cpp-3.0.0-py39h3e37d58_53_cpu.tar.bz2
osx-64::jaxlib-0.3.7-py39h12cb3c9_0.tar.bz2
osx-64::arrow-cpp-3.0.0-py310h77d0c5c_52_cpu.tar.bz2
osx-64::omniorb-4.2.5-py310hc818239_2.tar.bz2
osx-64::yoda-1.9.4-py37h52184bc_2.tar.bz2
osx-64::xrootd-5.4.2-py38h98c9e10_0.tar.bz2
osx-64::grpc-cpp-1.45.2-h9067f4e_3.tar.bz2
osx-64::jaxlib-0.3.10-cpu_py39h552bf4e_0.tar.bz2
osx-64::arrow-cpp-8.0.0-py310ha2d0369_1_cpu.tar.bz2
osx-64::grpc-cpp-1.46.3-h39bda65_0.tar.bz2
osx-64::tiledb-2.8.0-h190f7ed_0.tar.bz2
osx-64::gazebo-11.10.2-h23079e8_1.tar.bz2
osx-64::msgpack-c-3.3.0-hfcdac6d_4.tar.bz2
osx-64::grpc-cpp-1.44.0-h5dcc0b3_4.tar.bz2
osx-64::jaxlib-0.3.10-cpu_py38h227fd48_0.tar.bz2
osx-64::libxmlsec1-1.2.34-hf4718e7_0.tar.bz2
osx-64::arrow-cpp-5.0.0-py38hd51f7ad_34_cpu.tar.bz2
osx-64::libcurl-7.83.0-h372c54d_0.tar.bz2
osx-64::readdy-2.0.11-py310h56c2c07_1.tar.bz2
osx-64::arrow-cpp-3.0.0-py37h669e0fe_48_cpu.tar.bz2
osx-64::gsoap-2.8.122-had7b918_0.tar.bz2
osx-64::jaxlib-0.3.0-py310h1c40e90_4.tar.bz2
osx-64::panda3d-1.10.11-py39hb02d7b1_4.tar.bz2
osx-64::tensorflow-base-2.7.1-cpu_py38h2ac695d_0.tar.bz2
osx-64::libopencv-4.5.5-py38hcb2c4f9_9.tar.bz2
osx-64::gsoap-2.8.121-hba4f3e5_0.tar.bz2
osx-64::pypy3.9-7.3.9-h1e179d7_1.tar.bz2
osx-64::hugin-base-2021.0.0-py310pl5321hbb2489c_5.tar.bz2
osx-64::ndcctools-7.4.5-py39h76e1ea6_0.tar.bz2
osx-64::astrometry-0.90-py37hddf30e7_0.tar.bz2
osx-64::grpcio-1.46.1-py310h9983da3_0.tar.bz2
osx-64::gdcm-2.8.9-py310h892de89_5.tar.bz2
osx-64::root_base-6.24.6-py37hae46217_2.tar.bz2
osx-64::grpcio-1.46.1-py39hd862738_0.tar.bz2
osx-64::grpc-cpp-1.45.2-h81506c0_1.tar.bz2
osx-64::grpcio-1.46.0-py39h02843a8_0.tar.bz2
osx-64::grpcio-1.46.0-py38h0fbd9b5_1.tar.bz2
osx-64::grpc-cpp-1.43.2-h79d01a8_3.tar.bz2
osx-64::py-bgzip-0.4.0-py38h9121a6c_2.tar.bz2
osx-64::ambertools-22.0-py39hcd85542_0.tar.bz2
osx-64::panda3d-1.10.11-py310h4c68563_4.tar.bz2
osx-64::pygrib-2.1.4-py38h7a93348_5.tar.bz2
osx-64::arrow-cpp-6.0.1-py37hc17bbe7_19_cpu.tar.bz2
osx-64::libxml2-2.9.14-h08a9926_0.tar.bz2
osx-64::postgresql-plpython-14.3-py310h6331131_0.tar.bz2
osx-64::tiledb-2.8.3-hf17dc58_1.tar.bz2
osx-64::libtensorflow_cc-2.8.0-cpu_he5af24d_0.tar.bz2
osx-64::pp-sketchlib-2.0.0-py39h82ce9f9_0.tar.bz2
osx-64::pyinstaller-5.0.1-py310h5f16a0e_0.tar.bz2
osx-64::grpc-cpp-1.45.2-hd75a7ae_0.tar.bz2
osx-64::xrootd-5.4.2-py39h2b6761e_0.tar.bz2
osx-64::pyreadstat-1.1.6-py37hbb35929_0.tar.bz2
osx-64::lammps-2021.09.29-py38h6377f0c_openmpi_3.tar.bz2
osx-64::yoda-1.9.5-py310h38810cc_0.tar.bz2
osx-64::jaxlib-0.3.7-py310h811e547_0.tar.bz2
osx-64::indexed_gzip-1.6.13-py39h9f52193_1.tar.bz2
osx-64::conduit-0.8.3-py39h4f77508_0.tar.bz2
osx-64::arrow-cpp-5.0.0-py310h308b295_30_cpu.tar.bz2
osx-64::arrow-cpp-6.0.1-py38hd51f7ad_17_cpu.tar.bz2
osx-64::arrow-cpp-3.0.0-py310hcfe09f6_48_cpu.tar.bz2
osx-64::emacs-28.1-hfd0599e_0.tar.bz2
osx-64::libgdal-3.4.2-h12b3c45_7.tar.bz2
osx-64::ticcutils-0.28-h55d1964_1.tar.bz2
osx-64::indexed_gzip-1.6.13-py38he3e1023_0.tar.bz2
osx-64::curl-7.83.0-h23f1065_0.tar.bz2
osx-64::pillow-9.1.0-py39hd2c7aa1_0.tar.bz2
osx-64::rstudio-desktop-2022.02.2-r41h6e504f6_487.tar.bz2
osx-64::lammps-2021.09.29-py38hc2678fa_mpich_3.tar.bz2
osx-64::llvmlite-0.38.1-py310h8fbb61a_0.tar.bz2
osx-64::jaxlib-0.3.0-py310hec45b66_4.tar.bz2
osx-64::libnetcdf-4.8.1-mpi_openmpi_h6e52f38_2.tar.bz2
osx-64::nd2-0.2.3-py38h4586019_0.tar.bz2
osx-64::libprotobuf-3.20.1-h2292cb8_0.tar.bz2
osx-64::jaxlib-0.3.7-py39h734ad6e_0.tar.bz2
osx-64::pytng-0.2.2-py39h3337591_2.tar.bz2
osx-64::gazebo-11.10.2-hdf0c979_2.tar.bz2
osx-64::ffmpeg-5.0.1-h2c4a21e_1.tar.bz2
osx-64::jaxlib-0.3.7-py37h98ad878_0.tar.bz2
osx-64::gemmi-0.5.4-py38h6086acb_0.tar.bz2
osx-64::imagecodecs-2022.2.22-py39h0091ba8_3.tar.bz2
osx-64::arrow-cpp-6.0.1-py37ha46e8df_17_cpu.tar.bz2
osx-64::llvmlite-0.38.0-py38h6086acb_1.tar.bz2
osx-64::yoda-1.9.4-py39h8fbbf90_2.tar.bz2
osx-64::arrow-cpp-3.0.0-py310heb8dc28_48_cpu.tar.bz2
osx-64::libopencv-4.5.5-py38h152dacd_8.tar.bz2
osx-64::arrow-cpp-6.0.1-py310h77d0c5c_17_cpu.tar.bz2
osx-64::grpcio-1.46.1-py37h99645ed_0.tar.bz2
osx-64::grpcio-1.46.0-py39hd862738_0.tar.bz2
osx-64::libtiledb-sql-0.13.0-h2c77bcd_0.tar.bz2
osx-64::openscenegraph-3.6.5-h9ed35fa_13.tar.bz2
osx-64::poppler-qt-22.04.0-hd5146ce_0.tar.bz2
osx-64::fenics-libdolfin-2019.1.0-h8b70391_29.tar.bz2
osx-64::lammps-2021.09.29-py39hcb92f58_mpich_3.tar.bz2
osx-64::tensorflow-base-2.7.1-cpu_py37hc797e70_0.tar.bz2
osx-64::arrow-cpp-5.0.0-py38h8ce1a94_34_cpu.tar.bz2
osx-64::pypy3.9-7.3.9-h1e179d7_0.tar.bz2
osx-64::jaxlib-0.3.7-py37h3808775_0.tar.bz2
osx-64::libfido2-1.11.0-h3ad7f09_0.tar.bz2
osx-64::pdal-2.4.0-h5a841a7_4.tar.bz2
osx-64::openssh-9.0p1-hd27dfd1_0.tar.bz2
osx-64::pillow-9.1.1-py39h579eac4_0.tar.bz2
osx-64::yoda-1.9.5-py38h3351181_0.tar.bz2
osx-64::libtensorflow-2.8.1-cpu_h5b67d77_0.tar.bz2
osx-64::arrow-cpp-3.0.0-py39h3e37d58_51_cpu.tar.bz2
osx-64::ogre-1.12.13-h1ad7822_1.tar.bz2
osx-64::pypy3.8-7.3.9-hd7b965a_2.tar.bz2
osx-64::harp-1.15-py39r41h8c72817_1.tar.bz2
osx-64::postgresql-plpython-14.3-py38h26df6d1_0.tar.bz2
osx-64::vigra-1.11.1-py38h19c67b7_1032.tar.bz2
osx-64::harp-1.15.1-py38r40h5dbed13_0.tar.bz2
osx-64::libssh-0.8.9-ha4784be_2.tar.bz2
osx-64::tensorflow-base-2.7.1-cpu_py39hc561296_0.tar.bz2
osx-64::openssh-9.0p1-he782c1b_0.tar.bz2
osx-64::arrow-cpp-7.0.0-py38h2548bce_7_cpu.tar.bz2
osx-64::pyinstaller-5.1-py310h5f16a0e_0.tar.bz2
osx-64::postgresql-14.3-hd3ec586_0.tar.bz2
osx-64::grpcio-1.46.0-py39hd862738_1.tar.bz2
osx-64::ogre-13.3.4-h1ad7822_1.tar.bz2
osx-64::libgdal-3.4.3-h12b3c45_0.tar.bz2
osx-64::harp-1.15-py38r41h0664e9e_1.tar.bz2
osx-64::gazebo-11.10.2-h6a07665_1.tar.bz2
osx-64::tiledb-2.9.1-hb1ce2c0_0.tar.bz2
osx-64::grpc-cpp-1.45.2-h5dcc0b3_3.tar.bz2
osx-64::libcurl-7.83.0-h23f1065_0.tar.bz2
osx-64::imagecodecs-2022.2.22-py38h6428fbb_5.tar.bz2
osx-64::root_base-6.26.2-py37he4a5233_3.tar.bz2
osx-64::libssh-0.8.9-h15bec13_2.tar.bz2
osx-64::nginx-1.21.6-hd56c761_1.tar.bz2
osx-64::pypy3.9-7.3.9-h517dee8_2.tar.bz2
osx-64::arrow-cpp-7.0.0-py37hf8a2639_7_cpu.tar.bz2
osx-64::pillow-9.1.0-py37h2540ef4_1.tar.bz2
osx-64::panda3d-1.10.11-py37hd9174d1_4.tar.bz2
osx-64::ndcctools-7.4.5-py38h6d2bfc4_0.tar.bz2
osx-64::wxpython-4.1.1-py37h8745436_6.tar.bz2
osx-64::nss-3.78-ha8197d3_0.tar.bz2
osx-64::ffmpeg-5.0.1-h9220da4_0.tar.bz2
osx-64::arrow-cpp-3.0.0-py39h3e37d58_50_cpu.tar.bz2
osx-64::root_base-6.24.6-py39hdac8218_2.tar.bz2
osx-64::kaldi-5.5.1016-cpu_h1234567_0.tar.bz2
osx-64::arrow-cpp-3.0.0-py38h8ce1a94_53_cpu.tar.bz2
osx-64::tiledb-2.8.0-hd4ce1b4_1.tar.bz2
osx-64::python-3.9.13-hf8d34f4_0_cpython.tar.bz2
osx-64::cppyy-cling-6.25.3-py310h6622b4a_1.tar.bz2
osx-64::llvmlite-0.38.0-py39he90ae23_1.tar.bz2
osx-64::grpc-cpp-1.45.2-h3e9e271_2.tar.bz2
osx-64::vowpalwabbit-9.1.0-py37h9d88cfa_0.tar.bz2
osx-64::jaxlib-0.3.0-py39h0d862be_4.tar.bz2
osx-64::protozfits-2.0.1.post1-py310h8c407fa_8.tar.bz2
osx-64::grpcio-1.46.0-py310h23d8e5b_1.tar.bz2
osx-64::grpc-cpp-1.45.2-h9067f4e_2.tar.bz2
osx-64::grpc-cpp-1.45.2-h5dcc0b3_2.tar.bz2
osx-64::boost-cpp-1.78.0-h8b082ac_1.tar.bz2
osx-64::jaxlib-0.3.7-py38h39279b9_0.tar.bz2
osx-64::pdal-2.4.1-hc8be699_0.tar.bz2
osx-64::llvmlite-0.38.1-py39hdfe08e5_0.tar.bz2
osx-64::grpcio-1.46.0-py38h0fbd9b5_0.tar.bz2
osx-64::gazebo-11.10.2-h2c0a0d1_1.tar.bz2
osx-64::coda-2.23.1-py39h8c72817_1.tar.bz2
osx-64::jaxlib-0.3.2-py38hb231e15_0.tar.bz2
osx-64::yoda-1.9.5-py37haad64fb_0.tar.bz2
osx-64::tiledb-2.8.2-hf17dc58_0.tar.bz2
osx-64::arrow-cpp-5.0.0-py39h3e37d58_34_cpu.tar.bz2
osx-64::imagemagick-7.1.0_33-pl5321h1a6ef8d_0.tar.bz2
osx-64::pyreadstat-1.1.4-py310h76f859f_1.tar.bz2
osx-64::jaxlib-0.3.7-py39h0d3c28d_0.tar.bz2
osx-64::xrootd-5.4.2-py310h3cd1877_0.tar.bz2
osx-64::imagecodecs-2022.2.22-py310h90b4e0e_2.tar.bz2
osx-64::cppyy-cling-6.25.3-py38hdc1a088_1.tar.bz2
osx-64::tensorflow-base-2.8.0-cpu_py39hacdba1b_0.tar.bz2
osx-64::arrow-cpp-5.0.0-py310h77d0c5c_32_cpu.tar.bz2
osx-64::jaxlib-0.3.7-py39h992e876_0.tar.bz2
osx-64::jaxlib-0.3.7-py37h87682f6_0.tar.bz2
osx-64::openmpi-4.1.3-hc1c689a_101.tar.bz2
osx-64::libcurl-static-7.83.0-h23f1065_0.tar.bz2
osx-64::arrow-cpp-5.0.0-py310h77d0c5c_33_cpu.tar.bz2
osx-64::pytng-0.2.2-py39h19705d4_2.tar.bz2
osx-64::curl-7.83.1-h372c54d_0.tar.bz2
osx-64::tiledb-2.8.1-hd4ce1b4_0.tar.bz2
osx-64::mysql-client-8.0.28-h76d69bf_4.tar.bz2
osx-64::arrow-cpp-5.0.0-py310hed6c3eb_34_cpu.tar.bz2
osx-64::arrow-cpp-5.0.0-py39h69fe866_29_cpu.tar.bz2
osx-64::protozfits-2.0.1.post1-py37hd926f06_8.tar.bz2
osx-64::arrow-cpp-7.0.0-py39h2da71d5_7_cpu.tar.bz2
osx-64::grpc-cpp-1.44.0-h8e2f2ee_3.tar.bz2
osx-64::libmatio-1.5.23-hb7ac2cd_0.tar.bz2
osx-64::yoda-1.9.4-py39hcd86fd4_2.tar.bz2
osx-64::gemmi-0.5.4-py37h464c7a5_0.tar.bz2
osx-64::libvips-8.12.2-he70d912_4.tar.bz2
osx-64::arrow-cpp-3.0.0-py38hd51f7ad_52_cpu.tar.bz2
osx-64::mysql-libs-8.0.29-h8d0e597_1.tar.bz2
osx-64::gmsh-4.10.1-h8144cd1_0.tar.bz2
osx-64::grpcio-1.46.3-py310h23d8e5b_0.tar.bz2
osx-64::libopencv-4.5.5-py37h83ee73d_9.tar.bz2
osx-64::paraview-5.10.1-h0be49a0_104_qt.tar.bz2
osx-64::arrow-cpp-8.0.0-py38h4076a70_1_cpu.tar.bz2
osx-64::arrow-cpp-3.0.0-py310h308b295_49_cpu.tar.bz2
osx-64::gdstk-0.8.2-py310h41a46b3_1.tar.bz2
osx-64::coda-2.23.1-py39hcea63b7_1.tar.bz2
osx-64::gazebo-11.10.2-h86839b0_1.tar.bz2
osx-64::root_base-6.26.2-py310h02069a2_1.tar.bz2
osx-64::gct-6.2.1629922860-h15bec13_1.tar.bz2
osx-64::pypy3.8-7.3.9-hd6ecfba_1.tar.bz2
osx-64::root_base-6.26.2-py38h4001706_3.tar.bz2
osx-64::mysql-libs-8.0.28-h353f102_4.tar.bz2
osx-64::jaxlib-0.3.10-cpu_py37ha8dabb0_0.tar.bz2
osx-64::tensorflow-base-2.8.1-cpu_py310h196d2ec_0.tar.bz2
osx-64::grpc-cpp-1.43.2-hf8f7871_4.tar.bz2
osx-64::jaxlib-0.3.10-cpu_py38hfc92d86_0.tar.bz2
osx-64::libmediainfo-22.03-hefb38ac_0.tar.bz2
osx-64::yoda-1.9.4-py37haad64fb_2.tar.bz2
osx-64::arrow-cpp-8.0.0-py39hfe23411_1_cpu.tar.bz2
osx-64::pp-sketchlib-2.0.0-py38hc6187c4_0.tar.bz2
osx-64::jaxlib-0.3.7-py39h2092794_0.tar.bz2
osx-64::mysql-client-8.0.28-h76d69bf_3.tar.bz2
osx-64::libcurl-7.83.1-h23f1065_0.tar.bz2
osx-64::jaxlib-0.3.10-cpu_py38h7c3ec13_0.tar.bz2
osx-64::arrow-cpp-5.0.0-py37ha46e8df_31_cpu.tar.bz2
osx-64::jaxlib-0.3.7-py38heef063d_0.tar.bz2
osx-64::omniorb-4.2.5-py37h4340d80_2.tar.bz2
osx-64::gazebo-11.10.2-hf5a17d0_1.tar.bz2
osx-64::conduit-0.8.3-py37h2c0ecae_0.tar.bz2
osx-64::nco-5.0.7-h7491c92_0.tar.bz2
osx-64::gemmi-0.5.3-py38h6086acb_1.tar.bz2
osx-64::indexed_gzip-1.6.13-py310hc69d974_1.tar.bz2
osx-64::yoda-1.9.4-py310h38810cc_2.tar.bz2
osx-64::harp-1.15.1-py39r41h95401f7_0.tar.bz2
osx-64::sqlite-3.38.4-hd9f0692_0.tar.bz2
osx-64::gmsh-4.10.3-he204d90_0.tar.bz2
osx-64::grpcio-1.46.3-py37h99645ed_0.tar.bz2
osx-64::assimp-5.2.4-hfcdac6d_0.tar.bz2
osx-64::imagecodecs-2022.2.22-py310h0d10b90_5.tar.bz2
osx-64::grpcio-1.46.3-py39hd862738_0.tar.bz2
osx-64::pillow-9.1.0-py38h7207f37_2.tar.bz2
osx-64::arrow-cpp-5.0.0-py38hd51f7ad_33_cpu.tar.bz2
osx-64::grpc-cpp-1.45.1-hf4972c3_0.tar.bz2
osx-64::harp-1.15.1-py310r40h778f2a2_0.tar.bz2
osx-64::libopencv-4.5.5-py37hde3c3df_8.tar.bz2
osx-64::arrow-cpp-8.0.0-py38h137a19c_0_cpu.tar.bz2
osx-64::panda3d-1.10.11-py38h315ed96_4.tar.bz2
osx-64::mysql-libs-8.0.29-h3cab752_1.tar.bz2
osx-64::ndcctools-7.4.5-py37h167fce4_0.tar.bz2
osx-64::scip-8.0.0-hf28b5e5_1.tar.bz2
osx-64::tectonic-0.9.0-h3acbd81_0.tar.bz2
osx-64::tectonic-0.8.2-h2bfc6bf_3.tar.bz2
osx-64::llvmlite-0.38.1-py38h1e1b051_0.tar.bz2
osx-64::pyreadstat-1.1.5-py37hbb35929_0.tar.bz2
osx-64::arrow-cpp-8.0.0-py310h9b97d7e_1_cpu.tar.bz2
osx-64::nd2-0.2.4-py310hfb80a91_0.tar.bz2
osx-64::pyreadstat-1.1.4-py39h9fd43ae_1.tar.bz2
osx-64::arrow-cpp-5.0.0-py310h77d0c5c_34_cpu.tar.bz2
osx-64::harp-1.15.1-py39r40h1da5fad_0.tar.bz2
osx-64::arrow-cpp-7.0.0-py38h137a19c_5_cpu.tar.bz2
osx-64::papilo-2.0.0-h26b9c19_1.tar.bz2
osx-64::libxml2-2.9.13-he03b247_0.tar.bz2
osx-64::ambertools-22.0-py37hacd182f_0.tar.bz2
osx-64::harp-1.15.1-py38r41h5dbed13_0.tar.bz2
osx-64::paraview-5.10.1-py38h4a95c56_105_qt.tar.bz2
osx-64::conduit-0.8.3-py38ha40a6a4_0.tar.bz2
osx-64::orc-1.7.4-h4856350_1.tar.bz2
osx-64::libgit2-1.4.3-heec6b30_0.tar.bz2
osx-64::gemmi-0.5.4-py310hc82e721_0.tar.bz2
osx-64::libmediainfo-22.03-hefb38ac_1.tar.bz2
osx-64::arrow-cpp-8.0.0-py37h4ccaaa6_0_cpu.tar.bz2
osx-64::mysql-server-8.0.28-ha88527b_4.tar.bz2
osx-64::root_base-6.26.2-py37hae46217_1.tar.bz2
osx-64::arrow-cpp-5.0.0-py37ha46e8df_33_cpu.tar.bz2
osx-64::ruby-3.1.2-hcaea9d7_0.tar.bz2
osx-64::gdcm-2.8.9-py38h7652a54_5.tar.bz2
osx-64::qt-webengine-5.15.4-h055bd26_2.tar.bz2
osx-64::nodejs-17.9.0-h3cde592_0.tar.bz2
osx-64::libtensorflow-2.8.0-cpu_he5af24d_0.tar.bz2
osx-64::gemmi-0.5.3-py37h464c7a5_1.tar.bz2
osx-64::vigra-1.11.1-py37h9fb3134_1032.tar.bz2
osx-64::lammps-2021.09.29-py310h121345e_openmpi_3.tar.bz2
osx-64::gmsh-4.10.2-h8144cd1_0.tar.bz2
osx-64::harp-1.15.1-py37r41h4e666a4_0.tar.bz2
osx-64::jaxlib-0.3.7-py38h9dfd58f_0.tar.bz2
osx-64::ndcctools-7.4.4-py37hf36a506_0.tar.bz2
osx-64::gemmi-0.5.3-py38hbfc0824_1.tar.bz2
osx-64::grpc-cpp-1.45.2-h3e9e271_3.tar.bz2
osx-64::pypy3.8-7.3.9-hd7b965a_1.tar.bz2
osx-64::jaxlib-0.3.7-py37hdeb6003_0.tar.bz2
osx-64::pillow-9.1.0-py39hd2c7aa1_2.tar.bz2
osx-64::llvmdev-14.0.3-h41df66c_0.tar.bz2
osx-64::nd2-0.2.3-py39h79df2d4_0.tar.bz2
osx-64::grpc-cpp-1.43.2-h76973e4_3.tar.bz2
osx-64::pyinstaller-5.1-py37hca69792_0.tar.bz2
osx-64::protozfits-2.0.1.post1-py39hd8a468b_8.tar.bz2
osx-64::imagecodecs-2022.2.22-py38h27621cb_4.tar.bz2
osx-64::mysql-libs-8.0.29-h3cab752_0.tar.bz2
osx-64::mosh-1.3.2-pl5321hbb69899_1012.tar.bz2
osx-64::arrow-cpp-6.0.1-py38h4dff022_14_cpu.tar.bz2
osx-64::pyinstaller-5.0-py38h11e812f_0.tar.bz2
osx-64::gazebo-11.10.2-h721a7dc_2.tar.bz2
osx-64::jaxlib-0.3.2-py37h459d190_0.tar.bz2
osx-64::mandrake-1.2.2-py310h2a7cf1a_0.tar.bz2
osx-64::wxpython-4.1.1-py38he007270_7.tar.bz2
osx-64::fish-3.4.1-ha42faab_0.tar.bz2
osx-64::gdb-11.2-py310h31dcc76_0.tar.bz2
osx-64::mongodb-5.1.1-h281f97d_3.tar.bz2
osx-64::astrometry-0.90-py310hd6d18b6_0.tar.bz2
osx-64::coda-2.24-py310h778f2a2_0.tar.bz2
osx-64::omniorb-4.2.5-py310h3d7d5d8_2.tar.bz2
osx-64::qt-main-5.15.3-h938c29d_0.tar.bz2
osx-64::mysql-server-8.0.28-h7989f0c_4.tar.bz2
osx-64::arrow-cpp-5.0.0-py310heb8dc28_29_cpu.tar.bz2
osx-64::omniorb-4.2.5-py38ha04e45a_2.tar.bz2
osx-64::imagecodecs-2022.2.22-py38hb37bb36_3.tar.bz2
osx-64::gemmi-0.5.3-py39he90ae23_1.tar.bz2
osx-64::lammps-2021.09.29-py37hee20b2b_mpich_3.tar.bz2
osx-64::erlang-24.3.4-pl5321hbd0f5b5_0.tar.bz2
osx-64::pyinstaller-5.0.1-py37hca69792_0.tar.bz2
osx-64::grpcio-1.46.0-py37h99645ed_0.tar.bz2
osx-64::llvmdev-14.0.1-h89d5e19_0.tar.bz2
osx-64::quazip-1.3-ha88f3e4_0.tar.bz2
osx-64::grpc-cpp-1.44.0-h79d01a8_2.tar.bz2
osx-64::pillow-9.1.1-py38h8ad2bec_0.tar.bz2
osx-64::libgdal-3.4.3-h6474519_0.tar.bz2
osx-64::pyreadstat-1.1.6-py37hca69792_0.tar.bz2
osx-64::libtiledb-sql-0.14.2-hd314c81_0.tar.bz2
osx-64::tiledb-2.7.2-h190f7ed_0.tar.bz2
osx-64::arrow-cpp-8.0.0-py39h2da71d5_1_cpu.tar.bz2
osx-64::libtiledb-sql-0.14.0-ha287908_0.tar.bz2
osx-64::smesh-9.7.0.1-h2709245_1.tar.bz2
osx-64::soplex-6.0.0-h0d3c34b_1.tar.bz2
osx-64::jaxlib-0.3.0-py37h16e4cf6_4.tar.bz2
osx-64::arrow-cpp-7.0.0-py310h3e89f82_4_cpu.tar.bz2
osx-64::mosh-1.3.2-pl5321h9af9c5a_1012.tar.bz2
osx-64::grpc-cpp-1.45.2-hb472a99_3.tar.bz2
osx-64::pyreadstat-1.1.5-py38h66216d4_0.tar.bz2
osx-64::arrow-cpp-5.0.0-py38h57c148b_29_cpu.tar.bz2
osx-64::postgresql-plpython-14.3-py310h692a392_0.tar.bz2
osx-64::arrow-cpp-3.0.0-py37h77c286d_49_cpu.tar.bz2
osx-64::panda3d-1.10.11-py310h06982ac_4.tar.bz2
osx-64::ndcctools-7.4.4-py39h76e1ea6_0.tar.bz2
osx-64::arrow-cpp-7.0.0-py37h4ccaaa6_5_cpu.tar.bz2
osx-64::arrow-cpp-8.0.0-py39hfe23411_0_cpu.tar.bz2
osx-64::ffmpeg-5.0.1-hf5e6f72_2.tar.bz2
osx-64::vigra-1.11.1-py37h5af78d1_1031.tar.bz2
osx-64::jaxlib-0.3.7-py37hf642157_0.tar.bz2
osx-64::grpc-cpp-1.46.0-h9067f4e_0.tar.bz2
osx-64::coda-2.23.1-py37h8f1b641_1.tar.bz2
osx-64::git-2.35.3-pl5321h9a94999_0.tar.bz2
osx-64::grpcio-1.46.0-py37h7ec71ce_1.tar.bz2
osx-64::fenics-libdolfin-2019.1.0-h5e46fef_30.tar.bz2
osx-64::grpcio-1.46.0-py310h23d8e5b_0.tar.bz2
osx-64::subversion-1.14.2-pl5321h2c0cc23_0.tar.bz2
osx-64::harp-1.15-py39r40h8c72817_1.tar.bz2
osx-64::ndcctools-7.4.5-py310hc5a569c_0.tar.bz2
osx-64::py-bgzip-0.4.0-py37h9074259_2.tar.bz2
osx-64::mysql-libs-8.0.28-h2a44bf5_4.tar.bz2
osx-64::libtiff-4.3.0-hfca7e8f_4.tar.bz2
osx-64::lammps-2021.09.29-py39h33af542_openmpi_3.tar.bz2
osx-64::pillow-9.1.1-py37h1eb1bbc_0.tar.bz2
osx-64::arrow-cpp-5.0.0-py38h082a6f5_30_cpu.tar.bz2
osx-64::arrow-cpp-6.0.1-py310hcfe09f6_14_cpu.tar.bz2
osx-64::pyinstaller-5.0-py37hb9cd1ca_0.tar.bz2
osx-64::imagemagick-7.1.0_32-pl5321h1a6ef8d_0.tar.bz2
osx-64::harp-1.15-py38r40hb85ff19_1.tar.bz2
osx-64::pillow-9.1.1-py38h21af888_0.tar.bz2
osx-64::libcurl-static-7.83.1-h372c54d_0.tar.bz2
osx-64::nginx-1.21.6-hea7d202_1.tar.bz2
osx-64::pillow-9.1.0-py39hd2c7aa1_1.tar.bz2
osx-64::arrow-cpp-6.0.1-py39h69fe866_14_cpu.tar.bz2
osx-64::root_base-6.26.2-py310h95ca182_3.tar.bz2
osx-64::root_base-6.26.2-py39h3fcb224_2.tar.bz2
osx-64::grpcio-1.46.1-py38h0fbd9b5_0.tar.bz2
osx-64::harp-1.15-py310r40he448329_1.tar.bz2
osx-64::jaxlib-0.3.2-py310h1c40e90_0.tar.bz2
osx-64::gdb-11.2-py38h20d8f22_0.tar.bz2
osx-64::arrow-cpp-7.0.0-py310hcd44676_7_cpu.tar.bz2
osx-64::pp-sketchlib-2.0.0-py310hadf4328_0.tar.bz2
osx-64::harp-1.15.1-py38r40hac333f3_0.tar.bz2
osx-64::yoda-1.9.4-py39hbae0c82_2.tar.bz2
osx-64::conduit-0.8.3-py37h6aecd0e_0.tar.bz2
osx-64::arrow-cpp-8.0.0-py38h137a19c_1_cpu.tar.bz2
osx-64::libnetcdf-4.8.1-mpi_mpich_hf13189e_2.tar.bz2
osx-64::coda-2.24-py39h95401f7_0.tar.bz2
osx-64::erlang-25.0-pl5321hbd0f5b5_0.tar.bz2
osx-64::jaxlib-0.3.7-py39h5df823a_0.tar.bz2
osx-64::readdy-2.0.11-py39h2745eba_1.tar.bz2
osx-64::mongodb-5.1.1-h207facf_3.tar.bz2
osx-64::coin-or-clp-1.17.7-h79c0eca_0.tar.bz2
osx-64::libgdal-3.4.2-ha663369_6.tar.bz2
osx-64::blosc-1.21.1-h97e831e_3.tar.bz2
osx-64::pypy3.8-7.3.9-hd7b965a_0.tar.bz2
osx-64::postgresql-plpython-14.3-py38h52e5b9a_0.tar.bz2
osx-64::arrow-cpp-8.0.0-py310hcd44676_1_cpu.tar.bz2
osx-64::harp-1.15.1-py37r40h4e666a4_0.tar.bz2
osx-64::libfido2-1.11.0-h875bebe_0.tar.bz2
osx-64::jaxlib-0.3.2-py39h0d862be_0.tar.bz2
osx-64::grpc-cpp-1.43.2-ha04666b_3.tar.bz2
osx-64::gct-6.2.1629922860-ha4784be_1.tar.bz2
osx-64::nodejs-17.9.0-h40ae9cc_0.tar.bz2
osx-64::pyinstaller-5.1-py38h66216d4_0.tar.bz2
osx-64::imagecodecs-2022.2.22-py310h4038c1b_3.tar.bz2
osx-64::vowpalwabbit-9.1.0-py310h1a5585b_0.tar.bz2
osx-64::ndcctools-7.4.4-py38h6d2bfc4_0.tar.bz2
osx-64::tiledb-2.8.1-h190f7ed_0.tar.bz2
osx-64::pillow-9.1.0-py37h2540ef4_0.tar.bz2
osx-64::sqlite-3.38.2-hb516253_0.tar.bz2
osx-64::root_base-6.26.2-py37he4a5233_2.tar.bz2
osx-64::panda3d-1.10.11-py38h5c9b9c3_4.tar.bz2
osx-64::grpcio-1.46.0-py37h7ec71ce_0.tar.bz2
osx-64::vigra-1.11.1-py39hdc3c630_1031.tar.bz2
osx-64::libgdal-3.5.0-h6474519_0.tar.bz2
osx-64::arrow-cpp-3.0.0-py37ha46e8df_53_cpu.tar.bz2
osx-64::osmium-tool-1.13.2-h03072be_0.tar.bz2
osx-64::imagecodecs-2022.2.22-py310hd63e441_4.tar.bz2
osx-64::hugin-base-2021.0.0-py39pl5321he87987e_5.tar.bz2
osx-64::astrometry-0.90-py38ha96221d_1.tar.bz2
osx-64::harp-1.15-py39r40hcea63b7_1.tar.bz2
osx-64::grpc-cpp-1.44.0-h9067f4e_4.tar.bz2
osx-64::libnetcdf-4.8.1-nompi_h6609ca0_102.tar.bz2
osx-64::wxpython-4.1.1-py310hda2417f_6.tar.bz2
osx-64::pypy3.9-7.3.9-h517dee8_0.tar.bz2
osx-64::subversion-1.14.2-pl5321hc7dd170_1.tar.bz2
osx-64::postgresql-plpython-14.3-py37hecf6b4e_0.tar.bz2
osx-64::pyinstaller-5.0-py310he04095b_0.tar.bz2
osx-64::mysql-libs-8.0.29-h8d0e597_0.tar.bz2
osx-64::openconnect-8.10-h7457fae_4.tar.bz2
osx-64::libgit2-1.4.3-h514b3f4_0.tar.bz2
osx-64::gazebo-11.10.2-h856e2b8_2.tar.bz2
osx-64::arrow-cpp-6.0.1-py310heb8dc28_14_cpu.tar.bz2
osx-64::llvmdev-14.0.2-h41df66c_1.tar.bz2
osx-64::pyreadstat-1.1.5-py39h26d836a_0.tar.bz2
osx-64::qtwebkit-5.212-ha2e9019_6.tar.bz2
osx-64::fenics-libdolfin-2019.1.0-h70bf796_29.tar.bz2
osx-64::pygrib-2.1.4-py39hbce12c7_5.tar.bz2
osx-64::grpc-cpp-1.43.2-h3e9e271_5.tar.bz2
osx-64::librdkafka-1.8.2.post2-h5f2db2f_1.tar.bz2
osx-64::grpc-cpp-1.46.0-h5dcc0b3_0.tar.bz2
osx-64::arrow-cpp-6.0.1-py38hd51f7ad_19_cpu.tar.bz2
osx-64::pdal-2.4.0-hc75a851_3.tar.bz2
osx-64::arrow-cpp-7.0.0-py37h4ccaaa6_6_cpu.tar.bz2
osx-64::gdcm-2.8.9-py39h141b310_5.tar.bz2
osx-64::mysql-libs-8.0.28-h353f102_3.tar.bz2
osx-64::imagemagick-7.1.0_31-pl5321h1a6ef8d_0.tar.bz2
osx-64::magics-metview-4.12.0-ha93c7d5_0.tar.bz2
osx-64::cppyy-cling-6.25.3-py38hba2128d_1.tar.bz2
osx-64::mysql-server-8.0.29-ha7b25ec_1.tar.bz2
osx-64::arrow-cpp-6.0.1-py37h669e0fe_14_cpu.tar.bz2
osx-64::pyreadstat-1.1.6-py310h5f16a0e_0.tar.bz2
osx-64::pyreadstat-1.1.4-py38h4fe204b_1.tar.bz2
osx-64::tiledb-2.8.2-h349c43f_0.tar.bz2
osx-64::omniorb-4.2.5-py39he7779d6_2.tar.bz2
osx-64::pygrib-2.1.4-py38hd8f02b2_5.tar.bz2
osx-64::readdy-2.0.11-py37hcb06546_1.tar.bz2
osx-64::harp-1.15-py37r41h8f1b641_1.tar.bz2
osx-64::paraview-5.10.1-py37hddf441c_105_qt.tar.bz2
osx-64::harp-1.15-py38r41hb85ff19_1.tar.bz2
osx-64::grpc-cpp-1.45.1-hd75a7ae_1.tar.bz2
osx-64::cmake-3.23.2-hf2c7296_0.tar.bz2
osx-64::pillow-9.1.0-py38hf1b508f_2.tar.bz2
osx-64::mysql-client-8.0.29-h756fca8_1.tar.bz2
osx-64::magics-4.12.0-hf2e06ee_0.tar.bz2
osx-64::pillow-9.1.1-py39hbf29c74_0.tar.bz2
osx-64::gsoap-2.8.121-h5368dca_0.tar.bz2
osx-64::arrow-cpp-6.0.1-py310hed6c3eb_19_cpu.tar.bz2
osx-64::pypy3.9-7.3.8-h1e179d7_2.tar.bz2
osx-64::arrow-cpp-7.0.0-py38h137a19c_6_cpu.tar.bz2
osx-64::tectonic-0.8.2-hda40164_3.tar.bz2
osx-64::tomviz-1.10.0.post230-py37hdadab20_1.tar.bz2
osx-64::ndcctools-7.4.4-py38h3641052_0.tar.bz2
osx-64::arrow-cpp-6.0.1-py38h57c148b_14_cpu.tar.bz2
osx-64::indexed_gzip-1.6.13-py37h4915796_1.tar.bz2
osx-64::cctools_osx-64-973.0.1-h2b95895_10.tar.bz2
osx-64::erlang-25.0-pl5321hbad8640_0.tar.bz2
osx-64::arrow-cpp-7.0.0-py310h9b97d7e_6_cpu.tar.bz2
osx-64::coda-2.23.1-py38hb85ff19_1.tar.bz2
osx-64::harp-1.15-py38r40h0664e9e_1.tar.bz2
osx-64::indexed_gzip-1.6.13-py37hb6c0c2a_0.tar.bz2
osx-64::pillow-9.1.0-py37h2540ef4_2.tar.bz2
osx-64::indexed_gzip-1.6.13-py38h5421423_1.tar.bz2
osx-64::arrow-cpp-6.0.1-py39h3e37d58_16_cpu.tar.bz2
osx-64::paraview-5.10.1-h87da9b3_104_qt.tar.bz2
osx-64::root_base-6.26.2-py310h95ca182_2.tar.bz2
osx-64::arrow-cpp-3.0.0-py310hed6c3eb_53_cpu.tar.bz2
osx-64::pdal-2.4.1-hdf0380d_0.tar.bz2
osx-64::root_base-6.24.6-py310h02069a2_2.tar.bz2
osx-64::ndcctools-7.4.5-py39h0d687a8_0.tar.bz2
osx-64::grpc-cpp-1.43.2-h8e2f2ee_4.tar.bz2
osx-64::root_base-6.26.2-py38h4001706_2.tar.bz2
osx-64::libtiledb-sql-0.14.0-hf036110_0.tar.bz2
osx-64::collada-dom-2.5.0-hfeba9ce_4.tar.bz2
osx-64::tiledb-2.8.0-h190f7ed_1.tar.bz2
osx-64::jaxlib-0.3.0-py37h459d190_4.tar.bz2
osx-64::coda-2.24-py37h4e666a4_0.tar.bz2
osx-64::kaldi-5.5.1016-cpu_h2e0a662_2.tar.bz2
osx-64::sqlite-3.38.5-hd9f0692_0.tar.bz2
osx-64::arrow-cpp-3.0.0-py38hd51f7ad_53_cpu.tar.bz2
osx-64::llvmlite-0.38.1-py37h4db3d30_0.tar.bz2
osx-64::pypy3.8-7.3.9-hd6ecfba_0.tar.bz2
osx-64::ffmpeg-4.4.1-h2c4a21e_3.tar.bz2
osx-64::arrow-cpp-6.0.1-py37h981337d_14_cpu.tar.bz2
osx-64::vigra-1.11.1-py39h946d76f_1032.tar.bz2
osx-64::pypy3.8-7.3.8-hd7b965a_2.tar.bz2
osx-64::curl-7.83.0-h372c54d_0.tar.bz2
osx-64::harp-1.15-py37r40h8f1b641_1.tar.bz2
osx-64::harp-1.15-py310r41he448329_1.tar.bz2
osx-64::vowpalwabbit-9.1.0-py38h1d3a20a_0.tar.bz2
osx-64::pypy3.9-7.3.9-h1e179d7_2.tar.bz2
osx-64::postgresql-plpython-14.3-py39h10f0d74_0.tar.bz2
osx-64::jaxlib-0.3.7-py37he8ec28a_0.tar.bz2
osx-64::pdal-2.4.0-he4e4279_4.tar.bz2
osx-64::qtwebkit-5.212-hd9e313a_5.tar.bz2
osx-64::protozfits-2.0.1.post1-py38hd782910_8.tar.bz2
osx-64::arrow-cpp-6.0.1-py37ha46e8df_19_cpu.tar.bz2
osx-64::zstd-1.5.2-ha9df2e0_1.tar.bz2
osx-64::gemmi-0.5.4-py39he90ae23_0.tar.bz2
osx-64::lammps-2021.09.29-py37h39cad76_openmpi_3.tar.bz2
osx-64::rsync-3.2.3-h856fd78_4.tar.bz2
osx-64::nd2-0.2.4-py37hadc9cfe_0.tar.bz2
osx-64::root_base-6.26.2-py39h3fcb224_3.tar.bz2
osx-64::harp-1.15.1-py39r41h1da5fad_0.tar.bz2
osx-64::freeimage-3.18.0-haf7e230_8.tar.bz2
osx-64::git-2.35.2-pl5321h33a4a8a_0.tar.bz2
osx-64::libcurl-static-7.83.0-h372c54d_0.tar.bz2
osx-64::pillow-9.1.1-py310hb3240ae_0.tar.bz2
osx-64::jaxlib-0.3.7-py310hf887b78_0.tar.bz2
osx-64::py-bgzip-0.4.0-py39h48054f6_2.tar.bz2
osx-64::arrow-cpp-8.0.0-py310h9b97d7e_0_cpu.tar.bz2
osx-64::arrow-cpp-5.0.0-py39h1defeeb_34_cpu.tar.bz2
osx-64::rstudio-desktop-2022.02.2-r40h6e504f6_487.tar.bz2
osx-64::grpcio-1.46.1-py38hf25cc3e_0.tar.bz2
osx-64::fenics-libdolfin-2019.1.0-he8dd11a_30.tar.bz2
osx-64::paraview-5.10.1-py39h92c8d61_105_qt.tar.bz2
osx-64::hugin-base-2021.0.0-py37pl5321h4920456_5.tar.bz2
osx-64::cppyy-cling-6.25.3-py39h0e0114f_1.tar.bz2
osx-64::grpcio-1.46.0-py37h99645ed_1.tar.bz2
osx-64::fenics-libdolfin-2019.1.0-h02683bd_27.tar.bz2
osx-64::magics-metview-batch-4.12.0-hf2e06ee_0.tar.bz2
osx-64::git-2.35.3-pl5321h33a4a8a_0.tar.bz2
osx-64::tensorflow-base-2.8.1-cpu_py38h89fe887_0.tar.bz2
osx-64::tiledb-2.8.3-hf17dc58_0.tar.bz2
osx-64::paraview-5.10.1-h07b6fdb_104_qt.tar.bz2
osx-64::tensorflow-base-2.8.0-cpu_py37hc99b051_0.tar.bz2
osx-64::gemmi-0.5.4-py39ha9d9895_0.tar.bz2
osx-64::nd2-0.2.3-py37hadc9cfe_0.tar.bz2
osx-64::arrow-cpp-3.0.0-py39hfac286f_49_cpu.tar.bz2
osx-64::hugin-base-2021.0.0-py37pl5321h83151af_5.tar.bz2
osx-64::arrow-cpp-5.0.0-py39hfac286f_30_cpu.tar.bz2
osx-64::pygrib-2.1.4-py37h1083504_5.tar.bz2
osx-64::pypy3.8-7.3.8-hd6ecfba_2.tar.bz2
osx-64::squashfs-tools-4.4-h145a913_3.tar.bz2
osx-64::grpc-cpp-1.44.0-h7e3b474_3.tar.bz2
osx-64::arrow-cpp-7.0.0-py310h9b97d7e_5_cpu.tar.bz2
osx-64::mysql-server-8.0.29-h4a39eec_0.tar.bz2
osx-64::yoda-1.9.4-py37hb4ba4dc_2.tar.bz2
osx-64::vigra-1.11.1-py310h2d7e19f_1031.tar.bz2
osx-64::gdstk-0.8.2-py37h852ff97_1.tar.bz2
osx-64::tiledb-2.9.0-h86bd37b_1.tar.bz2
osx-64::mysql-client-8.0.28-h7ddd48c_4.tar.bz2
osx-64::ndcctools-7.4.5-py310ha2f8ce0_0.tar.bz2
osx-64::mandrake-1.2.2-py39h907b3a0_0.tar.bz2
osx-64::pyreadstat-1.1.4-py37h7298123_1.tar.bz2
osx-64::harp-1.15.1-py39r40h95401f7_0.tar.bz2
osx-64::tensorflow-base-2.8.1-cpu_py39h69e9f8f_0.tar.bz2
osx-64::libopencv-4.5.5-py310h1b0d4d8_9.tar.bz2
osx-64::libxmlsec1-1.2.33-h3bf9cfb_1.tar.bz2
osx-64::grpc-cpp-1.46.3-haf5484d_0.tar.bz2
osx-64::pygrib-2.1.4-py310ha08ed71_5.tar.bz2
osx-64::wxpython-4.1.1-py38he02b700_6.tar.bz2
osx-64::mandrake-1.2.2-py38h978b87f_0.tar.bz2
osx-64::libtiledb-sql-0.14.1-hd314c81_0.tar.bz2
osx-64::pypy3.9-7.3.9-h517dee8_1.tar.bz2
osx-64::imagemagick-7.1.0_34-pl5321h1a6ef8d_0.tar.bz2
osx-64::grpc-cpp-1.44.0-hcc48474_2.tar.bz2
osx-64::ambertools-22.0-py37hacd182f_1.tar.bz2
osx-64::grpc-cpp-1.44.0-ha04666b_2.tar.bz2
osx-64::panda3d-1.10.11-py39h45c60dc_4.tar.bz2
osx-64::osmium-tool-1.14.0-h03072be_1.tar.bz2
osx-64::arrow-cpp-5.0.0-py37ha46e8df_34_cpu.tar.bz2
osx-64::astrometry-0.90-py37h0860050_1.tar.bz2
osx-64::grpc-cpp-1.44.0-h6abb781_3.tar.bz2
osx-64::jaxlib-0.3.7-py310ha7ac9d2_0.tar.bz2
osx-64::imagecodecs-2022.2.22-py38h7f54194_2.tar.bz2
osx-64::shrinkwrap-1.2.0-h5647460_0.tar.bz2
osx-64::tiledb-2.7.2-hd4ce1b4_0.tar.bz2
osx-64::wxpython-4.1.1-py39hd1060eb_6.tar.bz2
osx-64::arrow-cpp-3.0.0-py39h1defeeb_53_cpu.tar.bz2
osx-64::pyreadstat-1.1.4-py37h83b74e4_1.tar.bz2
osx-64::root_base-6.26.2-py38h33e1717_1.tar.bz2
osx-64::paraview-5.10.1-py310h73fee77_105_qt.tar.bz2
osx-64::qt-main-5.15.3-h938c29d_1.tar.bz2
osx-64::jaxlib-0.3.10-cpu_py310h265b3eb_0.tar.bz2
osx-64::omniorb-libs-4.2.5-h15bec13_2.tar.bz2
osx-64::jaxlib-0.3.10-cpu_py39ha19811c_0.tar.bz2
osx-64::wxpython-4.1.1-py37h32baf98_7.tar.bz2
osx-64::coin-or-cgl-0.60.6-hdb64514_0.tar.bz2
osx-64::pygrib-2.1.4-py39h85a9db3_5.tar.bz2
osx-64::vtk-9.1.0-qt_py37h089976b_208.tar.bz2
osx-64::jaxlib-0.3.2-py37h16e4cf6_0.tar.bz2
osx-64::jaxlib-0.3.7-py310hd1535f3_0.tar.bz2
osx-64::pdal-2.4.0-h11d9f76_3.tar.bz2
osx-64::ndcctools-7.4.4-py310ha2f8ce0_0.tar.bz2
osx-64::panda3d-1.10.11-py37h9a434b4_4.tar.bz2
osx-64::arrow-cpp-3.0.0-py38h4dff022_48_cpu.tar.bz2
osx-64::arrow-cpp-7.0.0-py38h4076a70_7_cpu.tar.bz2
osx-64::llvmdev-14.0.4-h41df66c_0.tar.bz2
osx-64::imagemagick-7.1.0_30-pl5321h80d2495_0.tar.bz2
osx-64::gemmi-0.5.3-py39ha9d9895_1.tar.bz2
osx-64::ndcctools-7.4.4-py310hc5a569c_0.tar.bz2
osx-64::cpp-opentelemetry-sdk-1.3.0-hd702da9_1.tar.bz2
osx-64::pypy3.9-7.3.8-h517dee8_2.tar.bz2
osx-64::ndcctools-7.4.4-py37h167fce4_0.tar.bz2
osx-64::jaxlib-0.3.10-cpu_py310h5891f1b_0.tar.bz2
osx-64::pyreadstat-1.1.5-py37hca69792_0.tar.bz2
osx-64::ndcctools-7.4.5-py38h3641052_0.tar.bz2
osx-64::ambertools-22.0-py39hcd85542_1.tar.bz2
osx-64::imagecodecs-2022.2.22-py39h42efd52_4.tar.bz2
osx-64::ovito-3.7.2-h793821f_2.tar.bz2
osx-64::jaxlib-0.3.0-py39h3f5a88a_4.tar.bz2
osx-64::mysql-server-8.0.29-h4a39eec_1.tar.bz2
osx-64::root_base-6.26.2-py39hdac8218_1.tar.bz2
osx-64::rstudio-desktop-2022.02.2-r40h10945f1_486.tar.bz2
osx-64::arrow-cpp-6.0.1-py310h308b295_15_cpu.tar.bz2
osx-64::gdb-11.2-py37hdd40afb_0.tar.bz2
osx-64::texlive-core-20210325-he1746da_3.tar.bz2
osx-64::blosc-1.21.1-h6b673d3_1.tar.bz2
osx-64::pillow-9.1.0-py38h7207f37_1.tar.bz2
osx-64::arrow-cpp-6.0.1-py38hd51f7ad_18_cpu.tar.bz2
osx-64::jaxlib-0.3.10-cpu_py38hf114e49_0.tar.bz2
osx-64::jaxlib-0.3.7-py310h53d9d6e_0.tar.bz2
osx-64::cppyy-cling-6.25.3-py37h0b493f2_1.tar.bz2
osx-64::mysql-connector-cpp-8.0.29-hdc4c26a_0.tar.bz2
osx-64::pyinstaller-5.0.1-py39h26d836a_0.tar.bz2
osx-64::readdy-2.0.11-py38h48b7bc9_1.tar.bz2
osx-64::gdstk-0.8.2-py38h2ac8f62_1.tar.bz2
osx-64::omniorb-4.2.5-py39hd89b572_2.tar.bz2
osx-64::pyinstaller-5.1-py39h26d836a_0.tar.bz2
osx-64::tiledb-2.8.0-hd4ce1b4_0.tar.bz2
osx-64::rsync-3.2.3-h7841d2a_4.tar.bz2
osx-64::jaxlib-0.3.0-py38hb231e15_4.tar.bz2
osx-64::grpc-cpp-1.45.2-hb472a99_2.tar.bz2
osx-64::grpcio-1.46.3-py37h7ec71ce_0.tar.bz2
osx-64::curl-7.83.1-h23f1065_0.tar.bz2
osx-64::omniorb-4.2.5-py38h5aa3bf6_2.tar.bz2
osx-64::hugin-base-2021.0.0-py38pl5321h0255853_5.tar.bz2
osx-64::pyreadstat-1.1.6-py38h66216d4_0.tar.bz2
osx-64::llvmlite-0.38.1-py39hb75758d_0.tar.bz2
osx-64::omniorb-libs-4.2.5-ha4784be_2.tar.bz2
osx-64::grpc-cpp-1.45.1-hd522a8a_1.tar.bz2
osx-64::octave-7.1.0-h859be7c_0.tar.bz2
osx-64::mysql-server-8.0.28-h20e68e8_3.tar.bz2
osx-64::arrow-cpp-5.0.0-py310hcfe09f6_29_cpu.tar.bz2
osx-64::arrow-cpp-7.0.0-py39h13a4272_4_cpu.tar.bz2
osx-64::arrow-cpp-6.0.1-py38h8ce1a94_19_cpu.tar.bz2
osx-64::jaxlib-0.3.10-cpu_py37h24447ef_0.tar.bz2
osx-64::cctools_osx-arm64-973.0.1-h98580c8_10.tar.bz2
osx-64::jaxlib-0.3.10-cpu_py310h52bc2dc_0.tar.bz2
osx-64::rstudio-desktop-2022.02.2-r41h10945f1_486.tar.bz2
osx-64::gmsh-4.10.0-h8144cd1_0.tar.bz2
osx-64::arrow-cpp-6.0.1-py39hfac286f_15_cpu.tar.bz2
osx-64::libgdal-3.4.2-h7223d19_5.tar.bz2
osx-64::mysql-server-8.0.28-h51a86d0_3.tar.bz2
osx-64::grpcio-1.46.3-py310h9983da3_0.tar.bz2
osx-64::harp-1.15-py39r41hcea63b7_1.tar.bz2
osx-64::arrow-cpp-3.0.0-py37ha46e8df_52_cpu.tar.bz2
osx-64::pillow-9.1.0-py39h01d1379_1.tar.bz2
osx-64::yoda-1.9.4-py38h3351181_2.tar.bz2
osx-64::arrow-cpp-6.0.1-py37h77c286d_15_cpu.tar.bz2
osx-64::libopencv-4.5.5-py31h33a95dd_8.tar.bz2
osx-64::openmpi-4.1.3-h4ff0e22_0.tar.bz2
osx-64::arrow-cpp-3.0.0-py310h77d0c5c_53_cpu.tar.bz2
osx-64::arrow-cpp-5.0.0-py39h4993cbe_29_cpu.tar.bz2
osx-64::vigra-1.11.1-py38h1fc90aa_1031.tar.bz2
osx-64::libopencv-4.5.5-py39h4c9e1ea_8.tar.bz2
osx-64::jaxlib-0.3.7-py310h4b97c73_0.tar.bz2
osx-64::harp-1.15.1-py310r41h778f2a2_0.tar.bz2
osx-64::coda-2.24-py38hac333f3_0.tar.bz2
osx-64::emacs-27.2-h748090c_3.tar.bz2
osx-64::libopencv-4.5.5-py39h65567e8_9.tar.bz2
osx-64::jaxlib-0.3.7-py38he3c9012_0.tar.bz2
osx-64::arrow-cpp-7.0.0-py37hf7096f7_7_cpu.tar.bz2
osx-64::gsoap-2.8.122-h7d01bbe_0.tar.bz2
osx-64::grpc-cpp-1.43.2-hb472a99_5.tar.bz2
osx-64::arrow-cpp-3.0.0-py39h3e37d58_52_cpu.tar.bz2
osx-64::pillow-9.1.0-py39h01d1379_2.tar.bz2
osx-64::tensorflow-base-2.8.0-cpu_py38h2ff887e_0.tar.bz2
osx-64::ffmpeg-4.4.1-hf5e6f72_4.tar.bz2
osx-64::py-bgzip-0.4.0-py38hb2b665e_2.tar.bz2
osx-64::libprotobuf-static-3.20.1-h2292cb8_0.tar.bz2
osx-64::wxpython-4.1.1-py310h8a1cd26_7.tar.bz2
osx-64::pypy3.8-7.3.9-hd6ecfba_2.tar.bz2
osx-64::arrow-cpp-7.0.0-py39hfe23411_6_cpu.tar.bz2
osx-64::arrow-cpp-8.0.0-py37h4ccaaa6_1_cpu.tar.bz2
osx-64::vigra-1.11.1-py37h44ab3ab_1032.tar.bz2
osx-64::libcurl-7.83.1-h372c54d_0.tar.bz2
osx-64::mongodb-5.1.1-h0a1aecf_2.tar.bz2
osx-64::gazebo-11.10.2-h15c895d_1.tar.bz2
osx-64::python-3.9.13-h57e37ff_0_cpython.tar.bz2
osx-64::jaxlib-0.3.2-py39h3f5a88a_0.tar.bz2
osx-64::pyinstaller-5.0.1-py38h66216d4_0.tar.bz2
osx-64::indexed_gzip-1.6.13-py39h19705d4_0.tar.bz2
osx-64::imagecodecs-2022.2.22-py39hb99e1c7_5.tar.bz2
osx-64::xrootd-5.4.2-py38h08700f2_0.tar.bz2
osx-64::ndcctools-7.4.5-py37hf36a506_0.tar.bz2
osx-64::imagemagick-7.1.0_35-pl5321h1a6ef8d_0.tar.bz2
osx-64::osmium-tool-1.14.0-h03072be_0.tar.bz2
osx-64::astrometry-0.90-py39h0777b8e_1.tar.bz2
osx-64::libtiledb-sql-0.14.2-hd314c81_1.tar.bz2
osx-64::root_base-6.24.6-py38h33e1717_2.tar.bz2
osx-64::vtk-9.1.0-qt_py39hff59e51_208.tar.bz2
osx-64::smesh-9.8.0.2-hf066c19_0.tar.bz2
osx-64::vigra-1.11.1-py37h50f29fb_1031.tar.bz2
osx-64::pillow-9.1.0-py38h7207f37_0.tar.bz2
osx-64::ogre-1.10.12-hf29afee_8.tar.bz2
-    "libzlib >=1.2.11,<1.3.0a0",
+    "libzlib >=1.2.11,<2.0.0a0",
osx-64::libllvm14-14.0.2-h41df66c_0.tar.bz2
osx-64::lld-14.0.3-h165480e_0.tar.bz2
osx-64::gst-plugins-good-1.20.2-h50d9aa0_0.tar.bz2
osx-64::dotnet-sdk-6.0.202-h17d86ac_0.tar.bz2
osx-64::llvm-tools-14.0.2-h41df66c_0.tar.bz2
osx-64::llvm-tools-14.0.3-h41df66c_0.tar.bz2
osx-64::lld-14.0.4-h165480e_0.tar.bz2
osx-64::spidermonkey-91.9.1-hb8cc226_0.tar.bz2
osx-64::spidermonkey-bin-91.9.1-h1154517_0.tar.bz2
osx-64::openexr-3.1.5-h6fbc5c6_0.tar.bz2
osx-64::spidermonkey-bin-91.8.0-h1154517_1.tar.bz2
osx-64::openjdk-11.0.9.1-h2292cb8_3.tar.bz2
osx-64::clang-9-9.0.1-root_62600_h6072aa7_5.tar.bz2
osx-64::lld-14.0.0-h165480e_0.tar.bz2
osx-64::dotnet-sdk-5.0.407-h17d86ac_0.tar.bz2
osx-64::niftyreg-1.5.69.6-ha83c2c8_0.tar.bz2
osx-64::dotnet-runtime-3.1.24-h17d86ac_0.tar.bz2
osx-64::llvm-tools-14.0.4-h41df66c_0.tar.bz2
osx-64::spidermonkey-91.8.0-h63ff396_0.tar.bz2
osx-64::spidermonkey-91.9.0-hb8cc226_0.tar.bz2
osx-64::libdwarf-dev-0.3.4-h7823cad_0.tar.bz2
osx-64::llvm-14.0.4-h9d075a6_0.tar.bz2
osx-64::libclang-cpp9-9.0.1-cling_v0.9_h6431b02_5.tar.bz2
osx-64::gst-plugins-base-1.20.2-hda0ba4b_1.tar.bz2
osx-64::dotnet-aspnetcore-6.0.4-h17d86ac_0.tar.bz2
osx-64::lib3mf-2.2.0-h6c62c43_1.tar.bz2
osx-64::libllvm14-14.0.1-h89d5e19_0.tar.bz2
osx-64::libclang-cpp9-9.0.1-default_hf139c7e_5.tar.bz2
osx-64::dotnet-runtime-6.0.4-h17d86ac_0.tar.bz2
osx-64::libsolv-static-0.7.22-hd9580d2_0.tar.bz2
osx-64::pocl-1.8-h5552be4_4.tar.bz2
osx-64::libclang-cpp-9.0.1-default_hf139c7e_5.tar.bz2
osx-64::spidermonkey-bin-91.8.0-hadde9ef_0.tar.bz2
osx-64::llvm-tools-14.0.2-h41df66c_1.tar.bz2
osx-64::llvm-14.0.2-h9d075a6_0.tar.bz2
osx-64::dotnet-sdk-3.1.418-h17d86ac_0.tar.bz2
osx-64::libdwarf-testing-meta-0.3.4-h7823cad_0.tar.bz2
osx-64::spidermonkey-91.8.0-hb8cc226_1.tar.bz2
osx-64::coin-or-osi-0.108.7-h009c923_0.tar.bz2
osx-64::openjdk-11.0.9.1-h2292cb8_2.tar.bz2
osx-64::libclang-cpp-9.0.1-root_62600_h6072aa7_5.tar.bz2
osx-64::pocl-1.8-h8b4fca9_4.tar.bz2
osx-64::clang-9-9.0.1-cling_v0.9_h6431b02_5.tar.bz2
osx-64::libclang-cpp-9.0.1-cling_v0.9_h6431b02_5.tar.bz2
osx-64::dotnet-aspnetcore-3.1.24-h17d86ac_0.tar.bz2
osx-64::libdwarf-0.3.4-h7823cad_0.tar.bz2
osx-64::libllvm14-14.0.2-h41df66c_1.tar.bz2
osx-64::readstat-1.1.8-hf020fe2_0.tar.bz2
osx-64::gst-plugins-base-1.20.2-hda0ba4b_0.tar.bz2
osx-64::lld-14.0.2-h165480e_0.tar.bz2
osx-64::llvm-14.0.2-h9d075a6_1.tar.bz2
osx-64::spidermonkey-bin-91.9.0-h1154517_0.tar.bz2
osx-64::dotnet-runtime-5.0.16-h17d86ac_0.tar.bz2
osx-64::libsolv-0.7.22-hd9580d2_0.tar.bz2
osx-64::llvm-14.0.1-h9d075a6_0.tar.bz2
osx-64::niftyreg-1.5.69.6-h5d0dcd9_1.tar.bz2
osx-64::llvm-14.0.3-h9d075a6_0.tar.bz2
osx-64::libllvm14-14.0.4-h41df66c_0.tar.bz2
osx-64::zimpl-3.5.1-hff3dd85_1.tar.bz2
osx-64::libllvm14-14.0.3-h41df66c_0.tar.bz2
osx-64::gst-plugins-good-1.20.2-h50d9aa0_1.tar.bz2
osx-64::llvm-tools-14.0.1-h89d5e19_0.tar.bz2
osx-64::dwarfdump-0.3.4-h7823cad_0.tar.bz2
osx-64::clang-9-9.0.1-default_hf139c7e_5.tar.bz2
osx-64::libclang-cpp9-9.0.1-root_62600_h6072aa7_5.tar.bz2
osx-64::dotnet-aspnetcore-5.0.16-h17d86ac_0.tar.bz2
-    "libzlib >=1.2.11,<1.3.0a0"
+    "libzlib >=1.2.11,<2.0.0a0"
osx-64::gazebo-11.11.0-he15cf3b_0.tar.bz2
osx-64::pillow-9.1.1-py310hb3240ae_1.tar.bz2
osx-64::tiledb-2.9.2-hb1ce2c0_0.tar.bz2
osx-64::qt-main-5.15.3-h938c29d_2.tar.bz2
osx-64::libxslt-1.1.35-heaa0ce8_0.tar.bz2
osx-64::graphviz-4.0.0-ha5baa68_0.tar.bz2
osx-64::pillow-9.1.1-py38h8ad2bec_1.tar.bz2
osx-64::pillow-9.1.1-py38h21af888_1.tar.bz2
osx-64::gazebo-11.11.0-h7acc6e6_0.tar.bz2
osx-64::pillow-9.1.1-py37h1eb1bbc_1.tar.bz2
osx-64::mysql-connector-cpp-8.0.29-hdc4c26a_1.tar.bz2
osx-64::gazebo-11.11.0-h6e51473_0.tar.bz2
osx-64::emacs-28.1-h1d28d37_1.tar.bz2
osx-64::imagemagick-7.1.0_36-pl5321h1a6ef8d_0.tar.bz2
osx-64::sagelib-9.6-py38h24214df_0.tar.bz2
osx-64::sagelib-9.6-py37hb3411b0_0.tar.bz2
osx-64::tiledb-2.9.2-h86bd37b_0.tar.bz2
osx-64::freeimage-3.18.0-h33ef725_9.tar.bz2
osx-64::libprotobuf-static-21.1-h2292cb8_0.tar.bz2
osx-64::pillow-9.1.1-py39hbf29c74_1.tar.bz2
osx-64::sagelib-9.6-py39hd28857d_0.tar.bz2
osx-64::libtiff-4.4.0-hfca7e8f_0.tar.bz2
osx-64::libtiledb-sql-0.15.0-hd314c81_0.tar.bz2
osx-64::pillow-9.1.1-py39h579eac4_1.tar.bz2
osx-64::gazebo-11.11.0-hbe8f7c8_0.tar.bz2
osx-64::libprotobuf-static-3.21.1-h2292cb8_0.tar.bz2
osx-64::libprotobuf-3.21.1-h2292cb8_0.tar.bz2
osx-64::sagelib-9.6-py310h8cf5725_0.tar.bz2
osx-64::mysql-connector-cpp-8.0.29-ha5f195b_1.tar.bz2
osx-64::libtiledb-sql-0.15.0-hc318ded_0.tar.bz2
-    "libzlib >=1.2.12,<1.3.0a0",
+    "libzlib >=1.2.12,<2.0.0a0",
osx-64::spidermonkey-91.10.0-hb8cc226_0.tar.bz2
osx-64::spidermonkey-bin-91.10.0-h1154517_0.tar.bz2
-    "libzlib >=1.2.12,<1.3.0a0"
+    "libzlib >=1.2.12,<2.0.0a0"
================================================================================
================================================================================
linux-64
linux-64::arrow-cpp-6.0.1-py310h8bc34b8_19_cpu.tar.bz2
linux-64::coda-2.24-py39h665c6b1_0.tar.bz2
linux-64::tensorflow-base-2.8.0-cuda102py39h714d7d1_0.tar.bz2
linux-64::lammps-2021.09.29-py310hf77f3a6_mpich_3.tar.bz2
linux-64::pillow-9.1.0-py310he619898_0.tar.bz2
linux-64::ndcctools-7.4.5-py37h0327239_0.tar.bz2
linux-64::pillow-9.1.0-py38h0ee0e06_2.tar.bz2
linux-64::pypy3.8-7.3.9-h5001382_1.tar.bz2
linux-64::tiledb-2.8.1-h1e4a385_0.tar.bz2
linux-64::arrow-cpp-3.0.0-py37h8df67fa_53_cuda.tar.bz2
linux-64::jaxlib-0.3.10-cpu_py38h3c20414_0.tar.bz2
linux-64::lmod-8.7.3-lua54h71fc533_0.tar.bz2
linux-64::ortools-cpp-9.2-h69b0a62_5.tar.bz2
linux-64::xrootd-5.4.2-py310hf716355_0.tar.bz2
linux-64::arrow-cpp-6.0.1-py38h9de5444_18_cuda.tar.bz2
linux-64::arrow-cpp-3.0.0-py310hdade202_51_cuda.tar.bz2
linux-64::arrow-cpp-5.0.0-py37h9a5a6ad_34_cpu.tar.bz2
linux-64::harp-1.15-py310r41h2b6cc9b_1.tar.bz2
linux-64::gmsh-4.10.3-hc719622_0.tar.bz2
linux-64::ortools-python-9.2-py310hc16a451_4.tar.bz2
linux-64::root_base-6.26.2-py39h9749efa_3.tar.bz2
linux-64::vtk-9.1.0-qt_py39hd359688_208.tar.bz2
linux-64::panda3d-1.10.11-py38h528246e_4.tar.bz2
linux-64::grpcio-1.46.3-py38ha0cdfde_0.tar.bz2
linux-64::libtiledb-sql-0.14.1-h204bf05_0.tar.bz2
linux-64::arrow-cpp-5.0.0-py38h609ca95_29_cpu.tar.bz2
linux-64::dotnet-sdk-5.0.407-h751d214_0.tar.bz2
linux-64::arrow-cpp-3.0.0-py38h9550bf3_53_cpu.tar.bz2
linux-64::xrootd-5.4.2-py37h62c5c55_0.tar.bz2
linux-64::arrow-cpp-6.0.1-py310hdade202_17_cuda.tar.bz2
linux-64::arrow-cpp-3.0.0-py39h7582941_51_cuda.tar.bz2
linux-64::libnetcdf-4.8.1-mpi_mpich_hcdf9059_2.tar.bz2
linux-64::libtensorflow-2.7.1-cuda110h83f852c_0.tar.bz2
linux-64::arrow-cpp-3.0.0-py38h9de5444_50_cuda.tar.bz2
linux-64::pypy3.9-7.3.8-h56abe6f_2.tar.bz2
linux-64::arrow-cpp-5.0.0-py38h9550bf3_33_cpu.tar.bz2
linux-64::pillow-9.1.1-py38h9267336_0.tar.bz2
linux-64::arrow-cpp-3.0.0-py39h7582941_53_cuda.tar.bz2
linux-64::hugin-2021.0.0-pl5321hf01e071_5.tar.bz2
linux-64::grpc-cpp-1.45.2-hffcb1d1_3.tar.bz2
linux-64::vowpalwabbit-9.1.0-py39h55140af_0.tar.bz2
linux-64::arrow-cpp-3.0.0-py39ha560878_49_cuda.tar.bz2
linux-64::ndcctools-7.4.5-py310hba10ccf_0.tar.bz2
linux-64::paraview-5.10.1-h2244f48_104_qt.tar.bz2
linux-64::arrow-cpp-5.0.0-py310h4356942_34_cuda.tar.bz2
linux-64::lammps-2021.09.29-py39h23c6bc1_mpich_3.tar.bz2
linux-64::jaxlib-0.3.10-cpu_py37hf0fc7ea_0.tar.bz2
linux-64::ortools-cpp-9.2-he0e45df_2.tar.bz2
linux-64::pdal-2.4.0-hec91d99_4.tar.bz2
linux-64::gct-6.2.1629922860-he49606f_1.tar.bz2
linux-64::papilo-2.0.0-h5179897_1.tar.bz2
linux-64::jaxlib-0.3.10-cuda112py39h4d6bb82_0.tar.bz2
linux-64::jaxlib-0.3.2-py310hd983389_0.tar.bz2
linux-64::arrow-cpp-6.0.1-py37hace919c_15_cpu.tar.bz2
linux-64::pytng-0.2.2-py39hc217eb8_2.tar.bz2
linux-64::arrow-cpp-6.0.1-py310h38b329a_15_cpu.tar.bz2
linux-64::indexed_gzip-1.6.13-py37h7dba1dc_0.tar.bz2
linux-64::triton-1.1.2-cuda110py310ha240f09_0.tar.bz2
linux-64::arrow-cpp-3.0.0-py37h9a5a6ad_53_cpu.tar.bz2
linux-64::ambertools-22.0-py37ha6f76a1_1.tar.bz2
linux-64::pyinstaller-5.1-py37he2f7bc2_0.tar.bz2
linux-64::protozfits-2.0.1.post1-py38h7c7f477_8.tar.bz2
linux-64::pdal-2.4.0-hcbced32_4.tar.bz2
linux-64::arrow-cpp-6.0.1-py38h9550bf3_17_cpu.tar.bz2
linux-64::postgresql-plpython-14.3-py39hde6a39c_0.tar.bz2
linux-64::jaxlib-0.3.7-py39h8a5bac0_0.tar.bz2
linux-64::cctools_osx-arm64-973.0.1-h2c08d4f_10.tar.bz2
linux-64::mysql-client-8.0.28-hf89ab62_4.tar.bz2
linux-64::grpcio-1.46.0-py38h2e9ca35_0.tar.bz2
linux-64::imagemagick-7.1.0_31-pl5321heb7c40d_0.tar.bz2
linux-64::ortools-cpp-9.2-h1e72a14_5.tar.bz2
linux-64::py-bgzip-0.4.0-py310ha400145_2.tar.bz2
linux-64::coda-2.24-py37hcb5871f_0.tar.bz2
linux-64::arrow-cpp-7.0.0-py39h0ae2fab_7_cuda.tar.bz2
linux-64::pyreadstat-1.1.6-py39hd08d98e_0.tar.bz2
linux-64::kaldi-5.5.1016-cuda111h0690c12_2.tar.bz2
linux-64::llvmlite-0.38.0-py37h0761922_1.tar.bz2
linux-64::imagecodecs-2022.2.22-py39h9c0c3a3_5.tar.bz2
linux-64::arrow-cpp-7.0.0-py37ha08e9a0_7_cuda.tar.bz2
linux-64::hugin-2021.0.0-pl5321hf7c132f_5.tar.bz2
linux-64::astrometry-0.90-py310hbd7b93c_0.tar.bz2
linux-64::clangdev-14.0.4-default_h2e3cab8_0.tar.bz2
linux-64::tensorflow-base-2.7.1-cuda111py310h6b17f32_0.tar.bz2
linux-64::libopencv-4.5.5-py39h12858e4_9.tar.bz2
linux-64::tiledb-2.8.3-h1e4a385_1.tar.bz2
linux-64::ambertools-22.0-py38h6177452_1.tar.bz2
linux-64::arrow-cpp-5.0.0-py310h8bc34b8_31_cpu.tar.bz2
linux-64::fenics-libdolfin-2019.1.0-hc04c414_29.tar.bz2
linux-64::grpc-cpp-1.43.2-h3ebbd8c_5.tar.bz2
linux-64::paraview-5.10.1-hf86338e_104_qt.tar.bz2
linux-64::grpcio-1.46.0-py39h7fbbf82_1.tar.bz2
linux-64::grpcio-1.46.0-py38ha0cdfde_1.tar.bz2
linux-64::arrow-cpp-5.0.0-py37he5bb92b_29_cuda.tar.bz2
linux-64::folly-2022.04.18.00-h1234567_1.tar.bz2
linux-64::arrow-cpp-3.0.0-py37h4fb91f9_48_cpu.tar.bz2
linux-64::mandrake-1.2.2-py38h3cd5c1e_0.tar.bz2
linux-64::mongodb-5.1.1-h6f82f1e_3.tar.bz2
linux-64::vigra-1.11.1-py310hb5305c7_1031.tar.bz2
linux-64::ortools-cpp-9.2-h5d3e929_5.tar.bz2
linux-64::libtensorflow_cc-2.7.1-cuda111h95e6cbe_0.tar.bz2
linux-64::ortools-cpp-9.2-h0d7c4cb_5.tar.bz2
linux-64::pillow-9.1.0-py39hae2aec6_0.tar.bz2
linux-64::tiledb-2.8.3-h1e4a385_0.tar.bz2
linux-64::protozfits-2.0.1.post1-py310hc96baa2_8.tar.bz2
linux-64::harp-1.15-py310r40h2b6cc9b_1.tar.bz2
linux-64::jaxlib-0.3.0-py38h9fff4b3_4.tar.bz2
linux-64::coda-2.23.1-py39h665c6b1_1.tar.bz2
linux-64::libtiledb-sql-0.14.2-h204bf05_0.tar.bz2
linux-64::vowpalwabbit-9.1.0-py38hb8f647c_0.tar.bz2
linux-64::libcurl-static-7.83.0-h7bff187_0.tar.bz2
linux-64::pdal-2.4.0-ha5eef6e_3.tar.bz2
linux-64::gmsh-4.10.2-hee323ce_0.tar.bz2
linux-64::arrow-cpp-3.0.0-py310h8bc34b8_50_cpu.tar.bz2
linux-64::vigra-1.11.1-py39h21e563c_1031.tar.bz2
linux-64::arrow-cpp-8.0.0-py310hdc7e031_1_cuda.tar.bz2
linux-64::harp-1.15-py39r41he2a1b48_1.tar.bz2
linux-64::libxmlsec1-1.2.34-h5614a37_0.tar.bz2
linux-64::arrow-cpp-8.0.0-py310h78b1107_1_cpu.tar.bz2
linux-64::jaxlib-0.3.7-py38ha7251e3_0.tar.bz2
linux-64::arrow-cpp-3.0.0-py37h2573e4e_50_cpu.tar.bz2
linux-64::grpc-cpp-1.44.0-he70e3f0_4.tar.bz2
linux-64::llvmlite-0.38.0-py39h6b9fe7f_1.tar.bz2
linux-64::tensorflow-base-2.8.1-cuda102py38ha005362_0.tar.bz2
linux-64::arrow-cpp-5.0.0-py310h8bc34b8_33_cpu.tar.bz2
linux-64::arrow-cpp-5.0.0-py38hd79a172_34_cpu.tar.bz2
linux-64::arrow-cpp-6.0.1-py38h9f00d1f_14_cpu.tar.bz2
linux-64::arrow-cpp-3.0.0-py37h2573e4e_52_cpu.tar.bz2
linux-64::libopencv-4.5.5-py310h1897127_9.tar.bz2
linux-64::tensorflow-base-2.8.1-cpu_py38hc7a75a0_0.tar.bz2
linux-64::nginx-1.21.6-h27a1cb2_1.tar.bz2
linux-64::tensorflow-base-2.8.0-cuda111py38hf76636f_0.tar.bz2
linux-64::arrow-cpp-6.0.1-py38hbda2956_14_cuda.tar.bz2
linux-64::gct-6.2.1629922860-h727a467_1.tar.bz2
linux-64::arrow-cpp-5.0.0-py39h7582941_32_cuda.tar.bz2
linux-64::ortools-cpp-9.2-h20a92b3_2.tar.bz2
linux-64::arrow-cpp-5.0.0-py310h8bc34b8_34_cpu.tar.bz2
linux-64::arrow-cpp-3.0.0-py310h38b329a_49_cpu.tar.bz2
linux-64::ortools-cpp-9.2-h5d3e929_4.tar.bz2
linux-64::mysql-router-8.0.28-h77522e6_4.tar.bz2
linux-64::pillow-9.1.0-py38h9267336_2.tar.bz2
linux-64::root_base-6.26.2-py38h412b378_2.tar.bz2
linux-64::pyinstaller-5.0-py310ha400145_0.tar.bz2
linux-64::vigra-1.11.1-py38hadd2de3_1031.tar.bz2
linux-64::tiledb-2.8.2-h1e4a385_0.tar.bz2
linux-64::pyinstaller-5.0-py37he2f7bc2_0.tar.bz2
linux-64::libtensorflow_cc-2.8.0-cuda112h98e1010_0.tar.bz2
linux-64::libprotobuf-3.20.1-h6239696_0.tar.bz2
linux-64::arrow-cpp-6.0.1-py310h8bc34b8_17_cpu.tar.bz2
linux-64::pillow-9.1.0-py39hae2aec6_2.tar.bz2
linux-64::arrow-cpp-8.0.0-py37h0d6303b_1_cpu.tar.bz2
linux-64::grpc-cpp-1.45.1-h38f6961_1.tar.bz2
linux-64::grpcio-1.46.3-py37he500948_0.tar.bz2
linux-64::coda-2.23.1-py39he2a1b48_1.tar.bz2
linux-64::grpc-cpp-1.46.3-h0b91f02_0.tar.bz2
linux-64::arrow-cpp-8.0.0-py39h9f30d2d_1_cuda.tar.bz2
linux-64::root_base-6.26.2-py39h9749efa_2.tar.bz2
linux-64::ortools-cpp-9.2-h099f77f_5.tar.bz2
linux-64::conduit-0.8.3-py38h1bdec9d_0.tar.bz2
linux-64::tensorflow-base-2.7.1-cuda111py38h13b88b6_0.tar.bz2
linux-64::arrow-cpp-7.0.0-py38h8d849fc_4_cpu.tar.bz2
linux-64::indexed_gzip-1.6.13-py37h7dba1dc_1.tar.bz2
linux-64::rstudio-desktop-2022.02.2-r40h85c7ee8_486.tar.bz2
linux-64::tensorflow-base-2.8.1-cuda102py37hbbf6b52_0.tar.bz2
linux-64::triton-1.1.2-cuda110py38hcaa5fcb_0.tar.bz2
linux-64::libcurl-7.83.1-h7bff187_0.tar.bz2
linux-64::dotnet-aspnetcore-5.0.16-h751d214_0.tar.bz2
linux-64::emacs-28.1-hd32cc88_0.tar.bz2
linux-64::pyreadstat-1.1.4-py39hd38ffc4_1.tar.bz2
linux-64::nordugrid-arc-6.15.1-py37h95c8341_0.tar.bz2
linux-64::harp-1.15-py38r41h378a090_1.tar.bz2
linux-64::readdy-2.0.11-py38h2aaa93b_1.tar.bz2
linux-64::grpcio-1.46.0-py37h0327239_1.tar.bz2
linux-64::arrow-cpp-5.0.0-py38h96de00c_29_cuda.tar.bz2
linux-64::arrow-cpp-6.0.1-py39h54e1b86_14_cpu.tar.bz2
linux-64::subversion-1.14.2-pl5321h7f4fec2_1.tar.bz2
linux-64::erlang-24.3.4-pl5321hb9e9383_0.tar.bz2
linux-64::ffmpeg-5.0.1-h594f047_1.tar.bz2
linux-64::arrow-cpp-5.0.0-py39h54e1b86_29_cpu.tar.bz2
linux-64::pygrib-2.1.4-py39h7abfc60_5.tar.bz2
linux-64::grpc-cpp-1.43.2-h9e046d8_3.tar.bz2
linux-64::jaxlib-0.3.2-py37ha917288_0.tar.bz2
linux-64::arrow-cpp-6.0.1-py310hdade202_18_cuda.tar.bz2
linux-64::imagecodecs-2022.2.22-py310h31a0021_5.tar.bz2
linux-64::arrow-cpp-8.0.0-py39h74dfcfe_1_cpu.tar.bz2
linux-64::jaxlib-0.3.7-py310h93e7e90_0.tar.bz2
linux-64::arrow-cpp-6.0.1-py37h2573e4e_17_cpu.tar.bz2
linux-64::yoda-1.9.4-py38h3b1bcf3_2.tar.bz2
linux-64::libtensorflow-2.7.1-cuda111h95e6cbe_0.tar.bz2
linux-64::vigra-1.11.1-py38h2064be1_1032.tar.bz2
linux-64::llvmlite-0.38.1-py39h6b9fe7f_0.tar.bz2
linux-64::jaxlib-0.3.10-cpu_py38hcb1c0b8_0.tar.bz2
linux-64::arrow-cpp-7.0.0-py38h56c1a66_5_cuda.tar.bz2
linux-64::libtensorflow-2.8.0-cuda110h83f852c_0.tar.bz2
linux-64::ambertools-22.0-py37ha6f76a1_0.tar.bz2
linux-64::paraview-5.10.1-py39hf9a8f70_105_qt.tar.bz2
linux-64::arrow-cpp-5.0.0-py39h15c4769_34_cpu.tar.bz2
linux-64::cmake-3.23.2-h5432695_0.tar.bz2
linux-64::arrow-cpp-6.0.1-py310h8bc34b8_16_cpu.tar.bz2
linux-64::triton-1.1.2-cuda102py39h2ace330_0.tar.bz2
linux-64::pyreadstat-1.1.5-py38he5536e0_0.tar.bz2
linux-64::arrow-cpp-5.0.0-py37hc1bcd19_34_cuda.tar.bz2
linux-64::mysql-libs-8.0.28-h28c427c_4.tar.bz2
linux-64::harp-1.15.1-py37r41hcb5871f_0.tar.bz2
linux-64::lammps-2021.09.29-py37h337c22e_mpich_3.tar.bz2
linux-64::pp-sketchlib-2.0.0-py39h5d89285_0.tar.bz2
linux-64::ovito-3.7.2-h5126075_2.tar.bz2
linux-64::jaxlib-0.3.7-py310hb11b1dd_0.tar.bz2
linux-64::vtk-9.1.0-egl_py39h3374e66_8.tar.bz2
linux-64::grpc-cpp-1.45.2-hd8f4eba_3.tar.bz2
linux-64::poppler-qt-22.04.0-hf358c63_0.tar.bz2
linux-64::pyinstaller-5.0.1-py38he5536e0_0.tar.bz2
linux-64::libtensorflow-2.8.1-cuda112h918e9ab_0.tar.bz2
linux-64::arrow-cpp-7.0.0-py37he172e40_7_cuda.tar.bz2
linux-64::libtensorflow-2.7.1-cuda112h98e1010_0.tar.bz2
linux-64::gdstk-0.8.2-py38h0048722_1.tar.bz2
linux-64::mysql-client-8.0.29-hf89ab62_1.tar.bz2
linux-64::arrow-cpp-5.0.0-py39h1e51584_34_cuda.tar.bz2
linux-64::tensorflow-base-2.7.1-cuda112py38h1f4bd8a_0.tar.bz2
linux-64::arrow-cpp-6.0.1-py37h2573e4e_16_cpu.tar.bz2
linux-64::arrow-cpp-8.0.0-py310h8e8b783_1_cuda.tar.bz2
linux-64::arrow-cpp-3.0.0-py37he5bb92b_48_cuda.tar.bz2
linux-64::tiledb-2.9.1-h1e4a385_0.tar.bz2
linux-64::tensorflow-base-2.8.1-cuda102py39h1759960_0.tar.bz2
linux-64::root_base-6.26.2-py37ha671a63_3.tar.bz2
linux-64::grpc-cpp-1.45.2-h3c5545a_0.tar.bz2
linux-64::pypy3.8-7.3.9-h5bd2d06_1.tar.bz2
linux-64::cctools_osx-64-973.0.1-hd2fa2e2_10.tar.bz2
linux-64::mandrake-1.2.2-py310hf29f3b8_0.tar.bz2
linux-64::gemmi-0.5.4-py38h38d86a4_0.tar.bz2
linux-64::tensorflow-base-2.8.1-cuda110py37ha2ed0d1_0.tar.bz2
linux-64::arrow-cpp-8.0.0-py38h56c1a66_0_cuda.tar.bz2
linux-64::mysql-connector-cpp-8.0.29-hf18ea70_0.tar.bz2
linux-64::arrow-cpp-7.0.0-py39h74dfcfe_7_cpu.tar.bz2
linux-64::arrow-cpp-5.0.0-py38h9550bf3_32_cpu.tar.bz2
linux-64::libtensorflow_cc-2.7.1-cpu_h5cd7c79_0.tar.bz2
linux-64::libtiledb-sql-0.14.0-h0993566_0.tar.bz2
linux-64::pp-sketchlib-2.0.0-py310hd0ee772_0.tar.bz2
linux-64::arrow-cpp-5.0.0-py38h7b9fa56_30_cpu.tar.bz2
linux-64::postgresql-plpython-14.3-py37h7d20ccc_0.tar.bz2
linux-64::libtiledb-sql-0.14.2-h204bf05_1.tar.bz2
linux-64::arrow-cpp-7.0.0-py38hf79e478_4_cuda.tar.bz2
linux-64::grpc-cpp-1.44.0-h9e046d8_2.tar.bz2
linux-64::jaxlib-0.3.10-cuda112py37h13d6ec4_0.tar.bz2
linux-64::ndcctools-7.4.5-py37he500948_0.tar.bz2
linux-64::arrow-cpp-7.0.0-py310hf3556ec_5_cpu.tar.bz2
linux-64::libgdal-3.4.2-h5750acb_5.tar.bz2
linux-64::ipe-7.2.24-lua54hfb40d6d_6.tar.bz2
linux-64::ortools-cpp-9.2-he0e45df_5.tar.bz2
linux-64::tensorflow-base-2.8.0-cuda102py37h09db7f3_0.tar.bz2
linux-64::grpcio-1.46.1-py39h0f497a6_0.tar.bz2
linux-64::arrow-cpp-3.0.0-py37h2573e4e_53_cpu.tar.bz2
linux-64::postgresql-plpython-14.3-py39h4325d1c_0.tar.bz2
linux-64::openmpi-4.1.3-h846660c_103.tar.bz2
linux-64::pypy3.9-7.3.9-h56abe6f_2.tar.bz2
linux-64::grpc-cpp-1.44.0-hdffacd0_3.tar.bz2
linux-64::arrow-cpp-8.0.0-py37h0d6303b_0_cpu.tar.bz2
linux-64::paraview-5.10.1-h6f04dd4_4_egl.tar.bz2
linux-64::arrow-cpp-5.0.0-py37hc1bcd19_32_cuda.tar.bz2
linux-64::arrow-cpp-6.0.1-py39h7582941_17_cuda.tar.bz2
linux-64::pillow-9.1.1-py37h44f0d7a_0.tar.bz2
linux-64::pypy3.9-7.3.8-h986b250_2.tar.bz2
linux-64::grpc-cpp-1.43.2-h4315cb9_3.tar.bz2
linux-64::libvips-8.12.2-h4a8a4d3_4.tar.bz2
linux-64::lammps-2021.09.29-py37h63002c2_mpich_3.tar.bz2
linux-64::folly-2022.04.04.00-h1234567_1_jemalloc.tar.bz2
linux-64::arrow-cpp-8.0.0-py310h8cf3212_1_cuda.tar.bz2
linux-64::xrootd-5.4.2-py39hc7bb5bc_0.tar.bz2
linux-64::coda-2.23.1-py38h234bf9d_1.tar.bz2
linux-64::jaxlib-0.3.10-cpu_py310hacd7525_0.tar.bz2
linux-64::arrow-cpp-3.0.0-py37hc1bcd19_53_cuda.tar.bz2
linux-64::grpcio-1.46.3-py310h44b9e0c_0.tar.bz2
linux-64::arrow-cpp-6.0.1-py310hdade202_19_cuda.tar.bz2
linux-64::r-httpgd-1.3.0-r40h6dc9d2f_0.tar.bz2
linux-64::ndcctools-7.4.5-py38h2e9ca35_0.tar.bz2
linux-64::cppyy-cling-6.25.3-py39h13b352c_1.tar.bz2
linux-64::paraview-5.10.1-py37hf4adb0b_5_egl.tar.bz2
linux-64::ndcctools-7.4.4-py310hba10ccf_0.tar.bz2
linux-64::grpc-cpp-1.43.2-ha1152e8_4.tar.bz2
linux-64::arrow-cpp-5.0.0-py38h9550bf3_31_cpu.tar.bz2
linux-64::yoda-1.9.4-py39hcd944d7_2.tar.bz2
linux-64::jaxlib-0.3.10-cpu_py310h0283394_0.tar.bz2
linux-64::paraview-5.10.1-py39h51f1d71_5_egl.tar.bz2
linux-64::grpcio-1.46.3-py37h0327239_0.tar.bz2
linux-64::arrow-cpp-6.0.1-py38h9de5444_16_cuda.tar.bz2
linux-64::libcurl-7.83.0-h2283fc2_0.tar.bz2
linux-64::openssh-9.0p1-h67c24c5_0.tar.bz2
linux-64::lmod-8.7.2-lua54h71fc533_0.tar.bz2
linux-64::r-httpgd-1.3.0-r41h6dc9d2f_0.tar.bz2
linux-64::erlang-25.0-pl5321h5001644_0.tar.bz2
linux-64::jaxlib-0.3.2-py310h9eaf4a5_0.tar.bz2
linux-64::curl-7.83.1-h2283fc2_0.tar.bz2
linux-64::pypy3.8-7.3.9-h5001382_2.tar.bz2
linux-64::grpc-cpp-1.43.2-hdffacd0_4.tar.bz2
linux-64::tensorflow-base-2.8.1-cuda111py38hf8a263a_0.tar.bz2
linux-64::pdal-2.4.1-hec91d99_0.tar.bz2
linux-64::qt-webengine-5.15.4-hefd91c5_2.tar.bz2
linux-64::mysql-server-8.0.29-h4e426d9_0.tar.bz2
linux-64::libtensorflow-2.8.1-cpu_haf14b92_0.tar.bz2
linux-64::grpc-cpp-1.46.0-h3ebbd8c_0.tar.bz2
linux-64::arrow-cpp-5.0.0-py38h9de5444_32_cuda.tar.bz2
linux-64::nd2-0.2.4-py37h1425b33_0.tar.bz2
linux-64::qt-main-5.15.3-hf97cb25_1.tar.bz2
linux-64::pytng-0.2.2-py310hd25046b_2.tar.bz2
linux-64::cctools_osx-64-973.0.1-h4a160ef_10.tar.bz2
linux-64::gdstk-0.8.2-py37hcceba20_1.tar.bz2
linux-64::sqlite-3.38.4-h4ff8645_0.tar.bz2
linux-64::grpc-cpp-1.45.2-h3ebbd8c_1.tar.bz2
linux-64::grpc-cpp-1.43.2-he70e3f0_5.tar.bz2
linux-64::root_base-6.24.6-py38h412b378_2.tar.bz2
linux-64::imagecodecs-2022.2.22-py38hf887e2c_3.tar.bz2
linux-64::arrow-cpp-6.0.1-py310h27e2bb1_14_cpu.tar.bz2
linux-64::tensorflow-base-2.7.1-cuda102py310h5611d22_0.tar.bz2
linux-64::root_base-6.26.2-py310h59af190_1.tar.bz2
linux-64::libopencv-4.5.5-py37h56d80eb_8.tar.bz2
linux-64::mongodb-5.1.1-h64e8455_3.tar.bz2
linux-64::arrow-cpp-6.0.1-py39hb94f1ed_14_cuda.tar.bz2
linux-64::harp-1.15-py38r40h378a090_1.tar.bz2
linux-64::arrow-cpp-3.0.0-py37hace919c_49_cpu.tar.bz2
linux-64::coin-or-cgl-0.60.6-he2f9439_0.tar.bz2
linux-64::arrow-cpp-5.0.0-py38h9550bf3_34_cpu.tar.bz2
linux-64::arrow-cpp-3.0.0-py39h15c4769_53_cpu.tar.bz2
linux-64::vigra-1.11.1-py37hdb352e6_1032.tar.bz2
linux-64::nd2-0.2.3-py37h1425b33_0.tar.bz2
linux-64::arrow-cpp-3.0.0-py39h7582941_52_cuda.tar.bz2
linux-64::tensorflow-base-2.8.0-cuda112py38h6a3b174_0.tar.bz2
linux-64::harp-1.15-py39r40he2a1b48_1.tar.bz2
linux-64::pillow-9.1.0-py310he619898_2.tar.bz2
linux-64::arrow-cpp-3.0.0-py37hc1bcd19_52_cuda.tar.bz2
linux-64::libxml2-2.9.13-h22db469_0.tar.bz2
linux-64::grpcio-1.46.1-py39h7fbbf82_0.tar.bz2
linux-64::py-bgzip-0.4.0-py38h1795236_2.tar.bz2
linux-64::yoda-1.9.4-py39hf57fb9a_2.tar.bz2
linux-64::mysql-server-8.0.29-h356294a_1.tar.bz2
linux-64::mysql-client-8.0.29-h92c5bc7_0.tar.bz2
linux-64::pygrib-2.1.4-py39hb9ab73c_5.tar.bz2
linux-64::pyinstaller-5.0-py38he5536e0_0.tar.bz2
linux-64::arrow-cpp-3.0.0-py310hdade202_53_cuda.tar.bz2
linux-64::tensorflow-base-2.8.1-cpu_py39h45807a0_0.tar.bz2
linux-64::curl-7.83.1-h7bff187_0.tar.bz2
linux-64::coda-2.24-py38h234bf9d_0.tar.bz2
linux-64::mongodb-5.1.1-h6f82f1e_2.tar.bz2
linux-64::jaxlib-0.3.7-py310ha0f05d8_0.tar.bz2
linux-64::arrow-cpp-7.0.0-py37hffe81f3_4_cuda.tar.bz2
linux-64::grpc-cpp-1.45.2-h3ebbd8c_3.tar.bz2
linux-64::arrow-cpp-7.0.0-py310h8e8b783_6_cuda.tar.bz2
linux-64::lmod-8.6.18-lua54h71fc533_0.tar.bz2
linux-64::vigra-1.11.1-py37h5d33f1d_1032.tar.bz2
linux-64::pillow-9.1.0-py37h44f0d7a_2.tar.bz2
linux-64::openmpi-4.1.3-h414127c_0.tar.bz2
linux-64::ortools-cpp-9.2-hedc821d_3.tar.bz2
linux-64::tiledb-2.8.0-h3f4058f_1.tar.bz2
linux-64::arrow-cpp-5.0.0-py37h3331901_29_cuda.tar.bz2
linux-64::root_base-6.24.6-py39h9749efa_2.tar.bz2
linux-64::gdcm-2.8.9-py310h7e54b22_5.tar.bz2
linux-64::ndcctools-7.4.4-py37h0327239_0.tar.bz2
linux-64::jaxlib-0.3.10-cpu_py37h86b75d4_0.tar.bz2
linux-64::arrow-cpp-5.0.0-py39h7582941_34_cuda.tar.bz2
linux-64::grpc-cpp-1.45.2-h38f6961_0.tar.bz2
linux-64::indexed_gzip-1.6.13-py39hc217eb8_1.tar.bz2
linux-64::arrow-cpp-6.0.1-py310hd28874a_14_cuda.tar.bz2
linux-64::osmium-tool-1.14.0-h41609fd_1.tar.bz2
linux-64::qtwebkit-5.212-h7e02eee_5.tar.bz2
linux-64::grpcio-1.46.3-py39h0f497a6_0.tar.bz2
linux-64::py-bgzip-0.4.0-py39h197971b_2.tar.bz2
linux-64::nodejs-17.9.0-h8839609_0.tar.bz2
linux-64::paraview-5.10.1-hf4adb0b_4_egl.tar.bz2
linux-64::yoda-1.9.4-py37h60e1006_2.tar.bz2
linux-64::pp-sketchlib-2.0.0-py39h30129f5_0.tar.bz2
linux-64::tensorflow-base-2.8.0-cuda112py39h99c2b39_0.tar.bz2
linux-64::triton-1.1.2-cuda110py37hfb8431b_0.tar.bz2
linux-64::arrow-cpp-8.0.0-py37ha08e9a0_1_cuda.tar.bz2
linux-64::octave-7.1.0-hf58b02f_0.tar.bz2
linux-64::squashfs-tools-4.4-hd0129a2_3.tar.bz2
linux-64::arrow-cpp-5.0.0-py37hbaedfe8_29_cpu.tar.bz2
linux-64::gdcm-2.8.9-py38hec3b736_5.tar.bz2
linux-64::ndcctools-7.4.4-py38ha0cdfde_0.tar.bz2
linux-64::rstudio-desktop-2022.02.2-r40h85c7ee8_0.tar.bz2
linux-64::tensorflow-base-2.8.0-cpu_py38hdf8f09a_0.tar.bz2
linux-64::libtensorflow-2.8.1-cuda102he5e4e4b_0.tar.bz2
linux-64::arrow-cpp-6.0.1-py39h15c4769_19_cpu.tar.bz2
linux-64::tensorflow-base-2.8.0-cuda102py310h42bbde6_0.tar.bz2
linux-64::gsoap-2.8.121-h598caef_0.tar.bz2
linux-64::arrow-cpp-3.0.0-py37h3331901_48_cuda.tar.bz2
linux-64::paraview-5.10.1-h51f1d71_4_egl.tar.bz2
linux-64::harp-1.15.1-py38r40h234bf9d_0.tar.bz2
linux-64::arrow-cpp-6.0.1-py38h96de00c_14_cuda.tar.bz2
linux-64::grpcio-1.46.0-py310hba10ccf_1.tar.bz2
linux-64::arrow-cpp-6.0.1-py37hce248a4_15_cuda.tar.bz2
linux-64::ortools-cpp-9.2-h9620cb3_5.tar.bz2
linux-64::arrow-cpp-6.0.1-py37h9a5a6ad_19_cpu.tar.bz2
linux-64::vtk-9.1.0-osmesa_py37h29869c8_108.tar.bz2
linux-64::pyreadstat-1.1.6-py38he5536e0_0.tar.bz2
linux-64::triton-1.1.2-cuda111py39h15fc884_0.tar.bz2
linux-64::indexed_gzip-1.6.13-py38h3b715e4_0.tar.bz2
linux-64::arrow-cpp-5.0.0-py310hdade202_31_cuda.tar.bz2
linux-64::grpcio-1.46.0-py38h2e9ca35_1.tar.bz2
linux-64::arrow-cpp-8.0.0-py310hf3556ec_0_cpu.tar.bz2
linux-64::kaldi-5.5.1016-cuda110h7b400ab_1.tar.bz2
linux-64::libssh-0.8.9-h727a467_2.tar.bz2
linux-64::coda-2.24-py38h378a090_0.tar.bz2
linux-64::ortools-python-9.2-py39h3e85001_4.tar.bz2
linux-64::arrow-cpp-3.0.0-py310hdade202_52_cuda.tar.bz2
linux-64::libtensorflow_cc-2.8.1-cuda102he5e4e4b_0.tar.bz2
linux-64::libtensorflow_cc-2.8.0-cpu_h5cd7c79_0.tar.bz2
linux-64::pyinstaller-5.1-py38he5536e0_0.tar.bz2
linux-64::tensorflow-base-2.7.1-cpu_py39hfb6d7af_0.tar.bz2
linux-64::arrow-cpp-3.0.0-py39h15c4769_52_cpu.tar.bz2
linux-64::arrow-cpp-3.0.0-py38h9550bf3_51_cpu.tar.bz2
linux-64::py-bgzip-0.4.0-py37he2f7bc2_2.tar.bz2
linux-64::ortools-cpp-9.2-h9620cb3_4.tar.bz2
linux-64::root_base-6.26.2-py38h412b378_3.tar.bz2
linux-64::pypy3.8-7.3.9-h5bd2d06_0.tar.bz2
linux-64::xrootd-5.4.2-py38h3b6881a_0.tar.bz2
linux-64::ndcctools-7.4.4-py39h7fbbf82_0.tar.bz2
linux-64::mongodb-5.1.1-h0e13805_3.tar.bz2
linux-64::pp-sketchlib-2.0.0-py38h2dfb0b6_0.tar.bz2
linux-64::arrow-cpp-5.0.0-py37h2573e4e_31_cpu.tar.bz2
linux-64::assimp-5.2.4-h4c92fa2_0.tar.bz2
linux-64::zstd-1.5.2-h8a70e8d_1.tar.bz2
linux-64::triton-1.1.2-cuda110py39h289e8e7_0.tar.bz2
linux-64::libtensorflow_cc-2.7.1-cuda110h83f852c_0.tar.bz2
linux-64::hugin-2021.0.0-pl5321h8503502_5.tar.bz2
linux-64::root_base-6.24.6-py39h9749efa_3.tar.bz2
linux-64::pillow-9.1.0-py38h9267336_1.tar.bz2
linux-64::grpcio-1.46.0-py37he500948_0.tar.bz2
linux-64::pillow-9.1.1-py39hae2aec6_0.tar.bz2
linux-64::vtk-9.1.0-egl_py38h3346cfb_8.tar.bz2
linux-64::llvmdev-14.0.4-he0ac6c6_0.tar.bz2
linux-64::arrow-cpp-8.0.0-py310h178c6ae_1_cpu.tar.bz2
linux-64::harp-1.15-py38r41h234bf9d_1.tar.bz2
linux-64::ortools-python-9.2-py39h3e85001_5.tar.bz2
linux-64::grpc-cpp-1.44.0-hb0d6e40_3.tar.bz2
linux-64::arrow-cpp-7.0.0-py310h178c6ae_7_cpu.tar.bz2
linux-64::arrow-cpp-6.0.1-py310hd126ce0_19_cpu.tar.bz2
linux-64::arrow-cpp-6.0.1-py38h9550bf3_19_cpu.tar.bz2
linux-64::folly-2022.04.04.00-h1234567_1.tar.bz2
linux-64::triton-1.1.2-cuda112py37h6f56f88_0.tar.bz2
linux-64::poppler-22.04.0-h1434ded_0.tar.bz2
linux-64::ndcctools-7.4.5-py39h0f497a6_0.tar.bz2
linux-64::ortools-cpp-9.2-h69b0a62_3.tar.bz2
linux-64::jaxlib-0.3.0-py37ha917288_4.tar.bz2
linux-64::dotnet-runtime-3.1.24-h751d214_0.tar.bz2
linux-64::arrow-cpp-3.0.0-py310h8bc34b8_51_cpu.tar.bz2
linux-64::tensorflow-base-2.8.0-cuda110py37h9acc0b3_0.tar.bz2
linux-64::grpc-cpp-1.45.2-he70e3f0_1.tar.bz2
linux-64::harp-1.15.1-py39r40h665c6b1_0.tar.bz2
linux-64::libtensorflow-2.8.0-cpu_h5cd7c79_0.tar.bz2
linux-64::tensorflow-base-2.7.1-cuda111py37hdeab154_0.tar.bz2
linux-64::ortools-cpp-9.2-h9620cb3_2.tar.bz2
linux-64::hugin-base-2021.0.0-py37pl5321hf27b994_5.tar.bz2
linux-64::vtk-9.1.0-osmesa_py38hfe2dfd5_108.tar.bz2
linux-64::shrinkwrap-1.2.0-h8332532_0.tar.bz2
linux-64::grpcio-1.46.1-py310h44b9e0c_0.tar.bz2
linux-64::grpcio-1.46.0-py310hba10ccf_0.tar.bz2
linux-64::lighttpd-1.4.64-lua54h941b3f9_0.tar.bz2
linux-64::postgresql-plpython-14.3-py310h8a5a08d_0.tar.bz2
linux-64::ortools-python-9.2-py39h3e85001_3.tar.bz2
linux-64::imagecodecs-2022.2.22-py38h1fd79ab_2.tar.bz2
linux-64::libtensorflow_cc-2.8.1-cuda112h918e9ab_0.tar.bz2
linux-64::smesh-9.7.0.1-hb36138d_1.tar.bz2
linux-64::pillow-9.1.0-py39habab96e_2.tar.bz2
linux-64::libfido2-1.11.0-he49606f_0.tar.bz2
linux-64::grpc-cpp-1.45.1-h1021d7f_0.tar.bz2
linux-64::jaxlib-0.3.7-py37h0d9465a_0.tar.bz2
linux-64::tensorflow-base-2.7.1-cuda112py310h680fca1_0.tar.bz2
linux-64::pyreadstat-1.1.5-py39hd08d98e_0.tar.bz2
linux-64::libtensorflow_cc-2.7.1-cuda112h98e1010_0.tar.bz2
linux-64::rsync-3.2.3-hfa40b15_4.tar.bz2
linux-64::arrow-cpp-7.0.0-py38h3ad7428_7_cpu.tar.bz2
linux-64::arrow-cpp-5.0.0-py37hce248a4_30_cuda.tar.bz2
linux-64::arrow-cpp-6.0.1-py37h8df67fa_19_cuda.tar.bz2
linux-64::arrow-cpp-5.0.0-py39he2ccf02_29_cpu.tar.bz2
linux-64::smesh-9.8.0.2-hf3572f8_0.tar.bz2
linux-64::arrow-cpp-7.0.0-py38he106920_7_cuda.tar.bz2
linux-64::arrow-cpp-8.0.0-py37hda8b9b9_1_cuda.tar.bz2
linux-64::libgdal-3.5.0-h3886835_0.tar.bz2
linux-64::kaldi-5.5.1016-cuda110h36dbd2a_2.tar.bz2
linux-64::grpc-cpp-1.44.0-h3d78c48_2.tar.bz2
linux-64::imagecodecs-2022.2.22-py38h43af60f_5.tar.bz2
linux-64::jaxlib-0.3.0-py38h617afa0_4.tar.bz2
linux-64::erlang-25.0-pl5321hb9e9383_0.tar.bz2
linux-64::pyreadstat-1.1.4-py37h6828927_1.tar.bz2
linux-64::jaxlib-0.3.10-cuda112py310h9def920_0.tar.bz2
linux-64::pypy3.9-7.3.9-h986b250_0.tar.bz2
linux-64::mysql-libs-8.0.29-h28c427c_0.tar.bz2
linux-64::jaxlib-0.3.10-cpu_py39h320bf12_0.tar.bz2
linux-64::dotnet-sdk-3.1.418-h751d214_0.tar.bz2
linux-64::harp-1.15-py38r40h234bf9d_1.tar.bz2
linux-64::mandrake-1.2.2-py310h55d1516_0.tar.bz2
linux-64::vtk-9.1.0-egl_py37hc3f521b_8.tar.bz2
linux-64::libopencv-4.5.5-py38h2380011_9.tar.bz2
linux-64::curl-7.83.0-h2283fc2_0.tar.bz2
linux-64::pypy3.8-7.3.8-h5001382_2.tar.bz2
linux-64::nordugrid-arc-6.15.1-py39head2539_0.tar.bz2
linux-64::vtk-9.1.0-egl_py310hb16941e_8.tar.bz2
linux-64::pypy3.8-7.3.9-h5bd2d06_2.tar.bz2
linux-64::arrow-cpp-7.0.0-py37h6c59e74_7_cpu.tar.bz2
linux-64::cppyy-cling-6.25.3-py310hd64a29c_1.tar.bz2
linux-64::grpc-cpp-1.43.2-hffcb1d1_5.tar.bz2
linux-64::libtensorflow-2.8.0-cuda102h62ca224_0.tar.bz2
linux-64::mysql-server-8.0.28-hb19efba_3.tar.bz2
linux-64::libtensorflow-2.8.1-cuda111hd17d044_0.tar.bz2
linux-64::libtiledb-sql-0.14.0-h204bf05_0.tar.bz2
linux-64::arrow-cpp-7.0.0-py39heccc63a_5_cpu.tar.bz2
linux-64::pygrib-2.1.4-py310h815554b_5.tar.bz2
linux-64::jaxlib-0.3.10-cuda112py39h2d0c158_0.tar.bz2
linux-64::llvmlite-0.38.1-py310h58363a5_0.tar.bz2
linux-64::pdal-2.4.1-hcbced32_0.tar.bz2
linux-64::ffmpeg-4.4.1-h594f047_3.tar.bz2
linux-64::kaldi-5.5.1016-cuda112h4f032a0_1.tar.bz2
linux-64::dotnet-sdk-6.0.202-h751d214_0.tar.bz2
linux-64::lammps-2021.09.29-py38hbba2188_openmpi_3.tar.bz2
linux-64::libarchive-3.5.2-hada088e_2.tar.bz2
linux-64::arrow-cpp-3.0.0-py38h7b9fa56_49_cpu.tar.bz2
linux-64::gemmi-0.5.3-py37h0761922_1.tar.bz2
linux-64::nordugrid-arc-6.15.1-py37haf68709_0.tar.bz2
linux-64::jaxlib-0.3.7-py310hd98629c_0.tar.bz2
linux-64::pyinstaller-5.0.1-py39hd08d98e_0.tar.bz2
linux-64::folly-2022.04.18.00-h1234567_1_jemalloc.tar.bz2
linux-64::indexed_gzip-1.6.13-py310hd25046b_1.tar.bz2
linux-64::gdb-11.2-py39ha81a3ae_0.tar.bz2
linux-64::libtensorflow-2.7.1-cpu_h5cd7c79_0.tar.bz2
linux-64::kaldi-5.5.1016-cuda112h1e989f9_2.tar.bz2
linux-64::ortools-cpp-9.2-h20a92b3_3.tar.bz2
linux-64::postgresql-plpython-14.3-py310he4beaea_0.tar.bz2
linux-64::libcurl-static-7.83.1-h7bff187_0.tar.bz2
linux-64::cppyy-cling-6.25.3-py39h3d66fe8_1.tar.bz2
linux-64::triton-1.1.2-cuda112py38h5f5293b_0.tar.bz2
linux-64::jaxlib-0.3.0-py37h35e2301_4.tar.bz2
linux-64::orc-1.7.3-h6c59b99_1.tar.bz2
linux-64::cctools_osx-arm64-973.0.1-h19b41c2_10.tar.bz2
linux-64::arrow-cpp-6.0.1-py38hcea13ed_19_cuda.tar.bz2
linux-64::arrow-cpp-5.0.0-py37h2573e4e_33_cpu.tar.bz2
linux-64::mongodb-5.1.1-h0a4f5e4_3.tar.bz2
linux-64::arrow-cpp-5.0.0-py39h15c4769_33_cpu.tar.bz2
linux-64::arrow-cpp-3.0.0-py39hf5daf42_49_cpu.tar.bz2
linux-64::rstudio-desktop-2022.02.2-r41haf5249e_487.tar.bz2
linux-64::pyinstaller-5.0.1-py310ha400145_0.tar.bz2
linux-64::tiledb-2.8.0-h1e4a385_0.tar.bz2
linux-64::lammps-2021.09.29-py39h0727609_openmpi_3.tar.bz2
linux-64::arrow-cpp-8.0.0-py38hfe422aa_0_cpu.tar.bz2
linux-64::arrow-cpp-7.0.0-py38h69b25f9_7_cpu.tar.bz2
linux-64::astrometry-0.90-py39h1bc5e43_0.tar.bz2
linux-64::arrow-cpp-3.0.0-py38h96de00c_48_cuda.tar.bz2
linux-64::cpp-opentelemetry-sdk-1.3.0-h8e9fcac_0.tar.bz2
linux-64::gdstk-0.8.2-py38h1082054_1.tar.bz2
linux-64::sqlite-3.38.2-h4ff8645_0.tar.bz2
linux-64::boost-cpp-1.79.0-h75c5d50_0.tar.bz2
linux-64::libtensorflow_cc-2.8.1-cuda111hd17d044_0.tar.bz2
linux-64::gfal2-2.20.5-h1edf11a_1.tar.bz2
linux-64::arrow-cpp-3.0.0-py39h15c4769_51_cpu.tar.bz2
linux-64::libfido2-1.11.0-h727a467_0.tar.bz2
linux-64::ambertools-22.0-py39h904b211_1.tar.bz2
linux-64::llvmlite-0.38.1-py38hb85eefc_0.tar.bz2
linux-64::vowpalwabbit-9.1.0-py37hf82bc1b_0.tar.bz2
linux-64::coda-2.24-py39he2a1b48_0.tar.bz2
linux-64::lmod-8.7.1-lua54h71fc533_0.tar.bz2
linux-64::arrow-cpp-7.0.0-py310hf480ae0_4_cuda.tar.bz2
linux-64::arrow-cpp-6.0.1-py39h15c4769_18_cpu.tar.bz2
linux-64::libmatio-1.5.23-hbddd3af_0.tar.bz2
linux-64::readdy-2.0.11-py39h199b6f5_1.tar.bz2
linux-64::grpc-cpp-1.43.2-h1021d7f_3.tar.bz2
linux-64::arrow-cpp-5.0.0-py38hbda2956_29_cuda.tar.bz2
linux-64::nd2-0.2.3-py38h28b09c2_0.tar.bz2
linux-64::tensorflow-base-2.8.1-cuda110py39h0baf056_0.tar.bz2
linux-64::astrometry-0.90-py37h274e8da_1.tar.bz2
linux-64::hugin-base-2021.0.0-py310pl5321hc7f0858_5.tar.bz2
linux-64::conduit-0.8.3-py37h84c38f1_0.tar.bz2
linux-64::mysql-client-8.0.29-h92c5bc7_1.tar.bz2
linux-64::jaxlib-0.3.7-py39hbe21494_0.tar.bz2
linux-64::pypy3.9-7.3.9-h56abe6f_0.tar.bz2
linux-64::pillow-9.1.0-py310he619898_1.tar.bz2
linux-64::harp-1.15.1-py310r40h2b6cc9b_0.tar.bz2
linux-64::coin-or-clp-1.17.7-h256e9bb_0.tar.bz2
linux-64::gdb-11.2-py37h3c3eb0b_0.tar.bz2
linux-64::arrow-cpp-5.0.0-py310hdade202_33_cuda.tar.bz2
linux-64::pillow-9.1.1-py39habab96e_0.tar.bz2
linux-64::pygrib-2.1.4-py38h3eaf8db_5.tar.bz2
linux-64::arrow-cpp-8.0.0-py39heccc63a_1_cpu.tar.bz2
linux-64::arrow-cpp-7.0.0-py37hda8b9b9_6_cuda.tar.bz2
linux-64::pillow-9.1.1-py38h0ee0e06_0.tar.bz2
linux-64::arrow-cpp-7.0.0-py39h965a45d_4_cpu.tar.bz2
linux-64::python-3.9.13-h9a8a25e_0_cpython.tar.bz2
linux-64::arrow-cpp-3.0.0-py39h15c4769_50_cpu.tar.bz2
linux-64::curl-7.83.0-h7bff187_0.tar.bz2
linux-64::arrow-cpp-5.0.0-py39hf5daf42_30_cpu.tar.bz2
linux-64::tiledb-2.7.2-h3f4058f_0.tar.bz2
linux-64::ruby-3.1.2-hc054e64_0.tar.bz2
linux-64::mysql-client-8.0.28-hf89ab62_3.tar.bz2
linux-64::jaxlib-0.3.10-cuda112py37h4498987_0.tar.bz2
linux-64::jaxlib-0.3.10-cuda112py38hc2be4d7_0.tar.bz2
linux-64::libgdal-3.4.3-h56144a5_0.tar.bz2
linux-64::tensorflow-base-2.8.0-cuda111py310h4626a94_0.tar.bz2
linux-64::root_base-6.24.6-py310h59af190_2.tar.bz2
linux-64::arrow-cpp-5.0.0-py310h4af13b5_30_cuda.tar.bz2
linux-64::folly-2022.04.25.00-h1234567_1.tar.bz2
linux-64::cpp-opentelemetry-sdk-1.3.0-hb354d1b_1.tar.bz2
linux-64::arrow-cpp-6.0.1-py39h15c4769_17_cpu.tar.bz2
linux-64::arrow-cpp-7.0.0-py310h78b1107_7_cpu.tar.bz2
linux-64::arrow-cpp-8.0.0-py39heccc63a_0_cpu.tar.bz2
linux-64::hugin-2021.0.0-pl5321hdbff1f4_5.tar.bz2
linux-64::dotnet-runtime-6.0.4-h751d214_0.tar.bz2
linux-64::mysql-server-8.0.28-h4e426d9_4.tar.bz2
linux-64::pygrib-2.1.4-py37h3568e82_5.tar.bz2
linux-64::gdb-11.2-py38h031a905_0.tar.bz2
linux-64::arrow-cpp-5.0.0-py38hcea13ed_34_cuda.tar.bz2
linux-64::yoda-1.9.5-py37hdcc22df_0.tar.bz2
linux-64::fenics-libdolfin-2019.1.0-h5206b72_30.tar.bz2
linux-64::arrow-cpp-5.0.0-py39ha560878_30_cuda.tar.bz2
linux-64::jaxlib-0.3.10-cpu_py37h115581e_0.tar.bz2
linux-64::subversion-1.14.2-pl5321h7f4fec2_0.tar.bz2
linux-64::ambertools-22.0-py38h6177452_0.tar.bz2
linux-64::llvmdev-14.0.3-he0ac6c6_0.tar.bz2
linux-64::ortools-cpp-9.2-hedc821d_5.tar.bz2
linux-64::imagecodecs-2022.2.22-py38h43af60f_4.tar.bz2
linux-64::ortools-cpp-9.2-h7f5da84_4.tar.bz2
linux-64::ortools-python-9.2-py310hc16a451_3.tar.bz2
linux-64::postgresql-14.3-ha7cec9f_0.tar.bz2
linux-64::imagemagick-7.1.0_33-pl5321heb7c40d_0.tar.bz2
linux-64::libtiledb-sql-0.14.2-h0993566_1.tar.bz2
linux-64::paraview-5.10.1-py310h1b0e405_5_egl.tar.bz2
linux-64::ffmpeg-4.4.1-h964e5f1_4.tar.bz2
linux-64::imagecodecs-2022.2.22-py310h7681b03_2.tar.bz2
linux-64::nd2-0.2.3-py39h155c9d3_0.tar.bz2
linux-64::git-2.35.2-pl5321h04cb727_0.tar.bz2
linux-64::tiledb-2.8.3-h3f4058f_0.tar.bz2
linux-64::libtensorflow_cc-2.8.0-cuda111h95e6cbe_0.tar.bz2
linux-64::arrow-cpp-5.0.0-py39hb94f1ed_29_cuda.tar.bz2
linux-64::pyreadstat-1.1.4-py38ha8cb210_1.tar.bz2
linux-64::jaxlib-0.3.7-py37h2da7e31_0.tar.bz2
linux-64::harp-1.15.1-py38r41h234bf9d_0.tar.bz2
linux-64::ffmpeg-5.0.1-h964e5f1_2.tar.bz2
linux-64::tensorflow-base-2.8.1-cuda110py38hb43e109_0.tar.bz2
linux-64::arrow-cpp-7.0.0-py37h0d6303b_6_cpu.tar.bz2
linux-64::grpcio-1.46.0-py38ha0cdfde_0.tar.bz2
linux-64::ortools-cpp-9.2-hf61c867_5.tar.bz2
linux-64::gdstk-0.8.2-py310h1b6b022_1.tar.bz2
linux-64::ortools-cpp-9.2-h9620cb3_3.tar.bz2
linux-64::grpc-cpp-1.45.2-he70e3f0_3.tar.bz2
linux-64::arrow-cpp-8.0.0-py37hcc8ad85_1_cpu.tar.bz2
linux-64::ndcctools-7.4.5-py39h7fbbf82_0.tar.bz2
linux-64::tensorflow-base-2.8.0-cuda110py38h974df97_0.tar.bz2
linux-64::arrow-cpp-7.0.0-py38h56c1a66_6_cuda.tar.bz2
linux-64::imagemagick-7.1.0_32-pl5321heb7c40d_0.tar.bz2
linux-64::jaxlib-0.3.7-py37ha1fbc7c_0.tar.bz2
linux-64::harp-1.15-py37r40hcb5871f_1.tar.bz2
linux-64::jaxlib-0.3.2-py39h2090319_0.tar.bz2
linux-64::pyreadstat-1.1.4-py37h97b672c_1.tar.bz2
linux-64::fish-3.4.1-h682823d_0.tar.bz2
linux-64::pyreadstat-1.1.6-py310ha400145_0.tar.bz2
linux-64::lammps-2021.09.29-py37h10e08dd_openmpi_3.tar.bz2
linux-64::mysql-router-8.0.28-h3c52d87_4.tar.bz2
linux-64::pytng-0.2.2-py37h7dba1dc_2.tar.bz2
linux-64::nordugrid-arc-6.15.1-py310ha92cc82_0.tar.bz2
linux-64::grpc-cpp-1.45.2-hffcb1d1_2.tar.bz2
linux-64::arrow-cpp-6.0.1-py38h9550bf3_18_cpu.tar.bz2
linux-64::jaxlib-0.3.7-py37hb571cb5_0.tar.bz2
linux-64::jaxlib-0.3.7-py38h26235c9_0.tar.bz2
linux-64::nodejs-17.9.0-h96d913c_0.tar.bz2
linux-64::gemmi-0.5.4-py38hb85eefc_0.tar.bz2
linux-64::blosc-1.21.1-h83bc5f7_3.tar.bz2
linux-64::tensorflow-base-2.8.1-cpu_py37h0ff5a03_0.tar.bz2
linux-64::arrow-cpp-6.0.1-py39ha560878_15_cuda.tar.bz2
linux-64::postgresql-14.3-hfdbbde3_0.tar.bz2
linux-64::blosc-1.21.1-h56a5e14_1.tar.bz2
linux-64::arrow-cpp-3.0.0-py310h8bc34b8_53_cpu.tar.bz2
linux-64::pillow-9.1.0-py38h0ee0e06_0.tar.bz2
linux-64::arrow-cpp-7.0.0-py39he577829_7_cuda.tar.bz2
linux-64::wgrib2-3.1.1-h126ae06_0.tar.bz2
linux-64::arrow-cpp-8.0.0-py37he172e40_1_cuda.tar.bz2
linux-64::yoda-1.9.4-py37hdcc22df_2.tar.bz2
linux-64::arrow-cpp-3.0.0-py38h9de5444_52_cuda.tar.bz2
linux-64::ortools-cpp-9.2-hd2ecba2_5.tar.bz2
linux-64::jaxlib-0.3.10-cpu_py39h79d7c74_0.tar.bz2
linux-64::libpq-14.3-hd77ab85_0.tar.bz2
linux-64::tiledb-2.8.0-h1e4a385_1.tar.bz2
linux-64::pygrib-2.1.4-py38haabd3d0_5.tar.bz2
linux-64::ortools-python-9.2-py310h1e2cddb_5.tar.bz2
linux-64::arrow-cpp-5.0.0-py38h9f00d1f_29_cpu.tar.bz2
linux-64::root_base-6.26.2-py37ha671a63_2.tar.bz2
linux-64::triton-1.1.2-cuda112py310heeff9ee_0.tar.bz2
linux-64::grpcio-1.46.0-py310h44b9e0c_1.tar.bz2
linux-64::pypy3.9-7.3.9-h986b250_1.tar.bz2
linux-64::libcurl-7.83.0-h7bff187_0.tar.bz2
linux-64::mysql-server-8.0.29-h356294a_0.tar.bz2
linux-64::conduit-0.8.3-py39h6bbf736_0.tar.bz2
linux-64::arrow-cpp-3.0.0-py38h609ca95_48_cpu.tar.bz2
linux-64::openjdk-11.0.9.1-hc6918da_3.tar.bz2
linux-64::paraview-5.10.1-hf9a8f70_104_qt.tar.bz2
linux-64::vtk-9.1.0-qt_py310hf3393c1_208.tar.bz2
linux-64::mandrake-1.2.2-py39ha68ccf9_0.tar.bz2
linux-64::dotnet-aspnetcore-3.1.24-h751d214_0.tar.bz2
linux-64::postgresql-plpython-14.3-py38h70534a9_0.tar.bz2
linux-64::arrow-cpp-5.0.0-py310hd126ce0_34_cpu.tar.bz2
linux-64::astrometry-0.90-py310h47ba2b7_1.tar.bz2
linux-64::ortools-cpp-9.2-h7f5da84_5.tar.bz2
linux-64::wxpython-4.1.1-py310hdb6c39c_6.tar.bz2
linux-64::mysql-router-8.0.29-h77522e6_1.tar.bz2
linux-64::arrow-cpp-8.0.0-py39he577829_1_cuda.tar.bz2
linux-64::vigra-1.11.1-py37hd967b22_1031.tar.bz2
linux-64::openjdk-11.0.9.1-h0750383_2.tar.bz2
linux-64::yoda-1.9.5-py310h7566c02_0.tar.bz2
linux-64::tensorflow-base-2.8.0-cuda102py38hcbbd5f6_0.tar.bz2
linux-64::pillow-9.1.0-py39hae2aec6_1.tar.bz2
linux-64::arrow-cpp-3.0.0-py37hc1bcd19_51_cuda.tar.bz2
linux-64::tensorflow-base-2.7.1-cuda102py39hbb9dcef_0.tar.bz2
linux-64::arrow-cpp-7.0.0-py37hd133864_4_cpu.tar.bz2
linux-64::hugin-2021.0.0-pl5321h3571a3b_5.tar.bz2
linux-64::wxpython-4.1.1-py37hecb6014_7.tar.bz2
linux-64::tensorflow-base-2.7.1-cpu_py37h6aa720e_0.tar.bz2
linux-64::ambertools-22.0-py39h904b211_0.tar.bz2
linux-64::tensorflow-base-2.8.1-cuda112py310h666ff7d_0.tar.bz2
linux-64::arrow-cpp-5.0.0-py38h9de5444_33_cuda.tar.bz2
linux-64::tensorflow-base-2.8.1-cuda102py310ha277fc2_0.tar.bz2
linux-64::grpc-cpp-1.44.0-ha1152e8_3.tar.bz2
linux-64::arrow-cpp-6.0.1-py39h7582941_16_cuda.tar.bz2
linux-64::grpc-cpp-1.44.0-h3ebbd8c_4.tar.bz2
linux-64::libopencv-4.5.5-py31h1897127_8.tar.bz2
linux-64::vtk-9.1.0-qt_py37hfbe70cb_208.tar.bz2
linux-64::ogre-1.10.12-h7cc4a1d_8.tar.bz2
linux-64::tensorflow-base-2.8.1-cuda111py39hab2865d_0.tar.bz2
linux-64::root_base-6.24.6-py38h412b378_3.tar.bz2
linux-64::jaxlib-0.3.7-py38h5a7fad5_0.tar.bz2
linux-64::tensorflow-base-2.8.0-cuda110py310h1d26a15_0.tar.bz2
linux-64::arrow-cpp-3.0.0-py39h7582941_50_cuda.tar.bz2
linux-64::coda-2.23.1-py38h378a090_1.tar.bz2
linux-64::grpc-cpp-1.46.3-hc275302_0.tar.bz2
linux-64::arrow-cpp-3.0.0-py39h1e51584_53_cuda.tar.bz2
linux-64::mysql-router-8.0.29-h77522e6_0.tar.bz2
linux-64::tensorflow-base-2.8.1-cuda112py38had2df90_0.tar.bz2
linux-64::yoda-1.9.5-py38h3b1bcf3_0.tar.bz2
linux-64::triton-1.1.2-cuda102py37h9eb71c4_0.tar.bz2
linux-64::tensorflow-base-2.7.1-cpu_py310h643b9b6_0.tar.bz2
linux-64::tensorflow-base-2.7.1-cpu_py38ha28dbe6_0.tar.bz2
linux-64::mysql-router-8.0.28-h49c25b6_3.tar.bz2
linux-64::ortools-cpp-9.2-h20a92b3_4.tar.bz2
linux-64::arrow-cpp-6.0.1-py310h4356942_19_cuda.tar.bz2
linux-64::jaxlib-0.3.10-cuda112py37had983bc_0.tar.bz2
linux-64::arrow-cpp-8.0.0-py38h3ad7428_1_cpu.tar.bz2
linux-64::arrow-cpp-3.0.0-py310hd126ce0_53_cpu.tar.bz2
linux-64::magics-4.12.0-he381006_0.tar.bz2
linux-64::ortools-cpp-9.2-h099f77f_4.tar.bz2
linux-64::librdkafka-1.8.2.post2-hcf600c6_1.tar.bz2
linux-64::arrow-cpp-5.0.0-py310hd28874a_29_cuda.tar.bz2
linux-64::arrow-cpp-5.0.0-py310h8bc34b8_32_cpu.tar.bz2
linux-64::libgdal-3.5.0-h56144a5_0.tar.bz2
linux-64::tensorflow-base-2.8.1-cuda112py39he716a45_0.tar.bz2
linux-64::arrow-cpp-3.0.0-py38h9de5444_51_cuda.tar.bz2
linux-64::gemmi-0.5.3-py38h38d86a4_1.tar.bz2
linux-64::yoda-1.9.4-py310h7566c02_2.tar.bz2
linux-64::harp-1.15.1-py39r40he2a1b48_0.tar.bz2
linux-64::pyinstaller-5.1-py310ha400145_0.tar.bz2
linux-64::folly-2022.05.02.00-h1234567_1_jemalloc.tar.bz2
linux-64::ruby-3.1.2-h22ca3a2_0.tar.bz2
linux-64::grpc-cpp-1.45.1-h3c5545a_1.tar.bz2
linux-64::lammps-2021.09.29-py38h19224a0_mpich_3.tar.bz2
linux-64::panda3d-1.10.11-py310hcce1a33_4.tar.bz2
linux-64::triton-1.1.2-cuda111py310h3518a2a_0.tar.bz2
linux-64::py-bgzip-0.4.0-py38he5536e0_2.tar.bz2
linux-64::tiledb-2.7.2-h1e4a385_0.tar.bz2
linux-64::mysql-router-8.0.29-h3c52d87_1.tar.bz2
linux-64::pytng-0.2.2-py38h3b715e4_2.tar.bz2
linux-64::arrow-cpp-5.0.0-py37hc1bcd19_33_cuda.tar.bz2
linux-64::astrometry-0.90-py38h487418f_1.tar.bz2
linux-64::arrow-cpp-6.0.1-py38h7b9fa56_15_cpu.tar.bz2
linux-64::arrow-cpp-3.0.0-py38h9550bf3_50_cpu.tar.bz2
linux-64::pp-sketchlib-2.0.0-py38h727bcf1_0.tar.bz2
linux-64::libopencv-4.5.5-py37h56d80eb_9.tar.bz2
linux-64::llvmlite-0.38.0-py310h58363a5_1.tar.bz2
linux-64::mongodb-5.1.1-h0e13805_2.tar.bz2
linux-64::arrow-cpp-6.0.1-py37hbaedfe8_14_cpu.tar.bz2
linux-64::gsoap-2.8.122-h8dc497d_0.tar.bz2
linux-64::pyreadstat-1.1.5-py37he2f7bc2_0.tar.bz2
linux-64::mysql-server-8.0.29-h4e426d9_1.tar.bz2
linux-64::arrow-cpp-3.0.0-py310h8b2f871_48_cuda.tar.bz2
linux-64::root_base-6.26.2-py310h59af190_3.tar.bz2
linux-64::pyreadstat-1.1.6-py37he2f7bc2_0.tar.bz2
linux-64::arrow-cpp-3.0.0-py310hd28874a_48_cuda.tar.bz2
linux-64::llvmlite-0.38.0-py38h38d86a4_1.tar.bz2
linux-64::py-bgzip-0.4.0-py39hd08d98e_2.tar.bz2
linux-64::arrow-cpp-5.0.0-py38h9de5444_34_cuda.tar.bz2
linux-64::arrow-cpp-7.0.0-py38hfe422aa_5_cpu.tar.bz2
linux-64::arrow-cpp-6.0.1-py38hd79a172_19_cpu.tar.bz2
linux-64::yoda-1.9.5-py39hcd944d7_0.tar.bz2
linux-64::tensorflow-base-2.8.0-cuda110py39h3c9bc52_0.tar.bz2
linux-64::panda3d-1.10.11-py37h9795100_4.tar.bz2
linux-64::jaxlib-0.3.10-cuda112py38h6e6c269_0.tar.bz2
linux-64::pytng-0.2.2-py39hba1c43e_2.tar.bz2
linux-64::folly-2022.04.11.00-h1234567_1_jemalloc.tar.bz2
linux-64::coda-2.23.1-py310h2b6cc9b_1.tar.bz2
linux-64::arrow-cpp-3.0.0-py37hce248a4_49_cuda.tar.bz2
linux-64::ortools-python-9.2-py39h4ee71b3_5.tar.bz2
linux-64::conduit-0.8.3-py38h1164aaf_0.tar.bz2
linux-64::mosh-1.3.2-pl5321hf50b057_1012.tar.bz2
linux-64::jaxlib-0.3.10-cuda112py38h40808eb_0.tar.bz2
linux-64::arrow-cpp-5.0.0-py39h15c4769_31_cpu.tar.bz2
linux-64::git-2.35.3-pl5321h36853c3_0.tar.bz2
linux-64::astrometry-0.90-py37hfbcb4a1_1.tar.bz2
linux-64::openmpi-4.1.3-hbea3300_101.tar.bz2
linux-64::vigra-1.11.1-py37h90436ee_1031.tar.bz2
linux-64::nd2-0.2.3-py310h062fc0b_0.tar.bz2
linux-64::arrow-cpp-7.0.0-py39heccc63a_6_cpu.tar.bz2
linux-64::vtk-9.1.0-qt_py38hd5f6aaa_208.tar.bz2
linux-64::yoda-1.9.4-py38h8462fa0_2.tar.bz2
linux-64::arrow-cpp-6.0.1-py310hdade202_16_cuda.tar.bz2
linux-64::libgdal-3.4.2-h0e87c58_6.tar.bz2
linux-64::fenics-libdolfin-2019.1.0-h5416c5e_29.tar.bz2
linux-64::mysql-libs-8.0.28-hbc51c84_3.tar.bz2
linux-64::grpc-cpp-1.43.2-h707d0dd_4.tar.bz2
linux-64::triton-1.1.2-cuda111py37haac1ad2_0.tar.bz2
linux-64::clangdev-14.0.3-default_h2e3cab8_0.tar.bz2
linux-64::ortools-cpp-9.2-h69b0a62_4.tar.bz2
linux-64::jaxlib-0.3.2-py38h9fff4b3_0.tar.bz2
linux-64::grpc-cpp-1.45.1-h3d78c48_0.tar.bz2
linux-64::arrow-cpp-8.0.0-py37hda8b9b9_0_cuda.tar.bz2
linux-64::conduit-0.8.3-py39he7c82b7_0.tar.bz2
linux-64::wxpython-4.1.1-py38hc041153_6.tar.bz2
linux-64::llvmlite-0.38.0-py39h7d9a04d_1.tar.bz2
linux-64::qtwebkit-5.212-h3383a02_6.tar.bz2
linux-64::arrow-cpp-7.0.0-py39h9f30d2d_5_cuda.tar.bz2
linux-64::arrow-cpp-7.0.0-py39h9f30d2d_6_cuda.tar.bz2
linux-64::gdstk-0.8.2-py39h31e9908_1.tar.bz2
linux-64::arrow-cpp-5.0.0-py310h8b2f871_29_cuda.tar.bz2
linux-64::ortools-python-9.2-py39h3e85001_2.tar.bz2
linux-64::scip-8.0.0-h9ff405d_1.tar.bz2
linux-64::mysql-router-8.0.28-h3f0aed2_3.tar.bz2
linux-64::llvmlite-0.38.1-py37h0761922_0.tar.bz2
linux-64::folly-2022.05.02.00-h1234567_1.tar.bz2
linux-64::hugin-base-2021.0.0-py37pl5321h110199d_5.tar.bz2
linux-64::arrow-cpp-6.0.1-py38h9de5444_17_cuda.tar.bz2
linux-64::paraview-5.10.1-h1b0e405_4_egl.tar.bz2
linux-64::tiledb-2.9.0-h1e4a385_1.tar.bz2
linux-64::jaxlib-0.3.0-py39h87376c5_4.tar.bz2
linux-64::grpcio-1.46.1-py37he500948_0.tar.bz2
linux-64::arrow-cpp-3.0.0-py310h8bc34b8_52_cpu.tar.bz2
linux-64::imagecodecs-2022.2.22-py39hb284377_2.tar.bz2
linux-64::arrow-cpp-3.0.0-py37hc1bcd19_50_cuda.tar.bz2
linux-64::mysql-router-8.0.29-h3c52d87_0.tar.bz2
linux-64::jaxlib-0.3.10-cuda112py38h195edf8_0.tar.bz2
linux-64::arrow-cpp-6.0.1-py38hcda0e24_15_cuda.tar.bz2
linux-64::tomviz-1.10.0.post230-py37h3444f97_2.tar.bz2
linux-64::mysql-libs-8.0.28-hbc51c84_4.tar.bz2
linux-64::root_base-6.26.2-py39h9749efa_1.tar.bz2
linux-64::mysql-libs-8.0.29-hbc51c84_0.tar.bz2
linux-64::jaxlib-0.3.10-cuda112py39h8b761d8_0.tar.bz2
linux-64::libtiledb-sql-0.14.2-h0993566_0.tar.bz2
linux-64::qt-webengine-5.15.4-hcbadb6c_3.tar.bz2
linux-64::harp-1.15.1-py39r41he2a1b48_0.tar.bz2
linux-64::jaxlib-0.3.7-py38hd8f79a0_0.tar.bz2
linux-64::jaxlib-0.3.7-py310h328e986_0.tar.bz2
linux-64::ortools-python-9.2-py310hc16a451_5.tar.bz2
linux-64::coda-2.23.1-py37hcb5871f_1.tar.bz2
linux-64::libopencv-4.5.5-py39h12858e4_8.tar.bz2
linux-64::pyreadstat-1.1.5-py310ha400145_0.tar.bz2
linux-64::tensorflow-base-2.8.0-cpu_py39h7e02d9e_0.tar.bz2
linux-64::wxwidgets-3.1.6-h645ee20_0.tar.bz2
linux-64::grpcio-1.46.0-py39h0f497a6_0.tar.bz2
linux-64::astrometry-0.90-py37hcc40fe6_0.tar.bz2
linux-64::arrow-cpp-6.0.1-py39h9266689_14_cuda.tar.bz2
linux-64::tensorflow-base-2.8.1-cuda112py37h45fe353_0.tar.bz2
linux-64::conduit-0.8.3-py38h63fcf35_0.tar.bz2
linux-64::panda3d-1.10.11-py310h211d205_4.tar.bz2
linux-64::vtk-9.1.0-osmesa_py39h8ab48e2_108.tar.bz2
linux-64::arrow-cpp-7.0.0-py310h8e8b783_5_cuda.tar.bz2
linux-64::libnetcdf-4.8.1-mpi_openmpi_he7012b2_2.tar.bz2
linux-64::libtiledb-sql-0.13.0-h0993566_0.tar.bz2
linux-64::pp-sketchlib-2.0.0-py39h23cb127_0.tar.bz2
linux-64::tensorflow-base-2.8.0-cuda112py37hd7e45b3_0.tar.bz2
linux-64::kaldi-5.5.1016-cpu_h5da3505_1.tar.bz2
linux-64::ortools-cpp-9.2-hedc821d_4.tar.bz2
linux-64::arrow-cpp-6.0.1-py310h8bc34b8_18_cpu.tar.bz2
linux-64::arrow-cpp-8.0.0-py37h6c59e74_1_cpu.tar.bz2
linux-64::imagemagick-7.1.0_35-pl5321heb7c40d_0.tar.bz2
linux-64::coda-2.24-py310h2b6cc9b_0.tar.bz2
linux-64::gsoap-2.8.122-h598caef_0.tar.bz2
linux-64::git-2.35.2-pl5321h36853c3_0.tar.bz2
linux-64::arrow-cpp-6.0.1-py38h9de5444_19_cuda.tar.bz2
linux-64::libtiledb-sql-0.13.0-h204bf05_0.tar.bz2
linux-64::gemmi-0.5.3-py39h6b9fe7f_1.tar.bz2
linux-64::arrow-cpp-3.0.0-py38h9f00d1f_48_cpu.tar.bz2
linux-64::vtk-9.1.0-egl_py39h3374e66_7.tar.bz2
linux-64::llvmlite-0.38.1-py39h7d9a04d_0.tar.bz2
linux-64::arrow-cpp-5.0.0-py37h2573e4e_32_cpu.tar.bz2
linux-64::protozfits-2.0.1.post1-py39hac70843_8.tar.bz2
linux-64::mysql-client-8.0.29-hf89ab62_0.tar.bz2
linux-64::arrow-cpp-5.0.0-py310hdade202_34_cuda.tar.bz2
linux-64::erlang-24.3.4-pl5321h5001644_0.tar.bz2
linux-64::harp-1.15-py39r41h665c6b1_1.tar.bz2
linux-64::blosc-1.21.1-h83bc5f7_2.tar.bz2
linux-64::openjpeg-2.5.0-h7d73246_0.tar.bz2
linux-64::grpcio-1.46.0-py39h7fbbf82_0.tar.bz2
linux-64::tensorflow-base-2.8.0-cuda111py39h96f73e6_0.tar.bz2
linux-64::libgdal-3.4.2-h8ff35cd_5.tar.bz2
linux-64::vtk-9.1.0-osmesa_py310h9b2d59d_108.tar.bz2
linux-64::folly-2022.04.11.00-h1234567_1.tar.bz2
linux-64::grpcio-1.46.3-py38h2e9ca35_0.tar.bz2
linux-64::rust-1.61.0-h30be4a0_0.tar.bz2
linux-64::libgdal-3.4.2-h3886835_7.tar.bz2
linux-64::arrow-cpp-6.0.1-py39h15c4769_16_cpu.tar.bz2
linux-64::libtensorflow-2.7.1-cuda102h62ca224_0.tar.bz2
linux-64::libtensorflow_cc-2.8.0-cuda110h83f852c_0.tar.bz2
linux-64::tensorflow-base-2.7.1-cuda102py37hc592af7_0.tar.bz2
linux-64::sqlite-3.38.3-h4ff8645_0.tar.bz2
linux-64::triton-1.1.2-cuda102py310hd71e52d_0.tar.bz2
linux-64::gemmi-0.5.3-py310h58363a5_1.tar.bz2
linux-64::grpc-cpp-1.44.0-hffcb1d1_4.tar.bz2
linux-64::git-2.35.3-pl5321h04cb727_0.tar.bz2
linux-64::jaxlib-0.3.10-cpu_py310heb27631_0.tar.bz2
linux-64::arrow-cpp-8.0.0-py310h8e8b783_0_cuda.tar.bz2
linux-64::pillow-9.1.0-py37h44f0d7a_0.tar.bz2
linux-64::indexed_gzip-1.6.13-py39hc217eb8_0.tar.bz2
linux-64::pillow-9.1.0-py37h44f0d7a_1.tar.bz2
linux-64::openssh-9.0p1-hf695f80_0.tar.bz2
linux-64::jaxlib-0.3.7-py37h8b57fe3_0.tar.bz2
linux-64::libopencv-4.5.5-py38h2380011_8.tar.bz2
linux-64::jaxlib-0.3.7-py38ha4c1a69_0.tar.bz2
linux-64::root_base-6.26.2-py310h59af190_2.tar.bz2
linux-64::triton-1.1.2-cuda102py38h04c0bab_0.tar.bz2
linux-64::arrow-cpp-7.0.0-py310hf3556ec_6_cpu.tar.bz2
linux-64::gemmi-0.5.4-py39h6b9fe7f_0.tar.bz2
linux-64::imagecodecs-2022.2.22-py39h5fd7a1c_3.tar.bz2
linux-64::libxml2-2.9.14-h22db469_0.tar.bz2
linux-64::readdy-2.0.11-py37h6be68fe_1.tar.bz2
linux-64::arrow-cpp-5.0.0-py39h7582941_33_cuda.tar.bz2
linux-64::tensorflow-base-2.7.1-cuda112py39h6917f46_0.tar.bz2
linux-64::jaxlib-0.3.7-py39he93ace9_0.tar.bz2
linux-64::arrow-cpp-7.0.0-py37h0d6303b_5_cpu.tar.bz2
linux-64::panda3d-1.10.11-py38hdbc8bd3_4.tar.bz2
linux-64::magics-metview-4.12.0-hf89b6a3_0.tar.bz2
linux-64::harp-1.15-py39r40h665c6b1_1.tar.bz2
linux-64::boost-cpp-1.78.0-h75c5d50_1.tar.bz2
linux-64::arrow-cpp-6.0.1-py37h3331901_14_cuda.tar.bz2
linux-64::panda3d-1.10.11-py39hc3b9668_4.tar.bz2
linux-64::jaxlib-0.3.0-py310hd983389_4.tar.bz2
linux-64::sqlite-3.38.5-h4ff8645_0.tar.bz2
linux-64::arrow-cpp-5.0.0-py310hb9b719f_29_cpu.tar.bz2
linux-64::conduit-0.8.3-py37h913fca3_0.tar.bz2
linux-64::arrow-cpp-8.0.0-py39h0ae2fab_1_cuda.tar.bz2
linux-64::grpc-cpp-1.44.0-h4315cb9_2.tar.bz2
linux-64::arrow-cpp-5.0.0-py38hcda0e24_30_cuda.tar.bz2
linux-64::jaxlib-0.3.10-cuda112py310h59d0295_0.tar.bz2
linux-64::harp-1.15.1-py38r40h378a090_0.tar.bz2
linux-64::arrow-cpp-5.0.0-py310h27e2bb1_29_cpu.tar.bz2
linux-64::postgresql-plpython-14.3-py37h44beeb2_0.tar.bz2
linux-64::ndcctools-7.4.4-py37he500948_0.tar.bz2
linux-64::emacs-27.2-hd32cc88_3.tar.bz2
linux-64::arrow-cpp-3.0.0-py38hcea13ed_53_cuda.tar.bz2
linux-64::grpcio-1.46.0-py310h44b9e0c_0.tar.bz2
linux-64::arrow-cpp-6.0.1-py39h7582941_18_cuda.tar.bz2
linux-64::osmium-tool-1.14.0-h41609fd_0.tar.bz2
linux-64::grpcio-1.46.0-py37he500948_1.tar.bz2
linux-64::llvmdev-14.0.2-he0ac6c6_0.tar.bz2
linux-64::gmsh-4.10.1-hee323ce_0.tar.bz2
linux-64::arrow-cpp-3.0.0-py38h9550bf3_52_cpu.tar.bz2
linux-64::jaxlib-0.3.10-cpu_py39hc536ea5_0.tar.bz2
linux-64::libtiff-4.3.0-h0fcbabc_4.tar.bz2
linux-64::arrow-cpp-7.0.0-py38h3915496_7_cuda.tar.bz2
linux-64::arrow-cpp-8.0.0-py39h9f30d2d_0_cuda.tar.bz2
linux-64::arrow-cpp-5.0.0-py310hdade202_32_cuda.tar.bz2
linux-64::pillow-9.1.0-py38h0ee0e06_1.tar.bz2
linux-64::cppyy-cling-6.25.3-py38h8225899_1.tar.bz2
linux-64::arrow-cpp-3.0.0-py38hcda0e24_49_cuda.tar.bz2
linux-64::arrow-cpp-3.0.0-py310h27e2bb1_48_cpu.tar.bz2
linux-64::rsync-3.2.3-h36cecd6_4.tar.bz2
linux-64::arrow-cpp-8.0.0-py38h69b25f9_1_cpu.tar.bz2
linux-64::ortools-cpp-9.2-h0d7c4cb_3.tar.bz2
linux-64::arrow-cpp-7.0.0-py39h304645a_4_cuda.tar.bz2
linux-64::libtensorflow-2.8.1-cuda110h739ce5e_0.tar.bz2
linux-64::imagemagick-7.1.0_30-pl5321heb7c40d_0.tar.bz2
linux-64::tensorflow-base-2.8.0-cuda112py310hdce628a_0.tar.bz2
linux-64::jaxlib-0.3.7-py39ha2f42eb_0.tar.bz2
linux-64::arrow-cpp-6.0.1-py37hc1bcd19_17_cuda.tar.bz2
linux-64::git-annex-10.20220504-alldep_hc98582e_100.tar.bz2
linux-64::arrow-cpp-5.0.0-py39h1cac49a_34_cpu.tar.bz2
linux-64::cmake-3.23.1-h5432695_0.tar.bz2
linux-64::soplex-6.0.0-he9aab78_1.tar.bz2
linux-64::librdkafka-1.8.2.post2-h35f46da_1.tar.bz2
linux-64::pillow-9.1.1-py310he619898_0.tar.bz2
linux-64::dotnet-aspnetcore-6.0.4-h751d214_0.tar.bz2
linux-64::quazip-1.3-hb1258cd_0.tar.bz2
linux-64::pyinstaller-5.1-py39hd08d98e_0.tar.bz2
linux-64::gdb-11.2-py310h01e0b26_0.tar.bz2
linux-64::libcurl-static-7.83.1-h2283fc2_0.tar.bz2
linux-64::clangdev-14.0.0-default_h2e3cab8_0.tar.bz2
linux-64::wxpython-4.1.1-py39hea8757a_7.tar.bz2
linux-64::grpc-cpp-1.46.0-he70e3f0_0.tar.bz2
linux-64::nd2-0.2.4-py39h155c9d3_0.tar.bz2
linux-64::tensorflow-base-2.8.0-cpu_py310h75e90da_0.tar.bz2
linux-64::ffmpeg-5.0.1-h594f047_0.tar.bz2
linux-64::arrow-cpp-6.0.1-py37h4fb91f9_14_cpu.tar.bz2
linux-64::astrometry-0.90-py38hbbbb4d6_0.tar.bz2
linux-64::tectonic-0.9.0-h3a2b94f_0.tar.bz2
linux-64::arrow-cpp-6.0.1-py39h7582941_19_cuda.tar.bz2
linux-64::imagecodecs-2022.2.22-py39h9c0c3a3_4.tar.bz2
linux-64::pyreadstat-1.1.4-py310h516ecdb_1.tar.bz2
linux-64::arrow-cpp-8.0.0-py38he106920_1_cuda.tar.bz2
linux-64::ndcctools-7.4.5-py310h44b9e0c_0.tar.bz2
linux-64::msgpack-c-3.3.0-h4c92fa2_4.tar.bz2
linux-64::arrow-cpp-6.0.1-py37hc1bcd19_19_cuda.tar.bz2
linux-64::libprotobuf-static-3.20.1-h6239696_0.tar.bz2
linux-64::arrow-cpp-3.0.0-py39h9266689_48_cuda.tar.bz2
linux-64::ticcutils-0.28-h45a0d52_1.tar.bz2
linux-64::cppyy-cling-6.25.3-py38h2a4c724_1.tar.bz2
linux-64::arrow-cpp-7.0.0-py310hdc7e031_7_cuda.tar.bz2
linux-64::dotnet-runtime-5.0.16-h751d214_0.tar.bz2
linux-64::tensorflow-base-2.8.1-cuda111py37hc702159_0.tar.bz2
linux-64::mandrake-1.2.2-py39he5a6ce5_0.tar.bz2
linux-64::libgdal-3.4.3-h3886835_0.tar.bz2
linux-64::paraview-5.10.1-py310h2244f48_105_qt.tar.bz2
linux-64::lammps-2021.09.29-py310h9a97438_openmpi_3.tar.bz2
linux-64::arrow-cpp-5.0.0-py39h15c4769_32_cpu.tar.bz2
linux-64::ogre-1.12.13-h4b045b0_1.tar.bz2
linux-64::gdcm-2.8.9-py37h9a7466f_5.tar.bz2
linux-64::jaxlib-0.3.10-cuda112py310hc9977b2_0.tar.bz2
linux-64::harp-1.15.1-py310r41h2b6cc9b_0.tar.bz2
linux-64::libssh-0.8.9-he49606f_2.tar.bz2
linux-64::imagecodecs-2022.2.22-py310h31a0021_4.tar.bz2
linux-64::tensorflow-base-2.8.1-cuda110py310h9e8cd52_0.tar.bz2
linux-64::jaxlib-0.3.2-py37h35e2301_0.tar.bz2
linux-64::pp-sketchlib-2.0.0-py310he28df2a_0.tar.bz2
linux-64::kaldi-5.5.1016-cuda111h989a307_1.tar.bz2
linux-64::jaxlib-0.3.10-cpu_py38h95f6c42_0.tar.bz2
linux-64::arrow-cpp-6.0.1-py37h2573e4e_18_cpu.tar.bz2
linux-64::arrow-cpp-6.0.1-py39he2ccf02_14_cpu.tar.bz2
linux-64::ndcctools-7.4.5-py38ha0cdfde_0.tar.bz2
linux-64::nco-5.0.7-he531006_0.tar.bz2
linux-64::harp-1.15-py37r41hcb5871f_1.tar.bz2
linux-64::rstudio-desktop-2022.02.2-r41h85c7ee8_0.tar.bz2
linux-64::arrow-cpp-8.0.0-py38h3915496_1_cuda.tar.bz2
linux-64::protozfits-2.0.1.post1-py37h22a1cf0_8.tar.bz2
linux-64::orc-1.7.4-h6c59b99_1.tar.bz2
linux-64::tiledb-2.8.2-h3f4058f_0.tar.bz2
linux-64::tensorflow-base-2.7.1-cuda110py39h7593abd_0.tar.bz2
linux-64::arrow-cpp-6.0.1-py38h9550bf3_16_cpu.tar.bz2
linux-64::ortools-cpp-9.2-h0d7c4cb_4.tar.bz2
linux-64::mandrake-1.2.2-py310h89e137f_0.tar.bz2
linux-64::root_base-6.26.2-py38h412b378_1.tar.bz2
linux-64::mandrake-1.2.2-py38h13a4392_0.tar.bz2
linux-64::gemmi-0.5.4-py39h7d9a04d_0.tar.bz2
linux-64::tiledb-2.8.0-h3f4058f_0.tar.bz2
linux-64::ortools-cpp-9.2-he0e45df_4.tar.bz2
linux-64::libgit2-1.4.3-h6529ace_0.tar.bz2
linux-64::elfutils-0.187-h989201e_0.tar.bz2
linux-64::root_base-6.24.6-py37ha671a63_2.tar.bz2
linux-64::nss-3.78-h2350873_0.tar.bz2
linux-64::ogre-13.3.4-hdcbd623_0.tar.bz2
linux-64::harp-1.15.1-py37r40hcb5871f_0.tar.bz2
linux-64::tiledb-2.8.1-h3f4058f_0.tar.bz2
linux-64::jaxlib-0.3.10-cpu_py39hcc5685a_0.tar.bz2
linux-64::tensorflow-base-2.8.0-cpu_py37h4373017_0.tar.bz2
linux-64::imagemagick-7.1.0_34-pl5321heb7c40d_0.tar.bz2
linux-64::lammps-2021.09.29-py37h1b1769e_openmpi_3.tar.bz2
linux-64::arrow-cpp-6.0.1-py37he5bb92b_14_cuda.tar.bz2
linux-64::arrow-cpp-3.0.0-py39h1cac49a_53_cpu.tar.bz2
linux-64::rstudio-desktop-2022.02.2-r40haf5249e_487.tar.bz2
linux-64::pyinstaller-5.0.1-py37he2f7bc2_0.tar.bz2
linux-64::pillow-9.1.0-py39habab96e_1.tar.bz2
linux-64::root_base-6.26.2-py37ha671a63_1.tar.bz2
linux-64::freeimage-3.18.0-hf18588b_8.tar.bz2
linux-64::pillow-9.1.0-py37h5350b5b_0.tar.bz2
linux-64::readdy-2.0.11-py310h1eb03a2_1.tar.bz2
linux-64::ogre-13.3.4-h4b045b0_1.tar.bz2
linux-64::grpc-cpp-1.44.0-hd8f4eba_4.tar.bz2
linux-64::panda3d-1.10.11-py37h4f84a42_4.tar.bz2
linux-64::llvmdev-14.0.2-he0ac6c6_1.tar.bz2
linux-64::boost-cpp-1.74.0-h75c5d50_8.tar.bz2
linux-64::pypy3.8-7.3.8-h5bd2d06_2.tar.bz2
linux-64::ortools-cpp-9.2-h20a92b3_5.tar.bz2
linux-64::paraview-5.10.1-py38h392762f_105_qt.tar.bz2
linux-64::jaxlib-0.3.10-cpu_py37ha701b26_0.tar.bz2
linux-64::libcurl-static-7.83.0-h2283fc2_0.tar.bz2
linux-64::arrow-cpp-7.0.0-py37hcc8ad85_7_cpu.tar.bz2
linux-64::libtensorflow_cc-2.7.1-cuda102h62ca224_0.tar.bz2
linux-64::postgresql-plpython-14.3-py38he5fc2dc_0.tar.bz2
linux-64::jaxlib-0.3.0-py310h9eaf4a5_4.tar.bz2
linux-64::mosh-1.3.2-pl5321h4a694d4_1012.tar.bz2
linux-64::arrow-cpp-3.0.0-py37hbaedfe8_48_cpu.tar.bz2
linux-64::harp-1.15.1-py38r41h378a090_0.tar.bz2
linux-64::python-3.9.13-h2660328_0_cpython.tar.bz2
linux-64::arrow-cpp-6.0.1-py39h1e51584_19_cuda.tar.bz2
linux-64::paraview-5.10.1-py37hf86338e_105_qt.tar.bz2
linux-64::ortools-cpp-9.2-he0e45df_3.tar.bz2
linux-64::jaxlib-0.3.10-cpu_py38heba6e0f_0.tar.bz2
linux-64::gemmi-0.5.3-py39h7d9a04d_1.tar.bz2
linux-64::arrow-cpp-3.0.0-py310h4af13b5_49_cuda.tar.bz2
linux-64::grpcio-1.46.3-py310hba10ccf_0.tar.bz2
linux-64::cppyy-cling-6.25.3-py37had014c9_1.tar.bz2
linux-64::tiledb-2.8.3-h3f4058f_1.tar.bz2
linux-64::osmium-tool-1.13.2-h41609fd_0.tar.bz2
linux-64::grpc-cpp-1.44.0-h1021d7f_2.tar.bz2
linux-64::ndcctools-7.4.4-py39h0f497a6_0.tar.bz2
linux-64::arrow-cpp-6.0.1-py37hc1bcd19_18_cuda.tar.bz2
linux-64::triton-1.1.2-cuda111py38hce7b989_0.tar.bz2
linux-64::libpq-14.3-he2d8382_0.tar.bz2
linux-64::gemmi-0.5.4-py310h58363a5_0.tar.bz2
linux-64::jaxlib-0.3.10-cpu_py310h0f9bb56_0.tar.bz2
linux-64::grpcio-1.46.1-py38h2e9ca35_0.tar.bz2
linux-64::ortools-python-9.2-py39h4ee71b3_4.tar.bz2
linux-64::mysql-server-8.0.28-h356294a_4.tar.bz2
linux-64::libgdal-3.4.2-hb785293_6.tar.bz2
linux-64::nordugrid-arc-6.15.1-py38h92e75e1_0.tar.bz2
linux-64::libtensorflow-2.8.0-cuda112h98e1010_0.tar.bz2
linux-64::pp-sketchlib-2.0.0-py310h49aeaf4_0.tar.bz2
linux-64::arrow-cpp-7.0.0-py39h7490d1d_7_cpu.tar.bz2
linux-64::folly-2022.04.25.00-h1234567_1_jemalloc.tar.bz2
linux-64::libtensorflow_cc-2.8.1-cuda110h739ce5e_0.tar.bz2
linux-64::jaxlib-0.3.7-py37h599489c_0.tar.bz2
linux-64::arrow-cpp-7.0.0-py38hfe422aa_6_cpu.tar.bz2
linux-64::tensorflow-base-2.8.1-cpu_py310h17449b8_0.tar.bz2
linux-64::wxpython-4.1.1-py310hdb6c39c_7.tar.bz2
linux-64::gemmi-0.5.4-py37h0761922_0.tar.bz2
linux-64::grpcio-1.46.0-py39h0f497a6_1.tar.bz2
linux-64::arrow-cpp-8.0.0-py39h7490d1d_1_cpu.tar.bz2
linux-64::wxpython-4.1.1-py38hc041153_7.tar.bz2
linux-64::root_base-6.24.6-py37ha671a63_3.tar.bz2
linux-64::texlive-core-20210325-h5b4e33e_3.tar.bz2
linux-64::tensorflow-base-2.8.0-cuda111py37hf17b69b_0.tar.bz2
linux-64::root_base-6.24.6-py310h59af190_3.tar.bz2
linux-64::libmediainfo-22.03-ha998575_0.tar.bz2
linux-64::arrow-cpp-5.0.0-py37hace919c_30_cpu.tar.bz2
linux-64::libgdal-3.4.2-h56144a5_7.tar.bz2
linux-64::tensorflow-base-2.7.1-cuda112py37hf039c21_0.tar.bz2
linux-64::libcurl-7.83.1-h2283fc2_0.tar.bz2
linux-64::arrow-cpp-5.0.0-py39h7582941_31_cuda.tar.bz2
linux-64::indexed_gzip-1.6.13-py38h3b715e4_1.tar.bz2
linux-64::ambertools-22.0-py310hfade12a_1.tar.bz2
linux-64::astrometry-0.90-py39hd54e90f_1.tar.bz2
linux-64::arrow-cpp-5.0.0-py310h38b329a_30_cpu.tar.bz2
linux-64::pytng-0.2.2-py38h5678a39_2.tar.bz2
linux-64::rust-1.60.0-h30be4a0_0.tar.bz2
linux-64::gemmi-0.5.3-py38hb85eefc_1.tar.bz2
linux-64::jaxlib-0.3.7-py39h9378397_0.tar.bz2
linux-64::pdal-2.4.0-h2602d4b_3.tar.bz2
linux-64::arrow-cpp-5.0.0-py39h9266689_29_cuda.tar.bz2
linux-64::tensorflow-base-2.7.1-cuda110py310h1c8d5c9_0.tar.bz2
linux-64::arrow-cpp-3.0.0-py310hdade202_50_cuda.tar.bz2
linux-64::harp-1.15.1-py39r41h665c6b1_0.tar.bz2
linux-64::tiledb-2.9.0-h3f4058f_1.tar.bz2
linux-64::grpcio-1.46.1-py38ha0cdfde_0.tar.bz2
linux-64::astrometry-0.90-py37h2b97ff3_0.tar.bz2
linux-64::fenics-libdolfin-2019.1.0-hd78bcf9_30.tar.bz2
linux-64::conduit-0.8.3-py39h0ed5f21_0.tar.bz2
linux-64::cpp-opentelemetry-sdk-1.4.0-hb354d1b_0.tar.bz2
linux-64::libxmlsec1-1.2.33-h5614a37_1.tar.bz2
linux-64::mysql-libs-8.0.29-hbc51c84_1.tar.bz2
linux-64::vigra-1.11.1-py39h388219c_1032.tar.bz2
linux-64::tomviz-1.10.0.post230-py37h3444f97_1.tar.bz2
linux-64::pyreadstat-1.1.5-py37h7faf3f8_0.tar.bz2
linux-64::jaxlib-0.3.10-cuda112py39h8d07533_0.tar.bz2
linux-64::llvmlite-0.38.1-py38h38d86a4_0.tar.bz2
linux-64::arrow-cpp-6.0.1-py37hc1bcd19_16_cuda.tar.bz2
linux-64::libnetcdf-4.8.1-nompi_h329d8a1_102.tar.bz2
linux-64::gsoap-2.8.121-h8dc497d_0.tar.bz2
linux-64::mysql-libs-8.0.28-h28c427c_3.tar.bz2
linux-64::wxpython-4.1.1-py39hea8757a_6.tar.bz2
linux-64::fenics-libdolfin-2019.1.0-hbc0b921_27.tar.bz2
linux-64::arrow-cpp-6.0.1-py310h4af13b5_15_cuda.tar.bz2
linux-64::grpc-cpp-1.44.0-h707d0dd_3.tar.bz2
linux-64::indexed_gzip-1.6.13-py310hd25046b_0.tar.bz2
linux-64::rstudio-desktop-2022.02.2-r41h85c7ee8_486.tar.bz2
linux-64::conduit-0.8.3-py37h51fa381_0.tar.bz2
linux-64::fenics-libdolfin-2019.1.0-h5416c5e_28.tar.bz2
linux-64::pypy3.9-7.3.9-h56abe6f_1.tar.bz2
linux-64::qt-main-5.15.3-hf97cb25_0.tar.bz2
linux-64::nd2-0.2.4-py310h062fc0b_0.tar.bz2
linux-64::pypy3.9-7.3.9-h986b250_2.tar.bz2
linux-64::arrow-cpp-6.0.1-py39h1cac49a_19_cpu.tar.bz2
linux-64::jaxlib-0.3.2-py38h617afa0_0.tar.bz2
linux-64::arrow-cpp-6.0.1-py39hf5daf42_15_cpu.tar.bz2
linux-64::tectonic-0.9.0-h36fa118_0.tar.bz2
linux-64::jaxlib-0.3.7-py310h9f80311_0.tar.bz2
linux-64::jaxlib-0.3.7-py39h050f24e_0.tar.bz2
linux-64::kaldi-5.5.1016-cpu_h1234567_0.tar.bz2
linux-64::grpc-cpp-1.43.2-hd8f4eba_5.tar.bz2
linux-64::libgit2-1.4.3-h4c07d5c_0.tar.bz2
linux-64::grpcio-1.46.0-py37h0327239_0.tar.bz2
linux-64::ortools-python-9.2-py310h1e2cddb_4.tar.bz2
linux-64::mysql-client-8.0.28-h92c5bc7_4.tar.bz2
linux-64::hugin-base-2021.0.0-py39pl5321h725b965_5.tar.bz2
linux-64::ortools-cpp-9.2-h1e72a14_4.tar.bz2
linux-64::triton-1.1.2-cuda112py39hc560949_0.tar.bz2
linux-64::paraview-5.10.1-py38h6f04dd4_5_egl.tar.bz2
linux-64::openconnect-8.10-h9ba9c44_4.tar.bz2
linux-64::magics-metview-batch-4.12.0-he381006_0.tar.bz2
linux-64::ndcctools-7.4.4-py310h44b9e0c_0.tar.bz2
linux-64::xrootd-5.4.2-py38h92bdfd5_0.tar.bz2
linux-64::xrootd-5.4.2-py39hbfe9b54_0.tar.bz2
linux-64::tensorflow-base-2.8.1-cuda111py310h4e6f299_0.tar.bz2
linux-64::arrow-cpp-7.0.0-py37hda8b9b9_5_cuda.tar.bz2
linux-64::hugin-base-2021.0.0-py38pl5321h28aceeb_5.tar.bz2
linux-64::pyreadstat-1.1.6-py37h7faf3f8_0.tar.bz2
linux-64::squashfuse-0.1.104-hd0129a2_2.tar.bz2
linux-64::arrow-cpp-5.0.0-py37hc1bcd19_31_cuda.tar.bz2
linux-64::arrow-cpp-6.0.1-py310hb9b719f_14_cpu.tar.bz2
linux-64::grpcio-1.46.3-py39h7fbbf82_0.tar.bz2
linux-64::arrow-cpp-3.0.0-py37h2573e4e_51_cpu.tar.bz2
linux-64::grpc-cpp-1.45.2-h3ebbd8c_2.tar.bz2
linux-64::tiledb-2.9.1-h3f4058f_0.tar.bz2
linux-64::libtensorflow_cc-2.8.1-cpu_haf14b92_0.tar.bz2
linux-64::arrow-cpp-8.0.0-py38hfe422aa_1_cpu.tar.bz2
linux-64::libtensorflow_cc-2.8.0-cuda102h62ca224_0.tar.bz2
linux-64::libtiledb-sql-0.14.1-h0993566_0.tar.bz2
linux-64::grpc-cpp-1.45.2-hd8f4eba_2.tar.bz2
linux-64::vowpalwabbit-9.1.0-py37h1d83898_0.tar.bz2
linux-64::arrow-cpp-8.0.0-py38h56c1a66_1_cuda.tar.bz2
linux-64::tensorflow-base-2.7.1-cuda102py38h5246720_0.tar.bz2
linux-64::pp-sketchlib-2.0.0-py38h7ea20fc_0.tar.bz2
linux-64::arrow-cpp-8.0.0-py310hf3556ec_1_cpu.tar.bz2
linux-64::arrow-cpp-5.0.0-py37h2573e4e_34_cpu.tar.bz2
linux-64::panda3d-1.10.11-py39hcc42650_4.tar.bz2
linux-64::orc-1.7.4-h6c59b99_0.tar.bz2
linux-64::libmediainfo-22.03-ha998575_1.tar.bz2
linux-64::wxpython-4.1.1-py37hecb6014_6.tar.bz2
linux-64::paraview-5.10.1-h392762f_104_qt.tar.bz2
linux-64::arrow-cpp-3.0.0-py310hb9b719f_48_cpu.tar.bz2
linux-64::imagecodecs-2022.2.22-py310hd01aa24_3.tar.bz2
linux-64::arrow-cpp-5.0.0-py37h4fb91f9_29_cpu.tar.bz2
linux-64::jaxlib-0.3.7-py38hfbc2cbd_0.tar.bz2
linux-64::mandrake-1.2.2-py39h9444d23_0.tar.bz2
linux-64::arrow-cpp-6.0.1-py37h2573e4e_19_cpu.tar.bz2
linux-64::grpc-cpp-1.43.2-h3d78c48_3.tar.bz2
linux-64::arrow-cpp-3.0.0-py39he2ccf02_48_cpu.tar.bz2
linux-64::arrow-cpp-3.0.0-py39hb94f1ed_48_cuda.tar.bz2
linux-64::jaxlib-0.3.10-cuda112py310h637716b_0.tar.bz2
linux-64::nd2-0.2.4-py38h28b09c2_0.tar.bz2
linux-64::arrow-cpp-3.0.0-py310h4356942_53_cuda.tar.bz2
linux-64::gmsh-4.10.0-hee323ce_0.tar.bz2
linux-64::grpc-cpp-1.43.2-hb0d6e40_4.tar.bz2
linux-64::vowpalwabbit-9.1.0-py310h3584e85_0.tar.bz2
linux-64::ortools-cpp-9.2-hf61c867_4.tar.bz2
linux-64::pypy3.8-7.3.9-h5001382_0.tar.bz2
linux-64::arrow-cpp-7.0.0-py310h8cf3212_7_cuda.tar.bz2
linux-64::arrow-cpp-3.0.0-py38h9de5444_53_cuda.tar.bz2
linux-64::jaxlib-0.3.10-cuda112py37h964a14d_0.tar.bz2
linux-64::tensorflow-base-2.7.1-cuda110py38h4cd2a3c_0.tar.bz2
linux-64::vigra-1.11.1-py310hf2a0628_1032.tar.bz2
linux-64::tensorflow-base-2.7.1-cuda111py39h6f4cae7_0.tar.bz2
linux-64::libarchive-3.5.2-hb890918_2.tar.bz2
linux-64::openmpi-4.1.3-h846660c_102.tar.bz2
linux-64::arrow-cpp-3.0.0-py38hd79a172_53_cpu.tar.bz2
linux-64::llvmdev-14.0.1-he0ac6c6_0.tar.bz2
linux-64::mysql-client-8.0.28-h92c5bc7_3.tar.bz2
linux-64::arrow-cpp-6.0.1-py38h609ca95_14_cpu.tar.bz2
linux-64::collada-dom-2.5.0-hd1defe2_4.tar.bz2
linux-64::libtensorflow-2.8.0-cuda111h95e6cbe_0.tar.bz2
linux-64::grpcio-1.46.1-py37h0327239_0.tar.bz2
linux-64::pyinstaller-5.0-py39hd08d98e_0.tar.bz2
linux-64::arrow-cpp-5.0.0-py37h8df67fa_34_cuda.tar.bz2
linux-64::tensorflow-base-2.7.1-cuda110py37he1a3a50_0.tar.bz2
linux-64::arrow-cpp-6.0.1-py310h8b2f871_14_cuda.tar.bz2
linux-64::mysql-server-8.0.28-h0e96d49_3.tar.bz2
linux-64::jaxlib-0.3.2-py39h87376c5_0.tar.bz2
linux-64::mysql-libs-8.0.29-h28c427c_1.tar.bz2
linux-64::mandrake-1.2.2-py38hc748a8f_0.tar.bz2
linux-64::kaldi-5.5.1016-cpu_h63d7148_2.tar.bz2
linux-64::arrow-cpp-3.0.0-py39h54e1b86_48_cpu.tar.bz2
linux-64::ortools-cpp-9.2-hd2ecba2_4.tar.bz2
linux-64::llvmlite-0.38.0-py38hb85eefc_1.tar.bz2
linux-64::gdstk-0.8.2-py39hac9c483_1.tar.bz2
linux-64::arrow-cpp-7.0.0-py310h68f40c4_4_cpu.tar.bz2
linux-64::grpcio-1.46.1-py310hba10ccf_0.tar.bz2
linux-64::arrow-cpp-5.0.0-py38h9de5444_31_cuda.tar.bz2
linux-64::gdcm-2.8.9-py39h1f6dd6f_5.tar.bz2
linux-64::grpc-cpp-1.45.2-he70e3f0_2.tar.bz2
linux-64::nginx-1.21.6-hf2e6093_1.tar.bz2
linux-64::arrow-cpp-3.0.0-py38hbda2956_48_cuda.tar.bz2
linux-64::ndcctools-7.4.4-py38h2e9ca35_0.tar.bz2
-    "libzlib >=1.2.11,<1.3.0a0",
+    "libzlib >=1.2.11,<2.0.0a0",
linux-64::spidermonkey-91.9.1-hba313d4_0.tar.bz2
linux-64::lib3mf-2.2.0-he015d4a_1.tar.bz2
linux-64::libdwarf-testing-meta-0.3.4-h753d276_0.tar.bz2
linux-64::libsolv-static-0.7.22-h6239696_0.tar.bz2
linux-64::libclang-cpp14-14.0.0-default_h2e3cab8_0.tar.bz2
linux-64::libclang-cpp-14.0.3-default_h2e3cab8_0.tar.bz2
linux-64::clang-format-14-14.0.4-default_h2e3cab8_0.tar.bz2
linux-64::clang-9-9.0.1-cling_v0.9_h6699504_5.tar.bz2
linux-64::libclang-cpp9-9.0.1-root_62600_hea64019_5.tar.bz2
linux-64::gst-plugins-base-1.20.2-hcf0ee16_0.tar.bz2
linux-64::llvm-openmp-14.0.0-he0ac6c6_0.tar.bz2
linux-64::libclang-cpp-9.0.1-hcc_hd56f702_5.tar.bz2
linux-64::libclang-cpp-14.0.0-default_h2e3cab8_0.tar.bz2
linux-64::lld-14.0.4-ha190916_0.tar.bz2
linux-64::llvm-tools-14.0.3-he0ac6c6_0.tar.bz2
linux-64::libllvm14-14.0.2-he0ac6c6_0.tar.bz2
linux-64::llvm-openmp-14.0.4-he0ac6c6_0.tar.bz2
linux-64::dwarfdump-0.3.4-h753d276_0.tar.bz2
linux-64::libclang-14.0.0-default_h2e3cab8_0.tar.bz2
linux-64::clang-tools-14.0.0-default_h2e3cab8_0.tar.bz2
linux-64::clang-format-14.0.0-default_h2e3cab8_0.tar.bz2
linux-64::clang-14-14.0.4-default_h2e3cab8_0.tar.bz2
linux-64::readstat-1.1.8-hbe1e993_0.tar.bz2
linux-64::llvm-openmp-14.0.3-he0ac6c6_0.tar.bz2
linux-64::libclang-14.0.4-default_h2e3cab8_0.tar.bz2
linux-64::openexr-3.1.5-he0ac6c6_0.tar.bz2
linux-64::coin-or-osi-0.108.7-h3b589db_0.tar.bz2
linux-64::llvm-openmp-14.0.2-he0ac6c6_0.tar.bz2
linux-64::libclang-cpp14-14.0.3-default_h2e3cab8_0.tar.bz2
linux-64::spidermonkey-91.8.0-h6715016_0.tar.bz2
linux-64::libllvm14-14.0.1-he0ac6c6_0.tar.bz2
linux-64::llvm-tools-14.0.2-he0ac6c6_0.tar.bz2
linux-64::clang-tools-14.0.4-default_h2e3cab8_0.tar.bz2
linux-64::lld-14.0.0-ha190916_0.tar.bz2
linux-64::llvm-14.0.2-h32600fe_0.tar.bz2
linux-64::clang-14-14.0.3-default_h2e3cab8_0.tar.bz2
linux-64::llvm-14.0.4-h32600fe_0.tar.bz2
linux-64::llvm-tools-14.0.1-he0ac6c6_0.tar.bz2
linux-64::libclang-cpp9-9.0.1-hcc_hd56f702_5.tar.bz2
linux-64::spidermonkey-91.8.0-hba313d4_1.tar.bz2
linux-64::clang-format-14.0.4-default_h2e3cab8_0.tar.bz2
linux-64::libllvm14-14.0.4-he0ac6c6_0.tar.bz2
linux-64::clang-14-14.0.0-default_h2e3cab8_0.tar.bz2
linux-64::llvm-14.0.1-h32600fe_0.tar.bz2
linux-64::libdwarf-dev-0.3.4-h753d276_0.tar.bz2
linux-64::spidermonkey-bin-91.8.0-hb94ef7b_0.tar.bz2
linux-64::libclang-cpp-9.0.1-root_62600_hea64019_5.tar.bz2
linux-64::libclang13-14.0.4-default_h3a83d3e_0.tar.bz2
linux-64::zimpl-3.5.1-hb4bb7ca_1.tar.bz2
linux-64::spidermonkey-bin-91.9.0-hc8fd5ad_0.tar.bz2
linux-64::libdwarf-0.3.4-h753d276_0.tar.bz2
linux-64::lld-14.0.3-ha190916_0.tar.bz2
linux-64::libclang-cpp9-9.0.1-default_heb9c396_5.tar.bz2
linux-64::llvm-tools-14.0.4-he0ac6c6_0.tar.bz2
linux-64::libllvm14-14.0.3-he0ac6c6_0.tar.bz2
linux-64::gst-plugins-base-1.20.2-hf6a322e_1.tar.bz2
linux-64::libclang-cpp-14.0.4-default_h2e3cab8_0.tar.bz2
linux-64::lld-14.0.2-ha190916_0.tar.bz2
linux-64::gst-plugins-good-1.20.2-h20dca43_1.tar.bz2
linux-64::clang-9-9.0.1-hcc_hd56f702_5.tar.bz2
linux-64::libsolv-0.7.22-h6239696_0.tar.bz2
linux-64::libclang-cpp9-9.0.1-cling_v0.9_h6699504_5.tar.bz2
linux-64::libclang13-14.0.0-default_h3a83d3e_0.tar.bz2
linux-64::niftyreg-1.5.69.6-ha1279dc_1.tar.bz2
linux-64::libclang-14.0.3-default_h2e3cab8_0.tar.bz2
linux-64::clang-format-14.0.3-default_h2e3cab8_0.tar.bz2
linux-64::libllvm14-14.0.2-he0ac6c6_1.tar.bz2
linux-64::clang-format-14-14.0.0-default_h2e3cab8_0.tar.bz2
linux-64::llvm-14.0.3-h32600fe_0.tar.bz2
linux-64::clang-tools-14.0.3-default_h2e3cab8_0.tar.bz2
linux-64::spidermonkey-91.9.0-hba313d4_0.tar.bz2
linux-64::libclang-cpp-9.0.1-cling_v0.9_h6699504_5.tar.bz2
linux-64::llvm-tools-14.0.2-he0ac6c6_1.tar.bz2
linux-64::clang-9-9.0.1-default_heb9c396_5.tar.bz2
linux-64::gst-plugins-good-1.20.2-h20dca43_0.tar.bz2
linux-64::libclang-cpp14-14.0.4-default_h2e3cab8_0.tar.bz2
linux-64::spidermonkey-bin-91.9.1-hc8fd5ad_0.tar.bz2
linux-64::clang-9-9.0.1-root_62600_hea64019_5.tar.bz2
linux-64::libclang13-14.0.3-default_h3a83d3e_0.tar.bz2
linux-64::llvm-14.0.2-h32600fe_1.tar.bz2
linux-64::clang-format-14-14.0.3-default_h2e3cab8_0.tar.bz2
linux-64::niftyreg-1.5.69.6-ha1279dc_0.tar.bz2
linux-64::libclang-cpp-9.0.1-default_heb9c396_5.tar.bz2
linux-64::spidermonkey-bin-91.8.0-hc8fd5ad_1.tar.bz2
-    "libzlib >=1.2.11,<1.3.0a0"
+    "libzlib >=1.2.11,<2.0.0a0"
linux-64::tiledb-2.9.2-h1e4a385_0.tar.bz2
linux-64::mysql-connector-cpp-8.0.29-hc5ead5f_1.tar.bz2
linux-64::libtiledb-sql-0.15.0-h0993566_0.tar.bz2
linux-64::libprotobuf-static-21.1-h6239696_0.tar.bz2
linux-64::pillow-9.1.1-py310he619898_1.tar.bz2
linux-64::libprotobuf-static-3.21.1-h6239696_0.tar.bz2
linux-64::imagemagick-7.1.0_36-pl5321heb7c40d_0.tar.bz2
linux-64::libtiledb-sql-0.15.0-h204bf05_0.tar.bz2
linux-64::pillow-9.1.1-py37h44f0d7a_1.tar.bz2
linux-64::git-annex-10.20220525-alldep_hc98582e_100.tar.bz2
linux-64::libxslt-1.1.35-h8affb1d_0.tar.bz2
linux-64::sagelib-9.6-py310h4f38093_0.tar.bz2
linux-64::libprotobuf-3.21.1-h6239696_0.tar.bz2
linux-64::tiledb-2.9.2-h3f4058f_0.tar.bz2
linux-64::freeimage-3.18.0-hf18588b_9.tar.bz2
linux-64::libtiff-4.4.0-h0fcbabc_0.tar.bz2
linux-64::pillow-9.1.1-py38h9267336_1.tar.bz2
linux-64::sagelib-9.6-py39h601c6e1_0.tar.bz2
linux-64::pillow-9.1.1-py39habab96e_1.tar.bz2
linux-64::emacs-28.1-h9019b3f_1.tar.bz2
linux-64::graphviz-4.0.0-h5abf519_0.tar.bz2
linux-64::sagelib-9.6-py38h718827e_0.tar.bz2
linux-64::qt-main-5.15.3-hf97cb25_2.tar.bz2
linux-64::pillow-9.1.1-py38h0ee0e06_1.tar.bz2
linux-64::sagelib-9.6-py37ha49f77c_0.tar.bz2
linux-64::mysql-connector-cpp-8.0.29-hf18ea70_1.tar.bz2
linux-64::pillow-9.1.1-py39hae2aec6_1.tar.bz2
-    "libzlib >=1.2.12,<1.3.0a0",
+    "libzlib >=1.2.12,<2.0.0a0",
linux-64::spidermonkey-bin-91.10.0-hc8fd5ad_0.tar.bz2
linux-64::spidermonkey-91.10.0-hba313d4_0.tar.bz2
-    "libzlib >=1.2.12,<1.3.0a0"
+    "libzlib >=1.2.12,<2.0.0a0"
```

</details>