### PR TITLE
Loosen pin for libtiff 4.6.0-4.7.0

### DIFF
--- a/recipe/patch_yaml/libtiff.yaml
+++ b/recipe/patch_yaml/libtiff.yaml
@@ -32,3 +32,15 @@ if:
   timestamp_lt: 1678151067000
 then:
   - add_constrains: jpeg <0.0.0a
+
+---
+
+# libtiff 4.6.0 is ABI compatible with 4.7.0
+# https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/6432
+if:
+  has_depends: libtiff >=4.6.0,<4.7.0a0?( *)
+  timestamp_lt: 1726703338000
+then:
+  - loosen_depends:
+      name: libtiff
+      upper_bound: 4.8.0


### PR DESCRIPTION
Checklist

* [ ] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
