### PR TITLE
Add linting for comments

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -4,3 +4,7 @@ rules:
   document-start: disable
   line-length:
     max: 120
+  comments:
+    level: error
+    require-starting-space: true
+    min-spaces-from-content: 2


### PR DESCRIPTION
See: https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/858

This should mostly only trigger on the patch_yaml files.

We use non-standard syntax in the recipe, so you can't apply it to all files.