### PR TITLE
Fix pogo openjdk version

### DIFF
--- a/recipe/patch_yaml/pogo.yaml
+++ b/recipe/patch_yaml/pogo.yaml
@@ -1,0 +1,9 @@
+if:
+  name: pogo
+  version_ge: 9.9.0
+  version_le: 9.9.2
+  timestamp_le: 1727768204000
+then:
+  - replace_depends:
+      old: openjdk >=17
+      new: openjdk >=17,<22


### PR DESCRIPTION
Checklist

* [X] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [X] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [X] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

Running pogo generate with openjdk 22 raises some error.

Feedstock updated in https://github.com/conda-forge/pogo-feedstock/pull/9

Repodata needs to be patched to ensure openjdk < 22 is used for pogo 9.9.*.