### PR TITLE
make latest conda-build repodata patch also restrict lief 0.15

### DIFF
--- a/recipe/patch_yaml/conda-build.yaml
+++ b/recipe/patch_yaml/conda-build.yaml
@@ -116,8 +116,8 @@ then:
 if:
   name: conda-build
   version_le: 25.11.1
-  timestamp_le: 1737049820000  # 2024-01-16
+  timestamp_le: 1737049820000  # 2025-01-16
 then:
   - tighten_depends:
       name: py-lief
-      upper_bound: "0.16"
+      upper_bound: "0.15"


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

ref #946 and https://github.com/conda/conda-build/issues/5594

I don't have a local environment set up at the moment to immediately do the `show_diff.py` checklist step

(alternative version is 05f434ad589952d30f74bcfff8d1d741adcd3d33)