### PR TITLE
use a swapfile to help with memory pressure

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -25,6 +25,13 @@ jobs:
     displayName: Configure binfmt_misc
 
   - script: |
+         sudo fallocate -l 8GiB /swapfile || true
+         sudo chmod 600 /swapfile || true
+         sudo mkswap /swapfile || true
+         sudo swapon /swapfile || true
+    displayName: Create swap file
+
+  - script: |
         export CI=azure
         export flow_run_id=azure_$(Build.BuildNumber).$(System.JobAttempt)
         export remote_url=$(Build.Repository.Uri)


### PR DESCRIPTION
I see a lot of recent jobs are hard on the memory limits of the CI agents and occasionally fail. Let's add a swap file to fix this.

We could also free up some disk space, but 🤞 that we don't need to spend that time; c.f. https://github.com/conda-forge/cdt-builds/commit/2e36c633696ad2f82f50b9abf0d542f22c42daf8

