### PR TITLE
Loosen ABI compatibility for packages built with qt6.8

### DIFF
--- a/recipe/patch_yaml/qt6_main.yaml
+++ b/recipe/patch_yaml/qt6_main.yaml
@@ -6,180 +6,180 @@
 # https://code.qt.io/cgit/qt/qtreleasenotes.git/about/qt/6.9.0/release-note.md
 if:
   timestamp_lt: 1744562838000
-  has_depends: "qt6-main >=6.7*"
+  has_depends: qt6-main >=6.7*
 then:
   - loosen_depends:
       name: qt6-main
-      upper_bound: "6.10"
+      upper_bound: "6.9"
 
 ---
 if:
   timestamp_lt: 1744562838000
-  has_depends: "qt6-quick3d >=6.7*"
+  has_depends: qt6-quick3d >=6.7*
 then:
   - loosen_depends:
       name: qt6-quick3d
-      upper_bound: "6.10"
+      upper_bound: "6.9"
 
 ---
 if:
   timestamp_lt: 1744562838000
-  has_depends: "qt6-charts >=6.7*"
+  has_depends: qt6-charts >=6.7*
 then:
   - loosen_depends:
       name: qt6-charts
-      upper_bound: "6.10"
+      upper_bound: "6.9"
 
 ---
 if:
   timestamp_lt: 1744562838000
-  has_depends: "qt6-graphs >=6.7*"
+  has_depends: qt6-graphs >=6.7*
 then:
   - loosen_depends:
       name: qt6-graphs
-      upper_bound: "6.10"
+      upper_bound: "6.9"
 
 ---
 if:
   timestamp_lt: 1744562838000
-  has_depends: "qt6-multimedia >=6.7*"
+  has_depends: qt6-multimedia >=6.7*
 then:
   - loosen_depends:
       name: qt6-multimedia
-      upper_bound: "6.10"
+      upper_bound: "6.9"
 
 ---
 if:
   timestamp_lt: 1744562838000
-  has_depends: "qt6-wayland >=6.7*"
+  has_depends: qt6-wayland >=6.7*
 then:
   - loosen_depends:
       name: qt6-wayland
-      upper_bound: "6.10"
+      upper_bound: "6.9"
 
 ---
 if:
   timestamp_lt: 1744562838000
-  has_depends: "qt6-gtk-platformtheme >=6.7*"
+  has_depends: qt6-gtk-platformtheme >=6.7*
 then:
   - loosen_depends:
       name: qt6-gtk-platformtheme
-      upper_bound: "6.10"
+      upper_bound: "6.9"
 
 ---
 if:
   timestamp_lt: 1744562838000
-  has_depends: "qt6-networkauth >=6.7*"
+  has_depends: qt6-networkauth >=6.7*
 then:
   - loosen_depends:
       name: qt6-networkauth
-      upper_bound: "6.10"
+      upper_bound: "6.9"
 
 ---
 if:
   timestamp_lt: 1744562838000
-  has_depends: "qt6-3d >=6.7*"
+  has_depends: qt6-3d >=6.7*
 then:
   - loosen_depends:
       name: qt6-3d
-      upper_bound: "6.10"
+      upper_bound: "6.9"
 
 ---
 if:
   timestamp_lt: 1744562838000
-  has_depends: "qt6-datavis3d >=6.7*"
+  has_depends: qt6-datavis3d >=6.7*
 then:
   - loosen_depends:
       name: qt6-datavis3d
-      upper_bound: "6.10"
+      upper_bound: "6.9"
 
 
 ---
 if:
   timestamp_lt: 1744562838000
-  has_depends: "qt6-main >=6.8*"
+  has_depends: qt6-main *<6.9.0a0
 then:
   - loosen_depends:
       name: qt6-main
-      upper_bound: "6.10"
+      upper_bound: "6.10.0"
 
 ---
 if:
   timestamp_lt: 1744562838000
-  has_depends: "qt6-quick3d >=6.8*"
+  has_depends: qt6-quick3d *<6.9.0a0
 then:
   - loosen_depends:
       name: qt6-quick3d
-      upper_bound: "6.10"
+      upper_bound: "6.10.0"
 
 ---
 if:
   timestamp_lt: 1744562838000
-  has_depends: "qt6-charts >=6.8*"
+  has_depends: qt6-charts *<6.9.0a0
 then:
   - loosen_depends:
       name: qt6-charts
-      upper_bound: "6.10"
+      upper_bound: "6.10.0"
 
 ---
 if:
   timestamp_lt: 1744562838000
-  has_depends: "qt6-graphs >=6.8*"
+  has_depends: qt6-graphs *<6.9.0a0
 then:
   - loosen_depends:
       name: qt6-graphs
-      upper_bound: "6.10"
+      upper_bound: "6.10.0"
 
 ---
 if:
   timestamp_lt: 1744562838000
-  has_depends: "qt6-multimedia >=6.8*"
+  has_depends: qt6-multimedia *<6.9.0a0
 then:
   - loosen_depends:
       name: qt6-multimedia
-      upper_bound: "6.10"
+      upper_bound: "6.10.0"
 
 ---
 if:
   timestamp_lt: 1744562838000
-  has_depends: "qt6-wayland >=6.8*"
+  has_depends: qt6-wayland *<6.9.0a0
 then:
   - loosen_depends:
       name: qt6-wayland
-      upper_bound: "6.10"
+      upper_bound: "6.10.0"
 
 ---
 if:
   timestamp_lt: 1744562838000
-  has_depends: "qt6-gtk-platformtheme >=6.8*"
+  has_depends: qt6-gtk-platformtheme *<6.9.0a0
 then:
   - loosen_depends:
       name: qt6-gtk-platformtheme
-      upper_bound: "6.10"
+      upper_bound: "6.10.0"
 
 ---
 if:
   timestamp_lt: 1744562838000
-  has_depends: "qt6-networkauth >=6.8*"
+  has_depends: qt6-networkauth *<6.9.0a0
 then:
   - loosen_depends:
       name: qt6-networkauth
-      upper_bound: "6.10"
+      upper_bound: "6.10.0"
 
 ---
 if:
   timestamp_lt: 1744562838000
-  has_depends: "qt6-3d >=6.8*"
+  has_depends: qt6-3d *<6.9.0a0
 then:
   - loosen_depends:
       name: qt6-3d
-      upper_bound: "6.10"
+      upper_bound: "6.10.0"
 
 ---
 if:
   timestamp_lt: 1744562838000
-  has_depends: "qt6-datavis3d >=6.8*"
+  has_depends: qt6-datavis3d *<6.9.0a0
 then:
   - loosen_depends:
       name: qt6-datavis3d
-      upper_bound: "6.10"
+      upper_bound: "6.10.0"

--- a/recipe/patch_yaml/qt6_main.yaml
+++ b/recipe/patch_yaml/qt6_main.yaml
@@ -10,7 +10,7 @@ if:
 then:
   - loosen_depends:
       name: qt6-main
-      upper_bound: "6.10"
+      upper_bound: "6.9"
 
 ---
 if:
@@ -19,7 +19,7 @@ if:
 then:
   - loosen_depends:
       name: qt6-quick3d
-      upper_bound: "6.10"
+      upper_bound: "6.9"
 
 ---
 if:
@@ -28,7 +28,7 @@ if:
 then:
   - loosen_depends:
       name: qt6-charts
-      upper_bound: "6.10"
+      upper_bound: "6.9"
 
 ---
 if:
@@ -37,7 +37,7 @@ if:
 then:
   - loosen_depends:
       name: qt6-graphs
-      upper_bound: "6.10"
+      upper_bound: "6.9"
 
 ---
 if:
@@ -46,7 +46,7 @@ if:
 then:
   - loosen_depends:
       name: qt6-multimedia
-      upper_bound: "6.10"
+      upper_bound: "6.9"
 
 ---
 if:
@@ -55,7 +55,7 @@ if:
 then:
   - loosen_depends:
       name: qt6-wayland
-      upper_bound: "6.10"
+      upper_bound: "6.9"
 
 ---
 if:
@@ -64,7 +64,7 @@ if:
 then:
   - loosen_depends:
       name: qt6-gtk-platformtheme
-      upper_bound: "6.10"
+      upper_bound: "6.9"
 
 ---
 if:
@@ -73,7 +73,7 @@ if:
 then:
   - loosen_depends:
       name: qt6-networkauth
-      upper_bound: "6.10"
+      upper_bound: "6.9"
 
 ---
 if:
@@ -82,7 +82,7 @@ if:
 then:
   - loosen_depends:
       name: qt6-3d
-      upper_bound: "6.10"
+      upper_bound: "6.9"
 
 ---
 if:
@@ -91,95 +91,95 @@ if:
 then:
   - loosen_depends:
       name: qt6-datavis3d
-      upper_bound: "6.10"
+      upper_bound: "6.9"
 
 
 ---
 if:
   timestamp_lt: 1744562838000
-  has_depends: qt6-main *<6.9.0a0
+  has_depends: qt6-main >=6.8*
 then:
   - loosen_depends:
       name: qt6-main
-      upper_bound: "6.10.0"
+      upper_bound: "6.10"
 
 ---
 if:
   timestamp_lt: 1744562838000
-  has_depends: qt6-quick3d *<6.9.0a0
+  has_depends: qt6-quick3d >=6.8*
 then:
   - loosen_depends:
       name: qt6-quick3d
-      upper_bound: "6.10.0"
+      upper_bound: "6.10"
 
 ---
 if:
   timestamp_lt: 1744562838000
-  has_depends: qt6-charts *<6.9.0a0
+  has_depends: qt6-charts >=6.8*
 then:
   - loosen_depends:
       name: qt6-charts
-      upper_bound: "6.10.0"
+      upper_bound: "6.10"
 
 ---
 if:
   timestamp_lt: 1744562838000
-  has_depends: qt6-graphs *<6.9.0a0
+  has_depends: qt6-graphs >=6.8*
 then:
   - loosen_depends:
       name: qt6-graphs
-      upper_bound: "6.10.0"
+      upper_bound: "6.10"
 
 ---
 if:
   timestamp_lt: 1744562838000
-  has_depends: qt6-multimedia *<6.9.0a0
+  has_depends: qt6-multimedia >=6.8*
 then:
   - loosen_depends:
       name: qt6-multimedia
-      upper_bound: "6.10.0"
+      upper_bound: "6.10"
 
 ---
 if:
   timestamp_lt: 1744562838000
-  has_depends: qt6-wayland *<6.9.0a0
+  has_depends: qt6-wayland >=6.8*
 then:
   - loosen_depends:
       name: qt6-wayland
-      upper_bound: "6.10.0"
+      upper_bound: "6.10"
 
 ---
 if:
   timestamp_lt: 1744562838000
-  has_depends: qt6-gtk-platformtheme *<6.9.0a0
+  has_depends: qt6-gtk-platformtheme >=6.8*
 then:
   - loosen_depends:
       name: qt6-gtk-platformtheme
-      upper_bound: "6.10.0"
+      upper_bound: "6.10"
 
 ---
 if:
   timestamp_lt: 1744562838000
-  has_depends: qt6-networkauth *<6.9.0a0
+  has_depends: qt6-networkauth >=6.8*
 then:
   - loosen_depends:
       name: qt6-networkauth
-      upper_bound: "6.10.0"
+      upper_bound: "6.10"
 
 ---
 if:
   timestamp_lt: 1744562838000
-  has_depends: qt6-3d *<6.9.0a0
+  has_depends: qt6-3d >=6.8*
 then:
   - loosen_depends:
       name: qt6-3d
-      upper_bound: "6.10.0"
+      upper_bound: "6.10"
 
 ---
 if:
   timestamp_lt: 1744562838000
-  has_depends: qt6-datavis3d *<6.9.0a0
+  has_depends: qt6-datavis3d >=6.8*
 then:
   - loosen_depends:
       name: qt6-datavis3d
-      upper_bound: "6.10.0"
+      upper_bound: "6.10"

--- a/recipe/patch_yaml/qt6_main.yaml
+++ b/recipe/patch_yaml/qt6_main.yaml
@@ -183,3 +183,94 @@ then:
   - loosen_depends:
       name: qt6-datavis3d
       upper_bound: "6.10"
+
+---
+
+if:
+  timestamp_lt: 1744562838000
+  has_depends: qt6-main >=6.7*
+then:
+  - loosen_depends:
+      name: qt6-main
+      upper_bound: "6.10"
+
+---
+if:
+  timestamp_lt: 1744562838000
+  has_depends: qt6-quick3d >=6.7*
+then:
+  - loosen_depends:
+      name: qt6-quick3d
+      upper_bound: "6.10"
+
+---
+if:
+  timestamp_lt: 1744562838000
+  has_depends: qt6-charts >=6.7*
+then:
+  - loosen_depends:
+      name: qt6-charts
+      upper_bound: "6.10"
+
+---
+if:
+  timestamp_lt: 1744562838000
+  has_depends: qt6-graphs >=6.7*
+then:
+  - loosen_depends:
+      name: qt6-graphs
+      upper_bound: "6.10"
+
+---
+if:
+  timestamp_lt: 1744562838000
+  has_depends: qt6-multimedia >=6.7*
+then:
+  - loosen_depends:
+      name: qt6-multimedia
+      upper_bound: "6.10"
+
+---
+if:
+  timestamp_lt: 1744562838000
+  has_depends: qt6-wayland >=6.7*
+then:
+  - loosen_depends:
+      name: qt6-wayland
+      upper_bound: "6.10"
+
+---
+if:
+  timestamp_lt: 1744562838000
+  has_depends: qt6-gtk-platformtheme >=6.7*
+then:
+  - loosen_depends:
+      name: qt6-gtk-platformtheme
+      upper_bound: "6.10"
+
+---
+if:
+  timestamp_lt: 1744562838000
+  has_depends: qt6-networkauth >=6.7*
+then:
+  - loosen_depends:
+      name: qt6-networkauth
+      upper_bound: "6.10"
+
+---
+if:
+  timestamp_lt: 1744562838000
+  has_depends: qt6-3d >=6.7*
+then:
+  - loosen_depends:
+      name: qt6-3d
+      upper_bound: "6.10"
+
+---
+if:
+  timestamp_lt: 1744562838000
+  has_depends: qt6-datavis3d >=6.7*
+then:
+  - loosen_depends:
+      name: qt6-datavis3d
+      upper_bound: "6.10"

--- a/recipe/patch_yaml/qt6_main.yaml
+++ b/recipe/patch_yaml/qt6_main.yaml
@@ -6,7 +6,7 @@
 # https://code.qt.io/cgit/qt/qtreleasenotes.git/about/qt/6.9.0/release-note.md
 if:
   timestamp_lt: 1744562838000
-  has_depends: qt6-main >=6.(7|8)*
+  has_depends: "qt6-main >=6.7*"
 then:
   - loosen_depends:
       name: qt6-main
@@ -15,7 +15,7 @@ then:
 ---
 if:
   timestamp_lt: 1744562838000
-  has_depends: qt6-quick3d >=6.(7|8)*
+  has_depends: "qt6-quick3d >=6.7*"
 then:
   - loosen_depends:
       name: qt6-quick3d
@@ -24,7 +24,7 @@ then:
 ---
 if:
   timestamp_lt: 1744562838000
-  has_depends: qt6-charts >=6.(7|8)*
+  has_depends: "qt6-charts >=6.7*"
 then:
   - loosen_depends:
       name: qt6-charts
@@ -33,7 +33,7 @@ then:
 ---
 if:
   timestamp_lt: 1744562838000
-  has_depends: qt6-graphs >=6.(7|8)*
+  has_depends: "qt6-graphs >=6.7*"
 then:
   - loosen_depends:
       name: qt6-graphs
@@ -42,7 +42,7 @@ then:
 ---
 if:
   timestamp_lt: 1744562838000
-  has_depends: qt6-multimedia >=6.(7|8)*
+  has_depends: "qt6-multimedia >=6.7*"
 then:
   - loosen_depends:
       name: qt6-multimedia
@@ -51,7 +51,7 @@ then:
 ---
 if:
   timestamp_lt: 1744562838000
-  has_depends: qt6-wayland >=6.(7|8)*
+  has_depends: "qt6-wayland >=6.7*"
 then:
   - loosen_depends:
       name: qt6-wayland
@@ -60,7 +60,7 @@ then:
 ---
 if:
   timestamp_lt: 1744562838000
-  has_depends: qt6-gtk-platformtheme >=6.(7|8)*
+  has_depends: "qt6-gtk-platformtheme >=6.7*"
 then:
   - loosen_depends:
       name: qt6-gtk-platformtheme
@@ -69,7 +69,7 @@ then:
 ---
 if:
   timestamp_lt: 1744562838000
-  has_depends: qt6-networkauth >=6.(7|8)*
+  has_depends: "qt6-networkauth >=6.7*"
 then:
   - loosen_depends:
       name: qt6-networkauth
@@ -78,7 +78,7 @@ then:
 ---
 if:
   timestamp_lt: 1744562838000
-  has_depends: qt6-3d >=6.(7|8)*
+  has_depends: "qt6-3d >=6.7*"
 then:
   - loosen_depends:
       name: qt6-3d
@@ -87,7 +87,98 @@ then:
 ---
 if:
   timestamp_lt: 1744562838000
-  has_depends: qt6-datavis3d >=6.(7|8)*
+  has_depends: "qt6-datavis3d >=6.7*"
+then:
+  - loosen_depends:
+      name: qt6-datavis3d
+      upper_bound: "6.10"
+
+
+---
+if:
+  timestamp_lt: 1744562838000
+  has_depends: "qt6-main >=6.8*"
+then:
+  - loosen_depends:
+      name: qt6-main
+      upper_bound: "6.10"
+
+---
+if:
+  timestamp_lt: 1744562838000
+  has_depends: "qt6-quick3d >=6.8*"
+then:
+  - loosen_depends:
+      name: qt6-quick3d
+      upper_bound: "6.10"
+
+---
+if:
+  timestamp_lt: 1744562838000
+  has_depends: "qt6-charts >=6.8*"
+then:
+  - loosen_depends:
+      name: qt6-charts
+      upper_bound: "6.10"
+
+---
+if:
+  timestamp_lt: 1744562838000
+  has_depends: "qt6-graphs >=6.8*"
+then:
+  - loosen_depends:
+      name: qt6-graphs
+      upper_bound: "6.10"
+
+---
+if:
+  timestamp_lt: 1744562838000
+  has_depends: "qt6-multimedia >=6.8*"
+then:
+  - loosen_depends:
+      name: qt6-multimedia
+      upper_bound: "6.10"
+
+---
+if:
+  timestamp_lt: 1744562838000
+  has_depends: "qt6-wayland >=6.8*"
+then:
+  - loosen_depends:
+      name: qt6-wayland
+      upper_bound: "6.10"
+
+---
+if:
+  timestamp_lt: 1744562838000
+  has_depends: "qt6-gtk-platformtheme >=6.8*"
+then:
+  - loosen_depends:
+      name: qt6-gtk-platformtheme
+      upper_bound: "6.10"
+
+---
+if:
+  timestamp_lt: 1744562838000
+  has_depends: "qt6-networkauth >=6.8*"
+then:
+  - loosen_depends:
+      name: qt6-networkauth
+      upper_bound: "6.10"
+
+---
+if:
+  timestamp_lt: 1744562838000
+  has_depends: "qt6-3d >=6.8*"
+then:
+  - loosen_depends:
+      name: qt6-3d
+      upper_bound: "6.10"
+
+---
+if:
+  timestamp_lt: 1744562838000
+  has_depends: "qt6-datavis3d >=6.8*"
 then:
   - loosen_depends:
       name: qt6-datavis3d

--- a/recipe/patch_yaml/qt6_main.yaml
+++ b/recipe/patch_yaml/qt6_main.yaml
@@ -10,7 +10,7 @@ if:
 then:
   - loosen_depends:
       name: qt6-main
-      upper_bound: "6.9"
+      upper_bound: "6.10"
 
 ---
 if:
@@ -19,7 +19,7 @@ if:
 then:
   - loosen_depends:
       name: qt6-quick3d
-      upper_bound: "6.9"
+      upper_bound: "6.10"
 
 ---
 if:
@@ -28,7 +28,7 @@ if:
 then:
   - loosen_depends:
       name: qt6-charts
-      upper_bound: "6.9"
+      upper_bound: "6.10"
 
 ---
 if:
@@ -37,7 +37,7 @@ if:
 then:
   - loosen_depends:
       name: qt6-graphs
-      upper_bound: "6.9"
+      upper_bound: "6.10"
 
 ---
 if:
@@ -46,7 +46,7 @@ if:
 then:
   - loosen_depends:
       name: qt6-multimedia
-      upper_bound: "6.9"
+      upper_bound: "6.10"
 
 ---
 if:
@@ -55,7 +55,7 @@ if:
 then:
   - loosen_depends:
       name: qt6-wayland
-      upper_bound: "6.9"
+      upper_bound: "6.10"
 
 ---
 if:
@@ -64,7 +64,7 @@ if:
 then:
   - loosen_depends:
       name: qt6-gtk-platformtheme
-      upper_bound: "6.9"
+      upper_bound: "6.10"
 
 ---
 if:
@@ -73,7 +73,7 @@ if:
 then:
   - loosen_depends:
       name: qt6-networkauth
-      upper_bound: "6.9"
+      upper_bound: "6.10"
 
 ---
 if:
@@ -82,7 +82,7 @@ if:
 then:
   - loosen_depends:
       name: qt6-3d
-      upper_bound: "6.9"
+      upper_bound: "6.10"
 
 ---
 if:
@@ -91,7 +91,7 @@ if:
 then:
   - loosen_depends:
       name: qt6-datavis3d
-      upper_bound: "6.9"
+      upper_bound: "6.10"
 
 
 ---

--- a/recipe/patch_yaml/qt6_main.yaml
+++ b/recipe/patch_yaml/qt6_main.yaml
@@ -2,91 +2,93 @@
 # https://code.qt.io/cgit/qt/qtreleasenotes.git/about/qt/6.8.0/release-note.md
 # See https://github.com/conda-forge/qt-main-feedstock/issues/271
 # For all the extra packages to also migrate
+# qt6.9 then claims to be binary compatible with qt6.8
+# https://code.qt.io/cgit/qt/qtreleasenotes.git/about/qt/6.9.0/release-note.md
 if:
-  timestamp_lt: 1737890346000
-  has_depends: qt6-main >=6.7*
+  timestamp_lt: 1744562838000
+  has_depends: qt6-main >=6.[7|8]*
 then:
   - loosen_depends:
       name: qt6-main
-      upper_bound: "6.9"
+      upper_bound: "6.10"
 
 ---
 if:
-  timestamp_lt: 1737890346000
-  has_depends: qt6-quick3d >=6.7*
+  timestamp_lt: 1744562838000
+  has_depends: qt6-quick3d >=6.[7|8]*
 then:
   - loosen_depends:
       name: qt6-quick3d
-      upper_bound: "6.9"
+      upper_bound: "6.10"
 
 ---
 if:
-  timestamp_lt: 1737890346000
-  has_depends: qt6-charts >=6.7*
+  timestamp_lt: 1744562838000
+  has_depends: qt6-charts >=6.[7|8]*
 then:
   - loosen_depends:
       name: qt6-charts
-      upper_bound: "6.9"
+      upper_bound: "6.10"
 
 ---
 if:
-  timestamp_lt: 1737890346000
-  has_depends: qt6-graphs >=6.7*
+  timestamp_lt: 1744562838000
+  has_depends: qt6-graphs >=6.[7|8]*
 then:
   - loosen_depends:
       name: qt6-graphs
-      upper_bound: "6.9"
+      upper_bound: "6.10"
 
 ---
 if:
-  timestamp_lt: 1737890346000
-  has_depends: qt6-multimedia >=6.7*
+  timestamp_lt: 1744562838000
+  has_depends: qt6-multimedia >=6.[7|8]*
 then:
   - loosen_depends:
       name: qt6-multimedia
-      upper_bound: "6.9"
+      upper_bound: "6.10"
 
 ---
 if:
-  timestamp_lt: 1737890346000
-  has_depends: qt6-wayland >=6.7*
+  timestamp_lt: 1744562838000
+  has_depends: qt6-wayland >=6.[7|8]*
 then:
   - loosen_depends:
       name: qt6-wayland
-      upper_bound: "6.9"
+      upper_bound: "6.10"
 
 ---
 if:
-  timestamp_lt: 1737890346000
-  has_depends: qt6-gtk-platformtheme >=6.7*
+  timestamp_lt: 1744562838000
+  has_depends: qt6-gtk-platformtheme >=6.[7|8]*
 then:
   - loosen_depends:
       name: qt6-gtk-platformtheme
-      upper_bound: "6.9"
+      upper_bound: "6.10"
 
 ---
 if:
-  timestamp_lt: 1737890346000
-  has_depends: qt6-networkauth >=6.7*
+  timestamp_lt: 1744562838000
+  has_depends: qt6-networkauth >=6.[7|8]*
 then:
   - loosen_depends:
       name: qt6-networkauth
-      upper_bound: "6.9"
+      upper_bound: "6.10"
 
 ---
 if:
-  timestamp_lt: 1737890346000
-  has_depends: qt6-3d >=6.7*
+  timestamp_lt: 1744562838000
+  has_depends: qt6-3d >=6.[7|8]*
 then:
   - loosen_depends:
       name: qt6-3d
-      upper_bound: "6.9"
+      upper_bound: "6.10"
 
 ---
 if:
-  timestamp_lt: 1737890346000
-  has_depends: qt6-datavis3d >=6.7*
+  timestamp_lt: 1744562838000
+  has_depends: qt6-datavis3d >=6.[7|8]*
 then:
   - loosen_depends:
       name: qt6-datavis3d
-      upper_bound: "6.9"
+      upper_bound: "6.10"

--- a/recipe/patch_yaml/qt6_main.yaml
+++ b/recipe/patch_yaml/qt6_main.yaml
@@ -6,7 +6,7 @@
 # https://code.qt.io/cgit/qt/qtreleasenotes.git/about/qt/6.9.0/release-note.md
 if:
   timestamp_lt: 1744562838000
-  has_depends: qt6-main >=6.[7|8]*
+  has_depends: qt6-main >=6.(7|8)*
 then:
   - loosen_depends:
       name: qt6-main
@@ -15,7 +15,7 @@ then:
 ---
 if:
   timestamp_lt: 1744562838000
-  has_depends: qt6-quick3d >=6.[7|8]*
+  has_depends: qt6-quick3d >=6.(7|8)*
 then:
   - loosen_depends:
       name: qt6-quick3d
@@ -24,7 +24,7 @@ then:
 ---
 if:
   timestamp_lt: 1744562838000
-  has_depends: qt6-charts >=6.[7|8]*
+  has_depends: qt6-charts >=6.(7|8)*
 then:
   - loosen_depends:
       name: qt6-charts
@@ -33,7 +33,7 @@ then:
 ---
 if:
   timestamp_lt: 1744562838000
-  has_depends: qt6-graphs >=6.[7|8]*
+  has_depends: qt6-graphs >=6.(7|8)*
 then:
   - loosen_depends:
       name: qt6-graphs
@@ -42,7 +42,7 @@ then:
 ---
 if:
   timestamp_lt: 1744562838000
-  has_depends: qt6-multimedia >=6.[7|8]*
+  has_depends: qt6-multimedia >=6.(7|8)*
 then:
   - loosen_depends:
       name: qt6-multimedia
@@ -51,7 +51,7 @@ then:
 ---
 if:
   timestamp_lt: 1744562838000
-  has_depends: qt6-wayland >=6.[7|8]*
+  has_depends: qt6-wayland >=6.(7|8)*
 then:
   - loosen_depends:
       name: qt6-wayland
@@ -60,7 +60,7 @@ then:
 ---
 if:
   timestamp_lt: 1744562838000
-  has_depends: qt6-gtk-platformtheme >=6.[7|8]*
+  has_depends: qt6-gtk-platformtheme >=6.(7|8)*
 then:
   - loosen_depends:
       name: qt6-gtk-platformtheme
@@ -69,7 +69,7 @@ then:
 ---
 if:
   timestamp_lt: 1744562838000
-  has_depends: qt6-networkauth >=6.[7|8]*
+  has_depends: qt6-networkauth >=6.(7|8)*
 then:
   - loosen_depends:
       name: qt6-networkauth
@@ -78,7 +78,7 @@ then:
 ---
 if:
   timestamp_lt: 1744562838000
-  has_depends: qt6-3d >=6.[7|8]*
+  has_depends: qt6-3d >=6.(7|8)*
 then:
   - loosen_depends:
       name: qt6-3d
@@ -87,7 +87,7 @@ then:
 ---
 if:
   timestamp_lt: 1744562838000
-  has_depends: qt6-datavis3d >=6.[7|8]*
+  has_depends: qt6-datavis3d >=6.(7|8)*
 then:
   - loosen_depends:
       name: qt6-datavis3d


### PR DESCRIPTION
see 
* https://code.qt.io/cgit/qt/qtreleasenotes.git/about/qt/6.9.0/release-note.md
* https://code.qt.io/cgit/qt/qtreleasenotes.git/about/qt/6.8.0/release-note.md


* [ ] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
