### PR TITLE
Do not include build_number for mudata patch

### DIFF
--- a/recipe/patch_yaml/mudata.yaml
+++ b/recipe/patch_yaml/mudata.yaml
@@ -17,7 +17,6 @@ then:
 if:
   name: mudata
   version_lt: "0.3.1"
-  build_number: 0
   timestamp_lt: 1725468863000
 then:
   - tighten_depends:


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
---

This is a minor follow-up to my recent mudata patch in https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/839.

Right after it was merged, I noticed that I had accidentally included `build_number: 0`, which would result in any binaries with other build numbers being excluded from the patch. Now, just by luck, all the binaries with version <= 0.3.1 happened to also have build number 0. Therefore this PR will have no effect on the repodata. Its purpose is purely to clarify the intent of the original patch (and to avoid the potential for future readers of the patch, especially future me, from thinking that this mistake might have caused a problem).

cc: @xhochy 

```sh
python show_diff.py --subdirs noarch
================================================================================
================================================================================
noarch
```