### PR TITLE
scvi-tools 1.1.6.post2 requires anndata<=0.10.8

### DIFF
--- a/recipe/patch_yaml/scvi-tools.yaml
+++ b/recipe/patch_yaml/scvi-tools.yaml
@@ -9,3 +9,16 @@ then:
   - tighten_depends:
       name: lightning
       upper_bound: "2.2"
+---
+# scvi-tools 1.1.6.post2 requires anndata<=0.10.8
+# https://github.com/scverse/scvi-tools/pull/2971
+# https://github.com/conda-forge/scvi-tools-feedstock/pull/57#issuecomment-2353371071
+if:
+  name: scvi-tools
+  version: "1.1.6.post2"
+  build_number: 0
+  timestamp_lt: 1726588981000
+then:
+  - tighten_depends:
+      name: anndata
+      upper_bound: "0.10.9"


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
---

* Follow-up to https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/844
* Upper bound added in https://github.com/scverse/scvi-tools/pull/2971
* Already fixed in feedstock by https://github.com/conda-forge/scvi-tools-feedstock/pull/58
* I couldn't figure out a way to insert `<=0.10.8`. `upper_bound` uses `<`, and there was no diff when I tried `max_pin`. anndata [0.10.9](https://anaconda.org/conda-forge/anndata/files?version=0.10.9) has already been released (hence the need for the upper bound), so we know that `<0.10.9` is equivalent to `<=0.10.8`

xref: https://github.com/conda-forge/scvi-tools-feedstock/pull/57#issuecomment-2353371071, https://github.com/bioconda/bioconda-recipes/pull/50636#issuecomment-2353603566