### PR TITLE
tighten constraint on rattler-build-conda-compat for conda-smithy

### DIFF
--- a/recipe/patch_yaml/conda-forge-ci-setup.yaml
+++ b/recipe/patch_yaml/conda-forge-ci-setup.yaml
@@ -23,3 +23,12 @@ then:
   - tighten_depends:
       name: conda-build
       upper_bound: 24.5.0
+---
+if:
+  name: conda-forge-ci-setup
+  has_depends: rattler-build-conda-compat?( *)
+  timestamp_lt: 1722516295000
+then:
+  - tighten_depends:
+      name: rattler-build-conda-compat
+      max_pin: "x"

--- a/recipe/patch_yaml/conda-smithy.yaml
+++ b/recipe/patch_yaml/conda-smithy.yaml
@@ -50,3 +50,12 @@ then:
   - tighten_depends:
       name: conda-build
       upper_bound: 24.7.0
+---
+if:
+  name: conda-smithy
+  has_depends: rattler-build-conda-compat?( *)
+  timestamp_lt: 1722516295000
+then:
+  - tighten_depends:
+      name: rattler-build-conda-compat
+      max_pin: "x"


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

```
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
osx-arm64::conda-forge-ci-setup-4.5.0-py310hccab3ec_100.conda
osx-arm64::conda-forge-ci-setup-4.5.1-py310hccab3ec_100.conda
osx-arm64::conda-forge-ci-setup-4.5.0-py311hd329421_100.conda
osx-arm64::conda-forge-ci-setup-4.6.0-py38h9d9d116_100.conda
osx-arm64::conda-forge-ci-setup-4.6.0-py39hcb35892_100.conda
osx-arm64::conda-forge-ci-setup-4.5.1-py38h9d9d116_100.conda
osx-arm64::conda-forge-ci-setup-4.5.0-py39hcb35892_100.conda
osx-arm64::conda-forge-ci-setup-4.4.6-py311hd329421_100.conda
osx-arm64::conda-forge-ci-setup-4.5.1-py39hcb35892_100.conda
osx-arm64::conda-forge-ci-setup-4.6.0-py312h1881813_100.conda
osx-arm64::conda-forge-ci-setup-4.7.0-py39hcb35892_100.conda
osx-arm64::conda-forge-ci-setup-4.5.0-py38h9d9d116_100.conda
osx-arm64::conda-forge-ci-setup-4.4.7-py38h9d9d116_100.conda
osx-arm64::conda-forge-ci-setup-4.4.7-py312h1881813_100.conda
osx-arm64::conda-forge-ci-setup-4.4.6-py312h1881813_100.conda
osx-arm64::conda-forge-ci-setup-4.7.0-py38h9d9d116_100.conda
osx-arm64::conda-forge-ci-setup-4.6.0-py310hccab3ec_100.conda
osx-arm64::conda-forge-ci-setup-4.5.1-py312h1881813_100.conda
osx-arm64::conda-forge-ci-setup-4.4.6-py38h9d9d116_100.conda
osx-arm64::conda-forge-ci-setup-4.4.6-py310hccab3ec_100.conda
osx-arm64::conda-forge-ci-setup-4.4.7-py311hd329421_100.conda
osx-arm64::conda-forge-ci-setup-4.7.0-py311hd329421_100.conda
osx-arm64::conda-forge-ci-setup-4.4.7-py310hccab3ec_100.conda
osx-arm64::conda-forge-ci-setup-4.4.6-py39hcb35892_100.conda
osx-arm64::conda-forge-ci-setup-4.5.1-py311hd329421_100.conda
osx-arm64::conda-forge-ci-setup-4.6.0-py311hd329421_100.conda
osx-arm64::conda-forge-ci-setup-4.4.7-py39hcb35892_100.conda
osx-arm64::conda-forge-ci-setup-4.5.0-py312h1881813_100.conda
osx-arm64::conda-forge-ci-setup-4.7.0-py310hccab3ec_100.conda
osx-arm64::conda-forge-ci-setup-4.7.0-py312h1881813_100.conda
-    "rattler-build-conda-compat >=0.0.2",
+    "rattler-build-conda-compat >=0.0.2,<1.0.0a0",
================================================================================
================================================================================
linux-ppc64le
linux-ppc64le::conda-forge-ci-setup-4.4.6-py310haea6f79_0.conda
linux-ppc64le::conda-forge-ci-setup-4.5.1-py310h9f1fc6e_100.conda
linux-ppc64le::conda-forge-ci-setup-4.6.0-py310h70e29f4_0.conda
linux-ppc64le::conda-forge-ci-setup-4.4.6-py311h628fe42_100.conda
linux-ppc64le::conda-forge-ci-setup-4.5.1-py39h88da7f8_0.conda
linux-ppc64le::conda-forge-ci-setup-4.5.1-py311h628fe42_100.conda
linux-ppc64le::conda-forge-ci-setup-4.4.7-py310h9f1fc6e_100.conda
linux-ppc64le::conda-forge-ci-setup-4.4.6-py39hdbc9d5a_100.conda
linux-ppc64le::conda-forge-ci-setup-4.4.7-py38hdddf1cc_100.conda
linux-ppc64le::conda-forge-ci-setup-4.5.0-py310h70e29f4_0.conda
linux-ppc64le::conda-forge-ci-setup-4.5.1-py311h8044a92_0.conda
linux-ppc64le::conda-forge-ci-setup-4.4.6-py310h9f1fc6e_100.conda
linux-ppc64le::conda-forge-ci-setup-4.4.7-py38hc0a6509_0.conda
linux-ppc64le::conda-forge-ci-setup-4.4.7-py311h8044a92_0.conda
linux-ppc64le::conda-forge-ci-setup-4.5.0-py39h88da7f8_0.conda
linux-ppc64le::conda-forge-ci-setup-4.4.7-py39hd745fc2_0.conda
linux-ppc64le::conda-forge-ci-setup-4.7.0-py312h917f601_100.conda
linux-ppc64le::conda-forge-ci-setup-4.5.0-py38hc0a6509_0.conda
linux-ppc64le::conda-forge-ci-setup-4.5.1-py312h917f601_100.conda
linux-ppc64le::conda-forge-ci-setup-4.6.0-py311h628fe42_100.conda
linux-ppc64le::conda-forge-ci-setup-4.6.0-py312h917f601_100.conda
linux-ppc64le::conda-forge-ci-setup-4.5.1-py39hdbc9d5a_100.conda
linux-ppc64le::conda-forge-ci-setup-4.6.0-py38hc0a6509_0.conda
linux-ppc64le::conda-forge-ci-setup-4.4.6-py312hfb65a19_0.conda
linux-ppc64le::conda-forge-ci-setup-4.4.7-py39h88da7f8_0.conda
linux-ppc64le::conda-forge-ci-setup-4.4.6-py310hf96abab_0.conda
linux-ppc64le::conda-forge-ci-setup-4.4.6-py312h057c6a3_0.conda
linux-ppc64le::conda-forge-ci-setup-4.5.0-py39hdbc9d5a_100.conda
linux-ppc64le::conda-forge-ci-setup-4.4.7-py38h1a51129_0.conda
linux-ppc64le::conda-forge-ci-setup-4.5.0-py312ha6ae4b2_0.conda
linux-ppc64le::conda-forge-ci-setup-4.6.0-py311h8044a92_0.conda
linux-ppc64le::conda-forge-ci-setup-4.6.0-py39hdbc9d5a_100.conda
linux-ppc64le::conda-forge-ci-setup-4.7.0-py310h9f1fc6e_100.conda
linux-ppc64le::conda-forge-ci-setup-4.5.0-py311h628fe42_100.conda
linux-ppc64le::conda-forge-ci-setup-4.4.6-py311he0b60cb_0.conda
linux-ppc64le::conda-forge-ci-setup-4.4.7-py310h70e29f4_0.conda
linux-ppc64le::conda-forge-ci-setup-4.7.0-py39h88da7f8_0.conda
linux-ppc64le::conda-forge-ci-setup-4.4.7-py39hdbc9d5a_100.conda
linux-ppc64le::conda-forge-ci-setup-4.5.0-py310h9f1fc6e_100.conda
linux-ppc64le::conda-forge-ci-setup-4.7.0-py310h70e29f4_0.conda
linux-ppc64le::conda-forge-ci-setup-4.4.7-py312ha6ae4b2_0.conda
linux-ppc64le::conda-forge-ci-setup-4.4.7-py311h628fe42_100.conda
linux-ppc64le::conda-forge-ci-setup-4.4.7-py312h917f601_100.conda
linux-ppc64le::conda-forge-ci-setup-4.7.0-py38hdddf1cc_100.conda
linux-ppc64le::conda-forge-ci-setup-4.5.0-py312h917f601_100.conda
linux-ppc64le::conda-forge-ci-setup-4.4.6-py39heca8150_0.conda
linux-ppc64le::conda-forge-ci-setup-4.4.6-py39h3d00835_0.conda
linux-ppc64le::conda-forge-ci-setup-4.5.0-py38hdddf1cc_100.conda
linux-ppc64le::conda-forge-ci-setup-4.4.7-py312h364db40_0.conda
linux-ppc64le::conda-forge-ci-setup-4.6.0-py312ha6ae4b2_0.conda
linux-ppc64le::conda-forge-ci-setup-4.5.1-py38hdddf1cc_100.conda
linux-ppc64le::conda-forge-ci-setup-4.6.0-py38hdddf1cc_100.conda
linux-ppc64le::conda-forge-ci-setup-4.7.0-py311h8044a92_0.conda
linux-ppc64le::conda-forge-ci-setup-4.4.7-py311h8f408f1_0.conda
linux-ppc64le::conda-forge-ci-setup-4.5.1-py312ha6ae4b2_0.conda
linux-ppc64le::conda-forge-ci-setup-4.5.1-py38hc0a6509_0.conda
linux-ppc64le::conda-forge-ci-setup-4.4.7-py310ha52aade_0.conda
linux-ppc64le::conda-forge-ci-setup-4.4.6-py311h69efb07_0.conda
linux-ppc64le::conda-forge-ci-setup-4.4.6-py312h917f601_100.conda
linux-ppc64le::conda-forge-ci-setup-4.7.0-py312ha6ae4b2_0.conda
linux-ppc64le::conda-forge-ci-setup-4.4.6-py38h2844c73_0.conda
linux-ppc64le::conda-forge-ci-setup-4.7.0-py311h628fe42_100.conda
linux-ppc64le::conda-forge-ci-setup-4.7.0-py39hdbc9d5a_100.conda
linux-ppc64le::conda-forge-ci-setup-4.5.0-py311h8044a92_0.conda
linux-ppc64le::conda-forge-ci-setup-4.4.6-py38h80c3417_0.conda
linux-ppc64le::conda-forge-ci-setup-4.5.1-py310h70e29f4_0.conda
linux-ppc64le::conda-forge-ci-setup-4.6.0-py310h9f1fc6e_100.conda
linux-ppc64le::conda-forge-ci-setup-4.6.0-py39h88da7f8_0.conda
linux-ppc64le::conda-forge-ci-setup-4.4.6-py38hdddf1cc_100.conda
linux-ppc64le::conda-forge-ci-setup-4.7.0-py38hc0a6509_0.conda
-    "rattler-build-conda-compat >=0.0.2",
+    "rattler-build-conda-compat >=0.0.2,<1.0.0a0",
================================================================================
================================================================================
linux-aarch64
linux-aarch64::conda-forge-ci-setup-4.4.7-py39h909162b_0.conda
linux-aarch64::conda-forge-ci-setup-4.4.6-py39h9913a9e_0.conda
linux-aarch64::conda-forge-ci-setup-4.6.0-py38he8868b8_100.conda
linux-aarch64::conda-forge-ci-setup-4.5.1-py310h186cb4b_0.conda
linux-aarch64::conda-forge-ci-setup-4.6.0-py39h79b3062_100.conda
linux-aarch64::conda-forge-ci-setup-4.4.6-py312h177bf4b_0.conda
linux-aarch64::conda-forge-ci-setup-4.5.1-py311h7b9440e_0.conda
linux-aarch64::conda-forge-ci-setup-4.5.1-py310h5bef2de_100.conda
linux-aarch64::conda-forge-ci-setup-4.7.0-py39h909162b_0.conda
linux-aarch64::conda-forge-ci-setup-4.6.0-py39h909162b_0.conda
linux-aarch64::conda-forge-ci-setup-4.6.0-py311h7b9440e_0.conda
linux-aarch64::conda-forge-ci-setup-4.6.0-py38h677f2f6_0.conda
linux-aarch64::conda-forge-ci-setup-4.7.0-py311h7b9440e_0.conda
linux-aarch64::conda-forge-ci-setup-4.6.0-py312h3e13472_100.conda
linux-aarch64::conda-forge-ci-setup-4.7.0-py311h720b028_100.conda
linux-aarch64::conda-forge-ci-setup-4.5.1-py38he8868b8_100.conda
linux-aarch64::conda-forge-ci-setup-4.6.0-py310h186cb4b_0.conda
linux-aarch64::conda-forge-ci-setup-4.4.6-py312h31fb9f0_0.conda
linux-aarch64::conda-forge-ci-setup-4.5.0-py39h909162b_0.conda
linux-aarch64::conda-forge-ci-setup-4.4.7-py312h5a1d447_0.conda
linux-aarch64::conda-forge-ci-setup-4.4.7-py312hffbc5b9_0.conda
linux-aarch64::conda-forge-ci-setup-4.5.0-py311h7b9440e_0.conda
linux-aarch64::conda-forge-ci-setup-4.7.0-py312h5a1d447_0.conda
linux-aarch64::conda-forge-ci-setup-4.5.0-py310h5bef2de_100.conda
linux-aarch64::conda-forge-ci-setup-4.5.0-py38he8868b8_100.conda
linux-aarch64::conda-forge-ci-setup-4.5.1-py39h79b3062_100.conda
linux-aarch64::conda-forge-ci-setup-4.4.7-py38he8868b8_100.conda
linux-aarch64::conda-forge-ci-setup-4.4.7-py311h7b9440e_0.conda
linux-aarch64::conda-forge-ci-setup-4.5.0-py39h79b3062_100.conda
linux-aarch64::conda-forge-ci-setup-4.4.7-py38h677f2f6_0.conda
linux-aarch64::conda-forge-ci-setup-4.4.7-py311hd94e4f7_0.conda
linux-aarch64::conda-forge-ci-setup-4.4.7-py39hd6fd6c2_0.conda
linux-aarch64::conda-forge-ci-setup-4.7.0-py38he8868b8_100.conda
linux-aarch64::conda-forge-ci-setup-4.7.0-py38h677f2f6_0.conda
linux-aarch64::conda-forge-ci-setup-4.4.7-py311h720b028_100.conda
linux-aarch64::conda-forge-ci-setup-4.4.6-py310h5bef2de_100.conda
linux-aarch64::conda-forge-ci-setup-4.4.6-py311h720b028_100.conda
linux-aarch64::conda-forge-ci-setup-4.6.0-py310h5bef2de_100.conda
linux-aarch64::conda-forge-ci-setup-4.5.1-py312h3e13472_100.conda
linux-aarch64::conda-forge-ci-setup-4.7.0-py310h5bef2de_100.conda
linux-aarch64::conda-forge-ci-setup-4.6.0-py311h720b028_100.conda
linux-aarch64::conda-forge-ci-setup-4.5.0-py310h186cb4b_0.conda
linux-aarch64::conda-forge-ci-setup-4.4.6-py311h59a990d_0.conda
linux-aarch64::conda-forge-ci-setup-4.4.6-py310h86beee5_0.conda
linux-aarch64::conda-forge-ci-setup-4.4.7-py310h5bef2de_100.conda
linux-aarch64::conda-forge-ci-setup-4.7.0-py312h3e13472_100.conda
linux-aarch64::conda-forge-ci-setup-4.5.1-py312h5a1d447_0.conda
linux-aarch64::conda-forge-ci-setup-4.4.7-py312h3e13472_100.conda
linux-aarch64::conda-forge-ci-setup-4.4.7-py39h79b3062_100.conda
linux-aarch64::conda-forge-ci-setup-4.4.6-py38h657a575_0.conda
linux-aarch64::conda-forge-ci-setup-4.6.0-py312h5a1d447_0.conda
linux-aarch64::conda-forge-ci-setup-4.4.6-py311h1b309e6_0.conda
linux-aarch64::conda-forge-ci-setup-4.4.6-py312h3e13472_100.conda
linux-aarch64::conda-forge-ci-setup-4.4.6-py310hefc833d_0.conda
linux-aarch64::conda-forge-ci-setup-4.4.6-py39hea8fda1_0.conda
linux-aarch64::conda-forge-ci-setup-4.5.1-py39h909162b_0.conda
linux-aarch64::conda-forge-ci-setup-4.4.7-py310h186cb4b_0.conda
linux-aarch64::conda-forge-ci-setup-4.4.6-py39h79b3062_100.conda
linux-aarch64::conda-forge-ci-setup-4.4.7-py310hf7787c4_0.conda
linux-aarch64::conda-forge-ci-setup-4.5.0-py38h677f2f6_0.conda
linux-aarch64::conda-forge-ci-setup-4.5.0-py312h3e13472_100.conda
linux-aarch64::conda-forge-ci-setup-4.5.0-py311h720b028_100.conda
linux-aarch64::conda-forge-ci-setup-4.5.1-py38h677f2f6_0.conda
linux-aarch64::conda-forge-ci-setup-4.4.6-py38he8868b8_100.conda
linux-aarch64::conda-forge-ci-setup-4.5.0-py312h5a1d447_0.conda
linux-aarch64::conda-forge-ci-setup-4.7.0-py310h186cb4b_0.conda
linux-aarch64::conda-forge-ci-setup-4.4.6-py38h3bfe421_0.conda
linux-aarch64::conda-forge-ci-setup-4.7.0-py39h79b3062_100.conda
linux-aarch64::conda-forge-ci-setup-4.5.1-py311h720b028_100.conda
linux-aarch64::conda-forge-ci-setup-4.4.7-py38haae9ebc_0.conda
-    "rattler-build-conda-compat >=0.0.2",
+    "rattler-build-conda-compat >=0.0.2,<1.0.0a0",
================================================================================
================================================================================
noarch
noarch::conda-smithy-3.37.0-unix_pyh707e725_0.conda
noarch::conda-smithy-3.37.1-win_pyh7428d3b_0.conda
noarch::conda-smithy-3.37.1-unix_pyh707e725_0.conda
noarch::conda-smithy-3.37.0-win_pyh7428d3b_0.conda
-    "rattler-build-conda-compat >=0.0.6",
+    "rattler-build-conda-compat >=0.0.6,<1.0.0a0",
noarch::conda-smithy-3.37.2-unix_pyh707e725_0.conda
noarch::conda-smithy-3.37.2-win_pyh7428d3b_0.conda
-    "rattler-build-conda-compat >=0.2.4",
+    "rattler-build-conda-compat >=0.2.4,<1.0.0a0",
================================================================================
================================================================================
win-64
win-64::conda-forge-ci-setup-4.4.7-py312h5eb20be_100.conda
win-64::conda-forge-ci-setup-4.4.6-py38ha938f96_0.conda
win-64::conda-forge-ci-setup-4.4.7-py312hc396faf_0.conda
win-64::conda-forge-ci-setup-4.7.0-py311h5360e5d_100.conda
win-64::conda-forge-ci-setup-4.6.0-py38h8bd4248_0.conda
win-64::conda-forge-ci-setup-4.5.0-py311h1e0639e_0.conda
win-64::conda-forge-ci-setup-4.7.0-py310h82d9320_100.conda
win-64::conda-forge-ci-setup-4.4.6-py312hc0b5680_0.conda
win-64::conda-forge-ci-setup-4.4.6-py312h5eb20be_100.conda
win-64::conda-forge-ci-setup-4.6.0-py312h5eb20be_100.conda
win-64::conda-forge-ci-setup-4.4.6-py312h80306c3_0.conda
win-64::conda-forge-ci-setup-4.5.1-py39h0a9a198_0.conda
win-64::conda-forge-ci-setup-4.4.7-py310ha189c35_0.conda
win-64::conda-forge-ci-setup-4.5.1-py311h5360e5d_100.conda
win-64::conda-forge-ci-setup-4.6.0-py38hdbc86bd_100.conda
win-64::conda-forge-ci-setup-4.7.0-py312h5eb20be_100.conda
win-64::conda-forge-ci-setup-4.4.6-py310h40d06c3_0.conda
win-64::conda-forge-ci-setup-4.5.0-py39h0a9a198_0.conda
win-64::conda-forge-ci-setup-4.4.7-py310hfeb49de_0.conda
win-64::conda-forge-ci-setup-4.4.7-py39h0a9a198_0.conda
win-64::conda-forge-ci-setup-4.6.0-py310ha189c35_0.conda
win-64::conda-forge-ci-setup-4.4.7-py38h8bd4248_0.conda
win-64::conda-forge-ci-setup-4.4.6-py311h7ef19d5_0.conda
win-64::conda-forge-ci-setup-4.7.0-py310ha189c35_0.conda
win-64::conda-forge-ci-setup-4.5.0-py39h7090721_100.conda
win-64::conda-forge-ci-setup-4.4.7-py38hdbc86bd_100.conda
win-64::conda-forge-ci-setup-4.6.0-py310h82d9320_100.conda
win-64::conda-forge-ci-setup-4.4.7-py310h82d9320_100.conda
win-64::conda-forge-ci-setup-4.4.6-py38h1a11f15_0.conda
win-64::conda-forge-ci-setup-4.4.6-py310h82d9320_100.conda
win-64::conda-forge-ci-setup-4.5.0-py312h5eb20be_100.conda
win-64::conda-forge-ci-setup-4.5.1-py38h8bd4248_0.conda
win-64::conda-forge-ci-setup-4.7.0-py38h8bd4248_0.conda
win-64::conda-forge-ci-setup-4.5.1-py310ha189c35_0.conda
win-64::conda-forge-ci-setup-4.6.0-py311h5360e5d_100.conda
win-64::conda-forge-ci-setup-4.7.0-py39h0a9a198_0.conda
win-64::conda-forge-ci-setup-4.4.6-py38hdbc86bd_100.conda
win-64::conda-forge-ci-setup-4.4.7-py311h5360e5d_100.conda
win-64::conda-forge-ci-setup-4.5.0-py38h8bd4248_0.conda
win-64::conda-forge-ci-setup-4.4.6-py39h02a6612_0.conda
win-64::conda-forge-ci-setup-4.5.0-py310ha189c35_0.conda
win-64::conda-forge-ci-setup-4.5.0-py38hdbc86bd_100.conda
win-64::conda-forge-ci-setup-4.4.6-py310h3a44da4_0.conda
win-64::conda-forge-ci-setup-4.7.0-py38hdbc86bd_100.conda
win-64::conda-forge-ci-setup-4.5.1-py312hc396faf_0.conda
win-64::conda-forge-ci-setup-4.5.1-py311h1e0639e_0.conda
win-64::conda-forge-ci-setup-4.4.6-py311h75ed0fc_0.conda
win-64::conda-forge-ci-setup-4.4.7-py311h1e0639e_0.conda
win-64::conda-forge-ci-setup-4.4.7-py312h9ab329c_0.conda
win-64::conda-forge-ci-setup-4.4.7-py39h7090721_100.conda
win-64::conda-forge-ci-setup-4.5.1-py312h5eb20be_100.conda
win-64::conda-forge-ci-setup-4.6.0-py312hc396faf_0.conda
win-64::conda-forge-ci-setup-4.4.7-py39he761229_0.conda
win-64::conda-forge-ci-setup-4.4.6-py39h7090721_100.conda
win-64::conda-forge-ci-setup-4.5.1-py310h82d9320_100.conda
win-64::conda-forge-ci-setup-4.6.0-py39h7090721_100.conda
win-64::conda-forge-ci-setup-4.7.0-py311h1e0639e_0.conda
win-64::conda-forge-ci-setup-4.6.0-py311h1e0639e_0.conda
win-64::conda-forge-ci-setup-4.4.7-py38h79889ef_0.conda
win-64::conda-forge-ci-setup-4.7.0-py312hc396faf_0.conda
win-64::conda-forge-ci-setup-4.5.0-py312hc396faf_0.conda
win-64::conda-forge-ci-setup-4.5.0-py310h82d9320_100.conda
win-64::conda-forge-ci-setup-4.4.6-py39ha0fecdc_0.conda
win-64::conda-forge-ci-setup-4.5.0-py311h5360e5d_100.conda
win-64::conda-forge-ci-setup-4.5.1-py39h7090721_100.conda
win-64::conda-forge-ci-setup-4.6.0-py39h0a9a198_0.conda
win-64::conda-forge-ci-setup-4.5.1-py38hdbc86bd_100.conda
win-64::conda-forge-ci-setup-4.4.7-py311h7cffa3c_0.conda
win-64::conda-forge-ci-setup-4.4.6-py311h5360e5d_100.conda
win-64::conda-forge-ci-setup-4.7.0-py39h7090721_100.conda
-    "rattler-build-conda-compat >=0.0.2",
+    "rattler-build-conda-compat >=0.0.2,<1.0.0a0",
================================================================================
================================================================================
osx-64
osx-64::conda-forge-ci-setup-4.5.0-py310h84be057_100.conda
osx-64::conda-forge-ci-setup-4.7.0-py39ha13d70a_100.conda
osx-64::conda-forge-ci-setup-4.6.0-py310h84be057_100.conda
osx-64::conda-forge-ci-setup-4.7.0-py311hedae6b8_100.conda
osx-64::conda-forge-ci-setup-4.5.1-py312hd35cd3b_100.conda
osx-64::conda-forge-ci-setup-4.5.1-py310h84be057_100.conda
osx-64::conda-forge-ci-setup-4.4.7-py312hd35cd3b_100.conda
osx-64::conda-forge-ci-setup-4.4.6-py311hedae6b8_100.conda
osx-64::conda-forge-ci-setup-4.7.0-py312hd35cd3b_100.conda
osx-64::conda-forge-ci-setup-4.5.1-py38hef7b56c_100.conda
osx-64::conda-forge-ci-setup-4.6.0-py38hef7b56c_100.conda
osx-64::conda-forge-ci-setup-4.4.6-py39ha13d70a_100.conda
osx-64::conda-forge-ci-setup-4.5.0-py312hd35cd3b_100.conda
osx-64::conda-forge-ci-setup-4.6.0-py311hedae6b8_100.conda
osx-64::conda-forge-ci-setup-4.6.0-py312hd35cd3b_100.conda
osx-64::conda-forge-ci-setup-4.4.6-py310h84be057_100.conda
osx-64::conda-forge-ci-setup-4.7.0-py38hef7b56c_100.conda
osx-64::conda-forge-ci-setup-4.5.0-py311hedae6b8_100.conda
osx-64::conda-forge-ci-setup-4.4.7-py310h84be057_100.conda
osx-64::conda-forge-ci-setup-4.4.7-py39ha13d70a_100.conda
osx-64::conda-forge-ci-setup-4.7.0-py310h84be057_100.conda
osx-64::conda-forge-ci-setup-4.4.7-py311hedae6b8_100.conda
osx-64::conda-forge-ci-setup-4.4.6-py38hef7b56c_100.conda
osx-64::conda-forge-ci-setup-4.6.0-py39ha13d70a_100.conda
osx-64::conda-forge-ci-setup-4.5.1-py311hedae6b8_100.conda
osx-64::conda-forge-ci-setup-4.5.0-py39ha13d70a_100.conda
osx-64::conda-forge-ci-setup-4.5.1-py39ha13d70a_100.conda
osx-64::conda-forge-ci-setup-4.5.0-py38hef7b56c_100.conda
osx-64::conda-forge-ci-setup-4.4.7-py38hef7b56c_100.conda
osx-64::conda-forge-ci-setup-4.4.6-py312hd35cd3b_100.conda
-    "rattler-build-conda-compat >=0.0.2",
+    "rattler-build-conda-compat >=0.0.2,<1.0.0a0",
================================================================================
================================================================================
linux-64
linux-64::conda-forge-ci-setup-4.5.0-py38hfe6c714_100.conda
linux-64::conda-forge-ci-setup-4.5.0-py311ha4ce16e_0.conda
linux-64::conda-forge-ci-setup-4.4.7-py310h7a2d8a0_100.conda
linux-64::conda-forge-ci-setup-4.5.1-py311hbe2e365_100.conda
linux-64::conda-forge-ci-setup-4.7.0-py39h6cdaf8c_0.conda
linux-64::conda-forge-ci-setup-4.6.0-py310hedcc0dd_0.conda
linux-64::conda-forge-ci-setup-4.4.7-py312hb3d6910_100.conda
linux-64::conda-forge-ci-setup-4.5.1-py310hedcc0dd_0.conda
linux-64::conda-forge-ci-setup-4.4.6-py38he83e49f_0.conda
linux-64::conda-forge-ci-setup-4.7.0-py38hfe6c714_100.conda
linux-64::conda-forge-ci-setup-4.7.0-py312h3013600_0.conda
linux-64::conda-forge-ci-setup-4.4.6-py311h6ad0c23_0.conda
linux-64::conda-forge-ci-setup-4.4.6-py310hb39dd43_0.conda
linux-64::conda-forge-ci-setup-4.5.0-py312hb3d6910_100.conda
linux-64::conda-forge-ci-setup-4.4.6-py310h7a2d8a0_100.conda
linux-64::conda-forge-ci-setup-4.5.0-py39hb2a8d07_100.conda
linux-64::conda-forge-ci-setup-4.5.0-py38h2fa590b_0.conda
linux-64::conda-forge-ci-setup-4.4.6-py38h0301164_0.conda
linux-64::conda-forge-ci-setup-4.5.1-py312h3013600_0.conda
linux-64::conda-forge-ci-setup-4.5.0-py310hedcc0dd_0.conda
linux-64::conda-forge-ci-setup-4.5.0-py312h3013600_0.conda
linux-64::conda-forge-ci-setup-4.7.0-py310hedcc0dd_0.conda
linux-64::conda-forge-ci-setup-4.4.6-py39hb2a8d07_100.conda
linux-64::conda-forge-ci-setup-4.4.7-py39h002d112_0.conda
linux-64::conda-forge-ci-setup-4.4.7-py312hf5ffef0_0.conda
linux-64::conda-forge-ci-setup-4.5.0-py310h7a2d8a0_100.conda
linux-64::conda-forge-ci-setup-4.4.6-py39h6ed42a7_0.conda
linux-64::conda-forge-ci-setup-4.5.0-py311hbe2e365_100.conda
linux-64::conda-forge-ci-setup-4.6.0-py39h6cdaf8c_0.conda
linux-64::conda-forge-ci-setup-4.4.7-py39h6cdaf8c_0.conda
linux-64::conda-forge-ci-setup-4.7.0-py311hbe2e365_100.conda
linux-64::conda-forge-ci-setup-4.5.1-py39h6cdaf8c_0.conda
linux-64::conda-forge-ci-setup-4.4.6-py311h1b06165_0.conda
linux-64::conda-forge-ci-setup-4.6.0-py311hbe2e365_100.conda
linux-64::conda-forge-ci-setup-4.4.6-py312he12de3a_0.conda
linux-64::conda-forge-ci-setup-4.4.7-py311ha4ce16e_0.conda
linux-64::conda-forge-ci-setup-4.4.7-py312h3013600_0.conda
linux-64::conda-forge-ci-setup-4.4.7-py310h75e5732_0.conda
linux-64::conda-forge-ci-setup-4.5.1-py310h7a2d8a0_100.conda
linux-64::conda-forge-ci-setup-4.7.0-py310h7a2d8a0_100.conda
linux-64::conda-forge-ci-setup-4.5.1-py312hb3d6910_100.conda
linux-64::conda-forge-ci-setup-4.5.1-py38h2fa590b_0.conda
linux-64::conda-forge-ci-setup-4.4.7-py38h2fa590b_0.conda
linux-64::conda-forge-ci-setup-4.4.7-py39hb2a8d07_100.conda
linux-64::conda-forge-ci-setup-4.5.1-py39hb2a8d07_100.conda
linux-64::conda-forge-ci-setup-4.5.1-py38hfe6c714_100.conda
linux-64::conda-forge-ci-setup-4.4.7-py311h9eb38cf_0.conda
linux-64::conda-forge-ci-setup-4.6.0-py38hfe6c714_100.conda
linux-64::conda-forge-ci-setup-4.7.0-py312hb3d6910_100.conda
linux-64::conda-forge-ci-setup-4.6.0-py38h2fa590b_0.conda
linux-64::conda-forge-ci-setup-4.4.6-py311hbe2e365_100.conda
linux-64::conda-forge-ci-setup-4.7.0-py311ha4ce16e_0.conda
linux-64::conda-forge-ci-setup-4.4.7-py310hedcc0dd_0.conda
linux-64::conda-forge-ci-setup-4.6.0-py312hb3d6910_100.conda
linux-64::conda-forge-ci-setup-4.4.6-py312hb3d6910_100.conda
linux-64::conda-forge-ci-setup-4.6.0-py39hb2a8d07_100.conda
linux-64::conda-forge-ci-setup-4.5.0-py39h6cdaf8c_0.conda
linux-64::conda-forge-ci-setup-4.4.6-py312hed50e87_0.conda
linux-64::conda-forge-ci-setup-4.5.1-py311ha4ce16e_0.conda
linux-64::conda-forge-ci-setup-4.7.0-py38h2fa590b_0.conda
linux-64::conda-forge-ci-setup-4.4.7-py38h7f2e40a_0.conda
linux-64::conda-forge-ci-setup-4.6.0-py310h7a2d8a0_100.conda
linux-64::conda-forge-ci-setup-4.4.6-py310h097ba74_0.conda
linux-64::conda-forge-ci-setup-4.6.0-py312h3013600_0.conda
linux-64::conda-forge-ci-setup-4.4.7-py38hfe6c714_100.conda
linux-64::conda-forge-ci-setup-4.4.6-py39hd657eca_0.conda
linux-64::conda-forge-ci-setup-4.4.6-py38hfe6c714_100.conda
linux-64::conda-forge-ci-setup-4.7.0-py39hb2a8d07_100.conda
linux-64::conda-forge-ci-setup-4.6.0-py311ha4ce16e_0.conda
linux-64::conda-forge-ci-setup-4.4.7-py311hbe2e365_100.conda
-    "rattler-build-conda-compat >=0.0.2",
+    "rattler-build-conda-compat >=0.0.2,<1.0.0a0",
```

An upstream PR is created to make sure this doesnt happen again: 

- https://github.com/conda-forge/conda-smithy/pull/2009.
- https://github.com/conda-forge/conda-forge-ci-setup-feedstock/pull/333