### PR TITLE
Align scipy 1.8.1 dependency constraints with maintenance branch

### DIFF
--- a/recipe/patch_yaml/scipy.yaml
+++ b/recipe/patch_yaml/scipy.yaml
@@ -62,12 +62,12 @@ then:
 if:
   name: scipy
   version: 1.8.1
-  build_number_in: [0, 2]
+  build_number_in: [0, 1, 2]
   timestamp_le: 1686323537000
 then:
   - replace_depends:
       old: numpy >=1.19.5,<2.0a0
-      new: scipy >=1.17.3,<1.25.0
+      new: numpy >=1.19.5,<1.25.0
   - replace_depends:
       old: numpy >=1.21.6,<2.0a0
-      new: scipy >=1.17.3,<1.25.0
+      new: numpy >=1.19.5,<1.25.0

--- a/recipe/patch_yaml/scipy.yaml
+++ b/recipe/patch_yaml/scipy.yaml
@@ -70,4 +70,4 @@ then:
       new: numpy >=1.19.5,<1.25.0
   - replace_depends:
       old: numpy >=1.21.6,<2.0a0
-      new: numpy >=1.19.5,<1.25.0
+      new: numpy >=1.21.6,<1.25.0

--- a/recipe/patch_yaml/scipy.yaml
+++ b/recipe/patch_yaml/scipy.yaml
@@ -53,3 +53,21 @@ if:
 
 then:
   - add_constrains: libopenblas <0.3.26
+
+---
+# Allign constrains with limits in 1.8.x maintenance branch
+# The numpy min and max versions are documented here:
+# https://github.com/scipy/scipy/blob/maintenance/1.8.x/setup.py
+# https://github.com/scipy/scipy/blob/maintenance/1.8.x/scipy/__init__.py
+if:
+  name: scipy
+  version: 1.8.1
+  build_number_in: [0, 2]
+  timestamp_le: 1686323537000
+then:
+  - replace_depends:
+      old: numpy >=1.19.5,<2.0a0
+      new: scipy >=1.17.3,<1.25.0
+  - replace_depends:
+      old: numpy >=1.21.6,<2.0a0
+      new: scipy >=1.17.3,<1.25.0

--- a/recipe/patch_yaml/scipy.yaml
+++ b/recipe/patch_yaml/scipy.yaml
@@ -55,7 +55,7 @@ then:
   - add_constrains: libopenblas <0.3.26
 
 ---
-# Allign constrains with limits in 1.8.x maintenance branch
+# Align constrains with limits in 1.8.x maintenance branch
 # The numpy min and max versions are documented here:
 # https://github.com/scipy/scipy/blob/maintenance/1.8.x/setup.py
 # https://github.com/scipy/scipy/blob/maintenance/1.8.x/scipy/__init__.py


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
