### PR TITLE
Patch albumatentations for breaking change in albucore 0.0.17

### DIFF
--- a/recipe/patch_yaml/albumentations.yaml
+++ b/recipe/patch_yaml/albumentations.yaml
@@ -1,0 +1,12 @@
+# https://github.com/albumentations-team/albumentations/issues/1946
+# Upper bound set for albumnetations 1.4.15 and above
+# https://github.com/conda-forge/albumentations-feedstock/pull/38
+if:
+  timestamp_lt: 1727025727000
+  name: albumentations
+  version_lt: "1.4.15"
+  has_depends: albucore*
+then:
+  - tighten_depends:
+      name: albucore
+      upper_bound: 0.0.17


### PR DESCRIPTION
Closes https://github.com/conda-forge/albumentations-feedstock/issues/39

```
================================================================================
================================================================================
noarch
noarch::albumentations-1.4.14-pyhd8ed1ab_0.conda
noarch::albumentations-1.4.13-pyhd8ed1ab_0.conda
-    "albucore >=0.0.13",
+    "albucore >=0.0.13,<0.0.17.0a0",
noarch::albumentations-1.4.10-pyhd8ed1ab_0.conda
-    "albucore >=0.0.11",
+    "albucore >=0.0.11,<0.0.17.0a0",
```

Checklist

* [ ] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
