### PR TITLE
Add a patch to libva to add back the correct libxcb constraint

### DIFF
--- a/recipe/patch_yaml/libva.yaml
+++ b/recipe/patch_yaml/libva.yaml
@@ -1,0 +1,10 @@
+if:
+  timestamp_lt: 1717762383000
+  name: libva
+  # libxcb constraint was accidentally removed
+  # https://github.com/conda-forge/libva-feedstock/pull/38
+  version: 2.21.0
+  build_number: 2
+
+then:
+  - add_depends: libxcb >=1.15.0,<1.16.0


### PR DESCRIPTION
It was accidentally removed in https://github.com/conda-forge/libva-feedstock/pull/38

Checklist

* [ ] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
