### PR TITLE
Patch old nvcc_*, cudnn, and libcufile packages

### DIFF
--- a/recipe/patch_yaml/cudnn.yaml
+++ b/recipe/patch_yaml/cudnn.yaml
@@ -1,0 +1,10 @@
+# cuDNN is a redist. zlib has been statically linked into the windows library since cuDNN 9
+# Resolves: https://github.com/conda-forge/cudnn-feedstock/issues/98
+if:
+  name: "cudnn"
+  version_lt: 9.3.1
+  version_ge: 9.0.0
+  timestamp_lt: 1733272752000
+  subdir_in: win-64
+then:
+  - remove_depends: libzlib-wapi

--- a/recipe/patch_yaml/cudnn.yaml
+++ b/recipe/patch_yaml/cudnn.yaml
@@ -7,4 +7,4 @@ if:
   timestamp_lt: 1733272752000
   subdir_in: win-64
 then:
-  - remove_depends: libzlib-wapi
+  - remove_depends: "libzlib-wapi *"

--- a/recipe/patch_yaml/libcufile.yaml
+++ b/recipe/patch_yaml/libcufile.yaml
@@ -1,0 +1,13 @@
+# For uninvestigated reasons, old aarch64 builds of libcufile have no constraint on __glibc
+# This is a follow-up to https://github.com/conda-forge/libcufile-feedstock/pull/24
+if:
+  name: "libcufile*"
+  version_ge: 1.7.0
+  timestamp_lt: 1733272752000
+  subdir_in:
+    - linux-aarch64
+then:
+  - add_depends: __glibc >=2.28,<3.0.a0
+  - replace_depends:
+        old: __glibc [*]
+        new: __glibc >=2.28,<3.0.a0

--- a/recipe/patch_yaml/libcufile.yaml
+++ b/recipe/patch_yaml/libcufile.yaml
@@ -9,5 +9,5 @@ if:
 then:
   - add_depends: __glibc >=2.28,<3.0.a0
   - replace_depends:
-        old: __glibc [*]
-        new: __glibc >=2.28,<3.0.a0
+      old: __glibc [*]
+      new: __glibc >=2.28,<3.0.a0

--- a/recipe/patch_yaml/nvcc.yaml
+++ b/recipe/patch_yaml/nvcc.yaml
@@ -1,0 +1,18 @@
+# Fixes https://github.com/conda-forge/nvcc-feedstock/issues/108 for older builds by
+# appying https://github.com/conda-forge/nvcc-feedstock/pull/109/files#diff-f3725a55bf339595bf865fec73bda8ac99f283b0810c205442021f29c06eea9a
+# tl;dr prevents older versions of nvcc from being installed with newer 12+ versions
+if:
+  name: "nvcc_*"
+  version_lt: 12.0.0
+  version_ge: 11.2.0
+  timestamp_lt: 1733272752000
+then:
+  - add_depends: cudatoolkit >=${version},<12
+# No enhanced compatability until CUDA 11.2; everything before is pinned to minor version
+if:
+  name: "nvcc_*"
+  # This will patch all the way back to version 9.2
+  version_lt: 11.2.0
+  timestamp_lt: 1733272752000
+then:
+  - add_depends: "cudatoolkit ${version}.*"

--- a/recipe/patch_yaml/nvcc.yaml
+++ b/recipe/patch_yaml/nvcc.yaml
@@ -8,6 +8,7 @@ if:
   timestamp_lt: 1733272752000
 then:
   - add_depends: cudatoolkit >=${version},<12
+---
 # No enhanced compatability until CUDA 11.2; everything before is pinned to minor version
 if:
   name: "nvcc_*"

--- a/recipe/patch_yaml/nvcc.yaml
+++ b/recipe/patch_yaml/nvcc.yaml
@@ -6,6 +6,11 @@ if:
   version_lt: 12.0.0
   version_ge: 11.2.0
   timestamp_lt: 1733272752000
+  subdir_in:
+    - linux-64
+    - win-64
+    - linux-ppc64le
+    - linux-aarch64
 then:
   - add_depends: cudatoolkit >=${version},<12
 ---
@@ -15,5 +20,10 @@ if:
   # This will patch all the way back to version 9.2
   version_lt: 11.2.0
   timestamp_lt: 1733272752000
+  subdir_in:
+    - linux-64
+    - win-64
+    - linux-ppc64le
+    - linux-aarch64
 then:
   - add_depends: "cudatoolkit ${version}.*"

--- a/recipe/patch_yaml/nvcc.yaml
+++ b/recipe/patch_yaml/nvcc.yaml
@@ -1,5 +1,5 @@
-# Fixes https://github.com/conda-forge/nvcc-feedstock/issues/108 for older builds by
-# appying https://github.com/conda-forge/nvcc-feedstock/pull/109/files#diff-f3725a55bf339595bf865fec73bda8ac99f283b0810c205442021f29c06eea9a
+# Fixes https://github.com/conda-forge/nvcc-feedstock/issues/108 for older builds by applying
+# https://github.com/conda-forge/nvcc-feedstock/pull/109/files#diff-f3725a55bf339595bf865fec73bda8ac99f283b0810c205442021f29c06eea9a
 # tl;dr prevents older versions of nvcc from being installed with newer 12+ versions
 if:
   name: "nvcc_*"


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Didn't write code directly into `generate_patch_json.py`.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

Closes https://github.com/conda-forge/cudnn-feedstock/issues/98
Closes https://github.com/conda-forge/nvcc-feedstock/issues/108
Closes https://github.com/conda-forge/libcufile-feedstock/issues/25

```
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
linux-ppc64le
linux-ppc64le::nvcc_linux-ppc64le-11.7-h2ee9e26_22.conda
linux-ppc64le::nvcc_linux-ppc64le-11.7-h3060f6d_18.tar.bz2
linux-ppc64le::nvcc_linux-ppc64le-11.7-h3060f6d_19.tar.bz2
linux-ppc64le::nvcc_linux-ppc64le-11.7-h3060f6d_20.tar.bz2
linux-ppc64le::nvcc_linux-ppc64le-11.7-h3060f6d_21.tar.bz2
linux-ppc64le::nvcc_linux-ppc64le-11.7-h3060f6d_22.conda
linux-ppc64le::nvcc_linux-ppc64le-11.7-h8dcef9a_22.conda
linux-ppc64le::nvcc_linux-ppc64le-11.7-h8dcef9a_23.conda
+    "cudatoolkit >=11.7,<12",
linux-ppc64le::nvcc_linux-ppc64le-11.6-h398e8d3_16.tar.bz2
linux-ppc64le::nvcc_linux-ppc64le-11.6-h398e8d3_17.tar.bz2
linux-ppc64le::nvcc_linux-ppc64le-11.6-h398e8d3_18.tar.bz2
linux-ppc64le::nvcc_linux-ppc64le-11.6-h398e8d3_19.tar.bz2
linux-ppc64le::nvcc_linux-ppc64le-11.6-h398e8d3_20.tar.bz2
linux-ppc64le::nvcc_linux-ppc64le-11.6-h398e8d3_21.tar.bz2
linux-ppc64le::nvcc_linux-ppc64le-11.6-h398e8d3_22.conda
linux-ppc64le::nvcc_linux-ppc64le-11.6-h9cc4127_22.conda
linux-ppc64le::nvcc_linux-ppc64le-11.6-h9cc4127_23.conda
linux-ppc64le::nvcc_linux-ppc64le-11.6-hd86a89e_22.conda
+    "cudatoolkit >=11.6,<12",
linux-ppc64le::nvcc_linux-ppc64le-11.5-h349b5cc_16.tar.bz2
linux-ppc64le::nvcc_linux-ppc64le-11.5-h349b5cc_17.tar.bz2
linux-ppc64le::nvcc_linux-ppc64le-11.5-h349b5cc_18.tar.bz2
linux-ppc64le::nvcc_linux-ppc64le-11.5-h349b5cc_19.tar.bz2
linux-ppc64le::nvcc_linux-ppc64le-11.5-h349b5cc_20.tar.bz2
linux-ppc64le::nvcc_linux-ppc64le-11.5-h349b5cc_21.tar.bz2
linux-ppc64le::nvcc_linux-ppc64le-11.5-h349b5cc_22.conda
linux-ppc64le::nvcc_linux-ppc64le-11.5-h4760ff0_22.conda
linux-ppc64le::nvcc_linux-ppc64le-11.5-ha5e958c_22.conda
linux-ppc64le::nvcc_linux-ppc64le-11.5-ha5e958c_23.conda
+    "cudatoolkit >=11.5,<12",
linux-ppc64le::nvcc_linux-ppc64le-11.3-h3daf246_22.conda
linux-ppc64le::nvcc_linux-ppc64le-11.3-h701f48f_22.conda
linux-ppc64le::nvcc_linux-ppc64le-11.3-h701f48f_23.conda
linux-ppc64le::nvcc_linux-ppc64le-11.3-hbf53ffc_16.tar.bz2
linux-ppc64le::nvcc_linux-ppc64le-11.3-hbf53ffc_17.tar.bz2
linux-ppc64le::nvcc_linux-ppc64le-11.3-hbf53ffc_18.tar.bz2
linux-ppc64le::nvcc_linux-ppc64le-11.3-hbf53ffc_19.tar.bz2
linux-ppc64le::nvcc_linux-ppc64le-11.3-hbf53ffc_20.tar.bz2
linux-ppc64le::nvcc_linux-ppc64le-11.3-hbf53ffc_21.tar.bz2
linux-ppc64le::nvcc_linux-ppc64le-11.3-hbf53ffc_22.conda
+    "cudatoolkit >=11.3,<12",
linux-ppc64le::nvcc_linux-ppc64le-10.2-hb3d3a0a_13.tar.bz2
linux-ppc64le::nvcc_linux-ppc64le-10.2-hb3d3a0a_14.tar.bz2
linux-ppc64le::nvcc_linux-ppc64le-10.2-hb3d3a0a_15.tar.bz2
linux-ppc64le::nvcc_linux-ppc64le-10.2-hb3d3a0a_16.tar.bz2
linux-ppc64le::nvcc_linux-ppc64le-10.2-hb3d3a0a_17.tar.bz2
linux-ppc64le::nvcc_linux-ppc64le-10.2-hb3d3a0a_18.tar.bz2
linux-ppc64le::nvcc_linux-ppc64le-10.2-hb3d3a0a_19.tar.bz2
linux-ppc64le::nvcc_linux-ppc64le-10.2-hb3d3a0a_20.tar.bz2
linux-ppc64le::nvcc_linux-ppc64le-10.2-hb3d3a0a_21.tar.bz2
linux-ppc64le::nvcc_linux-ppc64le-10.2-hb3d3a0a_22.conda
linux-ppc64le::nvcc_linux-ppc64le-10.2-hba28c6f_22.conda
linux-ppc64le::nvcc_linux-ppc64le-10.2-hd4d3c69_22.conda
linux-ppc64le::nvcc_linux-ppc64le-10.2-hd4d3c69_23.conda
+    "cudatoolkit 10.2.*",
linux-ppc64le::nvcc_linux-ppc64le-11.4-h14fa167_22.conda
linux-ppc64le::nvcc_linux-ppc64le-11.4-h14fa167_23.conda
linux-ppc64le::nvcc_linux-ppc64le-11.4-h431f92d_22.conda
linux-ppc64le::nvcc_linux-ppc64le-11.4-hf5fa39f_16.tar.bz2
linux-ppc64le::nvcc_linux-ppc64le-11.4-hf5fa39f_17.tar.bz2
linux-ppc64le::nvcc_linux-ppc64le-11.4-hf5fa39f_18.tar.bz2
linux-ppc64le::nvcc_linux-ppc64le-11.4-hf5fa39f_19.tar.bz2
linux-ppc64le::nvcc_linux-ppc64le-11.4-hf5fa39f_20.tar.bz2
linux-ppc64le::nvcc_linux-ppc64le-11.4-hf5fa39f_21.tar.bz2
linux-ppc64le::nvcc_linux-ppc64le-11.4-hf5fa39f_22.conda
+    "cudatoolkit >=11.4,<12",
linux-ppc64le::nvcc_linux-ppc64le-11.1-h2008e65_22.conda
linux-ppc64le::nvcc_linux-ppc64le-11.1-h40cd4b9_16.tar.bz2
linux-ppc64le::nvcc_linux-ppc64le-11.1-h40cd4b9_17.tar.bz2
linux-ppc64le::nvcc_linux-ppc64le-11.1-h40cd4b9_18.tar.bz2
linux-ppc64le::nvcc_linux-ppc64le-11.1-h40cd4b9_19.tar.bz2
linux-ppc64le::nvcc_linux-ppc64le-11.1-h40cd4b9_20.tar.bz2
linux-ppc64le::nvcc_linux-ppc64le-11.1-h40cd4b9_21.tar.bz2
linux-ppc64le::nvcc_linux-ppc64le-11.1-h40cd4b9_22.conda
linux-ppc64le::nvcc_linux-ppc64le-11.1-h80a5a57_22.conda
linux-ppc64le::nvcc_linux-ppc64le-11.1-h80a5a57_23.conda
+    "cudatoolkit 11.1.*",
linux-ppc64le::nvcc_linux-ppc64le-11.0-h12468ac_22.conda
linux-ppc64le::nvcc_linux-ppc64le-11.0-h12468ac_23.conda
linux-ppc64le::nvcc_linux-ppc64le-11.0-h2878ec7_16.tar.bz2
linux-ppc64le::nvcc_linux-ppc64le-11.0-h2878ec7_17.tar.bz2
linux-ppc64le::nvcc_linux-ppc64le-11.0-h2878ec7_18.tar.bz2
linux-ppc64le::nvcc_linux-ppc64le-11.0-h2878ec7_19.tar.bz2
linux-ppc64le::nvcc_linux-ppc64le-11.0-h2878ec7_20.tar.bz2
linux-ppc64le::nvcc_linux-ppc64le-11.0-h2878ec7_21.tar.bz2
linux-ppc64le::nvcc_linux-ppc64le-11.0-h2878ec7_22.conda
linux-ppc64le::nvcc_linux-ppc64le-11.0-hbb751e8_22.conda
+    "cudatoolkit 11.0.*",
linux-ppc64le::nvcc_linux-ppc64le-11.2-h532adb0_22.conda
linux-ppc64le::nvcc_linux-ppc64le-11.2-h532adb0_23.conda
linux-ppc64le::nvcc_linux-ppc64le-11.2-h65ee2f8_16.tar.bz2
linux-ppc64le::nvcc_linux-ppc64le-11.2-h65ee2f8_17.tar.bz2
linux-ppc64le::nvcc_linux-ppc64le-11.2-h65ee2f8_18.tar.bz2
linux-ppc64le::nvcc_linux-ppc64le-11.2-h65ee2f8_19.tar.bz2
linux-ppc64le::nvcc_linux-ppc64le-11.2-h65ee2f8_20.tar.bz2
linux-ppc64le::nvcc_linux-ppc64le-11.2-h65ee2f8_21.tar.bz2
linux-ppc64le::nvcc_linux-ppc64le-11.2-h65ee2f8_22.conda
linux-ppc64le::nvcc_linux-ppc64le-11.2-hbd5fb8f_22.conda
+    "cudatoolkit >=11.2,<12",
linux-ppc64le::nvcc_linux-ppc64le-11.8-h1310280_22.conda
linux-ppc64le::nvcc_linux-ppc64le-11.8-h35f83fb_22.conda
linux-ppc64le::nvcc_linux-ppc64le-11.8-h35f83fb_23.conda
linux-ppc64le::nvcc_linux-ppc64le-11.8-h4f8557a_22.conda
linux-ppc64le::nvcc_linux-ppc64le-11.8-h559e326_24.conda
+    "cudatoolkit >=11.8,<12",
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-aarch64
linux-aarch64::nvcc_linux-aarch64-11.1-h07d5929_14.tar.bz2
linux-aarch64::nvcc_linux-aarch64-11.1-h07d5929_15.tar.bz2
linux-aarch64::nvcc_linux-aarch64-11.1-h3f38b74_22.conda
linux-aarch64::nvcc_linux-aarch64-11.1-h5f0809c_22.conda
linux-aarch64::nvcc_linux-aarch64-11.1-h5f0809c_23.conda
linux-aarch64::nvcc_linux-aarch64-11.1-ha9e409f_16.tar.bz2
linux-aarch64::nvcc_linux-aarch64-11.1-ha9e409f_17.tar.bz2
linux-aarch64::nvcc_linux-aarch64-11.1-ha9e409f_18.tar.bz2
linux-aarch64::nvcc_linux-aarch64-11.1-ha9e409f_19.tar.bz2
linux-aarch64::nvcc_linux-aarch64-11.1-ha9e409f_20.tar.bz2
linux-aarch64::nvcc_linux-aarch64-11.1-ha9e409f_21.tar.bz2
linux-aarch64::nvcc_linux-aarch64-11.1-ha9e409f_22.conda
+    "cudatoolkit 11.1.*",
linux-aarch64::nvcc_linux-aarch64-11.3-h672313b_22.conda
linux-aarch64::nvcc_linux-aarch64-11.3-h672313b_23.conda
linux-aarch64::nvcc_linux-aarch64-11.3-ha18af36_22.conda
linux-aarch64::nvcc_linux-aarch64-11.3-hf8ea675_16.tar.bz2
linux-aarch64::nvcc_linux-aarch64-11.3-hf8ea675_17.tar.bz2
linux-aarch64::nvcc_linux-aarch64-11.3-hf8ea675_18.tar.bz2
linux-aarch64::nvcc_linux-aarch64-11.3-hf8ea675_19.tar.bz2
linux-aarch64::nvcc_linux-aarch64-11.3-hf8ea675_20.tar.bz2
linux-aarch64::nvcc_linux-aarch64-11.3-hf8ea675_21.tar.bz2
linux-aarch64::nvcc_linux-aarch64-11.3-hf8ea675_22.conda
+    "cudatoolkit >=11.3,<12",
linux-aarch64::nvcc_linux-aarch64-11.7-hae9acc9_18.tar.bz2
linux-aarch64::nvcc_linux-aarch64-11.7-hae9acc9_19.tar.bz2
linux-aarch64::nvcc_linux-aarch64-11.7-hae9acc9_20.tar.bz2
linux-aarch64::nvcc_linux-aarch64-11.7-hae9acc9_21.tar.bz2
linux-aarch64::nvcc_linux-aarch64-11.7-hae9acc9_22.conda
linux-aarch64::nvcc_linux-aarch64-11.7-hd86609b_22.conda
linux-aarch64::nvcc_linux-aarch64-11.7-he65f043_22.conda
linux-aarch64::nvcc_linux-aarch64-11.7-he65f043_23.conda
+    "cudatoolkit >=11.7,<12",
linux-aarch64::nvcc_linux-aarch64-11.2-h3023cc8_22.conda
linux-aarch64::nvcc_linux-aarch64-11.2-h8127329_16.tar.bz2
linux-aarch64::nvcc_linux-aarch64-11.2-h8127329_17.tar.bz2
linux-aarch64::nvcc_linux-aarch64-11.2-h8127329_18.tar.bz2
linux-aarch64::nvcc_linux-aarch64-11.2-h8127329_19.tar.bz2
linux-aarch64::nvcc_linux-aarch64-11.2-h8127329_20.tar.bz2
linux-aarch64::nvcc_linux-aarch64-11.2-h8127329_21.tar.bz2
linux-aarch64::nvcc_linux-aarch64-11.2-h8127329_22.conda
linux-aarch64::nvcc_linux-aarch64-11.2-hcded775_22.conda
linux-aarch64::nvcc_linux-aarch64-11.2-hcded775_23.conda
linux-aarch64::nvcc_linux-aarch64-11.2-hd9c1ecf_14.tar.bz2
linux-aarch64::nvcc_linux-aarch64-11.2-hd9c1ecf_15.tar.bz2
+    "cudatoolkit >=11.2,<12",
linux-aarch64::nvcc_linux-aarch64-11.4-h1712b73_16.tar.bz2
linux-aarch64::nvcc_linux-aarch64-11.4-h1712b73_17.tar.bz2
linux-aarch64::nvcc_linux-aarch64-11.4-h1712b73_18.tar.bz2
linux-aarch64::nvcc_linux-aarch64-11.4-h1712b73_19.tar.bz2
linux-aarch64::nvcc_linux-aarch64-11.4-h1712b73_20.tar.bz2
linux-aarch64::nvcc_linux-aarch64-11.4-h1712b73_21.tar.bz2
linux-aarch64::nvcc_linux-aarch64-11.4-h1712b73_22.conda
linux-aarch64::nvcc_linux-aarch64-11.4-h83e62e8_22.conda
linux-aarch64::nvcc_linux-aarch64-11.4-h83e62e8_23.conda
linux-aarch64::nvcc_linux-aarch64-11.4-h96d3bfd_22.conda
+    "cudatoolkit >=11.4,<12",
linux-aarch64::nvcc_linux-aarch64-11.0-h9615d9b_14.tar.bz2
linux-aarch64::nvcc_linux-aarch64-11.0-h9615d9b_15.tar.bz2
linux-aarch64::nvcc_linux-aarch64-11.0-hadd6a7b_16.tar.bz2
linux-aarch64::nvcc_linux-aarch64-11.0-hadd6a7b_17.tar.bz2
linux-aarch64::nvcc_linux-aarch64-11.0-hadd6a7b_18.tar.bz2
linux-aarch64::nvcc_linux-aarch64-11.0-hadd6a7b_19.tar.bz2
linux-aarch64::nvcc_linux-aarch64-11.0-hadd6a7b_20.tar.bz2
linux-aarch64::nvcc_linux-aarch64-11.0-hadd6a7b_21.tar.bz2
linux-aarch64::nvcc_linux-aarch64-11.0-hadd6a7b_22.conda
linux-aarch64::nvcc_linux-aarch64-11.0-hd5f9bcf_22.conda
linux-aarch64::nvcc_linux-aarch64-11.0-hfe1e654_22.conda
linux-aarch64::nvcc_linux-aarch64-11.0-hfe1e654_23.conda
+    "cudatoolkit 11.0.*",
linux-aarch64::nvcc_linux-aarch64-11.6-h0c41e32_22.conda
linux-aarch64::nvcc_linux-aarch64-11.6-h1ac39a2_16.tar.bz2
linux-aarch64::nvcc_linux-aarch64-11.6-h1ac39a2_17.tar.bz2
linux-aarch64::nvcc_linux-aarch64-11.6-h1ac39a2_18.tar.bz2
linux-aarch64::nvcc_linux-aarch64-11.6-h1ac39a2_19.tar.bz2
linux-aarch64::nvcc_linux-aarch64-11.6-h1ac39a2_20.tar.bz2
linux-aarch64::nvcc_linux-aarch64-11.6-h1ac39a2_21.tar.bz2
linux-aarch64::nvcc_linux-aarch64-11.6-h1ac39a2_22.conda
linux-aarch64::nvcc_linux-aarch64-11.6-hca6400d_22.conda
linux-aarch64::nvcc_linux-aarch64-11.6-hca6400d_23.conda
+    "cudatoolkit >=11.6,<12",
linux-aarch64::nvcc_linux-aarch64-11.5-h4b00892_22.conda
linux-aarch64::nvcc_linux-aarch64-11.5-h4b00892_23.conda
linux-aarch64::nvcc_linux-aarch64-11.5-h972ea22_22.conda
linux-aarch64::nvcc_linux-aarch64-11.5-hd0f3f81_16.tar.bz2
linux-aarch64::nvcc_linux-aarch64-11.5-hd0f3f81_17.tar.bz2
linux-aarch64::nvcc_linux-aarch64-11.5-hd0f3f81_18.tar.bz2
linux-aarch64::nvcc_linux-aarch64-11.5-hd0f3f81_19.tar.bz2
linux-aarch64::nvcc_linux-aarch64-11.5-hd0f3f81_20.tar.bz2
linux-aarch64::nvcc_linux-aarch64-11.5-hd0f3f81_21.tar.bz2
linux-aarch64::nvcc_linux-aarch64-11.5-hd0f3f81_22.conda
+    "cudatoolkit >=11.5,<12",
linux-aarch64::libcufile-1.10.0.4-h614329b_0.conda
linux-aarch64::libcufile-1.10.1.7-h614329b_0.conda
linux-aarch64::libcufile-1.11.0.15-h614329b_0.conda
linux-aarch64::libcufile-1.11.1.6-h3ae8b8a_0.conda
linux-aarch64::libcufile-1.11.1.6-h3d08a35_2.conda
linux-aarch64::libcufile-1.11.1.6-h71dc0f0_1.conda
linux-aarch64::libcufile-1.7.2.10-hac28a21_0.conda
linux-aarch64::libcufile-1.8.1.2-hac28a21_0.conda
linux-aarch64::libcufile-1.8.1.2-hac28a21_1.conda
linux-aarch64::libcufile-1.9.0.20-hac28a21_0.conda
linux-aarch64::libcufile-1.9.1.3-h614329b_2.conda
linux-aarch64::libcufile-1.9.1.3-hac28a21_0.conda
linux-aarch64::libcufile-1.9.1.3-hac28a21_1.conda
linux-aarch64::libcufile-dev-1.10.0.4-h614329b_0.conda
linux-aarch64::libcufile-dev-1.10.1.7-h614329b_0.conda
linux-aarch64::libcufile-dev-1.11.0.15-h614329b_0.conda
linux-aarch64::libcufile-dev-1.11.1.6-h3ae8b8a_0.conda
linux-aarch64::libcufile-dev-1.11.1.6-h3ae8b8a_1.conda
linux-aarch64::libcufile-dev-1.11.1.6-h3ae8b8a_2.conda
linux-aarch64::libcufile-dev-1.7.2.10-hac28a21_0.conda
linux-aarch64::libcufile-dev-1.8.1.2-hac28a21_0.conda
linux-aarch64::libcufile-dev-1.8.1.2-hac28a21_1.conda
linux-aarch64::libcufile-dev-1.9.0.20-hac28a21_0.conda
linux-aarch64::libcufile-dev-1.9.1.3-h614329b_2.conda
linux-aarch64::libcufile-dev-1.9.1.3-hac28a21_0.conda
linux-aarch64::libcufile-dev-1.9.1.3-hac28a21_1.conda
linux-aarch64::libcufile-static-1.10.0.4-h614329b_0.conda
linux-aarch64::libcufile-static-1.10.1.7-h614329b_0.conda
linux-aarch64::libcufile-static-1.11.0.15-h614329b_0.conda
linux-aarch64::libcufile-static-1.11.1.6-h3ae8b8a_0.conda
linux-aarch64::libcufile-static-1.11.1.6-h3ae8b8a_1.conda
linux-aarch64::libcufile-static-1.11.1.6-h3ae8b8a_2.conda
linux-aarch64::libcufile-static-1.7.2.10-hac28a21_0.conda
linux-aarch64::libcufile-static-1.8.1.2-hac28a21_0.conda
linux-aarch64::libcufile-static-1.8.1.2-hac28a21_1.conda
linux-aarch64::libcufile-static-1.9.0.20-hac28a21_0.conda
linux-aarch64::libcufile-static-1.9.1.3-h614329b_2.conda
linux-aarch64::libcufile-static-1.9.1.3-hac28a21_0.conda
linux-aarch64::libcufile-static-1.9.1.3-hac28a21_1.conda
+    "__glibc >=2.28,<3.0.a0",
linux-aarch64::nvcc_linux-aarch64-11.8-h3750a1c_22.conda
linux-aarch64::nvcc_linux-aarch64-11.8-h5af4c76_24.conda
linux-aarch64::nvcc_linux-aarch64-11.8-h66f59ed_22.conda
linux-aarch64::nvcc_linux-aarch64-11.8-hc5fb5b2_22.conda
linux-aarch64::nvcc_linux-aarch64-11.8-hc5fb5b2_23.conda
+    "cudatoolkit >=11.8,<12",
================================================================================
================================================================================
noarch
================================================================================
================================================================================
win-64
win-64::nvcc_win-64-11.5-h030eb88_22.conda
win-64::nvcc_win-64-11.5-h030eb88_23.conda
win-64::nvcc_win-64-11.5-h350c050_22.conda
win-64::nvcc_win-64-11.5-h4cd819c_16.tar.bz2
win-64::nvcc_win-64-11.5-h4cd819c_17.tar.bz2
win-64::nvcc_win-64-11.5-h4cd819c_18.tar.bz2
win-64::nvcc_win-64-11.5-h4cd819c_19.tar.bz2
win-64::nvcc_win-64-11.5-h4cd819c_20.tar.bz2
win-64::nvcc_win-64-11.5-h4cd819c_21.tar.bz2
+    "cudatoolkit >=11.5,<12",
win-64::nvcc_win-64-11.7-h6995438_22.conda
win-64::nvcc_win-64-11.7-h6df02ae_18.tar.bz2
win-64::nvcc_win-64-11.7-h6df02ae_19.tar.bz2
win-64::nvcc_win-64-11.7-h6df02ae_20.tar.bz2
win-64::nvcc_win-64-11.7-h6df02ae_21.tar.bz2
win-64::nvcc_win-64-11.7-hd89f463_22.conda
win-64::nvcc_win-64-11.7-hd89f463_23.conda
+    "cudatoolkit >=11.7,<12",
win-64::nvcc_win-64-10.1-h000b869_22.conda
win-64::nvcc_win-64-10.1-h000b869_23.conda
win-64::nvcc_win-64-10.1-h0899034_22.conda
win-64::nvcc_win-64-10.1-h1ba89ec_10.tar.bz2
win-64::nvcc_win-64-10.1-h1ba89ec_11.tar.bz2
win-64::nvcc_win-64-10.1-h1ba89ec_12.tar.bz2
win-64::nvcc_win-64-10.1-h1ba89ec_13.tar.bz2
win-64::nvcc_win-64-10.1-h1ba89ec_14.tar.bz2
win-64::nvcc_win-64-10.1-h1ba89ec_15.tar.bz2
win-64::nvcc_win-64-10.1-h1ba89ec_16.tar.bz2
win-64::nvcc_win-64-10.1-h1ba89ec_17.tar.bz2
win-64::nvcc_win-64-10.1-h1ba89ec_18.tar.bz2
win-64::nvcc_win-64-10.1-h1ba89ec_19.tar.bz2
win-64::nvcc_win-64-10.1-h1ba89ec_20.tar.bz2
win-64::nvcc_win-64-10.1-h1ba89ec_21.tar.bz2
win-64::nvcc_win-64-10.1-h1ba89ec_7.tar.bz2
win-64::nvcc_win-64-10.1-h1ba89ec_8.tar.bz2
win-64::nvcc_win-64-10.1-h1ba89ec_9.tar.bz2
+    "cudatoolkit 10.1.*",
win-64::nvcc_win-64-11.0-h5987435_10.tar.bz2
win-64::nvcc_win-64-11.0-h5987435_11.tar.bz2
win-64::nvcc_win-64-11.0-h5987435_12.tar.bz2
win-64::nvcc_win-64-11.0-h5987435_13.tar.bz2
win-64::nvcc_win-64-11.0-h5987435_14.tar.bz2
win-64::nvcc_win-64-11.0-h5987435_15.tar.bz2
win-64::nvcc_win-64-11.0-h5987435_16.tar.bz2
win-64::nvcc_win-64-11.0-h5987435_17.tar.bz2
win-64::nvcc_win-64-11.0-h5987435_18.tar.bz2
win-64::nvcc_win-64-11.0-h5987435_19.tar.bz2
win-64::nvcc_win-64-11.0-h5987435_20.tar.bz2
win-64::nvcc_win-64-11.0-h5987435_21.tar.bz2
win-64::nvcc_win-64-11.0-h5987435_7.tar.bz2
win-64::nvcc_win-64-11.0-h5987435_8.tar.bz2
win-64::nvcc_win-64-11.0-h5987435_9.tar.bz2
win-64::nvcc_win-64-11.0-hd3bb8a4_22.conda
win-64::nvcc_win-64-11.0-hd3bb8a4_23.conda
win-64::nvcc_win-64-11.0-hdb97b34_22.conda
+    "cudatoolkit 11.0.*",
win-64::nvcc_win-64-11.1-h113b51f_12.tar.bz2
win-64::nvcc_win-64-11.1-h113b51f_13.tar.bz2
win-64::nvcc_win-64-11.1-h113b51f_14.tar.bz2
win-64::nvcc_win-64-11.1-h113b51f_15.tar.bz2
win-64::nvcc_win-64-11.1-h113b51f_16.tar.bz2
win-64::nvcc_win-64-11.1-h113b51f_17.tar.bz2
win-64::nvcc_win-64-11.1-h113b51f_18.tar.bz2
win-64::nvcc_win-64-11.1-h113b51f_19.tar.bz2
win-64::nvcc_win-64-11.1-h113b51f_20.tar.bz2
win-64::nvcc_win-64-11.1-h113b51f_21.tar.bz2
win-64::nvcc_win-64-11.1-h59fec25_22.conda
win-64::nvcc_win-64-11.1-h59fec25_23.conda
win-64::nvcc_win-64-11.1-h9ceb898_22.conda
+    "cudatoolkit 11.1.*",
win-64::nvcc_win-64-10.2-h54b9154_22.conda
win-64::nvcc_win-64-10.2-h54b9154_23.conda
win-64::nvcc_win-64-10.2-h9a3eccd_22.conda
win-64::nvcc_win-64-10.2-hcf0059e_10.tar.bz2
win-64::nvcc_win-64-10.2-hcf0059e_11.tar.bz2
win-64::nvcc_win-64-10.2-hcf0059e_12.tar.bz2
win-64::nvcc_win-64-10.2-hcf0059e_13.tar.bz2
win-64::nvcc_win-64-10.2-hcf0059e_14.tar.bz2
win-64::nvcc_win-64-10.2-hcf0059e_15.tar.bz2
win-64::nvcc_win-64-10.2-hcf0059e_16.tar.bz2
win-64::nvcc_win-64-10.2-hcf0059e_17.tar.bz2
win-64::nvcc_win-64-10.2-hcf0059e_18.tar.bz2
win-64::nvcc_win-64-10.2-hcf0059e_19.tar.bz2
win-64::nvcc_win-64-10.2-hcf0059e_20.tar.bz2
win-64::nvcc_win-64-10.2-hcf0059e_21.tar.bz2
win-64::nvcc_win-64-10.2-hcf0059e_7.tar.bz2
win-64::nvcc_win-64-10.2-hcf0059e_8.tar.bz2
win-64::nvcc_win-64-10.2-hcf0059e_9.tar.bz2
+    "cudatoolkit 10.2.*",
win-64::nvcc_win-64-11.6-h6e97533_16.tar.bz2
win-64::nvcc_win-64-11.6-h6e97533_17.tar.bz2
win-64::nvcc_win-64-11.6-h6e97533_18.tar.bz2
win-64::nvcc_win-64-11.6-h6e97533_19.tar.bz2
win-64::nvcc_win-64-11.6-h6e97533_20.tar.bz2
win-64::nvcc_win-64-11.6-h6e97533_21.tar.bz2
win-64::nvcc_win-64-11.6-h9df1389_22.conda
win-64::nvcc_win-64-11.6-hfb855fa_22.conda
win-64::nvcc_win-64-11.6-hfb855fa_23.conda
+    "cudatoolkit >=11.6,<12",
win-64::nvcc_win-64-10.0-hd4710ae_10.tar.bz2
win-64::nvcc_win-64-10.0-hd4710ae_11.tar.bz2
win-64::nvcc_win-64-10.0-hd4710ae_12.tar.bz2
win-64::nvcc_win-64-10.0-hd4710ae_13.tar.bz2
win-64::nvcc_win-64-10.0-hd4710ae_14.tar.bz2
win-64::nvcc_win-64-10.0-hd4710ae_15.tar.bz2
win-64::nvcc_win-64-10.0-hd4710ae_16.tar.bz2
win-64::nvcc_win-64-10.0-hd4710ae_17.tar.bz2
win-64::nvcc_win-64-10.0-hd4710ae_18.tar.bz2
win-64::nvcc_win-64-10.0-hd4710ae_19.tar.bz2
win-64::nvcc_win-64-10.0-hd4710ae_20.tar.bz2
win-64::nvcc_win-64-10.0-hd4710ae_21.tar.bz2
win-64::nvcc_win-64-10.0-hd4710ae_7.tar.bz2
win-64::nvcc_win-64-10.0-hd4710ae_8.tar.bz2
win-64::nvcc_win-64-10.0-hd4710ae_9.tar.bz2
+    "cudatoolkit 10.0.*",
win-64::nvcc_win-64-11.2-h043a383_22.conda
win-64::nvcc_win-64-11.2-h043a383_23.conda
win-64::nvcc_win-64-11.2-h929061a_12.tar.bz2
win-64::nvcc_win-64-11.2-h929061a_13.tar.bz2
win-64::nvcc_win-64-11.2-h929061a_14.tar.bz2
win-64::nvcc_win-64-11.2-h929061a_15.tar.bz2
win-64::nvcc_win-64-11.2-h929061a_16.tar.bz2
win-64::nvcc_win-64-11.2-h929061a_17.tar.bz2
win-64::nvcc_win-64-11.2-h929061a_18.tar.bz2
win-64::nvcc_win-64-11.2-h929061a_19.tar.bz2
win-64::nvcc_win-64-11.2-h929061a_20.tar.bz2
win-64::nvcc_win-64-11.2-h929061a_21.tar.bz2
win-64::nvcc_win-64-11.2-h9631440_22.conda
+    "cudatoolkit >=11.2,<12",
win-64::nvcc_win-64-11.3-h1bcacbc_22.conda
win-64::nvcc_win-64-11.3-h1bcacbc_23.conda
win-64::nvcc_win-64-11.3-hf9788b2_22.conda
win-64::nvcc_win-64-11.3-hfec8363_16.tar.bz2
win-64::nvcc_win-64-11.3-hfec8363_17.tar.bz2
win-64::nvcc_win-64-11.3-hfec8363_18.tar.bz2
win-64::nvcc_win-64-11.3-hfec8363_19.tar.bz2
win-64::nvcc_win-64-11.3-hfec8363_20.tar.bz2
win-64::nvcc_win-64-11.3-hfec8363_21.tar.bz2
+    "cudatoolkit >=11.3,<12",
win-64::nvcc_win-64-11.4-h7833534_22.conda
win-64::nvcc_win-64-11.4-h7992b1d_22.conda
win-64::nvcc_win-64-11.4-h7992b1d_23.conda
win-64::nvcc_win-64-11.4-h9e87cec_16.tar.bz2
win-64::nvcc_win-64-11.4-h9e87cec_17.tar.bz2
win-64::nvcc_win-64-11.4-h9e87cec_18.tar.bz2
win-64::nvcc_win-64-11.4-h9e87cec_19.tar.bz2
win-64::nvcc_win-64-11.4-h9e87cec_20.tar.bz2
win-64::nvcc_win-64-11.4-h9e87cec_21.tar.bz2
+    "cudatoolkit >=11.4,<12",
win-64::nvcc_win-64-11.8-h2db58eb_24.conda
win-64::nvcc_win-64-11.8-h57e875e_22.conda
win-64::nvcc_win-64-11.8-h57e875e_23.conda
win-64::nvcc_win-64-11.8-h84bb9a4_22.conda
+    "cudatoolkit >=11.8,<12",
win-64::cudnn-9.2.1.18-h49adc43_0.conda
win-64::cudnn-9.2.1.18-hb6d8d52_0.conda
-    "libzlib-wapi >=1.2.13,<2.0a0",
win-64::python-3.13.1-h1f59b40_1_cp313t.conda
-  "track_features": "py_freethreading",
win-64::cudnn-9.3.0.75-h4ba422f_0.conda
win-64::cudnn-9.3.0.75-h9cf4f96_0.conda
-    "libzlib-wapi >=1.3.1,<2.0a0",
================================================================================
================================================================================
osx-64
================================================================================
================================================================================
linux-64
linux-64::nvcc_linux-64-10.1-h30f2b25_13.tar.bz2
linux-64::nvcc_linux-64-10.1-h30f2b25_14.tar.bz2
linux-64::nvcc_linux-64-10.1-h30f2b25_15.tar.bz2
linux-64::nvcc_linux-64-10.1-h30f2b25_16.tar.bz2
linux-64::nvcc_linux-64-10.1-h30f2b25_17.tar.bz2
linux-64::nvcc_linux-64-10.1-h30f2b25_18.tar.bz2
linux-64::nvcc_linux-64-10.1-h30f2b25_19.tar.bz2
linux-64::nvcc_linux-64-10.1-h30f2b25_20.tar.bz2
linux-64::nvcc_linux-64-10.1-h30f2b25_21.tar.bz2
linux-64::nvcc_linux-64-10.1-h30f2b25_22.conda
linux-64::nvcc_linux-64-10.1-h8b44402_11.tar.bz2
linux-64::nvcc_linux-64-10.1-h8b44402_12.tar.bz2
linux-64::nvcc_linux-64-10.1-h9ecc89a_22.conda
linux-64::nvcc_linux-64-10.1-h9ecc89a_23.conda
+    "cudatoolkit 10.1.*",
linux-64::nvcc_linux-64-10.2-h1a5f58c_11.tar.bz2
linux-64::nvcc_linux-64-10.2-h1a5f58c_12.tar.bz2
linux-64::nvcc_linux-64-10.2-h2ec6930_22.conda
linux-64::nvcc_linux-64-10.2-h2ec6930_23.conda
linux-64::nvcc_linux-64-10.2-h7507d65_13.tar.bz2
linux-64::nvcc_linux-64-10.2-h7507d65_14.tar.bz2
linux-64::nvcc_linux-64-10.2-h7507d65_15.tar.bz2
linux-64::nvcc_linux-64-10.2-h7507d65_16.tar.bz2
linux-64::nvcc_linux-64-10.2-h7507d65_17.tar.bz2
linux-64::nvcc_linux-64-10.2-h7507d65_18.tar.bz2
linux-64::nvcc_linux-64-10.2-h7507d65_19.tar.bz2
linux-64::nvcc_linux-64-10.2-h7507d65_20.tar.bz2
linux-64::nvcc_linux-64-10.2-h7507d65_21.tar.bz2
linux-64::nvcc_linux-64-10.2-h7507d65_22.conda
+    "cudatoolkit 10.2.*",
linux-64::nvcc_linux-64-11.5-h1dce376_22.conda
linux-64::nvcc_linux-64-11.5-h1dce376_23.conda
linux-64::nvcc_linux-64-11.5-h44f499b_16.tar.bz2
linux-64::nvcc_linux-64-11.5-h44f499b_17.tar.bz2
linux-64::nvcc_linux-64-11.5-h44f499b_18.tar.bz2
linux-64::nvcc_linux-64-11.5-h44f499b_19.tar.bz2
linux-64::nvcc_linux-64-11.5-h44f499b_20.tar.bz2
linux-64::nvcc_linux-64-11.5-h44f499b_21.tar.bz2
linux-64::nvcc_linux-64-11.5-h44f499b_22.conda
linux-64::nvcc_linux-64-11.5-h7a8a3d2_22.conda
+    "cudatoolkit >=11.5,<12",
linux-64::nvcc_linux-64-11.1-h36652d0_22.conda
linux-64::nvcc_linux-64-11.1-h36652d0_23.conda
linux-64::nvcc_linux-64-11.1-h436fe5b_22.conda
linux-64::nvcc_linux-64-11.1-h6ecd8f1_13.tar.bz2
linux-64::nvcc_linux-64-11.1-h6ecd8f1_14.tar.bz2
linux-64::nvcc_linux-64-11.1-h6ecd8f1_15.tar.bz2
linux-64::nvcc_linux-64-11.1-h6ecd8f1_16.tar.bz2
linux-64::nvcc_linux-64-11.1-h6ecd8f1_17.tar.bz2
linux-64::nvcc_linux-64-11.1-h6ecd8f1_18.tar.bz2
linux-64::nvcc_linux-64-11.1-h6ecd8f1_19.tar.bz2
linux-64::nvcc_linux-64-11.1-h6ecd8f1_20.tar.bz2
linux-64::nvcc_linux-64-11.1-h6ecd8f1_21.tar.bz2
linux-64::nvcc_linux-64-11.1-h6ecd8f1_22.conda
linux-64::nvcc_linux-64-11.1-h97a9cb7_12.tar.bz2
+    "cudatoolkit 11.1.*",
linux-64::nvcc_linux-64-9.2-h7cc98d6_3.tar.bz2
linux-64::nvcc_linux-64-9.2-h7cc98d6_4.tar.bz2
linux-64::nvcc_linux-64-9.2-h7cc98d6_5.tar.bz2
linux-64::nvcc_linux-64-9.2-h7cc98d6_6.tar.bz2
linux-64::nvcc_linux-64-9.2-h8ae4b28_10.tar.bz2
linux-64::nvcc_linux-64-9.2-h8ae4b28_7.tar.bz2
linux-64::nvcc_linux-64-9.2-h8ae4b28_8.tar.bz2
linux-64::nvcc_linux-64-9.2-h8ae4b28_9.tar.bz2
linux-64::nvcc_linux-64-9.2-h8d8c1e6_6.tar.bz2
linux-64::nvcc_linux-64-9.2-hceaac93_0.tar.bz2
linux-64::nvcc_linux-64-9.2-hceaac93_1.tar.bz2
linux-64::nvcc_linux-64-9.2-hceaac93_2.tar.bz2
-  "depends": [],
+  "depends": [
+    "cudatoolkit 9.2.*"
+  ],
linux-64::nvcc_linux-64-11.6-h4222249_22.conda
linux-64::nvcc_linux-64-11.6-h4222249_23.conda
linux-64::nvcc_linux-64-11.6-h449e88d_22.conda
linux-64::nvcc_linux-64-11.6-hd0b5fcf_16.tar.bz2
linux-64::nvcc_linux-64-11.6-hd0b5fcf_17.tar.bz2
linux-64::nvcc_linux-64-11.6-hd0b5fcf_18.tar.bz2
linux-64::nvcc_linux-64-11.6-hd0b5fcf_19.tar.bz2
linux-64::nvcc_linux-64-11.6-hd0b5fcf_20.tar.bz2
linux-64::nvcc_linux-64-11.6-hd0b5fcf_21.tar.bz2
linux-64::nvcc_linux-64-11.6-hd0b5fcf_22.conda
+    "cudatoolkit >=11.6,<12",
linux-64::nvcc_linux-64-9.2-h8ae4b28_11.tar.bz2
linux-64::nvcc_linux-64-9.2-h8ae4b28_12.tar.bz2
linux-64::nvcc_linux-64-9.2-ha2a9e15_22.conda
linux-64::nvcc_linux-64-9.2-ha2a9e15_23.conda
linux-64::nvcc_linux-64-9.2-hd5ebcf1_13.tar.bz2
linux-64::nvcc_linux-64-9.2-hd5ebcf1_14.tar.bz2
linux-64::nvcc_linux-64-9.2-hd5ebcf1_15.tar.bz2
linux-64::nvcc_linux-64-9.2-hd5ebcf1_16.tar.bz2
linux-64::nvcc_linux-64-9.2-hd5ebcf1_17.tar.bz2
linux-64::nvcc_linux-64-9.2-hd5ebcf1_18.tar.bz2
linux-64::nvcc_linux-64-9.2-hd5ebcf1_19.tar.bz2
linux-64::nvcc_linux-64-9.2-hd5ebcf1_20.tar.bz2
linux-64::nvcc_linux-64-9.2-hd5ebcf1_21.tar.bz2
linux-64::nvcc_linux-64-9.2-hd5ebcf1_22.conda
+    "cudatoolkit 9.2.*",
linux-64::nvcc_linux-64-10.0-h5196b31_6.tar.bz2
linux-64::nvcc_linux-64-10.0-h7053e78_0.tar.bz2
linux-64::nvcc_linux-64-10.0-h7053e78_1.tar.bz2
linux-64::nvcc_linux-64-10.0-h7053e78_2.tar.bz2
linux-64::nvcc_linux-64-10.0-h86b6200_10.tar.bz2
linux-64::nvcc_linux-64-10.0-h86b6200_7.tar.bz2
linux-64::nvcc_linux-64-10.0-h86b6200_8.tar.bz2
linux-64::nvcc_linux-64-10.0-h86b6200_9.tar.bz2
linux-64::nvcc_linux-64-10.0-hd6f8bf8_3.tar.bz2
linux-64::nvcc_linux-64-10.0-hd6f8bf8_4.tar.bz2
linux-64::nvcc_linux-64-10.0-hd6f8bf8_5.tar.bz2
linux-64::nvcc_linux-64-10.0-hd6f8bf8_6.tar.bz2
-  "depends": [],
+  "depends": [
+    "cudatoolkit 10.0.*"
+  ],
linux-64::nvcc_linux-64-11.7-h05dbe86_22.conda
linux-64::nvcc_linux-64-11.7-h0fb96c7_18.tar.bz2
linux-64::nvcc_linux-64-11.7-h0fb96c7_19.tar.bz2
linux-64::nvcc_linux-64-11.7-h0fb96c7_20.tar.bz2
linux-64::nvcc_linux-64-11.7-h0fb96c7_21.tar.bz2
linux-64::nvcc_linux-64-11.7-h0fb96c7_22.conda
linux-64::nvcc_linux-64-11.7-ha25fe5e_22.conda
linux-64::nvcc_linux-64-11.7-ha25fe5e_23.conda
+    "cudatoolkit >=11.7,<12",
linux-64::nvcc_linux-64-11.0-h17a0586_10.tar.bz2
linux-64::nvcc_linux-64-11.0-h17a0586_11.tar.bz2
linux-64::nvcc_linux-64-11.0-h17a0586_8.tar.bz2
linux-64::nvcc_linux-64-11.0-h17a0586_9.tar.bz2
linux-64::nvcc_linux-64-11.0-h38088af_13.tar.bz2
linux-64::nvcc_linux-64-11.0-h38088af_14.tar.bz2
linux-64::nvcc_linux-64-11.0-h38088af_15.tar.bz2
linux-64::nvcc_linux-64-11.0-h38088af_16.tar.bz2
linux-64::nvcc_linux-64-11.0-h38088af_17.tar.bz2
linux-64::nvcc_linux-64-11.0-h38088af_18.tar.bz2
linux-64::nvcc_linux-64-11.0-h38088af_19.tar.bz2
linux-64::nvcc_linux-64-11.0-h38088af_20.tar.bz2
linux-64::nvcc_linux-64-11.0-h38088af_21.tar.bz2
linux-64::nvcc_linux-64-11.0-h38088af_22.conda
linux-64::nvcc_linux-64-11.0-h8438922_22.conda
linux-64::nvcc_linux-64-11.0-h8438922_23.conda
linux-64::nvcc_linux-64-11.0-h96e36e3_11.tar.bz2
linux-64::nvcc_linux-64-11.0-h96e36e3_12.tar.bz2
linux-64::nvcc_linux-64-11.0-h96e36e3_7.tar.bz2
linux-64::nvcc_linux-64-11.0-he443bbd_6.tar.bz2
linux-64::nvcc_linux-64-11.0-hec5d133_22.conda
+    "cudatoolkit 11.0.*",
linux-64::nvcc_linux-64-10.0-h86b6200_11.tar.bz2
linux-64::nvcc_linux-64-10.0-h86b6200_12.tar.bz2
linux-64::nvcc_linux-64-10.0-h9aa8f15_13.tar.bz2
linux-64::nvcc_linux-64-10.0-h9aa8f15_14.tar.bz2
linux-64::nvcc_linux-64-10.0-h9aa8f15_15.tar.bz2
linux-64::nvcc_linux-64-10.0-h9aa8f15_16.tar.bz2
linux-64::nvcc_linux-64-10.0-h9aa8f15_17.tar.bz2
linux-64::nvcc_linux-64-10.0-h9aa8f15_18.tar.bz2
linux-64::nvcc_linux-64-10.0-h9aa8f15_19.tar.bz2
linux-64::nvcc_linux-64-10.0-h9aa8f15_20.tar.bz2
linux-64::nvcc_linux-64-10.0-h9aa8f15_21.tar.bz2
linux-64::nvcc_linux-64-10.0-h9aa8f15_22.conda
linux-64::nvcc_linux-64-10.0-hdd9a186_22.conda
linux-64::nvcc_linux-64-10.0-hdd9a186_23.conda
+    "cudatoolkit 10.0.*",
linux-64::nvcc_linux-64-10.1-h3d80acd_0.tar.bz2
linux-64::nvcc_linux-64-10.1-h3d80acd_1.tar.bz2
linux-64::nvcc_linux-64-10.1-h3d80acd_2.tar.bz2
linux-64::nvcc_linux-64-10.1-h51cf6c1_3.tar.bz2
linux-64::nvcc_linux-64-10.1-h51cf6c1_4.tar.bz2
linux-64::nvcc_linux-64-10.1-h51cf6c1_5.tar.bz2
linux-64::nvcc_linux-64-10.1-h51cf6c1_6.tar.bz2
linux-64::nvcc_linux-64-10.1-h8b44402_10.tar.bz2
linux-64::nvcc_linux-64-10.1-h8b44402_7.tar.bz2
linux-64::nvcc_linux-64-10.1-h8b44402_8.tar.bz2
linux-64::nvcc_linux-64-10.1-h8b44402_9.tar.bz2
linux-64::nvcc_linux-64-10.1-hb3d2f79_6.tar.bz2
-  "depends": [],
+  "depends": [
+    "cudatoolkit 10.1.*"
+  ],
linux-64::nvcc_linux-64-11.3-h708beae_16.tar.bz2
linux-64::nvcc_linux-64-11.3-h708beae_17.tar.bz2
linux-64::nvcc_linux-64-11.3-h708beae_18.tar.bz2
linux-64::nvcc_linux-64-11.3-h708beae_19.tar.bz2
linux-64::nvcc_linux-64-11.3-h708beae_20.tar.bz2
linux-64::nvcc_linux-64-11.3-h708beae_21.tar.bz2
linux-64::nvcc_linux-64-11.3-h708beae_22.conda
linux-64::nvcc_linux-64-11.3-h8264844_22.conda
linux-64::nvcc_linux-64-11.3-h82bc13d_22.conda
linux-64::nvcc_linux-64-11.3-h82bc13d_23.conda
+    "cudatoolkit >=11.3,<12",
linux-64::nvcc_linux-64-10.2-h1a5f58c_10.tar.bz2
linux-64::nvcc_linux-64-10.2-h1a5f58c_7.tar.bz2
linux-64::nvcc_linux-64-10.2-h1a5f58c_8.tar.bz2
linux-64::nvcc_linux-64-10.2-h1a5f58c_9.tar.bz2
linux-64::nvcc_linux-64-10.2-h660353a_6.tar.bz2
linux-64::nvcc_linux-64-10.2-hc6a2c23_6.tar.bz2
-  "depends": [],
+  "depends": [
+    "cudatoolkit 10.2.*"
+  ],
linux-64::nvcc_linux-64-11.2-h309498c_13.tar.bz2
linux-64::nvcc_linux-64-11.2-h309498c_14.tar.bz2
linux-64::nvcc_linux-64-11.2-h309498c_15.tar.bz2
linux-64::nvcc_linux-64-11.2-h309498c_16.tar.bz2
linux-64::nvcc_linux-64-11.2-h309498c_17.tar.bz2
linux-64::nvcc_linux-64-11.2-h309498c_18.tar.bz2
linux-64::nvcc_linux-64-11.2-h309498c_19.tar.bz2
linux-64::nvcc_linux-64-11.2-h309498c_20.tar.bz2
linux-64::nvcc_linux-64-11.2-h309498c_21.tar.bz2
linux-64::nvcc_linux-64-11.2-h309498c_22.conda
linux-64::nvcc_linux-64-11.2-h5e203dc_22.conda
linux-64::nvcc_linux-64-11.2-hdb70940_22.conda
linux-64::nvcc_linux-64-11.2-hdb70940_23.conda
linux-64::nvcc_linux-64-11.2-hdc17891_12.tar.bz2
linux-64::nvcc_linux-aarch64-11.2-h6698bde_22.conda
linux-64::nvcc_linux-aarch64-11.2-ha2c2674_22.conda
linux-64::nvcc_linux-aarch64-11.2-ha2c2674_23.conda
linux-64::nvcc_linux-ppc64le-11.2-h331a0b7_22.conda
linux-64::nvcc_linux-ppc64le-11.2-h331a0b7_23.conda
linux-64::nvcc_linux-ppc64le-11.2-h4520a0e_22.conda
+    "cudatoolkit >=11.2,<12",
linux-64::nvcc_linux-64-11.4-h05adf2c_16.tar.bz2
linux-64::nvcc_linux-64-11.4-h05adf2c_17.tar.bz2
linux-64::nvcc_linux-64-11.4-h05adf2c_18.tar.bz2
linux-64::nvcc_linux-64-11.4-h05adf2c_19.tar.bz2
linux-64::nvcc_linux-64-11.4-h05adf2c_20.tar.bz2
linux-64::nvcc_linux-64-11.4-h05adf2c_21.tar.bz2
linux-64::nvcc_linux-64-11.4-h05adf2c_22.conda
linux-64::nvcc_linux-64-11.4-hc813330_22.conda
linux-64::nvcc_linux-64-11.4-hc813330_23.conda
linux-64::nvcc_linux-64-11.4-hcb1945a_22.conda
+    "cudatoolkit >=11.4,<12",
linux-64::nvcc_linux-64-11.8-h41dc85b_22.conda
linux-64::nvcc_linux-64-11.8-h41dc85b_23.conda
linux-64::nvcc_linux-64-11.8-h667003e_22.conda
linux-64::nvcc_linux-64-11.8-h9852d18_24.conda
linux-64::nvcc_linux-64-11.8-ha67cc55_22.conda
linux-64::nvcc_linux-aarch64-11.8-h3c4d780_24.conda
linux-64::nvcc_linux-aarch64-11.8-h52eb961_23.conda
linux-64::nvcc_linux-aarch64-11.8-h736447b_22.conda
linux-64::nvcc_linux-ppc64le-11.8-hb69a355_22.conda
linux-64::nvcc_linux-ppc64le-11.8-he6364cc_23.conda
linux-64::nvcc_linux-ppc64le-11.8-hf42c448_24.conda
+    "cudatoolkit >=11.8,<12",
```
