### PR TITLE
Fix pythonqwt in guiqwt

### DIFF
--- a/recipe/patch_yaml/guiqwt.yaml
+++ b/recipe/patch_yaml/guiqwt.yaml
@@ -12,3 +12,33 @@ then:
   - replace_depends:
       old: qtpy >=1.3
       new: qtpy >=1.3,<2.0
+---
+# pythonqwt 0.14.4 breaks compatibility with guiqwt
+# due to usage of QRectF instead of Qrect
+# See https://gitlab.com/taurus-org/taurus/-/merge_requests/1355
+if:
+  name: guiqwt
+  version_le: 3.0.4
+  timestamp_lt: 1745676356000
+then:
+  - replace_depends:
+      old: pythonqwt
+      new: pythonqwt <0.14.4
+---
+if:
+  name: guiqwt
+  version_le: 3.0.7
+  timestamp_lt: 1745676356000
+then:
+  - replace_depends:
+      old: pythonqwt >=0.5.0
+      new: pythonqwt >=0.5.0,<0.14.4
+---
+if:
+  name: guiqwt
+  timestamp_lt: 1745676356000
+  version_le: 4.4.5
+then:
+  - replace_depends:
+      old: pythonqwt >=0.10
+      new: pythonqwt >=0.10,<0.14.4


### PR DESCRIPTION
Checklist

* [X] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [X] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [X] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [X] Ran `python show_diff.py` and posted the output as part of the PR.
* [X] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
pythonqwt 0.14.4 breaks compatibility with guiqwt due to usage of QRectF instead of Qrect.

See https://gitlab.com/taurus-org/taurus/-/merge_requests/1355

guiqwt-feedstock has been updated: https://github.com/conda-forge/guiqwt-feedstock/pull/44

Ping @conda-forge/guiqwt 

```
python show_diff.py --subdirs linux-64 --use-cache
================================================================================
================================================================================
linux-64
linux-64::guiqwt-3.0.3-py27h964fd68_2.tar.bz2
linux-64::guiqwt-3.0.3-py27hb3f55d8_2.tar.bz2
linux-64::guiqwt-3.0.3-py27hc5175aa_1.tar.bz2
linux-64::guiqwt-3.0.3-py36h964fd68_2.tar.bz2
linux-64::guiqwt-3.0.3-py36hb3f55d8_2.tar.bz2
linux-64::guiqwt-3.0.3-py36hc5175aa_1.tar.bz2
linux-64::guiqwt-3.0.3-py37h964fd68_2.tar.bz2
linux-64::guiqwt-3.0.3-py37hb3f55d8_2.tar.bz2
linux-64::guiqwt-3.0.3-py37hc5175aa_1.tar.bz2
linux-64::guiqwt-3.0.3-py38hb3f55d8_2.tar.bz2
linux-64::guiqwt-3.0.4-py36h7c3b610_0.tar.bz2
linux-64::guiqwt-3.0.4-py37h9fdb41a_0.tar.bz2
linux-64::guiqwt-3.0.4-py38hc5bc63f_0.tar.bz2
-    "pythonqwt",
+    "pythonqwt <0.14.4",
linux-64::guiqwt-3.0.5-py36h7c3b610_0.tar.bz2
linux-64::guiqwt-3.0.5-py36hd87012b_1.tar.bz2
linux-64::guiqwt-3.0.5-py37h10a2094_1.tar.bz2
linux-64::guiqwt-3.0.5-py37h9fdb41a_0.tar.bz2
linux-64::guiqwt-3.0.5-py38h0ef3d22_1.tar.bz2
linux-64::guiqwt-3.0.5-py38hc5bc63f_0.tar.bz2
linux-64::guiqwt-3.0.5-py39h9cfe711_1.tar.bz2
linux-64::guiqwt-3.0.7-py310hb5077e9_1.tar.bz2
linux-64::guiqwt-3.0.7-py36h0cdc3f0_0.tar.bz2
linux-64::guiqwt-3.0.7-py37he8f5f7f_0.tar.bz2
linux-64::guiqwt-3.0.7-py37he8f5f7f_1.tar.bz2
linux-64::guiqwt-3.0.7-py38h43a58ef_0.tar.bz2
linux-64::guiqwt-3.0.7-py38h43a58ef_1.tar.bz2
linux-64::guiqwt-3.0.7-py39hde0f152_0.tar.bz2
linux-64::guiqwt-3.0.7-py39hde0f152_1.tar.bz2
-    "pythonqwt >=0.5.0",
+    "pythonqwt >=0.5.0,<0.14.4",
linux-64::guiqwt-4.3.1-py310h769672d_0.conda
linux-64::guiqwt-4.3.1-py310h769672d_1.conda
linux-64::guiqwt-4.3.1-py310h769672d_2.conda
linux-64::guiqwt-4.3.1-py310hb52acf9_3.conda
linux-64::guiqwt-4.3.1-py311h5e8e06c_3.conda
linux-64::guiqwt-4.3.1-py311h8b32b4d_1.conda
linux-64::guiqwt-4.3.1-py311h8b32b4d_2.conda
linux-64::guiqwt-4.3.1-py38h256d1c6_3.conda
linux-64::guiqwt-4.3.1-py38h8f669ce_0.conda
linux-64::guiqwt-4.3.1-py38h8f669ce_1.conda
linux-64::guiqwt-4.3.1-py38h8f669ce_2.conda
linux-64::guiqwt-4.3.1-py39h4661b88_0.conda
linux-64::guiqwt-4.3.1-py39h4661b88_1.conda
linux-64::guiqwt-4.3.1-py39h4661b88_2.conda
linux-64::guiqwt-4.3.1-py39h69184f1_3.conda
linux-64::guiqwt-4.3.3-py310h5610980_0.conda
linux-64::guiqwt-4.3.3-py311heaf5b70_0.conda
linux-64::guiqwt-4.3.3-py38h366d200_0.conda
linux-64::guiqwt-4.3.3-py39h38662b4_0.conda
linux-64::guiqwt-4.4.0-py310hc26ccc3_0.conda
linux-64::guiqwt-4.4.0-py311h4582280_0.conda
linux-64::guiqwt-4.4.0-py38h57206e8_0.conda
linux-64::guiqwt-4.4.0-py39h67e7d2b_0.conda
linux-64::guiqwt-4.4.1-py310hc26ccc3_0.conda
linux-64::guiqwt-4.4.1-py310hc26ccc3_1.conda
linux-64::guiqwt-4.4.1-py311h4582280_0.conda
linux-64::guiqwt-4.4.1-py311h4582280_1.conda
linux-64::guiqwt-4.4.1-py38h57206e8_0.conda
linux-64::guiqwt-4.4.1-py38h57206e8_1.conda
linux-64::guiqwt-4.4.1-py39h67e7d2b_0.conda
linux-64::guiqwt-4.4.1-py39h67e7d2b_1.conda
linux-64::guiqwt-4.4.3-py310h859080d_0.conda
linux-64::guiqwt-4.4.3-py311h4582280_0.conda
linux-64::guiqwt-4.4.3-py38h23a9ff6_0.conda
linux-64::guiqwt-4.4.3-py39h119a6b8_0.conda
linux-64::guiqwt-4.4.4-py310h859080d_0.conda
linux-64::guiqwt-4.4.4-py310h859080d_1.conda
linux-64::guiqwt-4.4.4-py311h4582280_0.conda
linux-64::guiqwt-4.4.4-py311h4582280_1.conda
linux-64::guiqwt-4.4.4-py312hf05d492_1.conda
linux-64::guiqwt-4.4.4-py38h23a9ff6_0.conda
linux-64::guiqwt-4.4.4-py38h23a9ff6_1.conda
linux-64::guiqwt-4.4.4-py39h119a6b8_0.conda
linux-64::guiqwt-4.4.4-py39h119a6b8_1.conda
linux-64::guiqwt-4.4.5-py310h3ec6d6c_1.conda
linux-64::guiqwt-4.4.5-py310h859080d_0.conda
linux-64::guiqwt-4.4.5-py310h91be489_2.conda
linux-64::guiqwt-4.4.5-py311h1e32ba8_2.conda
linux-64::guiqwt-4.4.5-py311h4582280_0.conda
linux-64::guiqwt-4.4.5-py311h4e15406_1.conda
linux-64::guiqwt-4.4.5-py312hc6afaba_2.conda
linux-64::guiqwt-4.4.5-py312he5a2b39_1.conda
linux-64::guiqwt-4.4.5-py312hf05d492_0.conda
linux-64::guiqwt-4.4.5-py313hde39a33_2.conda
linux-64::guiqwt-4.4.5-py38h23a9ff6_0.conda
linux-64::guiqwt-4.4.5-py38h5738928_1.conda
linux-64::guiqwt-4.4.5-py39h119a6b8_0.conda
linux-64::guiqwt-4.4.5-py39h91e8190_2.conda
linux-64::guiqwt-4.4.5-py39he386042_1.conda
-    "pythonqwt >=0.10",
+    "pythonqwt >=0.10,<0.14.4",
```