### PR TITLE
Don't patch llvm packages for new versions

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -676,17 +676,18 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
         if record_name in llvm_pkgs:
             new_constrains = record.get("constrains", [])
             version = record["version"]
-            for pkg in llvm_pkgs:
-                if record_name == pkg:
-                    continue
-                if pkg in new_constrains:
-                    del new_constrains[pkg]
-                if any(
-                    constraint.startswith(f"{pkg} ") for constraint in new_constrains
-                ):
-                    continue
-                new_constrains.append(f"{pkg} {version}.*")
-            record["constrains"] = new_constrains
+            if parse_version(version) < parse_version("17.0.0.a0"):
+                for pkg in llvm_pkgs:
+                    if record_name == pkg:
+                        continue
+                    if pkg in new_constrains:
+                        del new_constrains[pkg]
+                    if any(
+                        constraint.startswith(f"{pkg} ") for constraint in new_constrains
+                    ):
+                        continue
+                    new_constrains.append(f"{pkg} {version}.*")
+                record["constrains"] = new_constrains
 
         if record_name == "gcc_impl_{}".format(subdir):
             _relax_exact(fn, record, "binutils_impl_{}".format(subdir))

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -683,7 +683,8 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                     if pkg in new_constrains:
                         del new_constrains[pkg]
                     if any(
-                        constraint.startswith(f"{pkg} ") for constraint in new_constrains
+                        constraint.startswith(f"{pkg} ")
+                        for constraint in new_constrains
                     ):
                         continue
                     new_constrains.append(f"{pkg} {version}.*")


### PR DESCRIPTION
Checklist

* [ ] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->


cc @beckermr @h-vetinari 