### PR TITLE
FIX: Replace minimum required Python for scikit-hep-testdata v0.5.0.

### DIFF
--- a/recipe/patch_yaml/scikit-hep-testdata.yaml
+++ b/recipe/patch_yaml/scikit-hep-testdata.yaml
@@ -1,0 +1,16 @@
+# https://github.com/conda-forge/scikit-hep-testdata-feedstock has broken
+# metadata for package scikit-hep-testdata-0.5.0-pyhd8ed1ab_0.conda.
+# The package has a 'run' requirement of python >=3.8 but scikit-hep-testdata
+# v0.5.0 dropped 3.8 support and is Python 3.9+. This was fixed in PR
+# https://github.com/conda-forge/scikit-hep-testdata-feedstock/pull/68 on
+# 2024-11-20, so use 1732172400000 (2024-11-21 in human readable metadata)
+# as the cutoff timestamp.
+if:
+  name: scikit-hep-testdata
+  version_in:
+    - 0.5.0
+  timestamp_lt: 1732172400000
+then:
+  - replace_depends:
+      old: python >=3.8
+      new: python >=3.9


### PR DESCRIPTION
* https://github.com/conda-forge/scikit-hep-testdata-feedstock has broken metadata for package `scikit-hep-testdata-0.5.0-pyhd8ed1ab_0.conda`. (https://anaconda.org/conda-forge/scikit-hep-testdata/files?version=0.5.0) The package has a '`run`' requirement of `python >=3.8` but `scikit-hep-testdata` `v0.5.0` dropped `3.8` support and is Python `3.9+`. This was fixed in https://github.com/conda-forge/scikit-hep-testdata-feedstock/pull/68, so use `1732172400000` (`2024-11-21` in human readable metadata) as the cutoff timestamp.

```console
$ python -c "import datetime; print(f'{datetime.datetime(2024,11,21).timestamp():.0f}000')"
1732172400000
```

* Required for https://github.com/conda-forge/uproot-browser-feedstock/pull/13

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [N/A] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
```console
$ micromamba env create --yes --file recipe/dev-env-for-patches.yaml
$ micromamba activate repodata-patches
$ python recipe/show_diff.py
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
noarch
noarch::scikit-hep-testdata-0.5.0-pyhd8ed1ab_0.conda
-    "python >=3.8",
+    "python >=3.9",
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
================================================================================
================================================================================
linux-64
```
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

Used `2024-11-21` (the day after the fix was merged) as cut off date:

```console
$ python -c "import datetime; print(f'{datetime.datetime(2024,11,21).timestamp():.0f}000')" 
1732172400000
```

<!-- Put any other comments or information here -->
