### PR TITLE
Fix ollama-python httpx pin

### DIFF
--- a/recipe/patch_yaml/ollama-python.yaml
+++ b/recipe/patch_yaml/ollama-python.yaml
@@ -1,0 +1,9 @@
+# https://github.com/conda-forge/ollama-python-feedstock/pull/11
+if:
+  name: ollama-python
+  timestamp_lt: 1747837821000
+  version: 0.4.8
+then:
+  - replace_depends:
+      old: httpx >=0.27.0,<0.28.0
+      new: httpx >=0.27,<0.29


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
https://github.com/conda-forge/ollama-python-feedstock/pull/11

https://github.com/ollama/ollama-python/commit/7e64093df0e6a9f57e334bbe1fc6c9c9d107850a

```
================================================================================
================================================================================
noarch
noarch::ollama-python-0.4.8-pyhd8ed1ab_0.conda
-    "httpx >=0.27.0,<0.28.0",
+    "httpx >=0.27,<0.29",
```