### PR TITLE
Patch broken ArviZ packages

### DIFF
--- a/recipe/patch_yaml/arviz.yaml
+++ b/recipe/patch_yaml/arviz.yaml
@@ -1,3 +1,50 @@
+if:
+  name: arviz
+  version: 0.11.2
+  artifact_in: arviz-0.11.2-pyhd8ed1ab_0.tar.bz2
+  timestamp_lt: 1717950401000
+then:
+  - add_depends: setuptools >=38.4
+  - replace_depends:
+      old: numpy
+      new: numpy >=1.12
+  - replace_depends:
+      old: scipy
+      new: scipy >=0.19
+  - replace_depends:
+      old: pandas
+      new: pandas >=0.23
+  - replace_depends:
+      old: xarray
+      new: xarray >=0.16.1
+  - add_depends: typing_extensions >=3.7.4.3,<4
+
+---
+
+if:
+  name: arviz
+  version: 0.13.0
+  artifact_in: arviz-0.13.0-pyhd8ed1ab_0.tar.bz2
+  timestamp_lt: 1717950401000
+then:
+  - replace_depends:
+      old: scipy >=0.19
+      new: scipy >=1.8.0
+
+---
+
+if:
+  name: arviz
+  version: 0.16.1
+  artifact_in: arviz-0.16.1-pyhd8ed1ab_0.conda
+  timestamp_lt: 1717950401000
+then:
+  - replace_depends:
+      old: matplotlib-base >=3.2
+      new: matplotlib-base >=3.5
+
+---
+
 # ArviZ <=0.17.1 uses scipy.signal.gaussian which was moved to scipy.signal.windows.gaussian in scipy 1.13
 if:
   name: arviz

--- a/recipe/patch_yaml/arviz.yaml
+++ b/recipe/patch_yaml/arviz.yaml
@@ -28,8 +28,29 @@ if:
   timestamp_lt: 1717950401000
 then:
   - replace_depends:
+      old: setuptools >=38.4
+      new: setuptools >=60.0
+  - replace_depends:
+      old: matplotlib-base >=3.0
+      new: matplotlib-base >=3.5
+  - replace_depends:
+      old: numpy >=1.12
+      new: numpy >=1.20
+  - replace_depends:
       old: scipy >=0.19
       new: scipy >=1.8.0
+  - replace_depends:
+      old: pandas >=0.23
+      new: pandas >=1.4
+  - replace_depends:
+      old: xarray >=0.16.1
+      new: xarray >=0.21.0
+  - replace_depends:
+      old: typing_extensions >=3.7.4.3
+      new: typing_extensions >=4.1.0
+  - replace_depends:
+      old: xarray-einstats >=0.2
+      new: xarray-einstats >=0.3
 
 ---
 


### PR DESCRIPTION
Replaces <https://github.com/conda-forge/admin-requests/pull/1010/files>

```yaml
action: broken
packages:
# Has matplotlib-base>=3.2, but should be matplotlib-base>=3.5
# Fixed in <https://github.com/conda-forge/arviz-feedstock/pull/44>
- noarch/arviz-0.16.1-pyhd8ed1ab_0.conda
# Has scipy>=0.19, but should be scipy>=1.8.0
# Also has many other incorrect dependencies
# Fixed in <https://github.com/conda-forge/arviz-feedstock/pull/32>
- noarch/arviz-0.13.0-pyhd8ed1ab_0.tar.bz2
# Missing typing_extensions and several other pins
# Fixed in <https://github.com/conda-forge/arviz-feedstock/pull/19>
- noarch/arviz-0.11.2-pyhd8ed1ab_0.tar.bz2
```

Checklist

* [X] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [X] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [X] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [X] Ran `python show_diff.py` and posted the output as part of the PR.
* [X] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

```diff
noarch
noarch::arviz-0.11.2-pyhd8ed1ab_0.tar.bz2
-    "numpy",
+    "numpy >=1.12",
-    "pandas",
+    "pandas >=0.23",
-    "scipy",
-    "xarray"
+    "scipy >=0.19",
+    "setuptools >=38.4",
+    "typing_extensions >=3.7.4.3,<4",
+    "xarray >=0.16.1"
noarch::arviz-0.13.0-pyhd8ed1ab_0.tar.bz2
-    "matplotlib-base >=3.0",
+    "matplotlib-base >=3.5",
-    "numpy >=1.12",
+    "numpy >=1.20",
-    "pandas >=0.23",
+    "pandas >=1.4",
-    "scipy >=0.19",
-    "setuptools >=38.4",
-    "typing_extensions >=3.7.4.3",
-    "xarray >=0.16.1",
-    "xarray-einstats >=0.2"
+    "scipy >=1.8.0",
+    "setuptools >=60.0",
+    "typing_extensions >=4.1.0",
+    "xarray >=0.21.0",
+    "xarray-einstats >=0.3"
noarch::arviz-0.16.1-pyhd8ed1ab_0.conda
-    "matplotlib-base >=3.2",
+    "matplotlib-base >=3.5",
```