### PR TITLE
Add patch for numba 0.61.2 to pin to numpy less than 2.3

### DIFF
--- a/recipe/patch_yaml/numba.yaml
+++ b/recipe/patch_yaml/numba.yaml
@@ -49,3 +49,13 @@ then:
   - replace_depends:
       old: numpy >=*
       new: ${old},<1.21.0a0
+---
+if:
+  name: numba
+  timestamp_le: 1749486739000
+  version: "0.61.2"
+  has_depends: numpy >=1.24
+then:
+  - replace_depends:
+      old: numpy >=1.24
+      new: ${old},<2.3.0a0


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
Related to https://github.com/conda-forge/numba-feedstock/issues/158 and https://github.com/conda-forge/numba-feedstock/pull/157

Output of `python show_diff.py`:
```
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
linux-ppc64le
linux-ppc64le::numba-0.61.2-py310h27b5c11_0.conda
linux-ppc64le::numba-0.61.2-py311h24aa915_0.conda
linux-ppc64le::numba-0.61.2-py312h4f9b6b2_0.conda
linux-ppc64le::numba-0.61.2-py313hf138304_0.conda
-    "numpy >=1.24",
+    "numpy >=1.24,<2.3.0a0",
================================================================================
================================================================================
osx-arm64
osx-arm64::numba-0.61.2-py310h75d646b_0.conda
osx-arm64::numba-0.61.2-py311h74daea0_0.conda
osx-arm64::numba-0.61.2-py312hdf12f13_0.conda
osx-arm64::numba-0.61.2-py313h8aea8d6_0.conda
-    "numpy >=1.24",
+    "numpy >=1.24,<2.3.0a0",
================================================================================
================================================================================
linux-aarch64
linux-aarch64::numba-0.61.2-py310ha77abdd_0.conda
linux-aarch64::numba-0.61.2-py311h26ae67a_0.conda
linux-aarch64::numba-0.61.2-py312ha0c5ac9_0.conda
linux-aarch64::numba-0.61.2-py313ha927da1_0.conda
-    "numpy >=1.24",
+    "numpy >=1.24,<2.3.0a0",
================================================================================
================================================================================
noarch
================================================================================
================================================================================
win-64
win-64::numba-0.61.2-py310h7793332_0.conda
win-64::numba-0.61.2-py311h0673bce_0.conda
win-64::numba-0.61.2-py312hcccf92d_0.conda
win-64::numba-0.61.2-py313h4ca4f0f_0.conda
-    "numpy >=1.24",
+    "numpy >=1.24,<2.3.0a0",
================================================================================
================================================================================
osx-64
osx-64::numba-0.61.2-py310h6fcc139_0.conda
osx-64::numba-0.61.2-py311h5322ac9_0.conda
osx-64::numba-0.61.2-py312hfa89a5f_0.conda
osx-64::numba-0.61.2-py313h7d106be_0.conda
-    "numpy >=1.24",
+    "numpy >=1.24,<2.3.0a0",
================================================================================
================================================================================
linux-64
linux-64::numba-0.61.2-py310h699fe88_0.conda
linux-64::numba-0.61.2-py311h4e1c48f_0.conda
linux-64::numba-0.61.2-py312h2e6246c_0.conda
linux-64::numba-0.61.2-py313h0b724e9_0.conda
-    "numpy >=1.24",
+    "numpy >=1.24,<2.3.0a0",
```