### PR TITLE
Add upper bound for cryptography

### DIFF
--- a/recipe/patch_yaml/pyopenssl.yaml
+++ b/recipe/patch_yaml/pyopenssl.yaml
@@ -17,3 +17,24 @@ then:
   - replace_depends:
       old: cryptography >=35.0
       new: cryptography >=35.0,<39
+---
+# The above patch has the effect of encouraging the solver
+# to prefer pyopenssl 21.0.0 instead of the latest version
+# if there is a newer cryptography version available that is
+# incompatible with all modern versions of pyopenssl. Thus
+# we need to add upper bounds for all previous versions as
+# well.
+# The specific error I see with pyopenssl 21.0.0 and
+# cryptography 44.0.0 is:
+#   .pixi/envs/default/lib/python3.12/site-packages/OpenSSL/crypto.py:1598: in X509StoreFlags
+#       NOTIFY_POLICY = _lib.X509_V_FLAG_NOTIFY_POLICY
+#   E   AttributeError: module 'lib' has no attribute 'X509_V_FLAG_NOTIFY_POLICY'. Did you mean: 'X509_V_FLAG_EXPLICIT_POLICY'?
+if:
+  name: pyopenssl
+  version_lt: "22.0.0"
+  timestamp_lt: 1733175687000
+  has_depends: cryptography*
+then:
+  - tighten_depends:
+      name: cryptography
+      upper_bound: "39"

--- a/recipe/patch_yaml/pyopenssl.yaml
+++ b/recipe/patch_yaml/pyopenssl.yaml
@@ -28,7 +28,8 @@ then:
 # cryptography 44.0.0 is:
 #   .pixi/envs/default/lib/python3.12/site-packages/OpenSSL/crypto.py:1598: in X509StoreFlags
 #       NOTIFY_POLICY = _lib.X509_V_FLAG_NOTIFY_POLICY
-#   E   AttributeError: module 'lib' has no attribute 'X509_V_FLAG_NOTIFY_POLICY'. Did you mean: 'X509_V_FLAG_EXPLICIT_POLICY'?
+#   E   AttributeError: module 'lib' has no attribute 'X509_V_FLAG_NOTIFY_POLICY'.
+#       Did you mean: 'X509_V_FLAG_EXPLICIT_POLICY'?
 if:
   name: pyopenssl
   version_lt: "22.0.0"


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

This fixes breakage when the solver optimizes for a higher version of cryptography rather than pyopenssl. See https://github.com/conda-forge/pyopenssl-feedstock/pull/40#issuecomment-2511619715 and the YAML comments.