### PR TITLE
urllib3 2.2.2 not compatible with python 3.7

### DIFF
--- a/recipe/patch_yaml/urllib3.yaml
+++ b/recipe/patch_yaml/urllib3.yaml
@@ -1,0 +1,10 @@
+# https://github.com/conda-forge/urllib3-feedstock/issues/84
+# urllib3 2.2.2 is not compatible with Python 3.7
+if:
+  name: urllib3
+  version: 2.2.2
+  timestamp_lt: 1719424349134  # 2024/06/26 12:52 GMT
+then:
+  - replace_depends:
+      old: python >=3.7
+      new: python >=3.8

--- a/recipe/patch_yaml/urllib3.yaml
+++ b/recipe/patch_yaml/urllib3.yaml
@@ -3,6 +3,7 @@
 if:
   name: urllib3
   version: 2.2.2
+  build_number_in: [0]
   timestamp_lt: 1719424349134  # 2024/06/26 12:52 GMT
 then:
   - replace_depends:


### PR DESCRIPTION
See https://github.com/conda-forge/urllib3-feedstock/issues/84 and https://github.com/conda-forge/urllib3-feedstock/pull/85

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
```
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
noarch
noarch::urllib3-2.2.2-pyhd8ed1ab_0.conda
-    "python >=3.7"
+    "python >=3.8"
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
================================================================================
================================================================================
linux-64
```