### PR TITLE
Add repodata patch for rattler-build-conda-compat

### DIFF
--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -34,9 +34,9 @@ CONDARC
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 
 mamba install --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
+    pip mamba conda-build conda-forge-ci-setup=4 "conda-build>=24.1" "rattler-build-conda-compat!=0.1.2"
 mamba update --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
+    pip mamba conda-build conda-forge-ci-setup=4 "conda-build>=24.1" "rattler-build-conda-compat!=0.1.2"
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -7,3 +7,4 @@ conda_build:
 skip_render:
   - .github/PULL_REQUEST_TEMPLATE.md
 upload_on_branch: main
+remote_ci_setup: ["rattler-build-conda-compat!=0.1.2"]

--- a/recipe/patch_yaml/rattler-build-conda-compat.yaml
+++ b/recipe/patch_yaml/rattler-build-conda-compat.yaml
@@ -11,6 +11,6 @@ if:
   name: rattler-build-conda-compat
   timestamp_lt: 1721317413373
 then:
-  - tighten_depends:
-      name: python
-      lower_bound: "3.11"
+  - replace_depends:
+      old: "python >=3.8"
+      new: "python >=3.11"

--- a/recipe/patch_yaml/rattler-build-conda-compat.yaml
+++ b/recipe/patch_yaml/rattler-build-conda-compat.yaml
@@ -1,0 +1,16 @@
+# from this code
+# # this doesn't seem to match the _pin_looser or _pin_stricter patterns
+# # nor _replace_pin
+# if record_name == "jedi" and record.get("timestamp", 0) < 1592619891258:
+#     for i, dep in enumerate(record["depends"]):
+#         if dep.startswith("parso") and "<" not in dep:
+#             _dep_parts = dep.split(" ")
+#             _dep_parts[1] = _dep_parts[1] + ",<0.8.0"
+#             record["depends"][i] = " ".join(_dep_parts)
+if:
+  name: rattler-build-conda-compat
+  timestamp_lt: 1721317413373
+then:
+  - tighten_depends:
+      name: python
+      lower_bound: "3.11"


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

See https://github.com/conda-forge/status/issues/183