### PR TITLE
Patch packages built against libxml2 2.13

### DIFF
--- a/recipe/patch_yaml/libxml2.yaml
+++ b/recipe/patch_yaml/libxml2.yaml
@@ -44,18 +44,9 @@ then:
 if:
   timestamp_lt: 1744044827000
   has_depends:
-    - libxml2 >=2.12*
-then:
-  # tighten for builds against libxml 2.12 after https://github.com/conda-forge/libxml2-feedstock/pull/111
-  - tighten_depends:
-      name: libxml2
-      upper_bound: 2.14.0
----
-if:
-  timestamp_lt: 1744044827000
-  has_depends:
     - libxml2 >=2.13*
 then:
-  - tighten_depends:
+  # loosen for builds against libxml 2.13 before https://github.com/conda-forge/libxml2-feedstock/pull/111
+  - loosen_depends:
       name: libxml2
       upper_bound: 2.14.0


### PR DESCRIPTION
This is a follow up on #999.

Checklist

* [ ] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
