### PR TITLE
Patch scipy<1.15 for anndata<0.11.2

### DIFF
--- a/recipe/patch_yaml/anndata.yaml
+++ b/recipe/patch_yaml/anndata.yaml
@@ -35,3 +35,16 @@ then:
   - replace_depends:
       old: "h5py >=3.1"
       new: "h5py >=3.6"
+---
+# scipy 1.15 introduced an incompatibility, which anndata fixed in 0.11.2. This
+# patch prevents previous releases from being co-installed with scipy 1.15
+# https://github.com/scverse/anndata/pull/1806
+# https://github.com/conda-forge/anndata-feedstock/pull/49
+if:
+  name: anndata
+  version_lt: "0.11.2"
+  timestamp_lt: 1736438107000
+then:
+  - tighten_depends:
+      name: scipy
+      upper_bound: 1.15.0


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

---

scipy 1.15 introduced an incompatibility, which anndata fixed in 0.11.2. This patch prevents previous releases from being co-installed with scipy 1.15

cc: @flying-sheep, @conda-forge/anndata 
xref: https://github.com/scverse/anndata/pull/1806, https://github.com/conda-forge/anndata-feedstock/pull/49,     https://github.com/scverse/anndata/issues/1802, https://github.com/scverse/anndata/issues/1811, https://github.com/scverse/anndata/issues/1813

```diff
$ python show_diff.py --subdir noarch
================================================================================
================================================================================
noarch
noarch::anndata-0.6.22.post1-py_0.tar.bz2
noarch::anndata-0.6.22.post1-py_1.tar.bz2
-    "scipy"
+    "scipy <1.15.0a0"
noarch::anndata-0.8.0-pyhd8ed1ab_1.tar.bz2
noarch::anndata-0.9.0-pyhd8ed1ab_0.conda
-    "scipy >=1.4",
+    "scipy >=1.4,<1.15.0a0",
noarch::anndata-0.10.0-pyhd8ed1ab_0.conda
noarch::anndata-0.10.1-pyhd8ed1ab_0.conda
noarch::anndata-0.10.2-pyhd8ed1ab_0.conda
noarch::anndata-0.10.3-pyhd8ed1ab_0.conda
noarch::anndata-0.10.4-pyhd8ed1ab_0.conda
noarch::anndata-0.10.5-pyhd8ed1ab_0.conda
noarch::anndata-0.10.5.post1-pyhd8ed1ab_0.conda
noarch::anndata-0.9.0-pyhd8ed1ab_1.conda
noarch::anndata-0.9.1-pyhd8ed1ab_0.conda
noarch::anndata-0.9.2-pyhd8ed1ab_0.conda
-    "scipy >=1.4"
+    "scipy >=1.4,<1.15.0a0"
noarch::anndata-0.10.6-pyhd8ed1ab_0.conda
noarch::anndata-0.10.7-pyhd8ed1ab_0.conda
noarch::anndata-0.10.8-pyhd8ed1ab_0.conda
noarch::anndata-0.10.9-pyhd8ed1ab_0.conda
noarch::anndata-0.11.0-pyhd8ed1ab_0.conda
noarch::anndata-0.11.0-pyhff2d567_1.conda
noarch::anndata-0.11.1-pyhd8ed1ab_1.conda
noarch::anndata-0.11.1-pyhff2d567_0.conda
-    "scipy >=1.8"
+    "scipy >=1.8,<1.15.0a0"
```