### PR TITLE
re-add minor version for cling-constraint

### DIFF
--- a/recipe/patch_yaml/cling.yaml
+++ b/recipe/patch_yaml/cling.yaml
@@ -1,0 +1,10 @@
+# https://github.com/conda-forge/cling-feedstock/pull/63
+# https://github.com/conda/conda-build/issues/5624
+if:
+  name: cling
+  version: "1.2"
+  build_number_lt: 1
+then:
+  - replace_depends:
+      old: clangdev 18.1.8 cling_1.*
+      new: clangdev 18.1.8 cling_1.2*


### PR DESCRIPTION
Companion to https://github.com/conda-forge/cling-feedstock/pull/63 - the correct constraint (including the cling minor version) was broken with libmamba before 2.0.7, see the conda-build issue reference.