### PR TITLE
Pin APSW to a recent version for QCPortal

### DIFF
--- a/recipe/patch_yaml/qcportal.yaml
+++ b/recipe/patch_yaml/qcportal.yaml
@@ -12,3 +12,15 @@ then:
   - replace_depends:
       old: pydantic?( *)
       new: ${old},<2.0a0
+
+---
+
+# Pins APSW to a recent version
+# https://github.com/conda-forge/qcfractal-feedstock/pull/52
+if:
+  name: qcportal
+  timestamp_lt: 1727210616000
+then:
+  - replace_depends:
+      old: apsw
+      new: apsw >=3.42


### PR DESCRIPTION
Checklist

* [X] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [X] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [X] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [X] Ran `python show_diff.py` and posted the output as part of the PR.
* [X] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
Pin needed to fix some environment solves pulling in older version of APSW

Output from `python show_diff.py` below
```
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
noarch
noarch::qcportal-0.56-pyhd8ed1ab_0.conda
noarch::qcportal-0.55-pyhd8ed1ab_0.conda
-    "apsw",
+    "apsw >=3.42",
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
================================================================================
================================================================================
linux-64
```