### PR TITLE
Add patch for pytest benchmark

### DIFF
--- a/recipe/patch_yaml/pytest_benchmark.yaml
+++ b/recipe/patch_yaml/pytest_benchmark.yaml
@@ -1,0 +1,10 @@
+# See https://github.com/conda-forge/pytest-benchmark-feedstock/pull/27
+# for the fix in pytest-benchmark 5.1.0, build 2
+if:
+  name: pytest-benchmark
+  version_eq: 5.1.0
+  build_number_in: [0, 1]
+then:
+  - replace_depends:
+      old: pytest >=3.8
+      new: pytest >=8.1


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

```
❯ python show_diff.py --subdirs noarch
================================================================================
================================================================================
noarch
noarch::pytest-benchmark-5.1.0-pyhd8ed1ab_0.conda
noarch::pytest-benchmark-5.1.0-pyhd8ed1ab_1.conda
-    "pytest >=3.8",
+    "pytest >=8.1",
```
<!-- Put any other comments or information here -->
This is a repodata patch required to fix a dependency specification issue that is fixed in the pytest-benchmark feedstock in https://github.com/conda-forge/pytest-benchmark-feedstock/pull/27.