### PR TITLE
Patch libpnetcdf dependency for lammps

### DIFF
--- a/recipe/patch_yaml/lammps.yaml
+++ b/recipe/patch_yaml/lammps.yaml
@@ -8,3 +8,44 @@ then:
   - replace_depends:
       old: mlip
       new: mlip =1.0
+---
+# https://github.com/conda-forge/lammps-feedstock/issues/199
+# build against libpnetcdf 1.12.3
+# Affected versions: 2023.08.02 build 7 mpi ~ 2024.02.07 build 1
+if:
+  name: lammps
+  version: 2023.08.02
+  build_number_in: [7, 8]
+  # nompi is not affected
+  has_depends: mpi4py
+  timestamp_lt: 1719814219000
+then:
+  - add_depends: libpnetcdf ==1.12.3
+---
+if:
+  name: lammps
+  version: 2023.11.21
+  has_depends: mpi4py
+  timestamp_lt: 1719814219000
+then:
+  - add_depends: libpnetcdf ==1.12.3
+---
+if:
+  name: lammps
+  version: 2023.08.02
+  build_number_in: [0, 1]
+  has_depends: mpi4py
+  timestamp_lt: 1719814219000
+then:
+  - add_depends: libpnetcdf ==1.12.3
+---
+# build against libpnetcdf 1.13.0
+# Affected versions: 2024.02.07 build 2
+if:
+  name: lammps
+  version: 2024.02.07
+  build_number_in: [2]
+  has_depends: mpi4py
+  timestamp_lt: 1719814219000
+then:
+  - add_depends: libpnetcdf ==1.13.0

--- a/recipe/patch_yaml/lammps.yaml
+++ b/recipe/patch_yaml/lammps.yaml
@@ -17,7 +17,7 @@ if:
   version: 2023.08.02
   build_number_in: [7, 8]
   # nompi is not affected
-  has_depends: mpi4py
+  has_depends: "*mpi*"
   timestamp_lt: 1719814219000
 then:
   - add_depends: libpnetcdf ==1.12.3
@@ -25,7 +25,7 @@ then:
 if:
   name: lammps
   version: 2023.11.21
-  has_depends: mpi4py
+  has_depends: "*mpi*"
   timestamp_lt: 1719814219000
 then:
   - add_depends: libpnetcdf ==1.12.3
@@ -34,7 +34,7 @@ if:
   name: lammps
   version: 2023.08.02
   build_number_in: [0, 1]
-  has_depends: mpi4py
+  has_depends: "*mpi*"
   timestamp_lt: 1719814219000
 then:
   - add_depends: libpnetcdf ==1.12.3
@@ -45,7 +45,7 @@ if:
   name: lammps
   version: 2024.02.07
   build_number_in: [2]
-  has_depends: mpi4py
+  has_depends: "*mpi*"
   timestamp_lt: 1719814219000
 then:
   - add_depends: libpnetcdf ==1.13.0


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
Fix https://github.com/conda-forge/lammps-feedstock/issues/199. LAMMPS was built against libpnetcdf (through the dependency of libnetcdf), but libpnetcdf was not added into the dependency of LAMMPS, causing the version is not pinning.

Affected versions:
against libpnetcdf 1.12.3: 2023.08.02 build 7 ~ 2024.02.07 build 1 (except nompi variant)
against libpnetcdf 1.13.0: 2024.02.07 build 2 (except nompi variant)

```
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
osx-arm64::lammps-2023.08.02-cpu_py310_h4786252_mpi_mpich_7.conda
osx-arm64::lammps-2023.11.21-cpu_py310_h4786252_mpi_mpich_1.conda
osx-arm64::lammps-2023.11.21-cpu_py310_h49200cc_mpi_openmpi_5.conda
osx-arm64::lammps-2023.08.02-cpu_py39_hdb5a862_openmpi_0.conda
osx-arm64::lammps-2023.08.02-cpu_py311_hcedb0ea_openmpi_7.conda
osx-arm64::lammps-2023.08.02-cpu_py311_hd466178_mpich_1.conda
osx-arm64::lammps-2023.08.02-cpu_py39_hd590433_mpich_7.conda
osx-arm64::lammps-2023.11.21-cpu_py38_h74d7d60_mpi_openmpi_2.conda
osx-arm64::lammps-2023.11.21-cpu_py310_h4786252_mpi_mpich_0.conda
osx-arm64::lammps-2023.11.21-cpu_py38_h74d7d60_mpi_openmpi_1.conda
osx-arm64::lammps-2023.11.21-cpu_py311_h1b1bd21_mpi_openmpi_1.conda
osx-arm64::lammps-2023.11.21-cpu_py38_h74d7d60_mpi_openmpi_0.conda
osx-arm64::lammps-2023.11.21-cpu_py311_h0890928_mpi_mpich_3.conda
osx-arm64::lammps-2023.11.21-cpu_py311_h1b1bd21_mpi_openmpi_2.conda
osx-arm64::lammps-2023.08.02-cpu_py311_h23098a1_mpich_7.conda
osx-arm64::lammps-2023.08.02-cpu_py310_h7a37da0_mpich_0.conda
osx-arm64::lammps-2023.08.02-cpu_py311_h0890928_mpi_mpich_7.conda
osx-arm64::lammps-2023.08.02-cpu_py38_hb5f05e6_mpi_mpich_8.conda
osx-arm64::lammps-2023.08.02-cpu_py310_hd4ac30c_openmpi_1.conda
osx-arm64::lammps-2023.08.02-cpu_py38_ha19c33e_mpich_0.conda
osx-arm64::lammps-2023.11.21-cpu_py311_h0890928_mpi_mpich_4.conda
osx-arm64::lammps-2023.11.21-cpu_py310_h49200cc_mpi_openmpi_1.conda
osx-arm64::lammps-2023.11.21-cpu_py39_hb8cc403_mpi_mpich_1.conda
osx-arm64::lammps-2023.08.02-cpu_py38_h9d40a62_openmpi_1.conda
osx-arm64::lammps-2023.11.21-cpu_py39_hb8cc403_mpi_mpich_5.conda
osx-arm64::lammps-2023.08.02-cpu_py310_h6437ca0_openmpi_7.conda
osx-arm64::lammps-2023.08.02-cpu_py38_ha19c33e_mpich_1.conda
osx-arm64::lammps-2023.11.21-cpu_py311_h0890928_mpi_mpich_2.conda
osx-arm64::lammps-2023.11.21-cpu_py38_h74d7d60_mpi_openmpi_3.conda
osx-arm64::lammps-2023.11.21-cpu_py311_h0890928_mpi_mpich_1.conda
osx-arm64::lammps-2023.11.21-cpu_py39_h829d90f_mpi_openmpi_2.conda
osx-arm64::lammps-2023.08.02-cpu_py310_h49200cc_mpi_openmpi_8.conda
osx-arm64::lammps-2023.08.02-cpu_py310_h4786252_mpi_mpich_8.conda
osx-arm64::lammps-2023.11.21-cpu_py38_hb5f05e6_mpi_mpich_0.conda
osx-arm64::lammps-2023.11.21-cpu_py311_h1b1bd21_mpi_openmpi_0.conda
osx-arm64::lammps-2023.11.21-cpu_py38_hb5f05e6_mpi_mpich_4.conda
osx-arm64::lammps-2023.08.02-cpu_py39_hb8cc403_mpi_mpich_8.conda
osx-arm64::lammps-2023.08.02-cpu_py311_h0890928_mpi_mpich_8.conda
osx-arm64::lammps-2023.11.21-cpu_py310_h49200cc_mpi_openmpi_4.conda
osx-arm64::lammps-2023.11.21-cpu_py38_hb5f05e6_mpi_mpich_1.conda
osx-arm64::lammps-2023.11.21-cpu_py311_h1b1bd21_mpi_openmpi_4.conda
osx-arm64::lammps-2023.11.21-cpu_py38_hb5f05e6_mpi_mpich_3.conda
osx-arm64::lammps-2023.11.21-cpu_py310_h4786252_mpi_mpich_2.conda
osx-arm64::lammps-2023.08.02-cpu_py311_hb114475_openmpi_0.conda
osx-arm64::lammps-2023.11.21-cpu_py39_hb8cc403_mpi_mpich_3.conda
osx-arm64::lammps-2023.08.02-cpu_py39_h382c4a1_mpich_0.conda
osx-arm64::lammps-2023.11.21-cpu_py38_h74d7d60_mpi_openmpi_4.conda
osx-arm64::lammps-2023.11.21-cpu_py38_hb5f05e6_mpi_mpich_2.conda
osx-arm64::lammps-2023.11.21-cpu_py310_h4786252_mpi_mpich_3.conda
osx-arm64::lammps-2023.08.02-cpu_py38_h7c1f8ad_openmpi_7.conda
osx-arm64::lammps-2023.11.21-cpu_py310_h4786252_mpi_mpich_5.conda
osx-arm64::lammps-2023.08.02-cpu_py39_hdb5a862_openmpi_1.conda
osx-arm64::lammps-2023.08.02-cpu_py39_hb8cc403_mpi_mpich_7.conda
osx-arm64::lammps-2023.11.21-cpu_py39_hb8cc403_mpi_mpich_4.conda
osx-arm64::lammps-2023.08.02-cpu_py311_h1b1bd21_mpi_openmpi_8.conda
osx-arm64::lammps-2023.08.02-cpu_py310_hd4ac30c_openmpi_0.conda
osx-arm64::lammps-2023.11.21-cpu_py310_h49200cc_mpi_openmpi_2.conda
osx-arm64::lammps-2023.11.21-cpu_py39_h829d90f_mpi_openmpi_3.conda
osx-arm64::lammps-2023.08.02-cpu_py38_h9d40a62_openmpi_0.conda
osx-arm64::lammps-2023.08.02-cpu_py311_hd466178_mpich_0.conda
osx-arm64::lammps-2023.11.21-cpu_py310_h49200cc_mpi_openmpi_3.conda
osx-arm64::lammps-2023.08.02-cpu_py38_h74d7d60_mpi_openmpi_8.conda
osx-arm64::lammps-2023.11.21-cpu_py310_h49200cc_mpi_openmpi_0.conda
osx-arm64::lammps-2023.11.21-cpu_py311_h1b1bd21_mpi_openmpi_3.conda
osx-arm64::lammps-2023.11.21-cpu_py311_h0890928_mpi_mpich_0.conda
osx-arm64::lammps-2023.11.21-cpu_py39_h829d90f_mpi_openmpi_5.conda
osx-arm64::lammps-2023.08.02-cpu_py39_h829d90f_mpi_openmpi_7.conda
osx-arm64::lammps-2023.11.21-cpu_py38_hb5f05e6_mpi_mpich_5.conda
osx-arm64::lammps-2023.08.02-cpu_py39_h829d90f_mpi_openmpi_8.conda
osx-arm64::lammps-2023.08.02-cpu_py311_h1b1bd21_mpi_openmpi_7.conda
osx-arm64::lammps-2023.08.02-cpu_py38_h74d7d60_mpi_openmpi_7.conda
osx-arm64::lammps-2023.11.21-cpu_py39_h829d90f_mpi_openmpi_4.conda
osx-arm64::lammps-2023.08.02-cpu_py310_h7a37da0_mpich_1.conda
osx-arm64::lammps-2023.11.21-cpu_py311_h1b1bd21_mpi_openmpi_5.conda
osx-arm64::lammps-2023.08.02-cpu_py39_h7cd824f_openmpi_7.conda
osx-arm64::lammps-2023.08.02-cpu_py38_hb5f05e6_mpi_mpich_7.conda
osx-arm64::lammps-2023.11.21-cpu_py39_h829d90f_mpi_openmpi_0.conda
osx-arm64::lammps-2023.08.02-cpu_py311_hb114475_openmpi_1.conda
osx-arm64::lammps-2023.11.21-cpu_py39_hb8cc403_mpi_mpich_2.conda
osx-arm64::lammps-2023.08.02-cpu_py38_h159ea53_mpich_7.conda
osx-arm64::lammps-2023.08.02-cpu_py310_h13f71d6_mpich_7.conda
osx-arm64::lammps-2023.11.21-cpu_py311_h0890928_mpi_mpich_5.conda
osx-arm64::lammps-2023.11.21-cpu_py39_h829d90f_mpi_openmpi_1.conda
osx-arm64::lammps-2023.08.02-cpu_py39_h382c4a1_mpich_1.conda
osx-arm64::lammps-2023.11.21-cpu_py310_h4786252_mpi_mpich_4.conda
osx-arm64::lammps-2023.08.02-cpu_py310_h49200cc_mpi_openmpi_7.conda
osx-arm64::lammps-2023.11.21-cpu_py39_hb8cc403_mpi_mpich_0.conda
osx-arm64::lammps-2023.11.21-cpu_py38_h74d7d60_mpi_openmpi_5.conda
+    "libpnetcdf ==1.12.3",
osx-arm64::lammps-2024.02.07-cpu_py312_h6a1633e_mpi_mpich_2.conda
osx-arm64::lammps-2024.02.07-cpu_py311_h4d2beb0_mpi_mpich_2.conda
osx-arm64::lammps-2024.02.07-cpu_py310_h1593777_mpi_mpich_2.conda
osx-arm64::lammps-2024.02.07-cpu_py38_h7f22be0_mpi_mpich_2.conda
osx-arm64::lammps-2024.02.07-cpu_py38_hd363d9f_mpi_openmpi_2.conda
osx-arm64::lammps-2024.02.07-cpu_py39_h24856f0_mpi_mpich_2.conda
osx-arm64::lammps-2024.02.07-cpu_py311_h389f435_mpi_openmpi_2.conda
osx-arm64::lammps-2024.02.07-cpu_py39_hcc49ceb_mpi_openmpi_2.conda
osx-arm64::lammps-2024.02.07-cpu_py312_hec0f072_mpi_openmpi_2.conda
osx-arm64::lammps-2024.02.07-cpu_py310_h3e24ecf_mpi_openmpi_2.conda
+    "libpnetcdf ==1.13.0",
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
noarch
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
osx-64::lammps-2023.08.02-cpu_py310_h47242cf_mpich_0.conda
osx-64::lammps-2023.08.02-cpu_py38_ha83d5b2_mpich_1.conda
osx-64::lammps-2023.11.21-cpu_py39_hb2f5527_mpi_mpich_4.conda
osx-64::lammps-2023.08.02-cpu_py39_ha9147cc_mpich_1.conda
osx-64::lammps-2023.11.21-cpu_py311_h3ff7cfc_mpi_mpich_3.conda
osx-64::lammps-2023.08.02-cpu_py311_h38df71f_openmpi_0.conda
osx-64::lammps-2023.11.21-cpu_py38_h5baff61_mpi_mpich_0.conda
osx-64::lammps-2023.08.02-cpu_py39_hb9db24c_openmpi_1.conda
osx-64::lammps-2023.08.02-cpu_py39_h2e90f8d_openmpi_7.conda
osx-64::lammps-2023.08.02-cpu_py38_h40ed01f_openmpi_0.conda
osx-64::lammps-2023.11.21-cpu_py311_h3ff7cfc_mpi_mpich_1.conda
osx-64::lammps-2023.08.02-cpu_py38_h5baff61_mpi_mpich_7.conda
osx-64::lammps-2023.08.02-cpu_py39_hb9db24c_openmpi_0.conda
osx-64::lammps-2023.11.21-cpu_py39_hb2f5527_mpi_mpich_0.conda
osx-64::lammps-2023.11.21-cpu_py38_h5baff61_mpi_mpich_4.conda
osx-64::lammps-2023.11.21-cpu_py38_h5baff61_mpi_mpich_2.conda
osx-64::lammps-2023.11.21-cpu_py310_hbc8b412_mpi_openmpi_5.conda
osx-64::lammps-2023.11.21-cpu_py38_h9e2c45a_mpi_openmpi_5.conda
osx-64::lammps-2023.08.02-cpu_py311_h77be970_mpich_7.conda
osx-64::lammps-2023.11.21-cpu_py310_hbc8b412_mpi_openmpi_2.conda
osx-64::lammps-2023.08.02-cpu_py311_h3ff7cfc_mpi_mpich_8.conda
osx-64::lammps-2023.08.02-cpu_py39_h9bb1a43_mpi_openmpi_7.conda
osx-64::lammps-2023.08.02-cpu_py39_ha9147cc_mpich_0.conda
osx-64::lammps-2023.11.21-cpu_py310_hbc8b412_mpi_openmpi_1.conda
osx-64::lammps-2023.08.02-cpu_py311_h835ce97_mpi_openmpi_7.conda
osx-64::lammps-2023.11.21-cpu_py310_hbc8b412_mpi_openmpi_0.conda
osx-64::lammps-2023.11.21-cpu_py310_hbc8b412_mpi_openmpi_4.conda
osx-64::lammps-2023.11.21-cpu_py311_h3ff7cfc_mpi_mpich_2.conda
osx-64::lammps-2023.11.21-cpu_py39_h14e9caf_mpi_mpich_1.conda
osx-64::lammps-2023.08.02-cpu_py310_h7abf466_mpich_7.conda
osx-64::lammps-2023.08.02-cpu_py310_hdd5fa3c_mpi_mpich_7.conda
osx-64::lammps-2023.08.02-cpu_py311_h835ce97_mpi_openmpi_8.conda
osx-64::lammps-2023.11.21-cpu_py310_hbc8b412_mpi_openmpi_3.conda
osx-64::lammps-2023.11.21-cpu_py39_h7885287_mpi_openmpi_2.conda
osx-64::lammps-2023.08.02-cpu_py39_h67101a1_mpich_7.conda
osx-64::lammps-2023.11.21-cpu_py38_h9e2c45a_mpi_openmpi_0.conda
osx-64::lammps-2023.08.02-cpu_py310_h47242cf_mpich_1.conda
osx-64::lammps-2023.08.02-cpu_py39_h7885287_mpi_openmpi_7.conda
osx-64::lammps-2023.11.21-cpu_py310_hdd5fa3c_mpi_mpich_4.conda
osx-64::lammps-2023.11.21-cpu_py38_h9e2c45a_mpi_openmpi_3.conda
osx-64::lammps-2023.11.21-cpu_py39_h9bb1a43_mpi_openmpi_4.conda
osx-64::lammps-2023.11.21-cpu_py310_hdd5fa3c_mpi_mpich_1.conda
osx-64::lammps-2023.08.02-cpu_py39_hb2f5527_mpi_mpich_7.conda
osx-64::lammps-2023.11.21-cpu_py39_hb2f5527_mpi_mpich_2.conda
osx-64::lammps-2023.08.02-cpu_py310_h99287ef_openmpi_0.conda
osx-64::lammps-2023.11.21-cpu_py310_hdd5fa3c_mpi_mpich_5.conda
osx-64::lammps-2023.08.02-cpu_py310_hbc8b412_mpi_openmpi_7.conda
osx-64::lammps-2023.08.02-cpu_py38_hbb08593_mpich_7.conda
osx-64::lammps-2023.08.02-cpu_py39_h14e9caf_mpi_mpich_8.conda
osx-64::lammps-2023.08.02-cpu_py39_h7885287_mpi_openmpi_8.conda
osx-64::lammps-2023.11.21-cpu_py311_h835ce97_mpi_openmpi_4.conda
osx-64::lammps-2023.11.21-cpu_py311_h3ff7cfc_mpi_mpich_4.conda
osx-64::lammps-2023.11.21-cpu_py39_hb2f5527_mpi_mpich_1.conda
osx-64::lammps-2023.08.02-cpu_py38_ha83d5b2_mpich_0.conda
osx-64::lammps-2023.11.21-cpu_py39_h9bb1a43_mpi_openmpi_1.conda
osx-64::lammps-2023.11.21-cpu_py38_h5baff61_mpi_mpich_5.conda
osx-64::lammps-2023.08.02-cpu_py311_hb61bd1e_mpich_1.conda
osx-64::lammps-2023.08.02-cpu_py39_h4b01163_openmpi_1.conda
osx-64::lammps-2023.11.21-cpu_py39_h14e9caf_mpi_mpich_4.conda
osx-64::lammps-2023.11.21-cpu_py39_h7885287_mpi_openmpi_4.conda
osx-64::lammps-2023.08.02-cpu_py311_h3ff7cfc_mpi_mpich_7.conda
osx-64::lammps-2023.11.21-cpu_py39_hb2f5527_mpi_mpich_3.conda
osx-64::lammps-2023.11.21-cpu_py39_h7885287_mpi_openmpi_5.conda
osx-64::lammps-2023.08.02-cpu_py39_h2c79531_openmpi_7.conda
osx-64::lammps-2023.11.21-cpu_py39_h7885287_mpi_openmpi_0.conda
osx-64::lammps-2023.08.02-cpu_py38_h9e2c45a_mpi_openmpi_8.conda
osx-64::lammps-2023.08.02-cpu_py310_hdd5fa3c_mpi_mpich_8.conda
osx-64::lammps-2023.11.21-cpu_py311_h835ce97_mpi_openmpi_2.conda
osx-64::lammps-2023.08.02-cpu_py310_ha7c6565_openmpi_7.conda
osx-64::lammps-2023.11.21-cpu_py38_h9e2c45a_mpi_openmpi_4.conda
osx-64::lammps-2023.11.21-cpu_py39_h9bb1a43_mpi_openmpi_5.conda
osx-64::lammps-2023.08.02-cpu_py39_hb2f5527_mpi_mpich_8.conda
osx-64::lammps-2023.08.02-cpu_py310_hbc8b412_mpi_openmpi_8.conda
osx-64::lammps-2023.11.21-cpu_py39_h9bb1a43_mpi_openmpi_0.conda
osx-64::lammps-2023.08.02-cpu_py39_h3431d70_mpich_0.conda
osx-64::lammps-2023.08.02-cpu_py39_h3431d70_mpich_1.conda
osx-64::lammps-2023.08.02-cpu_py39_h9bb1a43_mpi_openmpi_8.conda
osx-64::lammps-2023.11.21-cpu_py39_h7885287_mpi_openmpi_3.conda
osx-64::lammps-2023.11.21-cpu_py39_h14e9caf_mpi_mpich_5.conda
osx-64::lammps-2023.08.02-cpu_py39_h14e9caf_mpi_mpich_7.conda
osx-64::lammps-2023.11.21-cpu_py39_hb2f5527_mpi_mpich_5.conda
osx-64::lammps-2023.11.21-cpu_py39_h7885287_mpi_openmpi_1.conda
osx-64::lammps-2023.08.02-cpu_py38_h5baff61_mpi_mpich_8.conda
osx-64::lammps-2023.08.02-cpu_py311_h38df71f_openmpi_1.conda
osx-64::lammps-2023.08.02-cpu_py39_h4b01163_openmpi_0.conda
osx-64::lammps-2023.11.21-cpu_py311_h3ff7cfc_mpi_mpich_0.conda
osx-64::lammps-2023.08.02-cpu_py39_he58e779_mpich_7.conda
osx-64::lammps-2023.11.21-cpu_py311_h835ce97_mpi_openmpi_1.conda
osx-64::lammps-2023.11.21-cpu_py311_h835ce97_mpi_openmpi_5.conda
osx-64::lammps-2023.08.02-cpu_py311_h4cfb842_openmpi_7.conda
osx-64::lammps-2023.11.21-cpu_py310_hdd5fa3c_mpi_mpich_0.conda
osx-64::lammps-2023.11.21-cpu_py310_hdd5fa3c_mpi_mpich_3.conda
osx-64::lammps-2023.08.02-cpu_py38_hba693f7_openmpi_0.conda
osx-64::lammps-2023.08.02-cpu_py38_h40ed01f_openmpi_1.conda
osx-64::lammps-2023.08.02-cpu_py311_hb61bd1e_mpich_0.conda
osx-64::lammps-2023.11.21-cpu_py311_h3ff7cfc_mpi_mpich_5.conda
osx-64::lammps-2023.08.02-cpu_py38_h69e58df_mpich_0.conda
osx-64::lammps-2023.11.21-cpu_py39_h14e9caf_mpi_mpich_2.conda
osx-64::lammps-2023.11.21-cpu_py311_h835ce97_mpi_openmpi_0.conda
osx-64::lammps-2023.11.21-cpu_py310_hdd5fa3c_mpi_mpich_2.conda
osx-64::lammps-2023.11.21-cpu_py39_h9bb1a43_mpi_openmpi_2.conda
osx-64::lammps-2023.11.21-cpu_py38_h5baff61_mpi_mpich_1.conda
osx-64::lammps-2023.11.21-cpu_py38_h9e2c45a_mpi_openmpi_2.conda
osx-64::lammps-2023.11.21-cpu_py39_h9bb1a43_mpi_openmpi_3.conda
osx-64::lammps-2023.11.21-cpu_py38_h9e2c45a_mpi_openmpi_1.conda
osx-64::lammps-2023.08.02-cpu_py38_h9e2c45a_mpi_openmpi_7.conda
osx-64::lammps-2023.08.02-cpu_py38_habfeadd_openmpi_7.conda
osx-64::lammps-2023.11.21-cpu_py311_h835ce97_mpi_openmpi_3.conda
osx-64::lammps-2023.08.02-cpu_py310_h99287ef_openmpi_1.conda
osx-64::lammps-2023.11.21-cpu_py39_h14e9caf_mpi_mpich_3.conda
+    "libpnetcdf ==1.12.3",
osx-64::lammps-2024.02.07-cpu_py39_ha650293_mpi_openmpi_2.conda
osx-64::lammps-2024.02.07-cpu_py38_h03b8ea8_mpi_mpich_2.conda
osx-64::lammps-2024.02.07-cpu_py39_h2dfca53_mpi_mpich_2.conda
osx-64::lammps-2024.02.07-cpu_py39_heb643cb_mpi_mpich_2.conda
osx-64::lammps-2024.02.07-cpu_py38_hab3a36f_mpi_openmpi_2.conda
osx-64::lammps-2024.02.07-cpu_py311_haafd32b_mpi_mpich_2.conda
osx-64::lammps-2024.02.07-cpu_py39_hcb3270c_mpi_openmpi_2.conda
osx-64::lammps-2024.02.07-cpu_py312_hb32dea1_mpi_openmpi_2.conda
osx-64::lammps-2024.02.07-cpu_py312_h28d6024_mpi_mpich_2.conda
osx-64::lammps-2024.02.07-cpu_py310_h4223226_mpi_openmpi_2.conda
osx-64::lammps-2024.02.07-cpu_py311_h44ad777_mpi_openmpi_2.conda
osx-64::lammps-2024.02.07-cpu_py310_h0c5b803_mpi_mpich_2.conda
+    "libpnetcdf ==1.13.0",
================================================================================
================================================================================
linux-64
linux-64::lammps-2023.08.02-cpu_py39_h7e86899_mpi_mpich_8.conda
linux-64::lammps-2023.08.02-cuda118_py39_h4a9cbaf_mpi_openmpi_8.conda
linux-64::lammps-2023.11.21-cpu_py39_h827286f_mpi_openmpi_1.conda
linux-64::lammps-2023.11.21-cpu_py311_hbb7bd43_mpi_openmpi_2.conda
linux-64::lammps-2023.11.21-cuda118_py310_h483aaed_mpi_openmpi_3.conda
linux-64::lammps-2023.11.21-cpu_py38_hda8f861_mpi_mpich_0.conda
linux-64::lammps-2023.08.02-cpu_py311_hdd49dfd_nompi_8.conda
linux-64::lammps-2023.08.02-cuda118_py39_h0d794d2_mpi_openmpi_8.conda
linux-64::lammps-2023.08.02-cpu_py39_hae2bcb2_openmpi_0.conda
linux-64::lammps-2023.11.21-cpu_py310_h8f80a90_mpi_mpich_4.conda
linux-64::lammps-2023.08.02-cpu_py39_hae2bcb2_openmpi_1.conda
linux-64::lammps-2023.11.21-cpu_py310_hcea6fc9_mpi_openmpi_2.conda
linux-64::lammps-2023.11.21-cpu_py39_h827286f_mpi_openmpi_4.conda
linux-64::lammps-2023.11.21-cuda118_py39_hcae4e68_mpi_mpich_4.conda
linux-64::lammps-2023.08.02-cuda118_py311_h96326dd_nompi_8.conda
linux-64::lammps-2023.11.21-cuda118_py38_h9c5a0ec_mpi_openmpi_1.conda
linux-64::lammps-2023.11.21-cuda118_py311_h80f0500_nompi_1.conda
linux-64::lammps-2023.11.21-cuda118_py38_h9c5a0ec_mpi_openmpi_4.conda
linux-64::lammps-2023.11.21-cpu_py38_hde207a7_mpi_openmpi_5.conda
linux-64::lammps-2023.11.21-cpu_py39_h5b957dd_nompi_0.conda
linux-64::lammps-2023.11.21-cuda118_py38_hc73eb01_mpi_openmpi_4.conda
linux-64::lammps-2023.11.21-cuda118_py38_h80d1e08_mpi_mpich_1.conda
linux-64::lammps-2023.11.21-cpu_py39_h7e86899_mpi_mpich_3.conda
linux-64::lammps-2023.11.21-cpu_py39_h5b957dd_nompi_2.conda
linux-64::lammps-2023.11.21-cuda118_py310_h483aaed_mpi_openmpi_0.conda
linux-64::lammps-2023.11.21-cpu_py311_hdd49dfd_nompi_2.conda
linux-64::lammps-2023.08.02-cuda118_py38_h9c5a0ec_mpi_openmpi_8.conda
linux-64::lammps-2023.11.21-cpu_py39_hade46e7_mpi_openmpi_2.conda
linux-64::lammps-2023.11.21-cuda118_py311_h0edc3ef_mpi_mpich_4.conda
linux-64::lammps-2023.08.02-cuda118_py39_h291e33b_mpi_openmpi_8.conda
linux-64::lammps-2023.11.21-cpu_py311_hd3d4698_mpi_mpich_5.conda
linux-64::lammps-2023.11.21-cuda118_py39_h4a9cbaf_mpi_openmpi_0.conda
linux-64::lammps-2023.11.21-cpu_py311_hbb7bd43_mpi_openmpi_3.conda
linux-64::lammps-2023.08.02-cuda118_py311_hdd7c1f1_mpi_mpich_8.conda
linux-64::lammps-2023.08.02-cpu_py310_h2521045_mpich_7.conda
linux-64::lammps-2023.11.21-cpu_py311_hbb7bd43_mpi_openmpi_5.conda
linux-64::lammps-2023.11.21-cuda118_py311_h96326dd_nompi_3.conda
linux-64::lammps-2023.11.21-cuda118_py38_h0bd2086_nompi_4.conda
linux-64::lammps-2023.11.21-cuda118_py310_hadf4ee5_nompi_5.conda
linux-64::lammps-2023.11.21-cpu_py39_hefd3d5c_mpi_mpich_0.conda
linux-64::lammps-2023.11.21-cpu_py39_h827286f_mpi_openmpi_3.conda
linux-64::lammps-2023.11.21-cuda118_py310_h077d75c_mpi_mpich_0.conda
linux-64::lammps-2023.11.21-cuda118_py38_h6de3bbc_mpi_mpich_4.conda
linux-64::lammps-2023.11.21-cpu_py39_h7e86899_mpi_mpich_4.conda
linux-64::lammps-2023.11.21-cuda118_py311_hdd7c1f1_mpi_mpich_3.conda
linux-64::lammps-2023.11.21-cpu_py310_h8f80a90_mpi_mpich_3.conda
linux-64::lammps-2023.08.02-cpu_py39_hf042188_nompi_7.conda
linux-64::lammps-2023.08.02-cpu_py310_h4b5e8b3_openmpi_1.conda
linux-64::lammps-2023.08.02-cpu_py39_hefd3d5c_mpi_mpich_8.conda
linux-64::lammps-2023.11.21-cuda118_py39_h0d794d2_mpi_openmpi_1.conda
linux-64::lammps-2023.08.02-cpu_py39_hade46e7_mpi_openmpi_7.conda
linux-64::lammps-2023.11.21-cpu_py38_hde207a7_mpi_openmpi_4.conda
linux-64::lammps-2023.11.21-cpu_py39_h827286f_mpi_openmpi_5.conda
linux-64::lammps-2023.08.02-cuda118_py39_hf8afb37_nompi_8.conda
linux-64::lammps-2023.11.21-cuda118_py39_h5417483_nompi_0.conda
linux-64::lammps-2023.11.21-cpu_py39_hf042188_nompi_5.conda
linux-64::lammps-2023.11.21-cuda118_py311_h0edc3ef_mpi_mpich_5.conda
linux-64::lammps-2023.08.02-cpu_py38_h5608ceb_nompi_7.conda
linux-64::lammps-2023.08.02-cuda118_py310_h483aaed_mpi_openmpi_8.conda
linux-64::lammps-2023.11.21-cuda118_py310_hadf4ee5_nompi_3.conda
linux-64::lammps-2023.11.21-cuda118_py38_he846794_nompi_3.conda
linux-64::lammps-2023.08.02-cpu_py38_hde207a7_mpi_openmpi_7.conda
linux-64::lammps-2023.11.21-cpu_py311_hdd49dfd_nompi_3.conda
linux-64::lammps-2023.11.21-cuda118_py39_hcae4e68_mpi_mpich_1.conda
linux-64::lammps-2023.08.02-cpu_py39_h2595f3c_mpich_1.conda
linux-64::lammps-2023.08.02-cpu_py311_h4aafb77_mpich_1.conda
linux-64::lammps-2023.08.02-cuda118_py310_h7730a0c_nompi_8.conda
linux-64::lammps-2023.08.02-cpu_py311_hbb7bd43_mpi_openmpi_8.conda
linux-64::lammps-2023.08.02-cpu_py39_h00752c8_mpich_0.conda
linux-64::lammps-2023.11.21-cuda118_py310_h38e9743_mpi_mpich_2.conda
linux-64::lammps-2023.11.21-cuda118_py39_h291e33b_mpi_openmpi_4.conda
linux-64::lammps-2023.11.21-cpu_py38_h5608ceb_nompi_2.conda
linux-64::lammps-2023.11.21-cuda118_py39_hdd7f1a5_mpi_mpich_1.conda
linux-64::lammps-2023.11.21-cuda118_py39_hf2cf36d_nompi_4.conda
linux-64::lammps-2023.11.21-cuda118_py311_h0edc3ef_mpi_mpich_0.conda
linux-64::lammps-2023.11.21-cpu_py38_h5608ceb_nompi_1.conda
linux-64::lammps-2023.08.02-cpu_py38_hffeb4a5_openmpi_0.conda
linux-64::lammps-2023.11.21-cpu_py38_h5608ceb_nompi_5.conda
linux-64::lammps-2023.08.02-cpu_py310_h5b57e7a_nompi_7.conda
linux-64::lammps-2023.08.02-cuda118_py39_h5417483_nompi_8.conda
linux-64::lammps-2023.11.21-cpu_py39_hefd3d5c_mpi_mpich_5.conda
linux-64::lammps-2023.11.21-cpu_py39_hefd3d5c_mpi_mpich_3.conda
linux-64::lammps-2023.11.21-cuda118_py310_h5811056_mpi_openmpi_2.conda
linux-64::lammps-2023.11.21-cpu_py310_hcea6fc9_mpi_openmpi_0.conda
linux-64::lammps-2023.08.02-cpu_py310_h8f80a90_mpi_mpich_7.conda
linux-64::lammps-2023.11.21-cpu_py310_hcea6fc9_mpi_openmpi_3.conda
linux-64::lammps-2023.08.02-cpu_py38_hc50ecde_mpich_7.conda
linux-64::lammps-2023.11.21-cuda118_py39_h291e33b_mpi_openmpi_2.conda
linux-64::lammps-2023.11.21-cpu_py39_hefd3d5c_mpi_mpich_1.conda
linux-64::lammps-2023.08.02-cpu_py39_hd328345_mpich_7.conda
linux-64::lammps-2023.08.02-cuda118_py310_hadf4ee5_nompi_8.conda
linux-64::lammps-2023.11.21-cpu_py310_h5b57e7a_nompi_5.conda
linux-64::lammps-2023.11.21-cpu_py38_hda8f861_mpi_mpich_5.conda
linux-64::lammps-2023.08.02-cpu_py311_hdbaa96a_mpich_7.conda
linux-64::lammps-2023.08.02-cuda118_py310_h38e9743_mpi_mpich_8.conda
linux-64::lammps-2023.11.21-cuda118_py39_h291e33b_mpi_openmpi_5.conda
linux-64::lammps-2023.08.02-cpu_py310_h8f80a90_mpi_mpich_8.conda
linux-64::lammps-2023.08.02-cpu_py310_hf267ffc_mpich_1.conda
linux-64::lammps-2023.11.21-cuda118_py39_h14e8439_mpi_mpich_0.conda
linux-64::lammps-2023.08.02-cuda118_py310_h077d75c_mpi_mpich_8.conda
linux-64::lammps-2023.11.21-cpu_py39_h7e86899_mpi_mpich_5.conda
linux-64::lammps-2023.08.02-cpu_py38_hc35b4e4_openmpi_7.conda
linux-64::lammps-2023.11.21-cpu_py38_hda8f861_mpi_mpich_2.conda
linux-64::lammps-2023.11.21-cpu_py39_hade46e7_mpi_openmpi_5.conda
linux-64::lammps-2023.08.02-cuda118_py38_h6de3bbc_mpi_mpich_8.conda
linux-64::lammps-2023.08.02-cuda118_py311_h9b6f9d6_mpi_openmpi_8.conda
linux-64::lammps-2023.11.21-cuda118_py311_hc5820a9_mpi_openmpi_4.conda
linux-64::lammps-2023.08.02-cpu_py38_hda8f861_mpi_mpich_7.conda
linux-64::lammps-2023.11.21-cuda118_py38_he846794_nompi_4.conda
linux-64::lammps-2023.11.21-cpu_py39_hf042188_nompi_4.conda
linux-64::lammps-2023.08.02-cpu_py38_h5608ceb_nompi_8.conda
linux-64::lammps-2023.11.21-cuda118_py39_hf8afb37_nompi_1.conda
linux-64::lammps-2023.11.21-cuda118_py310_h483aaed_mpi_openmpi_1.conda
linux-64::lammps-2023.11.21-cpu_py39_hf042188_nompi_1.conda
linux-64::lammps-2023.11.21-cuda118_py39_hdd7f1a5_mpi_mpich_4.conda
linux-64::lammps-2023.08.02-cuda118_py39_h14e8439_mpi_mpich_8.conda
linux-64::lammps-2023.11.21-cpu_py311_hd3d4698_mpi_mpich_2.conda
linux-64::lammps-2023.11.21-cuda118_py311_h80f0500_nompi_4.conda
linux-64::lammps-2023.11.21-cuda118_py38_h9c5a0ec_mpi_openmpi_2.conda
linux-64::lammps-2023.08.02-cpu_py38_hffeb4a5_openmpi_1.conda
linux-64::lammps-2023.11.21-cpu_py310_hcea6fc9_mpi_openmpi_1.conda
linux-64::lammps-2023.11.21-cpu_py38_hde207a7_mpi_openmpi_3.conda
linux-64::lammps-2023.08.02-cpu_py39_h5b957dd_nompi_8.conda
linux-64::lammps-2023.11.21-cpu_py311_hdd49dfd_nompi_1.conda
linux-64::lammps-2023.11.21-cuda118_py311_h9b6f9d6_mpi_openmpi_5.conda
linux-64::lammps-2023.11.21-cpu_py39_h827286f_mpi_openmpi_0.conda
linux-64::lammps-2023.11.21-cuda118_py38_hc73eb01_mpi_openmpi_5.conda
linux-64::lammps-2023.11.21-cpu_py39_hade46e7_mpi_openmpi_4.conda
linux-64::lammps-2023.11.21-cpu_py39_h5b957dd_nompi_1.conda
linux-64::lammps-2023.08.02-cpu_py38_h459ef18_mpich_0.conda
linux-64::lammps-2023.11.21-cpu_py39_h827286f_mpi_openmpi_2.conda
linux-64::lammps-2023.11.21-cuda118_py38_hc73eb01_mpi_openmpi_0.conda
linux-64::lammps-2023.08.02-cuda118_py39_h1a54f2e_nompi_8.conda
linux-64::lammps-2023.11.21-cuda118_py39_h14e8439_mpi_mpich_5.conda
linux-64::lammps-2023.11.21-cuda118_py39_h5417483_nompi_2.conda
linux-64::lammps-2023.08.02-cpu_py310_h4b5e8b3_openmpi_0.conda
linux-64::lammps-2023.08.02-cpu_py310_h6204e05_openmpi_7.conda
linux-64::lammps-2023.08.02-cpu_py39_hf042188_nompi_8.conda
linux-64::lammps-2023.11.21-cpu_py38_hda8f861_mpi_mpich_3.conda
linux-64::lammps-2023.11.21-cpu_py39_hade46e7_mpi_openmpi_3.conda
linux-64::lammps-2023.11.21-cpu_py39_hade46e7_mpi_openmpi_0.conda
linux-64::lammps-2023.11.21-cpu_py38_h5608ceb_nompi_4.conda
linux-64::lammps-2023.11.21-cpu_py39_hefd3d5c_mpi_mpich_4.conda
linux-64::lammps-2023.11.21-cuda118_py38_he846794_nompi_2.conda
linux-64::lammps-2023.11.21-cuda118_py310_hadf4ee5_nompi_4.conda
linux-64::lammps-2023.08.02-cpu_py39_h4b07ac6_openmpi_1.conda
linux-64::lammps-2023.11.21-cpu_py39_hade46e7_mpi_openmpi_1.conda
linux-64::lammps-2023.11.21-cpu_py39_hf042188_nompi_2.conda
linux-64::lammps-2023.11.21-cpu_py311_hdd49dfd_nompi_0.conda
linux-64::lammps-2023.11.21-cuda118_py39_h1a54f2e_nompi_2.conda
linux-64::lammps-2023.08.02-cpu_py39_h00752c8_mpich_1.conda
linux-64::lammps-2023.11.21-cpu_py311_hdd49dfd_nompi_4.conda
linux-64::lammps-2023.11.21-cuda118_py39_h43d3bb2_mpi_openmpi_0.conda
linux-64::lammps-2023.08.02-cpu_py310_hcea6fc9_mpi_openmpi_8.conda
linux-64::lammps-2023.11.21-cuda118_py39_h097bc08_mpi_mpich_3.conda
linux-64::lammps-2023.11.21-cpu_py311_hd3d4698_mpi_mpich_0.conda
linux-64::lammps-2023.11.21-cpu_py311_hbb7bd43_mpi_openmpi_1.conda
linux-64::lammps-2023.11.21-cuda118_py311_hdd7c1f1_mpi_mpich_2.conda
linux-64::lammps-2023.11.21-cpu_py311_hbb7bd43_mpi_openmpi_0.conda
linux-64::lammps-2023.08.02-cpu_py311_hdd49dfd_nompi_7.conda
linux-64::lammps-2023.11.21-cpu_py310_h5b57e7a_nompi_0.conda
linux-64::lammps-2023.08.02-cpu_py310_hf267ffc_mpich_0.conda
linux-64::lammps-2023.11.21-cuda118_py310_hadf4ee5_nompi_0.conda
linux-64::lammps-2023.11.21-cuda118_py310_h077d75c_mpi_mpich_5.conda
linux-64::lammps-2023.11.21-cpu_py310_h5b57e7a_nompi_4.conda
linux-64::lammps-2023.11.21-cuda118_py310_h483aaed_mpi_openmpi_4.conda
linux-64::lammps-2023.11.21-cuda118_py39_h1a54f2e_nompi_1.conda
linux-64::lammps-2023.08.02-cpu_py39_ha38254e_openmpi_7.conda
linux-64::lammps-2023.08.02-cpu_py39_hc9765a9_mpich_7.conda
linux-64::lammps-2023.11.21-cuda118_py38_h80d1e08_mpi_mpich_2.conda
linux-64::lammps-2023.08.02-cpu_py39_h7e86899_mpi_mpich_7.conda
linux-64::lammps-2023.11.21-cpu_py310_h5b57e7a_nompi_3.conda
linux-64::lammps-2023.08.02-cpu_py38_hda8f861_mpi_mpich_8.conda
linux-64::lammps-2023.08.02-cpu_py39_h2a3f179_openmpi_7.conda
linux-64::lammps-2023.11.21-cpu_py310_h8f80a90_mpi_mpich_0.conda
linux-64::lammps-2023.11.21-cpu_py39_h5b957dd_nompi_5.conda
linux-64::lammps-2023.11.21-cuda118_py39_h4a9cbaf_mpi_openmpi_3.conda
linux-64::lammps-2023.08.02-cpu_py38_h459ef18_mpich_1.conda
linux-64::lammps-2023.11.21-cuda118_py311_h0edc3ef_mpi_mpich_1.conda
linux-64::lammps-2023.11.21-cpu_py310_h8f80a90_mpi_mpich_2.conda
linux-64::lammps-2023.08.02-cuda118_py38_hc73eb01_mpi_openmpi_8.conda
linux-64::lammps-2023.11.21-cuda118_py311_h9b6f9d6_mpi_openmpi_3.conda
linux-64::lammps-2023.11.21-cuda118_py311_hc5820a9_mpi_openmpi_0.conda
linux-64::lammps-2023.11.21-cuda118_py39_hf8afb37_nompi_5.conda
linux-64::lammps-2023.11.21-cuda118_py39_h4a9cbaf_mpi_openmpi_4.conda
linux-64::lammps-2023.11.21-cuda118_py38_h80d1e08_mpi_mpich_4.conda
linux-64::lammps-2023.08.02-cpu_py39_h827286f_mpi_openmpi_8.conda
linux-64::lammps-2023.11.21-cuda118_py311_h80f0500_nompi_0.conda
linux-64::lammps-2023.11.21-cuda118_py39_h43d3bb2_mpi_openmpi_2.conda
linux-64::lammps-2023.11.21-cpu_py39_h7e86899_mpi_mpich_2.conda
linux-64::lammps-2023.08.02-cpu_py38_h71b0944_openmpi_0.conda
linux-64::lammps-2023.08.02-cpu_py310_hcea6fc9_mpi_openmpi_7.conda
linux-64::lammps-2023.11.21-cuda118_py39_hdd7f1a5_mpi_mpich_2.conda
linux-64::lammps-2023.11.21-cuda118_py39_h0d794d2_mpi_openmpi_3.conda
linux-64::lammps-2023.11.21-cpu_py311_hdd49dfd_nompi_5.conda
linux-64::lammps-2023.11.21-cpu_py310_h5b57e7a_nompi_1.conda
linux-64::lammps-2023.11.21-cpu_py38_hda8f861_mpi_mpich_1.conda
linux-64::lammps-2023.11.21-cpu_py39_hefd3d5c_mpi_mpich_2.conda
linux-64::lammps-2023.11.21-cpu_py39_hf042188_nompi_0.conda
linux-64::lammps-2023.11.21-cuda118_py39_h097bc08_mpi_mpich_2.conda
linux-64::lammps-2023.11.21-cpu_py39_h5b957dd_nompi_3.conda
linux-64::lammps-2023.08.02-cpu_py311_h4aafb77_mpich_0.conda
linux-64::lammps-2023.11.21-cuda118_py39_hcae4e68_mpi_mpich_0.conda
linux-64::lammps-2023.08.02-cpu_py311_hd3d4698_mpi_mpich_7.conda
linux-64::lammps-2023.11.21-cuda118_py310_h077d75c_mpi_mpich_3.conda
linux-64::lammps-2023.11.21-cuda118_py38_h6de3bbc_mpi_mpich_3.conda
linux-64::lammps-2023.08.02-cpu_py39_h5b957dd_nompi_7.conda
linux-64::lammps-2023.11.21-cuda118_py38_h0bd2086_nompi_1.conda
linux-64::lammps-2023.08.02-cpu_py38_hde207a7_mpi_openmpi_8.conda
linux-64::lammps-2023.11.21-cuda118_py38_he846794_nompi_0.conda
linux-64::lammps-2023.11.21-cuda118_py39_h43d3bb2_mpi_openmpi_5.conda
linux-64::lammps-2023.11.21-cuda118_py39_h0d794d2_mpi_openmpi_4.conda
linux-64::lammps-2023.11.21-cpu_py39_h7e86899_mpi_mpich_0.conda
linux-64::lammps-2023.11.21-cpu_py39_hf042188_nompi_3.conda
linux-64::lammps-2023.11.21-cuda118_py39_h1a54f2e_nompi_0.conda
linux-64::lammps-2023.11.21-cuda118_py39_hf8afb37_nompi_3.conda
linux-64::lammps-2023.11.21-cuda118_py39_h1a54f2e_nompi_4.conda
linux-64::lammps-2023.08.02-cuda118_py38_h0bd2086_nompi_8.conda
linux-64::lammps-2023.08.02-cpu_py38_h297bd8b_mpich_0.conda
linux-64::lammps-2023.11.21-cuda118_py39_h43d3bb2_mpi_openmpi_4.conda
linux-64::lammps-2023.08.02-cpu_py311_hbb7bd43_mpi_openmpi_7.conda
linux-64::lammps-2023.11.21-cuda118_py39_hf2cf36d_nompi_3.conda
linux-64::lammps-2023.11.21-cpu_py310_h8f80a90_mpi_mpich_5.conda
linux-64::lammps-2023.11.21-cpu_py310_h8f80a90_mpi_mpich_1.conda
linux-64::lammps-2023.11.21-cpu_py311_hd3d4698_mpi_mpich_3.conda
linux-64::lammps-2023.11.21-cuda118_py311_h80f0500_nompi_5.conda
linux-64::lammps-2023.11.21-cuda118_py39_h4a9cbaf_mpi_openmpi_1.conda
linux-64::lammps-2023.11.21-cuda118_py310_h077d75c_mpi_mpich_4.conda
linux-64::lammps-2023.11.21-cpu_py38_hda8f861_mpi_mpich_4.conda
linux-64::lammps-2023.11.21-cuda118_py310_h7730a0c_nompi_1.conda
linux-64::lammps-2023.11.21-cuda118_py311_h9b6f9d6_mpi_openmpi_4.conda
linux-64::lammps-2023.11.21-cpu_py39_h7e86899_mpi_mpich_1.conda
linux-64::lammps-2023.11.21-cpu_py311_hbb7bd43_mpi_openmpi_4.conda
linux-64::lammps-2023.11.21-cuda118_py311_hdd7c1f1_mpi_mpich_4.conda
linux-64::lammps-2023.08.02-cpu_py39_h827286f_mpi_openmpi_7.conda
linux-64::lammps-2023.11.21-cpu_py310_h5b57e7a_nompi_2.conda
linux-64::lammps-2023.11.21-cpu_py38_h5608ceb_nompi_0.conda
linux-64::lammps-2023.11.21-cpu_py38_h5608ceb_nompi_3.conda
linux-64::lammps-2023.11.21-cpu_py38_hde207a7_mpi_openmpi_2.conda
linux-64::lammps-2023.11.21-cuda118_py311_hc5820a9_mpi_openmpi_2.conda
linux-64::lammps-2023.11.21-cuda118_py38_he846794_nompi_5.conda
linux-64::lammps-2023.11.21-cpu_py39_h5b957dd_nompi_4.conda
linux-64::lammps-2023.08.02-cpu_py311_hb661868_openmpi_1.conda
linux-64::lammps-2023.11.21-cuda118_py311_h9b6f9d6_mpi_openmpi_1.conda
linux-64::lammps-2023.11.21-cpu_py38_hde207a7_mpi_openmpi_0.conda
linux-64::lammps-2023.11.21-cuda118_py38_h80d1e08_mpi_mpich_5.conda
linux-64::lammps-2023.08.02-cpu_py39_h4b07ac6_openmpi_0.conda
linux-64::lammps-2023.08.02-cpu_py311_hb661868_openmpi_0.conda
linux-64::lammps-2023.11.21-cpu_py311_hd3d4698_mpi_mpich_1.conda
linux-64::lammps-2023.08.02-cuda118_py311_h80f0500_nompi_8.conda
linux-64::lammps-2023.11.21-cuda118_py310_h5811056_mpi_openmpi_5.conda
linux-64::lammps-2023.11.21-cuda118_py39_hf8afb37_nompi_4.conda
linux-64::lammps-2023.11.21-cpu_py310_hcea6fc9_mpi_openmpi_4.conda
linux-64::lammps-2023.11.21-cuda118_py311_h96326dd_nompi_4.conda
linux-64::lammps-2023.11.21-cuda118_py38_h80d1e08_mpi_mpich_0.conda
linux-64::lammps-2023.08.02-cuda118_py39_hcae4e68_mpi_mpich_8.conda
linux-64::lammps-2023.11.21-cpu_py310_hcea6fc9_mpi_openmpi_5.conda
linux-64::lammps-2023.08.02-cuda118_py38_he846794_nompi_8.conda
linux-64::lammps-2023.11.21-cuda118_py310_h38e9743_mpi_mpich_1.conda
linux-64::lammps-2023.11.21-cuda118_py38_h9c5a0ec_mpi_openmpi_3.conda
linux-64::lammps-2023.08.02-cpu_py39_h2595f3c_mpich_0.conda
linux-64::lammps-2023.08.02-cpu_py39_hade46e7_mpi_openmpi_8.conda
linux-64::lammps-2023.11.21-cuda118_py310_h5811056_mpi_openmpi_4.conda
linux-64::lammps-2023.08.02-cpu_py310_h5b57e7a_nompi_8.conda
linux-64::lammps-2023.11.21-cuda118_py310_h7730a0c_nompi_2.conda
linux-64::lammps-2023.11.21-cuda118_py39_h1a54f2e_nompi_5.conda
linux-64::lammps-2023.08.02-cpu_py311_hd3d4698_mpi_mpich_8.conda
linux-64::lammps-2023.11.21-cpu_py38_hde207a7_mpi_openmpi_1.conda
linux-64::lammps-2023.08.02-cuda118_py310_h5811056_mpi_openmpi_8.conda
linux-64::lammps-2023.11.21-cuda118_py39_h14e8439_mpi_mpich_3.conda
linux-64::lammps-2023.11.21-cuda118_py311_h80f0500_nompi_2.conda
linux-64::lammps-2023.11.21-cuda118_py310_h38e9743_mpi_mpich_4.conda
linux-64::lammps-2023.11.21-cuda118_py39_hcae4e68_mpi_mpich_5.conda
linux-64::lammps-2023.08.02-cpu_py311_hf0e8f25_openmpi_7.conda
linux-64::lammps-2023.11.21-cpu_py311_hd3d4698_mpi_mpich_4.conda
linux-64::lammps-2023.08.02-cpu_py39_hefd3d5c_mpi_mpich_7.conda
+    "libpnetcdf ==1.12.3",
linux-64::lammps-2024.02.07-cuda118_py39_h801ebdd_nompi_2.conda
linux-64::lammps-2024.02.07-cpu_py39_h5aa9b76_nompi_2.conda
linux-64::lammps-2024.02.07-cpu_py310_hf457879_mpi_openmpi_2.conda
linux-64::lammps-2024.02.07-cuda118_py39_h5f97003_mpi_openmpi_2.conda
linux-64::lammps-2024.02.07-cuda118_py312_hdb6c1cb_mpi_mpich_2.conda
linux-64::lammps-2024.02.07-cuda118_py311_h0e65721_mpi_mpich_2.conda
linux-64::lammps-2024.02.07-cpu_py39_h4e97e3b_nompi_2.conda
linux-64::lammps-2024.02.07-cpu_py38_h4017397_nompi_2.conda
linux-64::lammps-2024.02.07-cpu_py311_h62f0ee3_nompi_2.conda
linux-64::lammps-2024.02.07-cuda118_py38_h7a9daa6_nompi_2.conda
linux-64::lammps-2024.02.07-cpu_py312_hf908f8c_mpi_openmpi_2.conda
linux-64::lammps-2024.02.07-cuda118_py312_h7aed2fd_nompi_2.conda
linux-64::lammps-2024.02.07-cpu_py312_hefd82b6_nompi_2.conda
linux-64::lammps-2024.02.07-cuda118_py310_h24fc79f_mpi_mpich_2.conda
linux-64::lammps-2024.02.07-cpu_py39_hd7917fe_mpi_openmpi_2.conda
linux-64::lammps-2024.02.07-cpu_py311_h0468192_mpi_openmpi_2.conda
linux-64::lammps-2024.02.07-cuda118_py39_h753bda8_mpi_openmpi_2.conda
linux-64::lammps-2024.02.07-cpu_py38_h31f1afe_mpi_mpich_2.conda
linux-64::lammps-2024.02.07-cuda118_py312_h9ab9060_mpi_openmpi_2.conda
linux-64::lammps-2024.02.07-cpu_py38_hc85b0c9_mpi_openmpi_2.conda
linux-64::lammps-2024.02.07-cuda118_py38_h9390d2f_mpi_openmpi_2.conda
linux-64::lammps-2024.02.07-cuda118_py39_hdffd256_nompi_2.conda
linux-64::lammps-2024.02.07-cuda118_py39_h37c86b2_mpi_mpich_2.conda
linux-64::lammps-2024.02.07-cpu_py310_h6fbc829_nompi_2.conda
linux-64::lammps-2024.02.07-cpu_py39_h8f18a96_mpi_mpich_2.conda
linux-64::lammps-2024.02.07-cpu_py39_h859596b_mpi_mpich_2.conda
linux-64::lammps-2024.02.07-cpu_py311_h3dcc12e_mpi_mpich_2.conda
linux-64::lammps-2024.02.07-cpu_py312_h5c756f9_mpi_mpich_2.conda
linux-64::lammps-2024.02.07-cuda118_py39_h3f7a61f_mpi_mpich_2.conda
linux-64::lammps-2024.02.07-cuda118_py311_h6406a08_nompi_2.conda
linux-64::lammps-2024.02.07-cuda118_py38_h4110e68_mpi_mpich_2.conda
linux-64::lammps-2024.02.07-cpu_py310_h580d745_mpi_mpich_2.conda
linux-64::lammps-2024.02.07-cpu_py39_h88df724_mpi_openmpi_2.conda
linux-64::lammps-2024.02.07-cuda118_py310_hb2d6157_nompi_2.conda
linux-64::lammps-2024.02.07-cuda118_py311_ha6fdadd_mpi_openmpi_2.conda
linux-64::lammps-2024.02.07-cuda118_py310_h461fbb2_mpi_openmpi_2.conda
+    "libpnetcdf ==1.13.0",
```