### PR TITLE
Add lxml upper bound for nbconvert

### DIFF
--- a/recipe/patch_yaml/nbconvert.yaml
+++ b/recipe/patch_yaml/nbconvert.yaml
@@ -108,6 +108,7 @@ then:
 if:
   name_in: [nbconvert, nbconvert-core]
   version_lt: "7.1.0"
+  version_ge: "7.0.0"
   timestamp_le: 1680046165000
 then:
   - add_depends: lxml <5.2.0a0

--- a/recipe/patch_yaml/nbconvert.yaml
+++ b/recipe/patch_yaml/nbconvert.yaml
@@ -104,3 +104,10 @@ then:
   - replace_constrains:
       old: pandoc?( *)
       new: pandoc >=1.12.1,<3.0.0
+---
+if:
+  name_in: [nbconvert, nbconvert-core]
+  version_lt: "7.1.0"
+  timestamp_le: 1680046165000
+then:
+  - add_depends: lxml <5.2.0a0


### PR DESCRIPTION
Checklist

* [ ] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
