### PR TITLE
make pre-split xz conflict with new liblzma

### DIFF
--- a/recipe/patch_yaml/xz_split.yaml
+++ b/recipe/patch_yaml/xz_split.yaml
@@ -1,0 +1,7 @@
+# old xz builds conflict with new liblzma output
+if:
+  name: xz
+  version_lt: "5.6"
+  timestamp_lt: 1736337155000
+then:
+  - add_constrains: liblzma ==0.0.0


### PR DESCRIPTION
ref: https://github.com/conda-forge/xz-feedstock/issues/47

makes sure pre-split `xz` package cannot be installed with new `liblzma`, both of which provide `liblzma`.

cc @xhochy

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<details>
<summary>diff</summary>

```
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
win-32::xz-5.2.2-0.tar.bz2
win-32::xz-5.2.3-0.tar.bz2
+  "constrains": [
+    "liblzma ==0.0.0"
+  ],
================================================================================
================================================================================
linux-ppc64le
linux-ppc64le::xz-5.2.4-h14c3975_1001.tar.bz2
linux-ppc64le::xz-5.2.4-h6eb9509_1002.tar.bz2
linux-ppc64le::xz-5.2.5-h6eb9509_0.tar.bz2
linux-ppc64le::xz-5.2.5-h6eb9509_1.tar.bz2
linux-ppc64le::xz-5.2.6-hb283c62_0.tar.bz2
+  "constrains": [
+    "liblzma ==0.0.0"
+  ],
================================================================================
================================================================================
osx-arm64
osx-arm64::xz-5.2.5-h642e427_1.tar.bz2
osx-arm64::xz-5.2.6-h57fd34a_0.tar.bz2
+  "constrains": [
+    "liblzma ==0.0.0"
+  ],
================================================================================
================================================================================
linux-aarch64
linux-aarch64::xz-5.2.4-h6dd45c4_1002.tar.bz2
linux-aarch64::xz-5.2.4-hda93590_1001.tar.bz2
linux-aarch64::xz-5.2.5-h6dd45c4_0.tar.bz2
linux-aarch64::xz-5.2.5-h6dd45c4_1.tar.bz2
linux-aarch64::xz-5.2.6-h9cdd2b7_0.tar.bz2
+  "constrains": [
+    "liblzma ==0.0.0"
+  ],
================================================================================
================================================================================
noarch
================================================================================
================================================================================
win-64
win-64::xz-5.2.2-0.tar.bz2
win-64::xz-5.2.3-0.tar.bz2
win-64::xz-5.2.4-h2fa13f4_0.tar.bz2
win-64::xz-5.2.4-h2fa13f4_1.tar.bz2
win-64::xz-5.2.4-h2fa13f4_1001.tar.bz2
win-64::xz-5.2.4-h2fa13f4_1002.tar.bz2
win-64::xz-5.2.4-h3cc03e0_0.tar.bz2
win-64::xz-5.2.4-h3cc03e0_1.tar.bz2
win-64::xz-5.2.4-h3cc03e0_1001.tar.bz2
win-64::xz-5.2.5-h2fa13f4_0.tar.bz2
win-64::xz-5.2.5-h62dcd97_1.tar.bz2
win-64::xz-5.2.6-h8d14728_0.tar.bz2
+  "constrains": [
+    "liblzma ==0.0.0"
+  ],
================================================================================
================================================================================
osx-64
osx-64::xz-5.0.5-1.tar.bz2
osx-64::xz-5.2.2-0.tar.bz2
osx-64::xz-5.2.3-0.tar.bz2
osx-64::xz-5.2.4-h0b31af3_1002.tar.bz2
osx-64::xz-5.2.4-h1de35cc_1001.tar.bz2
osx-64::xz-5.2.4-h470a237_0.tar.bz2
osx-64::xz-5.2.4-h470a237_1.tar.bz2
osx-64::xz-5.2.5-h0b31af3_0.tar.bz2
osx-64::xz-5.2.5-h0b31af3_1.tar.bz2
osx-64::xz-5.2.5-haf1e3a3_1.tar.bz2
osx-64::xz-5.2.6-h775f41a_0.tar.bz2
+  "constrains": [
+    "liblzma ==0.0.0"
+  ],
================================================================================
================================================================================
linux-64
linux-64::xz-5.0.5-1.tar.bz2
linux-64::xz-5.2.2-0.tar.bz2
linux-64::xz-5.2.3-0.tar.bz2
linux-64::xz-5.2.4-h14c3975_1001.tar.bz2
linux-64::xz-5.2.4-h470a237_0.tar.bz2
linux-64::xz-5.2.4-h470a237_1.tar.bz2
linux-64::xz-5.2.4-h516909a_1002.tar.bz2
linux-64::xz-5.2.5-h516909a_0.tar.bz2
linux-64::xz-5.2.5-h516909a_1.tar.bz2
linux-64::xz-5.2.6-h166bdaf_0.tar.bz2
+  "constrains": [
+    "liblzma ==0.0.0"
+  ],
```
</details>