### PR TITLE
astropy: pin Numpy < 2 on Windows 6.1.1

### DIFF
--- a/recipe/patch_yaml/astropy.yaml
+++ b/recipe/patch_yaml/astropy.yaml
@@ -1,0 +1,11 @@
+if:
+  name: astropy
+  version: 6.1.1
+  timestamp_lt: 1721656550000
+  build_number: 0
+  subdir_in:
+    - win-64
+then:
+  - replace_depends:
+      old: numpy >=1.19,<3
+      new: numpy >=1.19,<2


### PR DESCRIPTION
See https://github.com/conda-forge/astropy-feedstock/issues/140 . This particular release had an extra Numpy constraint added on Windows that wasn't captured in the Conda metadata. The extra constraint has since been removed, so I don't believe that the feedstock itself needs any updating.

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

The only changes reported by `show_diff.py` are, as desired:

```
================================================================================
win-64
win-64::astropy-6.1.1-py310hb0944cc_0.conda
win-64::astropy-6.1.1-py312h1a27103_0.conda
win-64::astropy-6.1.1-py311h0a17f05_0.conda
-    "numpy >=1.19,<3",
+    "numpy >=1.19,<2",
================================================================================
```