### PR TITLE
[statsmodels]: Pin scipy <1.16.0

### DIFF
--- a/recipe/patch_yaml/statsmodels.yaml
+++ b/recipe/patch_yaml/statsmodels.yaml
@@ -7,3 +7,14 @@ then:
   - tighten_depends:
       name: scipy
       upper_bound: 1.16.0
+---
+# constraint of the form `scipy !=1.9.2,>=1.8` doesn't work with tighen_depends ATM,
+# c.f. https://github.com/conda-forge/conda-smithy/issues/2343
+if:
+  name: statsmodels
+  timestamp_le: 1751302301000  # 2025-06-30
+  version_ge: 0.13.3
+then:
+  - replace_depends:
+      old: scipy !=1.9.2,>=1.8
+      new: scipy >=1.8,!=1.9.2,<1.16.0a0


### PR DESCRIPTION
See https://github.com/statsmodels/statsmodels/issues/9584.

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
See https://github.com/statsmodels/statsmodels/issues/9584.