### PR TITLE
Revert "patch builds built with fmt 11.1 to use 11.0"

### DIFF
--- a/recipe/patch_yaml/fmt.yaml
+++ b/recipe/patch_yaml/fmt.yaml
@@ -1,9 +1,0 @@
-# see https://github.com/conda-forge/fmt-feedstock/issues/61
-# and https://github.com/conda-forge/admin-requests/pull/1433
-if:
-  timestamp_lt: 1741816082000
-  has_depends: fmt >=11.1*
-then:
-  - replace_depends:
-      old: fmt >=11.1*
-      new: fmt >=11.0,<11.1


### PR DESCRIPTION
Reverts conda-forge/conda-forge-repodata-patches-feedstock#976

this patch led to [broken envs](https://github.com/conda-forge/dolfinx_mpc-feedstock/issues/27) because (at least some) builds with 11.1 depend on symbols not in 11.0. It seems better to me to leave these builds unsolvable than try to put them into broken envs.