### PR TITLE
Make libgdal/libpdal conflict with libgdal-core/libpdal-core

### DIFF
--- a/recipe/patch_yaml/gdal.yaml
+++ b/recipe/patch_yaml/gdal.yaml
@@ -29,3 +29,11 @@ then:
   - replace_depends:
       old: tiledb >=2.11,<3.0a0
       new: tiledb >=2.11.3,<2.12.0a0
+---
+if:
+  name: libgdal
+  timestamp_lt: 1720805984000
+  version: "3.9.1"
+
+then:
+  - add_constrains: libgdal-core <0.0a0

--- a/recipe/patch_yaml/pdal.yaml
+++ b/recipe/patch_yaml/pdal.yaml
@@ -1,7 +1,7 @@
 if:
   name: pdal
-  timestamp_lt: 1718743123000
-  version: "2.7.1"
+  timestamp_lt: 1720805984000
+  version_in: ["2.7.1", "2.7.2"]
 
 then:
   - add_constrains: libpdal-core <0.0a0


### PR DESCRIPTION
Checklist

* [ ] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
