### PR TITLE
Add patch to fix pytango 9.3.6 dependencies

### DIFF
--- a/recipe/patch_yaml/pytango.yaml
+++ b/recipe/patch_yaml/pytango.yaml
@@ -1,0 +1,7 @@
+if:
+  name: pytango
+  version: 9.3.6
+  build_number_in: [1, 2, 3]
+  timestamp_lt: 1728409721000
+then:
+  - add_depends: omniorb-libs >=4.2.5,<4.3.0a0


### PR DESCRIPTION
Checklist

* [X] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [X] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [X] Ran `python show_diff.py` and posted the output as part of the PR.
* [X] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

pytango 9.3.6 builds 1, 2, 3 miss the omniorb-libs runtime dependency (omniorb-libs >=4.2.5,<4.3.0a0). It was present in build 0, and it's there in 9.4...

This hasn't been a problem as the cpptango version used to build pytango had this dependency.

A new LTS version of cpptango (9.3.7) is soon gonna be released and will be built with omniorb 4.3. I built a rc1 and could install it with existing pytango 9.3.6. That shouldn't be possible as pytango was built with omniorb 4.2.5 and isn't compatible.

[pytango 9.3.6 ](https://anaconda.org/conda-forge/pytango/files?version=9.3.6) is only available on linux-64 and win-64.

```
(repodata-patches) [root@acd09dab6ac8 recipe]# python show_diff.py --subdirs win-64 linux-64
================================================================================
================================================================================
win-64
win-64::pytango-9.3.6-py311h17ff912_1.tar.bz2
win-64::pytango-9.3.6-py39h191c697_2.conda
win-64::pytango-9.3.6-py310he5437e6_1.tar.bz2
win-64::pytango-9.3.6-py311h44fd347_3.conda
win-64::pytango-9.3.6-py38h07a3158_2.conda
win-64::pytango-9.3.6-py310hdd9df50_3.conda
win-64::pytango-9.3.6-py311h44fd347_2.conda
win-64::pytango-9.3.6-py310hdd9df50_2.conda
win-64::pytango-9.3.6-py38hcf3fe0d_3.conda
win-64::pytango-9.3.6-py39ha440df3_1.tar.bz2
win-64::pytango-9.3.6-py38hc387ade_1.tar.bz2
win-64::pytango-9.3.6-py39h2cbf74c_3.conda
+    "omniorb-libs >=4.2.5,<4.3.0a0",
================================================================================
================================================================================
linux-64
linux-64::pytango-9.3.6-py310h150de76_2.conda
linux-64::pytango-9.3.6-py310hf02b7e0_3.conda
linux-64::pytango-9.3.6-py311h1085b10_2.conda
linux-64::pytango-9.3.6-py311he6adcff_3.conda
linux-64::pytango-9.3.6-py311hbaf9f4f_1.tar.bz2
linux-64::pytango-9.3.6-py310h0c06107_1.tar.bz2
linux-64::pytango-9.3.6-py39hd238b67_3.conda
linux-64::pytango-9.3.6-py38hf08a58d_3.conda
linux-64::pytango-9.3.6-py39h437e572_1.tar.bz2
linux-64::pytango-9.3.6-py38hb9d02da_2.conda
linux-64::pytango-9.3.6-py38hc5157fd_1.tar.bz2
linux-64::pytango-9.3.6-py39hf983217_2.conda
+    "omniorb-libs >=4.2.5,<4.3.0a0",
```
