### PR TITLE
backport constraint on libopeblas for mumps openmp builds

### DIFF
--- a/recipe/patch_yaml/mumps-openmp.yaml
+++ b/recipe/patch_yaml/mumps-openmp.yaml
@@ -1,0 +1,10 @@
+if:
+  name_in:
+    - mumps-seq
+    - mumps-mpi
+  version: 5.7.3
+  timestamp_lt: 1726574983858
+  build_number_in: [1, 2, 3]
+  subdir_in: linux-*
+then:
+  - add_constrains: libopenblas * *openmp*


### PR DESCRIPTION
openblas must be built with openmp if it might ever be called from openmp

backports constraint from mumps 5.7.3 build 4 (https://github.com/conda-forge/mumps-feedstock/pull/126) to builds 1-3, which were the first to link openmp

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->


<details>
<summary>diff</summary>

```
> python3 show_diff.py
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
linux-ppc64le
linux-ppc64le::mumps-seq-5.7.3-hfb5daf3_1.conda
linux-ppc64le::mumps-mpi-5.7.3-h7085ffb_3.conda
linux-ppc64le::mumps-mpi-5.7.3-h7085ffb_1.conda
linux-ppc64le::mumps-mpi-5.7.3-h7dd2716_1.conda
linux-ppc64le::mumps-mpi-5.7.3-h7dd2716_2.conda
linux-ppc64le::mumps-mpi-5.7.3-h7dd2716_3.conda
linux-ppc64le::mumps-seq-5.7.3-hfb5daf3_3.conda
linux-ppc64le::mumps-seq-5.7.3-hfb5daf3_2.conda
linux-ppc64le::mumps-mpi-5.7.3-h7085ffb_2.conda
+  "constrains": [
+    "libopenblas * *openmp*"
+  ],
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-aarch64
linux-aarch64::mumps-mpi-5.7.3-h0cc8c46_2.conda
linux-aarch64::mumps-seq-5.7.3-h6db4957_3.conda
linux-aarch64::mumps-mpi-5.7.3-h0cc8c46_3.conda
linux-aarch64::mumps-seq-5.7.3-h6db4957_2.conda
linux-aarch64::mumps-mpi-5.7.3-h3872456_1.conda
linux-aarch64::mumps-mpi-5.7.3-h3872456_2.conda
linux-aarch64::mumps-seq-5.7.3-h6db4957_1.conda
linux-aarch64::mumps-mpi-5.7.3-h3872456_3.conda
linux-aarch64::mumps-mpi-5.7.3-h0cc8c46_1.conda
+  "constrains": [
+    "libopenblas * *openmp*"
+  ],
================================================================================
================================================================================
noarch
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
================================================================================
================================================================================
linux-64
linux-64::mumps-mpi-5.7.3-ha8c5ff1_3.conda
linux-64::mumps-seq-5.7.3-h96124f5_1.conda
linux-64::mumps-mpi-5.7.3-h7bb8a9e_1.conda
linux-64::mumps-mpi-5.7.3-ha8c5ff1_1.conda
linux-64::mumps-seq-5.7.3-h96124f5_2.conda
linux-64::mumps-mpi-5.7.3-h7bb8a9e_2.conda
linux-64::mumps-mpi-5.7.3-ha8c5ff1_2.conda
linux-64::mumps-seq-5.7.3-h96124f5_3.conda
linux-64::mumps-mpi-5.7.3-h7bb8a9e_3.conda
+  "constrains": [
+    "libopenblas * *openmp*"
+  ],
```

</summary>

@traversaro 