### PR TITLE
loosen zlib-pin to major level (26/N; January 2022 & December 2021)

### DIFF
--- a/recipe/patch_yaml/zlib.yaml
+++ b/recipe/patch_yaml/zlib.yaml
@@ -250,3 +250,12 @@ then:
   - loosen_depends:
       name: libzlib
       upper_bound: "2"
+---
+if:
+  has_depends: libzlib >=1.2*
+  timestamp_lt: 1643673600000  # 2022-02-01 00:00 UTC
+  timestamp_ge: 1640995200000  # 2022-01-01 00:00 UTC
+then:
+  - loosen_depends:
+      name: libzlib
+      upper_bound: "2"

--- a/recipe/patch_yaml/zlib.yaml
+++ b/recipe/patch_yaml/zlib.yaml
@@ -259,3 +259,12 @@ then:
   - loosen_depends:
       name: libzlib
       upper_bound: "2"
+---
+if:
+  has_depends: libzlib >=1.2*
+  timestamp_lt: 1640995200000  # 2022-01-01 00:00 UTC
+  timestamp_ge: 1638316800000  # 2021-12-01 00:00 UTC
+then:
+  - loosen_depends:
+      name: libzlib
+      upper_bound: "2"


### PR DESCRIPTION
Follow-up to https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/739, about 3700 artefacts affected.

### Result of `python show_diff.py`

<details>

```diff
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
osx-arm64::wxpython-4.1.1-py39h6ef99b8_3.tar.bz2
osx-arm64::cppyy-cling-6.25.2-py310ha8278a6_1.tar.bz2
osx-arm64::cppyy-cling-6.25.2-py38h6afda19_1.tar.bz2
osx-arm64::qt-main-5.15.2-hfc65906_0.tar.bz2
osx-arm64::libcurl-7.81.0-h8fe1914_0.tar.bz2
osx-arm64::libopencv-4.5.3-py38hf332e9d_7.tar.bz2
osx-arm64::python-3.10.2-h70c1b39_0_cpython.tar.bz2
osx-arm64::cppyy-cling-6.25.2-py38h6afda19_0.tar.bz2
osx-arm64::pdal-2.3.0-h3df0c14_20.tar.bz2
osx-arm64::arrow-cpp-6.0.1-py38h238f244_7_cpu.tar.bz2
osx-arm64::vtk-9.0.1-qt_py39heafd9ae_210.tar.bz2
osx-arm64::arrow-cpp-6.0.1-py310h413e3ef_8_cpu.tar.bz2
osx-arm64::nodejs-16.13.0-habd0e26_1.tar.bz2
osx-arm64::arrow-cpp-5.0.0-py39h954ee65_18_cpu.tar.bz2
osx-arm64::gdstk-0.8.1-py39h871b273_1.tar.bz2
osx-arm64::llvmdev-9.0.1-default_he95f5d9_7.tar.bz2
osx-arm64::arrow-cpp-6.0.1-py38hec0ad9d_5_cpu.tar.bz2
osx-arm64::grpc-cpp-1.43.2-hedfbb7c_0.tar.bz2
osx-arm64::arrow-cpp-5.0.0-py39h9172ee1_22_cpu.tar.bz2
osx-arm64::tesseract-4.1.3-ha234a1a_6.tar.bz2
osx-arm64::arrow-cpp-5.0.0-py38h238f244_22_cpu.tar.bz2
osx-arm64::arrow-cpp-5.0.0-py38ha587dc1_18_cpu.tar.bz2
osx-arm64::hdf5-1.12.1-mpi_mpich_hfc22502_3.tar.bz2
osx-arm64::tesseract-5.0.0-ha234a1a_0.tar.bz2
osx-arm64::cctools_osx-64-973.0.1-h9133aa7_5.tar.bz2
osx-arm64::postgresql-plpython-13.5-py310h5e722aa_1.tar.bz2
osx-arm64::curl-7.81.0-h8fe1914_0.tar.bz2
osx-arm64::libcurl-static-7.81.0-h8d07098_0.tar.bz2
osx-arm64::r-git2r-0.29.0-r40hc56a9d0_0.tar.bz2
osx-arm64::nodejs-16.13.0-h15390d4_2.tar.bz2
osx-arm64::assimp-5.2.0-h0f81e16_0.tar.bz2
osx-arm64::python-3.10.1-h43b31ca_2_cpython.tar.bz2
osx-arm64::r-base-4.1.2-hc29f753_0.tar.bz2
osx-arm64::tiledb-2.6.1-h42267fc_0.tar.bz2
osx-arm64::libgdal-3.4.0-hd4f1285_13.tar.bz2
osx-arm64::vowpalwabbit-8.11.0-py310h57bf9b6_2.tar.bz2
osx-arm64::pyreadstat-1.1.4-py38h95a778e_0.tar.bz2
osx-arm64::arrow-cpp-3.0.0-py38hec0ad9d_39_cpu.tar.bz2
osx-arm64::tiledb-2.6.2-hade11cd_0.tar.bz2
osx-arm64::gsoap-2.8.118-h47592b2_0.tar.bz2
osx-arm64::gds-base-gdstrig-2.19.7-h90de5f7_1.tar.bz2
osx-arm64::r-git2r-0.29.0-r41h0c0968c_1.tar.bz2
osx-arm64::libgdal-3.4.1-hd607cb8_2.tar.bz2
osx-arm64::python-3.10.2-h38ef502_1_cpython.tar.bz2
osx-arm64::libprotobuf-static-3.19.2-hccf11d3_0.tar.bz2
osx-arm64::libprotobuf-static-3.19.3-hccf11d3_0.tar.bz2
osx-arm64::llvmdev-9.0.1-default_he95f5d9_5.tar.bz2
osx-arm64::python-3.10.1-h43b31ca_1_cpython.tar.bz2
osx-arm64::gds-base-monitors-2.19.7-h96f5bf0_3.tar.bz2
osx-arm64::arrow-cpp-6.0.1-py38h458bdf1_6_cpu.tar.bz2
osx-arm64::hdf5-1.12.1-mpi_openmpi_hfd77f34_3.tar.bz2
osx-arm64::grpcio-1.43.0-py39h9e1b6db_0.tar.bz2
osx-arm64::grpc-cpp-1.43.0-hcb46328_0.tar.bz2
osx-arm64::cppyy-cling-6.25.2-py39h300d7f1_1.tar.bz2
osx-arm64::ruby-3.1.0-h39ff962_0.tar.bz2
osx-arm64::grpc-cpp-1.42.0-hedfbb7c_1.tar.bz2
osx-arm64::wxpython-4.1.1-py38h83617f1_3.tar.bz2
osx-arm64::libgdal-3.3.3-hca92387_11.tar.bz2
osx-arm64::root_base-6.24.6-py38hadccc6e_1.tar.bz2
osx-arm64::libfido2-1.10.0-h62a264d_0.tar.bz2
osx-arm64::postgresql-plpython-13.5-py39hfb02eb8_1.tar.bz2
osx-arm64::python-3.9.9-h43b31ca_0_cpython.tar.bz2
osx-arm64::pytables-3.7.0-py39h086b50d_0.tar.bz2
osx-arm64::r-base-4.1.2-h294b00e_1.tar.bz2
osx-arm64::libgdal-3.4.0-hbb1e90a_13.tar.bz2
osx-arm64::vowpalwabbit-9.0.0-py39ha632e4d_2.tar.bz2
osx-arm64::oclgrind-21.10-h92fbbc6_0.tar.bz2
osx-arm64::libopencv-4.5.3-py31hc2a8503_6.tar.bz2
osx-arm64::grpcio-1.43.0-py310h6d64de0_0.tar.bz2
osx-arm64::gds-services-2.19.7-h96f5bf0_2.tar.bz2
osx-arm64::mysql-libs-8.0.27-h577abee_2.tar.bz2
osx-arm64::gds-base-gdstrig-2.19.7-h90de5f7_3.tar.bz2
osx-arm64::libglib-2.70.2-h67e64d8_1.tar.bz2
osx-arm64::gdstk-0.8.1-py310h1571982_1.tar.bz2
osx-arm64::grpc-cpp-1.43.0-hedfbb7c_0.tar.bz2
osx-arm64::pdal-2.3.0-h770894b_19.tar.bz2
osx-arm64::arrow-cpp-6.0.1-py38ha587dc1_3_cpu.tar.bz2
osx-arm64::cctools_osx-arm64-973.0.1-h83ffe51_5.tar.bz2
osx-arm64::arrow-cpp-3.0.0-py310h413e3ef_41_cpu.tar.bz2
osx-arm64::librdkafka-1.3.0-hc87a43b_3.tar.bz2
osx-arm64::libcurl-7.80.0-h8fe1914_1.tar.bz2
osx-arm64::hdf5-1.12.1-nompi_had0e5e0_103.tar.bz2
osx-arm64::arrow-cpp-5.0.0-py38h458bdf1_21_cpu.tar.bz2
osx-arm64::graphviz-2.50.0-h53cdc11_2.tar.bz2
osx-arm64::mysql-server-8.0.28-h4a495b3_0.tar.bz2
osx-arm64::librdkafka-1.8.2.post2-h5b30705_0.tar.bz2
osx-arm64::gds-base-crtools-2.19.7-h2b036f6_3.tar.bz2
osx-arm64::vowpalwabbit-9.0.0-py38h8080f16_3.tar.bz2
osx-arm64::xrootd-5.4.0-py39h54297fd_0.tar.bz2
osx-arm64::assimp-5.1.6-h0f81e16_0.tar.bz2
osx-arm64::imagemagick-7.1.0_22-pl5321hc21dce0_0.tar.bz2
osx-arm64::r-git2r-0.29.0-r40h0c0968c_0.tar.bz2
osx-arm64::assimp-5.2.0-h0f81e16_1.tar.bz2
osx-arm64::kaldi-5.5.992-cpu_py39h1234567_4.tar.bz2
osx-arm64::arrow-cpp-6.0.1-py39h954ee65_3_cpu.tar.bz2
osx-arm64::vtk-9.0.1-qt_py38h2475952_210.tar.bz2
osx-arm64::arrow-cpp-6.0.1-py310h413e3ef_7_cpu.tar.bz2
osx-arm64::libnghttp2-1.46.0-he4cd7f6_0.tar.bz2
osx-arm64::curl-7.80.0-h8fe1914_1.tar.bz2
osx-arm64::llvmlite-0.38.0-py38hacf2d7f_0.tar.bz2
osx-arm64::libopencv-4.5.5-py31ha7d2a18_0.tar.bz2
osx-arm64::grpc-cpp-1.43.2-hcb46328_0.tar.bz2
osx-arm64::libspatialite-5.0.1-hde20a99_14.tar.bz2
osx-arm64::llvmdev-9.0.1-cling_v0.9_hb344d6f_6.tar.bz2
osx-arm64::vtk-9.1.0-qt_py39h4b3f5a4_203.tar.bz2
osx-arm64::arrow-cpp-5.0.0-py39h71c7f51_20_cpu.tar.bz2
osx-arm64::tiledb-2.6.2-h42267fc_0.tar.bz2
osx-arm64::nodejs-16.13.2-h15390d4_2.tar.bz2
osx-arm64::libgdal-3.4.0-hea1255b_12.tar.bz2
osx-arm64::curl-7.80.0-h8d07098_1.tar.bz2
osx-arm64::gdstk-0.8.1-py38hcb11b71_1.tar.bz2
osx-arm64::gct-6.2.1550507116-he4cd7f6_2.tar.bz2
osx-arm64::python-3.10.2-h38ef502_2_cpython.tar.bz2
osx-arm64::ogre-13.2.2-h0aef09b_0.tar.bz2
osx-arm64::nodejs-17.4.0-habd0e26_0.tar.bz2
osx-arm64::python-3.10.1-h70c1b39_1_cpython.tar.bz2
osx-arm64::mysql-connector-cpp-8.0.27-hf0f4d4b_1.tar.bz2
osx-arm64::root_base-6.24.6-py39h339fd24_1.tar.bz2
osx-arm64::libopencv-4.5.3-py31ha7d2a18_7.tar.bz2
osx-arm64::gct-6.2.1629922860-h197f4d7_0.tar.bz2
osx-arm64::python-3.10.2-hd16f9c5_2_cpython.tar.bz2
osx-arm64::libpq-13.5-h8bb6238_1.tar.bz2
osx-arm64::pytables-3.7.0-py310hcb00eea_0.tar.bz2
osx-arm64::gds-base-2.19.7-h7a27528_2.tar.bz2
osx-arm64::libvips-8.12.1-hb78e3e2_1.tar.bz2
osx-arm64::libgdal-3.3.3-he61a94d_14.tar.bz2
osx-arm64::imagemagick-7.1.0_19-pl5321hc21dce0_0.tar.bz2
osx-arm64::libgdal-3.4.0-had24f79_12.tar.bz2
osx-arm64::arrow-cpp-6.0.1-py39h9172ee1_7_cpu.tar.bz2
osx-arm64::mosh-1.3.2-pl5321haa6d385_1011.tar.bz2
osx-arm64::pdal-2.3.0-hd2253f4_23.tar.bz2
osx-arm64::librdkafka-1.3.0-h5b30705_3.tar.bz2
osx-arm64::xrootd-5.4.0-py310h929af54_0.tar.bz2
osx-arm64::libcurl-static-7.81.0-h8fe1914_0.tar.bz2
osx-arm64::cctools_osx-64-973.0.1-h18f9b51_5.tar.bz2
osx-arm64::grpcio-1.43.0-py310h00ca444_0.tar.bz2
osx-arm64::protozfits-2.0.1.post1-py310hb94f336_7.tar.bz2
osx-arm64::arrow-cpp-6.0.1-py310h98578ca_5_cpu.tar.bz2
osx-arm64::tesseract-5.0.0-ha234a1a_1.tar.bz2
osx-arm64::grpcio-1.43.0-py38h69ee544_0.tar.bz2
osx-arm64::arrow-cpp-6.0.1-py310h93f1226_4_cpu.tar.bz2
osx-arm64::magics-4.10.0-hd0c1079_2.tar.bz2
osx-arm64::libcurl-7.81.0-h8d07098_0.tar.bz2
osx-arm64::protozfits-2.0.1.post1-py39h7195ac1_7.tar.bz2
osx-arm64::llvmdev-9.0.1-cling_v0.9_hb344d6f_5.tar.bz2
osx-arm64::qt-main-5.15.2-h76a31b5_1.tar.bz2
osx-arm64::python-3.10.1-h70c1b39_2_cpython.tar.bz2
osx-arm64::libcurl-static-7.80.0-h8fe1914_1.tar.bz2
osx-arm64::python-3.9.10-hd16f9c5_1_cpython.tar.bz2
osx-arm64::assimp-5.1.4-h0f81e16_0.tar.bz2
osx-arm64::kaldi-5.5.992-cpu_h1234567_6.tar.bz2
osx-arm64::libopencv-4.5.5-py38hf332e9d_0.tar.bz2
osx-arm64::libvips-8.12.2-hb78e3e2_0.tar.bz2
osx-arm64::pdal-2.3.0-hf71be5e_21.tar.bz2
osx-arm64::grpcio-1.43.0-py38h740c240_0.tar.bz2
osx-arm64::libcurl-static-7.80.0-h8d07098_1.tar.bz2
osx-arm64::magics-4.10.0-h9d4519d_0.tar.bz2
osx-arm64::arrow-cpp-3.0.0-py310h98578ca_39_cpu.tar.bz2
osx-arm64::cctools_osx-arm64-973.0.1-h92b3a8a_4.tar.bz2
osx-arm64::arrow-cpp-5.0.0-py310h93f1226_19_cpu.tar.bz2
osx-arm64::arrow-cpp-3.0.0-py38h238f244_41_cpu.tar.bz2
osx-arm64::pdal-2.3.0-hf71be5e_22.tar.bz2
osx-arm64::librdkafka-1.8.2.post2-hc87a43b_0.tar.bz2
osx-arm64::slang-2.3.2-h404cfac_1003.tar.bz2
osx-arm64::gds-base-crtools-2.19.7-h2b036f6_2.tar.bz2
osx-arm64::tiledb-2.6.0-hade11cd_0.tar.bz2
osx-arm64::vtk-9.1.0-qt_py310hf4e3207_203.tar.bz2
osx-arm64::git-2.35.0-pl5321h073b8a2_0.tar.bz2
osx-arm64::dcap-2.47.12-h833117e_5.tar.bz2
osx-arm64::magics-4.10.0-he4fbcf3_1.tar.bz2
osx-arm64::librdkafka-1.7.0-h5b30705_1.tar.bz2
osx-arm64::arrow-cpp-5.0.0-py310h97a2760_21_cpu.tar.bz2
osx-arm64::cpp-opentelemetry-sdk-1.1.1-h9e580e3_2.tar.bz2
osx-arm64::vowpalwabbit-9.0.0-py39ha632e4d_3.tar.bz2
osx-arm64::gct-6.2.1629922860-hfe0bdae_0.tar.bz2
osx-arm64::hdf5-1.12.1-mpi_mpich_h0caeaa1_3.tar.bz2
osx-arm64::glib-2.70.2-hccf11d3_0.tar.bz2
osx-arm64::arrow-cpp-5.0.0-py310h413e3ef_22_cpu.tar.bz2
osx-arm64::gmsh-4.9.3-h79b900e_0.tar.bz2
osx-arm64::nodejs-16.13.0-habd0e26_2.tar.bz2
osx-arm64::arrow-cpp-6.0.1-py39hacd0981_6_cpu.tar.bz2
osx-arm64::mysql-server-8.0.27-h4a495b3_2.tar.bz2
osx-arm64::llvmdev-9.0.1-cling_v0.9_hb344d6f_7.tar.bz2
osx-arm64::r-base-4.1.1-hc29f753_2.tar.bz2
osx-arm64::mysql-client-8.0.27-hb7e94d5_2.tar.bz2
osx-arm64::libgdal-3.4.0-had24f79_10.tar.bz2
osx-arm64::orc-1.7.1-hcb6706d_1.tar.bz2
osx-arm64::r-git2r-0.29.0-r41hc56a9d0_1.tar.bz2
osx-arm64::postgresql-plpython-13.5-py310h037995a_1.tar.bz2
osx-arm64::python-3.9.10-hd16f9c5_0_cpython.tar.bz2
osx-arm64::libprotobuf-static-3.19.4-hccf11d3_0.tar.bz2
osx-arm64::geotiff-1.7.0-h0dc1598_6.tar.bz2
osx-arm64::tesseract-5.0.1-ha234a1a_0.tar.bz2
osx-arm64::hdf5-1.12.1-mpi_openmpi_h0e1e6cd_3.tar.bz2
osx-arm64::pgplot-5.2.2-h507632e_1008.tar.bz2
osx-arm64::arrow-cpp-5.0.0-py310h98578ca_20_cpu.tar.bz2
osx-arm64::sagelib-9.4-py39h546258d_1.tar.bz2
osx-arm64::dcap-2.47.12-h1b4299d_5.tar.bz2
osx-arm64::r-git2r-0.29.0-r40h0c0968c_1.tar.bz2
osx-arm64::glib-2.70.2-hccf11d3_1.tar.bz2
osx-arm64::nodejs-16.13.0-h15390d4_1.tar.bz2
osx-arm64::libgdal-3.4.0-h5f4cd30_9.tar.bz2
osx-arm64::cctools_osx-arm64-973.0.1-h92b3a8a_3.tar.bz2
osx-arm64::llvmdev-9.0.1-default_he95f5d9_6.tar.bz2
osx-arm64::libopencv-4.5.5-py39hb8da993_0.tar.bz2
osx-arm64::vowpalwabbit-8.11.0-py38h8080f16_2.tar.bz2
osx-arm64::xrootd-5.3.4-py310h929af54_0.tar.bz2
osx-arm64::arrow-cpp-5.0.0-py38h1104dbe_19_cpu.tar.bz2
osx-arm64::ruby-2.7.2-h39ff962_8.tar.bz2
osx-arm64::cctools_osx-arm64-973.0.1-ha8964d5_5.tar.bz2
osx-arm64::zstd-1.5.1-h861e0a7_0.tar.bz2
osx-arm64::xrootd-5.3.4-py38h9a6776d_0.tar.bz2
osx-arm64::vowpalwabbit-9.0.0-py38h8080f16_2.tar.bz2
osx-arm64::libgdal-3.4.1-he61a94d_1.tar.bz2
osx-arm64::libgdal-3.3.3-had24f79_12.tar.bz2
osx-arm64::libgdal-3.4.1-hb5cd603_1.tar.bz2
osx-arm64::pyreadstat-1.1.4-py310h5363a0e_0.tar.bz2
osx-arm64::arrow-cpp-5.0.0-py39h3d853ae_19_cpu.tar.bz2
osx-arm64::plumed-2.7.3-nompi_h26e5bd4_100.tar.bz2
osx-arm64::libgdal-3.4.1-hd4f1285_0.tar.bz2
osx-arm64::pdal-2.3.0-h3df0c14_21.tar.bz2
osx-arm64::llvmlite-0.38.0-py310h1ef11ee_0.tar.bz2
osx-arm64::kaldi-5.5.992-cpu_h1234567_7.tar.bz2
osx-arm64::tiledb-2.6.1-hade11cd_0.tar.bz2
osx-arm64::pdal-2.3.0-h3df0c14_22.tar.bz2
osx-arm64::arrow-cpp-3.0.0-py39hacd0981_40_cpu.tar.bz2
osx-arm64::python-3.9.10-h38ef502_1_cpython.tar.bz2
osx-arm64::kaldi-5.5.992-cpu_h1234567_5.tar.bz2
osx-arm64::libprotobuf-3.19.3-hccf11d3_0.tar.bz2
osx-arm64::nss-3.73-h353d031_0.tar.bz2
osx-arm64::gds-services-2.19.7-h96f5bf0_1.tar.bz2
osx-arm64::orc-1.7.2-hcb6706d_0.tar.bz2
osx-arm64::cpp-opentelemetry-sdk-1.1.1-h2a3385c_0.tar.bz2
osx-arm64::gsoap-2.8.118-h012ac28_0.tar.bz2
osx-arm64::arrow-cpp-3.0.0-py39h954ee65_37_cpu.tar.bz2
osx-arm64::gds-base-crtools-2.19.7-h2b036f6_1.tar.bz2
osx-arm64::gds-base-monitors-2.19.7-h96f5bf0_2.tar.bz2
osx-arm64::nodejs-17.1.0-habd0e26_2.tar.bz2
osx-arm64::pyreadstat-1.1.4-py39h3753aae_0.tar.bz2
osx-arm64::gds-base-monitors-2.19.7-h96f5bf0_1.tar.bz2
osx-arm64::vowpalwabbit-9.0.0-py310h57bf9b6_2.tar.bz2
osx-arm64::nodejs-16.13.2-habd0e26_2.tar.bz2
osx-arm64::ogre-13.2.1-h0aef09b_0.tar.bz2
osx-arm64::mysql-server-8.0.27-h4a495b3_3.tar.bz2
osx-arm64::gmsh-4.9.3-h78df4b7_1.tar.bz2
osx-arm64::libprotobuf-3.19.2-hccf11d3_0.tar.bz2
osx-arm64::ogre-13.2.4-h0aef09b_0.tar.bz2
osx-arm64::gds-base-2.19.7-h7a27528_1.tar.bz2
osx-arm64::python-3.8.12-hab31e5c_3_cpython.tar.bz2
osx-arm64::assimp-5.1.5-h0f81e16_0.tar.bz2
osx-arm64::cpp-opentelemetry-sdk-1.1.0-h2a3385c_4.tar.bz2
osx-arm64::arrow-cpp-6.0.1-py310hf96f744_3_cpu.tar.bz2
osx-arm64::arrow-cpp-5.0.0-py39hacd0981_21_cpu.tar.bz2
osx-arm64::pdal-2.3.0-h7e67ea8_24.tar.bz2
osx-arm64::pdal-2.3.0-hd9aad4c_16.tar.bz2
osx-arm64::libfido2-1.10.0-he4cd7f6_0.tar.bz2
osx-arm64::python-3.8.12-hd949e87_3_cpython.tar.bz2
osx-arm64::libgdal-3.4.0-hca92387_9.tar.bz2
osx-arm64::imagemagick-7.1.0_18-pl5321hc21dce0_0.tar.bz2
osx-arm64::pytables-3.7.0-py38h37503a7_0.tar.bz2
osx-arm64::gds-services-2.19.7-h96f5bf0_3.tar.bz2
osx-arm64::arrow-cpp-3.0.0-py310h97a2760_40_cpu.tar.bz2
osx-arm64::mysql-libs-8.0.27-h577abee_3.tar.bz2
osx-arm64::root_base-6.24.6-py310h41e58fc_1.tar.bz2
osx-arm64::arrow-cpp-3.0.0-py310h93f1226_38_cpu.tar.bz2
osx-arm64::tiledb-2.6.0-h42267fc_0.tar.bz2
osx-arm64::arrow-cpp-6.0.1-py39h3d853ae_4_cpu.tar.bz2
osx-arm64::python-3.10.1-h43b31ca_0_cpython.tar.bz2
osx-arm64::curl-7.81.0-h8d07098_0.tar.bz2
osx-arm64::zstd-1.5.2-h861e0a7_0.tar.bz2
osx-arm64::vtk-9.1.0-qt_py38h9616c39_203.tar.bz2
osx-arm64::libgdal-3.3.3-hea1255b_12.tar.bz2
osx-arm64::arrow-cpp-3.0.0-py39h3d853ae_38_cpu.tar.bz2
osx-arm64::pdal-2.3.0-h1d22f53_23.tar.bz2
osx-arm64::grpc-cpp-1.42.0-hcb46328_1.tar.bz2
osx-arm64::protozfits-2.0.1.post1-py38h072c5dd_7.tar.bz2
osx-arm64::gfal2-2.20.3-h6659f22_1.tar.bz2
osx-arm64::hdf5-1.12.1-nompi_h829dc4f_103.tar.bz2
osx-arm64::libopencv-4.5.3-py39ha483e44_6.tar.bz2
osx-arm64::tensorflow-base-2.6.2-cpu_py39hd39b1ba_2.tar.bz2
osx-arm64::python-3.10.2-h43b31ca_0_cpython.tar.bz2
osx-arm64::libgsf-1.14.48-h7090ae8_0.tar.bz2
osx-arm64::arrow-cpp-6.0.1-py38h238f244_8_cpu.tar.bz2
osx-arm64::postgresql-plpython-13.5-py38hc74b889_1.tar.bz2
osx-arm64::python-3.9.9-h70c1b39_0_cpython.tar.bz2
osx-arm64::mysql-client-8.0.28-hb7e94d5_0.tar.bz2
osx-arm64::libnghttp2-1.46.0-h62a264d_0.tar.bz2
osx-arm64::libopencv-4.5.3-py38h6a05b4b_6.tar.bz2
osx-arm64::vtk-9.0.1-qt_py310hb7cf415_210.tar.bz2
osx-arm64::vowpalwabbit-8.11.0-py39ha632e4d_2.tar.bz2
osx-arm64::libgdal-3.4.0-hea1255b_10.tar.bz2
osx-arm64::python-3.10.1-h70c1b39_0_cpython.tar.bz2
osx-arm64::libgdal-3.4.1-hbb1e90a_0.tar.bz2
osx-arm64::cctools_osx-64-973.0.1-hed2cfe4_4.tar.bz2
osx-arm64::mesalib-21.2.5-h25af579_3.tar.bz2
osx-arm64::mysql-libs-8.0.28-h577abee_0.tar.bz2
osx-arm64::cppyy-cling-6.25.2-py39h300d7f1_0.tar.bz2
osx-arm64::libgdal-3.3.3-h5f4cd30_11.tar.bz2
osx-arm64::arrow-cpp-3.0.0-py39h71c7f51_39_cpu.tar.bz2
osx-arm64::postgresql-13.5-h9a9b6fe_1.tar.bz2
osx-arm64::pyinstaller-4.8-py38h95a778e_0.tar.bz2
osx-arm64::cpp-opentelemetry-sdk-1.1.1-h9e580e3_1.tar.bz2
osx-arm64::postgresql-plpython-13.5-py38h3fd6ac3_1.tar.bz2
osx-arm64::libgdal-3.4.0-h40813d5_11.tar.bz2
osx-arm64::mysql-connector-cpp-8.0.28-hf288942_0.tar.bz2
osx-arm64::xrootd-5.4.0-py38h9a6776d_0.tar.bz2
osx-arm64::llvmlite-0.38.0-py39h3235a92_0.tar.bz2
osx-arm64::pdal-2.3.0-h9f966fa_24.tar.bz2
osx-arm64::libpq-13.5-h2f670be_1.tar.bz2
osx-arm64::libgdal-3.3.3-hb5cd603_14.tar.bz2
osx-arm64::cppyy-cling-6.25.2-py310ha8278a6_0.tar.bz2
osx-arm64::arrow-cpp-6.0.1-py39h9172ee1_8_cpu.tar.bz2
osx-arm64::graphviz-2.50.0-h2097151_1.tar.bz2
osx-arm64::python-3.9.10-h38ef502_0_cpython.tar.bz2
osx-arm64::arrow-cpp-3.0.0-py39h9172ee1_41_cpu.tar.bz2
osx-arm64::python-3.10.2-hd16f9c5_1_cpython.tar.bz2
osx-arm64::pdal-2.3.0-h770894b_18.tar.bz2
osx-arm64::imagemagick-7.1.0_21-pl5321hc21dce0_0.tar.bz2
osx-arm64::pyinstaller-4.8-py39h3753aae_0.tar.bz2
osx-arm64::sagelib-9.4-py38h07b73e2_1.tar.bz2
osx-arm64::arrow-cpp-3.0.0-py38h458bdf1_40_cpu.tar.bz2
osx-arm64::postgresql-plpython-13.5-py39h9cfb23c_1.tar.bz2
osx-arm64::arrow-cpp-6.0.1-py38h1104dbe_4_cpu.tar.bz2
osx-arm64::ruby-3.1.0-hf84e2a5_1.tar.bz2
osx-arm64::mosh-1.3.2-pl5321h848afb5_1011.tar.bz2
osx-arm64::arrow-cpp-5.0.0-py310hf96f744_18_cpu.tar.bz2
osx-arm64::ogre-13.2.3-h0aef09b_0.tar.bz2
osx-arm64::librdkafka-1.3.0-hc87a43b_1.tar.bz2
osx-arm64::assimp-5.1.0-h0f81e16_0.tar.bz2
osx-arm64::libgdal-3.3.3-hd4f1285_13.tar.bz2
osx-arm64::cctools_osx-64-973.0.1-hed2cfe4_3.tar.bz2
osx-arm64::arrow-cpp-5.0.0-py38hec0ad9d_20_cpu.tar.bz2
osx-arm64::assimp-5.1.3-h0f81e16_1.tar.bz2
osx-arm64::libgdal-3.3.3-h4176159_15.tar.bz2
osx-arm64::libcurl-7.80.0-h8d07098_1.tar.bz2
osx-arm64::ruby-3.1.0-h39ff962_1.tar.bz2
osx-arm64::arrow-cpp-3.0.0-py38h1104dbe_38_cpu.tar.bz2
osx-arm64::libsoup-2.74.1-h3e8c93f_0.tar.bz2
osx-arm64::gds-base-gdstrig-2.19.7-h90de5f7_2.tar.bz2
osx-arm64::r-git2r-0.29.0-r41h0c0968c_0.tar.bz2
osx-arm64::nss-3.74-h353d031_0.tar.bz2
osx-arm64::pdal-2.3.0-h770894b_17.tar.bz2
osx-arm64::librdkafka-1.3.0-h5b30705_1.tar.bz2
osx-arm64::r-git2r-0.29.0-r41hc56a9d0_0.tar.bz2
osx-arm64::libopencv-4.5.3-py39hb8da993_7.tar.bz2
osx-arm64::graphviz-2.50.0-h2097151_0.tar.bz2
osx-arm64::tiledb-2.5.3-hade11cd_0.tar.bz2
osx-arm64::arrow-cpp-6.0.1-py310h97a2760_6_cpu.tar.bz2
osx-arm64::libspatialite-5.0.1-h94acc99_13.tar.bz2
osx-arm64::git-2.35.0-pl5321hfe47735_0.tar.bz2
osx-arm64::libgdal-3.4.1-h4176159_2.tar.bz2
osx-arm64::tensorflow-base-2.6.2-cpu_py38hb0db4bb_2.tar.bz2
osx-arm64::grpcio-1.43.0-py39h18b86b0_0.tar.bz2
osx-arm64::libglib-2.70.2-h67e64d8_0.tar.bz2
osx-arm64::arrow-cpp-3.0.0-py38ha587dc1_37_cpu.tar.bz2
osx-arm64::pyinstaller-4.8-py310h5363a0e_0.tar.bz2
osx-arm64::vowpalwabbit-9.0.0-py310h57bf9b6_3.tar.bz2
osx-arm64::gds-base-2.19.7-h7a27528_3.tar.bz2
osx-arm64::postgresql-13.5-h8fdef8c_1.tar.bz2
osx-arm64::tiledb-2.5.3-h42267fc_0.tar.bz2
osx-arm64::nodejs-17.4.0-h15390d4_0.tar.bz2
osx-arm64::r-git2r-0.29.0-r40hc56a9d0_1.tar.bz2
osx-arm64::kaldi-5.5.992-cpu_h1234567_8.tar.bz2
osx-arm64::poppler-22.01.0-hb0dbcdf_0.tar.bz2
osx-arm64::libgdal-3.3.3-hd607cb8_15.tar.bz2
osx-arm64::libgdal-3.3.3-hbb1e90a_13.tar.bz2
osx-arm64::cairomm-1.0-1.12.2-h580c98b_4.tar.bz2
osx-arm64::nodejs-17.1.0-h15390d4_2.tar.bz2
osx-arm64::xrootd-5.3.4-py39h54297fd_0.tar.bz2
osx-arm64::arrow-cpp-6.0.1-py39h71c7f51_5_cpu.tar.bz2
osx-arm64::libprotobuf-3.19.4-hccf11d3_0.tar.bz2
osx-arm64::wxpython-4.1.1-py310hb6bc216_3.tar.bz2
osx-arm64::mysql-client-8.0.27-hb7e94d5_3.tar.bz2
osx-arm64::arrow-cpp-3.0.0-py310hf96f744_37_cpu.tar.bz2
osx-arm64::imagemagick-7.1.0_20-pl5321hc21dce0_0.tar.bz2
osx-arm64::librdkafka-1.7.0-hc87a43b_1.tar.bz2
-    "libzlib >=1.2.11,<1.3.0a0",
+    "libzlib >=1.2.11,<2.0.0a0",
osx-arm64::libclang-cpp-9.0.1-root_62400_h1f0147e_3.tar.bz2
osx-arm64::libclang-cpp-9.0.1-default_h2c105f5_3.tar.bz2
osx-arm64::glib-tools-2.70.2-hccf11d3_0.tar.bz2
osx-arm64::libclang-cpp9-9.0.1-root_62400_h1f0147e_3.tar.bz2
osx-arm64::cpp-opentelemetry-sdk-1.1.0-h4db3e9a_3.tar.bz2
osx-arm64::dotnet-aspnetcore-6.0.1-hd68eb72_0.tar.bz2
osx-arm64::libclang-cpp9-9.0.1-cling_v0.9_h7a49ca7_3.tar.bz2
osx-arm64::libllvm9-9.0.1-default_he95f5d9_6.tar.bz2
osx-arm64::libllvm9-9.0.1-default_he95f5d9_7.tar.bz2
osx-arm64::libllvm9-9.0.1-cling_v0.9_hb344d6f_7.tar.bz2
osx-arm64::llvm-9.0.1-cling_v0.9_h5d1009f_5.tar.bz2
osx-arm64::libllvm9-9.0.1-cling_v0.9_hb344d6f_6.tar.bz2
osx-arm64::libclang-cpp-9.0.1-cling_v0.9_h7a49ca7_3.tar.bz2
osx-arm64::llvm-tools-9.0.1-default_he95f5d9_6.tar.bz2
osx-arm64::gst-plugins-base-1.18.5-h5bf8608_3.tar.bz2
osx-arm64::llvm-9.0.1-cling_v0.9_h5d1009f_6.tar.bz2
osx-arm64::dotnet-sdk-6.0.101-hd68eb72_0.tar.bz2
osx-arm64::dotnet-runtime-6.0.1-hd68eb72_0.tar.bz2
osx-arm64::clang-9-9.0.1-default_h2c105f5_3.tar.bz2
osx-arm64::gst-plugins-good-1.18.5-hda84e41_3.tar.bz2
osx-arm64::llvm-tools-9.0.1-cling_v0.9_hb344d6f_7.tar.bz2
osx-arm64::libllvm9-9.0.1-cling_v0.9_hb344d6f_5.tar.bz2
osx-arm64::glib-tools-2.70.2-hccf11d3_1.tar.bz2
osx-arm64::llvm-tools-9.0.1-cling_v0.9_hb344d6f_6.tar.bz2
osx-arm64::clang-9-9.0.1-root_62400_h1f0147e_3.tar.bz2
osx-arm64::liblal-7.1.6-fftw_h0bee9d2_101.tar.bz2
osx-arm64::llvm-9.0.1-default_hcc7b2e0_7.tar.bz2
osx-arm64::llvm-tools-9.0.1-default_he95f5d9_7.tar.bz2
osx-arm64::gcab-1.4-hfefc3ef_0.tar.bz2
osx-arm64::libclang-cpp9-9.0.1-default_h2c105f5_3.tar.bz2
osx-arm64::coin-or-utils-2.11.6-h8c5c8f5_0.tar.bz2
osx-arm64::llvm-tools-9.0.1-cling_v0.9_hb344d6f_5.tar.bz2
osx-arm64::llvm-9.0.1-default_hcc7b2e0_5.tar.bz2
osx-arm64::llvm-9.0.1-cling_v0.9_h5d1009f_7.tar.bz2
osx-arm64::pocl-1.8-h422b2f1_1.tar.bz2
osx-arm64::liblal-7.1.6-fftw_h0bee9d2_100.tar.bz2
osx-arm64::llvm-tools-9.0.1-default_he95f5d9_5.tar.bz2
osx-arm64::llvm-9.0.1-default_hcc7b2e0_6.tar.bz2
osx-arm64::libllvm9-9.0.1-default_he95f5d9_5.tar.bz2
osx-arm64::pocl-1.8-h422b2f1_0.tar.bz2
osx-arm64::liblal-7.1.4-fftw_h079364a_101.tar.bz2
osx-arm64::liblal-7.1.5-fftw_h0bee9d2_100.tar.bz2
osx-arm64::clang-9-9.0.1-cling_v0.9_h7a49ca7_3.tar.bz2
-    "libzlib >=1.2.11,<1.3.0a0"
+    "libzlib >=1.2.11,<2.0.0a0"
================================================================================
================================================================================
linux-ppc64le
linux-ppc64le::assimp-5.1.3-h0cf024e_1.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py38h172aaef_37_cpu.tar.bz2
linux-ppc64le::postgresql-plpython-13.5-py37h3bad2af_1.tar.bz2
linux-ppc64le::xrootd-5.3.4-py39h62e8dc7_0.tar.bz2
linux-ppc64le::python-3.10.1-h144377c_1_cpython.tar.bz2
linux-ppc64le::pdal-2.3.0-h316c8a8_23.tar.bz2
linux-ppc64le::mapserver-7.6.4-py39h6d4e14f_4.tar.bz2
linux-ppc64le::grpc-cpp-1.43.0-hdd29dff_0.tar.bz2
linux-ppc64le::omniorb-4.2.5-py310h68addab_0.tar.bz2
linux-ppc64le::postgresql-13.5-h90e3369_0.tar.bz2
linux-ppc64le::librdkafka-1.3.0-h76f88f1_3.tar.bz2
linux-ppc64le::gct-6.2.1629922860-habf8a3a_0.tar.bz2
linux-ppc64le::vtk-9.1.0-qt_py310h19b6d7b_203.tar.bz2
linux-ppc64le::pyinstaller-4.8-py39h322ed45_0.tar.bz2
linux-ppc64le::libprotobuf-static-3.19.2-h690f14c_0.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py38h269dbca_40_cpu.tar.bz2
linux-ppc64le::libglib-2.70.2-hd362787_0.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py37h2e13c3e_19_cpu.tar.bz2
linux-ppc64le::postgresql-plpython-13.5-py39hd2607ca_1.tar.bz2
linux-ppc64le::grpc-cpp-1.43.0-hacf608f_0.tar.bz2
linux-ppc64le::libsoup-2.74.0-h48114a4_0.tar.bz2
linux-ppc64le::gmsh-4.9.3-h6ed5c81_1.tar.bz2
linux-ppc64le::r-git2r-0.29.0-r41h745f0ae_1.tar.bz2
linux-ppc64le::xrootd-5.4.0-py39h62e8dc7_0.tar.bz2
linux-ppc64le::libspatialite-5.0.1-ha2d8625_13.tar.bz2
linux-ppc64le::assimp-5.1.4-h0cf024e_0.tar.bz2
linux-ppc64le::libcups-2.3.3-h9498048_1.tar.bz2
linux-ppc64le::git-2.35.0-pl5321h2a10221_0.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py37hf6629b9_3_cpu.tar.bz2
linux-ppc64le::cpp-opentelemetry-sdk-1.1.1-h710d41a_1.tar.bz2
linux-ppc64le::grpcio-1.43.0-py39hfeb9d76_0.tar.bz2
linux-ppc64le::python-3.10.1-h144377c_0_cpython.tar.bz2
linux-ppc64le::python-3.6.15-h57873ef_0_cpython.tar.bz2
linux-ppc64le::python-3.10.2-h144377c_0_cpython.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py39ha31dbce_5_cpu.tar.bz2
linux-ppc64le::tesseract-4.1.3-h2694a26_6.tar.bz2
linux-ppc64le::python-3.9.9-h3e5bdd0_0_cpython.tar.bz2
linux-ppc64le::grpcio-1.43.0-py38h62e2ba2_0.tar.bz2
linux-ppc64le::xrootd-5.4.0-py310h42d25e8_0.tar.bz2
linux-ppc64le::pytables-3.7.0-py310h1ab04c3_0.tar.bz2
linux-ppc64le::postgresql-plpython-13.5-py39h9cd38fc_1.tar.bz2
linux-ppc64le::xrootd-5.3.4-py310h42d25e8_0.tar.bz2
linux-ppc64le::vowpalwabbit-9.0.0-py38hddc5d0c_3.tar.bz2
linux-ppc64le::vowpalwabbit-9.0.0-py37h7b6ee61_2.tar.bz2
linux-ppc64le::pyinstaller-4.8-py38h6c92f57_0.tar.bz2
linux-ppc64le::llvmlite-0.38.0-py310h8d42d4a_0.tar.bz2
linux-ppc64le::grpcio-1.43.0-py37h349bca1_0.tar.bz2
linux-ppc64le::xrootd-5.3.4-py38h9db2268_0.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py39h4f6f96d_3_cpu.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py38hc6ecb2e_5_cpu.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py38hd47744f_19_cpu.tar.bz2
linux-ppc64le::cppyy-cling-6.25.2-py39h3ff9066_1.tar.bz2
linux-ppc64le::orc-1.7.1-h5df204f_1.tar.bz2
linux-ppc64le::libgdal-3.4.0-h59d179c_12.tar.bz2
linux-ppc64le::libpq-13.5-h3e31190_1.tar.bz2
linux-ppc64le::mesalib-21.2.5-ha5911c8_3.tar.bz2
linux-ppc64le::vowpalwabbit-8.11.0-py38hddc5d0c_2.tar.bz2
linux-ppc64le::llvmlite-0.38.0-py37h710df86_0.tar.bz2
linux-ppc64le::nodejs-16.13.2-he9a8890_2.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py39h712ea77_41_cpu.tar.bz2
linux-ppc64le::squashfuse-0.1.104-h1604791_1.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py310h4891621_8_cpu.tar.bz2
linux-ppc64le::tiledb-2.5.3-hadab2f2_0.tar.bz2
linux-ppc64le::python-3.10.2-h3e5bdd0_0_cpython.tar.bz2
linux-ppc64le::xrootd-5.4.0-py38h9db2268_0.tar.bz2
linux-ppc64le::libgdal-3.4.1-hc9d1d0e_2.tar.bz2
linux-ppc64le::r-git2r-0.29.0-r40h745f0ae_1.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py39h712ea77_8_cpu.tar.bz2
linux-ppc64le::mapserver-7.6.4-py37h1b2e9d5_4.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py37h4f673f8_39_cpu.tar.bz2
linux-ppc64le::ogre-13.2.3-h77e483d_0.tar.bz2
linux-ppc64le::gfal2-2.20.3-hfa6c224_1.tar.bz2
linux-ppc64le::llvmlite-0.38.0-py39h06fb8b6_0.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py39h712ea77_7_cpu.tar.bz2
linux-ppc64le::root_base-6.24.6-py38h8e45062_1.tar.bz2
linux-ppc64le::nordugrid-arc-6.14.0-py38h6bd1bec_0.tar.bz2
linux-ppc64le::ogre-13.2.2-h820d8c4_0.tar.bz2
linux-ppc64le::libcurl-static-7.81.0-he415e40_0.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py310hd761061_5_cpu.tar.bz2
linux-ppc64le::vowpalwabbit-8.11.0-py310h82fb54c_2.tar.bz2
linux-ppc64le::tiledb-2.6.0-hadab2f2_0.tar.bz2
linux-ppc64le::nodejs-17.4.0-he9a8890_0.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py39ha31dbce_39_cpu.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py38h598059b_8_cpu.tar.bz2
linux-ppc64le::hdf5-1.12.1-mpi_mpich_h39002f4_3.tar.bz2
linux-ppc64le::mysql-router-8.0.28-hdfabd79_0.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py310hd48bae2_6_cpu.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py39hf59e8c7_6_cpu.tar.bz2
linux-ppc64le::root_base-6.24.6-py37hb27b15c_2.tar.bz2
linux-ppc64le::r-base-4.1.2-hdf7a977_1.tar.bz2
linux-ppc64le::libgdal-3.4.0-heef2b06_13.tar.bz2
linux-ppc64le::postgresql-plpython-13.5-py37h5d2c8f2_0.tar.bz2
linux-ppc64le::libprotobuf-3.19.2-h690f14c_0.tar.bz2
linux-ppc64le::curl-7.81.0-he415e40_0.tar.bz2
linux-ppc64le::gsoap-2.8.118-h2b0589b_0.tar.bz2
linux-ppc64le::libgdal-3.3.3-ha6b820c_14.tar.bz2
linux-ppc64le::pdal-2.3.0-h439521c_23.tar.bz2
linux-ppc64le::libopencv-4.5.5-py39h8d7d62e_0.tar.bz2
linux-ppc64le::libopencv-4.5.3-py39hf5a0a19_6.tar.bz2
linux-ppc64le::nodejs-17.4.0-h2502c7a_0.tar.bz2
linux-ppc64le::libgdal-3.4.0-hcae29e1_9.tar.bz2
linux-ppc64le::cppyy-cling-6.25.2-py37h9b2364d_0.tar.bz2
linux-ppc64le::vowpalwabbit-8.11.0-py39h9313748_2.tar.bz2
linux-ppc64le::ruby-3.1.0-h7a0a435_1.tar.bz2
linux-ppc64le::assimp-5.1.5-h0cf024e_0.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py310hd761061_20_cpu.tar.bz2
linux-ppc64le::postgresql-13.5-h7cbc9f4_1.tar.bz2
linux-ppc64le::ruby-2.7.2-ha4e8978_8.tar.bz2
linux-ppc64le::ruby-3.1.0-h6c26aca_1.tar.bz2
linux-ppc64le::mapserver-7.6.4-py310h4399d55_4.tar.bz2
linux-ppc64le::libgsf-1.14.48-h4174a71_0.tar.bz2
linux-ppc64le::python-3.10.1-h3e5bdd0_0_cpython.tar.bz2
linux-ppc64le::libgdal-3.4.1-h2da5e39_2.tar.bz2
linux-ppc64le::libnghttp2-1.46.0-h66fdf1b_0.tar.bz2
linux-ppc64le::omniorb-4.2.5-py38h62e2ba2_0.tar.bz2
linux-ppc64le::r-base-4.1.2-h33b8345_0.tar.bz2
linux-ppc64le::llvmdev-9.0.1-default_h522564a_7.tar.bz2
linux-ppc64le::nodejs-16.13.0-h2502c7a_1.tar.bz2
linux-ppc64le::orc-1.7.2-h5df204f_0.tar.bz2
linux-ppc64le::pdal-2.3.0-h59a7a53_16.tar.bz2
linux-ppc64le::nodejs-16.13.0-he9a8890_2.tar.bz2
linux-ppc64le::python-3.8.12-hf10f7f0_3_cpython.tar.bz2
linux-ppc64le::assimp-5.2.0-h0cf024e_1.tar.bz2
linux-ppc64le::root_base-6.24.6-py39h53a1a56_1.tar.bz2
linux-ppc64le::mapserver-7.6.4-py39haa7aba4_5.tar.bz2
linux-ppc64le::r-git2r-0.29.0-r40h61fa1b9_1.tar.bz2
linux-ppc64le::libcurl-7.81.0-he415e40_0.tar.bz2
linux-ppc64le::mongodb-5.1.1-h725f506_0.tar.bz2
linux-ppc64le::libgdal-3.3.3-h50de17c_11.tar.bz2
linux-ppc64le::zstd-1.5.1-h65c4b1a_0.tar.bz2
linux-ppc64le::libopencv-4.5.3-py31h7f6d45c_6.tar.bz2
linux-ppc64le::postgresql-plpython-13.5-py310hc1f076e_0.tar.bz2
linux-ppc64le::libgdal-3.3.3-hc9d1d0e_15.tar.bz2
linux-ppc64le::postgresql-plpython-13.5-py38hc51dd72_1.tar.bz2
linux-ppc64le::poppler-22.01.0-h3df3d46_0.tar.bz2
linux-ppc64le::root_base-6.24.6-py310hf662311_2.tar.bz2
linux-ppc64le::pdal-2.3.0-h06d462f_17.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py37hf6629b9_37_cpu.tar.bz2
linux-ppc64le::libpq-13.5-he9d5e3e_1.tar.bz2
linux-ppc64le::llvmdev-9.0.1-cling_v0.9_h38e9fbe_6.tar.bz2
linux-ppc64le::libgdal-3.3.3-heef2b06_13.tar.bz2
linux-ppc64le::pdal-2.3.0-hac1458d_21.tar.bz2
linux-ppc64le::libopencv-4.5.3-py31h5f6ef38_7.tar.bz2
linux-ppc64le::grpcio-1.43.0-py39hff9cdcc_0.tar.bz2
linux-ppc64le::glib-2.70.2-h690f14c_1.tar.bz2
linux-ppc64le::omniorb-libs-4.2.5-h66fdf1b_0.tar.bz2
linux-ppc64le::geotiff-1.7.0-h265ee3c_6.tar.bz2
linux-ppc64le::python-3.10.2-h1456e17_2_cpython.tar.bz2
linux-ppc64le::libcurl-static-7.80.0-h3643067_1.tar.bz2
linux-ppc64le::python-3.9.10-h1456e17_1_cpython.tar.bz2
linux-ppc64le::cpp-opentelemetry-sdk-1.1.1-hef4517b_0.tar.bz2
linux-ppc64le::hdf5-1.12.1-nompi_h245c221_103.tar.bz2
linux-ppc64le::tesseract-5.0.0-h2694a26_1.tar.bz2
linux-ppc64le::libgdal-3.3.3-hfac28de_13.tar.bz2
linux-ppc64le::libopencv-4.5.3-py37hf4de090_6.tar.bz2
linux-ppc64le::nordugrid-arc-6.14.0-py38h880d361_1.tar.bz2
linux-ppc64le::git-2.35.0-pl5321h29e2a4d_0.tar.bz2
linux-ppc64le::omniorb-4.2.5-py37h349bca1_0.tar.bz2
linux-ppc64le::root_base-6.24.6-py39h53a1a56_2.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py310hd48bae2_40_cpu.tar.bz2
linux-ppc64le::vtk-9.0.1-qt_py38h4be3717_210.tar.bz2
linux-ppc64le::python-3.10.2-h1456e17_1_cpython.tar.bz2
linux-ppc64le::libcurl-7.81.0-h3643067_0.tar.bz2
linux-ppc64le::pdal-2.3.0-h1551cb4_24.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py39ha31dbce_20_cpu.tar.bz2
linux-ppc64le::mysql-server-8.0.28-he877b2a_0.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py310h4891621_41_cpu.tar.bz2
linux-ppc64le::libprotobuf-static-3.19.4-h690f14c_0.tar.bz2
linux-ppc64le::graphviz-2.50.0-h3ed3169_0.tar.bz2
linux-ppc64le::root_base-6.24.6-py37hb27b15c_1.tar.bz2
linux-ppc64le::libgdal-3.3.3-h01dbba9_12.tar.bz2
linux-ppc64le::mysql-libs-8.0.27-ha23194b_2.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py37hbd2d5a2_22_cpu.tar.bz2
linux-ppc64le::libgdal-3.4.0-h96b54f2_11.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py38h269dbca_6_cpu.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py39h4f6f96d_37_cpu.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py38h172aaef_18_cpu.tar.bz2
linux-ppc64le::xrootd-5.4.0-py37h26c0cc5_0.tar.bz2
linux-ppc64le::grpcio-1.43.0-py310hbc3273a_0.tar.bz2
linux-ppc64le::mysql-client-8.0.27-ha7fd285_2.tar.bz2
linux-ppc64le::mapserver-7.6.4-py38h61cae44_4.tar.bz2
linux-ppc64le::mapserver-7.6.4-py38h6b88cd3_5.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py310h15ba4cf_3_cpu.tar.bz2
linux-ppc64le::grpc-cpp-1.42.0-hdd29dff_1.tar.bz2
linux-ppc64le::mosh-1.3.2-pl5321hb5da3aa_1011.tar.bz2
linux-ppc64le::libprotobuf-3.19.4-h690f14c_0.tar.bz2
linux-ppc64le::libopencv-4.5.3-py38ha34fcec_7.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py310h4c10a2b_38_cpu.tar.bz2
linux-ppc64le::libgdal-3.4.0-h01dbba9_10.tar.bz2
linux-ppc64le::cpp-opentelemetry-sdk-1.1.0-hef4517b_4.tar.bz2
linux-ppc64le::xrootd-5.3.4-py37h26c0cc5_0.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py37hbd2d5a2_7_cpu.tar.bz2
linux-ppc64le::mysql-router-8.0.27-hdfabd79_2.tar.bz2
linux-ppc64le::mapserver-7.6.4-py37haf7c467_5.tar.bz2
linux-ppc64le::mysql-server-8.0.27-he877b2a_2.tar.bz2
linux-ppc64le::r-base-4.1.1-h33b8345_2.tar.bz2
linux-ppc64le::libgdal-3.4.1-heef2b06_0.tar.bz2
linux-ppc64le::vowpalwabbit-9.0.0-py39h9313748_3.tar.bz2
linux-ppc64le::pytables-3.7.0-py38h07b7bad_0.tar.bz2
linux-ppc64le::nodejs-14.18.3-hc9e7881_2.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py38hd47744f_38_cpu.tar.bz2
linux-ppc64le::llvmdev-9.0.1-cling_v0.9_h38e9fbe_7.tar.bz2
linux-ppc64le::cppyy-cling-6.25.2-py39h3ff9066_0.tar.bz2
linux-ppc64le::tiledb-2.6.2-hadab2f2_0.tar.bz2
linux-ppc64le::tesseract-5.0.1-h2694a26_0.tar.bz2
linux-ppc64le::pdal-2.3.0-h06d462f_18.tar.bz2
linux-ppc64le::libcurl-static-7.81.0-h3643067_0.tar.bz2
linux-ppc64le::libgdal-3.4.1-hfac28de_0.tar.bz2
linux-ppc64le::ogre-13.2.4-h77e483d_0.tar.bz2
linux-ppc64le::python-3.10.2-hb23fad7_2_cpython.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py38h598059b_22_cpu.tar.bz2
linux-ppc64le::nss-3.73-ha04f6ab_0.tar.bz2
linux-ppc64le::python-3.9.9-h144377c_0_cpython.tar.bz2
linux-ppc64le::nodejs-14.17.4-hc72f780_1.tar.bz2
linux-ppc64le::libgdal-3.3.3-hcae29e1_11.tar.bz2
linux-ppc64le::libgsf-1.14.47-h4174a71_4.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py37hbd2d5a2_8_cpu.tar.bz2
linux-ppc64le::tiledb-2.6.2-h5191074_0.tar.bz2
linux-ppc64le::pdal-2.3.0-h6ad39b2_21.tar.bz2
linux-ppc64le::pytables-3.7.0-py37h16cf26d_0.tar.bz2
linux-ppc64le::assimp-5.1.0-h0cf024e_1.tar.bz2
linux-ppc64le::pyinstaller-4.8-py37h8701beb_0.tar.bz2
linux-ppc64le::llvmdev-9.0.1-cling_v0.9_h38e9fbe_5.tar.bz2
linux-ppc64le::libnghttp2-1.46.0-h42039ad_0.tar.bz2
linux-ppc64le::librdkafka-1.7.0-h76f88f1_1.tar.bz2
linux-ppc64le::libopencv-4.5.3-py38h9208ff7_6.tar.bz2
linux-ppc64le::vowpalwabbit-9.0.0-py310h82fb54c_2.tar.bz2
linux-ppc64le::vowpalwabbit-9.0.0-py37h7b6ee61_3.tar.bz2
linux-ppc64le::hdf5-1.12.1-mpi_mpich_hda62196_3.tar.bz2
linux-ppc64le::pdal-2.3.0-h6ad39b2_22.tar.bz2
linux-ppc64le::libgdal-3.4.0-hfac28de_13.tar.bz2
linux-ppc64le::mysql-client-8.0.28-ha7fd285_0.tar.bz2
linux-ppc64le::nodejs-14.18.3-hc72f780_1.tar.bz2
linux-ppc64le::gfal2-2.20.2-he386ba5_0.tar.bz2
linux-ppc64le::pytables-3.7.0-py39h9ace1ec_0.tar.bz2
linux-ppc64le::rust-1.57.0-h8f6c405_0.tar.bz2
linux-ppc64le::libsoup-2.74.1-h48114a4_0.tar.bz2
linux-ppc64le::plumed-2.7.3-mpi_openmpi_hbe91807_0.tar.bz2
linux-ppc64le::r-git2r-0.29.0-r41h61fa1b9_1.tar.bz2
linux-ppc64le::libcurl-7.80.0-h3643067_1.tar.bz2
linux-ppc64le::mysql-client-8.0.27-ha7fd285_3.tar.bz2
linux-ppc64le::omniorb-4.2.5-py39hff9cdcc_0.tar.bz2
linux-ppc64le::librdkafka-1.7.0-hf21488e_1.tar.bz2
linux-ppc64le::llvmlite-0.38.0-py38h8d99f3c_0.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py310h4c10a2b_19_cpu.tar.bz2
linux-ppc64le::librdkafka-1.3.0-h76f88f1_1.tar.bz2
linux-ppc64le::glib-networking-2.70.1-h962fcee_0.tar.bz2
linux-ppc64le::vtk-9.1.0-qt_py39hfa2e90c_203.tar.bz2
linux-ppc64le::vtk-9.0.1-qt_py310h823a648_210.tar.bz2
linux-ppc64le::grpcio-1.43.0-py310h68addab_0.tar.bz2
linux-ppc64le::omniorb-4.2.5-py310hbc3273a_0.tar.bz2
linux-ppc64le::python-3.10.1-h3e5bdd0_2_cpython.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py310h15ba4cf_37_cpu.tar.bz2
linux-ppc64le::python-3.9.10-h1456e17_0_cpython.tar.bz2
linux-ppc64le::root_base-6.24.6-py38h8e45062_2.tar.bz2
linux-ppc64le::postgresql-plpython-13.5-py39h6a5c72c_0.tar.bz2
linux-ppc64le::libgdal-3.4.1-ha6b820c_1.tar.bz2
linux-ppc64le::dcap-2.47.12-h3d76588_5.tar.bz2
linux-ppc64le::nordugrid-arc-6.14.0-py39ha147154_1.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py310hd48bae2_21_cpu.tar.bz2
linux-ppc64le::libgdal-3.4.0-h50de17c_9.tar.bz2
linux-ppc64le::vtk-9.0.1-qt_py37h96e63d6_210.tar.bz2
linux-ppc64le::omniorb-libs-4.2.5-h42039ad_0.tar.bz2
linux-ppc64le::libgdal-3.3.3-h2da5e39_15.tar.bz2
linux-ppc64le::nordugrid-arc-6.14.0-py37he061a38_0.tar.bz2
linux-ppc64le::librdkafka-1.8.2.post2-h76f88f1_0.tar.bz2
linux-ppc64le::rust-1.58.0-h8f6c405_0.tar.bz2
linux-ppc64le::cppyy-cling-6.25.2-py310hced77cf_0.tar.bz2
linux-ppc64le::nodejs-16.13.2-h2502c7a_2.tar.bz2
linux-ppc64le::vowpalwabbit-9.0.0-py39h9313748_2.tar.bz2
linux-ppc64le::python-3.9.10-hb23fad7_0_cpython.tar.bz2
linux-ppc64le::assimp-5.1.6-h0cf024e_0.tar.bz2
linux-ppc64le::grpc-cpp-1.42.0-hacf608f_1.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py37h112afbd_6_cpu.tar.bz2
linux-ppc64le::postgresql-plpython-13.5-py37hc97c45a_1.tar.bz2
linux-ppc64le::omniorb-4.2.5-py37hd4870b4_0.tar.bz2
linux-ppc64le::pyinstaller-4.8-py310h6303893_0.tar.bz2
linux-ppc64le::postgresql-plpython-13.5-py310h348c42b_1.tar.bz2
linux-ppc64le::glib-2.70.2-h690f14c_0.tar.bz2
linux-ppc64le::libpq-13.5-he9d5e3e_0.tar.bz2
linux-ppc64le::mysql-router-8.0.27-hdfabd79_3.tar.bz2
linux-ppc64le::xrootd-5.3.4-py37h93fe7df_0.tar.bz2
linux-ppc64le::grpc-cpp-1.43.2-hdd29dff_0.tar.bz2
linux-ppc64le::xrootd-5.4.0-py37h93fe7df_0.tar.bz2
linux-ppc64le::plumed-2.7.3-nompi_hc114c32_100.tar.bz2
linux-ppc64le::libmatio-1.5.21-h43c31eb_1.tar.bz2
linux-ppc64le::ogre-13.2.3-h820d8c4_0.tar.bz2
linux-ppc64le::vtk-9.0.1-qt_py39h653527e_210.tar.bz2
linux-ppc64le::vtk-9.1.0-qt_py38h4ecf32d_203.tar.bz2
linux-ppc64le::postgresql-plpython-13.5-py310h9609dfd_1.tar.bz2
linux-ppc64le::gmsh-4.9.3-h92fbcc5_0.tar.bz2
linux-ppc64le::pdal-2.3.0-h06d462f_19.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py37hf6629b9_18_cpu.tar.bz2
linux-ppc64le::cppyy-cling-6.25.2-py37h9b2364d_1.tar.bz2
linux-ppc64le::nordugrid-arc-6.14.0-py39hb0f8fe0_0.tar.bz2
linux-ppc64le::gct-6.2.1629922860-h1df1992_0.tar.bz2
linux-ppc64le::ogre-13.2.2-h77e483d_0.tar.bz2
linux-ppc64le::libprotobuf-3.19.3-h690f14c_0.tar.bz2
linux-ppc64le::libspatialite-5.0.1-he0c8ced_14.tar.bz2
linux-ppc64le::libopencv-4.5.3-py39h8d7d62e_7.tar.bz2
linux-ppc64le::curl-7.80.0-h3643067_1.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py39h712ea77_22_cpu.tar.bz2
linux-ppc64le::mysql-server-8.0.27-he877b2a_3.tar.bz2
linux-ppc64le::libgdal-3.3.3-h59d179c_12.tar.bz2
linux-ppc64le::libgdal-3.4.0-h59d179c_10.tar.bz2
linux-ppc64le::mapserver-7.6.4-py310h56b2d08_5.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py39h6f7d95f_19_cpu.tar.bz2
linux-ppc64le::hdf5-1.12.1-nompi_h437d42d_103.tar.bz2
linux-ppc64le::python-3.10.1-h3e5bdd0_1_cpython.tar.bz2
linux-ppc64le::nordugrid-arc-6.14.0-py37hbdf7f9e_1.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py37h4f673f8_20_cpu.tar.bz2
linux-ppc64le::oclgrind-21.10-h9758d01_0.tar.bz2
linux-ppc64le::libopencv-4.5.5-py37h69d5711_0.tar.bz2
linux-ppc64le::libgdal-3.3.3-h2fc1bce_14.tar.bz2
linux-ppc64le::wxwidgets-3.1.3-h6166594_5.tar.bz2
linux-ppc64le::grpc-cpp-1.43.2-hacf608f_0.tar.bz2
linux-ppc64le::librdkafka-1.3.0-hf21488e_3.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py37h112afbd_40_cpu.tar.bz2
linux-ppc64le::tiledb-2.5.3-h5191074_0.tar.bz2
linux-ppc64le::gsoap-2.8.118-ha8ed123_0.tar.bz2
linux-ppc64le::vowpalwabbit-8.11.0-py37h7b6ee61_2.tar.bz2
linux-ppc64le::postgresql-plpython-13.5-py38hd0d5293_0.tar.bz2
linux-ppc64le::vowpalwabbit-9.0.0-py38hddc5d0c_2.tar.bz2
linux-ppc64le::libfido2-1.10.0-h66fdf1b_0.tar.bz2
linux-ppc64le::libopencv-4.5.5-py31h5f6ef38_0.tar.bz2
linux-ppc64le::ruby-3.1.0-ha4e8978_0.tar.bz2
linux-ppc64le::vowpalwabbit-9.0.0-py37h0dfffa5_3.tar.bz2
linux-ppc64le::libglib-2.70.2-hd362787_1.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py310h4891621_22_cpu.tar.bz2
linux-ppc64le::nordugrid-arc-6.14.0-py37ha5a21c1_0.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py310hd761061_39_cpu.tar.bz2
linux-ppc64le::nodejs-16.13.0-h2502c7a_2.tar.bz2
linux-ppc64le::postgresql-plpython-13.5-py38h79244f9_1.tar.bz2
linux-ppc64le::omniorb-4.2.5-py38h486b007_0.tar.bz2
linux-ppc64le::mapserver-7.6.4-py38hcb20451_3.tar.bz2
linux-ppc64le::vowpalwabbit-8.11.0-py37h0dfffa5_2.tar.bz2
linux-ppc64le::libfido2-1.10.0-h42039ad_0.tar.bz2
linux-ppc64le::libgdal-3.4.1-h2fc1bce_1.tar.bz2
linux-ppc64le::llvmdev-9.0.1-default_h522564a_6.tar.bz2
linux-ppc64le::grpcio-1.43.0-py38h486b007_0.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py38h598059b_41_cpu.tar.bz2
linux-ppc64le::llvmlite-0.38.0-py37h558f4f6_0.tar.bz2
linux-ppc64le::mysql-connector-odbc-8.0.28-h690f14c_0.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py37hbd2d5a2_41_cpu.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py39hf59e8c7_40_cpu.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py39h4f6f96d_18_cpu.tar.bz2
linux-ppc64le::vowpalwabbit-9.0.0-py310h82fb54c_3.tar.bz2
linux-ppc64le::nodejs-17.1.0-he9a8890_2.tar.bz2
linux-ppc64le::pdal-2.3.0-hac1458d_22.tar.bz2
linux-ppc64le::python-3.10.2-hb23fad7_1_cpython.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py37h4f673f8_5_cpu.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py39h6f7d95f_38_cpu.tar.bz2
linux-ppc64le::grpcio-1.43.0-py37hd4870b4_0.tar.bz2
linux-ppc64le::dcap-2.47.12-h6d94032_5.tar.bz2
linux-ppc64le::mosh-1.3.2-pl5321h0337d06_1011.tar.bz2
linux-ppc64le::curl-7.81.0-h3643067_0.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py39hf59e8c7_21_cpu.tar.bz2
linux-ppc64le::python-3.10.1-h144377c_2_cpython.tar.bz2
linux-ppc64le::libopencv-4.5.3-py37h69d5711_7.tar.bz2
linux-ppc64le::pdal-2.3.0-hd93985b_24.tar.bz2
linux-ppc64le::nodejs-16.13.0-he9a8890_1.tar.bz2
linux-ppc64le::ogre-13.2.1-h820d8c4_0.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py38h598059b_7_cpu.tar.bz2
linux-ppc64le::root_base-6.24.6-py310hf662311_1.tar.bz2
linux-ppc64le::omniorb-4.2.5-py39hfeb9d76_0.tar.bz2
linux-ppc64le::texlive-core-20210325-heec0aea_1.tar.bz2
linux-ppc64le::nodejs-17.1.0-h2502c7a_2.tar.bz2
linux-ppc64le::tiledb-2.6.0-h5191074_0.tar.bz2
linux-ppc64le::libprotobuf-static-3.19.3-h690f14c_0.tar.bz2
linux-ppc64le::mysql-libs-8.0.28-ha23194b_0.tar.bz2
linux-ppc64le::mapserver-7.6.4-py37hc5ea0b8_3.tar.bz2
linux-ppc64le::slang-2.3.2-hb2319dc_1003.tar.bz2
linux-ppc64le::cppyy-cling-6.25.2-py38hba0ec0c_1.tar.bz2
linux-ppc64le::vtk-9.1.0-qt_py37he5e3392_203.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py38hc6ecb2e_39_cpu.tar.bz2
linux-ppc64le::libopencv-4.5.5-py38ha34fcec_0.tar.bz2
linux-ppc64le::cpp-opentelemetry-sdk-1.1.1-h710d41a_2.tar.bz2
linux-ppc64le::libgdal-3.4.0-h01dbba9_12.tar.bz2
linux-ppc64le::plumed-2.7.3-mpi_mpich_h85f196e_0.tar.bz2
linux-ppc64le::nordugrid-arc-6.14.0-py37h11835dc_1.tar.bz2
linux-ppc64le::ogre-13.2.4-h820d8c4_0.tar.bz2
linux-ppc64le::llvmdev-9.0.1-default_h522564a_5.tar.bz2
linux-ppc64le::mapserver-7.6.4-py310h5dd935a_3.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py38h172aaef_3_cpu.tar.bz2
linux-ppc64le::hdf5-1.12.1-mpi_openmpi_h2cd0a35_3.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py37h112afbd_21_cpu.tar.bz2
linux-ppc64le::librdkafka-1.8.2.post2-hf21488e_0.tar.bz2
linux-ppc64le::arrow-cpp-6.0.1-py310h4891621_7_cpu.tar.bz2
linux-ppc64le::pdal-2.3.0-h6ad39b2_20.tar.bz2
linux-ppc64le::python-3.8.12-hbedf6d4_3_cpython.tar.bz2
linux-ppc64le::graphviz-2.50.0-hbe92010_2.tar.bz2
linux-ppc64le::postgresql-13.5-h90e3369_1.tar.bz2
linux-ppc64le::cppyy-cling-6.25.2-py310hced77cf_1.tar.bz2
linux-ppc64le::python-3.9.10-hb23fad7_1_cpython.tar.bz2
linux-ppc64le::librdkafka-1.3.0-hf21488e_1.tar.bz2
linux-ppc64le::graphviz-2.50.0-h3ed3169_1.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py310h15ba4cf_18_cpu.tar.bz2
linux-ppc64le::assimp-5.1.0-h0cf024e_0.tar.bz2
linux-ppc64le::mysql-libs-8.0.27-ha23194b_3.tar.bz2
linux-ppc64le::cppyy-cling-6.25.2-py38hba0ec0c_0.tar.bz2
linux-ppc64le::arrow-cpp-3.0.0-py37h2e13c3e_38_cpu.tar.bz2
linux-ppc64le::hdf5-1.12.1-mpi_openmpi_h5c49ede_3.tar.bz2
linux-ppc64le::mapserver-7.6.4-py39ha9c9aa8_3.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py38h269dbca_21_cpu.tar.bz2
linux-ppc64le::arrow-cpp-5.0.0-py38hc6ecb2e_20_cpu.tar.bz2
-    "libzlib >=1.2.11,<1.3.0a0",
+    "libzlib >=1.2.11,<2.0.0a0",
linux-ppc64le::gst-plugins-base-1.18.5-he376d82_3.tar.bz2
linux-ppc64le::libllvm9-9.0.1-cling_v0.9_h38e9fbe_7.tar.bz2
linux-ppc64le::clang-9-9.0.1-hcc_h1a31d8e_3.tar.bz2
linux-ppc64le::glib-tools-2.70.2-h690f14c_0.tar.bz2
linux-ppc64le::llvm-9.0.1-default_hda43a40_6.tar.bz2
linux-ppc64le::libllvm9-9.0.1-default_h522564a_6.tar.bz2
linux-ppc64le::llvm-9.0.1-default_hda43a40_5.tar.bz2
linux-ppc64le::libllvm9-9.0.1-default_h522564a_5.tar.bz2
linux-ppc64le::llvm-tools-9.0.1-cling_v0.9_h38e9fbe_5.tar.bz2
linux-ppc64le::gcab-1.4-h8a8b7f7_0.tar.bz2
linux-ppc64le::llvm-tools-9.0.1-default_h522564a_6.tar.bz2
linux-ppc64le::llvm-tools-9.0.1-cling_v0.9_h38e9fbe_6.tar.bz2
linux-ppc64le::cpp-opentelemetry-sdk-1.1.0-h5e8230a_2.tar.bz2
linux-ppc64le::llvm-tools-9.0.1-cling_v0.9_h38e9fbe_7.tar.bz2
linux-ppc64le::llvm-tools-9.0.1-default_h522564a_7.tar.bz2
linux-ppc64le::clang-9-9.0.1-cling_v0.9_hd7e4fd9_3.tar.bz2
linux-ppc64le::clang-9-9.0.1-root_62400_h5af412b_3.tar.bz2
linux-ppc64le::coin-or-utils-2.11.6-hd27ae0f_0.tar.bz2
linux-ppc64le::clang-9-9.0.1-default_h61deb75_3.tar.bz2
linux-ppc64le::llvm-9.0.1-cling_v0.9_h22e46dc_6.tar.bz2
linux-ppc64le::llvm-9.0.1-default_hda43a40_7.tar.bz2
linux-ppc64le::libclang-cpp-9.0.1-hcc_h1a31d8e_3.tar.bz2
linux-ppc64le::llvm-9.0.1-cling_v0.9_h22e46dc_7.tar.bz2
linux-ppc64le::libclang-cpp-9.0.1-root_62400_h5af412b_3.tar.bz2
linux-ppc64le::libclang-cpp9-9.0.1-cling_v0.9_hd7e4fd9_3.tar.bz2
linux-ppc64le::libclang-cpp9-9.0.1-hcc_h1a31d8e_3.tar.bz2
linux-ppc64le::libllvm9-9.0.1-cling_v0.9_h38e9fbe_5.tar.bz2
linux-ppc64le::libclang-cpp9-9.0.1-root_62400_h5af412b_3.tar.bz2
linux-ppc64le::libllvm9-9.0.1-default_h522564a_7.tar.bz2
linux-ppc64le::libclang-cpp-9.0.1-cling_v0.9_hd7e4fd9_3.tar.bz2
linux-ppc64le::libclang-cpp-9.0.1-default_h61deb75_3.tar.bz2
linux-ppc64le::llvm-tools-9.0.1-default_h522564a_5.tar.bz2
linux-ppc64le::llvm-9.0.1-cling_v0.9_h22e46dc_5.tar.bz2
linux-ppc64le::libllvm9-9.0.1-cling_v0.9_h38e9fbe_6.tar.bz2
linux-ppc64le::glib-tools-2.70.2-h690f14c_1.tar.bz2
linux-ppc64le::libclang-cpp9-9.0.1-default_h61deb75_3.tar.bz2
linux-ppc64le::cpp-opentelemetry-sdk-1.1.0-h725d05d_3.tar.bz2
-    "libzlib >=1.2.11,<1.3.0a0"
+    "libzlib >=1.2.11,<2.0.0a0"
================================================================================
================================================================================
linux-aarch64
linux-aarch64::libgdal-3.3.3-h6e68c36_12.tar.bz2
linux-aarch64::orc-1.7.2-h5c30ecb_0.tar.bz2
linux-aarch64::assimp-5.1.0-h66e8f5a_0.tar.bz2
linux-aarch64::hdf5-1.12.1-nompi_h774d4d8_103.tar.bz2
linux-aarch64::libtiledb-sql-0.12.2-h8c47da6_0.tar.bz2
linux-aarch64::libpq-13.5-he5b4f81_1.tar.bz2
linux-aarch64::mapserver-7.6.4-py38h7ccf3d0_3.tar.bz2
linux-aarch64::assimp-5.1.0-h66e8f5a_1.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py37hdf2df5d_7_cpu.tar.bz2
linux-aarch64::gfal2-2.20.2-h32dea9a_0.tar.bz2
linux-aarch64::vowpalwabbit-9.0.0-py39h90979d0_3.tar.bz2
linux-aarch64::ogre-13.2.3-hb360d1d_0.tar.bz2
linux-aarch64::postgresql-plpython-13.5-py39he700edf_1.tar.bz2
linux-aarch64::pgplot-5.2.2-h1703d9e_1008.tar.bz2
linux-aarch64::nordugrid-arc-6.14.0-py37h081fe45_1.tar.bz2
linux-aarch64::python-3.10.1-h2265c99_2_cpython.tar.bz2
linux-aarch64::graphviz-2.50.0-h9ece97c_1.tar.bz2
linux-aarch64::vowpalwabbit-9.0.0-py37he0afdef_3.tar.bz2
linux-aarch64::cppyy-cling-6.25.2-py37h2e926c5_1.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py38h2d4df83_39_cpu.tar.bz2
linux-aarch64::libgdal-3.4.0-h5866fe9_10.tar.bz2
linux-aarch64::gct-6.2.1550507116-h097699d_2.tar.bz2
linux-aarch64::r-git2r-0.29.0-r41h8aefce9_1.tar.bz2
linux-aarch64::pdal-2.3.0-h64549dd_23.tar.bz2
linux-aarch64::root_base-6.24.6-py310hc551258_2.tar.bz2
linux-aarch64::mysql-router-8.0.27-h643de97_3.tar.bz2
linux-aarch64::libgdal-3.3.3-h6db748c_11.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py39hb6ca752_3_cpu.tar.bz2
linux-aarch64::nodejs-16.13.2-h41a2d9d_2.tar.bz2
linux-aarch64::tiledb-2.6.2-h7c4f515_0.tar.bz2
linux-aarch64::libgdal-3.4.0-h533c527_13.tar.bz2
linux-aarch64::libopencv-4.5.3-py37h1fbf280_7.tar.bz2
linux-aarch64::libgdal-3.3.3-h57ec0f0_15.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py37h94f8420_20_cpu.tar.bz2
linux-aarch64::libprotobuf-3.19.2-h469bdbd_0.tar.bz2
linux-aarch64::grpc-cpp-1.42.0-h106df3f_1.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py37hb597320_18_cpu.tar.bz2
linux-aarch64::nordugrid-arc-6.14.0-py37h1771c39_0.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py310hc557b8b_19_cpu.tar.bz2
linux-aarch64::llvmlite-0.38.0-py38h68ca503_0.tar.bz2
linux-aarch64::ruby-2.7.2-h3fc8c45_8.tar.bz2
linux-aarch64::git-2.35.0-pl5321h063bab8_0.tar.bz2
linux-aarch64::libgdal-3.4.1-h57ec0f0_2.tar.bz2
linux-aarch64::mapserver-7.6.4-py39hff635e9_5.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py38hedbe7a4_41_cpu.tar.bz2
linux-aarch64::librdkafka-1.8.2.post2-hf9019d4_0.tar.bz2
linux-aarch64::grpc-cpp-1.43.0-h106df3f_0.tar.bz2
linux-aarch64::postgresql-13.5-hc7eaa15_1.tar.bz2
linux-aarch64::graphicsmagick-1.3.37-h5ab9525_0.tar.bz2
linux-aarch64::xrootd-5.4.0-py37h8bd4efe_0.tar.bz2
linux-aarch64::ogre-13.2.2-hb360d1d_0.tar.bz2
linux-aarch64::grpcio-1.43.0-py37h1263c2e_0.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py310h82f5e88_8_cpu.tar.bz2
linux-aarch64::nordugrid-arc-6.14.0-py39ha1c2c60_0.tar.bz2
linux-aarch64::sagelib-9.4-py39h0c97c74_1.tar.bz2
linux-aarch64::texlive-core-20210325-he1008a7_1.tar.bz2
linux-aarch64::pdal-2.3.0-hd0b1748_23.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py310h1242aec_40_cpu.tar.bz2
linux-aarch64::cppyy-cling-6.25.2-py39h675bf59_1.tar.bz2
linux-aarch64::libopencv-4.5.3-py37h533c580_6.tar.bz2
linux-aarch64::glib-2.70.2-h469bdbd_1.tar.bz2
linux-aarch64::glib-2.70.2-h469bdbd_0.tar.bz2
linux-aarch64::cpp-opentelemetry-sdk-1.1.1-h04c03b0_2.tar.bz2
linux-aarch64::libmatio-1.5.21-h94347fe_1.tar.bz2
linux-aarch64::librdkafka-1.3.0-hf9019d4_3.tar.bz2
linux-aarch64::cppyy-cling-6.25.2-py38hd707517_1.tar.bz2
linux-aarch64::postgresql-13.5-hf035830_1.tar.bz2
linux-aarch64::vowpalwabbit-9.0.0-py310h81719aa_3.tar.bz2
linux-aarch64::libprotobuf-static-3.19.3-h469bdbd_0.tar.bz2
linux-aarch64::vowpalwabbit-9.0.0-py39h90979d0_2.tar.bz2
linux-aarch64::postgresql-plpython-13.5-py38h3e1bf2c_1.tar.bz2
linux-aarch64::assimp-5.2.0-h66e8f5a_0.tar.bz2
linux-aarch64::qt-5.12.9-hb57a898_5.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py37hbca0647_19_cpu.tar.bz2
linux-aarch64::python-3.10.1-h2265c99_0_cpython.tar.bz2
linux-aarch64::llvmdev-9.0.1-cling_v0.9_he507bf8_7.tar.bz2
linux-aarch64::libcups-2.3.3-h5ca083f_1.tar.bz2
linux-aarch64::libopencv-4.5.3-py39h441fb25_7.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py39hc0b3ffd_7_cpu.tar.bz2
linux-aarch64::libgdal-3.3.3-h48b1ca4_14.tar.bz2
linux-aarch64::poppler-qt-22.01.0-he1d359d_0.tar.bz2
linux-aarch64::mapserver-7.6.4-py37hf00ff4b_5.tar.bz2
linux-aarch64::vowpalwabbit-8.11.0-py37he0afdef_2.tar.bz2
linux-aarch64::squashfuse-0.1.104-hf83b10a_1.tar.bz2
linux-aarch64::nodejs-17.4.0-hb281f33_0.tar.bz2
linux-aarch64::librdkafka-1.3.0-h125ba84_1.tar.bz2
linux-aarch64::grpcio-1.43.0-py39hc32559e_0.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py39hed4a9ec_6_cpu.tar.bz2
linux-aarch64::r-git2r-0.29.0-r40h8aefce9_1.tar.bz2
linux-aarch64::llvmdev-9.0.1-cling_v0.9_he507bf8_6.tar.bz2
linux-aarch64::python-3.10.1-hc23e7ad_2_cpython.tar.bz2
linux-aarch64::plumed-2.7.3-mpi_openmpi_hbb7ec53_0.tar.bz2
linux-aarch64::libgdal-3.4.0-h6e68c36_12.tar.bz2
linux-aarch64::pyinstaller-4.8-py310h5d2e7b6_0.tar.bz2
linux-aarch64::root_base-6.24.6-py39h8456a0e_2.tar.bz2
linux-aarch64::libopencv-4.5.3-py31hd6084f5_7.tar.bz2
linux-aarch64::python-3.9.10-h1b383ca_1_cpython.tar.bz2
linux-aarch64::vowpalwabbit-9.0.0-py37h9c328d3_2.tar.bz2
linux-aarch64::librdkafka-1.7.0-h125ba84_1.tar.bz2
linux-aarch64::root_base-6.24.6-py39h8456a0e_1.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py38hd1e8945_40_cpu.tar.bz2
linux-aarch64::assimp-5.1.3-h66e8f5a_1.tar.bz2
linux-aarch64::r-git2r-0.29.0-r40h9d30b52_1.tar.bz2
linux-aarch64::libgdal-3.4.1-h99933e3_2.tar.bz2
linux-aarch64::vtk-9.1.0-qt_py37h461d981_203.tar.bz2
linux-aarch64::mapserver-7.6.4-py37had70515_3.tar.bz2
linux-aarch64::oclgrind-21.10-hb21cbea_0.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py39hc0b3ffd_41_cpu.tar.bz2
linux-aarch64::libtiledb-sql-0.12.0-h5502914_0.tar.bz2
linux-aarch64::vowpalwabbit-9.0.0-py38h92eb830_3.tar.bz2
linux-aarch64::xeus-cling-0.13.0-hae6dd4f_2.tar.bz2
linux-aarch64::librdkafka-1.3.0-h125ba84_3.tar.bz2
linux-aarch64::mapserver-7.6.4-py38h4eb25f5_5.tar.bz2
linux-aarch64::grpc-cpp-1.43.0-h515346d_0.tar.bz2
linux-aarch64::git-2.35.0-pl5321h402f554_0.tar.bz2
linux-aarch64::hdf5-1.12.1-mpi_openmpi_h3eac370_3.tar.bz2
linux-aarch64::vowpalwabbit-8.11.0-py37h9c328d3_2.tar.bz2
linux-aarch64::librdkafka-1.7.0-hf9019d4_1.tar.bz2
linux-aarch64::libgdal-3.4.0-h6db748c_9.tar.bz2
linux-aarch64::libgdal-3.4.0-hd17d152_11.tar.bz2
linux-aarch64::libtiledb-sql-0.12.1-h8c47da6_0.tar.bz2
linux-aarch64::libopencv-4.5.3-py39hb6053e2_6.tar.bz2
linux-aarch64::python-3.10.2-he7f7bba_1_cpython.tar.bz2
linux-aarch64::mysql-libs-8.0.28-ha3f2873_0.tar.bz2
linux-aarch64::mysql-server-8.0.27-h88e2c03_3.tar.bz2
linux-aarch64::geotiff-1.7.0-h7c441a3_6.tar.bz2
linux-aarch64::libtiledb-sql-0.12.0-hb1db859_0.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py39ha4d5461_20_cpu.tar.bz2
linux-aarch64::libprotobuf-3.19.4-h469bdbd_0.tar.bz2
linux-aarch64::mysql-libs-8.0.27-ha3f2873_2.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py38h2d4df83_5_cpu.tar.bz2
linux-aarch64::libfido2-1.10.0-h097699d_0.tar.bz2
linux-aarch64::nodejs-14.18.3-ha6927ec_1.tar.bz2
linux-aarch64::cppyy-cling-6.25.2-py310h26d250e_1.tar.bz2
linux-aarch64::libfido2-1.10.0-h3bc09fb_0.tar.bz2
linux-aarch64::graphviz-2.50.0-hdfeb452_2.tar.bz2
linux-aarch64::gct-6.2.1629922860-h57bccc8_0.tar.bz2
linux-aarch64::dcap-2.47.12-h0ad4e35_5.tar.bz2
linux-aarch64::libopencv-4.5.5-py39h441fb25_0.tar.bz2
linux-aarch64::nodejs-16.13.2-hb281f33_2.tar.bz2
linux-aarch64::libpq-13.5-h29fb33b_1.tar.bz2
linux-aarch64::nordugrid-arc-6.14.0-py38heb641e5_1.tar.bz2
linux-aarch64::libcurl-7.80.0-hbeee725_1.tar.bz2
linux-aarch64::python-3.10.1-hc23e7ad_1_cpython.tar.bz2
linux-aarch64::vtk-9.0.1-qt_py38h0adfd3b_210.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py38haa0b588_37_cpu.tar.bz2
linux-aarch64::libtiledb-sql-0.11.1-h5502914_0.tar.bz2
linux-aarch64::grpc-cpp-1.42.0-h515346d_1.tar.bz2
linux-aarch64::mesalib-21.2.5-h0bd06be_3.tar.bz2
linux-aarch64::pdal-2.3.0-h1c52ec2_22.tar.bz2
linux-aarch64::ogre-13.2.1-h76c0471_0.tar.bz2
linux-aarch64::poppler-22.01.0-h5353b5d_0.tar.bz2
linux-aarch64::r-git2r-0.29.0-r41h9d30b52_1.tar.bz2
linux-aarch64::cppyy-cling-6.25.2-py310h26d250e_0.tar.bz2
linux-aarch64::mapserver-7.6.4-py310hbf3b1d0_5.tar.bz2
linux-aarch64::root_base-6.24.6-py38h719954b_2.tar.bz2
linux-aarch64::libgdal-3.4.0-h6e68c36_10.tar.bz2
linux-aarch64::postgresql-plpython-13.5-py39h7db0282_1.tar.bz2
linux-aarch64::gsoap-2.8.118-hbe024b6_0.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py39ha4d5461_39_cpu.tar.bz2
linux-aarch64::python-3.10.2-h1b383ca_1_cpython.tar.bz2
linux-aarch64::postgresql-plpython-13.5-py310h0cf528d_1.tar.bz2
linux-aarch64::ruby-2.6.6-hc041527_3.tar.bz2
linux-aarch64::mysql-server-8.0.28-h88e2c03_0.tar.bz2
linux-aarch64::zstd-1.5.2-h41fb7a4_0.tar.bz2
linux-aarch64::tesseract-5.0.0-hf7d8e37_1.tar.bz2
linux-aarch64::python-3.9.10-he7f7bba_1_cpython.tar.bz2
linux-aarch64::nodejs-16.13.0-hb281f33_1.tar.bz2
linux-aarch64::nodejs-16.13.0-h41a2d9d_2.tar.bz2
linux-aarch64::python-3.6.15-h30375ac_0_cpython.tar.bz2
linux-aarch64::vowpalwabbit-9.0.0-py38h92eb830_2.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py310hb8d3b8f_3_cpu.tar.bz2
linux-aarch64::grpcio-1.43.0-py38h72d72fb_0.tar.bz2
linux-aarch64::llvmlite-0.38.0-py37h973798e_0.tar.bz2
linux-aarch64::llvmlite-0.38.0-py310h89181d0_0.tar.bz2
linux-aarch64::ogre-13.2.2-h76c0471_0.tar.bz2
linux-aarch64::cppyy-cling-6.25.2-py38hd707517_0.tar.bz2
linux-aarch64::pyinstaller-4.8-py39h0992e24_0.tar.bz2
linux-aarch64::postgresql-plpython-13.5-py38ha461251_1.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py39ha4d5461_5_cpu.tar.bz2
linux-aarch64::rust-1.58.1-h9b2858f_0.tar.bz2
linux-aarch64::xrootd-5.4.0-py39hf4d087b_0.tar.bz2
linux-aarch64::grpcio-1.43.0-py38hcec6d83_0.tar.bz2
linux-aarch64::nordugrid-arc-6.14.0-py38h176402b_0.tar.bz2
linux-aarch64::zstd-1.5.1-h41fb7a4_0.tar.bz2
linux-aarch64::grpcio-1.43.0-py37haece1f2_0.tar.bz2
linux-aarch64::mongodb-5.1.1-hde4a6f1_0.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py39hb6ca752_37_cpu.tar.bz2
linux-aarch64::python-3.9.10-h1b383ca_0_cpython.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py38haa0b588_3_cpu.tar.bz2
linux-aarch64::grpc-cpp-1.43.2-h515346d_0.tar.bz2
linux-aarch64::tiledb-2.6.0-h239ccfd_0.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py37hdf2df5d_8_cpu.tar.bz2
linux-aarch64::libgdal-3.3.3-h80b9852_14.tar.bz2
linux-aarch64::rust-1.57.0-h9b2858f_0.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py38hedbe7a4_7_cpu.tar.bz2
linux-aarch64::curl-7.81.0-hcafe9da_0.tar.bz2
linux-aarch64::pdal-2.3.0-h6dca3ff_16.tar.bz2
linux-aarch64::libcurl-static-7.80.0-hbeee725_1.tar.bz2
linux-aarch64::postgresql-plpython-13.5-py37h623af64_1.tar.bz2
linux-aarch64::pytables-3.7.0-py310h6a1374c_0.tar.bz2
linux-aarch64::libopencv-4.5.3-py38hca1d110_6.tar.bz2
linux-aarch64::hdf5-1.12.1-mpi_openmpi_h1454249_3.tar.bz2
linux-aarch64::postgresql-plpython-13.5-py37hc1b2443_1.tar.bz2
linux-aarch64::libnghttp2-1.46.0-h097699d_0.tar.bz2
linux-aarch64::libopencv-4.5.5-py37h1fbf280_0.tar.bz2
linux-aarch64::mapserver-7.6.4-py37hd17986f_4.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py39hed4a9ec_21_cpu.tar.bz2
linux-aarch64::nordugrid-arc-6.14.0-py37h031ab1d_1.tar.bz2
linux-aarch64::xrootd-5.4.0-py37h20fd28d_0.tar.bz2
linux-aarch64::libgdal-3.4.1-h1e8850e_0.tar.bz2
linux-aarch64::libtiledb-sql-0.12.3-h8c47da6_0.tar.bz2
linux-aarch64::xrootd-5.3.4-py37h8bd4efe_0.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py39hc0b3ffd_22_cpu.tar.bz2
linux-aarch64::rust-1.58.0-h9b2858f_0.tar.bz2
linux-aarch64::libopencv-4.5.3-py31h5e08509_6.tar.bz2
linux-aarch64::pdal-2.3.0-ha176fc3_21.tar.bz2
linux-aarch64::vtk-9.1.0-qt_py38hf17af9d_203.tar.bz2
linux-aarch64::libgdal-3.4.1-h48b1ca4_1.tar.bz2
linux-aarch64::pytables-3.7.0-py37h8e4eae7_0.tar.bz2
linux-aarch64::llvmlite-0.38.0-py37h01f93d9_0.tar.bz2
linux-aarch64::libspatialite-5.0.1-hdcc3455_14.tar.bz2
linux-aarch64::llvmdev-9.0.1-default_h56056e8_7.tar.bz2
linux-aarch64::pytables-3.7.0-py39hdf442ea_0.tar.bz2
linux-aarch64::cppyy-cling-6.25.2-py37h2e926c5_0.tar.bz2
linux-aarch64::vtk-9.0.1-qt_py37haa674ff_210.tar.bz2
linux-aarch64::gmsh-4.9.3-h92c2329_0.tar.bz2
linux-aarch64::mapserver-7.6.4-py310h4262acc_3.tar.bz2
linux-aarch64::ruby-3.1.0-h6637a32_1.tar.bz2
linux-aarch64::cppyy-cling-6.25.2-py39h675bf59_0.tar.bz2
linux-aarch64::vowpalwabbit-9.0.0-py310h81719aa_2.tar.bz2
linux-aarch64::pdal-2.3.0-ha176fc3_22.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py37h94f8420_39_cpu.tar.bz2
linux-aarch64::libcurl-7.81.0-hbeee725_0.tar.bz2
linux-aarch64::mapserver-7.6.4-py310hf0ecb43_4.tar.bz2
linux-aarch64::gfal2-2.20.3-hc28b9ba_1.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py37hddd7dce_6_cpu.tar.bz2
linux-aarch64::ruby-2.5.7-hc041527_3.tar.bz2
linux-aarch64::mysql-router-8.0.28-h643de97_0.tar.bz2
linux-aarch64::librdkafka-1.8.2.post2-h125ba84_0.tar.bz2
linux-aarch64::assimp-5.1.5-h66e8f5a_0.tar.bz2
linux-aarch64::mysql-client-8.0.28-hb1fb64d_0.tar.bz2
linux-aarch64::xrootd-5.3.4-py37h20fd28d_0.tar.bz2
linux-aarch64::cpp-opentelemetry-sdk-1.1.1-h04c03b0_1.tar.bz2
linux-aarch64::ogre-13.2.4-h76c0471_0.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py39hed4a9ec_40_cpu.tar.bz2
linux-aarch64::libgdal-3.4.1-h533c527_0.tar.bz2
linux-aarch64::librdkafka-1.3.0-hf9019d4_1.tar.bz2
linux-aarch64::hdf5-1.12.1-nompi_he09bf5b_103.tar.bz2
linux-aarch64::libprotobuf-static-3.19.4-h469bdbd_0.tar.bz2
linux-aarch64::llvmdev-9.0.1-default_h56056e8_6.tar.bz2
linux-aarch64::gsoap-2.8.118-h080e37f_0.tar.bz2
linux-aarch64::libgdal-3.4.1-h80b9852_1.tar.bz2
linux-aarch64::dcap-2.47.12-ha4d4d2b_4.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py310hb8d3b8f_18_cpu.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py38hf8c9884_38_cpu.tar.bz2
linux-aarch64::xrootd-5.3.4-py38hd0dea64_0.tar.bz2
linux-aarch64::pdal-2.3.0-hd26638a_17.tar.bz2
linux-aarch64::ruby-3.1.0-h921ef09_1.tar.bz2
linux-aarch64::nss-3.73-hdd3d7a4_0.tar.bz2
linux-aarch64::vtk-9.0.1-qt_py310h102ddcd_210.tar.bz2
linux-aarch64::libgdal-3.3.3-hdc5e6e1_11.tar.bz2
linux-aarch64::libtiledb-sql-0.12.1-ha15cdb9_0.tar.bz2
linux-aarch64::pdal-2.3.0-ha176fc3_20.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py310h82f5e88_22_cpu.tar.bz2
linux-aarch64::mysql-client-8.0.27-hb1fb64d_2.tar.bz2
linux-aarch64::tiledb-2.6.0-h7c4f515_0.tar.bz2
linux-aarch64::mosh-1.3.2-pl5321hddf936e_1011.tar.bz2
linux-aarch64::grpc-cpp-1.43.2-h106df3f_0.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py39hc0b3ffd_8_cpu.tar.bz2
linux-aarch64::nodejs-16.13.0-h41a2d9d_1.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py38hd1e8945_21_cpu.tar.bz2
linux-aarch64::python-3.9.9-h2265c99_0_cpython.tar.bz2
linux-aarch64::assimp-5.2.0-h66e8f5a_1.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py39h4590324_38_cpu.tar.bz2
linux-aarch64::root_base-6.24.6-py37h881c2c0_2.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py310h8a0025e_20_cpu.tar.bz2
linux-aarch64::sagelib-9.4-py37h5066cd7_1.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py38hedbe7a4_8_cpu.tar.bz2
linux-aarch64::mosh-1.3.2-pl5321h51f555e_1011.tar.bz2
linux-aarch64::python-3.9.10-he7f7bba_0_cpython.tar.bz2
linux-aarch64::mysql-router-8.0.27-h643de97_2.tar.bz2
linux-aarch64::pyinstaller-4.8-py38hdcdda0e_0.tar.bz2
linux-aarch64::libgdal-3.3.3-h1e8850e_13.tar.bz2
linux-aarch64::hdf5-1.12.1-mpi_mpich_h1d4cc76_3.tar.bz2
linux-aarch64::libglib-2.70.2-hde3fb6c_1.tar.bz2
linux-aarch64::tesseract-4.1.3-hf7d8e37_6.tar.bz2
linux-aarch64::libgdal-3.3.3-h533c527_13.tar.bz2
linux-aarch64::xrootd-5.3.4-py39hf4d087b_0.tar.bz2
linux-aarch64::vtk-9.1.0-qt_py39h5e94cfd_203.tar.bz2
linux-aarch64::libopencv-4.5.3-py38h964b695_7.tar.bz2
linux-aarch64::mysql-connector-odbc-8.0.28-h469bdbd_0.tar.bz2
linux-aarch64::grpcio-1.43.0-py310h126c23a_0.tar.bz2
linux-aarch64::root_base-6.24.6-py38h719954b_1.tar.bz2
linux-aarch64::pdal-2.3.0-ha84b321_24.tar.bz2
linux-aarch64::nodejs-17.1.0-hb281f33_2.tar.bz2
linux-aarch64::tesseract-5.0.0-hf7d8e37_0.tar.bz2
linux-aarch64::vowpalwabbit-8.11.0-py310h81719aa_2.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py310h8a0025e_39_cpu.tar.bz2
linux-aarch64::libsoup-2.74.1-h926c323_0.tar.bz2
linux-aarch64::curl-7.80.0-hbeee725_1.tar.bz2
linux-aarch64::mysql-libs-8.0.27-ha3f2873_3.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py310h82f5e88_7_cpu.tar.bz2
linux-aarch64::llvmdev-9.0.1-default_h56056e8_5.tar.bz2
linux-aarch64::ruby-3.1.0-h3fc8c45_0.tar.bz2
linux-aarch64::libcurl-7.81.0-hcafe9da_0.tar.bz2
linux-aarch64::vowpalwabbit-9.0.0-py37h9c328d3_3.tar.bz2
linux-aarch64::libglib-2.70.2-hde3fb6c_0.tar.bz2
linux-aarch64::llvmlite-0.38.0-py39h4ebc84c_0.tar.bz2
linux-aarch64::libtiledb-sql-0.11.1-hb1db859_0.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py38hf8c9884_19_cpu.tar.bz2
linux-aarch64::ogre-13.2.3-h76c0471_0.tar.bz2
linux-aarch64::mapserver-7.6.4-py39h74b1938_3.tar.bz2
linux-aarch64::r-base-4.1.2-he52c857_1.tar.bz2
linux-aarch64::libspatialite-5.0.1-hd1854aa_13.tar.bz2
linux-aarch64::libopencv-4.5.5-py31hd6084f5_0.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py38hd1e8945_6_cpu.tar.bz2
linux-aarch64::grpcio-1.43.0-py39hf7c81b1_0.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py38h2d4df83_20_cpu.tar.bz2
linux-aarch64::xrootd-5.4.0-py38hd0dea64_0.tar.bz2
linux-aarch64::python-3.10.2-he7f7bba_2_cpython.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py37hb597320_37_cpu.tar.bz2
linux-aarch64::mysql-client-8.0.27-hb1fb64d_3.tar.bz2
linux-aarch64::libprotobuf-static-3.19.2-h469bdbd_0.tar.bz2
linux-aarch64::nodejs-17.4.0-h41a2d9d_0.tar.bz2
linux-aarch64::mapserver-7.6.4-py38hed5835a_4.tar.bz2
linux-aarch64::curl-7.81.0-hbeee725_0.tar.bz2
linux-aarch64::vowpalwabbit-8.11.0-py39h90979d0_2.tar.bz2
linux-aarch64::cpp-opentelemetry-sdk-1.1.1-h4f07f90_0.tar.bz2
linux-aarch64::python-3.9.9-hc23e7ad_0_cpython.tar.bz2
linux-aarch64::tiledb-2.5.3-h239ccfd_0.tar.bz2
linux-aarch64::root_base-6.24.6-py37h881c2c0_1.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py37hdf2df5d_22_cpu.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py37hbca0647_38_cpu.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py310h82f5e88_41_cpu.tar.bz2
linux-aarch64::nordugrid-arc-6.14.0-py37h54097b7_0.tar.bz2
linux-aarch64::pdal-2.3.0-h1c52ec2_21.tar.bz2
linux-aarch64::hdf5-1.12.1-mpi_mpich_hf3a1f19_3.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py37hb597320_3_cpu.tar.bz2
linux-aarch64::nordugrid-arc-6.14.0-py39he7d853f_1.tar.bz2
linux-aarch64::nodejs-14.18.3-h9e2e14b_2.tar.bz2
linux-aarch64::libgdal-3.3.3-h5866fe9_12.tar.bz2
linux-aarch64::glib-networking-2.70.1-h5d409ef_0.tar.bz2
linux-aarch64::python-3.10.2-h1b383ca_2_cpython.tar.bz2
linux-aarch64::pdal-2.3.0-hd26638a_18.tar.bz2
linux-aarch64::plumed-2.7.3-nompi_hd1c5552_100.tar.bz2
linux-aarch64::dcap-2.47.12-ha4d4d2b_5.tar.bz2
linux-aarch64::libgdal-3.3.3-h99933e3_15.tar.bz2
linux-aarch64::libgdal-3.4.0-hdc5e6e1_9.tar.bz2
linux-aarch64::tiledb-2.5.3-h7c4f515_0.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py39h4590324_19_cpu.tar.bz2
linux-aarch64::qt-main-5.15.2-h023c47d_1.tar.bz2
linux-aarch64::vtk-9.1.0-qt_py310h20a767c_203.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py310hc557b8b_38_cpu.tar.bz2
linux-aarch64::pdal-2.3.0-hd26638a_19.tar.bz2
linux-aarch64::pyinstaller-4.8-py37h18c5f2a_0.tar.bz2
linux-aarch64::xrootd-5.4.0-py310h84c2fee_0.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py37hddd7dce_21_cpu.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py310h8a0025e_5_cpu.tar.bz2
linux-aarch64::ogre-13.2.1-hb360d1d_0.tar.bz2
linux-aarch64::python-3.10.1-h2265c99_1_cpython.tar.bz2
linux-aarch64::graphviz-2.50.0-h9ece97c_0.tar.bz2
linux-aarch64::slang-2.3.2-h2c96333_1003.tar.bz2
linux-aarch64::root_base-6.24.6-py310hc551258_1.tar.bz2
linux-aarch64::assimp-5.1.6-h66e8f5a_0.tar.bz2
linux-aarch64::pdal-2.3.0-hfed4bd7_24.tar.bz2
linux-aarch64::libtiledb-sql-0.12.2-ha15cdb9_0.tar.bz2
linux-aarch64::libtiledb-sql-0.11.2-hb1db859_0.tar.bz2
linux-aarch64::mapserver-7.6.4-py39he6d61d3_4.tar.bz2
linux-aarch64::gmsh-4.9.3-h0b7d577_1.tar.bz2
linux-aarch64::nodejs-16.13.0-hb281f33_2.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py310h1242aec_6_cpu.tar.bz2
linux-aarch64::vowpalwabbit-8.11.0-py38h92eb830_2.tar.bz2
linux-aarch64::tiledb-2.6.2-h239ccfd_0.tar.bz2
linux-aarch64::nodejs-14.17.4-ha6927ec_1.tar.bz2
linux-aarch64::mysql-server-8.0.27-h88e2c03_2.tar.bz2
linux-aarch64::libgdal-3.4.0-h1e8850e_13.tar.bz2
linux-aarch64::wxwidgets-3.1.3-h792651f_5.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py37hddd7dce_40_cpu.tar.bz2
linux-aarch64::libprotobuf-3.19.3-h469bdbd_0.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py38haa0b588_18_cpu.tar.bz2
linux-aarch64::libnghttp2-1.46.0-h3bc09fb_0.tar.bz2
linux-aarch64::libgdal-3.4.0-h5866fe9_12.tar.bz2
linux-aarch64::vtk-9.0.1-qt_py39h03f8b2c_210.tar.bz2
linux-aarch64::tiledb-2.6.1-h239ccfd_0.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py310hb8d3b8f_37_cpu.tar.bz2
linux-aarch64::libgsf-1.14.47-h56347cf_4.tar.bz2
linux-aarch64::tiledb-2.6.1-h7c4f515_0.tar.bz2
linux-aarch64::libopencv-4.5.5-py38h964b695_0.tar.bz2
linux-aarch64::python-3.10.2-h2265c99_0_cpython.tar.bz2
linux-aarch64::ogre-13.2.4-hb360d1d_0.tar.bz2
linux-aarch64::libcurl-static-7.81.0-hbeee725_0.tar.bz2
linux-aarch64::arrow-cpp-6.0.1-py37h94f8420_5_cpu.tar.bz2
linux-aarch64::libcurl-static-7.81.0-hcafe9da_0.tar.bz2
linux-aarch64::plumed-2.7.3-mpi_mpich_hba48204_0.tar.bz2
linux-aarch64::r-base-4.1.2-h58144e6_0.tar.bz2
linux-aarch64::pytables-3.7.0-py38hb6cc7be_0.tar.bz2
linux-aarch64::r-base-4.1.1-h58144e6_2.tar.bz2
linux-aarch64::python-3.10.1-hc23e7ad_0_cpython.tar.bz2
linux-aarch64::nss-3.74-hdd3d7a4_0.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py39hb6ca752_18_cpu.tar.bz2
linux-aarch64::postgresql-plpython-13.5-py310h620a60a_1.tar.bz2
linux-aarch64::orc-1.7.1-h5c30ecb_1.tar.bz2
linux-aarch64::libgsf-1.14.48-h56347cf_0.tar.bz2
linux-aarch64::gct-6.2.1629922860-h099a514_0.tar.bz2
linux-aarch64::assimp-5.1.4-h66e8f5a_0.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py310h1242aec_21_cpu.tar.bz2
linux-aarch64::cpp-opentelemetry-sdk-1.1.0-h4f07f90_4.tar.bz2
linux-aarch64::arrow-cpp-3.0.0-py37hdf2df5d_41_cpu.tar.bz2
linux-aarch64::sagelib-9.4-py38h679a460_1.tar.bz2
linux-aarch64::python-3.10.2-hc23e7ad_0_cpython.tar.bz2
linux-aarch64::arrow-cpp-5.0.0-py38hedbe7a4_22_cpu.tar.bz2
linux-aarch64::libtiledb-sql-0.12.3-ha15cdb9_0.tar.bz2
linux-aarch64::llvmdev-9.0.1-cling_v0.9_he507bf8_5.tar.bz2
linux-aarch64::xrootd-5.3.4-py310h84c2fee_0.tar.bz2
-    "libzlib >=1.2.11,<1.3.0a0",
+    "libzlib >=1.2.11,<2.0.0a0",
linux-aarch64::gst-plugins-base-1.18.5-h227fc8a_3.tar.bz2
linux-aarch64::llvm-tools-9.0.1-cling_v0.9_he507bf8_7.tar.bz2
linux-aarch64::llvm-tools-9.0.1-default_h56056e8_6.tar.bz2
linux-aarch64::clang-9-9.0.1-default_h2e6fa06_3.tar.bz2
linux-aarch64::dotnet-sdk-3.1.416-h25a8a10_0.tar.bz2
linux-aarch64::dotnet-aspnetcore-5.0.13-h25a8a10_0.tar.bz2
linux-aarch64::llvm-9.0.1-cling_v0.9_had35603_5.tar.bz2
linux-aarch64::dotnet-aspnetcore-3.1.22-h25a8a10_0.tar.bz2
linux-aarch64::libclang-cpp9-9.0.1-hcc_h019ddfd_3.tar.bz2
linux-aarch64::coin-or-utils-2.11.6-h5060387_0.tar.bz2
linux-aarch64::gcab-1.4-hcb63b75_0.tar.bz2
linux-aarch64::llvm-9.0.1-cling_v0.9_had35603_6.tar.bz2
linux-aarch64::dotnet-sdk-5.0.404-h25a8a10_0.tar.bz2
linux-aarch64::llvm-9.0.1-cling_v0.9_had35603_7.tar.bz2
linux-aarch64::llvm-tools-9.0.1-default_h56056e8_7.tar.bz2
linux-aarch64::cpp-opentelemetry-sdk-1.1.0-hca391d2_3.tar.bz2
linux-aarch64::libclang-cpp-9.0.1-default_h2e6fa06_3.tar.bz2
linux-aarch64::dotnet-runtime-5.0.13-h25a8a10_0.tar.bz2
linux-aarch64::gst-plugins-good-1.18.5-hafdbc27_3.tar.bz2
linux-aarch64::dotnet-runtime-3.1.22-h3f6ae21_0.tar.bz2
linux-aarch64::libllvm9-9.0.1-default_h56056e8_7.tar.bz2
linux-aarch64::llvm-tools-9.0.1-cling_v0.9_he507bf8_6.tar.bz2
linux-aarch64::glib-tools-2.70.2-h469bdbd_1.tar.bz2
linux-aarch64::libclang-cpp-9.0.1-hcc_h019ddfd_3.tar.bz2
linux-aarch64::clang-9-9.0.1-hcc_h019ddfd_3.tar.bz2
linux-aarch64::libllvm9-9.0.1-cling_v0.9_he507bf8_5.tar.bz2
linux-aarch64::libclang-cpp9-9.0.1-root_62400_h87104f5_3.tar.bz2
linux-aarch64::llvm-9.0.1-default_h69fb49e_5.tar.bz2
linux-aarch64::libclang-cpp-9.0.1-root_62400_h87104f5_3.tar.bz2
linux-aarch64::libllvm9-9.0.1-cling_v0.9_he507bf8_6.tar.bz2
linux-aarch64::glib-tools-2.70.2-h469bdbd_0.tar.bz2
linux-aarch64::libllvm9-9.0.1-cling_v0.9_he507bf8_7.tar.bz2
linux-aarch64::clang-9-9.0.1-cling_v0.9_ha556c46_3.tar.bz2
linux-aarch64::llvm-tools-9.0.1-cling_v0.9_he507bf8_5.tar.bz2
linux-aarch64::llvm-tools-9.0.1-default_h56056e8_5.tar.bz2
linux-aarch64::libllvm9-9.0.1-default_h56056e8_6.tar.bz2
linux-aarch64::dotnet-sdk-6.0.101-h25a8a10_0.tar.bz2
linux-aarch64::dotnet-aspnetcore-6.0.1-h25a8a10_0.tar.bz2
linux-aarch64::llvm-9.0.1-default_h69fb49e_7.tar.bz2
linux-aarch64::cpp-opentelemetry-sdk-1.1.0-hd88be57_2.tar.bz2
linux-aarch64::clang-9-9.0.1-root_62400_h87104f5_3.tar.bz2
linux-aarch64::libllvm9-9.0.1-default_h56056e8_5.tar.bz2
linux-aarch64::libclang-cpp-9.0.1-cling_v0.9_ha556c46_3.tar.bz2
linux-aarch64::llvm-9.0.1-default_h69fb49e_6.tar.bz2
linux-aarch64::libclang-cpp9-9.0.1-cling_v0.9_ha556c46_3.tar.bz2
linux-aarch64::dotnet-runtime-6.0.1-h25a8a10_0.tar.bz2
linux-aarch64::libclang-cpp9-9.0.1-default_h2e6fa06_3.tar.bz2
-    "libzlib >=1.2.11,<1.3.0a0"
+    "libzlib >=1.2.11,<2.0.0a0"
================================================================================
================================================================================
noarch
================================================================================
================================================================================
win-64
win-64::vtk-9.0.1-qt_py310h040a9c1_210.tar.bz2
win-64::assimp-5.1.3-hc2aa0de_1.tar.bz2
win-64::libgdal-3.3.3-ha841e0a_15.tar.bz2
win-64::arrow-cpp-5.0.0-py37hb54f6c8_21_cpu.tar.bz2
win-64::pyretis-2.5.0-py37h556ddc3_2.tar.bz2
win-64::arrow-cpp-5.0.0-py38habfe946_21_cuda.tar.bz2
win-64::kaldi-5.5.992-cuda112h1234567_5.tar.bz2
win-64::llvmdev-9.0.1-default_hcbf89dc_5.tar.bz2
win-64::gmt-6.3.0-h9d8d656_1.tar.bz2
win-64::ogre-13.2.1-h927da9a_0.tar.bz2
win-64::pytables-3.7.0-py37hcd7ac32_0.tar.bz2
win-64::libprotobuf-static-3.19.4-h7755175_0.tar.bz2
win-64::omniorb-4.2.5-py310ha05212b_0.tar.bz2
win-64::capnproto-0.9.1-h8b1b97a_4.tar.bz2
win-64::omniorb-4.2.5-py37h04d2302_0.tar.bz2
win-64::gemmi-0.5.1-py310h2c03ce5_0.tar.bz2
win-64::curl-7.80.0-h789b8ee_1.tar.bz2
win-64::coda-2.23-py39h0989d49_0.tar.bz2
win-64::libgdal-3.3.3-h5eff6fd_13.tar.bz2
win-64::arrow-cpp-3.0.0-py39h0535864_38_cpu.tar.bz2
win-64::libprotobuf-static-3.19.2-h7755175_0.tar.bz2
win-64::libglib-2.70.2-h3be07f2_0.tar.bz2
win-64::libclang-cpp-9.0.1-default_h4233bec_3.tar.bz2
win-64::tomviz-1.10.0.post137-py37h735ec16_0.tar.bz2
win-64::pyinstaller-4.8-py39h4dafc3f_0.tar.bz2
win-64::hdf5-1.12.1-nompi_h57737ce_103.tar.bz2
win-64::r-git2r-0.29.0-r41h7c54dad_1.tar.bz2
win-64::vigra-1.11.1-py38hbee6ac1_1027.tar.bz2
win-64::vtk-9.1.0-qt_py37h55390ca_203.tar.bz2
win-64::pyretis-2.5.0-py310h65a939d_2.tar.bz2
win-64::vigra-1.11.1-py37h48b52a3_1028.tar.bz2
win-64::arrow-cpp-3.0.0-py310hc25b5fa_41_cuda.tar.bz2
win-64::libllvm9-9.0.1-default_hcbf89dc_7.tar.bz2
win-64::gemmi-0.5.2-py38h57a6900_0.tar.bz2
win-64::grpcio-1.43.0-py310ha05212b_0.tar.bz2
win-64::libgdal-3.4.0-h453e081_11.tar.bz2
win-64::clang-9-9.0.1-default_h4233bec_3.tar.bz2
win-64::arrow-cpp-5.0.0-py37hb54f6c8_22_cpu.tar.bz2
win-64::arrow-cpp-6.0.1-py39h591eb41_8_cpu.tar.bz2
win-64::arrow-cpp-6.0.1-py39h591eb41_7_cpu.tar.bz2
win-64::python-3.10.1-h9a09f29_1_cpython.tar.bz2
win-64::kaldi-5.5.992-cuda110h1234567_7.tar.bz2
win-64::glib-tools-2.70.2-h7755175_1.tar.bz2
win-64::coda-2.23-py310heba9ebb_0.tar.bz2
win-64::libgdal-3.4.0-h58f6a35_10.tar.bz2
win-64::wasmer-2.1.0-hc9dcdca_2.tar.bz2
win-64::arrow-cpp-5.0.0-py38h010afb3_18_cpu.tar.bz2
win-64::libgdal-3.3.3-ha74b9cd_11.tar.bz2
win-64::arrow-cpp-5.0.0-py38hcfbcb3e_21_cpu.tar.bz2
win-64::libllvm9-9.0.1-cling_v0.9_h265bc3a_5.tar.bz2
win-64::arrow-cpp-3.0.0-py39h591eb41_39_cpu.tar.bz2
win-64::postgresql-plpython-13.5-py37h44f2ed4_1.tar.bz2
win-64::gdstk-0.8.1-py39h845c095_0.tar.bz2
win-64::nifty-1.2.1-py310hd79a1d6_3.tar.bz2
win-64::nifty-1.2.1-py37h036d9df_1.tar.bz2
win-64::ruby-3.1.0-h1d9c0f5_1.tar.bz2
win-64::pyretis-2.5.0-py39ha19edc8_2.tar.bz2
win-64::ogre-13.2.1-h0650132_0.tar.bz2
win-64::arrow-cpp-5.0.0-py37h94fda74_18_cuda.tar.bz2
win-64::cpp-opentelemetry-sdk-1.1.1-ha77e48f_0.tar.bz2
win-64::tiledb-2.6.1-h95dad36_0.tar.bz2
win-64::zstd-1.5.1-h6255e5f_0.tar.bz2
win-64::libgdal-3.4.0-h58f6a35_12.tar.bz2
win-64::wasmer-2.1.0-hc9dcdca_1.tar.bz2
win-64::arrow-cpp-5.0.0-py39h591eb41_20_cpu.tar.bz2
win-64::pdal-2.3.0-h5bb3801_16.tar.bz2
win-64::qtwebkit-5.212-h3b0e7b7_2.tar.bz2
win-64::kaldi-5.5.992-cpu_h1234567_5.tar.bz2
win-64::libgdal-3.4.1-hb08d4f8_2.tar.bz2
win-64::pdal-2.3.0-h1b9c451_23.tar.bz2
win-64::arrow-cpp-3.0.0-py38hcfbcb3e_39_cpu.tar.bz2
win-64::vtk-9.1.0-qt_py39ha57d28d_203.tar.bz2
win-64::arrow-cpp-5.0.0-py310h0313859_20_cpu.tar.bz2
win-64::arrow-cpp-6.0.1-py37hf8493ad_8_cuda.tar.bz2
win-64::mysql-server-8.0.27-h77165ef_3.tar.bz2
win-64::libprotobuf-3.19.3-h7755175_0.tar.bz2
win-64::mongodb-5.1.1-h2fe6b32_0.tar.bz2
win-64::arrow-cpp-6.0.1-py310hc25b5fa_5_cuda.tar.bz2
win-64::arrow-cpp-3.0.0-py310hc25b5fa_39_cuda.tar.bz2
win-64::mysql-libs-8.0.28-h4d1747d_0.tar.bz2
win-64::postgresql-13.5-h1c22c4f_1.tar.bz2
win-64::nifty-1.2.1-py38h5865762_0.tar.bz2
win-64::arrow-cpp-5.0.0-py39hf53d898_19_cuda.tar.bz2
win-64::arrow-cpp-5.0.0-py37h59c7f16_18_cpu.tar.bz2
win-64::gmt-5.4.5-hdec49e6_17.tar.bz2
win-64::libopencv-4.5.3-py39h4b6fd43_6.tar.bz2
win-64::omniorb-4.2.5-py310h694bffd_0.tar.bz2
win-64::arrow-cpp-3.0.0-py39hf53d898_37_cuda.tar.bz2
win-64::wasmer-2.1.0-hfe322b1_0.tar.bz2
win-64::arrow-cpp-5.0.0-py310hc25b5fa_21_cuda.tar.bz2
win-64::arrow-cpp-3.0.0-py38hcfbcb3e_41_cpu.tar.bz2
win-64::arrow-cpp-5.0.0-py310hc25b5fa_22_cuda.tar.bz2
win-64::grpcio-1.43.0-py38he5377a8_0.tar.bz2
win-64::llvmlite-0.38.0-py39ha0cd8c8_0.tar.bz2
win-64::gdstk-0.8.1-py38haa2b6e7_0.tar.bz2
win-64::arrow-cpp-5.0.0-py37h59c7f16_19_cpu.tar.bz2
win-64::arrow-cpp-3.0.0-py310h1f3753b_37_cpu.tar.bz2
win-64::conduit-0.8.0-py37h5e611a3_0.tar.bz2
win-64::tiledb-2.6.2-h47404fa_0.tar.bz2
win-64::arrow-cpp-6.0.1-py37hb54f6c8_6_cpu.tar.bz2
win-64::gdstk-0.8.1-py37haae0f7f_0.tar.bz2
win-64::gmsh-4.9.3-ha4c064c_1.tar.bz2
win-64::arrow-cpp-5.0.0-py310h0313859_21_cpu.tar.bz2
win-64::librdkafka-1.3.0-h57a60f6_3.tar.bz2
win-64::arrow-cpp-6.0.1-py38habfe946_7_cuda.tar.bz2
win-64::arrow-cpp-3.0.0-py38habfe946_40_cuda.tar.bz2
win-64::arrow-cpp-3.0.0-py310h0313859_41_cpu.tar.bz2
win-64::arrow-cpp-3.0.0-py37h59c7f16_37_cpu.tar.bz2
win-64::netgen-6.2.2006-py310h0c3899f_4.tar.bz2
win-64::mysql-client-8.0.27-hf8b63c5_3.tar.bz2
win-64::llvm-tools-9.0.1-cling_v0.9_h265bc3a_6.tar.bz2
win-64::z5py-2.0.12-py310h5deb91e_0.tar.bz2
win-64::libspatialite-5.0.1-hd36faa7_13.tar.bz2
win-64::gdstk-0.8.1-py310h903a3d8_1.tar.bz2
win-64::wxwidgets-3.1.3-h8e1ed31_5.tar.bz2
win-64::nifty-1.2.1-py39h2ff02e8_2.tar.bz2
win-64::arrow-cpp-3.0.0-py39h1374f92_41_cuda.tar.bz2
win-64::vtk-9.1.0-qt_py310h46edce8_203.tar.bz2
win-64::llvm-tools-9.0.1-cling_v0.9_h265bc3a_7.tar.bz2
win-64::kaldi-5.5.992-cuda112h1234567_8.tar.bz2
win-64::assimp-5.1.0-hc2aa0de_0.tar.bz2
win-64::kaldi-5.5.992-h94960a0_2.tar.bz2
win-64::arrow-cpp-6.0.1-py39h1374f92_7_cuda.tar.bz2
win-64::capnproto-0.9.1-h8b1b97a_3.tar.bz2
win-64::conduit-0.8.1-py39h53d6734_0.tar.bz2
win-64::pyretis-2.5.0-py38h011f1d4_2.tar.bz2
win-64::papilo-2.0.0-h8955bf1_0.tar.bz2
win-64::arrow-cpp-3.0.0-py37h94fda74_37_cuda.tar.bz2
win-64::arrow-cpp-6.0.1-py37hb54f6c8_8_cpu.tar.bz2
win-64::vigra-1.11.1-py39hfe160f1_1027.tar.bz2
win-64::libpq-13.5-hfcc5ef8_1.tar.bz2
win-64::tiledb-2.5.3-h47404fa_0.tar.bz2
win-64::libgdal-3.4.0-hd873378_9.tar.bz2
win-64::kaldi-5.5.992-cpu_py39h1234567_4.tar.bz2
win-64::python-3.9.10-h9a09f29_0_cpython.tar.bz2
win-64::kaldi-5.5.992-h94960a0_1.tar.bz2
win-64::arrow-cpp-6.0.1-py39h1374f92_8_cuda.tar.bz2
win-64::arrow-cpp-6.0.1-py39h1374f92_5_cuda.tar.bz2
win-64::arrow-cpp-6.0.1-py37h59c7f16_3_cpu.tar.bz2
win-64::libgdal-3.4.0-hf8fe220_12.tar.bz2
win-64::pdal-2.3.0-hf7657dc_22.tar.bz2
win-64::llvm-tools-9.0.1-default_hcbf89dc_7.tar.bz2
win-64::conduit-0.7.1-py37h5e611a3_1.tar.bz2
win-64::gdstk-0.8.1-py38h4056165_1.tar.bz2
win-64::mysql-router-8.0.27-ha5f2955_2.tar.bz2
win-64::gmsh-4.9.3-h7544452_0.tar.bz2
win-64::assimp-5.1.4-hc2aa0de_0.tar.bz2
win-64::conduit-0.8.0-py39h53d6734_0.tar.bz2
win-64::llvmdev-9.0.1-cling_v0.9_h265bc3a_7.tar.bz2
win-64::librdkafka-1.3.0-he4d9d34_3.tar.bz2
win-64::kaldi-5.5.992-cuda111h1234567_8.tar.bz2
win-64::nifty-1.2.0-py37h036d9df_0.tar.bz2
win-64::arrow-cpp-6.0.1-py37h94fda74_3_cuda.tar.bz2
win-64::arrow-cpp-6.0.1-py37hf8493ad_7_cuda.tar.bz2
win-64::arrow-cpp-6.0.1-py310h3976e39_4_cuda.tar.bz2
win-64::omniorb-libs-4.2.5-hc7e8586_0.tar.bz2
win-64::libgdal-3.3.3-h4871699_13.tar.bz2
win-64::arrow-cpp-5.0.0-py310h0313859_22_cpu.tar.bz2
win-64::ogre-13.2.3-h927da9a_0.tar.bz2
win-64::libgdal-3.4.1-ha841e0a_2.tar.bz2
win-64::postgresql-13.5-he353ca9_1.tar.bz2
win-64::mysql-router-8.0.27-ha5f2955_3.tar.bz2
win-64::mysql-client-8.0.27-hf8b63c5_2.tar.bz2
win-64::libgdal-3.3.3-hd673501_14.tar.bz2
win-64::netgen-6.2.2006-py37h5acf806_4.tar.bz2
win-64::pytables-3.7.0-py39hbcfe41f_0.tar.bz2
win-64::tiledb-2.6.2-h95dad36_0.tar.bz2
win-64::libgdal-3.4.0-ha74b9cd_9.tar.bz2
win-64::python-3.10.2-h9a09f29_2_cpython.tar.bz2
win-64::arrow-cpp-3.0.0-py38habfe946_41_cuda.tar.bz2
win-64::capnproto-0.9.1-h7755175_5.tar.bz2
win-64::pdal-2.3.0-hd38ffa2_23.tar.bz2
win-64::python-3.10.1-hcf16a7b_2_cpython.tar.bz2
win-64::capnproto-0.9.1-hc7e8586_3.tar.bz2
win-64::ovito-3.6.0-h6f389ac_0.tar.bz2
win-64::pdal-2.3.0-hdde07dd_18.tar.bz2
win-64::libgdal-3.3.3-ha46b249_14.tar.bz2
win-64::arrow-cpp-6.0.1-py37h94fda74_4_cuda.tar.bz2
win-64::nifty-1.2.1-py37h036d9df_0.tar.bz2
win-64::conduit-0.8.1-py38hb6560f2_0.tar.bz2
win-64::nifty-1.2.1-py38h5865762_1.tar.bz2
win-64::libopencv-4.5.3-py31h6a2c607_7.tar.bz2
win-64::python-3.10.1-h9a09f29_0_cpython.tar.bz2
win-64::arrow-cpp-5.0.0-py39h1374f92_20_cuda.tar.bz2
win-64::pyinstaller-4.8-py37hd4a9ce8_0.tar.bz2
win-64::python-3.10.1-hcf16a7b_0_cpython.tar.bz2
win-64::pdal-2.3.0-h8c3116a_24.tar.bz2
win-64::libprotobuf-3.19.4-h7755175_0.tar.bz2
win-64::glib-tools-2.70.2-h7755175_0.tar.bz2
win-64::arrow-cpp-5.0.0-py39h1374f92_22_cuda.tar.bz2
win-64::python-3.10.2-h9a09f29_0_cpython.tar.bz2
win-64::qtwebkit-5.212-ha446f65_3.tar.bz2
win-64::r-git2r-0.29.0-r40h007cf7e_1.tar.bz2
win-64::arrow-cpp-5.0.0-py38hcfbcb3e_22_cpu.tar.bz2
win-64::arrow-cpp-3.0.0-py39h0535864_37_cpu.tar.bz2
win-64::conduit-0.8.1-py37h5e611a3_0.tar.bz2
win-64::arrow-cpp-5.0.0-py310h3976e39_18_cuda.tar.bz2
win-64::arrow-cpp-6.0.1-py310h1f3753b_3_cpu.tar.bz2
win-64::tesseract-5.0.0-h17c68af_1.tar.bz2
win-64::arrow-cpp-6.0.1-py39h591eb41_5_cpu.tar.bz2
win-64::grpcio-1.43.0-py310h694bffd_0.tar.bz2
win-64::llvmdev-9.0.1-default_hcbf89dc_6.tar.bz2
win-64::arrow-cpp-5.0.0-py310hc25b5fa_20_cuda.tar.bz2
win-64::omniorb-4.2.5-py39hf7b6eba_0.tar.bz2
win-64::libgdal-3.4.1-h5eff6fd_0.tar.bz2
win-64::libopencv-4.5.3-py37h0996282_6.tar.bz2
win-64::arrow-cpp-3.0.0-py39h591eb41_41_cpu.tar.bz2
win-64::llvm-tools-9.0.1-default_hcbf89dc_5.tar.bz2
win-64::vtk-9.1.0-qt_py38h565ee33_203.tar.bz2
win-64::arrow-cpp-6.0.1-py310h0313859_5_cpu.tar.bz2
win-64::kaldi-5.5.992-cuda111h1234567_6.tar.bz2
win-64::llvmdev-9.0.1-cling_v0.9_h265bc3a_6.tar.bz2
win-64::qt-main-5.15.2-he906bfe_0.tar.bz2
win-64::nifty-1.2.1-py39h2ff02e8_3.tar.bz2
win-64::postgresql-plpython-13.5-py38hda22b0a_1.tar.bz2
win-64::clang-9-9.0.1-cling_v0.9_h913594f_3.tar.bz2
win-64::kaldi-5.5.992-cuda110py39h1234567_4.tar.bz2
win-64::r-git2r-0.29.0-r41h007cf7e_1.tar.bz2
win-64::arrow-cpp-6.0.1-py310h0313859_7_cpu.tar.bz2
win-64::poppler-qt-22.01.0-h332a8cf_0.tar.bz2
win-64::kaldi-5.5.992-cpu_h1234567_7.tar.bz2
win-64::ogre-13.2.4-h0650132_0.tar.bz2
win-64::coda-2.23-py37hbabc145_0.tar.bz2
win-64::arrow-cpp-5.0.0-py39h1374f92_21_cuda.tar.bz2
win-64::libopencv-4.5.5-py31h6a2c607_0.tar.bz2
win-64::arrow-cpp-6.0.1-py38hcfbcb3e_5_cpu.tar.bz2
win-64::pyinstaller-4.8-py310h3cefddf_0.tar.bz2
win-64::nco-5.0.4-h5be7ecf_0.tar.bz2
win-64::llvmdev-9.0.1-default_hcbf89dc_7.tar.bz2
win-64::llvmlite-0.38.0-py38h57a6900_0.tar.bz2
win-64::cpp-opentelemetry-sdk-1.1.0-h3caef4a_2.tar.bz2
win-64::arrow-cpp-3.0.0-py38ha1cdc28_37_cuda.tar.bz2
win-64::librdkafka-1.3.0-h57a60f6_1.tar.bz2
win-64::libgdal-3.3.3-hf8fe220_12.tar.bz2
win-64::coda-2.23-py38h9644311_0.tar.bz2
win-64::kaldi-5.5.992-cuda111h1234567_7.tar.bz2
win-64::arrow-cpp-3.0.0-py38habfe946_39_cuda.tar.bz2
win-64::libpq-13.5-h1ea2d34_1.tar.bz2
win-64::librdkafka-1.3.0-he4d9d34_1.tar.bz2
win-64::tiledb-2.6.0-h95dad36_0.tar.bz2
win-64::pdal-2.3.0-hf7657dc_21.tar.bz2
win-64::arrow-cpp-5.0.0-py39hf53d898_18_cuda.tar.bz2
win-64::tiledb-2.5.3-h95dad36_0.tar.bz2
win-64::libopencv-4.5.3-py38hd5548a8_7.tar.bz2
win-64::freecad-0.19.3-py38h0470b87_3.tar.bz2
win-64::wasmer-2.1.1-hc9dcdca_0.tar.bz2
win-64::python-3.9.9-hcf16a7b_0_cpython.tar.bz2
win-64::assimp-5.2.0-hc2aa0de_0.tar.bz2
win-64::arrow-cpp-5.0.0-py37hf8493ad_20_cuda.tar.bz2
win-64::python-3.10.2-hcf16a7b_0_cpython.tar.bz2
win-64::arrow-cpp-6.0.1-py38habfe946_5_cuda.tar.bz2
win-64::llvmlite-0.38.0-py310h2c03ce5_0.tar.bz2
win-64::arrow-cpp-6.0.1-py310h0313859_6_cpu.tar.bz2
win-64::libgdal-3.4.1-hd673501_1.tar.bz2
win-64::arrow-cpp-6.0.1-py37hb54f6c8_5_cpu.tar.bz2
win-64::libgdal-3.4.0-h4871699_13.tar.bz2
win-64::glib-networking-2.70.1-h68a54cf_0.tar.bz2
win-64::arrow-cpp-6.0.1-py37h59c7f16_4_cpu.tar.bz2
win-64::netgen-6.2.2006-py39heeae859_4.tar.bz2
win-64::gdstk-0.8.1-py37h584bb85_1.tar.bz2
win-64::qt-main-5.15.2-hb84c757_1.tar.bz2
win-64::arrow-cpp-3.0.0-py310h0313859_40_cpu.tar.bz2
win-64::arrow-cpp-6.0.1-py39h1374f92_6_cuda.tar.bz2
win-64::gemmi-0.5.2-py37habb0c8c_0.tar.bz2
win-64::gdstk-0.8.1-py37hd54d70d_0.tar.bz2
win-64::pdal-2.3.0-hdde07dd_17.tar.bz2
win-64::arrow-cpp-3.0.0-py310hc25b5fa_40_cuda.tar.bz2
win-64::python-3.9.10-hcf16a7b_1_cpython.tar.bz2
win-64::librdkafka-1.8.2.post2-he4d9d34_0.tar.bz2
win-64::mysql-connector-cpp-8.0.27-h4b8edf9_0.tar.bz2
win-64::arrow-cpp-6.0.1-py38ha1cdc28_4_cuda.tar.bz2
win-64::libllvm9-9.0.1-default_hcbf89dc_5.tar.bz2
win-64::ogre-13.2.3-h0650132_0.tar.bz2
win-64::z5py-2.0.11-py37h196ee6d_1.tar.bz2
win-64::python-3.10.2-hcf16a7b_1_cpython.tar.bz2
win-64::kaldi-5.5.992-h94960a0_3.tar.bz2
win-64::tiledb-2.6.0-h47404fa_0.tar.bz2
win-64::kaldi-5.5.992-cuda110h1234567_5.tar.bz2
win-64::libmongoc-1.20.1-he3419e8_0.tar.bz2
win-64::kaldi-5.5.992-cuda112py39h1234567_4.tar.bz2
win-64::gmt-6.3.0-he50b5be_2.tar.bz2
win-64::nifty-1.2.0-py38h5865762_0.tar.bz2
win-64::mysql-libs-8.0.27-h4d1747d_3.tar.bz2
win-64::geotiff-1.7.0-h144821f_6.tar.bz2
win-64::pdal-2.3.0-haefb1d8_20.tar.bz2
win-64::mysql-libs-8.0.27-h4d1747d_2.tar.bz2
win-64::tesseract-5.0.0-h17c68af_0.tar.bz2
win-64::nifty-1.2.1-py38h5865762_2.tar.bz2
win-64::libopencv-4.5.5-py39h606fa8f_0.tar.bz2
win-64::gemmi-0.5.1-py37habb0c8c_0.tar.bz2
win-64::llvm-tools-9.0.1-cling_v0.9_h265bc3a_5.tar.bz2
win-64::z5py-2.0.11-py39hcf4c0ac_1.tar.bz2
win-64::glib-2.70.2-h7755175_1.tar.bz2
win-64::grpc-cpp-1.43.0-ha2e5525_0.tar.bz2
win-64::libllvm9-9.0.1-cling_v0.9_h265bc3a_7.tar.bz2
win-64::tiledb-2.6.1-h47404fa_0.tar.bz2
win-64::arrow-cpp-3.0.0-py310h1f3753b_38_cpu.tar.bz2
win-64::gdstk-0.8.1-py310h7ff0bff_0.tar.bz2
win-64::postgresql-plpython-13.5-py38h98422bd_1.tar.bz2
win-64::z5py-2.0.12-py37h196ee6d_0.tar.bz2
win-64::arrow-cpp-3.0.0-py37hf8493ad_40_cuda.tar.bz2
win-64::arrow-cpp-6.0.1-py39h0535864_4_cpu.tar.bz2
win-64::arrow-cpp-6.0.1-py38habfe946_8_cuda.tar.bz2
win-64::arrow-cpp-5.0.0-py310h1f3753b_19_cpu.tar.bz2
win-64::libgdal-3.4.1-h4871699_0.tar.bz2
win-64::gmt-6.3.0-he50b5be_1.tar.bz2
win-64::pdal-2.3.0-haefb1d8_21.tar.bz2
win-64::assimp-5.2.0-hc2aa0de_1.tar.bz2
win-64::arrow-cpp-5.0.0-py39h591eb41_22_cpu.tar.bz2
win-64::cpp-opentelemetry-sdk-1.1.0-h3caef4a_1.tar.bz2
win-64::libopencv-4.5.3-py37h04cf790_7.tar.bz2
win-64::arrow-cpp-6.0.1-py310hc25b5fa_8_cuda.tar.bz2
win-64::libmongoc-1.20.1-hf697a22_0.tar.bz2
win-64::libclang-cpp-9.0.1-cling_v0.9_h913594f_3.tar.bz2
win-64::python-3.9.10-hcf16a7b_0_cpython.tar.bz2
win-64::libllvm9-9.0.1-cling_v0.9_h265bc3a_6.tar.bz2
win-64::arrow-cpp-6.0.1-py38habfe946_6_cuda.tar.bz2
win-64::omniorb-4.2.5-py39hb76b349_0.tar.bz2
win-64::assimp-5.1.0-hc2aa0de_1.tar.bz2
win-64::arrow-cpp-6.0.1-py38h010afb3_4_cpu.tar.bz2
win-64::grpcio-1.43.0-py37h265e445_0.tar.bz2
win-64::ogre-13.2.2-h0650132_0.tar.bz2
win-64::postgresql-plpython-13.5-py39h2d4c99b_1.tar.bz2
win-64::grpc-cpp-1.43.0-he6c5f2b_0.tar.bz2
win-64::arrow-cpp-3.0.0-py38ha1cdc28_38_cuda.tar.bz2
win-64::mysql-connector-cpp-8.0.28-h4b8edf9_0.tar.bz2
win-64::omniorb-libs-4.2.5-h8b1b97a_0.tar.bz2
win-64::llvmdev-9.0.1-cling_v0.9_h265bc3a_5.tar.bz2
win-64::arrow-cpp-6.0.1-py37hf8493ad_6_cuda.tar.bz2
win-64::libgdal-3.4.0-h5eff6fd_13.tar.bz2
win-64::vtk-9.0.1-qt_py38h5b6aec5_210.tar.bz2
win-64::vigra-1.11.1-py39hfe160f1_1028.tar.bz2
win-64::gst-plugins-base-1.18.5-he07aa86_3.tar.bz2
win-64::libllvm9-9.0.1-default_hcbf89dc_6.tar.bz2
win-64::arrow-cpp-5.0.0-py37hf8493ad_21_cuda.tar.bz2
win-64::postgresql-plpython-13.5-py37h547e9a6_1.tar.bz2
win-64::arrow-cpp-6.0.1-py310h3976e39_3_cuda.tar.bz2
win-64::vtk-9.0.1-qt_py39hbb6573b_210.tar.bz2
win-64::libgdal-3.3.3-hb08d4f8_15.tar.bz2
win-64::arrow-cpp-3.0.0-py310h3976e39_38_cuda.tar.bz2
win-64::arrow-cpp-5.0.0-py310h1f3753b_18_cpu.tar.bz2
win-64::libopencv-4.5.5-py38hd5548a8_0.tar.bz2
win-64::postgresql-plpython-13.5-py310hb974fb4_1.tar.bz2
win-64::libsoup-2.74.1-h309951b_0.tar.bz2
win-64::omniorb-4.2.5-py38ha65041e_0.tar.bz2
win-64::libgdal-3.4.1-ha46b249_1.tar.bz2
win-64::omniorb-4.2.5-py38he5377a8_0.tar.bz2
win-64::z5py-2.0.11-py310h5deb91e_1.tar.bz2
win-64::z5py-2.0.12-py39hcf4c0ac_0.tar.bz2
win-64::libgdal-3.3.3-hd873378_11.tar.bz2
win-64::arrow-cpp-6.0.1-py310hc25b5fa_7_cuda.tar.bz2
win-64::grpc-cpp-1.43.2-he6c5f2b_0.tar.bz2
win-64::conduit-0.7.1-py39h53d6734_1.tar.bz2
win-64::libspatialite-5.0.1-hc2703d3_14.tar.bz2
win-64::python-3.10.2-h9a09f29_1_cpython.tar.bz2
win-64::kaldi-5.5.992-cuda110h1234567_8.tar.bz2
win-64::arrow-cpp-5.0.0-py38hcfbcb3e_20_cpu.tar.bz2
win-64::arrow-cpp-5.0.0-py37h94fda74_19_cuda.tar.bz2
win-64::gdstk-0.8.1-py39hcb63d39_1.tar.bz2
win-64::libopencv-4.5.3-py39h606fa8f_7.tar.bz2
win-64::glib-2.70.2-h7755175_0.tar.bz2
win-64::libharu-2.3.0-h546665d_2.tar.bz2
win-64::arrow-cpp-5.0.0-py39h0535864_18_cpu.tar.bz2
win-64::grpc-cpp-1.43.2-ha2e5525_0.tar.bz2
win-64::arrow-cpp-6.0.1-py39h0535864_3_cpu.tar.bz2
win-64::mysql-router-8.0.28-ha5f2955_0.tar.bz2
win-64::kaldi-5.5.992-cpu_h1234567_8.tar.bz2
win-64::grpcio-1.43.0-py39hf7b6eba_0.tar.bz2
win-64::arrow-cpp-3.0.0-py38h010afb3_38_cpu.tar.bz2
win-64::omniorb-4.2.5-py37h265e445_0.tar.bz2
win-64::vigra-1.11.1-py310h2461408_1028.tar.bz2
win-64::arrow-cpp-3.0.0-py39h591eb41_40_cpu.tar.bz2
win-64::arrow-cpp-3.0.0-py37hb54f6c8_41_cpu.tar.bz2
win-64::arrow-cpp-3.0.0-py38hcfbcb3e_40_cpu.tar.bz2
win-64::cpp-opentelemetry-sdk-1.1.0-ha77e48f_4.tar.bz2
win-64::arrow-cpp-3.0.0-py39h1374f92_40_cuda.tar.bz2
win-64::pyinstaller-4.8-py38hd0d6af5_0.tar.bz2
win-64::nifty-1.2.1-py39h2ff02e8_1.tar.bz2
win-64::arrow-cpp-6.0.1-py38h010afb3_3_cpu.tar.bz2
win-64::mysql-server-8.0.28-h77165ef_0.tar.bz2
win-64::assimp-5.1.5-hc2aa0de_0.tar.bz2
win-64::arrow-cpp-6.0.1-py38hcfbcb3e_6_cpu.tar.bz2
win-64::arrow-cpp-3.0.0-py39hf53d898_38_cuda.tar.bz2
win-64::capnproto-0.9.1-hc7e8586_4.tar.bz2
win-64::arrow-cpp-6.0.1-py38hcfbcb3e_8_cpu.tar.bz2
win-64::tesseract-4.1.3-h17c68af_6.tar.bz2
win-64::arrow-cpp-5.0.0-py38h010afb3_19_cpu.tar.bz2
win-64::arrow-cpp-6.0.1-py37hf8493ad_5_cuda.tar.bz2
win-64::arrow-cpp-6.0.1-py310h1f3753b_4_cpu.tar.bz2
win-64::arrow-cpp-3.0.0-py310h0313859_39_cpu.tar.bz2
win-64::libopencv-4.5.3-py38hb110498_6.tar.bz2
win-64::llvmlite-0.38.0-py37h5781856_0.tar.bz2
win-64::pdal-2.3.0-h9a9b16a_24.tar.bz2
win-64::libcurl-static-7.80.0-h789b8ee_1.tar.bz2
win-64::llvm-tools-9.0.1-default_hcbf89dc_6.tar.bz2
win-64::gdstk-0.8.1-py37hfb7eb7e_1.tar.bz2
win-64::ogre-13.2.4-h927da9a_0.tar.bz2
win-64::tomviz-1.10.0.post152-py37hb51cde3_0.tar.bz2
win-64::curl-7.81.0-h789b8ee_0.tar.bz2
win-64::pdal-2.3.0-haefb1d8_22.tar.bz2
win-64::nifty-1.2.1-py37h036d9df_3.tar.bz2
win-64::vigra-1.11.1-py38hbee6ac1_1028.tar.bz2
win-64::oclgrind-21.10-h6fda50d_0.tar.bz2
win-64::scip-8.0.0-h6aab56e_0.tar.bz2
win-64::grpcio-1.43.0-py39hb76b349_0.tar.bz2
win-64::gmt-6.3.0-h0cd9ecb_3.tar.bz2
win-64::kaldi-5.5.992-cuda111py39h1234567_4.tar.bz2
win-64::mysql-connector-cpp-8.0.27-h4b8edf9_1.tar.bz2
win-64::pytables-3.7.0-py38h7deab4d_0.tar.bz2
win-64::python-3.9.10-h9a09f29_1_cpython.tar.bz2
win-64::arrow-cpp-6.0.1-py38ha1cdc28_3_cuda.tar.bz2
win-64::llvmlite-0.38.0-py37habb0c8c_0.tar.bz2
win-64::wasmer-2.1.0-hf725046_2.tar.bz2
win-64::capnproto-0.9.1-h8b1b97a_2.tar.bz2
win-64::arrow-cpp-3.0.0-py310h3976e39_37_cuda.tar.bz2
win-64::arrow-cpp-3.0.0-py38h010afb3_37_cpu.tar.bz2
win-64::hdf5-1.12.1-nompi_h2a0e4a3_103.tar.bz2
win-64::arrow-cpp-5.0.0-py38habfe946_20_cuda.tar.bz2
win-64::libprotobuf-static-3.19.3-h7755175_0.tar.bz2
win-64::z5py-2.0.12-py38h6790dec_0.tar.bz2
win-64::arrow-cpp-3.0.0-py39h1374f92_39_cuda.tar.bz2
win-64::arrow-cpp-3.0.0-py37hb54f6c8_39_cpu.tar.bz2
win-64::grpcio-1.43.0-py37h04d2302_0.tar.bz2
win-64::nifty-1.2.1-py38h5865762_3.tar.bz2
win-64::libopencv-4.5.5-py37h04cf790_0.tar.bz2
win-64::arrow-cpp-5.0.0-py37hf8493ad_22_cuda.tar.bz2
win-64::kaldi-5.5.992-cuda111h1234567_5.tar.bz2
win-64::netgen-6.2.2006-py38h6585720_4.tar.bz2
win-64::conduit-0.7.1-py38hb6560f2_1.tar.bz2
win-64::libgdal-3.4.0-hf8fe220_10.tar.bz2
win-64::pytables-3.7.0-py37h9e9d995_0.tar.bz2
win-64::libprotobuf-3.19.2-h7755175_0.tar.bz2
win-64::pdal-2.3.0-hdde07dd_19.tar.bz2
win-64::libglib-2.70.2-h3be07f2_1.tar.bz2
win-64::gemmi-0.5.2-py310h2c03ce5_0.tar.bz2
win-64::grpc-cpp-1.42.0-he6c5f2b_1.tar.bz2
win-64::bgen-4.1.3-he0a40f0_0.tar.bz2
win-64::cpp-opentelemetry-sdk-1.1.1-h568589d_2.tar.bz2
win-64::grpcio-1.43.0-py38ha65041e_0.tar.bz2
win-64::kaldi-5.5.992-cuda112h1234567_6.tar.bz2
win-64::tesseract-5.0.1-h17c68af_0.tar.bz2
win-64::ruby-2.7.2-h1d9c0f5_8.tar.bz2
win-64::kaldi-5.5.992-cuda112h1234567_7.tar.bz2
win-64::arrow-cpp-3.0.0-py37hb54f6c8_40_cpu.tar.bz2
win-64::arrow-cpp-3.0.0-py37hf8493ad_41_cuda.tar.bz2
win-64::pytables-3.7.0-py310h5dd77a3_0.tar.bz2
win-64::arrow-cpp-3.0.0-py37h94fda74_38_cuda.tar.bz2
win-64::arrow-cpp-5.0.0-py39h0535864_19_cpu.tar.bz2
win-64::arrow-cpp-6.0.1-py38hcfbcb3e_7_cpu.tar.bz2
win-64::soplex-6.0.0-h1f26b8a_0.tar.bz2
win-64::nifty-1.2.0-py39h2ff02e8_0.tar.bz2
win-64::arrow-cpp-5.0.0-py38habfe946_22_cuda.tar.bz2
win-64::ogre-13.2.2-h927da9a_0.tar.bz2
win-64::librdkafka-1.7.0-he4d9d34_1.tar.bz2
win-64::vtk-9.0.1-qt_py37hc2356ab_210.tar.bz2
win-64::libcurl-7.81.0-h789b8ee_0.tar.bz2
win-64::python-3.10.1-hcf16a7b_1_cpython.tar.bz2
win-64::arrow-cpp-6.0.1-py37hb54f6c8_7_cpu.tar.bz2
win-64::arrow-cpp-6.0.1-py39hf53d898_3_cuda.tar.bz2
win-64::zstd-1.5.2-h6255e5f_0.tar.bz2
win-64::graphicsmagick-1.3.37-hd130993_0.tar.bz2
win-64::arrow-cpp-3.0.0-py37hf8493ad_39_cuda.tar.bz2
win-64::kaldi-5.5.992-h800c9b3_0.tar.bz2
win-64::wasmer-2.1.1-hf725046_0.tar.bz2
win-64::cpp-opentelemetry-sdk-1.1.0-h3caef4a_3.tar.bz2
win-64::tomviz-1.10.0.post152-py37h735ec16_0.tar.bz2
win-64::arrow-cpp-6.0.1-py310hc25b5fa_6_cuda.tar.bz2
win-64::nco-5.0.5-h5be7ecf_0.tar.bz2
win-64::librdkafka-1.8.2.post2-h57a60f6_0.tar.bz2
win-64::kaldi-5.5.992-cuda110h1234567_6.tar.bz2
win-64::gemmi-0.5.1-py38h57a6900_0.tar.bz2
win-64::python-3.10.2-hcf16a7b_2_cpython.tar.bz2
win-64::cpp-opentelemetry-sdk-1.1.1-h568589d_1.tar.bz2
win-64::kaldi-5.5.992-cpu_h1234567_6.tar.bz2
win-64::nifty-1.2.1-py39h2ff02e8_0.tar.bz2
win-64::freecad-0.19.3-py39hf29922c_3.tar.bz2
win-64::r-git2r-0.29.0-r40h7c54dad_1.tar.bz2
win-64::arrow-cpp-5.0.0-py38ha1cdc28_19_cuda.tar.bz2
win-64::arrow-cpp-3.0.0-py37h59c7f16_38_cpu.tar.bz2
win-64::libcurl-static-7.81.0-h789b8ee_0.tar.bz2
win-64::gemmi-0.5.2-py39ha0cd8c8_0.tar.bz2
win-64::arrow-cpp-6.0.1-py310h0313859_8_cpu.tar.bz2
win-64::python-3.9.9-h9a09f29_0_cpython.tar.bz2
win-64::arrow-cpp-5.0.0-py37hb54f6c8_20_cpu.tar.bz2
win-64::mysql-client-8.0.28-hf8b63c5_0.tar.bz2
win-64::arrow-cpp-6.0.1-py39h591eb41_6_cpu.tar.bz2
win-64::libopencv-4.5.3-py31h3d48b04_6.tar.bz2
win-64::postgresql-plpython-13.5-py310ha83e0bf_1.tar.bz2
win-64::ruby-3.1.0-h8ed59c0_1.tar.bz2
win-64::coda-2.23-py37hca80f52_0.tar.bz2
win-64::arrow-cpp-5.0.0-py39h591eb41_21_cpu.tar.bz2
win-64::librdkafka-1.7.0-h57a60f6_1.tar.bz2
win-64::mysql-server-8.0.27-h77165ef_2.tar.bz2
win-64::assimp-5.1.6-hc2aa0de_0.tar.bz2
win-64::libcurl-7.80.0-h789b8ee_1.tar.bz2
win-64::arrow-cpp-5.0.0-py310h3976e39_19_cuda.tar.bz2
win-64::libgdal-3.3.3-h58f6a35_12.tar.bz2
win-64::ruby-3.1.0-h1d9c0f5_0.tar.bz2
win-64::gemmi-0.5.1-py39ha0cd8c8_0.tar.bz2
win-64::postgresql-plpython-13.5-py39he868e5a_1.tar.bz2
win-64::vigra-1.11.1-py37h48b52a3_1027.tar.bz2
win-64::python-3.10.1-h9a09f29_2_cpython.tar.bz2
win-64::arrow-cpp-6.0.1-py39hf53d898_4_cuda.tar.bz2
win-64::gst-plugins-good-1.18.5-he07aa86_3.tar.bz2
win-64::arrow-cpp-5.0.0-py38ha1cdc28_18_cuda.tar.bz2
win-64::grpc-cpp-1.42.0-ha2e5525_1.tar.bz2
win-64::nifty-1.2.1-py37h036d9df_2.tar.bz2
-    "libzlib >=1.2.11,<1.3.0a0",
+    "libzlib >=1.2.11,<2.0.0a0",
win-64::llvm-9.0.1-cling_v0.9_h7125dd7_5.tar.bz2
win-64::llvm-9.0.1-default_hcb398ef_5.tar.bz2
win-64::llvm-9.0.1-default_hcb398ef_7.tar.bz2
win-64::llvm-9.0.1-cling_v0.9_h7125dd7_7.tar.bz2
win-64::llvm-9.0.1-default_hcb398ef_6.tar.bz2
win-64::llvm-9.0.1-cling_v0.9_h7125dd7_6.tar.bz2
-    "libzlib >=1.2.11,<1.3.0a0"
+    "libzlib >=1.2.11,<2.0.0a0"
================================================================================
================================================================================
osx-64
osx-64::ruby-2.7.2-h1c0b240_8.tar.bz2
osx-64::gazebo-11.9.1-hf853dad_0.tar.bz2
osx-64::assimp-5.1.4-h1224e73_0.tar.bz2
osx-64::wxpython-4.1.1-py38hba60f62_3.tar.bz2
osx-64::omniorb-4.2.5-py37h87f55f7_0.tar.bz2
osx-64::arrow-cpp-6.0.1-py39h9d2824b_6_cpu.tar.bz2
osx-64::nifty-1.2.1-py37hf670e59_3.tar.bz2
osx-64::grpcio-1.43.0-py310haaead3b_0.tar.bz2
osx-64::nodejs-14.18.3-hb529b34_1.tar.bz2
osx-64::arrow-cpp-3.0.0-py310hb6cbff4_40_cpu.tar.bz2
osx-64::mysql-client-8.0.27-h9c38be6_3.tar.bz2
osx-64::gds-base-gdstrig-2.19.7-hc1cc398_1.tar.bz2
osx-64::mysql-connector-cpp-8.0.27-h328bd3c_0.tar.bz2
osx-64::qt-main-5.15.2-h8f7a3c3_1.tar.bz2
osx-64::wxpython-4.1.1-py37h498246d_3.tar.bz2
osx-64::astrometry-0.88-py37h8ac32d7_0.tar.bz2
osx-64::dcap-2.47.12-he3abd7b_5.tar.bz2
osx-64::ogre-13.2.2-h5dd8d7a_0.tar.bz2
osx-64::nodejs-14.18.3-h25b689e_2.tar.bz2
osx-64::tomviz-1.10.0.post152-py37hadb2b92_0.tar.bz2
osx-64::qtwebkit-5.212-h06175b8_3.tar.bz2
osx-64::vtk-9.0.1-qt_py38h8316443_210.tar.bz2
osx-64::librdkafka-1.3.0-h530747d_3.tar.bz2
osx-64::wasmer-2.1.1-h06173f7_0.tar.bz2
osx-64::octave-6.4.0-hb9d2791_0.tar.bz2
osx-64::gmt-6.3.0-h9b82708_3.tar.bz2
osx-64::nodejs-17.4.0-h1fee019_0.tar.bz2
osx-64::tiledb-2.5.3-h2a16ea5_0.tar.bz2
osx-64::julia-1.7.1-h132cb31_1.tar.bz2
osx-64::conduit-0.8.0-py36he10306b_0.tar.bz2
osx-64::mysql-server-8.0.28-he1246a2_0.tar.bz2
osx-64::triqs-3.0.2-py39hc8335e0_0.tar.bz2
osx-64::libcurl-7.81.0-h97da3c1_0.tar.bz2
osx-64::imagemagick-7.1.0_20-pl5321h3e49128_0.tar.bz2
osx-64::nifty-1.2.1-py39h7b0b313_1.tar.bz2
osx-64::mandrake-1.2.1-py38hed967db_0.tar.bz2
osx-64::uwsgi-2.0.20-py37h32f2adb_2.tar.bz2
osx-64::wasmer-2.1.1-h7d3d4a7_0.tar.bz2
osx-64::arrow-cpp-5.0.0-py39hc83c8ec_19_cpu.tar.bz2
osx-64::arrow-cpp-5.0.0-py37h3fd9f21_18_cpu.tar.bz2
osx-64::liblal-7.1.6-mkl_hcfe4361_0.tar.bz2
osx-64::triqs-3.0.2-py38hb9fcd7f_0.tar.bz2
osx-64::z5py-2.0.11-py39haf96dd5_1.tar.bz2
osx-64::magics-metview-batch-4.10.0-hf29bfc3_1.tar.bz2
osx-64::papilo-2.0.0-h2d235a5_0.tar.bz2
osx-64::liblal-7.1.5-mkl_hcfe4361_0.tar.bz2
osx-64::ndcctools-7.4.1-py39hb974310_0.tar.bz2
osx-64::julia-1.6.4-h132cb31_2.tar.bz2
osx-64::arrow-cpp-5.0.0-py310h71bd60a_22_cpu.tar.bz2
osx-64::mysql-libs-8.0.27-h115446f_3.tar.bz2
osx-64::gazebo-11.9.1-he01bef3_2.tar.bz2
osx-64::uwsgi-2.0.20-py37h32f2adb_3.tar.bz2
osx-64::librdkafka-1.7.0-h530747d_1.tar.bz2
osx-64::grpc-cpp-1.43.2-h6da9ac5_0.tar.bz2
osx-64::gazebo-11.10.1-ha2fdce5_1.tar.bz2
osx-64::libpq-13.5-h8ce7ee7_1.tar.bz2
osx-64::assimp-5.1.5-h1224e73_0.tar.bz2
osx-64::ndcctools-7.4.2-py38h171f6b0_0.tar.bz2
osx-64::paraview-5.10.0-hf202402_103_qt.tar.bz2
osx-64::arrow-cpp-5.0.0-py310hc458819_18_cpu.tar.bz2
osx-64::tomviz-1.10.0.post152-py37hf986f44_0.tar.bz2
osx-64::magics-metview-4.10.0-h256ed8d_2.tar.bz2
osx-64::uwsgi-2.0.20-py38haf0cd8b_2.tar.bz2
osx-64::ogre-13.2.4-ha8acd6a_0.tar.bz2
osx-64::julia-1.6.5-h132cb31_1.tar.bz2
osx-64::nodejs-16.13.2-h1fee019_2.tar.bz2
osx-64::arrow-cpp-6.0.1-py37h172e15e_7_cpu.tar.bz2
osx-64::kaldi-5.5.992-hf12bd3d_2.tar.bz2
osx-64::libgdal-3.3.3-h149f711_12.tar.bz2
osx-64::vtk-9.1.0-qt_py38hf8e4d4e_203.tar.bz2
osx-64::pytables-3.7.0-py310hdbf068a_0.tar.bz2
osx-64::conduit-0.7.1-py39h16e84d1_1.tar.bz2
osx-64::paraview-5.10.0-h8e0c0f5_103_qt.tar.bz2
osx-64::arrow-cpp-6.0.1-py310hc458819_3_cpu.tar.bz2
osx-64::readdy-2.0.11-py38hc402ea3_0.tar.bz2
osx-64::gct-6.2.1629922860-hfd382f3_0.tar.bz2
osx-64::xrootd-5.3.4-py37ha8183f8_0.tar.bz2
osx-64::llvmdev-9.0.1-default_h2671707_7.tar.bz2
osx-64::libgdal-3.3.3-h09ae624_14.tar.bz2
osx-64::llvmlite-0.38.0-py39h798a4f4_0.tar.bz2
osx-64::ndcctools-7.4.1-py39hb974310_1.tar.bz2
osx-64::paraview-5.10.0-h6b87102_103_qt.tar.bz2
osx-64::ndcctools-7.4.1-py37hbece8e7_0.tar.bz2
osx-64::coda-2.23-py310h4c0e1fa_0.tar.bz2
osx-64::pdal-2.3.0-h5d9154f_23.tar.bz2
osx-64::arrow-cpp-3.0.0-py38h2edcfc6_40_cpu.tar.bz2
osx-64::libvips-8.12.2-h044158d_0.tar.bz2
osx-64::libprotobuf-3.19.3-hcf210ce_0.tar.bz2
osx-64::mandrake-1.2.0-py39h20b4717_0.tar.bz2
osx-64::llvmdev-9.0.1-cling_v0.9_hf28e3b7_5.tar.bz2
osx-64::dcap-2.47.12-h2d08458_5.tar.bz2
osx-64::z5py-2.0.12-py310h5fba041_0.tar.bz2
osx-64::tesseract-5.0.0-h6be3199_0.tar.bz2
osx-64::conduit-0.7.1-py38ha877268_1.tar.bz2
osx-64::gdstk-0.8.1-py38h6db56eb_0.tar.bz2
osx-64::cctools_osx-64-973.0.1-h3e07e27_4.tar.bz2
osx-64::postgresql-plpython-13.5-py37h67c5a11_1.tar.bz2
osx-64::pdal-2.3.0-h9be679a_21.tar.bz2
osx-64::conduit-0.8.1-py37he5bc6c3_0.tar.bz2
osx-64::arrow-cpp-3.0.0-py310h7c6ea7c_38_cpu.tar.bz2
osx-64::ruby-3.1.0-hed99dc5_0.tar.bz2
osx-64::vowpalwabbit-9.0.0-py39h60e5d19_2.tar.bz2
osx-64::arrow-cpp-6.0.1-py39hc83c8ec_4_cpu.tar.bz2
osx-64::python-3.10.2-h1dd9edd_2_cpython.tar.bz2
osx-64::hdf5-1.12.1-nompi_hd9e8a45_103.tar.bz2
osx-64::kaldi-5.5.992-hbbcd84e_0.tar.bz2
osx-64::astrometry-0.88-py310hb1ff3b3_0.tar.bz2
osx-64::tensorflow-base-2.6.2-cpu_py39h87c5db1_2.tar.bz2
osx-64::libtiledb-sql-0.12.3-h2446079_0.tar.bz2
osx-64::conduit-0.8.0-py37hb77c8a2_0.tar.bz2
osx-64::pdal-2.3.0-h1cd41a2_22.tar.bz2
osx-64::h5utils-1.13.1-nompi_h540873d_1113.tar.bz2
osx-64::libglib-2.70.2-hf1fb8c0_0.tar.bz2
osx-64::ndcctools-7.4.2-py310h407b262_0.tar.bz2
osx-64::protozfits-2.0.1.post1-py37hdabc7ef_7.tar.bz2
osx-64::ovito-3.6.0-he351b1d_0.tar.bz2
osx-64::magics-4.10.0-ha2da071_2.tar.bz2
osx-64::gemmi-0.5.2-py38h872f124_0.tar.bz2
osx-64::arrow-cpp-3.0.0-py39hf938c1e_41_cpu.tar.bz2
osx-64::netpbm-10.73.38-pl5321h08452c6_0.tar.bz2
osx-64::arrow-cpp-5.0.0-py38h03f22f6_19_cpu.tar.bz2
osx-64::nifty-1.2.1-py39h7b0b313_2.tar.bz2
osx-64::vigra-1.11.1-py37h0155546_1028.tar.bz2
osx-64::magics-metview-batch-4.10.0-ha2da071_2.tar.bz2
osx-64::vigra-1.11.1-py37h296af3d_1027.tar.bz2
osx-64::pyinstaller-4.8-py37h83b74e4_0.tar.bz2
osx-64::libtiledb-sql-0.12.2-h3a6e14b_0.tar.bz2
osx-64::libtiledb-sql-0.12.0-hac36de5_0.tar.bz2
osx-64::paraview-5.10.0-h5bcd3b3_103_qt.tar.bz2
osx-64::uwsgi-2.0.20-py37h053e2fb_3.tar.bz2
osx-64::cppyy-cling-6.25.2-py39h68a93c5_1.tar.bz2
osx-64::pyretis-2.5.0-py37h7b928b5_2.tar.bz2
osx-64::astrometry-0.89-py39h11a5eb4_0.tar.bz2
osx-64::arrow-cpp-6.0.1-py37hc0a5d74_5_cpu.tar.bz2
osx-64::nifty-1.2.1-py38h089c336_0.tar.bz2
osx-64::llvmdev-9.0.1-cling_v0.9_hf28e3b7_6.tar.bz2
osx-64::gct-6.2.1629922860-h6f36284_0.tar.bz2
osx-64::conduit-0.7.1-py37hefffe85_1.tar.bz2
osx-64::texlive-core-20210325-h03edc0b_1.tar.bz2
osx-64::conduit-0.8.0-py37he5bc6c3_0.tar.bz2
osx-64::llvmdev-9.0.1-cling_v0.9_hf28e3b7_7.tar.bz2
osx-64::llvmlite-0.38.0-py37hfcd02a2_0.tar.bz2
osx-64::pyreadstat-1.1.4-py39h9fd43ae_0.tar.bz2
osx-64::mysql-connector-cpp-8.0.28-h72c65b4_0.tar.bz2
osx-64::omniorb-4.2.5-py310h407b262_0.tar.bz2
osx-64::conduit-0.7.1-py39h402c14c_1.tar.bz2
osx-64::cppyy-cling-6.25.2-py310h8148c44_1.tar.bz2
osx-64::readdy-2.0.11-py39h5f657f7_0.tar.bz2
osx-64::libtiledb-sql-0.11.2-hac36de5_0.tar.bz2
osx-64::libgdal-3.4.1-hc728c2d_0.tar.bz2
osx-64::libcurl-7.80.0-hf45b732_1.tar.bz2
osx-64::arrow-cpp-5.0.0-py37hc0a5d74_20_cpu.tar.bz2
osx-64::python-3.8.12-h43ca1e7_3_cpython.tar.bz2
osx-64::libtiledb-sql-0.12.1-h2446079_0.tar.bz2
osx-64::z5py-2.0.12-py39haf96dd5_0.tar.bz2
osx-64::mysql-libs-8.0.28-h115446f_0.tar.bz2
osx-64::yoda-1.9.4-py37h4d928af_0.tar.bz2
osx-64::ndcctools-7.4.0-py310h407b262_0.tar.bz2
osx-64::cctools_osx-64-973.0.1-h609b070_5.tar.bz2
osx-64::protozfits-2.0.1.post1-py39h7d86f10_5.tar.bz2
osx-64::gsoap-2.8.118-h406289c_0.tar.bz2
osx-64::arrow-cpp-3.0.0-py37he317e60_40_cpu.tar.bz2
osx-64::astrometry-0.89-py38h1f0651f_0.tar.bz2
osx-64::postgresql-plpython-13.5-py38h7f62374_1.tar.bz2
osx-64::xrootd-5.4.0-py38h8ea2df0_0.tar.bz2
osx-64::ndcctools-7.4.1-py38h171f6b0_0.tar.bz2
osx-64::conduit-0.7.1-py38h349a63e_1.tar.bz2
osx-64::pdal-2.3.0-hdc4c2f4_23.tar.bz2
osx-64::mandrake-1.2.0-py38hed967db_0.tar.bz2
osx-64::python-3.9.10-hea1dfa3_0_cpython.tar.bz2
osx-64::triqs-3.0.2-py38hb9fcd7f_1.tar.bz2
osx-64::imagemagick-7.1.0_21-pl5321h3e49128_0.tar.bz2
osx-64::cppyy-cling-6.25.2-py38h6db56eb_0.tar.bz2
osx-64::libgdal-3.4.1-h6c40076_2.tar.bz2
osx-64::curl-7.80.0-h97da3c1_1.tar.bz2
osx-64::gazebo-11.10.1-ha2fdce5_0.tar.bz2
osx-64::libprotobuf-3.19.2-hcf210ce_0.tar.bz2
osx-64::librdkafka-1.8.2.post2-h530747d_0.tar.bz2
osx-64::gemmi-0.5.1-py39h798a4f4_0.tar.bz2
osx-64::grpcio-1.43.0-py39h76e8ba0_0.tar.bz2
osx-64::arrow-cpp-5.0.0-py310h2477c6a_20_cpu.tar.bz2
osx-64::omniorb-4.2.5-py310hd247ede_0.tar.bz2
osx-64::gsoap-2.8.118-he518799_0.tar.bz2
osx-64::conduit-0.7.1-py39h336f781_1.tar.bz2
osx-64::capnproto-0.9.1-h64a5342_2.tar.bz2
osx-64::pyreadstat-1.1.4-py37h83b74e4_0.tar.bz2
osx-64::conduit-0.8.0-py39h336f781_0.tar.bz2
osx-64::graphviz-2.50.0-h2b5222e_2.tar.bz2
osx-64::plumed-2.7.3-nompi_hebe3ea5_100.tar.bz2
osx-64::vowpalwabbit-9.0.0-py310h9076ab7_3.tar.bz2
osx-64::conduit-0.8.1-py38ha998f41_0.tar.bz2
osx-64::cctools_osx-arm64-973.0.1-h11dea68_3.tar.bz2
osx-64::postgresql-plpython-13.5-py37h43e72e4_1.tar.bz2
osx-64::cpp-opentelemetry-sdk-1.1.0-h152f89d_4.tar.bz2
osx-64::vtk-9.1.0-qt_py37hd791b3b_203.tar.bz2
osx-64::bgenix-1.1.4-h0c82f61_8.tar.bz2
osx-64::arrow-cpp-5.0.0-py38haa61a5c_22_cpu.tar.bz2
osx-64::libprotobuf-static-3.19.4-hcf210ce_0.tar.bz2
osx-64::gmt-5.4.5-ha5dbe71_17.tar.bz2
osx-64::readdy-2.0.11-py310h39430ac_0.tar.bz2
osx-64::arrow-cpp-5.0.0-py39h3020c35_20_cpu.tar.bz2
osx-64::tesseract-4.1.3-h6be3199_6.tar.bz2
osx-64::arrow-cpp-6.0.1-py38haa61a5c_8_cpu.tar.bz2
osx-64::gazebo-11.10.0-he01bef3_0.tar.bz2
osx-64::astrometry-0.88-py39h11a5eb4_0.tar.bz2
osx-64::arrow-cpp-5.0.0-py38h6b1b8bf_18_cpu.tar.bz2
osx-64::python-3.10.1-h1248fe1_2_cpython.tar.bz2
osx-64::uwsgi-2.0.20-py37h053e2fb_2.tar.bz2
osx-64::slang-2.3.2-h22a73de_1003.tar.bz2
osx-64::protozfits-2.0.1.post1-py38h05b67d1_5.tar.bz2
osx-64::vowpalwabbit-9.0.0-py37h9d266b7_3.tar.bz2
osx-64::conduit-0.8.1-py39h16e84d1_0.tar.bz2
osx-64::julia-1.6.4-h132cb31_1.tar.bz2
osx-64::omniorb-4.2.5-py37hbece8e7_0.tar.bz2
osx-64::tiledb-2.6.2-hca4410a_0.tar.bz2
osx-64::pyreadstat-1.1.4-py310h76f859f_0.tar.bz2
osx-64::triqs-3.0.2-py37h036b8c8_1.tar.bz2
osx-64::postgresql-plpython-13.5-py38h6b43ab9_1.tar.bz2
osx-64::magics-metview-4.10.0-hbf85780_0.tar.bz2
osx-64::conduit-0.8.0-py38ha998f41_0.tar.bz2
osx-64::nodejs-16.13.0-h1fee019_1.tar.bz2
osx-64::wasmer-2.1.0-h7d3d4a7_2.tar.bz2
osx-64::gazebo-11.9.1-h4f5c2f8_0.tar.bz2
osx-64::mongodb-5.1.1-h7e76b44_0.tar.bz2
osx-64::nifty-1.2.0-py38h089c336_0.tar.bz2
osx-64::arrow-cpp-3.0.0-py37h3fd9f21_37_cpu.tar.bz2
osx-64::root_base-6.24.6-py37h0aa7a66_2.tar.bz2
osx-64::arrow-cpp-5.0.0-py37h172e15e_22_cpu.tar.bz2
osx-64::grpcio-1.43.0-py38h4924b5d_0.tar.bz2
osx-64::conduit-0.8.1-py37h163bdb4_0.tar.bz2
osx-64::grpc-cpp-1.43.0-h3ce1240_0.tar.bz2
osx-64::bgenix-1.1.4-h30ae857_8.tar.bz2
osx-64::arrow-cpp-6.0.1-py38h6b1b8bf_3_cpu.tar.bz2
osx-64::gmt-6.3.0-h355c565_2.tar.bz2
osx-64::vowpalwabbit-9.0.0-py37hd6556a3_3.tar.bz2
osx-64::omniorb-libs-4.2.5-hfd382f3_0.tar.bz2
osx-64::nodejs-16.13.0-h1fee019_2.tar.bz2
osx-64::kaldi-5.5.992-cpu_py39h1234567_4.tar.bz2
osx-64::conduit-0.8.1-py39h336f781_0.tar.bz2
osx-64::paraview-5.10.0-hcca6f0e_103_qt.tar.bz2
osx-64::gds-base-crtools-2.19.7-hb960672_1.tar.bz2
osx-64::h5utils-1.13.1-nompi_h540873d_1112.tar.bz2
osx-64::mandrake-1.2.1-py39h20b4717_0.tar.bz2
osx-64::libgdal-3.4.0-h6b19ae8_13.tar.bz2
osx-64::ndcctools-7.4.1-py37h87f55f7_1.tar.bz2
osx-64::ogre-13.2.3-h5dd8d7a_0.tar.bz2
osx-64::nifty-1.2.1-py37hf670e59_2.tar.bz2
osx-64::root_base-6.24.6-py38h3c2d462_2.tar.bz2
osx-64::ncl-6.6.2-h37b54b6_36.tar.bz2
osx-64::vowpalwabbit-9.0.0-py39h60e5d19_3.tar.bz2
osx-64::arrow-cpp-3.0.0-py310hc458819_37_cpu.tar.bz2
osx-64::wasmer-2.1.0-h1292919_0.tar.bz2
osx-64::libgdal-3.4.1-hdf0c086_1.tar.bz2
osx-64::assimp-5.1.0-h1224e73_0.tar.bz2
osx-64::libharu-2.3.0-hf19b285_2.tar.bz2
osx-64::libtiledb-sql-0.11.2-he77a94c_0.tar.bz2
osx-64::gds-base-monitors-2.19.7-h27fb111_1.tar.bz2
osx-64::nss-3.73-h31e2bf1_0.tar.bz2
osx-64::imagemagick-7.1.0_19-pl5321h3e49128_0.tar.bz2
osx-64::r-git2r-0.29.0-r40h5ea82b1_1.tar.bz2
osx-64::nginx-1.21.5-hb80c099_0.tar.bz2
osx-64::glib-2.70.2-hcf210ce_1.tar.bz2
osx-64::gds-services-2.19.7-h27fb111_1.tar.bz2
osx-64::libgdal-3.4.0-h6e0c36c_9.tar.bz2
osx-64::libspatialite-5.0.1-h4dd8892_13.tar.bz2
osx-64::paraview-5.10.0-he9cc3e1_103_qt.tar.bz2
osx-64::uwsgi-2.0.20-py38hfa1b2f6_3.tar.bz2
osx-64::tiledb-2.6.1-hca4410a_0.tar.bz2
osx-64::nginx-1.21.5-hc9f9526_0.tar.bz2
osx-64::hdf5-1.12.1-nompi_h2f0ef1a_103.tar.bz2
osx-64::arrow-cpp-5.0.0-py37h8a735cd_19_cpu.tar.bz2
osx-64::wxpython-4.1.1-py310hd06deb7_3.tar.bz2
osx-64::triqs-3.0.2-py37h036b8c8_0.tar.bz2
osx-64::pdal-2.3.0-h377a18e_21.tar.bz2
osx-64::arrow-cpp-3.0.0-py37hc0a5d74_39_cpu.tar.bz2
osx-64::grpc-cpp-1.43.0-h6da9ac5_0.tar.bz2
osx-64::pdal-2.3.0-h0c614f6_17.tar.bz2
osx-64::python-3.10.1-h38b4d05_0_cpython.tar.bz2
osx-64::git-2.35.0-pl5321h9a53687_0.tar.bz2
osx-64::ndcctools-7.4.1-py38ha263829_0.tar.bz2
osx-64::z5py-2.0.11-py310h5fba041_1.tar.bz2
osx-64::libnghttp2-1.46.0-hfd382f3_0.tar.bz2
osx-64::gemmi-0.5.2-py310h003a20c_0.tar.bz2
osx-64::mysql-connector-odbc-8.0.28-hcf210ce_0.tar.bz2
osx-64::cpp-opentelemetry-sdk-1.1.1-h152f89d_0.tar.bz2
osx-64::protozfits-2.0.1.post1-py37hdabc7ef_6.tar.bz2
osx-64::pyinstaller-4.8-py310h76f859f_0.tar.bz2
osx-64::cairomm-1.0-1.12.2-h941ccef_4.tar.bz2
osx-64::ndcctools-7.4.1-py310hd247ede_0.tar.bz2
osx-64::kaldi-5.5.992-cpu_h1234567_6.tar.bz2
osx-64::gct-6.2.1550507116-h6f36284_2.tar.bz2
osx-64::gds-base-monitors-2.19.7-h27fb111_2.tar.bz2
osx-64::tesseract-5.0.0-h6be3199_1.tar.bz2
osx-64::libcurl-7.81.0-hf45b732_0.tar.bz2
osx-64::python-3.9.10-h1dd9edd_0_cpython.tar.bz2
osx-64::sagelib-9.4-py38hba57b99_1.tar.bz2
osx-64::capnproto-0.9.1-hd991315_4.tar.bz2
osx-64::mandrake-1.2.0-py37h7a85b67_0.tar.bz2
osx-64::arrow-cpp-5.0.0-py37he317e60_21_cpu.tar.bz2
osx-64::assimp-5.1.3-h1224e73_1.tar.bz2
osx-64::protozfits-2.0.1.post1-py39hea7e4ad_6.tar.bz2
osx-64::gazebo-11.9.1-hcf725f0_1.tar.bz2
osx-64::libgdal-3.4.0-h149f711_10.tar.bz2
osx-64::arrow-cpp-6.0.1-py310hb6cbff4_6_cpu.tar.bz2
osx-64::r-git2r-0.29.0-r41h5ea82b1_1.tar.bz2
osx-64::arrow-cpp-3.0.0-py38h03f22f6_38_cpu.tar.bz2
osx-64::libgdal-3.3.3-h3ab75b0_12.tar.bz2
osx-64::tiledb-2.5.3-hca4410a_0.tar.bz2
osx-64::h5utils-1.13.1-nompi_h1ef66f7_1112.tar.bz2
osx-64::arrow-cpp-3.0.0-py38haa61a5c_41_cpu.tar.bz2
osx-64::conduit-0.8.0-py36hec5f891_0.tar.bz2
osx-64::gemmi-0.5.1-py38h872f124_0.tar.bz2
osx-64::ndcctools-7.4.1-py38ha263829_1.tar.bz2
osx-64::geant4-10.7.3-py39h20ade89_0.tar.bz2
osx-64::tensorflow-base-2.6.2-cpu_py38heeb7c33_2.tar.bz2
osx-64::libcurl-static-7.81.0-h97da3c1_0.tar.bz2
osx-64::arrow-cpp-6.0.1-py37h8a735cd_4_cpu.tar.bz2
osx-64::conduit-0.8.0-py38h9ad073c_0.tar.bz2
osx-64::yoda-1.9.4-py39hfe8435e_0.tar.bz2
osx-64::geotiff-1.7.0-h0ca5f94_6.tar.bz2
osx-64::conduit-0.8.0-py37hefffe85_0.tar.bz2
osx-64::mysql-client-8.0.28-h9c38be6_0.tar.bz2
osx-64::magics-4.10.0-h4a96ced_0.tar.bz2
osx-64::paraview-5.10.0-h9d1abfe_103_qt.tar.bz2
osx-64::capnproto-0.9.1-h64a5342_3.tar.bz2
osx-64::arrow-cpp-3.0.0-py39hdde8cfe_37_cpu.tar.bz2
osx-64::tomviz-1.10.0.post137-py37hadb2b92_0.tar.bz2
osx-64::gemmi-0.5.2-py37h62ea057_0.tar.bz2
osx-64::tiledb-2.6.0-h2a16ea5_0.tar.bz2
osx-64::gds-services-2.19.7-h27fb111_3.tar.bz2
osx-64::conduit-0.8.0-py37h54223e2_0.tar.bz2
osx-64::xrootd-5.4.0-py37h5394c04_0.tar.bz2
osx-64::arrow-cpp-3.0.0-py38hdd0eeee_39_cpu.tar.bz2
osx-64::arrow-cpp-6.0.1-py38hdd0eeee_5_cpu.tar.bz2
osx-64::libgdal-3.4.0-hd659541_9.tar.bz2
osx-64::ticcutils-0.28-h7094d71_0.tar.bz2
osx-64::vowpalwabbit-9.0.0-py38haaa3206_3.tar.bz2
osx-64::protozfits-2.0.1.post1-py38h0c99956_6.tar.bz2
osx-64::nifty-1.2.1-py39h7b0b313_3.tar.bz2
osx-64::libvips-8.12.1-h044158d_1.tar.bz2
osx-64::llvmlite-0.38.0-py310h003a20c_0.tar.bz2
osx-64::pyinstaller-4.8-py38h4fe204b_0.tar.bz2
osx-64::ndcctools-7.4.1-py310hd247ede_1.tar.bz2
osx-64::astrometry-0.88-py38h1f0651f_0.tar.bz2
osx-64::nifty-1.2.1-py37hf670e59_1.tar.bz2
osx-64::tiledb-2.6.0-hca4410a_0.tar.bz2
osx-64::postgresql-plpython-13.5-py310h4b9c762_1.tar.bz2
osx-64::netgen-6.2.2006-py39h060e841_4.tar.bz2
osx-64::pyretis-2.5.0-py38h6e53e98_2.tar.bz2
osx-64::libgdal-3.4.1-h426f528_2.tar.bz2
osx-64::arrow-cpp-3.0.0-py37h172e15e_41_cpu.tar.bz2
osx-64::pdal-2.3.0-h377a18e_20.tar.bz2
osx-64::root_base-6.24.6-py310hce50cd7_2.tar.bz2
osx-64::arrow-cpp-5.0.0-py310hb6cbff4_21_cpu.tar.bz2
osx-64::julia-1.6.5-h132cb31_0.tar.bz2
osx-64::nco-5.0.5-hafbf2bc_0.tar.bz2
osx-64::gazebo-11.10.1-he01bef3_0.tar.bz2
osx-64::grpcio-1.43.0-py37hac9a2c0_0.tar.bz2
osx-64::libcurl-static-7.81.0-hf45b732_0.tar.bz2
osx-64::pyreadstat-1.1.4-py38h4fe204b_0.tar.bz2
osx-64::postgresql-13.5-h0fd25fa_1.tar.bz2
osx-64::gfal2-2.20.2-hc5feaaf_0.tar.bz2
osx-64::pytables-3.7.0-py38h5215406_0.tar.bz2
osx-64::vtk-9.0.1-qt_py310h5d4d6d6_210.tar.bz2
osx-64::omniorb-libs-4.2.5-h6f36284_0.tar.bz2
osx-64::coda-2.23-py38h4bf7c7c_0.tar.bz2
osx-64::ndcctools-7.4.1-py39h9247e91_1.tar.bz2
osx-64::nifty-1.2.1-py38h089c336_3.tar.bz2
osx-64::root_base-6.24.6-py39h5fbb1f1_1.tar.bz2
osx-64::arrow-cpp-3.0.0-py38h6b1b8bf_37_cpu.tar.bz2
osx-64::vtk-9.0.1-qt_py39h93184f3_210.tar.bz2
osx-64::conduit-0.7.1-py37h163bdb4_1.tar.bz2
osx-64::triqs-3.0.2-py37hbe42435_1.tar.bz2
osx-64::plumed-2.7.3-mpi_mpich_ha4917de_0.tar.bz2
osx-64::triqs-3.0.2-py39hc8335e0_1.tar.bz2
osx-64::protozfits-2.0.1.post1-py310hab34a77_6.tar.bz2
osx-64::vowpalwabbit-8.11.0-py310h9076ab7_2.tar.bz2
osx-64::mysql-connector-cpp-8.0.27-h328bd3c_1.tar.bz2
osx-64::octave-6.4.0-h2b8f047_1.tar.bz2
osx-64::ndcctools-7.4.0-py310hd247ede_0.tar.bz2
osx-64::gdstk-0.8.1-py39h68a93c5_0.tar.bz2
osx-64::librdkafka-1.3.0-hdbda98f_3.tar.bz2
osx-64::arrow-cpp-6.0.1-py310h71bd60a_7_cpu.tar.bz2
osx-64::libtiledb-sql-0.12.0-he77a94c_0.tar.bz2
osx-64::root_base-6.24.6-py38h3c2d462_1.tar.bz2
osx-64::r-base-4.1.1-h2b051ba_2.tar.bz2
osx-64::gds-base-crtools-2.19.7-hb960672_2.tar.bz2
osx-64::arrow-cpp-5.0.0-py39hdde8cfe_18_cpu.tar.bz2
osx-64::libgdal-3.3.3-hc728c2d_13.tar.bz2
osx-64::libnghttp2-1.46.0-h6f36284_0.tar.bz2
osx-64::zstd-1.5.2-h582d3a0_0.tar.bz2
osx-64::libmongoc-1.20.1-h8b266b5_0.tar.bz2
osx-64::qtwebkit-5.212-h65d0201_2.tar.bz2
osx-64::z5py-2.0.11-py37hc237eb2_1.tar.bz2
osx-64::gdstk-0.8.1-py37hce63d0a_1.tar.bz2
osx-64::arrow-cpp-6.0.1-py37h3fd9f21_3_cpu.tar.bz2
osx-64::cppyy-cling-6.25.2-py37ha99744d_0.tar.bz2
osx-64::root_base-6.24.6-py310hce50cd7_1.tar.bz2
osx-64::r-git2r-0.29.0-r40h829d76c_1.tar.bz2
osx-64::ndcctools-7.4.1-py39h9247e91_0.tar.bz2
osx-64::assimp-5.1.0-h1224e73_1.tar.bz2
osx-64::julia-1.7.1-h1f75604_0.tar.bz2
osx-64::libprotobuf-static-3.19.3-hcf210ce_0.tar.bz2
osx-64::libprotobuf-3.19.4-hcf210ce_0.tar.bz2
osx-64::nodejs-16.13.2-h0da8292_2.tar.bz2
osx-64::nodejs-17.1.0-h0da8292_2.tar.bz2
osx-64::nifty-1.2.1-py38h089c336_1.tar.bz2
osx-64::conduit-0.8.0-py39h402c14c_0.tar.bz2
osx-64::vtk-9.1.0-qt_py310h335d978_203.tar.bz2
osx-64::gmsh-4.9.3-hde0777f_1.tar.bz2
osx-64::pyretis-2.5.0-py39h996af62_2.tar.bz2
osx-64::libprotobuf-static-3.19.2-hcf210ce_0.tar.bz2
osx-64::paraview-5.10.0-hc3c1c09_103_qt.tar.bz2
osx-64::python-3.10.2-hea1dfa3_1_cpython.tar.bz2
osx-64::gazebo-11.10.0-ha2fdce5_0.tar.bz2
osx-64::pdal-2.3.0-h0c614f6_18.tar.bz2
osx-64::xrootd-5.4.0-py37ha8183f8_0.tar.bz2
osx-64::bgenix-1.1.4-h52bf80b_8.tar.bz2
osx-64::nodejs-14.17.4-hb529b34_1.tar.bz2
osx-64::curl-7.81.0-h97da3c1_0.tar.bz2
osx-64::imagemagick-7.1.0_22-pl5321h3e49128_0.tar.bz2
osx-64::arrow-cpp-6.0.1-py37he317e60_6_cpu.tar.bz2
osx-64::arrow-cpp-3.0.0-py39h9d2824b_40_cpu.tar.bz2
osx-64::triqs-3.0.2-py38he7d97e9_0.tar.bz2
osx-64::julia-1.7.0-h132cb31_0.tar.bz2
osx-64::soplex-6.0.0-ha97b6df_0.tar.bz2
osx-64::geant4-10.7.3-py310hb9b49dc_0.tar.bz2
osx-64::liblal-7.1.6-mkl_h511d20e_1.tar.bz2
osx-64::curl-7.81.0-hf45b732_0.tar.bz2
osx-64::yoda-1.9.4-py38h105c759_0.tar.bz2
osx-64::z5py-2.0.11-py38h65fb09a_1.tar.bz2
osx-64::vowpalwabbit-8.11.0-py37h9d266b7_2.tar.bz2
osx-64::arrow-cpp-6.0.1-py310h2477c6a_5_cpu.tar.bz2
osx-64::arrow-cpp-5.0.0-py38hdd0eeee_20_cpu.tar.bz2
osx-64::magics-4.10.0-hf29bfc3_1.tar.bz2
osx-64::mysql-libs-8.0.27-h115446f_2.tar.bz2
osx-64::julia-1.7.1-h132cb31_0.tar.bz2
osx-64::xrootd-5.4.0-py39heed53e9_0.tar.bz2
osx-64::libglib-2.70.2-hf1fb8c0_1.tar.bz2
osx-64::freecad-0.19.3-py38h66d0d0e_3.tar.bz2
osx-64::gazebo-11.10.1-he01bef3_1.tar.bz2
osx-64::llvmdev-9.0.1-default_h2671707_6.tar.bz2
osx-64::nifty-1.2.1-py310h6963627_3.tar.bz2
osx-64::libgdal-3.4.0-hc728c2d_13.tar.bz2
osx-64::gmt-6.3.0-h6bc67db_1.tar.bz2
osx-64::gdstk-0.8.1-py310h1a06441_1.tar.bz2
osx-64::pytables-3.7.0-py37hc0663ee_0.tar.bz2
osx-64::libgdal-3.4.0-h149f711_12.tar.bz2
osx-64::panda3d-1.10.11-py38h081c976_0.tar.bz2
osx-64::vowpalwabbit-9.0.0-py310h9076ab7_2.tar.bz2
osx-64::conduit-0.7.1-py37he5bc6c3_1.tar.bz2
osx-64::conduit-0.8.1-py39h402c14c_0.tar.bz2
osx-64::mosh-1.3.2-pl5321hd8d1172_1011.tar.bz2
osx-64::nodejs-17.1.0-h1fee019_2.tar.bz2
osx-64::vowpalwabbit-9.0.0-py38haaa3206_2.tar.bz2
osx-64::vowpalwabbit-8.11.0-py37hd6556a3_2.tar.bz2
osx-64::graphviz-2.50.0-h77de9ca_0.tar.bz2
osx-64::gemmi-0.5.2-py37hfcd02a2_0.tar.bz2
osx-64::grpcio-1.43.0-py310hc31b572_0.tar.bz2
osx-64::python-3.10.1-h38b4d05_2_cpython.tar.bz2
osx-64::xrootd-5.3.4-py37h5394c04_0.tar.bz2
osx-64::xrootd-5.3.4-py39heed53e9_0.tar.bz2
osx-64::ogre-13.2.3-ha8acd6a_0.tar.bz2
osx-64::r-base-4.1.2-h2b051ba_0.tar.bz2
osx-64::ndcctools-7.4.1-py37hbece8e7_1.tar.bz2
osx-64::arrow-cpp-6.0.1-py39hf938c1e_8_cpu.tar.bz2
osx-64::ndcctools-7.4.0-py39h9247e91_0.tar.bz2
osx-64::gds-base-crtools-2.19.7-hb960672_3.tar.bz2
osx-64::grpc-cpp-1.42.0-h3ce1240_1.tar.bz2
osx-64::liblal-7.1.4-mkl_hfeb6218_1.tar.bz2
osx-64::gemmi-0.5.2-py39h798a4f4_0.tar.bz2
osx-64::vigra-1.11.1-py39h93be1e2_1027.tar.bz2
osx-64::r-git2r-0.29.0-r41h829d76c_1.tar.bz2
osx-64::oclgrind-21.10-hbedb8b6_0.tar.bz2
osx-64::librdkafka-1.3.0-hdbda98f_1.tar.bz2
osx-64::ruby-2.6.6-h1c0b240_3.tar.bz2
osx-64::gds-base-2.19.7-h524ae44_1.tar.bz2
osx-64::arrow-cpp-3.0.0-py39hc83c8ec_38_cpu.tar.bz2
osx-64::arrow-cpp-6.0.1-py37h172e15e_8_cpu.tar.bz2
osx-64::tensorflow-base-2.6.2-cpu_py37h5759434_2.tar.bz2
osx-64::llvmdev-9.0.1-default_h2671707_5.tar.bz2
osx-64::erlang-24.2-pl5321hb7b0dc9_1.tar.bz2
osx-64::glib-2.70.2-hcf210ce_0.tar.bz2
osx-64::ndcctools-7.4.1-py37h87f55f7_0.tar.bz2
osx-64::arrow-cpp-6.0.1-py38h03f22f6_4_cpu.tar.bz2
osx-64::ogre-13.2.1-ha8acd6a_0.tar.bz2
osx-64::python-3.9.10-h1dd9edd_1_cpython.tar.bz2
osx-64::paraview-5.10.0-hc29e42d_103_qt.tar.bz2
osx-64::freecad-0.19.3-py39h99cb6fa_3.tar.bz2
osx-64::postgresql-plpython-13.5-py39h76a1e84_1.tar.bz2
osx-64::coda-2.23-py37h11ae6bb_0.tar.bz2
osx-64::paraview-5.10.0-h64e6165_103_qt.tar.bz2
osx-64::nodejs-17.4.0-h0da8292_0.tar.bz2
osx-64::netgen-6.2.2006-py37habadc7f_4.tar.bz2
osx-64::geant4-10.7.3-py38h383d1ea_0.tar.bz2
osx-64::arrow-cpp-6.0.1-py39hdde8cfe_3_cpu.tar.bz2
osx-64::ndcctools-7.4.1-py310h407b262_1.tar.bz2
osx-64::gdstk-0.8.1-py37h4c7ebfb_0.tar.bz2
osx-64::postgresql-plpython-13.5-py310h9631d35_1.tar.bz2
osx-64::omniorb-4.2.5-py38ha263829_0.tar.bz2
osx-64::qt-main-5.15.2-hfad5ee4_0.tar.bz2
osx-64::erlang-24.2-pl5321h6eff0d1_1.tar.bz2
osx-64::protozfits-2.0.1.post1-py310hb941dfa_5.tar.bz2
osx-64::orc-1.7.1-h84518c8_1.tar.bz2
osx-64::grpcio-1.43.0-py38h37dddf4_0.tar.bz2
osx-64::arrow-cpp-6.0.1-py310h7c6ea7c_4_cpu.tar.bz2
osx-64::conduit-0.8.0-py38h349a63e_0.tar.bz2
osx-64::erlang-24.2-pl5321hb7b0dc9_0.tar.bz2
osx-64::paraview-5.10.0-h0088080_103_qt.tar.bz2
osx-64::nss-3.74-h31e2bf1_0.tar.bz2
osx-64::triqs-3.0.2-py310h6993c70_1.tar.bz2
osx-64::assimp-5.1.6-h1224e73_0.tar.bz2
osx-64::pdal-2.3.0-hd1fe51c_24.tar.bz2
osx-64::assimp-5.2.0-h1224e73_0.tar.bz2
osx-64::hdf5-1.12.1-mpi_openmpi_hbcbd0bb_3.tar.bz2
osx-64::astrometry-0.89-py37h8ac32d7_0.tar.bz2
osx-64::nifty-1.2.0-py37hf670e59_0.tar.bz2
osx-64::gmsh-4.9.3-h2770bf5_0.tar.bz2
osx-64::cctools_osx-arm64-973.0.1-hd1d4517_5.tar.bz2
osx-64::omniorb-4.2.5-py39h9247e91_0.tar.bz2
osx-64::libgdal-3.3.3-h6c40076_15.tar.bz2
osx-64::vowpalwabbit-9.0.0-py37hd6556a3_2.tar.bz2
osx-64::julia-1.6.5-h132cb31_2.tar.bz2
osx-64::qt-5.12.9-h2a607e2_5.tar.bz2
osx-64::python-3.10.1-h1248fe1_1_cpython.tar.bz2
osx-64::ndcctools-7.4.0-py38ha263829_0.tar.bz2
osx-64::gfal2-2.20.3-h58ca8f1_1.tar.bz2
osx-64::netgen-6.2.2006-py310ha91567f_4.tar.bz2
osx-64::libgdal-3.4.1-h6b19ae8_0.tar.bz2
osx-64::vigra-1.11.1-py39h93be1e2_1028.tar.bz2
osx-64::cppyy-cling-6.25.2-py37h4c7ebfb_1.tar.bz2
osx-64::nifty-1.2.1-py39h7b0b313_0.tar.bz2
osx-64::libsoup-2.74.1-h72d9ae8_0.tar.bz2
osx-64::paraview-5.10.0-h5bc6a12_103_qt.tar.bz2
osx-64::python-3.9.9-h1248fe1_0_cpython.tar.bz2
osx-64::paraview-5.10.0-ha5762a3_103_qt.tar.bz2
osx-64::sagelib-9.4-py39hb5a7a70_1.tar.bz2
osx-64::cppyy-cling-6.25.2-py310h8148c44_0.tar.bz2
osx-64::conduit-0.8.0-py37h163bdb4_0.tar.bz2
osx-64::ndcctools-7.4.0-py37hbece8e7_0.tar.bz2
osx-64::python-3.10.2-h1dd9edd_1_cpython.tar.bz2
osx-64::git-2.35.0-pl5321h2185044_0.tar.bz2
osx-64::root_base-6.24.6-py37h0aa7a66_1.tar.bz2
osx-64::h5utils-1.13.1-mpi_mpich_h99bf298_1013.tar.bz2
osx-64::poppler-qt-22.01.0-hee1052d_0.tar.bz2
osx-64::gdstk-0.8.1-py39hde3ddfd_1.tar.bz2
osx-64::ruby-2.5.7-h1c0b240_3.tar.bz2
osx-64::geant4-10.7.3-py37h2260be7_0.tar.bz2
osx-64::libgdal-3.3.3-h426f528_15.tar.bz2
osx-64::gdstk-0.8.1-py310h8148c44_0.tar.bz2
osx-64::python-3.8.12-h17280f6_3_cpython.tar.bz2
osx-64::arrow-cpp-5.0.0-py39h9d2824b_21_cpu.tar.bz2
osx-64::vigra-1.11.1-py310hefd2f18_1028.tar.bz2
osx-64::grpc-cpp-1.43.2-h3ce1240_0.tar.bz2
osx-64::h5utils-1.13.1-nompi_h1ef66f7_1113.tar.bz2
osx-64::arrow-cpp-6.0.1-py310h71bd60a_8_cpu.tar.bz2
osx-64::libxmlsec1-1.2.32-h9a6ea52_1.tar.bz2
osx-64::libxmlsec1-1.2.33-h9a6ea52_0.tar.bz2
osx-64::python-3.10.2-h1248fe1_0_cpython.tar.bz2
osx-64::arrow-cpp-3.0.0-py310h71bd60a_41_cpu.tar.bz2
osx-64::mysql-server-8.0.27-he1246a2_3.tar.bz2
osx-64::capnproto-0.9.1-hd991315_3.tar.bz2
osx-64::librdkafka-1.3.0-h530747d_1.tar.bz2
osx-64::gmt-6.3.0-h355c565_1.tar.bz2
osx-64::protozfits-2.0.1.post1-py310hab34a77_7.tar.bz2
osx-64::libgsf-1.14.48-h4fe9cd3_0.tar.bz2
osx-64::libgdal-3.3.3-hdf0c086_14.tar.bz2
osx-64::tesseract-5.0.1-h6be3199_0.tar.bz2
osx-64::libtiledb-sql-0.12.3-h3a6e14b_0.tar.bz2
osx-64::gazebo-11.9.1-h4879cd1_1.tar.bz2
osx-64::python-3.10.2-hea1dfa3_2_cpython.tar.bz2
osx-64::cppyy-cling-6.25.2-py39h68a93c5_0.tar.bz2
osx-64::pyinstaller-4.8-py39h9fd43ae_0.tar.bz2
osx-64::cppyy-cling-6.25.2-py38h6db56eb_1.tar.bz2
osx-64::libcurl-static-7.80.0-h97da3c1_1.tar.bz2
osx-64::readdy-2.0.11-py37h503e92b_0.tar.bz2
osx-64::conduit-0.8.1-py38h349a63e_0.tar.bz2
osx-64::arrow-cpp-5.0.0-py39hf938c1e_22_cpu.tar.bz2
osx-64::libmongoc-1.20.1-h13b9c20_0.tar.bz2
osx-64::libfido2-1.10.0-h64a5342_0.tar.bz2
osx-64::paraview-5.10.0-hafdf0a6_103_qt.tar.bz2
osx-64::ruby-3.1.0-he9015dc_1.tar.bz2
osx-64::conduit-0.8.0-py38ha877268_0.tar.bz2
osx-64::vigra-1.11.1-py38hdc71d93_1028.tar.bz2
osx-64::libgdal-3.4.0-h97a9cf0_11.tar.bz2
osx-64::libtiledb-sql-0.11.1-he77a94c_0.tar.bz2
osx-64::triqs-3.0.2-py37hbe42435_0.tar.bz2
osx-64::tiledb-2.6.1-h2a16ea5_0.tar.bz2
osx-64::pgplot-5.2.2-h375df2d_1008.tar.bz2
osx-64::gemmi-0.5.1-py37h62ea057_0.tar.bz2
osx-64::magics-metview-batch-4.10.0-h4a96ced_0.tar.bz2
osx-64::protozfits-2.0.1.post1-py39hea7e4ad_7.tar.bz2
osx-64::ndcctools-7.4.0-py38h171f6b0_0.tar.bz2
osx-64::mysql-server-8.0.27-he1246a2_2.tar.bz2
osx-64::nifty-1.2.1-py38h089c336_2.tar.bz2
osx-64::nodejs-16.13.0-h0da8292_2.tar.bz2
osx-64::nodejs-16.13.0-h0da8292_1.tar.bz2
osx-64::pdal-2.3.0-h63fdac8_16.tar.bz2
osx-64::triqs-3.0.2-py39h0f8a94e_0.tar.bz2
osx-64::graphicsmagick-1.3.37-hc3d8c12_0.tar.bz2
osx-64::gds-base-gdstrig-2.19.7-hc1cc398_2.tar.bz2
osx-64::ogre-13.2.2-ha8acd6a_0.tar.bz2
osx-64::nco-5.0.4-hafbf2bc_0.tar.bz2
osx-64::julia-1.7.1-h132cb31_3.tar.bz2
osx-64::libgdal-3.4.0-h3ab75b0_12.tar.bz2
osx-64::plumed-2.7.3-mpi_openmpi_h3135ba3_0.tar.bz2
osx-64::hdf5-1.12.1-mpi_mpich_ha5b802e_3.tar.bz2
osx-64::python-3.10.1-h1248fe1_0_cpython.tar.bz2
osx-64::graphviz-2.50.0-h77de9ca_1.tar.bz2
osx-64::panda3d-1.10.11-py39hea92f9e_0.tar.bz2
osx-64::grpc-cpp-1.42.0-h6da9ac5_1.tar.bz2
osx-64::libgdal-3.3.3-hd659541_11.tar.bz2
osx-64::cppyy-cling-6.25.2-py37ha99744d_1.tar.bz2
osx-64::arrow-cpp-3.0.0-py37h8a735cd_38_cpu.tar.bz2
osx-64::llvmlite-0.38.0-py38h872f124_0.tar.bz2
osx-64::conduit-0.8.1-py37hefffe85_0.tar.bz2
osx-64::r-base-4.1.2-hbd3716f_1.tar.bz2
osx-64::pdal-2.3.0-ha9f31ae_22.tar.bz2
osx-64::conduit-0.8.0-py38h4f92aa4_0.tar.bz2
osx-64::xrootd-5.3.4-py310h9ab7fd2_0.tar.bz2
osx-64::libgdal-3.3.3-h6b19ae8_13.tar.bz2
osx-64::ruby-3.1.0-hed99dc5_1.tar.bz2
osx-64::kaldi-5.5.992-cpu_h1234567_8.tar.bz2
osx-64::xrootd-5.4.0-py310h9ab7fd2_0.tar.bz2
osx-64::tiledb-2.6.2-h2a16ea5_0.tar.bz2
osx-64::arrow-cpp-3.0.0-py310h2477c6a_39_cpu.tar.bz2
osx-64::gds-base-2.19.7-h524ae44_3.tar.bz2
osx-64::cpp-opentelemetry-sdk-1.1.1-h41dc615_1.tar.bz2
osx-64::arrow-cpp-6.0.1-py39h3020c35_5_cpu.tar.bz2
osx-64::protozfits-2.0.1.post1-py37h3e7ab6b_5.tar.bz2
osx-64::astrometry-0.89-py37h0de2a5d_0.tar.bz2
osx-64::libtiledb-sql-0.12.2-h2446079_0.tar.bz2
osx-64::conduit-0.7.1-py38ha998f41_1.tar.bz2
osx-64::vigra-1.11.1-py37h296af3d_1028.tar.bz2
osx-64::mysql-client-8.0.27-h9c38be6_2.tar.bz2
osx-64::omniorb-4.2.5-py38h171f6b0_0.tar.bz2
osx-64::wxpython-4.1.1-py39h591e7dd_3.tar.bz2
osx-64::cctools_osx-64-973.0.1-h3e07e27_3.tar.bz2
osx-64::vowpalwabbit-8.11.0-py39h60e5d19_2.tar.bz2
osx-64::libcurl-7.80.0-h97da3c1_1.tar.bz2
osx-64::uwsgi-2.0.20-py38haf0cd8b_3.tar.bz2
osx-64::omniorb-4.2.5-py39hb974310_0.tar.bz2
osx-64::kaldi-5.5.992-hf12bd3d_1.tar.bz2
osx-64::kaldi-5.5.992-cpu_h1234567_5.tar.bz2
osx-64::librdkafka-1.7.0-hdbda98f_1.tar.bz2
osx-64::z5py-2.0.12-py38h65fb09a_0.tar.bz2
osx-64::python-3.9.10-hea1dfa3_1_cpython.tar.bz2
osx-64::libtiledb-sql-0.11.1-hac36de5_0.tar.bz2
osx-64::cpp-opentelemetry-sdk-1.1.1-h41dc615_2.tar.bz2
osx-64::gds-base-gdstrig-2.19.7-hc1cc398_3.tar.bz2
osx-64::arrow-cpp-6.0.1-py38haa61a5c_7_cpu.tar.bz2
osx-64::sagelib-9.4-py37hf093b7e_1.tar.bz2
osx-64::triqs-3.0.2-py310hc230a87_1.tar.bz2
osx-64::pdal-2.3.0-h0c614f6_19.tar.bz2
osx-64::ndcctools-7.4.1-py310h407b262_0.tar.bz2
osx-64::h5utils-1.13.1-mpi_mpich_h99bf298_1012.tar.bz2
osx-64::python-3.10.1-h38b4d05_1_cpython.tar.bz2
osx-64::gds-base-2.19.7-h524ae44_2.tar.bz2
osx-64::ndcctools-7.4.0-py39hb974310_0.tar.bz2
osx-64::libcurl-static-7.80.0-hf45b732_1.tar.bz2
osx-64::python-3.10.2-h38b4d05_0_cpython.tar.bz2
osx-64::libgdal-3.3.3-h6e0c36c_11.tar.bz2
osx-64::ndcctools-7.4.1-py38h171f6b0_1.tar.bz2
osx-64::hdf5-1.12.1-mpi_openmpi_h85c87b3_3.tar.bz2
osx-64::pytables-3.7.0-py39hfd850c7_0.tar.bz2
osx-64::erlang-24.2.1-pl5321hd632bb8_0.tar.bz2
osx-64::vigra-1.11.1-py38hdc71d93_1027.tar.bz2
osx-64::netgen-6.2.2006-py38hc1d44a0_4.tar.bz2
osx-64::ndcctools-7.4.2-py38ha263829_0.tar.bz2
osx-64::nifty-1.2.1-py37hf670e59_0.tar.bz2
osx-64::arrow-cpp-5.0.0-py310h7c6ea7c_19_cpu.tar.bz2
osx-64::julia-1.7.1-h132cb31_2.tar.bz2
osx-64::uwsgi-2.0.20-py38hfa1b2f6_2.tar.bz2
osx-64::pyretis-2.5.0-py310h8e98eef_2.tar.bz2
osx-64::python-3.9.9-h38b4d05_0_cpython.tar.bz2
osx-64::conduit-0.8.0-py39h16e84d1_0.tar.bz2
osx-64::triqs-3.0.2-py39h0f8a94e_1.tar.bz2
osx-64::triqs-3.0.2-py38he7d97e9_1.tar.bz2
osx-64::cppyy-cling-6.25.2-py37h4c7ebfb_0.tar.bz2
osx-64::protozfits-2.0.1.post1-py38h0c99956_7.tar.bz2
osx-64::pyreadstat-1.1.4-py37h7298123_0.tar.bz2
osx-64::xrootd-5.3.4-py38h8ea2df0_0.tar.bz2
osx-64::ogre-13.2.1-h5dd8d7a_0.tar.bz2
osx-64::cctools_osx-64-973.0.1-hb41342b_5.tar.bz2
osx-64::arrow-cpp-6.0.1-py38h2edcfc6_6_cpu.tar.bz2
osx-64::grpcio-1.43.0-py37hc728aa8_0.tar.bz2
osx-64::wasmer-2.1.0-h06173f7_2.tar.bz2
osx-64::libfido2-1.10.0-hd991315_0.tar.bz2
osx-64::vigra-1.11.1-py37h0155546_1027.tar.bz2
osx-64::pdal-2.3.0-h3c6e63a_24.tar.bz2
osx-64::gazebo-11.9.1-ha2fdce5_2.tar.bz2
osx-64::paraview-5.10.0-h33d43f1_103_qt.tar.bz2
osx-64::erlang-24.2.1-pl5321h4ebe6b3_0.tar.bz2
osx-64::root_base-6.24.6-py39h5fbb1f1_2.tar.bz2
osx-64::python-3.6.15-haf480d7_0_cpython.tar.bz2
osx-64::mesalib-21.2.5-h2df1e00_3.tar.bz2
osx-64::paraview-5.10.0-h5e1ec18_103_qt.tar.bz2
osx-64::assimp-5.2.0-h1224e73_1.tar.bz2
osx-64::ndcctools-7.4.2-py37hbece8e7_0.tar.bz2
osx-64::arrow-cpp-6.0.1-py39hf938c1e_7_cpu.tar.bz2
osx-64::erlang-23.3.4.10-pl5321hb7b0dc9_0.tar.bz2
osx-64::z5py-2.0.12-py37hc237eb2_0.tar.bz2
osx-64::arrow-cpp-3.0.0-py39h3020c35_39_cpu.tar.bz2
osx-64::xeus-cling-0.13.0-h79ef1c8_2.tar.bz2
osx-64::vowpalwabbit-8.11.0-py38haaa3206_2.tar.bz2
osx-64::capnproto-0.9.1-h45c0eea_5.tar.bz2
osx-64::gds-services-2.19.7-h27fb111_2.tar.bz2
osx-64::postgresql-13.5-he8fe76e_1.tar.bz2
osx-64::gemmi-0.5.1-py37hfcd02a2_0.tar.bz2
osx-64::libpq-13.5-hea3049e_1.tar.bz2
osx-64::pytables-3.7.0-py37h85b9c76_0.tar.bz2
osx-64::imagemagick-7.1.0_18-pl5321h3e49128_0.tar.bz2
osx-64::arrow-cpp-5.0.0-py38h2edcfc6_21_cpu.tar.bz2
osx-64::astrometry-0.89-py310hb1ff3b3_0.tar.bz2
osx-64::librdkafka-1.8.2.post2-hdbda98f_0.tar.bz2
osx-64::libgdal-3.4.0-h3ab75b0_10.tar.bz2
osx-64::postgresql-plpython-13.5-py39h8c0c37d_1.tar.bz2
osx-64::gemmi-0.5.1-py310h003a20c_0.tar.bz2
osx-64::kaldi-5.5.992-cpu_h1234567_7.tar.bz2
osx-64::wasmer-2.1.0-h7d3d4a7_1.tar.bz2
osx-64::coda-2.23-py37h9385206_0.tar.bz2
osx-64::ndcctools-7.4.2-py39h9247e91_0.tar.bz2
osx-64::mosh-1.3.2-pl5321h56aacfd_1011.tar.bz2
osx-64::orc-1.7.2-h84518c8_0.tar.bz2
osx-64::gds-base-monitors-2.19.7-h27fb111_3.tar.bz2
osx-64::libgdal-3.4.1-h09ae624_1.tar.bz2
osx-64::gdstk-0.8.1-py38h7f088a7_1.tar.bz2
osx-64::kaldi-5.5.992-hf12bd3d_3.tar.bz2
osx-64::h5utils-1.13.1-mpi_mpich_hab242fb_1012.tar.bz2
osx-64::cctools_osx-arm64-973.0.1-h7ef2fa9_5.tar.bz2
osx-64::zstd-1.5.1-h582d3a0_0.tar.bz2
osx-64::mandrake-1.2.1-py37h7a85b67_0.tar.bz2
osx-64::h5utils-1.13.1-mpi_mpich_hab242fb_1013.tar.bz2
osx-64::curl-7.80.0-hf45b732_1.tar.bz2
osx-64::nifty-1.2.0-py39h7b0b313_0.tar.bz2
osx-64::magics-metview-4.10.0-h4bc112e_1.tar.bz2
osx-64::scip-8.0.0-h2adb400_0.tar.bz2
osx-64::vtk-9.1.0-qt_py39h5247bde_203.tar.bz2
osx-64::llvmlite-0.38.0-py37h62ea057_0.tar.bz2
osx-64::dcap-2.47.12-he3abd7b_4.tar.bz2
osx-64::panda3d-1.10.11-py37h6c89d06_0.tar.bz2
osx-64::cctools_osx-arm64-973.0.1-h11dea68_4.tar.bz2
osx-64::poppler-22.01.0-h9573804_0.tar.bz2
osx-64::conduit-0.8.1-py38ha877268_0.tar.bz2
osx-64::grpcio-1.43.0-py39h757451a_0.tar.bz2
osx-64::astrometry-0.88-py37h0de2a5d_0.tar.bz2
osx-64::capnproto-0.9.1-h64a5342_4.tar.bz2
osx-64::libspatialite-5.0.1-h88e7940_14.tar.bz2
osx-64::ogre-13.2.4-h5dd8d7a_0.tar.bz2
osx-64::gdstk-0.8.1-py37h37ffbef_1.tar.bz2
osx-64::vtk-9.0.1-qt_py37h471ee76_210.tar.bz2
osx-64::coda-2.23-py39hc1bdbbc_0.tar.bz2
osx-64::libtiledb-sql-0.12.1-h3a6e14b_0.tar.bz2
-    "libzlib >=1.2.11,<1.3.0a0",
+    "libzlib >=1.2.11,<2.0.0a0",
osx-64::libllvm9-9.0.1-cling_v0.9_hf28e3b7_7.tar.bz2
osx-64::dotnet-runtime-6.0.1-ha205975_0.tar.bz2
osx-64::zimpl-3.5.1-h59d7fac_0.tar.bz2
osx-64::liblal-7.1.5-fftw_h5aeb782_100.tar.bz2
osx-64::libclang-cpp-9.0.1-cling_v0.9_h6431b02_3.tar.bz2
osx-64::dotnet-aspnetcore-6.0.1-ha205975_0.tar.bz2
osx-64::libopencv-4.5.3-py38hbfaad8a_7.tar.bz2
osx-64::coin-or-utils-2.11.6-h07ff368_0.tar.bz2
osx-64::dotnet-aspnetcore-3.1.22-ha205975_0.tar.bz2
osx-64::gcab-1.4-h618d979_0.tar.bz2
osx-64::libllvm9-9.0.1-default_h2671707_7.tar.bz2
osx-64::liblal-7.1.6-fftw_h5aeb782_101.tar.bz2
osx-64::libopencv-4.5.3-py37hddc2c2b_6.tar.bz2
osx-64::llvm-tools-9.0.1-default_h2671707_6.tar.bz2
osx-64::libllvm9-9.0.1-default_h2671707_6.tar.bz2
osx-64::cpp-opentelemetry-sdk-1.1.0-hd11b572_1.tar.bz2
osx-64::cpp-opentelemetry-sdk-1.1.0-hd11b572_2.tar.bz2
osx-64::pocl-1.8-h8b4fca9_0.tar.bz2
osx-64::libllvm9-9.0.1-cling_v0.9_hf28e3b7_5.tar.bz2
osx-64::libopencv-4.5.5-py31h83f2b0d_0.tar.bz2
osx-64::pocl-1.8-h5552be4_0.tar.bz2
osx-64::dotnet-runtime-3.1.22-ha205975_0.tar.bz2
osx-64::clang-9-9.0.1-root_62400_h34fb430_3.tar.bz2
osx-64::llvm-tools-9.0.1-default_h2671707_5.tar.bz2
osx-64::libopencv-4.5.5-py39h3195029_0.tar.bz2
osx-64::libopencv-4.5.3-py38ha082d02_6.tar.bz2
osx-64::libclang-cpp-9.0.1-root_62400_h34fb430_3.tar.bz2
osx-64::libopencv-4.5.5-py37hc7bab3b_0.tar.bz2
osx-64::libllvm9-9.0.1-cling_v0.9_hf28e3b7_6.tar.bz2
osx-64::libopencv-4.5.3-py31h83f2b0d_7.tar.bz2
osx-64::gst-plugins-good-1.18.5-h9f3b8af_3.tar.bz2
osx-64::libopencv-4.5.3-py31hcfef52b_6.tar.bz2
osx-64::llvm-9.0.1-default_hd770a7d_6.tar.bz2
osx-64::llvm-9.0.1-cling_v0.9_h0d90672_7.tar.bz2
osx-64::llvm-tools-9.0.1-default_h2671707_7.tar.bz2
osx-64::libopencv-4.5.5-py38hbfaad8a_0.tar.bz2
osx-64::cpp-opentelemetry-sdk-1.1.0-hd11b572_3.tar.bz2
osx-64::libclang-cpp9-9.0.1-cling_v0.9_h6431b02_3.tar.bz2
osx-64::llvm-9.0.1-default_hd770a7d_5.tar.bz2
osx-64::libopencv-4.5.3-py39hd2a74c5_6.tar.bz2
osx-64::libclang-cpp9-9.0.1-default_hf139c7e_3.tar.bz2
osx-64::cpp-opentelemetry-sdk-1.1.0-hd11b572_0.tar.bz2
osx-64::pocl-1.8-h8b4fca9_1.tar.bz2
osx-64::dotnet-sdk-3.1.416-ha205975_0.tar.bz2
osx-64::llvm-9.0.1-cling_v0.9_h0d90672_5.tar.bz2
osx-64::libclang-cpp-9.0.1-default_hf139c7e_3.tar.bz2
osx-64::llvm-tools-9.0.1-cling_v0.9_hf28e3b7_7.tar.bz2
osx-64::dotnet-sdk-6.0.101-ha205975_0.tar.bz2
osx-64::llvm-tools-9.0.1-cling_v0.9_hf28e3b7_5.tar.bz2
osx-64::dotnet-runtime-5.0.13-ha205975_0.tar.bz2
osx-64::llvm-9.0.1-default_hd770a7d_7.tar.bz2
osx-64::dotnet-aspnetcore-5.0.13-ha205975_0.tar.bz2
osx-64::libopencv-4.5.3-py37hc7bab3b_7.tar.bz2
osx-64::libllvm9-9.0.1-default_h2671707_5.tar.bz2
osx-64::clang-9-9.0.1-default_hf139c7e_3.tar.bz2
osx-64::glib-tools-2.70.2-hcf210ce_1.tar.bz2
osx-64::dotnet-sdk-5.0.404-ha205975_0.tar.bz2
osx-64::llvm-tools-9.0.1-cling_v0.9_hf28e3b7_6.tar.bz2
osx-64::libclang-cpp9-9.0.1-root_62400_h34fb430_3.tar.bz2
osx-64::pocl-1.8-h5552be4_1.tar.bz2
osx-64::glib-tools-2.70.2-hcf210ce_0.tar.bz2
osx-64::liblal-7.1.4-fftw_h5a71d99_101.tar.bz2
osx-64::llvm-9.0.1-cling_v0.9_h0d90672_6.tar.bz2
osx-64::liblal-7.1.6-fftw_h5aeb782_100.tar.bz2
osx-64::gst-plugins-base-1.18.5-h63a84d5_3.tar.bz2
osx-64::clang-9-9.0.1-cling_v0.9_h6431b02_3.tar.bz2
osx-64::libopencv-4.5.3-py39h3195029_7.tar.bz2
-    "libzlib >=1.2.11,<1.3.0a0"
+    "libzlib >=1.2.11,<2.0.0a0"
================================================================================
================================================================================
linux-64
linux-64::root_base-6.24.6-py310h57d1b7e_1.tar.bz2
linux-64::gemmi-0.5.1-py310hee97dad_0.tar.bz2
linux-64::mandrake-1.2.1-py38h75d12e8_0.tar.bz2
linux-64::paraview-5.10.0-h3362f5c_103_qt.tar.bz2
linux-64::dotnet-aspnetcore-5.0.13-h73ebe80_0.tar.bz2
linux-64::gds-base-monitors-2.19.7-h6c31f13_3.tar.bz2
linux-64::mosh-1.3.2-pl5321hd1d9560_1011.tar.bz2
linux-64::vtk-9.1.0-qt_py39h6e664cc_203.tar.bz2
linux-64::libtiledb-sql-0.12.2-h1543684_0.tar.bz2
linux-64::libopencv-4.5.3-py39ha7f30a5_6.tar.bz2
linux-64::paraview-5.10.0-h962010e_3_egl.tar.bz2
linux-64::triqs-3.0.2-py38h4215b03_0.tar.bz2
linux-64::kaldi-5.5.992-cpu_h1234567_8.tar.bz2
linux-64::julia-1.6.4-h34dcedf_1.tar.bz2
linux-64::tensorflow-base-2.6.2-cuda111py39h26679cf_2.tar.bz2
linux-64::assimp-5.2.0-hedfc422_0.tar.bz2
linux-64::pdal-2.3.0-h628708d_23.tar.bz2
linux-64::python-3.10.2-hc74c709_1_cpython.tar.bz2
linux-64::libgdal-3.4.1-h59e13aa_1.tar.bz2
linux-64::arrow-cpp-3.0.0-py37h89b98cd_41_cuda.tar.bz2
linux-64::libgdal-3.4.0-h1504ab5_12.tar.bz2
linux-64::readdy-2.0.11-py310hfcd7171_0.tar.bz2
linux-64::paraview-5.10.0-hf63980a_3_egl.tar.bz2
linux-64::hdf5-1.12.1-mpi_openmpi_hb624a80_3.tar.bz2
linux-64::cpp-opentelemetry-sdk-1.1.0-h6ab31d3_4.tar.bz2
linux-64::julia-1.6.5-h989b2f6_2.tar.bz2
linux-64::libtensorflow_cc-2.6.2-cuda110h1bfb650_2.tar.bz2
linux-64::conduit-0.8.0-py39hacd2f33_0.tar.bz2
linux-64::libmongoc-1.20.1-hc232e51_0.tar.bz2
linux-64::lmod-8.6.1-lua54h14f7cff_0.tar.bz2
linux-64::zstd-1.5.1-ha95c52a_0.tar.bz2
linux-64::z5py-2.0.12-py37h47f1ee2_0.tar.bz2
linux-64::mandrake-1.2.1-py37hcc9ed4e_0.tar.bz2
linux-64::librdkafka-1.8.2.post2-hc49e61c_0.tar.bz2
linux-64::libopencv-4.5.5-py38hd60e7aa_0.tar.bz2
linux-64::ortools-cpp-9.2-hb095d27_0.tar.bz2
linux-64::nordugrid-arc-6.14.0-py37h88d4dd7_1.tar.bz2
linux-64::arrow-cpp-6.0.1-py37hbd77c41_5_cpu.tar.bz2
linux-64::nifty-1.2.1-py37h023b2db_0.tar.bz2
linux-64::paraview-5.10.0-h371a832_3_egl.tar.bz2
linux-64::ndcctools-7.4.2-py38hdd6454d_0.tar.bz2
linux-64::libgdal-3.4.0-h4471fe2_11.tar.bz2
linux-64::libopencv-4.5.3-py31he7a5e20_7.tar.bz2
linux-64::python-3.10.1-h62f1059_1_cpython.tar.bz2
linux-64::vowpalwabbit-9.0.0-py310h1daa79b_3.tar.bz2
linux-64::python-3.9.10-h85951f9_0_cpython.tar.bz2
linux-64::arrow-cpp-3.0.0-py39hcf6a9ae_41_cuda.tar.bz2
linux-64::vowpalwabbit-9.0.0-py39h8e5f8a4_3.tar.bz2
linux-64::arrow-cpp-3.0.0-py39hbe2a541_39_cuda.tar.bz2
linux-64::gct-6.2.1550507116-h812cca2_2.tar.bz2
linux-64::sagelib-9.4-py38hfd38005_1.tar.bz2
linux-64::vtk-9.0.1-osmesa_py39h728d570_110.tar.bz2
linux-64::omniorb-4.2.5-py310ha6b4e5e_0.tar.bz2
linux-64::ndcctools-7.4.0-py39h336bf08_0.tar.bz2
linux-64::ortools-python-9.1-py310h4995e31_3.tar.bz2
linux-64::ndcctools-7.4.1-py39hff7568b_0.tar.bz2
linux-64::libtiledb-sql-0.12.2-h1e20410_0.tar.bz2
linux-64::pdal-2.3.0-hf589941_20.tar.bz2
linux-64::assimp-5.1.0-hedfc422_1.tar.bz2
linux-64::magics-metview-4.10.0-hcdafe21_2.tar.bz2
linux-64::capnproto-0.9.1-ha19adfc_3.tar.bz2
linux-64::libtensorflow_cc-2.6.2-cuda111h58c461c_2.tar.bz2
linux-64::julia-1.6.4-h34dcedf_2.tar.bz2
linux-64::arrow-cpp-5.0.0-py37he4d610e_22_cpu.tar.bz2
linux-64::libgdal-3.3.3-h4ae554a_15.tar.bz2
linux-64::nordugrid-arc-6.14.0-py37h3943c3c_0.tar.bz2
linux-64::ogre-13.2.3-h457c5cf_0.tar.bz2
linux-64::paraview-5.10.0-h5432724_103_qt.tar.bz2
linux-64::kaldi-5.5.992-cuda110h1234567_7.tar.bz2
linux-64::assimp-5.1.5-hedfc422_0.tar.bz2
linux-64::libtensorflow-2.6.2-cuda102h4600cf6_2.tar.bz2
linux-64::kaldi-5.5.992-cuda111h1234567_7.tar.bz2
linux-64::coda-2.23-py38h233361c_0.tar.bz2
linux-64::libcups-2.3.3-hf5a7f15_1.tar.bz2
linux-64::arrow-cpp-6.0.1-py38h44d4a2f_8_cpu.tar.bz2
linux-64::cppyy-cling-6.25.2-py310h73e767e_1.tar.bz2
linux-64::vowpalwabbit-8.11.0-py38hdaa81c8_2.tar.bz2
linux-64::panda3d-1.10.11-py38h6644d6d_0.tar.bz2
linux-64::mandrake-1.2.1-py38h66dd620_0.tar.bz2
linux-64::gds-services-2.19.7-h6c31f13_2.tar.bz2
linux-64::grpc-cpp-1.43.2-ha1441d3_0.tar.bz2
linux-64::nordugrid-arc-6.14.0-py37hcc9d85f_1.tar.bz2
linux-64::arrow-cpp-6.0.1-py38h44d4a2f_7_cpu.tar.bz2
linux-64::protozfits-2.0.1.post1-py38h56585e2_7.tar.bz2
linux-64::libtensorflow_cc-2.7.0-cuda112he1a0a60_0.tar.bz2
linux-64::julia-1.6.4-h989b2f6_2.tar.bz2
linux-64::vigra-1.11.1-py37h71a3c6e_1027.tar.bz2
linux-64::createrepo_c-0.18.0-py39h7166461_0.tar.bz2
linux-64::folly-2021.12.20.00-h1234567_1.tar.bz2
linux-64::libgdal-3.4.0-hbe510e8_10.tar.bz2
linux-64::tensorflow-base-2.6.2-cuda102py37h55054dc_2.tar.bz2
linux-64::arrow-cpp-6.0.1-py37h815fc2d_3_cpu.tar.bz2
linux-64::mapserver-7.6.4-py310h03247d5_3.tar.bz2
linux-64::gdstk-0.8.1-py310h5941e77_1.tar.bz2
linux-64::kaldi-5.5.992-cuda111py38h1234567_4.tar.bz2
linux-64::imagemagick-7.1.0_22-pl5321hb118871_0.tar.bz2
linux-64::ogre-13.2.4-h457c5cf_0.tar.bz2
linux-64::hdf5-1.12.1-mpi_mpich_h9c45103_3.tar.bz2
linux-64::liblal-7.1.6-mkl_hc26672e_0.tar.bz2
linux-64::capnproto-0.9.1-h812cca2_3.tar.bz2
linux-64::glib-2.70.2-h780b84a_0.tar.bz2
linux-64::gemmi-0.5.2-py37hf2742bb_0.tar.bz2
linux-64::arrow-cpp-6.0.1-py310h3fc2682_8_cuda.tar.bz2
linux-64::arrow-cpp-3.0.0-py310h2d9d4a2_40_cpu.tar.bz2
linux-64::astrometry-0.89-py39h2fb4aad_0.tar.bz2
linux-64::julia-1.7.0-h989b2f6_0.tar.bz2
linux-64::h5utils-1.13.1-mpi_mpich_h88c8ee5_1012.tar.bz2
linux-64::nifty-1.2.1-py39h6dffa3a_3.tar.bz2
linux-64::ndcctools-7.4.0-py37hb27c1af_0.tar.bz2
linux-64::kaldi-5.5.992-cuda111h1234567_5.tar.bz2
linux-64::libtensorflow_cc-2.6.2-cuda102h4600cf6_2.tar.bz2
linux-64::ruby-3.1.0-h86e321c_1.tar.bz2
linux-64::gds-base-gdstrig-2.19.7-hf817b99_2.tar.bz2
linux-64::conduit-0.7.1-py39hb25f1e2_1.tar.bz2
linux-64::mongodb-5.1.1-h9d7aa6a_0.tar.bz2
linux-64::ovito-3.6.0-hc2f89fc_0.tar.bz2
linux-64::llvmdev-9.0.1-cling_v0.9_h2b820e9_5.tar.bz2
linux-64::cppyy-cling-6.25.2-py37hfa6fd77_0.tar.bz2
linux-64::ndcctools-7.4.1-py310h94ab34a_2.tar.bz2
linux-64::cppyy-cling-6.25.2-py37h278f77e_1.tar.bz2
linux-64::grpc-cpp-1.43.0-ha1441d3_0.tar.bz2
linux-64::python-3.9.10-h85951f9_1_cpython.tar.bz2
linux-64::lmod-8.5.29-lua54h14f7cff_0.tar.bz2
linux-64::tiledb-2.6.2-hf3d3071_0.tar.bz2
linux-64::mysql-client-8.0.27-hf09c6a7_3.tar.bz2
linux-64::tesseract-5.0.0-h84e3e21_1.tar.bz2
linux-64::triqs-3.0.2-py39h5214ecb_0.tar.bz2
linux-64::vtk-9.0.1-osmesa_py310hb613807_110.tar.bz2
linux-64::arrow-cpp-5.0.0-py310ha0b4ddf_19_cpu.tar.bz2
linux-64::vtk-9.0.1-qt_py310h8cd55b6_210.tar.bz2
linux-64::pytables-3.7.0-py37h5dea08b_0.tar.bz2
linux-64::wxpython-4.1.1-py38h1c15066_3.tar.bz2
linux-64::gds-base-crtools-2.19.7-ha89783c_3.tar.bz2
linux-64::libopencv-4.5.3-py37h4958a1a_7.tar.bz2
linux-64::tensorflow-base-2.6.2-cuda111py37ha84a828_2.tar.bz2
linux-64::pyreadstat-1.1.4-py37h6828927_0.tar.bz2
linux-64::tiledb-2.5.3-h2038895_0.tar.bz2
linux-64::gds-base-crtools-2.19.7-ha89783c_1.tar.bz2
linux-64::libharu-2.3.0-h0708190_2.tar.bz2
linux-64::coda-2.23-py39h4d6291d_0.tar.bz2
linux-64::bgenix-1.1.4-hfa204df_8.tar.bz2
linux-64::conduit-0.8.0-py37h8d921b5_0.tar.bz2
linux-64::ndcctools-7.4.1-py38hdd6454d_1.tar.bz2
linux-64::gemmi-0.5.1-py37h9d7f4d0_0.tar.bz2
linux-64::gds-base-gdstrig-2.19.7-hf817b99_3.tar.bz2
linux-64::folly-2022.01.03.00-h1234567_1.tar.bz2
linux-64::cpp-opentelemetry-sdk-1.1.1-h3035edd_2.tar.bz2
linux-64::erlang-24.2.1-pl5321h3e1d2c6_0.tar.bz2
linux-64::tensorflow-base-2.7.0-cuda112py38hd3dc81e_0.tar.bz2
linux-64::vtk-9.1.0-qt_py38h662b88e_203.tar.bz2
linux-64::libtiledb-sql-0.12.0-h82b1f98_0.tar.bz2
linux-64::conduit-0.8.0-py38hde377fb_0.tar.bz2
linux-64::capnproto-0.9.1-ha19adfc_4.tar.bz2
linux-64::geant4-10.7.3-py310hcea81dc_0.tar.bz2
linux-64::nordugrid-arc-6.14.0-py38h7f133e7_0.tar.bz2
linux-64::conduit-0.8.0-py37hd1c0ee6_0.tar.bz2
linux-64::cctools_osx-arm64-973.0.1-h7d46f33_4.tar.bz2
linux-64::vigra-1.11.1-py38ha0af0c1_1027.tar.bz2
linux-64::octave-6.4.0-h01f1e5b_1.tar.bz2
linux-64::triqs-3.0.2-py310h6c8d5f9_1.tar.bz2
linux-64::nifty-1.2.1-py37h023b2db_3.tar.bz2
linux-64::libtiledb-sql-0.12.0-h5e29d74_0.tar.bz2
linux-64::vtk-9.0.1-egl_py38hbbfcb68_10.tar.bz2
linux-64::llvmlite-0.38.0-py37hf2742bb_0.tar.bz2
linux-64::mysql-server-8.0.28-h5d765fb_0.tar.bz2
linux-64::libspatialite-5.0.1-h0e567f8_14.tar.bz2
linux-64::coda-2.23-py310h940c021_0.tar.bz2
linux-64::libopencv-4.5.5-py31he7a5e20_0.tar.bz2
linux-64::ruby-2.6.6-h86e321c_3.tar.bz2
linux-64::tensorflow-base-2.6.2-cuda112py39hc7f77e4_2.tar.bz2
linux-64::libgdal-3.3.3-h59e13aa_14.tar.bz2
linux-64::vigra-1.11.1-py39ha46d285_1028.tar.bz2
linux-64::pdal-2.3.0-h2d77ad1_21.tar.bz2
linux-64::nordugrid-arc-6.14.0-py37h24436a8_0.tar.bz2
linux-64::libgdal-3.4.0-h5ee51d2_13.tar.bz2
linux-64::ndcctools-7.4.1-py310ha6b4e5e_1.tar.bz2
linux-64::tensorflow-base-2.6.2-cuda110py38h7f44352_2.tar.bz2
linux-64::python-3.10.1-h62f1059_0_cpython.tar.bz2
linux-64::librdkafka-1.3.0-hc49e61c_1.tar.bz2
linux-64::libgdal-3.4.0-hbe510e8_12.tar.bz2
linux-64::netgen-6.2.2006-py39h83fa601_4.tar.bz2
linux-64::tensorflow-base-2.7.0-cuda111py39h2b78b69_0.tar.bz2
linux-64::uwsgi-2.0.20-py39h9c040ca_2.tar.bz2
linux-64::pytables-3.7.0-py37h6d96e8c_0.tar.bz2
linux-64::mysql-router-8.0.27-h1c6038f_3.tar.bz2
linux-64::vtk-9.1.0-qt_py310h5d501aa_203.tar.bz2
linux-64::conduit-0.7.1-py38hde377fb_1.tar.bz2
linux-64::git-2.35.0-pl5321hf874766_0.tar.bz2
linux-64::pyretis-2.5.0-py39h138c130_2.tar.bz2
linux-64::liblal-7.1.5-mkl_hc26672e_0.tar.bz2
linux-64::ndcctools-7.4.2-py38h2457d08_0.tar.bz2
linux-64::zstd-1.5.2-ha95c52a_0.tar.bz2
linux-64::ndcctools-7.4.1-py38h2457d08_0.tar.bz2
linux-64::vowpalwabbit-9.0.0-py38hdaa81c8_2.tar.bz2
linux-64::cppyy-cling-6.25.2-py38h7941ff8_1.tar.bz2
linux-64::git-2.35.0-pl5321hc30692c_0.tar.bz2
linux-64::arrow-cpp-3.0.0-py39h01fd06f_41_cpu.tar.bz2
linux-64::pdal-2.3.0-h3c03ee5_18.tar.bz2
linux-64::geant4-10.7.3-py39h2daeef8_0.tar.bz2
linux-64::dcap-2.47.12-h7e61378_5.tar.bz2
linux-64::arrow-cpp-3.0.0-py39hb340ef0_40_cpu.tar.bz2
linux-64::vowpalwabbit-9.0.0-py38hdaa81c8_3.tar.bz2
linux-64::triqs-3.0.2-py38he9169ed_0.tar.bz2
linux-64::ndcctools-7.4.1-py39h336bf08_1.tar.bz2
linux-64::libgsf-1.14.48-h88be47d_0.tar.bz2
linux-64::kaldi-5.5.992-cuda110py38h1234567_4.tar.bz2
linux-64::mysql-client-8.0.27-hf09c6a7_2.tar.bz2
linux-64::libcurl-7.81.0-h494985f_0.tar.bz2
linux-64::arrow-cpp-6.0.1-py38hc3077b4_3_cuda.tar.bz2
linux-64::conduit-0.7.1-py37h8d921b5_1.tar.bz2
linux-64::folly-2022.01.24.00-h1234567_1_jemalloc.tar.bz2
linux-64::gmt-6.3.0-haaaf7b6_1.tar.bz2
linux-64::pyinstaller-4.8-py38ha8cb210_0.tar.bz2
linux-64::folly-2022.01.24.00-h1234567_1.tar.bz2
linux-64::gds-base-2.19.7-h22af627_3.tar.bz2
linux-64::folly-2022.01.17.00-h1234567_1_jemalloc.tar.bz2
linux-64::mapserver-7.6.4-py38h22570ed_4.tar.bz2
linux-64::ruby-2.7.2-h86e321c_8.tar.bz2
linux-64::tensorflow-base-2.7.0-cuda112py39hd98b2dd_0.tar.bz2
linux-64::gfal2-2.20.2-h1f80e55_0.tar.bz2
linux-64::arrow-cpp-6.0.1-py37h89b98cd_8_cuda.tar.bz2
linux-64::libxmlsec1-1.2.32-hb6668e7_1.tar.bz2
linux-64::triqs-3.0.2-py38he9169ed_1.tar.bz2
linux-64::python-3.9.9-h543edf9_0_cpython.tar.bz2
linux-64::geant4-10.7.3-py37h118d875_0.tar.bz2
linux-64::omniorb-libs-4.2.5-ha19adfc_0.tar.bz2
linux-64::libtiledb-sql-0.12.3-h1e20410_0.tar.bz2
linux-64::gds-base-2.19.7-h22af627_2.tar.bz2
linux-64::freecad-0.19.3-py38h00d9433_3.tar.bz2
linux-64::geotiff-1.7.0-h6593c0a_6.tar.bz2
linux-64::pyreadstat-1.1.4-py39hd38ffc4_0.tar.bz2
linux-64::arrow-cpp-3.0.0-py38hab3e76a_40_cuda.tar.bz2
linux-64::paraview-5.10.0-h5a65f13_103_qt.tar.bz2
linux-64::llvmlite-0.38.0-py39h1bbdace_0.tar.bz2
linux-64::nodejs-17.1.0-h8ca31f7_2.tar.bz2
linux-64::ogre-13.2.1-h457c5cf_0.tar.bz2
linux-64::librdkafka-1.3.0-hb1989a6_3.tar.bz2
linux-64::uwsgi-2.0.20-py39hfd59d76_2.tar.bz2
linux-64::arrow-cpp-6.0.1-py38h87e2ab4_3_cpu.tar.bz2
linux-64::createrepo_c-0.18.0-py38h76767d8_0.tar.bz2
linux-64::arrow-cpp-3.0.0-py39h7e45aa4_37_cuda.tar.bz2
linux-64::xrootd-5.3.4-py310h2cd62ec_0.tar.bz2
linux-64::folly-2021.12.20.00-h1234567_1_jemalloc.tar.bz2
linux-64::protozfits-2.0.1.post1-py39h671e6d9_6.tar.bz2
linux-64::gmt-6.3.0-haaaf7b6_2.tar.bz2
linux-64::tensorflow-base-2.6.2-cuda112py38h1eec131_2.tar.bz2
linux-64::arrow-cpp-3.0.0-py38hd267840_38_cpu.tar.bz2
linux-64::plumed-2.7.3-nompi_h8de8e23_100.tar.bz2
linux-64::conduit-0.8.1-py39h8302f4d_0.tar.bz2
linux-64::ruby-3.1.0-h86e321c_0.tar.bz2
linux-64::ndcctools-7.4.0-py39hff7568b_0.tar.bz2
linux-64::nodejs-16.13.0-hb5e7134_2.tar.bz2
linux-64::arrow-cpp-3.0.0-py310hea7fbe8_39_cuda.tar.bz2
linux-64::tiledb-2.6.1-h2038895_0.tar.bz2
linux-64::postgresql-plpython-13.5-py39hf17921a_1.tar.bz2
linux-64::arrow-cpp-3.0.0-py37he4d610e_41_cpu.tar.bz2
linux-64::cppyy-cling-6.25.2-py38h7941ff8_0.tar.bz2
linux-64::pdal-2.3.0-hf589941_21.tar.bz2
linux-64::libtensorflow-2.7.0-cuda111hbb87069_0.tar.bz2
linux-64::pytables-3.7.0-py310hf5df6ce_0.tar.bz2
linux-64::pyreadstat-1.1.4-py37h97b672c_0.tar.bz2
linux-64::arrow-cpp-5.0.0-py310he8db510_18_cuda.tar.bz2
linux-64::arrow-cpp-3.0.0-py38h4dc56cc_39_cuda.tar.bz2
linux-64::triqs-3.0.2-py310h4b5cc0a_1.tar.bz2
linux-64::wasmer-2.1.0-h75bafa5_1.tar.bz2
linux-64::pytables-3.7.0-py38hdb04529_0.tar.bz2
linux-64::assimp-5.1.3-hedfc422_1.tar.bz2
linux-64::nss-3.73-hb5efdd6_0.tar.bz2
linux-64::arrow-cpp-5.0.0-py37h28966e8_19_cuda.tar.bz2
linux-64::protozfits-2.0.1.post1-py310hd40dcfe_5.tar.bz2
linux-64::nordugrid-arc-6.14.0-py38ha8e42a5_1.tar.bz2
linux-64::vtk-9.0.1-qt_py38h3ef61c0_210.tar.bz2
linux-64::python-3.9.10-hc74c709_0_cpython.tar.bz2
linux-64::paraview-5.10.0-h1af7cb3_103_qt.tar.bz2
linux-64::cppyy-cling-6.25.2-py37hfa6fd77_1.tar.bz2
linux-64::scip-8.0.0-hc3d86cf_0.tar.bz2
linux-64::mysql-connector-odbc-8.0.28-h780b84a_0.tar.bz2
linux-64::paraview-5.10.0-hd40d8ed_103_qt.tar.bz2
linux-64::llvmdev-9.0.1-cling_v0.9_h2b820e9_6.tar.bz2
linux-64::arrow-cpp-5.0.0-py39hb340ef0_21_cpu.tar.bz2
linux-64::nodejs-17.4.0-h8ca31f7_0.tar.bz2
linux-64::protozfits-2.0.1.post1-py38h56585e2_6.tar.bz2
linux-64::arrow-cpp-5.0.0-py37h89b98cd_22_cuda.tar.bz2
linux-64::triqs-3.0.2-py37ha613fed_0.tar.bz2
linux-64::arrow-cpp-6.0.1-py37h1973f06_6_cuda.tar.bz2
linux-64::conduit-0.8.0-py38h5ff8a9a_0.tar.bz2
linux-64::nginx-1.21.5-h9733db4_0.tar.bz2
linux-64::arrow-cpp-5.0.0-py310h500f8fe_22_cpu.tar.bz2
linux-64::tesseract-4.1.3-h84e3e21_6.tar.bz2
linux-64::qt-main-5.15.2-hf8cb05d_0.tar.bz2
linux-64::vtk-9.0.1-osmesa_py37hff4266d_110.tar.bz2
linux-64::kaldi-5.5.992-cpu_h1234567_5.tar.bz2
linux-64::arrow-cpp-3.0.0-py38h44d4a2f_41_cpu.tar.bz2
linux-64::julia-1.6.5-h989b2f6_1.tar.bz2
linux-64::mysql-connector-cpp-8.0.27-h7a4f57c_0.tar.bz2
linux-64::h5utils-1.13.1-nompi_hd2bf37e_1113.tar.bz2
linux-64::nifty-1.2.1-py39h6dffa3a_0.tar.bz2
linux-64::kaldi-5.5.992-cpu_h1234567_7.tar.bz2
linux-64::arrow-cpp-3.0.0-py37h1973f06_40_cuda.tar.bz2
linux-64::triqs-3.0.2-py39h32474f9_0.tar.bz2
linux-64::poppler-qt-22.01.0-h6ef9ed9_0.tar.bz2
linux-64::arrow-cpp-5.0.0-py37hb601090_18_cuda.tar.bz2
linux-64::mapserver-7.6.4-py39h49259f5_4.tar.bz2
linux-64::arrow-cpp-5.0.0-py38h9de81b1_20_cpu.tar.bz2
linux-64::nifty-1.2.1-py38h8343072_2.tar.bz2
linux-64::arrow-cpp-3.0.0-py37hbc6fab8_38_cpu.tar.bz2
linux-64::astrometry-0.88-py38hadafcda_0.tar.bz2
linux-64::pyinstaller-4.8-py39hd38ffc4_0.tar.bz2
linux-64::nordugrid-arc-6.14.0-py39h598e57a_0.tar.bz2
linux-64::erlang-24.2-pl5321hb6651ff_1.tar.bz2
linux-64::protozfits-2.0.1.post1-py38hf1ded1e_5.tar.bz2
linux-64::kaldi-5.5.992-cuda112py38h1234567_4.tar.bz2
linux-64::arrow-cpp-5.0.0-py37h3e80117_21_cpu.tar.bz2
linux-64::paraview-5.10.0-h0c1b1c9_3_egl.tar.bz2
linux-64::gmt-5.4.5-hdc35fa5_17.tar.bz2
linux-64::libopencv-4.5.3-py38hd60e7aa_7.tar.bz2
linux-64::librdkafka-1.3.0-hb1989a6_1.tar.bz2
linux-64::tensorflow-base-2.7.0-cuda111py38hca068ee_0.tar.bz2
linux-64::dcap-2.47.12-h41e18d1_5.tar.bz2
linux-64::folly-2022.01.10.00-h1234567_1_jemalloc.tar.bz2
linux-64::arrow-cpp-6.0.1-py310h3008b6d_3_cpu.tar.bz2
linux-64::kaldi-5.5.992-hb6825f7_0.tar.bz2
linux-64::omniorb-4.2.5-py37hd5d88b1_0.tar.bz2
linux-64::wasmer-2.1.0-h98e6a8f_0.tar.bz2
linux-64::llvmdev-9.0.1-default_hc23dcda_7.tar.bz2
linux-64::h5utils-1.13.1-nompi_h96f4c20_1113.tar.bz2
linux-64::conduit-0.8.0-py37h106d8db_0.tar.bz2
linux-64::julia-1.7.1-h989b2f6_1.tar.bz2
linux-64::vigra-1.11.1-py37h71a3c6e_1028.tar.bz2
linux-64::arrow-cpp-5.0.0-py38hc3077b4_18_cuda.tar.bz2
linux-64::omniorb-4.2.5-py37hb27c1af_0.tar.bz2
linux-64::mysql-router-8.0.28-h1c6038f_0.tar.bz2
linux-64::gemmi-0.5.1-py39h1bbdace_0.tar.bz2
linux-64::mysql-router-8.0.27-h1c6038f_2.tar.bz2
linux-64::libnghttp2-1.46.0-ha19adfc_0.tar.bz2
linux-64::mysql-server-8.0.27-h5d765fb_2.tar.bz2
linux-64::gdstk-0.8.1-py37hfa6fd77_0.tar.bz2
linux-64::tiledb-2.5.3-hf3d3071_0.tar.bz2
linux-64::r-base-4.1.1-hde4fec0_2.tar.bz2
linux-64::gemmi-0.5.2-py39h1bbdace_0.tar.bz2
linux-64::ndcctools-7.4.1-py38h2457d08_1.tar.bz2
linux-64::readdy-2.0.11-py38h35b03f1_0.tar.bz2
linux-64::qtwebkit-5.212-h7edf7c9_3.tar.bz2
linux-64::libpq-13.5-h676c864_1.tar.bz2
linux-64::pdal-2.3.0-h0a9dca5_24.tar.bz2
linux-64::libtensorflow_cc-2.6.2-cuda112hd70bc30_2.tar.bz2
linux-64::ortools-cpp-9.2-haaa9d00_0.tar.bz2
linux-64::postgresql-plpython-13.5-py310h1bbab67_1.tar.bz2
linux-64::libtiledb-sql-0.11.2-h5e29d74_0.tar.bz2
linux-64::julia-1.7.1-h989b2f6_2.tar.bz2
linux-64::xrootd-5.4.0-py37h834e20d_0.tar.bz2
linux-64::libopencv-4.5.3-py31hbd5a65a_6.tar.bz2
linux-64::grpc-cpp-1.43.2-ha36e17f_0.tar.bz2
linux-64::libtiledb-sql-0.11.1-h5e29d74_0.tar.bz2
linux-64::triqs-3.0.2-py37ha613fed_1.tar.bz2
linux-64::ruby-3.1.0-h134ee0a_1.tar.bz2
linux-64::paraview-5.10.0-h83713c8_3_egl.tar.bz2
linux-64::astrometry-0.88-py39h2fb4aad_0.tar.bz2
linux-64::nodejs-16.13.2-h8ca31f7_2.tar.bz2
linux-64::grpc-cpp-1.42.0-ha36e17f_1.tar.bz2
linux-64::paraview-5.10.0-h720592e_3_egl.tar.bz2
linux-64::folly-2021.12.27.00-h1234567_1.tar.bz2
linux-64::nodejs-17.1.0-hb5e7134_2.tar.bz2
linux-64::nodejs-14.18.3-h92b4a50_1.tar.bz2
linux-64::xrootd-5.3.4-py38h68ec80c_0.tar.bz2
linux-64::arrow-cpp-5.0.0-py37hbc6fab8_19_cpu.tar.bz2
linux-64::tiledb-2.6.0-h2038895_0.tar.bz2
linux-64::imagemagick-7.1.0_21-pl5321hb118871_0.tar.bz2
linux-64::arrow-cpp-5.0.0-py38h715243f_21_cpu.tar.bz2
linux-64::pdal-2.3.0-h3c03ee5_17.tar.bz2
linux-64::gct-6.2.1629922860-h812cca2_0.tar.bz2
linux-64::netpbm-10.73.38-pl5321h0d581c5_0.tar.bz2
linux-64::libgdal-3.4.1-h30f1481_1.tar.bz2
linux-64::lmod-8.6.7-lua54h14f7cff_0.tar.bz2
linux-64::r-base-4.1.2-h2553ce4_1.tar.bz2
linux-64::h5utils-1.13.1-nompi_hd2bf37e_1112.tar.bz2
linux-64::plumed-2.7.3-mpi_openmpi_heb59b2d_0.tar.bz2
linux-64::arrow-cpp-6.0.1-py39hb340ef0_6_cpu.tar.bz2
linux-64::gdstk-0.8.1-py310h73e767e_0.tar.bz2
linux-64::orc-1.7.1-h1be678f_1.tar.bz2
linux-64::root_base-6.24.6-py37hf5f6b79_2.tar.bz2
linux-64::conduit-0.8.0-py38h367b570_0.tar.bz2
linux-64::astrometry-0.88-py310h016e769_0.tar.bz2
linux-64::arrow-cpp-5.0.0-py37h815fc2d_18_cpu.tar.bz2
linux-64::conduit-0.8.1-py38h367b570_0.tar.bz2
linux-64::gsoap-2.8.118-h532c01c_0.tar.bz2
linux-64::ndcctools-7.4.1-py37hd5d88b1_0.tar.bz2
linux-64::vtk-9.1.0-egl_py310h68a8978_3.tar.bz2
linux-64::mapserver-7.6.4-py37h5f9b8b8_3.tar.bz2
linux-64::libopencv-4.5.5-py37h4958a1a_0.tar.bz2
linux-64::xrootd-5.4.0-py310h2cd62ec_0.tar.bz2
linux-64::gdstk-0.8.1-py38h4a4d8e3_1.tar.bz2
linux-64::lmod-8.6.3-lua54h14f7cff_0.tar.bz2
linux-64::conduit-0.7.1-py38h367b570_1.tar.bz2
linux-64::arrow-cpp-6.0.1-py38h579a05f_8_cuda.tar.bz2
linux-64::arrow-cpp-6.0.1-py38h4dc56cc_5_cuda.tar.bz2
linux-64::capnproto-0.9.1-h812cca2_4.tar.bz2
linux-64::python-3.10.1-h543edf9_0_cpython.tar.bz2
linux-64::libcurl-static-7.81.0-h2574ce0_0.tar.bz2
linux-64::xeus-cling-0.13.0-h560cc44_2.tar.bz2
linux-64::libgdal-3.4.1-h4ae554a_2.tar.bz2
linux-64::ndcctools-7.4.1-py37hb27c1af_0.tar.bz2
linux-64::gemmi-0.5.2-py37h9d7f4d0_0.tar.bz2
linux-64::geant4-10.7.3-py38ha75f61f_0.tar.bz2
linux-64::arrow-cpp-5.0.0-py38hcdf9ef9_19_cuda.tar.bz2
linux-64::xrootd-5.4.0-py37hb0090cc_0.tar.bz2
linux-64::h5utils-1.13.1-mpi_mpich_h88c8ee5_1013.tar.bz2
linux-64::arrow-cpp-3.0.0-py38hc3077b4_37_cuda.tar.bz2
linux-64::arrow-cpp-3.0.0-py39h2c67c1e_39_cpu.tar.bz2
linux-64::postgresql-plpython-13.5-py38hb26f4fd_1.tar.bz2
linux-64::paraview-5.10.0-hf0200fe_103_qt.tar.bz2
linux-64::readdy-2.0.11-py37h3f8df0d_0.tar.bz2
linux-64::mysql-connector-cpp-8.0.28-ha67dfc1_0.tar.bz2
linux-64::arrow-cpp-3.0.0-py37h6ab10f6_39_cuda.tar.bz2
linux-64::mapserver-7.6.4-py39he83cc67_3.tar.bz2
linux-64::libgdal-3.4.1-h5ee51d2_0.tar.bz2
linux-64::tensorflow-base-2.6.2-cuda112py37h8d33417_2.tar.bz2
linux-64::grpc-cpp-1.43.0-ha36e17f_0.tar.bz2
linux-64::libsoup-2.74.1-hdd0e21f_0.tar.bz2
linux-64::z5py-2.0.12-py39h3f3ea7e_0.tar.bz2
linux-64::arrow-cpp-3.0.0-py310h3008b6d_37_cpu.tar.bz2
linux-64::graphviz-2.50.0-h85b4f2f_0.tar.bz2
linux-64::gsoap-2.8.118-h90a1d37_0.tar.bz2
linux-64::nodejs-16.13.2-hb5e7134_2.tar.bz2
linux-64::cppyy-cling-6.25.2-py39h0f9e12e_1.tar.bz2
linux-64::mandrake-1.2.1-py37h56e43a9_0.tar.bz2
linux-64::libgdal-3.3.3-h7b6f8d3_15.tar.bz2
linux-64::panda3d-1.10.11-py39h50f9c69_0.tar.bz2
linux-64::cctools_osx-64-973.0.1-h6a0aaf5_4.tar.bz2
linux-64::uwsgi-2.0.20-py38hce04926_2.tar.bz2
linux-64::libcurl-7.81.0-h2574ce0_0.tar.bz2
linux-64::ogre-13.2.4-hef34edf_0.tar.bz2
linux-64::python-3.10.1-h543edf9_1_cpython.tar.bz2
linux-64::arrow-cpp-3.0.0-py39h2a895b2_38_cpu.tar.bz2
linux-64::kaldi-5.5.992-cuda112h1234567_5.tar.bz2
linux-64::arrow-cpp-6.0.1-py38h715243f_6_cpu.tar.bz2
linux-64::ndcctools-7.4.2-py310ha6b4e5e_0.tar.bz2
linux-64::nifty-1.2.1-py37h023b2db_2.tar.bz2
linux-64::ndcctools-7.4.0-py38h2457d08_0.tar.bz2
linux-64::qtwebkit-5.212-h70084a7_2.tar.bz2
linux-64::nordugrid-arc-6.14.0-py39hb91b651_1.tar.bz2
linux-64::gds-services-2.19.7-h6c31f13_3.tar.bz2
linux-64::lmod-8.6.8-lua54h14f7cff_0.tar.bz2
linux-64::nodejs-16.13.0-h8ca31f7_2.tar.bz2
linux-64::lmod-8.6.5-lua54h14f7cff_0.tar.bz2
linux-64::vtk-9.1.0-qt_py37h5198534_203.tar.bz2
linux-64::cctools_osx-arm64-973.0.1-hd7a0a63_5.tar.bz2
linux-64::protozfits-2.0.1.post1-py37hd29e5bf_5.tar.bz2
linux-64::paraview-5.10.0-h089a6c3_103_qt.tar.bz2
linux-64::libpq-13.5-hd57d9b9_1.tar.bz2
linux-64::ndcctools-7.4.1-py310ha6b4e5e_2.tar.bz2
linux-64::libspatialite-5.0.1-hd55babb_13.tar.bz2
linux-64::bgenix-1.1.4-h91246b1_8.tar.bz2
linux-64::kaldi-5.5.992-h7430895_3.tar.bz2
linux-64::omniorb-4.2.5-py38h2457d08_0.tar.bz2
linux-64::vtk-9.0.1-osmesa_py38h08810d9_110.tar.bz2
linux-64::magics-4.10.0-hb6baf3b_1.tar.bz2
linux-64::libprotobuf-3.19.3-h780b84a_0.tar.bz2
linux-64::ndcctools-7.4.1-py39h336bf08_2.tar.bz2
linux-64::z5py-2.0.11-py37h47f1ee2_1.tar.bz2
linux-64::cppyy-cling-6.25.2-py39h0f9e12e_0.tar.bz2
linux-64::python-3.10.1-h62f1059_2_cpython.tar.bz2
linux-64::tensorflow-base-2.6.2-cpu_py39h6349a3b_2.tar.bz2
linux-64::gdstk-0.8.1-py38h7941ff8_0.tar.bz2
linux-64::coda-2.23-py37h3c1224e_0.tar.bz2
linux-64::wasmer-2.1.1-h4e65ae5_0.tar.bz2
linux-64::pyretis-2.5.0-py37h527cbdb_2.tar.bz2
linux-64::gds-base-crtools-2.19.7-ha89783c_2.tar.bz2
linux-64::nodejs-16.13.0-h8ca31f7_1.tar.bz2
linux-64::conduit-0.8.0-py39hb25f1e2_0.tar.bz2
linux-64::nifty-1.2.0-py38h8343072_0.tar.bz2
linux-64::gmt-6.3.0-hcfc2acf_1.tar.bz2
linux-64::arrow-cpp-3.0.0-py37h815fc2d_37_cpu.tar.bz2
linux-64::kaldi-5.5.992-cpu_h1234567_6.tar.bz2
linux-64::astrometry-0.89-py37h76657be_0.tar.bz2
linux-64::octave-6.4.0-h8594d46_0.tar.bz2
linux-64::imagemagick-7.1.0_18-pl5321hb118871_0.tar.bz2
linux-64::qt-5.12.9-ha98a1a1_5.tar.bz2
linux-64::arrow-cpp-6.0.1-py39hcf6a9ae_8_cuda.tar.bz2
linux-64::arrow-cpp-5.0.0-py39ha1ff70b_19_cuda.tar.bz2
linux-64::librdkafka-1.7.0-hc49e61c_1.tar.bz2
linux-64::tensorflow-base-2.6.2-cuda110py39h1b3dc91_2.tar.bz2
linux-64::kaldi-5.5.992-cuda112h1234567_8.tar.bz2
linux-64::vowpalwabbit-8.11.0-py39h8e5f8a4_2.tar.bz2
linux-64::vtk-9.1.0-egl_py39h1945628_3.tar.bz2
linux-64::ndcctools-7.4.0-py37hd5d88b1_0.tar.bz2
linux-64::ndcctools-7.4.1-py37hd5d88b1_2.tar.bz2
linux-64::imagemagick-7.1.0_19-pl5321hb118871_0.tar.bz2
linux-64::netgen-6.2.2006-py37he358ceb_4.tar.bz2
linux-64::llvmdev-9.0.1-default_hc23dcda_5.tar.bz2
linux-64::kaldi-5.5.992-cuda110h1234567_8.tar.bz2
linux-64::vowpalwabbit-9.0.0-py37habe62f9_2.tar.bz2
linux-64::tensorflow-base-2.6.2-cuda102py38h8c73509_2.tar.bz2
linux-64::liblal-7.1.4-mkl_h63eb966_1.tar.bz2
linux-64::conduit-0.7.1-py38h5ff8a9a_1.tar.bz2
linux-64::grpcio-1.43.0-py39h336bf08_0.tar.bz2
linux-64::vtk-9.0.1-egl_py39h4ab89ca_10.tar.bz2
linux-64::vtk-9.0.1-egl_py37ha40b64d_10.tar.bz2
linux-64::lmod-8.6-lua54h14f7cff_0.tar.bz2
linux-64::astrometry-0.89-py37hca92f70_0.tar.bz2
linux-64::tomviz-1.10.0.post152-py37h895cc74_0.tar.bz2
linux-64::kaldi-5.5.992-cuda110h1234567_6.tar.bz2
linux-64::librdkafka-1.8.2.post2-hb1989a6_0.tar.bz2
linux-64::kaldi-5.5.992-cpu_py38h1234567_4.tar.bz2
linux-64::arrow-cpp-5.0.0-py39hcf6a9ae_22_cuda.tar.bz2
linux-64::nifty-1.2.0-py37h023b2db_0.tar.bz2
linux-64::createrepo_c-0.18.0-py37ha6d3d50_0.tar.bz2
linux-64::ndcctools-7.4.2-py310h94ab34a_0.tar.bz2
linux-64::r-git2r-0.29.0-r41h012fe3a_1.tar.bz2
linux-64::arrow-cpp-5.0.0-py310h2d9d4a2_21_cpu.tar.bz2
linux-64::libtensorflow_cc-2.7.0-cuda111hbb87069_0.tar.bz2
linux-64::mysql-server-8.0.27-h5d765fb_3.tar.bz2
linux-64::arrow-cpp-6.0.1-py38h9de81b1_5_cpu.tar.bz2
linux-64::texlive-core-20210325-h97429d4_1.tar.bz2
linux-64::libgdal-3.3.3-h1504ab5_12.tar.bz2
linux-64::tesseract-5.0.0-h84e3e21_0.tar.bz2
linux-64::vigra-1.11.1-py37h3bb4fe9_1027.tar.bz2
linux-64::gmt-6.3.0-h13dc416_3.tar.bz2
linux-64::arrow-cpp-5.0.0-py39hb8c629c_18_cpu.tar.bz2
linux-64::soplex-6.0.0-h7b2874a_0.tar.bz2
linux-64::kaldi-5.5.992-cuda111h1234567_6.tar.bz2
linux-64::arrow-cpp-6.0.1-py310h500f8fe_7_cpu.tar.bz2
linux-64::folly-2022.01.10.00-h1234567_1.tar.bz2
linux-64::mapserver-7.6.4-py310h5608d67_5.tar.bz2
linux-64::triqs-3.0.2-py39h32474f9_1.tar.bz2
linux-64::xrootd-5.3.4-py39hf708bbc_0.tar.bz2
linux-64::nodejs-16.13.0-hb5e7134_1.tar.bz2
linux-64::wasmer-2.1.0-h4e65ae5_2.tar.bz2
linux-64::h5utils-1.13.1-mpi_mpich_ha777a55_1012.tar.bz2
linux-64::python-3.10.2-hc74c709_2_cpython.tar.bz2
linux-64::astrometry-0.89-py310h016e769_0.tar.bz2
linux-64::r-base-4.1.2-hde4fec0_0.tar.bz2
linux-64::tensorflow-base-2.7.0-cuda112py37had06f64_0.tar.bz2
linux-64::pdal-2.3.0-h3c2e8f3_23.tar.bz2
linux-64::pdal-2.3.0-hb9c3aac_16.tar.bz2
linux-64::wxpython-4.1.1-py37h28db2d3_3.tar.bz2
linux-64::omniorb-4.2.5-py38hdd6454d_0.tar.bz2
linux-64::arrow-cpp-3.0.0-py37h28966e8_38_cuda.tar.bz2
linux-64::hdf5-1.12.1-nompi_h7f166f4_103.tar.bz2
linux-64::rust-1.57.0-h61edd41_0.tar.bz2
linux-64::ndcctools-7.4.1-py38hdd6454d_0.tar.bz2
linux-64::julia-1.7.1-h989b2f6_3.tar.bz2
linux-64::pdal-2.3.0-h2d77ad1_22.tar.bz2
linux-64::uwsgi-2.0.20-py38haf63009_2.tar.bz2
linux-64::mapserver-7.6.4-py37h32adef7_5.tar.bz2
linux-64::mesalib-21.2.5-h0e4506f_3.tar.bz2
linux-64::ogre-13.2.2-h457c5cf_0.tar.bz2
linux-64::uwsgi-2.0.20-py38haf63009_3.tar.bz2
linux-64::ndcctools-7.4.1-py37hb27c1af_1.tar.bz2
linux-64::mandrake-1.2.0-py38hd235e30_0.tar.bz2
linux-64::paraview-5.10.0-ha55d785_3_egl.tar.bz2
linux-64::libtiledb-sql-0.12.1-h1543684_0.tar.bz2
linux-64::arrow-cpp-6.0.1-py37he4d610e_8_cpu.tar.bz2
linux-64::vigra-1.11.1-py38ha0af0c1_1028.tar.bz2
linux-64::graphviz-2.50.0-h8e749b2_2.tar.bz2
linux-64::bgenix-1.1.4-h7b7a18c_8.tar.bz2
linux-64::ogre-13.2.3-hef34edf_0.tar.bz2
linux-64::libgdal-3.4.0-hfbb1d71_9.tar.bz2
linux-64::arrow-cpp-3.0.0-py38h715243f_40_cpu.tar.bz2
linux-64::grpc-cpp-1.42.0-ha1441d3_1.tar.bz2
linux-64::dotnet-aspnetcore-6.0.1-h73ebe80_0.tar.bz2
linux-64::cppyy-cling-6.25.2-py310h73e767e_0.tar.bz2
linux-64::tensorflow-base-2.7.0-cuda111py310h8463a45_0.tar.bz2
linux-64::wasmer-2.1.1-h75bafa5_0.tar.bz2
linux-64::ndcctools-7.4.1-py37hd5d88b1_1.tar.bz2
linux-64::conduit-0.8.1-py38hde377fb_0.tar.bz2
linux-64::python-3.9.10-hc74c709_1_cpython.tar.bz2
linux-64::cpp-opentelemetry-sdk-1.1.1-h6ab31d3_0.tar.bz2
linux-64::graphicsmagick-1.3.37-hdc87540_0.tar.bz2
linux-64::arrow-cpp-6.0.1-py37h89b98cd_7_cuda.tar.bz2
linux-64::libtiledb-sql-0.12.3-h1543684_0.tar.bz2
linux-64::arrow-cpp-5.0.0-py310h3fc2682_22_cuda.tar.bz2
linux-64::erlang-24.2.1-pl5321hddd2aab_0.tar.bz2
linux-64::dcap-2.47.12-h41e18d1_4.tar.bz2
linux-64::postgresql-plpython-13.5-py37h335248f_1.tar.bz2
linux-64::qt-main-5.15.2-h88c78e7_1.tar.bz2
linux-64::arrow-cpp-6.0.1-py310hea7fbe8_5_cuda.tar.bz2
linux-64::pdal-2.3.0-h3c03ee5_19.tar.bz2
linux-64::arrow-cpp-3.0.0-py38h87e2ab4_37_cpu.tar.bz2
linux-64::tensorflow-base-2.6.2-cpu_py38he70b6e8_2.tar.bz2
linux-64::cpp-opentelemetry-sdk-1.1.1-h3035edd_1.tar.bz2
linux-64::libcurl-static-7.81.0-h494985f_0.tar.bz2
linux-64::librdkafka-1.7.0-hb1989a6_1.tar.bz2
linux-64::tesseract-5.0.1-h84e3e21_0.tar.bz2
linux-64::pyinstaller-4.8-py310h516ecdb_0.tar.bz2
linux-64::lmod-8.5.28-lua54h14f7cff_0.tar.bz2
linux-64::arrow-cpp-3.0.0-py39hb8c629c_37_cpu.tar.bz2
linux-64::root_base-6.24.6-py38hd13ddb3_1.tar.bz2
linux-64::conduit-0.7.1-py39hacd2f33_1.tar.bz2
linux-64::libglib-2.70.2-h174f98d_0.tar.bz2
linux-64::postgresql-13.5-hce44dc1_1.tar.bz2
linux-64::postgresql-plpython-13.5-py310h5635984_1.tar.bz2
linux-64::vtk-9.1.0-egl_py37he8a1893_3.tar.bz2
linux-64::ticcutils-0.28-ha409f19_0.tar.bz2
linux-64::ndcctools-7.4.2-py39h336bf08_0.tar.bz2
linux-64::gds-base-2.19.7-h22af627_1.tar.bz2
linux-64::r-git2r-0.29.0-r40hf628c3e_1.tar.bz2
linux-64::libopencv-4.5.3-py37hbfc4018_6.tar.bz2
linux-64::gemmi-0.5.2-py38h4630a5e_0.tar.bz2
linux-64::libtiledb-sql-0.11.2-h82b1f98_0.tar.bz2
linux-64::arrow-cpp-6.0.1-py37he4d610e_7_cpu.tar.bz2
linux-64::llvmlite-0.38.0-py38h4630a5e_0.tar.bz2
linux-64::yoda-1.9.4-py37h304d640_0.tar.bz2
linux-64::freecad-0.19.3-py39h0f650a1_3.tar.bz2
linux-64::gds-services-2.19.7-h6c31f13_1.tar.bz2
linux-64::arrow-cpp-5.0.0-py38h87e2ab4_18_cpu.tar.bz2
linux-64::libglib-2.70.2-h174f98d_1.tar.bz2
linux-64::folly-2022.01.17.00-h1234567_1.tar.bz2
linux-64::lmod-8.6.2-lua54h14f7cff_0.tar.bz2
linux-64::triqs-3.0.2-py39h5214ecb_1.tar.bz2
linux-64::cctools_osx-64-973.0.1-h2971222_5.tar.bz2
linux-64::folly-2022.01.03.00-h1234567_1_jemalloc.tar.bz2
linux-64::pyreadstat-1.1.4-py38ha8cb210_0.tar.bz2
linux-64::arrow-cpp-5.0.0-py310hd595e90_21_cuda.tar.bz2
linux-64::paraview-5.10.0-h613f2a7_103_qt.tar.bz2
linux-64::libgdal-3.4.1-h7b6f8d3_2.tar.bz2
linux-64::libcurl-7.80.0-h494985f_1.tar.bz2
linux-64::mandrake-1.2.1-py38hd235e30_0.tar.bz2
linux-64::mandrake-1.2.0-py39h2e098be_0.tar.bz2
linux-64::cctools_osx-arm64-973.0.1-hcded490_5.tar.bz2
linux-64::nco-5.0.5-hcfc2ecc_0.tar.bz2
linux-64::ndcctools-7.4.1-py310ha6b4e5e_0.tar.bz2
linux-64::arrow-cpp-5.0.0-py39hbe2a541_20_cuda.tar.bz2
linux-64::arrow-cpp-3.0.0-py310ha0b4ddf_38_cpu.tar.bz2
linux-64::libfido2-1.10.0-ha19adfc_0.tar.bz2
linux-64::arrow-cpp-6.0.1-py310hd595e90_6_cuda.tar.bz2
linux-64::vowpalwabbit-9.0.0-py310h1daa79b_2.tar.bz2
linux-64::vigra-1.11.1-py310h868834b_1028.tar.bz2
linux-64::conduit-0.7.1-py39h8302f4d_1.tar.bz2
linux-64::erlang-24.2-pl5321hb6651ff_0.tar.bz2
linux-64::magics-4.10.0-h216ea75_0.tar.bz2
linux-64::hdf5-1.12.1-mpi_mpich_ha8a74db_3.tar.bz2
linux-64::ndcctools-7.4.1-py37hb27c1af_2.tar.bz2
linux-64::mysql-libs-8.0.27-hfa10184_3.tar.bz2
linux-64::pdal-2.3.0-h59b4854_24.tar.bz2
linux-64::vigra-1.11.1-py39ha46d285_1027.tar.bz2
linux-64::arrow-cpp-5.0.0-py310hbc9e441_19_cuda.tar.bz2
linux-64::conduit-0.8.1-py37h8d921b5_0.tar.bz2
linux-64::dotnet-runtime-5.0.13-h73ebe80_0.tar.bz2
linux-64::gds-base-monitors-2.19.7-h6c31f13_2.tar.bz2
linux-64::libtiledb-sql-0.12.1-h1e20410_0.tar.bz2
linux-64::erlang-23.3.4.10-pl5321hb6651ff_0.tar.bz2
linux-64::kaldi-5.5.992-cuda110h1234567_5.tar.bz2
linux-64::nss-3.74-hb5efdd6_0.tar.bz2
linux-64::astrometry-0.88-py37h76657be_0.tar.bz2
linux-64::erlang-24.2-pl5321hb11cd93_1.tar.bz2
linux-64::llvmlite-0.38.0-py37h9d7f4d0_0.tar.bz2
linux-64::magics-metview-4.10.0-hb8ed42f_0.tar.bz2
linux-64::tensorflow-base-2.6.2-cuda110py37h341a48a_2.tar.bz2
linux-64::conduit-0.8.1-py39hacd2f33_0.tar.bz2
linux-64::arrow-cpp-6.0.1-py39h2c67c1e_5_cpu.tar.bz2
linux-64::xrootd-5.4.0-py39hf708bbc_0.tar.bz2
linux-64::paraview-5.10.0-h9385240_103_qt.tar.bz2
linux-64::tomviz-1.10.0.post137-py37h3b5edeb_0.tar.bz2
linux-64::r-git2r-0.29.0-r41hf628c3e_1.tar.bz2
linux-64::python-3.10.2-h543edf9_0_cpython.tar.bz2
linux-64::libcurl-static-7.80.0-h494985f_1.tar.bz2
linux-64::cppyy-cling-6.25.2-py37h278f77e_0.tar.bz2
linux-64::sagelib-9.4-py39he34bcec_1.tar.bz2
linux-64::folly-2021.12.27.00-h1234567_1_jemalloc.tar.bz2
linux-64::arrow-cpp-6.0.1-py37hb601090_3_cuda.tar.bz2
linux-64::julia-1.7.1-h989b2f6_0.tar.bz2
linux-64::ndcctools-7.4.2-py37hd5d88b1_0.tar.bz2
linux-64::yoda-1.9.4-py38h99d1009_0.tar.bz2
linux-64::arrow-cpp-3.0.0-py39ha1ff70b_38_cuda.tar.bz2
linux-64::wxwidgets-3.1.3-h800c0ab_5.tar.bz2
linux-64::libtiledb-sql-0.11.1-h82b1f98_0.tar.bz2
linux-64::libgdal-3.4.1-h4f01073_0.tar.bz2
linux-64::magics-metview-4.10.0-he99b4a8_1.tar.bz2
linux-64::paraview-5.10.0-hb1d4b34_103_qt.tar.bz2
linux-64::libvips-8.12.2-hbb474f9_0.tar.bz2
linux-64::nodejs-14.18.3-h8ca31f7_2.tar.bz2
linux-64::libmongoc-1.20.1-h076a08c_0.tar.bz2
linux-64::paraview-5.10.0-hb02608c_3_egl.tar.bz2
linux-64::ndcctools-7.4.1-py38hdd6454d_2.tar.bz2
linux-64::arrow-cpp-3.0.0-py38h579a05f_41_cuda.tar.bz2
linux-64::protozfits-2.0.1.post1-py37hc044a54_6.tar.bz2
linux-64::mandrake-1.2.1-py37hc7467be_0.tar.bz2
linux-64::uwsgi-2.0.20-py310h3cb3e43_3.tar.bz2
linux-64::grpcio-1.43.0-py37hd5d88b1_0.tar.bz2
linux-64::kaldi-5.5.992-h7430895_1.tar.bz2
linux-64::libtensorflow_cc-2.6.2-cpu_haead9a5_2.tar.bz2
linux-64::paraview-5.10.0-h78c094c_103_qt.tar.bz2
linux-64::arrow-cpp-3.0.0-py39h964882e_40_cuda.tar.bz2
linux-64::julia-1.6.5-h989b2f6_0.tar.bz2
linux-64::paraview-5.10.0-h4ddf024_3_egl.tar.bz2
linux-64::libgdal-3.4.0-hf890fe0_9.tar.bz2
linux-64::conduit-0.8.1-py38h5ff8a9a_0.tar.bz2
linux-64::arrow-cpp-6.0.1-py39h7e45aa4_3_cuda.tar.bz2
linux-64::arrow-cpp-3.0.0-py310h500f8fe_41_cpu.tar.bz2
linux-64::netgen-6.2.2006-py310h6db9624_4.tar.bz2
linux-64::libvips-8.12.1-hbb474f9_1.tar.bz2
linux-64::yoda-1.9.4-py39hb2ea77c_0.tar.bz2
linux-64::arrow-cpp-6.0.1-py39hb8c629c_3_cpu.tar.bz2
linux-64::gdstk-0.8.1-py37h278f77e_0.tar.bz2
linux-64::papilo-2.0.0-he51c309_0.tar.bz2
linux-64::arrow-cpp-6.0.1-py38hab3e76a_6_cuda.tar.bz2
linux-64::arrow-cpp-5.0.0-py37h6ab10f6_20_cuda.tar.bz2
linux-64::libgdal-3.3.3-hbe510e8_12.tar.bz2
linux-64::nifty-1.2.0-py39h6dffa3a_0.tar.bz2
linux-64::vtk-9.0.1-egl_py310h820a9dd_10.tar.bz2
linux-64::paraview-5.10.0-h39c5f3b_3_egl.tar.bz2
linux-64::ncl-6.6.2-h71814c0_36.tar.bz2
linux-64::libtensorflow-2.6.2-cuda110h1bfb650_2.tar.bz2
linux-64::root_base-6.24.6-py39he8702db_1.tar.bz2
linux-64::libtensorflow-2.6.2-cuda112hd70bc30_2.tar.bz2
linux-64::libprotobuf-static-3.19.4-h780b84a_0.tar.bz2
linux-64::uwsgi-2.0.20-py37hc1dc9ca_3.tar.bz2
linux-64::protozfits-2.0.1.post1-py39h671e6d9_7.tar.bz2
linux-64::uwsgi-2.0.20-py310h51ab995_3.tar.bz2
linux-64::xrootd-5.4.0-py38h68ec80c_0.tar.bz2
linux-64::libfido2-1.10.0-h812cca2_0.tar.bz2
linux-64::capnproto-0.9.1-h780b84a_5.tar.bz2
linux-64::gfal2-2.20.3-hea365ab_1.tar.bz2
linux-64::cctools_osx-arm64-973.0.1-h7d46f33_3.tar.bz2
linux-64::mysql-libs-8.0.27-hfa10184_2.tar.bz2
linux-64::h5utils-1.13.1-nompi_h96f4c20_1112.tar.bz2
linux-64::arrow-cpp-6.0.1-py38h579a05f_7_cuda.tar.bz2
linux-64::uwsgi-2.0.20-py37h19899c5_3.tar.bz2
linux-64::pyreadstat-1.1.4-py310h516ecdb_0.tar.bz2
linux-64::nginx-1.21.5-h92772c7_0.tar.bz2
linux-64::ndcctools-7.4.1-py39h336bf08_0.tar.bz2
linux-64::nifty-1.2.1-py310h959a72a_3.tar.bz2
linux-64::arrow-cpp-5.0.0-py37hbd77c41_20_cpu.tar.bz2
linux-64::libgdal-3.4.0-h1504ab5_10.tar.bz2
linux-64::coda-2.23-py37hc64e62a_0.tar.bz2
linux-64::git-annex-8.20211231-alldep_ha6d434f_100.tar.bz2
linux-64::libgdal-3.3.3-hfbb1d71_11.tar.bz2
linux-64::mandrake-1.2.1-py39h2e098be_0.tar.bz2
linux-64::ndcctools-7.4.1-py310h94ab34a_1.tar.bz2
linux-64::vtk-9.1.0-osmesa_py38h834f139_103.tar.bz2
linux-64::cctools_osx-64-973.0.1-h531d5dd_5.tar.bz2
linux-64::arrow-cpp-5.0.0-py39h2a895b2_19_cpu.tar.bz2
linux-64::paraview-5.10.0-he5cd89c_103_qt.tar.bz2
linux-64::folly-2022.01.31.00-h1234567_1_jemalloc.tar.bz2
linux-64::cairomm-1.0-1.12.2-h96a316c_4.tar.bz2
linux-64::python-3.8.12-h0744224_3_cpython.tar.bz2
linux-64::python-3.8.12-ha38a3c6_3_cpython.tar.bz2
linux-64::slang-2.3.2-ha34c998_1003.tar.bz2
linux-64::xrootd-5.3.4-py37h834e20d_0.tar.bz2
linux-64::libopencv-4.5.3-py39h7d09d5f_7.tar.bz2
linux-64::julia-1.7.1-h620718c_0.tar.bz2
linux-64::libprotobuf-3.19.2-h780b84a_0.tar.bz2
linux-64::pytables-3.7.0-py39h2669a42_0.tar.bz2
linux-64::pyretis-2.5.0-py38h0f83e44_2.tar.bz2
linux-64::mandrake-1.2.0-py37hc7467be_0.tar.bz2
linux-64::mysql-client-8.0.28-hf09c6a7_0.tar.bz2
linux-64::libprotobuf-3.19.4-h780b84a_0.tar.bz2
linux-64::netgen-6.2.2006-py38h4daaae6_4.tar.bz2
linux-64::dotnet-sdk-5.0.404-h73ebe80_0.tar.bz2
linux-64::llvmdev-9.0.1-default_hc23dcda_6.tar.bz2
linux-64::tensorflow-base-2.7.0-cuda111py37hf266e69_0.tar.bz2
linux-64::mandrake-1.2.0-py37hcc9ed4e_0.tar.bz2
linux-64::ndcctools-7.4.1-py310h94ab34a_0.tar.bz2
linux-64::llvmdev-9.0.1-cling_v0.9_h2b820e9_7.tar.bz2
linux-64::conduit-0.8.1-py37h106d8db_0.tar.bz2
linux-64::assimp-5.1.4-hedfc422_0.tar.bz2
linux-64::nifty-1.2.1-py39h6dffa3a_1.tar.bz2
linux-64::libtensorflow-2.6.2-cpu_haead9a5_2.tar.bz2
linux-64::postgresql-plpython-13.5-py39h1dd3ba9_1.tar.bz2
linux-64::kaldi-5.5.992-cuda112h1234567_6.tar.bz2
linux-64::protozfits-2.0.1.post1-py37hc044a54_7.tar.bz2
linux-64::graphviz-2.50.0-h85b4f2f_1.tar.bz2
linux-64::mandrake-1.2.1-py39ha41bcff_0.tar.bz2
linux-64::arrow-cpp-6.0.1-py310h3fc2682_7_cuda.tar.bz2
linux-64::kaldi-5.5.992-cuda111h1234567_8.tar.bz2
linux-64::libxmlsec1-1.2.33-hb6668e7_0.tar.bz2
linux-64::llvmlite-0.38.0-py310hee97dad_0.tar.bz2
linux-64::paraview-5.10.0-hc070041_3_egl.tar.bz2
linux-64::uwsgi-2.0.20-py39hfd59d76_3.tar.bz2
linux-64::omniorb-4.2.5-py310h94ab34a_0.tar.bz2
linux-64::python-3.9.9-h62f1059_0_cpython.tar.bz2
linux-64::arrow-cpp-3.0.0-py310hd595e90_40_cuda.tar.bz2
linux-64::rust-1.58.1-h61edd41_0.tar.bz2
linux-64::vowpalwabbit-9.0.0-py37he11f6b3_3.tar.bz2
linux-64::gdstk-0.8.1-py39h95541c8_1.tar.bz2
linux-64::libgdal-3.4.0-h4f01073_13.tar.bz2
linux-64::arrow-cpp-6.0.1-py39hbe2a541_5_cuda.tar.bz2
linux-64::ipe-7.2.24-lua54hf2fd061_5.tar.bz2
linux-64::mandrake-1.2.0-py38h66dd620_0.tar.bz2
linux-64::gdstk-0.8.1-py37h720af38_1.tar.bz2
linux-64::z5py-2.0.11-py310h259c302_1.tar.bz2
linux-64::python-3.6.15-hb7a2778_0_cpython.tar.bz2
linux-64::arrow-cpp-3.0.0-py310he8db510_37_cuda.tar.bz2
linux-64::librdkafka-1.3.0-hc49e61c_3.tar.bz2
linux-64::orc-1.7.2-h1be678f_0.tar.bz2
linux-64::pdal-2.3.0-hf589941_22.tar.bz2
linux-64::liblal-7.1.6-mkl_h1b22d3e_1.tar.bz2
linux-64::grpcio-1.43.0-py38h2457d08_0.tar.bz2
linux-64::lmod-8.6.4-lua54h14f7cff_0.tar.bz2
linux-64::tensorflow-base-2.6.2-cuda102py39h42c91ab_2.tar.bz2
linux-64::arrow-cpp-3.0.0-py310h3fc2682_41_cuda.tar.bz2
linux-64::imagemagick-7.1.0_20-pl5321hb118871_0.tar.bz2
linux-64::astrometry-0.89-py38hadafcda_0.tar.bz2
linux-64::tiledb-2.6.0-hf3d3071_0.tar.bz2
linux-64::tiledb-2.6.1-hf3d3071_0.tar.bz2
linux-64::arrow-cpp-5.0.0-py38hab3e76a_21_cuda.tar.bz2
linux-64::vtk-9.1.0-egl_py38hb09aef5_3.tar.bz2
linux-64::mandrake-1.2.1-py39h550a694_0.tar.bz2
linux-64::panda3d-1.10.11-py37h4e89a3d_0.tar.bz2
linux-64::gmsh-4.9.3-h2ad51fa_0.tar.bz2
linux-64::nifty-1.2.1-py37h023b2db_1.tar.bz2
linux-64::arrow-cpp-6.0.1-py39h01fd06f_7_cpu.tar.bz2
linux-64::tomviz-1.10.0.post152-py37h3b5edeb_0.tar.bz2
linux-64::tensorflow-base-2.7.0-cuda112py310h2bd284a_0.tar.bz2
linux-64::curl-7.81.0-h2574ce0_0.tar.bz2
linux-64::root_base-6.24.6-py310h57d1b7e_2.tar.bz2
linux-64::capnproto-0.9.1-h812cca2_2.tar.bz2
linux-64::mapserver-7.6.4-py38h5d6239c_5.tar.bz2
linux-64::assimp-5.2.0-hedfc422_1.tar.bz2
linux-64::hdf5-1.12.1-mpi_openmpi_h3594f1f_3.tar.bz2
linux-64::triqs-3.0.2-py37hd880987_0.tar.bz2
linux-64::tiledb-2.6.2-h2038895_0.tar.bz2
linux-64::libopencv-4.5.5-py39h7d09d5f_0.tar.bz2
linux-64::poppler-22.01.0-ha39eefc_0.tar.bz2
linux-64::curl-7.80.0-h494985f_1.tar.bz2
linux-64::paraview-5.10.0-h4155c2b_3_egl.tar.bz2
linux-64::libtensorflow-2.6.2-cuda111h58c461c_2.tar.bz2
linux-64::lmod-8.6.6-lua54h14f7cff_0.tar.bz2
linux-64::uwsgi-2.0.20-py37hc1dc9ca_2.tar.bz2
linux-64::conduit-0.8.0-py39h8302f4d_0.tar.bz2
linux-64::arrow-cpp-6.0.1-py310h2d9d4a2_6_cpu.tar.bz2
linux-64::mapserver-7.6.4-py37hb7a4c7a_4.tar.bz2
linux-64::python-3.10.2-h85951f9_2_cpython.tar.bz2
linux-64::arrow-cpp-5.0.0-py310h1faeb61_20_cpu.tar.bz2
linux-64::omniorb-libs-4.2.5-h812cca2_0.tar.bz2
linux-64::uwsgi-2.0.20-py37h19899c5_2.tar.bz2
linux-64::python-3.10.1-h543edf9_2_cpython.tar.bz2
linux-64::kaldi-5.5.992-h7430895_2.tar.bz2
linux-64::mosh-1.3.2-pl5321h0b8dcd7_1011.tar.bz2
linux-64::libnghttp2-1.46.0-h812cca2_0.tar.bz2
linux-64::arrow-cpp-3.0.0-py310h1faeb61_39_cpu.tar.bz2
linux-64::arrow-cpp-5.0.0-py38hd267840_19_cpu.tar.bz2
linux-64::gmsh-4.9.3-h31d5161_1.tar.bz2
linux-64::arrow-cpp-5.0.0-py39h2c67c1e_20_cpu.tar.bz2
linux-64::vtk-9.0.1-qt_py39hd1b08ba_210.tar.bz2
linux-64::gds-base-gdstrig-2.19.7-hf817b99_1.tar.bz2
linux-64::nco-5.0.4-hcfc2ecc_0.tar.bz2
linux-64::git-annex-10.20220127-alldep_ha6d434f_100.tar.bz2
linux-64::gemmi-0.5.2-py310hee97dad_0.tar.bz2
linux-64::triqs-3.0.2-py38h4215b03_1.tar.bz2
linux-64::python-3.10.2-h85951f9_1_cpython.tar.bz2
linux-64::vigra-1.11.1-py37h3bb4fe9_1028.tar.bz2
linux-64::nifty-1.2.1-py39h6dffa3a_2.tar.bz2
linux-64::mapserver-7.6.4-py39hc344392_5.tar.bz2
linux-64::vowpalwabbit-8.11.0-py310h1daa79b_2.tar.bz2
linux-64::pyretis-2.5.0-py310hd8d60c7_2.tar.bz2
linux-64::xrootd-5.3.4-py37hb0090cc_0.tar.bz2
linux-64::triqs-3.0.2-py37hd880987_1.tar.bz2
linux-64::arrow-cpp-6.0.1-py37h6ab10f6_5_cuda.tar.bz2
linux-64::ndcctools-7.4.2-py39hff7568b_0.tar.bz2
linux-64::python-3.10.2-h62f1059_0_cpython.tar.bz2
linux-64::ogre-13.2.2-hef34edf_0.tar.bz2
linux-64::magics-metview-batch-4.10.0-hb6baf3b_1.tar.bz2
linux-64::arrow-cpp-6.0.1-py310h1faeb61_5_cpu.tar.bz2
linux-64::nifty-1.2.1-py38h8343072_3.tar.bz2
linux-64::arrow-cpp-3.0.0-py37hbd77c41_39_cpu.tar.bz2
linux-64::vowpalwabbit-9.0.0-py37habe62f9_3.tar.bz2
linux-64::gdstk-0.8.1-py39h0f9e12e_0.tar.bz2
linux-64::ndcctools-7.4.1-py39hff7568b_2.tar.bz2
linux-64::arrow-cpp-5.0.0-py38h579a05f_22_cuda.tar.bz2
linux-64::arrow-cpp-5.0.0-py310h3008b6d_18_cpu.tar.bz2
linux-64::arrow-cpp-6.0.1-py39hcf6a9ae_7_cuda.tar.bz2
linux-64::z5py-2.0.12-py38h36534de_0.tar.bz2
linux-64::wxpython-4.1.1-py39h50bbe46_3.tar.bz2
linux-64::libgdal-3.3.3-h4f01073_13.tar.bz2
linux-64::h5utils-1.13.1-mpi_mpich_ha777a55_1013.tar.bz2
linux-64::arrow-cpp-6.0.1-py310he8db510_3_cuda.tar.bz2
linux-64::glib-2.70.2-h780b84a_1.tar.bz2
linux-64::cctools_osx-64-973.0.1-h6a0aaf5_3.tar.bz2
linux-64::ortools-python-9.2-py39h409256e_0.tar.bz2
linux-64::ndcctools-7.4.2-py37hb27c1af_0.tar.bz2
linux-64::arrow-cpp-6.0.1-py37h3e80117_6_cpu.tar.bz2
linux-64::vtk-9.1.0-osmesa_py37he6777a5_103.tar.bz2
linux-64::ndcctools-7.4.1-py38h2457d08_2.tar.bz2
linux-64::arrow-cpp-5.0.0-py39h7e45aa4_18_cuda.tar.bz2
linux-64::mapserver-7.6.4-py310hd218035_4.tar.bz2
linux-64::nodejs-14.17.4-h92b4a50_1.tar.bz2
linux-64::uwsgi-2.0.20-py38hce04926_3.tar.bz2
linux-64::postgresql-plpython-13.5-py38h37142f6_1.tar.bz2
linux-64::ogre-13.2.1-hef34edf_0.tar.bz2
linux-64::wasmer-2.1.0-h75bafa5_2.tar.bz2
linux-64::assimp-5.1.0-hedfc422_0.tar.bz2
linux-64::conduit-0.8.1-py37hd1c0ee6_0.tar.bz2
linux-64::r-git2r-0.29.0-r40h012fe3a_1.tar.bz2
linux-64::libprotobuf-static-3.19.2-h780b84a_0.tar.bz2
linux-64::protozfits-2.0.1.post1-py39h68a355e_5.tar.bz2
linux-64::kaldi-5.5.992-cuda112h1234567_7.tar.bz2
linux-64::arrow-cpp-6.0.1-py39h01fd06f_8_cpu.tar.bz2
linux-64::magics-4.10.0-hf13fbce_2.tar.bz2
linux-64::gct-6.2.1629922860-ha19adfc_0.tar.bz2
linux-64::ortools-cpp-9.2-hcb8d0d0_0.tar.bz2
linux-64::arrow-cpp-3.0.0-py37hb601090_37_cuda.tar.bz2
linux-64::glib-networking-2.70.1-h3cf747a_0.tar.bz2
linux-64::ortools-python-9.2-py38h406be9c_0.tar.bz2
linux-64::gds-base-monitors-2.19.7-h6c31f13_1.tar.bz2
linux-64::oclgrind-21.10-hd56c0c9_0.tar.bz2
linux-64::libprotobuf-static-3.19.3-h780b84a_0.tar.bz2
linux-64::vtk-9.0.1-qt_py37h6782494_210.tar.bz2
linux-64::arrow-cpp-6.0.1-py39h964882e_6_cuda.tar.bz2
linux-64::vowpalwabbit-8.11.0-py37he11f6b3_2.tar.bz2
linux-64::vtk-9.1.0-osmesa_py39h51b9f08_103.tar.bz2
linux-64::postgresql-plpython-13.5-py37hc2b57fc_1.tar.bz2
linux-64::gemmi-0.5.1-py37hf2742bb_0.tar.bz2
linux-64::libgdal-3.3.3-hf890fe0_11.tar.bz2
linux-64::ruby-2.5.7-h86e321c_3.tar.bz2
linux-64::root_base-6.24.6-py37hf5f6b79_1.tar.bz2
linux-64::ndcctools-7.4.0-py310h94ab34a_0.tar.bz2
linux-64::arrow-cpp-3.0.0-py310hbc9e441_38_cuda.tar.bz2
linux-64::vowpalwabbit-8.11.0-py37habe62f9_2.tar.bz2
linux-64::assimp-5.1.6-hedfc422_0.tar.bz2
linux-64::grpcio-1.43.0-py38hdd6454d_0.tar.bz2
linux-64::curl-7.81.0-h494985f_0.tar.bz2
linux-64::arrow-cpp-5.0.0-py38h4dc56cc_20_cuda.tar.bz2
linux-64::conduit-0.7.1-py37h106d8db_1.tar.bz2
linux-64::arrow-cpp-3.0.0-py38h9de81b1_39_cpu.tar.bz2
linux-64::mysql-connector-cpp-8.0.27-h7a4f57c_1.tar.bz2
linux-64::ndcctools-7.4.0-py310ha6b4e5e_0.tar.bz2
linux-64::ndcctools-7.4.1-py39hff7568b_1.tar.bz2
linux-64::root_base-6.24.6-py38hd13ddb3_2.tar.bz2
linux-64::nodejs-17.4.0-hb5e7134_0.tar.bz2
linux-64::arrow-cpp-3.0.0-py37h3e80117_40_cpu.tar.bz2
linux-64::z5py-2.0.11-py39h3f3ea7e_1.tar.bz2
linux-64::arrow-cpp-3.0.0-py38hcdf9ef9_38_cuda.tar.bz2
linux-64::magics-metview-batch-4.10.0-h216ea75_0.tar.bz2
linux-64::plumed-2.7.3-mpi_mpich_hc4d6106_0.tar.bz2
linux-64::libtensorflow-2.7.0-cuda112he1a0a60_0.tar.bz2
linux-64::readdy-2.0.11-py39he0b64ab_0.tar.bz2
linux-64::arrow-cpp-6.0.1-py310h500f8fe_8_cpu.tar.bz2
linux-64::mandrake-1.2.0-py39ha41bcff_0.tar.bz2
linux-64::omniorb-4.2.5-py39hff7568b_0.tar.bz2
linux-64::arrow-cpp-5.0.0-py39h01fd06f_22_cpu.tar.bz2
linux-64::arrow-cpp-5.0.0-py38h44d4a2f_22_cpu.tar.bz2
linux-64::z5py-2.0.12-py310h259c302_0.tar.bz2
linux-64::omniorb-4.2.5-py39h336bf08_0.tar.bz2
linux-64::nifty-1.2.1-py38h8343072_0.tar.bz2
linux-64::folly-2022.01.31.00-h1234567_1.tar.bz2
linux-64::hdf5-1.12.1-nompi_h2750804_103.tar.bz2
linux-64::arrow-cpp-5.0.0-py310hea7fbe8_20_cuda.tar.bz2
linux-64::pyinstaller-4.8-py37h6828927_0.tar.bz2
linux-64::vowpalwabbit-9.0.0-py39h8e5f8a4_2.tar.bz2
linux-64::tensorflow-base-2.6.2-cuda111py38hf41bb10_2.tar.bz2
linux-64::conduit-0.8.1-py39hb25f1e2_0.tar.bz2
linux-64::protozfits-2.0.1.post1-py310h550f793_7.tar.bz2
linux-64::mapserver-7.6.4-py38h0925545_3.tar.bz2
linux-64::libopencv-4.5.3-py38h66b0e6b_6.tar.bz2
linux-64::rust-1.58.0-h61edd41_0.tar.bz2
linux-64::root_base-6.24.6-py39he8702db_2.tar.bz2
linux-64::dotnet-runtime-6.0.1-h73ebe80_0.tar.bz2
linux-64::arrow-cpp-5.0.0-py37h1973f06_21_cuda.tar.bz2
linux-64::vtk-9.1.0-osmesa_py310hc7a64fb_103.tar.bz2
linux-64::tensorflow-base-2.6.2-cpu_py37hf9aebbf_2.tar.bz2
linux-64::nifty-1.2.1-py38h8343072_1.tar.bz2
linux-64::dotnet-sdk-6.0.101-h73ebe80_0.tar.bz2
linux-64::grpcio-1.43.0-py310h94ab34a_0.tar.bz2
linux-64::z5py-2.0.11-py38h36534de_1.tar.bz2
linux-64::protozfits-2.0.1.post1-py310h550f793_6.tar.bz2
linux-64::magics-metview-batch-4.10.0-hf13fbce_2.tar.bz2
linux-64::gemmi-0.5.1-py38h4630a5e_0.tar.bz2
linux-64::wxpython-4.1.1-py310h6ae5039_3.tar.bz2
linux-64::postgresql-13.5-h2510834_1.tar.bz2
linux-64::libgdal-3.3.3-h5ee51d2_13.tar.bz2
linux-64::ndcctools-7.4.0-py38hdd6454d_0.tar.bz2
linux-64::astrometry-0.88-py37hca92f70_0.tar.bz2
linux-64::uwsgi-2.0.20-py39h9c040ca_3.tar.bz2
linux-64::mysql-libs-8.0.28-hfa10184_0.tar.bz2
linux-64::libgdal-3.3.3-h30f1481_14.tar.bz2
linux-64::arrow-cpp-5.0.0-py39h964882e_21_cuda.tar.bz2
linux-64::gdstk-0.8.1-py37hfb9f19d_1.tar.bz2
-    "libzlib >=1.2.11,<1.3.0a0",
+    "libzlib >=1.2.11,<2.0.0a0",
linux-64::libclang-cpp-9.0.1-cling_v0.9_h7b43b12_3.tar.bz2
linux-64::clang-9-9.0.1-root_62400_h2b994b2_3.tar.bz2
linux-64::llvm-tools-9.0.1-cling_v0.9_h2b820e9_6.tar.bz2
linux-64::llvm-tools-9.0.1-default_hc23dcda_5.tar.bz2
linux-64::libllvm9-9.0.1-default_hc23dcda_7.tar.bz2
linux-64::clang-9-9.0.1-default_hd635ce7_3.tar.bz2
linux-64::glib-tools-2.70.2-h780b84a_0.tar.bz2
linux-64::libclang-cpp9-9.0.1-cling_v0.9_h7b43b12_3.tar.bz2
linux-64::zimpl-3.5.1-h0e78468_0.tar.bz2
linux-64::libclang-cpp-9.0.1-hcc_h8af8d6c_3.tar.bz2
linux-64::libclang-cpp9-9.0.1-root_62400_h2b994b2_3.tar.bz2
linux-64::llvm-9.0.1-default_hd250732_7.tar.bz2
linux-64::gst-plugins-good-1.18.5-h0661c57_3.tar.bz2
linux-64::llvm-9.0.1-cling_v0.9_h03fe6b7_5.tar.bz2
linux-64::ortools-cpp-9.1-h4995e31_3.tar.bz2
linux-64::libllvm9-9.0.1-default_hc23dcda_6.tar.bz2
linux-64::libllvm9-9.0.1-cling_v0.9_h2b820e9_5.tar.bz2
linux-64::liblal-7.1.6-fftw_hbc48cad_101.tar.bz2
linux-64::libclang-cpp-9.0.1-default_hd635ce7_3.tar.bz2
linux-64::coin-or-utils-2.11.6-h573740c_0.tar.bz2
linux-64::liblal-7.1.6-fftw_hbc48cad_100.tar.bz2
linux-64::libllvm9-9.0.1-default_hc23dcda_5.tar.bz2
linux-64::llvm-tools-9.0.1-cling_v0.9_h2b820e9_7.tar.bz2
linux-64::libllvm9-9.0.1-cling_v0.9_h2b820e9_7.tar.bz2
linux-64::glib-tools-2.70.2-h780b84a_1.tar.bz2
linux-64::liblal-7.1.5-fftw_hbc48cad_100.tar.bz2
linux-64::llvm-9.0.1-cling_v0.9_h03fe6b7_7.tar.bz2
linux-64::llvm-tools-9.0.1-default_hc23dcda_7.tar.bz2
linux-64::gcab-1.4-hca8103f_0.tar.bz2
linux-64::clang-9-9.0.1-cling_v0.9_h7b43b12_3.tar.bz2
linux-64::libclang-cpp9-9.0.1-default_hd635ce7_3.tar.bz2
linux-64::llvm-9.0.1-cling_v0.9_h03fe6b7_6.tar.bz2
linux-64::llvm-tools-9.0.1-default_hc23dcda_6.tar.bz2
linux-64::cpp-opentelemetry-sdk-1.1.0-h24a1e9d_2.tar.bz2
linux-64::cpp-opentelemetry-sdk-1.1.0-h24a1e9d_3.tar.bz2
linux-64::libclang-cpp9-9.0.1-hcc_h8af8d6c_3.tar.bz2
linux-64::cpp-opentelemetry-sdk-1.1.0-h24a1e9d_1.tar.bz2
linux-64::clang-9-9.0.1-hcc_h8af8d6c_3.tar.bz2
linux-64::libllvm9-9.0.1-cling_v0.9_h2b820e9_6.tar.bz2
linux-64::gst-plugins-base-1.18.5-hf529b03_3.tar.bz2
linux-64::llvm-9.0.1-default_hd250732_5.tar.bz2
linux-64::cpp-opentelemetry-sdk-1.1.0-h24a1e9d_0.tar.bz2
linux-64::llvm-tools-9.0.1-cling_v0.9_h2b820e9_5.tar.bz2
linux-64::liblal-7.1.4-fftw_hace999c_101.tar.bz2
linux-64::llvm-9.0.1-default_hd250732_6.tar.bz2
linux-64::libclang-cpp-9.0.1-root_62400_h2b994b2_3.tar.bz2
-    "libzlib >=1.2.11,<1.3.0a0"
+    "libzlib >=1.2.11,<2.0.0a0"
```

</details>