### PR TITLE
Add ipython pinning to sardana-core

### DIFF
--- a/recipe/patch_yaml/sardana.yaml
+++ b/recipe/patch_yaml/sardana.yaml
@@ -31,3 +31,10 @@ then:
   - replace_depends:
       old: python >=3.5
       new: python >=3.5,<3.12
+---
+if:
+  name: sardana-core
+  version_le: 3.5.2
+  timestamp_lt: 1749040348000
+then:
+  - add_depends: ipython <9.0


### PR DESCRIPTION
Checklist

* [X] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [X] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [X] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [X] Ran `python show_diff.py` and posted the output as part of the PR.
* [X] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
ipython 9 broke sardana spock command.

Pending MR to add support: https://gitlab.com/sardana-org/sardana/-/merge_requests/2059
Recipe was fixed: https://github.com/conda-forge/sardana-feedstock/pull/33


```
$ python show_diff.py --subdirs noarch
================================================================================
================================================================================
noarch
noarch::sardana-core-3.4.0-pyhd8ed1ab_1.conda
noarch::sardana-core-3.4.0-pyhd8ed1ab_2.conda
noarch::sardana-core-3.4.1-pyhd8ed1ab_0.conda
noarch::sardana-core-3.4.2-pyhd8ed1ab_0.conda
noarch::sardana-core-3.4.3-pyhd8ed1ab_0.conda
noarch::sardana-core-3.4.3-pyhd8ed1ab_1.conda
noarch::sardana-core-3.4.4-pyhd8ed1ab_0.conda
noarch::sardana-core-3.5.0-pyhd8ed1ab_0.conda
noarch::sardana-core-3.5.0-pyhd8ed1ab_1.conda
noarch::sardana-core-3.5.1-pyhd8ed1ab_0.conda
noarch::sardana-core-3.5.2-pyhd8ed1ab_0.conda
+    "ipython <9.0",
```