### PR TITLE
past builds of fenics-ffc don't support numpy 2

### DIFF
--- a/recipe/patch_yaml/ffc-numpy.yaml
+++ b/recipe/patch_yaml/ffc-numpy.yaml
@@ -1,0 +1,14 @@
+# fenics-ffc up to 2019.1.0 doesn't support numpy 2
+# but has unbounded numpy dependency
+# conda-forge only has version 2019.1.0 of this package
+# a patch was backported in 2019.1.0 build 40
+if:
+  name: fenics-ffc
+  version: "2019.1.0"
+  build_number_lt: 40
+  timestamp_lt: 1733402352000
+then:
+  - tighten_depends:
+      # don't support numpy 2
+      name: numpy
+      upper_bound: 2.0.0


### PR DESCRIPTION
patch has been applied for build 40: https://github.com/conda-forge/fenics-ffc-feedstock/pull/3

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->


<details>
<summary>diff</summary>

```
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-ppc64le
linux-ppc64le::fenics-ffc-2019.1.0-py310hd032262_30.tar.bz2
linux-ppc64le::fenics-ffc-2019.1.0-py310hd032262_31.tar.bz2
linux-ppc64le::fenics-ffc-2019.1.0-py310hd032262_32.tar.bz2
linux-ppc64le::fenics-ffc-2019.1.0-py310hd032262_33.tar.bz2
linux-ppc64le::fenics-ffc-2019.1.0-py310hd032262_34.tar.bz2
linux-ppc64le::fenics-ffc-2019.1.0-py310hd032262_35.conda
linux-ppc64le::fenics-ffc-2019.1.0-py310hd032262_36.conda
linux-ppc64le::fenics-ffc-2019.1.0-py310hd032262_37.conda
linux-ppc64le::fenics-ffc-2019.1.0-py310hd032262_38.conda
linux-ppc64le::fenics-ffc-2019.1.0-py311h957a2fd_33.tar.bz2
linux-ppc64le::fenics-ffc-2019.1.0-py311h957a2fd_34.tar.bz2
linux-ppc64le::fenics-ffc-2019.1.0-py311h957a2fd_35.conda
linux-ppc64le::fenics-ffc-2019.1.0-py311h957a2fd_36.conda
linux-ppc64le::fenics-ffc-2019.1.0-py311h957a2fd_37.conda
linux-ppc64le::fenics-ffc-2019.1.0-py311h957a2fd_38.conda
linux-ppc64le::fenics-ffc-2019.1.0-py37h35e4cab_30.tar.bz2
linux-ppc64le::fenics-ffc-2019.1.0-py37h35e4cab_31.tar.bz2
linux-ppc64le::fenics-ffc-2019.1.0-py37h35e4cab_32.tar.bz2
linux-ppc64le::fenics-ffc-2019.1.0-py38hf8b3453_30.tar.bz2
linux-ppc64le::fenics-ffc-2019.1.0-py38hf8b3453_31.tar.bz2
linux-ppc64le::fenics-ffc-2019.1.0-py38hf8b3453_32.tar.bz2
linux-ppc64le::fenics-ffc-2019.1.0-py38hf8b3453_33.tar.bz2
linux-ppc64le::fenics-ffc-2019.1.0-py38hf8b3453_34.tar.bz2
linux-ppc64le::fenics-ffc-2019.1.0-py38hf8b3453_35.conda
linux-ppc64le::fenics-ffc-2019.1.0-py38hf8b3453_36.conda
linux-ppc64le::fenics-ffc-2019.1.0-py38hf8b3453_37.conda
linux-ppc64le::fenics-ffc-2019.1.0-py38hf8b3453_38.conda
linux-ppc64le::fenics-ffc-2019.1.0-py39hc1b9086_30.tar.bz2
linux-ppc64le::fenics-ffc-2019.1.0-py39hc1b9086_31.tar.bz2
linux-ppc64le::fenics-ffc-2019.1.0-py39hc1b9086_32.tar.bz2
linux-ppc64le::fenics-ffc-2019.1.0-py39hc1b9086_33.tar.bz2
linux-ppc64le::fenics-ffc-2019.1.0-py39hc1b9086_34.tar.bz2
linux-ppc64le::fenics-ffc-2019.1.0-py39hc1b9086_35.conda
linux-ppc64le::fenics-ffc-2019.1.0-py39hc1b9086_36.conda
linux-ppc64le::fenics-ffc-2019.1.0-py39hc1b9086_37.conda
linux-ppc64le::fenics-ffc-2019.1.0-py39hc1b9086_38.conda
-    "numpy",
+    "numpy <2.0.0a0",
================================================================================
================================================================================
linux-aarch64
linux-aarch64::fenics-ffc-2019.1.0-py310hbbe02a8_30.tar.bz2
linux-aarch64::fenics-ffc-2019.1.0-py310hbbe02a8_31.tar.bz2
linux-aarch64::fenics-ffc-2019.1.0-py310hbbe02a8_32.tar.bz2
linux-aarch64::fenics-ffc-2019.1.0-py310hbbe02a8_33.tar.bz2
linux-aarch64::fenics-ffc-2019.1.0-py310hbbe02a8_34.tar.bz2
linux-aarch64::fenics-ffc-2019.1.0-py310hbbe02a8_36.conda
linux-aarch64::fenics-ffc-2019.1.0-py310hbbe02a8_37.conda
linux-aarch64::fenics-ffc-2019.1.0-py310hbbe02a8_38.conda
linux-aarch64::fenics-ffc-2019.1.0-py311hfecb2dc_33.tar.bz2
linux-aarch64::fenics-ffc-2019.1.0-py311hfecb2dc_34.tar.bz2
linux-aarch64::fenics-ffc-2019.1.0-py311hfecb2dc_36.conda
linux-aarch64::fenics-ffc-2019.1.0-py311hfecb2dc_37.conda
linux-aarch64::fenics-ffc-2019.1.0-py311hfecb2dc_38.conda
linux-aarch64::fenics-ffc-2019.1.0-py37hd9ded2f_30.tar.bz2
linux-aarch64::fenics-ffc-2019.1.0-py37hd9ded2f_31.tar.bz2
linux-aarch64::fenics-ffc-2019.1.0-py37hd9ded2f_32.tar.bz2
linux-aarch64::fenics-ffc-2019.1.0-py38h2063c64_30.tar.bz2
linux-aarch64::fenics-ffc-2019.1.0-py38h2063c64_31.tar.bz2
linux-aarch64::fenics-ffc-2019.1.0-py38h2063c64_32.tar.bz2
linux-aarch64::fenics-ffc-2019.1.0-py38h2063c64_33.tar.bz2
linux-aarch64::fenics-ffc-2019.1.0-py38h2063c64_34.tar.bz2
linux-aarch64::fenics-ffc-2019.1.0-py38h2063c64_36.conda
linux-aarch64::fenics-ffc-2019.1.0-py38h2063c64_37.conda
linux-aarch64::fenics-ffc-2019.1.0-py38h2063c64_38.conda
linux-aarch64::fenics-ffc-2019.1.0-py39ha65689a_30.tar.bz2
linux-aarch64::fenics-ffc-2019.1.0-py39ha65689a_31.tar.bz2
linux-aarch64::fenics-ffc-2019.1.0-py39ha65689a_32.tar.bz2
linux-aarch64::fenics-ffc-2019.1.0-py39ha65689a_33.tar.bz2
linux-aarch64::fenics-ffc-2019.1.0-py39ha65689a_34.tar.bz2
linux-aarch64::fenics-ffc-2019.1.0-py39ha65689a_36.conda
linux-aarch64::fenics-ffc-2019.1.0-py39ha65689a_37.conda
linux-aarch64::fenics-ffc-2019.1.0-py39ha65689a_38.conda
-    "numpy",
+    "numpy <2.0.0a0",
================================================================================
================================================================================
noarch
noarch::fenics-ffc-2019.1.0-py_0.tar.bz2
noarch::fenics-ffc-2019.1.0-py_1.tar.bz2
noarch::fenics-ffc-2019.1.0-py_10.tar.bz2
noarch::fenics-ffc-2019.1.0-py_2.tar.bz2
noarch::fenics-ffc-2019.1.0-py_3.tar.bz2
noarch::fenics-ffc-2019.1.0-py_4.tar.bz2
noarch::fenics-ffc-2019.1.0-py_5.tar.bz2
noarch::fenics-ffc-2019.1.0-py_6.tar.bz2
noarch::fenics-ffc-2019.1.0-py_7.tar.bz2
noarch::fenics-ffc-2019.1.0-py_8.tar.bz2
noarch::fenics-ffc-2019.1.0-py_9.tar.bz2
noarch::fenics-ffc-2019.1.0-pyhd8ed1ab_11.tar.bz2
noarch::fenics-ffc-2019.1.0-pyhd8ed1ab_12.tar.bz2
noarch::fenics-ffc-2019.1.0-pyhd8ed1ab_13.tar.bz2
noarch::fenics-ffc-2019.1.0-pyhd8ed1ab_14.tar.bz2
noarch::fenics-ffc-2019.1.0-pyhd8ed1ab_15.tar.bz2
noarch::fenics-ffc-2019.1.0-pyhd8ed1ab_16.tar.bz2
noarch::fenics-ffc-2019.1.0-pyhd8ed1ab_39.conda
-    "numpy",
+    "numpy <2.0.0a0",
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
osx-64::fenics-ffc-2019.1.0-py310h2ec42d9_26.tar.bz2
osx-64::fenics-ffc-2019.1.0-py310h2ec42d9_27.tar.bz2
osx-64::fenics-ffc-2019.1.0-py310h2ec42d9_28.tar.bz2
osx-64::fenics-ffc-2019.1.0-py310h2ec42d9_29.tar.bz2
osx-64::fenics-ffc-2019.1.0-py310h2ec42d9_30.tar.bz2
osx-64::fenics-ffc-2019.1.0-py310h2ec42d9_31.tar.bz2
osx-64::fenics-ffc-2019.1.0-py310h2ec42d9_32.tar.bz2
osx-64::fenics-ffc-2019.1.0-py310h2ec42d9_33.tar.bz2
osx-64::fenics-ffc-2019.1.0-py310h2ec42d9_34.tar.bz2
osx-64::fenics-ffc-2019.1.0-py310h2ec42d9_35.conda
osx-64::fenics-ffc-2019.1.0-py310h2ec42d9_36.conda
osx-64::fenics-ffc-2019.1.0-py310h2ec42d9_37.conda
osx-64::fenics-ffc-2019.1.0-py310h2ec42d9_38.conda
osx-64::fenics-ffc-2019.1.0-py311h6eed73b_33.tar.bz2
osx-64::fenics-ffc-2019.1.0-py311h6eed73b_34.tar.bz2
osx-64::fenics-ffc-2019.1.0-py311h6eed73b_35.conda
osx-64::fenics-ffc-2019.1.0-py311h6eed73b_36.conda
osx-64::fenics-ffc-2019.1.0-py311h6eed73b_37.conda
osx-64::fenics-ffc-2019.1.0-py311h6eed73b_38.conda
osx-64::fenics-ffc-2019.1.0-py36h79c6626_18.tar.bz2
osx-64::fenics-ffc-2019.1.0-py36h79c6626_19.tar.bz2
osx-64::fenics-ffc-2019.1.0-py36h79c6626_20.tar.bz2
osx-64::fenics-ffc-2019.1.0-py36h79c6626_21.tar.bz2
osx-64::fenics-ffc-2019.1.0-py37hf985489_18.tar.bz2
osx-64::fenics-ffc-2019.1.0-py37hf985489_19.tar.bz2
osx-64::fenics-ffc-2019.1.0-py37hf985489_20.tar.bz2
osx-64::fenics-ffc-2019.1.0-py37hf985489_21.tar.bz2
osx-64::fenics-ffc-2019.1.0-py37hf985489_22.tar.bz2
osx-64::fenics-ffc-2019.1.0-py37hf985489_23.tar.bz2
osx-64::fenics-ffc-2019.1.0-py37hf985489_24.tar.bz2
osx-64::fenics-ffc-2019.1.0-py37hf985489_25.tar.bz2
osx-64::fenics-ffc-2019.1.0-py37hf985489_26.tar.bz2
osx-64::fenics-ffc-2019.1.0-py37hf985489_27.tar.bz2
osx-64::fenics-ffc-2019.1.0-py37hf985489_28.tar.bz2
osx-64::fenics-ffc-2019.1.0-py37hf985489_29.tar.bz2
osx-64::fenics-ffc-2019.1.0-py37hf985489_30.tar.bz2
osx-64::fenics-ffc-2019.1.0-py37hf985489_31.tar.bz2
osx-64::fenics-ffc-2019.1.0-py37hf985489_32.tar.bz2
osx-64::fenics-ffc-2019.1.0-py38h50d1736_18.tar.bz2
osx-64::fenics-ffc-2019.1.0-py38h50d1736_19.tar.bz2
osx-64::fenics-ffc-2019.1.0-py38h50d1736_20.tar.bz2
osx-64::fenics-ffc-2019.1.0-py38h50d1736_21.tar.bz2
osx-64::fenics-ffc-2019.1.0-py38h50d1736_22.tar.bz2
osx-64::fenics-ffc-2019.1.0-py38h50d1736_23.tar.bz2
osx-64::fenics-ffc-2019.1.0-py38h50d1736_24.tar.bz2
osx-64::fenics-ffc-2019.1.0-py38h50d1736_25.tar.bz2
osx-64::fenics-ffc-2019.1.0-py38h50d1736_26.tar.bz2
osx-64::fenics-ffc-2019.1.0-py38h50d1736_27.tar.bz2
osx-64::fenics-ffc-2019.1.0-py38h50d1736_28.tar.bz2
osx-64::fenics-ffc-2019.1.0-py38h50d1736_29.tar.bz2
osx-64::fenics-ffc-2019.1.0-py38h50d1736_30.tar.bz2
osx-64::fenics-ffc-2019.1.0-py38h50d1736_31.tar.bz2
osx-64::fenics-ffc-2019.1.0-py38h50d1736_32.tar.bz2
osx-64::fenics-ffc-2019.1.0-py38h50d1736_33.tar.bz2
osx-64::fenics-ffc-2019.1.0-py38h50d1736_34.tar.bz2
osx-64::fenics-ffc-2019.1.0-py38h50d1736_35.conda
osx-64::fenics-ffc-2019.1.0-py38h50d1736_36.conda
osx-64::fenics-ffc-2019.1.0-py38h50d1736_37.conda
osx-64::fenics-ffc-2019.1.0-py38h50d1736_38.conda
osx-64::fenics-ffc-2019.1.0-py39h6e9494a_18.tar.bz2
osx-64::fenics-ffc-2019.1.0-py39h6e9494a_19.tar.bz2
osx-64::fenics-ffc-2019.1.0-py39h6e9494a_20.tar.bz2
osx-64::fenics-ffc-2019.1.0-py39h6e9494a_21.tar.bz2
osx-64::fenics-ffc-2019.1.0-py39h6e9494a_22.tar.bz2
osx-64::fenics-ffc-2019.1.0-py39h6e9494a_23.tar.bz2
osx-64::fenics-ffc-2019.1.0-py39h6e9494a_24.tar.bz2
osx-64::fenics-ffc-2019.1.0-py39h6e9494a_25.tar.bz2
osx-64::fenics-ffc-2019.1.0-py39h6e9494a_26.tar.bz2
osx-64::fenics-ffc-2019.1.0-py39h6e9494a_27.tar.bz2
osx-64::fenics-ffc-2019.1.0-py39h6e9494a_28.tar.bz2
osx-64::fenics-ffc-2019.1.0-py39h6e9494a_29.tar.bz2
osx-64::fenics-ffc-2019.1.0-py39h6e9494a_30.tar.bz2
osx-64::fenics-ffc-2019.1.0-py39h6e9494a_31.tar.bz2
osx-64::fenics-ffc-2019.1.0-py39h6e9494a_32.tar.bz2
osx-64::fenics-ffc-2019.1.0-py39h6e9494a_33.tar.bz2
osx-64::fenics-ffc-2019.1.0-py39h6e9494a_34.tar.bz2
osx-64::fenics-ffc-2019.1.0-py39h6e9494a_35.conda
osx-64::fenics-ffc-2019.1.0-py39h6e9494a_36.conda
osx-64::fenics-ffc-2019.1.0-py39h6e9494a_37.conda
osx-64::fenics-ffc-2019.1.0-py39h6e9494a_38.conda
-    "numpy",
+    "numpy <2.0.0a0",
================================================================================
================================================================================
linux-64
linux-64::fenics-ffc-2019.1.0-py310hff52083_26.tar.bz2
linux-64::fenics-ffc-2019.1.0-py310hff52083_27.tar.bz2
linux-64::fenics-ffc-2019.1.0-py310hff52083_28.tar.bz2
linux-64::fenics-ffc-2019.1.0-py310hff52083_29.tar.bz2
linux-64::fenics-ffc-2019.1.0-py310hff52083_30.tar.bz2
linux-64::fenics-ffc-2019.1.0-py310hff52083_31.tar.bz2
linux-64::fenics-ffc-2019.1.0-py310hff52083_32.tar.bz2
linux-64::fenics-ffc-2019.1.0-py310hff52083_33.tar.bz2
linux-64::fenics-ffc-2019.1.0-py310hff52083_34.tar.bz2
linux-64::fenics-ffc-2019.1.0-py310hff52083_36.conda
linux-64::fenics-ffc-2019.1.0-py310hff52083_37.conda
linux-64::fenics-ffc-2019.1.0-py310hff52083_38.conda
linux-64::fenics-ffc-2019.1.0-py311h38be061_33.tar.bz2
linux-64::fenics-ffc-2019.1.0-py311h38be061_34.tar.bz2
linux-64::fenics-ffc-2019.1.0-py311h38be061_36.conda
linux-64::fenics-ffc-2019.1.0-py311h38be061_37.conda
linux-64::fenics-ffc-2019.1.0-py311h38be061_38.conda
linux-64::fenics-ffc-2019.1.0-py36h5fab9bb_18.tar.bz2
linux-64::fenics-ffc-2019.1.0-py36h5fab9bb_19.tar.bz2
linux-64::fenics-ffc-2019.1.0-py36h5fab9bb_20.tar.bz2
linux-64::fenics-ffc-2019.1.0-py36h5fab9bb_21.tar.bz2
linux-64::fenics-ffc-2019.1.0-py37h89c1867_18.tar.bz2
linux-64::fenics-ffc-2019.1.0-py37h89c1867_19.tar.bz2
linux-64::fenics-ffc-2019.1.0-py37h89c1867_20.tar.bz2
linux-64::fenics-ffc-2019.1.0-py37h89c1867_21.tar.bz2
linux-64::fenics-ffc-2019.1.0-py37h89c1867_22.tar.bz2
linux-64::fenics-ffc-2019.1.0-py37h89c1867_23.tar.bz2
linux-64::fenics-ffc-2019.1.0-py37h89c1867_24.tar.bz2
linux-64::fenics-ffc-2019.1.0-py37h89c1867_25.tar.bz2
linux-64::fenics-ffc-2019.1.0-py37h89c1867_26.tar.bz2
linux-64::fenics-ffc-2019.1.0-py37h89c1867_27.tar.bz2
linux-64::fenics-ffc-2019.1.0-py37h89c1867_28.tar.bz2
linux-64::fenics-ffc-2019.1.0-py37h89c1867_29.tar.bz2
linux-64::fenics-ffc-2019.1.0-py37h89c1867_30.tar.bz2
linux-64::fenics-ffc-2019.1.0-py37h89c1867_31.tar.bz2
linux-64::fenics-ffc-2019.1.0-py37h89c1867_32.tar.bz2
linux-64::fenics-ffc-2019.1.0-py38h578d9bd_18.tar.bz2
linux-64::fenics-ffc-2019.1.0-py38h578d9bd_19.tar.bz2
linux-64::fenics-ffc-2019.1.0-py38h578d9bd_20.tar.bz2
linux-64::fenics-ffc-2019.1.0-py38h578d9bd_21.tar.bz2
linux-64::fenics-ffc-2019.1.0-py38h578d9bd_22.tar.bz2
linux-64::fenics-ffc-2019.1.0-py38h578d9bd_23.tar.bz2
linux-64::fenics-ffc-2019.1.0-py38h578d9bd_24.tar.bz2
linux-64::fenics-ffc-2019.1.0-py38h578d9bd_25.tar.bz2
linux-64::fenics-ffc-2019.1.0-py38h578d9bd_26.tar.bz2
linux-64::fenics-ffc-2019.1.0-py38h578d9bd_27.tar.bz2
linux-64::fenics-ffc-2019.1.0-py38h578d9bd_28.tar.bz2
linux-64::fenics-ffc-2019.1.0-py38h578d9bd_29.tar.bz2
linux-64::fenics-ffc-2019.1.0-py38h578d9bd_30.tar.bz2
linux-64::fenics-ffc-2019.1.0-py38h578d9bd_31.tar.bz2
linux-64::fenics-ffc-2019.1.0-py38h578d9bd_32.tar.bz2
linux-64::fenics-ffc-2019.1.0-py38h578d9bd_33.tar.bz2
linux-64::fenics-ffc-2019.1.0-py38h578d9bd_34.tar.bz2
linux-64::fenics-ffc-2019.1.0-py38h578d9bd_36.conda
linux-64::fenics-ffc-2019.1.0-py38h578d9bd_37.conda
linux-64::fenics-ffc-2019.1.0-py38h578d9bd_38.conda
linux-64::fenics-ffc-2019.1.0-py39hf3d152e_18.tar.bz2
linux-64::fenics-ffc-2019.1.0-py39hf3d152e_19.tar.bz2
linux-64::fenics-ffc-2019.1.0-py39hf3d152e_20.tar.bz2
linux-64::fenics-ffc-2019.1.0-py39hf3d152e_21.tar.bz2
linux-64::fenics-ffc-2019.1.0-py39hf3d152e_22.tar.bz2
linux-64::fenics-ffc-2019.1.0-py39hf3d152e_23.tar.bz2
linux-64::fenics-ffc-2019.1.0-py39hf3d152e_24.tar.bz2
linux-64::fenics-ffc-2019.1.0-py39hf3d152e_25.tar.bz2
linux-64::fenics-ffc-2019.1.0-py39hf3d152e_26.tar.bz2
linux-64::fenics-ffc-2019.1.0-py39hf3d152e_27.tar.bz2
linux-64::fenics-ffc-2019.1.0-py39hf3d152e_28.tar.bz2
linux-64::fenics-ffc-2019.1.0-py39hf3d152e_29.tar.bz2
linux-64::fenics-ffc-2019.1.0-py39hf3d152e_30.tar.bz2
linux-64::fenics-ffc-2019.1.0-py39hf3d152e_31.tar.bz2
linux-64::fenics-ffc-2019.1.0-py39hf3d152e_32.tar.bz2
linux-64::fenics-ffc-2019.1.0-py39hf3d152e_33.tar.bz2
linux-64::fenics-ffc-2019.1.0-py39hf3d152e_34.tar.bz2
linux-64::fenics-ffc-2019.1.0-py39hf3d152e_36.conda
linux-64::fenics-ffc-2019.1.0-py39hf3d152e_37.conda
linux-64::fenics-ffc-2019.1.0-py39hf3d152e_38.conda
-    "numpy",
+    "numpy <2.0.0a0",
```

</details>
