### PR TITLE
Tighten `libxml2<3.0a0` bounds to 2.14 where appropriate

### DIFF
--- a/recipe/patch_yaml/libxml2.yaml
+++ b/recipe/patch_yaml/libxml2.yaml
@@ -47,4 +47,17 @@ if:
 then:
   - tighten_depends:
       name: libxml2
-      upper_bound: "2.14"
+      upper_bound: 2.14.0
+---
+if:
+  timestamp_lt: 1744044827000
+  # for anything not caught by the above, ensure that packages (built before 2.14)
+  # which assumed major-level compatibility get the right upper bound too
+  has_depends:
+    - libxml2 *<3.0a0
+  not_has_depends:
+    - libxml2 >=2.14*
+then:
+  - tighten_depends:
+      name: libxml2
+      upper_bound: 2.14.0

--- a/recipe/patch_yaml/libxml2.yaml
+++ b/recipe/patch_yaml/libxml2.yaml
@@ -11,7 +11,7 @@ if:
 then:
   - tighten_depends:
       name: libxml2
-      upper_bound: 2.11.0
+      upper_bound: "2.11.0"
 ---
 if:
   timestamp_lt: 1744044827000
@@ -20,4 +20,4 @@ if:
 then:
   - tighten_depends:
       name: libxml2
-      upper_bound: 2.14
+      upper_bound: "2.14"

--- a/recipe/patch_yaml/libxml2.yaml
+++ b/recipe/patch_yaml/libxml2.yaml
@@ -7,42 +7,15 @@ if:
   has_depends:
     - libxml2 >=2.9*
 then:
-  - loosen_depends:
+  - tighten_depends:
       name: libxml2
-      upper_bound: 2.14.0
+      upper_bound: 2.11.0
 ---
 if:
   timestamp_lt: 1744044827000
   has_depends:
-    - libxml2 >=2.10*
-then:
-  - loosen_depends:
-      name: libxml2
-      upper_bound: 2.14.0
----
-if:
-  timestamp_lt: 1744044827000
-  has_depends:
-    - libxml2 >=2.11*
-then:
-  - loosen_depends:
-      name: libxml2
-      upper_bound: 2.14.0
----
-if:
-  timestamp_lt: 1744044827000
-  has_depends:
-    - libxml2 >=2.12*
-then:
-  - loosen_depends:
-      name: libxml2
-      upper_bound: 2.14.0
----
-if:
-  timestamp_lt: 1744044827000
-  has_depends:
-    - libxml2 >=2.13*
+    - libxml2 <3.0a0
 then:
   - tighten_depends:
       name: libxml2
-      upper_bound: 2.14.0
+      upper_bound: 2.14

--- a/recipe/patch_yaml/libxml2.yaml
+++ b/recipe/patch_yaml/libxml2.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=../patch_yaml_model.json
+
 # from this snippet
 # if record.get('timestamp', 0) < 1666320182000:
 #     if any(dep.startswith("libxml2 >=2.9") for dep in deps):

--- a/recipe/patch_yaml/libxml2.yaml
+++ b/recipe/patch_yaml/libxml2.yaml
@@ -9,14 +9,41 @@ if:
   has_depends:
     - libxml2 >=2.9*
 then:
-  - tighten_depends:
+  - loosen_depends:
       name: libxml2
-      upper_bound: "2.11.0"
+      upper_bound: 2.14.0
 ---
 if:
   timestamp_lt: 1744044827000
   has_depends:
-    - libxml2 <3.0a0
+    - libxml2 >=2.10*
+then:
+  - loosen_depends:
+      name: libxml2
+      upper_bound: 2.14.0
+---
+if:
+  timestamp_lt: 1744044827000
+  has_depends:
+    - libxml2 >=2.11*
+then:
+  - loosen_depends:
+      name: libxml2
+      upper_bound: 2.14.0
+---
+if:
+  timestamp_lt: 1744044827000
+  has_depends:
+    - libxml2 >=2.12*
+then:
+  - loosen_depends:
+      name: libxml2
+      upper_bound: 2.14.0
+---
+if:
+  timestamp_lt: 1744044827000
+  has_depends:
+    - libxml2 >=2.13*
 then:
   - tighten_depends:
       name: libxml2


### PR DESCRIPTION
This patch builds on top of #998.