### PR TITLE
dohq-artifactory set upper bound python 3.12

### DIFF
--- a/recipe/patch_yaml/dohq-artifactory.yaml
+++ b/recipe/patch_yaml/dohq-artifactory.yaml
@@ -1,0 +1,9 @@
+# https://github.com/conda-forge/dohq-artifactory-feedstock/issues/5
+---
+if:
+  name: dohq-artifactory
+  timestamp_lt: 1724951023000  # 2024 Aug 29
+then:
+  - tighten_depends:
+      name: python
+      upper_bound: "3.12"


### PR DESCRIPTION
https://github.com/conda-forge/dohq-artifactory-feedstock/issues/5

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [/] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [/] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
```
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
noarch
noarch::dohq-artifactory-0.8.4-pyhd8ed1ab_0.conda
-    "python >=3.7",
+    "python >=3.7,<3.12.0a0",
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
================================================================================
================================================================================
linux-64
```