### PR TITLE
Make qt6.7 packages binary compatible with qt6.8

### DIFF
--- a/recipe/patch_yaml/qt6_main.yaml
+++ b/recipe/patch_yaml/qt6_main.yaml
@@ -1,0 +1,92 @@
+# qt6.8 was claimed to be binary compatible with qt6.7
+# https://code.qt.io/cgit/qt/qtreleasenotes.git/about/qt/6.8.0/release-note.md
+# See https://github.com/conda-forge/qt-main-feedstock/issues/271
+# For all the extra packages to also migrate
+if:
+  timestamp_lt: 1737890346000
+  has_depends: qt6-main >=6.7*
+then:
+  - loosen_depends:
+      name: qt6-main
+      upper_bound: "6.9"
+
+---
+if:
+  timestamp_lt: 1737890346000
+  has_depends: qt6-quick3d >=6.7*
+then:
+  - loosen_depends:
+      name: qt6-quick3d
+      upper_bound: "6.9"
+
+---
+if:
+  timestamp_lt: 1737890346000
+  has_depends: qt6-charts >=6.7*
+then:
+  - loosen_depends:
+      name: qt6-charts
+      upper_bound: "6.9"
+
+---
+if:
+  timestamp_lt: 1737890346000
+  has_depends: qt6-graphs >=6.7*
+then:
+  - loosen_depends:
+      name: qt6-graphs
+      upper_bound: "6.9"
+
+---
+if:
+  timestamp_lt: 1737890346000
+  has_depends: qt6-multimedia >=6.7*
+then:
+  - loosen_depends:
+      name: qt6-multimedia
+      upper_bound: "6.9"
+
+---
+if:
+  timestamp_lt: 1737890346000
+  has_depends: qt6-wayland >=6.7*
+then:
+  - loosen_depends:
+      name: qt6-wayland
+      upper_bound: "6.9"
+
+---
+if:
+  timestamp_lt: 1737890346000
+  has_depends: qt6-gtk-platformtheme >=6.7*
+then:
+  - loosen_depends:
+      name: qt6-gtk-platformtheme
+      upper_bound: "6.9"
+
+---
+if:
+  timestamp_lt: 1737890346000
+  has_depends: qt6-networkauth >=6.7*
+then:
+  - loosen_depends:
+      name: qt6-networkauth
+      upper_bound: "6.9"
+
+---
+if:
+  timestamp_lt: 1737890346000
+  has_depends: qt6-3d >=6.7*
+then:
+  - loosen_depends:
+      name: qt6-3d
+      upper_bound: "6.9"
+
+---
+if:
+  timestamp_lt: 1737890346000
+  has_depends: qt6-datavis3d >=6.7*
+then:
+  - loosen_depends:
+      name: qt6-datavis3d
+      upper_bound: "6.9"


### PR DESCRIPTION
Checklist

* [ ] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
