### PR TITLE
Mark pint 0.24 build 0 requires Python 3.10 rather than 3.9

### DIFF
--- a/recipe/patch_yaml/pint.yaml
+++ b/recipe/patch_yaml/pint.yaml
@@ -17,7 +17,7 @@ then:
 # pint 0.24 requires Python 3.10 and does not run on older versions
 if:
   name: pint
-  version: 0.24
+  version: "0.24"
   build_number_in: [0]
 then:
   - replace_depends:

--- a/recipe/patch_yaml/pint.yaml
+++ b/recipe/patch_yaml/pint.yaml
@@ -17,9 +17,9 @@ then:
 # pint 0.24 requires Python 3.10 and does not run on older versions
 if:
   name: pint
-  timestamp_le: 1717950401000
   version: 0.24
   build_number_in: [0]
 then:
   - replace_depends:
       old: python >=3.9
+      new: python >=3.10

--- a/recipe/patch_yaml/pint.yaml
+++ b/recipe/patch_yaml/pint.yaml
@@ -13,3 +13,13 @@ if:
   build_number: 0
 then:
   - add_constrains: numpy <2.0.0a0
+---
+# pint 0.24 requires Python 3.10 and does not run on older versions
+if:
+  name: pint
+  timestamp_le: 1717950401000
+  version: 0.24
+  build_number_in: [0]
+then:
+  - replace_depends:
+      old: python >=3.9


### PR DESCRIPTION
The pint package is released as `noarch` but dropped support for python 3.9 as reported in https://github.com/conda-forge/pint-feedstock/issues/65 . A new build was released https://github.com/conda-forge/pint-feedstock/pull/66 but on Python 3.9 conda still tries to install the previous build, so it should be marked as broken.

Based on the feedback in https://github.com/conda-forge/admin-requests/pull/1017

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
