### PR TITLE
fix #960

### DIFF
--- a/recipe/patch_yaml/asapdiscovery.yaml
+++ b/recipe/patch_yaml/asapdiscovery.yaml
@@ -10,4 +10,4 @@ then:
       # str of thing to be replaced
       old: openfe >0.14.0*
       # thing to replace `old` with
-      new: openfe =>1.1.0
+      new: openfe >=1.1.0


### PR DESCRIPTION
spec `=>1.1.0` is invalid, must be `>=1.1.0`

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
