### PR TITLE
Add libdispatch dependency for ld64 on linux

### DIFF
--- a/recipe/patch_yaml/cctools_and_ld64.yaml
+++ b/recipe/patch_yaml/cctools_and_ld64.yaml
@@ -1,0 +1,11 @@
+if:
+  name_in:
+    - "ld64_osx-64"
+    - "ld64_osx-arm64"
+  version: "951.9"
+  timestamp_lt: 1726767642000
+  subdir_in:
+    - "linux-64"
+then:
+  - add_depends:
+      - libdispatch 5.*


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

This fixes the issue from https://github.com/conda-forge/cctools-and-ld64-feedstock/pull/80 for the older builds

cc @conda-forge/cctools-and-ld64 

Diff:

```
…
================================================================================
osx-64
================================================================================
================================================================================
linux-64
linux-64::ld64_osx-64-951.9-h48bf820_0.conda
linux-64::ld64_osx-arm64-951.9-hd9165b5_0.conda
linux-64::ld64_osx-arm64-951.9-hbb6d65c_0.conda
linux-64::ld64_osx-64-951.9-h0e09005_0.conda
linux-64::ld64_osx-arm64-951.9-h03b0df2_0.conda
linux-64::ld64_osx-64-951.9-h852264e_0.conda
+    "libdispatch 5.*",
```
