### PR TITLE
Add missing readme_renderer dependency to twine

### DIFF
--- a/recipe/patch_yaml/twine.yaml
+++ b/recipe/patch_yaml/twine.yaml
@@ -1,0 +1,11 @@
+# twine version 1.13.0 build 0 is missing the
+# readme_renderer dependency that was added in
+# https://github.com/pypa/twine/pull/395
+if:
+  name: twine
+  version_eq: "1.13.0"
+  build_number_eq: 0
+  timestamp_lt: 1730900960000
+then:
+  - add_depends:
+      - readme_renderer >=21.0


### PR DESCRIPTION
Twine depends on readme_renderer depends on cmarkgfm. Cmarkgfm is compiled and doesn't exist for Python 3.13. I encountered an inconsistent solved environment with Python 3.13 and twine 1.13.0_0 because this build was missing those dependencies.

As an upcoming solution, I updated the stale cmarkgfm feedstock in https://github.com/conda-forge/cmarkgfm-feedstock/pull/33, and I triggered a pending bot-rerun for the Python 3.13 rebuild in https://github.com/conda-forge/cmarkgfm-feedstock/pull/32.

This patch is a retroactive solution.


Checklist

* [X] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [X] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [X] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [X] Ran `python show_diff.py` and posted the output as part of the PR.
* [X] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

```diff
noarch
noarch::twine-1.13.0-py_0.tar.bz2
+    "readme_renderer >=21.0",
```