### PR TITLE
Limit use of numpy 2.0 to imod > 0.17.1

### DIFF
--- a/recipe/patch_yaml/imod.yaml
+++ b/recipe/patch_yaml/imod.yaml
@@ -71,8 +71,8 @@ if:
   name: imod
   timestamp_le: 1731329388000
   version_le: "0.17.1"
-  has_depends: numpy >=2.0
+  has_depends: numpy
 then:
   - replace_depends:
-      old: numpy >=2.0
+      old: numpy
       new: numpy <2.0

--- a/recipe/patch_yaml/imod.yaml
+++ b/recipe/patch_yaml/imod.yaml
@@ -65,3 +65,14 @@ then:
   - replace_depends:
       old: xarray >=2023.04.0
       new: xarray >=2023.08.0
+---
+# iMOD Python <= 0.17.1 doesn't support numpy 2.0
+if:
+  name: imod
+  timestamp_le: 1731329388000
+  version_le: "0.17.1"
+  has_depends: numpy >=2.0
+then:
+  - replace_depends:
+      old: numpy >=2.0
+      new: numpy <2.0


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
I forgot to post the output of ``show_diff.py`` yesterday. So I re-ran it today, but today the output shows some noise. 
The hatchling things seem concerning, as that is an upstream dependency, so I wouldn't know how the imod patches would affect their dependency tree.

Let me know what I can do to make the output of show_diff.py look normal again / avoid affecting hatchling's dependency tree.

```
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
noarch
noarch::imod-0.10.0-py_0.tar.bz2
noarch::imod-0.10.1-py_0.tar.bz2
noarch::imod-0.11.2-pyhd8ed1ab_0.tar.bz2
noarch::imod-0.11.3-pyhd8ed1ab_0.tar.bz2
noarch::imod-0.11.4-pyhd8ed1ab_0.tar.bz2
noarch::imod-0.11.5-pyhd8ed1ab_0.conda
noarch::imod-0.11.6-pyhd8ed1ab_0.conda
noarch::imod-0.12.0-pyhd8ed1ab_0.conda
noarch::imod-0.13.0-pyhd8ed1ab_0.conda
noarch::imod-0.13.1-pyhd8ed1ab_0.conda
noarch::imod-0.13.2-pyhd8ed1ab_0.conda
noarch::imod-0.14.0-pyhd8ed1ab_0.conda
noarch::imod-0.14.1-pyhd8ed1ab_0.conda
noarch::imod-0.15.0-pyhd8ed1ab_0.conda
noarch::imod-0.15.1-pyhd8ed1ab_0.conda
noarch::imod-0.15.2-pyhd8ed1ab_0.conda
noarch::imod-0.15.3-pyhd8ed1ab_0.conda
noarch::imod-0.16.0-pyhd8ed1ab_0.conda
noarch::imod-0.17.0-pyhd8ed1ab_0.conda
noarch::imod-0.17.1-pyhd8ed1ab_0.conda
noarch::imod-0.6.1-py_0.tar.bz2
noarch::imod-0.7.0-py_0.tar.bz2
noarch::imod-0.7.1-py_0.tar.bz2
noarch::imod-0.8.0-py_0.tar.bz2
noarch::imod-0.9.0-py_0.tar.bz2
noarch::imod-0.9.0-py_1.tar.bz2
-    "numpy",
+    "numpy <2.0",
noarch::hatchling-1.18.0-pyhd8ed1ab_0.conda
noarch::hatchling-1.19.0-pyhd8ed1ab_0.conda
noarch::hatchling-1.19.1-pyhd8ed1ab_0.conda
noarch::hatchling-1.20.0-pyhd8ed1ab_0.conda
noarch::hatchling-1.21.0-pyhd8ed1ab_0.conda
noarch::hatchling-1.21.1-pyhd8ed1ab_0.conda
noarch::hatchling-1.22.1-pyhd8ed1ab_0.conda
noarch::hatchling-1.22.2-pyhd8ed1ab_0.conda
noarch::hatchling-1.22.3-pyhd8ed1ab_0.conda
noarch::hatchling-1.22.4-pyhd8ed1ab_0.conda
noarch::hatchling-1.22.5-pyhd8ed1ab_0.conda
noarch::hatchling-1.23.0-pyhd8ed1ab_0.conda
noarch::hatchling-1.24.0-pyhd8ed1ab_0.conda
noarch::hatchling-1.24.1-pyhd8ed1ab_0.conda
noarch::hatchling-1.24.2-pyhd8ed1ab_0.conda
noarch::hatchling-1.25.0-pyhd8ed1ab_0.conda
-    "python >=3.8",
+    "python >=3.7",
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
================================================================================
================================================================================
linux-64
```

