### PR TITLE
anndata requires zarr<3. Runtime constraint added in 0.11.3

### DIFF
--- a/recipe/patch_yaml/anndata.yaml
+++ b/recipe/patch_yaml/anndata.yaml
@@ -48,3 +48,14 @@ then:
   - tighten_depends:
       name: scipy
       upper_bound: 1.15.0
+---
+# anndata requires zarr<3. Runtime constraint added in 0.11.3
+# https://github.com/conda-forge/anndata-feedstock/pull/52
+# https://github.com/scverse/anndata/releases/tag/0.11.3
+# https://github.com/scverse/anndata/pull/1819
+if:
+  name: anndata
+  version_lt: "0.11.3"
+  timestamp_lt: 1736784424000
+then:
+  - add_constrains: "zarr<3"


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
---

cc: @flying-sheep, @conda-forge/anndata
xref: https://github.com/conda-forge/anndata-feedstock/pull/52, https://github.com/scverse/anndata/pull/1819