### PR TITLE
Relax `libcusolver` `libnvjitlink` dependency to match the major CUDA version

### DIFF
--- a/recipe/patch_yaml/libcusolver.yaml
+++ b/recipe/patch_yaml/libcusolver.yaml
@@ -1,0 +1,135 @@
+---
+if:
+  name: libcusolver
+  version: 11.4.2.57
+  timestamp_lt: 1751987921000
+then:
+  - replace_depends:
+      old: libnvjitlink >=12.0.76,<12.1.0a0
+      new: libnvjitlink >=12.0.76,<13.0a0
+---
+if:
+  name: libcusolver
+  version: 11.4.5.107
+  timestamp_lt: 1751987921000
+then:
+  - replace_depends:
+      old: libnvjitlink >=12.1.105,<12.2.0a0
+      new: libnvjitlink >=12.1.105,<13.0a0
+---
+if:
+  name: libcusolver
+  version: 11.5.2.141
+  timestamp_lt: 1751987921000
+then:
+  - replace_depends:
+      old: libnvjitlink >=12.2.140,<12.3.0a0
+      new: libnvjitlink >=12.2.140,<13.0a0
+---
+if:
+  name: libcusolver
+  version: 11.5.4.101
+  timestamp_lt: 1751987921000
+then:
+  - replace_depends:
+      old: libnvjitlink >=12.3.101,<12.4.0a0
+      new: libnvjitlink >=12.3.101,<13.0a0
+---
+if:
+  name: libcusolver
+  version: 11.6.0.99
+  timestamp_lt: 1751987921000
+then:
+  - replace_depends:
+      old: libnvjitlink >=12.4.99,<12.5.0a0
+      new: libnvjitlink >=12.4.99,<13.0a0
+---
+if:
+  name: libcusolver
+  version: 11.6.1.9
+  timestamp_lt: 1751987921000
+then:
+  - replace_depends:
+      old: libnvjitlink >=12.4.127,<12.5.0a0
+      new: libnvjitlink >=12.4.127,<13.0a0
+---
+if:
+  name: libcusolver
+  version: 11.6.2.40
+  timestamp_lt: 1751987921000
+then:
+  - replace_depends:
+      old: libnvjitlink >=12.5.40,<12.6.0a0
+      new: libnvjitlink >=12.5.40,<13.0a0
+---
+if:
+  name: libcusolver
+  version: 11.6.3.83
+  timestamp_lt: 1751987921000
+then:
+  - replace_depends:
+      old: libnvjitlink >=12.5.82,<12.6.0a0
+      new: libnvjitlink >=12.5.82,<13.0a0
+---
+if:
+  name: libcusolver
+  version: 11.6.4.38
+  timestamp_lt: 1751987921000
+then:
+  - replace_depends:
+      old: libnvjitlink >=12.6.20,<12.7.0a0
+      new: libnvjitlink >=12.6.20,<13.0a0
+---
+if:
+  name: libcusolver
+  version: 11.6.4.69
+  timestamp_lt: 1751987921000
+then:
+  - replace_depends:
+      old: libnvjitlink >=12.6.68,<12.7.0a0
+      new: libnvjitlink >=12.6.68,<13.0a0
+---
+if:
+  name: libcusolver
+  version: 11.7.1.2
+  timestamp_lt: 1751987921000
+then:
+  - replace_depends:
+      old: libnvjitlink >=12.6.77,<12.7.0a0
+      new: libnvjitlink >=12.6.77,<13.0a0
+---
+if:
+  name: libcusolver
+  version: 11.7.2.55
+  timestamp_lt: 1751987921000
+then:
+  - replace_depends:
+      old: libnvjitlink >=12.8.61,<12.9.0a0
+      new: libnvjitlink >=12.8.61,<13.0a0
+---
+if:
+  name: libcusolver
+  version: 11.7.3.90
+  timestamp_lt: 1751987921000
+then:
+  - replace_depends:
+      old: libnvjitlink >=12.8.93,<12.9.0a0
+      new: libnvjitlink >=12.8.93,<13.0a0
+---
+if:
+  name: libcusolver
+  version: 11.7.4.40
+  timestamp_lt: 1751987921000
+then:
+  - replace_depends:
+      old: libnvjitlink >=12.9.41,<12.10.0a0
+      new: libnvjitlink >=12.9.41,<13.0a0
+---
+if:
+  name: libcusolver
+  version: 11.7.5.82
+  timestamp_lt: 1751987921000
+then:
+  - replace_depends:
+      old: libnvjitlink >=12.9.86,<12.10.0a0
+      new: libnvjitlink >=12.9.86,<13.0a0


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

Backports changes from https://github.com/conda-forge/libcusolver-feedstock/pull/29.

Similar to https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/1048 but for `libcusolver` instead of `libcusparse`.

cc: @brandon-b-miller

`show_diff.py` output:

<details>

```diff
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
linux-ppc64le
linux-ppc64le::libcusolver-11.4.5.107-h46f38da_0.conda
-    "libnvjitlink >=12.1.105,<12.2.0a0",
+    "libnvjitlink >=12.1.105,<13.0a0",
linux-ppc64le::libcusolver-11.5.4.101-h46f38da_1.conda
linux-ppc64le::libcusolver-11.5.4.101-h46f38da_0.conda
-    "libnvjitlink >=12.3.101,<12.4.0a0",
+    "libnvjitlink >=12.3.101,<13.0a0",
linux-ppc64le::libcusolver-11.4.2.57-h883269e_1.conda
linux-ppc64le::libcusolver-11.4.2.57-h883269e_0.conda
linux-ppc64le::libcusolver-11.4.2.57-h46f38da_2.conda
-    "libnvjitlink >=12.0.76,<12.1.0a0",
+    "libnvjitlink >=12.0.76,<13.0a0",
linux-ppc64le::libcusolver-11.6.1.9-h4d352a9_2.conda
linux-ppc64le::libcusolver-11.6.1.9-h46f38da_0.conda
linux-ppc64le::libcusolver-11.6.1.9-h46f38da_1.conda
-    "libnvjitlink >=12.4.127,<12.5.0a0",
+    "libnvjitlink >=12.4.127,<13.0a0",
linux-ppc64le::libcusolver-11.6.0.99-h46f38da_0.conda
-    "libnvjitlink >=12.4.99,<12.5.0a0",
+    "libnvjitlink >=12.4.99,<13.0a0",
linux-ppc64le::libcusolver-11.5.2.141-h46f38da_0.conda
-    "libnvjitlink >=12.2.140,<12.3.0a0",
+    "libnvjitlink >=12.2.140,<13.0a0",
================================================================================
================================================================================
linux-aarch64
linux-aarch64::libcusolver-11.6.2.40-h614329b_0.conda
-    "libnvjitlink >=12.5.40,<12.6.0a0",
+    "libnvjitlink >=12.5.40,<13.0a0",
linux-aarch64::libcusolver-11.4.2.57-ha21bd82_0.conda
linux-aarch64::libcusolver-11.4.2.57-hac28a21_2.conda
linux-aarch64::libcusolver-11.4.2.57-ha21bd82_1.conda
-    "libnvjitlink >=12.0.76,<12.1.0a0",
+    "libnvjitlink >=12.0.76,<13.0a0",
linux-aarch64::libcusolver-11.7.3.90-hd55a8e4_1.conda
linux-aarch64::libcusolver-11.7.3.90-hd55a8e4_0.conda
-    "libnvjitlink >=12.8.93,<12.9.0a0",
+    "libnvjitlink >=12.8.93,<13.0a0",
linux-aarch64::libcusolver-11.6.4.38-h614329b_0.conda
-    "libnvjitlink >=12.6.20,<12.7.0a0",
+    "libnvjitlink >=12.6.20,<13.0a0",
linux-aarch64::libcusolver-11.7.5.82-hd55a8e4_0.conda
-    "libnvjitlink >=12.9.86,<12.10.0a0",
+    "libnvjitlink >=12.9.86,<13.0a0",
linux-aarch64::libcusolver-11.5.4.101-hac28a21_1.conda
linux-aarch64::libcusolver-11.5.4.101-hac28a21_0.conda
-    "libnvjitlink >=12.3.101,<12.4.0a0",
+    "libnvjitlink >=12.3.101,<13.0a0",
linux-aarch64::libcusolver-11.5.2.141-hac28a21_0.conda
-    "libnvjitlink >=12.2.140,<12.3.0a0",
+    "libnvjitlink >=12.2.140,<13.0a0",
linux-aarch64::libcusolver-11.7.2.55-hd55a8e4_0.conda
-    "libnvjitlink >=12.8.61,<12.9.0a0",
+    "libnvjitlink >=12.8.61,<13.0a0",
linux-aarch64::libcusolver-11.7.4.40-hd55a8e4_0.conda
-    "libnvjitlink >=12.9.41,<12.10.0a0",
+    "libnvjitlink >=12.9.41,<13.0a0",
linux-aarch64::libcusolver-11.7.1.2-h5101a13_0.conda
-    "libnvjitlink >=12.6.77,<12.7.0a0",
+    "libnvjitlink >=12.6.77,<13.0a0",
linux-aarch64::libcusolver-11.6.4.69-h3ae8b8a_0.conda
-    "libnvjitlink >=12.6.68,<12.7.0a0",
+    "libnvjitlink >=12.6.68,<13.0a0",
linux-aarch64::libcusolver-11.6.1.9-hac28a21_0.conda
linux-aarch64::libcusolver-11.6.1.9-h614329b_2.conda
linux-aarch64::libcusolver-11.6.1.9-hac28a21_1.conda
-    "libnvjitlink >=12.4.127,<12.5.0a0",
+    "libnvjitlink >=12.4.127,<13.0a0",
linux-aarch64::libcusolver-11.4.5.107-hac28a21_0.conda
-    "libnvjitlink >=12.1.105,<12.2.0a0",
+    "libnvjitlink >=12.1.105,<13.0a0",
linux-aarch64::libcusolver-11.6.3.83-h614329b_0.conda
-    "libnvjitlink >=12.5.82,<12.6.0a0",
+    "libnvjitlink >=12.5.82,<13.0a0",
linux-aarch64::libcusolver-11.6.0.99-hac28a21_0.conda
-    "libnvjitlink >=12.4.99,<12.5.0a0",
+    "libnvjitlink >=12.4.99,<13.0a0",
================================================================================
================================================================================
noarch
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-64
linux-64::libcusolver-11.5.2.141-hd3aeb46_0.conda
-    "libnvjitlink >=12.2.140,<12.3.0a0",
+    "libnvjitlink >=12.2.140,<13.0a0",
linux-64::libcusolver-11.6.3.83-he02047a_0.conda
-    "libnvjitlink >=12.5.82,<12.6.0a0",
+    "libnvjitlink >=12.5.82,<13.0a0",
linux-64::libcusolver-11.4.2.57-hcb278e6_0.conda
linux-64::libcusolver-11.4.2.57-hcb278e6_1.conda
linux-64::libcusolver-11.4.2.57-hd3aeb46_2.conda
-    "libnvjitlink >=12.0.76,<12.1.0a0",
+    "libnvjitlink >=12.0.76,<13.0a0",
linux-64::libcusolver-11.7.1.2-hbd13f7d_0.conda
-    "libnvjitlink >=12.6.77,<12.7.0a0",
+    "libnvjitlink >=12.6.77,<13.0a0",
linux-64::libcusolver-11.6.4.69-h5888daf_0.conda
-    "libnvjitlink >=12.6.68,<12.7.0a0",
+    "libnvjitlink >=12.6.68,<13.0a0",
linux-64::libcusolver-11.6.4.38-he02047a_0.conda
-    "libnvjitlink >=12.6.20,<12.7.0a0",
+    "libnvjitlink >=12.6.20,<13.0a0",
linux-64::libcusolver-11.5.4.101-hd3aeb46_1.conda
linux-64::libcusolver-11.5.4.101-hd3aeb46_0.conda
-    "libnvjitlink >=12.3.101,<12.4.0a0",
+    "libnvjitlink >=12.3.101,<13.0a0",
linux-64::libcusolver-11.7.2.55-h9ab20c4_0.conda
-    "libnvjitlink >=12.8.61,<12.9.0a0",
+    "libnvjitlink >=12.8.61,<13.0a0",
linux-64::libcusolver-11.7.5.82-h9ab20c4_0.conda
-    "libnvjitlink >=12.9.86,<12.10.0a0",
+    "libnvjitlink >=12.9.86,<13.0a0",
linux-64::libcusolver-11.6.2.40-he02047a_0.conda
-    "libnvjitlink >=12.5.40,<12.6.0a0",
+    "libnvjitlink >=12.5.40,<13.0a0",
linux-64::libcusolver-11.6.0.99-hd3aeb46_0.conda
-    "libnvjitlink >=12.4.99,<12.5.0a0",
+    "libnvjitlink >=12.4.99,<13.0a0",
linux-64::libcusolver-11.6.1.9-he02047a_2.conda
linux-64::libcusolver-11.6.1.9-hd3aeb46_0.conda
linux-64::libcusolver-11.6.1.9-hd3aeb46_1.conda
-    "libnvjitlink >=12.4.127,<12.5.0a0",
+    "libnvjitlink >=12.4.127,<13.0a0",
linux-64::libcusolver-11.7.3.90-h9ab20c4_0.conda
linux-64::libcusolver-11.7.3.90-h9ab20c4_1.conda
-    "libnvjitlink >=12.8.93,<12.9.0a0",
+    "libnvjitlink >=12.8.93,<13.0a0",
linux-64::libcusolver-11.7.4.40-h9ab20c4_0.conda
-    "libnvjitlink >=12.9.41,<12.10.0a0",
+    "libnvjitlink >=12.9.41,<13.0a0",
linux-64::libcusolver-11.4.5.107-hd3aeb46_0.conda
-    "libnvjitlink >=12.1.105,<12.2.0a0",
+    "libnvjitlink >=12.1.105,<13.0a0",
================================================================================
================================================================================
win-64
win-64::libcusolver-11.4.2.57-h63175ca_2.conda
win-64::libcusolver-11.4.2.57-h63175ca_1.conda
win-64::libcusolver-11.4.2.57-h63175ca_0.conda
-    "libnvjitlink >=12.0.76,<12.1.0a0",
+    "libnvjitlink >=12.0.76,<13.0a0",
win-64::libcusolver-11.7.4.40-he0c23c2_0.conda
-    "libnvjitlink >=12.9.41,<12.10.0a0",
+    "libnvjitlink >=12.9.41,<13.0a0",
win-64::libcusolver-11.7.1.2-he0c23c2_0.conda
-    "libnvjitlink >=12.6.77,<12.7.0a0",
+    "libnvjitlink >=12.6.77,<13.0a0",
win-64::libcusolver-11.7.2.55-he0c23c2_0.conda
-    "libnvjitlink >=12.8.61,<12.9.0a0",
+    "libnvjitlink >=12.8.61,<13.0a0",
win-64::libcusolver-11.6.4.38-he0c23c2_0.conda
-    "libnvjitlink >=12.6.20,<12.7.0a0",
+    "libnvjitlink >=12.6.20,<13.0a0",
win-64::libcusolver-11.7.3.90-he0c23c2_0.conda
win-64::libcusolver-11.7.3.90-he0c23c2_1.conda
-    "libnvjitlink >=12.8.93,<12.9.0a0",
+    "libnvjitlink >=12.8.93,<13.0a0",
win-64::libcusolver-11.5.4.101-h63175ca_1.conda
win-64::libcusolver-11.5.4.101-h63175ca_0.conda
-    "libnvjitlink >=12.3.101,<12.4.0a0",
+    "libnvjitlink >=12.3.101,<13.0a0",
win-64::libcusolver-11.7.5.82-he0c23c2_0.conda
-    "libnvjitlink >=12.9.86,<12.10.0a0",
+    "libnvjitlink >=12.9.86,<13.0a0",
win-64::libcusolver-11.6.2.40-he0c23c2_0.conda
-    "libnvjitlink >=12.5.40,<12.6.0a0",
+    "libnvjitlink >=12.5.40,<13.0a0",
win-64::libcusolver-11.6.3.83-he0c23c2_0.conda
-    "libnvjitlink >=12.5.82,<12.6.0a0",
+    "libnvjitlink >=12.5.82,<13.0a0",
win-64::libcusolver-11.6.1.9-h63175ca_1.conda
win-64::libcusolver-11.6.1.9-h63175ca_0.conda
win-64::libcusolver-11.6.1.9-he0c23c2_2.conda
-    "libnvjitlink >=12.4.127,<12.5.0a0",
+    "libnvjitlink >=12.4.127,<13.0a0",
win-64::libcusolver-11.5.2.141-h63175ca_0.conda
-    "libnvjitlink >=12.2.140,<12.3.0a0",
+    "libnvjitlink >=12.2.140,<13.0a0",
win-64::libcusolver-11.4.5.107-h63175ca_0.conda
-    "libnvjitlink >=12.1.105,<12.2.0a0",
+    "libnvjitlink >=12.1.105,<13.0a0",
win-64::libcusolver-11.6.0.99-h63175ca_0.conda
-    "libnvjitlink >=12.4.99,<12.5.0a0",
+    "libnvjitlink >=12.4.99,<13.0a0",
win-64::libcusolver-11.6.4.69-he0c23c2_0.conda
-    "libnvjitlink >=12.6.68,<12.7.0a0",
+    "libnvjitlink >=12.6.68,<13.0a0",
================================================================================
================================================================================
osx-64
```

</details>