### PR TITLE
added a constraint for mapbox_earcut to numpy < 2.0

### DIFF
--- a/recipe/patch_yaml/mapbox_earcut.yaml
+++ b/recipe/patch_yaml/mapbox_earcut.yaml
@@ -1,0 +1,10 @@
+# add constraint on numpy <2.0
+if:
+  name: mapbox_earcut
+  version: 1.0.1
+  timestamp_lt: 1720808421000
+  build_number: 0
+then:
+  - replace_depends:
+      old: numpy
+      new: numpy <2


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
```
 python show_diff.py
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
osx-arm64::mapbox_earcut-1.0.1-py311he4fd1f5_0.conda
osx-arm64::mapbox_earcut-1.0.1-py310h38f39d4_0.conda
osx-arm64::mapbox_earcut-1.0.1-py312h389731b_0.conda
osx-arm64::mapbox_earcut-1.0.1-py38h9afee92_0.conda
osx-arm64::mapbox_earcut-1.0.1-py39hbd775c9_0.conda
-    "numpy",
+    "numpy <2",
================================================================================
================================================================================
linux-ppc64le
linux-ppc64le::mapbox_earcut-1.0.1-py310hd9ef7bd_0.conda
linux-ppc64le::mapbox_earcut-1.0.1-py39h6903c34_0.conda
linux-ppc64le::mapbox_earcut-1.0.1-py38he737c5c_0.conda
linux-ppc64le::mapbox_earcut-1.0.1-py311h4cc6e39_0.conda
linux-ppc64le::mapbox_earcut-1.0.1-py39h4d47351_0.conda
linux-ppc64le::mapbox_earcut-1.0.1-py312h1e303ce_0.conda
-    "numpy",
+    "numpy <2",
================================================================================
================================================================================
linux-aarch64
linux-aarch64::mapbox_earcut-1.0.1-py310h586407a_0.conda
linux-aarch64::mapbox_earcut-1.0.1-py312h8f0b210_0.conda
linux-aarch64::mapbox_earcut-1.0.1-py38hb4b5b6f_0.conda
linux-aarch64::mapbox_earcut-1.0.1-py39hd16970a_0.conda
linux-aarch64::mapbox_earcut-1.0.1-py311h098ece5_0.conda
linux-aarch64::mapbox_earcut-1.0.1-py39h726f559_0.conda
-    "numpy",
+    "numpy <2",
================================================================================
================================================================================
noarch
================================================================================
================================================================================
win-64
win-64::mapbox_earcut-1.0.1-py39h314d263_0.conda
win-64::mapbox_earcut-1.0.1-py39h1f6ef14_0.conda
win-64::mapbox_earcut-1.0.1-py311h005e61a_0.conda
win-64::mapbox_earcut-1.0.1-py38hb1fd069_0.conda
win-64::mapbox_earcut-1.0.1-py310h232114e_0.conda
win-64::mapbox_earcut-1.0.1-py312h0d7def4_0.conda
-    "numpy",
+    "numpy <2",
================================================================================
================================================================================
osx-64
osx-64::mapbox_earcut-1.0.1-py311h5fe6e05_0.conda
osx-64::mapbox_earcut-1.0.1-py38h15a1a5b_0.conda
osx-64::mapbox_earcut-1.0.1-py310h88cfcbd_0.conda
osx-64::mapbox_earcut-1.0.1-py39h8ee36c8_0.conda
osx-64::mapbox_earcut-1.0.1-py312h49ebfd2_0.conda
osx-64::mapbox_earcut-1.0.1-py39h801e03e_0.conda
-    "numpy",
+    "numpy <2",
================================================================================
================================================================================
linux-64
linux-64::mapbox_earcut-1.0.1-py39ha90811c_0.conda
linux-64::mapbox_earcut-1.0.1-py38h7f3f72f_0.conda
linux-64::mapbox_earcut-1.0.1-py312h8572e83_0.conda
linux-64::mapbox_earcut-1.0.1-py311h9547e67_0.conda
linux-64::mapbox_earcut-1.0.1-py39h7633fee_0.conda
linux-64::mapbox_earcut-1.0.1-py310hd41b1e2_0.conda
-    "numpy",
+    "numpy <2",
```