### PR TITLE
fix: tighten depends for rattler-build-conda-compat for conda-smithy

### DIFF
--- a/recipe/patch_yaml/conda-smithy.yaml
+++ b/recipe/patch_yaml/conda-smithy.yaml
@@ -59,3 +59,11 @@ then:
   - tighten_depends:
       name: rattler-build-conda-compat
       max_pin: "x"
+---
+if:
+  name: conda-smithy
+  version_eq: 3.52.0
+then:
+  - tighten_depends:
+      name: rattler-build-conda-compat
+      lower_bound: 1.4.5

--- a/recipe/patch_yaml/conda-smithy.yaml
+++ b/recipe/patch_yaml/conda-smithy.yaml
@@ -63,7 +63,8 @@ then:
 if:
   name: conda-smithy
   version_eq: 3.52.0
+  build_number: 0
 then:
-  - tighten_depends:
-      name: rattler-build-conda-compat
-      lower_bound: 1.4.5
+  - replace_depends:
+      old: rattler-build-conda-compat >=1.2.0,<2.0.0a0
+      new: rattler-build-conda-compat >=1.4.5,<2.0.0a0


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
