### PR TITLE
add constraint MKL<2025 to blas/lapack metapackages

### DIFF
--- a/recipe/patch_yaml/blas.yaml
+++ b/recipe/patch_yaml/blas.yaml
@@ -34,3 +34,20 @@ then:
   - replace_depends:
       old: liblapacke >=3.8.0,<3.9.0a0
       new: liblapacke >=3.8.0,<4.0.0a0
+---
+# apply https://github.com/conda-forge/blas-feedstock/pull/134 to older builds
+# to avoid solver thrashing in the presence of new MKL version
+if:
+  name_in:
+    - libblas
+    - libcblas
+    - liblapack
+    - liblapacke
+  # MKL 2025 only exists on {linux,win}-x64
+  subdir_in:
+    - linux-64
+    - win-64
+  version_ge: 3.9.0
+  timestamp_lt: 1739090831114
+then:
+  - add_constrains: mkl <2025


### PR DESCRIPTION
Companion to https://github.com/conda-forge/blas-feedstock/pull/134 & https://github.com/conda-forge/lapack-feedstock/pull/79, to avoid spurious blas flavour switches if the solver (wrongly) optimizes for maximizing the MKL version.

## Output of `python show_diff.py`

<details>

```diff
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
noarch
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
win-64
win-64::liblapacke-3.9.0-10_mkl.tar.bz2
win-64::liblapacke-3.9.0-11_win64_mkl.tar.bz2
win-64::liblapacke-3.9.0-12_win64_mkl.tar.bz2
win-64::liblapacke-3.9.0-13_win64_mkl.tar.bz2
win-64::liblapacke-3.9.0-14_win64_mkl.tar.bz2
win-64::liblapacke-3.9.0-15_win64_mkl.tar.bz2
win-64::liblapacke-3.9.0-16_win64_mkl.tar.bz2
win-64::liblapacke-3.9.0-17_win64_mkl.conda
win-64::liblapacke-3.9.0-18_win64_mkl.conda
win-64::liblapacke-3.9.0-19_win64_mkl.conda
win-64::liblapacke-3.9.0-20_win64_mkl.conda
win-64::liblapacke-3.9.0-21_win64_mkl.conda
win-64::liblapacke-3.9.0-22_win64_mkl.conda
win-64::liblapacke-3.9.0-23_win64_mkl.conda
win-64::liblapacke-3.9.0-24_win64_mkl.conda
win-64::liblapacke-3.9.0-25_win64_mkl.conda
win-64::liblapacke-3.9.0-26_win64_mkl.conda
win-64::liblapacke-3.9.0-4_mkl.tar.bz2
win-64::liblapacke-3.9.0-5_mkl.tar.bz2
win-64::liblapacke-3.9.0-6_mkl.tar.bz2
win-64::liblapacke-3.9.0-7_mkl.tar.bz2
win-64::liblapacke-3.9.0-8_mkl.tar.bz2
win-64::liblapacke-3.9.0-9_mkl.tar.bz2
-    "blas * mkl"
+    "blas * mkl",
+    "mkl <2025"
win-64::libblas-3.9.0-0_openblas.tar.bz2
win-64::libcblas-3.9.0-0_openblas.tar.bz2
win-64::liblapack-3.9.0-0_openblas.tar.bz2
-    "liblapacke 3.9.0 0_openblas"
+    "liblapacke 3.9.0 0_openblas",
+    "mkl <2025"
win-64::libcblas-3.9.0-0_blis.tar.bz2
win-64::libcblas-3.9.0-10_blis.tar.bz2
win-64::libcblas-3.9.0-11_win64_blis.tar.bz2
win-64::libcblas-3.9.0-12_win64_blis.tar.bz2
win-64::libcblas-3.9.0-13_win64_blis.tar.bz2
win-64::libcblas-3.9.0-14_win64_blis.tar.bz2
win-64::libcblas-3.9.0-15_win64_blis.tar.bz2
win-64::libcblas-3.9.0-16_win64_blis.tar.bz2
win-64::libcblas-3.9.0-17_win64_blis.conda
win-64::libcblas-3.9.0-18_win64_blis.conda
win-64::libcblas-3.9.0-19_win64_blis.conda
win-64::libcblas-3.9.0-1_blis.tar.bz2
win-64::libcblas-3.9.0-20_win64_blis.conda
win-64::libcblas-3.9.0-21_win64_blis.conda
win-64::libcblas-3.9.0-22_win64_blis.conda
win-64::libcblas-3.9.0-23_win64_blis.conda
win-64::libcblas-3.9.0-24_win64_blis.conda
win-64::libcblas-3.9.0-25_win64_blis.conda
win-64::libcblas-3.9.0-26_win64_blis.conda
win-64::libcblas-3.9.0-2_blis.tar.bz2
win-64::libcblas-3.9.0-3_blis.tar.bz2
win-64::libcblas-3.9.0-4_blis.tar.bz2
win-64::libcblas-3.9.0-5_blis.tar.bz2
win-64::libcblas-3.9.0-6_blis.tar.bz2
win-64::libcblas-3.9.0-7_blis.tar.bz2
win-64::libcblas-3.9.0-8_blis.tar.bz2
win-64::libcblas-3.9.0-9_blis.tar.bz2
-    "blas * blis"
+    "blas * blis",
+    "mkl <2025"
win-64::libblas-3.9.0-10_openblas.tar.bz2
win-64::libcblas-3.9.0-10_openblas.tar.bz2
win-64::liblapack-3.9.0-10_openblas.tar.bz2
-    "liblapacke 3.9.0 10_openblas"
+    "liblapacke 3.9.0 10_openblas",
+    "mkl <2025"
win-64::libblas-3.9.0-0_h8933c1f_netlib.tar.bz2
win-64::libblas-3.9.0-1_h8933c1f_netlib.tar.bz2
win-64::libcblas-3.9.0-0_h8933c1f_netlib.tar.bz2
win-64::libcblas-3.9.0-1_h8933c1f_netlib.tar.bz2
win-64::libcblas-3.9.0-2_h8933c1f_netlib.tar.bz2
win-64::libcblas-3.9.0-3_hd5c7e75_netlib.tar.bz2
win-64::libcblas-3.9.0-4_hd5c7e75_netlib.tar.bz2
win-64::libcblas-3.9.0-5_hd5c7e75_netlib.tar.bz2
win-64::libcblas-3.9.0-6_h28841b1_netlib.conda
win-64::libcblas-3.9.0-7_h28841b1_netlib.conda
win-64::libcblas-3.9.0-8_h719fc58_netlib.conda
win-64::liblapack-3.9.0-0_h8933c1f_netlib.tar.bz2
win-64::liblapack-3.9.0-1_h8933c1f_netlib.tar.bz2
win-64::liblapack-3.9.0-2_h8933c1f_netlib.tar.bz2
win-64::liblapack-3.9.0-3_hd5c7e75_netlib.tar.bz2
win-64::liblapack-3.9.0-4_hd5c7e75_netlib.tar.bz2
win-64::liblapack-3.9.0-5_hd5c7e75_netlib.tar.bz2
win-64::liblapack-3.9.0-6_h28841b1_netlib.conda
win-64::liblapack-3.9.0-7_h28841b1_netlib.conda
win-64::liblapack-3.9.0-8_h719fc58_netlib.conda
win-64::liblapacke-3.9.0-0_h8933c1f_netlib.tar.bz2
win-64::liblapacke-3.9.0-1_h8933c1f_netlib.tar.bz2
win-64::liblapacke-3.9.0-2_h8933c1f_netlib.tar.bz2
win-64::liblapacke-3.9.0-3_hd5c7e75_netlib.tar.bz2
win-64::liblapacke-3.9.0-4_hd5c7e75_netlib.tar.bz2
win-64::liblapacke-3.9.0-5_hd5c7e75_netlib.tar.bz2
win-64::liblapacke-3.9.0-6_h28841b1_netlib.conda
win-64::liblapacke-3.9.0-7_h28841b1_netlib.conda
win-64::liblapacke-3.9.0-8_h719fc58_netlib.conda
+  "constrains": [
+    "mkl <2025"
+  ],
win-64::libblas-3.9.0-15_win64_mkl.tar.bz2
win-64::libcblas-3.9.0-15_win64_mkl.tar.bz2
win-64::liblapack-3.9.0-15_win64_mkl.tar.bz2
-    "liblapacke 3.9.0 15_win64_mkl"
+    "liblapacke 3.9.0 15_win64_mkl",
+    "mkl <2025"
win-64::libblas-3.9.0-8_mkl.tar.bz2
win-64::libcblas-3.9.0-8_mkl.tar.bz2
win-64::liblapack-3.9.0-8_mkl.tar.bz2
-    "liblapacke 3.9.0 8_mkl"
+    "liblapacke 3.9.0 8_mkl",
+    "mkl <2025"
win-64::libblas-3.9.0-9_mkl.tar.bz2
win-64::libcblas-3.9.0-9_mkl.tar.bz2
win-64::liblapack-3.9.0-9_mkl.tar.bz2
-    "liblapacke 3.9.0 9_mkl"
+    "liblapacke 3.9.0 9_mkl",
+    "mkl <2025"
win-64::libblas-3.9.0-11_win64_mkl.tar.bz2
win-64::libcblas-3.9.0-11_win64_mkl.tar.bz2
win-64::liblapack-3.9.0-11_win64_mkl.tar.bz2
-    "liblapacke 3.9.0 11_win64_mkl"
+    "liblapacke 3.9.0 11_win64_mkl",
+    "mkl <2025"
win-64::libblas-3.9.0-5_openblas.tar.bz2
win-64::libcblas-3.9.0-5_openblas.tar.bz2
win-64::liblapack-3.9.0-5_openblas.tar.bz2
-    "liblapacke 3.9.0 5_openblas"
+    "liblapacke 3.9.0 5_openblas",
+    "mkl <2025"
win-64::libblas-3.9.0-0_blis.tar.bz2
-    "libcblas 3.9.0 0_blis"
+    "libcblas 3.9.0 0_blis",
+    "mkl <2025"
win-64::libblas-3.9.0-3_openblas.tar.bz2
win-64::libcblas-3.9.0-3_openblas.tar.bz2
win-64::liblapack-3.9.0-3_openblas.tar.bz2
-    "liblapacke 3.9.0 3_openblas"
+    "liblapacke 3.9.0 3_openblas",
+    "mkl <2025"
win-64::liblapacke-3.9.0-0_openblas.tar.bz2
win-64::liblapacke-3.9.0-10_openblas.tar.bz2
win-64::liblapacke-3.9.0-11_win64_openblas.tar.bz2
win-64::liblapacke-3.9.0-12_win64_openblas.tar.bz2
win-64::liblapacke-3.9.0-13_win64_openblas.tar.bz2
win-64::liblapacke-3.9.0-14_win64_openblas.tar.bz2
win-64::liblapacke-3.9.0-15_win64_openblas.tar.bz2
win-64::liblapacke-3.9.0-16_win64_openblas.tar.bz2
win-64::liblapacke-3.9.0-17_win64_openblas.conda
win-64::liblapacke-3.9.0-18_win64_openblas.conda
win-64::liblapacke-3.9.0-19_win64_openblas.conda
win-64::liblapacke-3.9.0-1_openblas.tar.bz2
win-64::liblapacke-3.9.0-20_win64_openblas.conda
win-64::liblapacke-3.9.0-21_win64_openblas.conda
win-64::liblapacke-3.9.0-22_win64_openblas.conda
win-64::liblapacke-3.9.0-23_win64_openblas.conda
win-64::liblapacke-3.9.0-24_win64_openblas.conda
win-64::liblapacke-3.9.0-25_win64_openblas.conda
win-64::liblapacke-3.9.0-26_win64_openblas.conda
win-64::liblapacke-3.9.0-2_openblas.tar.bz2
win-64::liblapacke-3.9.0-3_openblas.tar.bz2
win-64::liblapacke-3.9.0-4_openblas.tar.bz2
win-64::liblapacke-3.9.0-5_openblas.tar.bz2
win-64::liblapacke-3.9.0-6_openblas.tar.bz2
win-64::liblapacke-3.9.0-7_openblas.tar.bz2
win-64::liblapacke-3.9.0-8_openblas.tar.bz2
win-64::liblapacke-3.9.0-9_openblas.tar.bz2
-    "blas * openblas"
+    "blas * openblas",
+    "mkl <2025"
win-64::libblas-3.9.0-15_win64_openblas.tar.bz2
win-64::libcblas-3.9.0-15_win64_openblas.tar.bz2
win-64::liblapack-3.9.0-15_win64_openblas.tar.bz2
-    "liblapacke 3.9.0 15_win64_openblas"
+    "liblapacke 3.9.0 15_win64_openblas",
+    "mkl <2025"
win-64::libblas-3.9.0-8_openblas.tar.bz2
win-64::libcblas-3.9.0-8_openblas.tar.bz2
win-64::liblapack-3.9.0-8_openblas.tar.bz2
-    "liblapacke 3.9.0 8_openblas"
+    "liblapacke 3.9.0 8_openblas",
+    "mkl <2025"
win-64::libblas-3.9.0-13_win64_openblas.tar.bz2
win-64::libcblas-3.9.0-13_win64_openblas.tar.bz2
win-64::liblapack-3.9.0-13_win64_openblas.tar.bz2
-    "liblapacke 3.9.0 13_win64_openblas"
+    "liblapacke 3.9.0 13_win64_openblas",
+    "mkl <2025"
win-64::libblas-3.9.0-4_blis.tar.bz2
-    "libcblas 3.9.0 4_blis"
+    "libcblas 3.9.0 4_blis",
+    "mkl <2025"
win-64::libblas-3.9.0-7_blis.tar.bz2
-    "libcblas 3.9.0 7_blis"
+    "libcblas 3.9.0 7_blis",
+    "mkl <2025"
win-64::libblas-3.9.0-6_openblas.tar.bz2
win-64::libcblas-3.9.0-6_openblas.tar.bz2
win-64::liblapack-3.9.0-6_openblas.tar.bz2
-    "liblapacke 3.9.0 6_openblas"
+    "liblapacke 3.9.0 6_openblas",
+    "mkl <2025"
win-64::libblas-3.9.0-7_mkl.tar.bz2
win-64::libcblas-3.9.0-7_mkl.tar.bz2
win-64::liblapack-3.9.0-7_mkl.tar.bz2
-    "liblapacke 3.9.0 7_mkl"
+    "liblapacke 3.9.0 7_mkl",
+    "mkl <2025"
win-64::libblas-3.9.0-2_openblas.tar.bz2
win-64::libcblas-3.9.0-2_openblas.tar.bz2
win-64::liblapack-3.9.0-2_openblas.tar.bz2
-    "liblapacke 3.9.0 2_openblas"
+    "liblapacke 3.9.0 2_openblas",
+    "mkl <2025"
win-64::libblas-3.9.0-5_mkl.tar.bz2
win-64::libcblas-3.9.0-5_mkl.tar.bz2
win-64::liblapack-3.9.0-5_mkl.tar.bz2
-    "liblapacke 3.9.0 5_mkl"
+    "liblapacke 3.9.0 5_mkl",
+    "mkl <2025"
win-64::libblas-3.9.0-4_mkl.tar.bz2
win-64::libcblas-3.9.0-4_mkl.tar.bz2
win-64::liblapack-3.9.0-4_mkl.tar.bz2
-    "liblapacke 3.9.0 4_mkl"
+    "liblapacke 3.9.0 4_mkl",
+    "mkl <2025"
win-64::libblas-3.9.0-16_win64_openblas.tar.bz2
win-64::libcblas-3.9.0-16_win64_openblas.tar.bz2
win-64::liblapack-3.9.0-16_win64_openblas.tar.bz2
-    "liblapacke 3.9.0 16_win64_openblas"
+    "liblapacke 3.9.0 16_win64_openblas",
+    "mkl <2025"
win-64::libblas-3.9.0-6_mkl.tar.bz2
win-64::libcblas-3.9.0-6_mkl.tar.bz2
win-64::liblapack-3.9.0-6_mkl.tar.bz2
-    "liblapacke 3.9.0 6_mkl"
+    "liblapacke 3.9.0 6_mkl",
+    "mkl <2025"
win-64::libblas-3.9.0-16_win64_blis.tar.bz2
-    "libcblas 3.9.0 16_win64_blis"
+    "libcblas 3.9.0 16_win64_blis",
+    "mkl <2025"
win-64::libblas-3.9.0-10_mkl.tar.bz2
win-64::libcblas-3.9.0-10_mkl.tar.bz2
win-64::liblapack-3.9.0-10_mkl.tar.bz2
-    "liblapacke 3.9.0 10_mkl"
+    "liblapacke 3.9.0 10_mkl",
+    "mkl <2025"
win-64::libblas-3.9.0-1_openblas.tar.bz2
win-64::libcblas-3.9.0-1_openblas.tar.bz2
win-64::liblapack-3.9.0-1_openblas.tar.bz2
-    "liblapacke 3.9.0 1_openblas"
+    "liblapacke 3.9.0 1_openblas",
+    "mkl <2025"
win-64::libblas-3.9.0-3_blis.tar.bz2
-    "libcblas 3.9.0 3_blis"
+    "libcblas 3.9.0 3_blis",
+    "mkl <2025"
win-64::libblas-3.9.0-9_blis.tar.bz2
-    "libcblas 3.9.0 9_blis"
+    "libcblas 3.9.0 9_blis",
+    "mkl <2025"
win-64::libblas-3.9.0-8_blis.tar.bz2
-    "libcblas 3.9.0 8_blis"
+    "libcblas 3.9.0 8_blis",
+    "mkl <2025"
win-64::libblas-3.9.0-9_openblas.tar.bz2
win-64::libcblas-3.9.0-9_openblas.tar.bz2
win-64::liblapack-3.9.0-9_openblas.tar.bz2
-    "liblapacke 3.9.0 9_openblas"
+    "liblapacke 3.9.0 9_openblas",
+    "mkl <2025"
win-64::libblas-3.9.0-16_win64_mkl.tar.bz2
win-64::libcblas-3.9.0-16_win64_mkl.tar.bz2
win-64::liblapack-3.9.0-16_win64_mkl.tar.bz2
-    "liblapacke 3.9.0 16_win64_mkl"
+    "liblapacke 3.9.0 16_win64_mkl",
+    "mkl <2025"
win-64::libblas-3.9.0-14_win64_mkl.tar.bz2
win-64::libcblas-3.9.0-14_win64_mkl.tar.bz2
win-64::liblapack-3.9.0-14_win64_mkl.tar.bz2
-    "liblapacke 3.9.0 14_win64_mkl"
+    "liblapacke 3.9.0 14_win64_mkl",
+    "mkl <2025"
win-64::libblas-3.9.0-14_win64_blis.tar.bz2
-    "libcblas 3.9.0 14_win64_blis"
+    "libcblas 3.9.0 14_win64_blis",
+    "mkl <2025"
win-64::libblas-3.9.0-12_win64_mkl.tar.bz2
win-64::libcblas-3.9.0-12_win64_mkl.tar.bz2
win-64::liblapack-3.9.0-12_win64_mkl.tar.bz2
-    "liblapacke 3.9.0 12_win64_mkl"
+    "liblapacke 3.9.0 12_win64_mkl",
+    "mkl <2025"
win-64::libblas-3.9.0-7_openblas.tar.bz2
win-64::libcblas-3.9.0-7_openblas.tar.bz2
win-64::liblapack-3.9.0-7_openblas.tar.bz2
-    "liblapacke 3.9.0 7_openblas"
+    "liblapacke 3.9.0 7_openblas",
+    "mkl <2025"
win-64::libblas-3.9.0-4_openblas.tar.bz2
win-64::libcblas-3.9.0-4_openblas.tar.bz2
win-64::liblapack-3.9.0-4_openblas.tar.bz2
-    "liblapacke 3.9.0 4_openblas"
+    "liblapacke 3.9.0 4_openblas",
+    "mkl <2025"
win-64::libblas-3.9.0-13_win64_mkl.tar.bz2
win-64::libcblas-3.9.0-13_win64_mkl.tar.bz2
win-64::liblapack-3.9.0-13_win64_mkl.tar.bz2
-    "liblapacke 3.9.0 13_win64_mkl"
+    "liblapacke 3.9.0 13_win64_mkl",
+    "mkl <2025"
win-64::libblas-3.9.0-2_h8933c1f_netlib.tar.bz2
win-64::libblas-3.9.0-3_hd5c7e75_netlib.tar.bz2
win-64::libblas-3.9.0-4_hd5c7e75_netlib.tar.bz2
win-64::libblas-3.9.0-5_hd5c7e75_netlib.tar.bz2
win-64::libblas-3.9.0-6_h28841b1_netlib.conda
win-64::libblas-3.9.0-7_h28841b1_netlib.conda
win-64::libblas-3.9.0-8_h719fc58_netlib.conda
-    "blas * netlib"
+    "blas * netlib",
+    "mkl <2025"
win-64::libblas-3.9.0-12_win64_openblas.tar.bz2
win-64::libcblas-3.9.0-12_win64_openblas.tar.bz2
win-64::liblapack-3.9.0-12_win64_openblas.tar.bz2
-    "liblapacke 3.9.0 12_win64_openblas"
+    "liblapacke 3.9.0 12_win64_openblas",
+    "mkl <2025"
win-64::libblas-3.9.0-10_blis.tar.bz2
-    "libcblas 3.9.0 10_blis"
+    "libcblas 3.9.0 10_blis",
+    "mkl <2025"
win-64::libblas-3.9.0-2_blis.tar.bz2
-    "libcblas 3.9.0 2_blis"
+    "libcblas 3.9.0 2_blis",
+    "mkl <2025"
win-64::libblas-3.9.0-6_blis.tar.bz2
-    "libcblas 3.9.0 6_blis"
+    "libcblas 3.9.0 6_blis",
+    "mkl <2025"
win-64::libblas-3.9.0-1_blis.tar.bz2
-    "libcblas 3.9.0 1_blis"
+    "libcblas 3.9.0 1_blis",
+    "mkl <2025"
win-64::libblas-3.9.0-14_win64_openblas.tar.bz2
win-64::libcblas-3.9.0-14_win64_openblas.tar.bz2
win-64::liblapack-3.9.0-14_win64_openblas.tar.bz2
-    "liblapacke 3.9.0 14_win64_openblas"
+    "liblapacke 3.9.0 14_win64_openblas",
+    "mkl <2025"
win-64::libblas-3.9.0-13_win64_blis.tar.bz2
-    "libcblas 3.9.0 13_win64_blis"
+    "libcblas 3.9.0 13_win64_blis",
+    "mkl <2025"
win-64::libblas-3.9.0-11_win64_blis.tar.bz2
-    "libcblas 3.9.0 11_win64_blis"
+    "libcblas 3.9.0 11_win64_blis",
+    "mkl <2025"
win-64::libblas-3.9.0-5_blis.tar.bz2
-    "libcblas 3.9.0 5_blis"
+    "libcblas 3.9.0 5_blis",
+    "mkl <2025"
win-64::libblas-3.9.0-15_win64_blis.tar.bz2
-    "libcblas 3.9.0 15_win64_blis"
+    "libcblas 3.9.0 15_win64_blis",
+    "mkl <2025"
win-64::libblas-3.9.0-11_win64_openblas.tar.bz2
win-64::libcblas-3.9.0-11_win64_openblas.tar.bz2
win-64::liblapack-3.9.0-11_win64_openblas.tar.bz2
-    "liblapacke 3.9.0 11_win64_openblas"
+    "liblapacke 3.9.0 11_win64_openblas",
+    "mkl <2025"
win-64::libblas-3.9.0-12_win64_blis.tar.bz2
-    "libcblas 3.9.0 12_win64_blis"
+    "libcblas 3.9.0 12_win64_blis",
+    "mkl <2025"
win-64::libblas-3.9.0-17_win64_openblas.conda
win-64::libcblas-3.9.0-17_win64_openblas.conda
win-64::liblapack-3.9.0-17_win64_openblas.conda
-    "liblapacke 3.9.0 17_win64_openblas"
+    "liblapacke 3.9.0 17_win64_openblas",
+    "mkl <2025"
win-64::libblas-3.9.0-22_win64_openblas.conda
win-64::libcblas-3.9.0-22_win64_openblas.conda
win-64::liblapack-3.9.0-22_win64_openblas.conda
-    "liblapacke 3.9.0 22_win64_openblas"
+    "liblapacke 3.9.0 22_win64_openblas",
+    "mkl <2025"
win-64::libblas-3.9.0-28_h576b46c_mkl.conda
win-64::libcblas-3.9.0-28_h7ad3364_mkl.conda
win-64::liblapack-3.9.0-28_hacfb0e4_mkl.conda
-    "liblapacke =3.9.0=28*_mkl"
+    "liblapacke =3.9.0=28*_mkl",
+    "mkl <2025"
win-64::libblas-3.9.0-23_win64_openblas.conda
win-64::libcblas-3.9.0-23_win64_openblas.conda
win-64::liblapack-3.9.0-23_win64_openblas.conda
-    "liblapacke 3.9.0 23_win64_openblas"
+    "liblapacke 3.9.0 23_win64_openblas",
+    "mkl <2025"
win-64::liblapacke-3.9.0-27_h1d0e49f_openblas.conda
win-64::liblapacke-3.9.0-27_hab6c6b4_openblas.conda
-    "blas =2.127=openblas"
+    "blas =2.127=openblas",
+    "mkl <2025"
win-64::libblas-3.9.0-24_win64_openblas.conda
win-64::libcblas-3.9.0-24_win64_openblas.conda
win-64::liblapack-3.9.0-24_win64_openblas.conda
-    "liblapacke 3.9.0 24_win64_openblas"
+    "liblapacke 3.9.0 24_win64_openblas",
+    "mkl <2025"
win-64::libblas-3.9.0-20_win64_mkl.conda
win-64::libcblas-3.9.0-20_win64_mkl.conda
win-64::liblapack-3.9.0-20_win64_mkl.conda
-    "liblapacke 3.9.0 20_win64_mkl"
+    "liblapacke 3.9.0 20_win64_mkl",
+    "mkl <2025"
win-64::libblas-3.9.0-26_win64_mkl.conda
win-64::libcblas-3.9.0-26_win64_mkl.conda
win-64::liblapack-3.9.0-26_win64_mkl.conda
-    "liblapacke 3.9.0 26_win64_mkl"
+    "liblapacke 3.9.0 26_win64_mkl",
+    "mkl <2025"
win-64::libblas-3.9.0-21_win64_mkl.conda
win-64::libcblas-3.9.0-21_win64_mkl.conda
win-64::liblapack-3.9.0-21_win64_mkl.conda
-    "liblapacke 3.9.0 21_win64_mkl"
+    "liblapacke 3.9.0 21_win64_mkl",
+    "mkl <2025"
win-64::libblas-3.9.0-26_win64_blis.conda
-    "libcblas 3.9.0 26_win64_blis"
+    "libcblas 3.9.0 26_win64_blis",
+    "mkl <2025"
win-64::libblas-3.9.0-26_win64_openblas.conda
win-64::libcblas-3.9.0-26_win64_openblas.conda
win-64::liblapack-3.9.0-26_win64_openblas.conda
-    "liblapacke 3.9.0 26_win64_openblas"
+    "liblapacke 3.9.0 26_win64_openblas",
+    "mkl <2025"
win-64::libblas-3.9.0-25_win64_openblas.conda
win-64::libcblas-3.9.0-25_win64_openblas.conda
win-64::liblapack-3.9.0-25_win64_openblas.conda
-    "liblapacke 3.9.0 25_win64_openblas"
+    "liblapacke 3.9.0 25_win64_openblas",
+    "mkl <2025"
win-64::libblas-3.9.0-27_h11dc60a_openblas.conda
win-64::libblas-3.9.0-27_h706a439_openblas.conda
win-64::libcblas-3.9.0-27_h04ea4e4_openblas.conda
win-64::libcblas-3.9.0-27_h423d235_openblas.conda
win-64::liblapack-3.9.0-27_h1c6d55f_openblas.conda
win-64::liblapack-3.9.0-27_h2526c6b_openblas.conda
-    "liblapacke =3.9.0=27*_openblas"
+    "liblapacke =3.9.0=27*_openblas",
+    "mkl <2025"
win-64::libblas-3.9.0-18_win64_openblas.conda
win-64::libcblas-3.9.0-18_win64_openblas.conda
win-64::liblapack-3.9.0-18_win64_openblas.conda
-    "liblapacke 3.9.0 18_win64_openblas"
+    "liblapacke 3.9.0 18_win64_openblas",
+    "mkl <2025"
win-64::libblas-3.9.0-27_h576b46c_mkl.conda
win-64::libcblas-3.9.0-27_h9cfd0ba_mkl.conda
win-64::liblapack-3.9.0-27_hacfb0e4_mkl.conda
-    "liblapacke =3.9.0=27*_mkl"
+    "liblapacke =3.9.0=27*_mkl",
+    "mkl <2025"
win-64::libblas-3.9.0-20_win64_openblas.conda
win-64::libcblas-3.9.0-20_win64_openblas.conda
win-64::liblapack-3.9.0-20_win64_openblas.conda
-    "liblapacke 3.9.0 20_win64_openblas"
+    "liblapacke 3.9.0 20_win64_openblas",
+    "mkl <2025"
win-64::libblas-3.9.0-19_win64_openblas.conda
win-64::libcblas-3.9.0-19_win64_openblas.conda
win-64::liblapack-3.9.0-19_win64_openblas.conda
-    "liblapacke 3.9.0 19_win64_openblas"
+    "liblapacke 3.9.0 19_win64_openblas",
+    "mkl <2025"
win-64::libblas-3.9.0-18_win64_mkl.conda
win-64::libcblas-3.9.0-18_win64_mkl.conda
win-64::liblapack-3.9.0-18_win64_mkl.conda
-    "liblapacke 3.9.0 18_win64_mkl"
+    "liblapacke 3.9.0 18_win64_mkl",
+    "mkl <2025"
win-64::libblas-3.9.0-24_win64_mkl.conda
win-64::libcblas-3.9.0-24_win64_mkl.conda
win-64::liblapack-3.9.0-24_win64_mkl.conda
-    "liblapacke 3.9.0 24_win64_mkl"
+    "liblapacke 3.9.0 24_win64_mkl",
+    "mkl <2025"
win-64::libblas-3.9.0-17_win64_mkl.conda
win-64::libcblas-3.9.0-17_win64_mkl.conda
win-64::liblapack-3.9.0-17_win64_mkl.conda
-    "liblapacke 3.9.0 17_win64_mkl"
+    "liblapacke 3.9.0 17_win64_mkl",
+    "mkl <2025"
win-64::libblas-3.9.0-28_h11dc60a_openblas.conda
win-64::libblas-3.9.0-28_h706a439_openblas.conda
win-64::libcblas-3.9.0-28_h9bd4c3b_openblas.conda
win-64::libcblas-3.9.0-28_ha692739_openblas.conda
win-64::liblapack-3.9.0-28_h1c6d55f_openblas.conda
win-64::liblapack-3.9.0-28_h2526c6b_openblas.conda
-    "liblapacke =3.9.0=28*_openblas"
+    "liblapacke =3.9.0=28*_openblas",
+    "mkl <2025"
win-64::libblas-3.9.0-22_win64_blis.conda
-    "libcblas 3.9.0 22_win64_blis"
+    "libcblas 3.9.0 22_win64_blis",
+    "mkl <2025"
win-64::libblas-3.9.0-27_h4b1af58_blis.conda
-    "libcblas =3.9.0=27*_blis"
+    "libcblas =3.9.0=27*_blis",
+    "mkl <2025"
win-64::libblas-3.9.0-21_win64_openblas.conda
win-64::libcblas-3.9.0-21_win64_openblas.conda
win-64::liblapack-3.9.0-21_win64_openblas.conda
-    "liblapacke 3.9.0 21_win64_openblas"
+    "liblapacke 3.9.0 21_win64_openblas",
+    "mkl <2025"
win-64::liblapacke-3.9.0-28_h8a98c43_mkl.conda
-    "blas =2.128=mkl"
+    "blas =2.128=mkl",
+    "mkl <2025"
win-64::libblas-3.9.0-22_win64_mkl.conda
win-64::libcblas-3.9.0-22_win64_mkl.conda
win-64::liblapack-3.9.0-22_win64_mkl.conda
-    "liblapacke 3.9.0 22_win64_mkl"
+    "liblapacke 3.9.0 22_win64_mkl",
+    "mkl <2025"
win-64::libblas-3.9.0-17_win64_blis.conda
-    "libcblas 3.9.0 17_win64_blis"
+    "libcblas 3.9.0 17_win64_blis",
+    "mkl <2025"
win-64::liblapacke-3.9.0-27_h8a98c43_mkl.conda
-    "blas =2.127=mkl"
+    "blas =2.127=mkl",
+    "mkl <2025"
win-64::libblas-3.9.0-24_win64_blis.conda
-    "libcblas 3.9.0 24_win64_blis"
+    "libcblas 3.9.0 24_win64_blis",
+    "mkl <2025"
win-64::libcblas-3.9.0-27_h70f2387_blis.conda
-    "blas =2.127=blis"
+    "blas =2.127=blis",
+    "mkl <2025"
win-64::liblapacke-3.9.0-28_h1d0e49f_openblas.conda
win-64::liblapacke-3.9.0-28_hab6c6b4_openblas.conda
-    "blas =2.128=openblas"
+    "blas =2.128=openblas",
+    "mkl <2025"
win-64::libblas-3.9.0-23_win64_mkl.conda
win-64::libcblas-3.9.0-23_win64_mkl.conda
win-64::liblapack-3.9.0-23_win64_mkl.conda
-    "liblapacke 3.9.0 23_win64_mkl"
+    "liblapacke 3.9.0 23_win64_mkl",
+    "mkl <2025"
win-64::libblas-3.9.0-19_win64_mkl.conda
win-64::libcblas-3.9.0-19_win64_mkl.conda
win-64::liblapack-3.9.0-19_win64_mkl.conda
-    "liblapacke 3.9.0 19_win64_mkl"
+    "liblapacke 3.9.0 19_win64_mkl",
+    "mkl <2025"
win-64::libblas-3.9.0-25_win64_blis.conda
-    "libcblas 3.9.0 25_win64_blis"
+    "libcblas 3.9.0 25_win64_blis",
+    "mkl <2025"
win-64::libblas-3.9.0-25_win64_mkl.conda
win-64::libcblas-3.9.0-25_win64_mkl.conda
win-64::liblapack-3.9.0-25_win64_mkl.conda
-    "liblapacke 3.9.0 25_win64_mkl"
+    "liblapacke 3.9.0 25_win64_mkl",
+    "mkl <2025"
win-64::libblas-3.9.0-18_win64_blis.conda
-    "libcblas 3.9.0 18_win64_blis"
+    "libcblas 3.9.0 18_win64_blis",
+    "mkl <2025"
win-64::libcblas-3.9.0-28_h263f4c5_blis.conda
-    "blas =2.128=blis"
+    "blas =2.128=blis",
+    "mkl <2025"
win-64::libblas-3.9.0-28_h4b1af58_blis.conda
-    "libcblas =3.9.0=28*_blis"
+    "libcblas =3.9.0=28*_blis",
+    "mkl <2025"
win-64::libblas-3.9.0-20_win64_blis.conda
-    "libcblas 3.9.0 20_win64_blis"
+    "libcblas 3.9.0 20_win64_blis",
+    "mkl <2025"
win-64::libblas-3.9.0-23_win64_blis.conda
-    "libcblas 3.9.0 23_win64_blis"
+    "libcblas 3.9.0 23_win64_blis",
+    "mkl <2025"
win-64::libblas-3.9.0-21_win64_blis.conda
-    "libcblas 3.9.0 21_win64_blis"
+    "libcblas 3.9.0 21_win64_blis",
+    "mkl <2025"
win-64::libblas-3.9.0-19_win64_blis.conda
-    "libcblas 3.9.0 19_win64_blis"
+    "libcblas 3.9.0 19_win64_blis",
+    "mkl <2025"
================================================================================
================================================================================
osx-64
================================================================================
================================================================================
linux-64
linux-64::libblas-3.9.0-7_openblas.tar.bz2
linux-64::libcblas-3.9.0-7_openblas.tar.bz2
linux-64::liblapack-3.9.0-7_openblas.tar.bz2
-    "liblapacke 3.9.0 7_openblas"
+    "liblapacke 3.9.0 7_openblas",
+    "mkl <2025"
linux-64::liblapacke-3.9.0-0_openblas.tar.bz2
linux-64::liblapacke-3.9.0-10_openblas.tar.bz2
linux-64::liblapacke-3.9.0-11_linux64_openblas.tar.bz2
linux-64::liblapacke-3.9.0-12_linux64_openblas.tar.bz2
linux-64::liblapacke-3.9.0-13_linux64_openblas.tar.bz2
linux-64::liblapacke-3.9.0-14_linux64_openblas.tar.bz2
linux-64::liblapacke-3.9.0-15_linux64_openblas.tar.bz2
linux-64::liblapacke-3.9.0-16_linux64_openblas.tar.bz2
linux-64::liblapacke-3.9.0-17_linux64_openblas.conda
linux-64::liblapacke-3.9.0-18_linux64_openblas.conda
linux-64::liblapacke-3.9.0-19_linux64_openblas.conda
linux-64::liblapacke-3.9.0-1_openblas.tar.bz2
linux-64::liblapacke-3.9.0-20_linux64_openblas.conda
linux-64::liblapacke-3.9.0-21_linux64_openblas.conda
linux-64::liblapacke-3.9.0-22_linux64_openblas.conda
linux-64::liblapacke-3.9.0-23_linux64_openblas.conda
linux-64::liblapacke-3.9.0-24_linux64_openblas.conda
linux-64::liblapacke-3.9.0-25_linux64_openblas.conda
linux-64::liblapacke-3.9.0-26_linux64_openblas.conda
linux-64::liblapacke-3.9.0-2_openblas.tar.bz2
linux-64::liblapacke-3.9.0-3_openblas.tar.bz2
linux-64::liblapacke-3.9.0-4_openblas.tar.bz2
linux-64::liblapacke-3.9.0-5_openblas.tar.bz2
linux-64::liblapacke-3.9.0-6_openblas.tar.bz2
linux-64::liblapacke-3.9.0-7_openblas.tar.bz2
linux-64::liblapacke-3.9.0-8_openblas.tar.bz2
linux-64::liblapacke-3.9.0-9_openblas.tar.bz2
-    "blas * openblas"
+    "blas * openblas",
+    "mkl <2025"
linux-64::libcblas-3.9.0-0_blis.tar.bz2
linux-64::libcblas-3.9.0-10_blis.tar.bz2
linux-64::libcblas-3.9.0-11_linux64_blis.tar.bz2
linux-64::libcblas-3.9.0-12_linux64_blis.tar.bz2
linux-64::libcblas-3.9.0-13_linux64_blis.tar.bz2
linux-64::libcblas-3.9.0-14_linux64_blis.tar.bz2
linux-64::libcblas-3.9.0-15_linux64_blis.tar.bz2
linux-64::libcblas-3.9.0-16_linux64_blis.tar.bz2
linux-64::libcblas-3.9.0-17_linux64_blis.conda
linux-64::libcblas-3.9.0-18_linux64_blis.conda
linux-64::libcblas-3.9.0-19_linux64_blis.conda
linux-64::libcblas-3.9.0-1_blis.tar.bz2
linux-64::libcblas-3.9.0-20_linux64_blis.conda
linux-64::libcblas-3.9.0-21_linux64_blis.conda
linux-64::libcblas-3.9.0-22_linux64_blis.conda
linux-64::libcblas-3.9.0-23_linux64_blis.conda
linux-64::libcblas-3.9.0-24_linux64_blis.conda
linux-64::libcblas-3.9.0-25_linux64_blis.conda
linux-64::libcblas-3.9.0-26_linux64_blis.conda
linux-64::libcblas-3.9.0-2_blis.tar.bz2
linux-64::libcblas-3.9.0-3_blis.tar.bz2
linux-64::libcblas-3.9.0-4_blis.tar.bz2
linux-64::libcblas-3.9.0-5_blis.tar.bz2
linux-64::libcblas-3.9.0-6_blis.tar.bz2
linux-64::libcblas-3.9.0-7_blis.tar.bz2
linux-64::libcblas-3.9.0-8_blis.tar.bz2
linux-64::libcblas-3.9.0-9_blis.tar.bz2
-    "blas * blis"
+    "blas * blis",
+    "mkl <2025"
linux-64::libblas-3.9.0-0_h6e990d7_netlib.tar.bz2
linux-64::libblas-3.9.0-0_h86c2bf4_netlib.tar.bz2
linux-64::libblas-3.9.0-1_h6e990d7_netlib.tar.bz2
linux-64::libblas-3.9.0-1_h86c2bf4_netlib.tar.bz2
linux-64::libcblas-3.9.0-0_h6e990d7_netlib.tar.bz2
linux-64::libcblas-3.9.0-0_h86c2bf4_netlib.tar.bz2
linux-64::libcblas-3.9.0-1_h6e990d7_netlib.tar.bz2
linux-64::libcblas-3.9.0-1_h86c2bf4_netlib.tar.bz2
linux-64::libcblas-3.9.0-2_h6e990d7_netlib.tar.bz2
linux-64::libcblas-3.9.0-2_h86c2bf4_netlib.tar.bz2
linux-64::libcblas-3.9.0-3_h893e4fe_netlib.tar.bz2
linux-64::libcblas-3.9.0-3_h92ddd45_netlib.tar.bz2
linux-64::libcblas-3.9.0-4_h92ddd45_netlib.tar.bz2
linux-64::libcblas-3.9.0-5_h92ddd45_netlib.tar.bz2
linux-64::libcblas-3.9.0-6_ha36c22a_netlib.conda
linux-64::libcblas-3.9.0-7_ha36c22a_netlib.conda
linux-64::libcblas-3.9.0-8_h3b12eaf_netlib.conda
linux-64::liblapack-3.9.0-0_h6e990d7_netlib.tar.bz2
linux-64::liblapack-3.9.0-0_h86c2bf4_netlib.tar.bz2
linux-64::liblapack-3.9.0-1_h6e990d7_netlib.tar.bz2
linux-64::liblapack-3.9.0-1_h86c2bf4_netlib.tar.bz2
linux-64::liblapack-3.9.0-2_h6e990d7_netlib.tar.bz2
linux-64::liblapack-3.9.0-2_h86c2bf4_netlib.tar.bz2
linux-64::liblapack-3.9.0-3_h893e4fe_netlib.tar.bz2
linux-64::liblapack-3.9.0-3_h92ddd45_netlib.tar.bz2
linux-64::liblapack-3.9.0-4_h92ddd45_netlib.tar.bz2
linux-64::liblapack-3.9.0-5_h92ddd45_netlib.tar.bz2
linux-64::liblapack-3.9.0-6_ha36c22a_netlib.conda
linux-64::liblapack-3.9.0-7_ha36c22a_netlib.conda
linux-64::liblapack-3.9.0-8_h3b12eaf_netlib.conda
linux-64::liblapacke-3.9.0-0_h6e990d7_netlib.tar.bz2
linux-64::liblapacke-3.9.0-0_h86c2bf4_netlib.tar.bz2
linux-64::liblapacke-3.9.0-1_h6e990d7_netlib.tar.bz2
linux-64::liblapacke-3.9.0-1_h86c2bf4_netlib.tar.bz2
linux-64::liblapacke-3.9.0-2_h6e990d7_netlib.tar.bz2
linux-64::liblapacke-3.9.0-2_h86c2bf4_netlib.tar.bz2
linux-64::liblapacke-3.9.0-3_h893e4fe_netlib.tar.bz2
linux-64::liblapacke-3.9.0-3_h92ddd45_netlib.tar.bz2
linux-64::liblapacke-3.9.0-4_h92ddd45_netlib.tar.bz2
linux-64::liblapacke-3.9.0-5_h92ddd45_netlib.tar.bz2
linux-64::liblapacke-3.9.0-6_ha36c22a_netlib.conda
linux-64::liblapacke-3.9.0-7_ha36c22a_netlib.conda
linux-64::liblapacke-3.9.0-8_h3b12eaf_netlib.conda
+  "constrains": [
+    "mkl <2025"
+  ],
linux-64::libblas-3.9.0-11_linux64_openblas.tar.bz2
linux-64::libcblas-3.9.0-11_linux64_openblas.tar.bz2
linux-64::liblapack-3.9.0-11_linux64_openblas.tar.bz2
-    "liblapacke 3.9.0 11_linux64_openblas"
+    "liblapacke 3.9.0 11_linux64_openblas",
+    "mkl <2025"
linux-64::libblas-3.9.0-13_linux64_openblas.tar.bz2
linux-64::libcblas-3.9.0-13_linux64_openblas.tar.bz2
linux-64::liblapack-3.9.0-13_linux64_openblas.tar.bz2
-    "liblapacke 3.9.0 13_linux64_openblas"
+    "liblapacke 3.9.0 13_linux64_openblas",
+    "mkl <2025"
linux-64::libblas-3.9.0-6_blis.tar.bz2
-    "libcblas 3.9.0 6_blis"
+    "libcblas 3.9.0 6_blis",
+    "mkl <2025"
linux-64::libblas-3.9.0-2_h6e990d7_netlib.tar.bz2
linux-64::libblas-3.9.0-2_h86c2bf4_netlib.tar.bz2
linux-64::libblas-3.9.0-3_h893e4fe_netlib.tar.bz2
linux-64::libblas-3.9.0-3_h92ddd45_netlib.tar.bz2
linux-64::libblas-3.9.0-4_h92ddd45_netlib.tar.bz2
linux-64::libblas-3.9.0-5_h92ddd45_netlib.tar.bz2
linux-64::libblas-3.9.0-6_ha36c22a_netlib.conda
linux-64::libblas-3.9.0-7_ha36c22a_netlib.conda
linux-64::libblas-3.9.0-8_h3b12eaf_netlib.conda
-    "blas * netlib"
+    "blas * netlib",
+    "mkl <2025"
linux-64::libblas-3.9.0-16_linux64_openblas.tar.bz2
linux-64::libcblas-3.9.0-16_linux64_openblas.tar.bz2
linux-64::liblapack-3.9.0-16_linux64_openblas.tar.bz2
-    "liblapacke 3.9.0 16_linux64_openblas"
+    "liblapacke 3.9.0 16_linux64_openblas",
+    "mkl <2025"
linux-64::libblas-3.9.0-12_linux64_mkl.tar.bz2
linux-64::libcblas-3.9.0-12_linux64_mkl.tar.bz2
linux-64::liblapack-3.9.0-12_linux64_mkl.tar.bz2
-    "liblapacke 3.9.0 12_linux64_mkl"
+    "liblapacke 3.9.0 12_linux64_mkl",
+    "mkl <2025"
linux-64::libblas-3.9.0-1_openblas.tar.bz2
linux-64::libcblas-3.9.0-1_openblas.tar.bz2
linux-64::liblapack-3.9.0-1_openblas.tar.bz2
-    "liblapacke 3.9.0 1_openblas"
+    "liblapacke 3.9.0 1_openblas",
+    "mkl <2025"
linux-64::libblas-3.9.0-8_mkl.tar.bz2
linux-64::libcblas-3.9.0-8_mkl.tar.bz2
linux-64::liblapack-3.9.0-8_mkl.tar.bz2
-    "liblapacke 3.9.0 8_mkl"
+    "liblapacke 3.9.0 8_mkl",
+    "mkl <2025"
linux-64::libblas-3.9.0-5_openblas.tar.bz2
linux-64::libcblas-3.9.0-5_openblas.tar.bz2
linux-64::liblapack-3.9.0-5_openblas.tar.bz2
-    "liblapacke 3.9.0 5_openblas"
+    "liblapacke 3.9.0 5_openblas",
+    "mkl <2025"
linux-64::libblas-3.9.0-14_linux64_mkl.tar.bz2
linux-64::libcblas-3.9.0-14_linux64_mkl.tar.bz2
linux-64::liblapack-3.9.0-14_linux64_mkl.tar.bz2
-    "liblapacke 3.9.0 14_linux64_mkl"
+    "liblapacke 3.9.0 14_linux64_mkl",
+    "mkl <2025"
linux-64::libblas-3.9.0-9_openblas.tar.bz2
linux-64::libcblas-3.9.0-9_openblas.tar.bz2
linux-64::liblapack-3.9.0-9_openblas.tar.bz2
-    "liblapacke 3.9.0 9_openblas"
+    "liblapacke 3.9.0 9_openblas",
+    "mkl <2025"
linux-64::libblas-3.9.0-4_mkl.tar.bz2
linux-64::libcblas-3.9.0-4_mkl.tar.bz2
linux-64::liblapack-3.9.0-4_mkl.tar.bz2
-    "liblapacke 3.9.0 4_mkl"
+    "liblapacke 3.9.0 4_mkl",
+    "mkl <2025"
linux-64::libblas-3.9.0-13_linux64_mkl.tar.bz2
linux-64::libcblas-3.9.0-13_linux64_mkl.tar.bz2
linux-64::liblapack-3.9.0-13_linux64_mkl.tar.bz2
-    "liblapacke 3.9.0 13_linux64_mkl"
+    "liblapacke 3.9.0 13_linux64_mkl",
+    "mkl <2025"
linux-64::libblas-3.9.0-9_mkl.tar.bz2
linux-64::libcblas-3.9.0-9_mkl.tar.bz2
linux-64::liblapack-3.9.0-9_mkl.tar.bz2
-    "liblapacke 3.9.0 9_mkl"
+    "liblapacke 3.9.0 9_mkl",
+    "mkl <2025"
linux-64::libblas-3.9.0-1_blis.tar.bz2
-    "libcblas 3.9.0 1_blis"
+    "libcblas 3.9.0 1_blis",
+    "mkl <2025"
linux-64::libblas-3.9.0-10_mkl.tar.bz2
linux-64::libcblas-3.9.0-10_mkl.tar.bz2
linux-64::liblapack-3.9.0-10_mkl.tar.bz2
-    "liblapacke 3.9.0 10_mkl"
+    "liblapacke 3.9.0 10_mkl",
+    "mkl <2025"
linux-64::libblas-3.9.0-7_blis.tar.bz2
-    "libcblas 3.9.0 7_blis"
+    "libcblas 3.9.0 7_blis",
+    "mkl <2025"
linux-64::libblas-3.9.0-7_mkl.tar.bz2
linux-64::libcblas-3.9.0-7_mkl.tar.bz2
linux-64::liblapack-3.9.0-7_mkl.tar.bz2
-    "liblapacke 3.9.0 7_mkl"
+    "liblapacke 3.9.0 7_mkl",
+    "mkl <2025"
linux-64::libblas-3.9.0-6_mkl.tar.bz2
linux-64::libcblas-3.9.0-6_mkl.tar.bz2
linux-64::liblapack-3.9.0-6_mkl.tar.bz2
-    "liblapacke 3.9.0 6_mkl"
+    "liblapacke 3.9.0 6_mkl",
+    "mkl <2025"
linux-64::liblapacke-3.9.0-10_mkl.tar.bz2
linux-64::liblapacke-3.9.0-11_linux64_mkl.tar.bz2
linux-64::liblapacke-3.9.0-12_linux64_mkl.tar.bz2
linux-64::liblapacke-3.9.0-13_linux64_mkl.tar.bz2
linux-64::liblapacke-3.9.0-14_linux64_mkl.tar.bz2
linux-64::liblapacke-3.9.0-15_linux64_mkl.tar.bz2
linux-64::liblapacke-3.9.0-16_linux64_mkl.tar.bz2
linux-64::liblapacke-3.9.0-19_linux64_mkl.conda
linux-64::liblapacke-3.9.0-20_linux64_mkl.conda
linux-64::liblapacke-3.9.0-21_linux64_mkl.conda
linux-64::liblapacke-3.9.0-22_linux64_mkl.conda
linux-64::liblapacke-3.9.0-23_linux64_mkl.conda
linux-64::liblapacke-3.9.0-24_linux64_mkl.conda
linux-64::liblapacke-3.9.0-25_linux64_mkl.conda
linux-64::liblapacke-3.9.0-26_linux64_mkl.conda
linux-64::liblapacke-3.9.0-4_mkl.tar.bz2
linux-64::liblapacke-3.9.0-5_mkl.tar.bz2
linux-64::liblapacke-3.9.0-6_mkl.tar.bz2
linux-64::liblapacke-3.9.0-7_mkl.tar.bz2
linux-64::liblapacke-3.9.0-8_mkl.tar.bz2
linux-64::liblapacke-3.9.0-9_mkl.tar.bz2
-    "blas * mkl"
+    "blas * mkl",
+    "mkl <2025"
linux-64::libblas-3.9.0-10_openblas.tar.bz2
linux-64::libcblas-3.9.0-10_openblas.tar.bz2
linux-64::liblapack-3.9.0-10_openblas.tar.bz2
-    "liblapacke 3.9.0 10_openblas"
+    "liblapacke 3.9.0 10_openblas",
+    "mkl <2025"
linux-64::libblas-3.9.0-8_openblas.tar.bz2
linux-64::libcblas-3.9.0-8_openblas.tar.bz2
linux-64::liblapack-3.9.0-8_openblas.tar.bz2
-    "liblapacke 3.9.0 8_openblas"
+    "liblapacke 3.9.0 8_openblas",
+    "mkl <2025"
linux-64::libblas-3.9.0-0_openblas.tar.bz2
linux-64::libcblas-3.9.0-0_openblas.tar.bz2
linux-64::liblapack-3.9.0-0_openblas.tar.bz2
-    "liblapacke 3.9.0 0_openblas"
+    "liblapacke 3.9.0 0_openblas",
+    "mkl <2025"
linux-64::libblas-3.9.0-2_openblas.tar.bz2
linux-64::libcblas-3.9.0-2_openblas.tar.bz2
linux-64::liblapack-3.9.0-2_openblas.tar.bz2
-    "liblapacke 3.9.0 2_openblas"
+    "liblapacke 3.9.0 2_openblas",
+    "mkl <2025"
linux-64::libblas-3.9.0-10_blis.tar.bz2
-    "libcblas 3.9.0 10_blis"
+    "libcblas 3.9.0 10_blis",
+    "mkl <2025"
linux-64::libblas-3.9.0-4_openblas.tar.bz2
linux-64::libcblas-3.9.0-4_openblas.tar.bz2
linux-64::liblapack-3.9.0-4_openblas.tar.bz2
-    "liblapacke 3.9.0 4_openblas"
+    "liblapacke 3.9.0 4_openblas",
+    "mkl <2025"
linux-64::libblas-3.9.0-15_linux64_mkl.tar.bz2
linux-64::libcblas-3.9.0-15_linux64_mkl.tar.bz2
linux-64::liblapack-3.9.0-15_linux64_mkl.tar.bz2
-    "liblapacke 3.9.0 15_linux64_mkl"
+    "liblapacke 3.9.0 15_linux64_mkl",
+    "mkl <2025"
linux-64::libblas-3.9.0-15_linux64_openblas.tar.bz2
linux-64::libcblas-3.9.0-15_linux64_openblas.tar.bz2
linux-64::liblapack-3.9.0-15_linux64_openblas.tar.bz2
-    "liblapacke 3.9.0 15_linux64_openblas"
+    "liblapacke 3.9.0 15_linux64_openblas",
+    "mkl <2025"
linux-64::libblas-3.9.0-6_openblas.tar.bz2
linux-64::libcblas-3.9.0-6_openblas.tar.bz2
linux-64::liblapack-3.9.0-6_openblas.tar.bz2
-    "liblapacke 3.9.0 6_openblas"
+    "liblapacke 3.9.0 6_openblas",
+    "mkl <2025"
linux-64::libblas-3.9.0-14_linux64_blis.tar.bz2
-    "libcblas 3.9.0 14_linux64_blis"
+    "libcblas 3.9.0 14_linux64_blis",
+    "mkl <2025"
linux-64::libblas-3.9.0-14_linux64_openblas.tar.bz2
linux-64::libcblas-3.9.0-14_linux64_openblas.tar.bz2
linux-64::liblapack-3.9.0-14_linux64_openblas.tar.bz2
-    "liblapacke 3.9.0 14_linux64_openblas"
+    "liblapacke 3.9.0 14_linux64_openblas",
+    "mkl <2025"
linux-64::libblas-3.9.0-3_blis.tar.bz2
-    "libcblas 3.9.0 3_blis"
+    "libcblas 3.9.0 3_blis",
+    "mkl <2025"
linux-64::libblas-3.9.0-16_linux64_mkl.tar.bz2
linux-64::libcblas-3.9.0-16_linux64_mkl.tar.bz2
linux-64::liblapack-3.9.0-16_linux64_mkl.tar.bz2
-    "liblapacke 3.9.0 16_linux64_mkl"
+    "liblapacke 3.9.0 16_linux64_mkl",
+    "mkl <2025"
linux-64::libblas-3.9.0-3_openblas.tar.bz2
linux-64::libcblas-3.9.0-3_openblas.tar.bz2
linux-64::liblapack-3.9.0-3_openblas.tar.bz2
-    "liblapacke 3.9.0 3_openblas"
+    "liblapacke 3.9.0 3_openblas",
+    "mkl <2025"
linux-64::libblas-3.9.0-12_linux64_openblas.tar.bz2
linux-64::libcblas-3.9.0-12_linux64_openblas.tar.bz2
linux-64::liblapack-3.9.0-12_linux64_openblas.tar.bz2
-    "liblapacke 3.9.0 12_linux64_openblas"
+    "liblapacke 3.9.0 12_linux64_openblas",
+    "mkl <2025"
linux-64::libblas-3.9.0-4_blis.tar.bz2
-    "libcblas 3.9.0 4_blis"
+    "libcblas 3.9.0 4_blis",
+    "mkl <2025"
linux-64::libblas-3.9.0-16_linux64_blis.tar.bz2
-    "libcblas 3.9.0 16_linux64_blis"
+    "libcblas 3.9.0 16_linux64_blis",
+    "mkl <2025"
linux-64::libblas-3.9.0-12_linux64_blis.tar.bz2
-    "libcblas 3.9.0 12_linux64_blis"
+    "libcblas 3.9.0 12_linux64_blis",
+    "mkl <2025"
linux-64::libblas-3.9.0-5_mkl.tar.bz2
linux-64::libcblas-3.9.0-5_mkl.tar.bz2
linux-64::liblapack-3.9.0-5_mkl.tar.bz2
-    "liblapacke 3.9.0 5_mkl"
+    "liblapacke 3.9.0 5_mkl",
+    "mkl <2025"
linux-64::libblas-3.9.0-11_linux64_mkl.tar.bz2
linux-64::libcblas-3.9.0-11_linux64_mkl.tar.bz2
linux-64::liblapack-3.9.0-11_linux64_mkl.tar.bz2
-    "liblapacke 3.9.0 11_linux64_mkl"
+    "liblapacke 3.9.0 11_linux64_mkl",
+    "mkl <2025"
linux-64::libblas-3.9.0-15_linux64_blis.tar.bz2
-    "libcblas 3.9.0 15_linux64_blis"
+    "libcblas 3.9.0 15_linux64_blis",
+    "mkl <2025"
linux-64::libblas-3.9.0-13_linux64_blis.tar.bz2
-    "libcblas 3.9.0 13_linux64_blis"
+    "libcblas 3.9.0 13_linux64_blis",
+    "mkl <2025"
linux-64::libblas-3.9.0-11_linux64_blis.tar.bz2
-    "libcblas 3.9.0 11_linux64_blis"
+    "libcblas 3.9.0 11_linux64_blis",
+    "mkl <2025"
linux-64::libblas-3.9.0-0_blis.tar.bz2
-    "libcblas 3.9.0 0_blis"
+    "libcblas 3.9.0 0_blis",
+    "mkl <2025"
linux-64::libblas-3.9.0-2_blis.tar.bz2
-    "libcblas 3.9.0 2_blis"
+    "libcblas 3.9.0 2_blis",
+    "mkl <2025"
linux-64::libblas-3.9.0-9_blis.tar.bz2
-    "libcblas 3.9.0 9_blis"
+    "libcblas 3.9.0 9_blis",
+    "mkl <2025"
linux-64::libblas-3.9.0-5_blis.tar.bz2
-    "libcblas 3.9.0 5_blis"
+    "libcblas 3.9.0 5_blis",
+    "mkl <2025"
linux-64::libblas-3.9.0-8_blis.tar.bz2
-    "libcblas 3.9.0 8_blis"
+    "libcblas 3.9.0 8_blis",
+    "mkl <2025"
linux-64::libblas-3.9.0-27_h59b9bed_openblas.conda
linux-64::libcblas-3.9.0-27_h89f5a98_openblas.conda
linux-64::liblapack-3.9.0-27_h7ac8fdf_openblas.conda
-    "liblapacke =3.9.0=27*_openblas"
+    "liblapacke =3.9.0=27*_openblas",
+    "mkl <2025"
linux-64::libblas-3.9.0-22_linux64_openblas.conda
linux-64::libcblas-3.9.0-22_linux64_openblas.conda
linux-64::liblapack-3.9.0-22_linux64_openblas.conda
-    "liblapacke 3.9.0 22_linux64_openblas"
+    "liblapacke 3.9.0 22_linux64_openblas",
+    "mkl <2025"
linux-64::libblas-3.9.0-28_h59b9bed_openblas.conda
linux-64::libcblas-3.9.0-28_he106b2a_openblas.conda
linux-64::liblapack-3.9.0-28_h7ac8fdf_openblas.conda
-    "liblapacke =3.9.0=28*_openblas"
+    "liblapacke =3.9.0=28*_openblas",
+    "mkl <2025"
linux-64::libblas-3.9.0-20_linux64_mkl.conda
linux-64::libcblas-3.9.0-20_linux64_mkl.conda
linux-64::liblapack-3.9.0-20_linux64_mkl.conda
-    "liblapacke 3.9.0 20_linux64_mkl"
+    "liblapacke 3.9.0 20_linux64_mkl",
+    "mkl <2025"
linux-64::libblas-3.9.0-23_linux64_openblas.conda
linux-64::libcblas-3.9.0-23_linux64_openblas.conda
linux-64::liblapack-3.9.0-23_linux64_openblas.conda
-    "liblapacke 3.9.0 23_linux64_openblas"
+    "liblapacke 3.9.0 23_linux64_openblas",
+    "mkl <2025"
linux-64::libblas-3.9.0-17_linux64_openblas.conda
linux-64::libcblas-3.9.0-17_linux64_openblas.conda
linux-64::liblapack-3.9.0-17_linux64_openblas.conda
-    "liblapacke 3.9.0 17_linux64_openblas"
+    "liblapacke 3.9.0 17_linux64_openblas",
+    "mkl <2025"
linux-64::libblas-3.9.0-27_h2556b6b_mkl.conda
linux-64::libcblas-3.9.0-27_h0f679e0_mkl.conda
linux-64::liblapack-3.9.0-27_hc41d3b0_mkl.conda
-    "liblapacke =3.9.0=27*_mkl"
+    "liblapacke =3.9.0=27*_mkl",
+    "mkl <2025"
linux-64::libblas-3.9.0-17_linux64_blis.conda
-    "libcblas 3.9.0 17_linux64_blis"
+    "libcblas 3.9.0 17_linux64_blis",
+    "mkl <2025"
linux-64::libblas-3.9.0-26_linux64_mkl.conda
linux-64::libcblas-3.9.0-26_linux64_mkl.conda
linux-64::liblapack-3.9.0-26_linux64_mkl.conda
-    "liblapacke 3.9.0 26_linux64_mkl"
+    "liblapacke 3.9.0 26_linux64_mkl",
+    "mkl <2025"
linux-64::libblas-3.9.0-19_linux64_blis.conda
-    "libcblas 3.9.0 19_linux64_blis"
+    "libcblas 3.9.0 19_linux64_blis",
+    "mkl <2025"
linux-64::libblas-3.9.0-28_h2556b6b_mkl.conda
linux-64::libcblas-3.9.0-28_h372d94f_mkl.conda
linux-64::liblapack-3.9.0-28_hc41d3b0_mkl.conda
-    "liblapacke =3.9.0=28*_mkl"
+    "liblapacke =3.9.0=28*_mkl",
+    "mkl <2025"
linux-64::libcblas-3.9.0-27_h526722b_blis.conda
-    "blas =2.127=blis"
+    "blas =2.127=blis",
+    "mkl <2025"
linux-64::libblas-3.9.0-28_h66dfbfd_blis.conda
-    "libcblas =3.9.0=28*_blis"
+    "libcblas =3.9.0=28*_blis",
+    "mkl <2025"
linux-64::libblas-3.9.0-22_linux64_mkl.conda
linux-64::libcblas-3.9.0-22_linux64_mkl.conda
linux-64::liblapack-3.9.0-22_linux64_mkl.conda
-    "liblapacke 3.9.0 22_linux64_mkl"
+    "liblapacke 3.9.0 22_linux64_mkl",
+    "mkl <2025"
linux-64::libblas-3.9.0-21_linux64_mkl.conda
linux-64::libcblas-3.9.0-21_linux64_mkl.conda
linux-64::liblapack-3.9.0-21_linux64_mkl.conda
-    "liblapacke 3.9.0 21_linux64_mkl"
+    "liblapacke 3.9.0 21_linux64_mkl",
+    "mkl <2025"
linux-64::libblas-3.9.0-23_linux64_mkl.conda
linux-64::libcblas-3.9.0-23_linux64_mkl.conda
linux-64::liblapack-3.9.0-23_linux64_mkl.conda
-    "liblapacke 3.9.0 23_linux64_mkl"
+    "liblapacke 3.9.0 23_linux64_mkl",
+    "mkl <2025"
linux-64::libblas-3.9.0-24_linux64_openblas.conda
linux-64::libcblas-3.9.0-24_linux64_openblas.conda
linux-64::liblapack-3.9.0-24_linux64_openblas.conda
-    "liblapacke 3.9.0 24_linux64_openblas"
+    "liblapacke 3.9.0 24_linux64_openblas",
+    "mkl <2025"
linux-64::libblas-3.9.0-26_linux64_openblas.conda
linux-64::libcblas-3.9.0-26_linux64_openblas.conda
linux-64::liblapack-3.9.0-26_linux64_openblas.conda
-    "liblapacke 3.9.0 26_linux64_openblas"
+    "liblapacke 3.9.0 26_linux64_openblas",
+    "mkl <2025"
linux-64::libblas-3.9.0-25_linux64_mkl.conda
linux-64::libcblas-3.9.0-25_linux64_mkl.conda
linux-64::liblapack-3.9.0-25_linux64_mkl.conda
-    "liblapacke 3.9.0 25_linux64_mkl"
+    "liblapacke 3.9.0 25_linux64_mkl",
+    "mkl <2025"
linux-64::liblapacke-3.9.0-27_he2f377e_openblas.conda
-    "blas =2.127=openblas"
+    "blas =2.127=openblas",
+    "mkl <2025"
linux-64::libblas-3.9.0-21_linux64_openblas.conda
linux-64::libcblas-3.9.0-21_linux64_openblas.conda
linux-64::liblapack-3.9.0-21_linux64_openblas.conda
-    "liblapacke 3.9.0 21_linux64_openblas"
+    "liblapacke 3.9.0 21_linux64_openblas",
+    "mkl <2025"
linux-64::libblas-3.9.0-19_linux64_openblas.conda
linux-64::libcblas-3.9.0-19_linux64_openblas.conda
linux-64::liblapack-3.9.0-19_linux64_openblas.conda
-    "liblapacke 3.9.0 19_linux64_openblas"
+    "liblapacke 3.9.0 19_linux64_openblas",
+    "mkl <2025"
linux-64::liblapacke-3.9.0-28_he2f377e_openblas.conda
-    "blas =2.128=openblas"
+    "blas =2.128=openblas",
+    "mkl <2025"
linux-64::libblas-3.9.0-23_linux64_blis.conda
-    "libcblas 3.9.0 23_linux64_blis"
+    "libcblas 3.9.0 23_linux64_blis",
+    "mkl <2025"
linux-64::libblas-3.9.0-21_linux64_blis.conda
-    "libcblas 3.9.0 21_linux64_blis"
+    "libcblas 3.9.0 21_linux64_blis",
+    "mkl <2025"
linux-64::libblas-3.9.0-24_linux64_mkl.conda
linux-64::libcblas-3.9.0-24_linux64_mkl.conda
linux-64::liblapack-3.9.0-24_linux64_mkl.conda
-    "liblapacke 3.9.0 24_linux64_mkl"
+    "liblapacke 3.9.0 24_linux64_mkl",
+    "mkl <2025"
linux-64::libblas-3.9.0-25_linux64_openblas.conda
linux-64::libcblas-3.9.0-25_linux64_openblas.conda
linux-64::liblapack-3.9.0-25_linux64_openblas.conda
-    "liblapacke 3.9.0 25_linux64_openblas"
+    "liblapacke 3.9.0 25_linux64_openblas",
+    "mkl <2025"
linux-64::libcblas-3.9.0-28_hba4ea11_blis.conda
-    "blas =2.128=blis"
+    "blas =2.128=blis",
+    "mkl <2025"
linux-64::libblas-3.9.0-19_linux64_mkl.conda
linux-64::libcblas-3.9.0-19_linux64_mkl.conda
linux-64::liblapack-3.9.0-19_linux64_mkl.conda
-    "liblapacke 3.9.0 19_linux64_mkl"
+    "liblapacke 3.9.0 19_linux64_mkl",
+    "mkl <2025"
linux-64::libblas-3.9.0-20_linux64_openblas.conda
linux-64::libcblas-3.9.0-20_linux64_openblas.conda
linux-64::liblapack-3.9.0-20_linux64_openblas.conda
-    "liblapacke 3.9.0 20_linux64_openblas"
+    "liblapacke 3.9.0 20_linux64_openblas",
+    "mkl <2025"
linux-64::libblas-3.9.0-18_linux64_openblas.conda
linux-64::libcblas-3.9.0-18_linux64_openblas.conda
linux-64::liblapack-3.9.0-18_linux64_openblas.conda
-    "liblapacke 3.9.0 18_linux64_openblas"
+    "liblapacke 3.9.0 18_linux64_openblas",
+    "mkl <2025"
linux-64::libblas-3.9.0-27_h66dfbfd_blis.conda
-    "libcblas =3.9.0=27*_blis"
+    "libcblas =3.9.0=27*_blis",
+    "mkl <2025"
linux-64::libblas-3.9.0-26_linux64_blis.conda
-    "libcblas 3.9.0 26_linux64_blis"
+    "libcblas 3.9.0 26_linux64_blis",
+    "mkl <2025"
linux-64::liblapacke-3.9.0-28_hbc6e62b_mkl.conda
-    "blas =2.128=mkl"
+    "blas =2.128=mkl",
+    "mkl <2025"
linux-64::libblas-3.9.0-24_linux64_blis.conda
-    "libcblas 3.9.0 24_linux64_blis"
+    "libcblas 3.9.0 24_linux64_blis",
+    "mkl <2025"
linux-64::libblas-3.9.0-22_linux64_blis.conda
-    "libcblas 3.9.0 22_linux64_blis"
+    "libcblas 3.9.0 22_linux64_blis",
+    "mkl <2025"
linux-64::libblas-3.9.0-25_linux64_blis.conda
-    "libcblas 3.9.0 25_linux64_blis"
+    "libcblas 3.9.0 25_linux64_blis",
+    "mkl <2025"
linux-64::libblas-3.9.0-18_linux64_blis.conda
-    "libcblas 3.9.0 18_linux64_blis"
+    "libcblas 3.9.0 18_linux64_blis",
+    "mkl <2025"
linux-64::liblapacke-3.9.0-27_hbc6e62b_mkl.conda
-    "blas =2.127=mkl"
+    "blas =2.127=mkl",
+    "mkl <2025"
linux-64::libblas-3.9.0-20_linux64_blis.conda
-    "libcblas 3.9.0 20_linux64_blis"
+    "libcblas 3.9.0 20_linux64_blis",
+    "mkl <2025"
```

</details>