### PR TITLE
Fix incorrect dependency in pymc-base

### DIFF
--- a/recipe/patch_yaml/pymc.yaml
+++ b/recipe/patch_yaml/pymc.yaml
@@ -30,3 +30,21 @@ then:
   - replace_depends:
       old: threadpoolctl
       new: threadpoolctl >=3.1.0,<4.0.0
+
+---
+
+# Build 0 of pymc-base 5.25.0 depends on:
+#   pytensor-base >=2.31.2,<2.32
+# but this should have been instead:
+#   pytensor-base >=2.31.7,<2.32
+# This error was fixed in build 1:
+# <https://github.com/conda-forge/pymc-feedstock/pull/149>
+if:
+  name: pymc-base
+  version: '5.25.0'
+  build_number: 0
+  timestamp_lt: 1753309834000
+then:
+  - replace_depends:
+      old: pytensor-base >=2.31.2,<2.32
+      new: pytensor-base >=2.31.7,<2.32


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->


Build 0 of pymc-base 5.25.0 depends on: `pytensor-base >=2.31.2,<2.32`
This should have been instead:       `         pytensor-base >=2.31.7,<2.32`
This error was fixed in build 1: <https://github.com/conda-forge/pymc-feedstock/pull/149>

```diff
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
noarch
noarch::pymc-base-5.25.0-pyhd8ed1ab_0.conda
-    "pytensor-base >=2.31.2,<2.32",
+    "pytensor-base >=2.31.7,<2.32",
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
================================================================================
================================================================================
linux-64
```
<!-- Put any other comments or information here -->
