### PR TITLE
time-box old cling repo-patches

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -850,7 +850,11 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
                 deps += ["clangdev * flang*"]
 
         # add as run_constrained for cling
-        if record_name == "cling" and record["version"] >= "0.8":
+        if (
+            record_name == "cling"
+            and record["version"] >= "0.8"
+            and record.get("timestamp", 0) < 1667260800000  # 2022-11-01
+        ):
             record.setdefault("constrains", []).extend(("gxx_linux-64 !=9.5.0",))
 
         ############################################


### PR DESCRIPTION
In #984, I got some weird diffs that made no sense to me:
```diff
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
linux-ppc64le
linux-ppc64le::cling-1.2-hf62710f_0.conda
-    "clangdev 18.1.8 cling_1.*",
+    "clangdev 18.1.8 cling_1.2*",
linux-ppc64le::cling-1.2-hf62710f_1.conda
+  "constrains": [
+    "gxx_linux-64 !=9.5.0"
+  ],
================================================================================
================================================================================
osx-arm64
osx-arm64::cling-1.2-h7870378_0.conda
-    "clangdev 18.1.8 cling_1.*",
+    "clangdev 18.1.8 cling_1.2*",
osx-arm64::cling-1.2-h7870378_1.conda
+  "constrains": [
+    "gxx_linux-64 !=9.5.0"
+  ],
================================================================================
================================================================================
linux-aarch64
linux-aarch64::cling-1.2-hc60a013_1.conda
+  "constrains": [
+    "gxx_linux-64 !=9.5.0"
+  ],
linux-aarch64::cling-1.2-hc60a013_0.conda
-    "clangdev 18.1.8 cling_1.*",
+    "clangdev 18.1.8 cling_1.2*",
================================================================================
================================================================================
noarch
================================================================================
================================================================================
win-64
win-64::cling-1.2-h3089188_1.conda
+  "constrains": [
+    "gxx_linux-64 !=9.5.0"
+  ],
win-64::cling-1.2-h3089188_0.conda
-    "clangdev 18.1.8 cling_1.*",
+    "clangdev 18.1.8 cling_1.2*",
================================================================================
================================================================================
osx-64
osx-64::cling-1.2-h7f16d7c_1.conda
+  "constrains": [
+    "gxx_linux-64 !=9.5.0"
+  ],
osx-64::cling-1.2-h7f16d7c_0.conda
-    "clangdev 18.1.8 cling_1.*",
+    "clangdev 18.1.8 cling_1.2*",
================================================================================
================================================================================
linux-64
linux-64::cling-1.2-h48f18f5_1.conda
+  "constrains": [
+    "gxx_linux-64 !=9.5.0"
+  ],
linux-64::cling-1.2-h48f18f5_0.conda
-    "clangdev 18.1.8 cling_1.*",
+    "clangdev 18.1.8 cling_1.2*",
```

Part of that is from an apparently not-yet-digested https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/981, but the `gxx_linux-64 !=9.5.0` constraints are spurious, and aren't specified in any patch_yaml file. As it turns out, there was some old un-timeboxed stuff in `gen_patch_json.py`:

https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/57de034f10c9d612e29e4dda04a2bbbd5de54692/recipe/gen_patch_json.py#L852-L854

The last cling builds before https://github.com/conda-forge/cling-feedstock/pull/62 were on 2022-10-30, so I've chosen a date shortly after that as the timebox.