### PR TITLE
Patch pytorch-cpu/gpu for 2.4.1 increased compatibility

### DIFF
--- a/recipe/patch_yaml/pytorch.yaml
+++ b/recipe/patch_yaml/pytorch.yaml
@@ -160,3 +160,66 @@ if:
 
 then:
   - add_constrains: pybind11 <0.0.0a0
+
+
+---
+# Pytorch 2.4.1 did not upload a package for pytorch-gpu and pytorch-cpu that
+# compatible with all versions of python
+# Only the linux builds use the "megabuild" that cause the issue
+# The OSX builds were "safe"
+# https://github.com/conda-forge/pytorch-cpu-feedstock/issues/338
+# https://github.com/conda-forge/pytorch-cpu-feedstock/pull/341
+
+if:
+  name: pytorch-gpu
+  version: 2.4.1
+  subdir_in: linux-64
+  # cpu is build number 0-5
+  # mkl is +100
+  # cuda compiler + mkl is +300
+  # Cuda without mkl doesn't exist for 2.4.1
+  # cuda compiler is +200
+  build_number_in:
+    - 300
+    - 301
+    - 302
+    - 303
+    - 304
+    - 305
+
+then:
+  - replace_depends:
+      old: "pytorch 2.4.1 cuda118_*"
+      new: "pytorch 2.4.1 cuda118_*_${build_number}"
+  - replace_depends:
+      old: "pytorch 2.4.1 cuda120_*"
+      new: "pytorch 2.4.1 cuda120_*_${build_number}"
+
+---
+if:
+  name: pytorch-cpu
+  version: 2.4.1
+  subdir_in: linux-64
+  # cpu is build number 0-5
+  # mkl is +100
+  # cuda compiler + mkl is +300
+  # Cuda without mkl doesn't exist for 2.4.1
+  # cuda compiler is +200
+  build_number_in:
+    - 0
+    - 1
+    - 2
+    - 3
+    - 4
+    - 5
+    - 100
+    - 101
+    - 102
+    - 103
+    - 104
+    - 105
+
+then:
+  - replace_depends:
+      old: "pytorch 2.4.1 cpu_*"
+      new: "pytorch 2.4.1 cpu_*_${build_number}"


### PR DESCRIPTION
xref:
* https://github.com/conda-forge/pytorch-cpu-feedstock/issues/338
* https://github.com/conda-forge/pytorch-cpu-feedstock/pull/341

----------------------

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
