### PR TITLE
Fix google-cloud-bigquery-storage-core protobuf pin

### DIFF
--- a/recipe/patch_yaml/google-cloud-bigquery-storage.yaml
+++ b/recipe/patch_yaml/google-cloud-bigquery-storage.yaml
@@ -1,0 +1,9 @@
+# Fix google-cloud-bigquery-storage-core protobuf pin
+if:
+  name: google-cloud-bigquery-storage-core
+  timestamp_lt: 1738005502000
+  version_ge: 2.26.0
+then:
+  - replace_depends:
+      old: protobuf >=3.19.5,<5.0.0dev,!=3.20.0,!=3.20.1,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5
+      new: protobuf >=3.20.2,<6.0.0dev,!=3.20.0,!=3.20.1,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

```
noarch
noarch::google-cloud-bigquery-storage-core-2.27.0-pyhd8ed1ab_1.conda
noarch::google-cloud-bigquery-storage-core-2.27.0-pyhff2d567_0.conda
noarch::google-cloud-bigquery-storage-core-2.26.0-pyhff2d567_0.conda
-    "protobuf >=3.19.5,<5.0.0dev,!=3.20.0,!=3.20.1,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5",
+    "protobuf >=3.20.2,<6.0.0dev,!=3.20.0,!=3.20.1,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5",

```

Since 2.26 upstream allows protobuf 5.x and requires at least 3.20.2

https://github.com/googleapis/python-bigquery-storage/commit/0a644e31b0280adf751755381e3357435837467d

https://github.com/conda-forge/google-cloud-bigquery-storage-feedstock/issues/44