### PR TITLE
Add opencv constraint on imath

### DIFF
--- a/recipe/patch_yaml/opencv.yaml
+++ b/recipe/patch_yaml/opencv.yaml
@@ -8,3 +8,16 @@ then:
   - replace_depends:
       old: numpy >=2.0.0rc.2,<3.0a0
       new: numpy >=1.19.0,<3.0a0
+
+---
+
+if:
+  name: libopencv
+  version_le: 4.12.0
+  timestamp_lt: 1755656470000
+then:
+  # For some reason imath was not caught in the package inspector
+  # and thus missed as a run_export
+  # in the older builds of libopencv
+  # https://github.com/conda-forge/opencv-feedstock/issues/486
+  - add_constrains: imath<3.2.0a0


### PR DESCRIPTION
Closes https://github.com/conda-forge/opencv-feedstock/issues/486

This addresses a missing runtime requirement with "as loose of a pin as I can add" and reasonable helps real users in a failure I've identified recently in libopencv

Checklist

* [ ] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
