### PR TITLE
timebox libgfortran patch

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -379,7 +379,12 @@ def _fix_libgfortran(fn, record):
     dep_idx = next(
         (q for q, dep in enumerate(depends) if dep.split(" ")[0] == "libgfortran"), None
     )
-    if dep_idx is not None:
+    if (
+        dep_idx is not None
+        # timestamp corresponds to 2025-06-21, just ahead of
+        # https://github.com/conda-forge/gfortran_osx-64-feedstock/commit/7764b8460e37355492aa058d69cf620f0aebeeec
+        and record.get("timestamp", 0) < 1655769600000
+    ):
         # make sure respect minimum versions still there
         # 'libgfortran'         -> >=3.0.1,<4.0.0.a0
         # 'libgfortran ==3.0.1' -> ==3.0.1


### PR DESCRIPTION
There's some spurious patching going on for `gfortran_osx-64` which causes resolver errors with gfortran 14.3

```
Could not solve for environment specs
The following package could not be installed
└─ gfortran_osx-64 =14.3 * is not installable because it requires
   ├─ gfortran_impl_osx-64 ==14.3.0 *, which requires
   │  └─ libgfortran5 >=14.3.0 * with the potential options
   │     ├─ libgfortran5 14.3.0 would require
   │     │  └─ libgfortran ==14.3.0 *, which can be installed;
   │     └─ libgfortran5 15.1.0 would require
   │        └─ libgfortran ==15.1.0 *, which can be installed;
   └─ libgfortran >=3.0.1,<4.0.0.a0 *, which conflicts with any installable versions previously reported.
```
or rather, it pulls in gfortran 14.2 and ends up being non-functional. See https://github.com/conda-forge/photochem-feedstock/pull/32 / https://github.com/conda-forge/photochem-feedstock/pull/33

This is due to patching of bare `libgfortran` that goes back to https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/commit/e86fb023c0e7ce52c4655a0ac3f2b2cf (from a PR in the single digits: #7 😱), before new gfortran infrastructure was being rolled out. Since https://github.com/conda-forge/gfortran_osx-64-feedstock/commit/7764b8460e37355492aa058d69cf620f0aebeeec, this patching mechanism has started firing again, this time incorrectly, and even on our own compiler packages.

Patching can be seen e.g. [here](https://conda-metadata-app.streamlit.app/?q=conda-forge%2Fosx-64%2Fgfortran_osx-64-14.3.0-h3223c34_0.conda)

```diff
 cctools_osx-64
 clang
 clang_osx-64
 gfortran_impl_osx-64 14.3.0
 ld64_osx-64
-libgfortran
+libgfortran >=3.0.1,<4.0.0.a0
 libgfortran-devel_osx-64 14.3.0
 libgfortran5 >=14.3.0
```

### Output of `python show_diff.py`

<details>

```diff
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
noarch
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
osx-64::eccodes-2.42.0-h5fc628f_0.conda
osx-64::gfortran_osx-64-13.4.0-h3223c34_0.conda
osx-64::gfortran_osx-64-14.3.0-h3223c34_0.conda
osx-64::gfortran_osx-64-15.1.0-h3223c34_0.conda
osx-64::openfast-4.1.0-hcee9fb3_1.conda
osx-64::openmeeg-2.4.2-py310h4d3c5e4_4.tar.bz2
osx-64::openmeeg-2.4.2-py37h2620256_4.tar.bz2
osx-64::openmeeg-2.4.2-py38h1a7c08e_4.tar.bz2
osx-64::openmeeg-2.4.2-py38h3d5a339_4.tar.bz2
osx-64::openmeeg-2.4.2-py39h048cf10_4.tar.bz2
osx-64::openmeeg-2.4.2-py39h5303b8a_4.tar.bz2
osx-64::openmeeg-2.4.4-py310h4d3c5e4_0.tar.bz2
osx-64::openmeeg-2.4.4-py37h2620256_0.tar.bz2
osx-64::openmeeg-2.4.4-py38h1a7c08e_0.tar.bz2
osx-64::openmeeg-2.4.4-py38h3d5a339_0.tar.bz2
osx-64::openmeeg-2.4.4-py39h048cf10_0.tar.bz2
osx-64::openmeeg-2.4.4-py39h5303b8a_0.tar.bz2
osx-64::openmeeg-2.4.6-py310h4d3c5e4_0.tar.bz2
osx-64::openmeeg-2.4.6-py37h2620256_0.tar.bz2
osx-64::openmeeg-2.4.6-py38h1a7c08e_0.tar.bz2
osx-64::openmeeg-2.4.6-py38h3d5a339_0.tar.bz2
osx-64::openmeeg-2.4.6-py39h048cf10_0.tar.bz2
osx-64::openmeeg-2.4.6-py39h5303b8a_0.tar.bz2
osx-64::openmeeg-2.4.7-py310h4d3c5e4_0.tar.bz2
osx-64::openmeeg-2.4.7-py310hfaa7085_0.tar.bz2
osx-64::openmeeg-2.4.7-py310hfaa7085_1.tar.bz2
osx-64::openmeeg-2.4.7-py37h2620256_0.tar.bz2
osx-64::openmeeg-2.4.7-py37hd1ba133_0.tar.bz2
osx-64::openmeeg-2.4.7-py37hd1ba133_1.tar.bz2
osx-64::openmeeg-2.4.7-py38h1a7c08e_0.tar.bz2
osx-64::openmeeg-2.4.7-py38h3d5a339_0.tar.bz2
osx-64::openmeeg-2.4.7-py38h7059dfd_0.tar.bz2
osx-64::openmeeg-2.4.7-py38h7059dfd_1.tar.bz2
osx-64::openmeeg-2.4.7-py38h8d1d246_0.tar.bz2
osx-64::openmeeg-2.4.7-py38h8d1d246_1.tar.bz2
osx-64::openmeeg-2.4.7-py39h048cf10_0.tar.bz2
osx-64::openmeeg-2.4.7-py39h5303b8a_0.tar.bz2
osx-64::openmeeg-2.4.7-py39h94d71c5_0.tar.bz2
osx-64::openmeeg-2.4.7-py39h94d71c5_1.tar.bz2
osx-64::openmeeg-2.4.7-py39hd38f6da_0.tar.bz2
osx-64::openmeeg-2.4.7-py39hd38f6da_1.tar.bz2
osx-64::openmeeg-2.5.0-py310hfaa7085_0.tar.bz2
osx-64::openmeeg-2.5.0-py37hd1ba133_0.tar.bz2
osx-64::openmeeg-2.5.0-py38h8d1d246_0.tar.bz2
osx-64::openmeeg-2.5.0-py39h94d71c5_0.tar.bz2
osx-64::openmeeg-2.5.0-py39hd38f6da_0.tar.bz2
osx-64::petsc4py-3.23.4-np2py310h051ad89_0.conda
osx-64::petsc4py-3.23.4-np2py310h3434d3a_0.conda
osx-64::petsc4py-3.23.4-np2py310h4840f74_0.conda
osx-64::petsc4py-3.23.4-np2py310h81f1a6f_0.conda
osx-64::petsc4py-3.23.4-np2py311h4e6b80f_0.conda
osx-64::petsc4py-3.23.4-np2py311h79b4024_0.conda
osx-64::petsc4py-3.23.4-np2py311hb1a6678_0.conda
osx-64::petsc4py-3.23.4-np2py311hd37899f_0.conda
osx-64::petsc4py-3.23.4-np2py312h18566da_0.conda
osx-64::petsc4py-3.23.4-np2py312h5bb0edb_0.conda
osx-64::petsc4py-3.23.4-np2py312h75a047b_0.conda
osx-64::petsc4py-3.23.4-np2py312hb6fc8f6_0.conda
osx-64::petsc4py-3.23.4-np2py313h0e28e10_0.conda
osx-64::petsc4py-3.23.4-np2py313h2f469f4_0.conda
osx-64::petsc4py-3.23.4-np2py313h992853c_0.conda
osx-64::petsc4py-3.23.4-np2py313hf919179_0.conda
osx-64::petsc4py-3.23.4-np2py39h1761bde_0.conda
osx-64::petsc4py-3.23.4-np2py39h3d369ac_0.conda
osx-64::petsc4py-3.23.4-np2py39h4452e2d_0.conda
osx-64::petsc4py-3.23.4-np2py39hb683ea0_0.conda
osx-64::precice-3.2.0-py310h956c006_2.conda
osx-64::precice-3.2.0-py310ha98da79_2.conda
osx-64::precice-3.2.0-py311h0494aba_2.conda
osx-64::precice-3.2.0-py311h2b64e87_2.conda
osx-64::precice-3.2.0-py312h809ca2e_2.conda
osx-64::precice-3.2.0-py312hbbf18ea_2.conda
osx-64::precice-3.2.0-py313h38757fe_2.conda
osx-64::precice-3.2.0-py313hdc64348_2.conda
osx-64::precice-3.2.0-py39h021c7ac_2.conda
osx-64::precice-3.2.0-py39h26a7367_2.conda
osx-64::slepc-3.23.2-complex_h22cc834_0.conda
osx-64::slepc-3.23.2-complex_h8c28ef1_0.conda
osx-64::slepc-3.23.2-real_h2b0dcfc_0.conda
osx-64::slepc-3.23.2-real_h59950a4_0.conda
-    "libgfortran >=3.0.1,<4.0.0.a0",
+    "libgfortran",
================================================================================
================================================================================
linux-64
```

I checked the affected artefacts, and everything except openmeeg is indeed after that date. The change is correct for openmeeg as well though, since those versions already had an explicit dependence on `libgfortran5`, see https://github.com/conda-forge/openmeeg-feedstock/commit/eae677a8806dfd8f78c7bd9eba16776802cfe7d4

</details>