### PR TITLE
Tighten Python <3.12.4 for pydantic v1 and v2

### DIFF
--- a/recipe/patch_yaml/pydantic.yaml
+++ b/recipe/patch_yaml/pydantic.yaml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=../patch_yaml_model.json
+# Fixes https://github.com/pydantic/pydantic/issues/9637
+if:
+  name_in: [pydantic, pydantic-core]
+  timestamp_lt: 1718714598887  # 2024-06-18
+then:
+  - tighten_depends:
+      name: python
+      upper_bound: "3.12.4"


### PR DESCRIPTION
Checklist

* [X] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [X] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

Addresses https://github.com/pydantic/pydantic/issues/9637