### PR TITLE
pin anyio 4.6.0 vs python >=3.9

### DIFF
--- a/recipe/patch_yaml/anyio.yaml
+++ b/recipe/patch_yaml/anyio.yaml
@@ -1,0 +1,9 @@
+# backport of https://github.com/conda-forge/anyio-feedstock/pull/67
+if:
+  name: anyio
+  version: 4.6.0
+  timestamp_lt: 1726930537000
+then:
+  - replace_depends:
+      old: python >=3.8
+      new: python >=3.9


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

references:
- backport of https://github.com/conda-forge/anyio-feedstock/pull/67
- ping @conda-forge/anyio

```diff
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
noarch
noarch::anyio-4.6.0-pyhd8ed1ab_0.conda
-    "python >=3.8",
+    "python >=3.9",
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
================================================================================
================================================================================
linux-64

```