### PR TITLE
Loosen harfbuzz pinnings

### DIFF
--- a/recipe/patch_yaml/harfbuzz.yaml
+++ b/recipe/patch_yaml/harfbuzz.yaml
@@ -1,0 +1,33 @@
+# hmaarrfk - 2025/06/15
+# Harfbuzz declares that it will always maintain ABI compatibility for ever.
+# https://github.com/conda-forge/harfbuzz-feedstock/issues/123
+# We loosened the pinning for harfbuzz packages built after 11.0.1 in 2025,
+# but here we loosen the packages built with all the way back to 8.1.0
+# Which was released in 2023/08/25 on conda-forge (seems far back enough)
+if:
+  has_depends: harfbuzz >=10.*
+  timestamp_lt: 1750018445000
+then:
+  - loosen_depends:
+      name: harfbuzz
+      upper_bound: None
+
+---
+
+if:
+  has_depends: harfbuzz >=9.*
+  timestamp_lt: 1750018445000
+then:
+  - loosen_depends:
+      name: harfbuzz
+      upper_bound: None
+
+---
+
+if:
+  has_depends: harfbuzz >=8.*
+  timestamp_lt: 1750018445000
+then:
+  - loosen_depends:
+      name: harfbuzz
+      upper_bound: None


### PR DESCRIPTION
we started to follow their ABI limits which is

> we will never break ABI

https://github.com/conda-forge/harfbuzz-feedstock/issues/123

https://gist.github.com/hmaarrfk/30fd3e000382e587c4ec994c6e554ee4

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
