### PR TITLE
pin python>=3.8 for python-graphviz 0.20.2

### DIFF
--- a/recipe/patch_yaml/python-graphviz.yaml
+++ b/recipe/patch_yaml/python-graphviz.yaml
@@ -1,0 +1,9 @@
+if:
+  name: python-graphviz
+  version_ge: 0.20.2
+  has_depends: python >=3
+  timestamp_lt: 1727836164000
+then:
+  - replace_depends:
+      old: python >=3
+      new: python >=3.8


### PR DESCRIPTION
## Description

`python-graphviz` v0.20.2 added a floor of `python>=3.8`, and code that runs at import time which is not syntactically valid Python on earlier versions. That wasn't reflected in packages on conda-forge until build `_1` of `v0.20.3` (https://github.com/conda-forge/python-graphviz-feedstock/pull/56).

This proposes a repodata patch for `v0.20.2` packages and that `_0` build of `v0.20.3`, to prevent those versions of `python-graphviz` being pulled into Python 3.7 and older environments.

## Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.

```text
noarch
noarch::python-graphviz-0.20.2-pyh717bed2_0.conda
noarch::python-graphviz-0.20.3-pyh717bed2_0.conda
-    "python >=3"
+    "python >=3.8"
```

* [x] Modifications won't affect packages built in the future.
   - *added `timestamp_lt: 1727836164000` to the patch YAML*
