### PR TITLE
Block problematic ligbc++ v15.1.0 with PyTensor

### DIFF
--- a/recipe/patch_yaml/pytensor.yaml
+++ b/recipe/patch_yaml/pytensor.yaml
@@ -41,5 +41,6 @@ if:
   name: pytensor
   timestamp_lt: 1747065846000
   version_le: '2.30.3'
+  subdir_in: win-64
 then:
   - add_constrains: libstdcxx !=15.1.0


### PR DESCRIPTION
Workaround for missing `_ZSt21ios_base_library_initv`: <https://github.com/conda-forge/ctng-compilers-feedstock/issues/174>

Fixed for the current version in <https://github.com/conda-forge/pytensor-suite-feedstock/pull/158>


Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
