### PR TITLE
constrain csp for numpy <2

### DIFF
--- a/recipe/patch_yaml/csp.yaml
+++ b/recipe/patch_yaml/csp.yaml
@@ -1,0 +1,7 @@
+# csp has not yet had a release that supports NumPy 2,
+# so we need to add a run_constrained requirement.
+if:
+  name: csp
+  version_lt: 0.0.5
+then:
+  - add_constrains: numpy <2.0.0a0


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
`show_diff.py`


<details>
<pre>
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
noarch
================================================================================
================================================================================
win-64
win-64::csp-0.0.4-py310hb5ba26c_0.conda
win-64::csp-0.0.4-py38h0ed3059_0.conda
win-64::csp-0.0.4-py311h8abaa30_0.conda
win-64::csp-0.0.4-py39h61769c9_0.conda
win-64::csp-0.0.4-py312hd6d32e5_0.conda
+  "constrains": [
+    "numpy <2.0.0a0"
+  ],
================================================================================
================================================================================
osx-64
osx-64::csp-0.0.3-py38h6d84713_3.conda
osx-64::csp-0.0.4-py312h92d700b_0.conda
osx-64::csp-0.0.3-py39h2c7527a_2.conda
osx-64::csp-0.0.3-py310hd521533_3.conda
osx-64::csp-0.0.3-py311h8882983_1.conda
osx-64::csp-0.0.3-py39hf14287e_1.conda
osx-64::csp-0.0.4-py38h6d84713_0.conda
osx-64::csp-0.0.3-py39h2c7527a_3.conda
osx-64::csp-0.0.3-py38h6d84713_1.conda
osx-64::csp-0.0.3-py311hf9119f2_0.conda
osx-64::csp-0.0.3-py311h8882983_3.conda
osx-64::csp-0.0.3-py39h5688ed5_0.conda
osx-64::csp-0.0.3-py310hd521533_1.conda
osx-64::csp-0.0.3-py311h8882983_2.conda
osx-64::csp-0.0.4-py39hf14287e_0.conda
osx-64::csp-0.0.4-py310hd521533_0.conda
osx-64::csp-0.0.3-py38h3925e28_2.conda
osx-64::csp-0.0.3-py38h18d4dbe_0.conda
osx-64::csp-0.0.4-py311h3d778aa_0.conda
osx-64::csp-0.0.3-py310h5cc7aca_2.conda
osx-64::csp-0.0.3-py310hfae02f7_0.conda
+  "constrains": [
+    "numpy <2.0.0a0"
+  ],
================================================================================
================================================================================
linux-64
linux-64::csp-0.0.3-py38h32bcd0c_1.conda
linux-64::csp-0.0.4-py311h96ec4e2_0.conda
linux-64::csp-0.0.3-py311h96ec4e2_2.conda
linux-64::csp-0.0.3-py310hb9ef8d8_0.conda
linux-64::csp-0.0.4-py310h278e1d9_0.conda
linux-64::csp-0.0.2-py39h7bcfaec_0.conda
linux-64::csp-0.0.3-py310h278e1d9_3.conda
linux-64::csp-0.0.3-py311he61f6ff_0.conda
linux-64::csp-0.0.2-py310hb4a4574_1.conda
linux-64::csp-0.0.4-py39ha4f1c5c_0.conda
linux-64::csp-0.0.2-py38hdd589b6_0.conda
linux-64::csp-0.0.2-py38haab76de_1.conda
linux-64::csp-0.0.3-py311h96ec4e2_1.conda
linux-64::csp-0.0.3-py310h278e1d9_2.conda
linux-64::csp-0.0.3-py38h865c9d8_0.conda
linux-64::csp-0.0.4-py38h32bcd0c_0.conda
linux-64::csp-0.0.2-py39hd57aad4_1.conda
linux-64::csp-0.0.3-py38h32bcd0c_3.conda
linux-64::csp-0.0.3-py39ha4f1c5c_1.conda
linux-64::csp-0.0.2-py311hf175825_1.conda
linux-64::csp-0.0.3-py39ha4f1c5c_2.conda
linux-64::csp-0.0.3-py39ha4f1c5c_3.conda
linux-64::csp-0.0.2-py310h7760271_0.conda
linux-64::csp-0.0.4-py312hd990dfd_0.conda
linux-64::csp-0.0.3-py39hcbdfff7_0.conda
linux-64::csp-0.0.3-py38h32bcd0c_2.conda
linux-64::csp-0.0.3-py311h96ec4e2_3.conda
linux-64::csp-0.0.2-py311h713329b_0.conda
linux-64::csp-0.0.3-py310h278e1d9_1.conda
+  "constrains": [
+    "numpy <2.0.0a0"
+  ],
</pre>
</details>
