### PR TITLE
feat: add back external mpich package for version 4.0.2

### DIFF
--- a/recipe/patch_yaml/mpich.yaml
+++ b/recipe/patch_yaml/mpich.yaml
@@ -19,7 +19,7 @@ if:
   subdir_in: linux-64
   name: mpich
   version: 4.0.2
-  build_number_in: [0]
+  build: external_0
 then:
   - add_depends:
       - libgcc-ng >=10.3.0

--- a/recipe/patch_yaml/mpich.yaml
+++ b/recipe/patch_yaml/mpich.yaml
@@ -19,7 +19,7 @@ if:
   subdir_in: linux-64
   name: mpich
   version: 4.0.2
-  build_number_in: [0,]
+  build_number_in: [0]
 then:
   - add_depends:
       - libgcc-ng >=10.3.0

--- a/recipe/patch_yaml/mpich.yaml
+++ b/recipe/patch_yaml/mpich.yaml
@@ -19,7 +19,7 @@ if:
   subdir_in: linux-64
   name: mpich
   version: 4.0.2
-  build_number_in: 0
+  build_number_in: [0,]
 then:
   - add_depends:
       - libgcc-ng >=10.3.0

--- a/recipe/patch_yaml/mpich.yaml
+++ b/recipe/patch_yaml/mpich.yaml
@@ -10,3 +10,20 @@ then:
   - loosen_depends:
       name: mpich
       upper_bound: "5.0"
+---
+# add back external package for v4.0.2 on linux per request here
+# https://github.com/conda-forge/admin-requests/pull/1009#issuecomment-2245501214
+# we add the deps of the real package to fix the solver issues per the issue above
+# and links in it.
+if:
+  subdir_in: linux-64
+  name: mpich
+  version: 4.0.2
+  build: external_0
+then:
+  - add_depends:
+      - libgcc-ng >=10.3.0
+      - libgfortran-ng
+      - libgfortran5 >=10.3.0
+      - libstdcxx-ng >=10.3.0
+      - mpi 1.0 mpich

--- a/recipe/patch_yaml/mpich.yaml
+++ b/recipe/patch_yaml/mpich.yaml
@@ -19,7 +19,7 @@ if:
   subdir_in: linux-64
   name: mpich
   version: 4.0.2
-  build: external_0
+  build_number_in: 0
 then:
   - add_depends:
       - libgcc-ng >=10.3.0


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

This PR adds back the external mpich package for version 4.0.2 by adding the deps of the regular mpich package to the external one. After this PR is merged, we need to remove the broken label.

xref: https://github.com/conda-forge/admin-requests/pull/1009#issuecomment-2245501214

We need to mark this package unbroken after this PR is merged. The diff will show nothing for now.
