### PR TITLE
Patch rabbitmq-delayed-message-exchange

### DIFF
--- a/recipe/patch_yaml/rabbitmq-delayed-message-exchange.yaml
+++ b/recipe/patch_yaml/rabbitmq-delayed-message-exchange.yaml
@@ -1,0 +1,26 @@
+if:
+  name: rabbitmq-delayed-message-exchange
+  timestamp_lt: 1692543265000
+  version_in: ["3.10.0", "3.10.2"]
+then:
+  - replace_depends:
+      old: rabbitmq-server >=3.8.16
+      new: rabbitmq-server >=3.10.0,<3.11
+---
+if:
+  name: rabbitmq-delayed-message-exchange
+  timestamp_lt: 1692543265000
+  version: 3.11.1
+then:
+  - replace_depends:
+      old: rabbitmq-server >=3.11.0
+      new: rabbitmq-server >=3.11.0,<3.12
+---
+if:
+  name: rabbitmq-delayed-message-exchange
+  timestamp_lt: 1692543265000
+  version: 3.9.0
+then:
+  - replace_depends:
+      old: rabbitmq-server >=3.8.16
+      new: rabbitmq-server >=3.9.0,<3.10


### PR DESCRIPTION
Old versions of this package didn't have the version constrained properly, so it would install incompatible plugin versions into newer rabbitmq installations.

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future.

Output of `show_diff.py`:
```
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
noarch
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
osx-64::rabbitmq-delayed-message-exchange-3.10.2-h694c41f_0.tar.bz2
osx-64::rabbitmq-delayed-message-exchange-3.10.0-h694c41f_0.tar.bz2
-    "rabbitmq-server >=3.8.16"
+    "rabbitmq-server >=3.10.0,<3.11"
osx-64::rabbitmq-delayed-message-exchange-3.11.1-h694c41f_0.tar.bz2
-    "rabbitmq-server >=3.11.0"
+    "rabbitmq-server >=3.11.0,<3.12"
osx-64::rabbitmq-delayed-message-exchange-3.9.0-h694c41f_0.tar.bz2
-    "rabbitmq-server >=3.8.16"
+    "rabbitmq-server >=3.9.0,<3.10"
================================================================================
================================================================================
linux-64
linux-64::rabbitmq-delayed-message-exchange-3.9.0-ha770c72_0.tar.bz2
-    "rabbitmq-server >=3.8.16"
+    "rabbitmq-server >=3.9.0,<3.10"
linux-64::rabbitmq-delayed-message-exchange-3.10.0-ha770c72_0.tar.bz2
linux-64::rabbitmq-delayed-message-exchange-3.10.2-ha770c72_0.tar.bz2
-    "rabbitmq-server >=3.8.16"
+    "rabbitmq-server >=3.10.0,<3.11"
linux-64::rabbitmq-delayed-message-exchange-3.11.1-ha770c72_0.tar.bz2
-    "rabbitmq-server >=3.11.0"
+    "rabbitmq-server >=3.11.0,<3.12"
```

This matches the [eight released packages](https://anaconda.org/conda-forge/rabbitmq-delayed-message-exchange/files) (before it was fixed in the 3.12 version of the feedstock)
