### PR TITLE
Fix libcxx repodata for cppyy-cling 6.30.0

### DIFF
--- a/recipe/patch_yaml/cppyy-cling.yaml
+++ b/recipe/patch_yaml/cppyy-cling.yaml
@@ -1,0 +1,10 @@
+if:
+  name: cppyy-cling
+  subdir_in: ["osx-64", "osx-arm64"]
+  version: 6.30.0
+  build_number_in: [0, 1, 2]
+  timestamp_lt: 1726941093000
+then:
+  - replace_depends:
+      old: libcxx >=14.0.6
+      new: ${old},<18


### PR DESCRIPTION
cppyy-cling builds 0, 1, 2 are mostly functional but they only work with a libcxx that is not too new. See also
https://github.com/conda-forge/admin-requests/pull/1091 which marks builds 3-5 as broken. (Builds 6 & 7 are functional and have the correct constraints.)

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary. Didn't change it.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
