### PR TITLE
Patch etils 1.6.0 to require python>=3.10

### DIFF
--- a/recipe/patch_yaml/etils.yaml
+++ b/recipe/patch_yaml/etils.yaml
@@ -14,3 +14,19 @@ then:
   - replace_depends:
       old: python >=3.7
       new: python >=3.8
+---
+# etils 1.6.0 dropped support for Python 3.9, but the initial conda-forge build
+# number 0 didn't update the minimum Python version. It was subsequently fixed
+# in build number 1
+# https://github.com/conda-forge/etils-feedstock/pull/21
+# https://github.com/google/etils/issues/531
+# https://github.com/conda-forge/etils-feedstock/pull/22
+if:
+  name: etils
+  version: "1.6.0"
+  build_number: 0
+  timestamp_lt: 1724770940000
+then:
+  - replace_depends:
+      old: "python >=3.9"
+      new: "python >=3.10"


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

---

etils 1.6.0 dropped support for Python 3.9 (https://github.com/google/etils/issues/531), but the initial conda-forge build number 0 didn't update the minimum Python version to 3.10 (https://github.com/conda-forge/etils-feedstock/pull/21). It was subsequently fixed in build number 1 (https://github.com/conda-forge/etils-feedstock/pull/22). This PR patches [etils 1.6.0](https://anaconda.org/conda-forge/etils/files?version=1.6.0) build number 0 to depend on `python>=3.10`

cc: @Shelnutt2, @conda-forge/etils 

I ran `show_diff.py` locally:

```sh
mamba activate repodata-patches
pre-commit run -a
## flake8...................................................................Passed
## ruff.....................................................................Passed
## black....................................................................Passed
## yamllint.................................................................Passed
cd recipe/
python show_diff.py --subdirs noarch
## ================================================================================
## ================================================================================
## noarch
## noarch::apache-airflow-providers-celery-3.8.0-pyhd8ed1ab_0.conda
## -    "python =3.8,<4.dev0"
## +    "python ==3.8,<4.dev0.*"
## noarch::etils-1.6.0-pyhd8ed1ab_0.conda
## -    "python >=3.9"
## +    "python >=3.10"
```

I assume that the `apache-airflow-providers-celery` patch is displaying because the CDN hasn't been cloned in over an hour ([status](https://conda-forge.org/status/)):

![image](https://github.com/user-attachments/assets/0869ee0c-3f40-4a17-9c50-1fb539a6cc6e)

And here is a minimal reprex to demonstrate the error when etils 1.6.0 is installed with Python 3.9:

```sh
mamba create --yes -n test-etils-1.6.0 -c conda-forge \
  etils==1.6.0 tensorflow-datasets==4.8.3 python==3.9
mamba activate test-etils-1.6.0
mamba list etils
## # packages in environment at /home/wsl/mambaforge/envs/test-etils-1.6.0:
## #
## # Name                    Version                   Build  Channel
## etils                     1.6.0              pyhd8ed1ab_0    conda-forge
python -c "import tensorflow_datasets"
## Traceback (most recent call last):
##   File "<string>", line 1, in <module>
##   File "/home/wsl/mambaforge/envs/test-etils-1.6.0/lib/python3.9/site-packages/tensorflow_datasets/__init__.py", line 43, in <module>
##     import tensorflow_datasets.core.logging as _tfds_logging
##   File "/home/wsl/mambaforge/envs/test-etils-1.6.0/lib/python3.9/site-packages/tensorflow_datasets/core/__init__.py", line 20, in <module>
##     from etils.epath import Path
##   File "/home/wsl/mambaforge/envs/test-etils-1.6.0/lib/python3.9/site-packages/etils/epath/__init__.py", line 19, in <module>
##     from etils.epath import testing
##   File "/home/wsl/mambaforge/envs/test-etils-1.6.0/lib/python3.9/site-packages/etils/epath/testing.py", line 27, in <module>
##     from etils.epath import gpath
##   File "/home/wsl/mambaforge/envs/test-etils-1.6.0/lib/python3.9/site-packages/etils/epath/gpath.py", line 29, in <module>
##     from etils import epy
##   File "/home/wsl/mambaforge/envs/test-etils-1.6.0/lib/python3.9/site-packages/etils/epy/__init__.py", line 22, in <module>
##     from etils.epy.binary_import import binary_adhoc
##   File "/home/wsl/mambaforge/envs/test-etils-1.6.0/lib/python3.9/site-packages/etils/epy/binary_import.py", line 55, in <module>
##     restrict: None | py_utils.StrOrStrList = None,
## TypeError: unsupported operand type(s) for |: 'NoneType' and '_UnionGenericAlias'
```
