### PR TITLE
pin zarr<3 in ome-zarr

### DIFF
--- a/recipe/patch_yaml/ome-zarr.yaml
+++ b/recipe/patch_yaml/ome-zarr.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=../patch_yaml_model.json
+# from this bit of code
+
+# zarr 2.18.x dropped support for Python 3.10 in a patch release with
+# https://github.com/zarr-developers/zarr-python/pull/2344 following
+# https://scientific-python.org/specs/spec-0000/
+
+# PRs https://github.com/conda-forge/ome-zarr-feedstock/pull/22
+# and https://github.com/conda-forge/ome-zarr-feedstock/pull/23
+# dealt with the immediate build issues.
+if:
+  name: ome-zarr
+  version_lt: "0.10.3"
+  timestamp_lt: 1736594995
+  # Saturday, January 11, 2025 12:29:55 PM GMT+01:00
+then:
+  - tighten_depends:
+      name: zarr
+      upper_bound: 3.0.0

--- a/recipe/patch_yaml/ome-zarr.yaml
+++ b/recipe/patch_yaml/ome-zarr.yaml
@@ -11,7 +11,7 @@
 if:
   name: ome-zarr
   version_lt: "0.10.3"
-  timestamp_lt: 1736594995
+  timestamp_lt: 1736594995000
   # Saturday, January 11, 2025 12:29:55 PM GMT+01:00
 then:
   - tighten_depends:


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->
* [x] Ran `python show_diff.py` and posted the output as part of the PR.

<details><summary>show_diff.py output</summary>

```
(conda-patches) /tmp/conda-forge-repodata-patches-feedstock/recipe $python show_diff.py
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
noarch
noarch::tptp-lark-parser-0.2.0-pyhd8ed1ab_1.conda
-{}
+{
+  "build": "pyhd8ed1ab_1",
+  "build_number": 1,
+  "depends": [
+    "importlib_resources",
+    "lark-parser",
+    "python >=3.9"
+  ],
+  "license": "Apache-2.0",
+  "md5": "ca71cdb1fcabd4ca07dab016e85535b5",
+  "name": "tptp-lark-parser",
+  "noarch": "python",
+  "sha256": "9ea88363a591cf7ef6b95f872e9af69fba222442b6ab4f148bc6c1860921ba40",
+  "size": 95879,
+  "subdir": "noarch",
+  "timestamp": 1736594695664,
+  "version": "0.2.0"
+}
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
osx-64::bmad-20250111.0-mpi_openmpi_h3948652_0.conda
-{}
+{
+  "build": "mpi_openmpi_h3948652_0",
+  "build_number": 0,
+  "depends": [
+    "__osx >=10.13",
+    "cairo >=1.18.2,<2.0a0",
+    "fftw >=3.3.10,<4.0a0",
+    "fgsl",
+    "gsl >=2.7,<2.8.0a0",
+    "hdf5 >=1.14.4,<1.14.5.0a0 mpi_openmpi_*",
+    "lapack95",
+    "libblas * *openblas",
+    "libcblas >=3.9.0,<4.0a0",
+    "libcxx >=18",
+    "libgfortran 5.*",
+    "libgfortran5 >=13.2.0",
+    "liblapack >=3.9.0,<4.0a0",
+    "llvm-openmp >=18.1.8",
+    "llvm-openmp >=19.1.6",
+    "ncurses >=6.5,<7.0a0",
+    "openblas",
+    "openmpi >=5.0.6,<6.0a0",
+    "pango >=1.56.0,<2.0a0",
+    "pgplot",
+    "readline >=8.2,<9.0a0",
+    "xorg-libx11 >=1.8.10,<2.0a0",
+    "xorg-libxt >=1.3.1,<2.0a0",
+    "xorg-xproto",
+    "xraylib >=4.1.5,<5.0a0"
+  ],
+  "license": "GPL-3.0-or-later",
+  "md5": "753601e7cec4148a3d950cfcd06d90c7",
+  "name": "bmad",
+  "sha256": "62959b380163a8d96ab26ac02ee0ce825c8cac38c79bf84b0048758db5a32bc1",
+  "size": 196614234,
+  "subdir": "osx-64",
+  "timestamp": 1736594021670,
+  "version": "20250111.0"
+}
osx-64::bmad-20250111.0-mpi_openmpi_h00887f8_0.conda
-{}
+{
+  "build": "mpi_openmpi_h00887f8_0",
+  "build_number": 0,
+  "depends": [
+    "__osx >=10.13",
+    "cairo >=1.18.2,<2.0a0",
+    "fftw >=3.3.10,<4.0a0",
+    "fgsl",
+    "gsl >=2.7,<2.8.0a0",
+    "hdf5 >=1.14.3,<1.14.4.0a0 mpi_openmpi_*",
+    "lapack95",
+    "libblas * *openblas",
+    "libcblas >=3.9.0,<4.0a0",
+    "libcxx >=18",
+    "libgfortran 5.*",
+    "libgfortran5 >=13.2.0",
+    "liblapack >=3.9.0,<4.0a0",
+    "llvm-openmp >=18.1.8",
+    "llvm-openmp >=19.1.6",
+    "ncurses >=6.5,<7.0a0",
+    "openblas",
+    "openmpi >=5.0.6,<6.0a0",
+    "pango >=1.56.0,<2.0a0",
+    "pgplot",
+    "readline >=8.2,<9.0a0",
+    "xorg-libx11 >=1.8.10,<2.0a0",
+    "xorg-libxt >=1.3.1,<2.0a0",
+    "xorg-xproto",
+    "xraylib >=4.1.5,<5.0a0"
+  ],
+  "license": "GPL-3.0-or-later",
+  "md5": "026360e247c52d46b219b4f8df8b1ae5",
+  "name": "bmad",
+  "sha256": "82b2f20f9e15a775f4cd7afa20de8e2a5263c8b80b37d22981cd4b1f905c0d5f",
+  "size": 197634097,
+  "subdir": "osx-64",
+  "timestamp": 1736594407517,
+  "version": "20250111.0"
+}
================================================================================
================================================================================
linux-64
```

</details>

<!-- Put any other comments or information here -->
