### PR TITLE
patch furo to have proper sphinx upper bound

### DIFF
--- a/recipe/patch_yaml/furo.yaml
+++ b/recipe/patch_yaml/furo.yaml
@@ -1,0 +1,9 @@
+# Versions of furo before 2023.5.20 do not work with sphinx 7.2 or greater.
+if:
+  name: furo
+  version_lt: 2023.5.21
+  timestamp_lt: 1686854880000  # 2023/06/15 18:48Z
+then:
+  - tighten_depends:
+      name: sphinx
+      upper_bound: 7.2.0


### PR DESCRIPTION
Relevant discussion https://github.com/conda-forge/furo-feedstock/issues/52

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

```
================================================================================                                                                                                             
================================================================================                                                                                                             
linux-armv7l                                                                                                                                                                                 
================================================================================              
================================================================================              
win-32                                                                                                                                                                                       
================================================================================                                                                                                             
================================================================================              
osx-arm64                                                                                                                                                                                    
================================================================================                                                                                                             
================================================================================                                                                                                             
linux-ppc64le                                                                                                                                                                                
================================================================================                                                                                                             
================================================================================                                                                                                             
linux-aarch64                                                                                 
================================================================================              
================================================================================                                                                                                             
noarch                                                                                                                                                                                       
noarch::furo-2022.6.4.1-pyhd8ed1ab_0.tar.bz2                                                                                                                                                 
noarch::furo-2021.8.31-pyhd8ed1ab_0.tar.bz2                                                                                                                                                  
noarch::furo-2021.9.8-pyhd8ed1ab_0.tar.bz2                                                                                                                                                   
noarch::furo-2022.6.21-pyhd8ed1ab_0.tar.bz2                                                                                                                                                  
noarch::furo-2021.9.22-pyhd8ed1ab_0.tar.bz2                                                                                                                                                  
noarch::furo-2022.4.7-pyhd8ed1ab_0.tar.bz2                                                                                                                                                   
noarch::furo-2021.8.17b43-pyhd8ed1ab_0.tar.bz2                                                                                                                                               
noarch::furo-2023.3.23-pyhd8ed1ab_0.conda                                                                                                                                                    
noarch::furo-2021.7.31b41-pyhd8ed1ab_0.tar.bz2                                                                                                                                               
noarch::furo-2022.2.23-pyhd8ed1ab_0.tar.bz2                                                                                                                                                  
noarch::furo-2023.5.20-pyhd8ed1ab_0.conda                                                                                                                                                    
noarch::furo-2022.3.4-pyhd8ed1ab_0.tar.bz2                                                                                                                                                   
noarch::furo-2021.7.5b38-pyhd8ed1ab_0.tar.bz2                                                                                                                                                
noarch::furo-2023.3.27-pyhd8ed1ab_0.conda                                                                                                                                                    
noarch::furo-2021.7.28b40-pyhd8ed1ab_0.tar.bz2                                                
noarch::furo-2022.12.7-pyhd8ed1ab_0.conda                                                     
noarch::furo-2021.8.11b42-pyhd8ed1ab_0.tar.bz2                                                
noarch::furo-2022.9.29-pyhd8ed1ab_0.tar.bz2                                                   
noarch::furo-2021.10.9-pyhd8ed1ab_0.tar.bz2                                                                                                                                                  
-    "sphinx >=4",                                                                                                                                                                           
+    "sphinx >=4,<7.2.0a0",                                                                                                                                                                  
================================================================================                                                                                                             
================================================================================                                                                                                             
win-64                                                                                                                                                                                       
================================================================================                                                                                                             
================================================================================              
osx-64                                                                                        
================================================================================                                                                                                             
================================================================================
linux-64     
```