### PR TITLE
[statsmodels]: Add scipy <1.16.0 pin to 0.14.0

### DIFF
--- a/recipe/patch_yaml/statsmodels.yaml
+++ b/recipe/patch_yaml/statsmodels.yaml
@@ -1,4 +1,5 @@
 # https://github.com/conda-forge/statsmodels-feedstock/pull/72
+# https://github.com/conda-forge/statsmodels-feedstock/pull/73
 if:
   name: statsmodels
   timestamp_le: 1751302301000  # 2025-06-30
@@ -18,3 +19,6 @@ then:
   - replace_depends:
       old: scipy !=1.9.2,>=1.8
       new: scipy >=1.8,!=1.9.2,<1.16.0a0
+  - replace_depends:
+      old: scipy !=1.9.2,>=1.4
+      new: scipy >=1.4,!=1.9.2,<1.16.0a0


### PR DESCRIPTION
Checklist

* [X] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [X] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
See https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/1044#issuecomment-3032839736 and https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/1044#issuecomment-3033559051.

