### PR TITLE
Fix a few recent mistakes in Pytensor

### DIFF
--- a/recipe/patch_yaml/pytensor.yaml
+++ b/recipe/patch_yaml/pytensor.yaml
@@ -8,7 +8,9 @@ then:
       name: numpy
       upper_bound: '1.26'
 ---
+# Updated the build/host deps but forgot the run deps.
 # <https://github.com/conda-forge/pytensor-suite-feedstock/issues/109>
+# Fixed in <https://github.com/conda-forge/pytensor-suite-feedstock/pull/108/files>
 if:
   name: pytensor-base
   version_ge: '2.24'
@@ -21,6 +23,7 @@ then:
 ---
 # Due to a skipped verison I merged a recipe update when the corresponding
 # dependency update was in a failed PR for the skipped version.
+# Fixed in <https://github.com/conda-forge/pytensor-suite-feedstock/pull/114>
 if:
   name: pytensor-base
   timestamp_lt: 1720687870000

--- a/recipe/patch_yaml/pytensor.yaml
+++ b/recipe/patch_yaml/pytensor.yaml
@@ -1,9 +1,32 @@
 if:
   name: pytensor-base
-  version_le: 2.16.1
+  version_le: '2.16.1'
   timestamp_lt: 1695061975000
   has_depends: numpy*
 then:
   - tighten_depends:
       name: numpy
       upper_bound: '1.26'
+---
+# <https://github.com/conda-forge/pytensor-suite-feedstock/issues/109>
+if:
+  name: pytensor-base
+  version_ge: '2.24'
+  version_le: '2.25'
+  timestamp_lt: 1720687870000
+then:
+  - replace_depends:
+      old: setuptools >=48.0.0
+      new: setuptools >=59.0.0
+---
+# Due to a skipped verison I merged a recipe update when the corresponding
+# dependency update was in a failed PR for the skipped version.
+if:
+  name: pytensor-base
+  timestamp_lt: 1720687870000
+  version_eq: '2.25.1'
+  build_number_eq: 0
+then:
+  - replace_depends:
+      old: filelock
+      new: filelock >=3.15


### PR DESCRIPTION
Checklist

* [X] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [X] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [X] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [X] Ran `python show_diff.py` and posted the output as part of the PR.
* [X] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

<details>

<summary>
show_diff output
</summary>

```diff
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
osx-arm64
osx-arm64::pytensor-base-2.24.1-py310hd4a36ba_0.conda
osx-arm64::pytensor-base-2.24.0-py312h2b2a681_0.conda
osx-arm64::pytensor-base-2.24.1-py311h0111b8e_0.conda
osx-arm64::pytensor-base-2.24.0-py311h0111b8e_0.conda
osx-arm64::pytensor-base-2.24.1-py312h2b2a681_0.conda
osx-arm64::pytensor-base-2.24.0-py310hd4a36ba_0.conda
-    "setuptools >=48.0.0"
+    "setuptools >=59.0.0"
osx-arm64::pytensor-base-2.25.1-py310hd4a36ba_0.conda
osx-arm64::pytensor-base-2.25.1-py312h2b2a681_0.conda
osx-arm64::pytensor-base-2.25.1-py311h0111b8e_0.conda
-    "filelock",
+    "filelock >=3.15",
================================================================================
================================================================================
linux-aarch64
linux-aarch64::pytensor-base-2.24.1-py310hf8cab0a_0.conda
linux-aarch64::pytensor-base-2.24.0-py310hf8cab0a_0.conda
linux-aarch64::pytensor-base-2.24.0-py311hfcadd50_0.conda
linux-aarch64::pytensor-base-2.24.0-py312h2f6e47d_0.conda
linux-aarch64::pytensor-base-2.24.1-py311hfcadd50_0.conda
linux-aarch64::pytensor-base-2.24.1-py312h2f6e47d_0.conda
-    "setuptools >=48.0.0"
+    "setuptools >=59.0.0"
linux-aarch64::pytensor-base-2.25.1-py312h2f6e47d_0.conda
linux-aarch64::pytensor-base-2.25.1-py311hfcadd50_0.conda
linux-aarch64::pytensor-base-2.25.1-py310hf8cab0a_0.conda
-    "filelock",
+    "filelock >=3.15",
================================================================================
================================================================================
noarch
================================================================================
================================================================================
win-64
win-64::pytensor-base-2.24.0-py312hd2403df_0.conda
win-64::pytensor-base-2.24.0-py311hbc92ba2_0.conda
win-64::pytensor-base-2.24.1-py312hd2403df_0.conda
win-64::pytensor-base-2.24.1-py311hbc92ba2_0.conda
win-64::pytensor-base-2.24.0-py310hbbd805c_0.conda
win-64::pytensor-base-2.24.1-py310hbbd805c_0.conda
-    "setuptools >=48.0.0",
+    "setuptools >=59.0.0",
win-64::pytensor-base-2.25.1-py312hd2403df_0.conda
win-64::pytensor-base-2.25.1-py310hbbd805c_0.conda
win-64::pytensor-base-2.25.1-py311hbc92ba2_0.conda
-    "filelock",
+    "filelock >=3.15",
================================================================================
================================================================================
osx-64
osx-64::awscli-2.17.12-py310h2ec42d9_0.conda
-{
-  "build": "py310h2ec42d9_0",
-  "build_number": 0,
-  "depends": [
-    "awscrt >=0.19.18,<=0.20.11",
-    "colorama >=0.2.5,<0.4.7",
-    "cryptography >=3.3.2,<=40.0.2",
-    "distro >=1.5.0,<1.9.0",
-    "docutils >=0.10,<0.20",
-    "jmespath >=0.7.1,<1.1.0",
-    "prompt_toolkit >=3.0.24,<3.0.39",
-    "pyopenssl <23.2",
-    "python >=3.10,<3.11.0a0",
-    "python-dateutil >=2.1,<=2.8.2",
-    "python_abi 3.10.* *_cp310",
-    "ruamel.yaml >=0.15.0,<=0.17.21",
-    "ruamel.yaml.clib >=0.2.0,<=0.2.7",
-    "urllib3 >=1.25.4,<1.27"
-  ],
-  "license": "Apache-2.0",
-  "md5": "2dfb768b05119d3ee0426c578b481497",
-  "name": "awscli",
-  "sha256": "6555ecc10a13f4231846e002df581c733ca050039f115075a050b16b98b00b46",
-  "size": 12049522,
-  "subdir": "osx-64",
-  "timestamp": 1720683151833,
-  "version": "2.17.12"
-}
+{}
osx-64::awscli-2.17.12-py311h6eed73b_0.conda
-{
-  "build": "py311h6eed73b_0",
-  "build_number": 0,
-  "depends": [
-    "awscrt >=0.19.18,<=0.20.11",
-    "colorama >=0.2.5,<0.4.7",
-    "cryptography >=3.3.2,<=40.0.2",
-    "distro >=1.5.0,<1.9.0",
-    "docutils >=0.10,<0.20",
-    "jmespath >=0.7.1,<1.1.0",
-    "prompt_toolkit >=3.0.24,<3.0.39",
-    "pyopenssl <23.2",
-    "python >=3.11,<3.12.0a0",
-    "python-dateutil >=2.1,<=2.8.2",
-    "python_abi 3.11.* *_cp311",
-    "ruamel.yaml >=0.15.0,<=0.17.21",
-    "ruamel.yaml.clib >=0.2.0,<=0.2.7",
-    "urllib3 >=1.25.4,<1.27"
-  ],
-  "license": "Apache-2.0",
-  "md5": "2e641ddb466b630bc24f754c4da5829f",
-  "name": "awscli",
-  "sha256": "dfb03f1aafd4698b3de7f2084936f526605f066946a21879124e70bba50d42ee",
-  "size": 12531215,
-  "subdir": "osx-64",
-  "timestamp": 1720683163667,
-  "version": "2.17.12"
-}
+{}
osx-64::awscli-2.17.12-py312hb401068_0.conda
-{
-  "build": "py312hb401068_0",
-  "build_number": 0,
-  "depends": [
-    "awscrt >=0.19.18,<=0.20.11",
-    "colorama >=0.2.5,<0.4.7",
-    "cryptography >=3.3.2,<=40.0.2",
-    "distro >=1.5.0,<1.9.0",
-    "docutils >=0.10,<0.20",
-    "jmespath >=0.7.1,<1.1.0",
-    "prompt_toolkit >=3.0.24,<3.0.39",
-    "pyopenssl <23.2",
-    "python >=3.12,<3.13.0a0",
-    "python-dateutil >=2.1,<=2.8.2",
-    "python_abi 3.12.* *_cp312",
-    "ruamel.yaml >=0.15.0,<=0.17.21",
-    "ruamel.yaml.clib >=0.2.0,<=0.2.7",
-    "urllib3 >=1.25.4,<1.27"
-  ],
-  "license": "Apache-2.0",
-  "md5": "fe7af90fd727efd8543df5c2fdf3e71f",
-  "name": "awscli",
-  "sha256": "b70863d7f17dd418012c37e6f17859e95d1b17ad321aa983965e0f9a1e9ed5f4",
-  "size": 12454425,
-  "subdir": "osx-64",
-  "timestamp": 1720683161166,
-  "version": "2.17.12"
-}
+{}
osx-64::awscli-2.17.12-py38h50d1736_0.conda
-{
-  "build": "py38h50d1736_0",
-  "build_number": 0,
-  "depends": [
-    "awscrt >=0.19.18,<=0.20.11",
-    "colorama >=0.2.5,<0.4.7",
-    "cryptography >=3.3.2,<=40.0.2",
-    "distro >=1.5.0,<1.9.0",
-    "docutils >=0.10,<0.20",
-    "jmespath >=0.7.1,<1.1.0",
-    "prompt_toolkit >=3.0.24,<3.0.39",
-    "pyopenssl <23.2",
-    "python >=3.8,<3.9.0a0",
-    "python-dateutil >=2.1,<=2.8.2",
-    "python_abi 3.8.* *_cp38",
-    "ruamel.yaml >=0.15.0,<=0.17.21",
-    "ruamel.yaml.clib >=0.2.0,<=0.2.7",
-    "urllib3 >=1.25.4,<1.27"
-  ],
-  "license": "Apache-2.0",
-  "md5": "b84ac6558c304ddba892f012c7eb0242",
-  "name": "awscli",
-  "sha256": "861b7884bcf672da89d71cfe2ef9edc73baa10c5d1d45261fd3d9d2c70f93488",
-  "size": 12016094,
-  "subdir": "osx-64",
-  "timestamp": 1720683264941,
-  "version": "2.17.12"
-}
+{}
osx-64::awscli-2.17.12-py39h43b90dd_0.conda
-{
-  "build": "py39h43b90dd_0",
-  "build_number": 0,
-  "depends": [
-    "awscrt >=0.19.18,<=0.20.11",
-    "colorama >=0.2.5,<0.4.7",
-    "cryptography >=3.3.2,<=40.0.2",
-    "distro >=1.5.0,<1.9.0",
-    "docutils >=0.10,<0.20",
-    "jmespath >=0.7.1,<1.1.0",
-    "prompt_toolkit >=3.0.24,<3.0.39",
-    "pyopenssl <23.2",
-    "pypy3.9 >=7.3.15",
-    "python >=3.9,<3.10.0a0",
-    "python-dateutil >=2.1,<=2.8.2",
-    "python_abi 3.9 *_pypy39_pp73",
-    "ruamel.yaml >=0.15.0,<=0.17.21",
-    "ruamel.yaml.clib >=0.2.0,<=0.2.7",
-    "urllib3 >=1.25.4,<1.27"
-  ],
-  "license": "Apache-2.0",
-  "md5": "06114152216ce4ec4dda073c378ee653",
-  "name": "awscli",
-  "sha256": "cad14e48d21617539ea9cdecced8a2312d63bd0b78d6182455884dab71dce3b6",
-  "size": 12036107,
-  "subdir": "osx-64",
-  "timestamp": 1720683396780,
-  "version": "2.17.12"
-}
+{}
osx-64::awscli-2.17.12-py39h6e9494a_0.conda
-{
-  "build": "py39h6e9494a_0",
-  "build_number": 0,
-  "depends": [
-    "awscrt >=0.19.18,<=0.20.11",
-    "colorama >=0.2.5,<0.4.7",
-    "cryptography >=3.3.2,<=40.0.2",
-    "distro >=1.5.0,<1.9.0",
-    "docutils >=0.10,<0.20",
-    "jmespath >=0.7.1,<1.1.0",
-    "prompt_toolkit >=3.0.24,<3.0.39",
-    "pyopenssl <23.2",
-    "python >=3.9,<3.10.0a0",
-    "python-dateutil >=2.1,<=2.8.2",
-    "python_abi 3.9.* *_cp39",
-    "ruamel.yaml >=0.15.0,<=0.17.21",
-    "ruamel.yaml.clib >=0.2.0,<=0.2.7",
-    "urllib3 >=1.25.4,<1.27"
-  ],
-  "license": "Apache-2.0",
-  "md5": "3c75991f965aa57d64c5f8f2afd13f52",
-  "name": "awscli",
-  "sha256": "8c4dbbf50d702bb34690e171d2158d8a2ad0528558172d3371baa2329b7d7379",
-  "size": 12009748,
-  "subdir": "osx-64",
-  "timestamp": 1720683330647,
-  "version": "2.17.12"
-}
+{}
osx-64::openmpi-5.0.3-h62bb914_110.conda
-{
-  "build": "h62bb914_110",
-  "build_number": 110,
-  "depends": [
-    "__osx >=10.13",
-    "libcxx >=16",
-    "libevent >=2.1.12,<2.1.13.0a0",
-    "libgfortran 5.*",
-    "libgfortran5 >=12.3.0",
-    "libgfortran5 >=13.2.0",
-    "libhwloc >=2.11.1,<2.11.2.0a0",
-    "libzlib >=1.3.1,<2.0a0",
-    "mpi 1.0 openmpi"
-  ],
-  "license": "BSD-3-Clause",
-  "md5": "781a68b189c85fe8187ec60ec496699a",
-  "name": "openmpi",
-  "sha256": "cb2d5dbdd47b715176ec2bf93b5243eba0d60e825698feda6bacb81dac5ee411",
-  "size": 13428946,
-  "subdir": "osx-64",
-  "timestamp": 1720683652324,
-  "version": "5.0.3"
-}
+{}
osx-64::openmpi-mpicc-5.0.3-hfdf4475_110.conda
-{
-  "build": "hfdf4475_110",
-  "build_number": 110,
-  "depends": [
-    "__osx >=10.13",
-    "clang_osx-64 16.*",
-    "openmpi 5.0.3 h62bb914_110"
-  ],
-  "license": "BSD-3-Clause",
-  "md5": "99c61d4e3df61f5a830b165bb5d05c4d",
-  "name": "openmpi-mpicc",
-  "sha256": "144a68bf62723279b0d7ea69c727367a403f69e8574f408d3bc1371c447bbb21",
-  "size": 13468,
-  "subdir": "osx-64",
-  "timestamp": 1720683705000,
-  "version": "5.0.3"
-}
+{}
osx-64::openmpi-mpicxx-5.0.3-h3c5361c_110.conda
-{
-  "build": "h3c5361c_110",
-  "build_number": 110,
-  "depends": [
-    "__osx >=10.13",
-    "clangxx_osx-64 16.*",
-    "openmpi 5.0.3 h62bb914_110"
-  ],
-  "license": "BSD-3-Clause",
-  "md5": "d905dca3024f1e0a819250989cd69d06",
-  "name": "openmpi-mpicxx",
-  "sha256": "ae0c356709e907110958ead347650dd96a1d765398697a84bd224e46780e87de",
-  "size": 13464,
-  "subdir": "osx-64",
-  "timestamp": 1720683714318,
-  "version": "5.0.3"
-}
+{}
osx-64::openmpi-mpifort-5.0.3-h70de70a_110.conda
-{
-  "build": "h70de70a_110",
-  "build_number": 110,
-  "depends": [
-    "__osx >=10.13",
-    "gfortran_osx-64 12.*",
-    "openmpi 5.0.3 h62bb914_110"
-  ],
-  "license": "BSD-3-Clause",
-  "md5": "ad4e3d150200af0a6095b77ad498b5cc",
-  "name": "openmpi-mpifort",
-  "sha256": "5d0d470c77bdcf7d0023d76dfe2a33fb1b03b053d44e76e5b6cf4a0e48d36a1a",
-  "size": 13488,
-  "subdir": "osx-64",
-  "timestamp": 1720683725371,
-  "version": "5.0.3"
-}
+{}
osx-64::pdata-2.2.1-py310h661909b_0.conda
-{
-  "build": "py310h661909b_0",
-  "build_number": 0,
-  "depends": [
-    "__osx >=10.13",
-    "ipykernel",
-    "ipylab",
-    "ipympl",
-    "ipython",
-    "ipywidgets",
-    "jinja2",
-    "jsondiff",
-    "libcxx >=16",
-    "matplotlib-base",
-    "notebook",
-    "numpy >=1.19,<3",
-    "python >=3.10,<3.11.0a0",
-    "python-dateutil",
-    "python_abi 3.10.* *_cp310",
-    "pytz",
-    "requests",
-    "uncertainties",
-    "xarray"
-  ],
-  "license": "MIT",
-  "md5": "af41a4df180ef9a70ed0000a72355ad8",
-  "name": "pdata",
-  "sha256": "87ea5fc09ea838f4cfbe8a4ef351fbd0d903cfcc93b41b2c0f1e86b588dae246",
-  "size": 194330,
-  "subdir": "osx-64",
-  "timestamp": 1720685351245,
-  "version": "2.2.1"
-}
+{}
osx-64::pdata-2.2.1-py311h49c5ead_0.conda
-{
-  "build": "py311h49c5ead_0",
-  "build_number": 0,
-  "depends": [
-    "__osx >=10.13",
-    "ipykernel",
-    "ipylab",
-    "ipympl",
-    "ipython",
-    "ipywidgets",
-    "jinja2",
-    "jsondiff",
-    "libcxx >=16",
-    "matplotlib-base",
-    "notebook",
-    "numpy >=1.19,<3",
-    "python >=3.11,<3.12.0a0",
-    "python-dateutil",
-    "python_abi 3.11.* *_cp311",
-    "pytz",
-    "requests",
-    "uncertainties",
-    "xarray"
-  ],
-  "license": "MIT",
-  "md5": "38f8434fdc47cc3f114aa9d7206160fb",
-  "name": "pdata",
-  "sha256": "b5a4ab114510b646096d7c6eb6ed5ee20e91594a3e5ea213b6630a898a05c94a",
-  "size": 217877,
-  "subdir": "osx-64",
-  "timestamp": 1720685440324,
-  "version": "2.2.1"
-}
+{}
osx-64::pdata-2.2.1-py312h44e70fa_0.conda
-{
-  "build": "py312h44e70fa_0",
-  "build_number": 0,
-  "depends": [
-    "__osx >=10.13",
-    "ipykernel",
-    "ipylab",
-    "ipympl",
-    "ipython",
-    "ipywidgets",
-    "jinja2",
-    "jsondiff",
-    "libcxx >=16",
-    "matplotlib-base",
-    "notebook",
-    "numpy >=1.19,<3",
-    "python >=3.12,<3.13.0a0",
-    "python-dateutil",
-    "python_abi 3.12.* *_cp312",
-    "pytz",
-    "requests",
-    "uncertainties",
-    "xarray"
-  ],
-  "license": "MIT",
-  "md5": "90db3ffc4d2f92616048ef3725c00752",
-  "name": "pdata",
-  "sha256": "081939f11569d1800ab69dbbb6dafbb0b84a4e03a8073ea0975e4c3d8fb8786a",
-  "size": 216687,
-  "subdir": "osx-64",
-  "timestamp": 1720685332164,
-  "version": "2.2.1"
-}
+{}
osx-64::pyfftw-0.13.1-py310hbec2021_1.conda
-{
-  "build": "py310hbec2021_1",
-  "build_number": 1,
-  "depends": [
-    "__osx >=10.13",
-    "numpy >=1.22.4,<2.0a0",
-    "python >=3.10,<3.11.0a0",
-    "python_abi 3.10.* *_cp310"
-  ],
-  "license": "BSD-3-Clause AND GPL-2.0-or-later",
-  "md5": "890c760f02e0d007f05e497e2fe0b84d",
-  "name": "pyfftw",
-  "sha256": "a2826a660dd6e2932bfd49f8d15a23eaf5b592c29da81f5de401fa8290c41d75",
-  "size": 1784980,
-  "subdir": "osx-64",
-  "timestamp": 1720683876106,
-  "version": "0.13.1"
-}
+{}
osx-64::pyfftw-0.13.1-py311he5d6b3b_1.conda
-{
-  "build": "py311he5d6b3b_1",
-  "build_number": 1,
-  "depends": [
-    "__osx >=10.13",
-    "numpy >=1.23.5,<2.0a0",
-    "python >=3.11,<3.12.0a0",
-    "python_abi 3.11.* *_cp311"
-  ],
-  "license": "BSD-3-Clause AND GPL-2.0-or-later",
-  "md5": "ca5640cbe5865f51b6f971afc74bdee0",
-  "name": "pyfftw",
-  "sha256": "66eeb0547ce661a96b2c8e9975d5d5e1baa3a22156ba646b551988e8174dcefd",
-  "size": 1792290,
-  "subdir": "osx-64",
-  "timestamp": 1720683875252,
-  "version": "0.13.1"
-}
+{}
osx-64::pyfftw-0.13.1-py39h1e1c333_1.conda
-{
-  "build": "py39h1e1c333_1",
-  "build_number": 1,
-  "depends": [
-    "__osx >=10.13",
-    "numpy >=1.22.4,<2.0a0",
-    "python >=3.9,<3.10.0a0",
-    "python_abi 3.9.* *_cp39"
-  ],
-  "license": "BSD-3-Clause AND GPL-2.0-or-later",
-  "md5": "0cb9343d298f1fc66829ea88a89b40db",
-  "name": "pyfftw",
-  "sha256": "bb3cf8c1bff8acb76d8b3fd32e6aeef44bdcdb66aa1ee44fe4d31cc5b9a9f906",
-  "size": 1784679,
-  "subdir": "osx-64",
-  "timestamp": 1720683820846,
-  "version": "0.13.1"
-}
+{}
osx-64::pyfftw-0.13.1-py39hc4e03c5_1.conda
-{
-  "build": "py39hc4e03c5_1",
-  "build_number": 1,
-  "depends": [
-    "__osx >=10.13",
-    "numpy >=1.22.4,<2.0a0",
-    "pypy3.9 >=7.3.15",
-    "python >=3.9,<3.10.0a0",
-    "python_abi 3.9 *_pypy39_pp73"
-  ],
-  "license": "BSD-3-Clause AND GPL-2.0-or-later",
-  "md5": "14da06693a1b2712be357c610378fb89",
-  "name": "pyfftw",
-  "sha256": "9e894a4c8a977de1973f5d1a82a096f15bcb13fb86e3fe83f5221915001ccd72",
-  "size": 1766604,
-  "subdir": "osx-64",
-  "timestamp": 1720683780715,
-  "version": "0.13.1"
-}
+{}
osx-64::pytensor-base-2.24.0-py310hc47d138_0.conda
osx-64::pytensor-base-2.24.1-py312hf1ba2cd_0.conda
osx-64::pytensor-base-2.24.0-py311he91a857_0.conda
osx-64::pytensor-base-2.24.1-py310hc47d138_0.conda
osx-64::pytensor-base-2.24.1-py311he91a857_0.conda
osx-64::pytensor-base-2.24.0-py312hf1ba2cd_0.conda
-    "setuptools >=48.0.0"
+    "setuptools >=59.0.0"
osx-64::pytensor-base-2.25.1-py310hc47d138_0.conda
osx-64::pytensor-base-2.25.1-py311he91a857_0.conda
osx-64::pytensor-base-2.25.1-py312hf1ba2cd_0.conda
-    "filelock",
+    "filelock >=3.15",
osx-64::warp-lang-1.2.2-cpu310_ha1fd986_1.conda
-{
-  "build": "cpu310_ha1fd986_1",
-  "build_number": 1,
-  "depends": [
-    "__osx >=10.13",
-    "jax",
-    "libcxx >=16",
-    "numpy >=1.19,<3",
-    "python >=3.10,<3.11.0a0",
-    "python_abi 3.10.* *_cp310",
-    "scipy",
-    "treelib",
-    "typeguard"
-  ],
-  "license": "LicenseRef-NvidiaProprietary",
-  "md5": "9d7faf01e3b5a356e5742a75b03bf20f",
-  "name": "warp-lang",
-  "sha256": "4f138e4fcdae4a64ffd73f140e198fa2e3a63ac68a6028fd264f3452fcf91726",
-  "size": 34068502,
-  "subdir": "osx-64",
-  "timestamp": 1720681022938,
-  "version": "1.2.2"
-}
+{}
osx-64::warp-lang-1.2.2-cpu311_h1d3041c_1.conda
-{
-  "build": "cpu311_h1d3041c_1",
-  "build_number": 1,
-  "depends": [
-    "__osx >=10.13",
-    "jax",
-    "libcxx >=16",
-    "numpy >=1.19,<3",
-    "python >=3.11,<3.12.0a0",
-    "python_abi 3.11.* *_cp311",
-    "scipy",
-    "treelib",
-    "typeguard"
-  ],
-  "license": "LicenseRef-NvidiaProprietary",
-  "md5": "97f0ebe84f26d2260a57837d9e44710f",
-  "name": "warp-lang",
-  "sha256": "3f7d777c1d409265a1e94fb26c4f7f9227dcb9ede8ed96f8dc73119435494e3f",
-  "size": 34664061,
-  "subdir": "osx-64",
-  "timestamp": 1720681148285,
-  "version": "1.2.2"
-}
+{}
osx-64::warp-lang-1.2.2-cpu312_h09a0025_1.conda
-{
-  "build": "cpu312_h09a0025_1",
-  "build_number": 1,
-  "depends": [
-    "__osx >=10.13",
-    "jax",
-    "libcxx >=16",
-    "numpy >=1.19,<3",
-    "python >=3.12,<3.13.0a0",
-    "python_abi 3.12.* *_cp312",
-    "scipy",
-    "treelib",
-    "typeguard"
-  ],
-  "license": "LicenseRef-NvidiaProprietary",
-  "md5": "5af694a79d779ed94d324ed68093303e",
-  "name": "warp-lang",
-  "sha256": "1cd72ec6895d676ec210794dfedadbe0772941edcea03bb27d8a23226336b126",
-  "size": 34633159,
-  "subdir": "osx-64",
-  "timestamp": 1720681157265,
-  "version": "1.2.2"
-}
+{}
osx-64::warp-lang-1.2.2-cpu38_hb7be54a_1.conda
-{
-  "build": "cpu38_hb7be54a_1",
-  "build_number": 1,
-  "depends": [
-    "__osx >=10.13",
-    "jax",
-    "libcxx >=16",
-    "numpy >=1.22.4,<2.0a0",
-    "python >=3.8,<3.9.0a0",
-    "python_abi 3.8.* *_cp38",
-    "scipy",
-    "treelib",
-    "typeguard"
-  ],
-  "license": "LicenseRef-NvidiaProprietary",
-  "md5": "9a261ebb0e6796d1383412d084a91f90",
-  "name": "warp-lang",
-  "sha256": "9c7b0407fb747e1eb0838eb3a30559710c210b8c4e7a152ed8e538e9e1f11c35",
-  "size": 34064805,
-  "subdir": "osx-64",
-  "timestamp": 1720681167238,
-  "version": "1.2.2"
-}
+{}
osx-64::warp-lang-1.2.2-cpu39_h21cc105_1.conda
-{
-  "build": "cpu39_h21cc105_1",
-  "build_number": 1,
-  "depends": [
-    "__osx >=10.13",
-    "jax",
-    "libcxx >=16",
-    "numpy >=1.19,<3",
-    "python >=3.9,<3.10.0a0",
-    "python_abi 3.9.* *_cp39",
-    "scipy",
-    "treelib",
-    "typeguard"
-  ],
-  "license": "LicenseRef-NvidiaProprietary",
-  "md5": "366da06975d6d19bab111c1ddbd7066e",
-  "name": "warp-lang",
-  "sha256": "7ae81df96b56935fd8126bb25f1e9a52311e76513cf7a130d741633f1b29fe23",
-  "size": 34058301,
-  "subdir": "osx-64",
-  "timestamp": 1720680993100,
-  "version": "1.2.2"
-}
+{}
================================================================================
================================================================================
linux-64
linux-64::pytensor-base-2.24.1-py310h27b3328_0.conda
linux-64::pytensor-base-2.24.1-py312h7122da0_0.conda
linux-64::pytensor-base-2.24.0-py312h7122da0_0.conda
linux-64::pytensor-base-2.24.0-py311h4a3439e_0.conda
linux-64::pytensor-base-2.24.0-py310h27b3328_0.conda
linux-64::pytensor-base-2.24.1-py311h4a3439e_0.conda
-    "setuptools >=48.0.0"
+    "setuptools >=59.0.0"
linux-64::pytensor-base-2.25.1-py310h27b3328_0.conda
linux-64::pytensor-base-2.25.1-py311h4a3439e_0.conda
linux-64::pytensor-base-2.25.1-py312h7122da0_0.conda
-    "filelock",
+    "filelock >=3.15",
```

</details>
