### PR TITLE
Limit libxml2 to <2.14

### DIFF
--- a/recipe/patch_yaml/libxml2.yaml
+++ b/recipe/patch_yaml/libxml2.yaml
@@ -9,7 +9,7 @@ if:
 then:
   - loosen_depends:
       name: libxml2
-      upper_bound: 3.0.0
+      upper_bound: 2.14.0
 ---
 if:
   timestamp_lt: 1705357488000
@@ -18,7 +18,7 @@ if:
 then:
   - loosen_depends:
       name: libxml2
-      upper_bound: 3.0.0
+      upper_bound: 2.14.0
 ---
 if:
   timestamp_lt: 1705357488000
@@ -27,7 +27,7 @@ if:
 then:
   - loosen_depends:
       name: libxml2
-      upper_bound: 3.0.0
+      upper_bound: 2.14.0
 ---
 if:
   timestamp_lt: 1705357488000
@@ -36,4 +36,13 @@ if:
 then:
   - loosen_depends:
       name: libxml2
-      upper_bound: 3.0.0
+      upper_bound: 2.14.0
+---
+if:
+  timestamp_lt: 1743792233000
+  has_depends:
+    - libxml2 >=2.13*
+then:
+  - loosen_depends:
+      name: libxml2
+      upper_bound: 2.14.0


### PR DESCRIPTION
Checklist

* [ ] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

See https://github.com/conda-forge/libxml2-feedstock/issues/145