### PR TITLE
update numpy dependency in adios_db

### DIFF
--- a/recipe/patch_yaml/adios_db.yaml
+++ b/recipe/patch_yaml/adios_db.yaml
@@ -1,0 +1,9 @@
+if:
+  name: adios_db
+  version: 1.2.4
+  timestamp_lt: 1724885983000
+  build_number: 0
+then:
+  - replace_depends:
+      old: numpy >=2
+      new: numpy >=1.24

--- a/recipe/patch_yaml/adios_db.yaml
+++ b/recipe/patch_yaml/adios_db.yaml
@@ -3,6 +3,8 @@ if:
   version: 1.2.4
   timestamp_lt: 1724885983000
   build_number: 0
+  subdir_in:
+    - noarch
 then:
   - replace_depends:
       old: numpy >=2

--- a/recipe/patch_yaml/mapbox_earcut.yaml
+++ b/recipe/patch_yaml/mapbox_earcut.yaml
@@ -1,0 +1,10 @@
+# add constraint on numpy <2.0
+if:
+  name: mapbox_earcut
+  version: 1.0.1
+  timestamp_lt: 1720808421000
+  build_number: 0
+then:
+  - replace_depends:
+      old: numpy
+      new: numpy <2


### PR DESCRIPTION
Checklist

* [x ] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ x] Ran `python show_diff.py` and posted the output as part of the PR.
* [ x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

```
$ python show_diff.py
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
noarch
noarch::adios_db-1.2.4-pyhd8ed1ab_0.conda
-    "numpy >=2",
+    "numpy >=1.24",
noarch::apache-airflow-providers-celery-3.8.1-pyhd8ed1ab_0.conda
-    "python =3.8,<4.dev0"
+    "python ==3.8,<4.dev0.*"
================================================================================
================================================================================
win-64
win-64::python-3.13.0rc1-h27ba58f_1_cp313t.conda
-  "track_features": "py_freethreading",
================================================================================
================================================================================
osx-64
================================================================================
================================================================================
linux-64
```

