### PR TITLE
Fix lazy loader pinning

### DIFF
--- a/recipe/patch_yaml/lazy_loader.yaml
+++ b/recipe/patch_yaml/lazy_loader.yaml
@@ -3,7 +3,6 @@
 if:
   timestamp_le: 1722783338000
   name: lazy_loader
-  not_has_depends: lazy-loader?( *)
 
 then:
-  - add_depends: lazy-loader <0.0a
+  - add_constrains: lazy-loader <0.0a


### PR DESCRIPTION
We added the wrong patch in https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/815#discussion_r1703950671 

This fixes that.


Checklist

* [ ] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
