### PR TITLE
bump libxml2 timestamp filters which omitted some broken packages

### DIFF
--- a/recipe/patch_yaml/libxml2.yaml
+++ b/recipe/patch_yaml/libxml2.yaml
@@ -12,7 +12,7 @@ then:
       upper_bound: 2.14.0
 ---
 if:
-  timestamp_lt: 1705357488000
+  timestamp_lt: 1744044827000
   has_depends:
     - libxml2 >=2.10*
 then:
@@ -21,7 +21,7 @@ then:
       upper_bound: 2.14.0
 ---
 if:
-  timestamp_lt: 1705357488000
+  timestamp_lt: 1744044827000
   has_depends:
     - libxml2 >=2.11*
 then:
@@ -30,7 +30,7 @@ then:
       upper_bound: 2.14.0
 ---
 if:
-  timestamp_lt: 1705357488000
+  timestamp_lt: 1744044827000
   has_depends:
     - libxml2 >=2.12*
 then:
@@ -39,7 +39,7 @@ then:
       upper_bound: 2.14.0
 ---
 if:
-  timestamp_lt: 1743792233000
+  timestamp_lt: 1744044827000
   has_depends:
     - libxml2 >=2.13*
 then:


### PR DESCRIPTION
Checklist

* [ ] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

The libxml2 patch from #993 filtered timestamps a little bit too zealously. This PR sets the timestamp upper bound to roughly the time of this PR, so these orphaned packages should be fixed with this change.

```
    "azure-storage-common-cpp-12.5.0-hc62b562_4.conda": {
      "build": "hc62b562_4",
      "build_number": 4,
      "depends": [
        "azure-core-cpp >=1.11.1,<1.11.2.0a0",
        "libgcc-ng >=12",
        "libstdcxx-ng >=12",
        "libxml2 >=2.12.5,<3.0a0",
        "openssl >=1.1.1w,<1.1.2a"
      ],
```

While `azure-storage-common-cpp` seems esoteric, this bubbles its way up to pyarrow, so it actually has very high impact.

<!-- Put any other comments or information here -->
