### PR TITLE
Patch constraints in conda-standalone 23.5.0 in osx-64

### DIFF
--- a/recipe/patch_yaml/conda-standalone.yaml
+++ b/recipe/patch_yaml/conda-standalone.yaml
@@ -1,9 +1,8 @@
 # yaml-language-server: $schema=../patch_yaml_model.json
 if:
   name: conda-standalone
-  timestamp_lt: 1718384287224  # 2024-06-14
+  timestamp_lt: 1718356255000  # 2024-06-14
   version_eq: "23.5.0"
   subdir_eq: osx-64
-  build_number_eq: 0
 then:
-  - add_constrains: __osx >=10.13
+  - add_depends: __osx >=10.13

--- a/recipe/patch_yaml/conda-standalone.yaml
+++ b/recipe/patch_yaml/conda-standalone.yaml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=../patch_yaml_model.json
+if:
+  name: conda-standalone
+  timestamp_lt: 1718384287224  # 2024-06-14
+  version_eq: "23.5.0"
+  subdir_eq: osx-64
+  build_number_eq: 0
+then:
+  - add_constrains: __osx >=10.13


### PR DESCRIPTION
Checklist

* [X] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [X] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

Comes from https://github.com/conda-forge/conda-standalone-feedstock/pull/76#issuecomment-2168263957