### PR TITLE
Fix loose conda-libmamba-solver pin on conda, part 2

### DIFF
--- a/recipe/patch_yaml/conda_patches.yaml
+++ b/recipe/patch_yaml/conda_patches.yaml
@@ -29,6 +29,6 @@ if:
   name: conda
   version_ge: "25.1.0"
   version_le: "25.3.1"
-  timestamp_lt: 1744201428000
+  timestamp_lt: 1744218305000
 then:
   - add_depends: conda-libmamba-solver >=24.11.0


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

This is a follow-up to https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/1006

~Due to https://github.com/conda-forge/conda-feedstock/pull/266 being merged before https://github.com/conda-forge/conda-feedstock/pull/267, another build with bad dependencies was released. This increases the timestamp to cover that build.~

According to https://github.com/conda-forge/conda-feedstock/pull/266#issuecomment-2789992569, v25.3.1 build 0 of conda was released on a deleted branch. Incidentally, the osx-64 py311 variant [failed to build due to a connection error](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=1215613&view=logs&j=c8b8640e-759f-5af3-65b5-809c078c71b1&t=afb740aa-a99a-548c-edee-7cc314e30345). Meanwhile, https://github.com/conda-forge/conda-feedstock/pull/266 was merged to create a build 0 in the `main` branch. The net effect was to upload the osx-64 py311 build. Since https://github.com/conda-forge/conda-feedstock/pull/267 is not yet merged, this single build has the incorrect lower bound for conda-libmamba-solver.

To prevent further bad builds from being released, we should merge https://github.com/conda-forge/conda-feedstock/pull/267.

<details>
<summary>Diff</summary>

```diff
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
linux-ppc64le
linux-ppc64le::conda-25.1.0-py310h194a6c8_0.conda
linux-ppc64le::conda-25.1.0-py311h1af927a_0.conda
linux-ppc64le::conda-25.1.0-py312h7864ebf_0.conda
linux-ppc64le::conda-25.1.0-py39h0b1cf3c_0.conda
linux-ppc64le::conda-25.1.1-py310h194a6c8_0.conda
linux-ppc64le::conda-25.1.1-py310h194a6c8_1.conda
linux-ppc64le::conda-25.1.1-py311h1af927a_0.conda
linux-ppc64le::conda-25.1.1-py311h1af927a_1.conda
linux-ppc64le::conda-25.1.1-py312h7864ebf_0.conda
linux-ppc64le::conda-25.1.1-py312h7864ebf_1.conda
linux-ppc64le::conda-25.1.1-py313h726a011_1.conda
linux-ppc64le::conda-25.1.1-py39h0b1cf3c_0.conda
linux-ppc64le::conda-25.1.1-py39h0b1cf3c_1.conda
linux-ppc64le::conda-25.3.0-py310h194a6c8_0.conda
linux-ppc64le::conda-25.3.0-py311h1af927a_0.conda
linux-ppc64le::conda-25.3.0-py312h7864ebf_0.conda
linux-ppc64le::conda-25.3.0-py313h726a011_0.conda
linux-ppc64le::conda-25.3.0-py39h0b1cf3c_0.conda
linux-ppc64le::conda-25.3.1-py310h194a6c8_0.conda
linux-ppc64le::conda-25.3.1-py311h1af927a_0.conda
linux-ppc64le::conda-25.3.1-py312h7864ebf_0.conda
linux-ppc64le::conda-25.3.1-py313h726a011_0.conda
linux-ppc64le::conda-25.3.1-py39h0b1cf3c_0.conda
+    "conda-libmamba-solver >=24.11.0",
================================================================================
================================================================================
osx-arm64
osx-arm64::conda-25.1.0-py310hbe9552e_0.conda
osx-arm64::conda-25.1.0-py311h267d04e_0.conda
osx-arm64::conda-25.1.0-py312h81bd7bf_0.conda
osx-arm64::conda-25.1.0-py39h2804cbe_0.conda
osx-arm64::conda-25.1.1-py310hbe9552e_0.conda
osx-arm64::conda-25.1.1-py310hbe9552e_1.conda
osx-arm64::conda-25.1.1-py311h267d04e_0.conda
osx-arm64::conda-25.1.1-py311h267d04e_1.conda
osx-arm64::conda-25.1.1-py312h81bd7bf_0.conda
osx-arm64::conda-25.1.1-py312h81bd7bf_1.conda
osx-arm64::conda-25.1.1-py313h8f79df9_1.conda
osx-arm64::conda-25.1.1-py39h2804cbe_0.conda
osx-arm64::conda-25.1.1-py39h2804cbe_1.conda
osx-arm64::conda-25.3.0-py310hbe9552e_0.conda
osx-arm64::conda-25.3.0-py311h267d04e_0.conda
osx-arm64::conda-25.3.0-py312h81bd7bf_0.conda
osx-arm64::conda-25.3.0-py313h8f79df9_0.conda
osx-arm64::conda-25.3.0-py39h2804cbe_0.conda
osx-arm64::conda-25.3.1-py310hbe9552e_0.conda
osx-arm64::conda-25.3.1-py311h267d04e_0.conda
osx-arm64::conda-25.3.1-py312h81bd7bf_0.conda
osx-arm64::conda-25.3.1-py313h8f79df9_0.conda
osx-arm64::conda-25.3.1-py39h2804cbe_0.conda
+    "conda-libmamba-solver >=24.11.0",
================================================================================
================================================================================
linux-aarch64
linux-aarch64::conda-25.1.0-py310h4c7bcd0_0.conda
linux-aarch64::conda-25.1.0-py311hec3470c_0.conda
linux-aarch64::conda-25.1.0-py312h996f985_0.conda
linux-aarch64::conda-25.1.0-py39h4420490_0.conda
linux-aarch64::conda-25.1.1-py310h4c7bcd0_0.conda
linux-aarch64::conda-25.1.1-py310h4c7bcd0_1.conda
linux-aarch64::conda-25.1.1-py311hec3470c_0.conda
linux-aarch64::conda-25.1.1-py311hec3470c_1.conda
linux-aarch64::conda-25.1.1-py312h996f985_0.conda
linux-aarch64::conda-25.1.1-py312h996f985_1.conda
linux-aarch64::conda-25.1.1-py313hd81a959_1.conda
linux-aarch64::conda-25.1.1-py39h4420490_0.conda
linux-aarch64::conda-25.1.1-py39h4420490_1.conda
linux-aarch64::conda-25.3.0-py310h4c7bcd0_0.conda
linux-aarch64::conda-25.3.0-py311hec3470c_0.conda
linux-aarch64::conda-25.3.0-py312h996f985_0.conda
linux-aarch64::conda-25.3.0-py313hd81a959_0.conda
linux-aarch64::conda-25.3.0-py39h4420490_0.conda
linux-aarch64::conda-25.3.1-py310h4c7bcd0_0.conda
linux-aarch64::conda-25.3.1-py311hec3470c_0.conda
linux-aarch64::conda-25.3.1-py312h996f985_0.conda
linux-aarch64::conda-25.3.1-py313hd81a959_0.conda
linux-aarch64::conda-25.3.1-py39h4420490_0.conda
+    "conda-libmamba-solver >=24.11.0",
================================================================================
================================================================================
noarch
================================================================================
================================================================================
win-64
win-64::conda-25.1.0-py310h5588dad_0.conda
win-64::conda-25.1.0-py311h1ea47a8_0.conda
win-64::conda-25.1.0-py312h2e8e312_0.conda
win-64::conda-25.1.0-py39hcbf5309_0.conda
win-64::conda-25.1.1-py310h5588dad_0.conda
win-64::conda-25.1.1-py310h5588dad_1.conda
win-64::conda-25.1.1-py311h1ea47a8_0.conda
win-64::conda-25.1.1-py311h1ea47a8_1.conda
win-64::conda-25.1.1-py312h2e8e312_0.conda
win-64::conda-25.1.1-py312h2e8e312_1.conda
win-64::conda-25.1.1-py313hfa70ccb_1.conda
win-64::conda-25.1.1-py39hcbf5309_0.conda
win-64::conda-25.1.1-py39hcbf5309_1.conda
win-64::conda-25.3.0-py310h5588dad_0.conda
win-64::conda-25.3.0-py311h1ea47a8_0.conda
win-64::conda-25.3.0-py312h2e8e312_0.conda
win-64::conda-25.3.0-py313hfa70ccb_0.conda
win-64::conda-25.3.0-py39hcbf5309_0.conda
win-64::conda-25.3.1-py310h5588dad_0.conda
win-64::conda-25.3.1-py311h1ea47a8_0.conda
win-64::conda-25.3.1-py312h2e8e312_0.conda
win-64::conda-25.3.1-py313hfa70ccb_0.conda
win-64::conda-25.3.1-py39hcbf5309_0.conda
+    "conda-libmamba-solver >=24.11.0",
================================================================================
================================================================================
osx-64
osx-64::conda-25.1.0-py310h2ec42d9_0.conda
osx-64::conda-25.1.0-py311h6eed73b_0.conda
osx-64::conda-25.1.0-py312hb401068_0.conda
osx-64::conda-25.1.0-py39h6e9494a_0.conda
osx-64::conda-25.1.1-py310h2ec42d9_0.conda
osx-64::conda-25.1.1-py310h2ec42d9_1.conda
osx-64::conda-25.1.1-py311h6eed73b_0.conda
osx-64::conda-25.1.1-py311h6eed73b_1.conda
osx-64::conda-25.1.1-py312hb401068_0.conda
osx-64::conda-25.1.1-py312hb401068_1.conda
osx-64::conda-25.1.1-py313habf4b1d_1.conda
osx-64::conda-25.1.1-py39h6e9494a_0.conda
osx-64::conda-25.1.1-py39h6e9494a_1.conda
osx-64::conda-25.3.0-py310h2ec42d9_0.conda
osx-64::conda-25.3.0-py311h6eed73b_0.conda
osx-64::conda-25.3.0-py312hb401068_0.conda
osx-64::conda-25.3.0-py313habf4b1d_0.conda
osx-64::conda-25.3.0-py39h6e9494a_0.conda
osx-64::conda-25.3.1-py310h2ec42d9_0.conda
osx-64::conda-25.3.1-py311h6eed73b_0.conda
osx-64::conda-25.3.1-py312hb401068_0.conda
osx-64::conda-25.3.1-py313habf4b1d_0.conda
osx-64::conda-25.3.1-py39h6e9494a_0.conda
+    "conda-libmamba-solver >=24.11.0",
================================================================================
================================================================================
linux-64
linux-64::conda-25.1.0-py310hff52083_0.conda
linux-64::conda-25.1.0-py311h38be061_0.conda
linux-64::conda-25.1.0-py312h7900ff3_0.conda
linux-64::conda-25.1.0-py39hf3d152e_0.conda
linux-64::conda-25.1.1-py310hff52083_0.conda
linux-64::conda-25.1.1-py310hff52083_1.conda
linux-64::conda-25.1.1-py311h38be061_0.conda
linux-64::conda-25.1.1-py311h38be061_1.conda
linux-64::conda-25.1.1-py312h7900ff3_0.conda
linux-64::conda-25.1.1-py312h7900ff3_1.conda
linux-64::conda-25.1.1-py313h78bf25f_1.conda
linux-64::conda-25.1.1-py39hf3d152e_0.conda
linux-64::conda-25.1.1-py39hf3d152e_1.conda
linux-64::conda-25.3.0-py310hff52083_0.conda
linux-64::conda-25.3.0-py311h38be061_0.conda
linux-64::conda-25.3.0-py312h7900ff3_0.conda
linux-64::conda-25.3.0-py313h78bf25f_0.conda
linux-64::conda-25.3.0-py39hf3d152e_0.conda
linux-64::conda-25.3.1-py310hff52083_0.conda
linux-64::conda-25.3.1-py311h38be061_0.conda
linux-64::conda-25.3.1-py312h7900ff3_0.conda
linux-64::conda-25.3.1-py313h78bf25f_0.conda
linux-64::conda-25.3.1-py39hf3d152e_0.conda
+    "conda-libmamba-solver >=24.11.0",
```

</details>

Diff with #1006 since the repodata from that hasn't yet propagated:

```diff
+ osx-64::conda-25.3.1-py311h6eed73b_0.conda
```

