### PR TITLE
Tighten the runtime version of rav1e

### DIFF
--- a/recipe/patch_yaml/rav1e.yaml
+++ b/recipe/patch_yaml/rav1e.yaml
@@ -1,0 +1,7 @@
+if:
+  has_depends: rav1e?( *)
+  timestamp_lt: 1746485181000
+then:
+  - tighten_depends:
+      name: rav1e
+      max_pin: x.x


### PR DESCRIPTION
https://github.com/conda-forge/rav1e-feedstock/pull/12


1. I tried to tighten the run_exports in https://github.com/conda-forge/rav1e-feedstock/pull/11
2. But I feel like it created more problems  https://github.com/conda-forge/rav1e-feedstock/issues/13


I want to:
1. Merge this
2. Merge version 0.7.1. - https://github.com/conda-forge/rav1e-feedstock/pull/12
3. Add to global pin https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/7356
4. Rebuild the 1 package that needs this software manually - https://github.com/conda-forge/libavif-feedstock


Checklist

* [ ] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
