### PR TITLE
correct upper numpy bound for scipy 1.9

### DIFF
--- a/recipe/patch_yaml/scipy.yaml
+++ b/recipe/patch_yaml/scipy.yaml
@@ -3,7 +3,19 @@
 
 if:
   name: scipy
-  version_le: 1.9.2
+  version: 1.9.2
+  timestamp_lt: 1737471013000
+
+then:
+  - replace_depends:
+      old: numpy >=1.20.3,<2.0a0
+      new: numpy >=1.20.3,<1.26.0
+
+---
+
+if:
+  name: scipy
+  version_le: 1.9.1
   version_ge: 1.9.0
   timestamp_lt: 1737471013000
 

--- a/recipe/patch_yaml/scipy.yaml
+++ b/recipe/patch_yaml/scipy.yaml
@@ -1,3 +1,18 @@
+# upper bound for numpy in version 1.9.0, 1.9.1, 1.9.2 not tight enough
+# which allowed installation next with numpy 1.26
+
+if:
+  name: scipy
+  version_le: 1.9.2
+  version_ge: 1.9.0
+
+then:
+  - replace_depends:
+      old: numpy<2.0a0
+      new: numpy<1.26.0
+
+---
+
 # missing lower bounds for numpy after 2.0 migration, c.f.
 # https://github.com/conda-forge/numpy-feedstock/issues/324
 # the upper bound has been there correctly, c.f.

--- a/recipe/patch_yaml/scipy.yaml
+++ b/recipe/patch_yaml/scipy.yaml
@@ -5,6 +5,7 @@ if:
   name: scipy
   version_le: 1.9.2
   version_ge: 1.9.0
+  timestamp_lt: 1737471013000
 
 then:
   - replace_depends:

--- a/recipe/patch_yaml/scipy.yaml
+++ b/recipe/patch_yaml/scipy.yaml
@@ -9,8 +9,8 @@ if:
 
 then:
   - replace_depends:
-      old: numpy<2.0a0
-      new: numpy<1.26.0
+      old: numpy >=1.19.5,<2.0a0
+      new: numpy >=1.19.5,<1.26.0
 
 ---
 


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
