### PR TITLE
fix: add back deps to pip 24.1.2

### DIFF
--- a/recipe/patch_yaml/pip.yaml
+++ b/recipe/patch_yaml/pip.yaml
@@ -37,7 +37,7 @@ then:
 # we dropped setuptools+wheel from pip before a proper deprecation cycle
 if:
   name: pip
-  version: "24.1.2"
+  version_in: ["24.1.2"]
 then:
   - add_depends:
       - setuptools

--- a/recipe/patch_yaml/pip.yaml
+++ b/recipe/patch_yaml/pip.yaml
@@ -32,3 +32,13 @@ then:
   - replace_depends:
       old: python >=3.6
       new: python >=3.7
+---
+# https://github.com/conda-forge/admin-requests/pull/1041#issuecomment-2261656228
+# we dropped setuptools+wheel from pip before a proper deprecation cycle
+if:
+  name: pip
+  version: "24.1.2"
+then:
+  - add_depends:
+      - setuptools
+      - wheel


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
