### PR TITLE
loosen zlib-pin to major level (25/N; February & March 2022)

### DIFF
--- a/recipe/patch_yaml/zlib.yaml
+++ b/recipe/patch_yaml/zlib.yaml
@@ -241,3 +241,12 @@ then:
   - loosen_depends:
       name: libzlib
       upper_bound: "2"
+---
+if:
+  has_depends: libzlib >=1.2*
+  timestamp_lt: 1646092800000  # 2022-03-01 00:00 UTC
+  timestamp_ge: 1643673600000  # 2022-02-01 00:00 UTC
+then:
+  - loosen_depends:
+      name: libzlib
+      upper_bound: "2"

--- a/recipe/patch_yaml/zlib.yaml
+++ b/recipe/patch_yaml/zlib.yaml
@@ -232,3 +232,12 @@ then:
   - loosen_depends:
       name: libzlib
       upper_bound: "2"
+---
+if:
+  has_depends: libzlib >=1.2*
+  timestamp_lt: 1648771200000  # 2022-04-01 00:00 UTC
+  timestamp_ge: 1646092800000  # 2022-03-01 00:00 UTC
+then:
+  - loosen_depends:
+      name: libzlib
+      upper_bound: "2"


### PR DESCRIPTION
Follow-up to https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/739, about 4100 artefacts affected.

### Result of `python show_diff.py`

<details>

```diff
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
osx-arm64::grpcio-1.44.0-py310h00ca444_0.tar.bz2
osx-arm64::pyinstaller-4.9-py39h3753aae_1.tar.bz2
osx-arm64::tectonic-0.8.2-h705f8be_0.tar.bz2
osx-arm64::pillow-9.0.0-py38he7148d4_0.tar.bz2
osx-arm64::sagelib-9.5-py39hc334225_2.tar.bz2
osx-arm64::tippecanoe-1.36.0-h11911d8_2.tar.bz2
osx-arm64::wxpython-4.1.1-py38hb97f6a1_4.tar.bz2
osx-arm64::arrow-cpp-6.0.1-py39h75128fe_10_cpu.tar.bz2
osx-arm64::nodejs-17.8.0-h8da9806_0.tar.bz2
osx-arm64::curl-7.82.0-hb0e6552_0.tar.bz2
osx-arm64::cctools_osx-arm64-973.0.1-h83ffe51_10.tar.bz2
osx-arm64::arrow-cpp-6.0.1-py310h41d483d_13_cpu.tar.bz2
osx-arm64::cmake-3.23.0-he7c8c24_0.tar.bz2
osx-arm64::libopencv-4.5.5-py31ha7d2a18_1.tar.bz2
osx-arm64::ffmpeg-4.4.1-h2f96316_2.tar.bz2
osx-arm64::cctools_osx-arm64-973.0.1-h83ffe51_6.tar.bz2
osx-arm64::wxpython-4.1.1-py38hb97f6a1_5.tar.bz2
osx-arm64::arrow-cpp-5.0.0-py310h0273c55_26_cpu.tar.bz2
osx-arm64::tiledb-2.6.4-h9fb27ea_0.tar.bz2
osx-arm64::arrow-cpp-7.0.0-py39h1259d77_3_cpu.tar.bz2
osx-arm64::libgdal-3.4.2-hb18a185_2.tar.bz2
osx-arm64::ffmpeg-5.0.0-h2f96316_0.tar.bz2
osx-arm64::libopencv-4.5.5-py38hf332e9d_2.tar.bz2
osx-arm64::jaxlib-0.3.0-py310h1d06672_3.tar.bz2
osx-arm64::libopencv-4.5.5-py38hd5ba69c_4.tar.bz2
osx-arm64::cctools_osx-64-973.0.1-he94699d_10.tar.bz2
osx-arm64::tensorflow-base-2.7.0-cpu_py38h93cb87e_0.tar.bz2
osx-arm64::ptscotch-6.0.9-h1aec651_2.tar.bz2
osx-arm64::arrow-cpp-3.0.0-py38h0187a5a_42_cpu.tar.bz2
osx-arm64::pillow-9.0.1-py39hcb29f89_1.tar.bz2
osx-arm64::jaxlib-0.3.0-py39h336c7f0_4.tar.bz2
osx-arm64::tiledb-2.7.1-h29b8279_0.tar.bz2
osx-arm64::cctools_osx-arm64-973.0.1-ha8964d5_9.tar.bz2
osx-arm64::libopencv-4.5.5-py39h8339426_3.tar.bz2
osx-arm64::tectonic-0.8.2-h12364cf_1.tar.bz2
osx-arm64::libgdal-3.4.1-h556da2b_3.tar.bz2
osx-arm64::irrlicht-1.8.5-h3869ffb_2.tar.bz2
osx-arm64::cctools_osx-arm64-973.0.1-ha8964d5_10.tar.bz2
osx-arm64::sagelib-9.5-py310h58a2b93_4.tar.bz2
osx-arm64::grpcio-1.44.0-py38h740c240_0.tar.bz2
osx-arm64::gemmi-0.5.3-py38hd1051fe_0.tar.bz2
osx-arm64::cppyy-cling-6.25.3-py39ha71e53e_0.tar.bz2
osx-arm64::pillow-9.0.1-py310h3e63bf8_0.tar.bz2
osx-arm64::postgresql-14.2-h9a9b6fe_0.tar.bz2
osx-arm64::python-3.9.12-hfc7342c_1_cpython.tar.bz2
osx-arm64::cctools_osx-arm64-973.0.1-ha8964d5_7.tar.bz2
osx-arm64::git-2.35.1-pl5321hdb569e8_0.tar.bz2
osx-arm64::tensorflow-base-2.7.0-cpu_py310h8c911da_0.tar.bz2
osx-arm64::libgsf-1.14.49-hce81377_0.tar.bz2
osx-arm64::cctools_osx-64-973.0.1-h9133aa7_6.tar.bz2
osx-arm64::pillow-9.0.1-py38he7148d4_1.tar.bz2
osx-arm64::arrow-cpp-6.0.1-py38hd3fa324_10_cpu.tar.bz2
osx-arm64::assimp-5.2.3-hd77be17_0.tar.bz2
osx-arm64::arrow-cpp-7.0.0-py38h2c2d69a_2_cpu.tar.bz2
osx-arm64::glib-2.70.2-hccf11d3_4.tar.bz2
osx-arm64::imagecodecs-2021.11.20-py310ha08e9c9_2.tar.bz2
osx-arm64::postgresql-plpython-14.2-py39h9cfb23c_0.tar.bz2
osx-arm64::python-3.9.12-h14b404e_1_cpython.tar.bz2
osx-arm64::nodejs-16.14.2-h941bd55_1.tar.bz2
osx-arm64::nodejs-16.14.2-h8da9806_0.tar.bz2
osx-arm64::pillow-9.0.1-py39hd72dd6b_2.tar.bz2
osx-arm64::arrow-cpp-5.0.0-py38h674b21d_28_cpu.tar.bz2
osx-arm64::poppler-22.01.0-hb0e405e_2.tar.bz2
osx-arm64::ptscotch-6.0.9-hd02db47_2.tar.bz2
osx-arm64::tiledb-2.6.2-hade11cd_1.tar.bz2
osx-arm64::jaxlib-0.3.0-py310h1d06672_4.tar.bz2
osx-arm64::tensorflow-base-2.7.0-cpu_py39hbdae8f9_0.tar.bz2
osx-arm64::cmake-3.22.3-he7c8c24_0.tar.bz2
osx-arm64::pyinstaller-4.9-py310h5363a0e_1.tar.bz2
osx-arm64::ffmpeg-4.3.2-h38cfed3_3.tar.bz2
osx-arm64::libthrift-0.16.0-h95ff8ae_1.tar.bz2
osx-arm64::imagecodecs-2022.2.22-py38hd10c09d_0.tar.bz2
osx-arm64::cmake-3.23.0-he7c8c24_1.tar.bz2
osx-arm64::libgd-2.3.3-ha764fb0_2.tar.bz2
osx-arm64::jaxlib-0.3.0-py39hee6749c_4.tar.bz2
osx-arm64::cctools_osx-64-973.0.1-he94699d_7.tar.bz2
osx-arm64::sagelib-9.5-py38h830c1dc_3.tar.bz2
osx-arm64::gds-base-2.19.8-h7a27528_0.tar.bz2
osx-arm64::sagelib-9.5-py38h7824bfe_4.tar.bz2
osx-arm64::grpc-cpp-1.44.0-h1b780c8_1.tar.bz2
osx-arm64::gemmi-0.5.3-py310hc7cf0d3_0.tar.bz2
osx-arm64::boost-cpp-1.74.0-h3afdda6_7.tar.bz2
osx-arm64::libgdal-3.4.2-h48f03e8_3.tar.bz2
osx-arm64::sagelib-9.5-py38h07b73e2_0.tar.bz2
osx-arm64::libthrift-0.16.0-h82e8d0e_0.tar.bz2
osx-arm64::libpq-14.2-h8bb6238_0.tar.bz2
osx-arm64::grpc-cpp-1.45.0-h21168a7_0.tar.bz2
osx-arm64::vtk-9.1.0-qt_py39hde179ea_206.tar.bz2
osx-arm64::git-2.35.1-pl5321h8b11ce0_0.tar.bz2
osx-arm64::ogre-13.3.1-h0aef09b_0.tar.bz2
osx-arm64::grpc-cpp-1.43.2-ha9bca3c_1.tar.bz2
osx-arm64::grpcio-1.45.0-py38hdbc235a_0.tar.bz2
osx-arm64::llvmdev-14.0.0-hfd59cb2_0.tar.bz2
osx-arm64::gds-base-2.19.8-h7a27528_1.tar.bz2
osx-arm64::mysql-client-8.0.28-h039e5bf_2.tar.bz2
osx-arm64::grpcio-1.45.0-py39hcf421d0_0.tar.bz2
osx-arm64::arrow-cpp-3.0.0-py310h41d483d_47_cpu.tar.bz2
osx-arm64::r-git2r-0.30.1-r41hcac8a30_0.tar.bz2
osx-arm64::geotiff-1.7.1-hdd9897c_1.tar.bz2
osx-arm64::cairo-1.16.0-h3e596be_1011.tar.bz2
osx-arm64::arrow-cpp-7.0.0-py38hc57d2f6_3_cpu.tar.bz2
osx-arm64::vtk-9.1.0-qt_py310h04a9894_206.tar.bz2
osx-arm64::libgdal-3.4.2-h0bd00c1_1.tar.bz2
osx-arm64::gazebo-11.10.1-h9e7006a_5.tar.bz2
osx-arm64::libopencv-4.5.5-py31hba62dce_5.tar.bz2
osx-arm64::r-git2r-0.30.1-r41hdb45d14_0.tar.bz2
osx-arm64::python-3.10.2-hd16f9c5_4_cpython.tar.bz2
osx-arm64::nodejs-17.7.1-h7222cb3_0.tar.bz2
osx-arm64::glib-2.70.2-hccf11d3_3.tar.bz2
osx-arm64::thrift-compiler-0.16.0-h82e8d0e_1.tar.bz2
osx-arm64::postgresql-plpython-14.2-py38hc74b889_0.tar.bz2
osx-arm64::libxslt-1.1.33-h29d35be_4.tar.bz2
osx-arm64::cctools_osx-64-973.0.1-h18f9b51_8.tar.bz2
osx-arm64::libopencv-4.5.5-py39h8339426_4.tar.bz2
osx-arm64::grpcio-1.45.0-py38hcb8a1bf_0.tar.bz2
osx-arm64::imagemagick-7.1.0_27-pl5321h7fa8d43_1.tar.bz2
osx-arm64::arrow-cpp-5.0.0-py38hde8cdbd_27_cpu.tar.bz2
osx-arm64::pyinstaller-4.10-py38h2495b5b_0.tar.bz2
osx-arm64::arrow-cpp-7.0.0-py310hf208a88_1_cpu.tar.bz2
osx-arm64::xrootd-5.4.1-py38h5789955_0.tar.bz2
osx-arm64::libgdal-3.4.2-hf30a3e3_0.tar.bz2
osx-arm64::libcurl-7.82.0-h9476f53_0.tar.bz2
osx-arm64::jaxlib-0.1.76-py310h4a9df4e_0.tar.bz2
osx-arm64::cctools_osx-arm64-973.0.1-ha8964d5_6.tar.bz2
osx-arm64::ruby-3.1.1-h462d72a_0.tar.bz2
osx-arm64::mysql-libs-8.0.28-hb723b2b_2.tar.bz2
osx-arm64::imagecodecs-2021.11.20-py39hb60319c_2.tar.bz2
osx-arm64::llvmdev-11.1.0-h93073aa_3.tar.bz2
osx-arm64::pdal-2.4.0-h71c66b6_2.tar.bz2
osx-arm64::gsoap-2.8.119-h012ac28_0.tar.bz2
osx-arm64::nss-3.77-h3fd8894_0.tar.bz2
osx-arm64::ogre-13.3.2-hcb396c5_0.tar.bz2
osx-arm64::libnghttp2-1.47.0-hf30690b_0.tar.bz2
osx-arm64::cctools_osx-arm64-973.0.1-h6d0d814_7.tar.bz2
osx-arm64::arrow-cpp-7.0.0-py310hdcb6bdc_2_cpu.tar.bz2
osx-arm64::gemmi-0.5.2-py39hd599773_0.tar.bz2
osx-arm64::ptscotch-6.1.3-h1aec651_0.tar.bz2
osx-arm64::tiledb-2.6.2-h42267fc_1.tar.bz2
osx-arm64::cppyy-cling-6.25.3-py38h2ad942f_0.tar.bz2
osx-arm64::imagecodecs-2022.2.22-py310h091b352_0.tar.bz2
osx-arm64::sdl_image-1.2.12-he1e29eb_2.tar.bz2
osx-arm64::arrow-cpp-3.0.0-py39h124ca9e_45_cpu.tar.bz2
osx-arm64::grpcio-1.44.0-py39h9e1b6db_0.tar.bz2
osx-arm64::hdf5-1.12.1-mpi_mpich_h102acf4_4.tar.bz2
osx-arm64::gsoap-2.8.119-h47592b2_0.tar.bz2
osx-arm64::imagemagick-7.1.0_28-pl5321h7fa8d43_0.tar.bz2
osx-arm64::cpp-opentelemetry-sdk-1.2.0-hc73a0e7_1.tar.bz2
osx-arm64::vtk-9.1.0-qt_py310he7581b8_205.tar.bz2
osx-arm64::jaxlib-0.1.76-py39h47e937f_0.tar.bz2
osx-arm64::wxpython-4.1.1-py39h2f097a1_4.tar.bz2
osx-arm64::libxml2-2.9.12-h97d9dda_2.tar.bz2
osx-arm64::r-git2r-0.30.1-r40hdb45d14_0.tar.bz2
osx-arm64::arrow-cpp-5.0.0-py310hf208a88_25_cpu.tar.bz2
osx-arm64::gsoap-2.8.120-h0bb0491_0.tar.bz2
osx-arm64::imagecodecs-2021.11.20-py38hb506a02_2.tar.bz2
osx-arm64::llvmdev-13.0.1-hfd59cb2_2.tar.bz2
osx-arm64::scotch-6.1.3-h876676f_0.tar.bz2
osx-arm64::pillow-9.0.1-py310h3e63bf8_1.tar.bz2
osx-arm64::pillow-9.0.1-py310hade9107_2.tar.bz2
osx-arm64::arrow-cpp-3.0.0-py39h9a70de5_42_cpu.tar.bz2
osx-arm64::libgdal-3.4.1-hf30a3e3_6.tar.bz2
osx-arm64::sagelib-9.5-py39hc334225_3.tar.bz2
osx-arm64::tiledb-2.6.4-h29b8279_0.tar.bz2
osx-arm64::arrow-cpp-3.0.0-py310h4f50a0f_46_cpu.tar.bz2
osx-arm64::geotiff-1.7.0-hdd9897c_7.tar.bz2
osx-arm64::cctools_osx-64-973.0.1-h18f9b51_7.tar.bz2
osx-arm64::libopencv-4.5.5-py38he783a06_6.tar.bz2
osx-arm64::pdal-2.4.0-h5f7a6e7_1.tar.bz2
osx-arm64::ffmpeg-4.4.1-hdbd4ad8_1.tar.bz2
osx-arm64::arrow-cpp-5.0.0-py310h1c50ec5_24_cpu.tar.bz2
osx-arm64::nodejs-17.8.0-h7222cb3_0.tar.bz2
osx-arm64::libgdal-3.4.2-h08ccaa9_4.tar.bz2
osx-arm64::pdal-2.4.0-h1595254_1.tar.bz2
osx-arm64::arrow-cpp-6.0.1-py310h1c50ec5_10_cpu.tar.bz2
osx-arm64::ffmpeg-4.3.2-h38cfed3_2.tar.bz2
osx-arm64::libvips-8.12.2-heab14ee_3.tar.bz2
osx-arm64::arrow-cpp-3.0.0-py38hbe1c6da_44_cpu.tar.bz2
osx-arm64::grpcio-1.45.0-py39hc66773f_0.tar.bz2
osx-arm64::pyinstaller-4.9-py38h95a778e_0.tar.bz2
osx-arm64::grpc-cpp-1.44.0-h21168a7_1.tar.bz2
osx-arm64::assimp-5.2.1-h0f81e16_0.tar.bz2
osx-arm64::sagelib-9.5-py310h405397e_2.tar.bz2
osx-arm64::gap-core-4.11.1-h733227d_3.tar.bz2
osx-arm64::cctools_osx-arm64-973.0.1-h83ffe51_8.tar.bz2
osx-arm64::vtk-9.1.0-qt_py39h5db3e32_204.tar.bz2
osx-arm64::curl-7.82.0-h9476f53_0.tar.bz2
osx-arm64::jaxlib-0.3.0-py38hc725b12_3.tar.bz2
osx-arm64::pdal-2.3.0-ha33626d_27.tar.bz2
osx-arm64::arrow-cpp-3.0.0-py39h75128fe_43_cpu.tar.bz2
osx-arm64::libopencv-4.5.5-py38hd5ba69c_3.tar.bz2
osx-arm64::llvmdev-13.0.1-hfd59cb2_1.tar.bz2
osx-arm64::tiledb-2.7.0-h9fb27ea_0.tar.bz2
osx-arm64::vigra-1.11.1-py38hb7c60bc_1029.tar.bz2
osx-arm64::mysql-server-8.0.28-hcb2789f_2.tar.bz2
osx-arm64::cpp-opentelemetry-sdk-1.1.1-h302c441_3.tar.bz2
osx-arm64::libglib-2.70.2-h67e64d8_4.tar.bz2
osx-arm64::gazebo-11.10.1-hce63f14_5.tar.bz2
osx-arm64::fish-3.3.1-h0569eea_0.tar.bz2
osx-arm64::r-base-4.0.5-h8038371_6.tar.bz2
osx-arm64::postgresql-plpython-14.2-py310h5e722aa_0.tar.bz2
osx-arm64::libopencv-4.5.5-py31ha7d2a18_2.tar.bz2
osx-arm64::libxmlsec1-1.2.33-hc1f9ae4_0.tar.bz2
osx-arm64::hdf5-1.12.1-nompi_hd9dbc9e_104.tar.bz2
osx-arm64::scotch-6.0.9-h7537618_2.tar.bz2
osx-arm64::pdal-2.3.0-h85820b7_26.tar.bz2
osx-arm64::cppyy-cling-6.25.3-py310h5297d37_0.tar.bz2
osx-arm64::gdstk-0.8.2-py310h4ae449b_0.tar.bz2
osx-arm64::pdal-2.4.0-hc55c685_2.tar.bz2
osx-arm64::graphviz-3.0.0-hd4d4665_1.tar.bz2
osx-arm64::libgdal-3.4.2-h48f03e8_2.tar.bz2
osx-arm64::thrift-compiler-0.16.0-h82e8d0e_0.tar.bz2
osx-arm64::magics-metview-batch-4.11.0-h4915a05_0.tar.bz2
osx-arm64::orc-1.7.3-hcb6706d_0.tar.bz2
osx-arm64::vtk-9.1.0-qt_py38h709e697_204.tar.bz2
osx-arm64::thrift-compiler-0.16.0-h95ff8ae_0.tar.bz2
osx-arm64::arrow-cpp-6.0.1-py310hf208a88_10_cpu.tar.bz2
osx-arm64::libgit2-1.4.2-h6407d7d_0.tar.bz2
osx-arm64::jaxlib-0.3.0-py39h336c7f0_3.tar.bz2
osx-arm64::cctools_osx-64-973.0.1-h9133aa7_9.tar.bz2
osx-arm64::grpcio-1.44.0-py310h6d64de0_0.tar.bz2
osx-arm64::vtk-9.1.0-qt_py39hb86dead_207.tar.bz2
osx-arm64::mysql-client-8.0.28-hee60060_2.tar.bz2
osx-arm64::arrow-cpp-5.0.0-py39h124ca9e_26_cpu.tar.bz2
osx-arm64::cctools_osx-64-973.0.1-he94699d_8.tar.bz2
osx-arm64::pdal-2.4.0-hf9b4732_0.tar.bz2
osx-arm64::libopencv-4.5.5-py31hbb3386e_3.tar.bz2
osx-arm64::arrow-cpp-5.0.0-py39h75128fe_24_cpu.tar.bz2
osx-arm64::imagemagick-7.1.0_26-pl5321h459a37b_0.tar.bz2
osx-arm64::arrow-cpp-3.0.0-py39hbc74010_44_cpu.tar.bz2
osx-arm64::arrow-cpp-6.0.1-py39h124ca9e_11_cpu.tar.bz2
osx-arm64::vigra-1.11.1-py39h16694f6_1029.tar.bz2
osx-arm64::cctools_osx-64-973.0.1-h9133aa7_7.tar.bz2
osx-arm64::sagelib-9.5-py38h07b73e2_1.tar.bz2
osx-arm64::jaxlib-0.3.0-py38hd48e246_3.tar.bz2
osx-arm64::jaxlib-0.3.0-py38hc725b12_4.tar.bz2
osx-arm64::vowpalwabbit-9.0.1-py38h8080f16_0.tar.bz2
osx-arm64::libglib-2.70.2-h67e64d8_2.tar.bz2
osx-arm64::pdal-2.3.0-ha33626d_26.tar.bz2
osx-arm64::cmake-3.22.2-hda3674b_0.tar.bz2
osx-arm64::gazebo-11.10.2-hce63f14_0.tar.bz2
osx-arm64::libopencv-4.5.5-py31hbb3386e_4.tar.bz2
osx-arm64::ogre-13.3.3-hcb396c5_0.tar.bz2
osx-arm64::tectonic-0.8.2-h12364cf_2.tar.bz2
osx-arm64::libnghttp2-1.47.0-he723fca_0.tar.bz2
osx-arm64::arrow-cpp-5.0.0-py38hbe1c6da_25_cpu.tar.bz2
osx-arm64::arrow-cpp-3.0.0-py38h674b21d_47_cpu.tar.bz2
osx-arm64::python-3.10.2-h38ef502_4_cpython.tar.bz2
osx-arm64::xrootd-5.4.1-py310hd2c8f92_0.tar.bz2
osx-arm64::python-3.10.4-hfc7342c_0_cpython.tar.bz2
osx-arm64::openssh-8.9p1-h1704389_0.tar.bz2
osx-arm64::libcurl-static-7.82.0-h9476f53_0.tar.bz2
osx-arm64::libopencv-4.5.5-py38hf332e9d_1.tar.bz2
osx-arm64::cairo-1.16.0-h933af38_1010.tar.bz2
osx-arm64::sagelib-9.5-py39h546258d_0.tar.bz2
osx-arm64::arrow-cpp-3.0.0-py38h23c31fd_45_cpu.tar.bz2
osx-arm64::wxpython-4.1.1-py310h88f142e_4.tar.bz2
osx-arm64::cctools_osx-64-973.0.1-h18f9b51_9.tar.bz2
osx-arm64::imagecodecs-2022.2.22-py310h236f8b5_1.tar.bz2
osx-arm64::libgdal-3.4.1-h574e511_4.tar.bz2
osx-arm64::tectonic-0.8.2-hc9dd725_3.tar.bz2
osx-arm64::jaxlib-0.3.0-py39hee6749c_3.tar.bz2
osx-arm64::libprotobuf-3.20.0-h1280f1d_0.tar.bz2
osx-arm64::imagecodecs-2022.2.22-py38hb1af012_1.tar.bz2
osx-arm64::libgdal-3.4.1-h16baebc_4.tar.bz2
osx-arm64::xrootd-5.4.1-py39h18e9571_0.tar.bz2
osx-arm64::cctools_osx-64-973.0.1-he94699d_9.tar.bz2
osx-arm64::arrow-cpp-7.0.0-py39hbc74010_1_cpu.tar.bz2
osx-arm64::arrow-cpp-7.0.0-py310hb73aeef_3_cpu.tar.bz2
osx-arm64::libspatialite-5.0.1-he30b116_15.tar.bz2
osx-arm64::pyinstaller-4.10-py310h5e5bb13_0.tar.bz2
osx-arm64::cctools_osx-arm64-973.0.1-ha8964d5_8.tar.bz2
osx-arm64::python-3.8.13-hd3575e6_0_cpython.tar.bz2
osx-arm64::gemmi-0.5.2-py38hd1051fe_0.tar.bz2
osx-arm64::plumed-2.8.0-nompi_h3f8a045_100.tar.bz2
osx-arm64::pillow-9.0.1-py38he7148d4_0.tar.bz2
osx-arm64::wxpython-4.1.1-py310h88f142e_5.tar.bz2
osx-arm64::tiledb-2.6.3-h29b8279_0.tar.bz2
osx-arm64::tectonic-0.8.2-hc2ce5c4_1.tar.bz2
osx-arm64::thrift-compiler-0.16.0-h95ff8ae_1.tar.bz2
osx-arm64::vigra-1.11.1-py310h96ff711_1029.tar.bz2
osx-arm64::gmsh-4.9.4-h78df4b7_0.tar.bz2
osx-arm64::grpcio-1.45.0-py310hcce4227_0.tar.bz2
osx-arm64::libprotobuf-static-3.20.0-h1280f1d_0.tar.bz2
osx-arm64::gmsh-4.9.5-hed44fa3_0.tar.bz2
osx-arm64::cctools_osx-64-973.0.1-h18f9b51_10.tar.bz2
osx-arm64::imagemagick-7.1.0_25-pl5321hc21dce0_0.tar.bz2
osx-arm64::arrow-cpp-3.0.0-py310h0273c55_45_cpu.tar.bz2
osx-arm64::vowpalwabbit-9.0.1-py39ha632e4d_0.tar.bz2
osx-arm64::imagemagick-7.1.0_24-pl5321hc21dce0_0.tar.bz2
osx-arm64::gmt-6.3.0-h4282587_4.tar.bz2
osx-arm64::arrow-cpp-3.0.0-py38hd3fa324_43_cpu.tar.bz2
osx-arm64::tiledb-2.6.3-h9fb27ea_0.tar.bz2
osx-arm64::scotch-6.0.9-h1dec63b_2.tar.bz2
osx-arm64::libopencv-4.5.5-py38he783a06_5.tar.bz2
osx-arm64::python-3.8.13-h7e095e3_0_cpython.tar.bz2
osx-arm64::vtk-9.1.0-qt_py38habe854f_207.tar.bz2
osx-arm64::imagecodecs-2022.2.22-py39h62e9cd5_0.tar.bz2
osx-arm64::grpcio-1.45.0-py310he998f7c_0.tar.bz2
osx-arm64::mlir-13.0.1-hc6d3c91_0.tar.bz2
osx-arm64::arrow-cpp-6.0.1-py38hde8cdbd_12_cpu.tar.bz2
osx-arm64::pillow-9.0.1-py39hcb29f89_0.tar.bz2
osx-arm64::postgresql-plpython-14.2-py310h037995a_0.tar.bz2
osx-arm64::grpc-cpp-1.45.0-h1b780c8_0.tar.bz2
osx-arm64::ptscotch-6.1.3-hd02db47_0.tar.bz2
osx-arm64::grpc-cpp-1.43.2-heebc63f_2.tar.bz2
osx-arm64::r-base-4.0.5-hccdfac8_5.tar.bz2
osx-arm64::libvips-8.12.2-h9dee988_2.tar.bz2
osx-arm64::sagelib-9.5-py39h1ccef93_4.tar.bz2
osx-arm64::pdal-2.4.0-heeebd26_0.tar.bz2
osx-arm64::r-base-4.1.3-ha8bc873_0.tar.bz2
osx-arm64::qt-main-5.15.2-h76a31b5_2.tar.bz2
osx-arm64::r-git2r-0.30.1-r40hcac8a30_0.tar.bz2
osx-arm64::libcurl-static-7.82.0-hb0e6552_0.tar.bz2
osx-arm64::postgresql-plpython-14.2-py38h3fd6ac3_0.tar.bz2
osx-arm64::libopencv-4.5.5-py38hbbff82d_7.tar.bz2
osx-arm64::root_base-6.26.0-py310h4f1623d_0.tar.bz2
osx-arm64::sqlite-3.37.1-h7e3ccbd_0.tar.bz2
osx-arm64::root_base-6.26.0-py39hd7d9cc8_0.tar.bz2
osx-arm64::grpc-cpp-1.44.0-h4ab3678_0.tar.bz2
osx-arm64::pyinstaller-4.10-py39hd623912_0.tar.bz2
osx-arm64::libthrift-0.16.0-h95ff8ae_0.tar.bz2
osx-arm64::cctools_osx-64-973.0.1-he94699d_6.tar.bz2
osx-arm64::r-base-4.1.3-h29de36c_1.tar.bz2
osx-arm64::gdstk-0.8.2-py39h698fb12_0.tar.bz2
osx-arm64::grpcio-1.44.0-py39h18b86b0_0.tar.bz2
osx-arm64::python-3.9.10-hd16f9c5_2_cpython.tar.bz2
osx-arm64::gsoap-2.8.120-h4b682c6_0.tar.bz2
osx-arm64::graphviz-3.0.0-hd4d4665_0.tar.bz2
osx-arm64::vtk-9.1.0-qt_py39h98aef19_205.tar.bz2
osx-arm64::libopencv-4.5.5-py39hb8da993_1.tar.bz2
osx-arm64::jaxlib-0.3.0-py310h0555b46_3.tar.bz2
osx-arm64::imagemagick-7.1.0_27-pl5321h459a37b_0.tar.bz2
osx-arm64::python-3.10.4-h14b404e_0_cpython.tar.bz2
osx-arm64::libgdal-3.4.1-hf16eb10_5.tar.bz2
osx-arm64::cpp-opentelemetry-sdk-1.2.0-hdcb62f1_0.tar.bz2
osx-arm64::postgresql-14.2-h8fdef8c_0.tar.bz2
osx-arm64::libopencv-4.5.5-py31hba62dce_6.tar.bz2
osx-arm64::mysql-libs-8.0.28-h39b7a3a_2.tar.bz2
osx-arm64::libtiff-4.3.0-h77dc3b6_3.tar.bz2
osx-arm64::libopencv-4.5.5-py39hb8da993_2.tar.bz2
osx-arm64::jaxlib-0.3.0-py310h0555b46_4.tar.bz2
osx-arm64::llvmdev-13.0.1-h93073aa_0.tar.bz2
osx-arm64::libgdal-3.4.2-h4a3f275_4.tar.bz2
osx-arm64::nodejs-16.14.2-h7222cb3_0.tar.bz2
osx-arm64::python-3.9.10-h38ef502_2_cpython.tar.bz2
osx-arm64::arrow-cpp-5.0.0-py38hd3fa324_24_cpu.tar.bz2
osx-arm64::libthrift-0.16.0-h82e8d0e_1.tar.bz2
osx-arm64::tectonic-0.8.2-hc2ce5c4_2.tar.bz2
osx-arm64::ogre-13.3.0-h0aef09b_0.tar.bz2
osx-arm64::vtk-9.1.0-qt_py310hed62226_207.tar.bz2
osx-arm64::poppler-22.01.0-hb0e405e_1.tar.bz2
osx-arm64::vtk-9.1.0-qt_py310he2ab8b9_204.tar.bz2
osx-arm64::nodejs-17.8.0-hf46ff2d_1.tar.bz2
osx-arm64::scotch-6.1.3-hd898c4b_0.tar.bz2
osx-arm64::cctools_osx-arm64-973.0.1-h6d0d814_9.tar.bz2
osx-arm64::cctools_osx-arm64-973.0.1-h6d0d814_10.tar.bz2
osx-arm64::libgdal-3.4.2-hb7db5c1_0.tar.bz2
osx-arm64::arrow-cpp-3.0.0-py310hf8be076_42_cpu.tar.bz2
osx-arm64::glib-2.70.2-hccf11d3_2.tar.bz2
osx-arm64::libgd-2.3.3-hede1055_3.tar.bz2
osx-arm64::libopencv-4.5.5-py39h4853228_6.tar.bz2
osx-arm64::arrow-cpp-5.0.0-py310h4f50a0f_27_cpu.tar.bz2
osx-arm64::jaxlib-0.1.76-py38h4e528d7_0.tar.bz2
osx-arm64::arrow-cpp-6.0.1-py310h4f50a0f_12_cpu.tar.bz2
osx-arm64::arrow-cpp-5.0.0-py39hcec9aaf_27_cpu.tar.bz2
osx-arm64::libgdal-3.4.2-hc7d5716_1.tar.bz2
osx-arm64::cctools_osx-64-973.0.1-h9133aa7_10.tar.bz2
osx-arm64::voms-2.1.0rc0-h85681d6_6.tar.bz2
osx-arm64::pdal-2.3.0-h85820b7_27.tar.bz2
osx-arm64::libgdal-3.4.1-h302e65c_3.tar.bz2
osx-arm64::python-3.10.2-h38ef502_3_cpython.tar.bz2
osx-arm64::sagelib-9.5-py39h546258d_1.tar.bz2
osx-arm64::arrow-cpp-6.0.1-py39hbc74010_10_cpu.tar.bz2
osx-arm64::libglib-2.70.2-h67e64d8_3.tar.bz2
osx-arm64::pyinstaller-4.9-py310h5363a0e_0.tar.bz2
osx-arm64::ffmpeg-5.0.0-he648476_1.tar.bz2
osx-arm64::giac-1.6.0.47-h70c726c_4.tar.bz2
osx-arm64::root_base-6.26.0-py38h1017486_0.tar.bz2
osx-arm64::pillow-9.0.0-py310h3e63bf8_0.tar.bz2
osx-arm64::nodejs-17.7.1-h8da9806_0.tar.bz2
osx-arm64::nodejs-17.8.0-h941bd55_1.tar.bz2
osx-arm64::symengine-0.9.0-hbe37ca7_0.tar.bz2
osx-arm64::jaxlib-0.3.0-py38hd48e246_4.tar.bz2
osx-arm64::nss-3.76-h3fd8894_0.tar.bz2
osx-arm64::libvips-8.12.2-h9dee988_1.tar.bz2
osx-arm64::python-3.10.2-hd16f9c5_3_cpython.tar.bz2
osx-arm64::arrow-cpp-7.0.0-py38h0187a5a_0_cpu.tar.bz2
osx-arm64::arrow-cpp-5.0.0-py39hbc74010_25_cpu.tar.bz2
osx-arm64::vtk-9.1.0-qt_py38h52883c0_206.tar.bz2
osx-arm64::imagemagick-7.1.0_23-pl5321hc21dce0_0.tar.bz2
osx-arm64::arrow-cpp-7.0.0-py38hbe1c6da_1_cpu.tar.bz2
osx-arm64::emacs-27.2-hcba963b_2.tar.bz2
osx-arm64::arrow-cpp-7.0.0-py39h9a70de5_0_cpu.tar.bz2
osx-arm64::gemmi-0.5.3-py39hd599773_0.tar.bz2
osx-arm64::tectonic-0.8.2-h642f594_0.tar.bz2
osx-arm64::arrow-cpp-7.0.0-py39h763d086_2_cpu.tar.bz2
osx-arm64::magics-metview-batch-4.11.0-hd09d65e_1.tar.bz2
osx-arm64::gdk-pixbuf-2.42.8-hdded42e_0.tar.bz2
osx-arm64::cctools_osx-arm64-973.0.1-h83ffe51_9.tar.bz2
osx-arm64::libgdal-3.4.1-hc1673d3_5.tar.bz2
osx-arm64::gfal2-2.20.5-hbc81552_0.tar.bz2
osx-arm64::tiledb-2.7.0-h29b8279_0.tar.bz2
osx-arm64::pillow-9.0.0-py39hcb29f89_0.tar.bz2
osx-arm64::libgdal-3.4.2-hb18a185_3.tar.bz2
osx-arm64::gemmi-0.5.2-py310hc7cf0d3_0.tar.bz2
osx-arm64::sagelib-9.5-py38h830c1dc_2.tar.bz2
osx-arm64::cctools_osx-arm64-973.0.1-h83ffe51_7.tar.bz2
osx-arm64::arrow-cpp-6.0.1-py38h23c31fd_11_cpu.tar.bz2
osx-arm64::libgit2-1.4.2-he56d1ff_0.tar.bz2
osx-arm64::giac-1.6.0.47-h70c726c_5.tar.bz2
osx-arm64::geotiff-1.7.1-hdd9897c_0.tar.bz2
osx-arm64::magics-4.11.0-h4915a05_0.tar.bz2
osx-arm64::cctools_osx-64-973.0.1-h18f9b51_6.tar.bz2
osx-arm64::libopencv-4.5.5-py39h982fb10_7.tar.bz2
osx-arm64::grpc-cpp-1.44.0-heebc63f_0.tar.bz2
osx-arm64::cctools_osx-arm64-973.0.1-h6d0d814_8.tar.bz2
osx-arm64::sagelib-9.5-py310h653da02_1.tar.bz2
osx-arm64::arrow-cpp-6.0.1-py39hcec9aaf_12_cpu.tar.bz2
osx-arm64::grpc-cpp-1.43.2-h4d76dc1_1.tar.bz2
osx-arm64::vtk-9.1.0-qt_py38hda1d4d4_205.tar.bz2
osx-arm64::grpc-cpp-1.43.2-h4ab3678_2.tar.bz2
osx-arm64::gazebo-11.10.2-h9e7006a_0.tar.bz2
osx-arm64::vowpalwabbit-9.0.1-py310h57bf9b6_0.tar.bz2
osx-arm64::hdf5-1.12.1-mpi_openmpi_h615f523_4.tar.bz2
osx-arm64::tiledb-2.7.1-h9fb27ea_0.tar.bz2
osx-arm64::hdf5-1.12.1-nompi_hf9525e8_104.tar.bz2
osx-arm64::wxpython-4.1.1-py39h2f097a1_5.tar.bz2
osx-arm64::magics-4.11.0-hd09d65e_1.tar.bz2
osx-arm64::sagelib-9.5-py310h405397e_3.tar.bz2
osx-arm64::openssh-8.9p1-h00f9d85_0.tar.bz2
osx-arm64::imagemagick-7.1.0_29-pl5321h7fa8d43_0.tar.bz2
osx-arm64::cctools_osx-arm64-973.0.1-h6d0d814_6.tar.bz2
osx-arm64::arrow-cpp-5.0.0-py310h41d483d_28_cpu.tar.bz2
osx-arm64::postgresql-plpython-14.2-py39hfb02eb8_0.tar.bz2
osx-arm64::assimp-5.2.3-hd77be17_1.tar.bz2
osx-arm64::arrow-cpp-6.0.1-py39h7f895e8_13_cpu.tar.bz2
osx-arm64::nodejs-16.14.2-hf46ff2d_1.tar.bz2
osx-arm64::mysql-server-8.0.28-h9f3fbdc_2.tar.bz2
osx-arm64::ruby-3.1.1-h0bd3743_0.tar.bz2
osx-arm64::pyinstaller-4.9-py39h3753aae_0.tar.bz2
osx-arm64::libcurl-7.82.0-hb0e6552_0.tar.bz2
osx-arm64::arrow-cpp-3.0.0-py39h7f895e8_47_cpu.tar.bz2
osx-arm64::imagecodecs-2022.2.22-py39h9494253_1.tar.bz2
osx-arm64::libpq-14.2-h2f670be_0.tar.bz2
osx-arm64::sagelib-9.5-py310h653da02_0.tar.bz2
osx-arm64::hdf5-1.12.1-mpi_mpich_hc830fdb_4.tar.bz2
osx-arm64::gdstk-0.8.2-py38habd9e6c_0.tar.bz2
osx-arm64::libgdal-3.4.1-hb7db5c1_6.tar.bz2
osx-arm64::arrow-cpp-6.0.1-py38hbe1c6da_10_cpu.tar.bz2
osx-arm64::pillow-9.0.1-py38h7ff1586_2.tar.bz2
osx-arm64::pyinstaller-4.9-py38h95a778e_1.tar.bz2
osx-arm64::hdf5-1.12.1-mpi_openmpi_hd5758bf_4.tar.bz2
osx-arm64::grpcio-1.44.0-py38h69ee544_0.tar.bz2
osx-arm64::qt-webengine-5.15.4-h0a2fcd7_1.tar.bz2
osx-arm64::arrow-cpp-5.0.0-py39h7f895e8_28_cpu.tar.bz2
osx-arm64::arrow-cpp-5.0.0-py38h23c31fd_26_cpu.tar.bz2
osx-arm64::libopencv-4.5.5-py39h4853228_5.tar.bz2
osx-arm64::libopencv-4.5.5-py31hb029696_7.tar.bz2
-    "libzlib >=1.2.11,<1.3.0a0",
+    "libzlib >=1.2.11,<2.0.0a0",
osx-arm64::cgns-4.3.0-h6c8e85d_0.tar.bz2
osx-arm64::gst-plugins-good-1.20.0-h6b740ab_1.tar.bz2
osx-arm64::dotnet-sdk-6.0.201-h35bb5c4_0.tar.bz2
osx-arm64::libmlir-13.0.1-hc6d3c91_0.tar.bz2
osx-arm64::gst-plugins-good-1.20.1-h34a15c1_1.tar.bz2
osx-arm64::libclang-cpp-9.0.1-root_62600_hc092715_4.tar.bz2
osx-arm64::libllvm13-13.0.1-hfd59cb2_1.tar.bz2
osx-arm64::libclang-cpp-9.0.1-default_h2c105f5_4.tar.bz2
osx-arm64::gst-plugins-good-1.20.1-h3a5e4cc_0.tar.bz2
osx-arm64::gst-plugins-base-1.20.0-h5bf8608_1.tar.bz2
osx-arm64::imath-3.1.5-h1280f1d_0.tar.bz2
osx-arm64::gst-plugins-good-1.20.0-hda84e41_0.tar.bz2
osx-arm64::llvm-tools-13.0.1-hfd59cb2_2.tar.bz2
osx-arm64::llvm-tools-13.0.1-h93073aa_0.tar.bz2
osx-arm64::imath-3.1.4-h1280f1d_0.tar.bz2
osx-arm64::dotnet-runtime-6.0.3-h35bb5c4_0.tar.bz2
osx-arm64::llvm-13.0.1-h95d0606_2.tar.bz2
osx-arm64::llvm-tools-14.0.0-hfd59cb2_0.tar.bz2
osx-arm64::llvm-tools-13.0.1-hfd59cb2_1.tar.bz2
osx-arm64::llvm-14.0.0-h95d0606_0.tar.bz2
osx-arm64::clang-9-9.0.1-default_h2c105f5_4.tar.bz2
osx-arm64::pocl-1.8-h422b2f1_2.tar.bz2
osx-arm64::cargo-bundle-licenses-0.4.0-h44762e8_1.tar.bz2
osx-arm64::glib-tools-2.70.2-hccf11d3_4.tar.bz2
osx-arm64::dotnet-aspnetcore-6.0.2-hd68eb72_0.tar.bz2
osx-arm64::pocl-1.8-h422b2f1_3.tar.bz2
osx-arm64::libllvm14-14.0.0-hfd59cb2_0.tar.bz2
osx-arm64::clang-9-9.0.1-cling_v0.9_h7a49ca7_4.tar.bz2
osx-arm64::llvm-11.1.0-h95d0606_3.tar.bz2
osx-arm64::llvm-tools-11.1.0-h93073aa_3.tar.bz2
osx-arm64::dotnet-aspnetcore-6.0.3-h35bb5c4_0.tar.bz2
osx-arm64::llvm-13.0.1-h95d0606_0.tar.bz2
osx-arm64::llvm-13.0.1-h95d0606_1.tar.bz2
osx-arm64::libclang-cpp9-9.0.1-default_h2c105f5_4.tar.bz2
osx-arm64::glib-tools-2.70.2-hccf11d3_2.tar.bz2
osx-arm64::liblal-7.1.7-fftw_hf0d75d2_100.tar.bz2
osx-arm64::cfitsio-4.1.0-hd4f5c17_0.tar.bz2
osx-arm64::openexr-3.1.4-h264c651_0.tar.bz2
osx-arm64::libclang-cpp-9.0.1-cling_v0.9_h7a49ca7_4.tar.bz2
osx-arm64::tk-8.6.12-he1e0b03_0.tar.bz2
osx-arm64::libllvm13-13.0.1-hfd59cb2_2.tar.bz2
osx-arm64::gst-plugins-base-1.20.0-h5bf8608_0.tar.bz2
osx-arm64::libllvm11-11.1.0-h93073aa_3.tar.bz2
osx-arm64::clang-9-9.0.1-root_62600_hc092715_4.tar.bz2
osx-arm64::gst-plugins-base-1.20.1-ha7673a1_1.tar.bz2
osx-arm64::dotnet-runtime-6.0.2-hd68eb72_0.tar.bz2
osx-arm64::libclang-cpp9-9.0.1-root_62600_hc092715_4.tar.bz2
osx-arm64::gst-plugins-base-1.20.1-ha7673a1_0.tar.bz2
osx-arm64::libmlir13-13.0.1-hc6d3c91_0.tar.bz2
osx-arm64::dotnet-sdk-6.0.102-hd68eb72_0.tar.bz2
osx-arm64::libclang-cpp9-9.0.1-cling_v0.9_h7a49ca7_4.tar.bz2
osx-arm64::libllvm13-13.0.1-h93073aa_0.tar.bz2
osx-arm64::glib-tools-2.70.2-hccf11d3_3.tar.bz2
osx-arm64::cgns-4.2.0-haf52726_4.tar.bz2
-    "libzlib >=1.2.11,<1.3.0a0"
+    "libzlib >=1.2.11,<2.0.0a0"
================================================================================
================================================================================
linux-ppc64le
linux-ppc64le::libgdal-3.4.2-hde13726_4.tar.bz2
linux-ppc64le::libgdal-3.4.2-h2eabd62_3.tar.bz2
linux-ppc64le::pypy3.9-7.3.8-h80351e3_1.tar.bz2
linux-ppc64le::nodejs-17.8.0-h2502c7a_0.tar.bz2
linux-ppc64le::libopencv-4.5.5-py39hcaffa48_4.tar.bz2
linux-ppc64le::vtk-9.1.0-qt_py39h237216a_207.tar.bz2
linux-ppc64le::libopencv-4.5.5-py39h58a90b4_5.tar.bz2
linux-ppc64le::git-2.35.1-pl5321h131946c_0.tar.bz2
linux-ppc64le::omniorb-4.2.5-py38h8129e00_1.tar.bz2
linux-ppc64le::ogre-13.3.1-h77e483d_0.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py310h859b7b6_27_cpu.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py310hb248296_47_cpu.tar.bz2
linux-ppc64le::grpcio-1.44.0-py39hfeb9d76_0.tar.bz2
linux-ppc64le::arrow-cpp-7.0.0-py37h4b8999b_3_cpu.tar.bz2
linux-ppc64le::pillow-9.0.0-py37h3c198d4_0.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py39h9ae4781_45_cpu.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py38h0092b8d_12_cpu.tar.bz2
linux-ppc64le::vtk-9.1.0-qt_py39h4969613_205.tar.bz2
linux-ppc64le::libopencv-4.5.5-py31h08c2d4d_3.tar.bz2
linux-ppc64le::nodejs-16.14.2-h93803ed_1.tar.bz2
linux-ppc64le::thrift-compiler-0.16.0-hbd5a2ea_1.tar.bz2
linux-ppc64le::pdal-2.4.0-hfc7abf7_1.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py38h5b96e63_44_cpu.tar.bz2
linux-ppc64le::vtk-9.1.0-qt_py37h8980a6c_205.tar.bz2
linux-ppc64le::mapserver-7.6.4-py38hfd71d6b_6.tar.bz2
linux-ppc64le::gsoap-2.8.119-h2b0589b_0.tar.bz2
linux-ppc64le::mapserver-7.6.4-py310h672423c_6.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py310hb248296_28_cpu.tar.bz2
linux-ppc64le::pillow-9.0.1-py310h1aa5e56_1.tar.bz2
linux-ppc64le::grpcio-1.45.0-py39headc9c4_0.tar.bz2
linux-ppc64le::hdf5-1.12.1-mpi_mpich_hdcbb436_4.tar.bz2
linux-ppc64le::pypy3.9-7.3.8-hf38bb15_1.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py310hff60ef8_10_cpu.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py38hf2a9520_26_cpu.tar.bz2
linux-ppc64le::pillow-9.0.1-py39he66da4f_1.tar.bz2
linux-ppc64le::postgresql-plpython-14.2-py38h79244f9_0.tar.bz2
linux-ppc64le::libopencv-4.5.5-py37h2601f1a_3.tar.bz2
linux-ppc64le::cairo-1.16.0-h9ac834e_1011.tar.bz2
linux-ppc64le::grpcio-1.44.0-py38h486b007_0.tar.bz2
linux-ppc64le::tiledb-2.6.4-h11b1e19_0.tar.bz2
linux-ppc64le::python-3.10.2-hb23fad7_3_cpython.tar.bz2
linux-ppc64le::r-base-4.1.3-h0f6f9f5_1.tar.bz2
linux-ppc64le::mapserver-7.6.4-py37h4dc27e4_6.tar.bz2
linux-ppc64le::pygrib-2.1.4-py37hf03c97d_4.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py38h6568a88_13_cpu.tar.bz2
linux-ppc64le::grpc-cpp-1.45.0-hb435f04_0.tar.bz2
linux-ppc64le::gsoap-2.8.120-ha019378_0.tar.bz2
linux-ppc64le::glib-2.70.2-h690f14c_4.tar.bz2
linux-ppc64le::clangdev-13.0.1-default_he4a137d_0.tar.bz2
linux-ppc64le::pdal-2.3.0-h31382d2_27.tar.bz2
linux-ppc64le::libopencv-4.5.5-py38h133b85f_7.tar.bz2
linux-ppc64le::libthrift-0.16.0-hbd5a2ea_1.tar.bz2
linux-ppc64le::libopencv-4.5.5-py39h8d7d62e_2.tar.bz2
linux-ppc64le::pygrib-2.1.4-py310h33b1636_4.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py39h9ae4781_11_cpu.tar.bz2
linux-ppc64le::libopencv-4.5.5-py39hcaffa48_3.tar.bz2
linux-ppc64le::libgdal-3.4.1-h983206e_6.tar.bz2
linux-ppc64le::pillow-9.0.0-py37haf5d9ea_0.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py37h667d868_46_cpu.tar.bz2
linux-ppc64le::libglib-2.70.2-hd362787_2.tar.bz2
linux-ppc64le::glib-2.70.2-h690f14c_2.tar.bz2
linux-ppc64le::arrow-cpp-7.0.0-py39h22b16e9_0_cpu.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py38he3cf795_42_cpu.tar.bz2
linux-ppc64le::curl-7.82.0-h1ac174b_0.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py38h0092b8d_27_cpu.tar.bz2
linux-ppc64le::cppyy-cling-6.25.3-py39h51b9803_0.tar.bz2
linux-ppc64le::voms-2.1.0rc0-h1c01908_6.tar.bz2
linux-ppc64le::libopencv-4.5.5-py31h5f6ef38_2.tar.bz2
linux-ppc64le::scotch-6.0.9-hb559f6d_2.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py37h87ee449_28_cpu.tar.bz2
linux-ppc64le::arrow-cpp-7.0.0-py38h5b96e63_1_cpu.tar.bz2
linux-ppc64le::pdal-2.3.0-had4e385_27.tar.bz2
linux-ppc64le::omniorb-4.2.5-py39h002269c_2.tar.bz2
linux-ppc64le::cppyy-cling-6.25.3-py37hdd56643_0.tar.bz2
linux-ppc64le::python-3.9.10-h1456e17_2_cpython.tar.bz2
linux-ppc64le::hdf5-1.12.1-nompi_he7b1174_104.tar.bz2
linux-ppc64le::arrow-cpp-7.0.0-py39h4d25238_3_cpu.tar.bz2
linux-ppc64le::ogre-13.3.2-h4fe95a5_0.tar.bz2
linux-ppc64le::libgdal-3.4.1-hf377565_5.tar.bz2
linux-ppc64le::nodejs-17.8.0-he9a8890_0.tar.bz2
linux-ppc64le::gfal2-2.20.5-hefd8611_0.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py39hfe1cfb8_47_cpu.tar.bz2
linux-ppc64le::cppyy-cling-6.25.3-py38hb6edf9e_0.tar.bz2
linux-ppc64le::libopencv-4.5.5-py37h103a70e_5.tar.bz2
linux-ppc64le::cmake-3.23.0-h4f7acd8_0.tar.bz2
linux-ppc64le::postgresql-plpython-14.2-py38hc51dd72_0.tar.bz2
linux-ppc64le::mysql-server-8.0.28-h6d70402_2.tar.bz2
linux-ppc64le::nodejs-17.7.1-he9a8890_0.tar.bz2
linux-ppc64le::xrootd-5.4.1-py37h139d166_0.tar.bz2
linux-ppc64le::nordugrid-arc-6.15.0-py310h02e3743_1.tar.bz2
linux-ppc64le::libgdal-3.4.2-hafa46ec_0.tar.bz2
linux-ppc64le::pdal-2.3.0-had4e385_26.tar.bz2
linux-ppc64le::mongodb-5.1.1-hc9fa4be_1.tar.bz2
linux-ppc64le::poppler-22.01.0-ha15b90a_2.tar.bz2
linux-ppc64le::libopencv-4.5.5-py39h58a90b4_6.tar.bz2
linux-ppc64le::pillow-9.0.1-py38hccce32e_1.tar.bz2
linux-ppc64le::nss-3.76-h4ed01ee_0.tar.bz2
linux-ppc64le::pillow-9.0.1-py310hc96afb3_2.tar.bz2
linux-ppc64le::xrootd-5.4.1-py37hbc4a76d_0.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py37h667d868_12_cpu.tar.bz2
linux-ppc64le::ffmpeg-4.4.1-h9ed9a75_2.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py37h49f8b1b_25_cpu.tar.bz2
linux-ppc64le::libgdal-3.4.2-h983206e_0.tar.bz2
linux-ppc64le::omniorb-4.2.5-py310h790102e_1.tar.bz2
linux-ppc64le::libprotobuf-3.20.0-ha72a2fa_0.tar.bz2
linux-ppc64le::grpcio-1.45.0-py39h002269c_0.tar.bz2
linux-ppc64le::ffmpeg-4.4.1-h9ed9a75_1.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py37h57b0ba0_26_cpu.tar.bz2
linux-ppc64le::python-3.8.13-h0cb8861_0_cpython.tar.bz2
linux-ppc64le::pypy3.8-7.3.8-h7e6389c_1.tar.bz2
linux-ppc64le::tiledb-2.6.2-h5191074_1.tar.bz2
linux-ppc64le::nodejs-17.7.1-h2502c7a_0.tar.bz2
linux-ppc64le::pypy3.8-7.3.8-h50729ec_1.tar.bz2
linux-ppc64le::python-3.9.10-hb23fad7_2_cpython.tar.bz2
linux-ppc64le::libcurl-7.82.0-h1ac174b_0.tar.bz2
linux-ppc64le::vowpalwabbit-9.0.1-py310h82fb54c_0.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py37h49f8b1b_44_cpu.tar.bz2
linux-ppc64le::hdf5-1.12.1-mpi_openmpi_hd7df8e7_4.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py39hdf3ac75_10_cpu.tar.bz2
linux-ppc64le::pillow-9.0.1-py37h9d9d421_2.tar.bz2
linux-ppc64le::nodejs-17.8.0-h93803ed_1.tar.bz2
linux-ppc64le::libopencv-4.5.5-py37h69d5711_1.tar.bz2
linux-ppc64le::nordugrid-arc-6.15.0-py38h7b2d203_1.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py38hcd9339b_43_cpu.tar.bz2
linux-ppc64le::vowpalwabbit-9.0.1-py39h9313748_0.tar.bz2
linux-ppc64le::tiledb-2.6.3-ha4bc364_0.tar.bz2
linux-ppc64le::libglib-2.70.2-hd362787_4.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py37h87ee449_47_cpu.tar.bz2
linux-ppc64le::cmake-3.23.0-h4f7acd8_1.tar.bz2
linux-ppc64le::r-git2r-0.30.1-r41h525679c_0.tar.bz2
linux-ppc64le::giac-1.6.0.47-h744312f_4.tar.bz2
linux-ppc64le::texlive-core-20210325-he677223_2.tar.bz2
linux-ppc64le::gfal2-2.20.4-hefd8611_0.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py39hfe1cfb8_28_cpu.tar.bz2
linux-ppc64le::python-3.9.12-h08a33c2_1_cpython.tar.bz2
linux-ppc64le::libnghttp2-1.47.0-h262a72d_0.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py37hcc7e9fa_24_cpu.tar.bz2
linux-ppc64le::omniorb-4.2.5-py310hef85685_1.tar.bz2
linux-ppc64le::gmsh-4.9.4-h6ed5c81_0.tar.bz2
linux-ppc64le::pillow-9.0.0-py39he66da4f_0.tar.bz2
linux-ppc64le::imagemagick-7.1.0_28-pl5321h2621fa6_0.tar.bz2
linux-ppc64le::postgresql-14.2-h90e3369_0.tar.bz2
linux-ppc64le::omniorb-4.2.5-py37h8c7194f_2.tar.bz2
linux-ppc64le::libgit2-1.4.2-heee76ec_0.tar.bz2
linux-ppc64le::grpcio-1.44.0-py38h62e2ba2_0.tar.bz2
linux-ppc64le::python-3.8.13-h2c4edbf_0_cpython.tar.bz2
linux-ppc64le::pillow-9.0.1-py37h3c198d4_0.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py310hff60ef8_44_cpu.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py39hfb22fb8_46_cpu.tar.bz2
linux-ppc64le::libgit2-1.4.2-h5f335ab_0.tar.bz2
linux-ppc64le::boost-cpp-1.74.0-haa3b612_7.tar.bz2
linux-ppc64le::nss-3.77-h4ed01ee_0.tar.bz2
linux-ppc64le::python-3.9.12-h88f7be1_1_cpython.tar.bz2
linux-ppc64le::imagecodecs-2022.2.22-py310h8eb6c30_1.tar.bz2
linux-ppc64le::grpcio-1.44.0-py310h68addab_0.tar.bz2
linux-ppc64le::cpp-opentelemetry-sdk-1.1.1-hd6d2a79_3.tar.bz2
linux-ppc64le::arrow-cpp-7.0.0-py37h49f8b1b_1_cpu.tar.bz2
linux-ppc64le::assimp-5.2.3-h52ce049_1.tar.bz2
linux-ppc64le::llvmdev-11.1.0-h6c99497_3.tar.bz2
linux-ppc64le::gsoap-2.8.120-hfabde2d_0.tar.bz2
linux-ppc64le::python-3.10.2-h1456e17_3_cpython.tar.bz2
linux-ppc64le::r-base-4.0.5-hdb9422a_6.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py37h57b0ba0_45_cpu.tar.bz2
linux-ppc64le::pillow-9.0.1-py39he47bc6b_2.tar.bz2
linux-ppc64le::pillow-9.0.1-py38hdb37dd1_2.tar.bz2
linux-ppc64le::pygrib-2.1.4-py39hadee8c2_4.tar.bz2
linux-ppc64le::grpc-cpp-1.44.0-hb435f04_1.tar.bz2
linux-ppc64le::thrift-compiler-0.16.0-hbd5a2ea_0.tar.bz2
linux-ppc64le::cpp-opentelemetry-sdk-1.2.0-hb6a04ad_1.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py38hcd9339b_10_cpu.tar.bz2
linux-ppc64le::geotiff-1.7.0-h263ce79_7.tar.bz2
linux-ppc64le::cmake-3.22.2-h812a133_0.tar.bz2
linux-ppc64le::plumed-2.8.0-mpi_mpich_h8f48b83_0.tar.bz2
linux-ppc64le::libopencv-4.5.5-py37hb1107e3_4.tar.bz2
linux-ppc64le::mapserver-7.6.4-py37h481afb3_6.tar.bz2
linux-ppc64le::r-base-4.1.3-h9984037_0.tar.bz2
linux-ppc64le::ogre-13.3.2-h1036217_0.tar.bz2
linux-ppc64le::scotch-6.1.3-hd07e43d_0.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py39h6eb465e_10_cpu.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py310he84995d_24_cpu.tar.bz2
linux-ppc64le::git-2.35.1-pl5321hbceff91_0.tar.bz2
linux-ppc64le::omniorb-4.2.5-py38h8129e00_2.tar.bz2
linux-ppc64le::nordugrid-arc-6.15.0-py39h3f4f55c_1.tar.bz2
linux-ppc64le::pdal-2.4.0-h0218297_2.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py39h6eb465e_43_cpu.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py38h5b96e63_10_cpu.tar.bz2
linux-ppc64le::omniorb-4.2.5-py310hef85685_2.tar.bz2
linux-ppc64le::libcurl-static-7.82.0-h1ac174b_0.tar.bz2
linux-ppc64le::r-base-4.0.5-hd2fdd4b_5.tar.bz2
linux-ppc64le::pillow-9.0.1-py37haf5d9ea_0.tar.bz2
linux-ppc64le::scotch-6.0.9-hdebe675_2.tar.bz2
linux-ppc64le::grpcio-1.44.0-py37h349bca1_0.tar.bz2
linux-ppc64le::libpq-14.2-he9d5e3e_0.tar.bz2
linux-ppc64le::vowpalwabbit-9.0.1-py37h7b6ee61_0.tar.bz2
linux-ppc64le::root_base-6.26.0-py310h9e88668_0.tar.bz2
linux-ppc64le::grpc-cpp-1.44.0-h448807a_1.tar.bz2
linux-ppc64le::grpc-cpp-1.44.0-h448807a_0.tar.bz2
linux-ppc64le::gsoap-2.8.119-ha8ed123_0.tar.bz2
linux-ppc64le::mapserver-7.6.4-py39he16d880_6.tar.bz2
linux-ppc64le::postgresql-plpython-14.2-py39h9cd38fc_0.tar.bz2
linux-ppc64le::llvmdev-13.0.1-h3b69f5b_1.tar.bz2
linux-ppc64le::libgsf-1.14.49-h74189ae_0.tar.bz2
linux-ppc64le::libcurl-7.82.0-h2ae36b4_0.tar.bz2
linux-ppc64le::llvmdev-13.0.1-h3b69f5b_2.tar.bz2
linux-ppc64le::omniorb-4.2.5-py39headc9c4_2.tar.bz2
linux-ppc64le::tiledb-2.6.4-ha4bc364_0.tar.bz2
linux-ppc64le::ogre-13.3.3-h4fe95a5_0.tar.bz2
linux-ppc64le::grpcio-1.45.0-py38h8129e00_0.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py39hdf3ac75_44_cpu.tar.bz2
linux-ppc64le::pdal-2.4.0-he20ec76_0.tar.bz2
linux-ppc64le::libvips-8.12.2-h7fbc68d_3.tar.bz2
linux-ppc64le::openssh-8.9p1-h41524dc_0.tar.bz2
linux-ppc64le::vtk-9.1.0-qt_py37hc5e4439_204.tar.bz2
linux-ppc64le::imagemagick-7.1.0_29-pl5321h2621fa6_0.tar.bz2
linux-ppc64le::omniorb-libs-4.2.5-h350ef5c_2.tar.bz2
linux-ppc64le::nodejs-16.14.2-ha3ae8d5_1.tar.bz2
linux-ppc64le::mapserver-7.6.4-py310hede0e3e_6.tar.bz2
linux-ppc64le::libgdal-3.4.1-hf88b8da_5.tar.bz2
linux-ppc64le::nodejs-16.14.2-h2502c7a_0.tar.bz2
linux-ppc64le::vtk-9.1.0-qt_py39ha1e1e53_206.tar.bz2
linux-ppc64le::omniorb-4.2.5-py310h790102e_2.tar.bz2
linux-ppc64le::ptscotch-6.1.3-h98907d5_0.tar.bz2
linux-ppc64le::thrift-compiler-0.16.0-h0c11152_0.tar.bz2
linux-ppc64le::arrow-cpp-7.0.0-py37hdcca7cc_2_cpu.tar.bz2
linux-ppc64le::libspatialite-5.0.1-h4e21e43_15.tar.bz2
linux-ppc64le::pygrib-2.1.4-py38h56deedf_4.tar.bz2
linux-ppc64le::pillow-9.0.1-py310h1aa5e56_0.tar.bz2
linux-ppc64le::libxml2-2.9.12-hc8bd4e3_2.tar.bz2
linux-ppc64le::libopencv-4.5.5-py37h69d5711_2.tar.bz2
linux-ppc64le::grpc-cpp-1.43.2-hdd124a7_1.tar.bz2
linux-ppc64le::libopencv-4.5.5-py37h0fefff6_7.tar.bz2
linux-ppc64le::cpp-opentelemetry-sdk-1.2.0-h798aaae_0.tar.bz2
linux-ppc64le::gmsh-4.9.5-hdf1b8cf_0.tar.bz2
linux-ppc64le::vtk-9.1.0-qt_py310h201117f_207.tar.bz2
linux-ppc64le::tiledb-2.7.1-h11b1e19_0.tar.bz2
linux-ppc64le::libprotobuf-static-3.20.0-ha72a2fa_0.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py39h9ae4781_26_cpu.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py38h6568a88_47_cpu.tar.bz2
linux-ppc64le::libgd-2.3.3-h774b3a9_2.tar.bz2
linux-ppc64le::wxwidgets-3.1.5-h6166594_0.tar.bz2
linux-ppc64le::libthrift-0.16.0-h0c11152_0.tar.bz2
linux-ppc64le::mapserver-7.6.4-py38h9aba87b_6.tar.bz2
linux-ppc64le::libopencv-4.5.5-py38hbcec484_3.tar.bz2
linux-ppc64le::grpcio-1.45.0-py38h064c1e6_0.tar.bz2
linux-ppc64le::pillow-9.0.0-py38hccce32e_0.tar.bz2
linux-ppc64le::libopencv-4.5.5-py37h103a70e_6.tar.bz2
linux-ppc64le::symengine-0.9.0-h8c3c122_0.tar.bz2
linux-ppc64le::libgdal-3.4.2-h2eabd62_2.tar.bz2
linux-ppc64le::mongodb-5.1.1-h119bcc4_1.tar.bz2
linux-ppc64le::arrow-cpp-7.0.0-py310hff60ef8_1_cpu.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py38h6568a88_28_cpu.tar.bz2
linux-ppc64le::nodejs-16.14.2-he9a8890_0.tar.bz2
linux-ppc64le::cairo-1.16.0-h2e03771_1010.tar.bz2
linux-ppc64le::root_base-6.26.0-py38h0c2d454_0.tar.bz2
linux-ppc64le::poppler-22.01.0-ha15b90a_1.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py310ha5f5442_45_cpu.tar.bz2
linux-ppc64le::imagecodecs-2022.2.22-py310h916663f_0.tar.bz2
linux-ppc64le::omniorb-4.2.5-py37h8c7194f_1.tar.bz2
linux-ppc64le::rust-1.59.0-hf3e60ca_0.tar.bz2
linux-ppc64le::nordugrid-arc-6.15.0-py37hc76ad04_0.tar.bz2
linux-ppc64le::mysql-libs-8.0.28-h3ac40eb_2.tar.bz2
linux-ppc64le::gap-core-4.11.1-hf604d9a_3.tar.bz2
linux-ppc64le::libopencv-4.5.5-py38ha34fcec_2.tar.bz2
linux-ppc64le::hdf5-1.12.1-mpi_mpich_h3c62663_4.tar.bz2
linux-ppc64le::libopencv-4.5.5-py38h413b418_4.tar.bz2
linux-ppc64le::vtk-9.1.0-qt_py38h838cf9a_205.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py39hfb22fb8_12_cpu.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py310ha5f5442_26_cpu.tar.bz2
linux-ppc64le::hdf5-1.12.1-mpi_openmpi_h31519e4_4.tar.bz2
linux-ppc64le::geotiff-1.7.1-h263ce79_0.tar.bz2
linux-ppc64le::vtk-9.1.0-qt_py37h1c4d9d1_206.tar.bz2
linux-ppc64le::ptscotch-6.1.3-h1290c27_0.tar.bz2
linux-ppc64le::mlir-13.0.1-h96f6aa1_0.tar.bz2
linux-ppc64le::libgdal-3.4.1-h56fdc24_3.tar.bz2
linux-ppc64le::orc-1.7.3-h5df204f_0.tar.bz2
linux-ppc64le::postgresql-plpython-14.2-py310h9609dfd_0.tar.bz2
linux-ppc64le::pdal-2.3.0-h31382d2_26.tar.bz2
linux-ppc64le::omniorb-4.2.5-py38h064c1e6_2.tar.bz2
linux-ppc64le::glib-2.70.2-h690f14c_3.tar.bz2
linux-ppc64le::omniorb-4.2.5-py37h0d21115_2.tar.bz2
linux-ppc64le::vtk-9.1.0-qt_py310h3aeffdd_205.tar.bz2
linux-ppc64le::ambertools-21.12-py39hf3add01_0.tar.bz2
linux-ppc64le::r-git2r-0.30.1-r41h1fc590f_0.tar.bz2
linux-ppc64le::geotiff-1.7.1-h263ce79_1.tar.bz2
linux-ppc64le::nordugrid-arc-6.15.0-py39h3f4f55c_0.tar.bz2
linux-ppc64le::mysql-router-8.0.28-hf17d03d_2.tar.bz2
linux-ppc64le::vtk-9.1.0-qt_py310h5741c1d_204.tar.bz2
linux-ppc64le::graphviz-3.0.0-h2dab0cd_0.tar.bz2
linux-ppc64le::python-3.9.12-h88f7be1_0_cpython.tar.bz2
linux-ppc64le::ogre-13.3.0-h820d8c4_0.tar.bz2
linux-ppc64le::gdk-pixbuf-2.42.8-hbeea2fb_0.tar.bz2
linux-ppc64le::libthrift-0.16.0-hbd5a2ea_0.tar.bz2
linux-ppc64le::grpcio-1.45.0-py37h8c7194f_0.tar.bz2
linux-ppc64le::xrootd-5.4.1-py310ha7ad7bd_0.tar.bz2
linux-ppc64le::omniorb-4.2.5-py39h002269c_1.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py39hfe1cfb8_13_cpu.tar.bz2
linux-ppc64le::grpcio-1.45.0-py310hef85685_0.tar.bz2
linux-ppc64le::sqlite-3.37.1-h3bd21b8_0.tar.bz2
linux-ppc64le::libcurl-static-7.82.0-h2ae36b4_0.tar.bz2
linux-ppc64le::ogre-13.3.1-h820d8c4_0.tar.bz2
linux-ppc64le::vtk-9.1.0-qt_py37h96ef7a9_207.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py38hcd9339b_24_cpu.tar.bz2
linux-ppc64le::grpcio-1.44.0-py39hff9cdcc_0.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py310h859b7b6_12_cpu.tar.bz2
linux-ppc64le::tiledb-2.6.2-hadab2f2_1.tar.bz2
linux-ppc64le::pillow-9.0.1-py37h3c198d4_1.tar.bz2
linux-ppc64le::irrlicht-1.8.5-h9c50326_2.tar.bz2
linux-ppc64le::nordugrid-arc-6.15.0-py37hfecfb3a_0.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py38h0092b8d_46_cpu.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py310hff60ef8_25_cpu.tar.bz2
linux-ppc64le::irrlicht-1.8.5-h9c50326_1.tar.bz2
linux-ppc64le::libgdal-3.4.2-hd41d216_3.tar.bz2
linux-ppc64le::assimp-5.2.1-h0cf024e_0.tar.bz2
linux-ppc64le::libnghttp2-1.47.0-h350ef5c_0.tar.bz2
linux-ppc64le::mysql-client-8.0.28-ha7fd285_2.tar.bz2
linux-ppc64le::libvips-8.12.2-hfce16b2_2.tar.bz2
linux-ppc64le::sdl_image-1.2.12-hcda331e_2.tar.bz2
linux-ppc64le::libxslt-1.1.33-h7dda857_4.tar.bz2
linux-ppc64le::pillow-9.0.1-py37haf5d9ea_1.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py39hdf3ac75_25_cpu.tar.bz2
linux-ppc64le::nodejs-17.8.0-ha3ae8d5_1.tar.bz2
linux-ppc64le::libgdal-3.4.2-hb7d27fe_1.tar.bz2
linux-ppc64le::arrow-cpp-7.0.0-py310hb5d1a8f_2_cpu.tar.bz2
linux-ppc64le::omniorb-4.2.5-py38h064c1e6_1.tar.bz2
linux-ppc64le::libgd-2.3.3-ha137eda_3.tar.bz2
linux-ppc64le::grpc-cpp-1.43.2-h8e12c62_1.tar.bz2
linux-ppc64le::arrow-cpp-7.0.0-py39hdf3ac75_1_cpu.tar.bz2
linux-ppc64le::root_base-6.26.0-py39h2c86c93_0.tar.bz2
linux-ppc64le::assimp-5.2.3-h52ce049_0.tar.bz2
linux-ppc64le::imagecodecs-2021.11.20-py38h08ab5ab_2.tar.bz2
linux-ppc64le::python-3.10.4-h88f7be1_0_cpython.tar.bz2
linux-ppc64le::mysql-server-8.0.28-he877b2a_2.tar.bz2
linux-ppc64le::r-git2r-0.30.1-r40h525679c_0.tar.bz2
linux-ppc64le::tiledb-2.7.1-ha4bc364_0.tar.bz2
linux-ppc64le::vowpalwabbit-9.0.1-py37h0dfffa5_0.tar.bz2
linux-ppc64le::ptscotch-6.0.9-h98907d5_2.tar.bz2
linux-ppc64le::arrow-cpp-7.0.0-py38hdf3962b_3_cpu.tar.bz2
linux-ppc64le::postgresql-14.2-h7cbc9f4_0.tar.bz2
linux-ppc64le::cppyy-cling-6.25.3-py310hbbdc3b4_0.tar.bz2
linux-ppc64le::vtk-9.1.0-qt_py310hfc5c6c0_206.tar.bz2
linux-ppc64le::xrootd-5.4.1-py38ha4d49f2_0.tar.bz2
linux-ppc64le::openssh-8.9p1-hbe330f9_0.tar.bz2
linux-ppc64le::libopencv-4.5.5-py31h5f6ef38_1.tar.bz2
linux-ppc64le::hdf5-1.12.1-nompi_h85f07b9_104.tar.bz2
linux-ppc64le::imagecodecs-2021.11.20-py39h7493cce_2.tar.bz2
linux-ppc64le::omniorb-4.2.5-py39headc9c4_1.tar.bz2
linux-ppc64le::arrow-cpp-7.0.0-py310h1e49579_0_cpu.tar.bz2
linux-ppc64le::pdal-2.4.0-hc541e0c_0.tar.bz2
linux-ppc64le::libgdal-3.4.1-h97096da_4.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py38h5b96e63_25_cpu.tar.bz2
linux-ppc64le::libopencv-4.5.5-py39hf7a273d_7.tar.bz2
linux-ppc64le::postgresql-plpython-14.2-py310h348c42b_0.tar.bz2
linux-ppc64le::giac-1.6.0.47-h744312f_5.tar.bz2
linux-ppc64le::ruby-3.1.1-h41c096d_0.tar.bz2
linux-ppc64le::tiledb-2.6.3-h11b1e19_0.tar.bz2
linux-ppc64le::libthrift-0.16.0-h0c11152_1.tar.bz2
linux-ppc64le::libglib-2.70.2-hd362787_3.tar.bz2
linux-ppc64le::libopencv-4.5.5-py38ha34fcec_1.tar.bz2
linux-ppc64le::ffmpeg-4.3.2-h39139ff_3.tar.bz2
linux-ppc64le::ogre-13.3.0-h77e483d_0.tar.bz2
linux-ppc64le::libgdal-3.4.2-hac65bbf_1.tar.bz2
linux-ppc64le::root_base-6.26.0-py37h8d57858_0.tar.bz2
linux-ppc64le::mapserver-7.6.4-py39hd3ab609_6.tar.bz2
linux-ppc64le::pillow-9.0.1-py38hccce32e_0.tar.bz2
linux-ppc64le::omniorb-libs-4.2.5-h262a72d_2.tar.bz2
linux-ppc64le::libgdal-3.4.2-h413b933_4.tar.bz2
linux-ppc64le::ptscotch-6.0.9-h1290c27_2.tar.bz2
linux-ppc64le::libgdal-3.4.2-hd41d216_2.tar.bz2
linux-ppc64le::grpc-cpp-1.45.0-h448807a_0.tar.bz2
linux-ppc64le::tiledb-2.7.0-h11b1e19_0.tar.bz2
linux-ppc64le::libtiff-4.3.0-hecb0ed6_3.tar.bz2
linux-ppc64le::nordugrid-arc-6.15.0-py37hfecfb3a_1.tar.bz2
linux-ppc64le::libopencv-4.5.5-py31h19e07a3_6.tar.bz2
linux-ppc64le::arrow-cpp-7.0.0-py38he3cf795_0_cpu.tar.bz2
linux-ppc64le::vtk-9.1.0-qt_py38h4fc2d26_206.tar.bz2
linux-ppc64le::arrow-cpp-7.0.0-py38hb59f2cf_2_cpu.tar.bz2
linux-ppc64le::pygrib-2.1.4-py37h51d9ca7_4.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py37h49f8b1b_10_cpu.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py310hb248296_13_cpu.tar.bz2
linux-ppc64le::r-git2r-0.30.1-r40h1fc590f_0.tar.bz2
linux-ppc64le::python-3.10.4-h08a33c2_0_cpython.tar.bz2
linux-ppc64le::pillow-9.0.1-py39he66da4f_0.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py38hf2a9520_11_cpu.tar.bz2
linux-ppc64le::libopencv-4.5.5-py38h50a938b_6.tar.bz2
linux-ppc64le::fish-3.3.1-h28d1537_0.tar.bz2
linux-ppc64le::imagecodecs-2021.11.20-py310hf7562e2_2.tar.bz2
linux-ppc64le::grpcio-1.44.0-py37hd4870b4_0.tar.bz2
linux-ppc64le::tiledb-2.7.0-ha4bc364_0.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py310he84995d_10_cpu.tar.bz2
linux-ppc64le::pdal-2.4.0-hcaf9475_1.tar.bz2
linux-ppc64le::ffmpeg-4.3.2-h39139ff_2.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py310h1e49579_42_cpu.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py38hf2a9520_45_cpu.tar.bz2
linux-ppc64le::ruby-3.1.1-hf3f6e89_0.tar.bz2
linux-ppc64le::grpc-cpp-1.43.2-hb435f04_2.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py310ha5f5442_11_cpu.tar.bz2
linux-ppc64le::thrift-compiler-0.16.0-h0c11152_1.tar.bz2
linux-ppc64le::imagecodecs-2022.2.22-py38hc7adad8_0.tar.bz2
linux-ppc64le::libopencv-4.5.5-py31h19e07a3_5.tar.bz2
linux-ppc64le::scotch-6.1.3-h5bbcfbc_0.tar.bz2
linux-ppc64le::imagecodecs-2022.2.22-py39h919635a_0.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py39h6eb465e_24_cpu.tar.bz2
linux-ppc64le::arrow-cpp-7.0.0-py39h2fc6aac_2_cpu.tar.bz2
linux-ppc64le::imagecodecs-2021.11.20-py37h1fdab17_2.tar.bz2
linux-ppc64le::libgdal-3.4.1-hc137bb9_3.tar.bz2
linux-ppc64le::vowpalwabbit-9.0.1-py38hddc5d0c_0.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py37h57b0ba0_11_cpu.tar.bz2
linux-ppc64le::libopencv-4.5.5-py38h50a938b_5.tar.bz2
linux-ppc64le::arrow-cpp-7.0.0-py37h86914f8_0_cpu.tar.bz2
linux-ppc64le::vtk-9.1.0-qt_py38h6ce26e7_204.tar.bz2
linux-ppc64le::nodejs-14.18.3-h9a3953a_3.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py37h87ee449_13_cpu.tar.bz2
linux-ppc64le::libgdal-3.4.1-h5bd74a4_4.tar.bz2
linux-ppc64le::imagemagick-7.1.0_27-pl5321h2621fa6_1.tar.bz2
linux-ppc64le::postgresql-plpython-14.2-py39hd2607ca_0.tar.bz2
linux-ppc64le::plumed-2.8.0-mpi_openmpi_h4b8123d_0.tar.bz2
linux-ppc64le::mysql-libs-8.0.28-ha23194b_2.tar.bz2
linux-ppc64le::curl-7.82.0-h2ae36b4_0.tar.bz2
linux-ppc64le::libxmlsec1-1.2.33-h15f123c_0.tar.bz2
linux-ppc64le::nordugrid-arc-6.15.0-py37hc76ad04_1.tar.bz2
linux-ppc64le::grpc-cpp-1.43.2-h448807a_2.tar.bz2
linux-ppc64le::libopencv-4.5.5-py31h177112c_7.tar.bz2
linux-ppc64le::libopencv-4.5.5-py31h08c2d4d_4.tar.bz2
linux-ppc64le::grpc-cpp-1.44.0-hb435f04_0.tar.bz2
linux-ppc64le::llvmdev-13.0.1-hd51dc09_0.tar.bz2
linux-ppc64le::postgresql-plpython-14.2-py37h3bad2af_0.tar.bz2
linux-ppc64le::mysql-client-8.0.28-hfff87ee_2.tar.bz2
linux-ppc64le::graphviz-3.0.0-h2dab0cd_1.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py39hfb22fb8_27_cpu.tar.bz2
linux-ppc64le::mysql-router-8.0.28-hdfabd79_2.tar.bz2
linux-ppc64le::imagecodecs-2022.2.22-py38hea14779_1.tar.bz2
linux-ppc64le::pillow-9.0.1-py37h5061cd4_2.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py37hcc7e9fa_43_cpu.tar.bz2
linux-ppc64le::libopencv-4.5.5-py39h8d7d62e_1.tar.bz2
linux-ppc64le::vtk-9.1.0-qt_py39h24aef15_204.tar.bz2
linux-ppc64le::nordugrid-arc-6.15.0-py38h7b2d203_0.tar.bz2
linux-ppc64le::pdal-2.4.0-h626f0fb_2.tar.bz2
linux-ppc64le::vtk-9.1.0-qt_py38hfa66816_207.tar.bz2
linux-ppc64le::llvmdev-14.0.0-h3b69f5b_0.tar.bz2
linux-ppc64le::grpcio-1.45.0-py37h0d21115_0.tar.bz2
linux-ppc64le::postgresql-plpython-14.2-py37hc97c45a_0.tar.bz2
linux-ppc64le::libgdal-3.4.1-hafa46ec_6.tar.bz2
linux-ppc64le::omniorb-4.2.5-py37h0d21115_1.tar.bz2
linux-ppc64le::libpq-14.2-h3e31190_0.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py310h859b7b6_46_cpu.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py310he84995d_43_cpu.tar.bz2
linux-ppc64le::ffmpeg-5.0.0-h7cb130c_0.tar.bz2
linux-ppc64le::python-3.9.12-h08a33c2_0_cpython.tar.bz2
linux-ppc64le::imagecodecs-2021.11.20-py37hb4986eb_2.tar.bz2
linux-ppc64le::btrfs-progs-5.16.2-hd390d64_0.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py37hcc7e9fa_10_cpu.tar.bz2
linux-ppc64le::grpcio-1.44.0-py310hbc3273a_0.tar.bz2
linux-ppc64le::ffmpeg-5.0.0-h9bc31b5_1.tar.bz2
linux-ppc64le::pillow-9.0.0-py310h1aa5e56_0.tar.bz2
linux-ppc64le::arrow-cpp-7.0.0-py310hbcd6b92_3_cpu.tar.bz2
linux-ppc64le::imagecodecs-2022.2.22-py39h68611b5_1.tar.bz2
linux-ppc64le::xrootd-5.4.1-py39hefb4610_0.tar.bz2
linux-ppc64le::cmake-3.22.3-h4f7acd8_0.tar.bz2
linux-ppc64le::grpcio-1.45.0-py310h790102e_0.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py37h667d868_27_cpu.tar.bz2
-    "libzlib >=1.2.11,<1.3.0a0",
+    "libzlib >=1.2.11,<2.0.0a0",
linux-ppc64le::plumed-2.8.0-nompi_h80597af_100.tar.bz2
linux-ppc64le::libmlir-13.0.1-h96f6aa1_0.tar.bz2
linux-ppc64le::clang-9-9.0.1-hcc_h7fea5d2_4.tar.bz2
linux-ppc64le::clang-tools-13.0.1-default_he4a137d_0.tar.bz2
linux-ppc64le::libclang-cpp-9.0.1-default_h6b7f2a5_4.tar.bz2
linux-ppc64le::clang-format-13.0.1-default_he4a137d_0.tar.bz2
linux-ppc64le::imath-3.1.4-ha72a2fa_0.tar.bz2
linux-ppc64le::libllvm13-13.0.1-hd51dc09_0.tar.bz2
linux-ppc64le::glib-tools-2.70.2-h690f14c_2.tar.bz2
linux-ppc64le::libclang-cpp13-13.0.1-default_he4a137d_0.tar.bz2
linux-ppc64le::libllvm13-13.0.1-h3b69f5b_1.tar.bz2
linux-ppc64le::llvm-openmp-13.0.1-h3b69f5b_1.tar.bz2
linux-ppc64le::libclang-cpp9-9.0.1-cling_v0.9_h8d17fa5_4.tar.bz2
linux-ppc64le::clang-9-9.0.1-root_62600_hfe130f6_4.tar.bz2
linux-ppc64le::libclang-13.0.1-default_he4a137d_0.tar.bz2
linux-ppc64le::libllvm13-13.0.1-h3b69f5b_2.tar.bz2
linux-ppc64le::libclang-cpp-9.0.1-cling_v0.9_h8d17fa5_4.tar.bz2
linux-ppc64le::gst-plugins-base-1.20.0-he376d82_0.tar.bz2
linux-ppc64le::libclang-cpp9-9.0.1-hcc_h7fea5d2_4.tar.bz2
linux-ppc64le::llvm-tools-11.1.0-h6c99497_3.tar.bz2
linux-ppc64le::clang-9-9.0.1-default_h6b7f2a5_4.tar.bz2
linux-ppc64le::glib-tools-2.70.2-h690f14c_4.tar.bz2
linux-ppc64le::llvm-11.1.0-h12068cf_3.tar.bz2
linux-ppc64le::llvm-tools-13.0.1-hd51dc09_0.tar.bz2
linux-ppc64le::llvm-13.0.1-h12068cf_2.tar.bz2
linux-ppc64le::libclang-cpp9-9.0.1-default_h6b7f2a5_4.tar.bz2
linux-ppc64le::llvm-tools-13.0.1-h3b69f5b_2.tar.bz2
linux-ppc64le::clang-9-9.0.1-cling_v0.9_h8d17fa5_4.tar.bz2
linux-ppc64le::llvm-tools-13.0.1-h3b69f5b_1.tar.bz2
linux-ppc64le::cfitsio-4.1.0-hb2f3dc4_0.tar.bz2
linux-ppc64le::glib-tools-2.70.2-h690f14c_3.tar.bz2
linux-ppc64le::libllvm11-11.1.0-h6c99497_3.tar.bz2
linux-ppc64le::llvm-14.0.0-h12068cf_0.tar.bz2
linux-ppc64le::cargo-bundle-licenses-0.4.0-hdd816bb_1.tar.bz2
linux-ppc64le::libmlir13-13.0.1-h96f6aa1_0.tar.bz2
linux-ppc64le::imath-3.1.5-ha72a2fa_0.tar.bz2
linux-ppc64le::openexr-3.1.4-h3b69f5b_0.tar.bz2
linux-ppc64le::libclang-cpp9-9.0.1-root_62600_hfe130f6_4.tar.bz2
linux-ppc64le::gst-plugins-base-1.20.1-hf9bd150_0.tar.bz2
linux-ppc64le::tk-8.6.12-h41c6715_0.tar.bz2
linux-ppc64le::clang-13-13.0.1-default_he4a137d_0.tar.bz2
linux-ppc64le::libclang-cpp-9.0.1-hcc_h7fea5d2_4.tar.bz2
linux-ppc64le::llvm-13.0.1-h12068cf_0.tar.bz2
linux-ppc64le::clang-format-13-13.0.1-default_he4a137d_0.tar.bz2
linux-ppc64le::gst-plugins-base-1.20.1-hf9bd150_1.tar.bz2
linux-ppc64le::libclang-cpp-13.0.1-default_he4a137d_0.tar.bz2
linux-ppc64le::libllvm14-14.0.0-h3b69f5b_0.tar.bz2
linux-ppc64le::gst-plugins-base-1.20.0-he376d82_1.tar.bz2
linux-ppc64le::llvm-13.0.1-h12068cf_1.tar.bz2
linux-ppc64le::liblal-7.1.7-fftw_h8ac15d0_100.tar.bz2
linux-ppc64le::llvm-openmp-13.0.1-hd51dc09_0.tar.bz2
linux-ppc64le::libclang-cpp-9.0.1-root_62600_hfe130f6_4.tar.bz2
linux-ppc64le::llvm-tools-14.0.0-h3b69f5b_0.tar.bz2
-    "libzlib >=1.2.11,<1.3.0a0"
+    "libzlib >=1.2.11,<2.0.0a0"
================================================================================
================================================================================
linux-aarch64
linux-aarch64::imagemagick-7.1.0_27-pl5321hde91a41_1.tar.bz2
linux-aarch64::libgdal-3.4.2-hd306ad9_0.tar.bz2
linux-aarch64::libprotobuf-static-3.20.0-h7866ba4_0.tar.bz2
linux-aarch64::libtiff-4.3.0-hdea21e4_3.tar.bz2
linux-aarch64::nodejs-17.8.0-h84b8f93_0.tar.bz2
linux-aarch64::postgresql-plpython-14.2-py38ha461251_0.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py37hba11ac2_12_cpu.tar.bz2
linux-aarch64::pdal-2.4.0-h2029a75_2.tar.bz2
linux-aarch64::tiledb-2.7.0-h354e0e1_0.tar.bz2
linux-aarch64::libgdal-3.4.1-hc21fa19_4.tar.bz2
linux-aarch64::grpcio-1.43.0-py310heffe441_0.tar.bz2
linux-aarch64::arrow-cpp-7.0.0-py37hda1d783_0_cpu.tar.bz2
linux-aarch64::postgresql-14.2-hc7eaa15_0.tar.bz2
linux-aarch64::libcurl-7.82.0-h22f3f83_0.tar.bz2
linux-aarch64::grpcio-1.44.0-py38hcec6d83_0.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py310h0def9e1_44_cpu.tar.bz2
linux-aarch64::sagelib-9.5-py38h679a460_1.tar.bz2
linux-aarch64::vtk-9.1.0-qt_py38h57b2951_207.tar.bz2
linux-aarch64::nodejs-17.7.1-ha87be73_0.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py38h98a65e9_27_cpu.tar.bz2
linux-aarch64::nodejs-16.14.2-he850d6a_1.tar.bz2
linux-aarch64::hdf5-1.12.1-mpi_openmpi_h4189069_4.tar.bz2
linux-aarch64::r-base-4.0.5-h9784139_6.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py310h6d820a4_45_cpu.tar.bz2
linux-aarch64::vtk-9.1.0-qt_py38h214980f_204.tar.bz2
linux-aarch64::grpc-cpp-1.45.0-h9af5783_0.tar.bz2
linux-aarch64::libgdal-3.4.1-hdb593d3_4.tar.bz2
linux-aarch64::python-3.9.12-h5016f1d_1_cpython.tar.bz2
linux-aarch64::arrow-cpp-7.0.0-py39h193aa1e_0_cpu.tar.bz2
linux-aarch64::ogre-13.3.3-h42ef9eb_0.tar.bz2
linux-aarch64::vtk-9.1.0-qt_py39h605cb67_205.tar.bz2
linux-aarch64::ffmpeg-5.0.0-h6e4b094_0.tar.bz2
linux-aarch64::cmake-3.22.2-hdbbab26_0.tar.bz2
linux-aarch64::libgsf-1.14.49-h11073c9_0.tar.bz2
linux-aarch64::grpc-cpp-1.43.2-h4e595cf_1.tar.bz2
linux-aarch64::libtiledb-sql-0.12.5-heaa659b_0.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py310h0def9e1_25_cpu.tar.bz2
linux-aarch64::gmsh-4.9.5-ha086f09_0.tar.bz2
linux-aarch64::pygrib-2.1.4-py38h1f4e960_4.tar.bz2
linux-aarch64::gfal2-2.20.4-h19bd88d_0.tar.bz2
linux-aarch64::libglib-2.70.2-hde3fb6c_2.tar.bz2
linux-aarch64::pdal-2.4.0-h8b68a80_1.tar.bz2
linux-aarch64::python-3.10.4-h2eada40_0_cpython.tar.bz2
linux-aarch64::ptscotch-6.0.9-he18ce4a_2.tar.bz2
linux-aarch64::libopencv-4.5.5-py37h1fbf280_2.tar.bz2
linux-aarch64::grpcio-1.45.0-py310hab61ab1_0.tar.bz2
linux-aarch64::nss-3.77-h1b46d77_0.tar.bz2
linux-aarch64::assimp-5.2.3-hf7258a5_1.tar.bz2
linux-aarch64::ptscotch-6.1.3-he18ce4a_0.tar.bz2
linux-aarch64::arrow-cpp-7.0.0-py37h668e315_1_cpu.tar.bz2
linux-aarch64::python-3.9.12-h2eada40_0_cpython.tar.bz2
linux-aarch64::libthrift-0.16.0-h0cb72c4_1.tar.bz2
linux-aarch64::libopencv-4.5.5-py31hd3adfd5_3.tar.bz2
linux-aarch64::libgdal-3.4.2-h20c5e9f_3.tar.bz2
linux-aarch64::libcurl-static-7.82.0-h8fd98b7_0.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py310h2c066bb_10_cpu.tar.bz2
linux-aarch64::thrift-compiler-0.16.0-h0bc7dfc_1.tar.bz2
linux-aarch64::postgresql-plpython-14.2-py39h7db0282_0.tar.bz2
linux-aarch64::grpcio-1.45.0-py39h8a0731a_0.tar.bz2
linux-aarch64::graphviz-3.0.0-h856fde9_1.tar.bz2
linux-aarch64::vowpalwabbit-9.0.1-py39h90979d0_0.tar.bz2
linux-aarch64::libopencv-4.5.5-py37h00382ff_6.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py39h779ff14_44_cpu.tar.bz2
linux-aarch64::grpc-cpp-1.44.0-h6befb7c_1.tar.bz2
linux-aarch64::r-base-4.1.3-h4238062_0.tar.bz2
linux-aarch64::cairo-1.16.0-h007064d_1010.tar.bz2
linux-aarch64::yoda-1.9.4-py37h19cc558_1.tar.bz2
linux-aarch64::sagelib-9.5-py310h26f1b71_3.tar.bz2
linux-aarch64::r-git2r-0.30.1-r41h25179a8_0.tar.bz2
linux-aarch64::libopencv-4.5.5-py37h00382ff_5.tar.bz2
linux-aarch64::imagecodecs-2021.11.20-py38hed24f9a_2.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py39h4df7de6_11_cpu.tar.bz2
linux-aarch64::grpc-cpp-1.43.2-hbb61a01_1.tar.bz2
linux-aarch64::ptscotch-6.0.9-h836f696_2.tar.bz2
linux-aarch64::libgdal-3.4.2-he0111e3_1.tar.bz2
linux-aarch64::sagelib-9.5-py37h12edca8_3.tar.bz2
linux-aarch64::rust-1.59.0-h26fb2b7_0.tar.bz2
linux-aarch64::grpcio-1.44.0-py310heffe441_0.tar.bz2
linux-aarch64::sagelib-9.5-py39h0c97c74_1.tar.bz2
linux-aarch64::ffmpeg-4.3.2-hf67a8e1_2.tar.bz2
linux-aarch64::pillow-9.0.1-py38h3870bda_2.tar.bz2
linux-aarch64::vowpalwabbit-9.0.1-py38h92eb830_0.tar.bz2
linux-aarch64::ruby-3.1.1-hd1861fb_0.tar.bz2
linux-aarch64::nodejs-17.8.0-ha87be73_0.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py310h6d820a4_11_cpu.tar.bz2
linux-aarch64::vtk-9.1.0-qt_py310hfaf1808_205.tar.bz2
linux-aarch64::mysql-client-8.0.28-h1208568_2.tar.bz2
linux-aarch64::plumed-2.8.0-mpi_mpich_ha6e5718_0.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py38h9be9019_45_cpu.tar.bz2
linux-aarch64::arrow-cpp-7.0.0-py38hb1655cc_0_cpu.tar.bz2
linux-aarch64::pillow-9.0.1-py38h2494775_1.tar.bz2
linux-aarch64::postgresql-plpython-14.2-py39he700edf_0.tar.bz2
linux-aarch64::cmake-3.22.3-hcad14f8_0.tar.bz2
linux-aarch64::nss-3.76-h1b46d77_0.tar.bz2
linux-aarch64::xrootd-5.4.1-py38h458bdfd_0.tar.bz2
linux-aarch64::sagelib-9.5-py38h0a3289c_3.tar.bz2
linux-aarch64::tiledb-2.7.0-h6866cf4_0.tar.bz2
linux-aarch64::hdf5-1.12.1-mpi_mpich_h7253f08_4.tar.bz2
linux-aarch64::sagelib-9.5-py37h5066cd7_1.tar.bz2
linux-aarch64::libgdal-3.4.1-h896f3c9_3.tar.bz2
linux-aarch64::cmake-3.23.0-hcad14f8_1.tar.bz2
linux-aarch64::giac-1.6.0.47-h1b1c90d_4.tar.bz2
linux-aarch64::mapserver-7.6.4-py310h3081c6f_6.tar.bz2
linux-aarch64::ruby-3.1.1-h53e0626_0.tar.bz2
linux-aarch64::arrow-cpp-7.0.0-py310hd42363a_0_cpu.tar.bz2
linux-aarch64::pygrib-2.1.4-py37hbece616_4.tar.bz2
linux-aarch64::libopencv-4.5.5-py39h441fb25_1.tar.bz2
linux-aarch64::sagelib-9.5-py39h5ab2d25_4.tar.bz2
linux-aarch64::ptscotch-6.1.3-h836f696_0.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py38h411a457_44_cpu.tar.bz2
linux-aarch64::python-3.9.12-h5016f1d_0_cpython.tar.bz2
linux-aarch64::graphviz-3.0.0-h856fde9_0.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py39h0c9104c_10_cpu.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py38h0b42888_28_cpu.tar.bz2
linux-aarch64::cpp-opentelemetry-sdk-1.1.1-h0a73361_3.tar.bz2
linux-aarch64::libpq-14.2-he5b4f81_0.tar.bz2
linux-aarch64::git-2.35.1-pl5321hd6c143b_0.tar.bz2
linux-aarch64::sagelib-9.5-py310ha089417_1.tar.bz2
linux-aarch64::nodejs-14.18.3-h4df20a3_3.tar.bz2
linux-aarch64::libvips-8.12.2-hd8c6d2c_2.tar.bz2
linux-aarch64::libnghttp2-1.47.0-h75cb1c7_0.tar.bz2
linux-aarch64::python-3.9.12-h2eada40_1_cpython.tar.bz2
linux-aarch64::libopencv-4.5.5-py38h3f6393a_7.tar.bz2
linux-aarch64::pdal-2.4.0-h0f33e3e_1.tar.bz2
linux-aarch64::pillow-9.0.1-py37had6dad8_1.tar.bz2
linux-aarch64::libopencv-4.5.5-py37h015eee0_4.tar.bz2
linux-aarch64::r-git2r-0.30.1-r40h25179a8_0.tar.bz2
linux-aarch64::arrow-cpp-7.0.0-py310h657d143_3_cpu.tar.bz2
linux-aarch64::sagelib-9.5-py310h26f1b71_2.tar.bz2
linux-aarch64::imagecodecs-2021.11.20-py310h4b6ca13_2.tar.bz2
linux-aarch64::postgresql-plpython-14.2-py37hc1b2443_0.tar.bz2
linux-aarch64::imagemagick-7.1.0_28-pl5321hde91a41_0.tar.bz2
linux-aarch64::btrfs-progs-5.16.2-h4ac1b1c_0.tar.bz2
linux-aarch64::libgdal-3.4.2-h1fa74ba_0.tar.bz2
linux-aarch64::libopencv-4.5.5-py39h51b6b72_5.tar.bz2
linux-aarch64::mapserver-7.6.4-py39h458f684_6.tar.bz2
linux-aarch64::libopencv-4.5.5-py31hd6084f5_1.tar.bz2
linux-aarch64::pillow-9.0.0-py310h7bfeb00_0.tar.bz2
linux-aarch64::fish-3.3.1-h21c7b91_0.tar.bz2
linux-aarch64::irrlicht-1.8.5-h78a9d08_1.tar.bz2
linux-aarch64::gsoap-2.8.119-h080e37f_0.tar.bz2
linux-aarch64::pillow-9.0.1-py37hf1aa6b7_1.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py310hd5443ca_27_cpu.tar.bz2
linux-aarch64::sagelib-9.5-py38h679a460_0.tar.bz2
linux-aarch64::libxmlsec1-1.2.33-h5d7be6c_0.tar.bz2
linux-aarch64::assimp-5.2.3-hf7258a5_0.tar.bz2
linux-aarch64::grpcio-1.45.0-py38h7d9ddd4_0.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py37h668e315_44_cpu.tar.bz2
linux-aarch64::ogre-13.3.0-h76c0471_0.tar.bz2
linux-aarch64::root_base-6.26.0-py38hbcb1073_0.tar.bz2
linux-aarch64::mysql-server-8.0.28-h63e11dc_2.tar.bz2
linux-aarch64::grpcio-1.45.0-py38hff8890e_0.tar.bz2
linux-aarch64::libgdal-3.4.2-h76eda60_4.tar.bz2
linux-aarch64::libopencv-4.5.5-py31hfb71c74_7.tar.bz2
linux-aarch64::tiledb-2.6.4-h6866cf4_0.tar.bz2
linux-aarch64::qt-main-5.15.2-h7c38af3_3.tar.bz2
linux-aarch64::llvmdev-14.0.0-hb2805f8_0.tar.bz2
linux-aarch64::mapserver-7.6.4-py37hc0e371d_6.tar.bz2
linux-aarch64::pillow-9.0.1-py310h7bfeb00_1.tar.bz2
linux-aarch64::libgdal-3.4.2-hcdf57d0_1.tar.bz2
linux-aarch64::gfal2-2.20.5-h19bd88d_0.tar.bz2
linux-aarch64::libgdal-3.4.2-h418152d_2.tar.bz2
linux-aarch64::scotch-6.1.3-h685a7d7_0.tar.bz2
linux-aarch64::mysql-libs-8.0.28-h8735f6a_2.tar.bz2
linux-aarch64::libopencv-4.5.5-py37hae79d8a_3.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py39h193aa1e_42_cpu.tar.bz2
linux-aarch64::mysql-router-8.0.28-h06fb26e_2.tar.bz2
linux-aarch64::gsoap-2.8.119-hbe024b6_0.tar.bz2
linux-aarch64::libglib-2.70.2-hde3fb6c_4.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py37hba11ac2_46_cpu.tar.bz2
linux-aarch64::nordugrid-arc-6.15.0-py38he97988b_0.tar.bz2
linux-aarch64::vowpalwabbit-9.0.1-py37h9c328d3_0.tar.bz2
linux-aarch64::libtiledb-sql-0.12.4-ha15cdb9_0.tar.bz2
linux-aarch64::pillow-9.0.1-py310h31078c8_2.tar.bz2
linux-aarch64::llvmdev-13.0.1-hb2805f8_2.tar.bz2
linux-aarch64::sagelib-9.5-py37h63a14cd_4.tar.bz2
linux-aarch64::libglib-2.70.2-hde3fb6c_3.tar.bz2
linux-aarch64::libvips-8.12.2-h279fa56_3.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py310h03ab647_13_cpu.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py38h542a2c6_24_cpu.tar.bz2
linux-aarch64::arrow-cpp-7.0.0-py38h62f05b8_3_cpu.tar.bz2
linux-aarch64::llvmdev-11.1.0-h6293a0b_3.tar.bz2
linux-aarch64::root_base-6.26.0-py310h48bfee5_0.tar.bz2
linux-aarch64::nordugrid-arc-6.15.0-py39h0a375b4_0.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py37hf44b4b2_11_cpu.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py37h4ecc894_43_cpu.tar.bz2
linux-aarch64::arrow-cpp-7.0.0-py38h411a457_1_cpu.tar.bz2
linux-aarch64::cppyy-cling-6.25.3-py39h20a37df_0.tar.bz2
linux-aarch64::poppler-22.01.0-h27ad1b0_1.tar.bz2
linux-aarch64::tiledb-2.6.3-h6866cf4_0.tar.bz2
linux-aarch64::ogre-13.3.0-hb360d1d_0.tar.bz2
linux-aarch64::postgresql-plpython-14.2-py37h623af64_0.tar.bz2
linux-aarch64::libopencv-4.5.5-py37h1fbf280_1.tar.bz2
linux-aarch64::grpcio-1.45.0-py37h1fda7f6_0.tar.bz2
linux-aarch64::pypy3.9-7.3.8-h6058f72_1.tar.bz2
linux-aarch64::curl-7.82.0-h22f3f83_0.tar.bz2
linux-aarch64::gsoap-2.8.120-hf52ca08_0.tar.bz2
linux-aarch64::cppyy-cling-6.25.3-py38h986aded_0.tar.bz2
linux-aarch64::python-3.10.2-h1b383ca_3_cpython.tar.bz2
linux-aarch64::poppler-qt-22.01.0-hbd36401_1.tar.bz2
linux-aarch64::vtk-9.1.0-qt_py38haf9ba21_206.tar.bz2
linux-aarch64::vtk-9.1.0-qt_py39ha89d615_206.tar.bz2
linux-aarch64::imagecodecs-2022.2.22-py38h6ecb375_0.tar.bz2
linux-aarch64::scotch-6.1.3-ha5648a0_0.tar.bz2
linux-aarch64::grpcio-1.45.0-py39h535dcc4_0.tar.bz2
linux-aarch64::qt-webengine-5.15.4-h7c9c5db_1.tar.bz2
linux-aarch64::pillow-9.0.0-py39h060b360_0.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py39h779ff14_10_cpu.tar.bz2
linux-aarch64::python-3.8.13-h92ab765_0_cpython.tar.bz2
linux-aarch64::libgdal-3.4.2-h418152d_3.tar.bz2
linux-aarch64::vtk-9.1.0-qt_py39h2f9a542_204.tar.bz2
linux-aarch64::pillow-9.0.0-py37had6dad8_0.tar.bz2
linux-aarch64::vtk-9.1.0-qt_py37hdf0b591_204.tar.bz2
linux-aarch64::arrow-cpp-7.0.0-py39h44d0cde_3_cpu.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py310h6d820a4_26_cpu.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py38h411a457_10_cpu.tar.bz2
linux-aarch64::libtiledb-sql-0.12.4-h8c47da6_0.tar.bz2
linux-aarch64::pillow-9.0.1-py39h060b360_0.tar.bz2
linux-aarch64::python-3.9.10-h1b383ca_2_cpython.tar.bz2
linux-aarch64::postgresql-14.2-hf035830_0.tar.bz2
linux-aarch64::cppyy-cling-6.25.3-py310h4eb0b0e_0.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py37h668e315_25_cpu.tar.bz2
linux-aarch64::pygrib-2.1.4-py39h740e202_4.tar.bz2
linux-aarch64::postgresql-plpython-14.2-py310h620a60a_0.tar.bz2
linux-aarch64::pdal-2.4.0-h7ae15fb_0.tar.bz2
linux-aarch64::libgdal-3.4.1-hd306ad9_6.tar.bz2
linux-aarch64::ffmpeg-4.4.1-h4d489e9_1.tar.bz2
linux-aarch64::tiledb-2.7.1-h6866cf4_0.tar.bz2
linux-aarch64::cmake-3.23.0-hcad14f8_0.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py310h2c066bb_43_cpu.tar.bz2
linux-aarch64::ffmpeg-5.0.0-h3bda925_1.tar.bz2
linux-aarch64::hdf5-1.12.1-mpi_openmpi_hf150c17_4.tar.bz2
linux-aarch64::grpc-cpp-1.43.2-h9af5783_2.tar.bz2
linux-aarch64::mysql-router-8.0.28-h9e0b997_2.tar.bz2
linux-aarch64::xrootd-5.4.1-py37ha2b2fc6_0.tar.bz2
linux-aarch64::xrootd-5.4.1-py310h7156f15_0.tar.bz2
linux-aarch64::sagelib-9.5-py310ha089417_0.tar.bz2
linux-aarch64::git-2.35.1-pl5321haf30559_0.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py37h4ecc894_24_cpu.tar.bz2
linux-aarch64::grpcio-1.44.0-py310h126c23a_0.tar.bz2
linux-aarch64::cpp-opentelemetry-sdk-1.2.0-hc77b397_0.tar.bz2
linux-aarch64::curl-7.82.0-h8fd98b7_0.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py310hd42363a_42_cpu.tar.bz2
linux-aarch64::grpc-cpp-1.45.0-h6befb7c_0.tar.bz2
linux-aarch64::pygrib-2.1.4-py37ha86fc3d_4.tar.bz2
linux-aarch64::libgdal-3.4.1-h50a1f3c_5.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py38h542a2c6_10_cpu.tar.bz2
linux-aarch64::sagelib-9.5-py37h5066cd7_0.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py39h779ff14_25_cpu.tar.bz2
linux-aarch64::libthrift-0.16.0-h0cb72c4_0.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py37ha127aac_47_cpu.tar.bz2
linux-aarch64::python-3.10.2-he7f7bba_3_cpython.tar.bz2
linux-aarch64::ogre-13.3.2-h2692d7c_0.tar.bz2
linux-aarch64::pypy3.8-7.3.8-hfb6fae5_1.tar.bz2
linux-aarch64::python-3.10.2-h1b383ca_4_cpython.tar.bz2
linux-aarch64::pdal-2.3.0-hcf82062_27.tar.bz2
linux-aarch64::mapserver-7.6.4-py38heb49dde_6.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py39h5ec5858_28_cpu.tar.bz2
linux-aarch64::orc-1.7.3-h5c30ecb_0.tar.bz2
linux-aarch64::vtk-9.1.0-qt_py37hac61793_207.tar.bz2
linux-aarch64::xrootd-5.4.1-py37hf74f12a_0.tar.bz2
linux-aarch64::libcurl-7.82.0-h8fd98b7_0.tar.bz2
linux-aarch64::nordugrid-arc-6.15.0-py38he97988b_1.tar.bz2
linux-aarch64::grpcio-1.44.0-py38h72d72fb_0.tar.bz2
linux-aarch64::libgdal-3.4.2-hc271e6c_4.tar.bz2
linux-aarch64::pdal-2.3.0-h31246dd_26.tar.bz2
linux-aarch64::mapserver-7.6.4-py310hca76ccc_6.tar.bz2
linux-aarch64::tiledb-2.7.1-h354e0e1_0.tar.bz2
linux-aarch64::libgit2-1.4.2-ha9a0767_0.tar.bz2
linux-aarch64::thrift-compiler-0.16.0-h0cb72c4_1.tar.bz2
linux-aarch64::assimp-5.2.1-h66e8f5a_0.tar.bz2
linux-aarch64::gdk-pixbuf-2.42.8-hb98dc3c_0.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py37ha127aac_28_cpu.tar.bz2
linux-aarch64::libopencv-4.5.5-py38h964b695_2.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py39h4df7de6_45_cpu.tar.bz2
linux-aarch64::libthrift-0.16.0-h0bc7dfc_1.tar.bz2
linux-aarch64::sqlite-3.37.1-hc74f5b8_0.tar.bz2
linux-aarch64::pdal-2.4.0-h46a4021_2.tar.bz2
linux-aarch64::llvmdev-13.0.1-hb2805f8_1.tar.bz2
linux-aarch64::nordugrid-arc-6.15.0-py37hc6c70b4_1.tar.bz2
linux-aarch64::openssh-8.9p1-h68e116c_0.tar.bz2
linux-aarch64::xrootd-5.4.1-py39h54fc799_0.tar.bz2
linux-aarch64::sagelib-9.5-py39h1e42bcf_2.tar.bz2
linux-aarch64::pillow-9.0.1-py39h060b360_1.tar.bz2
linux-aarch64::grpcio-1.45.0-py310h64fc9e5_0.tar.bz2
linux-aarch64::libopencv-4.5.5-py31hd6084f5_2.tar.bz2
linux-aarch64::mysql-server-8.0.28-h818eb89_2.tar.bz2
linux-aarch64::mapserver-7.6.4-py39h923c49c_6.tar.bz2
linux-aarch64::geotiff-1.7.1-hbb859d2_0.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py37hf44b4b2_26_cpu.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py39ha18acd0_46_cpu.tar.bz2
linux-aarch64::libtiledb-sql-0.12.6-h2f14679_0.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py310h2c066bb_24_cpu.tar.bz2
linux-aarch64::ffmpeg-4.3.2-hf67a8e1_3.tar.bz2
linux-aarch64::arrow-cpp-7.0.0-py38h48161d5_2_cpu.tar.bz2
linux-aarch64::libopencv-4.5.5-py37he514a57_7.tar.bz2
linux-aarch64::glib-2.70.2-h469bdbd_2.tar.bz2
linux-aarch64::vtk-9.1.0-qt_py38h6bbfa1e_205.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py310h0def9e1_10_cpu.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py37hba11ac2_27_cpu.tar.bz2
linux-aarch64::arrow-cpp-7.0.0-py37h4286154_3_cpu.tar.bz2
linux-aarch64::r-git2r-0.30.1-r40h4880197_0.tar.bz2
linux-aarch64::imagecodecs-2022.2.22-py38he2f143b_1.tar.bz2
linux-aarch64::pillow-9.0.1-py37hf1aa6b7_0.tar.bz2
linux-aarch64::openssh-8.9p1-h0f47c37_0.tar.bz2
linux-aarch64::vtk-9.1.0-qt_py310h69a615a_204.tar.bz2
linux-aarch64::vtk-9.1.0-qt_py310h2169390_207.tar.bz2
linux-aarch64::nordugrid-arc-6.15.0-py37h6350fa1_1.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py38h9be9019_11_cpu.tar.bz2
linux-aarch64::scotch-6.0.9-h07b6642_2.tar.bz2
linux-aarch64::boost-cpp-1.74.0-h0980f12_7.tar.bz2
linux-aarch64::vtk-9.1.0-qt_py37habaf3b4_206.tar.bz2
linux-aarch64::voms-2.1.0rc0-haa74b47_6.tar.bz2
linux-aarch64::hdf5-1.12.1-mpi_mpich_hdab57eb_4.tar.bz2
linux-aarch64::pillow-9.0.1-py39h2a8e185_2.tar.bz2
linux-aarch64::vtk-9.1.0-qt_py39hbef8b53_207.tar.bz2
linux-aarch64::thrift-compiler-0.16.0-h0bc7dfc_0.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py310h03ab647_28_cpu.tar.bz2
linux-aarch64::libpq-14.2-h29fb33b_0.tar.bz2
linux-aarch64::qt-5.12.9-hd3f9f3d_6.tar.bz2
linux-aarch64::libgdal-3.4.1-h1fa74ba_6.tar.bz2
linux-aarch64::nordugrid-arc-6.15.0-py37hc6c70b4_0.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py38h98a65e9_46_cpu.tar.bz2
linux-aarch64::r-git2r-0.30.1-r41h4880197_0.tar.bz2
linux-aarch64::giac-1.6.0.47-h1b1c90d_5.tar.bz2
linux-aarch64::tiledb-2.6.2-h7c4f515_1.tar.bz2
linux-aarch64::ogre-13.3.1-hb360d1d_0.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py38h0b42888_13_cpu.tar.bz2
linux-aarch64::grpcio-1.45.0-py37h781dd95_0.tar.bz2
linux-aarch64::pypy3.8-7.3.8-h4c41721_1.tar.bz2
linux-aarch64::tiledb-2.6.4-h354e0e1_0.tar.bz2
linux-aarch64::sagelib-9.5-py38h0a3289c_2.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py37ha127aac_13_cpu.tar.bz2
linux-aarch64::root_base-6.26.0-py39h12be8c7_0.tar.bz2
linux-aarch64::imagemagick-7.1.0_29-pl5321hde91a41_0.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py310h03ab647_47_cpu.tar.bz2
linux-aarch64::nodejs-17.8.0-h928fb59_1.tar.bz2
linux-aarch64::vtk-9.1.0-qt_py310h5bff2fa_206.tar.bz2
linux-aarch64::libopencv-4.5.5-py38h654c8ac_6.tar.bz2
linux-aarch64::arrow-cpp-7.0.0-py39hf9328f6_2_cpu.tar.bz2
linux-aarch64::pillow-9.0.1-py38h2494775_0.tar.bz2
linux-aarch64::r-base-4.1.3-hd6ebe66_1.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py310hd5443ca_12_cpu.tar.bz2
linux-aarch64::pillow-9.0.1-py310h7bfeb00_0.tar.bz2
linux-aarch64::libopencv-4.5.5-py38h964b695_1.tar.bz2
linux-aarch64::geotiff-1.7.0-hbb859d2_7.tar.bz2
linux-aarch64::geotiff-1.7.1-hbb859d2_1.tar.bz2
linux-aarch64::sagelib-9.5-py310hc770ad4_4.tar.bz2
linux-aarch64::grpc-cpp-1.44.0-h6befb7c_0.tar.bz2
linux-aarch64::sdl_image-1.2.12-h7c83ee0_2.tar.bz2
linux-aarch64::libopencv-4.5.5-py39h57ed271_4.tar.bz2
linux-aarch64::mapserver-7.6.4-py38h3334f97_6.tar.bz2
linux-aarch64::pillow-9.0.0-py38h2494775_0.tar.bz2
linux-aarch64::libopencv-4.5.5-py31h802d7a1_5.tar.bz2
linux-aarch64::imagecodecs-2022.2.22-py310h9d6bd64_1.tar.bz2
linux-aarch64::libgdal-3.4.1-hab45034_5.tar.bz2
linux-aarch64::mysql-client-8.0.28-h546d73d_2.tar.bz2
linux-aarch64::sagelib-9.5-py39h1e42bcf_3.tar.bz2
linux-aarch64::glib-2.70.2-h469bdbd_3.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py39ha18acd0_12_cpu.tar.bz2
linux-aarch64::libopencv-4.5.5-py31hd3adfd5_4.tar.bz2
linux-aarch64::grpcio-1.44.0-py39hc32559e_0.tar.bz2
linux-aarch64::sagelib-9.5-py39h0c97c74_0.tar.bz2
linux-aarch64::libcurl-static-7.82.0-h22f3f83_0.tar.bz2
linux-aarch64::r-base-4.0.5-h218dbd6_5.tar.bz2
linux-aarch64::libspatialite-5.0.1-h166e878_15.tar.bz2
linux-aarch64::libgd-2.3.3-h1aa4b80_3.tar.bz2
linux-aarch64::grpcio-1.44.0-py39hf7c81b1_0.tar.bz2
linux-aarch64::libopencv-4.5.5-py39h51b6b72_6.tar.bz2
linux-aarch64::pillow-9.0.1-py37h6ad5fca_2.tar.bz2
linux-aarch64::pdal-2.3.0-h31246dd_27.tar.bz2
linux-aarch64::gap-core-4.11.1-h8bdaa18_3.tar.bz2
linux-aarch64::tiledb-2.6.2-h239ccfd_1.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py37hf44b4b2_45_cpu.tar.bz2
linux-aarch64::hdf5-1.12.1-nompi_h7bde11e_104.tar.bz2
linux-aarch64::pdal-2.3.0-hcf82062_26.tar.bz2
linux-aarch64::grpc-cpp-1.44.0-h9af5783_0.tar.bz2
linux-aarch64::ogre-13.3.1-h76c0471_0.tar.bz2
linux-aarch64::glib-2.70.2-h469bdbd_4.tar.bz2
linux-aarch64::nodejs-17.8.0-he850d6a_1.tar.bz2
linux-aarch64::ffmpeg-4.4.1-h6e4b094_2.tar.bz2
linux-aarch64::mapserver-7.6.4-py37hd572635_6.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py37h668e315_10_cpu.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py37h4ecc894_10_cpu.tar.bz2
linux-aarch64::cairo-1.16.0-hd19fb6e_1011.tar.bz2
linux-aarch64::python-3.10.2-he7f7bba_4_cpython.tar.bz2
linux-aarch64::libtiledb-sql-0.12.5-h2f14679_0.tar.bz2
linux-aarch64::symengine-0.9.0-h1ee702e_0.tar.bz2
linux-aarch64::imagecodecs-2021.11.20-py37hcc94c64_2.tar.bz2
linux-aarch64::libxml2-2.9.12-h370961a_2.tar.bz2
linux-aarch64::hdf5-1.12.1-nompi_h3900512_104.tar.bz2
linux-aarch64::libgit2-1.4.2-he9ce915_0.tar.bz2
linux-aarch64::libopencv-4.5.5-py38h000b065_4.tar.bz2
linux-aarch64::ogre-13.3.2-h42ef9eb_0.tar.bz2
linux-aarch64::libnghttp2-1.47.0-h2b6b862_0.tar.bz2
linux-aarch64::pygrib-2.1.4-py310he793fdb_4.tar.bz2
linux-aarch64::xeus-cling-0.13.0-hf59949a_3.tar.bz2
linux-aarch64::python-3.8.13-h023d47c_0_cpython.tar.bz2
linux-aarch64::python-3.9.10-he7f7bba_2_cpython.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py37hda1d783_42_cpu.tar.bz2
linux-aarch64::vowpalwabbit-9.0.1-py37he0afdef_0.tar.bz2
linux-aarch64::clangdev-13.0.1-default_hf9dac01_0.tar.bz2
linux-aarch64::sagelib-9.5-py37h12edca8_2.tar.bz2
linux-aarch64::grpcio-1.44.0-py37h1263c2e_0.tar.bz2
linux-aarch64::arrow-cpp-7.0.0-py310h63414df_2_cpu.tar.bz2
linux-aarch64::yoda-1.9.4-py38h586b997_1.tar.bz2
linux-aarch64::plumed-2.8.0-mpi_openmpi_hf8b425f_0.tar.bz2
linux-aarch64::nordugrid-arc-6.15.0-py37h6350fa1_0.tar.bz2
linux-aarch64::libtiledb-sql-0.12.6-heaa659b_0.tar.bz2
linux-aarch64::nordugrid-arc-6.15.0-py310h4a6bc45_1.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py38h411a457_25_cpu.tar.bz2
linux-aarch64::python-3.10.4-h5016f1d_0_cpython.tar.bz2
linux-aarch64::vowpalwabbit-9.0.1-py310h81719aa_0.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py39h0c9104c_43_cpu.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py39h5ec5858_47_cpu.tar.bz2
linux-aarch64::grpcio-1.44.0-py37haece1f2_0.tar.bz2
linux-aarch64::libthrift-0.16.0-h0bc7dfc_0.tar.bz2
linux-aarch64::libopencv-4.5.5-py39h57ed271_3.tar.bz2
linux-aarch64::gmsh-4.9.4-h0b7d577_0.tar.bz2
linux-aarch64::libopencv-4.5.5-py39h4f041bc_7.tar.bz2
linux-aarch64::postgresql-plpython-14.2-py38h3e1bf2c_0.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py310hd5443ca_46_cpu.tar.bz2
linux-aarch64::root_base-6.26.0-py37he85acaf_0.tar.bz2
linux-aarch64::nordugrid-arc-6.15.0-py39h0a375b4_1.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py39ha18acd0_27_cpu.tar.bz2
linux-aarch64::grpc-cpp-1.44.0-h9af5783_1.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py39h0c9104c_24_cpu.tar.bz2
linux-aarch64::cpp-opentelemetry-sdk-1.2.0-h0ada592_1.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py38h542a2c6_43_cpu.tar.bz2
linux-aarch64::thrift-compiler-0.16.0-h0cb72c4_0.tar.bz2
linux-aarch64::libopencv-4.5.5-py39h441fb25_2.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py38h9be9019_26_cpu.tar.bz2
linux-aarch64::llvmdev-13.0.1-h6293a0b_0.tar.bz2
linux-aarch64::cppyy-cling-6.25.3-py37h21e75f5_0.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py38h0b42888_47_cpu.tar.bz2
linux-aarch64::libgdal-3.4.1-h57759cc_3.tar.bz2
linux-aarch64::wxwidgets-3.1.5-h792651f_0.tar.bz2
linux-aarch64::vtk-9.1.0-qt_py37h952f598_205.tar.bz2
linux-aarch64::libopencv-4.5.5-py31h802d7a1_6.tar.bz2
linux-aarch64::libgd-2.3.3-h680d75f_2.tar.bz2
linux-aarch64::arrow-cpp-7.0.0-py37hadfe9cd_2_cpu.tar.bz2
linux-aarch64::mysql-libs-8.0.28-h913e832_2.tar.bz2
linux-aarch64::nodejs-16.14.2-ha87be73_0.tar.bz2
linux-aarch64::arrow-cpp-7.0.0-py39h779ff14_1_cpu.tar.bz2
linux-aarch64::libxslt-1.1.33-h55d2cec_4.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py39h4df7de6_26_cpu.tar.bz2
linux-aarch64::scotch-6.0.9-h93574f1_2.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py38h98a65e9_12_cpu.tar.bz2
linux-aarch64::sagelib-9.5-py38h9ad6be3_4.tar.bz2
linux-aarch64::pypy3.9-7.3.8-h57c6639_1.tar.bz2
linux-aarch64::grpc-cpp-1.43.2-h6befb7c_2.tar.bz2
linux-aarch64::pillow-9.0.1-py37h2dc4c6d_2.tar.bz2
linux-aarch64::pillow-9.0.0-py37hf1aa6b7_0.tar.bz2
linux-aarch64::arrow-cpp-7.0.0-py310h0def9e1_1_cpu.tar.bz2
linux-aarch64::mlir-13.0.1-h5ca471e_0.tar.bz2
linux-aarch64::texlive-core-20210325-hc11b95f_2.tar.bz2
linux-aarch64::libopencv-4.5.5-py38h811645e_3.tar.bz2
linux-aarch64::imagecodecs-2021.11.20-py37h0792fde_2.tar.bz2
linux-aarch64::nodejs-16.14.2-h928fb59_1.tar.bz2
linux-aarch64::mongodb-5.1.1-h0faac0a_1.tar.bz2
linux-aarch64::irrlicht-1.8.5-h78a9d08_2.tar.bz2
linux-aarch64::yoda-1.9.4-py39h865afa5_1.tar.bz2
linux-aarch64::nodejs-17.7.1-h84b8f93_0.tar.bz2
linux-aarch64::gsoap-2.8.120-h6af4a7d_0.tar.bz2
linux-aarch64::imagecodecs-2022.2.22-py310ha82d71e_0.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py39h5ec5858_13_cpu.tar.bz2
linux-aarch64::libgdal-3.4.2-h20c5e9f_2.tar.bz2
linux-aarch64::imagecodecs-2022.2.22-py39h5f74cc3_0.tar.bz2
linux-aarch64::mongodb-5.1.1-h51493c5_1.tar.bz2
linux-aarch64::pillow-9.0.1-py37had6dad8_0.tar.bz2
linux-aarch64::postgresql-plpython-14.2-py310h0cf528d_0.tar.bz2
linux-aarch64::libprotobuf-3.20.0-h7866ba4_0.tar.bz2
linux-aarch64::tiledb-2.6.3-h354e0e1_0.tar.bz2
linux-aarch64::nodejs-16.14.2-h84b8f93_0.tar.bz2
-    "libzlib >=1.2.11,<1.3.0a0",
+    "libzlib >=1.2.11,<2.0.0a0",
linux-aarch64::clang-9-9.0.1-hcc_hfb8c119_4.tar.bz2
linux-aarch64::clang-tools-13.0.1-default_hf9dac01_0.tar.bz2
linux-aarch64::dotnet-aspnetcore-6.0.3-hb062e78_0.tar.bz2
linux-aarch64::libclang-cpp9-9.0.1-default_h2caf41e_4.tar.bz2
linux-aarch64::clang-9-9.0.1-default_h2caf41e_4.tar.bz2
linux-aarch64::llvm-13.0.1-h40ce709_0.tar.bz2
linux-aarch64::libllvm14-14.0.0-hb2805f8_0.tar.bz2
linux-aarch64::gst-plugins-base-1.20.0-h227fc8a_1.tar.bz2
linux-aarch64::libclang-cpp-9.0.1-default_h2caf41e_4.tar.bz2
linux-aarch64::clang-13-13.0.1-default_hf9dac01_0.tar.bz2
linux-aarch64::cargo-bundle-licenses-0.4.0-h68db54e_1.tar.bz2
linux-aarch64::llvm-tools-13.0.1-hb2805f8_2.tar.bz2
linux-aarch64::dotnet-sdk-6.0.102-h25a8a10_0.tar.bz2
linux-aarch64::dotnet-runtime-5.0.14-h25a8a10_0.tar.bz2
linux-aarch64::libllvm13-13.0.1-hb2805f8_1.tar.bz2
linux-aarch64::llvm-openmp-13.0.1-h6293a0b_0.tar.bz2
linux-aarch64::llvm-tools-14.0.0-hb2805f8_0.tar.bz2
linux-aarch64::libllvm13-13.0.1-hb2805f8_2.tar.bz2
linux-aarch64::glib-tools-2.70.2-h469bdbd_2.tar.bz2
linux-aarch64::dotnet-aspnetcore-5.0.14-h25a8a10_0.tar.bz2
linux-aarch64::dotnet-sdk-5.0.406-hb062e78_0.tar.bz2
linux-aarch64::plumed-2.8.0-nompi_h33bb3f5_100.tar.bz2
linux-aarch64::gst-plugins-good-1.20.1-h660f13c_1.tar.bz2
linux-aarch64::clang-9-9.0.1-cling_v0.9_h27cd1b6_4.tar.bz2
linux-aarch64::gst-plugins-base-1.20.1-hbea7648_1.tar.bz2
linux-aarch64::libmlir-13.0.1-h5ca471e_0.tar.bz2
linux-aarch64::libclang-cpp-9.0.1-root_62600_h487e30a_4.tar.bz2
linux-aarch64::dotnet-runtime-6.0.3-hb062e78_0.tar.bz2
linux-aarch64::dotnet-runtime-3.1.23-hf32e593_0.tar.bz2
linux-aarch64::gst-plugins-good-1.20.1-h5a17035_0.tar.bz2
linux-aarch64::libclang-cpp9-9.0.1-hcc_hfb8c119_4.tar.bz2
linux-aarch64::dotnet-runtime-5.0.15-hb062e78_0.tar.bz2
linux-aarch64::dotnet-aspnetcore-6.0.2-h25a8a10_0.tar.bz2
linux-aarch64::libclang-cpp9-9.0.1-root_62600_h487e30a_4.tar.bz2
linux-aarch64::openexr-3.1.4-hb2805f8_0.tar.bz2
linux-aarch64::tk-8.6.12-hd8af866_0.tar.bz2
linux-aarch64::llvm-14.0.0-h40ce709_0.tar.bz2
linux-aarch64::imath-3.1.5-h7866ba4_0.tar.bz2
linux-aarch64::dotnet-runtime-6.0.2-h25a8a10_0.tar.bz2
linux-aarch64::libclang-13.0.1-default_hf9dac01_0.tar.bz2
linux-aarch64::dotnet-runtime-3.1.22-h3f6ae21_1.tar.bz2
linux-aarch64::glib-tools-2.70.2-h469bdbd_3.tar.bz2
linux-aarch64::libllvm13-13.0.1-h6293a0b_0.tar.bz2
linux-aarch64::libclang-cpp13-13.0.1-default_hf9dac01_0.tar.bz2
linux-aarch64::libclang-cpp-9.0.1-hcc_hfb8c119_4.tar.bz2
linux-aarch64::glib-tools-2.70.2-h469bdbd_4.tar.bz2
linux-aarch64::libclang-cpp-9.0.1-cling_v0.9_h27cd1b6_4.tar.bz2
linux-aarch64::libclang-cpp-13.0.1-default_hf9dac01_0.tar.bz2
linux-aarch64::llvm-tools-13.0.1-hb2805f8_1.tar.bz2
linux-aarch64::libmlir13-13.0.1-h5ca471e_0.tar.bz2
linux-aarch64::llvm-openmp-13.0.1-hb2805f8_1.tar.bz2
linux-aarch64::libllvm11-11.1.0-h6293a0b_3.tar.bz2
linux-aarch64::imath-3.1.4-h7866ba4_0.tar.bz2
linux-aarch64::dotnet-aspnetcore-5.0.15-hb062e78_0.tar.bz2
linux-aarch64::llvm-11.1.0-h40ce709_3.tar.bz2
linux-aarch64::libclang-cpp9-9.0.1-cling_v0.9_h27cd1b6_4.tar.bz2
linux-aarch64::dotnet-sdk-5.0.405-h25a8a10_0.tar.bz2
linux-aarch64::clang-format-13-13.0.1-default_hf9dac01_0.tar.bz2
linux-aarch64::gst-plugins-base-1.20.1-hbea7648_0.tar.bz2
linux-aarch64::clang-9-9.0.1-root_62600_h487e30a_4.tar.bz2
linux-aarch64::dotnet-sdk-3.1.417-hb062e78_0.tar.bz2
linux-aarch64::gst-plugins-good-1.20.0-hafdbc27_0.tar.bz2
linux-aarch64::liblal-7.1.7-fftw_h691cb72_100.tar.bz2
linux-aarch64::dotnet-sdk-3.1.416-h25a8a10_1.tar.bz2
linux-aarch64::dotnet-aspnetcore-3.1.22-h25a8a10_1.tar.bz2
linux-aarch64::clang-format-13.0.1-default_hf9dac01_0.tar.bz2
linux-aarch64::llvm-tools-13.0.1-h6293a0b_0.tar.bz2
linux-aarch64::dotnet-aspnetcore-3.1.23-hb062e78_0.tar.bz2
linux-aarch64::dotnet-sdk-6.0.201-hb062e78_0.tar.bz2
linux-aarch64::llvm-13.0.1-h40ce709_1.tar.bz2
linux-aarch64::cfitsio-4.1.0-h8b262d6_0.tar.bz2
linux-aarch64::llvm-tools-11.1.0-h6293a0b_3.tar.bz2
linux-aarch64::gst-plugins-good-1.20.0-h1b198a9_1.tar.bz2
linux-aarch64::gst-plugins-base-1.20.0-h227fc8a_0.tar.bz2
linux-aarch64::llvm-13.0.1-h40ce709_2.tar.bz2
-    "libzlib >=1.2.11,<1.3.0a0"
+    "libzlib >=1.2.11,<2.0.0a0"
================================================================================
================================================================================
noarch
================================================================================
================================================================================
win-64
win-64::python-3.10.2-h9a09f29_3_cpython.tar.bz2
win-64::llvmdev-13.0.1-hab3b255_0.tar.bz2
win-64::arrow-cpp-3.0.0-py38h39d4669_46_cpu.tar.bz2
win-64::intel-opencl-rt-2022.0.0-h88e0c9f_3663.tar.bz2
win-64::llvm-tools-11.1.0-ha327e53_3.tar.bz2
win-64::pyinstaller-4.9-py37hd4a9ce8_0.tar.bz2
win-64::arrow-cpp-6.0.1-py37hde46c1f_11_cpu.tar.bz2
win-64::arrow-cpp-3.0.0-py38h0edc84b_43_cpu.tar.bz2
win-64::gdstk-0.8.2-py37hfb7eb7e_0.tar.bz2
win-64::omniorb-4.2.5-py37h265e445_1.tar.bz2
win-64::conduit-0.8.2-py39h53d6734_0.tar.bz2
win-64::omniorb-libs-4.2.5-h8b1b97a_2.tar.bz2
win-64::paraview-5.10.0-h8c98a6f_104_qt.tar.bz2
win-64::arrow-cpp-3.0.0-py37h7ed211d_47_cpu.tar.bz2
win-64::libopencv-4.5.5-py38hd5548a8_2.tar.bz2
win-64::omniorb-4.2.5-py39hf7b6eba_1.tar.bz2
win-64::grpcio-1.45.0-py38he5377a8_0.tar.bz2
win-64::arrow-cpp-3.0.0-py38hecd582c_45_cpu.tar.bz2
win-64::pyinstaller-4.9-py39h4dafc3f_0.tar.bz2
win-64::arrow-cpp-7.0.0-py38hdb2ae4d_1_cuda.tar.bz2
win-64::libthrift-0.16.0-h532d1ae_1.tar.bz2
win-64::wxwidgets-3.1.5-h8e1ed31_0.tar.bz2
win-64::grpcio-1.44.0-py37h265e445_0.tar.bz2
win-64::pyinstaller-4.9-py37hd4a9ce8_1.tar.bz2
win-64::libopencv-4.5.5-py38hd5548a8_3.tar.bz2
win-64::mdsrv-0.3.5.post1-py37h19112f0_3.tar.bz2
win-64::libtiff-4.3.0-hc4061b1_3.tar.bz2
win-64::grpcio-1.44.0-py38ha65041e_0.tar.bz2
win-64::imath-3.1.4-h12d4b20_0.tar.bz2
win-64::pypy3.9-7.3.8-hc3b0203_1.tar.bz2
win-64::libmongoc-1.21.0-he3419e8_0.tar.bz2
win-64::gemmi-0.5.3-py37habb0c8c_0.tar.bz2
win-64::pypy3.8-7.3.8-hd58c836_1.tar.bz2
win-64::libgdal-3.4.2-hc8ef25b_2.tar.bz2
win-64::arrow-cpp-6.0.1-py310ha27884a_10_cuda.tar.bz2
win-64::wasmer-2.2.0-hf725046_0.tar.bz2
win-64::intel-cmplr-lib-rt-2022.0.0-h7755175_3663.tar.bz2
win-64::tomviz-1.10.0.post154-py37hb51cde3_0.tar.bz2
win-64::python-3.9.12-hcf16a7b_0_cpython.tar.bz2
win-64::arrow-cpp-5.0.0-py37hdb5bd5f_27_cuda.tar.bz2
win-64::pypy3.8-7.3.8-hd58c836_0.tar.bz2
win-64::arrow-cpp-6.0.1-py39h9cf5611_13_cuda.tar.bz2
win-64::sdl_image-1.2.12-hfb6e5ed_2.tar.bz2
win-64::arrow-cpp-5.0.0-py38h4db582a_27_cuda.tar.bz2
win-64::ogre-13.3.0-h927da9a_0.tar.bz2
win-64::arrow-cpp-6.0.1-py37hdb5bd5f_12_cuda.tar.bz2
win-64::glib-2.70.2-h7755175_2.tar.bz2
win-64::assimp-5.2.3-hc2aa0de_0.tar.bz2
win-64::gst-libav-1.20.1-h4b3502a_1.tar.bz2
win-64::pyinstaller-4.10-py38hd0d6af5_0.tar.bz2
win-64::arrow-cpp-5.0.0-py37ha695cbc_25_cuda.tar.bz2
win-64::arrow-cpp-7.0.0-py310h3ee9c5f_1_cuda.tar.bz2
win-64::vtk-9.1.0-qt_py310hc43dec9_204.tar.bz2
win-64::libthrift-0.16.0-h636ae23_1.tar.bz2
win-64::qt-main-5.15.2-h2fa537f_3.tar.bz2
win-64::libgdal-3.4.1-h49875e8_4.tar.bz2
win-64::tiledb-2.6.4-h47404fa_0.tar.bz2
win-64::libgdal-3.4.1-h49875e8_3.tar.bz2
win-64::tomviz-1.10.0.post228-py37hb51cde3_0.tar.bz2
win-64::thrift-compiler-0.16.0-h532d1ae_0.tar.bz2
win-64::arrow-cpp-3.0.0-py310h96d1096_44_cpu.tar.bz2
win-64::libcurl-static-7.82.0-h789b8ee_0.tar.bz2
win-64::glib-tools-2.70.2-h7755175_2.tar.bz2
win-64::arrow-cpp-6.0.1-py37hbda1282_10_cpu.tar.bz2
win-64::pdal-2.4.0-h88c4889_0.tar.bz2
win-64::qt-webengine-5.15.4-ha014ca1_1.tar.bz2
win-64::arrow-cpp-7.0.0-py39h2ca45b4_2_cuda.tar.bz2
win-64::arrow-cpp-3.0.0-py37he7a1960_45_cuda.tar.bz2
win-64::arrow-cpp-5.0.0-py38h9b658b2_26_cuda.tar.bz2
win-64::arrow-cpp-3.0.0-py37hdb5bd5f_46_cuda.tar.bz2
win-64::z5py-2.0.13-py37h196ee6d_0.tar.bz2
win-64::grpcio-1.45.0-py39hb76b349_0.tar.bz2
win-64::wasmer-2.2.1-hf725046_0.tar.bz2
win-64::arrow-cpp-6.0.1-py39ha659b48_10_cuda.tar.bz2
win-64::python-3.9.12-h9a09f29_1_cpython.tar.bz2
win-64::tiledb-2.6.2-h95dad36_1.tar.bz2
win-64::vtk-9.1.0-qt_py39h4e9baff_204.tar.bz2
win-64::arrow-cpp-6.0.1-py310h8d3282a_11_cpu.tar.bz2
win-64::ruby-3.1.1-h1d9c0f5_0.tar.bz2
win-64::r-git2r-0.30.1-r41h007cf7e_0.tar.bz2
win-64::pillow-9.0.0-py39ha53f419_0.tar.bz2
win-64::libprotobuf-static-3.20.0-h7755175_0.tar.bz2
win-64::libgd-2.3.3-h891f43f_3.tar.bz2
win-64::tiledb-2.7.1-h47404fa_0.tar.bz2
win-64::arrow-cpp-3.0.0-py310he69c752_47_cuda.tar.bz2
win-64::grpc-cpp-1.43.2-he33f7c1_1.tar.bz2
win-64::imath-3.1.5-h12d4b20_0.tar.bz2
win-64::cgns-4.2.0-hef47513_4.tar.bz2
win-64::arrow-cpp-7.0.0-py310ha27884a_0_cuda.tar.bz2
win-64::qt-main-5.15.2-hb84c757_2.tar.bz2
win-64::thrift-compiler-0.16.0-h636ae23_1.tar.bz2
win-64::postgresql-plpython-14.2-py37h44f2ed4_0.tar.bz2
win-64::arrow-cpp-5.0.0-py39ha659b48_24_cuda.tar.bz2
win-64::arrow-cpp-6.0.1-py38h0edc84b_10_cpu.tar.bz2
win-64::pillow-9.0.1-py39ha53f419_1.tar.bz2
win-64::paraview-5.10.1-h8c98a6f_104_qt.tar.bz2
win-64::arrow-cpp-3.0.0-py37hcbb77e5_47_cuda.tar.bz2
win-64::gemmi-0.5.3-py310h2c03ce5_0.tar.bz2
win-64::llvm-tools-13.0.1-ha327e53_1.tar.bz2
win-64::arrow-cpp-6.0.1-py39ha4bed21_10_cuda.tar.bz2
win-64::arrow-cpp-7.0.0-py37ha695cbc_1_cuda.tar.bz2
win-64::arrow-cpp-6.0.1-py39h5cd028b_12_cpu.tar.bz2
win-64::tomviz-1.10.0.post156-py37hb51cde3_0.tar.bz2
win-64::grpcio-1.45.0-py310h694bffd_0.tar.bz2
win-64::arrow-cpp-3.0.0-py39ha4bed21_44_cuda.tar.bz2
win-64::mysql-client-8.0.28-hf8b63c5_2.tar.bz2
win-64::cpp-opentelemetry-sdk-1.1.1-h830ff55_3.tar.bz2
win-64::pillow-9.0.1-py39ha53f419_2.tar.bz2
win-64::arrow-cpp-5.0.0-py38h0edc84b_24_cpu.tar.bz2
win-64::arrow-cpp-6.0.1-py38h39d4669_12_cpu.tar.bz2
win-64::postgresql-plpython-14.2-py310hb974fb4_0.tar.bz2
win-64::openexr-python-1.3.7-py39h394fbb4_0.tar.bz2
win-64::libopencv-4.5.5-py39h606fa8f_3.tar.bz2
win-64::arrow-cpp-5.0.0-py38h4fb41b6_28_cuda.tar.bz2
win-64::vtk-9.1.0-qt_py37h0a0c120_205.tar.bz2
win-64::arrow-cpp-6.0.1-py39h9b61a56_13_cpu.tar.bz2
win-64::libgdal-3.4.2-hf817787_3.tar.bz2
win-64::cpp-opentelemetry-sdk-1.2.0-h830ff55_0.tar.bz2
win-64::omniorb-4.2.5-py37h04d2302_2.tar.bz2
win-64::arrow-cpp-5.0.0-py310h4825f69_27_cpu.tar.bz2
win-64::grpc-cpp-1.44.0-h7b4b439_1.tar.bz2
win-64::vigra-1.11.1-py37h48b52a3_1029.tar.bz2
win-64::arrow-cpp-7.0.0-py37ha798795_2_cuda.tar.bz2
win-64::cargo-bundle-licenses-0.4.0-hbfaa246_1.tar.bz2
win-64::libthrift-0.16.0-h636ae23_0.tar.bz2
win-64::symengine-0.9.0-hde5acf3_0.tar.bz2
win-64::pyinstaller-4.9-py310h3cefddf_1.tar.bz2
win-64::arrow-cpp-6.0.1-py38h4fb41b6_13_cuda.tar.bz2
win-64::gst-plugins-good-1.20.0-h69687a5_1.tar.bz2
win-64::r-seqminer-8.4-r41h5bfd6cc_0.tar.bz2
win-64::mdsrv-0.3.5.post1-py38h3ec5bfc_3.tar.bz2
win-64::libclang-cpp-9.0.1-cling_v0.9_h913594f_4.tar.bz2
win-64::openexr-python-1.3.7-py37h99541a9_0.tar.bz2
win-64::libgd-2.3.3-h217ff3b_2.tar.bz2
win-64::tiledb-2.7.0-h95dad36_0.tar.bz2
win-64::arrow-cpp-3.0.0-py37h59864f1_43_cuda.tar.bz2
win-64::arrow-cpp-5.0.0-py37he7a1960_26_cuda.tar.bz2
win-64::wasmer-2.2.0-hc9dcdca_0.tar.bz2
win-64::arrow-cpp-7.0.0-py39ha4bed21_1_cuda.tar.bz2
win-64::arrow-cpp-6.0.1-py310h116faca_12_cuda.tar.bz2
win-64::arrow-cpp-6.0.1-py38hcd21f02_13_cpu.tar.bz2
win-64::omniorb-4.2.5-py38he5377a8_1.tar.bz2
win-64::omniorb-4.2.5-py39hb76b349_2.tar.bz2
win-64::pdal-2.4.0-h8acb19c_2.tar.bz2
win-64::arrow-cpp-3.0.0-py37ha695cbc_44_cuda.tar.bz2
win-64::arrow-cpp-3.0.0-py310h8d3282a_45_cpu.tar.bz2
win-64::arrow-cpp-5.0.0-py39h9cf5611_28_cuda.tar.bz2
win-64::vtk-9.1.0-qt_py38hb34eaa0_204.tar.bz2
win-64::pypy3.9-7.3.8-h1738a25_0.tar.bz2
win-64::pillow-9.0.1-py310h767b3fd_0.tar.bz2
win-64::tomviz-1.10.0.post156-py37hb51cde3_1.tar.bz2
win-64::clang-tools-13.0.1-default_h81446c8_0.tar.bz2
win-64::conduit-0.8.2-py37h5e611a3_0.tar.bz2
win-64::tiledb-2.6.3-h95dad36_0.tar.bz2
win-64::harp-1.15-py37r40hca80f52_0.tar.bz2
win-64::arrow-cpp-6.0.1-py38hecd582c_11_cpu.tar.bz2
win-64::pillow-9.0.1-py37h8675073_2.tar.bz2
win-64::harp-1.15-py310r40heba9ebb_0.tar.bz2
win-64::arrow-cpp-3.0.0-py38h7563d09_43_cuda.tar.bz2
win-64::vtk-9.1.0-qt_py310h99a8838_207.tar.bz2
win-64::arrow-cpp-3.0.0-py39h9cf5611_47_cuda.tar.bz2
win-64::arrow-cpp-6.0.1-py310h69c7e7f_11_cuda.tar.bz2
win-64::libxslt-1.1.33-h34f844d_4.tar.bz2
win-64::arrow-cpp-6.0.1-py38h7563d09_10_cuda.tar.bz2
win-64::ogre-13.3.0-h0650132_0.tar.bz2
win-64::arrow-cpp-3.0.0-py310ha27884a_43_cuda.tar.bz2
win-64::tomviz-1.10.0.post220-py37hb51cde3_0.tar.bz2
win-64::grpc-cpp-1.43.2-h7b4b439_2.tar.bz2
win-64::gmsh-4.9.5-ha4c064c_0.tar.bz2
win-64::pypy3.8-7.3.8-h4acdc65_1.tar.bz2
win-64::arrow-cpp-7.0.0-py39ha659b48_0_cuda.tar.bz2
win-64::imagecodecs-2021.11.20-py310h7704284_2.tar.bz2
win-64::arrow-cpp-6.0.1-py38hdb2ae4d_10_cuda.tar.bz2
win-64::libxml2-2.9.12-hf5bbc77_2.tar.bz2
win-64::libgdal-3.4.2-he73c9d4_1.tar.bz2
win-64::arrow-cpp-3.0.0-py310h4825f69_46_cpu.tar.bz2
win-64::thrift-compiler-0.16.0-h636ae23_0.tar.bz2
win-64::libgdal-3.4.2-hc2921ad_4.tar.bz2
win-64::arrow-cpp-7.0.0-py38h7563d09_0_cuda.tar.bz2
win-64::arrow-cpp-6.0.1-py37hcbb77e5_13_cuda.tar.bz2
win-64::arrow-cpp-6.0.1-py310h3ee9c5f_10_cuda.tar.bz2
win-64::vigra-1.11.1-py38hbee6ac1_1029.tar.bz2
win-64::pyinstaller-4.9-py38hd0d6af5_0.tar.bz2
win-64::pillow-9.0.1-py37h8675073_1.tar.bz2
win-64::arrow-cpp-6.0.1-py38heba19f7_10_cpu.tar.bz2
win-64::z5py-2.0.15-py310h5deb91e_0.tar.bz2
win-64::arrow-cpp-3.0.0-py38heba19f7_44_cpu.tar.bz2
win-64::arrow-cpp-7.0.0-py37h424161a_3_cpu.tar.bz2
win-64::poppler-22.01.0-h24fffdf_2.tar.bz2
win-64::coda-2.23.1-py38h9644311_0.tar.bz2
win-64::arrow-cpp-7.0.0-py37hf68b466_3_cuda.tar.bz2
win-64::libllvm11-11.1.0-hab3b255_3.tar.bz2
win-64::arrow-cpp-7.0.0-py310hae54c66_3_cpu.tar.bz2
win-64::tiledb-2.6.2-h47404fa_1.tar.bz2
win-64::nco-5.0.6-h5be7ecf_0.tar.bz2
win-64::postgresql-plpython-14.2-py39h2d4c99b_0.tar.bz2
win-64::vtk-9.1.0-qt_py38h1df8eee_207.tar.bz2
win-64::grpcio-1.45.0-py39hf7b6eba_0.tar.bz2
win-64::pyinstaller-4.10-py310h3cefddf_0.tar.bz2
win-64::arrow-cpp-7.0.0-py38hf2b7030_3_cuda.tar.bz2
win-64::arrow-cpp-6.0.1-py37he7a1960_11_cuda.tar.bz2
win-64::libgdal-3.4.1-h31b6810_5.tar.bz2
win-64::gdstk-0.8.2-py37h584bb85_0.tar.bz2
win-64::gst-plugins-base-1.20.0-he07aa86_0.tar.bz2
win-64::arrow-cpp-6.0.1-py39h5cea007_10_cpu.tar.bz2
win-64::mysql-libs-8.0.28-h8b0d2c3_2.tar.bz2
win-64::libopencv-4.5.5-py38hcb67736_5.tar.bz2
win-64::arrow-cpp-3.0.0-py39h5cd028b_46_cpu.tar.bz2
win-64::libopencv-4.5.5-py37h04cf790_3.tar.bz2
win-64::arrow-cpp-5.0.0-py37hde46c1f_26_cpu.tar.bz2
win-64::arrow-cpp-5.0.0-py39h4b5c73b_26_cpu.tar.bz2
win-64::gst-plugins-good-1.20.1-he07aa86_0.tar.bz2
win-64::tiledb-2.6.3-h47404fa_0.tar.bz2
win-64::python-3.10.2-hcf16a7b_3_cpython.tar.bz2
win-64::omniorb-4.2.5-py39hf7b6eba_2.tar.bz2
win-64::arrow-cpp-5.0.0-py310h66cdff5_24_cpu.tar.bz2
win-64::arrow-cpp-5.0.0-py310h96d1096_25_cpu.tar.bz2
win-64::arrow-cpp-3.0.0-py39h7187707_45_cuda.tar.bz2
win-64::libopencv-4.5.5-py31h6a2c607_3.tar.bz2
win-64::python-3.10.2-h9a09f29_4_cpython.tar.bz2
win-64::harp-1.15-py39r41h0989d49_0.tar.bz2
win-64::postgresql-14.2-he353ca9_0.tar.bz2
win-64::python-3.10.4-h9a09f29_0_cpython.tar.bz2
win-64::libgdal-3.4.1-h6b2b983_3.tar.bz2
win-64::arrow-cpp-5.0.0-py37h7ed211d_28_cpu.tar.bz2
win-64::ovito-3.7.0-h6f389ac_0.tar.bz2
win-64::arrow-cpp-5.0.0-py37hbda1282_24_cpu.tar.bz2
win-64::pdal-2.3.0-h9a9b16a_27.tar.bz2
win-64::paraview-5.10.1-h92a56fa_104_qt.tar.bz2
win-64::omniorb-4.2.5-py310ha05212b_2.tar.bz2
win-64::arrow-cpp-6.0.1-py310he69c752_13_cuda.tar.bz2
win-64::arrow-cpp-6.0.1-py310h4825f69_12_cpu.tar.bz2
win-64::omniorb-4.2.5-py38he5377a8_2.tar.bz2
win-64::arrow-cpp-6.0.1-py39h26802fc_12_cuda.tar.bz2
win-64::glib-2.70.2-h7755175_4.tar.bz2
win-64::imagecodecs-2022.2.22-py310hc7b5ebd_1.tar.bz2
win-64::pillow-9.0.1-py38hd8e0db4_1.tar.bz2
win-64::libgit2-1.4.2-h8648793_0.tar.bz2
win-64::assimp-5.2.1-hc2aa0de_0.tar.bz2
win-64::grpcio-1.44.0-py39hf7b6eba_0.tar.bz2
win-64::pillow-9.0.1-py310h767b3fd_1.tar.bz2
win-64::grpcio-1.44.0-py38he5377a8_0.tar.bz2
win-64::cfitsio-4.1.0-h5a969a9_0.tar.bz2
win-64::llvmdev-11.1.0-hab3b255_3.tar.bz2
win-64::libmongoc-1.21.0-hf697a22_0.tar.bz2
win-64::grpcio-1.44.0-py39hb76b349_0.tar.bz2
win-64::arrow-cpp-3.0.0-py39h26802fc_46_cuda.tar.bz2
win-64::lld-13.0.1-h5b8fc05_0.tar.bz2
win-64::ogre-13.3.3-h0650132_0.tar.bz2
win-64::mongodb-5.1.1-hc5854b8_1.tar.bz2
win-64::z5py-2.0.14-py38h5d279e6_0.tar.bz2
win-64::omniorb-4.2.5-py38ha65041e_1.tar.bz2
win-64::imagecodecs-2021.11.20-py37hc29e159_2.tar.bz2
win-64::pillow-9.0.0-py37h57c0a70_0.tar.bz2
win-64::arrow-cpp-7.0.0-py38h913fed0_3_cpu.tar.bz2
win-64::arrow-cpp-3.0.0-py39ha659b48_43_cuda.tar.bz2
win-64::ogre-13.3.2-h927da9a_0.tar.bz2
win-64::omniorb-libs-4.2.5-hc7e8586_2.tar.bz2
win-64::arrow-cpp-5.0.0-py310h69c7e7f_26_cuda.tar.bz2
win-64::openexr-python-1.3.7-py38h893e902_0.tar.bz2
win-64::arrow-cpp-5.0.0-py38h7563d09_24_cuda.tar.bz2
win-64::pdal-2.3.0-h8c3116a_26.tar.bz2
win-64::grpcio-1.44.0-py310h694bffd_0.tar.bz2
win-64::vtk-9.1.0-qt_py39h1ab545e_206.tar.bz2
win-64::geotiff-1.7.0-h38b14a8_7.tar.bz2
win-64::libgdal-3.4.2-ha5e465b_1.tar.bz2
win-64::libcurl-7.82.0-h789b8ee_0.tar.bz2
win-64::arrow-cpp-7.0.0-py37hc7983af_1_cpu.tar.bz2
win-64::conduit-0.8.2-py38hb6560f2_0.tar.bz2
win-64::harp-1.15-py38r40h9644311_0.tar.bz2
win-64::libllvm13-13.0.1-hab3b255_1.tar.bz2
win-64::z5py-2.0.14-py310h5deb91e_0.tar.bz2
win-64::arrow-cpp-5.0.0-py39h735a502_25_cpu.tar.bz2
win-64::python-3.10.2-hcf16a7b_4_cpython.tar.bz2
win-64::libopencv-4.5.5-py31h6a2c607_2.tar.bz2
win-64::arrow-cpp-3.0.0-py310h69c7e7f_45_cuda.tar.bz2
win-64::postgresql-plpython-14.2-py39he868e5a_0.tar.bz2
win-64::vtk-9.1.0-qt_py39h1ab545e_207.tar.bz2
win-64::pillow-9.0.0-py37h8675073_0.tar.bz2
win-64::arrow-cpp-3.0.0-py38hdb2ae4d_44_cuda.tar.bz2
win-64::tectonic-0.8.2-h88bc303_0.tar.bz2
win-64::arrow-cpp-7.0.0-py39hd8ba4b1_2_cpu.tar.bz2
win-64::arrow-cpp-7.0.0-py310h66cdff5_0_cpu.tar.bz2
win-64::pyinstaller-4.9-py310h3cefddf_0.tar.bz2
win-64::arrow-cpp-5.0.0-py39h9b61a56_28_cpu.tar.bz2
win-64::arrow-cpp-3.0.0-py38h4fb41b6_47_cuda.tar.bz2
win-64::arrow-cpp-3.0.0-py38hcd21f02_47_cpu.tar.bz2
win-64::imagecodecs-2022.2.22-py39hf46ed64_0.tar.bz2
win-64::arrow-cpp-6.0.1-py38h4db582a_12_cuda.tar.bz2
win-64::llvm-tools-14.0.0-hf00eed6_0.tar.bz2
win-64::gst-plugins-good-1.20.1-h69687a5_1.tar.bz2
win-64::dpcpp_impl_win-64-2022.0.0-hc818a6f_3663.tar.bz2
win-64::libgdal-3.4.1-h6b2b983_4.tar.bz2
win-64::mysql-server-8.0.28-h597400e_2.tar.bz2
win-64::imagecodecs-2022.2.22-py310h7704284_0.tar.bz2
win-64::arrow-cpp-7.0.0-py310h4fe2401_2_cpu.tar.bz2
win-64::arrow-cpp-5.0.0-py38hdb2ae4d_25_cuda.tar.bz2
win-64::pillow-9.0.0-py310h767b3fd_0.tar.bz2
win-64::grpcio-1.45.0-py38ha65041e_0.tar.bz2
win-64::arrow-cpp-3.0.0-py310h116faca_46_cuda.tar.bz2
win-64::gst-plugins-base-1.20.1-he07aa86_1.tar.bz2
win-64::arrow-cpp-5.0.0-py38h39d4669_27_cpu.tar.bz2
win-64::arrow-cpp-5.0.0-py310h36447aa_28_cpu.tar.bz2
win-64::libopencv-4.5.5-py38hcb67736_4.tar.bz2
win-64::libopencv-4.5.5-py31h6a2c607_5.tar.bz2
win-64::grpcio-1.45.0-py310ha05212b_0.tar.bz2
win-64::arrow-cpp-7.0.0-py38heba19f7_1_cpu.tar.bz2
win-64::gdstk-0.8.2-py310h903a3d8_0.tar.bz2
win-64::mysql-router-8.0.28-ha5f2955_2.tar.bz2
win-64::arrow-cpp-5.0.0-py39h5cd028b_27_cpu.tar.bz2
win-64::arrow-cpp-7.0.0-py38ha62b944_2_cuda.tar.bz2
win-64::arrow-cpp-6.0.1-py37h59864f1_10_cuda.tar.bz2
win-64::llvm-tools-13.0.1-ha327e53_2.tar.bz2
win-64::r-git2r-0.30.1-r40h007cf7e_0.tar.bz2
win-64::coda-2.23.1-py39h0989d49_0.tar.bz2
win-64::arrow-cpp-5.0.0-py37h59864f1_24_cuda.tar.bz2
win-64::libmlir-13.0.1-haa24688_0.tar.bz2
win-64::gemmi-0.5.3-py39ha0cd8c8_0.tar.bz2
win-64::libglib-2.70.2-h3be07f2_2.tar.bz2
win-64::openscenegraph-3.6.5-h145966f_12.tar.bz2
win-64::mdsrv-0.3.5.post1-py310hcdd6db8_3.tar.bz2
win-64::mysql-libs-8.0.28-h4d1747d_2.tar.bz2
win-64::arrow-cpp-5.0.0-py39h7187707_26_cuda.tar.bz2
win-64::omniorb-4.2.5-py310ha05212b_1.tar.bz2
win-64::qt-5.12.9-h556501e_6.tar.bz2
win-64::gdk-pixbuf-2.42.8-h1c5aac7_0.tar.bz2
win-64::glib-2.70.2-h7755175_3.tar.bz2
win-64::arrow-cpp-7.0.0-py37hbda1282_0_cpu.tar.bz2
win-64::irrlicht-1.8.5-h739eaf8_1.tar.bz2
win-64::omniorb-4.2.5-py37h265e445_2.tar.bz2
win-64::python-3.9.12-h9a09f29_0_cpython.tar.bz2
win-64::paraview-5.10.0-h823340b_104_qt.tar.bz2
win-64::glib-tools-2.70.2-h7755175_4.tar.bz2
win-64::arrow-cpp-5.0.0-py310h116faca_27_cuda.tar.bz2
win-64::arrow-cpp-5.0.0-py38hcd21f02_28_cpu.tar.bz2
win-64::gst-plugins-base-1.20.0-he07aa86_1.tar.bz2
win-64::pdal-2.4.0-h8b47602_2.tar.bz2
win-64::tomviz-1.10.0.post152-py37hb51cde3_1.tar.bz2
win-64::arrow-cpp-5.0.0-py37hc7983af_25_cpu.tar.bz2
win-64::vtk-9.1.0-qt_py39h4e9baff_205.tar.bz2
win-64::vigra-1.11.1-py39hfe160f1_1029.tar.bz2
win-64::postgresql-plpython-14.2-py38h98422bd_0.tar.bz2
win-64::libopencv-4.5.5-py38hcb67736_7.tar.bz2
win-64::gdstk-0.8.2-py39hcb63d39_0.tar.bz2
win-64::arrow-cpp-3.0.0-py39h5cea007_43_cpu.tar.bz2
win-64::grpc-cpp-1.44.0-hcf7c36f_0.tar.bz2
win-64::z5py-2.0.15-py37hffd1e0c_0.tar.bz2
win-64::libopencv-4.5.5-py37h04cf790_2.tar.bz2
win-64::postgresql-plpython-14.2-py37h547e9a6_0.tar.bz2
win-64::ovito-3.7.1-h6f389ac_0.tar.bz2
win-64::arrow-cpp-5.0.0-py38hecd582c_26_cpu.tar.bz2
win-64::grpcio-1.45.0-py37h04d2302_0.tar.bz2
win-64::arrow-cpp-3.0.0-py310h36447aa_47_cpu.tar.bz2
win-64::thrift-compiler-0.16.0-h532d1ae_1.tar.bz2
win-64::arrow-cpp-5.0.0-py310h3ee9c5f_25_cuda.tar.bz2
win-64::pillow-9.0.1-py37h8675073_0.tar.bz2
win-64::libclang-13.0.1-default_h81446c8_0.tar.bz2
win-64::arrow-cpp-7.0.0-py39hb2547c8_3_cuda.tar.bz2
win-64::libpq-14.2-hfcc5ef8_0.tar.bz2
win-64::llvmdev-13.0.1-hab3b255_1.tar.bz2
win-64::arrow-cpp-3.0.0-py310h3ee9c5f_44_cuda.tar.bz2
win-64::arrow-cpp-5.0.0-py39h5cea007_24_cpu.tar.bz2
win-64::libopencv-4.5.5-py37h04cf790_1.tar.bz2
win-64::arrow-cpp-5.0.0-py310he69c752_28_cuda.tar.bz2
win-64::vtk-9.1.0-qt_py38h1df8eee_206.tar.bz2
win-64::arrow-cpp-6.0.1-py310h66cdff5_10_cpu.tar.bz2
win-64::pillow-9.0.1-py37h57c0a70_2.tar.bz2
win-64::arrow-cpp-5.0.0-py39ha4bed21_25_cuda.tar.bz2
win-64::tectonic-0.8.2-h7de81d9_0.tar.bz2
win-64::openscenegraph-3.6.5-h145966f_13.tar.bz2
win-64::ovito-3.7.2-h6f389ac_0.tar.bz2
win-64::coda-2.23.1-py37hca80f52_0.tar.bz2
win-64::libgdal-3.4.2-h0bdba65_4.tar.bz2
win-64::paraview-5.10.0-h92a56fa_104_qt.tar.bz2
win-64::libopencv-4.5.5-py38hcb67736_6.tar.bz2
win-64::arrow-cpp-5.0.0-py37hb6549fe_27_cpu.tar.bz2
win-64::libgdal-3.4.1-hb48b412_5.tar.bz2
win-64::grpc-cpp-1.43.2-hd599c1a_1.tar.bz2
win-64::libopencv-4.5.5-py38hd5548a8_1.tar.bz2
win-64::z5py-2.0.14-py39hcf4c0ac_0.tar.bz2
win-64::arrow-cpp-6.0.1-py37hb6549fe_12_cpu.tar.bz2
win-64::poppler-qt-22.01.0-h332a8cf_1.tar.bz2
win-64::libopencv-4.5.5-py39h606fa8f_2.tar.bz2
win-64::pillow-9.0.1-py37h57c0a70_0.tar.bz2
win-64::hdf5-1.12.1-nompi_h57737ce_104.tar.bz2
win-64::clang-format-13.0.1-default_h81446c8_0.tar.bz2
win-64::mysql-client-8.0.28-hed9f4ee_2.tar.bz2
win-64::boost-cpp-1.74.0-h9f4b32c_7.tar.bz2
win-64::arrow-cpp-7.0.0-py39h735a502_1_cpu.tar.bz2
win-64::libopencv-4.5.5-py37h1df08fc_6.tar.bz2
win-64::arrow-cpp-3.0.0-py38h9b658b2_45_cuda.tar.bz2
win-64::grpcio-1.44.0-py37h04d2302_0.tar.bz2
win-64::vtk-9.1.0-qt_py310hc43dec9_205.tar.bz2
win-64::vtk-9.1.0-qt_py38hb34eaa0_205.tar.bz2
win-64::grpcio-1.45.0-py37h265e445_0.tar.bz2
win-64::python-3.9.10-hcf16a7b_2_cpython.tar.bz2
win-64::harp-1.15-py37r41hca80f52_0.tar.bz2
win-64::libopencv-4.5.5-py39h606fa8f_6.tar.bz2
win-64::r-seqminer-8.4-r40h5bfd6cc_0.tar.bz2
win-64::vtk-9.1.0-qt_py37h04430da_206.tar.bz2
win-64::omniorb-4.2.5-py310h694bffd_1.tar.bz2
win-64::arrow-cpp-6.0.1-py39h4b5c73b_11_cpu.tar.bz2
win-64::cgns-4.3.0-hef47513_0.tar.bz2
win-64::pdal-2.4.0-h61850d0_0.tar.bz2
win-64::arrow-cpp-7.0.0-py37h59864f1_0_cuda.tar.bz2
win-64::geotiff-1.7.1-h38b14a8_0.tar.bz2
win-64::arrow-cpp-7.0.0-py38h0edc84b_0_cpu.tar.bz2
win-64::poppler-qt-22.01.0-h332a8cf_2.tar.bz2
win-64::gdstk-0.8.2-py38h4056165_0.tar.bz2
win-64::libllvm13-13.0.1-hab3b255_0.tar.bz2
win-64::tectonic-0.8.2-h999ec5b_1.tar.bz2
win-64::libthrift-0.16.0-h532d1ae_0.tar.bz2
win-64::assimp-5.2.3-hc2aa0de_1.tar.bz2
win-64::gst-libav-1.20.1-h4b3502a_0.tar.bz2
win-64::omniorb-4.2.5-py310h694bffd_2.tar.bz2
win-64::python-3.9.10-h9a09f29_2_cpython.tar.bz2
win-64::wasmer-2.2.1-hc9dcdca_0.tar.bz2
win-64::libspatialite-5.0.1-h36c16d9_15.tar.bz2
win-64::arrow-cpp-7.0.0-py310h3dc91fe_3_cuda.tar.bz2
win-64::libopencv-4.5.5-py31h6a2c607_4.tar.bz2
win-64::cairo-1.16.0-h0ac17fb_1011.tar.bz2
win-64::paraview-5.10.0-hdd9fa2d_104_qt.tar.bz2
win-64::postgresql-plpython-14.2-py310ha83e0bf_0.tar.bz2
win-64::pypy3.9-7.3.8-hc3b0203_0.tar.bz2
win-64::mysql-server-8.0.28-h77165ef_2.tar.bz2
win-64::pdal-2.3.0-h9a9b16a_26.tar.bz2
win-64::libopencv-4.5.5-py39h606fa8f_1.tar.bz2
win-64::pdal-2.4.0-hb9befcd_1.tar.bz2
win-64::libgdal-3.4.2-hc8ef25b_3.tar.bz2
win-64::curl-7.82.0-h789b8ee_0.tar.bz2
win-64::mdsrv-0.3.5.post1-py39h6778c38_3.tar.bz2
win-64::python-3.9.12-hcf16a7b_1_cpython.tar.bz2
win-64::arrow-cpp-3.0.0-py37hb6549fe_46_cpu.tar.bz2
win-64::z5py-2.0.15-py38h5d279e6_0.tar.bz2
win-64::tomviz-1.10.0.post230-py37hb51cde3_0.tar.bz2
win-64::gmsh-4.9.4-ha4c064c_0.tar.bz2
win-64::ovito-3.7.2-h6f389ac_1.tar.bz2
win-64::pyinstaller-4.9-py39h4dafc3f_1.tar.bz2
win-64::harp-1.15-py38r41h9644311_0.tar.bz2
win-64::libpq-14.2-h1ea2d34_0.tar.bz2
win-64::arrow-cpp-5.0.0-py39h26802fc_27_cuda.tar.bz2
win-64::grpc-cpp-1.45.0-hcf7c36f_0.tar.bz2
win-64::libprotobuf-3.20.0-h7755175_0.tar.bz2
win-64::harp-1.15-py37r40hbabc145_0.tar.bz2
win-64::harp-1.15-py37r41hbabc145_0.tar.bz2
win-64::z5py-2.0.15-py39hcf4c0ac_0.tar.bz2
win-64::arrow-cpp-3.0.0-py39h735a502_44_cpu.tar.bz2
win-64::pdal-2.3.0-h8c3116a_27.tar.bz2
win-64::gst-libav-1.18.5-hb05e5e5_2.tar.bz2
win-64::arrow-cpp-5.0.0-py38heba19f7_25_cpu.tar.bz2
win-64::pyinstaller-4.9-py38hd0d6af5_1.tar.bz2
win-64::glib-tools-2.70.2-h7755175_3.tar.bz2
win-64::openexr-3.1.4-hab3b255_0.tar.bz2
win-64::libglib-2.70.2-h3be07f2_3.tar.bz2
win-64::imagecodecs-2021.11.20-py37hfea8715_2.tar.bz2
win-64::grpc-cpp-1.44.0-hcf7c36f_1.tar.bz2
win-64::qtwebkit-5.212-hd8ed034_4.tar.bz2
win-64::imagecodecs-2021.11.20-py38h19b08ce_2.tar.bz2
win-64::libopencv-4.5.5-py31h6a2c607_1.tar.bz2
win-64::libopencv-4.5.5-py37h1df08fc_7.tar.bz2
win-64::arrow-cpp-7.0.0-py37hfb47b6f_2_cpu.tar.bz2
win-64::arrow-cpp-5.0.0-py310ha27884a_24_cuda.tar.bz2
win-64::arrow-cpp-3.0.0-py37hbda1282_43_cpu.tar.bz2
win-64::harp-1.15-py39r40h0989d49_0.tar.bz2
win-64::paraview-5.10.1-hdd9fa2d_104_qt.tar.bz2
win-64::arrow-cpp-3.0.0-py37hc7983af_44_cpu.tar.bz2
win-64::omniorb-4.2.5-py38ha65041e_2.tar.bz2
win-64::pillow-9.0.1-py38hd8e0db4_2.tar.bz2
win-64::grpcio-1.44.0-py310ha05212b_0.tar.bz2
win-64::pillow-9.0.0-py38hd8e0db4_0.tar.bz2
win-64::python-3.10.4-hcf16a7b_0_cpython.tar.bz2
win-64::tiledb-2.7.0-h47404fa_0.tar.bz2
win-64::imagecodecs-2022.2.22-py38h19b08ce_0.tar.bz2
win-64::libopencv-4.5.5-py39h606fa8f_4.tar.bz2
win-64::pillow-9.0.1-py38hd8e0db4_0.tar.bz2
win-64::llvmdev-14.0.0-h97333cc_0.tar.bz2
win-64::arrow-cpp-6.0.1-py38h9b658b2_11_cuda.tar.bz2
win-64::tectonic-0.8.2-h8ea4404_1.tar.bz2
win-64::libmongoc-1.21.1-he3419e8_0.tar.bz2
win-64::libllvm13-13.0.1-hab3b255_2.tar.bz2
win-64::pyinstaller-4.10-py39h4dafc3f_0.tar.bz2
win-64::libopencv-4.5.5-py39h606fa8f_7.tar.bz2
win-64::libopencv-4.5.5-py39h606fa8f_5.tar.bz2
win-64::pillow-9.0.1-py37h57c0a70_1.tar.bz2
win-64::gemmi-0.5.3-py38h57a6900_0.tar.bz2
win-64::mysql-router-8.0.28-h2885b7f_2.tar.bz2
win-64::imagecodecs-2021.11.20-py39hf46ed64_2.tar.bz2
win-64::arrow-cpp-3.0.0-py310h66cdff5_43_cpu.tar.bz2
win-64::geotiff-1.7.1-h38b14a8_1.tar.bz2
win-64::grpc-cpp-1.43.2-hcf7c36f_2.tar.bz2
win-64::gst-libav-1.20.0-h4b3502a_0.tar.bz2
win-64::arrow-cpp-7.0.0-py38h2ffb270_2_cpu.tar.bz2
win-64::libmongoc-1.21.1-hf697a22_0.tar.bz2
win-64::arrow-cpp-3.0.0-py37hde46c1f_45_cpu.tar.bz2
win-64::ruby-3.1.1-h8ed59c0_0.tar.bz2
win-64::pypy3.8-7.3.8-h4acdc65_0.tar.bz2
win-64::arrow-cpp-7.0.0-py39ha40e333_3_cpu.tar.bz2
win-64::ogre-13.3.2-h0650132_0.tar.bz2
win-64::vtk-9.1.0-qt_py37h0a0c120_204.tar.bz2
win-64::grpc-cpp-1.45.0-h7b4b439_0.tar.bz2
win-64::coda-2.23.1-py37hbabc145_0.tar.bz2
win-64::libglib-2.70.2-h3be07f2_4.tar.bz2
win-64::arrow-cpp-3.0.0-py38h4db582a_46_cuda.tar.bz2
win-64::pdal-2.4.0-h299ffe6_1.tar.bz2
win-64::vtk-9.1.0-qt_py310h99a8838_206.tar.bz2
win-64::arrow-cpp-6.0.1-py39h7187707_11_cuda.tar.bz2
win-64::pillow-9.0.1-py39ha53f419_0.tar.bz2
win-64::tectonic-0.8.2-h8ea4404_2.tar.bz2
win-64::imagecodecs-2022.2.22-py39hbafb5ae_1.tar.bz2
win-64::z5py-2.0.14-py37hffd1e0c_0.tar.bz2
win-64::arrow-cpp-5.0.0-py310h8d3282a_26_cpu.tar.bz2
win-64::pyinstaller-4.10-py37hd4a9ce8_0.tar.bz2
win-64::gst-plugins-good-1.20.0-he07aa86_0.tar.bz2
win-64::cpp-opentelemetry-sdk-1.2.0-h728dffb_1.tar.bz2
win-64::arrow-cpp-3.0.0-py39h4b5c73b_45_cpu.tar.bz2
win-64::arrow-cpp-7.0.0-py310h96d1096_1_cpu.tar.bz2
win-64::hdf5-1.12.1-nompi_h2a0e4a3_104.tar.bz2
win-64::gst-plugins-base-1.20.1-he07aa86_0.tar.bz2
win-64::python-3.8.13-hcf16a7b_0_cpython.tar.bz2
win-64::tiledb-2.6.4-h95dad36_0.tar.bz2
win-64::imagecodecs-2022.2.22-py38h4b28521_1.tar.bz2
win-64::arrow-cpp-6.0.1-py37h7ed211d_13_cpu.tar.bz2
win-64::libgdal-3.4.2-h75db800_0.tar.bz2
win-64::irrlicht-1.8.5-h739eaf8_2.tar.bz2
win-64::libclang-cpp-9.0.1-default_h4233bec_4.tar.bz2
win-64::ogre-13.3.1-h0650132_0.tar.bz2
win-64::arrow-cpp-6.0.1-py37ha695cbc_10_cuda.tar.bz2
win-64::grpc-cpp-1.44.0-h7b4b439_0.tar.bz2
win-64::pypy3.9-7.3.8-h1738a25_1.tar.bz2
win-64::postgresql-14.2-h1c22c4f_0.tar.bz2
win-64::arrow-cpp-6.0.1-py310h36447aa_13_cpu.tar.bz2
win-64::omniorb-4.2.5-py39hb76b349_1.tar.bz2
win-64::arrow-cpp-6.0.1-py310h96d1096_10_cpu.tar.bz2
win-64::vtk-9.1.0-qt_py37h04430da_207.tar.bz2
win-64::libgdal-3.4.1-h7f66a12_6.tar.bz2
win-64::tiledb-2.7.1-h95dad36_0.tar.bz2
win-64::clang-13-13.0.1-default_h81446c8_0.tar.bz2
win-64::libopencv-4.5.5-py37h1df08fc_5.tar.bz2
win-64::harp-1.15-py310r41heba9ebb_0.tar.bz2
win-64::z5py-2.0.13-py39hcf4c0ac_0.tar.bz2
win-64::libgdal-3.4.1-h75db800_6.tar.bz2
win-64::omniorb-4.2.5-py37h04d2302_1.tar.bz2
win-64::clang-9-9.0.1-default_h4233bec_4.tar.bz2
win-64::python-3.8.13-h9a09f29_0_cpython.tar.bz2
win-64::r-git2r-0.30.1-r41h7c54dad_0.tar.bz2
win-64::ogre-13.3.1-h927da9a_0.tar.bz2
win-64::arrow-cpp-6.0.1-py37hc7983af_10_cpu.tar.bz2
win-64::vigra-1.11.1-py310h2461408_1029.tar.bz2
win-64::openexr-python-1.3.7-py310hffeabb8_0.tar.bz2
win-64::llvmdev-13.0.1-hab3b255_2.tar.bz2
win-64::libllvm14-14.0.0-h97333cc_0.tar.bz2
win-64::libgdal-3.4.2-hf817787_2.tar.bz2
win-64::libgdal-3.4.2-h7f66a12_0.tar.bz2
win-64::arrow-cpp-5.0.0-py37hcbb77e5_28_cuda.tar.bz2
win-64::arrow-cpp-6.0.1-py39h735a502_10_cpu.tar.bz2
win-64::arrow-cpp-7.0.0-py310h4317a25_2_cuda.tar.bz2
win-64::clang-9-9.0.1-cling_v0.9_h913594f_4.tar.bz2
win-64::tectonic-0.8.2-h999ec5b_2.tar.bz2
win-64::libopencv-4.5.5-py37h1df08fc_4.tar.bz2
win-64::pillow-9.0.1-py310h767b3fd_2.tar.bz2
win-64::libopencv-4.5.5-py31h6a2c607_6.tar.bz2
win-64::arrow-cpp-3.0.0-py39h9b61a56_47_cpu.tar.bz2
win-64::mlir-13.0.1-haa24688_0.tar.bz2
win-64::gmt-6.3.0-h0cd9ecb_4.tar.bz2
win-64::r-git2r-0.30.1-r40h7c54dad_0.tar.bz2
win-64::coda-2.23.1-py310heba9ebb_0.tar.bz2
win-64::arrow-cpp-7.0.0-py39h5cea007_0_cpu.tar.bz2
win-64::postgresql-plpython-14.2-py38hda22b0a_0.tar.bz2
win-64::libopencv-4.5.5-py31h6a2c607_7.tar.bz2
win-64::llvm-tools-13.0.1-ha327e53_0.tar.bz2
win-64::cairo-1.16.0-h15b3021_1010.tar.bz2
-    "libzlib >=1.2.11,<1.3.0a0",
+    "libzlib >=1.2.11,<2.0.0a0",
win-64::llvm-13.0.1-h6fda50d_1.tar.bz2
win-64::clang-13.0.1-h8e541a6_0.tar.bz2
win-64::clangxx-13.0.1-default_h81446c8_0.tar.bz2
win-64::llvm-13.0.1-h6fda50d_0.tar.bz2
win-64::llvm-13.0.1-h6fda50d_2.tar.bz2
win-64::llvm-11.1.0-h6fda50d_3.tar.bz2
win-64::llvm-14.0.0-h6fda50d_0.tar.bz2
-    "libzlib >=1.2.11,<1.3.0a0"
+    "libzlib >=1.2.11,<2.0.0a0"
================================================================================
================================================================================
osx-64
osx-64::python-3.10.2-h1dd9edd_4_cpython.tar.bz2
osx-64::tomviz-1.10.0.post156-py37hf986f44_1.tar.bz2
osx-64::grpc-cpp-1.43.2-heb2ec06_2.tar.bz2
osx-64::mysql-libs-8.0.28-h353f102_2.tar.bz2
osx-64::pyngl-1.6.1-py39hdf8353c_4.tar.bz2
osx-64::libtiledb-sql-0.12.4-h2446079_0.tar.bz2
osx-64::arrow-cpp-6.0.1-py39hc94c03c_12_cpu.tar.bz2
osx-64::mdsrv-0.3.5.post1-py38h6589590_3.tar.bz2
osx-64::jaxlib-0.3.0-py39h472c9ed_3.tar.bz2
osx-64::jaxlib-0.3.0-py39h472c9ed_4.tar.bz2
osx-64::tiledb-2.7.0-hd4ce1b4_0.tar.bz2
osx-64::arrow-cpp-6.0.1-py37hef463ef_10_cpu.tar.bz2
osx-64::gfal2-2.20.5-h8bdd576_0.tar.bz2
osx-64::pillow-9.0.1-py310h382dc3b_2.tar.bz2
osx-64::gsoap-2.8.120-hba4f3e5_0.tar.bz2
osx-64::conduit-0.8.2-py37h163bdb4_0.tar.bz2
osx-64::grpcio-1.44.0-py39h76e8ba0_0.tar.bz2
osx-64::cctools_osx-64-973.0.1-h2b735b3_7.tar.bz2
osx-64::tensorflow-base-2.7.0-cpu_py38h91e8603_0.tar.bz2
osx-64::nss-3.77-hfce436b_0.tar.bz2
osx-64::arrow-cpp-3.0.0-py39hc94c03c_46_cpu.tar.bz2
osx-64::libnghttp2-1.47.0-hca56917_0.tar.bz2
osx-64::pillow-9.0.0-py38h47ebe08_0.tar.bz2
osx-64::grpc-cpp-1.45.0-h62077fd_0.tar.bz2
osx-64::postgresql-plpython-14.2-py38h6b43ab9_0.tar.bz2
osx-64::scotch-6.0.9-h3da7401_2.tar.bz2
osx-64::jaxlib-0.1.76-py38he0b5543_0.tar.bz2
osx-64::geant4-11.0.1-py38h550ab12_0.tar.bz2
osx-64::jaxlib-0.3.0-py310ha13e1e0_4.tar.bz2
osx-64::libspatialite-5.0.1-hadde3e2_15.tar.bz2
osx-64::vtk-9.1.0-qt_py39hf980fce_207.tar.bz2
osx-64::cpp-opentelemetry-sdk-1.1.1-hd2fd36d_3.tar.bz2
osx-64::nodejs-17.8.0-h3cde592_1.tar.bz2
osx-64::mlir-13.0.1-h6fbc5c6_0.tar.bz2
osx-64::pillow-9.0.0-py39h768cb32_0.tar.bz2
osx-64::paraview-5.10.0-h5bc6a12_104_qt.tar.bz2
osx-64::panda3d-1.10.11-py310h4ac14b0_2.tar.bz2
osx-64::arrow-cpp-6.0.1-py310h7e225dc_10_cpu.tar.bz2
osx-64::libgdal-3.4.2-h9359d5b_3.tar.bz2
osx-64::vtk-9.1.0-qt_py37h36d6864_206.tar.bz2
osx-64::poppler-qt-22.01.0-hd5146ce_1.tar.bz2
osx-64::pyngl-1.6.1-py38hb9e1374_4.tar.bz2
osx-64::scotch-6.0.9-h300cfde_2.tar.bz2
osx-64::nd2-0.2.1-py37h33c42b1_1.tar.bz2
osx-64::glib-2.70.2-hcf210ce_2.tar.bz2
osx-64::jaxlib-0.3.0-py39h430860b_4.tar.bz2
osx-64::wxpython-4.1.1-py310hda2417f_5.tar.bz2
osx-64::pyinstaller-4.9-py37h83b74e4_1.tar.bz2
osx-64::cctools_osx-64-973.0.1-h609b070_7.tar.bz2
osx-64::jaxlib-0.3.0-py38hbbde29c_3.tar.bz2
osx-64::conduit-0.8.2-py38h349a63e_0.tar.bz2
osx-64::ffmpeg-5.0.0-h2579ba5_0.tar.bz2
osx-64::postgresql-14.2-h0fd25fa_0.tar.bz2
osx-64::postgresql-plpython-14.2-py39h8c0c37d_0.tar.bz2
osx-64::xrootd-5.4.1-py38h98c9e10_0.tar.bz2
osx-64::geotiff-1.7.1-had63758_1.tar.bz2
osx-64::arrow-cpp-5.0.0-py38h5c101bd_25_cpu.tar.bz2
osx-64::tiledb-2.6.2-h2a16ea5_1.tar.bz2
osx-64::gemmi-0.5.2-py310hc82e721_0.tar.bz2
osx-64::libtiledb-sql-0.12.6-h2c77bcd_0.tar.bz2
osx-64::pyngl-1.6.1-py37h3131757_4.tar.bz2
osx-64::texlive-core-20210325-h03edc0b_2.tar.bz2
osx-64::libgdal-3.4.1-h23c56e6_3.tar.bz2
osx-64::nd2-0.2.1-py38ha69a837_0.tar.bz2
osx-64::libthrift-0.16.0-h9702cd6_0.tar.bz2
osx-64::hdf5-1.12.1-mpi_openmpi_h0d5d0c2_4.tar.bz2
osx-64::vtk-9.1.0-qt_py38hfa3bd3d_205.tar.bz2
osx-64::libglib-2.70.2-hf1fb8c0_4.tar.bz2
osx-64::grpcio-1.45.0-py37h38938f7_0.tar.bz2
osx-64::grpc-cpp-1.44.0-hd879e33_0.tar.bz2
osx-64::geotiff-1.7.1-had63758_0.tar.bz2
osx-64::cppyy-cling-6.25.3-py37h0b493f2_0.tar.bz2
osx-64::geant4-11.0.1-py37he775213_0.tar.bz2
osx-64::yoda-1.9.4-py39hbae0c82_1.tar.bz2
osx-64::vtk-9.1.0-qt_py38h2f9316a_206.tar.bz2
osx-64::panda3d-1.10.11-py37h64ec42a_2.tar.bz2
osx-64::ffmpeg-4.3.2-hbf27d7b_3.tar.bz2
osx-64::geant4-11.0.0-py310hb9b49dc_0.tar.bz2
osx-64::gemmi-0.5.3-py37h464c7a5_0.tar.bz2
osx-64::xrootd-5.4.1-py37hb63d6a9_0.tar.bz2
osx-64::pillow-9.0.1-py37ha6be8fa_1.tar.bz2
osx-64::z5py-2.0.15-py310hf13eea0_0.tar.bz2
osx-64::vtk-9.1.0-qt_py37h5f2ae2d_207.tar.bz2
osx-64::triqs-3.1.0-py38h55a3a32_0.tar.bz2
osx-64::arrow-cpp-3.0.0-py39hd30a12f_47_cpu.tar.bz2
osx-64::gazebo-11.10.1-h35936aa_2.tar.bz2
osx-64::cctools_osx-64-973.0.1-h2b735b3_9.tar.bz2
osx-64::libgsf-1.14.49-h956dc07_0.tar.bz2
osx-64::vowpalwabbit-9.0.1-py37h9d266b7_0.tar.bz2
osx-64::harp-1.15-py310r41he448329_0.tar.bz2
osx-64::tensorflow-base-2.7.0-cpu_py37ha7bdf64_0.tar.bz2
osx-64::gmt-6.3.0-h0c9b6a7_4.tar.bz2
osx-64::nodejs-16.14.2-h40ae9cc_1.tar.bz2
osx-64::ndcctools-7.4.3-py37h87f55f7_1.tar.bz2
osx-64::sagelib-9.5-py310hdc53c30_2.tar.bz2
osx-64::cctools_osx-64-973.0.1-h609b070_9.tar.bz2
osx-64::arrow-cpp-7.0.0-py38h5c101bd_1_cpu.tar.bz2
osx-64::astrometry-0.89-py38h94e3bb3_1.tar.bz2
osx-64::tiledb-2.7.0-h190f7ed_0.tar.bz2
osx-64::mandrake-1.2.1-py310h3194726_1.tar.bz2
osx-64::mandrake-1.2.1-py38hed967db_1.tar.bz2
osx-64::arrow-cpp-6.0.1-py39hd30a12f_13_cpu.tar.bz2
osx-64::sdl_image-1.2.12-hb978175_2.tar.bz2
osx-64::z5py-2.0.15-py39h74502c3_0.tar.bz2
osx-64::cctools_osx-64-973.0.1-h609b070_8.tar.bz2
osx-64::grpcio-1.45.0-py39h1e2a180_0.tar.bz2
osx-64::geant4-11.0.1-py310hb5f68b8_0.tar.bz2
osx-64::voms-2.1.0rc0-h98aa168_4.tar.bz2
osx-64::cairo-1.16.0-h9e0e54b_1010.tar.bz2
osx-64::tensorflow-base-2.7.0-cpu_py39h326c378_0.tar.bz2
osx-64::xrootd-5.4.1-py39h4006b3f_0.tar.bz2
osx-64::arrow-cpp-5.0.0-py38h4792887_26_cpu.tar.bz2
osx-64::r-base-4.0.5-h234e2ac_6.tar.bz2
osx-64::z5py-2.0.14-py39h74502c3_0.tar.bz2
osx-64::pillow-9.0.1-py39hd2c7aa1_2.tar.bz2
osx-64::libmongoc-1.21.0-h13b9c20_0.tar.bz2
osx-64::wxpython-4.1.1-py38he02b700_5.tar.bz2
osx-64::ambertools-21.12-py38h7fd0d5f_0.tar.bz2
osx-64::ogre-13.3.0-h5dd8d7a_0.tar.bz2
osx-64::pillow-9.0.1-py39h768cb32_0.tar.bz2
osx-64::sagelib-9.5-py39h1fbcbea_2.tar.bz2
osx-64::arrow-cpp-6.0.1-py38h5c101bd_10_cpu.tar.bz2
osx-64::ovito-3.7.0-h4f644a8_0.tar.bz2
osx-64::gazebo-11.10.1-h366c09f_5.tar.bz2
osx-64::panda3d-1.10.11-py37h83f6f40_2.tar.bz2
osx-64::grpc-cpp-1.45.0-hf4972c3_0.tar.bz2
osx-64::astrometry-0.89-py37ha15c758_1.tar.bz2
osx-64::jaxlib-0.3.0-py37h30a518d_4.tar.bz2
osx-64::arrow-cpp-5.0.0-py37hef463ef_24_cpu.tar.bz2
osx-64::pdal-2.4.0-h5564dda_0.tar.bz2
osx-64::nodejs-14.18.3-h6d46477_3.tar.bz2
osx-64::harp-1.15-py38r40h0664e9e_0.tar.bz2
osx-64::verilator-4.034-hd9580d2_2.tar.bz2
osx-64::cctools_osx-arm64-973.0.1-h7ef2fa9_10.tar.bz2
osx-64::gazebo-11.10.1-h6d68d98_2.tar.bz2
osx-64::pdal-2.4.0-hfdafff2_1.tar.bz2
osx-64::tomviz-1.10.0.post156-py37hf986f44_0.tar.bz2
osx-64::sagelib-9.5-py37hc39770f_2.tar.bz2
osx-64::arrow-cpp-7.0.0-py37hfc63dcb_0_cpu.tar.bz2
osx-64::arrow-cpp-6.0.1-py37h89d3345_12_cpu.tar.bz2
osx-64::arrow-cpp-6.0.1-py39heebe0f7_10_cpu.tar.bz2
osx-64::cctools_osx-arm64-973.0.1-hef7e2f4_9.tar.bz2
osx-64::python-3.8.13-h66c20e1_0_cpython.tar.bz2
osx-64::mysql-client-8.0.28-h7ddd48c_2.tar.bz2
osx-64::gstlal-1.9.0-py39h5d70037_4.tar.bz2
osx-64::gsoap-2.8.120-h5368dca_0.tar.bz2
osx-64::astrometry-0.89-py37h5832633_1.tar.bz2
osx-64::verilator-4.034-h6fbc5c6_3.tar.bz2
osx-64::gemmi-0.5.2-py39ha9d9895_0.tar.bz2
osx-64::arrow-cpp-3.0.0-py37h5782a94_45_cpu.tar.bz2
osx-64::python-3.10.2-hea1dfa3_3_cpython.tar.bz2
osx-64::libvips-8.12.2-hc3c11f0_3.tar.bz2
osx-64::tectonic-0.8.2-h2f7c6a6_1.tar.bz2
osx-64::cctools_osx-arm64-973.0.1-hd1d4517_10.tar.bz2
osx-64::cctools_osx-64-973.0.1-hb41342b_8.tar.bz2
osx-64::conduit-0.8.2-py38ha877268_0.tar.bz2
osx-64::jaxlib-0.3.0-py39h430860b_3.tar.bz2
osx-64::libpq-14.2-hea3049e_0.tar.bz2
osx-64::vtk-9.1.0-qt_py310hf21c004_205.tar.bz2
osx-64::omniorb-libs-4.2.5-h942079c_2.tar.bz2
osx-64::omniorb-4.2.5-py37h167fce4_2.tar.bz2
osx-64::ndcctools-7.4.3-py39hb974310_1.tar.bz2
osx-64::arrow-cpp-6.0.1-py38hc4caabc_12_cpu.tar.bz2
osx-64::ndcctools-7.4.3-py38ha263829_0.tar.bz2
osx-64::sagelib-9.5-py38h97b3fe5_2.tar.bz2
osx-64::pyngl-1.6.1-py38h46798f7_3.tar.bz2
osx-64::sagelib-9.5-py38hba57b99_1.tar.bz2
osx-64::cppyy-cling-6.25.3-py39hda0e682_0.tar.bz2
osx-64::nd2-0.2.1-py37h33c42b1_0.tar.bz2
osx-64::erlang-24.2.2-pl5321h91513c9_0.tar.bz2
osx-64::ndcctools-7.4.3-py38ha263829_1.tar.bz2
osx-64::panda3d-1.10.11-py38h795fea6_2.tar.bz2
osx-64::wasmer-2.2.0-ha33abc2_0.tar.bz2
osx-64::ogre-13.3.2-hb89e613_0.tar.bz2
osx-64::arrow-cpp-5.0.0-py39heebe0f7_24_cpu.tar.bz2
osx-64::triqs-3.1.0-py37h6c834fe_0.tar.bz2
osx-64::panda3d-1.10.11-py310h49eee0d_3.tar.bz2
osx-64::curl-7.82.0-h9f20792_0.tar.bz2
osx-64::panda3d-1.10.11-py38h30ccdfe_3.tar.bz2
osx-64::tiledb-2.6.4-hd4ce1b4_0.tar.bz2
osx-64::arrow-cpp-6.0.1-py310h866d496_11_cpu.tar.bz2
osx-64::arrow-cpp-6.0.1-py310hcf39433_13_cpu.tar.bz2
osx-64::tomviz-1.10.0.post220-py37hcb7a6d5_0.tar.bz2
osx-64::r-base-4.0.5-h56d3809_5.tar.bz2
osx-64::panda3d-1.10.11-py310hbd0e557_3.tar.bz2
osx-64::pyngl-1.6.1-py39h957a3ab_3.tar.bz2
osx-64::panda3d-1.10.11-py39hea92f9e_1.tar.bz2
osx-64::gds-base-2.19.8-h524ae44_0.tar.bz2
osx-64::magics-4.11.0-h4ea44cf_1.tar.bz2
osx-64::gmsh-4.9.4-hde0777f_0.tar.bz2
osx-64::omniorb-4.2.5-py37h167fce4_1.tar.bz2
osx-64::paraview-5.10.0-h33d43f1_104_qt.tar.bz2
osx-64::ffmpeg-4.4.1-h2579ba5_2.tar.bz2
osx-64::sagelib-9.5-py38ha7a50e7_4.tar.bz2
osx-64::mandrake-1.2.1-py37h7a85b67_1.tar.bz2
osx-64::libglib-2.70.2-hf1fb8c0_2.tar.bz2
osx-64::arrow-cpp-5.0.0-py310hc56d562_27_cpu.tar.bz2
osx-64::python-3.10.4-h8b4d769_0_cpython.tar.bz2
osx-64::libgit2-1.4.2-h514b3f4_0.tar.bz2
osx-64::nd2-0.2.2-py310had5fa56_0.tar.bz2
osx-64::grpcio-1.45.0-py310hd5a3808_0.tar.bz2
osx-64::postgresql-plpython-14.2-py310h9631d35_0.tar.bz2
osx-64::ndcctools-7.4.3-py310h407b262_1.tar.bz2
osx-64::paraview-5.10.0-hf202402_104_qt.tar.bz2
osx-64::gdk-pixbuf-2.42.8-hb161b9c_0.tar.bz2
osx-64::grpcio-1.45.0-py38h627a94d_0.tar.bz2
osx-64::qt-main-5.15.2-h8f7a3c3_2.tar.bz2
osx-64::magics-metview-4.11.0-h324be13_0.tar.bz2
osx-64::vtk-9.1.0-qt_py37h2260a90_204.tar.bz2
osx-64::nodejs-17.7.1-h8f7c3f9_0.tar.bz2
osx-64::gazebo-11.10.1-h203b9c6_4.tar.bz2
osx-64::arrow-cpp-5.0.0-py37h89d3345_27_cpu.tar.bz2
osx-64::sagelib-9.5-py37hf093b7e_0.tar.bz2
osx-64::pillow-9.0.1-py38h7207f37_2.tar.bz2
osx-64::pillow-9.0.1-py37h2540ef4_2.tar.bz2
osx-64::pypy3.9-7.3.8-h1e179d7_1.tar.bz2
osx-64::erlang-24.3.3-pl5321h37eb3dd_0.tar.bz2
osx-64::libglib-2.70.2-hf1fb8c0_3.tar.bz2
osx-64::libthrift-0.16.0-h9702cd6_1.tar.bz2
osx-64::python-3.8.13-h394c593_0_cpython.tar.bz2
osx-64::wxpython-4.1.1-py310hda2417f_4.tar.bz2
osx-64::gazebo-11.10.2-h08bfaa4_0.tar.bz2
osx-64::pillow-9.0.0-py37ha6be8fa_0.tar.bz2
osx-64::gazebo-11.10.2-h8ea4871_0.tar.bz2
osx-64::z5py-2.0.13-py38h65fb09a_0.tar.bz2
osx-64::nodejs-16.14.2-h8f7c3f9_0.tar.bz2
osx-64::omniorb-4.2.5-py310ha2f8ce0_1.tar.bz2
osx-64::grpcio-1.44.0-py37hc728aa8_0.tar.bz2
osx-64::arrow-cpp-6.0.1-py37h98911d1_10_cpu.tar.bz2
osx-64::nest-simulator-3.3-py39hb4563f7_0.tar.bz2
osx-64::omniorb-libs-4.2.5-hca56917_2.tar.bz2
osx-64::conduit-0.8.2-py39h16e84d1_0.tar.bz2
osx-64::arrow-cpp-3.0.0-py310h866d496_45_cpu.tar.bz2
osx-64::tomviz-1.10.0.post230-py37hcb7a6d5_0.tar.bz2
osx-64::geant4-11.0.0-py37h2260be7_0.tar.bz2
osx-64::arrow-cpp-7.0.0-py310h7e225dc_1_cpu.tar.bz2
osx-64::omniorb-4.2.5-py39h76e1ea6_2.tar.bz2
osx-64::nss-3.76-hfce436b_0.tar.bz2
osx-64::astrometry-0.89-py310h29752dc_1.tar.bz2
osx-64::gsoap-2.8.119-h406289c_0.tar.bz2
osx-64::imagecodecs-2022.2.22-py310h16327c3_0.tar.bz2
osx-64::grpc-cpp-1.44.0-hf4972c3_1.tar.bz2
osx-64::assimp-5.2.1-h1224e73_0.tar.bz2
osx-64::nd2-0.2.2-py38h4bd8d5b_0.tar.bz2
osx-64::cctools_osx-arm64-973.0.1-hef7e2f4_6.tar.bz2
osx-64::hdf5-1.12.1-mpi_mpich_hfd824e9_4.tar.bz2
osx-64::jaxlib-0.3.0-py38he6ee80c_4.tar.bz2
osx-64::sagelib-9.5-py310hdc53c30_3.tar.bz2
osx-64::ndcctools-7.4.3-py39hb974310_0.tar.bz2
osx-64::harp-1.15-py310r40he448329_0.tar.bz2
osx-64::ogre-13.3.3-h188a5dd_0.tar.bz2
osx-64::cctools_osx-arm64-973.0.1-hef7e2f4_8.tar.bz2
osx-64::libvips-8.12.2-h443074a_2.tar.bz2
osx-64::arrow-cpp-3.0.0-py38h747fb2b_43_cpu.tar.bz2
osx-64::grpc-cpp-1.44.0-heb2ec06_0.tar.bz2
osx-64::arrow-cpp-7.0.0-py310hdcfcbb4_3_cpu.tar.bz2
osx-64::gds-base-2.19.8-h524ae44_1.tar.bz2
osx-64::erlang-24.3.2-pl5321h37eb3dd_0.tar.bz2
osx-64::postgresql-plpython-14.2-py38h7f62374_0.tar.bz2
osx-64::pyinstaller-4.9-py38h4fe204b_0.tar.bz2
osx-64::panda3d-1.10.11-py310hdd79d93_1.tar.bz2
osx-64::nd2-0.2.1-py310had5fa56_1.tar.bz2
osx-64::libgdal-3.4.1-h52a0caa_6.tar.bz2
osx-64::pillow-9.0.0-py310h9351100_0.tar.bz2
osx-64::omniorb-4.2.5-py37hf36a506_2.tar.bz2
osx-64::hdf5-1.12.1-mpi_mpich_hf636e3b_3.tar.bz2
osx-64::cmake-3.22.2-h4d639be_0.tar.bz2
osx-64::conduit-0.8.2-py39h336f781_0.tar.bz2
osx-64::arrow-cpp-3.0.0-py37h98911d1_44_cpu.tar.bz2
osx-64::cctools_osx-arm64-973.0.1-h7ef2fa9_9.tar.bz2
osx-64::imagecodecs-2022.2.22-py310hecd8173_1.tar.bz2
osx-64::arrow-cpp-5.0.0-py37hc607cf8_28_cpu.tar.bz2
osx-64::yoda-1.9.4-py37hb4ba4dc_1.tar.bz2
osx-64::arrow-cpp-7.0.0-py38hc57d628_0_cpu.tar.bz2
osx-64::r-git2r-0.30.1-r40h3bbc60d_0.tar.bz2
osx-64::wasmer-2.2.1-h0ed409e_0.tar.bz2
osx-64::grpc-cpp-1.43.2-hd879e33_2.tar.bz2
osx-64::ndcctools-7.4.3-py39h9247e91_1.tar.bz2
osx-64::giac-1.6.0.47-hd7a58db_5.tar.bz2
osx-64::libgdal-3.4.2-hd9f1e37_4.tar.bz2
osx-64::vigra-1.11.1-py37h0155546_1029.tar.bz2
osx-64::cctools_osx-64-973.0.1-h2b735b3_8.tar.bz2
osx-64::verilator-4.218-hd9580d2_0.tar.bz2
osx-64::ffmpeg-4.4.1-h79e7b16_1.tar.bz2
osx-64::gfal2-2.20.4-h8bdd576_0.tar.bz2
osx-64::panda3d-1.10.11-py38h081c976_1.tar.bz2
osx-64::imagemagick-7.1.0_26-pl5321he4e8d81_0.tar.bz2
osx-64::pyngl-1.6.1-py37h35df3db_3.tar.bz2
osx-64::scotch-6.1.3-h584d7c3_0.tar.bz2
osx-64::voms-2.1.0rc0-h4e782fa_6.tar.bz2
osx-64::vtk-9.1.0-qt_py310h1812388_207.tar.bz2
osx-64::paraview-5.10.1-h2c983c6_104_qt.tar.bz2
osx-64::ndcctools-7.4.3-py37hbece8e7_0.tar.bz2
osx-64::harp-1.15-py39r41hcea63b7_0.tar.bz2
osx-64::mongodb-5.1.1-h51580be_1.tar.bz2
osx-64::pdal-2.3.0-ha2ab78e_27.tar.bz2
osx-64::imagemagick-7.1.0_24-pl5321h3e49128_0.tar.bz2
osx-64::libgd-2.3.3-h02d8a21_2.tar.bz2
osx-64::geant4-11.0.1-py39h0b0a40a_0.tar.bz2
osx-64::arrow-cpp-5.0.0-py37h5782a94_26_cpu.tar.bz2
osx-64::pillow-9.0.1-py39h768cb32_1.tar.bz2
osx-64::omniorb-4.2.5-py39h0d687a8_1.tar.bz2
osx-64::libcurl-7.82.0-h9f20792_0.tar.bz2
osx-64::arrow-cpp-3.0.0-py38hcc255e5_47_cpu.tar.bz2
osx-64::vowpalwabbit-9.0.1-py310h9076ab7_0.tar.bz2
osx-64::libtiledb-sql-0.12.6-hf429a70_0.tar.bz2
osx-64::pyinstaller-4.9-py39h9fd43ae_0.tar.bz2
osx-64::tectonic-0.8.2-h8b3b6ed_0.tar.bz2
osx-64::python-3.9.12-h8b4d769_1_cpython.tar.bz2
osx-64::tomviz-1.10.0.post152-py37hf986f44_1.tar.bz2
osx-64::triqs-3.1.0-py310h174faaf_0.tar.bz2
osx-64::libgdal-3.4.2-h86656dd_1.tar.bz2
osx-64::poppler-22.01.0-h39497b0_2.tar.bz2
osx-64::erlang-24.3.1-pl5321h91513c9_0.tar.bz2
osx-64::nodejs-17.7.1-h247dfb2_0.tar.bz2
osx-64::arrow-cpp-3.0.0-py38h4792887_45_cpu.tar.bz2
osx-64::netpbm-10.73.39-pl5321h73583f9_0.tar.bz2
osx-64::llvmdev-13.0.1-h64f94b2_2.tar.bz2
osx-64::jaxlib-0.3.0-py310hc3794dd_3.tar.bz2
osx-64::ffmpeg-5.0.0-h9220da4_1.tar.bz2
osx-64::tiledb-2.7.1-hd4ce1b4_0.tar.bz2
osx-64::qt-webengine-5.15.4-h3a3182f_1.tar.bz2
osx-64::libmongoc-1.21.1-h029cd87_0.tar.bz2
osx-64::wxpython-4.1.1-py37h8745436_5.tar.bz2
osx-64::mdsrv-0.3.5.post1-py310hebf023d_3.tar.bz2
osx-64::omniorb-4.2.5-py38h6d2bfc4_1.tar.bz2
osx-64::geant4-11.0.0-py39h20ade89_0.tar.bz2
osx-64::irrlicht-1.8.5-he00d70a_2.tar.bz2
osx-64::gazebo-11.10.1-h8ea4871_5.tar.bz2
osx-64::openssh-8.9p1-hd27dfd1_0.tar.bz2
osx-64::panda3d-1.10.11-py39h8e4f19e_3.tar.bz2
osx-64::ndcctools-7.4.3-py38h171f6b0_0.tar.bz2
osx-64::postgresql-plpython-14.2-py39h76a1e84_0.tar.bz2
osx-64::coda-2.23.1-py37h8b7f7fd_0.tar.bz2
osx-64::jaxlib-0.3.0-py310hc3794dd_4.tar.bz2
osx-64::graphviz-3.0.0-h6f567cf_1.tar.bz2
osx-64::coda-2.23.1-py37h8f1b641_0.tar.bz2
osx-64::llvmdev-11.1.0-hd011deb_3.tar.bz2
osx-64::mupdf-1.17.0-hfde1fec_2.tar.bz2
osx-64::arrow-cpp-6.0.1-py39hbb8db60_10_cpu.tar.bz2
osx-64::pdal-2.3.0-ha2ab78e_26.tar.bz2
osx-64::vowpalwabbit-9.0.1-py38haaa3206_0.tar.bz2
osx-64::cctools_osx-arm64-973.0.1-h7ef2fa9_8.tar.bz2
osx-64::jaxlib-0.3.0-py37h30a518d_3.tar.bz2
osx-64::arrow-cpp-6.0.1-py38hcc255e5_13_cpu.tar.bz2
osx-64::magics-metview-batch-4.11.0-h4ea44cf_1.tar.bz2
osx-64::root_base-6.26.0-py39h3c47336_0.tar.bz2
osx-64::magics-metview-4.11.0-he389bf2_1.tar.bz2
osx-64::libgdal-3.4.1-h2df2ef8_4.tar.bz2
osx-64::arrow-cpp-5.0.0-py38hc4caabc_27_cpu.tar.bz2
osx-64::mandrake-1.2.1-py39h20b4717_1.tar.bz2
osx-64::llvmdev-13.0.1-hd011deb_0.tar.bz2
osx-64::nodejs-17.8.0-h40ae9cc_1.tar.bz2
osx-64::thrift-compiler-0.16.0-ha6dc762_0.tar.bz2
osx-64::tiledb-2.6.2-hca4410a_1.tar.bz2
osx-64::cpp-opentelemetry-sdk-1.2.0-h6fa4495_0.tar.bz2
osx-64::cctools_osx-arm64-973.0.1-hd1d4517_7.tar.bz2
osx-64::r-seqminer-8.4-r41h15e7a47_0.tar.bz2
osx-64::arrow-cpp-3.0.0-py310h7e225dc_44_cpu.tar.bz2
osx-64::python-3.9.12-h8b4d769_0_cpython.tar.bz2
osx-64::pyinstaller-4.9-py38h4fe204b_1.tar.bz2
osx-64::cctools_osx-arm64-973.0.1-hd1d4517_8.tar.bz2
osx-64::ptscotch-6.0.9-h6295d7f_2.tar.bz2
osx-64::gdstk-0.8.2-py310h41a46b3_0.tar.bz2
osx-64::paraview-5.10.1-h189e62d_104_qt.tar.bz2
osx-64::erlang-24.3-pl5321h37eb3dd_0.tar.bz2
osx-64::tectonic-0.8.2-h019caf1_2.tar.bz2
osx-64::pillow-9.0.1-py37h0fe8677_2.tar.bz2
osx-64::panda3d-1.10.11-py38ha842901_2.tar.bz2
osx-64::libgdal-3.4.2-hc3b582a_2.tar.bz2
osx-64::arrow-cpp-5.0.0-py310h866d496_26_cpu.tar.bz2
osx-64::imagecodecs-2022.2.22-py39hd8e92b5_0.tar.bz2
osx-64::wxpython-4.1.1-py39hd1060eb_4.tar.bz2
osx-64::arrow-cpp-6.0.1-py38h4792887_11_cpu.tar.bz2
osx-64::graphviz-3.0.0-h6f567cf_0.tar.bz2
osx-64::assimp-5.2.3-hbcca2e3_0.tar.bz2
osx-64::vowpalwabbit-9.0.1-py37hd6556a3_0.tar.bz2
osx-64::arrow-cpp-3.0.0-py39hae7bdae_45_cpu.tar.bz2
osx-64::libxml2-2.9.12-he03b247_2.tar.bz2
osx-64::plumed-2.8.0-mpi_mpich_h2957eff_0.tar.bz2
osx-64::gdstk-0.8.2-py38h7cbb373_0.tar.bz2
osx-64::panda3d-1.10.11-py37h79fd146_3.tar.bz2
osx-64::arrow-cpp-7.0.0-py38h04388a0_2_cpu.tar.bz2
osx-64::vtk-9.1.0-qt_py310h414f686_204.tar.bz2
osx-64::julia-1.7.2-hbcac894_1.tar.bz2
osx-64::arrow-cpp-6.0.1-py37hc607cf8_13_cpu.tar.bz2
osx-64::panda3d-1.10.11-py39hdcf86a6_2.tar.bz2
osx-64::nco-5.0.6-h346761d_0.tar.bz2
osx-64::wasmer-2.2.0-h0ed409e_0.tar.bz2
osx-64::arrow-cpp-5.0.0-py39hd30a12f_28_cpu.tar.bz2
osx-64::ndcctools-7.4.3-py310h407b262_0.tar.bz2
osx-64::wasmer-2.2.1-ha33abc2_0.tar.bz2
osx-64::root_base-6.26.0-py37h7165b58_0.tar.bz2
osx-64::libgdal-3.4.1-h467bfbe_3.tar.bz2
osx-64::erlang-24.3.3-pl5321h91513c9_0.tar.bz2
osx-64::vtk-9.1.0-qt_py39he31bdf0_204.tar.bz2
osx-64::imagemagick-7.1.0_27-pl5321he4e8d81_0.tar.bz2
osx-64::postgresql-14.2-he8fe76e_0.tar.bz2
osx-64::openssh-8.9p1-he782c1b_0.tar.bz2
osx-64::python-3.9.12-h1cc4136_1_cpython.tar.bz2
osx-64::plumed-2.8.0-nompi_h3651d47_100.tar.bz2
osx-64::grpcio-1.44.0-py38h4924b5d_0.tar.bz2
osx-64::vtk-9.1.0-qt_py38h04bf400_204.tar.bz2
osx-64::triqs-3.1.0-py37hbfa7aa9_0.tar.bz2
osx-64::imagemagick-7.1.0_23-pl5321h3e49128_0.tar.bz2
osx-64::cctools_osx-64-973.0.1-h609b070_6.tar.bz2
osx-64::gstlal-1.9.0-py38hc40a69a_4.tar.bz2
osx-64::python-3.9.10-hea1dfa3_2_cpython.tar.bz2
osx-64::grpc-cpp-1.43.2-h99b9177_1.tar.bz2
osx-64::ovito-3.7.2-h4f644a8_0.tar.bz2
osx-64::omniorb-4.2.5-py310hc5a569c_2.tar.bz2
osx-64::paraview-5.10.1-h7c9a14d_104_qt.tar.bz2
osx-64::tippecanoe-1.36.0-hababd50_2.tar.bz2
osx-64::arrow-cpp-5.0.0-py310h60f5776_24_cpu.tar.bz2
osx-64::arrow-cpp-6.0.1-py37h5782a94_11_cpu.tar.bz2
osx-64::pyinstaller-4.9-py310h76f859f_1.tar.bz2
osx-64::grpcio-1.44.0-py310haaead3b_0.tar.bz2
osx-64::jaxlib-0.3.0-py310ha13e1e0_3.tar.bz2
osx-64::nodejs-16.14.2-h3cde592_1.tar.bz2
osx-64::imagecodecs-2021.11.20-py37h1599e18_2.tar.bz2
osx-64::grpcio-1.45.0-py39hf618ae8_0.tar.bz2
osx-64::libgit2-1.4.2-heec6b30_0.tar.bz2
osx-64::magics-metview-batch-4.11.0-hd7d451e_0.tar.bz2
osx-64::jaxlib-0.3.0-py38he6ee80c_3.tar.bz2
osx-64::arrow-cpp-7.0.0-py310hd49938f_0_cpu.tar.bz2
osx-64::cctools_osx-64-973.0.1-h2b735b3_6.tar.bz2
osx-64::gemmi-0.5.3-py39ha9d9895_0.tar.bz2
osx-64::coda-2.23.1-py38h0664e9e_0.tar.bz2
osx-64::postgresql-plpython-14.2-py37h43e72e4_0.tar.bz2
osx-64::r-git2r-0.30.1-r41h3bbc60d_0.tar.bz2
osx-64::arrow-cpp-5.0.0-py310h7e225dc_25_cpu.tar.bz2
osx-64::wxpython-4.1.1-py37h8745436_4.tar.bz2
osx-64::grpcio-1.44.0-py37hac9a2c0_0.tar.bz2
osx-64::plumed-2.8.0-mpi_openmpi_h4e6900d_0.tar.bz2
osx-64::glib-2.70.2-hcf210ce_3.tar.bz2
osx-64::pillow-9.0.0-py37h942db99_0.tar.bz2
osx-64::arrow-cpp-3.0.0-py310hc56d562_46_cpu.tar.bz2
osx-64::nest-simulator-3.3-py310h1996c3e_0.tar.bz2
osx-64::mysql-server-8.0.28-h4cafbb6_2.tar.bz2
osx-64::panda3d-1.10.11-py37h6c89d06_1.tar.bz2
osx-64::tensorflow-base-2.7.0-cpu_py310h437b8d6_0.tar.bz2
osx-64::triqs-3.1.0-py39ha25f952_0.tar.bz2
osx-64::panda3d-1.10.11-py37h055a0a8_3.tar.bz2
osx-64::gemmi-0.5.2-py37h2079f12_0.tar.bz2
osx-64::pillow-9.0.1-py310h9351100_0.tar.bz2
osx-64::imagecodecs-2021.11.20-py38h2c9dbd4_2.tar.bz2
osx-64::tiledb-2.6.3-h190f7ed_0.tar.bz2
osx-64::pdal-2.4.0-ha70b4ee_0.tar.bz2
osx-64::tectonic-0.8.2-h732483a_0.tar.bz2
osx-64::assimp-5.2.3-hbcca2e3_1.tar.bz2
osx-64::omniorb-4.2.5-py37hf36a506_1.tar.bz2
osx-64::imagecodecs-2022.2.22-py38hbfa6760_0.tar.bz2
osx-64::vtk-9.1.0-qt_py39h1ca8bac_206.tar.bz2
osx-64::gemmi-0.5.3-py38hbfc0824_0.tar.bz2
osx-64::emacs-27.2-h748090c_2.tar.bz2
osx-64::arrow-cpp-7.0.0-py37h98911d1_1_cpu.tar.bz2
osx-64::nodejs-16.14.2-h247dfb2_0.tar.bz2
osx-64::nd2-0.2.2-py39hed0b74c_0.tar.bz2
osx-64::libgdal-3.4.2-h52a0caa_0.tar.bz2
osx-64::pyinstaller-4.9-py310h76f859f_0.tar.bz2
osx-64::cmake-3.23.0-h35a7dd9_1.tar.bz2
osx-64::libpq-14.2-h8ce7ee7_0.tar.bz2
osx-64::openscenegraph-3.6.5-h794d469_13.tar.bz2
osx-64::cctools_osx-arm64-973.0.1-h7ef2fa9_6.tar.bz2
osx-64::gazebo-11.10.2-h12311cb_0.tar.bz2
osx-64::vtk-9.1.0-qt_py310h64e1a64_206.tar.bz2
osx-64::conduit-0.8.2-py37he5bc6c3_0.tar.bz2
osx-64::ogre-13.3.2-h188a5dd_0.tar.bz2
osx-64::libgdal-3.4.1-h412265b_6.tar.bz2
osx-64::z5py-2.0.13-py39haf96dd5_0.tar.bz2
osx-64::arrow-cpp-3.0.0-py310hcf39433_47_cpu.tar.bz2
osx-64::cctools_osx-arm64-973.0.1-h7ef2fa9_7.tar.bz2
osx-64::r-seqminer-8.4-r40h15e7a47_0.tar.bz2
osx-64::xrootd-5.4.1-py310h3cd1877_0.tar.bz2
osx-64::pillow-9.0.1-py38h47ebe08_0.tar.bz2
osx-64::ndcctools-7.4.3-py38h171f6b0_1.tar.bz2
osx-64::omniorb-4.2.5-py310hc5a569c_1.tar.bz2
osx-64::ovito-3.7.2-h3f2f798_1.tar.bz2
osx-64::sagelib-9.5-py39hb5a7a70_1.tar.bz2
osx-64::jaxlib-0.1.76-py310h787ba27_0.tar.bz2
osx-64::pillow-9.0.1-py37ha6be8fa_0.tar.bz2
osx-64::r-git2r-0.30.1-r40he6f0618_0.tar.bz2
osx-64::jaxlib-0.3.0-py37h8ce5ef6_4.tar.bz2
osx-64::pypy3.9-7.3.8-h517dee8_1.tar.bz2
osx-64::arrow-cpp-7.0.0-py37h04e314c_2_cpu.tar.bz2
osx-64::wxpython-4.1.1-py38he02b700_4.tar.bz2
osx-64::imagecodecs-2021.11.20-py39h94a26a9_2.tar.bz2
osx-64::hdfeos2-2.20-h2ea4a1d_1001.tar.bz2
osx-64::cpp-opentelemetry-sdk-1.2.0-hf4b11f9_1.tar.bz2
osx-64::z5py-2.0.13-py37hc237eb2_0.tar.bz2
osx-64::arrow-cpp-6.0.1-py39hae7bdae_11_cpu.tar.bz2
osx-64::tiledb-2.6.4-h190f7ed_0.tar.bz2
osx-64::vowpalwabbit-9.0.1-py39h60e5d19_0.tar.bz2
osx-64::boost-cpp-1.74.0-hdbf7018_7.tar.bz2
osx-64::python-3.10.2-hea1dfa3_4_cpython.tar.bz2
osx-64::jaxlib-0.1.76-py39h8f424c2_0.tar.bz2
osx-64::liblal-7.1.7-mkl_hc7e7627_0.tar.bz2
osx-64::cppyy-cling-6.25.3-py37h0ec75ca_0.tar.bz2
osx-64::paraview-5.10.1-h6c9e04e_104_qt.tar.bz2
osx-64::grpcio-1.44.0-py310hc31b572_0.tar.bz2
osx-64::arrow-cpp-7.0.0-py39h3c1ee8c_0_cpu.tar.bz2
osx-64::cctools_osx-64-973.0.1-hb41342b_7.tar.bz2
osx-64::grpcio-1.44.0-py39h757451a_0.tar.bz2
osx-64::libmongoc-1.21.0-h8b266b5_0.tar.bz2
osx-64::gemmi-0.5.2-py37h464c7a5_0.tar.bz2
osx-64::libgdal-3.4.1-h3c130a2_5.tar.bz2
osx-64::imagemagick-7.1.0_29-pl5321h80d2495_0.tar.bz2
osx-64::ncl-6.6.2-h4d57837_37.tar.bz2
osx-64::tomviz-1.10.0.post228-py37hcb7a6d5_0.tar.bz2
osx-64::geotiff-1.7.0-had63758_7.tar.bz2
osx-64::nd2-0.2.1-py39hed0b74c_1.tar.bz2
osx-64::cctools_osx-64-973.0.1-hb41342b_9.tar.bz2
osx-64::gazebo-11.10.1-h6d68d98_3.tar.bz2
osx-64::sagelib-9.5-py310ha1b8b38_1.tar.bz2
osx-64::arrow-cpp-5.0.0-py38hcc255e5_28_cpu.tar.bz2
osx-64::vigra-1.11.1-py310hefd2f18_1029.tar.bz2
osx-64::r-base-4.1.3-h56d3809_0.tar.bz2
osx-64::harp-1.15-py37r41h8f1b641_0.tar.bz2
osx-64::qpdf-10.6.1-hefd3b78_0.tar.bz2
osx-64::pypy3.8-7.3.8-hd6ecfba_1.tar.bz2
osx-64::gemmi-0.5.3-py37h2079f12_0.tar.bz2
osx-64::qt-main-5.15.2-hcd8bfff_3.tar.bz2
osx-64::imagemagick-7.1.0_25-pl5321h3e49128_0.tar.bz2
osx-64::sagelib-9.5-py310ha1b8b38_0.tar.bz2
osx-64::erlang-24.3.1-pl5321h37eb3dd_0.tar.bz2
osx-64::ndcctools-7.4.3-py310hd247ede_1.tar.bz2
osx-64::libmongoc-1.21.1-h0422d0a_0.tar.bz2
osx-64::qpdf-10.6.2-ha68c33c_1.tar.bz2
osx-64::arrow-cpp-7.0.0-py37hd6d5da5_3_cpu.tar.bz2
osx-64::libgdal-3.4.1-h3eb346c_5.tar.bz2
osx-64::imagecodecs-2021.11.20-py37h04bde26_2.tar.bz2
osx-64::pyinstaller-4.10-py38h11e812f_0.tar.bz2
osx-64::mysql-libs-8.0.28-h2a44bf5_2.tar.bz2
osx-64::hdf5-1.12.1-mpi_openmpi_hcdc8fb9_4.tar.bz2
osx-64::arrow-cpp-5.0.0-py39hbb8db60_25_cpu.tar.bz2
osx-64::nodejs-17.8.0-h8f7c3f9_0.tar.bz2
osx-64::ogre-13.3.0-ha8acd6a_0.tar.bz2
osx-64::grpc-cpp-1.43.2-hb6405b5_1.tar.bz2
osx-64::cairo-1.16.0-h1680b09_1011.tar.bz2
osx-64::imagemagick-7.1.0_27-pl5321h80d2495_1.tar.bz2
osx-64::libtiledb-sql-0.12.4-h3a6e14b_0.tar.bz2
osx-64::imagecodecs-2022.2.22-py39ha3729fb_1.tar.bz2
osx-64::hdf5-1.12.1-mpi_mpich_h611ac81_4.tar.bz2
osx-64::paraview-5.10.0-he9cc3e1_104_qt.tar.bz2
osx-64::ovito-3.7.1-h4f644a8_0.tar.bz2
osx-64::libcurl-static-7.82.0-h9dce1e3_0.tar.bz2
osx-64::sagelib-9.5-py39hb5a7a70_0.tar.bz2
osx-64::giac-1.6.0.47-hd7a58db_4.tar.bz2
osx-64::triqs-3.1.0-py39h9750a7f_0.tar.bz2
osx-64::ndcctools-7.4.3-py37hbece8e7_1.tar.bz2
osx-64::vigra-1.11.1-py37h296af3d_1029.tar.bz2
osx-64::pyinstaller-4.9-py39h9fd43ae_1.tar.bz2
osx-64::omniorb-4.2.5-py310ha2f8ce0_2.tar.bz2
osx-64::libcurl-7.82.0-h9dce1e3_0.tar.bz2
osx-64::arrow-cpp-6.0.1-py310hc56d562_12_cpu.tar.bz2
osx-64::gmsh-4.9.5-hee79192_0.tar.bz2
osx-64::pyinstaller-4.10-py310he04095b_0.tar.bz2
osx-64::arrow-cpp-5.0.0-py38h747fb2b_24_cpu.tar.bz2
osx-64::erlang-24.2.2-pl5321h37eb3dd_0.tar.bz2
osx-64::thrift-compiler-0.16.0-h9702cd6_0.tar.bz2
osx-64::jaxlib-0.3.0-py37h8ce5ef6_3.tar.bz2
osx-64::libgdal-3.4.2-h9359d5b_2.tar.bz2
osx-64::gdstk-0.8.2-py37hd9beaf6_0.tar.bz2
osx-64::nd2-0.2.1-py38ha69a837_1.tar.bz2
osx-64::libnghttp2-1.47.0-h942079c_0.tar.bz2
osx-64::xrootd-5.4.1-py37he6b4dc7_0.tar.bz2
osx-64::ambertools-21.12-py39hf80593e_0.tar.bz2
osx-64::libgdal-3.4.2-hc3b582a_3.tar.bz2
osx-64::r-git2r-0.30.1-r41he6f0618_0.tar.bz2
osx-64::wxpython-4.1.1-py39hd1060eb_5.tar.bz2
osx-64::gap-core-4.11.1-h4855eeb_3.tar.bz2
osx-64::pyngl-1.6.1-py310hf946f83_4.tar.bz2
osx-64::r-base-4.1.3-h234e2ac_1.tar.bz2
osx-64::arrow-cpp-7.0.0-py310h5d67baf_2_cpu.tar.bz2
osx-64::nest-simulator-3.3-py38h0c095de_0.tar.bz2
osx-64::pdal-2.4.0-h52d5574_1.tar.bz2
osx-64::libgdal-3.4.1-he416c16_4.tar.bz2
osx-64::imagemagick-7.1.0_28-pl5321h80d2495_0.tar.bz2
osx-64::conduit-0.8.2-py39h402c14c_0.tar.bz2
osx-64::tomviz-1.10.0.post154-py37hf986f44_0.tar.bz2
osx-64::omniorb-4.2.5-py38h3641052_2.tar.bz2
osx-64::gazebo-11.10.1-haf02b10_4.tar.bz2
osx-64::arrow-cpp-7.0.0-py38hbe5ac90_3_cpu.tar.bz2
osx-64::sagelib-9.5-py37h527333e_4.tar.bz2
osx-64::pdal-2.3.0-h8255b4b_26.tar.bz2
osx-64::gdstk-0.8.2-py37haf41239_0.tar.bz2
osx-64::nginx-1.21.6-hc9f9526_0.tar.bz2
osx-64::arrow-cpp-7.0.0-py39h651b205_3_cpu.tar.bz2
osx-64::cctools_osx-arm64-973.0.1-hd1d4517_9.tar.bz2
osx-64::libgdal-3.4.2-hc7881c0_4.tar.bz2
osx-64::xeus-cling-0.13.0-h03f8c5d_3.tar.bz2
osx-64::arrow-cpp-3.0.0-py39h3c1ee8c_42_cpu.tar.bz2
osx-64::z5py-2.0.14-py37hc9e9c12_0.tar.bz2
osx-64::astrometry-0.89-py39h3face37_1.tar.bz2
osx-64::arrow-cpp-5.0.0-py37h98911d1_25_cpu.tar.bz2
osx-64::pillow-9.0.1-py310h9351100_1.tar.bz2
osx-64::thrift-compiler-0.16.0-h9702cd6_1.tar.bz2
osx-64::ptscotch-6.0.9-h4f3afa6_2.tar.bz2
osx-64::magics-4.11.0-hd7d451e_0.tar.bz2
osx-64::erlang-24.3.2-pl5321h91513c9_0.tar.bz2
osx-64::root_base-6.26.0-py38h9f24bb7_0.tar.bz2
osx-64::z5py-2.0.13-py310h5fba041_0.tar.bz2
osx-64::fish-3.3.1-h6c1fd46_0.tar.bz2
osx-64::coda-2.23.1-py310he448329_0.tar.bz2
osx-64::nodejs-17.8.0-h247dfb2_0.tar.bz2
osx-64::pyinstaller-4.10-py37hb9cd1ca_0.tar.bz2
osx-64::geant4-11.0.0-py38h383d1ea_0.tar.bz2
osx-64::git-2.35.1-pl5321h9a94999_0.tar.bz2
osx-64::glib-2.70.2-hcf210ce_4.tar.bz2
osx-64::arrow-cpp-3.0.0-py310h60f5776_43_cpu.tar.bz2
osx-64::omniorb-4.2.5-py38h3641052_1.tar.bz2
osx-64::ptscotch-6.1.3-h4f3afa6_0.tar.bz2
osx-64::ptscotch-6.1.3-h6295d7f_0.tar.bz2
osx-64::tiledb-2.7.1-h190f7ed_0.tar.bz2
osx-64::jaxlib-0.3.0-py38hbbde29c_4.tar.bz2
osx-64::grpc-cpp-1.44.0-h62077fd_1.tar.bz2
osx-64::mysql-server-8.0.28-h6edde1b_2.tar.bz2
osx-64::cppyy-cling-6.25.3-py310h6622b4a_0.tar.bz2
osx-64::libtiledb-sql-0.12.5-h2c77bcd_0.tar.bz2
osx-64::z5py-2.0.15-py37hc9e9c12_0.tar.bz2
osx-64::orc-1.7.3-h84518c8_0.tar.bz2
osx-64::vtk-9.1.0-qt_py38h2a16d86_207.tar.bz2
osx-64::cmake-3.22.3-h35a7dd9_0.tar.bz2
osx-64::vtk-9.1.0-qt_py39h5692acc_205.tar.bz2
osx-64::curl-7.82.0-h9dce1e3_0.tar.bz2
osx-64::arrow-cpp-3.0.0-py37h89d3345_46_cpu.tar.bz2
osx-64::harp-1.15-py39r40hcea63b7_0.tar.bz2
osx-64::ncl-6.6.2-hfa49d39_38.tar.bz2
osx-64::mdsrv-0.3.5.post1-py39h021302a_3.tar.bz2
osx-64::pyinstaller-4.9-py37h83b74e4_0.tar.bz2
osx-64::python-3.10.4-h1cc4136_0_cpython.tar.bz2
osx-64::conduit-0.8.2-py37hefffe85_0.tar.bz2
osx-64::vtk-9.1.0-qt_py37h4e1c85f_205.tar.bz2
osx-64::nd2-0.2.2-py37hf64c819_0.tar.bz2
osx-64::arrow-cpp-3.0.0-py39heebe0f7_43_cpu.tar.bz2
osx-64::ndcctools-7.4.3-py37h87f55f7_0.tar.bz2
osx-64::pdal-2.4.0-h11d9f76_2.tar.bz2
osx-64::pdal-2.3.0-h8255b4b_27.tar.bz2
osx-64::llvmdev-14.0.0-h89d5e19_0.tar.bz2
osx-64::gstlal-1.9.0-py37hbbbed50_4.tar.bz2
osx-64::verilator-4.220-hd9580d2_0.tar.bz2
osx-64::ambertools-21.12-py37h319d3f3_0.tar.bz2
osx-64::sagelib-9.5-py310h2bac986_4.tar.bz2
osx-64::z5py-2.0.14-py38h9bf16d6_0.tar.bz2
osx-64::hdf5-1.12.1-nompi_h0aa1fa2_104.tar.bz2
osx-64::triqs-3.1.0-py310hedc0968_0.tar.bz2
osx-64::qpdf-10.6.3-ha68c33c_0.tar.bz2
osx-64::omniorb-4.2.5-py39h0d687a8_2.tar.bz2
osx-64::sqlite-3.37.1-hb516253_0.tar.bz2
osx-64::mdsrv-0.3.5.post1-py37h14c5e16_3.tar.bz2
osx-64::openscenegraph-3.6.5-hdfaeef0_12.tar.bz2
osx-64::postgresql-plpython-14.2-py310h4b9c762_0.tar.bz2
osx-64::nginx-1.21.6-hb80c099_0.tar.bz2
osx-64::poppler-qt-22.01.0-hd5146ce_2.tar.bz2
osx-64::gazebo-11.10.1-h12311cb_5.tar.bz2
osx-64::erlang-24.3-pl5321h91513c9_0.tar.bz2
osx-64::ogre-13.3.1-h5dd8d7a_0.tar.bz2
osx-64::cctools_osx-arm64-973.0.1-hef7e2f4_7.tar.bz2
osx-64::arrow-cpp-6.0.1-py310h60f5776_10_cpu.tar.bz2
osx-64::cctools_osx-64-973.0.1-h2b735b3_10.tar.bz2
osx-64::libthrift-0.16.0-ha6dc762_0.tar.bz2
osx-64::gazebo-11.10.1-h35936aa_3.tar.bz2
osx-64::postgresql-plpython-14.2-py37h67c5a11_0.tar.bz2
osx-64::llvmdev-13.0.1-h64f94b2_1.tar.bz2
osx-64::mysql-client-8.0.28-h76d69bf_2.tar.bz2
osx-64::libvips-8.12.2-h443074a_1.tar.bz2
osx-64::ndcctools-7.4.3-py39h9247e91_0.tar.bz2
osx-64::yoda-1.9.4-py38h5ecb58d_1.tar.bz2
osx-64::libtiff-4.3.0-h17f2ce3_3.tar.bz2
osx-64::arrow-cpp-5.0.0-py310hcf39433_28_cpu.tar.bz2
osx-64::cctools_osx-64-973.0.1-hb41342b_6.tar.bz2
osx-64::grpcio-1.45.0-py38h67a8561_0.tar.bz2
osx-64::gemmi-0.5.2-py38hbfc0824_0.tar.bz2
osx-64::gdstk-0.8.2-py39h8bd3d57_0.tar.bz2
osx-64::ffmpeg-4.3.2-hbf27d7b_2.tar.bz2
osx-64::cctools_osx-64-973.0.1-hb41342b_10.tar.bz2
osx-64::python-3.9.12-h1cc4136_0_cpython.tar.bz2
osx-64::conduit-0.8.2-py38ha998f41_0.tar.bz2
osx-64::python-3.9.10-h1dd9edd_2_cpython.tar.bz2
osx-64::libtiledb-sql-0.12.5-hf429a70_0.tar.bz2
osx-64::harp-1.15-py38r41h0664e9e_0.tar.bz2
osx-64::scotch-6.1.3-h601ff3b_0.tar.bz2
osx-64::sagelib-9.5-py37hf093b7e_1.tar.bz2
osx-64::ruby-3.1.1-h586acb3_0.tar.bz2
osx-64::python-3.10.2-h1dd9edd_3_cpython.tar.bz2
osx-64::cctools_osx-arm64-973.0.1-hef7e2f4_10.tar.bz2
osx-64::libxslt-1.1.33-h5bff336_4.tar.bz2
osx-64::panda3d-1.10.11-py38hf4321cd_3.tar.bz2
osx-64::pillow-9.0.1-py37h942db99_0.tar.bz2
osx-64::libprotobuf-3.20.0-hd9580d2_0.tar.bz2
osx-64::arrow-cpp-3.0.0-py39hbb8db60_44_cpu.tar.bz2
osx-64::nd2-0.2.1-py39hed0b74c_0.tar.bz2
osx-64::cppyy-cling-6.25.3-py38hdc1a088_0.tar.bz2
osx-64::tiledb-2.6.3-hd4ce1b4_0.tar.bz2
osx-64::ruby-3.1.1-hcaea9d7_0.tar.bz2
osx-64::imagecodecs-2021.11.20-py310h16c5d60_2.tar.bz2
osx-64::libgdal-3.4.2-h412265b_0.tar.bz2
osx-64::panda3d-1.10.11-py39hcf24356_2.tar.bz2
osx-64::vigra-1.11.1-py38hdc71d93_1029.tar.bz2
osx-64::libgdal-3.4.2-h960ea06_1.tar.bz2
osx-64::pdal-2.4.0-hc75a851_2.tar.bz2
osx-64::arrow-cpp-3.0.0-py38hc4caabc_46_cpu.tar.bz2
osx-64::panda3d-1.10.11-py310heb66378_2.tar.bz2
osx-64::ogre-13.3.1-ha8acd6a_0.tar.bz2
osx-64::jaxlib-0.1.76-py37h6a11830_0.tar.bz2
osx-64::sagelib-9.5-py38h97b3fe5_3.tar.bz2
osx-64::julia-1.7.2-h132cb31_0.tar.bz2
osx-64::gazebo-11.10.2-h366c09f_0.tar.bz2
osx-64::tectonic-0.8.2-h019caf1_1.tar.bz2
osx-64::pypy3.8-7.3.8-hd7b965a_1.tar.bz2
osx-64::ndcctools-7.4.3-py310hd247ede_0.tar.bz2
osx-64::z5py-2.0.15-py38h9bf16d6_0.tar.bz2
osx-64::imagecodecs-2022.2.22-py38h4e8169c_1.tar.bz2
osx-64::triqs-3.1.0-py38hf09b428_0.tar.bz2
osx-64::arrow-cpp-3.0.0-py37hfc63dcb_42_cpu.tar.bz2
osx-64::poppler-22.01.0-h39497b0_1.tar.bz2
osx-64::cctools_osx-64-973.0.1-h609b070_10.tar.bz2
osx-64::git-2.35.1-pl5321h33a4a8a_0.tar.bz2
osx-64::tectonic-0.8.2-h2f7c6a6_2.tar.bz2
osx-64::vigra-1.11.1-py39h93be1e2_1029.tar.bz2
osx-64::coda-2.23.1-py39hcea63b7_0.tar.bz2
osx-64::root_base-6.26.0-py310h8cd194a_0.tar.bz2
osx-64::omniorb-4.2.5-py38h6d2bfc4_2.tar.bz2
osx-64::grpcio-1.44.0-py38h37dddf4_0.tar.bz2
osx-64::libcurl-static-7.82.0-h9f20792_0.tar.bz2
osx-64::omniorb-4.2.5-py39h76e1ea6_1.tar.bz2
osx-64::arrow-cpp-5.0.0-py39hc94c03c_27_cpu.tar.bz2
osx-64::gemmi-0.5.3-py310hc82e721_0.tar.bz2
osx-64::gazebo-11.10.1-h08bfaa4_5.tar.bz2
osx-64::irrlicht-1.8.5-he00d70a_1.tar.bz2
osx-64::sagelib-9.5-py37hc39770f_3.tar.bz2
osx-64::cmake-3.23.0-h35a7dd9_0.tar.bz2
osx-64::grpcio-1.45.0-py37h4d48e09_0.tar.bz2
osx-64::grpcio-1.45.0-py310h1da61bb_0.tar.bz2
osx-64::arrow-cpp-7.0.0-py39h731a60b_2_cpu.tar.bz2
osx-64::arrow-cpp-3.0.0-py38h5c101bd_44_cpu.tar.bz2
osx-64::cctools_osx-arm64-973.0.1-hd1d4517_6.tar.bz2
osx-64::libprotobuf-static-3.20.0-hd9580d2_0.tar.bz2
osx-64::harp-1.15-py37r40h8f1b641_0.tar.bz2
osx-64::gsoap-2.8.119-he518799_0.tar.bz2
osx-64::qtwebkit-5.212-hd626f61_4.tar.bz2
osx-64::hdf5-1.12.1-nompi_ha60fbc9_104.tar.bz2
osx-64::sagelib-9.5-py39he794440_4.tar.bz2
osx-64::panda3d-1.10.11-py39h5637eb6_3.tar.bz2
osx-64::sagelib-9.5-py38hba57b99_0.tar.bz2
osx-64::symengine-0.9.0-he032496_0.tar.bz2
osx-64::libgd-2.3.3-h1e214de_3.tar.bz2
osx-64::pillow-9.0.1-py38h47ebe08_1.tar.bz2
osx-64::tomviz-1.10.0.post196-py37hf986f44_1.tar.bz2
osx-64::pillow-9.0.1-py37h942db99_1.tar.bz2
osx-64::sagelib-9.5-py39h1fbcbea_3.tar.bz2
osx-64::pyinstaller-4.10-py39h0e58486_0.tar.bz2
osx-64::z5py-2.0.14-py310hf13eea0_0.tar.bz2
-    "libzlib >=1.2.11,<1.3.0a0",
+    "libzlib >=1.2.11,<2.0.0a0",
osx-64::pocl-1.8-h8b4fca9_2.tar.bz2
osx-64::liblal-7.1.7-fftw_h292f3b3_100.tar.bz2
osx-64::libopencv-4.5.5-py39h4c4289c_4.tar.bz2
osx-64::dotnet-runtime-3.1.22-ha205975_1.tar.bz2
osx-64::clang-9-9.0.1-default_hf139c7e_4.tar.bz2
osx-64::libopencv-4.5.5-py38h8d1cd93_7.tar.bz2
osx-64::libopencv-4.5.5-py37hc7bab3b_2.tar.bz2
osx-64::glib-tools-2.70.2-hcf210ce_3.tar.bz2
osx-64::llvm-tools-13.0.1-h64f94b2_1.tar.bz2
osx-64::dotnet-aspnetcore-3.1.22-ha205975_1.tar.bz2
osx-64::openexr-3.1.4-h6fbc5c6_0.tar.bz2
osx-64::dotnet-sdk-6.0.102-ha205975_0.tar.bz2
osx-64::cargo-bundle-licenses-0.4.0-h9e9b156_1.tar.bz2
osx-64::libopencv-4.5.5-py31hdb7f62c_6.tar.bz2
osx-64::libopencv-4.5.5-py37h54a4c39_3.tar.bz2
osx-64::libmlir13-13.0.1-h6fbc5c6_0.tar.bz2
osx-64::libopencv-4.5.5-py31hdb7f62c_5.tar.bz2
osx-64::libopencv-4.5.5-py31h1f8f45b_3.tar.bz2
osx-64::libass-0.14.0-h2aeada4_2.tar.bz2
osx-64::pocl-1.8-h8b4fca9_3.tar.bz2
osx-64::libopencv-4.5.5-py31h1f8f45b_4.tar.bz2
osx-64::dotnet-runtime-5.0.14-ha205975_0.tar.bz2
osx-64::libllvm14-14.0.0-h89d5e19_0.tar.bz2
osx-64::pocl-1.8-h5552be4_3.tar.bz2
osx-64::libllvm13-13.0.1-hd011deb_0.tar.bz2
osx-64::libopencv-4.5.5-py39hea06cf1_5.tar.bz2
osx-64::libopencv-4.5.5-py37hfc3e7e4_7.tar.bz2
osx-64::libopencv-4.5.5-py37h6397abf_6.tar.bz2
osx-64::glib-tools-2.70.2-hcf210ce_2.tar.bz2
osx-64::libclang-cpp-9.0.1-root_62600_h6072aa7_4.tar.bz2
osx-64::dotnet-aspnetcore-6.0.2-ha205975_0.tar.bz2
osx-64::libclang-cpp-9.0.1-default_hf139c7e_4.tar.bz2
osx-64::libopencv-4.5.5-py38hbfaad8a_1.tar.bz2
osx-64::libopencv-4.5.5-py39h3195029_2.tar.bz2
osx-64::libclang-cpp9-9.0.1-root_62600_h6072aa7_4.tar.bz2
osx-64::libllvm11-11.1.0-hd011deb_3.tar.bz2
osx-64::libclang-cpp9-9.0.1-default_hf139c7e_4.tar.bz2
osx-64::libopencv-4.5.5-py38h33f951f_6.tar.bz2
osx-64::gst-plugins-base-1.20.0-h63a84d5_0.tar.bz2
osx-64::llvm-13.0.1-h9d075a6_0.tar.bz2
osx-64::cgns-4.3.0-h0ae4fdc_0.tar.bz2
osx-64::pocl-1.8-h5552be4_2.tar.bz2
osx-64::llvm-tools-13.0.1-hd011deb_0.tar.bz2
osx-64::dotnet-runtime-5.0.15-h17d86ac_0.tar.bz2
osx-64::dotnet-runtime-3.1.23-h17d86ac_0.tar.bz2
osx-64::cgns-4.2.0-h5aa2f6e_4.tar.bz2
osx-64::gst-plugins-good-1.20.1-h1150fce_0.tar.bz2
osx-64::libopencv-4.5.5-py39hc2bf5a6_7.tar.bz2
osx-64::gst-plugins-good-1.20.1-hdaab12b_1.tar.bz2
osx-64::libclang-cpp9-9.0.1-cling_v0.9_h6431b02_4.tar.bz2
osx-64::gst-plugins-base-1.20.0-h63a84d5_1.tar.bz2
osx-64::libopencv-4.5.5-py38h0f039c0_3.tar.bz2
osx-64::libllvm13-13.0.1-h64f94b2_1.tar.bz2
osx-64::gst-plugins-base-1.20.1-hfbec525_1.tar.bz2
osx-64::dotnet-sdk-5.0.405-ha205975_0.tar.bz2
osx-64::llvm-11.1.0-h9d075a6_3.tar.bz2
osx-64::llvm-tools-14.0.0-h89d5e19_0.tar.bz2
osx-64::clang-9-9.0.1-root_62600_h6072aa7_4.tar.bz2
osx-64::libopencv-4.5.5-py39h4c4289c_3.tar.bz2
osx-64::cfitsio-4.1.0-h2c97ad1_0.tar.bz2
osx-64::libopencv-4.5.5-py37h3c29e2b_4.tar.bz2
osx-64::gst-plugins-good-1.20.0-h490c928_1.tar.bz2
osx-64::llvm-tools-13.0.1-h64f94b2_2.tar.bz2
osx-64::libopencv-4.5.5-py31h83f2b0d_1.tar.bz2
osx-64::libclang-cpp-9.0.1-cling_v0.9_h6431b02_4.tar.bz2
osx-64::gst-plugins-base-1.20.1-hfbec525_0.tar.bz2
osx-64::llvm-14.0.0-h9d075a6_0.tar.bz2
osx-64::clang-9-9.0.1-cling_v0.9_h6431b02_4.tar.bz2
osx-64::xapian-core-1.4.19-hc1cc398_0.tar.bz2
osx-64::imath-3.1.5-hd9580d2_0.tar.bz2
osx-64::tk-8.6.12-h5dbffcc_0.tar.bz2
osx-64::libopencv-4.5.5-py38hbfaad8a_2.tar.bz2
osx-64::libopencv-4.5.5-py37hc7bab3b_1.tar.bz2
osx-64::dotnet-runtime-6.0.3-h17d86ac_0.tar.bz2
osx-64::libopencv-4.5.5-py39h3195029_1.tar.bz2
osx-64::dotnet-aspnetcore-3.1.23-h17d86ac_0.tar.bz2
osx-64::libopencv-4.5.5-py38h33f951f_5.tar.bz2
osx-64::libass-0.14.0-h3a4a191_3.tar.bz2
osx-64::dotnet-sdk-6.0.201-h17d86ac_0.tar.bz2
osx-64::llvm-13.0.1-h9d075a6_2.tar.bz2
osx-64::dotnet-sdk-3.1.416-ha205975_1.tar.bz2
osx-64::libllvm13-13.0.1-h64f94b2_2.tar.bz2
osx-64::dotnet-aspnetcore-6.0.3-h17d86ac_0.tar.bz2
osx-64::dotnet-aspnetcore-5.0.15-h17d86ac_0.tar.bz2
osx-64::dotnet-aspnetcore-5.0.14-ha205975_0.tar.bz2
osx-64::dotnet-sdk-5.0.406-h17d86ac_0.tar.bz2
osx-64::glib-tools-2.70.2-hcf210ce_4.tar.bz2
osx-64::libopencv-4.5.5-py31h9e621a0_7.tar.bz2
osx-64::dotnet-sdk-3.1.417-h17d86ac_0.tar.bz2
osx-64::dotnet-runtime-6.0.2-ha205975_0.tar.bz2
osx-64::gst-plugins-good-1.20.0-h9f3b8af_0.tar.bz2
osx-64::llvm-tools-11.1.0-hd011deb_3.tar.bz2
osx-64::llvm-13.0.1-h9d075a6_1.tar.bz2
osx-64::libopencv-4.5.5-py38h86ebdae_4.tar.bz2
osx-64::libopencv-4.5.5-py37h6397abf_5.tar.bz2
osx-64::libmlir-13.0.1-h6fbc5c6_0.tar.bz2
osx-64::libopencv-4.5.5-py31h83f2b0d_2.tar.bz2
osx-64::libopencv-4.5.5-py39hea06cf1_6.tar.bz2
osx-64::imath-3.1.4-hd9580d2_0.tar.bz2
-    "libzlib >=1.2.11,<1.3.0a0"
+    "libzlib >=1.2.11,<2.0.0a0"
================================================================================
================================================================================
linux-64
linux-64::ndcctools-7.4.3-py310ha6b4e5e_0.tar.bz2
linux-64::r-seqminer-8.4-r40h9434ad5_0.tar.bz2
linux-64::arrow-cpp-7.0.0-py310hdc93d96_1_cuda.tar.bz2
linux-64::libgit2-1.4.2-h6529ace_0.tar.bz2
linux-64::panda3d-1.10.11-py39h1129042_2.tar.bz2
linux-64::libopencv-4.5.5-py37h677c78e_3.tar.bz2
linux-64::folly-2022.02.28.00-h1234567_1_jemalloc.tar.bz2
linux-64::nordugrid-arc-6.15.0-py37haf68709_0.tar.bz2
linux-64::gemmi-0.5.3-py37h0761922_0.tar.bz2
linux-64::lmod-8.6.10-lua54h14f7cff_0.tar.bz2
linux-64::libtensorflow-2.7.0-cuda102h92e7a29_0.tar.bz2
linux-64::vtk-9.1.0-qt_py39hd5cda67_206.tar.bz2
linux-64::arrow-cpp-6.0.1-py310h8db4b28_11_cpu.tar.bz2
linux-64::root_base-6.26.0-py37h23bc0b9_0.tar.bz2
linux-64::libopencv-4.5.5-py38hd60e7aa_2.tar.bz2
linux-64::omniorb-4.2.5-py38ha0cdfde_1.tar.bz2
linux-64::folly-2022.02.07.00-h1234567_1_jemalloc.tar.bz2
linux-64::nodejs-17.7.1-hfba9c51_0.tar.bz2
linux-64::ndcctools-7.4.3-py37hd5d88b1_0.tar.bz2
linux-64::arrow-cpp-5.0.0-py310h8db4b28_26_cpu.tar.bz2
linux-64::gdstk-0.8.2-py37h6b9b1b3_0.tar.bz2
linux-64::nodejs-14.18.3-h96d913c_3.tar.bz2
linux-64::cmake-3.23.0-h5432695_1.tar.bz2
linux-64::netpbm-10.73.39-pl5321h79e5dd2_0.tar.bz2
linux-64::omniorb-4.2.5-py38h2e9ca35_1.tar.bz2
linux-64::ncl-6.6.2-hfd31305_37.tar.bz2
linux-64::conduit-0.8.2-py37h8d921b5_0.tar.bz2
linux-64::ndcctools-7.4.3-py39hff7568b_0.tar.bz2
linux-64::nco-5.0.6-hcfc2ecc_0.tar.bz2
linux-64::gemmi-0.5.2-py37h393a2ae_0.tar.bz2
linux-64::git-2.35.1-pl5321h04cb727_0.tar.bz2
linux-64::dotnet-sdk-6.0.102-h73ebe80_0.tar.bz2
linux-64::vtk-9.1.0-osmesa_py39hdf2ac64_106.tar.bz2
linux-64::clangdev-13.0.1-default_hc23dcda_0.tar.bz2
linux-64::arrow-cpp-7.0.0-py37h9835a9e_0_cpu.tar.bz2
linux-64::cctools_osx-64-973.0.1-h1c3958c_10.tar.bz2
linux-64::z5py-2.0.14-py38h5407690_0.tar.bz2
linux-64::paraview-5.10.0-h78c094c_104_qt.tar.bz2
linux-64::conduit-0.8.2-py39hacd2f33_0.tar.bz2
linux-64::arrow-cpp-5.0.0-py310hdc93d96_25_cuda.tar.bz2
linux-64::gsoap-2.8.120-h8dc497d_0.tar.bz2
linux-64::folly-2022.02.28.00-h1234567_1.tar.bz2
linux-64::imagecodecs-2021.11.20-py37h119f88a_2.tar.bz2
linux-64::omniorb-4.2.5-py310h44b9e0c_2.tar.bz2
linux-64::pillow-9.0.1-py37h351210d_1.tar.bz2
linux-64::sagelib-9.5-py37hc8fef4d_3.tar.bz2
linux-64::libvips-8.12.2-h6d0bfdf_1.tar.bz2
linux-64::gds-base-2.19.8-h22af627_0.tar.bz2
linux-64::yoda-1.9.4-py38h8462fa0_1.tar.bz2
linux-64::libtensorflow_cc-2.7.0-cpu_h0a78848_0.tar.bz2
linux-64::libopencv-4.5.5-py37h4958a1a_1.tar.bz2
linux-64::cctools_osx-arm64-973.0.1-hd7a0a63_7.tar.bz2
linux-64::omniorb-4.2.5-py310hba10ccf_1.tar.bz2
linux-64::giac-1.6.0.47-haa4998e_4.tar.bz2
linux-64::libgd-2.3.3-h18fbbfe_3.tar.bz2
linux-64::arrow-cpp-5.0.0-py39h98bb539_24_cpu.tar.bz2
linux-64::pillow-9.0.1-py39he69867a_1.tar.bz2
linux-64::orc-1.7.3-h1be678f_0.tar.bz2
linux-64::nginx-1.21.6-h9733db4_0.tar.bz2
linux-64::arrow-cpp-7.0.0-py38hc6c4b8d_2_cuda.tar.bz2
linux-64::geant4-11.0.1-py37hc0c0af5_0.tar.bz2
linux-64::tomviz-1.10.0.post156-py37h895cc74_1.tar.bz2
linux-64::erlang-24.3-pl5321h5001644_0.tar.bz2
linux-64::folly-2022.02.07.00-h1234567_1.tar.bz2
linux-64::arrow-cpp-7.0.0-py37h932a894_1_cuda.tar.bz2
linux-64::lmod-8.6.17-lua54h71fc533_0.tar.bz2
linux-64::omniorb-4.2.5-py37h0327239_2.tar.bz2
linux-64::vtk-9.1.0-qt_py38hd5f6aaa_207.tar.bz2
linux-64::cctools_osx-arm64-973.0.1-ha590ccf_10.tar.bz2
linux-64::tectonic-0.8.2-hcd83be8_1.tar.bz2
linux-64::arrow-cpp-6.0.1-py310h544fd39_12_cpu.tar.bz2
linux-64::ovito-3.7.1-hbec523a_0.tar.bz2
linux-64::python-3.10.4-h9a8a25e_0_cpython.tar.bz2
linux-64::grpc-cpp-1.44.0-h3d78c48_1.tar.bz2
linux-64::gmt-6.3.0-h793420d_4.tar.bz2
linux-64::cctools_osx-64-973.0.1-h531d5dd_6.tar.bz2
linux-64::postgresql-plpython-14.2-py39hf17921a_0.tar.bz2
linux-64::arrow-cpp-3.0.0-py39hbfed05e_45_cuda.tar.bz2
linux-64::geant4-11.0.0-py39h2daeef8_0.tar.bz2
linux-64::panda3d-1.10.11-py37h4b6227b_2.tar.bz2
linux-64::libopencv-4.5.5-py31hdf3eee9_3.tar.bz2
linux-64::ptscotch-6.0.9-h0a9c416_2.tar.bz2
linux-64::imagecodecs-2022.2.22-py39hf577088_0.tar.bz2
linux-64::python-3.9.12-h9a8a25e_0_cpython.tar.bz2
linux-64::jaxlib-0.3.0-py39h3498573_4.tar.bz2
linux-64::arrow-cpp-5.0.0-py38hc7e9479_28_cuda.tar.bz2
linux-64::root_base-6.26.0-py38h848653d_0.tar.bz2
linux-64::coda-2.23.1-py37hcb5871f_0.tar.bz2
linux-64::erlang-24.3.1-pl5321h5001644_0.tar.bz2
linux-64::sagelib-9.5-py39he34bcec_1.tar.bz2
linux-64::z5py-2.0.15-py310h2f9a825_0.tar.bz2
linux-64::arrow-cpp-7.0.0-py39h116028d_0_cpu.tar.bz2
linux-64::vtk-9.1.0-egl_py310hdcc750d_5.tar.bz2
linux-64::drpm-0.5.1-h7eb2ce2_0.tar.bz2
linux-64::vtk-9.1.0-egl_py37h2014e58_4.tar.bz2
linux-64::curl-7.82.0-h7bff187_0.tar.bz2
linux-64::arrow-cpp-5.0.0-py39hbfed05e_26_cuda.tar.bz2
linux-64::r-base-4.1.3-hd930d0e_0.tar.bz2
linux-64::verilator-4.034-h32600fe_3.tar.bz2
linux-64::folly-2022.03.14.00-h1234567_1.tar.bz2
linux-64::cctools_osx-64-973.0.1-h531d5dd_7.tar.bz2
linux-64::vtk-9.1.0-qt_py310h8af6549_206.tar.bz2
linux-64::ovito-3.7.2-hbb7e7d1_1.tar.bz2
linux-64::nest-simulator-3.3-py39hea80380_0.tar.bz2
linux-64::ncl-6.6.2-h116a55f_38.tar.bz2
linux-64::qt-main-5.15.2-h88c78e7_2.tar.bz2
linux-64::libcurl-7.82.0-h7bff187_0.tar.bz2
linux-64::tiledb-2.7.1-h3f4058f_0.tar.bz2
linux-64::ndcctools-7.4.3-py39h336bf08_1.tar.bz2
linux-64::vtk-9.1.0-egl_py38h10abafb_6.tar.bz2
linux-64::ffmpeg-4.4.1-hd7ab26d_2.tar.bz2
linux-64::vtk-9.1.0-qt_py38hbc4c0ad_205.tar.bz2
linux-64::libgdal-3.4.2-haa48f22_0.tar.bz2
linux-64::openssh-8.9p1-hf695f80_0.tar.bz2
linux-64::symengine-0.9.0-hc116c36_0.tar.bz2
linux-64::pyinstaller-4.9-py310h516ecdb_0.tar.bz2
linux-64::nordugrid-arc-6.15.0-py39head2539_0.tar.bz2
linux-64::arrow-cpp-6.0.1-py39h6c41701_10_cuda.tar.bz2
linux-64::pyinstaller-4.10-py38he5536e0_0.tar.bz2
linux-64::sagelib-9.5-py310h990377c_0.tar.bz2
linux-64::postgresql-plpython-14.2-py38h37142f6_0.tar.bz2
linux-64::libvips-8.12.2-hc84ea03_3.tar.bz2
linux-64::cppyy-cling-6.25.3-py310hd64a29c_0.tar.bz2
linux-64::arrow-cpp-6.0.1-py37h664b6cd_13_cpu.tar.bz2
linux-64::arrow-cpp-7.0.0-py37h8f1ee2f_0_cuda.tar.bz2
linux-64::libspatialite-5.0.1-ha867d66_15.tar.bz2
linux-64::vigra-1.11.1-py37h71a3c6e_1029.tar.bz2
linux-64::r-git2r-0.30.1-r40hf72769b_0.tar.bz2
linux-64::arrow-cpp-7.0.0-py38h7cbaac1_0_cuda.tar.bz2
linux-64::arrow-cpp-7.0.0-py37hf4e0554_3_cuda.tar.bz2
linux-64::arrow-cpp-5.0.0-py38h06c329b_25_cpu.tar.bz2
linux-64::arrow-cpp-6.0.1-py37h932a894_10_cuda.tar.bz2
linux-64::vtk-9.1.0-osmesa_py37h29869c8_107.tar.bz2
linux-64::arrow-cpp-5.0.0-py38h4d8a8fd_24_cpu.tar.bz2
linux-64::arrow-cpp-7.0.0-py39heb87e93_1_cpu.tar.bz2
linux-64::createrepo_c-0.20.0-py38hcb80abe_0.tar.bz2
linux-64::cctools_osx-64-973.0.1-h7e2fc85_9.tar.bz2
linux-64::postgresql-plpython-14.2-py38hb26f4fd_0.tar.bz2
linux-64::wxpython-4.1.1-py37h83aca99_4.tar.bz2
linux-64::mapserver-7.6.4-py310h47d5798_6.tar.bz2
linux-64::arrow-cpp-5.0.0-py39heb87e93_25_cpu.tar.bz2
linux-64::coda-2.23.1-py37hcc7a067_0.tar.bz2
linux-64::ndcctools-7.4.3-py38h2457d08_0.tar.bz2
linux-64::arrow-cpp-3.0.0-py38hc7e9479_47_cuda.tar.bz2
linux-64::scotch-6.0.9-hb2e6521_2.tar.bz2
linux-64::ogre-13.3.0-hef34edf_0.tar.bz2
linux-64::arrow-cpp-5.0.0-py37h45430d2_25_cpu.tar.bz2
linux-64::yoda-1.9.4-py37h60e1006_1.tar.bz2
linux-64::cctools_osx-64-973.0.1-h2971222_7.tar.bz2
linux-64::openscenegraph-3.6.5-ha5fa11e_12.tar.bz2
linux-64::gstlal-1.9.0-py37h22c94cc_4.tar.bz2
linux-64::arrow-cpp-7.0.0-py38h8e1947f_3_cpu.tar.bz2
linux-64::pillow-9.0.1-py310h2f95282_1.tar.bz2
linux-64::tectonic-0.8.2-h3a2b94f_3.tar.bz2
linux-64::cctools_osx-arm64-973.0.1-h78d1351_7.tar.bz2
linux-64::arrow-cpp-5.0.0-py39h653df1f_28_cuda.tar.bz2
linux-64::pdal-2.4.0-h2602d4b_2.tar.bz2
linux-64::libopencv-4.5.5-py38hd60e7aa_1.tar.bz2
linux-64::tensorflow-base-2.7.0-cpu_py38h48ebf30_0.tar.bz2
linux-64::libthrift-0.16.0-h519c5ea_0.tar.bz2
linux-64::mysql-router-8.0.28-h3f0aed2_2.tar.bz2
linux-64::sqlite-3.37.1-h4ff8645_0.tar.bz2
linux-64::xrootd-5.4.1-py37hadea8d7_0.tar.bz2
linux-64::arrow-cpp-3.0.0-py310h979fbeb_46_cuda.tar.bz2
linux-64::grpcio-1.44.0-py38h2457d08_0.tar.bz2
linux-64::mdsrv-0.3.5.post1-py39h4a16fb3_3.tar.bz2
linux-64::triqs-3.1.0-py39h6dd1721_0.tar.bz2
linux-64::julia-1.7.2-h35b96e5_1.tar.bz2
linux-64::gemmi-0.5.2-py38h38d86a4_0.tar.bz2
linux-64::python-3.8.13-ha86cf86_0_cpython.tar.bz2
linux-64::libgdal-3.4.2-h886d1c3_1.tar.bz2
linux-64::sagelib-9.5-py38hd903835_3.tar.bz2
linux-64::omniorb-4.2.5-py39h7fbbf82_2.tar.bz2
linux-64::grpcio-1.43.0-py37hb27c1af_0.tar.bz2
linux-64::arrow-cpp-7.0.0-py38hdbd6c21_2_cpu.tar.bz2
linux-64::gsoap-2.8.119-h532c01c_0.tar.bz2
linux-64::vtk-9.1.0-qt_py37h0c07e69_205.tar.bz2
linux-64::libgdal-3.4.2-he509a2e_3.tar.bz2
linux-64::createrepo_c-0.20.0-py37h0332789_0.tar.bz2
linux-64::pillow-9.0.1-py310h2f95282_0.tar.bz2
linux-64::arrow-cpp-3.0.0-py39h9769348_42_cuda.tar.bz2
linux-64::paraview-5.10.1-hd250490_4_egl.tar.bz2
linux-64::dotnet-sdk-6.0.201-h751d214_0.tar.bz2
linux-64::postgresql-plpython-14.2-py37hc2b57fc_0.tar.bz2
linux-64::giac-1.6.0.47-haa4998e_5.tar.bz2
linux-64::libxslt-1.1.33-h8affb1d_4.tar.bz2
linux-64::postgresql-14.2-h2510834_0.tar.bz2
linux-64::imagemagick-7.1.0_27-pl5321hae5efcc_0.tar.bz2
linux-64::arrow-cpp-3.0.0-py38h16edd8c_42_cpu.tar.bz2
linux-64::arrow-cpp-5.0.0-py38hd6554b4_27_cpu.tar.bz2
linux-64::arrow-cpp-6.0.1-py38h4d8a8fd_10_cpu.tar.bz2
linux-64::libopencv-4.5.5-py38h9b278ad_5.tar.bz2
linux-64::erlang-24.3.1-pl5321hb9e9383_0.tar.bz2
linux-64::nd2-0.2.1-py37hfedb2cf_1.tar.bz2
linux-64::r-git2r-0.30.1-r40h96773ce_0.tar.bz2
linux-64::conduit-0.8.2-py39h8302f4d_0.tar.bz2
linux-64::cctools_osx-arm64-973.0.1-ha590ccf_8.tar.bz2
linux-64::ffmpeg-5.0.0-hd7ab26d_0.tar.bz2
linux-64::arrow-cpp-7.0.0-py38h06c329b_1_cpu.tar.bz2
linux-64::tensorflow-base-2.7.0-cpu_py310h8d3bea7_0.tar.bz2
linux-64::arrow-cpp-5.0.0-py37hb12d6d6_28_cuda.tar.bz2
linux-64::hdf5-1.12.1-mpi_openmpi_h41b9b70_4.tar.bz2
linux-64::arrow-cpp-6.0.1-py38h1ae68a0_11_cpu.tar.bz2
linux-64::harp-1.15-py39r40h665c6b1_0.tar.bz2
linux-64::pillow-9.0.1-py39hae2aec6_2.tar.bz2
linux-64::hdf5-1.12.1-nompi_h2386368_104.tar.bz2
linux-64::imagemagick-7.1.0_29-pl5321heb7c40d_0.tar.bz2
linux-64::mysql-server-8.0.28-hb253900_2.tar.bz2
linux-64::wasmer-2.2.1-h542c21f_0.tar.bz2
linux-64::hdf5-1.12.1-nompi_h4df4325_104.tar.bz2
linux-64::gemmi-0.5.2-py39h7d9a04d_0.tar.bz2
linux-64::libopencv-4.5.5-py37h4436bc0_7.tar.bz2
linux-64::thrift-compiler-0.16.0-h519c5ea_0.tar.bz2
linux-64::panda3d-1.10.11-py38h6644d6d_1.tar.bz2
linux-64::qpdf-10.6.1-h10796ff_0.tar.bz2
linux-64::qt-main-5.15.2-hdf1cb14_3.tar.bz2
linux-64::tomviz-1.10.0.post154-py37h895cc74_0.tar.bz2
linux-64::pillow-9.0.1-py37hc8ad62e_1.tar.bz2
linux-64::arrow-cpp-5.0.0-py310h979fbeb_27_cuda.tar.bz2
linux-64::vtk-9.1.0-qt_py39h7d03e14_205.tar.bz2
linux-64::arrow-cpp-7.0.0-py310h63ee207_3_cuda.tar.bz2
linux-64::arrow-cpp-3.0.0-py38h0e30523_46_cuda.tar.bz2
linux-64::vtk-9.1.0-egl_py310h8073011_4.tar.bz2
linux-64::geant4-11.0.1-py310he864562_0.tar.bz2
linux-64::arrow-cpp-3.0.0-py310h43910b9_43_cuda.tar.bz2
linux-64::graphviz-3.0.0-h5abf519_1.tar.bz2
linux-64::scotch-6.1.3-hdbe3ccb_0.tar.bz2
linux-64::root_base-6.26.0-py310hfaa99c0_0.tar.bz2
linux-64::tensorflow-base-2.7.0-cuda110py39h0c9afd6_0.tar.bz2
linux-64::libtiledb-sql-0.12.4-h1e20410_0.tar.bz2
linux-64::hdf5-1.12.1-mpi_mpich_h5d83325_4.tar.bz2
linux-64::astrometry-0.89-py37hcc40fe6_1.tar.bz2
linux-64::cctools_osx-64-973.0.1-h7e2fc85_10.tar.bz2
linux-64::wxpython-4.1.1-py38h4cb294d_4.tar.bz2
linux-64::julia-1.7.2-h989b2f6_0.tar.bz2
linux-64::z5py-2.0.13-py310h259c302_0.tar.bz2
linux-64::assimp-5.2.3-h4c92fa2_0.tar.bz2
linux-64::gmsh-4.9.4-h31d5161_0.tar.bz2
linux-64::tectonic-0.8.2-hcd83be8_2.tar.bz2
linux-64::createrepo_c-0.19.0-py38hcb80abe_1.tar.bz2
linux-64::libgdal-3.4.1-hc3d8651_3.tar.bz2
linux-64::pillow-9.0.1-py37h351210d_0.tar.bz2
linux-64::tensorflow-base-2.7.0-cuda102py38h021f141_0.tar.bz2
linux-64::thrift-compiler-0.16.0-h519c5ea_1.tar.bz2
linux-64::panda3d-1.10.11-py38hb11ba3b_3.tar.bz2
linux-64::tomviz-1.10.0.post228-py37h2b09141_0.tar.bz2
linux-64::libopencv-4.5.5-py39hd0eba51_4.tar.bz2
linux-64::vtk-9.1.0-osmesa_py38h6a440f9_105.tar.bz2
linux-64::mysql-client-8.0.28-hf89ab62_2.tar.bz2
linux-64::grpcio-1.44.0-py310ha6b4e5e_0.tar.bz2
linux-64::arrow-cpp-7.0.0-py310h08c4360_0_cuda.tar.bz2
linux-64::libmongoc-1.21.0-hc232e51_0.tar.bz2
linux-64::libgdal-3.4.2-he830e9d_4.tar.bz2
linux-64::imagemagick-7.1.0_23-pl5321hb118871_0.tar.bz2
linux-64::grpcio-1.44.0-py310h94ab34a_0.tar.bz2
linux-64::tomviz-1.10.0.post152-py37h895cc74_1.tar.bz2
linux-64::glib-2.70.2-h780b84a_3.tar.bz2
linux-64::pypy3.8-7.3.8-h5001382_1.tar.bz2
linux-64::postgresql-plpython-14.2-py310h1bbab67_0.tar.bz2
linux-64::dotnet-sdk-3.1.416-h73ebe80_1.tar.bz2
linux-64::cmake-3.22.3-h5432695_0.tar.bz2
linux-64::libglib-2.70.2-h174f98d_2.tar.bz2
linux-64::poppler-qt-22.01.0-hf358c63_2.tar.bz2
linux-64::ambertools-21.12-py39hc630cb1_0.tar.bz2
linux-64::grpc-cpp-1.44.0-h1021d7f_0.tar.bz2
linux-64::scotch-6.0.9-h2546e76_2.tar.bz2
linux-64::pillow-9.0.1-py37hc8ad62e_0.tar.bz2
linux-64::tensorflow-base-2.7.0-cpu_py39hf4995fd_0.tar.bz2
linux-64::cctools_osx-arm64-973.0.1-hf04072b_9.tar.bz2
linux-64::tensorflow-base-2.7.0-cuda102py310hf4be40b_0.tar.bz2
linux-64::gstlal-1.9.0-py38hdfc6eb5_4.tar.bz2
linux-64::cppyy-cling-6.25.3-py37h88bc003_0.tar.bz2
linux-64::pyinstaller-4.9-py37h6828927_0.tar.bz2
linux-64::lmod-8.6.9-lua54h14f7cff_0.tar.bz2
linux-64::tensorflow-base-2.7.0-cuda102py39h15c874f_0.tar.bz2
linux-64::libopencv-4.5.5-py31ha05c7f6_6.tar.bz2
linux-64::nodejs-17.7.1-h784f1fd_0.tar.bz2
linux-64::arrow-cpp-7.0.0-py39hb1e3516_3_cuda.tar.bz2
linux-64::grpcio-1.45.0-py39h7fbbf82_0.tar.bz2
linux-64::cctools_osx-64-973.0.1-h9893a0d_9.tar.bz2
linux-64::tectonic-0.8.2-h1ab8788_0.tar.bz2
linux-64::pdal-2.4.0-ha5eef6e_2.tar.bz2
linux-64::libopencv-4.5.5-py31ha05c7f6_5.tar.bz2
linux-64::arrow-cpp-6.0.1-py310h979fbeb_12_cuda.tar.bz2
linux-64::mysql-libs-8.0.28-hbc51c84_2.tar.bz2
linux-64::panda3d-1.10.11-py38h5ae5ca9_2.tar.bz2
linux-64::arrow-cpp-7.0.0-py310hecbc1bb_1_cpu.tar.bz2
linux-64::arrow-cpp-3.0.0-py38hc46b33e_47_cpu.tar.bz2
linux-64::magics-metview-4.11.0-h02ccd2a_0.tar.bz2
linux-64::gemmi-0.5.3-py37h393a2ae_0.tar.bz2
linux-64::nd2-0.2.2-py37h1425b33_0.tar.bz2
linux-64::geant4-11.0.1-py39h0aa766a_0.tar.bz2
linux-64::coda-2.23.1-py310h2b6cc9b_0.tar.bz2
linux-64::vigra-1.11.1-py310h868834b_1029.tar.bz2
linux-64::vtk-9.1.0-osmesa_py37hcbc0ab7_105.tar.bz2
linux-64::imagemagick-7.1.0_27-pl5321heb7c40d_1.tar.bz2
linux-64::graphviz-3.0.0-h5abf519_0.tar.bz2
linux-64::cctools_osx-arm64-973.0.1-hf04072b_10.tar.bz2
linux-64::gap-core-4.11.1-h1725ef4_3.tar.bz2
linux-64::xrootd-5.4.1-py37h62c5c55_0.tar.bz2
linux-64::root_base-6.26.0-py39hd053ead_0.tar.bz2
linux-64::arrow-cpp-6.0.1-py39h50a2650_13_cpu.tar.bz2
linux-64::verilator-4.218-h6239696_0.tar.bz2
linux-64::mupdf-1.17.0-h97dd835_2.tar.bz2
linux-64::libopencv-4.5.5-py37h875a6d8_4.tar.bz2
linux-64::arrow-cpp-7.0.0-py39h7a27593_1_cuda.tar.bz2
linux-64::wxpython-4.1.1-py38hc041153_5.tar.bz2
linux-64::arrow-cpp-5.0.0-py310h97fd767_28_cuda.tar.bz2
linux-64::panda3d-1.10.11-py39h238915d_3.tar.bz2
linux-64::imagecodecs-2022.2.22-py38h58c7917_0.tar.bz2
linux-64::arrow-cpp-3.0.0-py37h45430d2_44_cpu.tar.bz2
linux-64::vtk-9.1.0-osmesa_py37h0d47c8c_106.tar.bz2
linux-64::panda3d-1.10.11-py310ha3fb24a_1.tar.bz2
linux-64::dotnet-sdk-3.1.417-h751d214_0.tar.bz2
linux-64::pyinstaller-4.9-py39hd38ffc4_1.tar.bz2
linux-64::nd2-0.2.2-py310h062fc0b_0.tar.bz2
linux-64::conduit-0.8.2-py39hb25f1e2_0.tar.bz2
linux-64::paraview-5.10.0-h720592e_4_egl.tar.bz2
linux-64::pdal-2.3.0-h23f837d_26.tar.bz2
linux-64::harp-1.15-py39r41h665c6b1_0.tar.bz2
linux-64::arrow-cpp-6.0.1-py38hc46b33e_13_cpu.tar.bz2
linux-64::erlang-24.3.3-pl5321hb9e9383_0.tar.bz2
linux-64::ndcctools-7.4.3-py38hdd6454d_1.tar.bz2
linux-64::arrow-cpp-7.0.0-py37hd9b1504_2_cpu.tar.bz2
linux-64::magics-metview-batch-4.11.0-habfef7d_0.tar.bz2
linux-64::vtk-9.1.0-osmesa_py310h1a652af_104.tar.bz2
linux-64::lmod-8.6.15-lua54h71fc533_0.tar.bz2
linux-64::arrow-cpp-3.0.0-py37h4d9a7e3_45_cuda.tar.bz2
linux-64::grpcio-1.45.0-py38h2e9ca35_0.tar.bz2
linux-64::createrepo_c-0.19.0-py37h0332789_1.tar.bz2
linux-64::nd2-0.2.1-py38h197abaa_0.tar.bz2
linux-64::postgresql-plpython-14.2-py39h1dd3ba9_0.tar.bz2
linux-64::ndcctools-7.4.3-py37hd5d88b1_1.tar.bz2
linux-64::libgd-2.3.3-h283352f_2.tar.bz2
linux-64::tiledb-2.7.0-h3f4058f_0.tar.bz2
linux-64::libopencv-4.5.5-py37hc03c0b8_5.tar.bz2
linux-64::irrlicht-1.8.5-h80a045a_1.tar.bz2
linux-64::libgdal-3.4.1-haddd6ec_5.tar.bz2
linux-64::hdfeos2-2.20-hca1e490_1001.tar.bz2
linux-64::vtk-9.1.0-egl_py38h3346cfb_7.tar.bz2
linux-64::arrow-cpp-3.0.0-py37h74d72d7_46_cpu.tar.bz2
linux-64::geotiff-1.7.1-h509b78c_0.tar.bz2
linux-64::llvmdev-13.0.1-hf817b99_0.tar.bz2
linux-64::arrow-cpp-6.0.1-py39had3a21f_11_cpu.tar.bz2
linux-64::arrow-cpp-3.0.0-py37hb12d6d6_47_cuda.tar.bz2
linux-64::mapserver-7.6.4-py38hdefe2dd_6.tar.bz2
linux-64::panda3d-1.10.11-py310h4b45230_2.tar.bz2
linux-64::python-3.9.10-hc74c709_2_cpython.tar.bz2
linux-64::arrow-cpp-3.0.0-py310hecbc1bb_44_cpu.tar.bz2
linux-64::hdf5-1.12.1-mpi_mpich_h08b82f9_4.tar.bz2
linux-64::jaxlib-0.3.0-py310hb56f407_3.tar.bz2
linux-64::astrometry-0.89-py310hbd7b93c_1.tar.bz2
linux-64::arrow-cpp-6.0.1-py37h74d72d7_12_cpu.tar.bz2
linux-64::libvips-8.12.2-h6d0bfdf_2.tar.bz2
linux-64::arrow-cpp-5.0.0-py37h4d9a7e3_26_cuda.tar.bz2
linux-64::arrow-cpp-6.0.1-py37h45430d2_10_cpu.tar.bz2
linux-64::cctools_osx-64-973.0.1-h6eed546_6.tar.bz2
linux-64::arrow-cpp-6.0.1-py37h4c43799_11_cpu.tar.bz2
linux-64::z5py-2.0.14-py37h2f61680_0.tar.bz2
linux-64::vtk-9.1.0-qt_py37h992be8c_204.tar.bz2
linux-64::arrow-cpp-6.0.1-py39h7a27593_10_cuda.tar.bz2
linux-64::pdal-2.3.0-h0754925_26.tar.bz2
linux-64::createrepo_c-0.20.0-py310hb52ebc5_1.tar.bz2
linux-64::pillow-9.0.1-py37h44f0d7a_2.tar.bz2
linux-64::wxpython-4.1.1-py39hf4f2c7f_4.tar.bz2
linux-64::harp-1.15-py310r40h2b6cc9b_0.tar.bz2
linux-64::tectonic-0.8.2-ha1425e2_0.tar.bz2
linux-64::openssh-8.9p1-h67c24c5_0.tar.bz2
linux-64::astrometry-0.89-py38hbbbb4d6_1.tar.bz2
linux-64::gstlal-1.9.0-py39h1de9ae1_4.tar.bz2
linux-64::libmongoc-1.21.0-h076a08c_0.tar.bz2
linux-64::python-3.9.12-h2660328_1_cpython.tar.bz2
linux-64::gemmi-0.5.3-py310h58363a5_0.tar.bz2
linux-64::texlive-core-20210325-hecf3c9b_2.tar.bz2
linux-64::vtk-9.1.0-osmesa_py39h7fa7cb2_104.tar.bz2
linux-64::libgdal-3.4.1-hc4e7d83_4.tar.bz2
linux-64::arrow-cpp-3.0.0-py38hd6554b4_46_cpu.tar.bz2
linux-64::jaxlib-0.3.0-py39h3498573_3.tar.bz2
linux-64::arrow-cpp-7.0.0-py310h01ec951_3_cpu.tar.bz2
linux-64::nd2-0.2.1-py310h062fc0b_1.tar.bz2
linux-64::panda3d-1.10.11-py37h65d8795_2.tar.bz2
linux-64::pdal-2.3.0-h0754925_27.tar.bz2
linux-64::arrow-cpp-3.0.0-py38h4d8a8fd_43_cpu.tar.bz2
linux-64::arrow-cpp-5.0.0-py310hecbc1bb_25_cpu.tar.bz2
linux-64::libglib-2.70.2-h174f98d_3.tar.bz2
linux-64::jaxlib-0.3.0-py310h0e91589_4.tar.bz2
linux-64::libtiledb-sql-0.12.4-h1543684_0.tar.bz2
linux-64::erlang-24.3.2-pl5321hb9e9383_0.tar.bz2
linux-64::gds-base-2.19.8-h22af627_1.tar.bz2
linux-64::z5py-2.0.15-py38h5407690_0.tar.bz2
linux-64::libprotobuf-3.20.0-h6239696_0.tar.bz2
linux-64::folly-2022.03.21.00-h1234567_1_jemalloc.tar.bz2
linux-64::arrow-cpp-3.0.0-py310h544fd39_46_cpu.tar.bz2
linux-64::pypy3.9-7.3.8-h56abe6f_1.tar.bz2
linux-64::arrow-cpp-6.0.1-py37ha7c06bf_10_cuda.tar.bz2
linux-64::libgdal-3.4.1-haa48f22_6.tar.bz2
linux-64::omniorb-4.2.5-py310hba10ccf_2.tar.bz2
linux-64::arrow-cpp-5.0.0-py37ha7c06bf_24_cuda.tar.bz2
linux-64::ffmpeg-5.0.0-h594f047_1.tar.bz2
linux-64::tiledb-2.7.1-h1e4a385_0.tar.bz2
linux-64::paraview-5.10.1-h1e4f957_4_egl.tar.bz2
linux-64::pyinstaller-4.10-py37he2f7bc2_0.tar.bz2
linux-64::libglib-2.70.2-h174f98d_4.tar.bz2
linux-64::imagemagick-7.1.0_28-pl5321heb7c40d_0.tar.bz2
linux-64::lmod-8.6.11-lua54h14f7cff_0.tar.bz2
linux-64::arrow-cpp-5.0.0-py310hc2d03c8_26_cuda.tar.bz2
linux-64::cctools_osx-arm64-973.0.1-h91eca3c_8.tar.bz2
linux-64::arrow-cpp-6.0.1-py310hc2d03c8_11_cuda.tar.bz2
linux-64::magics-metview-batch-4.11.0-he381006_1.tar.bz2
linux-64::qt-webengine-5.15.4-h19fc7b4_1.tar.bz2
linux-64::cctools_osx-64-973.0.1-h2971222_6.tar.bz2
linux-64::cctools_osx-arm64-973.0.1-h91eca3c_9.tar.bz2
linux-64::createrepo_c-0.20.0-py37h85cd5c2_1.tar.bz2
linux-64::arrow-cpp-6.0.1-py310hca8f35d_13_cpu.tar.bz2
linux-64::voms-2.1.0rc0-h82ee70a_4.tar.bz2
linux-64::pypy3.9-7.3.8-h986b250_1.tar.bz2
linux-64::omniorb-4.2.5-py39h7fbbf82_1.tar.bz2
linux-64::arrow-cpp-7.0.0-py39h7420976_2_cuda.tar.bz2
linux-64::arrow-cpp-6.0.1-py39h043cfbb_12_cuda.tar.bz2
linux-64::folly-2022.03.28.00-h1234567_1_jemalloc.tar.bz2
linux-64::ispc-1.17.0-h16cee57_0.tar.bz2
linux-64::python-3.9.12-h2660328_0_cpython.tar.bz2
linux-64::libtiledb-sql-0.12.6-h0993566_0.tar.bz2
linux-64::mandrake-1.2.1-py310he39914e_1.tar.bz2
linux-64::arrow-cpp-3.0.0-py310h97fd767_47_cuda.tar.bz2
linux-64::z5py-2.0.13-py37h47f1ee2_0.tar.bz2
linux-64::folly-2022.03.07.00-h1234567_1_jemalloc.tar.bz2
linux-64::pyngl-1.6.1-py37h95b611b_4.tar.bz2
linux-64::pillow-9.0.0-py39he69867a_0.tar.bz2
linux-64::scotch-6.1.3-hfeb400c_0.tar.bz2
linux-64::conduit-0.8.2-py38h5ff8a9a_0.tar.bz2
linux-64::cctools_osx-64-973.0.1-h9893a0d_8.tar.bz2
linux-64::arrow-cpp-6.0.1-py37hb12d6d6_13_cuda.tar.bz2
linux-64::folly-2022.03.14.00-h1234567_1_jemalloc.tar.bz2
linux-64::intel-cmplr-lib-rt-2022.0.1-h780b84a_3633.tar.bz2
linux-64::geant4-11.0.1-py38had2d439_0.tar.bz2
linux-64::python-3.9.12-h9a8a25e_1_cpython.tar.bz2
linux-64::btrfs-progs-5.16.2-h1985649_0.tar.bz2
linux-64::grpcio-1.45.0-py38ha0cdfde_0.tar.bz2
linux-64::jaxlib-0.3.0-py37hf82ebc2_3.tar.bz2
linux-64::vigra-1.11.1-py38ha0af0c1_1029.tar.bz2
linux-64::z5py-2.0.13-py39h3f3ea7e_0.tar.bz2
linux-64::imagemagick-7.1.0_25-pl5321hb118871_0.tar.bz2
linux-64::arrow-cpp-3.0.0-py38h06c329b_44_cpu.tar.bz2
linux-64::vtk-9.1.0-osmesa_py310h9b2d59d_107.tar.bz2
linux-64::cppyy-cling-6.25.3-py38h8225899_0.tar.bz2
linux-64::ortools-cpp-9.2-h4b47555_1.tar.bz2
linux-64::ambertools-21.12-py37h5d2b9b6_0.tar.bz2
linux-64::panda3d-1.10.11-py310hc4bf879_3.tar.bz2
linux-64::vtk-9.1.0-osmesa_py310h6093818_105.tar.bz2
linux-64::arrow-cpp-5.0.0-py38h0e30523_27_cuda.tar.bz2
linux-64::arrow-cpp-5.0.0-py37h932a894_25_cuda.tar.bz2
linux-64::libtiledb-sql-0.12.6-h204bf05_0.tar.bz2
linux-64::arrow-cpp-6.0.1-py38hf621f4d_10_cuda.tar.bz2
linux-64::panda3d-1.10.11-py310h48cf204_3.tar.bz2
linux-64::dpcpp_impl_linux-64-2022.0.1-haf1e4ac_3633.tar.bz2
linux-64::libopencv-4.5.5-py38h001db16_4.tar.bz2
linux-64::vtk-9.1.0-egl_py39h0756d23_6.tar.bz2
linux-64::arrow-cpp-3.0.0-py38h0002f4e_45_cuda.tar.bz2
linux-64::libopencv-4.5.5-py38h4249626_7.tar.bz2
linux-64::arrow-cpp-3.0.0-py310hdc93d96_44_cuda.tar.bz2
linux-64::arrow-cpp-3.0.0-py38h1ae68a0_45_cpu.tar.bz2
linux-64::arrow-cpp-3.0.0-py39h98bb539_43_cpu.tar.bz2
linux-64::libgdal-3.4.2-h1db9fa4_3.tar.bz2
linux-64::pillow-9.0.1-py39he69867a_0.tar.bz2
linux-64::jaxlib-0.3.0-py39hf127329_4.tar.bz2
linux-64::arrow-cpp-6.0.1-py38h0e30523_12_cuda.tar.bz2
linux-64::dotnet-runtime-5.0.15-h751d214_0.tar.bz2
linux-64::pillow-9.0.1-py38he2f12e7_1.tar.bz2
linux-64::tomviz-1.10.0.post156-py37h895cc74_0.tar.bz2
linux-64::cairo-1.16.0-ha12eb4b_1010.tar.bz2
linux-64::libgdal-3.4.2-h1db9fa4_2.tar.bz2
linux-64::libcurl-static-7.82.0-h7bff187_0.tar.bz2
linux-64::arrow-cpp-6.0.1-py38hd6554b4_12_cpu.tar.bz2
linux-64::grpcio-1.45.0-py39h0f497a6_0.tar.bz2
linux-64::ovito-3.7.0-hbec523a_0.tar.bz2
linux-64::gsoap-2.8.120-h598caef_0.tar.bz2
linux-64::arrow-cpp-3.0.0-py39had3a21f_45_cpu.tar.bz2
linux-64::paraview-5.10.0-h4155c2b_4_egl.tar.bz2
linux-64::folly-2022.02.14.00-h1234567_1.tar.bz2
linux-64::geant4-11.0.0-py310hcea81dc_0.tar.bz2
linux-64::arrow-cpp-5.0.0-py38hf621f4d_24_cuda.tar.bz2
linux-64::nest-simulator-3.3-py38h87eb7b7_0.tar.bz2
linux-64::arrow-cpp-5.0.0-py37h74d72d7_27_cpu.tar.bz2
linux-64::arrow-cpp-7.0.0-py39h9769348_0_cuda.tar.bz2
linux-64::vowpalwabbit-9.0.1-py37habe62f9_0.tar.bz2
linux-64::astrometry-0.89-py37h2b97ff3_1.tar.bz2
linux-64::tensorflow-base-2.7.0-cpu_py37h8697747_0.tar.bz2
linux-64::sagelib-9.5-py37h0c4da78_1.tar.bz2
linux-64::arrow-cpp-6.0.1-py39h653df1f_13_cuda.tar.bz2
linux-64::nodejs-16.14.2-hfba9c51_0.tar.bz2
linux-64::imagecodecs-2022.2.22-py310h8534204_0.tar.bz2
linux-64::nordugrid-arc-6.15.0-py37h95c8341_0.tar.bz2
linux-64::arrow-cpp-3.0.0-py310h08c4360_42_cuda.tar.bz2
linux-64::jaxlib-0.3.0-py37hc49aa5a_3.tar.bz2
linux-64::jaxlib-0.1.76-py37h339b70c_0.tar.bz2
linux-64::mandrake-1.2.1-py39ha41bcff_1.tar.bz2
linux-64::pypy3.8-7.3.8-h5bd2d06_1.tar.bz2
linux-64::harp-1.15-py37r40hcb5871f_0.tar.bz2
linux-64::triqs-3.1.0-py38h2c6223b_0.tar.bz2
linux-64::imagecodecs-2022.2.22-py38he865337_1.tar.bz2
linux-64::git-annex-10.20220222-alldep_hc98582e_100.tar.bz2
linux-64::magics-4.11.0-habfef7d_0.tar.bz2
linux-64::gfal2-2.20.5-h897e8d7_0.tar.bz2
linux-64::pyinstaller-4.9-py37h6828927_1.tar.bz2
linux-64::arrow-cpp-3.0.0-py37h9835a9e_42_cpu.tar.bz2
linux-64::grpcio-1.44.0-py37hd5d88b1_0.tar.bz2
linux-64::arrow-cpp-6.0.1-py37h4d9a7e3_11_cuda.tar.bz2
linux-64::libopencv-4.5.5-py31hdf3eee9_4.tar.bz2
linux-64::libopencv-4.5.5-py38h4fbf536_3.tar.bz2
linux-64::libprotobuf-static-3.20.0-h6239696_0.tar.bz2
linux-64::ndcctools-7.4.3-py38h2457d08_1.tar.bz2
linux-64::nodejs-17.8.0-h784f1fd_0.tar.bz2
linux-64::triqs-3.1.0-py37hc9b784c_0.tar.bz2
linux-64::poppler-22.01.0-h1434ded_1.tar.bz2
linux-64::cpp-opentelemetry-sdk-1.2.0-h8e9fcac_1.tar.bz2
linux-64::gsoap-2.8.119-h90a1d37_0.tar.bz2
linux-64::postgresql-plpython-14.2-py37h335248f_0.tar.bz2
linux-64::xeus-cling-0.13.0-h8150be3_3.tar.bz2
linux-64::arrow-cpp-3.0.0-py39h50a2650_47_cpu.tar.bz2
linux-64::omniorb-4.2.5-py38h2e9ca35_2.tar.bz2
linux-64::libnghttp2-1.47.0-he49606f_0.tar.bz2
linux-64::openscenegraph-3.6.5-hc4f35c9_13.tar.bz2
linux-64::pillow-9.0.1-py37h5350b5b_2.tar.bz2
linux-64::liblal-7.1.7-mkl_h4510956_0.tar.bz2
linux-64::postgresql-plpython-14.2-py310h5635984_0.tar.bz2
linux-64::nest-simulator-3.3-py310h7844f28_0.tar.bz2
linux-64::mdsrv-0.3.5.post1-py37he2e3b7d_3.tar.bz2
linux-64::arrow-cpp-3.0.0-py39h6c41701_43_cuda.tar.bz2
linux-64::python-3.10.2-hc74c709_4_cpython.tar.bz2
linux-64::panda3d-1.10.11-py37h4e89a3d_1.tar.bz2
linux-64::pyngl-1.6.1-py38h1ea8692_3.tar.bz2
linux-64::nd2-0.2.2-py39h155c9d3_0.tar.bz2
linux-64::dotnet-runtime-6.0.2-h73ebe80_0.tar.bz2
linux-64::arrow-cpp-6.0.1-py310h97fd767_13_cuda.tar.bz2
linux-64::kitty-0.23.1-py39h99a8b51_1.tar.bz2
linux-64::mandrake-1.2.1-py38h66dd620_1.tar.bz2
linux-64::dotnet-aspnetcore-5.0.15-h751d214_0.tar.bz2
linux-64::dotnet-sdk-5.0.405-h73ebe80_0.tar.bz2
linux-64::cppyy-cling-6.25.3-py37had014c9_0.tar.bz2
linux-64::z5py-2.0.14-py39ha5c6dc3_0.tar.bz2
linux-64::cctools_osx-64-973.0.1-h1c3958c_9.tar.bz2
linux-64::libxml2-2.9.12-h22db469_2.tar.bz2
linux-64::createrepo_c-0.19.0-py39h3c599e5_1.tar.bz2
linux-64::panda3d-1.10.11-py39h4b651ad_2.tar.bz2
linux-64::grpcio-1.43.0-py39hff7568b_0.tar.bz2
linux-64::ptscotch-6.1.3-hb499603_0.tar.bz2
linux-64::cctools_osx-arm64-973.0.1-hcded490_6.tar.bz2
linux-64::python-3.8.13-h582c2e5_0_cpython.tar.bz2
linux-64::cmake-3.23.0-h5432695_0.tar.bz2
linux-64::poppler-22.01.0-h1434ded_2.tar.bz2
linux-64::nd2-0.2.2-py38h28b09c2_0.tar.bz2
linux-64::ruby-3.1.1-hc054e64_0.tar.bz2
linux-64::pdal-2.3.0-h23f837d_27.tar.bz2
linux-64::panda3d-1.10.11-py38h164a067_2.tar.bz2
linux-64::sagelib-9.5-py39he34bcec_0.tar.bz2
linux-64::arrow-cpp-3.0.0-py39heb87e93_44_cpu.tar.bz2
linux-64::pyngl-1.6.1-py37ha7eadc2_3.tar.bz2
linux-64::nd2-0.2.1-py37hfedb2cf_0.tar.bz2
linux-64::dotnet-runtime-6.0.3-h751d214_0.tar.bz2
linux-64::grpcio-1.44.0-py39hff7568b_0.tar.bz2
linux-64::tiledb-2.7.0-h1e4a385_0.tar.bz2
linux-64::jaxlib-0.3.0-py37hc49aa5a_4.tar.bz2
linux-64::grpc-cpp-1.43.2-h1021d7f_2.tar.bz2
linux-64::ogre-13.3.1-h457c5cf_0.tar.bz2
linux-64::gemmi-0.5.3-py38h38d86a4_0.tar.bz2
linux-64::libgdal-3.4.2-hd724a2d_4.tar.bz2
linux-64::triqs-3.1.0-py310h3b52e2b_0.tar.bz2
linux-64::thrift-compiler-0.16.0-h6b813eb_0.tar.bz2
linux-64::dotnet-runtime-3.1.23-h751d214_0.tar.bz2
linux-64::gdstk-0.8.2-py37h16bd8b9_0.tar.bz2
linux-64::verilator-4.220-h6239696_0.tar.bz2
linux-64::arrow-cpp-5.0.0-py310hb8df629_24_cpu.tar.bz2
linux-64::tectonic-0.8.2-h36fa118_3.tar.bz2
linux-64::pillow-9.0.0-py37hc8ad62e_0.tar.bz2
linux-64::cpp-opentelemetry-sdk-1.2.0-hb306224_0.tar.bz2
linux-64::libtensorflow_cc-2.7.0-cuda102h92e7a29_0.tar.bz2
linux-64::paraview-5.10.0-hc070041_4_egl.tar.bz2
linux-64::nordugrid-arc-6.15.0-py38h92e75e1_0.tar.bz2
linux-64::ptscotch-6.1.3-h0a9c416_0.tar.bz2
linux-64::libpq-14.2-hd57d9b9_0.tar.bz2
linux-64::mapserver-7.6.4-py310h5059256_6.tar.bz2
linux-64::conduit-0.8.2-py37hd1c0ee6_0.tar.bz2
linux-64::vtk-9.1.0-egl_py39hcf36b99_4.tar.bz2
linux-64::imagecodecs-2021.11.20-py37h7d456fb_2.tar.bz2
linux-64::arrow-cpp-3.0.0-py39h043cfbb_46_cuda.tar.bz2
linux-64::verilator-4.034-h6239696_2.tar.bz2
linux-64::nordugrid-arc-6.15.0-py37h95c8341_1.tar.bz2
linux-64::ffmpeg-4.4.1-h6987444_1.tar.bz2
linux-64::pyinstaller-4.9-py38ha8cb210_0.tar.bz2
linux-64::vigra-1.11.1-py37h3bb4fe9_1029.tar.bz2
linux-64::arrow-cpp-5.0.0-py39h043cfbb_27_cuda.tar.bz2
linux-64::vtk-9.1.0-egl_py37h3aaa0a5_5.tar.bz2
linux-64::conduit-0.8.2-py38hde377fb_0.tar.bz2
linux-64::paraview-5.10.0-hb1d4b34_104_qt.tar.bz2
linux-64::arrow-cpp-3.0.0-py37hc76924d_46_cuda.tar.bz2
linux-64::createrepo_c-0.19.0-py39hb908eda_0.tar.bz2
linux-64::arrow-cpp-3.0.0-py37h664b6cd_47_cpu.tar.bz2
linux-64::glib-2.70.2-h780b84a_4.tar.bz2
linux-64::irrlicht-1.8.5-h80a045a_2.tar.bz2
linux-64::nginx-1.21.6-h92772c7_0.tar.bz2
linux-64::arrow-cpp-6.0.1-py310hb8df629_10_cpu.tar.bz2
linux-64::gemmi-0.5.2-py37h0761922_0.tar.bz2
linux-64::arrow-cpp-5.0.0-py37h664b6cd_28_cpu.tar.bz2
linux-64::geotiff-1.7.1-h509b78c_1.tar.bz2
linux-64::libgdal-3.4.2-he509a2e_2.tar.bz2
linux-64::arrow-cpp-5.0.0-py310h544fd39_27_cpu.tar.bz2
linux-64::arrow-cpp-6.0.1-py38hc7e9479_13_cuda.tar.bz2
linux-64::arrow-cpp-7.0.0-py37h1be195e_2_cuda.tar.bz2
linux-64::mysql-server-8.0.28-h756ea22_2.tar.bz2
linux-64::arrow-cpp-5.0.0-py39h7a27593_25_cuda.tar.bz2
linux-64::jaxlib-0.3.0-py37hf82ebc2_4.tar.bz2
linux-64::arrow-cpp-6.0.1-py38h06c329b_10_cpu.tar.bz2
linux-64::libtiledb-sql-0.12.5-h204bf05_0.tar.bz2
linux-64::createrepo_c-0.20.0-py37h85cd5c2_0.tar.bz2
linux-64::dotnet-runtime-5.0.14-h73ebe80_0.tar.bz2
linux-64::nodejs-16.14.2-h96d913c_1.tar.bz2
linux-64::arrow-cpp-6.0.1-py38h0002f4e_11_cuda.tar.bz2
linux-64::llvmdev-13.0.1-hf817b99_1.tar.bz2
linux-64::arrow-cpp-3.0.0-py310hb8df629_43_cpu.tar.bz2
linux-64::folly-2022.03.07.00-h1234567_1.tar.bz2
linux-64::arrow-cpp-7.0.0-py310h6cd1d22_2_cuda.tar.bz2
linux-64::mapserver-7.6.4-py39h954ffe8_6.tar.bz2
linux-64::omniorb-4.2.5-py39h0f497a6_2.tar.bz2
linux-64::tiledb-2.6.3-h1e4a385_0.tar.bz2
linux-64::libopencv-4.5.5-py39hb0e02d1_7.tar.bz2
linux-64::erlang-24.3.3-pl5321h5001644_0.tar.bz2
linux-64::omniorb-libs-4.2.5-h727a467_2.tar.bz2
linux-64::mandrake-1.2.1-py37h56e43a9_1.tar.bz2
linux-64::gdstk-0.8.2-py310h1b6b022_0.tar.bz2
linux-64::libgdal-3.4.1-h42fb820_3.tar.bz2
linux-64::imagecodecs-2021.11.20-py310h43db4a6_2.tar.bz2
linux-64::arrow-cpp-3.0.0-py38hf621f4d_43_cuda.tar.bz2
linux-64::arrow-cpp-7.0.0-py38h437b12e_1_cuda.tar.bz2
linux-64::mandrake-1.2.1-py39h2e098be_1.tar.bz2
linux-64::arrow-cpp-6.0.1-py37h817bbc3_10_cpu.tar.bz2
linux-64::paraview-5.10.1-h049c25e_4_egl.tar.bz2
linux-64::arrow-cpp-7.0.0-py38h16edd8c_0_cpu.tar.bz2
linux-64::cctools_osx-arm64-973.0.1-hd7a0a63_6.tar.bz2
linux-64::arrow-cpp-6.0.1-py37hc76924d_12_cuda.tar.bz2
linux-64::pillow-9.0.1-py310he619898_2.tar.bz2
linux-64::pyinstaller-4.9-py39hd38ffc4_0.tar.bz2
linux-64::ogre-13.3.3-hdcbd623_0.tar.bz2
linux-64::arrow-cpp-5.0.0-py37h817bbc3_24_cpu.tar.bz2
linux-64::libthrift-0.16.0-h6b813eb_1.tar.bz2
linux-64::cctools_osx-arm64-973.0.1-ha590ccf_9.tar.bz2
linux-64::arrow-cpp-3.0.0-py310hca8f35d_47_cpu.tar.bz2
linux-64::dotnet-aspnetcore-6.0.2-h73ebe80_0.tar.bz2
linux-64::git-annex-10.20220322-alldep_hc98582e_100.tar.bz2
linux-64::sagelib-9.5-py310h771e0a6_2.tar.bz2
linux-64::wxpython-4.1.1-py39hea8757a_5.tar.bz2
linux-64::libopencv-4.5.5-py39hfb30bf4_6.tar.bz2
linux-64::sagelib-9.5-py38hd903835_2.tar.bz2
linux-64::pdal-2.4.0-h59012b2_0.tar.bz2
linux-64::sagelib-9.5-py38hfd38005_1.tar.bz2
linux-64::vowpalwabbit-9.0.1-py310h1daa79b_0.tar.bz2
linux-64::z5py-2.0.15-py37h2f61680_0.tar.bz2
linux-64::python-3.10.2-h85951f9_4_cpython.tar.bz2
linux-64::arrow-cpp-5.0.0-py310h43910b9_24_cuda.tar.bz2
linux-64::createrepo_c-0.19.0-py38hcb80abe_0.tar.bz2
linux-64::pdal-2.4.0-hb48eabe_1.tar.bz2
linux-64::conduit-0.8.2-py38h367b570_0.tar.bz2
linux-64::qt-5.12.9-h1304e3e_6.tar.bz2
linux-64::arrow-cpp-7.0.0-py310hc1cefbc_0_cpu.tar.bz2
linux-64::vtk-9.1.0-qt_py37hfbe70cb_207.tar.bz2
linux-64::grpc-cpp-1.43.2-h3d78c48_2.tar.bz2
linux-64::imagecodecs-2021.11.20-py38hdfda6c5_2.tar.bz2
linux-64::omniorb-4.2.5-py310h44b9e0c_1.tar.bz2
linux-64::arrow-cpp-5.0.0-py39h50a2650_28_cpu.tar.bz2
linux-64::tippecanoe-1.36.0-ha331528_2.tar.bz2
linux-64::vtk-9.1.0-osmesa_py39h4cfbece_105.tar.bz2
linux-64::git-2.35.1-pl5321h36853c3_0.tar.bz2
linux-64::arrow-cpp-5.0.0-py37hc76924d_27_cuda.tar.bz2
linux-64::cctools_osx-arm64-973.0.1-h78d1351_6.tar.bz2
linux-64::erlang-24.2.2-pl5321hb9e9383_0.tar.bz2
linux-64::sagelib-9.5-py39h3decf45_4.tar.bz2
linux-64::pillow-9.0.1-py38h0ee0e06_2.tar.bz2
linux-64::ortools-python-9.2-py39h06b2a2a_1.tar.bz2
linux-64::pillow-9.0.0-py37h351210d_0.tar.bz2
linux-64::cmake-3.22.2-h1021d11_0.tar.bz2
linux-64::nordugrid-arc-6.15.0-py38h92e75e1_1.tar.bz2
linux-64::pyinstaller-4.9-py310h516ecdb_1.tar.bz2
linux-64::vtk-9.1.0-osmesa_py310h7872e40_106.tar.bz2
linux-64::mysql-libs-8.0.28-h28c427c_2.tar.bz2
linux-64::ndcctools-7.4.3-py37hb27c1af_0.tar.bz2
linux-64::libtiff-4.3.0-h542a066_3.tar.bz2
linux-64::ogre-13.3.2-hdcbd623_0.tar.bz2
linux-64::nd2-0.2.1-py39h155c9d3_1.tar.bz2
linux-64::mapserver-7.6.4-py39h98e9062_6.tar.bz2
linux-64::grpc-cpp-1.45.0-h3d78c48_0.tar.bz2
linux-64::createrepo_c-0.20.0-py39hb908eda_0.tar.bz2
linux-64::libthrift-0.16.0-h519c5ea_1.tar.bz2
linux-64::sagelib-9.5-py38hff34d62_4.tar.bz2
linux-64::libopencv-4.5.5-py31h3121f02_7.tar.bz2
linux-64::rust-1.59.0-h30be4a0_0.tar.bz2
linux-64::libcurl-7.82.0-h2283fc2_0.tar.bz2
linux-64::ambertools-21.12-py38hfd5a1b6_0.tar.bz2
linux-64::folly-2022.02.14.00-h1234567_1_jemalloc.tar.bz2
linux-64::libthrift-0.16.0-h6b813eb_0.tar.bz2
linux-64::libopencv-4.5.5-py39hfb30bf4_5.tar.bz2
linux-64::z5py-2.0.14-py310h2f9a825_0.tar.bz2
linux-64::imagecodecs-2021.11.20-py39h7ac1185_2.tar.bz2
linux-64::tensorflow-base-2.7.0-cuda110py38h76162fe_0.tar.bz2
linux-64::sagelib-9.5-py310h771e0a6_3.tar.bz2
linux-64::createrepo_c-0.19.0-py37h85cd5c2_1.tar.bz2
linux-64::vowpalwabbit-9.0.1-py38hdaa81c8_0.tar.bz2
linux-64::xrootd-5.4.1-py310hf716355_0.tar.bz2
linux-64::nodejs-17.8.0-h96d913c_1.tar.bz2
linux-64::sagelib-9.5-py39h1c80623_2.tar.bz2
linux-64::vtk-9.1.0-qt_py38h36527ae_206.tar.bz2
linux-64::libgdal-3.4.1-hff5c5e8_5.tar.bz2
linux-64::arrow-cpp-5.0.0-py38hc46b33e_28_cpu.tar.bz2
linux-64::arrow-cpp-7.0.0-py37h65f474c_3_cpu.tar.bz2
linux-64::mandrake-1.2.1-py38hd235e30_1.tar.bz2
linux-64::ndcctools-7.4.3-py39h336bf08_0.tar.bz2
linux-64::createrepo_c-0.19.0-py38h9030dcd_1.tar.bz2
linux-64::createrepo_c-0.20.0-py38h9030dcd_1.tar.bz2
linux-64::curl-7.82.0-h2283fc2_0.tar.bz2
linux-64::libopencv-4.5.5-py37hc03c0b8_6.tar.bz2
linux-64::createrepo_c-0.20.0-py37h0332789_1.tar.bz2
linux-64::geant4-11.0.0-py38ha75f61f_0.tar.bz2
linux-64::wxpython-4.1.1-py37hecb6014_5.tar.bz2
linux-64::ndcctools-7.4.3-py310ha6b4e5e_1.tar.bz2
linux-64::ndcctools-7.4.3-py39hff7568b_1.tar.bz2
linux-64::pillow-9.0.0-py38he2f12e7_0.tar.bz2
linux-64::paraview-5.10.1-h0fd889d_4_egl.tar.bz2
linux-64::tiledb-2.6.4-h1e4a385_0.tar.bz2
linux-64::ffmpeg-4.3.2-h37c90e5_3.tar.bz2
linux-64::libgdal-3.4.2-hda961b2_0.tar.bz2
linux-64::nordugrid-arc-6.15.0-py39head2539_1.tar.bz2
linux-64::dotnet-aspnetcore-3.1.22-h73ebe80_1.tar.bz2
linux-64::boost-cpp-1.74.0-h6cacc03_7.tar.bz2
linux-64::grpc-cpp-1.44.0-h3d78c48_0.tar.bz2
linux-64::gemmi-0.5.3-py39h7d9a04d_0.tar.bz2
linux-64::r-git2r-0.30.1-r41h96773ce_0.tar.bz2
linux-64::libopencv-4.5.5-py31he7a5e20_2.tar.bz2
linux-64::sdl_image-1.2.12-hab73425_2.tar.bz2
linux-64::grpcio-1.44.0-py38hdd6454d_0.tar.bz2
linux-64::vtk-9.1.0-qt_py37h2054c44_206.tar.bz2
linux-64::intel-opencl-rt-2022.0.1-h9a4f129_3633.tar.bz2
linux-64::imagemagick-7.1.0_26-pl5321hae5efcc_0.tar.bz2
linux-64::xrootd-5.4.1-py39hbfe9b54_0.tar.bz2
linux-64::triqs-3.1.0-py39hf080271_0.tar.bz2
linux-64::triqs-3.1.0-py38h5311979_0.tar.bz2
linux-64::mapserver-7.6.4-py37hdcf79b4_6.tar.bz2
linux-64::mandrake-1.2.1-py37hc7467be_1.tar.bz2
linux-64::arrow-cpp-7.0.0-py39h6409b3a_2_cpu.tar.bz2
linux-64::mdsrv-0.3.5.post1-py38h99c03f7_3.tar.bz2
linux-64::llvmdev-13.0.1-hf817b99_2.tar.bz2
linux-64::geotiff-1.7.0-h509b78c_7.tar.bz2
linux-64::sagelib-9.5-py310h5946b9b_4.tar.bz2
linux-64::arrow-cpp-7.0.0-py310h09bd4ed_2_cpu.tar.bz2
linux-64::conduit-0.8.2-py37h106d8db_0.tar.bz2
linux-64::panda3d-1.10.11-py37h64dc4b6_3.tar.bz2
linux-64::libtensorflow-2.7.0-cpu_h0a78848_0.tar.bz2
linux-64::pyngl-1.6.1-py39h380e493_3.tar.bz2
linux-64::pdal-2.4.0-h48dbd94_0.tar.bz2
linux-64::omniorb-libs-4.2.5-he49606f_2.tar.bz2
linux-64::dotnet-sdk-5.0.406-h751d214_0.tar.bz2
linux-64::grpcio-1.45.0-py310h44b9e0c_0.tar.bz2
linux-64::mlir-13.0.1-he0ac6c6_0.tar.bz2
linux-64::plumed-2.8.0-mpi_mpich_h8d9947c_0.tar.bz2
linux-64::jaxlib-0.3.0-py39hf127329_3.tar.bz2
linux-64::paraview-5.10.1-h401edd0_104_qt.tar.bz2
linux-64::vtk-9.1.0-egl_py37h9d7138a_6.tar.bz2
linux-64::folly-2022.03.21.00-h1234567_1.tar.bz2
linux-64::vtk-9.1.0-qt_py310h4254d84_205.tar.bz2
linux-64::pillow-9.0.0-py310h2f95282_0.tar.bz2
linux-64::vtk-9.1.0-egl_py39hae96e35_5.tar.bz2
linux-64::libnghttp2-1.47.0-h727a467_0.tar.bz2
linux-64::paraview-5.10.1-h50247e9_104_qt.tar.bz2
linux-64::paraview-5.10.0-h613f2a7_104_qt.tar.bz2
linux-64::ptscotch-6.0.9-hb499603_2.tar.bz2
linux-64::paraview-5.10.0-h0c1b1c9_4_egl.tar.bz2
linux-64::nordugrid-arc-6.15.0-py37haf68709_1.tar.bz2
linux-64::ndcctools-7.4.3-py310h94ab34a_0.tar.bz2
linux-64::grpcio-1.43.0-py310ha6b4e5e_0.tar.bz2
linux-64::vtk-9.1.0-egl_py38h7a10f25_5.tar.bz2
linux-64::r-base-4.0.5-h06d3f91_6.tar.bz2
linux-64::ndcctools-7.4.3-py38hdd6454d_0.tar.bz2
linux-64::serf-1.3.9-h4d54922_1.tar.bz2
linux-64::createrepo_c-0.20.0-py310h7ca2958_1.tar.bz2
linux-64::libgit2-1.4.2-h4c07d5c_0.tar.bz2
linux-64::triqs-3.1.0-py37h1b74b80_0.tar.bz2
linux-64::arrow-cpp-5.0.0-py38h0002f4e_26_cuda.tar.bz2
linux-64::nd2-0.2.1-py39h155c9d3_0.tar.bz2
linux-64::magics-4.11.0-he381006_1.tar.bz2
linux-64::cctools_osx-arm64-973.0.1-hf04072b_8.tar.bz2
linux-64::sagelib-9.5-py39h1c80623_3.tar.bz2
linux-64::xrootd-5.4.1-py38h92bdfd5_0.tar.bz2
linux-64::tomviz-1.10.0.post220-py37h2b09141_0.tar.bz2
linux-64::vtk-9.1.0-osmesa_py38h36535f7_106.tar.bz2
linux-64::tensorflow-base-2.7.0-cuda110py310hae929b1_0.tar.bz2
linux-64::erlang-24.2.2-pl5321h5001644_0.tar.bz2
linux-64::imagemagick-7.1.0_24-pl5321hb118871_0.tar.bz2
linux-64::cctools_osx-64-973.0.1-h1c3958c_8.tar.bz2
linux-64::llvmdev-11.1.0-hf817b99_3.tar.bz2
linux-64::grpcio-1.44.0-py39h336bf08_0.tar.bz2
linux-64::nodejs-17.8.0-hfba9c51_0.tar.bz2
linux-64::btrfs-progs-5.16.2-h30ae7ac_0.tar.bz2
linux-64::arrow-cpp-5.0.0-py38h1ae68a0_26_cpu.tar.bz2
linux-64::mdsrv-0.3.5.post1-py310h3509554_3.tar.bz2
linux-64::arrow-cpp-6.0.1-py38h437b12e_10_cuda.tar.bz2
linux-64::pyinstaller-4.10-py39hd08d98e_0.tar.bz2
linux-64::sagelib-9.5-py37ha43dc88_4.tar.bz2
linux-64::tiledb-2.6.2-hf3d3071_1.tar.bz2
linux-64::paraview-5.10.0-hf0200fe_104_qt.tar.bz2
linux-64::omniorb-4.2.5-py38ha0cdfde_2.tar.bz2
linux-64::arrow-cpp-3.0.0-py37h932a894_44_cuda.tar.bz2
linux-64::vtk-9.1.0-qt_py310hf3393c1_207.tar.bz2
linux-64::sagelib-9.5-py310h990377c_1.tar.bz2
linux-64::ogre-13.3.1-hef34edf_0.tar.bz2
linux-64::nodejs-17.8.0-h8839609_1.tar.bz2
linux-64::erlang-24.3.2-pl5321h5001644_0.tar.bz2
linux-64::createrepo_c-0.19.0-py37h85cd5c2_0.tar.bz2
linux-64::libopencv-4.5.5-py38h9b278ad_6.tar.bz2
linux-64::mandrake-1.2.1-py310he9ae36c_1.tar.bz2
linux-64::vtk-9.1.0-egl_py310h20c2137_6.tar.bz2
linux-64::tomviz-1.10.0.post230-py37h2b09141_0.tar.bz2
linux-64::libgsf-1.14.49-he99f2b3_0.tar.bz2
linux-64::panda3d-1.10.11-py38heeb1c8f_3.tar.bz2
linux-64::grpc-cpp-1.43.2-h4315cb9_1.tar.bz2
linux-64::serf-1.3.9-hb3fec43_1.tar.bz2
linux-64::qtwebkit-5.212-h7a17519_4.tar.bz2
linux-64::mandrake-1.2.1-py39h550a694_1.tar.bz2
linux-64::gdstk-0.8.2-py38hab637ae_0.tar.bz2
linux-64::r-git2r-0.30.1-r41hf72769b_0.tar.bz2
linux-64::ndcctools-7.4.3-py37hb27c1af_1.tar.bz2
linux-64::mongodb-5.1.1-hc5cbecd_1.tar.bz2
linux-64::tensorflow-base-2.7.0-cuda110py37h3fa1966_0.tar.bz2
linux-64::libgdal-3.4.1-hda961b2_6.tar.bz2
linux-64::arrow-cpp-3.0.0-py39h653df1f_47_cuda.tar.bz2
linux-64::wasmer-2.2.0-h2af65a9_0.tar.bz2
linux-64::vowpalwabbit-9.0.1-py37he11f6b3_0.tar.bz2
linux-64::panda3d-1.10.11-py310h0ae0343_2.tar.bz2
linux-64::tomviz-1.10.0.post196-py37h2b09141_0.tar.bz2
linux-64::grpcio-1.45.0-py37h0327239_0.tar.bz2
linux-64::postgresql-14.2-hce44dc1_0.tar.bz2
linux-64::cpp-opentelemetry-sdk-1.1.1-h289dcfb_3.tar.bz2
linux-64::tiledb-2.6.3-h3f4058f_0.tar.bz2
linux-64::libopencv-4.5.5-py31he7a5e20_1.tar.bz2
linux-64::coda-2.23.1-py38h234bf9d_0.tar.bz2
linux-64::julia-1.7.2-h52e3dff_1.tar.bz2
linux-64::lmod-8.6.16-lua54h71fc533_0.tar.bz2
linux-64::ruby-3.1.1-h22ca3a2_0.tar.bz2
linux-64::tectonic-0.8.2-h0b62f0d_2.tar.bz2
linux-64::ortools-cpp-9.2-hf441cbe_1.tar.bz2
linux-64::tectonic-0.8.2-h0b62f0d_1.tar.bz2
linux-64::ffmpeg-4.3.2-h37c90e5_2.tar.bz2
linux-64::jaxlib-0.3.0-py38hbfb726d_4.tar.bz2
linux-64::geant4-11.0.0-py37h118d875_0.tar.bz2
linux-64::harp-1.15-py310r41h2b6cc9b_0.tar.bz2
linux-64::panda3d-1.10.11-py39h611d5dc_3.tar.bz2
linux-64::nss-3.77-h2350873_0.tar.bz2
linux-64::vtk-9.1.0-osmesa_py39h8ab48e2_107.tar.bz2
linux-64::folly-2022.02.21.00-h1234567_1.tar.bz2
linux-64::lmod-8.6.12-lua54h14f7cff_0.tar.bz2
linux-64::vtk-9.1.0-qt_py38h961b7ba_204.tar.bz2
linux-64::createrepo_c-0.20.0-py39h3c599e5_0.tar.bz2
linux-64::omniorb-4.2.5-py37he500948_2.tar.bz2
linux-64::arrow-cpp-6.0.1-py310hecbc1bb_10_cpu.tar.bz2
linux-64::pillow-9.0.1-py38he2f12e7_0.tar.bz2
linux-64::grpcio-1.45.0-py37he500948_0.tar.bz2
linux-64::vtk-9.1.0-qt_py310h6f7c0ab_204.tar.bz2
linux-64::gdstk-0.8.2-py39hac9c483_0.tar.bz2
linux-64::nss-3.76-h2350873_0.tar.bz2
linux-64::arrow-cpp-3.0.0-py39hb93bef5_46_cpu.tar.bz2
linux-64::arrow-cpp-5.0.0-py39hb93bef5_27_cpu.tar.bz2
linux-64::omniorb-4.2.5-py39h0f497a6_1.tar.bz2
linux-64::cairo-1.16.0-ha61ee94_1011.tar.bz2
linux-64::cctools_osx-64-973.0.1-h9893a0d_10.tar.bz2
linux-64::folly-2022.03.28.00-h1234567_1.tar.bz2
linux-64::nodejs-16.14.2-h8839609_1.tar.bz2
linux-64::cctools_osx-arm64-973.0.1-h91eca3c_10.tar.bz2
linux-64::libopencv-4.5.5-py37h4958a1a_2.tar.bz2
linux-64::sagelib-9.5-py37hc8fef4d_2.tar.bz2
linux-64::arrow-cpp-5.0.0-py39had3a21f_26_cpu.tar.bz2
linux-64::z5py-2.0.15-py39ha5c6dc3_0.tar.bz2
linux-64::vowpalwabbit-9.0.1-py39h8e5f8a4_0.tar.bz2
linux-64::arrow-cpp-7.0.0-py37h45430d2_1_cpu.tar.bz2
linux-64::nordugrid-arc-6.15.0-py310ha92cc82_1.tar.bz2
linux-64::plumed-2.8.0-mpi_openmpi_hb44a2e6_0.tar.bz2
linux-64::arrow-cpp-6.0.1-py39h98bb539_10_cpu.tar.bz2
linux-64::nd2-0.2.1-py38h197abaa_1.tar.bz2
linux-64::folly-2022.02.21.00-h1234567_1_jemalloc.tar.bz2
linux-64::fish-3.3.1-hd5af85a_0.tar.bz2
linux-64::hdf5-1.12.1-mpi_openmpi_hb3f3608_4.tar.bz2
linux-64::arrow-cpp-3.0.0-py39h7a27593_44_cuda.tar.bz2
linux-64::panda3d-1.10.11-py37h81ffb61_3.tar.bz2
linux-64::paraview-5.10.1-hbadb171_104_qt.tar.bz2
linux-64::llvmdev-14.0.0-he0ac6c6_0.tar.bz2
linux-64::gdk-pixbuf-2.42.8-hff1cb4f_0.tar.bz2
linux-64::gmsh-4.9.5-hee323ce_0.tar.bz2
linux-64::assimp-5.2.1-hedfc422_0.tar.bz2
linux-64::pdal-2.4.0-hce4d343_1.tar.bz2
linux-64::grpc-cpp-1.44.0-h1021d7f_1.tar.bz2
linux-64::harp-1.15-py38r41h234bf9d_0.tar.bz2
linux-64::arrow-cpp-6.0.1-py310h43910b9_10_cuda.tar.bz2
linux-64::arrow-cpp-6.0.1-py310hdc93d96_10_cuda.tar.bz2
linux-64::vtk-9.1.0-osmesa_py37h9d55293_104.tar.bz2
linux-64::mapserver-7.6.4-py38h3922216_6.tar.bz2
linux-64::libmongoc-1.21.1-h0506597_0.tar.bz2
linux-64::sagelib-9.5-py38hfd38005_0.tar.bz2
linux-64::omniorb-4.2.5-py37he500948_1.tar.bz2
linux-64::arrow-cpp-3.0.0-py310h8db4b28_45_cpu.tar.bz2
linux-64::vtk-9.1.0-egl_py38h4593b9e_4.tar.bz2
linux-64::drpm-0.5.1-h6c0c0dd_0.tar.bz2
linux-64::libtiledb-sql-0.12.5-h0993566_0.tar.bz2
linux-64::voms-2.1.0rc0-h46dc511_6.tar.bz2
linux-64::mysql-router-8.0.28-h49c25b6_2.tar.bz2
linux-64::jaxlib-0.3.0-py38hbfb726d_3.tar.bz2
linux-64::arrow-cpp-3.0.0-py38h437b12e_44_cuda.tar.bz2
linux-64::omniorb-4.2.5-py37h0327239_1.tar.bz2
linux-64::arrow-cpp-3.0.0-py38h7cbaac1_42_cuda.tar.bz2
linux-64::ndcctools-7.4.3-py310h94ab34a_1.tar.bz2
linux-64::tomviz-1.10.0.post196-py37h895cc74_1.tar.bz2
linux-64::qpdf-10.6.3-h9772cbc_0.tar.bz2
linux-64::createrepo_c-0.20.0-py39h3c599e5_1.tar.bz2
linux-64::arrow-cpp-6.0.1-py39hbfed05e_11_cuda.tar.bz2
linux-64::pyngl-1.6.1-py39h3e4e5b0_4.tar.bz2
linux-64::jaxlib-0.3.0-py310h0e91589_3.tar.bz2
linux-64::arrow-cpp-6.0.1-py39hb93bef5_12_cpu.tar.bz2
linux-64::vtk-9.1.0-osmesa_py38h6f17df5_104.tar.bz2
linux-64::libtensorflow_cc-2.7.0-cuda110h42b7d06_0.tar.bz2
linux-64::jaxlib-0.3.0-py310hb56f407_4.tar.bz2
linux-64::r-base-4.1.3-h06d3f91_1.tar.bz2
linux-64::grpc-cpp-1.43.2-h9e046d8_1.tar.bz2
linux-64::imagecodecs-2022.2.22-py39hd807fc7_1.tar.bz2
linux-64::jaxlib-0.1.76-py38h1bdff21_0.tar.bz2
linux-64::wxpython-4.1.1-py310hdb6c39c_5.tar.bz2
linux-64::grpcio-1.44.0-py37hb27c1af_0.tar.bz2
linux-64::python-3.10.2-hc74c709_3_cpython.tar.bz2
linux-64::arrow-cpp-3.0.0-py39h116028d_42_cpu.tar.bz2
linux-64::mandrake-1.2.1-py310hb67d796_1.tar.bz2
linux-64::wxpython-4.1.1-py310h8b4016e_4.tar.bz2
linux-64::mysql-client-8.0.28-h92c5bc7_2.tar.bz2
linux-64::r-base-4.0.5-hd930d0e_5.tar.bz2
linux-64::pyngl-1.6.1-py38he7e58a4_4.tar.bz2
linux-64::arrow-cpp-3.0.0-py37h4c43799_45_cpu.tar.bz2
linux-64::gemmi-0.5.2-py310h58363a5_0.tar.bz2
linux-64::arrow-cpp-7.0.0-py38hd028fc6_3_cuda.tar.bz2
linux-64::cctools_osx-64-973.0.1-h6eed546_7.tar.bz2
linux-64::jaxlib-0.1.76-py39h3778252_0.tar.bz2
linux-64::vtk-9.1.0-qt_py39h82018a2_204.tar.bz2
linux-64::libtensorflow-2.7.0-cuda110h42b7d06_0.tar.bz2
linux-64::mandrake-1.2.1-py38h75d12e8_1.tar.bz2
linux-64::arrow-cpp-5.0.0-py38h437b12e_25_cuda.tar.bz2
linux-64::mongodb-5.1.1-h5638ace_1.tar.bz2
linux-64::thrift-compiler-0.16.0-h6b813eb_1.tar.bz2
linux-64::kitty-0.23.1-py38hd396ce5_1.tar.bz2
linux-64::tiledb-2.6.2-h2038895_1.tar.bz2
linux-64::arrow-cpp-5.0.0-py37h4c43799_26_cpu.tar.bz2
linux-64::arrow-cpp-3.0.0-py310hc2d03c8_45_cuda.tar.bz2
linux-64::ortools-cpp-9.2-h5d7e8d6_1.tar.bz2
linux-64::libpq-14.2-h676c864_0.tar.bz2
linux-64::arrow-cpp-7.0.0-py39h7b053a0_3_cpu.tar.bz2
linux-64::cctools_osx-64-973.0.1-h7e2fc85_8.tar.bz2
linux-64::z5py-2.0.13-py38h36534de_0.tar.bz2
linux-64::triqs-3.1.0-py310had2d5d8_0.tar.bz2
linux-64::sagelib-9.5-py37h0c4da78_0.tar.bz2
linux-64::createrepo_c-0.20.0-py39hb908eda_1.tar.bz2
linux-64::pyngl-1.6.1-py310hc9be37a_4.tar.bz2
linux-64::vtk-9.1.0-egl_py37hc3f521b_7.tar.bz2
linux-64::arrow-cpp-5.0.0-py39h6c41701_24_cuda.tar.bz2
linux-64::createrepo_c-0.19.0-py39hb908eda_1.tar.bz2
linux-64::wxwidgets-3.1.5-h800c0ab_0.tar.bz2
linux-64::libmongoc-1.21.1-h15e390e_0.tar.bz2
linux-64::kitty-0.23.1-py37hc920b52_1.tar.bz2
linux-64::mandrake-1.2.1-py37hcc9ed4e_1.tar.bz2
linux-64::pyinstaller-4.10-py310ha400145_0.tar.bz2
linux-64::arrow-cpp-6.0.1-py39heb87e93_10_cpu.tar.bz2
linux-64::libgdal-3.4.2-hdfc60d4_1.tar.bz2
linux-64::tiledb-2.6.4-h3f4058f_0.tar.bz2
linux-64::lmod-8.6.14-lua54h71fc533_0.tar.bz2
linux-64::wasmer-2.2.0-h542c21f_0.tar.bz2
linux-64::libopencv-4.5.5-py39h7d09d5f_2.tar.bz2
linux-64::tensorflow-base-2.7.0-cuda102py37h44d275c_0.tar.bz2
linux-64::dotnet-aspnetcore-5.0.14-h73ebe80_0.tar.bz2
linux-64::poppler-qt-22.01.0-hf358c63_1.tar.bz2
linux-64::libcurl-static-7.82.0-h2283fc2_0.tar.bz2
linux-64::arrow-cpp-3.0.0-py37h817bbc3_43_cpu.tar.bz2
linux-64::harp-1.15-py38r40h234bf9d_0.tar.bz2
linux-64::python-3.9.10-h85951f9_2_cpython.tar.bz2
linux-64::gfal2-2.20.4-h897e8d7_0.tar.bz2
linux-64::erlang-24.3-pl5321hb9e9383_0.tar.bz2
linux-64::panda3d-1.10.11-py39h50f9c69_1.tar.bz2
linux-64::createrepo_c-0.20.0-py38h9030dcd_0.tar.bz2
linux-64::magics-metview-4.11.0-hf89b6a3_1.tar.bz2
linux-64::mapserver-7.6.4-py37h9261824_6.tar.bz2
linux-64::ovito-3.7.2-hbec523a_0.tar.bz2
linux-64::libopencv-4.5.5-py39hd0eba51_3.tar.bz2
linux-64::vigra-1.11.1-py39ha46d285_1029.tar.bz2
linux-64::assimp-5.2.3-h4c92fa2_1.tar.bz2
linux-64::pyinstaller-4.9-py38ha8cb210_1.tar.bz2
linux-64::grpcio-1.45.0-py310hba10ccf_0.tar.bz2
linux-64::dotnet-runtime-3.1.22-h73ebe80_1.tar.bz2
linux-64::grpc-cpp-1.45.0-h1021d7f_0.tar.bz2
linux-64::cctools_osx-arm64-973.0.1-hcded490_7.tar.bz2
linux-64::qpdf-10.6.2-h9772cbc_1.tar.bz2
linux-64::vtk-9.1.0-egl_py310hb16941e_7.tar.bz2
linux-64::arrow-cpp-5.0.0-py310hca8f35d_28_cpu.tar.bz2
linux-64::coda-2.23.1-py39h665c6b1_0.tar.bz2
linux-64::python-3.10.2-h85951f9_3_cpython.tar.bz2
linux-64::ogre-13.3.0-h457c5cf_0.tar.bz2
linux-64::dotnet-aspnetcore-6.0.3-h751d214_0.tar.bz2
linux-64::python-3.10.4-h2660328_0_cpython.tar.bz2
linux-64::glib-2.70.2-h780b84a_2.tar.bz2
linux-64::ogre-13.3.2-h3d802dc_0.tar.bz2
linux-64::libopencv-4.5.5-py39h7d09d5f_1.tar.bz2
linux-64::jaxlib-0.3.0-py38h1302da7_4.tar.bz2
linux-64::dotnet-aspnetcore-3.1.23-h751d214_0.tar.bz2
linux-64::vtk-9.1.0-osmesa_py38hfe2dfd5_107.tar.bz2
linux-64::createrepo_c-0.20.0-py38hcb80abe_1.tar.bz2
linux-64::cppyy-cling-6.25.3-py39h3d66fe8_0.tar.bz2
linux-64::paraview-5.10.1-h796822d_104_qt.tar.bz2
linux-64::harp-1.15-py37r41hcb5871f_0.tar.bz2
linux-64::vtk-9.1.0-qt_py39hd359688_207.tar.bz2
linux-64::astrometry-0.89-py39h1bc5e43_1.tar.bz2
linux-64::nodejs-16.14.2-h784f1fd_0.tar.bz2
linux-64::yoda-1.9.4-py39hf57fb9a_1.tar.bz2
linux-64::libgdal-3.4.1-he20be3c_4.tar.bz2
linux-64::arrow-cpp-3.0.0-py37ha7c06bf_43_cuda.tar.bz2
linux-64::wasmer-2.2.1-h2af65a9_0.tar.bz2
linux-64::r-seqminer-8.4-r41h9434ad5_0.tar.bz2
-    "libzlib >=1.2.11,<1.3.0a0",
+    "libzlib >=1.2.11,<2.0.0a0",
linux-64::llvm-openmp-13.0.1-hf817b99_0.tar.bz2
linux-64::gst-plugins-base-1.20.1-hcf0ee16_0.tar.bz2
linux-64::gst-plugins-base-1.20.1-hcf0ee16_1.tar.bz2
linux-64::llvm-openmp-13.0.1-he0ac6c6_1.tar.bz2
linux-64::liblal-7.1.7-fftw_h8377b92_100.tar.bz2
linux-64::llvm-14.0.0-h32600fe_0.tar.bz2
linux-64::llvm-13.0.1-h32600fe_0.tar.bz2
linux-64::libllvm13-13.0.1-hf817b99_0.tar.bz2
linux-64::clang-9-9.0.1-root_62600_hea64019_4.tar.bz2
linux-64::libass-0.14.0-hc2a3f6d_3.tar.bz2
linux-64::llvm-13.0.1-h32600fe_2.tar.bz2
linux-64::libclang-cpp9-9.0.1-cling_v0.9_h6699504_4.tar.bz2
linux-64::libclang-cpp9-9.0.1-default_heb9c396_4.tar.bz2
linux-64::clang-format-13-13.0.1-default_hc23dcda_0.tar.bz2
linux-64::cfitsio-4.1.0-hd9d235c_0.tar.bz2
linux-64::imath-3.1.4-h6239696_0.tar.bz2
linux-64::clang-9-9.0.1-default_heb9c396_4.tar.bz2
linux-64::libllvm13-13.0.1-hf817b99_1.tar.bz2
linux-64::plumed-2.8.0-nompi_h3dbea63_100.tar.bz2
linux-64::libclang-cpp-9.0.1-hcc_hd56f702_4.tar.bz2
linux-64::openexr-3.1.4-he0ac6c6_0.tar.bz2
linux-64::libllvm14-14.0.0-he0ac6c6_0.tar.bz2
linux-64::gst-plugins-good-1.20.0-h88e00e1_1.tar.bz2
linux-64::libllvm13-13.0.1-hf817b99_2.tar.bz2
linux-64::cgns-4.2.0-h6a78c49_4.tar.bz2
linux-64::libmlir13-13.0.1-he0ac6c6_0.tar.bz2
linux-64::libass-0.14.0-h7ae3f97_2.tar.bz2
linux-64::libclang-cpp9-9.0.1-root_62600_hea64019_4.tar.bz2
linux-64::llvm-tools-11.1.0-hf817b99_3.tar.bz2
linux-64::libclang-cpp-9.0.1-cling_v0.9_h6699504_4.tar.bz2
linux-64::clang-13-13.0.1-default_hc23dcda_0.tar.bz2
linux-64::clang-format-13.0.1-default_hc23dcda_0.tar.bz2
linux-64::clang-9-9.0.1-cling_v0.9_h6699504_4.tar.bz2
linux-64::gst-plugins-good-1.20.0-h0661c57_0.tar.bz2
linux-64::gst-plugins-base-1.20.0-hf529b03_0.tar.bz2
linux-64::llvm-tools-13.0.1-hf817b99_0.tar.bz2
linux-64::glib-tools-2.70.2-h780b84a_3.tar.bz2
linux-64::libllvm11-11.1.0-hf817b99_3.tar.bz2
linux-64::cgns-4.3.0-h7ef0e0a_0.tar.bz2
linux-64::llvm-13.0.1-h32600fe_1.tar.bz2
linux-64::libclang-cpp13-13.0.1-default_hc23dcda_0.tar.bz2
linux-64::llvm-tools-13.0.1-hf817b99_1.tar.bz2
linux-64::libclang-cpp-13.0.1-default_hc23dcda_0.tar.bz2
linux-64::clang-tools-13.0.1-default_hc23dcda_0.tar.bz2
linux-64::glib-tools-2.70.2-h780b84a_2.tar.bz2
linux-64::clang-9-9.0.1-hcc_hd56f702_4.tar.bz2
linux-64::llvm-tools-14.0.0-he0ac6c6_0.tar.bz2
linux-64::llvm-11.1.0-h32600fe_3.tar.bz2
linux-64::tk-8.6.12-h27826a3_0.tar.bz2
linux-64::gst-plugins-good-1.20.1-h20dca43_1.tar.bz2
linux-64::libclang-cpp-9.0.1-root_62600_hea64019_4.tar.bz2
linux-64::cargo-bundle-licenses-0.4.0-h2c80289_1.tar.bz2
linux-64::libclang-cpp9-9.0.1-hcc_hd56f702_4.tar.bz2
linux-64::libclang-cpp-9.0.1-default_heb9c396_4.tar.bz2
linux-64::xapian-core-1.4.19-hf817b99_0.tar.bz2
linux-64::llvm-tools-13.0.1-hf817b99_2.tar.bz2
linux-64::imath-3.1.5-h6239696_0.tar.bz2
linux-64::glib-tools-2.70.2-h780b84a_4.tar.bz2
linux-64::gst-plugins-base-1.20.0-hf529b03_1.tar.bz2
linux-64::gst-plugins-good-1.20.1-h18a9a4d_0.tar.bz2
linux-64::libmlir-13.0.1-he0ac6c6_0.tar.bz2
linux-64::libclang-13.0.1-default_hc23dcda_0.tar.bz2
-    "libzlib >=1.2.11,<1.3.0a0"
+    "libzlib >=1.2.11,<2.0.0a0"
```

</details>