### PR TITLE
Fix jax 0.4.31 to depend on python >=3.10

### DIFF
--- a/recipe/patch_yaml/jax.yaml
+++ b/recipe/patch_yaml/jax.yaml
@@ -150,3 +150,14 @@ then:
 #   - replace_depends:
 #       old: jaxlib
 #       new: jaxlib >=???
+---
+# Fix for incorrect minimum python version in jax 0.4.31
+# See https://github.com/conda-forge/jax-feedstock/issues/155
+if:
+  name: jax
+  version: 0.4.31
+  timestamp_lt: 1728645860000
+then:
+  - replace_depends:
+      old: python >=3.9
+      new: python >=3.10


### PR DESCRIPTION
Fix part of https://github.com/conda-forge/jax-feedstock/issues/155 .

Merge once https://github.com/conda-forge/jax-feedstock/pull/156 is merged.

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
