### PR TITLE
Patch simpeg dependencies

### DIFF
--- a/recipe/patch_yaml/simpeg.yml
+++ b/recipe/patch_yaml/simpeg.yml
@@ -1,0 +1,8 @@
+# simpeg is not compatible with numpy 2.0 yet; see
+if:
+  name: simpeg
+  timestamp_lt: 1729807935403
+then:
+  - tighten_depends:
+      name: numpy
+      upper_bound: "2.0"


### PR DESCRIPTION
Patch simpeg for numpy upper bounds, next version will support 2.0

Checklist

* [ ] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
