### PR TITLE
Fix NumPy 2 upper bound for older CuPy packages

### DIFF
--- a/recipe/patch_yaml/numpy2_known_lower_bound.yaml
+++ b/recipe/patch_yaml/numpy2_known_lower_bound.yaml
@@ -63,8 +63,7 @@ then:
 ---
 if:
   name: cupy
-  version_lt: 14.0.0
-  has_depends: python >=3.9*
+  version_lt: 13.0.0
   not_has_depends: numpy *,<2.0a0
 then:
   - tighten_depends:


### PR DESCRIPTION
This wasn't being applied correctly to older CuPy packages. As a result they could still be installed with NumPy 2. Fix the patch to ensure old CuPy packages are not installable with NumPy 2.

Sample failure mode below:

<details>

```
$ conda create -n tst python=3.10 cupy=12.2 numpy=2 --dry-run
Channels:
 - conda-forge
Platform: linux-aarch64
Collecting package metadata (repodata.json): done
Solving environment: done

## Package Plan ##

  environment location: /opt/conda/envs/tst

  added / updated specs:
    - cupy=12.2
    - numpy=2
    - python=3.10


The following packages will be downloaded:

    package                    |            build
    ---------------------------|-----------------
    _openmp_mutex-4.5          |            2_gnu          23 KB  conda-forge
    cuda-cudart-12.6.77        |       h3ae8b8a_0          22 KB  conda-forge
    cuda-cudart_linux-aarch64-12.6.77|       h3ae8b8a_0         197 KB  conda-forge
    cuda-nvrtc-12.6.77         |       h5101a13_0        17.0 MB  conda-forge
    cuda-nvtx-12.6.77          |       h5101a13_0          32 KB  conda-forge
    cuda-version-12.6          |       h7480c83_3          20 KB  conda-forge
    cupy-12.2.0                |  py310heef24c7_1        23.5 MB  conda-forge
    fastrlock-0.8.2            |  py310hbb3657e_2          37 KB  conda-forge
    libblas-3.9.0              |24_linuxaarch64_openblas          15 KB  conda-forge
    libcblas-3.9.0             |24_linuxaarch64_openblas          15 KB  conda-forge
    libcublas-12.6.3.3         |       h5101a13_0       256.0 MB  conda-forge
    libcufft-11.3.0.4          |       h5101a13_0       156.2 MB  conda-forge
    libcurand-10.3.7.77        |       h5101a13_0        39.7 MB  conda-forge
    libcusolver-11.7.1.2       |       h5101a13_0        95.6 MB  conda-forge
    libcusparse-12.5.4.2       |       h5101a13_0       118.9 MB  conda-forge
    libgcc-ng-14.1.0           |       he9431aa_1          51 KB  conda-forge
    libgfortran-14.1.0         |       he9431aa_1          51 KB  conda-forge
    libgfortran-ng-14.1.0      |       he9431aa_1          51 KB  conda-forge
    libgfortran5-14.1.0        |       h9420597_1         1.0 MB  conda-forge
    liblapack-3.9.0            |24_linuxaarch64_openblas          15 KB  conda-forge
    libnvjitlink-12.6.77       |       h5101a13_1        14.6 MB  conda-forge
    libopenblas-0.3.27         |pthreads_h076ed1e_1         4.1 MB  conda-forge
    libstdcxx-ng-14.1.0        |       hf1166c9_1          51 KB  conda-forge
    numpy-2.1.2                |  py310hed039d9_0         6.2 MB  conda-forge
    python_abi-3.10            |          5_cp310           6 KB  conda-forge
    ------------------------------------------------------------
                                           Total:       733.3 MB

The following NEW packages will be INSTALLED:

  _openmp_mutex      conda-forge/linux-aarch64::_openmp_mutex-4.5-2_gnu 
  bzip2              conda-forge/linux-aarch64::bzip2-1.0.8-h68df207_7 
  ca-certificates    conda-forge/linux-aarch64::ca-certificates-2024.8.30-hcefe29a_0 
  cuda-cudart        conda-forge/linux-aarch64::cuda-cudart-12.6.77-h3ae8b8a_0 
  cuda-cudart_linux~ conda-forge/noarch::cuda-cudart_linux-aarch64-12.6.77-h3ae8b8a_0 
  cuda-nvrtc         conda-forge/linux-aarch64::cuda-nvrtc-12.6.77-h5101a13_0 
  cuda-nvtx          conda-forge/linux-aarch64::cuda-nvtx-12.6.77-h5101a13_0 
  cuda-version       conda-forge/noarch::cuda-version-12.6-h7480c83_3 
  cupy               conda-forge/linux-aarch64::cupy-12.2.0-py310heef24c7_1 
  fastrlock          conda-forge/linux-aarch64::fastrlock-0.8.2-py310hbb3657e_2 
  ld_impl_linux-aar~ conda-forge/linux-aarch64::ld_impl_linux-aarch64-2.43-h80caac9_1 
  libblas            conda-forge/linux-aarch64::libblas-3.9.0-24_linuxaarch64_openblas 
  libcblas           conda-forge/linux-aarch64::libcblas-3.9.0-24_linuxaarch64_openblas 
  libcublas          conda-forge/linux-aarch64::libcublas-12.6.3.3-h5101a13_0 
  libcufft           conda-forge/linux-aarch64::libcufft-11.3.0.4-h5101a13_0 
  libcurand          conda-forge/linux-aarch64::libcurand-10.3.7.77-h5101a13_0 
  libcusolver        conda-forge/linux-aarch64::libcusolver-11.7.1.2-h5101a13_0 
  libcusparse        conda-forge/linux-aarch64::libcusparse-12.5.4.2-h5101a13_0 
  libffi             conda-forge/linux-aarch64::libffi-3.4.2-h3557bc0_5 
  libgcc             conda-forge/linux-aarch64::libgcc-14.1.0-he277a41_1 
  libgcc-ng          conda-forge/linux-aarch64::libgcc-ng-14.1.0-he9431aa_1 
  libgfortran        conda-forge/linux-aarch64::libgfortran-14.1.0-he9431aa_1 
  libgfortran-ng     conda-forge/linux-aarch64::libgfortran-ng-14.1.0-he9431aa_1 
  libgfortran5       conda-forge/linux-aarch64::libgfortran5-14.1.0-h9420597_1 
  libgomp            conda-forge/linux-aarch64::libgomp-14.1.0-he277a41_1 
  liblapack          conda-forge/linux-aarch64::liblapack-3.9.0-24_linuxaarch64_openblas 
  libnsl             conda-forge/linux-aarch64::libnsl-2.0.1-h31becfc_0 
  libnvjitlink       conda-forge/linux-aarch64::libnvjitlink-12.6.77-h5101a13_1 
  libopenblas        conda-forge/linux-aarch64::libopenblas-0.3.27-pthreads_h076ed1e_1 
  libsqlite          conda-forge/linux-aarch64::libsqlite-3.46.1-hc4a20ef_0 
  libstdcxx          conda-forge/linux-aarch64::libstdcxx-14.1.0-h3f4de04_1 
  libstdcxx-ng       conda-forge/linux-aarch64::libstdcxx-ng-14.1.0-hf1166c9_1 
  libuuid            conda-forge/linux-aarch64::libuuid-2.38.1-hb4cce97_0 
  libxcrypt          conda-forge/linux-aarch64::libxcrypt-4.4.36-h31becfc_1 
  libzlib            conda-forge/linux-aarch64::libzlib-1.3.1-h86ecc28_2 
  ncurses            conda-forge/linux-aarch64::ncurses-6.5-hcccb83c_1 
  numpy              conda-forge/linux-aarch64::numpy-2.1.2-py310hed039d9_0 
  openssl            conda-forge/linux-aarch64::openssl-3.3.2-h86ecc28_0 
  pip                conda-forge/noarch::pip-24.2-pyh8b19718_1 
  python             conda-forge/linux-aarch64::python-3.10.15-hbf90c55_1_cpython 
  python_abi         conda-forge/linux-aarch64::python_abi-3.10-5_cp310 
  readline           conda-forge/linux-aarch64::readline-8.2-h8fc344f_1 
  setuptools         conda-forge/noarch::setuptools-75.1.0-pyhd8ed1ab_0 
  tk                 conda-forge/linux-aarch64::tk-8.6.13-h194ca79_0 
  tzdata             conda-forge/noarch::tzdata-2024b-hc8b5060_0 
  wheel              conda-forge/noarch::wheel-0.44.0-pyhd8ed1ab_0 
  xz                 conda-forge/linux-aarch64::xz-5.2.6-h9cdd2b7_0 



DryRunExit: Dry run. Exiting.
```

</details>

<hr>

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
