### PR TITLE
make liblzma conflict with older xz

### DIFF
--- a/recipe/patch_yaml/xz_split.yaml
+++ b/recipe/patch_yaml/xz_split.yaml
@@ -1,0 +1,5 @@
+if:
+  name: liblzma
+  timestamp_lt: 1737022431000
+then:
+  - add_constrains: xz ==${version}=*_${build_number}


### PR DESCRIPTION
backport https://github.com/conda-forge/xz-feedstock/pull/48 to the first two builds of liblzma

closes #936

<details>

<summary>diff</summary>

```
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
linux-ppc64le
linux-ppc64le::liblzma-5.6.3-h190368a_0.conda
+  "constrains": [
+    "xz ==5.6.3=*_0"
+  ],
linux-ppc64le::liblzma-5.6.3-h190368a_1.conda
+  "constrains": [
+    "xz ==5.6.3=*_1"
+  ],
================================================================================
================================================================================
osx-arm64
osx-arm64::liblzma-5.6.3-h39f12f2_0.conda
+  "constrains": [
+    "xz ==5.6.3=*_0"
+  ],
osx-arm64::liblzma-5.6.3-h39f12f2_1.conda
+  "constrains": [
+    "xz ==5.6.3=*_1"
+  ],
================================================================================
================================================================================
linux-aarch64
linux-aarch64::liblzma-5.6.3-h86ecc28_1.conda
+  "constrains": [
+    "xz ==5.6.3=*_1"
+  ],
linux-aarch64::liblzma-5.6.3-h86ecc28_0.conda
+  "constrains": [
+    "xz ==5.6.3=*_0"
+  ],
================================================================================
================================================================================
noarch
================================================================================
================================================================================
win-64
win-64::liblzma-5.6.3-h2466b09_1.conda
+  "constrains": [
+    "xz ==5.6.3=*_1"
+  ],
win-64::liblzma-5.6.3-h2466b09_0.conda
+  "constrains": [
+    "xz ==5.6.3=*_0"
+  ],
================================================================================
================================================================================
osx-64
osx-64::liblzma-5.6.3-hd471939_1.conda
+  "constrains": [
+    "xz ==5.6.3=*_1"
+  ],
osx-64::liblzma-5.6.3-hd471939_0.conda
+  "constrains": [
+    "xz ==5.6.3=*_0"
+  ],
================================================================================
================================================================================
linux-64
linux-64::liblzma-5.6.3-hb9d3cd8_1.conda
+  "constrains": [
+    "xz ==5.6.3=*_1"
+  ],
linux-64::liblzma-5.6.3-hb9d3cd8_0.conda
+  "constrains": [
+    "xz ==5.6.3=*_0"
+  ],
```

</details>