### PR TITLE
anndata 0.10.9 is incompatible with mudata<0.3.1

### DIFF
--- a/recipe/patch_yaml/mudata.yaml
+++ b/recipe/patch_yaml/mudata.yaml
@@ -13,3 +13,13 @@ then:
   - replace_depends:
       old: "python >=3.9"
       new: "python >=3.10"
+---
+if:
+  name: mudata
+  version_lt: "0.3.1"
+  build_number: 0
+  timestamp_lt: 1725468863000
+then:
+  - tighten_depends:
+      name: anndata
+      upper_bound: 0.10.9


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
---

The recently released anndata 0.10.9 is incompatible with mudata <0.3.1. mudata 0.3.1 was released immediately after 0.3.0 in order to fix this incompatibility.

cc: @conda-forge/mudata, @conda-forge/anndata 
xref: https://github.com/scverse/mudata/issues/77, https://github.com/conda-forge/mudata-feedstock/pull/14, https://github.com/conda-forge/mudata-feedstock/pull/15

Demonstrating the problem:

```sh
# 0.2.0
mamba create --yes -n test-mudata-0.2.0 \
  -c conda-forge --override-channels \
  anndata=0.10.9 mudata=0.2.0
mamba activate test-mudata-0.2.0
python -c "import mudata"
## ImportError: cannot import name 'AlignedViewMixin' from 'anndata._core.aligned_mapping' (/home/wsl/mambaforge/envs/test-mudata-0.2.0/lib/python3.12/site-packages/anndata/_core/aligned_mapping.py). Did you mean: 'AlignedView'?
mamba deactivate

# 0.2.4
mamba create --yes -n test-mudata-0.2.4 \
  -c conda-forge --override-channels \
  anndata=0.10.9 mudata=0.2.4
mamba activate test-mudata-0.2.4
python -c "import mudata"
## ImportError: cannot import name 'AlignedViewMixin' from 'anndata._core.aligned_mapping' (/home/wsl/mambaforge/envs/test-mudata-0.2.4/lib/python3.12/site-packages/anndata/_core/aligned_mapping.py). Did you mean: 'AlignedView'?
mamba deactivate

# 0.3.0
mamba create --yes -n test-mudata-0.3.0 \
  -c conda-forge --override-channels \
  anndata=0.10.9 mudata=0.3.0
mamba activate test-mudata-0.3.0
python -c "import mudata"
## ImportError: cannot import name 'AlignedViewMixin' from 'anndata._core.aligned_mapping' (/home/wsl/mambaforge/envs/test-mudata-0.3.0/lib/python3.12/site-packages/anndata/_core/aligned_mapping.py). Did you mean: 'AlignedView'?
mamba deactivate

# 0.3.1 (works)
mamba create --yes -n test-mudata-0.3.1 \
  -c conda-forge --override-channels \
  anndata=0.10.9 mudata=0.3.1
mamba activate test-mudata-0.3.1
python -c "import mudata"
echo $?
## 0
mamba deactivate
```

<details>
<summary>Click for local diff
</summary>

```diff
python show_diff.py --subdirs noarch
================================================================================
================================================================================
noarch
noarch::mudata-0.2.3-pyhd8ed1ab_0.conda
noarch::mudata-0.2.1-pyhd8ed1ab_0.conda
noarch::mudata-0.2.2-pyhd8ed1ab_0.conda
noarch::mudata-0.2.0-pyhd8ed1ab_0.tar.bz2
-    "anndata >=0.8",
+    "anndata >=0.8,<0.10.9.0a0",
noarch::mudata-0.3.0-pyhd8ed1ab_0.conda
noarch::mudata-0.2.4-pyhd8ed1ab_0.conda
-    "anndata >=0.10.8",
+    "anndata >=0.10.8,<0.10.9.0a0",
```

</details>
