### PR TITLE
Patch typo in `msal_extensions` 1.2.0 build 1

### DIFF
--- a/recipe/patch_yaml/msal_extensions.yaml
+++ b/recipe/patch_yaml/msal_extensions.yaml
@@ -1,0 +1,9 @@
+# typo in constraints for msal_extensions 1.2.0 build 1
+if:
+  name: msal_extensions
+  version: 1.2.0
+  build_number: 1
+then:
+  - replace_depends:
+      old: msal >=1.2.9,<2.0
+      new: msal >=1.29,<2.0


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
