### PR TITLE
fix: remove track_features from all pytorch-cpu repodata

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -614,6 +614,12 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
         ):
             record["track_features"] = "pypy"
 
+        # Remove `track_features` key from the `pytorch-cpu` packages
+        # Related change in pytorch-cpu package: 
+        # https://github.com/conda-forge/pytorch-cpu-feedstock/pull/394
+        if record_name == "pytorch-cpu" and "track_features" in record:
+            record["track_features"] = None
+        
         # replace =2.7 with ==2.7.* for compatibility with older conda
         new_deps = []
         changed = False

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -614,10 +614,6 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
         ):
             record["track_features"] = "pypy"
 
-        # # Remove `track_features` key from the `pytorch-cpu` packages
-        # if record_name == "pytorch-cpu" and "track_features" in record:
-        #     record["track_features"] = None
-        
         # replace =2.7 with ==2.7.* for compatibility with older conda
         new_deps = []
         changed = False

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -614,11 +614,9 @@ def _gen_new_index_per_key(repodata, subdir, index_key):
         ):
             record["track_features"] = "pypy"
 
-        # Remove `track_features` key from the `pytorch-cpu` packages
-        # Related change in pytorch-cpu package: 
-        # https://github.com/conda-forge/pytorch-cpu-feedstock/pull/394
-        if record_name == "pytorch-cpu" and "track_features" in record:
-            record["track_features"] = None
+        # # Remove `track_features` key from the `pytorch-cpu` packages
+        # if record_name == "pytorch-cpu" and "track_features" in record:
+        #     record["track_features"] = None
         
         # replace =2.7 with ==2.7.* for compatibility with older conda
         new_deps = []

--- a/recipe/patch_yaml/pytorch-cpu.yaml
+++ b/recipe/patch_yaml/pytorch-cpu.yaml
@@ -1,6 +1,6 @@
 # from this code
 # Remove track_features from pytorch-cpu records
-# Related change in pytorch-cpu package: 
+# Related change in pytorch-cpu package:
 # https://github.com/conda-forge/pytorch-cpu-feedstock/pull/394
 # if record_name == "pytorch-cpu" and "track_features" in record:
 #     recordd_["track_features"] = None

--- a/recipe/patch_yaml/pytorch-cpu.yaml
+++ b/recipe/patch_yaml/pytorch-cpu.yaml
@@ -1,0 +1,12 @@
+# from this code
+# Remove track_features from pytorch-cpu records
+# Related change in pytorch-cpu package: 
+# https://github.com/conda-forge/pytorch-cpu-feedstock/pull/394
+# if record_name == "pytorch-cpu" and "track_features" in record:
+#     recordd_["track_features"] = None
+if:
+  name: "pytorch-cpu"
+  # 23-Jun-2025
+  timestamp_lt: 1750671297000
+then:
+  - remove_track_features: pytorch-cpu


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

Removing all `track_features` from the repodata for `pytorch-cpu`. 

# Reasoning
The fix in `pytorch-cpu-feedstock`: https://github.com/conda-forge/pytorch-cpu-feedstock/pull/394

There is currently no use (known to me and the others involved) to have a track_features in the package. It currently results in getting the latest version if there are no other constraints due to this field. 

*ps. would you be interested in a pixi project for this repo?, I struggled with reading the readme's and understanding what to do with this project*
