### PR TITLE
Pin openkim models kim api dependency

### DIFF
--- a/recipe/patch_yaml/openkim-models-kim-api.yaml
+++ b/recipe/patch_yaml/openkim-models-kim-api.yaml
@@ -1,5 +1,6 @@
 if:
   name: openkim-models
+  timestamp_lt: 1741895610000
 then:
   - tighten_depends:
       name: kim-api

--- a/recipe/patch_yaml/openkim-models-kim-api.yaml
+++ b/recipe/patch_yaml/openkim-models-kim-api.yaml
@@ -1,0 +1,6 @@
+if:
+  name: openkim-models
+then:
+  - tighten_depends:
+      name: kim-api
+      upper_bound: 2.3.0


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. 

The `openkim-models` package is no longer being updated, but it is still perfectly operational. However, `kim-api` will soon be updated to 2.4.0 (we have already released it, but are working on some issues with the conda-forge build). The new version of `kim-api` has changed the binary API, and will not work with the models in `openkim-models`. Therefore we are patching `openkim-models` to prevent users from installing it with kim-api 2.4.0 and having a non-operational package.

Output of show_diff.py:

```
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
noarch
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
osx-64::openkim-models-2019.07.25-h131c384_1.tar.bz2
osx-64::openkim-models-2019.07.25-h1423387_1.tar.bz2
osx-64::openkim-models-2019.07.25-hd17c0aa_0.tar.bz2
-    "kim-api",
+    "kim-api <2.3.0a0",
osx-64::openkim-models-2021.01.28-h2beb688_1.tar.bz2
osx-64::openkim-models-2021.01.28-h7cc9f77_0.tar.bz2
osx-64::openkim-models-2021.01.28-h7cc9f77_1.tar.bz2
-    "kim-api >=2.2.1",
+    "kim-api >=2.2.1,<2.3.0a0",
================================================================================
================================================================================
linux-64
linux-64::openkim-models-2019.07.25-h616b090_1.tar.bz2
linux-64::openkim-models-2019.07.25-hc99cbb1_0.tar.bz2
linux-64::openkim-models-2019.07.25-hc99cbb1_1.tar.bz2
-    "kim-api",
+    "kim-api <2.3.0a0",
linux-64::openkim-models-2021.01.28-h2cc385e_0.tar.bz2
linux-64::openkim-models-2021.01.28-h2cc385e_1.tar.bz2
-    "kim-api >=2.2.1",
+    "kim-api >=2.2.1,<2.3.0a0",
```
