### PR TITLE
Add uxarray patch to fix python constraints

### DIFF
--- a/recipe/patch_yaml/uxarray.yaml
+++ b/recipe/patch_yaml/uxarray.yaml
@@ -1,0 +1,11 @@
+# this patch fixes incorrect python constraints in uxarray
+# https://github.com/conda-forge/uxarray-feedstock/issues/89
+if:
+  name: uxarray
+  version_ge: "2024.12.0"
+  version_le: "2025.01.0"
+  timestamp_lt: 1737840060000
+then:
+  - replace_depends:
+      old: python >=3.9
+      new: python >=3.10


### PR DESCRIPTION
These are needed for 2 recent versions, 2024.12.0 and 2025.01.0

See https://github.com/conda-forge/uxarray-feedstock/issues/89

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

ping @conda-forge/uxarray