### PR TITLE
Downconstrain openff-units in old openff-toolkit packages

### DIFF
--- a/recipe/patch_yaml/openff-toolkit-patch.yaml
+++ b/recipe/patch_yaml/openff-toolkit-patch.yaml
@@ -35,5 +35,6 @@ if:
   subdir_in: noarch
   name: openff-toolkit-base
   timestamp_lt: 1739572714000
+  version_le: 0.16.7
 then:
   - add_constrains: "openff-units<0.3.0a0"

--- a/recipe/patch_yaml/openff-toolkit-patch.yaml
+++ b/recipe/patch_yaml/openff-toolkit-patch.yaml
@@ -10,3 +10,17 @@ then:
       old: qcportal
       # thing to replace `old` with
       new: qcportal <0.50.0a0
+
+---
+
+# Changes in openff-units 0.3.0 (an update for Pint 0.24 and enabling caching in Pint)
+# causes an unforseen interaction with openff-toolkit <0.16.8
+# Details at: https://github.com/conda-forge/openff-units-feedstock/pull/27
+
+if:
+  subdir_in: noarch
+  name: openff-toolkit-base
+  #has_depends: "openff-units"
+  timestamp_lt: 1739572714000
+then:
+  - add_constrains: "openff-units<0.3.0a0"

--- a/recipe/patch_yaml/openff-toolkit-patch.yaml
+++ b/recipe/patch_yaml/openff-toolkit-patch.yaml
@@ -20,7 +20,6 @@ then:
 if:
   subdir_in: noarch
   name: openff-toolkit-base
-  #has_depends: "openff-units"
   timestamp_lt: 1739572714000
 then:
   - add_constrains: "openff-units<0.3.0a0"

--- a/recipe/patch_yaml/openff-toolkit-patch.yaml
+++ b/recipe/patch_yaml/openff-toolkit-patch.yaml
@@ -15,7 +15,21 @@ then:
 
 # Changes in openff-units 0.3.0 (an update for Pint 0.24 and enabling caching in Pint)
 # causes an unforseen interaction with openff-toolkit <0.16.8
-# Details at: https://github.com/conda-forge/openff-units-feedstock/pull/27
+
+
+# The root issue here is that a change in openff-units 0.3.0 [1]
+# introduced a somewhat hard to trigger bug[2], and a change [3]
+# that went into openff-toolkit 0.16.8 avoids triggering it.
+# However, openff-toolkit 0.16.7 and earlier trigger the bug, so
+# this metadata patch aims to keep those earlier versions of
+# openff-toolkit from being installed with openff-units 0.3.0
+
+# [1] https://github.com/openforcefield/openff-units/pull/98/
+# files#diff-3d4f287a6f0aeda573b6079ebdc718f057cbb04243c01179c37433448da9b834R79
+# [2] https://github.com/openforcefield/openff-units/issues/116
+# [3] https://github.com/openforcefield/openff-toolkit/pull/1990/
+# files#diff-68cb3f9873e00994ccf957cc089b18cbaf34302d5eeb90c34ca289803e10a69eL3181
+# Additional discussion at https://github.com/conda-forge/openff-units-feedstock/pull/27
 
 if:
   subdir_in: noarch


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
