### PR TITLE
Add missing cudnn run dependency in jaxlib cudnn 9.10 builds

### DIFF
--- a/recipe/patch_yaml/jaxlib.yaml
+++ b/recipe/patch_yaml/jaxlib.yaml
@@ -29,3 +29,16 @@ if:
 then:
   - add_depends:
       - "cuda-cupti >=12.0.90,<13.0a0"
+---
+# To fix https://github.com/conda-forge/jaxlib-feedstock/issues/312
+# cudnn 9.10.0 initiall had missing run_exports, see
+# https://github.com/conda-forge/cudnn-feedstock/pull/114
+if:
+  name: jaxlib
+  version: 0.5.2
+  build_number_in: [202]
+  has_depends: cuda-version >=12.6,<13
+  subdir_in: [linux-64]
+then:
+  - add_depends:
+      - "cudnn >=9.10.0.56,<10.0a0"


### PR DESCRIPTION
Fix https://github.com/conda-forge/jaxlib-feedstock/issues/312, the initial cudnn 9.10 build had missing run_exports, see https://github.com/conda-forge/cudnn-feedstock/pull/114 .

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
