### PR TITLE
NEW: Make arm-variant a run dependency instead of constraint

### DIFF
--- a/recipe/patch_yaml/arm-variant.yaml
+++ b/recipe/patch_yaml/arm-variant.yaml
@@ -1,0 +1,83 @@
+# https://github.com/conda-forge/arm-variant-feedstock/issues/6 arm-variant should be a run
+# dependency not a run constrained. We want to move the dependency from run_constrained to
+# run, but the patcher raises an error if we do that, so we just add the dependency to run.
+if:
+  subdir_in:
+    - linux-aarch64
+    - noarch
+  has_constrains: "arm-variant * sbsa"
+  timestamp_lt: 1748544655000
+  name_in:
+    - cuda-*
+    - cudatoolkit
+    - cudensitymat
+    - cudnn
+    - cuquantum*
+    - cusparselt
+    - custatevec
+    - cutensor
+    - cutensornet
+    - libcal*
+    - libcublas*
+    - libcudss*
+    - libcufft*
+    - libcufile*
+    - libcurand*
+    - libcusolver*
+    - libcusparse*
+    - libmathdx*
+    - libnpp*
+    - libnvfatbin*
+    - libnvjitlink*
+    - libnvjpeg*
+    - libnvshmem*
+    - libnvtiff*
+    - nccl*
+    - nsight-compute
+    - nvcomp*
+    - nvimgcodec*
+    - nvmath-python*
+then:
+  - add_depends: "arm-variant * sbsa"
+  # - remove_constrains: "arm-variant * sbsa"
+---
+if:
+  subdir_in:
+    - linux-aarch64
+    - noarch
+  has_constrains: "arm-variant * tegra"
+  timestamp_lt: 1748544655000
+  name_in:
+    - cuda-*
+    - cudatoolkit
+    - cudensitymat
+    - cudnn
+    - cuquantum*
+    - cusparselt
+    - custatevec
+    - cutensor
+    - cutensornet
+    - libcal*
+    - libcublas*
+    - libcudss*
+    - libcufft*
+    - libcufile*
+    - libcurand*
+    - libcusolver*
+    - libcusparse*
+    - libmathdx*
+    - libnpp*
+    - libnvfatbin*
+    - libnvjitlink*
+    - libnvjpeg*
+    - libnvshmem*
+    - libnvtiff*
+    - nccl*
+    - nsight-compute
+    - nvcomp*
+    - nvimgcodec*
+    - nvmath-python*
+then:
+  - add_depends: "arm-variant * tegra"
+  # - remove_constrains: "arm-variant * tegra"
+---


### PR DESCRIPTION
https://github.com/conda-forge/arm-variant-feedstock/issues/6

Checklist

* [ ] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
