### PR TITLE
Fix flax 0.9.0 to depend on python >=3.10

### DIFF
--- a/recipe/patch_yaml/flax.yaml
+++ b/recipe/patch_yaml/flax.yaml
@@ -19,3 +19,14 @@ then:
   - replace_depends:
       old: jax >=0.2.6
       new: jax >=0.2.6,<0.4.14
+---
+# Fix for incorrect minimum python version in flax 0.9.0
+# See https://github.com/conda-forge/flax-feedstock/pull/38
+if:
+  name: flax
+  version: 0.9.0
+  build: pyhd8ed1ab_0
+then:
+  - replace_depends:
+      old: python >=3.9
+      new: python >=3.10


### PR DESCRIPTION
Similar to https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/877, to be merged after https://github.com/conda-forge/flax-feedstock/pull/38 .


Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
