### PR TITLE
Limit python and xarray version for imod<=0.18.1

### DIFF
--- a/recipe/patch_yaml/imod.yaml
+++ b/recipe/patch_yaml/imod.yaml
@@ -85,7 +85,7 @@ if:
 then:
   - tighten_depends:
       name: python
-      upper_bound: 3.13
+      upper_bound: "3.13"
 ---
 # iMOD Python <= 0.18.1 gives trouble with copying and writing HFBs for
 # xarray < 2024.10.0
@@ -96,4 +96,4 @@ if:
 then:
   - tighten_depends:
       name: xarray
-      upper_bound: 2024.10.0
+      upper_bound: "2024.10.0"

--- a/recipe/patch_yaml/imod.yaml
+++ b/recipe/patch_yaml/imod.yaml
@@ -82,21 +82,18 @@ if:
   name: imod
   timestamp_le: 1733911551000
   version_le: "0.18.1"
-  has_depends: python
 then:
-  - replace_depends:
-      old: python >=3.10
-      new: python >=3.10,<3.13
+  - tighten_depends:
+      name: python
+      upper_bound: 3.13
 ---
-# iMOD Python <= 0.18.1 gives trouble with copyging and writing HFBs for
+# iMOD Python <= 0.18.1 gives trouble with copying and writing HFBs for
 # xarray < 2024.10.0
 if:
   name: imod
   timestamp_le: 1733911551000
   version_le: "0.18.1"
-  has_depends: xarray
 then:
-  - replace_depends:
-      old: xarray >=2023.08.0
-      new: xarray >=2023.08.0,<2024.10.0
----
+  - tighten_depends:
+      name: xarray
+      upper_bound: 2024.10.0

--- a/recipe/patch_yaml/imod.yaml
+++ b/recipe/patch_yaml/imod.yaml
@@ -88,7 +88,7 @@ then:
       old: python >=3.10
       new: python >=3.10,<3.13
 ---
-# iMOD Python <= 0.18.1 gives trouble with copyging and writing HFBs for 
+# iMOD Python <= 0.18.1 gives trouble with copyging and writing HFBs for
 # xarray < 2024.10.0
 if:
   name: imod

--- a/recipe/patch_yaml/imod.yaml
+++ b/recipe/patch_yaml/imod.yaml
@@ -80,7 +80,7 @@ then:
 # iMOD Python <= 0.18.1 doesn't support Python 3.13
 if:
   name: imod
-  timestamp_le: 1733909310000
+  timestamp_le: 1733911551000
   version_le: "0.18.1"
   has_depends: python
 then:
@@ -92,7 +92,7 @@ then:
 # xarray < 2024.10.0
 if:
   name: imod
-  timestamp_le: 1733909310000
+  timestamp_le: 1733911551000
   version_le: "0.18.1"
   has_depends: xarray
 then:

--- a/recipe/patch_yaml/imod.yaml
+++ b/recipe/patch_yaml/imod.yaml
@@ -76,3 +76,27 @@ then:
   - replace_depends:
       old: numpy
       new: numpy <2.0
+---
+# iMOD Python <= 0.18.1 doesn't support Python 3.13
+if:
+  name: imod
+  timestamp_le: 1733909310000
+  version_le: "0.18.1"
+  has_depends: python
+then:
+  - replace_depends:
+      old: python >=3.10
+      new: python >=3.10,<3.13
+---
+# iMOD Python <= 0.18.1 gives trouble with copyging and writing HFBs for 
+# xarray < 2024.10.0
+if:
+  name: imod
+  timestamp_le: 1733909310000
+  version_le: "0.18.1"
+  has_depends: xarray
+then:
+  - replace_depends:
+      old: xarray >=2023.08.0
+      new: xarray >=2023.08.0,<2024.10.0
+---


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

Results show diff:

```
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
noarch
noarch::imod-0.11.2-pyhd8ed1ab_0.tar.bz2
noarch::imod-0.11.3-pyhd8ed1ab_0.tar.bz2
noarch::imod-0.11.4-pyhd8ed1ab_0.tar.bz2
noarch::imod-0.11.5-pyhd8ed1ab_0.conda
noarch::imod-0.11.6-pyhd8ed1ab_0.conda
noarch::imod-0.12.0-pyhd8ed1ab_0.conda
noarch::imod-0.13.0-pyhd8ed1ab_0.conda
noarch::imod-0.13.1-pyhd8ed1ab_0.conda
noarch::imod-0.13.2-pyhd8ed1ab_0.conda
noarch::imod-0.14.0-pyhd8ed1ab_0.conda
noarch::imod-0.14.1-pyhd8ed1ab_0.conda
-    "xarray >=0.15",
+    "xarray >=0.15,<2024.10.0a0",
noarch::imod-0.10.0-py_0.tar.bz2
noarch::imod-0.10.1-py_0.tar.bz2
-    "xarray >=0.15"
+    "xarray >=0.15,<2024.10.0a0"
noarch::imod-0.6.1-py_0.tar.bz2
noarch::imod-0.7.0-py_0.tar.bz2
noarch::imod-0.7.1-py_0.tar.bz2
noarch::imod-0.8.0-py_0.tar.bz2
noarch::imod-0.9.0-py_0.tar.bz2
noarch::imod-0.9.0-py_1.tar.bz2
-    "xarray >=0.11"
+    "xarray >=0.11,<2024.10.0a0"
noarch::imod-0.15.0-pyhd8ed1ab_0.conda
noarch::imod-0.15.1-pyhd8ed1ab_0.conda
-    "python >=3.10",
+    "python >=3.10,<3.13.0a0",
-    "xarray >=0.15",
+    "xarray >=0.15,<2024.10.0a0",
noarch::imod-0.15.2-pyhd8ed1ab_0.conda
noarch::imod-0.15.3-pyhd8ed1ab_0.conda
noarch::imod-0.16.0-pyhd8ed1ab_0.conda
noarch::imod-0.17.0-pyhd8ed1ab_0.conda
noarch::imod-0.17.1-pyhd8ed1ab_0.conda
noarch::imod-0.17.2-pyhd8ed1ab_0.conda
noarch::imod-0.18.0-pyhd8ed1ab_0.conda
noarch::imod-0.18.1-pyhd8ed1ab_0.conda
-    "python >=3.10",
+    "python >=3.10,<3.13.0a0",
-    "xarray >=2023.08.0",
+    "xarray >=2023.08.0,<2024.10.0a0",
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
================================================================================
================================================================================
linux-64
```


