### PR TITLE
patch numexpr 2.10.1 to add np 1.23

### DIFF
--- a/recipe/patch_yaml/numexpr.yaml
+++ b/recipe/patch_yaml/numexpr.yaml
@@ -1,0 +1,8 @@
+# numexpr numexpr requires numpy >=1.23.0
+if:
+  name: numexpr
+  timestamp_le: 1728901402000  # 2024-10-14
+  version: 2.10.1
+  build_number_in: [0, 1, 100, 101]
+then:
+  - add_depends: numpy >=1.23.0


### PR DESCRIPTION
Checklist

* [X] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [X] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [X] Ran `python show_diff.py` and posted the output as part of the PR.
* [X] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
```
./show_diff.py                                         
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
osx-arm64::numexpr-2.10.1-py313h1a208bf_1.conda
osx-arm64::numexpr-2.10.1-py39h93d5594_0.conda
osx-arm64::numexpr-2.10.1-py39h93d5594_1.conda
osx-arm64::numexpr-2.10.1-py312hd613be9_1.conda
osx-arm64::numexpr-2.10.1-py311h09358ca_0.conda
osx-arm64::numexpr-2.10.1-py311h09358ca_1.conda
osx-arm64::numexpr-2.10.1-py312hd613be9_0.conda
osx-arm64::numexpr-2.10.1-py310hd35d3cb_0.conda
osx-arm64::numexpr-2.10.1-py310hd35d3cb_1.conda
+    "numpy >=1.23.0",
================================================================================
================================================================================
linux-ppc64le
linux-ppc64le::numexpr-2.10.1-py39ha839b37_1.conda
linux-ppc64le::numexpr-2.10.1-py312hd5457d1_0.conda
linux-ppc64le::numexpr-2.10.1-py39ha839b37_0.conda
linux-ppc64le::numexpr-2.10.1-py313h277c1ff_1.conda
linux-ppc64le::numexpr-2.10.1-py310haea273d_0.conda
linux-ppc64le::numexpr-2.10.1-py312hd5457d1_1.conda
linux-ppc64le::numexpr-2.10.1-py310haea273d_1.conda
linux-ppc64le::numexpr-2.10.1-py311hcbe9762_0.conda
linux-ppc64le::numexpr-2.10.1-py311hcbe9762_1.conda
+    "numpy >=1.23.0",
================================================================================
================================================================================
linux-aarch64
linux-aarch64::numexpr-2.10.1-py39hd141f3b_0.conda
linux-aarch64::numexpr-2.10.1-py311hf56e606_1.conda
linux-aarch64::numexpr-2.10.1-py313h1125dcc_1.conda
linux-aarch64::numexpr-2.10.1-py310h79a6789_0.conda
linux-aarch64::numexpr-2.10.1-py39hd141f3b_1.conda
linux-aarch64::numexpr-2.10.1-py312he70282a_0.conda
linux-aarch64::numexpr-2.10.1-py310h79a6789_1.conda
linux-aarch64::numexpr-2.10.1-py312he70282a_1.conda
linux-aarch64::numexpr-2.10.1-py311hf56e606_0.conda
+    "numpy >=1.23.0",
================================================================================
================================================================================
noarch
================================================================================
================================================================================
win-64
win-64::numexpr-2.10.1-py313hae86e4f_101.conda
win-64::numexpr-2.10.1-py310h944a073_100.conda
win-64::numexpr-2.10.1-mkl_py312h295738f_0.conda
win-64::numexpr-2.10.1-mkl_py310hca09094_1.conda
win-64::numexpr-2.10.1-mkl_py311hc8aec83_0.conda
win-64::numexpr-2.10.1-mkl_py312h295738f_1.conda
win-64::numexpr-2.10.1-mkl_py311hc8aec83_1.conda
win-64::numexpr-2.10.1-py39h4919eaa_100.conda
win-64::numexpr-2.10.1-py312h2aa74e6_101.conda
win-64::numexpr-2.10.1-py312h2aa74e6_100.conda
win-64::numexpr-2.10.1-mkl_py39h95c3c23_1.conda
win-64::numexpr-2.10.1-py311h2673713_100.conda
win-64::numexpr-2.10.1-py311h2673713_101.conda
win-64::numexpr-2.10.1-mkl_py313h9cb9ed2_1.conda
win-64::numexpr-2.10.1-py39h4919eaa_101.conda
win-64::numexpr-2.10.1-mkl_py39h95c3c23_0.conda
win-64::numexpr-2.10.1-mkl_py310hca09094_0.conda
win-64::numexpr-2.10.1-py310h944a073_101.conda
+    "numpy >=1.23.0",
================================================================================
================================================================================
osx-64
osx-64::numexpr-2.10.1-py310h803f913_0.conda
osx-64::numexpr-2.10.1-py310h803f913_1.conda
osx-64::numexpr-2.10.1-py39hf9f5ab3_1.conda
osx-64::numexpr-2.10.1-py311h749d821_0.conda
osx-64::numexpr-2.10.1-py311h749d821_1.conda
osx-64::numexpr-2.10.1-py312heedee6e_1.conda
osx-64::numexpr-2.10.1-py312heedee6e_0.conda
osx-64::numexpr-2.10.1-py313h7183858_1.conda
osx-64::numexpr-2.10.1-py39hf9f5ab3_0.conda
+    "numpy >=1.23.0",
================================================================================
================================================================================
linux-64
linux-64::numexpr-2.10.1-py313ha35f5e3_101.conda
linux-64::numexpr-2.10.1-mkl_py311ha2dc773_0.conda
linux-64::numexpr-2.10.1-py39h2eb9cd8_100.conda
linux-64::numexpr-2.10.1-py39h2eb9cd8_101.conda
linux-64::numexpr-2.10.1-mkl_py39h8c978b6_0.conda
linux-64::numexpr-2.10.1-py310hf7b50c6_101.conda
linux-64::numexpr-2.10.1-py311h74da373_100.conda
linux-64::numexpr-2.10.1-mkl_py312h8037d79_1.conda
linux-64::numexpr-2.10.1-mkl_py310h2bbc3fe_0.conda
linux-64::numexpr-2.10.1-mkl_py313hbb91307_1.conda
linux-64::numexpr-2.10.1-mkl_py312h8037d79_0.conda
linux-64::numexpr-2.10.1-py311h74da373_101.conda
linux-64::numexpr-2.10.1-py310hf7b50c6_100.conda
linux-64::numexpr-2.10.1-py312h18e9d8c_100.conda
linux-64::numexpr-2.10.1-mkl_py39h8c978b6_1.conda
linux-64::numexpr-2.10.1-mkl_py310h2bbc3fe_1.conda
linux-64::numexpr-2.10.1-mkl_py311ha2dc773_1.conda
linux-64::numexpr-2.10.1-py312h18e9d8c_101.conda
+    "numpy >=1.23.0",
```