### PR TITLE
limit zarr to under 3 if installed with python-elf

### DIFF
--- a/recipe/patch_yaml/python-elf.yaml
+++ b/recipe/patch_yaml/python-elf.yaml
@@ -1,0 +1,9 @@
+# Python Elf 0.6.0 isn't yet compatible with zarr 3
+# https://github.com/conda-forge/micro_sam-feedstock/pull/29
+# https://github.com/conda-forge/python-elf-feedstock/pull/20
+if:
+  name: python-elf
+  version_le: 0.6.0
+  timestamp_lt: 1736608309000
+then:
+  - add_constrains: zarr <3.0a0


### PR DESCRIPTION

Merge after: https://github.com/conda-forge/python-elf-feedstock/pull/20

See discussion in: https://github.com/conda-forge/micro_sam-feedstock/pull/29

Checklist

* [ ] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
