### PR TITLE
Pin upper bound for conda (<24.11.0) in mamba 1.5.{9,10,11} to avoid using problematic shell function

### DIFF
--- a/recipe/patch_yaml/mamba.yaml
+++ b/recipe/patch_yaml/mamba.yaml
@@ -153,3 +153,16 @@ then:
   - replace_depends:
       old: "conda >=24,<25"
       new: "conda >=24,<24.9.0"
+---
+# conda 24.11.0 deprecated a shell function used by mamba 1.x
+# conda 24.11.2 reintroduced with a faulty deprecation message
+# see https://github.com/conda/conda/pull/14468
+# mamba 1.5.12 added a fix to stop using that shell function
+if:
+  name: mamba
+  version_in: ["1.5.9", "1.5.10", "1.5.11"]
+  timestamp_lt: 1735926001000  # 2025-01-03 17:40 UTC
+then:
+  - replace_depends:
+      old: "conda >=24,<25"
+      new: "conda >=24,<24.11.0"


### PR DESCRIPTION

Checklist

* [X] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [X] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [X] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

xref https://github.com/conda/conda/pull/14468