### PR TITLE
update pins for anaconda-cloud-cli 0.1.0

### DIFF
--- a/recipe/patch_yaml/anaconda-cloud-cli.yaml
+++ b/recipe/patch_yaml/anaconda-cloud-cli.yaml
@@ -11,3 +11,17 @@ then:
   - replace_depends:
       old: anaconda-cloud-auth
       new: anaconda-cloud-auth <0.6.0
+---
+if:
+  artifact_in: anaconda-cloud-cli-0.2.0-pyhd8ed1ab_0.conda
+  timestamp_lt: 1724944679000
+then:
+  - replace_depends:
+      old: anaconda-cli-base >=0.2
+      new: anaconda-cli-base >=0.2,<0.3
+  - replace_depends:
+      old: anaconda-cloud-auth >=0.3
+      new: anaconda-cloud-auth >=0.3,<0.6
+  - replace_depends:
+      old: anaconda-client >=1.12.2
+      new: anaconda-client >=1.12.2,<1.13

--- a/recipe/patch_yaml/anaconda-cloud-cli.yaml
+++ b/recipe/patch_yaml/anaconda-cloud-cli.yaml
@@ -1,0 +1,12 @@
+# In anaconda-cli-base 0.3.0 the plugin structure changed and this package
+# is no longer utilized. Updating pins here to avoid this package being installed
+# alongside the new plugin implementation.
+if:
+  artifact_in: anaconda-cloud-cli-0.1.0-pyhd8ed1ab_0.conda
+then:
+  - replace_depends:
+      old: anaconda-cli-base
+      new: anaconda-cli-base <0.3.0
+  - replace_depends:
+      old: anaconda-cloud-auth
+      new: anaconda-cloud-auth <0.6.0

--- a/recipe/patch_yaml/anaconda-cloud-cli.yaml
+++ b/recipe/patch_yaml/anaconda-cloud-cli.yaml
@@ -3,6 +3,7 @@
 # alongside the new plugin implementation.
 if:
   artifact_in: anaconda-cloud-cli-0.1.0-pyhd8ed1ab_0.conda
+  timestamp_lt: 1724944679000
 then:
   - replace_depends:
       old: anaconda-cli-base


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

show_diff.py output limited to this pacakge

```
noarch::anaconda-cloud-cli-0.2.0-pyhd8ed1ab_0.conda
-    "anaconda-cli-base >=0.2",
-    "anaconda-client >=1.12.2",
-    "anaconda-cloud-auth >=0.3",
+    "anaconda-cli-base >=0.2,<0.3",
+    "anaconda-client >=1.12.2,<1.13",
+    "anaconda-cloud-auth >=0.3,<0.6",
noarch::anaconda-cloud-cli-0.1.0-pyhd8ed1ab_0.conda
-    "anaconda-cli-base",
-    "anaconda-cloud-auth",
+    "anaconda-cli-base <0.3.0",
+    "anaconda-cloud-auth <0.6.0",
```
