### PR TITLE
Fix version of pip with wrong python constraints

### DIFF
--- a/recipe/patch_yaml/pip.yaml
+++ b/recipe/patch_yaml/pip.yaml
@@ -42,3 +42,15 @@ then:
   - add_depends:
       - setuptools
       - wheel
+---
+# See https://github.com/conda-forge/pip-feedstock/issues/132
+# There is a build of pip that does not have wheel and setuptools
+# dependency, and does not have the correct constraint on the python version
+if:
+  name: pip
+  version_in: ["24.3.1"]
+  build: pyh145f28c_1
+then:
+  - replace_depends:
+      old: python >=3.9
+      new: python >=3.13.0a0


### PR DESCRIPTION
Fix part of https://github.com/conda-forge/pip-feedstock/issues/132 .

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
