### PR TITLE
libxml 2.12 needs both `{loosen,tighten}_depends`

### DIFF
--- a/recipe/patch_yaml/libxml2.yaml
+++ b/recipe/patch_yaml/libxml2.yaml
@@ -36,7 +36,18 @@ if:
   has_depends:
     - libxml2 >=2.12*
 then:
+  # loosen for builds against libxml 2.12 before https://github.com/conda-forge/libxml2-feedstock/pull/111
   - loosen_depends:
+      name: libxml2
+      upper_bound: 2.14.0
+---
+if:
+  timestamp_lt: 1744044827000
+  has_depends:
+    - libxml2 >=2.12*
+then:
+  # tighten for builds against libxml 2.12 after https://github.com/conda-forge/libxml2-feedstock/pull/111
+  - tighten_depends:
       name: libxml2
       upper_bound: 2.14.0
 ---


### PR DESCRIPTION
Follow-up to #999 

Closes #1000 

This is because https://github.com/conda-forge/libxml2-feedstock/pull/111 landed during the libxml2 2.12.x cycle, so builds before that PR need `loosen_depends` (in order to allow libxml 2.13, which is compatible), whereas builds after that PR need `tighten_depends` to avoid https://github.com/conda-forge/libxml2-feedstock/issues/145.