### PR TITLE
FIX: Replace minimum required Python for hatchling v1.18.0+

### DIFF
--- a/recipe/patch_yaml/hatchling.yaml
+++ b/recipe/patch_yaml/hatchling.yaml
@@ -1,0 +1,37 @@
+# https://github.com/conda-forge/hatchling-feedstock has broken metadata for
+# the minimum Python version required from v1.18.0 onwards (currently v1.25.0).
+# The last version of hatchling that was compatible with Python 3.7 was v1.17.1
+# as after that https://github.com/pypa/hatch/pull/1386 introduced Python 3.8+
+# syntax that made its way into hatchling v1.23.0 onward, though hatchling v1.18.0
+# was the first version to require Python 3.8+
+# (c.f. https://github.com/pypa/hatch/releases/tag/hatchling-v1.18.0).
+# c.f. https://github.com/conda-forge/pyhf-feedstock/pull/28#issuecomment-2464060369
+#
+# This is getting patched for hatchling v1.25.0 (rebuild) and future versions
+# in https://github.com/conda-forge/hatchling-feedstock/pull/59, so only apply this
+# python replacement patch for releases created prior to now (1731056098000
+# which in human readable metadata is on 2024-11-08.)
+if:
+  name: hatchling
+  version_in:
+    - 1.18.0
+    - 1.19.0
+    - 1.19.1
+    - 1.20.0
+    - 1.21.0
+    - 1.21.1
+    - 1.22.1
+    - 1.22.2
+    - 1.22.3
+    - 1.22.4
+    - 1.22.5
+    - 1.23.0
+    - 1.24.0
+    - 1.24.1
+    - 1.24.2
+    - 1.25.0
+  timestamp_lt: 1731056098000
+then:
+  - replace_depends:
+      old: python >=3.7
+      new: python >=3.8


### PR DESCRIPTION
https://github.com/conda-forge/hatchling-feedstock has broken metadata for the minimum Python version required from `v1.18.0` onwards (currently `v1.25.0`). The last version of `hatchling` that was compatible with Python 3.7 was `v1.17.1` as after that https://github.com/pypa/hatch/pull/1386 introduced Python 3.8+ syntax that made its way into hatchling `v1.23.0` onward, though `hatchling` `v1.18.0` was the first version to require Python 3.8+ (c.f. https://github.com/pypa/hatch/releases/tag/hatchling-v1.18.0).

c.f. https://github.com/conda-forge/pyhf-feedstock/pull/28#issuecomment-2464060369

This is getting patched for `hatchling` `v1.25.0` (rebuild) and future versions in https://github.com/conda-forge/hatchling-feedstock/pull/59, so only apply this `python` replacement patch for releases created prior to now (`1731056098000` which in human readable metadata is on 2024-11-08.)

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [N/A] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
   - `version_in` is split across multiple lines to pass `yamllint`
* [x] Ran `python show_diff.py` and posted the output as part of the PR.

```console
$ micromamba env create --yes --file dev-env-for-patches.yaml
$ micromamba activate repodata-patches
$ cd ..
$ python recipe/show_diff.py 
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
noarch
noarch::hatchling-1.18.0-pyhd8ed1ab_0.conda
noarch::hatchling-1.19.0-pyhd8ed1ab_0.conda
noarch::hatchling-1.19.1-pyhd8ed1ab_0.conda
noarch::hatchling-1.20.0-pyhd8ed1ab_0.conda
noarch::hatchling-1.21.0-pyhd8ed1ab_0.conda
noarch::hatchling-1.21.1-pyhd8ed1ab_0.conda
noarch::hatchling-1.22.1-pyhd8ed1ab_0.conda
noarch::hatchling-1.22.2-pyhd8ed1ab_0.conda
noarch::hatchling-1.22.3-pyhd8ed1ab_0.conda
noarch::hatchling-1.22.4-pyhd8ed1ab_0.conda
noarch::hatchling-1.22.5-pyhd8ed1ab_0.conda
noarch::hatchling-1.23.0-pyhd8ed1ab_0.conda
noarch::hatchling-1.24.0-pyhd8ed1ab_0.conda
noarch::hatchling-1.24.1-pyhd8ed1ab_0.conda
noarch::hatchling-1.24.2-pyhd8ed1ab_0.conda
noarch::hatchling-1.25.0-pyhd8ed1ab_0.conda
-    "python >=3.7",
+    "python >=3.8",
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
================================================================================
================================================================================
linux-64
$ 
```

* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

I use
```yaml
timestamp_lt: 1731056098000
```

to ensure that this only affects packages built in the past of today (2024-11-08).

<!-- Put any other comments or information here -->
