### PR TITLE
Remove gstreamer pin from qt-webengine

### DIFF
--- a/recipe/patch_yaml/qt-webengine.yaml
+++ b/recipe/patch_yaml/qt-webengine.yaml
@@ -16,7 +16,7 @@ then:
 ---
 
 if:
-  name: qt-webngine
+  name: qt-webengine
   version: 5.15.8
   build_number_ge: 4
   build_number_lt: 7

--- a/recipe/patch_yaml/qt-webengine.yaml
+++ b/recipe/patch_yaml/qt-webengine.yaml
@@ -12,3 +12,16 @@ then:
   - replace_constrains:
       old: qt *
       new: qt 5.15.2|5.15.3|5.15.4
+
+---
+
+if:
+  name: qt-webngine
+  version: 5.15.8
+  build_number_ge: 4
+  build_number_lt: 7
+
+then:
+  - remove_depends:
+    - gstreamer*
+    - gst-plugins-base*

--- a/recipe/patch_yaml/qt-webengine.yaml
+++ b/recipe/patch_yaml/qt-webengine.yaml
@@ -23,5 +23,5 @@ if:
 
 then:
   - remove_depends:
-    - gstreamer*
-    - gst-plugins-base*
+      - gstreamer*
+      - gst-plugins-base*


### PR DESCRIPTION
See: https://github.com/conda-forge/qt-webengine-feedstock/issues/25#issuecomment-2184141348

cc: @conda-forge/qt-main @conda-forge/qt-webengine 
Checklist

* [ ] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
