### PR TITLE
backport extra netlib feature on blas/lapack

### DIFF
--- a/recipe/patch_yaml/netlib_features.yaml
+++ b/recipe/patch_yaml/netlib_features.yaml
@@ -1,0 +1,19 @@
+# backport https://github.com/conda-forge/lapack-feedstock/pull/71
+if:
+  name_in:
+    - libblas
+    - libtmglib
+    - libcblas
+    - liblapack
+    - liblapacke
+    - blas-devel
+    - blas
+    - lapack
+  build: "*netlib*"
+  timestamp_lt: 1727167107000
+then:
+  # no reset_track_features, so remove & add to avoid duplicating
+  - remove_track_features:
+      - blas_netlib_2
+  - add_track_features:
+      - blas_netlib_2


### PR DESCRIPTION
backports track_features added in https://github.com/conda-forge/lapack-feedstock/pull/71

adding track_features needs repodata backports because the high priority of track_features-minimization will just exclude all newer builds that add the track_feature, rather than apply the preference within newer builds.

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->
