### PR TITLE
Use Numcodecs pre-0.16.0 with Zarr 2

### DIFF
--- a/recipe/patch_yaml/zarr.yaml
+++ b/recipe/patch_yaml/zarr.yaml
@@ -18,3 +18,16 @@ then:
   - replace_depends:
       old: numcodecs >=0.6.4
       new: numcodecs >=0.10.0
+
+
+---
+
+
+if:
+  name: zarr
+  version_lt: 3.0.0
+  timestamp_lt: 1735718400000
+then:
+  - tighten_depends:
+      name: numcodecs
+      upper_bound: 0.16.0


### PR DESCRIPTION
Numcodecs 0.16.0 introduced incompatible changes with Zarr 2. So set an upperbound on Zarr's Numcodecs dependency to ensure only a compatible version is installed. This doesn't matter for Zarr 3, which has already dropped the deprecated functions.

xref: https://github.com/zarr-developers/zarr-python/issues/2963

<hr>

Checklist

* [ ] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
