### PR TITLE
avoid numpy 2 for pyspark

### DIFF
--- a/recipe/patch_yaml/pyspark.yaml
+++ b/recipe/patch_yaml/pyspark.yaml
@@ -1,0 +1,10 @@
+# pyspark is not compatible with numpy 2.0 yet; see
+# https://github.com/conda-forge/pyspark-feedstock/pull/51
+if:
+  name: pyspark
+  subdir_in: noarch
+  timestamp_lt: 1729807935403
+then:
+  - tighten_depends:
+      name: numpy
+      upper_bound: 2.0

--- a/recipe/patch_yaml/pyspark.yaml
+++ b/recipe/patch_yaml/pyspark.yaml
@@ -7,4 +7,4 @@ if:
 then:
   - tighten_depends:
       name: numpy
-      upper_bound: 2.0
+      upper_bound: "2.0"


### PR DESCRIPTION
This is not supported yet, see https://github.com/conda-forge/pyspark-feedstock/pull/51 & https://github.com/apache/spark/pull/47175

CC @conda-forge/pyspark 

```diff
>python show_diff.py
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
noarch
noarch::pyspark-2.4.1-py_0.tar.bz2
noarch::pyspark-2.4.2-py_0.tar.bz2
noarch::pyspark-2.4.3-py_0.tar.bz2
noarch::pyspark-2.4.4-py_0.tar.bz2
noarch::pyspark-2.4.5-py_0.tar.bz2
noarch::pyspark-2.4.6-py_0.tar.bz2
noarch::pyspark-2.4.7-pyhd8ed1ab_0.tar.bz2
noarch::pyspark-2.4.8-pyhd8ed1ab_0.tar.bz2
noarch::pyspark-3.0.0-py_0.tar.bz2
noarch::pyspark-3.0.1-pyh9f0ad1d_0.tar.bz2
noarch::pyspark-3.0.2-pyh44b312d_0.tar.bz2
noarch::pyspark-3.0.3-pyhd8ed1ab_0.tar.bz2
noarch::pyspark-3.1.1-pyh44b312d_0.tar.bz2
noarch::pyspark-3.1.2-pyh6c4a22f_0.tar.bz2
noarch::pyspark-3.1.3-pyhd8ed1ab_0.tar.bz2
-    "numpy >=1.7",
+    "numpy >=1.7,<2.0a0",
noarch::pyspark-3.2.0-pyh6c4a22f_0.tar.bz2
noarch::pyspark-3.2.1-pyhd8ed1ab_0.tar.bz2
noarch::pyspark-3.2.2-pyhd8ed1ab_0.tar.bz2
noarch::pyspark-3.2.3-pyhd8ed1ab_0.conda
-    "numpy >=1.14",
+    "numpy >=1.14,<2.0a0",
noarch::pyspark-3.3.0-pyhd8ed1ab_0.tar.bz2
noarch::pyspark-3.3.1-pyhd8ed1ab_0.tar.bz2
noarch::pyspark-3.3.2-pyhd8ed1ab_0.conda
noarch::pyspark-3.4.0-pyhd8ed1ab_0.conda
noarch::pyspark-3.4.1-pyhd8ed1ab_0.conda
noarch::pyspark-3.5.0-pyhd8ed1ab_0.conda
noarch::pyspark-3.5.1-pyhd8ed1ab_0.conda
-    "numpy >=1.15",
+    "numpy >=1.15,<2.0a0",
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
================================================================================
================================================================================
linux-64
```

Only taking the noarch builds because the previous builds were on ancient python versions that never got numpy 2 anyway.