### PR TITLE
patch missing run_exports from petsc, fenics-libdolfinx rattler-build bug

### DIFF
--- a/recipe/patch_yaml/petsc_rattler_tighten.yaml
+++ b/recipe/patch_yaml/petsc_rattler_tighten.yaml
@@ -1,0 +1,18 @@
+if:
+  has_depends: petsc *
+  not_has_depends: petsc >=*
+  timestamp_lt: 1741092174000
+  timestamp_gt: 1738128903000
+then:
+  - add_depends:
+      - petsc >=3.22.3,<3.23
+---
+if:
+  has_depends: fenics-dolfinx
+  not_has_depends: fenics-libdolfinx
+  not_subdir_in: noarch
+  timestamp_lt: 1741092174000
+  timestamp_gt: 1736935395000
+then:
+  - add_depends:
+      - fenics-libdolfinx >=0.9.0,<0.9.1


### PR DESCRIPTION
Bug in rattler-build means that any package with multiple run_exports in a single list will only produce packages with the last item in `run_exports`: https://github.com/prefix-dev/rattler-build/issues/1468

Probably not too many packages affected, as most have a single run_export. But petsc and fenics-libdolfinx have multiple run_exports fields, which have been producing downstream packages with inadequate pinning. Only packages published in a relatively short window are affected, so this uses `timestamp_gt` because the conditions aren't perfect and would pull in some very old packages that are not affected, but all the matched packages within the time window get correct patches.

This is fixed by PRs:

- https://github.com/conda-forge/fenics-dolfinx-feedstock/pull/104
- https://github.com/conda-forge/petsc-feedstock/pull/233


Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<details>
<summary>diff</summary>

```
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
linux-ppc64le
linux-ppc64le::fenics-libdolfin-2019.1.0-h0c8c8ed_56.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-h2026497_54.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-h2026497_56.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-h39a3a85_54.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-h39a3a85_56.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-h6f66321_54.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-h6f66321_56.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-h73796bb_54.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-h73796bb_56.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-hb302238_54.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-hb302238_56.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-he3a6e98_54.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-he3a6e98_56.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-hed4de27_54.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-hed4de27_56.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-hf44f6d1_56.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-hff99bd1_54.conda
linux-ppc64le::fenics-libdolfin-2019.1.0-hff99bd1_56.conda
linux-ppc64le::petsc4py-3.22.3-np20py310h0bc9a5f_0.conda
linux-ppc64le::petsc4py-3.22.3-np20py310h0e74a0f_0.conda
linux-ppc64le::petsc4py-3.22.3-np20py310h2478c08_0.conda
linux-ppc64le::petsc4py-3.22.3-np20py310h4d01f25_0.conda
linux-ppc64le::petsc4py-3.22.3-np20py310h515caba_0.conda
linux-ppc64le::petsc4py-3.22.3-np20py310h605901a_0.conda
linux-ppc64le::petsc4py-3.22.3-np20py310hb65b7b7_0.conda
linux-ppc64le::petsc4py-3.22.3-np20py310hbe3725f_0.conda
linux-ppc64le::petsc4py-3.22.3-np20py310hcd8c864_0.conda
linux-ppc64le::petsc4py-3.22.3-np20py310hdf1cb78_0.conda
linux-ppc64le::petsc4py-3.22.3-np20py310hf527660_0.conda
linux-ppc64le::petsc4py-3.22.3-np20py310hf7b7185_0.conda
linux-ppc64le::petsc4py-3.22.3-np20py311h204c74c_0.conda
linux-ppc64le::petsc4py-3.22.3-np20py311h26b4da0_0.conda
linux-ppc64le::petsc4py-3.22.3-np20py311h416991d_0.conda
linux-ppc64le::petsc4py-3.22.3-np20py311h4eb8180_0.conda
linux-ppc64le::petsc4py-3.22.3-np20py311h51b0248_0.conda
linux-ppc64le::petsc4py-3.22.3-np20py311h5cfd9ec_0.conda
linux-ppc64le::petsc4py-3.22.3-np20py311h5ddfabc_0.conda
linux-ppc64le::petsc4py-3.22.3-np20py311h6f68983_0.conda
linux-ppc64le::petsc4py-3.22.3-np20py311h935f2ec_0.conda
linux-ppc64le::petsc4py-3.22.3-np20py311hc1b8e90_0.conda
linux-ppc64le::petsc4py-3.22.3-np20py311hee8bc6c_0.conda
linux-ppc64le::petsc4py-3.22.3-np20py311hfdd74e4_0.conda
linux-ppc64le::petsc4py-3.22.3-np20py312h30e1ed8_0.conda
linux-ppc64le::petsc4py-3.22.3-np20py312h3420783_0.conda
linux-ppc64le::petsc4py-3.22.3-np20py312h3e26fcf_0.conda
linux-ppc64le::petsc4py-3.22.3-np20py312h423e40d_0.conda
linux-ppc64le::petsc4py-3.22.3-np20py312h473b71a_0.conda
linux-ppc64le::petsc4py-3.22.3-np20py312h51696c9_0.conda
linux-ppc64le::petsc4py-3.22.3-np20py312h5890c65_0.conda
linux-ppc64le::petsc4py-3.22.3-np20py312h834ba96_0.conda
linux-ppc64le::petsc4py-3.22.3-np20py312hb62ed8b_0.conda
linux-ppc64le::petsc4py-3.22.3-np20py312hd967f09_0.conda
linux-ppc64le::petsc4py-3.22.3-np20py312he4ed56e_0.conda
linux-ppc64le::petsc4py-3.22.3-np20py312he5dbe44_0.conda
linux-ppc64le::petsc4py-3.22.3-np20py39h1aa2c62_0.conda
linux-ppc64le::petsc4py-3.22.3-np20py39h4206850_0.conda
linux-ppc64le::petsc4py-3.22.3-np20py39h42b7713_0.conda
linux-ppc64le::petsc4py-3.22.3-np20py39h6f3896a_0.conda
linux-ppc64le::petsc4py-3.22.3-np20py39h8c0373b_0.conda
linux-ppc64le::petsc4py-3.22.3-np20py39h9468ef0_0.conda
linux-ppc64le::petsc4py-3.22.3-np20py39h977c88f_0.conda
linux-ppc64le::petsc4py-3.22.3-np20py39ha90e8e3_0.conda
linux-ppc64le::petsc4py-3.22.3-np20py39he5a1344_0.conda
linux-ppc64le::petsc4py-3.22.3-np20py39hed5762f_0.conda
linux-ppc64le::petsc4py-3.22.3-np20py39hf24cfde_0.conda
linux-ppc64le::petsc4py-3.22.3-np20py39hf5ebddc_0.conda
linux-ppc64le::petsc4py-3.22.3-np2py313h0aae7cf_0.conda
linux-ppc64le::petsc4py-3.22.3-np2py313h1a4019e_0.conda
linux-ppc64le::petsc4py-3.22.3-np2py313h3e1aa23_0.conda
linux-ppc64le::petsc4py-3.22.3-np2py313h3fe7cc7_0.conda
linux-ppc64le::petsc4py-3.22.3-np2py313h68b5944_0.conda
linux-ppc64le::petsc4py-3.22.3-np2py313h9e5bcfb_0.conda
linux-ppc64le::petsc4py-3.22.3-np2py313hb694e8d_0.conda
linux-ppc64le::petsc4py-3.22.3-np2py313hcc839ef_0.conda
linux-ppc64le::petsc4py-3.22.3-np2py313hd99c3a3_0.conda
linux-ppc64le::petsc4py-3.22.3-np2py313he8df855_0.conda
linux-ppc64le::petsc4py-3.22.3-np2py313heedb067_0.conda
linux-ppc64le::petsc4py-3.22.3-np2py313hfe0ae12_0.conda
+    "petsc >=3.22.3,<3.23",
linux-ppc64le::scifem-0.3.0-py310h1840c1f_1.conda
linux-ppc64le::scifem-0.3.0-py310h1840c1f_2.conda
linux-ppc64le::scifem-0.3.0-py310h4454e22_1.conda
linux-ppc64le::scifem-0.3.0-py310h4454e22_2.conda
linux-ppc64le::scifem-0.3.0-py310h7c617a2_1.conda
linux-ppc64le::scifem-0.3.0-py310h7c617a2_2.conda
linux-ppc64le::scifem-0.3.0-py310h9794e3b_0.conda
linux-ppc64le::scifem-0.3.0-py310h9794e3b_1.conda
linux-ppc64le::scifem-0.3.0-py310h9794e3b_2.conda
linux-ppc64le::scifem-0.3.0-py311hc7f3298_1.conda
linux-ppc64le::scifem-0.3.0-py311hc7f3298_2.conda
linux-ppc64le::scifem-0.3.0-py311hdf1fbce_1.conda
linux-ppc64le::scifem-0.3.0-py311hdf1fbce_2.conda
linux-ppc64le::scifem-0.3.0-py311hedc445d_1.conda
linux-ppc64le::scifem-0.3.0-py311hedc445d_2.conda
linux-ppc64le::scifem-0.3.0-py311hfa0cf3a_1.conda
linux-ppc64le::scifem-0.3.0-py311hfa0cf3a_2.conda
linux-ppc64le::scifem-0.3.0-py312h4002565_1.conda
linux-ppc64le::scifem-0.3.0-py312h4002565_2.conda
linux-ppc64le::scifem-0.3.0-py312h5107f64_1.conda
linux-ppc64le::scifem-0.3.0-py312h5107f64_2.conda
linux-ppc64le::scifem-0.3.0-py312hb4cdaf3_1.conda
linux-ppc64le::scifem-0.3.0-py312hb4cdaf3_2.conda
linux-ppc64le::scifem-0.3.0-py312hc4f1d56_1.conda
linux-ppc64le::scifem-0.3.0-py312hc4f1d56_2.conda
linux-ppc64le::scifem-0.3.0-py313h28f07fa_2.conda
linux-ppc64le::scifem-0.3.0-py313h378772d_2.conda
linux-ppc64le::scifem-0.3.0-py313h46a2ac0_2.conda
linux-ppc64le::scifem-0.3.0-py313h86d37c5_2.conda
linux-ppc64le::scifem-0.3.1-py310h1840c1f_0.conda
linux-ppc64le::scifem-0.3.1-py310h4454e22_0.conda
linux-ppc64le::scifem-0.3.1-py310h7c617a2_0.conda
linux-ppc64le::scifem-0.3.1-py310h9794e3b_0.conda
linux-ppc64le::scifem-0.3.1-py311hc7f3298_0.conda
linux-ppc64le::scifem-0.3.1-py311hdf1fbce_0.conda
linux-ppc64le::scifem-0.3.1-py311hedc445d_0.conda
linux-ppc64le::scifem-0.3.1-py311hfa0cf3a_0.conda
linux-ppc64le::scifem-0.3.1-py312h4002565_0.conda
linux-ppc64le::scifem-0.3.1-py312h5107f64_0.conda
linux-ppc64le::scifem-0.3.1-py312hb4cdaf3_0.conda
linux-ppc64le::scifem-0.3.1-py312hc4f1d56_0.conda
linux-ppc64le::scifem-0.3.1-py313h28f07fa_0.conda
linux-ppc64le::scifem-0.3.1-py313h378772d_0.conda
linux-ppc64le::scifem-0.3.1-py313h46a2ac0_0.conda
linux-ppc64le::scifem-0.3.1-py313h86d37c5_0.conda
+    "fenics-libdolfinx >=0.9.0,<0.9.1",
+    "petsc >=3.22.3,<3.23",
================================================================================
================================================================================
osx-arm64
osx-arm64::scifem-0.3.0-py310h2732f5f_1.conda
osx-arm64::scifem-0.3.0-py310h2732f5f_2.conda
osx-arm64::scifem-0.3.0-py310h51ce5a0_1.conda
osx-arm64::scifem-0.3.0-py310h51ce5a0_2.conda
osx-arm64::scifem-0.3.0-py310h9e41d37_1.conda
osx-arm64::scifem-0.3.0-py310h9e41d37_2.conda
osx-arm64::scifem-0.3.0-py310hd39df81_1.conda
osx-arm64::scifem-0.3.0-py310hd39df81_2.conda
osx-arm64::scifem-0.3.0-py311h2b0d3d2_1.conda
osx-arm64::scifem-0.3.0-py311h2b0d3d2_2.conda
osx-arm64::scifem-0.3.0-py311h2f3e2b8_1.conda
osx-arm64::scifem-0.3.0-py311h2f3e2b8_2.conda
osx-arm64::scifem-0.3.0-py311h84085be_1.conda
osx-arm64::scifem-0.3.0-py311h84085be_2.conda
osx-arm64::scifem-0.3.0-py311hfb23cb4_1.conda
osx-arm64::scifem-0.3.0-py311hfb23cb4_2.conda
osx-arm64::scifem-0.3.0-py312ha5ac760_1.conda
osx-arm64::scifem-0.3.0-py312ha5ac760_2.conda
osx-arm64::scifem-0.3.0-py312haddffb1_1.conda
osx-arm64::scifem-0.3.0-py312haddffb1_2.conda
osx-arm64::scifem-0.3.0-py312hbe7f9c0_1.conda
osx-arm64::scifem-0.3.0-py312hbe7f9c0_2.conda
osx-arm64::scifem-0.3.0-py312hc2a3bc5_1.conda
osx-arm64::scifem-0.3.0-py312hc2a3bc5_2.conda
osx-arm64::scifem-0.3.0-py313h6f0bc08_2.conda
osx-arm64::scifem-0.3.0-py313h70af5a1_2.conda
osx-arm64::scifem-0.3.0-py313haa546bd_2.conda
osx-arm64::scifem-0.3.0-py313hfd1d6c2_2.conda
osx-arm64::scifem-0.3.1-py310h2732f5f_0.conda
osx-arm64::scifem-0.3.1-py310h51ce5a0_0.conda
osx-arm64::scifem-0.3.1-py310h9e41d37_0.conda
osx-arm64::scifem-0.3.1-py310hd39df81_0.conda
osx-arm64::scifem-0.3.1-py311h2b0d3d2_0.conda
osx-arm64::scifem-0.3.1-py311h2f3e2b8_0.conda
osx-arm64::scifem-0.3.1-py311h84085be_0.conda
osx-arm64::scifem-0.3.1-py311hfb23cb4_0.conda
osx-arm64::scifem-0.3.1-py312ha5ac760_0.conda
osx-arm64::scifem-0.3.1-py312haddffb1_0.conda
osx-arm64::scifem-0.3.1-py312hbe7f9c0_0.conda
osx-arm64::scifem-0.3.1-py312hc2a3bc5_0.conda
osx-arm64::scifem-0.3.1-py313h6f0bc08_0.conda
osx-arm64::scifem-0.3.1-py313h70af5a1_0.conda
osx-arm64::scifem-0.3.1-py313haa546bd_0.conda
osx-arm64::scifem-0.3.1-py313hfd1d6c2_0.conda
+    "fenics-libdolfinx >=0.9.0,<0.9.1",
+    "petsc >=3.22.3,<3.23",
osx-arm64::fenics-libdolfin-2019.1.0-h16cc71b_54.conda
osx-arm64::fenics-libdolfin-2019.1.0-h16cc71b_56.conda
osx-arm64::fenics-libdolfin-2019.1.0-h42964c9_54.conda
osx-arm64::fenics-libdolfin-2019.1.0-h42964c9_56.conda
osx-arm64::fenics-libdolfin-2019.1.0-h47f7f06_54.conda
osx-arm64::fenics-libdolfin-2019.1.0-h47f7f06_56.conda
osx-arm64::fenics-libdolfin-2019.1.0-h949d307_54.conda
osx-arm64::fenics-libdolfin-2019.1.0-h949d307_56.conda
osx-arm64::fenics-libdolfin-2019.1.0-he624db7_56.conda
osx-arm64::petsc4py-3.22.3-np20py310h47c35b5_0.conda
osx-arm64::petsc4py-3.22.3-np20py312h4d474df_0.conda
osx-arm64::petsc4py-3.22.3-np20py39h66650ce_0.conda
osx-arm64::petsc4py-3.22.3-np20py39h6faf10e_0.conda
+    "petsc >=3.22.3,<3.23",
================================================================================
================================================================================
linux-aarch64
linux-aarch64::fenics-libdolfin-2019.1.0-h0c832b3_54.conda
linux-aarch64::fenics-libdolfin-2019.1.0-h0c832b3_56.conda
linux-aarch64::fenics-libdolfin-2019.1.0-h2b94334_56.conda
linux-aarch64::fenics-libdolfin-2019.1.0-h3154708_56.conda
linux-aarch64::fenics-libdolfin-2019.1.0-h401f47b_54.conda
linux-aarch64::fenics-libdolfin-2019.1.0-h401f47b_56.conda
linux-aarch64::fenics-libdolfin-2019.1.0-h55a10b1_54.conda
linux-aarch64::fenics-libdolfin-2019.1.0-h55a10b1_56.conda
linux-aarch64::fenics-libdolfin-2019.1.0-h5e3d82d_54.conda
linux-aarch64::fenics-libdolfin-2019.1.0-h5e3d82d_56.conda
linux-aarch64::fenics-libdolfin-2019.1.0-h7fb4025_54.conda
linux-aarch64::fenics-libdolfin-2019.1.0-h7fb4025_56.conda
linux-aarch64::fenics-libdolfin-2019.1.0-hacd1c28_54.conda
linux-aarch64::fenics-libdolfin-2019.1.0-hacd1c28_56.conda
linux-aarch64::fenics-libdolfin-2019.1.0-hdfabbdc_54.conda
linux-aarch64::fenics-libdolfin-2019.1.0-hdfabbdc_56.conda
linux-aarch64::fenics-libdolfin-2019.1.0-hfd91608_54.conda
linux-aarch64::fenics-libdolfin-2019.1.0-hfd91608_56.conda
linux-aarch64::petsc4py-3.22.3-np20py310h16914b6_0.conda
linux-aarch64::petsc4py-3.22.3-np20py310h3041b20_0.conda
linux-aarch64::petsc4py-3.22.3-np20py310h33395fc_0.conda
linux-aarch64::petsc4py-3.22.3-np20py310h44b2bea_0.conda
linux-aarch64::petsc4py-3.22.3-np20py310h64fe5b4_0.conda
linux-aarch64::petsc4py-3.22.3-np20py310h7ab014f_0.conda
linux-aarch64::petsc4py-3.22.3-np20py310h902497e_0.conda
linux-aarch64::petsc4py-3.22.3-np20py310hae80672_0.conda
linux-aarch64::petsc4py-3.22.3-np20py310hb460303_0.conda
linux-aarch64::petsc4py-3.22.3-np20py310hdadd83c_0.conda
linux-aarch64::petsc4py-3.22.3-np20py310hddb35f1_0.conda
linux-aarch64::petsc4py-3.22.3-np20py310he1fe3a5_0.conda
linux-aarch64::petsc4py-3.22.3-np20py311h019a7d2_0.conda
linux-aarch64::petsc4py-3.22.3-np20py311h318d6e4_0.conda
linux-aarch64::petsc4py-3.22.3-np20py311h3ff514c_0.conda
linux-aarch64::petsc4py-3.22.3-np20py311h46536ab_0.conda
linux-aarch64::petsc4py-3.22.3-np20py311h5d1cfe5_0.conda
linux-aarch64::petsc4py-3.22.3-np20py311h73f5b07_0.conda
linux-aarch64::petsc4py-3.22.3-np20py311h91198c2_0.conda
linux-aarch64::petsc4py-3.22.3-np20py311hce6f7a3_0.conda
linux-aarch64::petsc4py-3.22.3-np20py311hde82af4_0.conda
linux-aarch64::petsc4py-3.22.3-np20py311hed65900_0.conda
linux-aarch64::petsc4py-3.22.3-np20py311hf0af95f_0.conda
linux-aarch64::petsc4py-3.22.3-np20py311hfb5d2c8_0.conda
linux-aarch64::petsc4py-3.22.3-np20py312h2f6b470_0.conda
linux-aarch64::petsc4py-3.22.3-np20py312h419a700_0.conda
linux-aarch64::petsc4py-3.22.3-np20py312h4e06021_0.conda
linux-aarch64::petsc4py-3.22.3-np20py312h6e923a2_0.conda
linux-aarch64::petsc4py-3.22.3-np20py312h6f0eca1_0.conda
linux-aarch64::petsc4py-3.22.3-np20py312h88aef86_0.conda
linux-aarch64::petsc4py-3.22.3-np20py312habb8a44_0.conda
linux-aarch64::petsc4py-3.22.3-np20py312haeadef3_0.conda
linux-aarch64::petsc4py-3.22.3-np20py312hc5801b0_0.conda
linux-aarch64::petsc4py-3.22.3-np20py312hd0b1d35_0.conda
linux-aarch64::petsc4py-3.22.3-np20py312he693b1e_0.conda
linux-aarch64::petsc4py-3.22.3-np20py312hfeb49be_0.conda
linux-aarch64::petsc4py-3.22.3-np20py39h03eb745_0.conda
linux-aarch64::petsc4py-3.22.3-np20py39h0e97185_0.conda
linux-aarch64::petsc4py-3.22.3-np20py39h1d3e1fe_0.conda
linux-aarch64::petsc4py-3.22.3-np20py39h27479ac_0.conda
linux-aarch64::petsc4py-3.22.3-np20py39h2fb6aee_0.conda
linux-aarch64::petsc4py-3.22.3-np20py39h36285e2_0.conda
linux-aarch64::petsc4py-3.22.3-np20py39h8cefdb8_0.conda
linux-aarch64::petsc4py-3.22.3-np20py39h9e7fc5f_0.conda
linux-aarch64::petsc4py-3.22.3-np20py39hb46296a_0.conda
linux-aarch64::petsc4py-3.22.3-np20py39hbc4254b_0.conda
linux-aarch64::petsc4py-3.22.3-np20py39hc33bfe0_0.conda
linux-aarch64::petsc4py-3.22.3-np20py39hc343855_0.conda
linux-aarch64::petsc4py-3.22.3-np2py313h139e935_0.conda
linux-aarch64::petsc4py-3.22.3-np2py313h1ac33b6_0.conda
linux-aarch64::petsc4py-3.22.3-np2py313h20519a9_0.conda
linux-aarch64::petsc4py-3.22.3-np2py313h30ecd4c_0.conda
linux-aarch64::petsc4py-3.22.3-np2py313h311879d_0.conda
linux-aarch64::petsc4py-3.22.3-np2py313h7eb3c5b_0.conda
linux-aarch64::petsc4py-3.22.3-np2py313hb9ffb53_0.conda
linux-aarch64::petsc4py-3.22.3-np2py313hc2f2f49_0.conda
linux-aarch64::petsc4py-3.22.3-np2py313hdb1c434_0.conda
linux-aarch64::petsc4py-3.22.3-np2py313he67ba32_0.conda
linux-aarch64::petsc4py-3.22.3-np2py313hefbaf0a_0.conda
linux-aarch64::petsc4py-3.22.3-np2py313hf1716b5_0.conda
+    "petsc >=3.22.3,<3.23",
linux-aarch64::scifem-0.3.0-py310h11f2bdc_1.conda
linux-aarch64::scifem-0.3.0-py310h11f2bdc_2.conda
linux-aarch64::scifem-0.3.0-py310h3a1cfe9_1.conda
linux-aarch64::scifem-0.3.0-py310h3a1cfe9_2.conda
linux-aarch64::scifem-0.3.0-py310h447c210_1.conda
linux-aarch64::scifem-0.3.0-py310h447c210_2.conda
linux-aarch64::scifem-0.3.0-py310he7bc72b_1.conda
linux-aarch64::scifem-0.3.0-py310he7bc72b_2.conda
linux-aarch64::scifem-0.3.0-py311h20d2f0e_1.conda
linux-aarch64::scifem-0.3.0-py311h20d2f0e_2.conda
linux-aarch64::scifem-0.3.0-py311h3621690_1.conda
linux-aarch64::scifem-0.3.0-py311h3621690_2.conda
linux-aarch64::scifem-0.3.0-py311h7c69854_1.conda
linux-aarch64::scifem-0.3.0-py311h7c69854_2.conda
linux-aarch64::scifem-0.3.0-py311ha346d8c_1.conda
linux-aarch64::scifem-0.3.0-py311ha346d8c_2.conda
linux-aarch64::scifem-0.3.0-py312h46445b4_1.conda
linux-aarch64::scifem-0.3.0-py312h46445b4_2.conda
linux-aarch64::scifem-0.3.0-py312h5cb53bd_1.conda
linux-aarch64::scifem-0.3.0-py312h5cb53bd_2.conda
linux-aarch64::scifem-0.3.0-py312hc68b5a2_1.conda
linux-aarch64::scifem-0.3.0-py312hc68b5a2_2.conda
linux-aarch64::scifem-0.3.0-py312hdeb37d5_1.conda
linux-aarch64::scifem-0.3.0-py312hdeb37d5_2.conda
linux-aarch64::scifem-0.3.0-py313h08db7a2_2.conda
linux-aarch64::scifem-0.3.0-py313h97e522e_2.conda
linux-aarch64::scifem-0.3.0-py313ha79924c_2.conda
linux-aarch64::scifem-0.3.0-py313hb0b80f3_2.conda
linux-aarch64::scifem-0.3.1-py310h11f2bdc_0.conda
linux-aarch64::scifem-0.3.1-py310h3a1cfe9_0.conda
linux-aarch64::scifem-0.3.1-py310h447c210_0.conda
linux-aarch64::scifem-0.3.1-py310he7bc72b_0.conda
linux-aarch64::scifem-0.3.1-py311h20d2f0e_0.conda
linux-aarch64::scifem-0.3.1-py311h3621690_0.conda
linux-aarch64::scifem-0.3.1-py311h7c69854_0.conda
linux-aarch64::scifem-0.3.1-py311ha346d8c_0.conda
linux-aarch64::scifem-0.3.1-py312h46445b4_0.conda
linux-aarch64::scifem-0.3.1-py312h5cb53bd_0.conda
linux-aarch64::scifem-0.3.1-py312hc68b5a2_0.conda
linux-aarch64::scifem-0.3.1-py312hdeb37d5_0.conda
linux-aarch64::scifem-0.3.1-py313h08db7a2_0.conda
linux-aarch64::scifem-0.3.1-py313h97e522e_0.conda
linux-aarch64::scifem-0.3.1-py313ha79924c_0.conda
linux-aarch64::scifem-0.3.1-py313hb0b80f3_0.conda
+    "fenics-libdolfinx >=0.9.0,<0.9.1",
+    "petsc >=3.22.3,<3.23",
================================================================================
================================================================================
noarch
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
osx-64::scifem-0.3.0-py310h1710a42_1.conda
osx-64::scifem-0.3.0-py310h1710a42_2.conda
osx-64::scifem-0.3.0-py310h8d709b3_1.conda
osx-64::scifem-0.3.0-py310h8d709b3_2.conda
osx-64::scifem-0.3.0-py310h90019a4_1.conda
osx-64::scifem-0.3.0-py310h90019a4_2.conda
osx-64::scifem-0.3.0-py310hb0de53a_1.conda
osx-64::scifem-0.3.0-py310hb0de53a_2.conda
osx-64::scifem-0.3.0-py311h28a1780_1.conda
osx-64::scifem-0.3.0-py311h28a1780_2.conda
osx-64::scifem-0.3.0-py311h3e6608f_1.conda
osx-64::scifem-0.3.0-py311h3e6608f_2.conda
osx-64::scifem-0.3.0-py311hb94e202_1.conda
osx-64::scifem-0.3.0-py311hb94e202_2.conda
osx-64::scifem-0.3.0-py311hcf7f688_1.conda
osx-64::scifem-0.3.0-py312h2c36965_1.conda
osx-64::scifem-0.3.0-py312h2c36965_2.conda
osx-64::scifem-0.3.0-py312h2d3073e_1.conda
osx-64::scifem-0.3.0-py312h2d3073e_2.conda
osx-64::scifem-0.3.0-py312h402ce67_0.conda
osx-64::scifem-0.3.0-py312h402ce67_1.conda
osx-64::scifem-0.3.0-py312h402ce67_2.conda
osx-64::scifem-0.3.0-py312hbf4e2ce_1.conda
osx-64::scifem-0.3.0-py312hbf4e2ce_2.conda
osx-64::scifem-0.3.0-py313h3d65bad_2.conda
osx-64::scifem-0.3.0-py313h51e693a_2.conda
osx-64::scifem-0.3.0-py313h8f663b8_2.conda
osx-64::scifem-0.3.0-py313ha523412_2.conda
osx-64::scifem-0.3.1-py310h1710a42_0.conda
osx-64::scifem-0.3.1-py310h8d709b3_0.conda
osx-64::scifem-0.3.1-py310h90019a4_0.conda
osx-64::scifem-0.3.1-py310hb0de53a_0.conda
osx-64::scifem-0.3.1-py311h28a1780_0.conda
osx-64::scifem-0.3.1-py311h3e6608f_0.conda
osx-64::scifem-0.3.1-py311hb94e202_0.conda
osx-64::scifem-0.3.1-py311hcf7f688_0.conda
osx-64::scifem-0.3.1-py312h2c36965_0.conda
osx-64::scifem-0.3.1-py312h2d3073e_0.conda
osx-64::scifem-0.3.1-py312h402ce67_0.conda
osx-64::scifem-0.3.1-py312hbf4e2ce_0.conda
osx-64::scifem-0.3.1-py313h3d65bad_0.conda
osx-64::scifem-0.3.1-py313h51e693a_0.conda
osx-64::scifem-0.3.1-py313h8f663b8_0.conda
osx-64::scifem-0.3.1-py313ha523412_0.conda
+    "fenics-libdolfinx >=0.9.0,<0.9.1",
+    "petsc >=3.22.3,<3.23",
osx-64::fenics-libdolfin-2019.1.0-h262ed3c_54.conda
osx-64::fenics-libdolfin-2019.1.0-h262ed3c_56.conda
osx-64::fenics-libdolfin-2019.1.0-h509cb0a_54.conda
osx-64::fenics-libdolfin-2019.1.0-h509cb0a_56.conda
osx-64::fenics-libdolfin-2019.1.0-h8b52098_56.conda
osx-64::fenics-libdolfin-2019.1.0-hcc1fd83_54.conda
osx-64::fenics-libdolfin-2019.1.0-hcc1fd83_56.conda
osx-64::fenics-libdolfin-2019.1.0-hfef2803_54.conda
osx-64::fenics-libdolfin-2019.1.0-hfef2803_56.conda
osx-64::petsc4py-3.22.3-np20py310h913603b_0.conda
osx-64::petsc4py-3.22.3-np20py310hd99017b_0.conda
osx-64::petsc4py-3.22.3-np20py311h9300887_0.conda
osx-64::petsc4py-3.22.3-np20py311h963ca13_0.conda
osx-64::petsc4py-3.22.3-np20py312h15fb14d_0.conda
osx-64::petsc4py-3.22.3-np20py312h44fc0a1_0.conda
osx-64::petsc4py-3.22.3-np20py312hb3499de_0.conda
osx-64::petsc4py-3.22.3-np20py39h054098e_0.conda
osx-64::petsc4py-3.22.3-np20py39h05d5300_0.conda
osx-64::petsc4py-3.22.3-np20py39hbd1d5f1_0.conda
osx-64::petsc4py-3.22.3-np2py313h6aebf65_0.conda
+    "petsc >=3.22.3,<3.23",
================================================================================
================================================================================
linux-64
linux-64::fenics-libdolfin-2019.1.0-h128cb16_54.conda
linux-64::fenics-libdolfin-2019.1.0-h128cb16_56.conda
linux-64::fenics-libdolfin-2019.1.0-h22a46a8_56.conda
linux-64::fenics-libdolfin-2019.1.0-h252932a_56.conda
linux-64::fenics-libdolfin-2019.1.0-h31a1a0a_54.conda
linux-64::fenics-libdolfin-2019.1.0-h31a1a0a_56.conda
linux-64::fenics-libdolfin-2019.1.0-h3556aca_54.conda
linux-64::fenics-libdolfin-2019.1.0-h3556aca_56.conda
linux-64::fenics-libdolfin-2019.1.0-h4757252_54.conda
linux-64::fenics-libdolfin-2019.1.0-h4757252_56.conda
linux-64::fenics-libdolfin-2019.1.0-h8186ea9_54.conda
linux-64::fenics-libdolfin-2019.1.0-h8186ea9_56.conda
linux-64::fenics-libdolfin-2019.1.0-hd71ec70_54.conda
linux-64::fenics-libdolfin-2019.1.0-hd71ec70_56.conda
linux-64::fenics-libdolfin-2019.1.0-hebfc17a_54.conda
linux-64::fenics-libdolfin-2019.1.0-hebfc17a_56.conda
linux-64::fenics-libdolfin-2019.1.0-heddad5c_54.conda
linux-64::fenics-libdolfin-2019.1.0-heddad5c_56.conda
linux-64::petsc4py-3.22.3-np20py310h045389f_0.conda
linux-64::petsc4py-3.22.3-np20py310h2f98c88_0.conda
linux-64::petsc4py-3.22.3-np20py310h3985071_0.conda
linux-64::petsc4py-3.22.3-np20py310h39959b3_0.conda
linux-64::petsc4py-3.22.3-np20py310h3fa2be7_0.conda
linux-64::petsc4py-3.22.3-np20py310h5038441_0.conda
linux-64::petsc4py-3.22.3-np20py310h86083de_0.conda
linux-64::petsc4py-3.22.3-np20py310h90b8446_0.conda
linux-64::petsc4py-3.22.3-np20py310h9df9fb8_0.conda
linux-64::petsc4py-3.22.3-np20py310hd2082f0_0.conda
linux-64::petsc4py-3.22.3-np20py310he4e1fd3_0.conda
linux-64::petsc4py-3.22.3-np20py310hf1b72f8_0.conda
linux-64::petsc4py-3.22.3-np20py311h47a8f90_0.conda
linux-64::petsc4py-3.22.3-np20py311h48bf7a6_0.conda
linux-64::petsc4py-3.22.3-np20py311h4a1e6fb_0.conda
linux-64::petsc4py-3.22.3-np20py311h4a5e3e2_0.conda
linux-64::petsc4py-3.22.3-np20py311h53cb11e_0.conda
linux-64::petsc4py-3.22.3-np20py311h727c045_0.conda
linux-64::petsc4py-3.22.3-np20py311h7ac2df9_0.conda
linux-64::petsc4py-3.22.3-np20py311ha2cc17c_0.conda
linux-64::petsc4py-3.22.3-np20py311hdbbd244_0.conda
linux-64::petsc4py-3.22.3-np20py311he0ba447_0.conda
linux-64::petsc4py-3.22.3-np20py311he28b882_0.conda
linux-64::petsc4py-3.22.3-np20py311hee93172_0.conda
linux-64::petsc4py-3.22.3-np20py312h28b4ab8_0.conda
linux-64::petsc4py-3.22.3-np20py312h2d2643b_0.conda
linux-64::petsc4py-3.22.3-np20py312h3ab541d_0.conda
linux-64::petsc4py-3.22.3-np20py312h421dcc3_0.conda
linux-64::petsc4py-3.22.3-np20py312h47f9b88_0.conda
linux-64::petsc4py-3.22.3-np20py312h5b4818c_0.conda
linux-64::petsc4py-3.22.3-np20py312h77cb511_0.conda
linux-64::petsc4py-3.22.3-np20py312h8274df9_0.conda
linux-64::petsc4py-3.22.3-np20py312hb45adcb_0.conda
linux-64::petsc4py-3.22.3-np20py312hb50f3a1_0.conda
linux-64::petsc4py-3.22.3-np20py312hd0b2988_0.conda
linux-64::petsc4py-3.22.3-np20py312he0bd3b1_0.conda
linux-64::petsc4py-3.22.3-np20py39h107c3ea_0.conda
linux-64::petsc4py-3.22.3-np20py39h15c8cb5_0.conda
linux-64::petsc4py-3.22.3-np20py39h26c83bb_0.conda
linux-64::petsc4py-3.22.3-np20py39h3533dd9_0.conda
linux-64::petsc4py-3.22.3-np20py39h427150c_0.conda
linux-64::petsc4py-3.22.3-np20py39h57dece4_0.conda
linux-64::petsc4py-3.22.3-np20py39hb3e120b_0.conda
linux-64::petsc4py-3.22.3-np20py39hce9fbc5_0.conda
linux-64::petsc4py-3.22.3-np20py39hed60a07_0.conda
linux-64::petsc4py-3.22.3-np20py39hf067fb4_0.conda
linux-64::petsc4py-3.22.3-np20py39hf11d1dd_0.conda
linux-64::petsc4py-3.22.3-np20py39hf197f4a_0.conda
linux-64::petsc4py-3.22.3-np2py313h071d88a_0.conda
linux-64::petsc4py-3.22.3-np2py313h295e0c7_0.conda
linux-64::petsc4py-3.22.3-np2py313h31e1dc8_0.conda
linux-64::petsc4py-3.22.3-np2py313h37800a8_0.conda
linux-64::petsc4py-3.22.3-np2py313h490083c_0.conda
linux-64::petsc4py-3.22.3-np2py313h7a7a374_0.conda
linux-64::petsc4py-3.22.3-np2py313h8d17e78_0.conda
linux-64::petsc4py-3.22.3-np2py313hb53d446_0.conda
linux-64::petsc4py-3.22.3-np2py313hcb91c87_0.conda
linux-64::petsc4py-3.22.3-np2py313hcbaf30b_0.conda
linux-64::petsc4py-3.22.3-np2py313hd652ad6_0.conda
linux-64::petsc4py-3.22.3-np2py313he98d100_0.conda
+    "petsc >=3.22.3,<3.23",
linux-64::scifem-0.3.0-py310h0d49125_0.conda
linux-64::scifem-0.3.0-py310h0d49125_1.conda
linux-64::scifem-0.3.0-py310h0d49125_2.conda
linux-64::scifem-0.3.0-py310h15cf5b9_1.conda
linux-64::scifem-0.3.0-py310h15cf5b9_2.conda
linux-64::scifem-0.3.0-py310h278bce3_1.conda
linux-64::scifem-0.3.0-py310h278bce3_2.conda
linux-64::scifem-0.3.0-py310h5e11928_0.conda
linux-64::scifem-0.3.0-py310h5e11928_1.conda
linux-64::scifem-0.3.0-py310h5e11928_2.conda
linux-64::scifem-0.3.0-py311h353a4fd_0.conda
linux-64::scifem-0.3.0-py311h353a4fd_1.conda
linux-64::scifem-0.3.0-py311h353a4fd_2.conda
linux-64::scifem-0.3.0-py311h3dac298_0.conda
linux-64::scifem-0.3.0-py311h3dac298_1.conda
linux-64::scifem-0.3.0-py311h3dac298_2.conda
linux-64::scifem-0.3.0-py311ha733225_1.conda
linux-64::scifem-0.3.0-py311ha733225_2.conda
linux-64::scifem-0.3.0-py311hf7b6948_1.conda
linux-64::scifem-0.3.0-py311hf7b6948_2.conda
linux-64::scifem-0.3.0-py312h0b7dda1_1.conda
linux-64::scifem-0.3.0-py312h0b7dda1_2.conda
linux-64::scifem-0.3.0-py312h430aa74_1.conda
linux-64::scifem-0.3.0-py312h430aa74_2.conda
linux-64::scifem-0.3.0-py312h8fe4e0b_1.conda
linux-64::scifem-0.3.0-py312h8fe4e0b_2.conda
linux-64::scifem-0.3.0-py312h98fd230_1.conda
linux-64::scifem-0.3.0-py312h98fd230_2.conda
linux-64::scifem-0.3.0-py313h081c02e_2.conda
linux-64::scifem-0.3.0-py313h5cf39bb_2.conda
linux-64::scifem-0.3.0-py313h683b224_2.conda
linux-64::scifem-0.3.0-py313hf7a2d3a_2.conda
linux-64::scifem-0.3.1-py310h0d49125_0.conda
linux-64::scifem-0.3.1-py310h15cf5b9_0.conda
linux-64::scifem-0.3.1-py310h278bce3_0.conda
linux-64::scifem-0.3.1-py310h5e11928_0.conda
linux-64::scifem-0.3.1-py311h353a4fd_0.conda
linux-64::scifem-0.3.1-py311h3dac298_0.conda
linux-64::scifem-0.3.1-py311ha733225_0.conda
linux-64::scifem-0.3.1-py311hf7b6948_0.conda
linux-64::scifem-0.3.1-py312h0b7dda1_0.conda
linux-64::scifem-0.3.1-py312h430aa74_0.conda
linux-64::scifem-0.3.1-py312h8fe4e0b_0.conda
linux-64::scifem-0.3.1-py312h98fd230_0.conda
linux-64::scifem-0.3.1-py313h081c02e_0.conda
linux-64::scifem-0.3.1-py313h5cf39bb_0.conda
linux-64::scifem-0.3.1-py313h683b224_0.conda
linux-64::scifem-0.3.1-py313hf7a2d3a_0.conda
+    "fenics-libdolfinx >=0.9.0,<0.9.1",
+    "petsc >=3.22.3,<3.23",
```

</details>

