### PR TITLE
Fix omniorb dependency for cpptango on macOS

### DIFF
--- a/recipe/patch_yaml/cpptango.yaml
+++ b/recipe/patch_yaml/cpptango.yaml
@@ -8,3 +8,16 @@ then:
   - tighten_depends:
       name: omniorb-libs
       max_pin: 'x.x.x'
+---
+if:
+  name: cpptango
+  version_in:
+    - 10.0.0
+    - 10.0.2
+  has_depends: omniorb-libs >=4.3.2,<4.4.0a0
+  subdir_in: ["osx-64", "osx-arm64"]
+  timestamp_lt: 1743520876000
+then:
+  - tighten_depends:
+      name: omniorb-libs
+      max_pin: 'x.x.x'


### PR DESCRIPTION
Checklist

* [X] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [X] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [X] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [X] Ran `python show_diff.py` and posted the output as part of the PR.
* [X] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

```
python show_diff.py --subdirs osx-64 osx-arm64 --use-cache
================================================================================
================================================================================
osx-arm64
osx-arm64::cpptango-10.0.0-h04e6e66_2.conda
osx-arm64::cpptango-10.0.0-h3593fa6_0.conda
osx-arm64::cpptango-10.0.0-h3ac0051_1.conda
osx-arm64::cpptango-10.0.2-h04e6e66_0.conda
osx-arm64::cpptango-10.0.2-h8543741_1.conda
-    "omniorb-libs >=4.3.2,<4.4.0a0",
+    "omniorb-libs >=4.3.2,<4.3.3.0a0",
================================================================================
================================================================================
osx-64
osx-64::cpptango-10.0.0-h25a8138_2.conda
osx-64::cpptango-10.0.0-h4b0f150_0.conda
osx-64::cpptango-10.0.0-hede3940_1.conda
osx-64::cpptango-10.0.2-h25a8138_0.conda
osx-64::cpptango-10.0.2-he5df91b_1.conda
-    "omniorb-libs >=4.3.2,<4.4.0a0",
+    "omniorb-libs >=4.3.2,<4.3.3.0a0",
```

Note: there was no cpptango 10.0.1

On macOS, cpptango 10.0.x is explicitely linked against omniorb 4.3.2. Releasing 4.3.3 currently broke 10.0.x installation as run_export is set to x.x. It must be tighten to x.x.x

```
$ otool -L libtango.10.0.2.dylib
libtango.10.0.2.dylib:
	@rpath/libtango.10.0.dylib (compatibility version 10.0.0, current version 10.0.2)
	@rpath/libomniORB4.3.2.dylib (compatibility version 4.3.0, current version 4.3.2)
	@rpath/libCOS4.3.2.dylib (compatibility version 4.3.0, current version 4.3.2)
	@rpath/libomniDynamic4.3.2.dylib (compatibility version 4.3.0, current version 4.3.2)
	@rpath/libjpeg.8.dylib (compatibility version 8.0.0, current version 8.3.2)
```

This is the same as https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/636 :-(

I thought this had been fixed by setting properly the compatibility version in omniorb but it looks like the pb is when compiling cpptango.

