### PR TITLE
add missing numpy lower bounds to scipy

### DIFF
--- a/recipe/patch_yaml/scipy.yaml
+++ b/recipe/patch_yaml/scipy.yaml
@@ -1,3 +1,28 @@
+# missing lower bounds for numpy after 2.0 migration, c.f.
+# https://github.com/conda-forge/numpy-feedstock/issues/324
+# the upper bound has been there correctly, c.f.
+# https://github.com/conda-forge/scipy-feedstock/commit/0711eb22f502ce2f1ea1bd7a22ffd4b8f73b73a7
+if:
+  name: scipy
+  version: 1.14.0
+
+then:
+  # https://github.com/scipy/scipy/blob/v1.14.0/pyproject.toml#L55
+  - add_constrains: numpy >=1.23.5
+
+---
+
+if:
+  name: scipy
+  version_lt: 1.14.0
+  version_ge: 1.13.0
+
+then:
+  # https://github.com/scipy/scipy/blob/v1.13.1/pyproject.toml#L55
+  - add_constrains: numpy >=1.22.4
+
+---
+
 # 2024/01 -- hmaarrfk
 # scipy version 1.12.0 build 2 was patched
 # for compatibility with libopenblas 0.3.26

--- a/recipe/patch_yaml/scipy.yaml
+++ b/recipe/patch_yaml/scipy.yaml
@@ -8,7 +8,9 @@ if:
 
 then:
   # https://github.com/scipy/scipy/blob/v1.14.0/pyproject.toml#L55
-  - add_constrains: numpy >=1.23.5
+  - replace_depends:
+      old: numpy <2.3
+      new: numpy >=1.23.5,<2.3
 
 ---
 
@@ -19,7 +21,9 @@ if:
 
 then:
   # https://github.com/scipy/scipy/blob/v1.13.1/pyproject.toml#L55
-  - add_constrains: numpy >=1.22.4
+  - replace_depends:
+      old: numpy <2.3
+      new: numpy >=1.22.4,<2.3
 
 ---
 


### PR DESCRIPTION
Noticed by @hmaarrfk in the context of https://github.com/conda-forge/numpy-feedstock/issues/324 - thanks! 🙏 

Output of `python show_diff.py` (excluding some obviously unrelated ffmpeg changes)

```diff
>python show_diff.py
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
osx-arm64::scipy-1.13.0-py312h14ffa8f_1.conda
osx-arm64::scipy-1.13.1-py312h14ffa8f_0.conda
osx-arm64::scipy-1.13.0-py311hceeca8c_1.conda
osx-arm64::scipy-1.13.0-py310h7057308_1.conda
osx-arm64::scipy-1.13.0-py39h3d5391c_1.conda
osx-arm64::scipy-1.13.1-py310h7057308_0.conda
osx-arm64::scipy-1.13.1-py39h3d5391c_0.conda
osx-arm64::scipy-1.13.1-py311hceeca8c_0.conda
-    "numpy <2.3",
+    "numpy >=1.22.4,<2.3",
osx-arm64::scipy-1.14.0-py312h14ffa8f_1.conda
osx-arm64::scipy-1.14.0-py310h7057308_2.conda
osx-arm64::scipy-1.14.0-py312h14ffa8f_0.conda
osx-arm64::scipy-1.14.0-py311hceeca8c_1.conda
osx-arm64::scipy-1.14.0-py310h7057308_0.conda
osx-arm64::scipy-1.14.0-py310h7057308_1.conda
osx-arm64::scipy-1.14.0-py311hceeca8c_0.conda
-    "numpy <2.3",
+    "numpy >=1.23.5,<2.3",
================================================================================
================================================================================
linux-ppc64le
linux-ppc64le::scipy-1.14.0-py312h9bfcd4c_0.conda
linux-ppc64le::scipy-1.14.0-py311hbefd982_0.conda
linux-ppc64le::scipy-1.14.0-py312h9bfcd4c_1.conda
linux-ppc64le::scipy-1.14.0-py310h784e85a_0.conda
linux-ppc64le::scipy-1.14.0-py311hbefd982_1.conda
linux-ppc64le::scipy-1.14.0-py310h784e85a_1.conda
-    "numpy <2.3",
+    "numpy >=1.23.5,<2.3",
linux-ppc64le::scipy-1.13.1-py310h784e85a_0.conda
linux-ppc64le::scipy-1.13.0-py310h784e85a_1.conda
linux-ppc64le::scipy-1.13.0-py312h9bfcd4c_1.conda
linux-ppc64le::scipy-1.13.1-py39h30478d8_0.conda
linux-ppc64le::scipy-1.13.0-py39h30478d8_1.conda
linux-ppc64le::scipy-1.13.1-py312h9bfcd4c_0.conda
linux-ppc64le::scipy-1.13.0-py311hbefd982_1.conda
linux-ppc64le::scipy-1.13.1-py311hbefd982_0.conda
-    "numpy <2.3",
+    "numpy >=1.22.4,<2.3",
================================================================================
================================================================================
linux-aarch64
linux-aarch64::scipy-1.13.0-py312h37abc14_1.conda
linux-aarch64::scipy-1.13.1-py39hb921187_0.conda
linux-aarch64::scipy-1.13.1-py310h70fbbe5_0.conda
linux-aarch64::scipy-1.13.1-py312h37abc14_0.conda
linux-aarch64::scipy-1.13.0-py39hb921187_1.conda
linux-aarch64::scipy-1.13.1-py311hbd9a39d_0.conda
linux-aarch64::scipy-1.13.0-py310h70fbbe5_1.conda
linux-aarch64::scipy-1.13.0-py311hbd9a39d_1.conda
-    "numpy <2.3",
+    "numpy >=1.22.4,<2.3",
linux-aarch64::scipy-1.14.0-py312h37abc14_1.conda
linux-aarch64::scipy-1.14.0-py311hbd9a39d_1.conda
linux-aarch64::scipy-1.14.0-py310h70fbbe5_1.conda
linux-aarch64::scipy-1.14.0-py312h37abc14_0.conda
linux-aarch64::scipy-1.14.0-py310h70fbbe5_0.conda
linux-aarch64::scipy-1.14.0-py311hbd9a39d_0.conda
-    "numpy <2.3",
+    "numpy >=1.23.5,<2.3",
================================================================================
================================================================================
noarch
================================================================================
================================================================================
win-64
win-64::scipy-1.14.0-py310h46043a1_1.conda
win-64::scipy-1.14.0-py310h46043a1_0.conda
win-64::scipy-1.14.0-py311hd4686c6_0.conda
win-64::scipy-1.14.0-py311hd4686c6_1.conda
win-64::scipy-1.14.0-py312h1f4e10d_1.conda
win-64::scipy-1.14.0-py312h1f4e10d_0.conda
-    "numpy <2.3",
+    "numpy >=1.23.5,<2.3",
win-64::scipy-1.13.0-py310h46043a1_1.conda
win-64::scipy-1.13.1-py311hd4686c6_0.conda
win-64::scipy-1.13.0-py311hd4686c6_1.conda
win-64::scipy-1.13.1-py312h1f4e10d_0.conda
win-64::scipy-1.13.0-py39h1a10956_1.conda
win-64::scipy-1.13.0-py312h1f4e10d_1.conda
win-64::scipy-1.13.1-py39h1a10956_0.conda
win-64::scipy-1.13.1-py310h46043a1_0.conda
-    "numpy <2.3",
+    "numpy >=1.22.4,<2.3",
================================================================================
================================================================================
osx-64
osx-64::scipy-1.14.0-py311h40a1ab3_0.conda
osx-64::scipy-1.14.0-py310h35d8cac_0.conda
osx-64::scipy-1.14.0-py310h35d8cac_1.conda
osx-64::scipy-1.14.0-py312hb9702fa_1.conda
osx-64::scipy-1.14.0-py311h40a1ab3_1.conda
osx-64::scipy-1.14.0-py312hb9702fa_0.conda
-    "numpy <2.3",
+    "numpy >=1.23.5,<2.3",
osx-64::scipy-1.13.0-py311hd5d9b8d_1.conda
osx-64::scipy-1.13.0-py310hca31a43_1.conda
osx-64::scipy-1.13.0-py39h72a3afc_1.conda
osx-64::scipy-1.13.0-py312h741d2f9_1.conda
osx-64::scipy-1.13.1-py311h40a1ab3_0.conda
osx-64::scipy-1.13.1-py39h038d4f4_0.conda
osx-64::scipy-1.13.1-py310h35d8cac_0.conda
osx-64::scipy-1.13.1-py312hb9702fa_0.conda
-    "numpy <2.3",
+    "numpy >=1.22.4,<2.3",
================================================================================
================================================================================
linux-64
linux-64::scipy-1.14.0-py310h93e2701_0.conda
linux-64::scipy-1.14.0-py310h93e2701_1.conda
linux-64::scipy-1.14.0-py312hc2bc53b_0.conda
linux-64::scipy-1.14.0-py312hc2bc53b_1.conda
linux-64::scipy-1.14.0-py311h517d4fd_0.conda
linux-64::scipy-1.14.0-py311h517d4fd_1.conda
-    "numpy <2.3",
+    "numpy >=1.23.5,<2.3",
linux-64::scipy-1.13.0-py39haf93ffa_1.conda
linux-64::scipy-1.13.0-py312hc2bc53b_1.conda
linux-64::scipy-1.13.1-py39haf93ffa_0.conda
linux-64::scipy-1.13.0-py310h93e2701_1.conda
linux-64::scipy-1.13.1-py311h517d4fd_0.conda
linux-64::scipy-1.13.1-py312hc2bc53b_0.conda
linux-64::scipy-1.13.1-py310h93e2701_0.conda
linux-64::scipy-1.13.0-py311h517d4fd_1.conda
-    "numpy <2.3",
+    "numpy >=1.22.4,<2.3",
```