### PR TITLE
Fix h11 dependency in httpcore=0.13.3

### DIFF
--- a/recipe/patch_yaml/httpcore.yaml
+++ b/recipe/patch_yaml/httpcore.yaml
@@ -1,0 +1,9 @@
+if:
+  name: httpcore
+  version: 0.13.3
+  build_number: 0
+  timestamp_lt: 1745600455000
+then:
+  - replace_depends:
+      old: h11 0.*
+      new: h11 >=0.11,<0.13


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

This was fixed in https://github.com/conda-forge/httpcore-feedstock/pull/30 but needs a patch for the `*_0` builds.

cc @conda-forge/httpcore 
