### PR TITLE
Fix napari constraint  for pyside6 (AND should be OR)

### DIFF
--- a/recipe/patch_yaml/napari.yaml
+++ b/recipe/patch_yaml/napari.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../patch_yaml_model.json
 # from this bit of code
 # if record_name == "napari":
 #     timestamp = record.get("timestamp", 0)
@@ -72,3 +73,15 @@ then:
   - replace_depends:
       old: pydantic >=1.9.0
       new: pydantic >=1.9.0,<2.0a0
+---
+# https://github.com/conda-forge/napari-feedstock/pull/65
+if:
+  name: napari
+  timestamp_lt: 1721096299000 # 2024-07-16
+  version: 0.5.0
+  build_number: 0
+then:
+  - replace_constrains:
+      old: pyside6 <6.5,>=6.7
+      new: pyside6 <6.5|>=6.7
+

--- a/recipe/patch_yaml/napari.yaml
+++ b/recipe/patch_yaml/napari.yaml
@@ -84,4 +84,3 @@ then:
   - replace_constrains:
       old: pyside6 <6.5,>=6.7
       new: pyside6 <6.5|>=6.7
-


### PR DESCRIPTION
Checklist

* [X] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [X] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

Ports patch from https://github.com/conda-forge/napari-feedstock/pull/65
cc @conda-forge/napari 