### PR TITLE
Patch opencv 4.10.0 for numpy 2.0 compatibility

### DIFF
--- a/recipe/patch_yaml/opencv.yaml
+++ b/recipe/patch_yaml/opencv.yaml
@@ -1,5 +1,5 @@
 if:
-  name: opencv
+  name: py-opencv
   version: 4.10.0
   build_number_in: [0, 500, 600]
   timestamp_lt: 1718160989000

--- a/recipe/patch_yaml/opencv.yaml
+++ b/recipe/patch_yaml/opencv.yaml
@@ -1,0 +1,10 @@
+if:
+  name: opencv
+  version: 4.10.0
+  build_number_in: [0, 500, 600]
+  timestamp_lt: 1718160989000
+
+then:
+  - replace_depends:
+      old: numpy >=2.0.0rc.2,<3.0a0
+      new: numpy >=1.19.0,<3.0a0


### PR DESCRIPTION
See: https://github.com/conda-forge/opencv-feedstock/issues/418
We left a `pin_compatible('numpy')` in the latest build.

But becaues opencv is so many builds, I would rather not push to main.

I've prepared a big pull request:
https://github.com/conda-forge/opencv-feedstock/pull/419
that should prepare things for the next build.

<details><summary>The diff seems ok</summary>

```
$ python show_diff.py  --use-cache
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
osx-arm64::clang-16.0.6-default_h095aff0_8.conda
osx-arm64::clang-16.0.6-root_63200_h61999a4_8.conda
+  "constrains": [
+    "clang-tools 16.0.6.*",
+    "llvm 16.0.6.*",
+    "llvm-tools 16.0.6.*",
+    "llvmdev 16.0.6.*"
+  ],
osx-arm64::clang-tools-16.0.6-default_hb63da90_8.conda
osx-arm64::clang-tools-16.0.6-root_63200_h1b1baf2_8.conda
-    "clangdev 16.0.6"
+    "clang 16.0.6.*",
+    "clangdev 16.0.6",
+    "llvm 16.0.6.*",
+    "llvm-tools 16.0.6.*",
+    "llvmdev 16.0.6.*"
osx-arm64::py-opencv-4.10.0-headless_py310h68867fe_0.conda
osx-arm64::py-opencv-4.10.0-headless_py312hd31a7ba_0.conda
osx-arm64::py-opencv-4.10.0-headless_py311hee2cd3c_0.conda
osx-arm64::py-opencv-4.10.0-headless_py39hef12fc8_0.conda
-    "numpy >=2.0.0rc.2,<3.0a0",
+    "numpy >=1.19.0,<3.0a0",
================================================================================
================================================================================
linux-ppc64le
linux-ppc64le::clang-16.0.6-root_63200_h0c09681_8.conda
linux-ppc64le::clang-16.0.6-default_h60175c1_8.conda
+  "constrains": [
+    "clang-tools 16.0.6.*",
+    "llvm 16.0.6.*",
+    "llvm-tools 16.0.6.*",
+    "llvmdev 16.0.6.*"
+  ],
linux-ppc64le::clang-tools-16.0.6-root_63200_h5eb6582_8.conda
linux-ppc64le::clang-tools-16.0.6-default_hb73a959_8.conda
-    "clangdev 16.0.6"
+    "clang 16.0.6.*",
+    "clangdev 16.0.6",
+    "llvm 16.0.6.*",
+    "llvm-tools 16.0.6.*",
+    "llvmdev 16.0.6.*"
linux-ppc64le::py-opencv-4.10.0-headless_py312h0d68769_0.conda
linux-ppc64le::py-opencv-4.10.0-headless_py311hcc3f660_0.conda
linux-ppc64le::py-opencv-4.10.0-headless_py39h79246a3_0.conda
linux-ppc64le::py-opencv-4.10.0-headless_py310hdf8f1aa_0.conda
-    "numpy >=2.0.0rc.2,<3.0a0",
+    "numpy >=1.19.0,<3.0a0",
================================================================================
================================================================================
linux-aarch64
linux-aarch64::clang-16.0.6-default_h33a044b_8.conda
linux-aarch64::clang-16.0.6-root_63200_he11732f_8.conda
+  "constrains": [
+    "clang-tools 16.0.6.*",
+    "llvm 16.0.6.*",
+    "llvm-tools 16.0.6.*",
+    "llvmdev 16.0.6.*"
+  ],
linux-aarch64::clang-tools-16.0.6-root_63200_haf6839b_8.conda
linux-aarch64::clang-tools-16.0.6-default_h9270250_8.conda
-    "clangdev 16.0.6"
+    "clang 16.0.6.*",
+    "clangdev 16.0.6",
+    "llvm 16.0.6.*",
+    "llvm-tools 16.0.6.*",
+    "llvmdev 16.0.6.*"
linux-aarch64::py-opencv-4.10.0-headless_py39h1039adf_0.conda
linux-aarch64::py-opencv-4.10.0-headless_py310h8f60461_0.conda
linux-aarch64::py-opencv-4.10.0-headless_py312h503b738_0.conda
linux-aarch64::py-opencv-4.10.0-headless_py311h01998f2_0.conda
-    "numpy >=2.0.0rc.2,<3.0a0",
+    "numpy >=1.19.0,<3.0a0",
================================================================================
================================================================================
noarch
================================================================================
================================================================================
win-64
win-64::clang-16.0.6-default_hb53fc94_8.conda
+  "constrains": [
+    "clang-tools 16.0.6.*",
+    "llvm 16.0.6.*",
+    "llvm-tools 16.0.6.*",
+    "llvmdev 16.0.6.*"
+  ],
win-64::clang-tools-16.0.6-default_h204ce9a_8.conda
-    "clangdev 16.0.6"
+    "clang 16.0.6.*",
+    "clangdev 16.0.6",
+    "llvm 16.0.6.*",
+    "llvm-tools 16.0.6.*",
+    "llvmdev 16.0.6.*"
win-64::py-opencv-4.10.0-qt5_py312he776b22_500.conda
win-64::py-opencv-4.10.0-qt5_py311h2fbd31c_500.conda
win-64::py-opencv-4.10.0-qt5_py39h11cfab3_500.conda
win-64::py-opencv-4.10.0-qt6_py311h53ff086_600.conda
win-64::py-opencv-4.10.0-qt6_py312h8df5404_600.conda
win-64::py-opencv-4.10.0-qt6_py39hec3ffa1_600.conda
win-64::py-opencv-4.10.0-qt6_py310h7364d9e_600.conda
win-64::py-opencv-4.10.0-qt5_py310h9853d23_500.conda
-    "numpy >=2.0.0rc.2,<3.0a0",
+    "numpy >=1.19.0,<3.0a0",
================================================================================
================================================================================
osx-64
osx-64::clang-16.0.6-root_63200_h75dac37_8.conda
osx-64::clang-16.0.6-default_ha3b9224_8.conda
+  "constrains": [
+    "clang-tools 16.0.6.*",
+    "llvm 16.0.6.*",
+    "llvm-tools 16.0.6.*",
+    "llvmdev 16.0.6.*"
+  ],
osx-64::clang-tools-16.0.6-default_h4c8afb6_8.conda
osx-64::clang-tools-16.0.6-root_63200_hc9e1f4b_8.conda
-    "clangdev 16.0.6"
+    "clang 16.0.6.*",
+    "clangdev 16.0.6",
+    "llvm 16.0.6.*",
+    "llvm-tools 16.0.6.*",
+    "llvmdev 16.0.6.*"
osx-64::py-opencv-4.10.0-headless_py311h0c3459f_0.conda
osx-64::py-opencv-4.10.0-headless_py312h15c56b3_0.conda
osx-64::py-opencv-4.10.0-headless_py39h3d9cbdb_0.conda
osx-64::py-opencv-4.10.0-headless_py310hb1d7d25_0.conda
-    "numpy >=2.0.0rc.2,<3.0a0",
+    "numpy >=1.19.0,<3.0a0",

================================================================================
================================================================================
linux-64
linux-64::clang-16.0.6-default_h90ac42e_8.conda
linux-64::clang-16.0.6-root_63200_h57dad58_8.conda
+  "constrains": [
+    "clang-tools 16.0.6.*",
+    "llvm 16.0.6.*",
+    "llvm-tools 16.0.6.*",
+    "llvmdev 16.0.6.*"
+  ],
linux-64::clang-tools-16.0.6-root_63200_h43a3b7a_8.conda
linux-64::clang-tools-16.0.6-default_h9bb3924_8.conda
-    "clangdev 16.0.6"
+    "clang 16.0.6.*",
+    "clangdev 16.0.6",
+    "llvm 16.0.6.*",
+    "llvm-tools 16.0.6.*",
+    "llvmdev 16.0.6.*"
linux-64::py-opencv-4.10.0-qt6_py310h3d6a5e7_600.conda
linux-64::py-opencv-4.10.0-qt6_py312h071dcc1_600.conda
linux-64::py-opencv-4.10.0-qt5_py312h6356dd0_500.conda
linux-64::py-opencv-4.10.0-qt5_py310h48ee24f_500.conda
linux-64::py-opencv-4.10.0-headless_py39h1c9db89_0.conda
linux-64::py-opencv-4.10.0-headless_py312h24d6bb4_0.conda
linux-64::py-opencv-4.10.0-headless_py310h59be988_0.conda
linux-64::py-opencv-4.10.0-headless_py311he415c94_0.conda
linux-64::py-opencv-4.10.0-qt5_py311hfd853f2_500.conda
linux-64::py-opencv-4.10.0-qt6_py39h1b361a7_600.conda
linux-64::py-opencv-4.10.0-qt5_py39h4d4e425_500.conda
linux-64::py-opencv-4.10.0-qt6_py311h074fb97_600.conda
-    "numpy >=2.0.0rc.2,<3.0a0",
+    "numpy >=1.19.0,<3.0a0",

```

</details>

Not sure what the changes in llvm is.
Checklist

* [ ] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
