### PR TITLE
Use repodata.json.zst instead of .bz2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,6 +26,7 @@ requirements:
     - pydantic
     - pytest
     - conda-build
+    - zstandard
   host:
   run:
 

--- a/recipe/patch_yaml_model.py
+++ b/recipe/patch_yaml_model.py
@@ -3,13 +3,14 @@ Pydantic model for patch_yaml documents
 """
 
 from __future__ import annotations
+
 import itertools
 import json
 from pathlib import Path
 from typing import Annotated
 
-from annotated_types import MinLen, Ge
-from pydantic import BaseModel, Field, ConfigDict
+from annotated_types import Ge, MinLen
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class _ForbidExtra(BaseModel):

--- a/recipe/patch_yaml_utils.py
+++ b/recipe/patch_yaml_utils.py
@@ -1,11 +1,12 @@
-import yaml
+import fnmatch as _fnmatch
 import glob
 import os
-import string
-from packaging.version import parse as parse_version
-import fnmatch as _fnmatch
 import re
+import string
 from functools import lru_cache
+
+import yaml
+from packaging.version import parse as parse_version
 
 ALLOWED_TEMPLATE_KEYS = [
     "name",

--- a/recipe/test_gen_patch_json.py
+++ b/recipe/test_gen_patch_json.py
@@ -1,5 +1,6 @@
-from gen_patch_json import _gen_patch_instructions, REMOVALS, add_python_abi
 import copy
+
+from gen_patch_json import REMOVALS, _gen_patch_instructions, add_python_abi
 
 
 def test_gen_patch_instructions():

--- a/recipe/test_patch_yaml_utils.py
+++ b/recipe/test_patch_yaml_utils.py
@@ -2,9 +2,8 @@ from pathlib import Path
 
 import pytest
 import yaml
-
-from patch_yaml_utils import _test_patch_yaml, _apply_patch_yaml, ALLOWED_TEMPLATE_KEYS
-from patch_yaml_model import generate_schema, PatchYaml
+from patch_yaml_model import PatchYaml, generate_schema
+from patch_yaml_utils import ALLOWED_TEMPLATE_KEYS, _apply_patch_yaml, _test_patch_yaml
 
 
 def test_test_patch_yaml_record_key():


### PR DESCRIPTION
This takes advantage of the fact that `repodata*.json.zst` is available, providing a small speedup.

ruff was also used to sort imports.

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
