### PR TITLE
Relax `libcusparse` `libnvjitlink` dependency to match the major cuda version

### DIFF
--- a/recipe/patch_yaml/libcusparse.yaml
+++ b/recipe/patch_yaml/libcusparse.yaml
@@ -1,0 +1,135 @@
+---
+if:
+  name: libcusparse
+  version: 12.0.0.76
+  timestamp_lt: 1751987921000
+then:
+  - replace_depends:
+      old: libnvjitlink >=12.0.76,<12.1.0a0
+      new: libnvjitlink >=12.0.76,<13
+---
+if:
+  name: libcusparse
+  version: 12.1.0.106
+  timestamp_lt: 1751987921000
+then:
+  - replace_depends:
+      old: libnvjitlink >=12.1.105,<12.2.0a0
+      new: libnvjitlink >=12.1.105,<13
+---
+if:
+  name: libcusparse
+  version: 12.1.2.141
+  timestamp_lt: 1751987921000
+then:
+  - replace_depends:
+      old: libnvjitlink >=12.2.140,<12.3.0a0
+      new: libnvjitlink >=12.2.140,<13
+---
+if:
+  name: libcusparse
+  version: 12.2.0.103
+  timestamp_lt: 1751987921000
+then:
+  - replace_depends:
+      old: libnvjitlink >=12.3.101,<12.4.0a0
+      new: libnvjitlink >=12.3.101,<13
+---
+if:
+  name: libcusparse
+  version: 12.3.0.142
+  timestamp_lt: 1751987921000
+then:
+  - replace_depends:
+      old: libnvjitlink >=12.4.99,<12.5.0a0
+      new: libnvjitlink >=12.4.99,<13
+---
+if:
+  name: libcusparse
+  version: 12.3.1.170
+  timestamp_lt: 1751987921000
+then:
+  - replace_depends:
+      old: libnvjitlink >=12.4.127,<12.5.0a0
+      new: libnvjitlink >=12.4.127,<13
+---
+if:
+  name: libcusparse
+  version: 12.4.1.24
+  timestamp_lt: 1751987921000
+then:
+  - replace_depends:
+      old: libnvjitlink >=12.5.40,<12.6.0a0
+      new: libnvjitlink >=12.5.40,<13
+---
+if:
+  name: libcusparse
+  version: 12.5.1.3
+  timestamp_lt: 1751987921000
+then:
+  - replace_depends:
+      old: libnvjitlink >=12.5.82,<12.6.0a0
+      new: libnvjitlink >=12.5.82,<13
+---
+if:
+  name: libcusparse
+  version: 12.5.2.23
+  timestamp_lt: 1751987921000
+then:
+  - replace_depends:
+      old: libnvjitlink >=12.6.20,<12.7.0a0
+      new: libnvjitlink >=12.6.20,<13
+---
+if:
+  name: libcusparse
+  version: 12.5.3.3
+  timestamp_lt: 1751987921000
+then:
+  - replace_depends:
+      old: libnvjitlink >=12.6.68,<12.7.0a0
+      new: libnvjitlink >=12.6.68,<13
+---
+if:
+  name: libcusparse
+  version: 12.5.4.2
+  timestamp_lt: 1751987921000
+then:
+  - replace_depends:
+      old: libnvjitlink >=12.6.77,<12.7.0a0
+      new: libnvjitlink >=12.6.77,<13
+---
+if:
+  name: libcusparse
+  version: 12.5.7.53
+  timestamp_lt: 1751987921000
+then:
+  - replace_depends:
+      old: libnvjitlink >=12.8.61,<12.9.0a0
+      new: libnvjitlink >=12.8.61,<13
+---
+if:
+  name: libcusparse
+  version: 12.5.8.93
+  timestamp_lt: 1751987921000
+then:
+  - replace_depends:
+      old: libnvjitlink >=12.8.93,<12.9.0a0
+      new: libnvjitlink >=12.8.93,<13
+---
+if:
+  name: libcusparse
+  version: 12.5.9.5
+  timestamp_lt: 1751987921000
+then:
+  - replace_depends:
+      old: libnvjitlink >=12.9.41,<12.10.0a0
+      new: libnvjitlink >=12.9.41,<13
+---
+if:
+  name: libcusparse
+  version: 12.5.10.65
+  timestamp_lt: 1751987921000
+then:
+  - replace_depends:
+      old: libnvjitlink >=12.9.86,<12.10.0a0
+      new: libnvjitlink >=12.9.86,<13

--- a/recipe/patch_yaml/libcusparse.yaml
+++ b/recipe/patch_yaml/libcusparse.yaml
@@ -6,7 +6,7 @@ if:
 then:
   - replace_depends:
       old: libnvjitlink >=12.0.76,<12.1.0a0
-      new: libnvjitlink >=12.0.76,<13
+      new: libnvjitlink >=12.0.76,<13.0a0
 ---
 if:
   name: libcusparse
@@ -15,7 +15,7 @@ if:
 then:
   - replace_depends:
       old: libnvjitlink >=12.1.105,<12.2.0a0
-      new: libnvjitlink >=12.1.105,<13
+      new: libnvjitlink >=12.1.105,<13.0a0
 ---
 if:
   name: libcusparse
@@ -24,7 +24,7 @@ if:
 then:
   - replace_depends:
       old: libnvjitlink >=12.2.140,<12.3.0a0
-      new: libnvjitlink >=12.2.140,<13
+      new: libnvjitlink >=12.2.140,<13.0a0
 ---
 if:
   name: libcusparse
@@ -33,7 +33,7 @@ if:
 then:
   - replace_depends:
       old: libnvjitlink >=12.3.101,<12.4.0a0
-      new: libnvjitlink >=12.3.101,<13
+      new: libnvjitlink >=12.3.101,<13.0a0
 ---
 if:
   name: libcusparse
@@ -42,7 +42,7 @@ if:
 then:
   - replace_depends:
       old: libnvjitlink >=12.4.99,<12.5.0a0
-      new: libnvjitlink >=12.4.99,<13
+      new: libnvjitlink >=12.4.99,<13.0a0
 ---
 if:
   name: libcusparse
@@ -51,7 +51,7 @@ if:
 then:
   - replace_depends:
       old: libnvjitlink >=12.4.127,<12.5.0a0
-      new: libnvjitlink >=12.4.127,<13
+      new: libnvjitlink >=12.4.127,<13.0a0
 ---
 if:
   name: libcusparse
@@ -60,7 +60,7 @@ if:
 then:
   - replace_depends:
       old: libnvjitlink >=12.5.40,<12.6.0a0
-      new: libnvjitlink >=12.5.40,<13
+      new: libnvjitlink >=12.5.40,<13.0a0
 ---
 if:
   name: libcusparse
@@ -69,7 +69,7 @@ if:
 then:
   - replace_depends:
       old: libnvjitlink >=12.5.82,<12.6.0a0
-      new: libnvjitlink >=12.5.82,<13
+      new: libnvjitlink >=12.5.82,<13.0a0
 ---
 if:
   name: libcusparse
@@ -78,7 +78,7 @@ if:
 then:
   - replace_depends:
       old: libnvjitlink >=12.6.20,<12.7.0a0
-      new: libnvjitlink >=12.6.20,<13
+      new: libnvjitlink >=12.6.20,<13.0a0
 ---
 if:
   name: libcusparse
@@ -87,7 +87,7 @@ if:
 then:
   - replace_depends:
       old: libnvjitlink >=12.6.68,<12.7.0a0
-      new: libnvjitlink >=12.6.68,<13
+      new: libnvjitlink >=12.6.68,<13.0a0
 ---
 if:
   name: libcusparse
@@ -96,7 +96,7 @@ if:
 then:
   - replace_depends:
       old: libnvjitlink >=12.6.77,<12.7.0a0
-      new: libnvjitlink >=12.6.77,<13
+      new: libnvjitlink >=12.6.77,<13.0a0
 ---
 if:
   name: libcusparse
@@ -105,7 +105,7 @@ if:
 then:
   - replace_depends:
       old: libnvjitlink >=12.8.61,<12.9.0a0
-      new: libnvjitlink >=12.8.61,<13
+      new: libnvjitlink >=12.8.61,<13.0a0
 ---
 if:
   name: libcusparse
@@ -114,7 +114,7 @@ if:
 then:
   - replace_depends:
       old: libnvjitlink >=12.8.93,<12.9.0a0
-      new: libnvjitlink >=12.8.93,<13
+      new: libnvjitlink >=12.8.93,<13.0a0
 ---
 if:
   name: libcusparse
@@ -123,7 +123,7 @@ if:
 then:
   - replace_depends:
       old: libnvjitlink >=12.9.41,<12.10.0a0
-      new: libnvjitlink >=12.9.41,<13
+      new: libnvjitlink >=12.9.41,<13.0a0
 ---
 if:
   name: libcusparse
@@ -132,4 +132,4 @@ if:
 then:
   - replace_depends:
       old: libnvjitlink >=12.9.86,<12.10.0a0
-      new: libnvjitlink >=12.9.86,<13
+      new: libnvjitlink >=12.9.86,<13.0a0


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

Backport https://github.com/conda-forge/libcusparse-feedstock/pull/26


`show_diff` output:
<details>

```
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
linux-ppc64le
linux-ppc64le::libcusparse-12.3.0.142-h46f38da_0.conda
-    "libnvjitlink >=12.4.99,<12.5.0a0",
+    "libnvjitlink >=12.4.99,<13",
linux-ppc64le::libcusparse-12.1.2.141-h46f38da_0.conda
-    "libnvjitlink >=12.2.140,<12.3.0a0",
+    "libnvjitlink >=12.2.140,<13",
linux-ppc64le::libcusparse-12.0.0.76-h46f38da_2.conda
linux-ppc64le::libcusparse-12.0.0.76-h883269e_0.conda
linux-ppc64le::libcusparse-12.0.0.76-h883269e_1.conda
-    "libnvjitlink >=12.0.76,<12.1.0a0",
+    "libnvjitlink >=12.0.76,<13",
linux-ppc64le::libcusparse-12.1.0.106-h46f38da_0.conda
-    "libnvjitlink >=12.1.105,<12.2.0a0",
+    "libnvjitlink >=12.1.105,<13",
linux-ppc64le::libcusparse-12.3.1.170-h46f38da_0.conda
linux-ppc64le::libcusparse-12.3.1.170-h46f38da_1.conda
linux-ppc64le::libcusparse-12.3.1.170-h4d352a9_2.conda
-    "libnvjitlink >=12.4.127,<12.5.0a0",
+    "libnvjitlink >=12.4.127,<13",
linux-ppc64le::libcusparse-12.2.0.103-h46f38da_0.conda
linux-ppc64le::libcusparse-12.2.0.103-h46f38da_1.conda
-    "libnvjitlink >=12.3.101,<12.4.0a0",
+    "libnvjitlink >=12.3.101,<13",
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-aarch64
linux-aarch64::libcusparse-12.3.1.170-h614329b_2.conda
linux-aarch64::libcusparse-12.3.1.170-hac28a21_0.conda
linux-aarch64::libcusparse-12.3.1.170-hac28a21_1.conda
-    "libnvjitlink >=12.4.127,<12.5.0a0",
+    "libnvjitlink >=12.4.127,<13",
linux-aarch64::libcusparse-12.5.3.3-h3ae8b8a_0.conda
-    "libnvjitlink >=12.6.68,<12.7.0a0",
+    "libnvjitlink >=12.6.68,<13",
linux-aarch64::libcusparse-12.5.7.53-h5101a13_0.conda
-    "libnvjitlink >=12.8.61,<12.9.0a0",
+    "libnvjitlink >=12.8.61,<13",
linux-aarch64::libcusparse-12.5.10.65-h3ae8b8a_0.conda
-    "libnvjitlink >=12.9.86,<12.10.0a0",
+    "libnvjitlink >=12.9.86,<13",
linux-aarch64::libcusparse-12.5.1.3-h614329b_0.conda
-    "libnvjitlink >=12.5.82,<12.6.0a0",
+    "libnvjitlink >=12.5.82,<13",
linux-aarch64::libcusparse-12.5.9.5-h3ae8b8a_0.conda
-    "libnvjitlink >=12.9.41,<12.10.0a0",
+    "libnvjitlink >=12.9.41,<13",
linux-aarch64::libcusparse-12.0.0.76-ha21bd82_0.conda
linux-aarch64::libcusparse-12.0.0.76-ha21bd82_1.conda
linux-aarch64::libcusparse-12.0.0.76-hac28a21_2.conda
-    "libnvjitlink >=12.0.76,<12.1.0a0",
+    "libnvjitlink >=12.0.76,<13",
linux-aarch64::libcusparse-12.5.4.2-h5101a13_0.conda
-    "libnvjitlink >=12.6.77,<12.7.0a0",
+    "libnvjitlink >=12.6.77,<13",
linux-aarch64::libcusparse-12.1.0.106-hac28a21_0.conda
-    "libnvjitlink >=12.1.105,<12.2.0a0",
+    "libnvjitlink >=12.1.105,<13",
linux-aarch64::libcusparse-12.5.2.23-h614329b_0.conda
-    "libnvjitlink >=12.6.20,<12.7.0a0",
+    "libnvjitlink >=12.6.20,<13",
linux-aarch64::libcusparse-12.2.0.103-hac28a21_0.conda
linux-aarch64::libcusparse-12.2.0.103-hac28a21_1.conda
-    "libnvjitlink >=12.3.101,<12.4.0a0",
+    "libnvjitlink >=12.3.101,<13",
linux-aarch64::libcusparse-12.5.8.93-h3ae8b8a_1.conda
-    "libnvjitlink >=12.8.93,<12.9.0a0",
+    "libnvjitlink >=12.8.93,<13",
linux-aarch64::libcusparse-12.1.2.141-hac28a21_0.conda
-    "libnvjitlink >=12.2.140,<12.3.0a0",
+    "libnvjitlink >=12.2.140,<13",
linux-aarch64::libcusparse-12.3.0.142-hac28a21_0.conda
-    "libnvjitlink >=12.4.99,<12.5.0a0",
+    "libnvjitlink >=12.4.99,<13",
linux-aarch64::libcusparse-12.4.1.24-h614329b_0.conda
-    "libnvjitlink >=12.5.40,<12.6.0a0",
+    "libnvjitlink >=12.5.40,<13",
================================================================================
================================================================================
noarch
================================================================================
================================================================================
win-64
win-64::libcusparse-12.5.3.3-he0c23c2_0.conda
-    "libnvjitlink >=12.6.68,<12.7.0a0",
+    "libnvjitlink >=12.6.68,<13",
win-64::libcusparse-12.3.0.142-h63175ca_0.conda
-    "libnvjitlink >=12.4.99,<12.5.0a0",
+    "libnvjitlink >=12.4.99,<13",
win-64::libcusparse-12.5.9.5-he0c23c2_0.conda
-    "libnvjitlink >=12.9.41,<12.10.0a0",
+    "libnvjitlink >=12.9.41,<13",
win-64::libcusparse-12.5.10.65-he0c23c2_0.conda
-    "libnvjitlink >=12.9.86,<12.10.0a0",
+    "libnvjitlink >=12.9.86,<13",
win-64::libcusparse-12.0.0.76-h63175ca_0.conda
win-64::libcusparse-12.0.0.76-h63175ca_1.conda
win-64::libcusparse-12.0.0.76-h63175ca_2.conda
-    "libnvjitlink >=12.0.76,<12.1.0a0",
+    "libnvjitlink >=12.0.76,<13",
win-64::libcusparse-12.3.1.170-h63175ca_0.conda
win-64::libcusparse-12.3.1.170-h63175ca_1.conda
win-64::libcusparse-12.3.1.170-he0c23c2_2.conda
-    "libnvjitlink >=12.4.127,<12.5.0a0",
+    "libnvjitlink >=12.4.127,<13",
win-64::libcusparse-12.5.1.3-he0c23c2_0.conda
-    "libnvjitlink >=12.5.82,<12.6.0a0",
+    "libnvjitlink >=12.5.82,<13",
win-64::libcusparse-12.1.2.141-h63175ca_0.conda
-    "libnvjitlink >=12.2.140,<12.3.0a0",
+    "libnvjitlink >=12.2.140,<13",
win-64::libcusparse-12.5.7.53-he0c23c2_0.conda
-    "libnvjitlink >=12.8.61,<12.9.0a0",
+    "libnvjitlink >=12.8.61,<13",
win-64::libcusparse-12.4.1.24-he0c23c2_0.conda
-    "libnvjitlink >=12.5.40,<12.6.0a0",
+    "libnvjitlink >=12.5.40,<13",
win-64::libcusparse-12.1.0.106-h63175ca_0.conda
-    "libnvjitlink >=12.1.105,<12.2.0a0",
+    "libnvjitlink >=12.1.105,<13",
win-64::libcusparse-12.5.4.2-he0c23c2_0.conda
-    "libnvjitlink >=12.6.77,<12.7.0a0",
+    "libnvjitlink >=12.6.77,<13",
win-64::libcusparse-12.2.0.103-h63175ca_0.conda
win-64::libcusparse-12.2.0.103-h63175ca_1.conda
-    "libnvjitlink >=12.3.101,<12.4.0a0",
+    "libnvjitlink >=12.3.101,<13",
win-64::libcusparse-12.5.2.23-he0c23c2_0.conda
-    "libnvjitlink >=12.6.20,<12.7.0a0",
+    "libnvjitlink >=12.6.20,<13",
win-64::libcusparse-12.5.8.93-he0c23c2_1.conda
-    "libnvjitlink >=12.8.93,<12.9.0a0",
+    "libnvjitlink >=12.8.93,<13",
================================================================================
================================================================================
osx-64
================================================================================
================================================================================
linux-64
linux-64::libcusparse-12.0.0.76-hcb278e6_0.conda
linux-64::libcusparse-12.0.0.76-hcb278e6_1.conda
linux-64::libcusparse-12.0.0.76-hd3aeb46_2.conda
-    "libnvjitlink >=12.0.76,<12.1.0a0",
+    "libnvjitlink >=12.0.76,<13",
linux-64::libcusparse-12.3.1.170-hd3aeb46_0.conda
linux-64::libcusparse-12.3.1.170-hd3aeb46_1.conda
linux-64::libcusparse-12.3.1.170-he02047a_2.conda
-    "libnvjitlink >=12.4.127,<12.5.0a0",
+    "libnvjitlink >=12.4.127,<13",
linux-64::libcusparse-12.5.7.53-hbd13f7d_0.conda
-    "libnvjitlink >=12.8.61,<12.9.0a0",
+    "libnvjitlink >=12.8.61,<13",
linux-64::libcusparse-12.5.8.93-h5888daf_1.conda
-    "libnvjitlink >=12.8.93,<12.9.0a0",
+    "libnvjitlink >=12.8.93,<13",
linux-64::libcusparse-12.5.3.3-h5888daf_0.conda
-    "libnvjitlink >=12.6.68,<12.7.0a0",
+    "libnvjitlink >=12.6.68,<13",
linux-64::libcusparse-12.1.0.106-hd3aeb46_0.conda
-    "libnvjitlink >=12.1.105,<12.2.0a0",
+    "libnvjitlink >=12.1.105,<13",
linux-64::libcusparse-12.1.2.141-hd3aeb46_0.conda
-    "libnvjitlink >=12.2.140,<12.3.0a0",
+    "libnvjitlink >=12.2.140,<13",
linux-64::libcusparse-12.4.1.24-he02047a_0.conda
-    "libnvjitlink >=12.5.40,<12.6.0a0",
+    "libnvjitlink >=12.5.40,<13",
linux-64::libcusparse-12.3.0.142-hd3aeb46_0.conda
-    "libnvjitlink >=12.4.99,<12.5.0a0",
+    "libnvjitlink >=12.4.99,<13",
linux-64::libcusparse-12.5.2.23-he02047a_0.conda
-    "libnvjitlink >=12.6.20,<12.7.0a0",
+    "libnvjitlink >=12.6.20,<13",
linux-64::libcusparse-12.5.1.3-he02047a_0.conda
-    "libnvjitlink >=12.5.82,<12.6.0a0",
+    "libnvjitlink >=12.5.82,<13",
linux-64::libcusparse-12.5.9.5-h5888daf_0.conda
-    "libnvjitlink >=12.9.41,<12.10.0a0",
+    "libnvjitlink >=12.9.41,<13",
linux-64::libcusparse-12.5.4.2-hbd13f7d_0.conda
-    "libnvjitlink >=12.6.77,<12.7.0a0",
+    "libnvjitlink >=12.6.77,<13",
linux-64::libcusparse-12.2.0.103-hd3aeb46_0.conda
linux-64::libcusparse-12.2.0.103-hd3aeb46_1.conda
-    "libnvjitlink >=12.3.101,<12.4.0a0",
+    "libnvjitlink >=12.3.101,<13",
linux-64::libcusparse-12.5.10.65-h5888daf_0.conda
-    "libnvjitlink >=12.9.86,<12.10.0a0",
+    "libnvjitlink >=12.9.86,<13",

```

</details>
