### PR TITLE
add missing dependency for ipopt on libscotch

### DIFF
--- a/recipe/patch_yaml/ipopt-scotch.yaml
+++ b/recipe/patch_yaml/ipopt-scotch.yaml
@@ -1,0 +1,12 @@
+# ipopt links libscotch without depending on it
+# This affects versions back to 3.13.3,
+# but tracking down scotches that far is too tedious
+# and mumps-seq's transitive pin is generally enough for past builds
+# because all 5.6 and 5.7 builds before 5.7.3 pin scotch 7.0.4
+if:
+  name: ipopt
+  version: 3.14.16
+  build_number_lt: 6
+  not_subdir_in: win-*
+then:
+  - add_depends: libscotch 7.0.4


### PR DESCRIPTION
See https://github.com/conda-forge/ipopt-feedstock/pull/112#issuecomment-2376805755

ipopt linked libscotch as a transitive dependency of mumps without declaring it as a dependency, meaning a mumps rebuild against an updated libscotch would break ipopt, which happened with mumps 5.7.3 build 5.

Since mumps pins libscotch all the way down, the only builds for which this is a problem is when a given version of mumps bumps libscotch after ipopt has been built against that mumps.

Since tracking down the scotch at build time for each ipopt build is tedious and the transitive pin from mumps is ~always right for past builds, only apply this patch to the latest version of ipopt (3.14.16).

All builds against mumps 5.6-5.7.2 only have builds against scotch 7.0.4, and only ipopt 3.14.16 has builds against 5.7.3. So while this added dependency is correct, it's only _strictly_ needed to solve a problem for ipopt 3.14.16 build number 5, the first build against mumps 5.7.3.

<details>
<summary>diff</summary>

```
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
linux-ppc64le
linux-ppc64le::ipopt-3.14.16-h8df03a8_2.conda
linux-ppc64le::ipopt-3.14.16-h4364184_4.conda
linux-ppc64le::ipopt-3.14.16-h8df03a8_3.conda
linux-ppc64le::ipopt-3.14.16-h8d0114a_0.conda
linux-ppc64le::ipopt-3.14.16-h4531137_1.conda
linux-ppc64le::ipopt-3.14.16-h98ba2a6_5.conda
+    "libscotch 7.0.4",
================================================================================
================================================================================
osx-arm64
osx-arm64::ipopt-3.14.16-h4500666_5.conda
osx-arm64::ipopt-3.14.16-h26a4e44_1.conda
osx-arm64::ipopt-3.14.16-h387674d_4.conda
osx-arm64::ipopt-3.14.16-hb0bf214_2.conda
osx-arm64::ipopt-3.14.16-hb0bf214_3.conda
osx-arm64::ipopt-3.14.16-h0662023_0.conda
+    "libscotch 7.0.4",
================================================================================
================================================================================
linux-aarch64
linux-aarch64::ipopt-3.14.16-h7194c4c_0.conda
linux-aarch64::ipopt-3.14.16-hb720d22_1.conda
linux-aarch64::ipopt-3.14.16-h95b2e97_4.conda
linux-aarch64::ipopt-3.14.16-he04425c_2.conda
linux-aarch64::ipopt-3.14.16-ha450752_5.conda
linux-aarch64::ipopt-3.14.16-he04425c_3.conda
+    "libscotch 7.0.4",
================================================================================
================================================================================
noarch
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
osx-64::ipopt-3.14.16-h8b46a37_4.conda
osx-64::ipopt-3.14.16-h2f7c220_1.conda
osx-64::ipopt-3.14.16-h37bbb85_0.conda
osx-64::ipopt-3.14.16-h024ff17_3.conda
osx-64::ipopt-3.14.16-h7b94dc9_5.conda
osx-64::ipopt-3.14.16-h024ff17_2.conda
+    "libscotch 7.0.4",
================================================================================
================================================================================
linux-64
linux-64::ipopt-3.14.16-hf967516_0.conda
linux-64::ipopt-3.14.16-h3696c94_4.conda
linux-64::ipopt-3.14.16-h8c03dd0_2.conda
linux-64::ipopt-3.14.16-h8c03dd0_3.conda
linux-64::ipopt-3.14.16-h573144d_1.conda
linux-64::ipopt-3.14.16-h3a0b567_5.conda
+    "libscotch 7.0.4",
```

</details>