### PR TITLE
Fix pandera subpackage pins

### DIFF
--- a/recipe/patch_yaml/pandera.yaml
+++ b/recipe/patch_yaml/pandera.yaml
@@ -1,0 +1,26 @@
+# https://github.com/conda-forge/pandera-feedstock/issues/82
+if:
+  name: pandera*
+  version: 0.24.0
+  build: hd8ed1ab_0
+  timestamp_lt: 1749288107000
+then:
+  - replace_depends:
+      old: pandera-base >=0.24.0,<0.24.1.0a0
+      new: pandera-base 0.24.0 pyhd8ed1ab_0
+  - replace_depends:
+      old: pandera >=0.24.0,<0.24.1.0a0
+      new: pandera 0.24.0 hd8ed1ab_0
+---
+if:
+  name: pandera*
+  version: 0.24.0
+  build: hd8ed1ab_1
+  timestamp_lt: 1749288107000
+then:
+  - replace_depends:
+      old: pandera-base >=0.24.0,<0.24.1.0a0
+      new: pandera-base 0.24.0 pyhd8ed1ab_1
+  - replace_depends:
+      old: pandera >=0.24.0,<0.24.1.0a0
+      new: pandera 0.24.0 hd8ed1ab_1


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
https://github.com/conda-forge/pandera-feedstock/issues/82

```
================================================================================
================================================================================
noarch
noarch::pandera-geopandas-0.24.0-hd8ed1ab_0.conda
noarch::pandera-hypotheses-0.24.0-hd8ed1ab_0.conda
noarch::pandera-io-0.24.0-hd8ed1ab_0.conda
noarch::pandera-polars-0.24.0-hd8ed1ab_0.conda
noarch::pandera-pyspark-0.24.0-hd8ed1ab_0.conda
-    "pandera-base >=0.24.0,<0.24.1.0a0",
+    "pandera-base 0.24.0 pyhd8ed1ab_0",
noarch::pandera-0.24.0-hd8ed1ab_0.conda
noarch::pandera-dask-0.24.0-hd8ed1ab_0.conda
noarch::pandera-fastapi-0.24.0-hd8ed1ab_0.conda
noarch::pandera-modin-0.24.0-hd8ed1ab_0.conda
noarch::pandera-modin-dask-0.24.0-hd8ed1ab_0.conda
noarch::pandera-modin-ray-0.24.0-hd8ed1ab_0.conda
noarch::pandera-mypy-0.24.0-hd8ed1ab_0.conda
noarch::pandera-strategies-0.24.0-hd8ed1ab_0.conda
-    "pandera-base >=0.24.0,<0.24.1.0a0"
+    "pandera-base 0.24.0 pyhd8ed1ab_0"
noarch::pandera-0.24.0-hd8ed1ab_1.conda
noarch::pandera-dask-0.24.0-hd8ed1ab_1.conda
noarch::pandera-modin-0.24.0-hd8ed1ab_1.conda
noarch::pandera-modin-dask-0.24.0-hd8ed1ab_1.conda
noarch::pandera-modin-ray-0.24.0-hd8ed1ab_1.conda
noarch::pandera-pandas-0.24.0-hd8ed1ab_1.conda
-    "pandera-base >=0.24.0,<0.24.1.0a0"
+    "pandera-base 0.24.0 pyhd8ed1ab_1"
noarch::pandera-fastapi-0.24.0-hd8ed1ab_1.conda
noarch::pandera-mypy-0.24.0-hd8ed1ab_1.conda
noarch::pandera-strategies-0.24.0-hd8ed1ab_1.conda
-    "pandera >=0.24.0,<0.24.1.0a0"
+    "pandera 0.24.0 hd8ed1ab_1"
noarch::pandera-geopandas-0.24.0-hd8ed1ab_1.conda
noarch::pandera-hypotheses-0.24.0-hd8ed1ab_1.conda
noarch::pandera-io-0.24.0-hd8ed1ab_1.conda
-    "pandera >=0.24.0,<0.24.1.0a0",
+    "pandera 0.24.0 hd8ed1ab_1",
noarch::pandera-polars-0.24.0-hd8ed1ab_1.conda
noarch::pandera-pyspark-0.24.0-hd8ed1ab_1.conda
-    "pandera-base >=0.24.0,<0.24.1.0a0",
+    "pandera-base 0.24.0 pyhd8ed1ab_1",
```
