### PR TITLE
Fix pyarrow pinnings for dask>=2024.8.2,<2024.10.0

### DIFF
--- a/recipe/patch_yaml/dask.yaml
+++ b/recipe/patch_yaml/dask.yaml
@@ -91,3 +91,14 @@ then:
   - replace_depends:
       old: distributed *${version}*
       new: distributed >=${version},<${next_version}.0a0
+---
+# pyarrow minimum version was bumped to 14.0.1 in dask 2024.8.2
+if:
+  name: dask
+  version_ge: 2024.8.2
+  version_lt: 2024.10.0
+then:
+  - replace_depends:
+      old: pyarrow >=7.0
+      new: pyarrow >=14.0.1
+  - remove_depends: pyarrow-hotfix


### PR DESCRIPTION
Checklist

* [ ] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

Dask bumped its minimum supported pyarrow version to 14.0.1 with their [2024.8.2 release](https://github.com/dask/dask/releases/tag/2024.8.2), but this was not reflected in the metadata of the `dask` metapackage until the 2024.10.0 release (see https://github.com/conda-forge/dask-feedstock/pull/274#discussion_r1805413301).

Output of `python show_diff.py`:

```
noarch
noarch::dask-2024.8.2-pyhd8ed1ab_0.conda
noarch::dask-2024.9.0-pyhd8ed1ab_0.conda
noarch::dask-2024.9.1-pyhd8ed1ab_0.conda
-    "pyarrow >=7.0",
-    "pyarrow-hotfix",
+    "pyarrow >=14.0.1",
```

cc @jrbourbeau @fjetter @hendrikmakait @phofl