### PR TITLE
xarray constrains  seaborn-base not seaborn

### DIFF
--- a/recipe/patch_yaml/xarray.yaml
+++ b/recipe/patch_yaml/xarray.yaml
@@ -106,3 +106,13 @@ then:
   - replace_depends:
       old: numpy >=1.21
       new: numpy >=1.22
+---
+# xarray depends on seaborn-base not seaborn
+# Fixed in https://github.com/conda-forge/xarray-feedstock/pull/118
+if:
+  name: xarray
+  timestamp_lt: 1728373192000
+then:
+  - rename_depends:
+      old: seaborn
+      new: seaborn-base

--- a/recipe/patch_yaml/xarray.yaml
+++ b/recipe/patch_yaml/xarray.yaml
@@ -113,6 +113,6 @@ if:
   name: xarray
   timestamp_lt: 1728373192000
 then:
-  - rename_depends:
+  - rename_constrains:
       old: seaborn
       new: seaborn-base


### PR DESCRIPTION
See https://github.com/conda-forge/xarray-feedstock/pull/118

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
