### PR TITLE
Make intel-openmp and llvm-openmp conflict with each other

### DIFF
--- a/recipe/patch_yaml/openmp.yaml
+++ b/recipe/patch_yaml/openmp.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=../patch_yaml_model.json
+if:
+  timestamp_lt: 1753975951000
+  name: llvm-openmp
+  subdir_in: win-64
+then:
+  - add_constrains:
+      - intel-openmp <0.0a0


### PR DESCRIPTION
Checklist

* [ ] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

See https://github.com/conda-forge/intel_repack-feedstock/issues/72
