### PR TITLE
Constrain bitstring to bitarray<3.0

### DIFF
--- a/recipe/patch_yaml/bitstring.yaml
+++ b/recipe/patch_yaml/bitstring.yaml
@@ -1,0 +1,8 @@
+# bitstring is not compatable with bitarray 3.0
+if:
+  name: bitstring
+  timestamp_lt: 1733161794000
+then:
+  - replace_depends:
+      old: bitarray >=2.8.0
+      new: bitarray >=2.8.0,<3


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
*  Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. 

refs conda-forge/bitstring-feedstock#15

With bitarray=3.0 on conda-forge, the dep solver will find an older bitstring that had an open ended dep on `bitarray>=2.8`

```
$ python show_diff.py
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
noarch
noarch::bitstring-4.1.0-pyhd8ed1ab_0.conda
-    "bitarray >=2.8.0",
+    "bitarray >=2.8.0,<3",
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
================================================================================
================================================================================
linux-64
```

cc: @conda-forge/bitstring 