### PR TITLE
Pint doesn't support python 3.13 yet

### DIFF
--- a/recipe/patch_yaml/pint.yaml
+++ b/recipe/patch_yaml/pint.yaml
@@ -23,3 +23,14 @@ then:
   - replace_depends:
       old: python >=3.9
       new: python >=3.10
+---
+# pint doesn't support python 3.13 yet
+# see https://github.com/hgrecco/pint/pull/2037
+if:
+  name: pint
+  version_le: 0.24.3
+  timestamp_lt: 1729953082000
+then:
+  - tighten_depends:
+      name: python
+      upper_bound: "3.13"


### PR DESCRIPTION
Checklist

* [X] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [X] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [X] Ran `python show_diff.py` and posted the output as part of the PR.
* [X] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

Pint doesn't support python 3.13 yet.  See https://github.com/hgrecco/pint/pull/2037

```
$ python show_diff.py --use-cache --subdirs noarch
================================================================================
================================================================================
noarch
noarch::pint-0.10-py_0.tar.bz2
noarch::pint-0.10-py_1.tar.bz2
noarch::pint-0.10.1-py_0.tar.bz2
noarch::pint-0.11-py_0.tar.bz2
noarch::pint-0.11-py_1.tar.bz2
noarch::pint-0.12-py_0.tar.bz2
noarch::pint-0.13-py_0.tar.bz2
noarch::pint-0.14-py_0.tar.bz2
noarch::pint-0.15-py_0.tar.bz2
noarch::pint-0.16-py_0.tar.bz2
noarch::pint-0.16-py_1.tar.bz2
noarch::pint-0.16.1-py_0.tar.bz2
noarch::pint-0.17-pyhd8ed1ab_0.tar.bz2
noarch::pint-0.17-pyhd8ed1ab_1.tar.bz2
-    "python >=3.6",
+    "python >=3.6,<3.13.0a0",
noarch::pint-0.19-pyhd8ed1ab_0.tar.bz2
noarch::pint-0.19.1-pyhd8ed1ab_0.tar.bz2
noarch::pint-0.19.2-pyhd8ed1ab_0.tar.bz2
noarch::pint-0.20-pyhd8ed1ab_0.tar.bz2
noarch::pint-0.20.1-pyhd8ed1ab_0.tar.bz2
noarch::pint-0.21-pyhd8ed1ab_0.conda
-    "python >=3.8"
+    "python >=3.8,<3.13.0a0"
noarch::pint-0.18-pyhd8ed1ab_0.tar.bz2
-    "python >=3.7"
+    "python >=3.7,<3.13.0a0"
noarch::pint-0.8.1-py_1.tar.bz2
noarch::pint-0.9-py_0.tar.bz2
-    "python",
+    "python <3.13.0a0",
noarch::pint-0.24-pyhd8ed1ab_0.conda
noarch::pint-0.24-pyhd8ed1ab_1.conda
noarch::pint-0.24-pyhd8ed1ab_2.conda
noarch::pint-0.24.1-pyhd8ed1ab_0.conda
-    "python >=3.10",
+    "python >=3.10,<3.13.0a0",
noarch::pint-0.22-pyhd8ed1ab_1.conda
noarch::pint-0.23-pyhd8ed1ab_0.conda
noarch::pint-0.23-pyhd8ed1ab_1.conda
noarch::pint-0.24.1-pyhd8ed1ab_1.conda
noarch::pint-0.24.3-pyhd8ed1ab_0.conda
-    "python >=3.9",
+    "python >=3.9,<3.13.0a0",
```

Ping @conda-forge/pint 