### PR TITLE
Add a conflict between old lazy_loader and new lazy-loader

### DIFF
--- a/recipe/patch_yaml/lazy_loader.yaml
+++ b/recipe/patch_yaml/lazy_loader.yaml
@@ -1,0 +1,9 @@
+# The lazy_loader package got renamed to lazy-loader
+# https://github.com/conda-forge/lazy_loader-feedstock/pull/11
+if:
+  timestamp_le: 1722783338000
+  name: lazy_loader
+  not_has_depends: lazy-loader?( *)
+
+then:
+  - add_depends: lazy-loader <0.0a


### PR DESCRIPTION
xref: https://github.com/conda-forge/lazy_loader-feedstock/pull/11

@jni honestly, this was way more work than I anticipated. Package transitions are still an issue with conda
https://github.com/conda-forge/conda-forge.github.io/issues/1894

and these kinds of "small changes" have real impact on the maintainability of packages for downstream packages.

Hopefully these can be avoided in the future....

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
