### PR TITLE
fix(piecash): tighten sqlalchemy to <1.4 on piecash<1.2.1

### DIFF
--- a/recipe/patch_yaml/piecash.yaml
+++ b/recipe/patch_yaml/piecash.yaml
@@ -1,0 +1,9 @@
+if:
+  name: piecash
+  timestamp_lt: 1722691941000
+  version_lt: 1.2.1
+  has_depends: sqlalchemy?( *)
+then:
+  - tighten_depends:
+      name: sqlalchemy
+      upper_bound: "1.4"


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

closes https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/issues/813

diff:
```diff
================================================================================
================================================================================
noarch
noarch::piecash-1.1.4-pyh44b312d_0.tar.bz2
noarch::piecash-1.1.2-pyhd3deb0d_0.tar.bz2
noarch::piecash-1.1.3-pyh44b312d_0.tar.bz2
-    "sqlalchemy >=1.0",
+    "sqlalchemy >=1.0,<1.4.0a0",
```