### PR TITLE
fix too-tight run-export on libre2-11

### DIFF
--- a/recipe/patch_yaml/re2.yaml
+++ b/recipe/patch_yaml/re2.yaml
@@ -18,4 +18,4 @@ if:
 then:
   - loosen_depends:
       name: libre2-11
-      upper_bound: None
+      upper_bound: null

--- a/recipe/patch_yaml/re2.yaml
+++ b/recipe/patch_yaml/re2.yaml
@@ -8,3 +8,14 @@ then:
   - rename_depends:
       old: re2
       new: re2 <2020.05.01
+---
+# libre2-<x> encodes the SOVERSION in the package name, and is intended to not have
+# an upper bound; however the implicit `max_pin='x'` in pin_subpackage caused one
+# to be added anyway, until https://github.com/conda-forge/re2-feedstock/pull/84
+if:
+  has_depends: libre2-11 >=*
+  timestamp_lt: 1728778173959
+then:
+  - loosen_depends:
+      name: libre2-11
+      upper_bound: None

--- a/recipe/patch_yaml_model.json
+++ b/recipe/patch_yaml_model.json
@@ -1820,11 +1820,17 @@
           "type": "string"
         },
         "upper_bound": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
           "default": null,
           "description": "Explicit upper bound version to apply to the package (e.g. `2.0`).",
-          "minLength": 1,
-          "title": "Upper Bound",
-          "type": "string"
+          "title": "Upper Bound"
         }
       },
       "required": [

--- a/recipe/patch_yaml_model.py
+++ b/recipe/patch_yaml_model.py
@@ -64,7 +64,7 @@ class _Name_MaxPin_UpperBound(_ForbidExtra):
         None,
         description="Maximum version pin expression to apply to the package (e.g. `x.x`).",  # noqa: E501
     )
-    upper_bound: _NonEmptyStr = Field(
+    upper_bound: str = Field(
         None,
         description="Explicit upper bound version to apply to the package (e.g. `2.0`).",  # noqa: E501
     )

--- a/recipe/patch_yaml_model.py
+++ b/recipe/patch_yaml_model.py
@@ -64,7 +64,7 @@ class _Name_MaxPin_UpperBound(_ForbidExtra):
         None,
         description="Maximum version pin expression to apply to the package (e.g. `x.x`).",  # noqa: E501
     )
-    upper_bound: str = Field(
+    upper_bound: str | None = Field(
         None,
         description="Explicit upper bound version to apply to the package (e.g. `2.0`).",  # noqa: E501
     )

--- a/recipe/patch_yaml_utils.py
+++ b/recipe/patch_yaml_utils.py
@@ -385,6 +385,13 @@ def _pin_looser(fn, record, fix_dep, max_pin=None, upper_bound=None):
         lower = m.group("lower")
         upper = m.group("upper").split(".")
 
+        if upper_bound == "None":
+            msg = (
+                "To remove an upper bound, use `upper_bound: null`; "
+                "`upper_bound: None` wrongly gets interpreted as a string!"
+            )
+            raise ValueError(msg)
+
         if upper_bound is None and max_pin is None:
             # case where we fully remove upper bound
             depends[dep_idx] = f"{dep_parts[0]} >={lower}"

--- a/recipe/patch_yaml_utils.py
+++ b/recipe/patch_yaml_utils.py
@@ -385,7 +385,7 @@ def _pin_looser(fn, record, fix_dep, max_pin=None, upper_bound=None):
         lower = m.group("lower")
         upper = m.group("upper").split(".")
 
-        if (upper_bound is None or str(upper_bound).lower() == "none") and max_pin is None:
+        if (upper_bound is None or upper_bound == "None") and max_pin is None:
             # case where we fully remove upper bound
             depends[dep_idx] = f"{dep_parts[0]} >={lower}"
             if len(dep_parts) == 3:

--- a/recipe/patch_yaml_utils.py
+++ b/recipe/patch_yaml_utils.py
@@ -385,14 +385,7 @@ def _pin_looser(fn, record, fix_dep, max_pin=None, upper_bound=None):
         lower = m.group("lower")
         upper = m.group("upper").split(".")
 
-        if upper_bound == "None":
-            msg = (
-                "To remove an upper bound, use `upper_bound: null`; "
-                "`upper_bound: None` wrongly gets interpreted as a string!"
-            )
-            raise ValueError(msg)
-
-        if upper_bound is None and max_pin is None:
+        if (upper_bound is None or str(upper_bound).lower() == "none") and max_pin is None:
             # case where we fully remove upper bound
             depends[dep_idx] = f"{dep_parts[0]} >={lower}"
             if len(dep_parts) == 3:

--- a/recipe/patch_yaml_utils.py
+++ b/recipe/patch_yaml_utils.py
@@ -385,7 +385,14 @@ def _pin_looser(fn, record, fix_dep, max_pin=None, upper_bound=None):
         lower = m.group("lower")
         upper = m.group("upper").split(".")
 
-        if upper_bound is None:
+        if upper_bound is None and max_pin is None:
+            # case where we fully remove upper bound
+            depends[dep_idx] = f"{dep_parts[0]} >={lower}"
+            if len(dep_parts) == 3:
+                depends[dep_idx] = f"{depends[dep_idx]} {dep_parts[2]}"
+            record["depends"] = depends
+            continue
+        elif upper_bound is None:
             new_upper = get_upper_bound(lower, max_pin).split(".")
         else:
             new_upper = upper_bound.split(".")

--- a/recipe/show_diff.py
+++ b/recipe/show_diff.py
@@ -222,6 +222,8 @@ if __name__ == "__main__":
                     print(val, flush=True)
             else:
                 for key, val in vals.items():
+                    # sort packages belonging to a given repodata diff
+                    val = sorted(list(val))
                     for v in val:
                         print(v, flush=True)
                     for k in key:


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

`libre2-<x>` encodes the SOVERSION in the package name, and is intended to not have an upper bound; however the implicit `max_pin='x'` in pin_subpackage caused one to be added anyway, until https://github.com/conda-forge/re2-feedstock/pull/84.
