### PR TITLE
fix: add upper bound for smithy due to conda-build deprecations

### DIFF
--- a/recipe/patch_yaml/conda-smithy.yaml
+++ b/recipe/patch_yaml/conda-smithy.yaml
@@ -49,4 +49,4 @@ if:
 then:
   - tighten_depends:
       name: conda-build
-      upper_bound: 24.7.1
+      upper_bound: 24.7.0

--- a/recipe/patch_yaml/conda-smithy.yaml
+++ b/recipe/patch_yaml/conda-smithy.yaml
@@ -42,3 +42,11 @@ then:
   - tighten_depends:
       name: conda-build
       upper_bound: 24.5.0
+---
+if:
+  name: conda-smithy
+  version_le: 3.37.1
+then:
+  - tighten_depends:
+      name: conda-build
+      upper_bound: 24.7.1


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
