### PR TITLE
Pin all libutf8proc dependencies to <2.9

### DIFF
--- a/recipe/patch_yaml/libutf8proc.yaml
+++ b/recipe/patch_yaml/libutf8proc.yaml
@@ -1,0 +1,5 @@
+if:
+  has_depends: libutf8proc*,<3.0a0
+  timestamp_lt: 1732866506000
+then:
+  - add_depends: libutf8proc <2.9


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->


They broke the ABI with 2.9; run_exports has been fixed in https://github.com/conda-forge/libutf8proc-feedstock/pull/18