### PR TITLE
Add pyqt constraint against pyqt_builder

### DIFF
--- a/recipe/patch_yaml/pyqt.yaml
+++ b/recipe/patch_yaml/pyqt.yaml
@@ -1,0 +1,8 @@
+if:
+  name: pyqt
+  version_lt: 6.0.0
+  timestamp_lt: 1749235324000
+then:
+  - replace_depends:
+      old: pyqt-builder
+      new: pyqt-builder <1.16.0


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

Currently adding a patch to `pyqt-builder` to be used for all `pyqt` v6 versions. All current and new `v5` versions should use `pyqt-builder <1.16.0`. I tried running `show_diff.py` but didn't see anything; so I'll wait for the Azure output.

As advised in https://github.com/conda-forge/pyqt-builder-feedstock/pull/22

@hmaarrfk 


<details>

<summary> Patching output </summary>

```
================================================================================
================================================================================
linux-armv7l

patching repodata:   0%|          | 0/9 [00:00<?, ?it/s]
patching repodata:  11%|█         | 1/9 [00:00<00:06,  1.32it/s]

================================================================================
================================================================================
linux-ppc64le

patching repodata:  22%|██▏       | 2/9 [03:16<13:28, 115.47s/it]

================================================================================
================================================================================
linux-aarch64

patching repodata:  33%|███▎      | 3/9 [03:48<07:43, 77.22s/it] 

================================================================================
================================================================================
noarch

patching repodata:  44%|████▍     | 4/9 [04:09<04:36, 55.32s/it]

================================================================================
================================================================================
win-32


patching repodata:  56%|█████▌    | 5/9 [04:33<02:54, 43.70s/it]
================================================================================
================================================================================
osx-arm64


================================================================================
================================================================================
linux-64

patching repodata:  67%|██████▋   | 6/9 [07:22<04:19, 86.39s/it]
patching repodata:  78%|███████▊  | 7/9 [09:08<03:05, 92.70s/it]

================================================================================
================================================================================
win-64

patching repodata:  89%|████████▉ | 8/9 [10:09<01:22, 82.90s/it]

================================================================================
================================================================================
osx-64

patching repodata: 100%|██████████| 9/9 [10:47<00:00, 68.77s/it]
patching repodata: 100%|██████████| 9/9 [10:47<00:00, 71.96s/it]
```

</details>