### PR TITLE
azure-storage-blob 12.20.0 requires python >=3.8

### DIFF
--- a/recipe/patch_yaml/azure-storage-blob.yaml
+++ b/recipe/patch_yaml/azure-storage-blob.yaml
@@ -1,0 +1,11 @@
+# https://github.com/conda-forge/azure-storage-blob-feedstock/issues/51
+# azure-storage-blob 12.20.0 is not compatible with Python 3.7
+if:
+  name: azure-storage-blob
+  version: 12.20.0
+  build_number_in: [0]
+  timestamp_lt: 1719583158000  # 2024/06/28 GMT
+then:
+  - replace_depends:
+      old: python >=3.7
+      new: python >=3.8


### PR DESCRIPTION
See:

https://github.com/conda-forge/azure-storage-blob-feedstock/issues/51

https://github.com/conda-forge/azure-storage-blob-feedstock/pull/52

@dhirschfeld

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

My `show_diff.py` gave funny results (changes in irrelevant packages), we will see what CI says.

```
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
osx-arm64::ngmix-2.3.1-py310hb6292c7_0.conda
osx-arm64::ngmix-2.3.1-py311ha1ab1f8_0.conda
osx-arm64::ngmix-2.3.1-py39hdf13c20_0.conda
osx-arm64::ngmix-2.3.1-py312h1f38498_0.conda
osx-arm64::ngmix-2.3.1-py38h150bfb4_0.conda
+    "numba !=0.54.0",
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
linux-aarch64
linux-aarch64::ngmix-2.3.1-py312h8025657_0.conda
linux-aarch64::ngmix-2.3.1-py38h2063c64_0.conda
linux-aarch64::ngmix-2.3.1-py39ha65689a_0.conda
linux-aarch64::ngmix-2.3.1-py311hfecb2dc_0.conda
linux-aarch64::ngmix-2.3.1-py310hbbe02a8_0.conda
+    "numba !=0.54.0",
================================================================================
================================================================================
noarch
noarch::azure-storage-blob-12.20.0-pyhd8ed1ab_0.conda
-    "python >=3.7",
+    "python >=3.8",
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
osx-64::ngmix-2.3.1-py39h6e9494a_0.conda
osx-64::ngmix-2.3.1-py310h2ec42d9_0.conda
osx-64::ngmix-2.3.1-py311h6eed73b_0.conda
osx-64::ngmix-2.3.1-py312hb401068_0.conda
osx-64::ngmix-2.3.1-py38h50d1736_0.conda
+    "numba !=0.54.0",
================================================================================
================================================================================
linux-64
linux-64::ngmix-2.3.1-py39hf3d152e_0.conda
linux-64::ngmix-2.3.1-py311h38be061_0.conda
linux-64::ngmix-2.3.1-py312h7900ff3_0.conda
linux-64::ngmix-2.3.1-py310hff52083_0.conda
linux-64::ngmix-2.3.1-py38h578d9bd_0.conda
+    "numba !=0.54.0",
```
