### PR TITLE
anndata 0.11.0 requires python >= 3.10

### DIFF
--- a/recipe/patch_yaml/anndata.yaml
+++ b/recipe/patch_yaml/anndata.yaml
@@ -19,3 +19,19 @@ then:
   - replace_depends:
       old: "python >=3.6"
       new: "python >=3.8"
+---
+# anndata 0.11.0 dropped support for Python 3.9 but build 0 didn't update the
+# Python pin. Fixed for build_number 1 in
+# https://github.com/conda-forge/anndata-feedstock/pull/45
+if:
+  name: anndata
+  version: "0.11.0"
+  build_number: 0
+  timestamp_lt: 1731005774000
+then:
+  - replace_depends:
+      old: "python >=3.9"
+      new: "python >=3.10"
+  - replace_depends:
+      old: "h5py >=3.1"
+      new: "h5py >=3.6"


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

---

* anndata 0.11.0 was automerged before its requirements (minimum python, h5py) could be updated (https://github.com/conda-forge/anndata-feedstock/pull/42, https://github.com/scverse/anndata/pull/1712)
* I already fixed the recipe and uploaded build number 1 (https://github.com/conda-forge/anndata-feedstock/pull/45)
* @conda-forge/anndata please review

```sh
python show_diff.py --subdirs noarch
================================================================================
================================================================================
noarch
noarch::anndata-0.11.0-pyhd8ed1ab_0.conda
-    "h5py >=3.1",
+    "h5py >=3.6",
-    "python >=3.9",
+    "python >=3.10",
```