### PR TITLE
GPU versions of lightgbm should depend on cuda

### DIFF
--- a/recipe/patch_yaml/lightgbm.yaml
+++ b/recipe/patch_yaml/lightgbm.yaml
@@ -1,0 +1,7 @@
+if:
+  name: lightgbm
+  version: 4.4.0
+  has_depends: cudatoolkit*
+  timestamp_lt: 1720034169000
+then:
+  - add_depends: __cuda


### PR DESCRIPTION
This fixes https://github.com/conda-forge/lightgbm-feedstock/issues/57

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

```
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-ppc64le
linux-ppc64le::lightgbm-4.4.0-cuda_py3.10heec9851_2.conda
linux-ppc64le::lightgbm-4.4.0-cuda_py3.9h1ed5323_2.conda
linux-ppc64le::lightgbm-4.4.0-cuda_py3.12h8aee507_2.conda
linux-ppc64le::lightgbm-4.4.0-cuda_py3.8hde3c7a3_2.conda
linux-ppc64le::lightgbm-4.4.0-cuda_py3.11hc51090e_2.conda
+    "__cuda",
================================================================================
================================================================================
linux-aarch64
linux-aarch64::lightgbm-4.4.0-cuda_py3.11he0bac36_2.conda
linux-aarch64::lightgbm-4.4.0-cuda_py3.12h3142daa_2.conda
linux-aarch64::lightgbm-4.4.0-cuda_py3.8hfa6eae1_2.conda
linux-aarch64::lightgbm-4.4.0-cuda_py3.10h72681ff_2.conda
linux-aarch64::lightgbm-4.4.0-cuda_py3.9h453dfd6_2.conda
+    "__cuda",
================================================================================
================================================================================
noarch
================================================================================
================================================================================
win-64
================================================================================
================================================================================
================================================================================
================================================================================
linux-64
linux-64::lightgbm-4.4.0-cuda_py3.11h2c6edaf_2.conda
linux-64::lightgbm-4.4.0-cuda_py3.9h6461835_2.conda
linux-64::lightgbm-4.4.0-cuda_py3.8haafc6ae_2.conda
linux-64::lightgbm-4.4.0-cuda_py3.10hda4ad70_2.conda
linux-64::lightgbm-4.4.0-cuda_py3.12h6952350_2.conda
+    "__cuda",
```