### PR TITLE
Relax libgfortran patch to change libgfortran version scheme on osx to match linux

### DIFF
--- a/recipe/patch_yaml/libgfortran.yaml
+++ b/recipe/patch_yaml/libgfortran.yaml
@@ -1,0 +1,7 @@
+if:
+  timestamp_lt: 1743886623000
+  has_depends: libgfortran 5.*
+then:
+  - replace_depends:
+      old: libgfortran 5.*
+      new: libgfortran >=5


### PR DESCRIPTION
Checklist

* [ ] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

To allow https://github.com/conda-forge/gfortran_impl_osx-64-feedstock/pull/89