### PR TITLE
pin python>=3.9 for pyparsing 3.2.0

### DIFF
--- a/recipe/patch_yaml/pyparsing.yaml
+++ b/recipe/patch_yaml/pyparsing.yaml
@@ -1,0 +1,9 @@
+if:
+  name: pyparsing
+  version_ge: 3.2.0
+  has_depends: python >=3.6
+  timestamp_lt: 1728924419000
+then:
+  - replace_depends:
+      old: python >=3.6
+      new: python >=3.9


### PR DESCRIPTION
## Description

In its recent v3.2.0 release, `pyparsing` moved its Python floor to `requires-python >=3.9`. The first build of that here on conda-forge didn't have that change, and so the v3.2.0 packages can still get installed in environments using older Python versions. Those immediately break on import because of syntax errors related to type hints.

Fixed that in the feedstock: https://github.com/conda-forge/pyparsing-feedstock/pull/49

This proposes a corresponding repodata patch.

A note on potential impact: `pyparsing` is a direct dependency of `matplotlib-base` ([code link](https://github.com/conda-forge/matplotlib-feedstock/blob/d22b1c7baa0585c566e09f7167dfa3d539135b67/recipe/meta.yaml#L70)).

## Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.

```text
noarch
noarch::pyparsing-3.2.0-pyhd8ed1ab_0.conda
-    "python >=3.6"
+    "python >=3.9"
```

* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
