### PR TITLE
Patch existing `openmmforcefields` packages for an upstream behavior change

### DIFF
--- a/recipe/patch_yaml/openmmforcefields-openff-interchange.yaml
+++ b/recipe/patch_yaml/openmmforcefields-openff-interchange.yaml
@@ -1,0 +1,8 @@
+if:
+  subdir_in: noarch
+  name: openmmforcefields
+  timestamp_lt: 1740770689000
+  version_le: 0.14.1
+then:
+  - add_constrains:
+      - openff-interchange <0.4.2


### PR DESCRIPTION
We made a bit of a snafu in a recent release of one of our packages - this is a patch that adds a constraint which fixes it. We have this constraint in the new builds - but that does not update the old builds as we all know.

---

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

```console
$ python recipe/show_diff.py --subdirs noarch
================================================================================
================================================================================
noarch
noarch::openmmforcefields-0.11.2-pyhd8ed1ab_0.tar.bz2
noarch::openmmforcefields-0.11.2-pyhd8ed1ab_1.tar.bz2
noarch::openmmforcefields-0.11.2-pyhd8ed1ab_2.conda
noarch::openmmforcefields-0.12.0-pyhd8ed1ab_0.conda
noarch::openmmforcefields-0.13.0-pyhd8ed1ab_0.conda
noarch::openmmforcefields-0.14.0-pyhd8ed1ab_0.conda
noarch::openmmforcefields-0.14.1-pyhd8ed1ab_0.conda
noarch::openmmforcefields-0.14.1-pyhd8ed1ab_1.conda
noarch::openmmforcefields-0.14.1-pyhd8ed1ab_2.conda
noarch::openmmforcefields-0.14.1-pyhd8ed1ab_3.conda
+    "openff-interchange <0.4.2",
noarch::openmmforcefields-0.10.0-pyhd8ed1ab_0.tar.bz2
noarch::openmmforcefields-0.11.0-pyhd8ed1ab_0.tar.bz2
noarch::openmmforcefields-0.11.1-pyhd8ed1ab_0.tar.bz2
noarch::openmmforcefields-0.11.1-pyhd8ed1ab_1.tar.bz2
noarch::openmmforcefields-0.9.0-pyhd8ed1ab_0.tar.bz2
+  "constrains": [
+    "openff-interchange <0.4.2"
+  ],
$