### PR TITLE
mudata 0.3.0 requires python>=3.10

### DIFF
--- a/recipe/patch_yaml/mudata.yaml
+++ b/recipe/patch_yaml/mudata.yaml
@@ -1,0 +1,15 @@
+# mudata 0.3.0 dropped support for Python 3.9, but the initial conda-forge build
+# number 0 didn't update the minimum Python version. It was subsequently fixed
+# in build number 1
+# https://github.com/scverse/mudata/commit/ce28ac42c941103f1d8521a5d805777d1af3651e
+# https://github.com/conda-forge/mudata-feedstock/pull/12
+# https://github.com/conda-forge/mudata-feedstock/pull/13
+if:
+  name: mudata
+  version: "0.3.0"
+  build_number: 0
+  timestamp_lt: 1724770940000
+then:
+  - replace_depends:
+      old: "python >=3.9"
+      new: "python >=3.10"


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

---

Title says it all

cc: @Shelnutt2, @conda-forge/mudata
xref: https://github.com/scverse/mudata/commit/ce28ac42c941103f1d8521a5d805777d1af3651e, https://github.com/conda-forge/mudata-feedstock/pull/12, https://github.com/conda-forge/mudata-feedstock/pull/13
