### PR TITLE
avoid py-lief 0.16 with current conda-build

### DIFF
--- a/recipe/patch_yaml/conda-build.yaml
+++ b/recipe/patch_yaml/conda-build.yaml
@@ -111,3 +111,13 @@ then:
   - tighten_depends:
       name: py-lief
       upper_bound: "0.15"
+---
+# https://github.com/conda/conda-build/issues/5594
+if:
+  name: conda-build
+  version_le: 25.11.1
+  timestamp_le: 1737049820000  # 2024-01-16
+then:
+  - tighten_depends:
+      name: py-lief
+      upper_bound: "0.16"


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

C.f. https://github.com/conda-forge/conda-build-feedstock/pull/239 & https://github.com/conda/conda-build/issues/5594

```
>python show_diff.py
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
osx-arm64::conda-build-25.1.1-py310hbe9552e_0.conda
osx-arm64::conda-build-25.1.1-py311h267d04e_0.conda
osx-arm64::conda-build-25.1.1-py312h81bd7bf_0.conda
osx-arm64::conda-build-25.1.1-py39h2804cbe_0.conda
-    "py-lief",
+    "py-lief <0.16.0a0",
================================================================================
================================================================================
linux-ppc64le
linux-ppc64le::conda-build-25.1.1-py310h194a6c8_0.conda
linux-ppc64le::conda-build-25.1.1-py311h1af927a_0.conda
linux-ppc64le::conda-build-25.1.1-py312h7864ebf_0.conda
linux-ppc64le::conda-build-25.1.1-py39h0b1cf3c_0.conda
-    "py-lief",
+    "py-lief <0.16.0a0",
================================================================================
================================================================================
linux-aarch64
linux-aarch64::conda-build-25.1.1-py310h4c7bcd0_0.conda
linux-aarch64::conda-build-25.1.1-py311hec3470c_0.conda
linux-aarch64::conda-build-25.1.1-py312h996f985_0.conda
linux-aarch64::conda-build-25.1.1-py39h4420490_0.conda
-    "py-lief",
+    "py-lief <0.16.0a0",
================================================================================
================================================================================
noarch
================================================================================
================================================================================
win-64
win-64::conda-build-25.1.1-py310h5588dad_0.conda
win-64::conda-build-25.1.1-py311h1ea47a8_0.conda
win-64::conda-build-25.1.1-py312h2e8e312_0.conda
win-64::conda-build-25.1.1-py39hcbf5309_0.conda
-    "py-lief",
+    "py-lief <0.16.0a0",
================================================================================
================================================================================
osx-64
osx-64::conda-build-25.1.1-py310h2ec42d9_0.conda
osx-64::conda-build-25.1.1-py311h6eed73b_0.conda
osx-64::conda-build-25.1.1-py312hb401068_0.conda
osx-64::conda-build-25.1.1-py39h6e9494a_0.conda
-    "py-lief",
+    "py-lief <0.16.0a0",
================================================================================
================================================================================
linux-64
linux-64::conda-build-25.1.1-py310hff52083_0.conda
linux-64::conda-build-25.1.1-py311h38be061_0.conda
linux-64::conda-build-25.1.1-py312h7900ff3_0.conda
linux-64::conda-build-25.1.1-py39hf3d152e_0.conda
-    "py-lief",
+    "py-lief <0.16.0a0",
```
