### PR TITLE
fix: show all diffs either way

### DIFF
--- a/recipe/show_diff.py
+++ b/recipe/show_diff.py
@@ -35,14 +35,14 @@ def show_record_diffs(subdir, ref_repodata, new_repodata, fail_fast, group_diffs
         final_lines = {}
     else:
         final_lines = []
-    for index_key in ["packages", "packages.conda"]:
-        for name, ref_pkg in ref_repodata[index_key].items():
-            if name in new_repodata[index_key]:
-                new_pkg = new_repodata[index_key][name]
-            else:
-                new_pkg = {}
 
-            if keep_pkgs is not None and ref_pkg["name"] not in keep_pkgs:
+    for index_key in ["packages", "packages.conda"]:
+        all_names = set(ref_repodata.get(index_key, {}).keys()) | set(new_repodata.get(index_key, {}).keys())
+        for name in all_names:
+            ref_pkg = ref_repodata.get(index_key, {}).get(name, {})
+            new_pkg = new_repodata.get(index_key, {}).get(name, {})
+
+            if keep_pkgs is not None and ref_pkg and ref_pkg["name"] not in keep_pkgs:
                 continue
 
             # license_family gets added for new packages, ignore it in the diff

--- a/recipe/show_diff.py
+++ b/recipe/show_diff.py
@@ -37,7 +37,9 @@ def show_record_diffs(subdir, ref_repodata, new_repodata, fail_fast, group_diffs
         final_lines = []
 
     for index_key in ["packages", "packages.conda"]:
-        all_names = set(ref_repodata.get(index_key, {}).keys()) | set(new_repodata.get(index_key, {}).keys())
+        all_names = set(ref_repodata.get(index_key, {}).keys()) | set(
+            new_repodata.get(index_key, {}).keys()
+        )
         for name in all_names:
             ref_pkg = ref_repodata.get(index_key, {}).get(name, {})
             new_pkg = new_repodata.get(index_key, {}).get(name, {})


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

This PR fixes a bug where diffs that involve a package not in the current index do not show. It is a weird edge case that we basically never encounter in practice except when I did.
