### PR TITLE
constrain requests-oauthlib<2 for tweepy

### DIFF
--- a/recipe/patch_yaml/tweepy.yaml
+++ b/recipe/patch_yaml/tweepy.yaml
@@ -1,0 +1,8 @@
+# tweepy is not compatible with requests-oauthlib 2.0 yet
+if:
+  name: tweepy
+  timestamp_lt: 1733163793000
+then:
+  - tighten_depends:
+      name: requests-oauthlib
+      upper_bound: "2.0"


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
*  Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. 

refs conda-forge/tweepy-feedstock#32

The dep solver is finding older tweepy releases with an unconstrained dep on `requests-oauthlib`

```
$ python show_diff.py 
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
win-32::tweepy-3.5.0-py27_0.tar.bz2
win-32::tweepy-3.5.0-py35_0.tar.bz2
win-32::tweepy-3.5.0-py36_0.tar.bz2
win-32::tweepy-3.6.0-py27_0.tar.bz2
win-32::tweepy-3.6.0-py35_0.tar.bz2
win-32::tweepy-3.6.0-py36_0.tar.bz2
-    "requests-oauthlib >=0.7.0",
+    "requests-oauthlib >=0.7.0,<2.0.0a0",
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
noarch
noarch::tweepy-3.10.0-pyhd8ed1ab_0.tar.bz2
noarch::tweepy-3.7.0-py_0.tar.bz2
noarch::tweepy-3.8.0-py_0.tar.bz2
noarch::tweepy-3.9.0-pyh9f0ad1d_0.tar.bz2
noarch::tweepy-4.0.0-pyhd8ed1ab_0.tar.bz2
noarch::tweepy-4.0.1-pyhd8ed1ab_0.tar.bz2
noarch::tweepy-4.1.0-pyhd8ed1ab_0.tar.bz2
noarch::tweepy-4.2.0-pyhd8ed1ab_0.tar.bz2
noarch::tweepy-4.3.0-pyhd8ed1ab_0.tar.bz2
noarch::tweepy-4.4.0-pyhd8ed1ab_0.tar.bz2
noarch::tweepy-4.5.0-pyhd8ed1ab_0.tar.bz2
noarch::tweepy-4.6.0-pyhd8ed1ab_0.tar.bz2
noarch::tweepy-4.7.0-pyhd8ed1ab_0.tar.bz2
noarch::tweepy-4.8.0-pyhd8ed1ab_0.tar.bz2
-    "requests-oauthlib >=0.7.0",
+    "requests-oauthlib >=0.7.0,<2.0.0a0",
================================================================================
================================================================================
win-64
win-64::tweepy-3.5.0-py27_0.tar.bz2
win-64::tweepy-3.5.0-py35_0.tar.bz2
win-64::tweepy-3.5.0-py36_0.tar.bz2
win-64::tweepy-3.6.0-py27_0.tar.bz2
win-64::tweepy-3.6.0-py35_0.tar.bz2
win-64::tweepy-3.6.0-py36_0.tar.bz2
-    "requests-oauthlib >=0.7.0",
+    "requests-oauthlib >=0.7.0,<2.0.0a0",
================================================================================
================================================================================
osx-64
osx-64::tweepy-3.5.0-py27_0.tar.bz2
osx-64::tweepy-3.5.0-py35_0.tar.bz2
osx-64::tweepy-3.5.0-py36_0.tar.bz2
osx-64::tweepy-3.6.0-py27_0.tar.bz2
osx-64::tweepy-3.6.0-py35_0.tar.bz2
osx-64::tweepy-3.6.0-py36_0.tar.bz2
-    "requests-oauthlib >=0.7.0",
+    "requests-oauthlib >=0.7.0,<2.0.0a0",
================================================================================
================================================================================
linux-64
linux-64::tweepy-3.5.0-py27_0.tar.bz2
linux-64::tweepy-3.5.0-py35_0.tar.bz2
linux-64::tweepy-3.5.0-py36_0.tar.bz2
-    "requests-oauthlib >=0.7.0",
+    "requests-oauthlib >=0.7.0,<2.0.0a0",
```

cc: @conda-forge/tweepy 