### PR TITLE
Fix missing cudnn depedendency in jaxlib 0.5.3 cuda builds

### DIFF
--- a/recipe/patch_yaml/jaxlib.yaml
+++ b/recipe/patch_yaml/jaxlib.yaml
@@ -42,3 +42,17 @@ if:
 then:
   - add_depends:
       - "cudnn >=9.10.0.56,<10.0a0"
+---
+# also the "fixed" cudnn 9.10.0 had missing run_exports, see
+# https://github.com/conda-forge/jaxlib-feedstock/issues/312#issuecomment-2892174716
+# so we need to fix also the jaxlib 0.5.3 buids, this was then fixed in
+# https://github.com/conda-forge/cudnn-feedstock/pull/116
+if:
+  name: jaxlib
+  version: 0.5.3
+  build_number_in: [200]
+  has_depends: cuda-version >=12.6,<13
+  subdir_in: [linux-64]
+then:
+  - add_depends:
+      - "cudnn >=9.10.0.56,<10.0a0"


### PR DESCRIPTION
Fix for the issue spotted in https://github.com/conda-forge/jaxlib-feedstock/issues/312#issuecomment-2892174716 .

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
