### PR TITLE
Add ligo.em-bright repodata patch

### DIFF
--- a/recipe/patch_yaml/ligo.em-bright.yaml
+++ b/recipe/patch_yaml/ligo.em-bright.yaml
@@ -1,0 +1,20 @@
+---
+# backport https://github.com/conda-forge/ligo.em-bright-feedstock/pull/28
+if:
+  name: ligo.em-bright
+  subdir_in: noarch
+  version: 1.2.2
+  build_number_lt: 2
+then:
+  - replace_depends:
+      old: astropy >=6.0
+      new: astropy >=6.0,<7.0.0a0
+  - replace_depends:
+      old: astropy-base >=6.0
+      new: astropy-base >=6.0,<7.0.0a0
+  - replace_depends:
+      old: h5py >=3.11.0
+      new: h5py >=3.11.0,<4.0.0a0
+  - replace_depends:
+      old: pandas >=2.2
+      new: pandas >=2.2,<3.0.0a0


### PR DESCRIPTION
This PR adds a `ligo.em-bright.yaml` repodata patch YAML file to backport https://github.com/conda-forge/ligo.em-bright-feedstock/pull/28 to older builds for the affected release.

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

Output of `show_diff.py`:

```console
$ python show_diff.py
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
noarch
noarch::ligo.em-bright-1.2.2-pyh0610db2_1.conda
-    "astropy-base >=6.0",
-    "h5py >=3.11.0",
-    "pandas >=2.2",
+    "astropy-base >=6.0,<7.0.0a0",
+    "h5py >=3.11.0,<4.0.0a0",
+    "pandas >=2.2,<3.0.0a0",
noarch::ligo.em-bright-1.2.2-pyhd8ed1ab_0.conda
-    "astropy >=6.0",
-    "h5py >=3.11.0",
-    "pandas >=2.2",
+    "astropy >=6.0,<7.0.0a0",
+    "h5py >=3.11.0,<4.0.0a0",
+    "pandas >=2.2,<3.0.0a0",
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
================================================================================
================================================================================
linux-64
```