### PR TITLE
Relax `cuda-version` minimum bound for `libnvjitlink>12.0,<12.6` 

### DIFF
--- a/recipe/patch_yaml/libnvjitlink.yaml
+++ b/recipe/patch_yaml/libnvjitlink.yaml
@@ -1,0 +1,54 @@
+# Relax cuda-version lower bound
+if:
+  name: libnvjitlink
+  timestamp_lt: 1751470107000
+  version: 12.1.105
+then:
+  - replace_depends:
+      old: cuda-version*
+      new: cuda-version>=12.0.0,<12.2.0a0
+---
+if:
+  name: libnvjitlink
+  timestamp_lt: 1751470107000
+  version: 12.2.140
+then:
+  - replace_depends:
+      old: cuda-version*
+      new: cuda-version>=12.0.0,<12.3.0a0
+---
+if:
+  name: libnvjitlink
+  timestamp_lt: 1751470107000
+  version: 12.3.101
+then:
+  - replace_depends:
+      old: cuda-version*
+      new: cuda-version>=12.0.0,<12.4.0a0
+---
+if:
+  name: libnvjitlink
+  timestamp_lt: 1751470107000
+  version: 12.4.127
+then:
+  - replace_depends:
+      old: cuda-version*
+      new: cuda-version>=12.0.0,<12.5.0a0
+---
+if:
+  name: libnvjitlink
+  timestamp_lt: 1751470107000
+  version: 12.5.40
+then:
+  - replace_depends:
+      old: cuda-version*
+      new: cuda-version>=12.0.0,<12.6.0a0
+---
+if:
+  name: libnvjitlink
+  timestamp_lt: 1751470107000
+  version: 12.5.82
+then:
+  - replace_depends:
+      old: cuda-version*
+      new: cuda-version>=12.0.0,<12.6.0a0


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

<details>

```                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
================================================================================                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                
================================================================================                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                
linux-armv7l                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
================================================================================                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                
================================================================================                                                        
win-32                                                                                                                                  
================================================================================                                                        
================================================================================                                                        
linux-ppc64le                                                                                                                           
linux-ppc64le::libnvjitlink-12.4.127-h46f38da_0.conda                                                                                   
linux-ppc64le::libnvjitlink-12.4.127-h46f38da_1.conda                                                                                   
linux-ppc64le::libnvjitlink-12.4.127-h4d352a9_2.conda                                                                                   
-    "cuda-version >=12.4,<12.5.0a0",                                                                                                   
+    "cuda-version>=12.0.0,<12.5.0a0",                                                                                                  
linux-ppc64le::libnvjitlink-12.3.101-h46f38da_0.conda                                                                                   
linux-ppc64le::libnvjitlink-12.3.101-h46f38da_1.conda                                                                                   
-    "cuda-version >=12.3,<12.4.0a0",                                                                                                   
+    "cuda-version>=12.0.0,<12.4.0a0",                                                                                                  
linux-ppc64le::libnvjitlink-12.2.140-h46f38da_0.conda                                                                                   
-    "cuda-version >=12.2,<12.3.0a0",                                                                                                   
+    "cuda-version>=12.0.0,<12.3.0a0",                                                                                                  
linux-ppc64le::libnvjitlink-12.1.105-h46f38da_0.conda                                                                                   
-    "cuda-version >=12.1,<12.2.0a0",                                                                                                   
+    "cuda-version>=12.0.0,<12.2.0a0",                                                                                                  
================================================================================                                                        
================================================================================                                                                                                                                                                                                
osx-arm64                                                                                                                               
================================================================================                                                        
================================================================================                                                        
linux-aarch64                                                                                                                           
linux-aarch64::libnvjitlink-12.4.127-h614329b_2.conda                                                                                                                                                                                                                                                                                                                                                                                 
linux-aarch64::libnvjitlink-12.4.127-hac28a21_0.conda                                                                                   
linux-aarch64::libnvjitlink-12.4.127-hac28a21_1.conda                                                                                   
-    "cuda-version >=12.4,<12.5.0a0",                                                                                                   
+    "cuda-version>=12.0.0,<12.5.0a0",                                                                                                  
linux-aarch64::libnvjitlink-12.2.140-hac28a21_0.conda                                                                                   
-    "cuda-version >=12.2,<12.3.0a0",                                                                                                   
+    "cuda-version>=12.0.0,<12.3.0a0",                                                                                                  
linux-aarch64::libnvjitlink-12.5.40-h614329b_0.conda                                                                                    
linux-aarch64::libnvjitlink-12.5.82-h614329b_0.conda                                                                                    
-    "cuda-version >=12.5,<12.6.0a0",                                                                                                   
+    "cuda-version>=12.0.0,<12.6.0a0",                                                                                                  
linux-aarch64::libnvjitlink-12.3.101-hac28a21_0.conda                                                                                   
linux-aarch64::libnvjitlink-12.3.101-hac28a21_1.conda                                                                                   
-    "cuda-version >=12.3,<12.4.0a0",                                                                                                                                                                              
+    "cuda-version>=12.0.0,<12.4.0a0",                                                                                                                                                                             
linux-aarch64::libnvjitlink-12.1.105-hac28a21_0.conda                                                                                                                                                              
-    "cuda-version >=12.1,<12.2.0a0",                                                                                                                                                                              
+    "cuda-version>=12.0.0,<12.2.0a0",                                                                                                                                                                             
================================================================================                                                                                                
================================================================================                                                                                                
noarch                                                                                                                                                                          
================================================================================                                                                                                
================================================================================                                                                                                
win-64                                                                                                                                                                          
win-64::libnvjitlink-12.5.40-he0c23c2_0.conda                                                                                                                                   
win-64::libnvjitlink-12.5.82-he0c23c2_0.conda                                                                                                                                   
-    "cuda-version >=12.5,<12.6.0a0",                                                                                                                                           
+    "cuda-version>=12.0.0,<12.6.0a0",                                                                                                                                          
win-64::libnvjitlink-12.4.127-h63175ca_0.conda                                                                                                                                  
win-64::libnvjitlink-12.4.127-h63175ca_1.conda                                                                                                                                  
win-64::libnvjitlink-12.4.127-he0c23c2_2.conda                                                                                                                                  
-    "cuda-version >=12.4,<12.5.0a0",                                                                                                                                           
+    "cuda-version>=12.0.0,<12.5.0a0",                                                                                                                                          
win-64::libnvjitlink-12.3.101-h63175ca_0.conda                                                                                                                                  
win-64::libnvjitlink-12.3.101-h63175ca_1.conda                                                                                                                                  
-    "cuda-version >=12.3,<12.4.0a0",                                                                                                                                           
+    "cuda-version>=12.0.0,<12.4.0a0",                                                                                                                                          
win-64::libnvjitlink-12.1.105-h63175ca_0.conda                                                                                                                                  
-    "cuda-version >=12.1,<12.2.0a0",                                                                                                                                           
+    "cuda-version>=12.0.0,<12.2.0a0",                                                                                                                                          
win-64::libnvjitlink-12.2.140-h63175ca_0.conda                                                                                                                                  
-    "cuda-version >=12.2,<12.3.0a0",                                                                                                                                           
+    "cuda-version>=12.0.0,<12.3.0a0",                                                                                                                                          
================================================================================                                                                                                                                                
================================================================================                                                                                                
osx-64                                                                                                                                                                          
================================================================================                                                                                                
================================================================================                                                                                                
linux-64                                                                                                                                                                        
linux-64::libnvjitlink-12.2.140-hd3aeb46_0.conda                                                                                                                                
-    "cuda-version >=12.2,<12.3.0a0",                                                                                                                                           
+    "cuda-version>=12.0.0,<12.3.0a0",                                                                                                                                          
linux-64::libnvjitlink-12.1.105-hd3aeb46_0.conda                                                                                                                                
-    "cuda-version >=12.1,<12.2.0a0",                                                                                                                                           
+    "cuda-version>=12.0.0,<12.2.0a0",                                                                                                                                          
linux-64::libnvjitlink-12.3.101-hd3aeb46_0.conda                                                                                                                                
linux-64::libnvjitlink-12.3.101-hd3aeb46_1.conda                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     "dgx02" 10:10 02-Jul-25
-    "cuda-version >=12.3,<12.4.0a0",                                                                                                                                           
+    "cuda-version>=12.0.0,<12.4.0a0",                                                                                                                                          
linux-64::libnvjitlink-12.4.127-hd3aeb46_0.conda                                                                                                                                
linux-64::libnvjitlink-12.4.127-hd3aeb46_1.conda                                                                                                                                
linux-64::libnvjitlink-12.4.127-he02047a_2.conda                                                                                                                                
-    "cuda-version >=12.4,<12.5.0a0",                                                                                                                                           
+    "cuda-version>=12.0.0,<12.5.0a0",                                                                                                                                          
linux-64::libnvjitlink-12.5.40-he02047a_0.conda                                                                                                                                 
linux-64::libnvjitlink-12.5.82-he02047a_0.conda                                                                                                                                 
-    "cuda-version >=12.5,<12.6.0a0",                                                                                                                                           
+    "cuda-version>=12.0.0,<12.6.0a0",   
```


</details>


xref https://github.com/conda-forge/libnvjitlink-feedstock/issues/28