### PR TITLE
Fix missing pins on threadpoolctl for pymc

### DIFF
--- a/recipe/patch_yaml/pymc.yaml
+++ b/recipe/patch_yaml/pymc.yaml
@@ -19,3 +19,14 @@ then:
   - tighten_depends:
       name: numpy
       upper_bound: '1.24'
+
+---
+
+if:
+  name: pymc
+  version: '5.15.1'
+  timestamp_lt: 1717950401000
+then:
+  - replace_depends:
+      old: threadpoolctl
+      new: threadpoolctl >=3.1.0,<4.0.0

--- a/recipe/patch_yaml/pymc.yaml
+++ b/recipe/patch_yaml/pymc.yaml
@@ -23,7 +23,7 @@ then:
 ---
 
 if:
-  name: pymc
+  name: pymc-base
   version: '5.15.1'
   timestamp_lt: 1717950401000
 then:


### PR DESCRIPTION
The last `pymc-base` build was missing pins on the `threadpoolctl` dependency as mentioned in https://github.com/conda-forge/pymc-feedstock/pull/119#issuecomment-2143936221.

The feedstock was fixed in https://github.com/conda-forge/pymc-feedstock/pull/120.

This fixes build 0.

Checklist

* [X] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [X] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [X] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [X] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
