### PR TITLE
Patch opentelemetry-exporter-prometheus v0.56b0

### DIFF
--- a/recipe/patch_yaml/opentelemetry-exporter-prometheus.yaml
+++ b/recipe/patch_yaml/opentelemetry-exporter-prometheus.yaml
@@ -1,0 +1,9 @@
+if:
+  name: opentelemetry-exporter-prometheus
+  version: 0.56b0
+  build_number: 0
+  timestamp_lt: 1754204438000
+then:
+  - replace_depends:
+      old: opentelemetry-sdk >=1.35.0
+      new: opentelemetry-sdk >=1.35.0,<1.36.dev0


### PR DESCRIPTION
A constraint has been fixed in build 1 but downstream packages are still picking up build 0.

See:
https://github.com/conda-forge/opentelemetry-exporter-prometheus-feedstock/pull/23 
https://github.com/conda-forge/opentelemetry-exporter-prometheus-feedstock/pull/24
https://github.com/conda-forge/apache-airflow-providers-google-feedstock/pull/71

ping @conda-forge/opentelemetry-exporter-prometheus

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
