### PR TITLE
Remove the wrong addition of `depends` from `cuda-core` v0.2.0 build 0

### DIFF
--- a/recipe/patch_yaml/cuda-python.yaml
+++ b/recipe/patch_yaml/cuda-python.yaml
@@ -11,3 +11,10 @@ then:
   - replace_depends:
       old: cuda-nvrtc*
       new: cuda-nvrtc >=12,<13.0a0
+---
+if:
+  name: cuda-core
+  version: 0.2.0
+  build_number: 0
+then:
+  - remove_depends: "cuda-version >=12.8,<13"


### PR DESCRIPTION
Fix https://github.com/conda-forge/cuda-python-feedstock/issues/123.

See https://github.com/conda-forge/cuda-python-feedstock/issues/123#issuecomment-2947306820 for explanation.

cc @conda-forge/cuda-python for vis


Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

Outputs: <details><summary>**Click me**</summary>

```shell
$ python show_diff.py                     
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-aarch64
linux-aarch64::cuda-core-0.2.0-py310haafe215_0.conda
linux-aarch64::cuda-core-0.2.0-py311hc4d3499_0.conda
linux-aarch64::cuda-core-0.2.0-py312hf625020_0.conda
linux-aarch64::cuda-core-0.2.0-py313h352a73e_0.conda
linux-aarch64::cuda-core-0.2.0-py39hee18035_0.conda
-    "cuda-version >=12.8,<13",
================================================================================
================================================================================
noarch
================================================================================
================================================================================
win-64
win-64::cuda-core-0.2.0-py310h5b089da_0.conda
win-64::cuda-core-0.2.0-py311h080927e_0.conda
win-64::cuda-core-0.2.0-py312h4b61ef1_0.conda
win-64::cuda-core-0.2.0-py313h7ea4753_0.conda
win-64::cuda-core-0.2.0-py39hfde3066_0.conda
-    "cuda-version >=12.8,<13",
================================================================================
================================================================================
osx-64
================================================================================
================================================================================
linux-64
linux-64::cuda-core-0.2.0-py310h56eac83_0.conda
linux-64::cuda-core-0.2.0-py311h7982059_0.conda
linux-64::cuda-core-0.2.0-py312h843de2b_0.conda
linux-64::cuda-core-0.2.0-py313h717814b_0.conda
linux-64::cuda-core-0.2.0-py39hf0e9986_0.conda
-    "cuda-version >=12.8,<13",
```

</details>