### PR TITLE
fix: ensure cmake-no-system conflicts with cmake

### DIFF
--- a/recipe/patch_yaml/cmake_no_system.yaml
+++ b/recipe/patch_yaml/cmake_no_system.yaml
@@ -1,0 +1,6 @@
+if:
+  name: cmake-no-system
+  version_le: "4.0.0"
+  timestamp_lt: 1743434525000
+then:
+  - add_constrains: cmake ==dev


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->


xref: https://github.com/conda-forge/cmake-no-system-feedstock/pull/64