### PR TITLE
Patch spatial-image 1.2.3 to have lower bound xarray >=2024.10.0

### DIFF
--- a/recipe/patch_yaml/spatial-image.yaml
+++ b/recipe/patch_yaml/spatial-image.yaml
@@ -1,0 +1,11 @@
+# Missing lower bound xarray >=2024.10.0 for spatial-image 1.2.3
+# https://github.com/conda-forge/spatial-image-feedstock/pull/14
+if:
+  name: spatial-image
+  version: "1.2.3"
+  build_number: 0
+  timestamp_lt: 1755797300000
+then:
+  - replace_depends:
+      old: xarray
+      new: "xarray >=2024.10.0"


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
---

cc: @conda-forge/spatial-image 
xref: https://github.com/conda-forge/spatial-image-feedstock/pull/8, https://github.com/conda-forge/spatial-image-feedstock/pull/14, https://github.com/TileDB-Inc/tiledbsoma-feedstock/issues/331

```sh
mamba create --yes -n spatial-image-xarray spatial-image=1.2.3 xarray=2024.9.0
mamba activate spatial-image-xarray
pip check
## spatial-image 1.2.3 has requirement xarray>=2024.10.0, but you have xarray 2024.9.0.
```