### PR TITLE
Add dask-core and xarray upper bounds to spatialdata

### DIFF
--- a/recipe/patch_yaml/spatialdata.yaml
+++ b/recipe/patch_yaml/spatialdata.yaml
@@ -1,0 +1,14 @@
+# Both dask-core and xarray introduced breaking changes that cause earlier
+# versions of spatialdata to fail. Upper bounds were added to spatialdata 0.2.3
+# build number 1 in https://github.com/conda-forge/spatialdata-feedstock/pull/17
+if:
+  name: spatialdata
+  version_le: "0.2.3"
+  timestamp_lt: 1749755828000
+then:
+  - tighten_depends:
+      name: dask-core
+      upper_bound: "2024.11.0"
+  - tighten_depends:
+      name: xarray
+      upper_bound: "2024.10"


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
---

Both dask-core and xarray introduced breaking changes that cause earlier versions of spatialdata to fail. Upper bounds were added to spatialdata 0.2.3 build number 1 in https://github.com/conda-forge/spatialdata-feedstock/pull/17

cc: @LucaMarconato, @giovp, @conda-forge/spatialdata 
