### PR TITLE
fix incomplete furo/sphinx patching in #850

### DIFF
--- a/recipe/patch_yaml/furo.yaml
+++ b/recipe/patch_yaml/furo.yaml
@@ -1,4 +1,5 @@
 # Versions of furo before 2023.5.20 do not work with sphinx 7.2 or greater.
+---
 if:
   name: furo
   version_lt: 2023.5.21
@@ -7,3 +8,6 @@ then:
   - tighten_depends:
       name: sphinx
       upper_bound: 7.2.0
+  - replace_depends:
+      old: sphinx >3.0
+      new: sphinx >3.0,<7.2.0


### PR DESCRIPTION
Supposed to have been fixed in #850, It seems as though `upper_bound` does not always work, and so missed two packages. I use `replace_depends` to remedy this.

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
```
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
noarch
noarch::furo-2020.12.9b21-pyhd8ed1ab_1.tar.bz2
noarch::furo-2020.12.30b24-pyhd8ed1ab_1.tar.bz2
noarch::furo-2020.12.30b24-pyhd8ed1ab_0.tar.bz2
noarch::furo-2021.2.21b25-pyhd8ed1ab_0.tar.bz2
-    "sphinx >3.0",
+    "sphinx >3.0,<7.2.0",
noarch::furo-2020.12.9b21-pyhd8ed1ab_0.tar.bz2
-    "sphinx >3.0"
+    "sphinx >3.0,<7.2.0"
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
osx-64::rabbitmq-delayed-message-exchange-3.10.0-h694c41f_0.tar.bz2
osx-64::rabbitmq-delayed-message-exchange-3.10.2-h694c41f_0.tar.bz2
-    "rabbitmq-server >=3.10.0,<3.11"
+    "rabbitmq-server >=3.8.16"
osx-64::rabbitmq-delayed-message-exchange-3.11.1-h694c41f_0.tar.bz2
-    "rabbitmq-server >=3.11.0,<3.12"
+    "rabbitmq-server >=3.11.0"
osx-64::rabbitmq-delayed-message-exchange-3.9.0-h694c41f_0.tar.bz2
-    "rabbitmq-server >=3.9.0,<3.10"
+    "rabbitmq-server >=3.8.16"
================================================================================
================================================================================
linux-64
linux-64::rabbitmq-delayed-message-exchange-3.10.2-ha770c72_0.tar.bz2
linux-64::rabbitmq-delayed-message-exchange-3.10.0-ha770c72_0.tar.bz2
-    "rabbitmq-server >=3.10.0,<3.11"
+    "rabbitmq-server >=3.8.16"
linux-64::rabbitmq-delayed-message-exchange-3.11.1-ha770c72_0.tar.bz2
-    "rabbitmq-server >=3.11.0,<3.12"
+    "rabbitmq-server >=3.11.0"
linux-64::rabbitmq-delayed-message-exchange-3.9.0-ha770c72_0.tar.bz2
-    "rabbitmq-server >=3.9.0,<3.10"
+    "rabbitmq-server >=3.8.16"
```