### PR TITLE
chromadb depends on uvicorn-standard not uvicorn

### DIFF
--- a/recipe/patch_yaml/chromadb.yaml
+++ b/recipe/patch_yaml/chromadb.yaml
@@ -1,0 +1,9 @@
+# chromadb depends on uvicorn-standard not uvicorn
+# Fixed in https://github.com/conda-forge/chromadb-feedstock/pull/51
+if:
+  name: chromadb
+  timestamp_lt: 1727439944000
+then:
+  - replace_depends:
+      old: uvicorn
+      new: uvicorn-standard

--- a/recipe/patch_yaml/chromadb.yaml
+++ b/recipe/patch_yaml/chromadb.yaml
@@ -4,6 +4,6 @@ if:
   name: chromadb
   timestamp_lt: 1727439944000
 then:
-  - replace_depends:
+  - rename_depends:
       old: uvicorn
       new: uvicorn-standard


### PR DESCRIPTION
chromadb depends on uvicorn-standard not uvicorn
Fixed in https://github.com/conda-forge/chromadb-feedstock/pull/51

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
