### PR TITLE
add __win constraint to libboost 1.87 on windows

### DIFF
--- a/recipe/patch_yaml/libboost.yaml
+++ b/recipe/patch_yaml/libboost.yaml
@@ -5,4 +5,4 @@ if:
   version: "1.87.0"
   subdir_in: win-64
 then:
-  - add_constrains: __win>=10
+  - add_constrains: __win==0|>=10

--- a/recipe/patch_yaml/libboost.yaml
+++ b/recipe/patch_yaml/libboost.yaml
@@ -1,0 +1,8 @@
+# see https://github.com/conda-forge/boost-feedstock/pull/228
+if:
+  name: libboost
+  timestamp_lt: 1742094791000
+  version: "1.87.0"
+  subdir_in: win-64
+then:
+  - add_constrains: __win>=10


### PR DESCRIPTION
Companion to https://github.com/conda-forge/boost-feedstock/pull/228. Quoting from there

> Given that boost 1.87 is not in wide-spread use in conda-forge, I think it's OK to impose this constraint, despite the relatively recent [installer] versions required to handle it. For affected windows users (on win<10 _and_ older installers), it's still better to get an unresolvable constraint rather than a broken package.