### PR TITLE
adjust r-cowplot-1.2.0 r-ggplot2 dep

### DIFF
--- a/recipe/patch_yaml/r-cowplot.yaml
+++ b/recipe/patch_yaml/r-cowplot.yaml
@@ -1,4 +1,4 @@
-# cowplot v1.2.0 set its ggplot2 minimum to v3.5.2 
+# cowplot v1.2.0 set its ggplot2 minimum to v3.5.2
 # but this was not adjusted in build 0, hence the patch
 # see https://github.com/conda-forge/r-cowplot-feedstock/issues/24
 

--- a/recipe/patch_yaml/r-cowplot.yaml
+++ b/recipe/patch_yaml/r-cowplot.yaml
@@ -1,0 +1,13 @@
+# cowplot v1.2.0 set its ggplot2 minimum to v3.5.2 
+# but this was not adjusted in build 0, hence the patch
+# see https://github.com/conda-forge/r-cowplot-feedstock/issues/24
+
+if:
+  name: r-cowplot
+  version_in: ["1.2.0"]
+  build_number_in: [0]
+  timestamp_lt: 1752000000000
+then:
+  - replace_depends:
+      old: r-ggplot2*
+      new: r-ggplot2 >=3.5.2


### PR DESCRIPTION
The `r-cowplot` feedstock issued a v1.2.0 build (0) missing a dependency bound (`ggplot2 >=3.5.2`). This patches that.

See https://github.com/conda-forge/r-cowplot-feedstock/issues/24.

## Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

### `show_diff.py` output
<details>

```bash
> python show_diff.py
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
noarch
noarch::r-cowplot-1.2.0-r43hc72bb7e_0.conda
noarch::r-cowplot-1.2.0-r44hc72bb7e_0.conda
-    "r-ggplot2 >2.2.1",
+    "r-ggplot2 >=3.5.2",
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
================================================================================
================================================================================
linux-64
```

</details>