### PR TITLE
fix: ultraplot needs mpl <3.10

### DIFF
--- a/recipe/patch_yaml/ultraplot.yaml
+++ b/recipe/patch_yaml/ultraplot.yaml
@@ -13,3 +13,10 @@ if:
 then:
   - add_constrains:
       - ipython <9.0a0
+---
+if:
+  name: ultraplot
+  version_le: 1.50.2
+then:
+  - add_depends:
+      - matplotlib-base <3.10


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
