### PR TITLE
replace azure-core 1.31 python dep to >=3.9

### DIFF
--- a/recipe/patch_yaml/azure-core.yaml
+++ b/recipe/patch_yaml/azure-core.yaml
@@ -1,0 +1,12 @@
+---
+# Versions of invoke from before version 2.0.0 are not compatible with
+# Python 3.11 because of inspect.getargspec being removed.
+if:
+  name: azure-core
+  subdir_in: noarch
+  artifact_in: azure-core-1.31.0-pyhd8ed1ab_0.conda
+  timestamp_lt: 1731940921000  # 2024/11/18
+then:
+  - replace_depends:
+      old: python >=3.7
+      new: python >=3.9


### PR DESCRIPTION
related to

https://github.com/conda-forge/azure-core-feedstock/pull/55 https://github.com/conda-forge/azure-core-feedstock/issues/54

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
```
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
noarch
noarch::azure-core-1.31.0-pyhd8ed1ab_0.conda
-    "python >=3.7",
+    "python >=3.9",
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
================================================================================
================================================================================
linux-64
```