### PR TITLE
adjust libxml bounds to only affect <3.0 bound

### DIFF
--- a/recipe/patch_yaml/libxml2.yaml
+++ b/recipe/patch_yaml/libxml2.yaml
@@ -11,7 +11,7 @@ if:
 then:
   - tighten_depends:
       name: libxml2
-      upper_bound: 2.11.0
+      upper_bound: "2.11.0"
 ---
 if:
   timestamp_lt: 1744044827000
@@ -20,4 +20,4 @@ if:
 then:
   - tighten_depends:
       name: libxml2
-      upper_bound: 2.14
+      upper_bound: "2.14"

--- a/recipe/patch_yaml/libxml2.yaml
+++ b/recipe/patch_yaml/libxml2.yaml
@@ -7,42 +7,15 @@ if:
   has_depends:
     - libxml2 >=2.9*
 then:
-  - loosen_depends:
+  - tighten_depends:
       name: libxml2
-      upper_bound: 2.14.0
+      upper_bound: 2.11.0
 ---
 if:
   timestamp_lt: 1744044827000
   has_depends:
-    - libxml2 >=2.10*
-then:
-  - loosen_depends:
-      name: libxml2
-      upper_bound: 2.14.0
----
-if:
-  timestamp_lt: 1744044827000
-  has_depends:
-    - libxml2 >=2.11*
-then:
-  - loosen_depends:
-      name: libxml2
-      upper_bound: 2.14.0
----
-if:
-  timestamp_lt: 1744044827000
-  has_depends:
-    - libxml2 >=2.12*
-then:
-  - loosen_depends:
-      name: libxml2
-      upper_bound: 2.14.0
----
-if:
-  timestamp_lt: 1744044827000
-  has_depends:
-    - libxml2 >=2.13*
+    - libxml2 <3.0a0
 then:
   - tighten_depends:
       name: libxml2
-      upper_bound: 2.14.0
+      upper_bound: 2.14

--- a/recipe/patch_yaml/libxml2.yaml
+++ b/recipe/patch_yaml/libxml2.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=../patch_yaml_model.json
+
 # from this snippet
 # if record.get('timestamp', 0) < 1666320182000:
 #     if any(dep.startswith("libxml2 >=2.9") for dep in deps):


### PR DESCRIPTION
#996 was still not a complete fix. I don't understand why. Nevertheless, the simplified code here leaves more of the original pins alone. There were many pins on minor versions that we were overwriting with 2.14, and I'm not sure that they were ok.

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

There's a huge number of changes reported by show_diff.py. They fall into two categories:

This one is fixing the 2.14 bound, which is likely the most pressing issue
```
linux-64::clang-tools-20.1.2-default_hb5137d0_0.conda
-    "libxml2 >=2.13.7,<2.14.0a0"
+    "libxml2 >=2.13.7,<3.0a0"
```

These are reverting the change from #993, preserving the existing x.x pin
```
linux-64::mdal-1.0.1-hba616fa_7.conda
-    "libxml2 >=2.10.4,<2.14.0a0"
+    "libxml2 >=2.10.4,<2.11.0a0"
linux-64::mdal-1.1.0-hccb4986_1.conda
-    "libxml2 >=2.12.2,<2.14.0a0"
+    "libxml2 >=2.12.2,<2.13.0a0"
```