### PR TITLE
old libfabric builds conflict with new libfabric1

### DIFF
--- a/recipe/patch_yaml/libabric1.yaml
+++ b/recipe/patch_yaml/libabric1.yaml
@@ -1,0 +1,5 @@
+if:
+  name: libfabric
+  timestamp_lt: 1734374000000
+then:
+  - add_constrains: libfabric1 ==0.0.0


### PR DESCRIPTION
libfabric is now an empty metapackage, but the old packages are still allowed to be installed with the new libfabric1 because libfabric1 does not have run_constrains on libfabric


* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<details>
<summary>diff</summary>

```
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
osx-arm64::libfabric-1.22.0-h5505292_0.conda
osx-arm64::libfabric-1.22.0-h5505292_1.conda
osx-arm64::libfabric-1.22.0-h5505292_2.conda
+  "constrains": [
+    "libfabric1 ==0.0.0"
+  ],
================================================================================
================================================================================
linux-ppc64le
linux-ppc64le::libfabric-1.15.2-h289c837_2.conda
linux-ppc64le::libfabric-1.17.0-h289c837_0.conda
linux-ppc64le::libfabric-1.19.1-h289c837_0.conda
linux-ppc64le::libfabric-1.19.1-h289c837_1.conda
linux-ppc64le::libfabric-1.22.0-h289c837_0.conda
linux-ppc64le::libfabric-1.22.0-h289c837_1.conda
linux-ppc64le::libfabric-1.22.0-h289c837_2.conda
+  "constrains": [
+    "libfabric1 ==0.0.0"
+  ],
================================================================================
================================================================================
linux-aarch64
linux-aarch64::libfabric-1.15.2-h4110fac_2.conda
linux-aarch64::libfabric-1.17.0-h4110fac_0.conda
linux-aarch64::libfabric-1.19.1-h4110fac_0.conda
linux-aarch64::libfabric-1.19.1-h4110fac_1.conda
linux-aarch64::libfabric-1.22.0-h4110fac_0.conda
linux-aarch64::libfabric-1.22.0-h4110fac_1.conda
linux-aarch64::libfabric-1.22.0-h4110fac_2.conda
+  "constrains": [
+    "libfabric1 ==0.0.0"
+  ],
================================================================================
================================================================================
noarch
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
osx-64::libfabric-1.22.0-h6e16a3a_0.conda
osx-64::libfabric-1.22.0-h6e16a3a_1.conda
osx-64::libfabric-1.22.0-h6e16a3a_2.conda
+  "constrains": [
+    "libfabric1 ==0.0.0"
+  ],
================================================================================
================================================================================
linux-64
linux-64::libfabric-1.15.2-ha594dbc_2.conda
linux-64::libfabric-1.17.0-ha594dbc_0.conda
linux-64::libfabric-1.19.1-ha594dbc_0.conda
linux-64::libfabric-1.19.1-ha594dbc_1.conda
linux-64::libfabric-1.22.0-ha594dbc_0.conda
linux-64::libfabric-1.22.0-ha594dbc_1.conda
linux-64::libfabric-1.22.0-ha594dbc_2.conda
+  "constrains": [
+    "libfabric1 ==0.0.0"
+  ],

```

</details>