### PR TITLE
add lower pins for jupyter_server 2.14.*

### DIFF
--- a/recipe/patch_yaml/jupyter_server.yaml
+++ b/recipe/patch_yaml/jupyter_server.yaml
@@ -6,3 +6,31 @@ then:
   - tighten_depends:
       name: anyio
       upper_bound: "4"
+---
+# backport of https://github.com/conda-forge/jupyter_server-feedstock/pull/156
+if:
+  name: jupyter_server
+  version: 2.14.*
+  timestamp_lt: 1720533911000
+then:
+  - replace_depends:
+      old: argon2-cffi
+      new: argon2-cffi >=21.1
+  - replace_depends:
+      old: jinja2
+      new: jinja2 >=3.0.3
+  - replace_depends:
+      old: jupyter_server_terminals
+      new: jupyter_server_terminals >=0.4.4
+  - replace_depends:
+      old: overrides
+      new: overrides >=5.0
+  - replace_depends:
+      old: packaging
+      new: packaging >=22.0
+  - replace_depends:
+      old: prometheus_client
+      new: prometheus_client >=0.9
+  - replace_depends:
+      old: websocket-client
+      new: websocket-client >=1.7


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->



references:
- https://github.com/conda-forge/jupyter_server-feedstock/pull/156 by @danielhollas
- @conda-forge/jupyter_server

```diff
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
noarch
noarch::jupyter_server-2.14.0-pyhd8ed1ab_0.conda
noarch::jupyter_server-2.14.1-pyhd8ed1ab_0.conda
-    "argon2-cffi",
-    "jinja2",
+    "argon2-cffi >=21.1",
+    "jinja2 >=3.0.3",
-    "jupyter_server_terminals",
+    "jupyter_server_terminals >=0.4.4",
-    "overrides",
-    "packaging",
-    "prometheus_client",
+    "overrides >=5.0",
+    "packaging >=22.0",
+    "prometheus_client >=0.9",
-    "websocket-client"
+    "websocket-client >=1.7"
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
================================================================================
================================================================================
linux-64
```