### PR TITLE
Pin cryptography to versions compatible with pyopenssl

### DIFF
--- a/recipe/patch_yaml/pyopenssl.yaml
+++ b/recipe/patch_yaml/pyopenssl.yaml
@@ -11,9 +11,27 @@
 #     _replace_pin("cryptography >=35.0", "cryptography >=35.0,<39", record["depends"], record)
 if:
   name: pyopenssl
-  version: "22.0.0"
+  version: 22.0.0
   timestamp_lt: 1678096271000
 then:
   - replace_depends:
       old: cryptography >=35.0
       new: cryptography >=35.0,<39
+
+---
+
+# The X509_V_FLAG_NOTIFY_POLICY constant was removed from cryptography in version 42.0.0.
+# xref: https://github.com/pyca/cryptography/pull/9163
+# This constant was used in pyopenssl versions prior to version 23.2.0.
+# xref: https://github.com/pyca/pyopenssl/pull/1213
+# pyopenssl versions prior to 22.0.0 did not have an upper bound on cryptograpy to exclude newer versions.
+# Therefore, pyopenssl less than 23.2.0 is not compatible with cryptography greater than or equal to 42.0.0,
+# but there is nothing preventing pyopenssl<22.0.0 being solved with later versions of cryptography.
+if:
+  name: pyopenssl
+  version_lt: 23.2.0
+  timestamp_lt: 1733152856000  # Mon 2 Dec 2024 15:20:56 GMT
+then:
+  - tighten_depends:
+      name: cryptography
+      upper_bound: 42.0.0


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

<details>
<summary>Diff output</summary>

```
$ python show_diff.py
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
win-32::pyopenssl-16.2.0-py27_0.tar.bz2
win-32::pyopenssl-16.2.0-py35_0.tar.bz2
win-32::pyopenssl-16.2.0-py36_0.tar.bz2
-    "cryptography >=1.3.4",
+    "cryptography >=1.3.4,<42.0.0a0",
win-32::pyopenssl-17.2.0-py27_0.tar.bz2
win-32::pyopenssl-17.2.0-py35_0.tar.bz2
win-32::pyopenssl-17.2.0-py36_0.tar.bz2
-    "cryptography >=1.9",
+    "cryptography >=1.9,<42.0.0a0",
win-32::pyopenssl-16.0.0-py27_0.tar.bz2
win-32::pyopenssl-16.0.0-py34_0.tar.bz2
win-32::pyopenssl-16.0.0-py35_0.tar.bz2
-    "cryptography >=1.3",
+    "cryptography >=1.3,<42.0.0a0",
win-32::pyopenssl-17.5.0-py27_1.tar.bz2
win-32::pyopenssl-17.5.0-py35_1.tar.bz2
win-32::pyopenssl-17.5.0-py36_1.tar.bz2
-    "cryptography >=2.1.4",
+    "cryptography >=2.1.4,<42.0.0a0",
================================================================================
================================================================================
linux-ppc64le
linux-ppc64le::pyopenssl-19.0.0-py27_0.tar.bz2
linux-ppc64le::pyopenssl-19.0.0-py36_0.tar.bz2
linux-ppc64le::pyopenssl-19.0.0-py37_0.tar.bz2
linux-ppc64le::pyopenssl-19.0.0-py38_0.tar.bz2
-    "cryptography >=2.2.1",
+    "cryptography >=2.2.1,<42.0.0a0",
linux-ppc64le::pyopenssl-19.1.0-py36_0.tar.bz2
linux-ppc64le::pyopenssl-19.1.0-py37_0.tar.bz2
linux-ppc64le::pyopenssl-19.1.0-py38_0.tar.bz2
-    "cryptography >=2.8",
+    "cryptography >=2.8,<42.0.0a0",
================================================================================
================================================================================
linux-aarch64
linux-aarch64::pyopenssl-19.0.0-py27_0.tar.bz2
linux-aarch64::pyopenssl-19.0.0-py36_0.tar.bz2
linux-aarch64::pyopenssl-19.0.0-py37_0.tar.bz2
linux-aarch64::pyopenssl-19.0.0-py38_0.tar.bz2
-    "cryptography >=2.2.1",
+    "cryptography >=2.2.1,<42.0.0a0",
linux-aarch64::pyopenssl-19.1.0-py36_0.tar.bz2
linux-aarch64::pyopenssl-19.1.0-py37_0.tar.bz2
linux-aarch64::pyopenssl-19.1.0-py38_0.tar.bz2
-    "cryptography >=2.8",
+    "cryptography >=2.8,<42.0.0a0",
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
noarch
noarch::pyopenssl-21.0.0-pyhd8ed1ab_0.tar.bz2
-    "cryptography >=3.3",
+    "cryptography >=3.3,<42.0.0a0",
noarch::pyopenssl-19.1.0-py_1.tar.bz2
-    "cryptography >=2.8",
+    "cryptography >=2.8,<42.0.0a0",
noarch::pyopenssl-20.0.0-pyhd8ed1ab_0.tar.bz2
noarch::pyopenssl-20.0.1-pyhd8ed1ab_0.tar.bz2
-    "cryptography >=3.2",
+    "cryptography >=3.2,<42.0.0a0",
noarch::bitstring-4.1.0-pyhd8ed1ab_0.conda
-    "bitarray >=2.8.0,<3",
+    "bitarray >=2.8.0",
================================================================================
================================================================================
win-64
win-64::pyopenssl-17.5.0-py27_1.tar.bz2
win-64::pyopenssl-17.5.0-py35_1.tar.bz2
win-64::pyopenssl-17.5.0-py36_1.tar.bz2
-    "cryptography >=2.1.4",
+    "cryptography >=2.1.4,<42.0.0a0",
win-64::pyopenssl-16.0.0-py27_0.tar.bz2
win-64::pyopenssl-16.0.0-py34_0.tar.bz2
win-64::pyopenssl-16.0.0-py35_0.tar.bz2
-    "cryptography >=1.3",
+    "cryptography >=1.3,<42.0.0a0",
win-64::pyopenssl-18.0.0-py27_0.tar.bz2
win-64::pyopenssl-18.0.0-py27_1000.tar.bz2
win-64::pyopenssl-18.0.0-py35_0.tar.bz2
win-64::pyopenssl-18.0.0-py36_0.tar.bz2
win-64::pyopenssl-18.0.0-py36_1000.tar.bz2
win-64::pyopenssl-18.0.0-py37_0.tar.bz2
win-64::pyopenssl-18.0.0-py37_1000.tar.bz2
win-64::pyopenssl-19.0.0-py27_0.tar.bz2
win-64::pyopenssl-19.0.0-py36_0.tar.bz2
win-64::pyopenssl-19.0.0-py37_0.tar.bz2
win-64::pyopenssl-19.0.0-py38_0.tar.bz2
-    "cryptography >=2.2.1",
+    "cryptography >=2.2.1,<42.0.0a0",
win-64::pyopenssl-17.2.0-py27_0.tar.bz2
win-64::pyopenssl-17.2.0-py35_0.tar.bz2
win-64::pyopenssl-17.2.0-py36_0.tar.bz2
-    "cryptography >=1.9",
+    "cryptography >=1.9,<42.0.0a0",
win-64::pyopenssl-16.2.0-py27_0.tar.bz2
win-64::pyopenssl-16.2.0-py35_0.tar.bz2
win-64::pyopenssl-16.2.0-py36_0.tar.bz2
-    "cryptography >=1.3.4",
+    "cryptography >=1.3.4,<42.0.0a0",
win-64::pyopenssl-19.1.0-py27_0.tar.bz2
win-64::pyopenssl-19.1.0-py36_0.tar.bz2
win-64::pyopenssl-19.1.0-py37_0.tar.bz2
win-64::pyopenssl-19.1.0-py38_0.tar.bz2
-    "cryptography >=2.8",
+    "cryptography >=2.8,<42.0.0a0",
================================================================================
================================================================================
osx-64
osx-64::pyopenssl-17.2.0-py27_0.tar.bz2
osx-64::pyopenssl-17.2.0-py35_0.tar.bz2
osx-64::pyopenssl-17.2.0-py36_0.tar.bz2
osx-64::pyopenssl-17.4.0-py27_0.tar.bz2
osx-64::pyopenssl-17.4.0-py35_0.tar.bz2
osx-64::pyopenssl-17.4.0-py36_0.tar.bz2
-    "cryptography >=1.9",
+    "cryptography >=1.9,<42.0.0a0",
osx-64::pyopenssl-16.2.0-py27_0.tar.bz2
osx-64::pyopenssl-16.2.0-py35_0.tar.bz2
osx-64::pyopenssl-16.2.0-py36_0.tar.bz2
-    "cryptography >=1.3.4",
+    "cryptography >=1.3.4,<42.0.0a0",
osx-64::pyopenssl-19.1.0-py27_0.tar.bz2
osx-64::pyopenssl-19.1.0-py36_0.tar.bz2
osx-64::pyopenssl-19.1.0-py37_0.tar.bz2
osx-64::pyopenssl-19.1.0-py38_0.tar.bz2
-    "cryptography >=2.8",
+    "cryptography >=2.8,<42.0.0a0",
osx-64::pyopenssl-18.0.0-py27_0.tar.bz2
osx-64::pyopenssl-18.0.0-py27_1000.tar.bz2
osx-64::pyopenssl-18.0.0-py35_0.tar.bz2
osx-64::pyopenssl-18.0.0-py36_0.tar.bz2
osx-64::pyopenssl-18.0.0-py36_1000.tar.bz2
osx-64::pyopenssl-18.0.0-py37_0.tar.bz2
osx-64::pyopenssl-18.0.0-py37_1000.tar.bz2
osx-64::pyopenssl-19.0.0-py27_0.tar.bz2
osx-64::pyopenssl-19.0.0-py36_0.tar.bz2
osx-64::pyopenssl-19.0.0-py37_0.tar.bz2
osx-64::pyopenssl-19.0.0-py38_0.tar.bz2
-    "cryptography >=2.2.1",
+    "cryptography >=2.2.1,<42.0.0a0",
osx-64::pyopenssl-17.5.0-py27_1.tar.bz2
osx-64::pyopenssl-17.5.0-py35_1.tar.bz2
osx-64::pyopenssl-17.5.0-py36_1.tar.bz2
-    "cryptography >=2.1.4",
+    "cryptography >=2.1.4,<42.0.0a0",
osx-64::pyopenssl-16.0.0-py27_0.tar.bz2
osx-64::pyopenssl-16.0.0-py34_0.tar.bz2
osx-64::pyopenssl-16.0.0-py35_0.tar.bz2
osx-64::pyopenssl-16.0.0-py36_0.tar.bz2
-    "cryptography >=1.3",
+    "cryptography >=1.3,<42.0.0a0",
================================================================================
================================================================================
linux-64
linux-64::pyopenssl-17.2.0-py27_0.tar.bz2
linux-64::pyopenssl-17.2.0-py35_0.tar.bz2
linux-64::pyopenssl-17.2.0-py36_0.tar.bz2
linux-64::pyopenssl-17.4.0-py27_0.tar.bz2
linux-64::pyopenssl-17.4.0-py35_0.tar.bz2
linux-64::pyopenssl-17.4.0-py36_0.tar.bz2
-    "cryptography >=1.9",
+    "cryptography >=1.9,<42.0.0a0",
linux-64::pyopenssl-18.0.0-py27_0.tar.bz2
linux-64::pyopenssl-18.0.0-py27_1000.tar.bz2
linux-64::pyopenssl-18.0.0-py35_0.tar.bz2
linux-64::pyopenssl-18.0.0-py36_0.tar.bz2
linux-64::pyopenssl-18.0.0-py36_1000.tar.bz2
linux-64::pyopenssl-18.0.0-py37_0.tar.bz2
linux-64::pyopenssl-18.0.0-py37_1000.tar.bz2
linux-64::pyopenssl-19.0.0-py27_0.tar.bz2
linux-64::pyopenssl-19.0.0-py36_0.tar.bz2
linux-64::pyopenssl-19.0.0-py37_0.tar.bz2
linux-64::pyopenssl-19.0.0-py38_0.tar.bz2
-    "cryptography >=2.2.1",
+    "cryptography >=2.2.1,<42.0.0a0",
linux-64::pyopenssl-16.0.0-py27_0.tar.bz2
linux-64::pyopenssl-16.0.0-py34_0.tar.bz2
linux-64::pyopenssl-16.0.0-py35_0.tar.bz2
linux-64::pyopenssl-16.0.0-py36_0.tar.bz2
-    "cryptography >=1.3",
+    "cryptography >=1.3,<42.0.0a0",
linux-64::pyopenssl-19.1.0-py27_0.tar.bz2
linux-64::pyopenssl-19.1.0-py36_0.tar.bz2
linux-64::pyopenssl-19.1.0-py37_0.tar.bz2
linux-64::pyopenssl-19.1.0-py38_0.tar.bz2
-    "cryptography >=2.8",
+    "cryptography >=2.8,<42.0.0a0",
linux-64::pyopenssl-17.5.0-py27_1.tar.bz2
linux-64::pyopenssl-17.5.0-py35_1.tar.bz2
linux-64::pyopenssl-17.5.0-py36_1.tar.bz2
-    "cryptography >=2.1.4",
+    "cryptography >=2.1.4,<42.0.0a0",
linux-64::pyopenssl-16.2.0-py27_0.tar.bz2
linux-64::pyopenssl-16.2.0-py35_0.tar.bz2
linux-64::pyopenssl-16.2.0-py36_0.tar.bz2
-    "cryptography >=1.3.4",
+    "cryptography >=1.3.4,<42.0.0a0",
```
</details>