### PR TITLE
fix: add jaxlib min versions for old jax packages

### DIFF
--- a/recipe/patch_yaml/jax.yaml
+++ b/recipe/patch_yaml/jax.yaml
@@ -43,7 +43,7 @@ then:
 if:
   name: jax
   version_le: 0.3.5
-  version_ge: 0.3.0
+  version_gt: 0.3.0
 then:
   - replace_depends:
       old: jaxlib

--- a/recipe/patch_yaml/jax.yaml
+++ b/recipe/patch_yaml/jax.yaml
@@ -21,3 +21,29 @@ then:
   - replace_depends:
       old: jaxlib >=0.4.11
       new: jaxlib >=0.4.14
+---
+# no minimum jaxlib version which causes issues
+if:
+  name: jax
+  version_le: 0.3.14
+  version_gt: 0.3.7
+then:
+  - replace_depends:
+      old: jaxlib
+      new: jaxlib >=0.3.7
+---
+if:
+  name: jax
+  version: 0.3.7
+then:
+  - replace_depends:
+      old: jaxlib
+      new: jaxlib >=0.3.2
+---
+if:
+  name: jax
+  version: 0.3.5
+then:
+  - replace_depends:
+      old: jaxlib
+      new: jaxlib >=0.3.0

--- a/recipe/patch_yaml/jax.yaml
+++ b/recipe/patch_yaml/jax.yaml
@@ -25,7 +25,7 @@ then:
 # up to v 0.3.14, the jax recipe had no minimum jaxlib version
 # which causes issues
 # from the source code we have (mapping min jaxlib version to jax versions)
-# '0.3.7': ['0.3.10', '0.3.11', '0.3.12', '0.3.13', '0.3.14', '0.3.8', '0.3.9'], 
+# '0.3.7': ['0.3.10', '0.3.11', '0.3.12', '0.3.13', '0.3.14', '0.3.8', '0.3.9'],
 if:
   name: jax
   version_le: 0.3.14

--- a/recipe/patch_yaml/jax.yaml
+++ b/recipe/patch_yaml/jax.yaml
@@ -22,7 +22,10 @@ then:
       old: jaxlib >=0.4.11
       new: jaxlib >=0.4.14
 ---
-# no minimum jaxlib version which causes issues
+# up to v 0.3.14, the jax recipe had no minimum jaxlib version
+# which causes issues
+# from the source code we have (mapping min jaxlib version to jax versions)
+# '0.3.7': ['0.3.10', '0.3.11', '0.3.12', '0.3.13', '0.3.14', '0.3.8', '0.3.9'], 
 if:
   name: jax
   version_le: 0.3.14
@@ -32,6 +35,7 @@ then:
       old: jaxlib
       new: jaxlib >=0.3.7
 ---
+# '0.3.2': ['0.3.7'],
 if:
   name: jax
   version: 0.3.7
@@ -40,20 +44,109 @@ then:
       old: jaxlib
       new: jaxlib >=0.3.2
 ---
+# '0.3.0': ['0.3.2', '0.3.3', '0.3.4', '0.3.5', '0.3.6'],
 if:
   name: jax
   version_le: 0.3.5
-  version_gt: 0.3.0
+  version_gt: 0.3.1
 then:
   - replace_depends:
       old: jaxlib
       new: jaxlib >=0.3.0
 ---
+# '0.1.74': ['0.2.26', '0.2.27', '0.2.28', '0.3.0', '0.3.1'],
 if:
   name: jax
-  version_le: 0.3.0
+  version_le: 0.3.1
   version_ge: 0.2.26
 then:
   - replace_depends:
       old: jaxlib
       new: jaxlib >=0.1.74
+---
+# '0.1.69': ['0.2.18',
+#            '0.2.19',
+#            '0.2.20',
+#            '0.2.21',
+#            '0.2.22',
+#            '0.2.23',
+#            '0.2.24',
+#            '0.2.25'],
+if:
+  name: jax
+  version_le: 0.2.25
+  version_ge: 0.2.18
+then:
+  - replace_depends:
+      old: jaxlib
+      new: jaxlib >=0.1.69
+---
+# '0.1.65': ['0.2.13', '0.2.14', '0.2.15', '0.2.16', '0.2.17'],
+if:
+  name: jax
+  version_le: 0.2.17
+  version_ge: 0.2.13
+then:
+  - replace_depends:
+      old: jaxlib
+      new: jaxlib >=0.1.65
+---
+# '0.1.64': ['0.2.12'],
+if:
+  name: jax
+  version: 0.2.12
+then:
+  - replace_depends:
+      old: jaxlib
+      new: jaxlib >=0.1.64
+---
+# '0.1.62': ['0.2.11'],
+if:
+  name: jax
+  version: 0.2.11
+then:
+  - replace_depends:
+      old: jaxlib
+      new: jaxlib >=0.1.62
+# I could not find a min version for these, so
+# we do not apply a constraint
+# None: ['0.1.49',
+#        '0.1.55',
+#        '0.1.58',
+#        '0.1.59',
+#        '0.1.60',
+#        '0.1.61',
+#        '0.1.62',
+#        '0.1.63',
+#        '0.1.64',
+#        '0.1.65',
+#        '0.1.66',
+#        '0.1.67',
+#        '0.1.68',
+#        '0.1.69',
+#        '0.1.70',
+#        '0.1.71',
+#        '0.1.72',
+#        '0.1.73',
+#        '0.1.74',
+#        '0.1.75',
+#        '0.1.76',
+#        '0.1.77',
+#        '0.2.0',
+#        '0.2.1',
+#        '0.2.10',
+#        '0.2.2',
+#        '0.2.3',
+#        '0.2.4',
+#        '0.2.5',
+#        '0.2.6',
+#        '0.2.7',
+#        '0.2.8',
+#        '0.2.9'],
+# if:
+#   name: jax
+#   version_le: 0.2.10
+# then:
+#   - replace_depends:
+#       old: jaxlib
+#       new: jaxlib >=???

--- a/recipe/patch_yaml/jax.yaml
+++ b/recipe/patch_yaml/jax.yaml
@@ -42,8 +42,17 @@ then:
 ---
 if:
   name: jax
-  version: 0.3.5
+  version_le: 0.3.5
+  version_ge: 0.3.0
 then:
   - replace_depends:
       old: jaxlib
       new: jaxlib >=0.3.0
+---
+if:
+  name: jax
+  version_le: 0.3.0
+then:
+  - replace_depends:
+      old: jaxlib
+      new: jaxlib >=0.1.74

--- a/recipe/patch_yaml/jax.yaml
+++ b/recipe/patch_yaml/jax.yaml
@@ -52,6 +52,7 @@ then:
 if:
   name: jax
   version_le: 0.3.0
+  version_ge: 0.2.26
 then:
   - replace_depends:
       old: jaxlib

--- a/recipe/patch_yaml/jax.yaml
+++ b/recipe/patch_yaml/jax.yaml
@@ -47,7 +47,7 @@ then:
 # '0.3.0': ['0.3.2', '0.3.3', '0.3.4', '0.3.5', '0.3.6'],
 if:
   name: jax
-  version_le: 0.3.5
+  version_le: 0.3.6
   version_gt: 0.3.1
 then:
   - replace_depends:


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

<details>

```diff
noarch
noarch::jax-0.2.11-pyhd8ed1ab_0.tar.bz2
-    "jaxlib",
+    "jaxlib >=0.1.62",
noarch::jax-0.2.12-pyhd8ed1ab_0.tar.bz2
-    "jaxlib",
+    "jaxlib >=0.1.64",
noarch::jax-0.2.13-pyhd8ed1ab_0.tar.bz2
noarch::jax-0.2.16-pyhd8ed1ab_0.tar.bz2
noarch::jax-0.2.16-pyhd8ed1ab_1.tar.bz2
noarch::jax-0.2.15-pyhd8ed1ab_0.tar.bz2
noarch::jax-0.2.17-pyhd8ed1ab_0.tar.bz2
noarch::jax-0.2.14-pyhd8ed1ab_0.tar.bz2
-    "jaxlib",
+    "jaxlib >=0.1.65",
noarch::jax-0.2.19-pyhd8ed1ab_0.tar.bz2
noarch::jax-0.2.24-pyhd8ed1ab_0.tar.bz2
noarch::jax-0.2.18-pyhd8ed1ab_0.tar.bz2
noarch::jax-0.2.22-pyhd8ed1ab_0.tar.bz2
noarch::jax-0.2.21-pyhd8ed1ab_0.tar.bz2
noarch::jax-0.2.25-pyhd8ed1ab_0.tar.bz2
noarch::jax-0.2.20-pyhd8ed1ab_0.tar.bz2
-    "jaxlib",
+    "jaxlib >=0.1.69",
noarch::jax-0.2.27-pyhd8ed1ab_0.tar.bz2
noarch::jax-0.2.26-pyhd8ed1ab_0.tar.bz2
noarch::jax-0.2.28-pyhd8ed1ab_0.tar.bz2
noarch::jax-0.3.0-pyhd8ed1ab_0.tar.bz2
-    "jaxlib",
+    "jaxlib >=0.1.74",
noarch::jax-0.3.14-pyhd8ed1ab_0.tar.bz2
noarch::jax-0.3.10-pyhd8ed1ab_0.tar.bz2
noarch::jax-0.3.13-pyhd8ed1ab_0.tar.bz2
noarch::jax-0.3.12-pyhd8ed1ab_0.tar.bz2
noarch::jax-0.3.11-pyhd8ed1ab_0.tar.bz2
-    "jaxlib",
+    "jaxlib >=0.3.7",
noarch::jax-0.3.5-pyhd8ed1ab_0.tar.bz2
noarch::jax-0.3.3-pyhd8ed1ab_0.tar.bz2
noarch::jax-0.3.2-pyhd8ed1ab_0.tar.bz2
noarch::jax-0.3.6-pyhd8ed1ab_0.tar.bz2
noarch::jax-0.3.4-pyhd8ed1ab_0.tar.bz2
-    "jaxlib",
+    "jaxlib >=0.3.0",
noarch::jax-0.3.7-pyhd8ed1ab_0.tar.bz2
-    "jaxlib",
+    "jaxlib >=0.3.2",
```

</details>