### PR TITLE
openmpi conflict with libmpix, libprrte

### DIFF
--- a/recipe/patch_yaml/openmpi-pmix.yaml
+++ b/recipe/patch_yaml/openmpi-pmix.yaml
@@ -1,0 +1,7 @@
+# openmpi prior to
+if:
+  name: openmpi
+  timestamp_lt: 1734349656000
+then:
+  - add_constrains: libpmix ==0.0.0
+  - add_constrains: libprrte ==0.0.0


### PR DESCRIPTION
openmpi bundles these, which are now packaged independently

PR fixing this for future builds of openmpi (unbundling pmix, conflicting with prrte since openmpi has forked prrte): https://github.com/conda-forge/openmpi-feedstock/pull/188

closes https://github.com/conda-forge/openpmix-feedstock/issues/1

closes https://github.com/conda-forge/prrte-feedstock/issues/1

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->


<details>
<summary>diff</summary>

```
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
linux-ppc64le
linux-ppc64le::openmpi-4.0.1-hcbf1d47_1.tar.bz2
linux-ppc64le::openmpi-4.0.1-hcbf1d47_2.tar.bz2
linux-ppc64le::openmpi-4.0.2-hf9f02d8_0.tar.bz2
linux-ppc64le::openmpi-4.0.2-hf9f02d8_1.tar.bz2
linux-ppc64le::openmpi-4.0.2-hf9f02d8_2.tar.bz2
linux-ppc64le::openmpi-4.0.2-hf9f02d8_3.tar.bz2
linux-ppc64le::openmpi-4.0.2-hf9f02d8_4.tar.bz2
linux-ppc64le::openmpi-4.0.3-hf9f02d8_0.tar.bz2
linux-ppc64le::openmpi-4.0.3-hf9f02d8_1.tar.bz2
linux-ppc64le::openmpi-4.0.4-hf9f02d8_0.tar.bz2
linux-ppc64le::openmpi-4.0.5-h2a30cff_3.tar.bz2
linux-ppc64le::openmpi-4.0.5-h2a30cff_4.tar.bz2
linux-ppc64le::openmpi-4.0.5-hc1fbbe7_3.tar.bz2
linux-ppc64le::openmpi-4.0.5-hc1fbbe7_4.tar.bz2
linux-ppc64le::openmpi-4.0.5-hcc3d906_3.tar.bz2
linux-ppc64le::openmpi-4.0.5-hd42b1cc_0.tar.bz2
linux-ppc64le::openmpi-4.0.5-hd42b1cc_1.tar.bz2
linux-ppc64le::openmpi-4.0.5-hd42b1cc_2.tar.bz2
linux-ppc64le::openmpi-4.0.5-hd42b1cc_3.tar.bz2
linux-ppc64le::openmpi-4.1.0-hc1fbbe7_0.tar.bz2
linux-ppc64le::openmpi-4.1.0-hc1fbbe7_1.tar.bz2
linux-ppc64le::openmpi-4.1.0-hc1fbbe7_2.tar.bz2
linux-ppc64le::openmpi-4.1.0-hc1fbbe7_3.tar.bz2
linux-ppc64le::openmpi-4.1.0-hc1fbbe7_4.tar.bz2
linux-ppc64le::openmpi-4.1.0-hc1fbbe7_5.tar.bz2
linux-ppc64le::openmpi-4.1.1-hc1fbbe7_0.tar.bz2
linux-ppc64le::openmpi-4.1.2-hc1fbbe7_0.tar.bz2
linux-ppc64le::openmpi-4.1.3-external_1.tar.bz2
linux-ppc64le::openmpi-4.1.3-external_2.tar.bz2
linux-ppc64le::openmpi-4.1.3-external_3.tar.bz2
linux-ppc64le::openmpi-4.1.3-h6dec02d_0.tar.bz2
linux-ppc64le::openmpi-4.1.3-ha6b021e_105.tar.bz2
linux-ppc64le::openmpi-4.1.3-hb1f5ef7_102.tar.bz2
linux-ppc64le::openmpi-4.1.3-hb1f5ef7_103.tar.bz2
linux-ppc64le::openmpi-4.1.3-hb1f5ef7_104.tar.bz2
linux-ppc64le::openmpi-4.1.3-he12334d_101.tar.bz2
linux-ppc64le::openmpi-4.1.4-external_2.conda
linux-ppc64le::openmpi-4.1.4-ha6b021e_100.tar.bz2
linux-ppc64le::openmpi-4.1.4-ha6b021e_101.tar.bz2
linux-ppc64le::openmpi-4.1.5-external_0.conda
linux-ppc64le::openmpi-4.1.5-external_1.conda
linux-ppc64le::openmpi-4.1.6-external_0.conda
linux-ppc64le::openmpi-4.1.6-external_1.conda
+  "constrains": [
+    "libpmix ==0.0.0",
+    "libprrte ==0.0.0"
+  ],
linux-ppc64le::openmpi-4.1.4-h317bbcb_102.conda
linux-ppc64le::openmpi-4.1.5-h2821484_100.conda
linux-ppc64le::openmpi-4.1.5-hfa2ad77_101.conda
linux-ppc64le::openmpi-4.1.6-h7f051ca_101.conda
linux-ppc64le::openmpi-4.1.6-hd9f040f_100.conda
linux-ppc64le::openmpi-5.0.0-h7b0d4e8_100.conda
linux-ppc64le::openmpi-5.0.0-h7b0d4e8_101.conda
linux-ppc64le::openmpi-5.0.0-h7b0d4e8_102.conda
linux-ppc64le::openmpi-5.0.1-h45ed331_102.conda
linux-ppc64le::openmpi-5.0.1-h45ed331_103.conda
linux-ppc64le::openmpi-5.0.1-h7b0d4e8_100.conda
linux-ppc64le::openmpi-5.0.1-hc2f713b_101.conda
linux-ppc64le::openmpi-5.0.2-h3390e8d_102.conda
linux-ppc64le::openmpi-5.0.2-h45ed331_100.conda
linux-ppc64le::openmpi-5.0.2-h45ed331_101.conda
linux-ppc64le::openmpi-5.0.3-external_h2bdf6cd_8.conda
linux-ppc64le::openmpi-5.0.3-external_h5dcd2b8_10.conda
linux-ppc64le::openmpi-5.0.3-external_h5dcd2b8_9.conda
linux-ppc64le::openmpi-5.0.3-external_h9c15330_7.conda
linux-ppc64le::openmpi-5.0.3-external_hfb91e3d_3.conda
linux-ppc64le::openmpi-5.0.3-external_hfb91e3d_4.conda
linux-ppc64le::openmpi-5.0.3-external_hfb91e3d_5.conda
linux-ppc64le::openmpi-5.0.3-external_hfb91e3d_6.conda
linux-ppc64le::openmpi-5.0.3-h2fa3e9f_109.conda
linux-ppc64le::openmpi-5.0.3-h2fa3e9f_110.conda
linux-ppc64le::openmpi-5.0.3-h3390e8d_100.conda
linux-ppc64le::openmpi-5.0.3-h6d7889c_107.conda
linux-ppc64le::openmpi-5.0.3-h6ea4b54_108.conda
linux-ppc64le::openmpi-5.0.3-h9b5b211_103.conda
linux-ppc64le::openmpi-5.0.3-h9b5b211_104.conda
linux-ppc64le::openmpi-5.0.3-h9b5b211_105.conda
linux-ppc64le::openmpi-5.0.3-h9b5b211_106.conda
linux-ppc64le::openmpi-5.0.3-hc00db8d_102.conda
linux-ppc64le::openmpi-5.0.3-hc7cc000_101.conda
linux-ppc64le::openmpi-5.0.4-external_h5dcd2b8_0.conda
linux-ppc64le::openmpi-5.0.4-h2fa3e9f_100.conda
linux-ppc64le::openmpi-5.0.5-external_h5dcd2b8_0.conda
linux-ppc64le::openmpi-5.0.5-h2fa3e9f_100.conda
+    "libpmix ==0.0.0",
+    "libprrte ==0.0.0",
linux-ppc64le::openmpi-5.0.5-external_h4bd3674_4.conda
linux-ppc64le::openmpi-5.0.5-external_h4bd3674_5.conda
linux-ppc64le::openmpi-5.0.5-external_h5dcd2b8_1.conda
linux-ppc64le::openmpi-5.0.5-external_hf0c5f57_2.conda
linux-ppc64le::openmpi-5.0.5-external_hf0c5f57_3.conda
linux-ppc64le::openmpi-5.0.5-h1c6bb0c_102.conda
linux-ppc64le::openmpi-5.0.5-h1c6bb0c_103.conda
linux-ppc64le::openmpi-5.0.5-h2fa3e9f_101.conda
linux-ppc64le::openmpi-5.0.5-h6faa2b5_104.conda
linux-ppc64le::openmpi-5.0.5-h6faa2b5_105.conda
linux-ppc64le::openmpi-5.0.6-external_h4bd3674_0.conda
linux-ppc64le::openmpi-5.0.6-h6faa2b5_100.conda
-    "cuda-version  >= 11.0"
+    "cuda-version  >= 11.0",
+    "libpmix ==0.0.0",
+    "libprrte ==0.0.0"
================================================================================
================================================================================
osx-arm64
osx-arm64::openmpi-4.0.5-h385ff2b_3.tar.bz2
osx-arm64::openmpi-4.0.5-h385ff2b_4.tar.bz2
osx-arm64::openmpi-4.1.0-h385ff2b_0.tar.bz2
osx-arm64::openmpi-4.1.0-h385ff2b_1.tar.bz2
osx-arm64::openmpi-4.1.0-h385ff2b_2.tar.bz2
osx-arm64::openmpi-4.1.0-h385ff2b_3.tar.bz2
osx-arm64::openmpi-4.1.0-h385ff2b_4.tar.bz2
osx-arm64::openmpi-4.1.0-h3abb732_5.tar.bz2
osx-arm64::openmpi-4.1.1-h3abb732_0.tar.bz2
osx-arm64::openmpi-4.1.2-h3abb732_0.tar.bz2
osx-arm64::openmpi-4.1.3-external_1.tar.bz2
osx-arm64::openmpi-4.1.3-external_2.tar.bz2
osx-arm64::openmpi-4.1.3-external_3.tar.bz2
osx-arm64::openmpi-4.1.3-h23c1900_101.tar.bz2
osx-arm64::openmpi-4.1.3-h63a3ee9_105.tar.bz2
osx-arm64::openmpi-4.1.3-h8490d8b_0.tar.bz2
osx-arm64::openmpi-4.1.3-hd4b5bf3_102.tar.bz2
osx-arm64::openmpi-4.1.3-hd4b5bf3_103.tar.bz2
osx-arm64::openmpi-4.1.3-hd4b5bf3_104.tar.bz2
osx-arm64::openmpi-4.1.4-h4e676fc_101.tar.bz2
osx-arm64::openmpi-4.1.4-h4e676fc_102.conda
osx-arm64::openmpi-4.1.4-h63a3ee9_100.tar.bz2
osx-arm64::openmpi-4.1.5-h4e676fc_100.conda
osx-arm64::openmpi-4.1.5-h4e676fc_101.conda
osx-arm64::openmpi-4.1.6-h4971d84_100.conda
osx-arm64::openmpi-4.1.6-h526c993_101.conda
osx-arm64::openmpi-5.0.0-h2dea082_100.conda
osx-arm64::openmpi-5.0.0-h2dea082_101.conda
osx-arm64::openmpi-5.0.0-h2dea082_102.conda
osx-arm64::openmpi-5.0.1-h1b401ff_102.conda
osx-arm64::openmpi-5.0.1-h1b401ff_103.conda
osx-arm64::openmpi-5.0.1-h2dea082_100.conda
osx-arm64::openmpi-5.0.1-h58cf721_101.conda
osx-arm64::openmpi-5.0.2-h1b401ff_100.conda
osx-arm64::openmpi-5.0.2-h1b401ff_101.conda
osx-arm64::openmpi-5.0.2-hbd96bf3_102.conda
osx-arm64::openmpi-5.0.3-h324cb95_103.conda
osx-arm64::openmpi-5.0.3-h324cb95_104.conda
osx-arm64::openmpi-5.0.3-h324cb95_105.conda
osx-arm64::openmpi-5.0.3-h324cb95_106.conda
osx-arm64::openmpi-5.0.3-h439865c_102.conda
osx-arm64::openmpi-5.0.3-h4dd7bb5_101.conda
osx-arm64::openmpi-5.0.3-hba4779a_109.conda
osx-arm64::openmpi-5.0.3-hba4779a_110.conda
osx-arm64::openmpi-5.0.3-hbd96bf3_100.conda
osx-arm64::openmpi-5.0.3-he01d045_107.conda
osx-arm64::openmpi-5.0.3-hfb32c3b_108.conda
osx-arm64::openmpi-5.0.4-hba4779a_100.conda
osx-arm64::openmpi-5.0.5-h5750160_102.conda
osx-arm64::openmpi-5.0.5-h5750160_103.conda
osx-arm64::openmpi-5.0.5-hba4779a_100.conda
osx-arm64::openmpi-5.0.5-hd39a424_104.conda
osx-arm64::openmpi-5.0.5-hd39a424_105.conda
osx-arm64::openmpi-5.0.5-hde90a11_100.conda
osx-arm64::openmpi-5.0.5-hde90a11_101.conda
osx-arm64::openmpi-5.0.6-hd39a424_100.conda
+  "constrains": [
+    "libpmix ==0.0.0",
+    "libprrte ==0.0.0"
+  ],
================================================================================
================================================================================
linux-aarch64
linux-aarch64::openmpi-4.0.1-hc99cbb1_1.tar.bz2
linux-aarch64::openmpi-4.0.1-hc99cbb1_2.tar.bz2
linux-aarch64::openmpi-4.0.2-hd49bf07_0.tar.bz2
linux-aarch64::openmpi-4.0.2-hd49bf07_1.tar.bz2
linux-aarch64::openmpi-4.0.2-hd49bf07_2.tar.bz2
linux-aarch64::openmpi-4.0.2-hd49bf07_3.tar.bz2
linux-aarch64::openmpi-4.0.3-hd49bf07_0.tar.bz2
linux-aarch64::openmpi-4.0.3-hd49bf07_1.tar.bz2
linux-aarch64::openmpi-4.0.4-hd49bf07_0.tar.bz2
linux-aarch64::openmpi-4.0.5-h0e8a5b7_3.tar.bz2
linux-aarch64::openmpi-4.0.5-h0e8a5b7_4.tar.bz2
linux-aarch64::openmpi-4.0.5-hcc3d906_3.tar.bz2
linux-aarch64::openmpi-4.0.5-hd1a70f5_0.tar.bz2
linux-aarch64::openmpi-4.0.5-hd1a70f5_3.tar.bz2
linux-aarch64::openmpi-4.0.5-hef8c4d9_3.tar.bz2
linux-aarch64::openmpi-4.0.5-hef8c4d9_4.tar.bz2
linux-aarch64::openmpi-4.0.5-hf656395_1.tar.bz2
linux-aarch64::openmpi-4.0.5-hf656395_2.tar.bz2
linux-aarch64::openmpi-4.1.0-h0e8a5b7_0.tar.bz2
linux-aarch64::openmpi-4.1.0-h0e8a5b7_1.tar.bz2
linux-aarch64::openmpi-4.1.0-h0e8a5b7_2.tar.bz2
linux-aarch64::openmpi-4.1.0-h0e8a5b7_3.tar.bz2
linux-aarch64::openmpi-4.1.0-h0e8a5b7_4.tar.bz2
linux-aarch64::openmpi-4.1.0-h0e8a5b7_5.tar.bz2
linux-aarch64::openmpi-4.1.1-h0e8a5b7_0.tar.bz2
linux-aarch64::openmpi-4.1.2-h0e8a5b7_0.tar.bz2
linux-aarch64::openmpi-4.1.3-external_1.tar.bz2
linux-aarch64::openmpi-4.1.3-external_2.tar.bz2
linux-aarch64::openmpi-4.1.3-external_3.tar.bz2
linux-aarch64::openmpi-4.1.3-h26b3c96_102.tar.bz2
linux-aarch64::openmpi-4.1.3-h26b3c96_103.tar.bz2
linux-aarch64::openmpi-4.1.3-h26b3c96_104.tar.bz2
linux-aarch64::openmpi-4.1.3-h34d0eb5_105.tar.bz2
linux-aarch64::openmpi-4.1.3-h7728b8d_0.tar.bz2
linux-aarch64::openmpi-4.1.3-hfeb99b9_101.tar.bz2
linux-aarch64::openmpi-4.1.4-external_2.conda
linux-aarch64::openmpi-4.1.4-h34d0eb5_100.tar.bz2
linux-aarch64::openmpi-4.1.4-h34d0eb5_101.tar.bz2
linux-aarch64::openmpi-4.1.5-external_0.conda
linux-aarch64::openmpi-4.1.5-external_1.conda
linux-aarch64::openmpi-4.1.6-external_0.conda
linux-aarch64::openmpi-4.1.6-external_1.conda
+  "constrains": [
+    "libpmix ==0.0.0",
+    "libprrte ==0.0.0"
+  ],
linux-aarch64::openmpi-5.0.5-external_h39db2fe_4.conda
linux-aarch64::openmpi-5.0.5-external_h39db2fe_5.conda
linux-aarch64::openmpi-5.0.5-hf2a86e7_104.conda
linux-aarch64::openmpi-5.0.5-hf2a86e7_105.conda
linux-aarch64::openmpi-5.0.6-external_h39db2fe_0.conda
linux-aarch64::openmpi-5.0.6-hf2a86e7_100.conda
-    "cuda-version  >= 11.0"
+    "cuda-version  >= 11.0",
+    "libpmix ==0.0.0",
+    "libprrte ==0.0.0"
linux-aarch64::openmpi-4.1.4-hcfdb870_102.conda
linux-aarch64::openmpi-4.1.5-h35c388c_100.conda
linux-aarch64::openmpi-4.1.5-hd86f6cd_101.conda
linux-aarch64::openmpi-4.1.6-h06852b5_100.conda
linux-aarch64::openmpi-4.1.6-h1f4154d_101.conda
linux-aarch64::openmpi-5.0.0-hf462296_100.conda
linux-aarch64::openmpi-5.0.0-hf462296_101.conda
linux-aarch64::openmpi-5.0.0-hf462296_102.conda
linux-aarch64::openmpi-5.0.1-h9ca730b_102.conda
linux-aarch64::openmpi-5.0.1-h9ca730b_103.conda
linux-aarch64::openmpi-5.0.1-hf462296_100.conda
linux-aarch64::openmpi-5.0.1-hfb79068_101.conda
linux-aarch64::openmpi-5.0.2-h9c6a67e_102.conda
linux-aarch64::openmpi-5.0.2-h9ca730b_100.conda
linux-aarch64::openmpi-5.0.2-h9ca730b_101.conda
linux-aarch64::openmpi-5.0.3-external_h44a1b07_3.conda
linux-aarch64::openmpi-5.0.3-external_h44a1b07_4.conda
linux-aarch64::openmpi-5.0.3-external_h44a1b07_5.conda
linux-aarch64::openmpi-5.0.3-external_h44a1b07_6.conda
linux-aarch64::openmpi-5.0.3-external_hb8f007b_10.conda
linux-aarch64::openmpi-5.0.3-external_hb8f007b_9.conda
linux-aarch64::openmpi-5.0.3-external_hd5573d5_8.conda
linux-aarch64::openmpi-5.0.3-external_he4e0efa_7.conda
linux-aarch64::openmpi-5.0.3-h33611b1_107.conda
linux-aarch64::openmpi-5.0.3-h509015f_102.conda
linux-aarch64::openmpi-5.0.3-h8c191f3_108.conda
linux-aarch64::openmpi-5.0.3-h950cf0a_101.conda
linux-aarch64::openmpi-5.0.3-h9c6a67e_100.conda
linux-aarch64::openmpi-5.0.3-hb9aeabb_103.conda
linux-aarch64::openmpi-5.0.3-hb9aeabb_104.conda
linux-aarch64::openmpi-5.0.3-hb9aeabb_105.conda
linux-aarch64::openmpi-5.0.3-hb9aeabb_106.conda
linux-aarch64::openmpi-5.0.3-hd954dfa_109.conda
linux-aarch64::openmpi-5.0.3-hd954dfa_110.conda
linux-aarch64::openmpi-5.0.4-external_hb8f007b_0.conda
linux-aarch64::openmpi-5.0.4-hd954dfa_100.conda
linux-aarch64::openmpi-5.0.5-external_hb8f007b_0.conda
linux-aarch64::openmpi-5.0.5-external_hb8f007b_1.conda
linux-aarch64::openmpi-5.0.5-external_hee542dc_2.conda
linux-aarch64::openmpi-5.0.5-external_hee542dc_3.conda
linux-aarch64::openmpi-5.0.5-hd954dfa_100.conda
linux-aarch64::openmpi-5.0.5-hd954dfa_101.conda
linux-aarch64::openmpi-5.0.5-hef64f28_102.conda
linux-aarch64::openmpi-5.0.5-hef64f28_103.conda
+    "libpmix ==0.0.0",
+    "libprrte ==0.0.0",
================================================================================
================================================================================
noarch
noarch::openmpi-4.1.3-h8b79891_4.tar.bz2
+  "constrains": [
+    "libpmix ==0.0.0",
+    "libprrte ==0.0.0"
+  ],
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
osx-64::openmpi-3.1.0-h26a2512_3.tar.bz2
osx-64::openmpi-3.1.2-h12d9a10_1000.tar.bz2
osx-64::openmpi-3.1.2-h12d9a10_1001.tar.bz2
osx-64::openmpi-3.1.2-h12d9a10_1002.tar.bz2
osx-64::openmpi-3.1.2-h26a2512_0.tar.bz2
osx-64::openmpi-3.1.2-h26a2512_1.tar.bz2
osx-64::openmpi-3.1.2-h26a2512_2.tar.bz2
osx-64::openmpi-3.1.3-h12d9a10_1000.tar.bz2
osx-64::openmpi-3.1.3-h26a2512_0.tar.bz2
osx-64::openmpi-3.1.3-h71abe9c_1001.tar.bz2
osx-64::openmpi-3.1.4-ha90c164_0.tar.bz2
osx-64::openmpi-4.0.2-hed52333_0.tar.bz2
osx-64::openmpi-4.0.2-hed52333_1.tar.bz2
osx-64::openmpi-4.0.2-hed52333_2.tar.bz2
osx-64::openmpi-4.0.2-hed52333_3.tar.bz2
osx-64::openmpi-4.0.2-hed52333_4.tar.bz2
osx-64::openmpi-4.0.3-hed52333_1.tar.bz2
osx-64::openmpi-4.0.4-hed52333_0.tar.bz2
osx-64::openmpi-4.0.5-h57552c6_3.tar.bz2
osx-64::openmpi-4.0.5-h5807002_4.tar.bz2
osx-64::openmpi-4.0.5-h609164f_1.tar.bz2
osx-64::openmpi-4.0.5-h609164f_2.tar.bz2
osx-64::openmpi-4.0.5-h809c96e_4.tar.bz2
osx-64::openmpi-4.0.5-h8709ff6_3.tar.bz2
osx-64::openmpi-4.0.5-hd7132dd_4.tar.bz2
osx-64::openmpi-4.0.5-hde3a368_3.tar.bz2
osx-64::openmpi-4.0.5-hdff9a4c_4.tar.bz2
osx-64::openmpi-4.0.5-hebb22fb_0.tar.bz2
osx-64::openmpi-4.0.5-hebb22fb_3.tar.bz2
osx-64::openmpi-4.1.0-h5807002_0.tar.bz2
osx-64::openmpi-4.1.0-h5807002_1.tar.bz2
osx-64::openmpi-4.1.0-h67a2264_1.tar.bz2
osx-64::openmpi-4.1.0-hd3cd54c_2.tar.bz2
osx-64::openmpi-4.1.0-hd3cd54c_3.tar.bz2
osx-64::openmpi-4.1.0-hd3cd54c_4.tar.bz2
osx-64::openmpi-4.1.0-hd3cd54c_5.tar.bz2
osx-64::openmpi-4.1.1-hd3cd54c_0.tar.bz2
osx-64::openmpi-4.1.2-hd3cd54c_0.tar.bz2
osx-64::openmpi-4.1.3-external_1.tar.bz2
osx-64::openmpi-4.1.3-external_2.tar.bz2
osx-64::openmpi-4.1.3-external_3.tar.bz2
osx-64::openmpi-4.1.3-h4ff0e22_0.tar.bz2
osx-64::openmpi-4.1.3-h8589876_105.tar.bz2
osx-64::openmpi-4.1.3-hc1c689a_101.tar.bz2
osx-64::openmpi-4.1.3-hd33e60e_102.tar.bz2
osx-64::openmpi-4.1.3-hd33e60e_103.tar.bz2
osx-64::openmpi-4.1.3-hd33e60e_104.tar.bz2
osx-64::openmpi-4.1.4-h4fe9131_101.tar.bz2
osx-64::openmpi-4.1.4-h4fe9131_102.conda
osx-64::openmpi-4.1.4-h8589876_100.tar.bz2
osx-64::openmpi-4.1.5-h4fe9131_100.conda
osx-64::openmpi-4.1.5-h4fe9131_101.conda
osx-64::openmpi-4.1.6-h2961c6d_100.conda
osx-64::openmpi-4.1.6-h7406208_101.conda
osx-64::openmpi-5.0.0-h01516ab_100.conda
osx-64::openmpi-5.0.0-h01516ab_101.conda
osx-64::openmpi-5.0.0-h01516ab_102.conda
osx-64::openmpi-5.0.1-h01516ab_100.conda
osx-64::openmpi-5.0.1-h794f02a_102.conda
osx-64::openmpi-5.0.1-h794f02a_103.conda
osx-64::openmpi-5.0.1-hf8846d2_101.conda
osx-64::openmpi-5.0.2-h794f02a_100.conda
osx-64::openmpi-5.0.2-h794f02a_101.conda
osx-64::openmpi-5.0.2-h7cf3660_102.conda
osx-64::openmpi-5.0.3-h2dcfb57_102.conda
osx-64::openmpi-5.0.3-h5bb6cfe_108.conda
osx-64::openmpi-5.0.3-h62bb914_109.conda
osx-64::openmpi-5.0.3-h62bb914_110.conda
osx-64::openmpi-5.0.3-h7cf3660_100.conda
osx-64::openmpi-5.0.3-hba0472f_103.conda
osx-64::openmpi-5.0.3-hba0472f_104.conda
osx-64::openmpi-5.0.3-hba0472f_105.conda
osx-64::openmpi-5.0.3-hba0472f_106.conda
osx-64::openmpi-5.0.3-hcb021dc_107.conda
osx-64::openmpi-5.0.4-h62bb914_100.conda
osx-64::openmpi-5.0.5-h3dc8ad4_100.conda
osx-64::openmpi-5.0.5-h3dc8ad4_101.conda
osx-64::openmpi-5.0.5-h4a6bc07_102.conda
osx-64::openmpi-5.0.5-h4a6bc07_103.conda
osx-64::openmpi-5.0.5-h62bb914_100.conda
osx-64::openmpi-5.0.5-h9f30aec_104.conda
osx-64::openmpi-5.0.5-h9f30aec_105.conda
osx-64::openmpi-5.0.6-h9f30aec_100.conda
+  "constrains": [
+    "libpmix ==0.0.0",
+    "libprrte ==0.0.0"
+  ],
osx-64::openmpi-4.0.1-ha90c164_0.tar.bz2
osx-64::openmpi-4.0.1-ha90c164_1.tar.bz2
osx-64::openmpi-4.0.1-ha90c164_2.tar.bz2
osx-64::openmpi-4.0.1-hfcebdee_2.tar.bz2
-    "__osx >=10.12"
+    "__osx >=10.12",
+    "libpmix ==0.0.0",
+    "libprrte ==0.0.0"
================================================================================
================================================================================
linux-64
linux-64::openmpi-4.1.0-hbfc84c5_5.tar.bz2
linux-64::openmpi-4.1.1-hbfc84c5_0.tar.bz2
linux-64::openmpi-4.1.2-hbfc84c5_0.tar.bz2
linux-64::openmpi-4.1.3-h414127c_0.tar.bz2
linux-64::openmpi-4.1.3-h846660c_102.tar.bz2
linux-64::openmpi-4.1.3-h846660c_103.tar.bz2
linux-64::openmpi-4.1.3-h846660c_104.tar.bz2
linux-64::openmpi-4.1.3-ha1ae619_105.tar.bz2
linux-64::openmpi-4.1.3-hbea3300_101.tar.bz2
linux-64::openmpi-4.1.4-ha1ae619_100.tar.bz2
linux-64::openmpi-4.1.4-ha1ae619_101.tar.bz2
linux-64::openmpi-4.1.4-ha1ae619_102.conda
linux-64::openmpi-4.1.5-h414af15_101.conda
linux-64::openmpi-4.1.5-h9a2ec32_100.conda
linux-64::openmpi-4.1.6-h336e698_100.conda
linux-64::openmpi-4.1.6-hc5af2df_101.conda
linux-64::openmpi-5.0.0-hb0ee255_100.conda
linux-64::openmpi-5.0.0-hb0ee255_101.conda
linux-64::openmpi-5.0.0-hb0ee255_102.conda
linux-64::openmpi-5.0.1-h4970cb7_101.conda
linux-64::openmpi-5.0.1-h5b47a53_103.conda
linux-64::openmpi-5.0.1-hb0ee255_100.conda
linux-64::openmpi-5.0.2-h5b47a53_100.conda
linux-64::openmpi-5.0.2-h5b47a53_101.conda
linux-64::openmpi-5.0.2-h7fc1de5_102.conda
linux-64::openmpi-5.0.3-external_h4e476d2_7.conda
linux-64::openmpi-5.0.3-external_h71a06d8_10.conda
linux-64::openmpi-5.0.3-external_h71a06d8_9.conda
linux-64::openmpi-5.0.3-external_h95fb2f6_8.conda
linux-64::openmpi-5.0.3-external_hfb3d4eb_3.conda
linux-64::openmpi-5.0.3-external_hfb3d4eb_4.conda
linux-64::openmpi-5.0.3-external_hfb3d4eb_5.conda
linux-64::openmpi-5.0.3-external_hfb3d4eb_6.conda
linux-64::openmpi-5.0.3-h3d533c0_108.conda
linux-64::openmpi-5.0.3-h3f251e2_107.conda
linux-64::openmpi-5.0.3-h47314c5_102.conda
linux-64::openmpi-5.0.3-h7fc1de5_100.conda
linux-64::openmpi-5.0.3-h817cd4e_101.conda
linux-64::openmpi-5.0.3-h9a79eee_109.conda
linux-64::openmpi-5.0.3-h9a79eee_110.conda
linux-64::openmpi-5.0.3-hfd7b305_103.conda
linux-64::openmpi-5.0.3-hfd7b305_104.conda
linux-64::openmpi-5.0.3-hfd7b305_105.conda
linux-64::openmpi-5.0.3-hfd7b305_106.conda
linux-64::openmpi-5.0.4-external_h71a06d8_0.conda
linux-64::openmpi-5.0.4-h9a79eee_100.conda
linux-64::openmpi-5.0.5-external_h6b209bc_2.conda
linux-64::openmpi-5.0.5-external_h6b209bc_3.conda
linux-64::openmpi-5.0.5-external_h71a06d8_0.conda
linux-64::openmpi-5.0.5-external_h71a06d8_1.conda
linux-64::openmpi-5.0.5-h6ae21d5_102.conda
linux-64::openmpi-5.0.5-h6ae21d5_103.conda
linux-64::openmpi-5.0.5-h9a79eee_100.conda
linux-64::openmpi-5.0.5-h9a79eee_101.conda
+    "libpmix ==0.0.0",
+    "libprrte ==0.0.0",
linux-64::openmpi-3.1.0-h26a2512_2.tar.bz2
linux-64::openmpi-3.1.0-h26a2512_3.tar.bz2
linux-64::openmpi-3.1.2-h1c2f66e_1000.tar.bz2
linux-64::openmpi-3.1.2-h1c2f66e_1001.tar.bz2
linux-64::openmpi-3.1.2-h1c2f66e_1002.tar.bz2
linux-64::openmpi-3.1.2-h26a2512_0.tar.bz2
linux-64::openmpi-3.1.2-h26a2512_1.tar.bz2
linux-64::openmpi-3.1.2-h26a2512_2.tar.bz2
linux-64::openmpi-3.1.3-h1c2f66e_1000.tar.bz2
linux-64::openmpi-3.1.3-h1c2f66e_1001.tar.bz2
linux-64::openmpi-3.1.4-hc99cbb1_0.tar.bz2
linux-64::openmpi-4.0.1-hc99cbb1_0.tar.bz2
linux-64::openmpi-4.0.1-hc99cbb1_1.tar.bz2
linux-64::openmpi-4.0.1-hc99cbb1_2.tar.bz2
linux-64::openmpi-4.0.2-hd49bf07_0.tar.bz2
linux-64::openmpi-4.0.2-hd49bf07_1.tar.bz2
linux-64::openmpi-4.0.2-hd49bf07_2.tar.bz2
linux-64::openmpi-4.1.3-external_1.tar.bz2
linux-64::openmpi-4.1.3-external_2.tar.bz2
linux-64::openmpi-4.1.3-external_3.tar.bz2
linux-64::openmpi-4.1.3-external_5.tar.bz2
linux-64::openmpi-4.1.4-external_0.tar.bz2
linux-64::openmpi-4.1.4-external_1.tar.bz2
linux-64::openmpi-4.1.4-external_2.conda
linux-64::openmpi-4.1.5-external_0.conda
linux-64::openmpi-4.1.5-external_1.conda
linux-64::openmpi-4.1.6-external_0.conda
linux-64::openmpi-4.1.6-external_1.conda
+  "constrains": [
+    "libpmix ==0.0.0",
+    "libprrte ==0.0.0"
+  ],
linux-64::openmpi-4.0.2-hdf1f1ad_4.tar.bz2
linux-64::openmpi-4.0.3-hdf1f1ad_0.tar.bz2
linux-64::openmpi-4.0.3-hdf1f1ad_1.tar.bz2
linux-64::openmpi-4.0.4-hdf1f1ad_0.tar.bz2
linux-64::openmpi-4.0.5-h2c4babf_3.tar.bz2
linux-64::openmpi-4.0.5-h9b22176_3.tar.bz2
linux-64::openmpi-4.0.5-h9b22176_4.tar.bz2
linux-64::openmpi-4.0.5-ha4a8674_3.tar.bz2
linux-64::openmpi-4.0.5-ha4a8674_4.tar.bz2
linux-64::openmpi-4.0.5-hdf1f1ad_0.tar.bz2
linux-64::openmpi-4.0.5-hdf1f1ad_1.tar.bz2
linux-64::openmpi-4.0.5-hdf1f1ad_2.tar.bz2
linux-64::openmpi-4.0.5-hdf1f1ad_3.tar.bz2
linux-64::openmpi-4.1.0-h9b22176_0.tar.bz2
linux-64::openmpi-4.1.0-h9b22176_1.tar.bz2
linux-64::openmpi-4.1.0-hbfc84c5_2.tar.bz2
linux-64::openmpi-4.1.0-hbfc84c5_3.tar.bz2
linux-64::openmpi-4.1.0-hbfc84c5_4.tar.bz2
-    "cudatoolkit >=9.2"
+    "cudatoolkit >=9.2",
+    "libpmix ==0.0.0",
+    "libprrte ==0.0.0"
linux-64::openmpi-5.0.5-external_h8b98117_4.conda
linux-64::openmpi-5.0.5-external_h8b98117_5.conda
linux-64::openmpi-5.0.5-hd45feaf_105.conda
linux-64::openmpi-5.0.6-external_h8b98117_0.conda
linux-64::openmpi-5.0.6-hd45feaf_100.conda
-    "cuda-version  >= 11.0"
+    "cuda-version  >= 11.0",
+    "libpmix ==0.0.0",
+    "libprrte ==0.0.0"
```

</details>