### PR TITLE
scvi-tools 1.1.6 requires lightning<2.2

### DIFF
--- a/recipe/patch_yaml/scvi-tools.yaml
+++ b/recipe/patch_yaml/scvi-tools.yaml
@@ -1,0 +1,11 @@
+# scvi-tools 1.1.6 requires lightning<2.2
+# https://github.com/conda-forge/scvi-tools-feedstock/issues/54
+if:
+  name: scvi-tools
+  version: "1.1.6"
+  build_number: 1
+  timestamp_lt: 1726156541000
+then:
+  - tighten_depends:
+      name: lightning
+      upper_bound: 2.2

--- a/recipe/patch_yaml/scvi-tools.yaml
+++ b/recipe/patch_yaml/scvi-tools.yaml
@@ -8,4 +8,4 @@ if:
 then:
   - tighten_depends:
       name: lightning
-      upper_bound: 2.2
+      upper_bound: "2.2"


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

---

* Incorrect metadata introduced in https://github.com/conda-forge/scvi-tools-feedstock/pull/52
* Reported to feedstock maintainers in https://github.com/conda-forge/scvi-tools-feedstock/issues/54
* PR to fix the recipe for build number 2 https://github.com/conda-forge/scvi-tools-feedstock/pull/55

cc: @conda-forge/scvi-tools 


```diff
python show_diff.py --subdirs noarch
================================================================================
================================================================================
noarch
noarch::anaconda-cloud-cli-0.1.0-pyhd8ed1ab_0.conda
-    "anaconda-cli-base",
-    "anaconda-cloud-auth",
+    "anaconda-cli-base <0.3.0",
+    "anaconda-cloud-auth <0.6.0",
noarch::anaconda-cloud-cli-0.2.0-pyhd8ed1ab_0.conda
-    "anaconda-cli-base >=0.2",
-    "anaconda-client >=1.12.2",
-    "anaconda-cloud-auth >=0.3",
+    "anaconda-cli-base >=0.2,<0.3",
+    "anaconda-client >=1.12.2,<1.13",
+    "anaconda-cloud-auth >=0.3,<0.6",
noarch::scvi-tools-1.1.6-pyhd8ed1ab_1.conda
-    "lightning >=2.0",
+    "lightning >=2.0,<2.2.0a0",
```