### PR TITLE
scanpy v1.10.2 requires numpy<2

### DIFF
--- a/recipe/patch_yaml/scanpy.yaml
+++ b/recipe/patch_yaml/scanpy.yaml
@@ -1,0 +1,10 @@
+# add constrating on numpy <2.0
+if:
+  name: scanpy
+  version: 1.10.2
+  timestamp_lt: 1720623323000
+  build_number: 0
+then:
+  - replace_depends:
+      old: numpy >=1.23
+      new: numpy >=1.23,<2


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

<details>
<summary>Show Diff Result</summary>

```txt
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
noarch
noarch::scanpy-1.10.2-pyhd8ed1ab_0.conda
-    "numpy >=1.23",
+    "numpy >=1.23,<2",
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
================================================================================
================================================================================
linux-64
linux-64::libcxx-18.1.8-h84d6215_0.conda
-{
-  "build": "h84d6215_0",
-  "build_number": 0,
-  "constrains": [
-    "sysroot_linux-64 >=2.17"
-  ],
-  "depends": [
-    "__glibc >=2.17,<3.0.a0",
-    "libcxxabi 18.1.8 ha4b6fd6_0",
-    "libgcc-ng >=13"
-  ],
-  "license": "Apache-2.0 WITH LLVM-exception",
-  "md5": "f61d78c788ab0957365cc50efca9c877",
-  "name": "libcxx",
-  "sha256": "7bc69e74fcc068977c24aa0758de367a70d6d55184b91c9fd7adf5ab930dce4d",
-  "size": 1432097,
-  "subdir": "linux-64",
-  "timestamp": 1720589469670,
-  "version": "18.1.8"
-}
+{}
linux-64::libcxxabi-18.1.8-ha4b6fd6_0.conda
-{
-  "build": "ha4b6fd6_0",
-  "build_number": 0,
-  "depends": [
-    "__glibc >=2.17,<3.0.a0",
-    "libunwind 18.1.8 ha4b6fd6_0"
-  ],
-  "license": "Apache-2.0 WITH LLVM-exception",
-  "md5": "fb398f8c6cf791e8c9436c87786a2f14",
-  "name": "libcxxabi",
-  "sha256": "3c1bf6c78c0f0e7892d40069565110b78b16aaabf66eb1fb22a9b5bf17d6cdb9",
-  "size": 157788,
-  "subdir": "linux-64",
-  "timestamp": 1720589461357,
-  "version": "18.1.8"
-}
+{}
```
</details>
