### PR TITLE
NEW: Fixup arm-variant dependencies in CUDA compiler packages

### DIFF
--- a/recipe/patch_yaml/arm-variant.yaml
+++ b/recipe/patch_yaml/arm-variant.yaml
@@ -1,0 +1,36 @@
+# https://github.com/conda-forge/cuda-nvcc-impl-feedstock/issues/42 an arm-variant
+# dependency is needed to be added to the outputs of cuda-nvcc-impl-feedstock because
+# run_exports do not work for noarch packages
+if:
+  timestamp_lt: 1748544655000
+  subdir_in:
+    - linux-aarch64
+    - noarch
+  artifact_in:
+    - cuda-crt-dev_linux-aarch64-12.8.93-h579c4fd_2.conda
+    - cuda-crt-tools-12.8.93-h579c4fd_2.conda
+    - cuda-nvcc-dev_linux-aarch64-12.8.93-h4310d6a_2.conda
+    - cuda-nvcc-impl-12.8.93-h614329b_2.conda
+    - cuda-nvcc-tools-12.8.93-h614329b_2.conda
+    - cuda-nvvm-dev_linux-aarch64-12.8.93-h579c4fd_2.conda
+    - cuda-nvvm-impl-12.8.93-h614329b_2.conda
+    - cuda-nvvm-tools-12.8.93-h614329b_2.conda
+then:
+  - add_depends: "arm-variant * sbsa"
+---
+if:
+  timestamp_lt: 1748544655000
+  subdir_in:
+    - linux-aarch64
+    - noarch
+  artifact_in:
+    - cuda-crt-dev_linux-aarch64-12.8.93-h465204a_2.conda
+    - cuda-crt-tools-12.8.93-h465204a_2.conda
+    - cuda-nvcc-dev_linux-aarch64-12.8.93-hef5b290_2.conda
+    - cuda-nvcc-impl-12.8.93-hcab966f_2.conda
+    - cuda-nvcc-tools-12.8.93-h32d051c_2.conda
+    - cuda-nvvm-dev_linux-aarch64-12.8.93-h465204a_2.conda
+    - cuda-nvvm-impl-12.8.93-h32d051c_2.conda
+    - cuda-nvvm-tools-12.8.93-h32d051c_2.conda
+then:
+  - add_depends: "arm-variant * tegra"


### PR DESCRIPTION
An arm-variant dependency is needed to be added to the outputs of cuda-nvcc-impl-feedstock because run_exports do not work for noarch packages.

https://github.com/conda-forge/cuda-nvcc-impl-feedstock/issues/42

This MR is a subset of https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/973

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

```
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
noarch
noarch::cuda-crt-dev_linux-aarch64-12.8.93-h465204a_2.conda
noarch::cuda-nvcc-dev_linux-aarch64-12.8.93-hef5b290_2.conda
noarch::cuda-nvvm-dev_linux-aarch64-12.8.93-h465204a_2.conda
+    "arm-variant * tegra",
noarch::cuda-crt-dev_linux-aarch64-12.8.93-h579c4fd_2.conda
noarch::cuda-nvcc-dev_linux-aarch64-12.8.93-h4310d6a_2.conda
noarch::cuda-nvvm-dev_linux-aarch64-12.8.93-h579c4fd_2.conda
+    "arm-variant * sbsa",
```
