### PR TITLE
shap versions before 0.40 don't support numpy>=2.*. This fixes that.

### DIFF
--- a/recipe/patch_yaml/shap.yaml
+++ b/recipe/patch_yaml/shap.yaml
@@ -1,7 +1,7 @@
 # add constraint on numpy <2.0
 if:
   name: shap
-  version_le: 0.40
+  version_le: 0.40.0
   timestamp_lt: 1726005600 # 2024-09-11
 then:
   - replace_depends:

--- a/recipe/patch_yaml/shap.yaml
+++ b/recipe/patch_yaml/shap.yaml
@@ -1,0 +1,9 @@
+# add constraint on numpy <2.0
+if:
+  name: shap
+  version_le: 0.40
+  timestamp_lt: 1726005600 # 2024-09-11
+then:
+  - replace_depends:
+      old: numpy
+      new: numpy <2.0a0


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->


```
================================================================================
noarch
noarch::anaconda-cloud-cli-0.2.0-pyhd8ed1ab_0.conda
-    "anaconda-cli-base >=0.2",
-    "anaconda-client >=1.12.2",
-    "anaconda-cloud-auth >=0.3",
+    "anaconda-cli-base >=0.2,<0.3",
+    "anaconda-client >=1.12.2,<1.13",
+    "anaconda-cloud-auth >=0.3,<0.6",
noarch::anaconda-cloud-cli-0.1.0-pyhd8ed1ab_0.conda
-    "anaconda-cli-base",
-    "anaconda-cloud-auth",
+    "anaconda-cli-base <0.3.0",
+    "anaconda-cloud-auth <0.6.0",
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
linux-64
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-64
================================================================================
================================================================================
win-64
win-64::python-3.13.0rc2-h4077693_0_cp313t.conda
```