### PR TITLE
constrain msrest<0.6 on older vsts-python-api

### DIFF
--- a/recipe/patch_yaml/vsts-python-api.yaml
+++ b/recipe/patch_yaml/vsts-python-api.yaml
@@ -1,0 +1,8 @@
+# older vsts-python-api needs constrained msrest dep
+if:
+  name: vsts-python-api
+  timestamp_lt: 1733163793000
+then:
+  - tighten_depends:
+      name: msrest
+      upper_bound: "0.6"


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
*  Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. 

refs conda-forge/vsts-python-api-feedstock#11

Fixing up older vsts-python-api packages with open ended `msrest>=0.5` dependency.

```
$ python show_diff.py 
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
noarch
noarch::vsts-python-api-0.1.17-py_0.tar.bz2
noarch::vsts-python-api-0.1.18-py_0.tar.bz2
noarch::vsts-python-api-0.1.21-py_0.tar.bz2
noarch::vsts-python-api-0.1.22-py_0.tar.bz2
-    "msrest >=0.5.0",
+    "msrest >=0.5.0,<0.6.0a0",
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
================================================================================
================================================================================
linux-64
```

cc: @conda-forge/vsts-python-api 