### PR TITLE
Patch contourpy 1.3.3

### DIFF
--- a/recipe/patch_yaml/contourpy.yaml
+++ b/recipe/patch_yaml/contourpy.yaml
@@ -1,0 +1,9 @@
+if:
+  name: contourpy
+  version: 1.3.3
+  build_number: 0
+  timestamp_lt: 1755068536000
+then:
+  - replace_depends:
+      old: numpy >=1.23
+      new: numpy >=1.25


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

ContourPy 1.3.3 build number 0 had the wrong pin for `numpy` dependency, which was fixed in build number 1 (conda-forge/contourpy-feedstock#38). This PR is to patch the patch the dependency info in build number 0 so that it is correct.