### PR TITLE
Use pydicom < 3.0 for Python < 3.10

### DIFF
--- a/recipe/patch_yaml/pydicom.yaml
+++ b/recipe/patch_yaml/pydicom.yaml
@@ -1,0 +1,10 @@
+# Fix to use pydicom < 3.0 for Python < 3.10
+if:
+  name: pydicom
+  subdir_in: noarch
+  timestamp_lt: 1727272800000
+  version_ge: 3.0.0
+then:
+  - replace_depends:
+      old: python
+      new: python >=3.10

--- a/recipe/patch_yaml/pydicom.yaml
+++ b/recipe/patch_yaml/pydicom.yaml
@@ -1,10 +1,9 @@
 # Fix to use pydicom < 3.0 for Python < 3.10
 if:
   name: pydicom
-  subdir_in: noarch
-  timestamp_lt: 1727272800000
+  timestamp_lt: 1727272800000  # 2024-09-26
   version_ge: 3.0.0
 then:
   - replace_depends:
-      old: python
+      old: python >=3.7
       new: python >=3.10


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

[Feedstock has been updated](https://github.com/conda-forge/pydicom-feedstock/pull/40)

<!-- Put any other comments or information here -->
```
patching repodata:   0%|          | 0/9 [00:00<?, ?it/s]
================================================================================
================================================================================
noarch
noarch::pydicom-3.0.0-pyhd8ed1ab_0.conda
noarch::pydicom-3.0.1-pyhd8ed1ab_0.conda
-    "python >=3.7"
+    "python >=3.10"


patching repodata:  11%|█         | 1/9 [03:06<24:54, 186.85s/it]
patching repodata:  22%|██▏       | 2/9 [03:07<09:01, 77.34s/it] 
================================================================================
================================================================================
linux-armv7l


================================================================================
================================================================================
linux-aarch64


patching repodata:  33%|███▎      | 3/9 [05:55<11:52, 118.68s/it]
================================================================================
================================================================================


patching repodata: 100%|██████████| 9/9 [16:12<00:00, 110.92s/it]
patching repodata: 100%|██████████| 9/9 [16:12<00:00, 108.10s/it]
```
