### PR TITLE
Raise minimum Python version for voluptuous 0.15

### DIFF
--- a/recipe/patch_yaml/voluptuous.yaml
+++ b/recipe/patch_yaml/voluptuous.yaml
@@ -1,0 +1,8 @@
+if:
+  name: voluptuous
+  version: 0.15.*
+  timestamp_lt: 1724427343000
+then:
+  - replace_depends:
+      old: python >=3.6
+      new: python >=3.9


### PR DESCRIPTION
This accounts for https://github.com/conda-forge/voluptuous-feedstock/pull/32.

With voluptuous 0.15, I see strange errors in other packages with Pyhon 3.8. For example, `stestr run --help` fails.

Checklist

* [ ] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

`show_diff.py` output:

```
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
noarch
noarch::voluptuous-0.15.1-pyhd8ed1ab_0.conda
noarch::voluptuous-0.15.0-pyhd8ed1ab_0.conda
noarch::voluptuous-0.15.2-pyhd8ed1ab_0.conda
-    "python >=3.6"
+    "python >=3.9"
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
================================================================================
================================================================================
linux-64
```
