### PR TITLE
patch pyjwt 2.7, 2.8 and 2.9 python support

### DIFF
--- a/recipe/patch_yaml/pyjwt.yaml
+++ b/recipe/patch_yaml/pyjwt.yaml
@@ -1,0 +1,31 @@
+# https://github.com/conda-forge/pyjwt-feedstock/issues/33
+# pyjwt 2.7 and 2.8 need typing_extensions
+---
+if:
+  name: pyjwt
+  version: 2.7.0
+  timestamp_lt: 1724951023000  # 2024 Aug 29
+then:
+  - add_depends:
+      - typing_extensions
+---
+if:
+  name: pyjwt
+  version: 2.8.0
+  timestamp_lt: 1724951023000  # 2024 Aug 29
+then:
+  - add_depends:
+      - typing_extensions
+---
+# pyjwt 2.9 doesn't support py37
+if:
+  name: pyjwt
+  version: 2.9.0
+  timestamp_lt: 1724951023000  # 2024 Aug 29
+then:
+  - replace_constrains:
+      old: "cryptography >=3.3.1"
+      new: "cryptography >=3.4.0"
+  - replace_depends:
+      old: "python >=3.7"
+      new: "python >=3.8"


### PR DESCRIPTION
See https://github.com/conda-forge/pyjwt-feedstock/issues/33

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
```
$ python show_diff.py --subdirs noarch
================================================================================
================================================================================
noarch
noarch::pyjwt-2.8.0-pyhd8ed1ab_1.conda
-    "python >=3.7"
+    "python >=3.7",
+    "typing_extensions"
noarch::pyjwt-2.9.0-pyhd8ed1ab_0.conda
-    "cryptography >=3.3.1"
+    "cryptography >=3.4.0"
-    "python >=3.7"
+    "python >=3.8"
noarch::pyjwt-2.8.0-pyhd8ed1ab_0.conda
noarch::pyjwt-2.7.0-pyhd8ed1ab_0.conda
-    "python >=3.6"
+    "python >=3.6",
+    "typing_extensions"
noarch::apache-airflow-providers-celery-3.8.1-pyhd8ed1ab_0.conda
-    "python =3.8,<4.dev0"
+    "python ==3.8,<4.dev0.*"
```