### PR TITLE
imod: Limit fastcore version

### DIFF
--- a/recipe/patch_yaml/imod.yaml
+++ b/recipe/patch_yaml/imod.yaml
@@ -97,3 +97,13 @@ then:
   - tighten_depends:
       name: xarray
       upper_bound: "2024.10.0"
+---
+# fastcore removed typedispatching, pin versions before migration to plum.
+if:
+  name: imod
+  timestamp_le: 1744722730000
+  version_le: "1.0.0rc2"
+then:
+  - tighten_depends:
+      name: fastcore
+      upper_bound: "1.7.20"

--- a/recipe/patch_yaml/imod.yaml
+++ b/recipe/patch_yaml/imod.yaml
@@ -106,4 +106,4 @@ if:
 then:
   - tighten_depends:
       name: fastcore
-      upper_bound: "1.7.20"
+      upper_bound: "1.7.21"


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
Limits fastcore for all released versions of imod depending on it. (FYI: The next release will not use fastcore anymore).

``show_diff.py`` prints (note imod-1.0.0rc1 has never been released on conda-forge):

```
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
noarch
noarch::imod-0.14.0-pyhd8ed1ab_0.conda
noarch::imod-0.14.1-pyhd8ed1ab_0.conda
noarch::imod-0.15.0-pyhd8ed1ab_0.conda
noarch::imod-0.15.1-pyhd8ed1ab_0.conda
noarch::imod-0.15.2-pyhd8ed1ab_0.conda
noarch::imod-0.15.3-pyhd8ed1ab_0.conda
noarch::imod-0.16.0-pyhd8ed1ab_0.conda
noarch::imod-0.17.0-pyhd8ed1ab_0.conda
noarch::imod-0.17.1-pyhd8ed1ab_0.conda
noarch::imod-0.17.2-pyhd8ed1ab_0.conda
noarch::imod-0.18.0-pyhd8ed1ab_0.conda
noarch::imod-0.18.1-pyhd8ed1ab_0.conda
noarch::imod-0.18.1-pyhd8ed1ab_1.conda
noarch::imod-0.18.1-pyhd8ed1ab_2.conda
noarch::imod-1.0.0rc0-pyhd8ed1ab_0.conda
noarch::imod-1.0.0rc2-pyhd8ed1ab_0.conda
-    "fastcore",
+    "fastcore <1.7.21.0a0",
================================================================================
================================================================================
win-64
win-64::python-3.13.3-hd7c436d_1_cp313t.conda
-  "track_features": "py_freethreading",
================================================================================
================================================================================
osx-64
================================================================================
================================================================================
linux-64
```
