### PR TITLE
avoid new pytorch with ancient torchvision

### DIFF
--- a/recipe/patch_yaml/torchvision.yaml
+++ b/recipe/patch_yaml/torchvision.yaml
@@ -24,6 +24,19 @@ then:
       old: "pytorch [*] cuda[*]"
       new: "pytorch 1.10.* cuda*"
 ---
+# avoid that old torchvision (with unpinned pytorch) gets pulled in when
+# we release a new pytorch version but haven't migrated torchvision yet;
+# as seen above 0.11 was built against pytorch 1.10, so <2 is a very loose
+# constraint, owing to how long things have been like this. See
+# https://github.com/conda-forge/torchvision-feedstock/issues/71
+if:
+  name: "torchvision"
+  version_lt: "0.11.0"
+then:
+  - tighten_depends:
+      name: pytorch
+      upper_bound: 2.0.0
+---
 # Nov 13, 2023 -- hmaarrfk
 # It seems that torchvision wants to have the same cuda build as pytorch
 if:


### PR DESCRIPTION
Fixes https://github.com/conda-forge/torchvision-feedstock/issues/71

Xref: https://github.com/conda-forge/torchvision-feedstock/issues/118, https://github.com/conda/conda-libmamba-solver/pull/661

### Output of `python show_diff.py`

```diff
>python show_diff.py
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
osx-arm64
osx-arm64::torchvision-0.9.0-py38h10c60ff_0_cpu.tar.bz2
osx-arm64::torchvision-0.9.0-py38h4ddca67_0_cpu.tar.bz2
osx-arm64::torchvision-0.9.0-py39h0a40b5a_0_cpu.tar.bz2
osx-arm64::torchvision-0.9.0-py39hc5dd9f3_0_cpu.tar.bz2
osx-arm64::torchvision-0.9.1-py38h4ddca67_0_cpu.tar.bz2
osx-arm64::torchvision-0.9.1-py38h4ddca67_1_cpu.tar.bz2
osx-arm64::torchvision-0.9.1-py39h0a40b5a_0_cpu.tar.bz2
osx-arm64::torchvision-0.9.1-py39h0a40b5a_1_cpu.tar.bz2
-    "pytorch >=1.8.0 cpu*"
+    "pytorch >=1.8.0,<2.0.0a0 cpu*"
osx-arm64::torchvision-0.10.0-py38h4ddca67_0_cpu.tar.bz2
osx-arm64::torchvision-0.10.0-py39h0a40b5a_0_cpu.tar.bz2
osx-arm64::torchvision-0.10.1-py38h4ddca67_0_cpu.tar.bz2
osx-arm64::torchvision-0.10.1-py39h0a40b5a_0_cpu.tar.bz2
-    "pytorch",
+    "pytorch <2.0.0a0",
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
noarch
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
osx-64::torchvision-0.9.0-py36h54c8da7_0_cpu.tar.bz2
osx-64::torchvision-0.9.0-py36h67b27ce_0_cpu.tar.bz2
osx-64::torchvision-0.9.0-py37h561b37a_0_cpu.tar.bz2
osx-64::torchvision-0.9.0-py37hca4f876_0_cpu.tar.bz2
osx-64::torchvision-0.9.0-py38h0a49c68_0_cpu.tar.bz2
osx-64::torchvision-0.9.0-py38h83b45b8_0_cpu.tar.bz2
osx-64::torchvision-0.9.0-py39hb9ceeaa_0_cpu.tar.bz2
osx-64::torchvision-0.9.1-py36h67b27ce_1_cpu.tar.bz2
osx-64::torchvision-0.9.1-py37hca4f876_1_cpu.tar.bz2
osx-64::torchvision-0.9.1-py38h0a49c68_1_cpu.tar.bz2
osx-64::torchvision-0.9.1-py39hb9ceeaa_1_cpu.tar.bz2
-    "pytorch >=1.8.0 cpu*"
+    "pytorch >=1.8.0,<2.0.0a0 cpu*"
osx-64::torchvision-0.10.0-py36h18d0bfc_0_cpu.tar.bz2
osx-64::torchvision-0.10.0-py37he4a07f4_0_cpu.tar.bz2
osx-64::torchvision-0.10.0-py38h8b12d5a_0_cpu.tar.bz2
osx-64::torchvision-0.10.0-py39hb9ceeaa_0_cpu.tar.bz2
osx-64::torchvision-0.10.1-py36h18d0bfc_0_cpu.tar.bz2
osx-64::torchvision-0.10.1-py37he4a07f4_0_cpu.tar.bz2
osx-64::torchvision-0.10.1-py38h8b12d5a_0_cpu.tar.bz2
osx-64::torchvision-0.10.1-py39hb9ceeaa_0_cpu.tar.bz2
osx-64::torchvision-0.9.1-py36h18d0bfc_1_cpu.tar.bz2
osx-64::torchvision-0.9.1-py37he4a07f4_1_cpu.tar.bz2
osx-64::torchvision-0.9.1-py38h8b12d5a_1_cpu.tar.bz2
-    "pytorch",
+    "pytorch <2.0.0a0",
================================================================================
================================================================================
linux-64
linux-64::torchvision-0.9.0-py36cuda102h29a7989_0_cuda.tar.bz2
linux-64::torchvision-0.9.0-py36cuda102hd385f6e_0_cuda.tar.bz2
linux-64::torchvision-0.9.0-py36cuda110h3337770_0_cuda.tar.bz2
linux-64::torchvision-0.9.0-py36cuda110hb4cfe18_0_cuda.tar.bz2
linux-64::torchvision-0.9.0-py36cuda111hf588187_0_cuda.tar.bz2
linux-64::torchvision-0.9.0-py36cuda112h6a8e4e1_0_cuda.tar.bz2
linux-64::torchvision-0.9.0-py37cuda102h1bb5596_0_cuda.tar.bz2
linux-64::torchvision-0.9.0-py37cuda102h83dce31_0_cuda.tar.bz2
linux-64::torchvision-0.9.0-py37cuda110ha9b8171_0_cuda.tar.bz2
linux-64::torchvision-0.9.0-py37cuda110hbaaeff8_0_cuda.tar.bz2
linux-64::torchvision-0.9.0-py37cuda111h7179ef7_0_cuda.tar.bz2
linux-64::torchvision-0.9.0-py37cuda112h2cfdc58_0_cuda.tar.bz2
linux-64::torchvision-0.9.0-py38cuda102h336b079_0_cuda.tar.bz2
linux-64::torchvision-0.9.0-py38cuda102h5ac7205_0_cuda.tar.bz2
linux-64::torchvision-0.9.0-py38cuda110h17eb98a_0_cuda.tar.bz2
linux-64::torchvision-0.9.0-py38cuda111h462acda_0_cuda.tar.bz2
linux-64::torchvision-0.9.0-py38cuda112h4067301_0_cuda.tar.bz2
linux-64::torchvision-0.9.0-py39cuda102h5ebb52a_0_cuda.tar.bz2
linux-64::torchvision-0.9.0-py39cuda110ha5f9ec3_0_cuda.tar.bz2
linux-64::torchvision-0.9.0-py39cuda111hcd06603_0_cuda.tar.bz2
linux-64::torchvision-0.9.0-py39cuda112hc5182df_0_cuda.tar.bz2
linux-64::torchvision-0.9.1-py36cuda102hd385f6e_1_cuda.tar.bz2
linux-64::torchvision-0.9.1-py36cuda110h3337770_1_cuda.tar.bz2
linux-64::torchvision-0.9.1-py36cuda111hf588187_1_cuda.tar.bz2
linux-64::torchvision-0.9.1-py36cuda112h6a8e4e1_1_cuda.tar.bz2
linux-64::torchvision-0.9.1-py37cuda102h1bb5596_1_cuda.tar.bz2
linux-64::torchvision-0.9.1-py37cuda110hbaaeff8_1_cuda.tar.bz2
linux-64::torchvision-0.9.1-py37cuda111h7179ef7_1_cuda.tar.bz2
linux-64::torchvision-0.9.1-py37cuda112h2cfdc58_1_cuda.tar.bz2
linux-64::torchvision-0.9.1-py38cuda102h336b079_1_cuda.tar.bz2
linux-64::torchvision-0.9.1-py38cuda110hd0a72be_1_cuda.tar.bz2
linux-64::torchvision-0.9.1-py38cuda111h462acda_1_cuda.tar.bz2
linux-64::torchvision-0.9.1-py38cuda112h4067301_1_cuda.tar.bz2
linux-64::torchvision-0.9.1-py39cuda102h5ebb52a_1_cuda.tar.bz2
linux-64::torchvision-0.9.1-py39cuda110ha5f9ec3_1_cuda.tar.bz2
linux-64::torchvision-0.9.1-py39cuda111hcd06603_1_cuda.tar.bz2
linux-64::torchvision-0.9.1-py39cuda112hc5182df_1_cuda.tar.bz2
-    "pytorch >=1.8.0 cuda*"
+    "pytorch >=1.8.0,<2.0.0a0 cuda*"
linux-64::torchvision-0.10.0-py36cuda102hd220d44_0_cuda.tar.bz2
linux-64::torchvision-0.10.0-py36cuda110h0c4e2d7_0_cuda.tar.bz2
linux-64::torchvision-0.10.0-py36cuda111h50ec057_0_cuda.tar.bz2
linux-64::torchvision-0.10.0-py36cuda112h71db1b3_0_cuda.tar.bz2
linux-64::torchvision-0.10.0-py36h2de9e49_0_cpu.tar.bz2
linux-64::torchvision-0.10.0-py37cuda102hbbb9a51_0_cuda.tar.bz2
linux-64::torchvision-0.10.0-py37cuda110hbff3922_0_cuda.tar.bz2
linux-64::torchvision-0.10.0-py37cuda111hfcef1eb_0_cuda.tar.bz2
linux-64::torchvision-0.10.0-py37cuda112h1384e8b_0_cuda.tar.bz2
linux-64::torchvision-0.10.0-py37h9e046cd_0_cpu.tar.bz2
linux-64::torchvision-0.10.0-py38cuda102h1e64cea_0_cuda.tar.bz2
linux-64::torchvision-0.10.0-py38cuda110h0daf3c9_0_cuda.tar.bz2
linux-64::torchvision-0.10.0-py38cuda111he221d04_0_cuda.tar.bz2
linux-64::torchvision-0.10.0-py38cuda112h04b465a_0_cuda.tar.bz2
linux-64::torchvision-0.10.0-py38h9e2e28c_0_cpu.tar.bz2
linux-64::torchvision-0.10.0-py39cuda102h5ebb52a_0_cuda.tar.bz2
linux-64::torchvision-0.10.0-py39cuda110ha5f9ec3_0_cuda.tar.bz2
linux-64::torchvision-0.10.0-py39cuda111hcd06603_0_cuda.tar.bz2
linux-64::torchvision-0.10.0-py39cuda112hc5182df_0_cuda.tar.bz2
linux-64::torchvision-0.10.0-py39h93e5132_0_cpu.tar.bz2
linux-64::torchvision-0.10.1-py36cuda102hd220d44_0_cuda.tar.bz2
linux-64::torchvision-0.10.1-py36cuda110h0c4e2d7_0_cuda.tar.bz2
linux-64::torchvision-0.10.1-py36cuda111h50ec057_0_cuda.tar.bz2
linux-64::torchvision-0.10.1-py36cuda112h71db1b3_0_cuda.tar.bz2
linux-64::torchvision-0.10.1-py36h2de9e49_0_cpu.tar.bz2
linux-64::torchvision-0.10.1-py37cuda102hbbb9a51_0_cuda.tar.bz2
linux-64::torchvision-0.10.1-py37cuda110hbff3922_0_cuda.tar.bz2
linux-64::torchvision-0.10.1-py37cuda111hfcef1eb_0_cuda.tar.bz2
linux-64::torchvision-0.10.1-py37cuda112h1384e8b_0_cuda.tar.bz2
linux-64::torchvision-0.10.1-py37h9e046cd_0_cpu.tar.bz2
linux-64::torchvision-0.10.1-py38cuda102h1e64cea_0_cuda.tar.bz2
linux-64::torchvision-0.10.1-py38cuda110h0daf3c9_0_cuda.tar.bz2
linux-64::torchvision-0.10.1-py38cuda111he221d04_0_cuda.tar.bz2
linux-64::torchvision-0.10.1-py38cuda112h04b465a_0_cuda.tar.bz2
linux-64::torchvision-0.10.1-py38h9e2e28c_0_cpu.tar.bz2
linux-64::torchvision-0.10.1-py39cuda102h5ebb52a_0_cuda.tar.bz2
linux-64::torchvision-0.10.1-py39cuda110ha5f9ec3_0_cuda.tar.bz2
linux-64::torchvision-0.10.1-py39cuda111hcd06603_0_cuda.tar.bz2
linux-64::torchvision-0.10.1-py39cuda112hc5182df_0_cuda.tar.bz2
linux-64::torchvision-0.10.1-py39h93e5132_0_cpu.tar.bz2
linux-64::torchvision-0.9.1-py36cuda102hd220d44_1_cuda.tar.bz2
linux-64::torchvision-0.9.1-py36cuda110h0c4e2d7_1_cuda.tar.bz2
linux-64::torchvision-0.9.1-py36cuda111h50ec057_1_cuda.tar.bz2
linux-64::torchvision-0.9.1-py36cuda112h71db1b3_1_cuda.tar.bz2
linux-64::torchvision-0.9.1-py36h2de9e49_1_cpu.tar.bz2
linux-64::torchvision-0.9.1-py37cuda102hbbb9a51_1_cuda.tar.bz2
linux-64::torchvision-0.9.1-py37cuda110hbff3922_1_cuda.tar.bz2
linux-64::torchvision-0.9.1-py37cuda111hfcef1eb_1_cuda.tar.bz2
linux-64::torchvision-0.9.1-py37cuda112h1384e8b_1_cuda.tar.bz2
linux-64::torchvision-0.9.1-py37h9e046cd_1_cpu.tar.bz2
linux-64::torchvision-0.9.1-py38cuda102h1e64cea_1_cuda.tar.bz2
linux-64::torchvision-0.9.1-py38cuda110h0daf3c9_1_cuda.tar.bz2
linux-64::torchvision-0.9.1-py38cuda111he221d04_1_cuda.tar.bz2
linux-64::torchvision-0.9.1-py38cuda112h04b465a_1_cuda.tar.bz2
linux-64::torchvision-0.9.1-py38h9e2e28c_1_cpu.tar.bz2
-    "pytorch",
+    "pytorch <2.0.0a0",
linux-64::torchvision-0.9.0-py36h9122fb0_0_cpu.tar.bz2
linux-64::torchvision-0.9.0-py36hd7fc4de_0_cpu.tar.bz2
linux-64::torchvision-0.9.0-py37h2413bea_0_cpu.tar.bz2
linux-64::torchvision-0.9.0-py37h6dc5373_0_cpu.tar.bz2
linux-64::torchvision-0.9.0-py38h3f3a366_0_cpu.tar.bz2
linux-64::torchvision-0.9.0-py38h89b28b9_0_cpu.tar.bz2
linux-64::torchvision-0.9.0-py39h93e5132_0_cpu.tar.bz2
linux-64::torchvision-0.9.1-py36hd7fc4de_1_cpu.tar.bz2
linux-64::torchvision-0.9.1-py37h2413bea_1_cpu.tar.bz2
linux-64::torchvision-0.9.1-py38h3f3a366_1_cpu.tar.bz2
linux-64::torchvision-0.9.1-py39h93e5132_1_cpu.tar.bz2
-    "pytorch >=1.8.0 cpu*"
+    "pytorch >=1.8.0,<2.0.0a0 cpu*"
```