### PR TITLE
fix(prefect): add historic pydantic<2 constraints

### DIFF
--- a/recipe/patch_yaml/prefect.yaml
+++ b/recipe/patch_yaml/prefect.yaml
@@ -1,0 +1,9 @@
+# https://github.com/conda-forge/prefect-feedstock/issues/320
+if:
+  name: prefect
+  version_lt: "2.11.0"
+  timestamp_lt: 1722325657000
+then:
+  - replace_depends:
+      old: pydantic >=1.8.2
+      new: pydantic >=1.8.2,<2


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
fixes: https://github.com/conda-forge/prefect-feedstock/issues/320

changes:
```diff
================================================================================
================================================================================
noarch
noarch::prefect-2.6.0-pyhd8ed1ab_0.tar.bz2
noarch::prefect-2.8.6-pyhd8ed1ab_0.conda
noarch::prefect-2.10.3-pyhd8ed1ab_0.conda
noarch::prefect-2.10.5-pyhd8ed1ab_0.conda
noarch::prefect-2.10.10-pyhd8ed1ab_0.conda
noarch::prefect-2.6.2-pyhd8ed1ab_0.tar.bz2
noarch::prefect-2.8.5-pyhd8ed1ab_0.conda
noarch::prefect-2.10.8-pyhd8ed1ab_0.conda
noarch::prefect-2.6.1-pyhd8ed1ab_0.tar.bz2
noarch::prefect-2.6.5-pyhd8ed1ab_0.tar.bz2
noarch::prefect-2.8.1-pyhd8ed1ab_0.conda
noarch::prefect-2.6.3-pyhd8ed1ab_0.tar.bz2
noarch::prefect-2.0.2-pyhd8ed1ab_0.tar.bz2
noarch::prefect-2.10.11-pyhd8ed1ab_0.conda
noarch::prefect-2.10.18-pyhd8ed1ab_0.conda
noarch::prefect-2.10.17-pyhd8ed1ab_0.conda
noarch::prefect-2.7.10-pyhd8ed1ab_0.conda
noarch::prefect-2.6.7-pyhd8ed1ab_0.tar.bz2
noarch::prefect-2.0.4-pyhd8ed1ab_0.tar.bz2
noarch::prefect-2.3.1-pyhd8ed1ab_0.tar.bz2
noarch::prefect-2.10.0-pyhd8ed1ab_0.conda
noarch::prefect-2.7.3-pyhd8ed1ab_0.conda
noarch::prefect-2.2.0-pyhd8ed1ab_0.tar.bz2
noarch::prefect-2.7.12-pyhd8ed1ab_0.conda
noarch::prefect-2.9.0-pyhd8ed1ab_0.conda
noarch::prefect-2.4.0-pyhd8ed1ab_0.tar.bz2
noarch::prefect-2.10.13-pyhd8ed1ab_0.conda
noarch::prefect-2.6.8-pyhd8ed1ab_0.conda
noarch::prefect-2.7.11-pyhd8ed1ab_0.conda
noarch::prefect-2.7.10-pyhd8ed1ab_1.conda
noarch::prefect-2.3.2-pyhd8ed1ab_0.tar.bz2
noarch::prefect-2.4.5-pyhd8ed1ab_0.tar.bz2
noarch::prefect-2.1.1-pyhd8ed1ab_0.tar.bz2
noarch::prefect-2.8.7-pyhd8ed1ab_0.conda
noarch::prefect-2.6.9-pyhd8ed1ab_0.conda
noarch::prefect-2.10.6-pyhd8ed1ab_0.conda
noarch::prefect-2.8.4-pyhd8ed1ab_0.conda
noarch::prefect-2.7.0-pyhd8ed1ab_0.conda
noarch::prefect-2.10.2-pyhd8ed1ab_0.conda
noarch::prefect-2.6.6-pyhd8ed1ab_0.tar.bz2
noarch::prefect-2.6.4-pyhd8ed1ab_0.tar.bz2
noarch::prefect-2.10.12-pyhd8ed1ab_0.conda
noarch::prefect-2.10.9-pyhd8ed1ab_0.conda
noarch::prefect-2.7.4-pyhd8ed1ab_0.conda
noarch::prefect-2.7.5-pyhd8ed1ab_0.conda
noarch::prefect-2.0.1-pyhd8ed1ab_1.tar.bz2
noarch::prefect-2.0.2-pyhd8ed1ab_1.tar.bz2
noarch::prefect-2.10.7-pyhd8ed1ab_0.conda
noarch::prefect-2.7.2-pyhd8ed1ab_0.conda
noarch::prefect-2.7.7-pyhd8ed1ab_0.conda
noarch::prefect-2.7.1-pyhd8ed1ab_0.conda
noarch::prefect-2.8.3-pyhd8ed1ab_0.conda
noarch::prefect-2.10.14-pyhd8ed1ab_0.conda
noarch::prefect-2.4.2-pyhd8ed1ab_0.tar.bz2
noarch::prefect-2.10.1-pyhd8ed1ab_0.conda
noarch::prefect-2.8.0-pyhd8ed1ab_0.conda
noarch::prefect-2.7.6-pyhd8ed1ab_0.conda
noarch::prefect-2.10.19-pyhd8ed1ab_0.conda
noarch::prefect-2.7.9-pyhd8ed1ab_0.conda
noarch::prefect-2.8.2-pyhd8ed1ab_0.conda
noarch::prefect-2.10.4-pyhd8ed1ab_0.conda
noarch::prefect-2.10.15-pyhd8ed1ab_0.conda
noarch::prefect-2.0.3-pyhd8ed1ab_0.tar.bz2
noarch::prefect-2.7.8-pyhd8ed1ab_0.conda
noarch::prefect-2.3.0-pyhd8ed1ab_0.tar.bz2
noarch::prefect-2.5.0-pyhd8ed1ab_0.tar.bz2
-    "pydantic >=1.8.2",
+    "pydantic >=1.8.2,<2",
================================================================================
================================================================================
linux-64
linux-64::prefect-2.0.1-py39ha770c72_0.tar.bz2
-    "pydantic >=1.8.2",
+    "pydantic >=1.8.2,<2",
```