### PR TITLE
Fix jsonrpcclient dependencies

### DIFF
--- a/recipe/patch_yaml/jsonrpcclient.yaml
+++ b/recipe/patch_yaml/jsonrpcclient.yaml
@@ -1,0 +1,29 @@
+# jsonrpcclient removed click dependency in 4.0.0
+# See https://github.com/explodinglabs/jsonrpcclient/commit/3a5fa2a33e6aa63ceb6eac4843df97631aa48e81
+if:
+  name: jsonrpcclient
+  version_ge: 4.0.0
+  timestamp_lt: 1732100712000
+  has_depends: click <7
+then:
+  - remove_depends: click <7
+---
+# jsonrpcclient removed apply_defaults dependency in 4.0.1
+# See https://github.com/explodinglabs/jsonrpcclient/blob/4.0.1/setup.py
+if:
+  name: jsonrpcclient
+  version_ge: 4.0.1
+  timestamp_lt: 1732100712000
+  has_depends: apply_defaults <1
+then:
+  - remove_depends: apply_defaults <1
+---
+# jsonrpcclient removed jsonschema dependency in 4.0.1
+# See https://github.com/explodinglabs/jsonrpcclient/blob/4.0.1/setup.py
+if:
+  name: jsonrpcclient
+  version_ge: 4.0.1
+  timestamp_lt: 1732100712000
+  has_depends: jsonschema <4
+then:
+  - remove_depends: jsonschema <4


### PR DESCRIPTION
Checklist

* [X] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [X] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [X] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [X] Ran `python show_diff.py` and posted the output as part of the PR.
* [X] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

`jsonrpcclient` 4.0.0 was a complete rewrite and previous dependencies were removed but they are still in the conda recipe:

* `click` dependency was removed in 4.0.0
* `apply_defaults` and `jsonschema` were removed in 4.0.1

The `click <7` is quite annoying as it prevents to install `jsonrpclient` with packages that require a newer version of `click`.

I made a MR to update the recipe: https://github.com/conda-forge/jsonrpcclient-feedstock/pull/6

@conda-forge/jsonrpcclient FYI


```shell
$ python show_diff.py --subdirs noarch
================================================================================
================================================================================
noarch
noarch::jsonrpcclient-4.0.0-pyhd8ed1ab_0.tar.bz2
-    "click <7",
noarch::jsonrpcclient-4.0.1-pyhd8ed1ab_0.tar.bz2
noarch::jsonrpcclient-4.0.2-pyhd8ed1ab_0.tar.bz2
-    "apply_defaults <1",
-    "click <7",
-    "jsonschema <4",
```
