### PR TITLE
tighten run-dependency for packages built against fmt

### DIFF
--- a/recipe/patch_yaml/fmt.yaml
+++ b/recipe/patch_yaml/fmt.yaml
@@ -1,0 +1,9 @@
+# see https://github.com/conda-forge/fmt-feedstock/issues/61
+# and https://github.com/conda-forge/admin-requests/pull/1433
+if:
+  timestamp_lt: 1743030622335
+  has_depends: fmt >=11.0*
+then:
+  - replace_depends:
+      old: fmt >=11.0*
+      new: fmt >=11.0,<11.1

--- a/recipe/patch_yaml/fmt.yaml
+++ b/recipe/patch_yaml/fmt.yaml
@@ -7,7 +7,7 @@ if:
 then:
   - replace_depends:
       old: fmt >=11.0.1,<12.0a0
-      new: fmt >=11.0.1,<11.1
+      new: fmt >=11.0.1,<11.1a0
   - replace_depends:
       old: fmt >=11.0.2,<12.0a0
-      new: fmt >=11.0.2,<11.1
+      new: fmt >=11.0.2,<11.1a0

--- a/recipe/patch_yaml/fmt.yaml
+++ b/recipe/patch_yaml/fmt.yaml
@@ -3,7 +3,11 @@
 if:
   timestamp_lt: 1743030622335
   has_depends: fmt >=11.0*
+  subdir_in: win-64
 then:
   - replace_depends:
-      old: fmt >=11.0*
-      new: fmt >=11.0,<11.1
+      old: fmt >=11.0.1,<12.0a0
+      new: fmt >=11.0.1,<11.1
+  - replace_depends:
+      old: fmt >=11.0.2,<12.0a0
+      new: fmt >=11.0.2,<11.1


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

Follow-up to https://github.com/conda-forge/fmt-feedstock/issues/61 /  https://github.com/conda-forge/fmt-feedstock/pull/62

## Output of `python show_diff.py`

see below