### PR TITLE
Relax `nvcc`'s `sysroot` upper bound

### DIFF
--- a/recipe/patch_yaml/nvcc.yaml
+++ b/recipe/patch_yaml/nvcc.yaml
@@ -27,3 +27,46 @@ if:
     - linux-aarch64
 then:
   - add_depends: "cudatoolkit ${version}.*"
+---
+
+
+# Relax `sysroot` pins of `nvcc_{{ target_platform }}`
+# Done by arch to handle package name differences
+if:
+  name: nvcc_linux-64
+  version_lt: 12.0.0
+  timestamp_lt: 1737594364000
+  has_depends: "sysroot_linux-64?( *)"
+then:
+  - replace_depends:
+      old: sysroot_linux-64 2.17.*
+      new: sysroot_linux-64 >=2.17,<3.0a0
+  - replace_depends:
+      old: sysroot_linux-64 >=2.17
+      new: sysroot_linux-64 >=2.17,<3.0a0
+---
+if:
+  name: nvcc_linux-aarch64
+  version_lt: 12.0.0
+  timestamp_lt: 1737594364000
+  has_depends: "sysroot_linux-aarch64?( *)"
+then:
+  - replace_depends:
+      old: sysroot_linux-aarch64 2.17.*
+      new: sysroot_linux-aarch64 >=2.17,<3.0a0
+  - replace_depends:
+      old: sysroot_linux-aarch64 >=2.17
+      new: sysroot_linux-aarch64 >=2.17,<3.0a0
+---
+if:
+  name: nvcc_linux-ppc64le
+  version_lt: 12.0.0
+  timestamp_lt: 1737594364000
+  has_depends: "sysroot_linux-ppc64le?( *)"
+then:
+  - replace_depends:
+      old: sysroot_linux-ppc64le 2.17.*
+      new: sysroot_linux-ppc64le >=2.17,<3.0a0
+  - replace_depends:
+      old: sysroot_linux-ppc64le >=2.17
+      new: sysroot_linux-ppc64le >=2.17,<3.0a0


### PR DESCRIPTION
Previously the `nvcc` package tightly pinned to an exact `sysroot` version (`2.17`), which caused issues when installing with newer `sysroot`s ( https://github.com/conda-forge/nvcc-feedstock/issues/107 ). This was subsequently fixed in PR ( https://github.com/conda-forge/nvcc-feedstock/pull/106 ) for the latest `nvcc` packages

Also recently discovered that `sysroot` lacked an appropriate upper bound (namely keeping it to 2 instead of 3+). Have fixed this with PR ( https://github.com/conda-forge/nvcc-feedstock/pull/115 ) by borrowing the same logic already used in `cuda-nvcc`

However older `nvcc` packages still have these issues. This repodata patch fixes those older package versions to have more relaxed `sysroot` constraints

<hr>

Checklist

* [ ] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
