### PR TITLE
Patch nptyping with unpinned numpy

### DIFF
--- a/recipe/patch_yaml/nptyping.yaml
+++ b/recipe/patch_yaml/nptyping.yaml
@@ -1,0 +1,8 @@
+if:
+  name: nptyping
+  timestamp_lt: 1726607615000
+  has_depends: numpy
+then:
+  - replace_depends:
+      old: numpy
+      new: numpy <2


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

`show_diff.py` output:
```
% python3 show_diff.py
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
noarch
noarch::nptyping-2.4.1-pyhd8ed1ab_0.tar.bz2
noarch::nptyping-2.0.0-pyhd8ed1ab_0.tar.bz2
noarch::nptyping-2.1.1-pyhd8ed1ab_0.tar.bz2
noarch::nptyping-1.4.4-pyhd8ed1ab_0.tar.bz2
noarch::nptyping-2.4.0-pyhd8ed1ab_0.tar.bz2
noarch::nptyping-1.4.2-pyhd8ed1ab_0.tar.bz2
noarch::nptyping-1.3.0-pyh9f0ad1d_1.tar.bz2
noarch::nptyping-1.4.0-pyhd3deb0d_0.tar.bz2
noarch::nptyping-2.0.1-pyhd8ed1ab_0.tar.bz2
noarch::nptyping-2.3.1-pyhd8ed1ab_0.tar.bz2
noarch::nptyping-2.1.0-pyhd8ed1ab_0.tar.bz2
noarch::nptyping-2.3.0-pyhd8ed1ab_0.tar.bz2
noarch::nptyping-2.5.0-pyhd8ed1ab_0.conda
noarch::nptyping-1.4.1-pyhd8ed1ab_0.tar.bz2
noarch::nptyping-2.1.2-pyhd8ed1ab_0.tar.bz2
noarch::nptyping-1.4.3-pyhd8ed1ab_0.tar.bz2
noarch::nptyping-2.1.3-pyhd8ed1ab_0.tar.bz2
noarch::nptyping-2.2.0-pyhd8ed1ab_0.tar.bz2
-    "numpy",
+    "numpy <2",
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
================================================================================
================================================================================
linux-64
```
This package [recently](https://github.com/conda-forge/nptyping-feedstock/pull/22) had the latest version patched to restrict to numpy<2, to match the upstream package. This patches the metadata of all the old versions of the package.

I was running into 2.5.0=_0 installing alongside numpy2, which caused `pip check` fails further down the tree as the actual upstream [pins <2](https://github.com/ramonhagenaars/nptyping/blob/master/dependencies/requirements.txt#L2).