### PR TITLE
Pin libitk for two latest releases of ANTs

### DIFF
--- a/recipe/patch_yaml/ants.yaml
+++ b/recipe/patch_yaml/ants.yaml
@@ -1,0 +1,19 @@
+if:
+  artifact_in:
+    - ants-2.5.3-h434a139_0.conda
+    - ants-2.5.3-h3c5361c_0.conda
+    - ants-2.5.3-h420ef59_0.conda
+then:
+  - replace_depends:
+      old: libitk
+      new: libitk >=5.4,<5.5
+---
+if:
+  artifact_in:
+    - ants-2.5.1-h7728843_0.conda
+    - ants-2.5.1-h2ffa867_0.conda
+    - ants-2.5.1-h00ab1b0_0.conda
+then:
+  - replace_depends:
+      old: libitk
+      new: libitk >=5.3,<5.4


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->


```console
$ python show_diff.py
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
osx-arm64::ants-2.5.1-h2ffa867_0.conda
-    "libitk"
+    "libitk >=5.3,<5.4"
osx-arm64::ants-2.5.3-h420ef59_0.conda
-    "libitk"
+    "libitk >=5.4,<5.5"
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
noarch
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
osx-64::ants-2.5.1-h7728843_0.conda
-    "libitk"
+    "libitk >=5.3,<5.4"
osx-64::ants-2.5.3-h3c5361c_0.conda
-    "libitk"
+    "libitk >=5.4,<5.5"
================================================================================
================================================================================
linux-64
linux-64::ants-2.5.3-h434a139_0.conda
-    "libitk",
+    "libitk >=5.4,<5.5",
linux-64::ants-2.5.1-h00ab1b0_0.conda
-    "libitk",
+    "libitk >=5.3,<5.4",
```

cc @ghisvail, who maintains the feedstock.

xref https://github.com/conda-forge/ants-feedstock/pull/12, which patches the recipe to ensure the libitk dependency does get pinned in the future.