### PR TITLE
Fix prompt_toolkit range for questionary v2

### DIFF
--- a/recipe/patch_yaml/questionary
+++ b/recipe/patch_yaml/questionary
@@ -1,0 +1,31 @@
+# pip prompt_toolkit constrain was relaxed in 2.1.0
+# This was missed by the auto bump bot
+# Package fix: https://github.com/conda-forge/questionary-feedstock/pull/14
+if:
+  name: questionary
+  version: 2.1.0
+  build_number_lt: 2
+then:
+  - replace_depends:
+      old: prompt_toolkit <=3.0.36,>=2.0
+      new: prompt_toolkit >=2.0,<4.0
+---
+# pip prompt_toolkit constrain was more stringent for 2.0.x
+# https://github.com/conda-forge/questionary-feedstock/pull/7
+if:
+  name: questionary
+  version: 2.0.1
+  build_number_lt: 1
+then:
+  - replace_depends:
+      old: prompt_toolkit >=2.0,<4.0
+      new: prompt_toolkit >=2.0,<=3.0.36
+---
+if:
+  name: questionary
+  version: 2.0.0
+  build_number_lt: 1
+then:
+  - replace_depends:
+      old: prompt_toolkit >=2.0,<4.0
+      new: prompt_toolkit >=2.0,<=3.0.36


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
