### PR TITLE
Pin rhash more strictly on osx

### DIFF
--- a/recipe/patch_yaml/rhash.yaml
+++ b/recipe/patch_yaml/rhash.yaml
@@ -8,3 +8,14 @@ then:
   - replace_depends:
       old: rhash >=1.4.3,<2.0a0
       new: rhash >=1.4.3,<1.4.4a0
+---
+if:
+  has_depends: rhash?( *)
+  timestamp_lt: 1747216048000
+  subdir_in:
+    - osx-64
+    - osx-arm64
+then:
+  - replace_depends:
+      old: rhash >=1.4.5,<2.0a0
+      new: rhash >=1.4.5,<1.4.6a0


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->


```
================================================================================
================================================================================
osx-arm64
osx-arm64::cmake-3.31.0-h326f17c_0.conda
osx-arm64::cmake-3.31.1-h326f17c_0.conda
osx-arm64::cmake-3.31.2-h326f17c_0.conda
osx-arm64::cmake-3.31.2-ha25475f_1.conda
osx-arm64::cmake-3.31.4-ha25475f_0.conda
osx-arm64::cmake-3.31.5-ha25475f_0.conda
osx-arm64::cmake-3.31.6-ha25475f_0.conda
osx-arm64::cmake-4.0.0-ha25475f_0.conda
osx-arm64::cmake-4.0.1-ha25475f_0.conda
osx-arm64::cmake-4.0.2-ha25475f_0.conda
-    "rhash >=1.4.5,<2.0a0",
+    "rhash >=1.4.5,<1.4.6a0",
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
osx-64::cmake-3.31.0-heacca2f_0.conda
osx-64::cmake-3.31.1-heacca2f_0.conda
osx-64::cmake-3.31.2-h477996e_1.conda
osx-64::cmake-3.31.2-heacca2f_0.conda
osx-64::cmake-3.31.4-h477996e_0.conda
osx-64::cmake-3.31.5-h477996e_0.conda
osx-64::cmake-3.31.6-h477996e_0.conda
osx-64::cmake-4.0.0-h477996e_0.conda
osx-64::cmake-4.0.1-h477996e_0.conda
osx-64::cmake-4.0.2-h477996e_0.conda
-    "rhash >=1.4.5,<2.0a0",
+    "rhash >=1.4.5,<1.4.6a0",
```