### PR TITLE
Patch ome-zarr 0.12.0+ to have lower bound zarr >=3.0.0

### DIFF
--- a/recipe/patch_yaml/ome-zarr.yaml
+++ b/recipe/patch_yaml/ome-zarr.yaml
@@ -17,3 +17,15 @@ then:
   - tighten_depends:
       name: zarr
       upper_bound: 3.0.0
+---
+# pip understands "zarr >=v3.0.0" but not conda. Need to patch all ome-zarr
+# 0.12.0+ binaries https://github.com/conda-forge/ome-zarr-feedstock/pull/31
+if:
+  name: ome-zarr
+  version_ge: "0.12.0"
+  version_le: "0.12.2"
+  timestamp_lt: 1756219577000
+then:
+  - replace_depends:
+      old: zarr >=v3.0.0
+      new: zarr >=3.0.0


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

---

cc: @conda-forge/ome-zarr 
xref: https://github.com/conda-forge/ome-zarr-feedstock/pull/31, https://github.com/conda-forge/ome-zarr-feedstock/pull/28

conda does not correctly parse the lower bound `zarr >=v3.0.0`

```diff
python show_diff.py --subdirs noarch
================================================================================
================================================================================
noarch
noarch::ome-zarr-0.12.0-pyhd8ed1ab_0.conda
noarch::ome-zarr-0.12.2-pyhd8ed1ab_0.conda
-    "zarr >=v3.0.0"
+    "zarr >=3.0.0"
```