### PR TITLE
fix: constrain ipython for ultraplot le 1.0.8.post2

### DIFF
--- a/recipe/patch_yaml/ultraplot.yaml
+++ b/recipe/patch_yaml/ultraplot.yaml
@@ -6,3 +6,10 @@ then:
   - replace_depends:
       old: matplotlib-base
       new: matplotlib-base >=3.9.2
+---
+if:
+  name: ultraplot
+  version_le: 1.0.8.post2
+then:
+  - add_constrains:
+      - ipython <9.0a0


### PR DESCRIPTION
Checklist

* [ ] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
