### PR TITLE
Pint flexparser

### DIFF
--- a/recipe/patch_yaml/pint.yaml
+++ b/recipe/patch_yaml/pint.yaml
@@ -34,3 +34,12 @@ then:
   - tighten_depends:
       name: python
       upper_bound: "3.13"
+---
+if:
+  name: pint
+  timestamp_lt: 1730982234000
+  has_depends: flexparser
+then:
+  replace_depends:
+    old: flexparser >=0.3
+    new: flexparser >=0.3,<0.4

--- a/recipe/patch_yaml/pint.yaml
+++ b/recipe/patch_yaml/pint.yaml
@@ -38,8 +38,8 @@ then:
 if:
   name: pint
   timestamp_lt: 1730982234000
-  has_depends: flexparser
+  version_gt: 0.24.0
 then:
-  replace_depends:
-    old: flexparser >=0.3
-    new: flexparser >=0.3,<0.4
+  - replace_depends:
+      old: flexparser >=0.3
+      new: flexparser >=0.3,<0.4


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

show_diff output:
```
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
noarch
noarch::pint-0.24.1-pyhd8ed1ab_0.conda
noarch::pint-0.24.1-pyhd8ed1ab_1.conda
noarch::pint-0.24.3-pyhd8ed1ab_0.conda
-    "flexparser >=0.3",
+    "flexparser >=0.3,<0.4",
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
================================================================================
================================================================================
linux-64
```

See https://github.com/conda-forge/pint-feedstock/pull/71 and upstream comments; `flexparser=0.4` broke with older pint versions. I've only patched 0.24.* here because that's when the `flexparser >=0.3` constraint was added.