### PR TITLE
Add __cuda dependency to lightgbm

### DIFF
--- a/recipe/patch_yaml/lightgbm.yaml
+++ b/recipe/patch_yaml/lightgbm.yaml
@@ -5,3 +5,14 @@ if:
   timestamp_lt: 1720034169000
 then:
   - add_depends: __cuda
+
+---
+
+if:
+  name: lightgbm
+  version: 4.4.0
+  build: cuda*
+  not_has_depends: cudatoolkit*
+  timestamp_lt: 1720034169000
+then:
+  - add_depends: __cuda

--- a/recipe/patch_yaml/lightgbm.yaml
+++ b/recipe/patch_yaml/lightgbm.yaml
@@ -1,18 +1,7 @@
 if:
   name: lightgbm
   version: 4.4.0
-  has_depends: cudatoolkit*
-  timestamp_lt: 1720034169000
-then:
-  - add_depends: __cuda
-
----
-
-if:
-  name: lightgbm
-  version: 4.4.0
   build: cuda*
-  not_has_depends: cudatoolkit*
   timestamp_lt: 1720034169000
 then:
   - add_depends: __cuda


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
### Further context
#789 Added `__cuda` as a dependency for lightgbm packages depending on `cudatoolkit`. However, not all cuda builds have that dependency and were thus missed. 

### Output of `show_diff.py`:
```
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-ppc64le
linux-ppc64le::lightgbm-4.4.0-cuda_py3.10h75e58fc_2.conda
linux-ppc64le::lightgbm-4.4.0-cuda_py3.11h9f78bff_2.conda
linux-ppc64le::lightgbm-4.4.0-cuda_py3.12h3c335b5_2.conda
linux-ppc64le::lightgbm-4.4.0-cuda_py3.8hf861fb2_2.conda
linux-ppc64le::lightgbm-4.4.0-cuda_py3.9h14537e7_2.conda
+    "__cuda",
================================================================================
================================================================================
linux-aarch64
linux-aarch64::lightgbm-4.4.0-cuda_py3.10h9048c5e_2.conda
linux-aarch64::lightgbm-4.4.0-cuda_py3.11h80a3fbe_2.conda
linux-aarch64::lightgbm-4.4.0-cuda_py3.12h85ffe43_2.conda
linux-aarch64::lightgbm-4.4.0-cuda_py3.8h7428acc_2.conda
linux-aarch64::lightgbm-4.4.0-cuda_py3.9h7b0233e_2.conda
+    "__cuda",
================================================================================
================================================================================
noarch
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
================================================================================
================================================================================
linux-64
linux-64::lightgbm-4.4.0-cuda_py3.10hdc26961_2.conda
linux-64::lightgbm-4.4.0-cuda_py3.11h78b1082_2.conda
linux-64::lightgbm-4.4.0-cuda_py3.12h374d3f4_2.conda
linux-64::lightgbm-4.4.0-cuda_py3.8hd013c3a_2.conda
linux-64::lightgbm-4.4.0-cuda_py3.9h8ad4a74_2.conda
+    "__cuda",
```
