### PR TITLE
Let `nvidia-ml-py` and `pynvml` `12.*` coexist

### DIFF
--- a/recipe/patch_yaml/nvidia-ml-py.yaml
+++ b/recipe/patch_yaml/nvidia-ml-py.yaml
@@ -1,0 +1,9 @@
+if:
+  name: nvidia-ml-py
+  version_ge: 12.0.0
+  version_le: 12.560.30
+  timestamp_lt: 1734561375000
+then:
+  - replace_constrains:
+      old: "pynvml ==9999999999"
+      new: "pynvml ~=12.0"


### PR DESCRIPTION
Beginning with `pynvml` version `12.0.0`, the `pynvml` library and package now depend on `nvidia-ml-py` for core functionality and merely provide a few extras on top of `nvidia-ml-py`. Given this, these two packages no longer clobber each other and instead `nvidia-ml-py` needs to be coinstallable with `pynvml`. Changes were made to both feedstocks to support this (as referenced below). This repodata patch extends this to `nvidia-ml-py` version `12.*`.

References:
* https://github.com/gpuopenanalytics/pynvml/pull/57
* https://github.com/conda-forge/pynvml-feedstock/pull/18
* https://github.com/conda-forge/nvidia-ml-py-feedstock/pull/24

<hr>

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
