### PR TITLE
pin nbconvert <7.16.5 to mistune <3.1

### DIFF
--- a/recipe/patch_yaml/nbconvert.yaml
+++ b/recipe/patch_yaml/nbconvert.yaml
@@ -112,3 +112,13 @@ if:
   timestamp_le: 1680046165000
 then:
   - add_depends: lxml <5.2.0a0
+---
+# mistune 3.1 renamed a class member which causes nbconver to fail on import
+if:
+  name: nbconvert-core
+  version_lt: "7.16.5"
+  timestamp_le: 1735668549000
+then:
+  - replace_depends:
+      old: mistune >=2.0.3,<4
+      new: mistune >=2.0.3,<3.1


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

ping:
- @conda-forge/nbconvert
- @conda-forge/mistune

references:
- https://github.com/conda-forge/mistune-feedstock/pull/37
- https://github.com/conda-forge/nbconvert-feedstock/pull/141
- https://github.com/jupyter/nbconvert/issues/2198

```diff
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
noarch
noarch::nbconvert-core-7.10.0-pyhd8ed1ab_0.conda
noarch::nbconvert-core-7.11.0-pyhd8ed1ab_0.conda
noarch::nbconvert-core-7.12.0-pyhd8ed1ab_0.conda
noarch::nbconvert-core-7.13.0-pyhd8ed1ab_0.conda
noarch::nbconvert-core-7.13.1-pyhd8ed1ab_0.conda
noarch::nbconvert-core-7.14.0-pyhd8ed1ab_0.conda
noarch::nbconvert-core-7.14.1-pyhd8ed1ab_0.conda
noarch::nbconvert-core-7.14.2-pyhd8ed1ab_0.conda
noarch::nbconvert-core-7.15.0-pyhd8ed1ab_0.conda
noarch::nbconvert-core-7.16.0-pyhd8ed1ab_0.conda
noarch::nbconvert-core-7.16.1-pyhd8ed1ab_0.conda
noarch::nbconvert-core-7.16.2-pyhd8ed1ab_0.conda
noarch::nbconvert-core-7.16.3-pyhd8ed1ab_0.conda
noarch::nbconvert-core-7.16.3-pyhd8ed1ab_1.conda
noarch::nbconvert-core-7.16.4-pyhd8ed1ab_0.conda
noarch::nbconvert-core-7.16.4-pyhd8ed1ab_1.conda
noarch::nbconvert-core-7.16.4-pyhff2d567_2.conda
noarch::nbconvert-core-7.6.0-pyhd8ed1ab_0.conda
noarch::nbconvert-core-7.7.1-pyhd8ed1ab_0.conda
noarch::nbconvert-core-7.7.1-pyhd8ed1ab_1.conda
noarch::nbconvert-core-7.7.2-pyhd8ed1ab_0.conda
noarch::nbconvert-core-7.7.3-pyhd8ed1ab_0.conda
noarch::nbconvert-core-7.7.4-pyhd8ed1ab_0.conda
noarch::nbconvert-core-7.8.0-pyhd8ed1ab_0.conda
noarch::nbconvert-core-7.9.1-pyhd8ed1ab_0.conda
noarch::nbconvert-core-7.9.2-pyhd8ed1ab_0.conda
-    "mistune >=2.0.3,<4",
+    "mistune >=2.0.3,<3.1",
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
================================================================================
================================================================================
linux-64

```