### PR TITLE
pin jupyter-collaboration 3.x subpackages to 2.x

### DIFF
--- a/recipe/patch_yaml/jupyter-collaboration.yaml
+++ b/recipe/patch_yaml/jupyter-collaboration.yaml
@@ -1,0 +1,14 @@
+if:
+  name: jupyter-collaboration
+  version: 3.*
+  timestamp_lt: 1744114015000
+then:
+  - tighten_depends:
+      name: jupyter-collaboration
+      upper_bound: "2.0"
+  - tighten_depends:
+      name: jupyter-docprovider
+      upper_bound: "2.0"
+  - tighten_depends:
+      name: jupyter_server_ydoc
+      upper_bound: "2.0"


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

This pins the subpackages of `jupyter-collaboration` for the 3.x line to only pull compatible 2.x `jupyter-*` subpackages.

Links:
- fixed in feedstock by https://github.com/conda-forge/jupyter-collaboration-feedstock/pull/22
- current upstream PyPI releases (and the @conda-forge/jupyter-collaboration feedstock) on the 4.x line include a major pin for these subpackages

The relevant diff:

```diff
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
noarch
noarch::jupyter-collaboration-3.0.1-pyhd8ed1ab_0.conda
-    "jupyter-docprovider >=1.0.1",
-    "jupyter_server_ydoc >=1.0.1",
+    "jupyter-docprovider >=1.0.1,<2.0.0a0",
+    "jupyter_server_ydoc >=1.0.1,<2.0.0a0",
noarch::jupyter-collaboration-3.1.0-pyhd8ed1ab_0.conda
-    "jupyter-docprovider >=1.1.0",
-    "jupyter_server_ydoc >=1.1.0",
+    "jupyter-docprovider >=1.1.0,<2.0.0a0",
+    "jupyter_server_ydoc >=1.1.0,<2.0.0a0",
noarch::jupyter-collaboration-3.0.0-pyhd8ed1ab_0.conda
-    "jupyter-docprovider >=1.0.0",
-    "jupyter_server_ydoc >=1.0.0",
+    "jupyter-docprovider >=1.0.0,<2.0.0a0",
+    "jupyter_server_ydoc >=1.0.0,<2.0.0a0",
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
================================================================================
================================================================================
linux-64

```