### PR TITLE
feat: add clangdev <19 constraint for ROOT on macOS

### DIFF
--- a/recipe/patch_yaml/root.yaml
+++ b/recipe/patch_yaml/root.yaml
@@ -33,3 +33,11 @@ then:
   - replace_depends:
       old: vector-classes >=1.4.1,<1.5.0a0
       new: vector-classes >=1.4.1,<1.4.2a0
+---
+# Patch ROOT on OSX to require clangdev <19 due to compatibility issues
+if:
+  name: root*
+  subdir_in: ["osx-64", "osx-arm64"]
+  timestamp_lt: 1756841604000
+then:
+  - add_depends: clangdev <19.0.0a0


### PR DESCRIPTION
Adds repodata patch to constrain ROOT packages on macOS (osx-64, osx-arm64)
to use clangdev <19.0.0a0 due to compatibility issues with newer clang versions.

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

<details>
<summary>python show_diff.py</summary>

```
$ python show_diff.py
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
linux-ppc64le
linux-ppc64le::pydantic-core-2.39.0-py311h7069f6e_1.conda
-{}
+{
+  "build": "py311h7069f6e_1",
+  "build_number": 1,
+  "constrains": [
+    "__glibc >=2.17"
+  ],
+  "depends": [
+    "libgcc >=14",
+    "python",
+    "python 3.11.* *_cpython",
+    "python_abi 3.11.* *_cp311",
+    "typing-extensions >=4.6.0,!=4.7.0"
+  ],
+  "license": "MIT",
+  "md5": "4c28fecef504bceac12c5372e9492f99",
+  "name": "pydantic-core",
+  "sha256": "1f70cbbec97375c7f3e1d107e380feea6d0692d46b8c3a638132277886a6dcb9",
+  "size": 2008441,
+  "subdir": "linux-ppc64le",
+  "timestamp": 1756840688557,
+  "version": "2.39.0"
+}
linux-ppc64le::typos-1.36.0-h0de4f61_0.conda
-{}
+{
+  "build": "h0de4f61_0",
+  "build_number": 0,
+  "constrains": [
+    "__glibc >=2.17"
+  ],
+  "depends": [
+    "libgcc >=14"
+  ],
+  "license": "MIT",
+  "md5": "77cd3f75ce88d734001fbb4329ed6f99",
+  "name": "typos",
+  "sha256": "ce8a354e7b0d97d197431ebf29b8cbd2dbe6d76b7679cbdcae9dab747fa0c59c",
+  "size": 3588156,
+  "subdir": "linux-ppc64le",
+  "timestamp": 1756840677431,
+  "version": "1.36.0"
+}
linux-ppc64le::pydantic-core-2.39.0-py310hc6a4cfa_1.conda
-{}
+{
+  "build": "py310hc6a4cfa_1",
+  "build_number": 1,
+  "constrains": [
+    "__glibc >=2.17"
+  ],
+  "depends": [
+    "libgcc >=14",
+    "python",
+    "python 3.10.* *_cpython",
+    "python_abi 3.10.* *_cp310",
+    "typing-extensions >=4.6.0,!=4.7.0"
+  ],
+  "license": "MIT",
+  "md5": "30fdceaa26feb2da3dc701dec38e901f",
+  "name": "pydantic-core",
+  "sha256": "e0494873315486659b72f255b42635349fc6836ca85b84cd8b337b74c35e1faa",
+  "size": 2001631,
+  "subdir": "linux-ppc64le",
+  "timestamp": 1756840681248,
+  "version": "2.39.0"
+}
linux-ppc64le::pydantic-core-2.39.0-py313h3fce93e_1.conda
-{}
+{
+  "build": "py313h3fce93e_1",
+  "build_number": 1,
+  "constrains": [
+    "__glibc >=2.17"
+  ],
+  "depends": [
+    "libgcc >=14",
+    "python",
+    "python 3.13.* *_cp313",
+    "python_abi 3.13.* *_cp313",
+    "typing-extensions >=4.6.0,!=4.7.0"
+  ],
+  "license": "MIT",
+  "md5": "50e7f058eb6a66a1e21195b710a20536",
+  "name": "pydantic-core",
+  "sha256": "c5216c116e4d3185ac9065fd9af5f52c7ff9838ac54acbb5497e227481372855",
+  "size": 1974987,
+  "subdir": "linux-ppc64le",
+  "timestamp": 1756840686228,
+  "version": "2.39.0"
+}
================================================================================
================================================================================
osx-arm64
osx-arm64::root-6.22.6-py38he9c1451_0.tar.bz2
osx-arm64::root-6.22.6-py39h373ef0f_0.tar.bz2
osx-arm64::root-6.22.8-py38h595776f_3.tar.bz2
osx-arm64::root-6.22.8-py39h7188df7_3.tar.bz2
osx-arm64::root-6.24.0-py38h92c76d4_0.tar.bz2
osx-arm64::root-6.24.0-py39ha49f62b_0.tar.bz2
osx-arm64::root-6.24.6-py310h2de7ec9_3.tar.bz2
osx-arm64::root-6.24.6-py310h423892c_2.tar.bz2
osx-arm64::root-6.24.6-py310h9789135_1.tar.bz2
osx-arm64::root-6.24.6-py38h0c038dc_2.tar.bz2
osx-arm64::root-6.24.6-py38h4df394f_1.tar.bz2
osx-arm64::root-6.24.6-py38hb2b5d55_0.tar.bz2
osx-arm64::root-6.24.6-py38hcc0ee5d_3.tar.bz2
osx-arm64::root-6.24.6-py39h521ba16_0.tar.bz2
osx-arm64::root-6.24.6-py39h8c6f5f3_1.tar.bz2
osx-arm64::root-6.24.6-py39hba7d7d6_2.tar.bz2
osx-arm64::root-6.24.6-py39hbe18b87_3.tar.bz2
osx-arm64::root-6.26.0-py310h2de7ec9_0.tar.bz2
osx-arm64::root-6.26.0-py38hcc0ee5d_0.tar.bz2
osx-arm64::root-6.26.0-py39hbe18b87_0.tar.bz2
osx-arm64::root-6.26.10-py310h29a126f_1.conda
osx-arm64::root-6.26.10-py311h1ea38e0_1.conda
osx-arm64::root-6.26.10-py38hca5ca8b_1.conda
osx-arm64::root-6.26.10-py39h41e5feb_1.conda
osx-arm64::root-6.26.2-py310h423892c_1.tar.bz2
osx-arm64::root-6.26.2-py310h9d7d203_2.tar.bz2
osx-arm64::root-6.26.2-py310h9d7d203_3.tar.bz2
osx-arm64::root-6.26.2-py38h0c038dc_1.tar.bz2
osx-arm64::root-6.26.2-py38ha3e59a3_2.tar.bz2
osx-arm64::root-6.26.2-py38ha3e59a3_3.tar.bz2
osx-arm64::root-6.26.2-py39ha8c52a1_2.tar.bz2
osx-arm64::root-6.26.2-py39ha8c52a1_3.tar.bz2
osx-arm64::root-6.26.2-py39hba7d7d6_1.tar.bz2
osx-arm64::root-6.26.4-py310h9d7d203_3.tar.bz2
osx-arm64::root-6.26.4-py38ha3e59a3_3.tar.bz2
osx-arm64::root-6.26.4-py39ha8c52a1_3.tar.bz2
osx-arm64::root-6.26.6-py310h9d7d203_0.tar.bz2
osx-arm64::root-6.26.6-py38ha3e59a3_0.tar.bz2
osx-arm64::root-6.26.6-py39ha8c52a1_0.tar.bz2
osx-arm64::root-6.26.8-py310h29a126f_1.tar.bz2
osx-arm64::root-6.26.8-py38hca5ca8b_1.tar.bz2
osx-arm64::root-6.26.8-py39h41e5feb_1.tar.bz2
osx-arm64::root-6.28.0-py310h1057fd0_1.conda
osx-arm64::root-6.28.0-py310h29a126f_0.conda
osx-arm64::root-6.28.0-py311h1ea38e0_0.conda
osx-arm64::root-6.28.0-py311hb4519a3_1.conda
osx-arm64::root-6.28.0-py38h490b07e_1.conda
osx-arm64::root-6.28.0-py39h05ca73f_1.conda
osx-arm64::root-6.28.0-py39h41e5feb_0.conda
osx-arm64::root-6.28.10-py310he485b48_0.conda
osx-arm64::root-6.28.10-py310he485b48_2.conda
osx-arm64::root-6.28.10-py311h66530a1_0.conda
osx-arm64::root-6.28.10-py311h66530a1_2.conda
osx-arm64::root-6.28.10-py38h9173aeb_0.conda
osx-arm64::root-6.28.10-py38h9173aeb_2.conda
osx-arm64::root-6.28.10-py39hcbf3f86_0.conda
osx-arm64::root-6.28.10-py39hcbf3f86_2.conda
osx-arm64::root-6.28.12-py310he485b48_0.conda
osx-arm64::root-6.28.12-py311h66530a1_0.conda
osx-arm64::root-6.28.12-py38h9173aeb_0.conda
osx-arm64::root-6.28.12-py39hcbf3f86_0.conda
osx-arm64::root-6.28.4-py310h01d5013_0.conda
osx-arm64::root-6.28.4-py310h01d5013_1.conda
osx-arm64::root-6.28.4-py311hd2e109b_0.conda
osx-arm64::root-6.28.4-py311hd2e109b_1.conda
osx-arm64::root-6.28.4-py38ha838594_0.conda
osx-arm64::root-6.28.4-py38ha838594_1.conda
osx-arm64::root-6.28.4-py39h954cb88_0.conda
osx-arm64::root-6.28.4-py39h954cb88_1.conda
osx-arm64::root-6.30.2-py310he485b48_0.conda
osx-arm64::root-6.30.2-py311h66530a1_0.conda
osx-arm64::root-6.30.2-py38h9173aeb_0.conda
osx-arm64::root-6.30.2-py39hcbf3f86_0.conda
osx-arm64::root-6.30.4-py310he485b48_0.conda
osx-arm64::root-6.30.4-py311h66530a1_0.conda
osx-arm64::root-6.30.4-py38h9173aeb_0.conda
osx-arm64::root-6.30.4-py39hcbf3f86_0.conda
osx-arm64::root-6.32.0-py310hcfcc87f_0.conda
osx-arm64::root-6.32.0-py312hce2618c_0.conda
osx-arm64::root-6.32.0-py38h51b4a27_0.conda
osx-arm64::root-6.32.0-py39h85261e1_0.conda
osx-arm64::root-6.32.10-py310h738ef64_0.conda
osx-arm64::root-6.32.10-py311h30e88fc_0.conda
osx-arm64::root-6.32.10-py312h3ae5e48_0.conda
osx-arm64::root-6.32.10-py313h9bc2c58_0.conda
osx-arm64::root-6.32.10-py39hf5acd91_0.conda
osx-arm64::root-6.32.16-py310h3e72c03_0.conda
osx-arm64::root-6.32.16-py311h5dec009_0.conda
osx-arm64::root-6.32.16-py312h835fd7b_0.conda
osx-arm64::root-6.32.16-py313h15117c1_0.conda
osx-arm64::root-6.32.8-py310h50c8123_0.conda
osx-arm64::root-6.32.8-py311h516e7e2_0.conda
osx-arm64::root-6.32.8-py312hb40617c_0.conda
osx-arm64::root-6.32.8-py313hf8683a7_0.conda
osx-arm64::root-6.32.8-py39hb1195e8_0.conda
osx-arm64::root-6.34.04-py310hd154332_1.conda
osx-arm64::root-6.34.04-py311h258ac19_1.conda
osx-arm64::root-6.34.04-py312h882146a_1.conda
osx-arm64::root-6.34.04-py313h08a37ff_1.conda
osx-arm64::root-6.34.04-py39h01fdcbf_1.conda
osx-arm64::root-6.34.06-py310h7fff273_1.conda
osx-arm64::root-6.34.06-py310h9a1243f_0.conda
osx-arm64::root-6.34.06-py311h83c9208_0.conda
osx-arm64::root-6.34.06-py311haf662ff_1.conda
osx-arm64::root-6.34.06-py312hb033222_0.conda
osx-arm64::root-6.34.06-py312hf9fb03c_1.conda
osx-arm64::root-6.34.06-py313h6c1d75a_1.conda
osx-arm64::root-6.34.06-py313hc876e38_0.conda
osx-arm64::root-6.34.06-py39h219753f_1.conda
osx-arm64::root-6.34.06-py39hac58b45_0.conda
osx-arm64::root-6.34.10-py310h7e9883a_1.conda
osx-arm64::root-6.34.10-py311h43ab844_1.conda
osx-arm64::root-6.34.10-py311h5b0413e_0.conda
osx-arm64::root-6.34.10-py312hd80f5a7_1.conda
osx-arm64::root-6.34.10-py312he383245_0.conda
osx-arm64::root-6.34.10-py313h46a5430_1.conda
osx-arm64::root-6.34.10-py313h46f5e35_0.conda
osx-arm64::root-6.34.10-py39h6be7185_0.conda
osx-arm64::root-6.34.4-py310hf841dc2_0.conda
osx-arm64::root-6.34.4-py311h67fab9a_0.conda
osx-arm64::root-6.34.4-py312h946da9a_0.conda
osx-arm64::root-6.34.4-py313h7eb37b6_0.conda
osx-arm64::root-6.34.4-py39h0ef7cd9_0.conda
osx-arm64::root-6.36.02-py310h19ebf90_0.conda
osx-arm64::root-6.36.02-py311h7c67588_0.conda
osx-arm64::root-6.36.02-py312hf1a98d7_0.conda
osx-arm64::root-6.36.02-py313hd321197_0.conda
osx-arm64::root-6.36.04-py310h716c416_0.conda
osx-arm64::root-6.36.04-py310hbb83fed_1.conda
osx-arm64::root-6.36.04-py311h7dc24f2_0.conda
osx-arm64::root-6.36.04-py311h9481387_1.conda
osx-arm64::root-6.36.04-py312h438ee3e_0.conda
osx-arm64::root-6.36.04-py312h63a62bf_1.conda
osx-arm64::root-6.36.04-py313h8ad1c7b_1.conda
osx-arm64::root-6.36.04-py313hd1cc1a6_0.conda
osx-arm64::root-binaries-6.22.6-py38he9c1451_0.tar.bz2
osx-arm64::root-binaries-6.22.6-py39h373ef0f_0.tar.bz2
osx-arm64::root-binaries-6.22.8-py38h595776f_3.tar.bz2
osx-arm64::root-binaries-6.22.8-py39h7188df7_3.tar.bz2
osx-arm64::root-dependencies-6.22.6-py38he9c1451_0.tar.bz2
osx-arm64::root-dependencies-6.22.6-py39h373ef0f_0.tar.bz2
osx-arm64::root-dependencies-6.22.8-py38h595776f_3.tar.bz2
osx-arm64::root-dependencies-6.22.8-py39h7188df7_3.tar.bz2
osx-arm64::root_base-6.22.6-py38h1381eaf_0.tar.bz2
osx-arm64::root_base-6.22.6-py39hcbb6425_0.tar.bz2
osx-arm64::root_base-6.22.8-py38h9d209ef_3.tar.bz2
osx-arm64::root_base-6.22.8-py39h56fb6bf_3.tar.bz2
osx-arm64::root_base-6.24.0-py38h21e4016_0.tar.bz2
osx-arm64::root_base-6.24.0-py39hdf834e2_0.tar.bz2
osx-arm64::root_base-6.24.6-py310h186c2fd_3.tar.bz2
osx-arm64::root_base-6.24.6-py310h41e58fc_1.tar.bz2
osx-arm64::root_base-6.24.6-py310h6d57595_2.tar.bz2
osx-arm64::root_base-6.24.6-py38h1a1db37_0.tar.bz2
osx-arm64::root_base-6.24.6-py38h377e93d_2.tar.bz2
osx-arm64::root_base-6.24.6-py38h3e22404_3.tar.bz2
osx-arm64::root_base-6.24.6-py38hadccc6e_1.tar.bz2
osx-arm64::root_base-6.24.6-py39h1f657f7_2.tar.bz2
osx-arm64::root_base-6.24.6-py39h339fd24_1.tar.bz2
osx-arm64::root_base-6.24.6-py39ha807db5_0.tar.bz2
osx-arm64::root_base-6.24.6-py39haccfeaf_3.tar.bz2
osx-arm64::root_base-6.26.0-py310h4f1623d_0.tar.bz2
osx-arm64::root_base-6.26.0-py38h1017486_0.tar.bz2
osx-arm64::root_base-6.26.0-py39hd7d9cc8_0.tar.bz2
osx-arm64::root_base-6.26.10-py310h62bb4df_1.conda
osx-arm64::root_base-6.26.10-py310he39f453_1.conda
osx-arm64::root_base-6.26.10-py311h26794ff_1.conda
osx-arm64::root_base-6.26.10-py311hb8b5134_1.conda
osx-arm64::root_base-6.26.10-py38hce1135a_1.conda
osx-arm64::root_base-6.26.10-py38hfaf977f_1.conda
osx-arm64::root_base-6.26.10-py39h1847e19_1.conda
osx-arm64::root_base-6.26.10-py39h611b57b_1.conda
osx-arm64::root_base-6.26.2-py310h31ace29_2.tar.bz2
osx-arm64::root_base-6.26.2-py310h31ace29_3.tar.bz2
osx-arm64::root_base-6.26.2-py310h6d57595_1.tar.bz2
osx-arm64::root_base-6.26.2-py38h377e93d_1.tar.bz2
osx-arm64::root_base-6.26.2-py38he532589_2.tar.bz2
osx-arm64::root_base-6.26.2-py38he532589_3.tar.bz2
osx-arm64::root_base-6.26.2-py39h1f657f7_1.tar.bz2
osx-arm64::root_base-6.26.2-py39h2ec9a04_2.tar.bz2
osx-arm64::root_base-6.26.2-py39h2ec9a04_3.tar.bz2
osx-arm64::root_base-6.26.4-py310h31ace29_3.tar.bz2
osx-arm64::root_base-6.26.4-py38he532589_3.tar.bz2
osx-arm64::root_base-6.26.4-py39h2ec9a04_3.tar.bz2
osx-arm64::root_base-6.26.6-py310h91aa8d4_0.tar.bz2
osx-arm64::root_base-6.26.6-py38h21a5581_0.tar.bz2
osx-arm64::root_base-6.26.6-py39ha729eb5_0.tar.bz2
osx-arm64::root_base-6.26.8-py310h62bb4df_1.tar.bz2
osx-arm64::root_base-6.26.8-py310he39f453_1.tar.bz2
osx-arm64::root_base-6.26.8-py38hce1135a_1.tar.bz2
osx-arm64::root_base-6.26.8-py38hfaf977f_1.tar.bz2
osx-arm64::root_base-6.26.8-py39h1847e19_1.tar.bz2
osx-arm64::root_base-6.26.8-py39h611b57b_1.tar.bz2
osx-arm64::root_base-6.28.0-py310h0c5752d_0.conda
osx-arm64::root_base-6.28.0-py310he3e615b_1.conda
osx-arm64::root_base-6.28.0-py311h193e499_0.conda
osx-arm64::root_base-6.28.0-py311h9ee8b40_1.conda
osx-arm64::root_base-6.28.0-py38h2dd2aa4_1.conda
osx-arm64::root_base-6.28.0-py38hbc96720_0.conda
osx-arm64::root_base-6.28.0-py39h6285e97_0.conda
osx-arm64::root_base-6.28.0-py39ha7d3e57_1.conda
osx-arm64::root_base-6.28.10-py310h44eaee5_0.conda
osx-arm64::root_base-6.28.10-py310h44eaee5_2.conda
osx-arm64::root_base-6.28.10-py311h2a25b9c_0.conda
osx-arm64::root_base-6.28.10-py311h2a25b9c_2.conda
osx-arm64::root_base-6.28.10-py38h27b35fb_0.conda
osx-arm64::root_base-6.28.10-py38h27b35fb_2.conda
osx-arm64::root_base-6.28.10-py39h06fd22f_0.conda
osx-arm64::root_base-6.28.10-py39h06fd22f_2.conda
osx-arm64::root_base-6.28.12-py310h498b7c9_0.conda
osx-arm64::root_base-6.28.12-py311hca8578e_0.conda
osx-arm64::root_base-6.28.12-py38h24ac074_0.conda
osx-arm64::root_base-6.28.12-py39h5968530_0.conda
osx-arm64::root_base-6.28.4-py310h38a37bc_0.conda
osx-arm64::root_base-6.28.4-py310h38a37bc_1.conda
osx-arm64::root_base-6.28.4-py311h8e5954a_0.conda
osx-arm64::root_base-6.28.4-py311h8e5954a_1.conda
osx-arm64::root_base-6.28.4-py38h4e07059_0.conda
osx-arm64::root_base-6.28.4-py38h4e07059_1.conda
osx-arm64::root_base-6.28.4-py39hfe5a6d5_0.conda
osx-arm64::root_base-6.28.4-py39hfe5a6d5_1.conda
osx-arm64::root_base-6.30.2-py310h44eaee5_0.conda
osx-arm64::root_base-6.30.2-py311h2a25b9c_0.conda
osx-arm64::root_base-6.30.2-py38h27b35fb_0.conda
osx-arm64::root_base-6.30.2-py39h06fd22f_0.conda
osx-arm64::root_base-6.30.4-py310h498b7c9_0.conda
osx-arm64::root_base-6.30.4-py311hca8578e_0.conda
osx-arm64::root_base-6.30.4-py38h24ac074_0.conda
osx-arm64::root_base-6.30.4-py39h5968530_0.conda
osx-arm64::root_base-6.32.0-py310hc0d634b_0.conda
osx-arm64::root_base-6.32.0-py312hef6964a_0.conda
osx-arm64::root_base-6.32.0-py38h5ae74bb_0.conda
osx-arm64::root_base-6.32.0-py39he7856a1_0.conda
osx-arm64::root_base-6.32.10-np20py310hedeaa24_0.conda
osx-arm64::root_base-6.32.10-np20py311hd0fe195_0.conda
osx-arm64::root_base-6.32.10-np20py312h56bb2b0_0.conda
osx-arm64::root_base-6.32.10-np20py39h05b7f93_0.conda
osx-arm64::root_base-6.32.10-np2py313hd126fb6_0.conda
osx-arm64::root_base-6.32.16-np2py310h88abb89_0.conda
osx-arm64::root_base-6.32.16-np2py311hddd473f_0.conda
osx-arm64::root_base-6.32.16-np2py312hf7de823_0.conda
osx-arm64::root_base-6.32.16-np2py313h322f2fc_0.conda
osx-arm64::root_base-6.32.8-np20py310hedeaa24_0.conda
osx-arm64::root_base-6.32.8-np20py311hd0fe195_0.conda
osx-arm64::root_base-6.32.8-np20py312h56bb2b0_0.conda
osx-arm64::root_base-6.32.8-np20py39h05b7f93_0.conda
osx-arm64::root_base-6.32.8-np2py313hd126fb6_0.conda
osx-arm64::root_base-6.34.04-np2py310h7cb6625_1.conda
osx-arm64::root_base-6.34.04-np2py311h94dd177_1.conda
osx-arm64::root_base-6.34.04-np2py312h6710672_1.conda
osx-arm64::root_base-6.34.04-np2py313h4df0e88_1.conda
osx-arm64::root_base-6.34.04-np2py39h2858bb6_1.conda
osx-arm64::root_base-6.34.06-np2py310hae527a6_0.conda
osx-arm64::root_base-6.34.06-np2py310hae527a6_1.conda
osx-arm64::root_base-6.34.06-np2py311h6148cc1_0.conda
osx-arm64::root_base-6.34.06-np2py311h6148cc1_1.conda
osx-arm64::root_base-6.34.06-np2py312h808d4fc_0.conda
osx-arm64::root_base-6.34.06-np2py312h808d4fc_1.conda
osx-arm64::root_base-6.34.06-np2py313h6019a6c_0.conda
osx-arm64::root_base-6.34.06-np2py313h6019a6c_1.conda
osx-arm64::root_base-6.34.06-np2py39h0baf4f7_0.conda
osx-arm64::root_base-6.34.06-np2py39h0baf4f7_1.conda
osx-arm64::root_base-6.34.10-np2py310hae527a6_1.conda
osx-arm64::root_base-6.34.10-np2py311h6148cc1_0.conda
osx-arm64::root_base-6.34.10-np2py311h6148cc1_1.conda
osx-arm64::root_base-6.34.10-np2py312h808d4fc_0.conda
osx-arm64::root_base-6.34.10-np2py312h808d4fc_1.conda
osx-arm64::root_base-6.34.10-np2py313h6019a6c_0.conda
osx-arm64::root_base-6.34.10-np2py313h6019a6c_1.conda
osx-arm64::root_base-6.34.10-np2py39h0baf4f7_0.conda
osx-arm64::root_base-6.34.4-np20py310hedeaa24_0.conda
osx-arm64::root_base-6.34.4-np20py311hd0fe195_0.conda
osx-arm64::root_base-6.34.4-np20py312h56bb2b0_0.conda
osx-arm64::root_base-6.34.4-np20py39h05b7f93_0.conda
osx-arm64::root_base-6.34.4-np2py313hd126fb6_0.conda
osx-arm64::root_base-6.36.02-np2py310h7cb6625_0.conda
osx-arm64::root_base-6.36.02-np2py311h94dd177_0.conda
osx-arm64::root_base-6.36.02-np2py312h6710672_0.conda
osx-arm64::root_base-6.36.02-np2py313h4df0e88_0.conda
osx-arm64::root_base-6.36.04-np2py310h7cb6625_0.conda
osx-arm64::root_base-6.36.04-np2py310h7cb6625_1.conda
osx-arm64::root_base-6.36.04-np2py311h94dd177_0.conda
osx-arm64::root_base-6.36.04-np2py311h94dd177_1.conda
osx-arm64::root_base-6.36.04-np2py312h6710672_0.conda
osx-arm64::root_base-6.36.04-np2py312h6710672_1.conda
osx-arm64::root_base-6.36.04-np2py313h4df0e88_0.conda
osx-arm64::root_base-6.36.04-np2py313h4df0e88_1.conda
+    "clangdev <19.0.0a0",
osx-arm64::pykrb5-0.8.0-py310hffd263e_0.conda
-{}
+{
+  "build": "py310hffd263e_0",
+  "build_number": 0,
+  "depends": [
+    "__osx >=11.0",
+    "cryptography >=1.3",
+    "krb5 >=1.21.3,<1.22.0a0",
+    "python >=3.10,<3.11.0a0",
+    "python >=3.10,<3.11.0a0 *_cpython",
+    "python_abi 3.10.* *_cp310"
+  ],
+  "license": "MIT",
+  "md5": "a99bd068ed7eb0ebae1c39235dfab64e",
+  "name": "pykrb5",
+  "sha256": "ce4d9f8d44673c1f2e0d8f4172a62418d16803813f65c508db753e66425e3a7c",
+  "size": 409943,
+  "subdir": "osx-arm64",
+  "timestamp": 1756840328145,
+  "version": "0.8.0"
+}
osx-arm64::ruamel.yaml-0.18.15-py312h4409184_1.conda
-{}
+{
+  "build": "py312h4409184_1",
+  "build_number": 1,
+  "depends": [
+    "__osx >=11.0",
+    "python >=3.12,<3.13.0a0",
+    "python >=3.12,<3.13.0a0 *_cpython",
+    "python_abi 3.12.* *_cp312",
+    "ruamel.yaml.clib >=0.1.2"
+  ],
+  "license": "MIT",
+  "md5": "80416b2d9187fa126dc9c99c696329dc",
+  "name": "ruamel.yaml",
+  "sha256": "f4e3fddef9c4926676cf5cb009b2f9446a34cc11cb56bf4330ae897375a6e69b",
+  "size": 269034,
+  "subdir": "osx-arm64",
+  "timestamp": 1756839535469,
+  "version": "0.18.15"
+}
osx-arm64::geant4-11.3.2-py311h30d97ec_4.conda
-{}
+{
+  "build": "py311h30d97ec_4",
+  "build_number": 4,
+  "depends": [
+    "__osx >=11.0",
+    "clhep >=2.4.7.1,<2.4.7.2.0a0",
+    "expat",
+    "freetype",
+    "geant4-data-abla 3.3.0.*",
+    "geant4-data-channeling 1.0.0.*",
+    "geant4-data-emlow 8.6.1.*",
+    "geant4-data-ensdfstate 3.0.0.*",
+    "geant4-data-incl 1.2.0.*",
+    "geant4-data-ndl 4.7.1.*",
+    "geant4-data-particlexs 4.1.0.*",
+    "geant4-data-photonevaporation 6.1.0.*",
+    "geant4-data-pii 1.3.0.*",
+    "geant4-data-radioactivedecay 6.1.2.*",
+    "geant4-data-realsurface 2.2.0.*",
+    "geant4-data-saiddata 2.0.0.*",
+    "hdf5 >=1.14.6,<1.14.7.0a0",
+    "libboost-python >=1.88.0,<1.89.0a0",
+    "libcxx >=19",
+    "libexpat >=2.7.1,<3.0a0",
+    "libfreetype >=2.13.3",
+    "libfreetype6 >=2.13.3",
+    "libzlib >=1.3.1,<2.0a0",
+    "python >=3.11,<3.12.0a0",
+    "python >=3.11,<3.12.0a0 *_cpython",
+    "python_abi 3.11.* *_cp311",
+    "qt-main >=5.15.15,<5.16.0a0",
+    "xerces-c >=3.2.5,<3.3.0a0",
+    "xorg-libx11 >=1.8.12,<2.0a0",
+    "xorg-libxfixes >=6.0.1,<7.0a0",
+    "xorg-libxmu >=1.2.1,<2.0a0",
+    "zlib"
+  ],
+  "license": "LicenseRef-Geant4",
+  "md5": "bcb9a314af2811dd91ad1882d4b5cfc5",
+  "name": "geant4",
+  "sha256": "0def2eec5d887d81356673fd1393b8c53c4887de121ffff7ef1c01eced5c2cba",
+  "size": 32901394,
+  "subdir": "osx-arm64",
+  "timestamp": 1756840089404,
+  "version": "11.3.2"
+}
osx-arm64::fastjet-cxx-python-3.5.1-py310h92dc006_1.conda
-{}
+{
+  "build": "py310h92dc006_1",
+  "build_number": 1,
+  "depends": [
+    "__osx >=11.0",
+    "fastjet-cxx >=3.5.1,<3.6.0a0",
+    "libcxx >=19",
+    "python",
+    "python 3.10.* *_cpython",
+    "python_abi 3.10.* *_cp310"
+  ],
+  "license": "GPL-2.0-or-later",
+  "md5": "ef3bef0984c335794e5612aa95463521",
+  "name": "fastjet-cxx-python",
+  "sha256": "f79287eed6a459a0195800e088a11179fab78cceb10a8f2cd46e9bc943b7b0d6",
+  "size": 402509,
+  "subdir": "osx-arm64",
+  "timestamp": 1756839554308,
+  "version": "3.5.1"
+}
osx-arm64::fastjet-cxx-python-3.5.1-py313hf88c9ab_1.conda
-{}
+{
+  "build": "py313hf88c9ab_1",
+  "build_number": 1,
+  "depends": [
+    "__osx >=11.0",
+    "fastjet-cxx >=3.5.1,<3.6.0a0",
+    "libcxx >=19",
+    "python",
+    "python 3.13.* *_cp313",
+    "python_abi 3.13.* *_cp313"
+  ],
+  "license": "GPL-2.0-or-later",
+  "md5": "4a8377a6ccbbf8479bf39bbe2252d4a7",
+  "name": "fastjet-cxx-python",
+  "sha256": "21dee3318ec4e737a6c6a53866cacc14fe75446fdd3fc16393ff45a1fc66e3fe",
+  "size": 412171,
+  "subdir": "osx-arm64",
+  "timestamp": 1756839554308,
+  "version": "3.5.1"
+}
osx-arm64::pykrb5-0.8.0-py311h73378af_0.conda
-{}
+{
+  "build": "py311h73378af_0",
+  "build_number": 0,
+  "depends": [
+    "__osx >=11.0",
+    "cryptography >=1.3",
+    "krb5 >=1.21.3,<1.22.0a0",
+    "python >=3.11,<3.12.0a0",
+    "python >=3.11,<3.12.0a0 *_cpython",
+    "python_abi 3.11.* *_cp311"
+  ],
+  "license": "MIT",
+  "md5": "1217b1e2d5826947aafa018735e78492",
+  "name": "pykrb5",
+  "sha256": "6168dbc5ee38efb00d5e7eeeabb8146dff33f7c74012252195fe1bbaf7a4213a",
+  "size": 406956,
+  "subdir": "osx-arm64",
+  "timestamp": 1756840315946,
+  "version": "0.8.0"
+}
osx-arm64::fastjet-cxx-python-3.5.1-py312hdc12c9d_1.conda
-{}
+{
+  "build": "py312hdc12c9d_1",
+  "build_number": 1,
+  "depends": [
+    "__osx >=11.0",
+    "fastjet-cxx >=3.5.1,<3.6.0a0",
+    "libcxx >=19",
+    "python",
+    "python 3.12.* *_cpython",
+    "python_abi 3.12.* *_cp312"
+  ],
+  "license": "GPL-2.0-or-later",
+  "md5": "043114ad0b1424d8e2fbfe889a1e326b",
+  "name": "fastjet-cxx-python",
+  "sha256": "ec1b0394e6c95ac16bf7300c43388a9cb0ebaf7a079cb31f33cd46977dccd97c",
+  "size": 411562,
+  "subdir": "osx-arm64",
+  "timestamp": 1756839554308,
+  "version": "3.5.1"
+}
osx-arm64::fastjet-cxx-3.5.1-h4f10f1e_1.conda
-{}
+{
+  "build": "h4f10f1e_1",
+  "build_number": 1,
+  "depends": [
+    "__osx >=11.0",
+    "libcxx >=19",
+    "siscone >=3.1.2,<3.2.0a0"
+  ],
+  "license": "GPL-2.0-or-later",
+  "md5": "9a6a5fcb5ef0a5b723155f789d62d074",
+  "name": "fastjet-cxx",
+  "sha256": "bbb10832ac47f9d6866b1c93bdd500386d5c1a9ea884c2b899452bc8a670ff8a",
+  "size": 747069,
+  "subdir": "osx-arm64",
+  "timestamp": 1756839554306,
+  "version": "3.5.1"
+}
osx-arm64::pykrb5-0.8.0-py312h9d7026a_0.conda
-{}
+{
+  "build": "py312h9d7026a_0",
+  "build_number": 0,
+  "depends": [
+    "__osx >=11.0",
+    "cryptography >=1.3",
+    "krb5 >=1.21.3,<1.22.0a0",
+    "python >=3.12,<3.13.0a0",
+    "python >=3.12,<3.13.0a0 *_cpython",
+    "python_abi 3.12.* *_cp312"
+  ],
+  "license": "MIT",
+  "md5": "e54e9e5e6c79615d8fdfc51fc8b04cad",
+  "name": "pykrb5",
+  "sha256": "6c248ad952a0b1a66ceed447161bf89cd086b2eb3da08410086ccf5bed31cf45",
+  "size": 417157,
+  "subdir": "osx-arm64",
+  "timestamp": 1756840308060,
+  "version": "0.8.0"
+}
osx-arm64::pykrb5-0.8.0-py313h5add26c_0.conda
-{}
+{
+  "build": "py313h5add26c_0",
+  "build_number": 0,
+  "depends": [
+    "__osx >=11.0",
+    "cryptography >=1.3",
+    "krb5 >=1.21.3,<1.22.0a0",
+    "python >=3.13,<3.14.0a0",
+    "python >=3.13,<3.14.0a0 *_cp313",
+    "python_abi 3.13.* *_cp313"
+  ],
+  "license": "MIT",
+  "md5": "f3921682317eee04670e04359078a3cb",
+  "name": "pykrb5",
+  "sha256": "463d3f5599119cb6fefff60283b174070dfbd4b50a44e7de77b862e076d84bac",
+  "size": 421824,
+  "subdir": "osx-arm64",
+  "timestamp": 1756840313290,
+  "version": "0.8.0"
+}
osx-arm64::fastjet-cxx-python-3.5.1-py311h63e5c0c_1.conda
-{}
+{
+  "build": "py311h63e5c0c_1",
+  "build_number": 1,
+  "depends": [
+    "__osx >=11.0",
+    "fastjet-cxx >=3.5.1,<3.6.0a0",
+    "libcxx >=19",
+    "python",
+    "python 3.11.* *_cpython",
+    "python_abi 3.11.* *_cp311"
+  ],
+  "license": "GPL-2.0-or-later",
+  "md5": "8749600b09332132676a907f89a7a745",
+  "name": "fastjet-cxx-python",
+  "sha256": "6ecc2da4531d4e1f0231dc01bf3f19dff16b0bb12597bdcf8eef9c783b89fbbc",
+  "size": 413615,
+  "subdir": "osx-arm64",
+  "timestamp": 1756839554308,
+  "version": "3.5.1"
+}
================================================================================
================================================================================
linux-aarch64
linux-aarch64::fastjet-cxx-python-3.5.1-py310h2a7b93a_1.conda
-{}
+{
+  "build": "py310h2a7b93a_1",
+  "build_number": 1,
+  "depends": [
+    "fastjet-cxx >=3.5.1,<3.6.0a0",
+    "libgcc >=14",
+    "libstdcxx >=14",
+    "python",
+    "python 3.10.* *_cpython",
+    "python_abi 3.10.* *_cp310"
+  ],
+  "license": "GPL-2.0-or-later",
+  "md5": "260082a1b9dc96a359c624d41c5f4d48",
+  "name": "fastjet-cxx-python",
+  "sha256": "02b8843f2808aabc0f95d4211783f128d0b3794eb4e22011a32ef01d3b5a8984",
+  "size": 449324,
+  "subdir": "linux-aarch64",
+  "timestamp": 1756839559383,
+  "version": "3.5.1"
+}
linux-aarch64::fastjet-cxx-python-3.5.1-py313h75bc965_1.conda
-{}
+{
+  "build": "py313h75bc965_1",
+  "build_number": 1,
+  "depends": [
+    "fastjet-cxx >=3.5.1,<3.6.0a0",
+    "libgcc >=14",
+    "libstdcxx >=14",
+    "python",
+    "python 3.13.* *_cp313",
+    "python_abi 3.13.* *_cp313"
+  ],
+  "license": "GPL-2.0-or-later",
+  "md5": "fdf53a7332b91473367b4769a859c0c0",
+  "name": "fastjet-cxx-python",
+  "sha256": "4aad2fa70fa2debc2ca17d8a80458a7ba0591adfb24951fed3a9578bcabf2582",
+  "size": 460928,
+  "subdir": "linux-aarch64",
+  "timestamp": 1756839559383,
+  "version": "3.5.1"
+}
linux-aarch64::typos-1.36.0-h1ebd7d5_0.conda
-{}
+{
+  "build": "h1ebd7d5_0",
+  "build_number": 0,
+  "constrains": [
+    "__glibc >=2.17"
+  ],
+  "depends": [
+    "libgcc >=14"
+  ],
+  "license": "MIT",
+  "md5": "a0d84c27e048688679a69e21420d86da",
+  "name": "typos",
+  "sha256": "1134b9f231997f74bec3f260d10757124332db4bd370ac2a7591237e71a873b4",
+  "size": 3375707,
+  "subdir": "linux-aarch64",
+  "timestamp": 1756840380087,
+  "version": "1.36.0"
+}
linux-aarch64::fastjet-cxx-3.5.1-hdc560ac_1.conda
-{}
+{
+  "build": "hdc560ac_1",
+  "build_number": 1,
+  "depends": [
+    "libgcc >=14",
+    "libstdcxx >=14",
+    "siscone >=3.1.2,<3.2.0a0"
+  ],
+  "license": "GPL-2.0-or-later",
+  "md5": "fb278d246ab53937af535d8936b68518",
+  "name": "fastjet-cxx",
+  "sha256": "0fafd7b31eda14337ca91ccb13034df07df3963b93bdff4edd25b7ee037b0bbc",
+  "size": 996630,
+  "subdir": "linux-aarch64",
+  "timestamp": 1756839559383,
+  "version": "3.5.1"
+}
linux-aarch64::pydantic-core-2.39.0-py312h5eb8f6c_1.conda
-{}
+{
+  "build": "py312h5eb8f6c_1",
+  "build_number": 1,
+  "constrains": [
+    "__glibc >=2.17"
+  ],
+  "depends": [
+    "libgcc >=14",
+    "python",
+    "python 3.12.* *_cpython",
+    "python_abi 3.12.* *_cp312",
+    "typing-extensions >=4.6.0,!=4.7.0"
+  ],
+  "license": "MIT",
+  "md5": "9be8c9189169ea8c0ab9ca18f1eb2a2f",
+  "name": "pydantic-core",
+  "sha256": "abeb914d05ecdfb5856dece95ac60b0c52a745d57167cbf52d4ab4567fd8d53f",
+  "size": 1809979,
+  "subdir": "linux-aarch64",
+  "timestamp": 1756840689792,
+  "version": "2.39.0"
+}
linux-aarch64::fastjet-cxx-3.5.1-h6c2971b_1.conda
-{}
+{
+  "build": "h6c2971b_1",
+  "build_number": 1,
+  "depends": [
+    "libgcc >=14",
+    "libstdcxx >=14",
+    "siscone >=3.1.2,<3.2.0a0"
+  ],
+  "license": "GPL-2.0-or-later",
+  "md5": "73419623cea3873d49b3c94f8fb43783",
+  "name": "fastjet-cxx",
+  "sha256": "407f9684bcaea0e5d2e2e7def19e0c044ea6c8e9276a78b3edceb77fa6f00070",
+  "size": 996653,
+  "subdir": "linux-aarch64",
+  "timestamp": 1756839535708,
+  "version": "3.5.1"
+}
linux-aarch64::fastjet-cxx-python-3.5.1-py312hf18b547_1.conda
-{}
+{
+  "build": "py312hf18b547_1",
+  "build_number": 1,
+  "depends": [
+    "fastjet-cxx >=3.5.1,<3.6.0a0",
+    "libgcc >=14",
+    "libstdcxx >=14",
+    "python",
+    "python 3.12.* *_cpython",
+    "python_abi 3.12.* *_cp312"
+  ],
+  "license": "GPL-2.0-or-later",
+  "md5": "a8505bccc8e9c7910b3a0bbeb8fea571",
+  "name": "fastjet-cxx-python",
+  "sha256": "d25d07739afa86718dc4dc7aeed5a6c625149ad224123f524a04e80f13f2334a",
+  "size": 459035,
+  "subdir": "linux-aarch64",
+  "timestamp": 1756839559383,
+  "version": "3.5.1"
+}
linux-aarch64::fastjet-cxx-python-3.5.1-py311h04741b4_1.conda
-{}
+{
+  "build": "py311h04741b4_1",
+  "build_number": 1,
+  "depends": [
+    "fastjet-cxx >=3.5.1,<3.6.0a0",
+    "libgcc >=14",
+    "libstdcxx >=14",
+    "python",
+    "python 3.11.* *_cpython",
+    "python_abi 3.11.* *_cp311"
+  ],
+  "license": "GPL-2.0-or-later",
+  "md5": "af196f5c2f6f3e5c98ba2ba21f81ffb8",
+  "name": "fastjet-cxx-python",
+  "sha256": "9becf70bcaee94d446e41edcbc9d69ce5c2a171dc394e3e932769b68cc25c909",
+  "size": 460277,
+  "subdir": "linux-aarch64",
+  "timestamp": 1756839559383,
+  "version": "3.5.1"
+}
linux-aarch64::fastjet-cxx-python-3.5.1-py314hea58c66_1.conda
-{}
+{
+  "build": "py314hea58c66_1",
+  "build_number": 1,
+  "depends": [
+    "fastjet-cxx >=3.5.1,<3.6.0a0",
+    "libgcc >=14",
+    "libstdcxx >=14",
+    "python",
+    "python 3.14.* *_cp314",
+    "python_abi 3.14.* *_cp314"
+  ],
+  "license": "GPL-2.0-or-later",
+  "md5": "f82e2af158cedd5c9e0b51cd2611e6eb",
+  "name": "fastjet-cxx-python",
+  "sha256": "27aff29cc96bdb294f42c5d503887811b067a038076622ab9808732fcf5c3571",
+  "size": 461171,
+  "subdir": "linux-aarch64",
+  "timestamp": 1756839535708,
+  "version": "3.5.1"
+}
================================================================================
================================================================================
noarch
noarch::r-dtrackr-0.5.0-r44hc72bb7e_0.conda
-{}
+{
+  "build": "r44hc72bb7e_0",
+  "build_number": 0,
+  "depends": [
+    "r-base >=4.4,<4.5.0a0",
+    "r-base64enc",
+    "r-dplyr >=1.1.0",
+    "r-fs",
+    "r-glue",
+    "r-htmltools",
+    "r-lifecycle",
+    "r-magrittr",
+    "r-pdftools",
+    "r-png",
+    "r-purrr",
+    "r-rlang",
+    "r-rsvg",
+    "r-scales",
+    "r-stringr",
+    "r-tibble",
+    "r-tidyr",
+    "r-v8"
+  ],
+  "license": "MIT",
+  "md5": "8cfa47c97667c0507363187477125a52",
+  "name": "r-dtrackr",
+  "noarch": "generic",
+  "sha256": "71599eaf6226481e3da60876c1d8650e01b185825781fa3b28230efb29d7930b",
+  "size": 1303826,
+  "subdir": "noarch",
+  "timestamp": 1756839917096,
+  "version": "0.5.0"
+}
noarch::r-dtrackr-0.5.0-r43hc72bb7e_0.conda
-{}
+{
+  "build": "r43hc72bb7e_0",
+  "build_number": 0,
+  "depends": [
+    "r-base >=4.3,<4.4.0a0",
+    "r-base64enc",
+    "r-dplyr >=1.1.0",
+    "r-fs",
+    "r-glue",
+    "r-htmltools",
+    "r-lifecycle",
+    "r-magrittr",
+    "r-pdftools",
+    "r-png",
+    "r-purrr",
+    "r-rlang",
+    "r-rsvg",
+    "r-scales",
+    "r-stringr",
+    "r-tibble",
+    "r-tidyr",
+    "r-v8"
+  ],
+  "license": "MIT",
+  "md5": "2965522dfbf4fead9c79ca78c3b6a167",
+  "name": "r-dtrackr",
+  "noarch": "generic",
+  "sha256": "b93f1b761451d8ade6b9070d7676ee32d21115e051febe7bcd8d0317fbfe49e2",
+  "size": 1264716,
+  "subdir": "noarch",
+  "timestamp": 1756839917833,
+  "version": "0.5.0"
+}
noarch::pynguin-0.43.0-pyhcf101f3_0.conda
-{}
+{
+  "build": "pyhcf101f3_0",
+  "build_number": 0,
+  "depends": [
+    "asciitree >=0.3.3,<0.4.0",
+    "astroid >=3.3.9,<4.0.0",
+    "black >=25.1.0,<26.0.0",
+    "bytecode >=0.16.1,<0.17.0",
+    "dill >=0.3.9,<0.4.0",
+    "jinja2 >=3.1.6,<4.0.0",
+    "libcst >=1.7.0,<2.0.0",
+    "multiprocess >=0.70.16,<0.71.0",
+    "networkx >=3.4.0,<4.0.0",
+    "numpy",
+    "psutil >=7.0.0,<8.0.0",
+    "pygments >=2.19.2,<3.0.0",
+    "pytest >=8.3.5,<9.0.0",
+    "python",
+    "python >=3.10,<3.14",
+    "rich >=14.0.0,<15.0.0",
+    "setuptools >=78.1,<79.0",
+    "simple-parsing >=0.1.7,<0.2.0",
+    "toml >=0.10.2,<0.11.0",
+    "typing_inspect >=0.9.0,<0.10.0"
+  ],
+  "license": "LGPL-3.0-only",
+  "md5": "8d6384fa2e456852e5714f0902f5610b",
+  "name": "pynguin",
+  "noarch": "python",
+  "sha256": "b4833c111e3cf69bce571f6053118d38e8c7b73ab24cf27a36bf088954fa5b55",
+  "size": 299242,
+  "subdir": "noarch",
+  "timestamp": 1756839810846,
+  "version": "0.43.0"
+}
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
osx-64::root-6.16.00-py27_blas_openblash6de8b3b_7.tar.bz2
osx-64::root-6.16.00-py27_blas_openblash77af0b3_4.tar.bz2
osx-64::root-6.16.00-py27_blas_openblash77af0b3_5.tar.bz2
osx-64::root-6.16.00-py27_blas_openblash77af0b3_6.tar.bz2
osx-64::root-6.16.00-py27_blas_openblashb3e4954_2.tar.bz2
osx-64::root-6.16.00-py27_blas_openblashb3e4954_3.tar.bz2
osx-64::root-6.16.00-py27h0c3f1a6_8.tar.bz2
osx-64::root-6.16.00-py27h50fd8ba_14.tar.bz2
osx-64::root-6.16.00-py27h82bc3df_12.tar.bz2
osx-64::root-6.16.00-py27h82bc3df_13.tar.bz2
osx-64::root-6.16.00-py27h8c27c36_10.tar.bz2
osx-64::root-6.16.00-py27h8c27c36_11.tar.bz2
osx-64::root-6.16.00-py27h8c27c36_9.tar.bz2
osx-64::root-6.16.00-py36_blas_openblash6de8b3b_7.tar.bz2
osx-64::root-6.16.00-py36_blas_openblash77af0b3_4.tar.bz2
osx-64::root-6.16.00-py36_blas_openblash77af0b3_5.tar.bz2
osx-64::root-6.16.00-py36_blas_openblash77af0b3_6.tar.bz2
osx-64::root-6.16.00-py36_blas_openblashb3e4954_2.tar.bz2
osx-64::root-6.16.00-py36_blas_openblashb3e4954_3.tar.bz2
osx-64::root-6.16.00-py36h0c3f1a6_8.tar.bz2
osx-64::root-6.16.00-py36h50fd8ba_14.tar.bz2
osx-64::root-6.16.00-py36h82bc3df_12.tar.bz2
osx-64::root-6.16.00-py36h82bc3df_13.tar.bz2
osx-64::root-6.16.00-py36h8c27c36_10.tar.bz2
osx-64::root-6.16.00-py36h8c27c36_11.tar.bz2
osx-64::root-6.16.00-py36h8c27c36_9.tar.bz2
osx-64::root-6.16.00-py37_blas_openblash6de8b3b_7.tar.bz2
osx-64::root-6.16.00-py37_blas_openblash77af0b3_4.tar.bz2
osx-64::root-6.16.00-py37_blas_openblash77af0b3_5.tar.bz2
osx-64::root-6.16.00-py37_blas_openblash77af0b3_6.tar.bz2
osx-64::root-6.16.00-py37_blas_openblashb3e4954_2.tar.bz2
osx-64::root-6.16.00-py37_blas_openblashb3e4954_3.tar.bz2
osx-64::root-6.16.00-py37h0c3f1a6_8.tar.bz2
osx-64::root-6.16.00-py37h50fd8ba_14.tar.bz2
osx-64::root-6.16.00-py37h82bc3df_12.tar.bz2
osx-64::root-6.16.00-py37h82bc3df_13.tar.bz2
osx-64::root-6.16.00-py37h8c27c36_10.tar.bz2
osx-64::root-6.16.00-py37h8c27c36_11.tar.bz2
osx-64::root-6.16.00-py37h8c27c36_9.tar.bz2
osx-64::root-6.18.00-py27h500fca7_17.tar.bz2
osx-64::root-6.18.00-py27h5cda73f_18.tar.bz2
osx-64::root-6.18.00-py27h5fd7429_18.tar.bz2
osx-64::root-6.18.00-py27heb021e6_14.tar.bz2
osx-64::root-6.18.00-py27heb021e6_15.tar.bz2
osx-64::root-6.18.00-py27heb021e6_16.tar.bz2
osx-64::root-6.18.00-py36h500fca7_17.tar.bz2
osx-64::root-6.18.00-py36h5cda73f_18.tar.bz2
osx-64::root-6.18.00-py36h5fd7429_18.tar.bz2
osx-64::root-6.18.00-py36heb021e6_14.tar.bz2
osx-64::root-6.18.00-py36heb021e6_15.tar.bz2
osx-64::root-6.18.00-py36heb021e6_16.tar.bz2
osx-64::root-6.18.00-py37h500fca7_17.tar.bz2
osx-64::root-6.18.00-py37h5cda73f_18.tar.bz2
osx-64::root-6.18.00-py37h5fd7429_18.tar.bz2
osx-64::root-6.18.00-py37heb021e6_14.tar.bz2
osx-64::root-6.18.00-py37heb021e6_15.tar.bz2
osx-64::root-6.18.00-py37heb021e6_16.tar.bz2
osx-64::root-6.18.04-py27h07973f4_21.tar.bz2
osx-64::root-6.18.04-py27h47db2f6_20.tar.bz2
osx-64::root-6.18.04-py27h5293c5b_20.tar.bz2
osx-64::root-6.18.04-py27h5cda73f_0.tar.bz2
osx-64::root-6.18.04-py27h5fd7429_0.tar.bz2
osx-64::root-6.18.04-py27h95b5a52_22.tar.bz2
osx-64::root-6.18.04-py27hbb522cf_28.tar.bz2
osx-64::root-6.18.04-py27hffc68f4_25.tar.bz2
osx-64::root-6.18.04-py27hffc68f4_26.tar.bz2
osx-64::root-6.18.04-py36h07973f4_21.tar.bz2
osx-64::root-6.18.04-py36h47db2f6_20.tar.bz2
osx-64::root-6.18.04-py36h5293c5b_20.tar.bz2
osx-64::root-6.18.04-py36h5cda73f_0.tar.bz2
osx-64::root-6.18.04-py36h5fd7429_0.tar.bz2
osx-64::root-6.18.04-py36h95b5a52_22.tar.bz2
osx-64::root-6.18.04-py36hbb522cf_28.tar.bz2
osx-64::root-6.18.04-py36hffc68f4_25.tar.bz2
osx-64::root-6.18.04-py36hffc68f4_26.tar.bz2
osx-64::root-6.18.04-py37h07973f4_21.tar.bz2
osx-64::root-6.18.04-py37h47db2f6_20.tar.bz2
osx-64::root-6.18.04-py37h5293c5b_20.tar.bz2
osx-64::root-6.18.04-py37h5cda73f_0.tar.bz2
osx-64::root-6.18.04-py37h5fd7429_0.tar.bz2
osx-64::root-6.18.04-py37h81b6a41_27.tar.bz2
osx-64::root-6.18.04-py37h95b5a52_22.tar.bz2
osx-64::root-6.18.04-py37hbb522cf_28.tar.bz2
osx-64::root-6.18.04-py37hffc68f4_25.tar.bz2
osx-64::root-6.18.04-py37hffc68f4_26.tar.bz2
osx-64::root-6.18.04-py38h07973f4_21.tar.bz2
osx-64::root-6.18.04-py38h81b6a41_27.tar.bz2
osx-64::root-6.18.04-py38h95b5a52_22.tar.bz2
osx-64::root-6.18.04-py38hbb522cf_28.tar.bz2
osx-64::root-6.18.04-py38hffc68f4_25.tar.bz2
osx-64::root-6.18.04-py38hffc68f4_26.tar.bz2
osx-64::root-6.20.0-py27hbadf3b9_0.tar.bz2
osx-64::root-6.20.0-py27hbadf3b9_1.tar.bz2
osx-64::root-6.20.0-py36hbadf3b9_0.tar.bz2
osx-64::root-6.20.0-py36hbadf3b9_1.tar.bz2
osx-64::root-6.20.0-py37hbadf3b9_0.tar.bz2
osx-64::root-6.20.0-py37hbadf3b9_1.tar.bz2
osx-64::root-6.20.0-py38hbadf3b9_0.tar.bz2
osx-64::root-6.20.0-py38hbadf3b9_1.tar.bz2
osx-64::root-6.20.2-py27h7ce42fa_0.tar.bz2
osx-64::root-6.20.2-py36h69b0a59_1.tar.bz2
osx-64::root-6.20.2-py36hb7dde67_0.tar.bz2
osx-64::root-6.20.2-py37h65fef63_0.tar.bz2
osx-64::root-6.20.2-py37hcc4ca02_1.tar.bz2
osx-64::root-6.20.2-py38h9a6c036_0.tar.bz2
osx-64::root-6.20.2-py38hbc92c2f_1.tar.bz2
osx-64::root-6.20.4-py36h69b0a59_3.tar.bz2
osx-64::root-6.20.4-py37hcc4ca02_3.tar.bz2
osx-64::root-6.20.4-py38hbc92c2f_3.tar.bz2
osx-64::root-6.20.6-py36hc7c2e62_0.tar.bz2
osx-64::root-6.20.6-py37h2a0c050_0.tar.bz2
osx-64::root-6.20.6-py38he5e888e_0.tar.bz2
osx-64::root-6.22.0-py27hdf2d85e_1.tar.bz2
osx-64::root-6.22.0-py27hdf2d85e_2.tar.bz2
osx-64::root-6.22.0-py36h056c9e4_3.tar.bz2
osx-64::root-6.22.0-py36h056c9e4_4.tar.bz2
osx-64::root-6.22.0-py36h8f02a94_0.tar.bz2
osx-64::root-6.22.0-py36hbd3365f_1.tar.bz2
osx-64::root-6.22.0-py36hbd3365f_2.tar.bz2
osx-64::root-6.22.0-py37h1b7e055_3.tar.bz2
osx-64::root-6.22.0-py37h1b7e055_4.tar.bz2
osx-64::root-6.22.0-py37h1d67377_1.tar.bz2
osx-64::root-6.22.0-py37h1d67377_2.tar.bz2
osx-64::root-6.22.0-py37h4e51ed6_0.tar.bz2
osx-64::root-6.22.0-py38h011e58f_0.tar.bz2
osx-64::root-6.22.0-py38h84d0887_4.tar.bz2
osx-64::root-6.22.0-py38hbb65a81_1.tar.bz2
osx-64::root-6.22.0-py38hbb65a81_2.tar.bz2
osx-64::root-6.22.2-py36h056c9e4_0.tar.bz2
osx-64::root-6.22.2-py36h0f67a46_1.tar.bz2
osx-64::root-6.22.2-py36h0f67a46_2.tar.bz2
osx-64::root-6.22.2-py36h311cf85_2.tar.bz2
osx-64::root-6.22.2-py36hbf12218_1.tar.bz2
osx-64::root-6.22.2-py37h1b7e055_0.tar.bz2
osx-64::root-6.22.2-py37h3138373_1.tar.bz2
osx-64::root-6.22.2-py37h3138373_2.tar.bz2
osx-64::root-6.22.2-py37hb6426ff_1.tar.bz2
osx-64::root-6.22.2-py37he7b288f_2.tar.bz2
osx-64::root-6.22.2-py38h1e33425_1.tar.bz2
osx-64::root-6.22.2-py38h3170eaa_2.tar.bz2
osx-64::root-6.22.2-py38h5a485f8_1.tar.bz2
osx-64::root-6.22.2-py38h5a485f8_2.tar.bz2
osx-64::root-6.22.2-py38h84d0887_0.tar.bz2
osx-64::root-6.22.2-py39h31b5726_1.tar.bz2
osx-64::root-6.22.2-py39h31b5726_2.tar.bz2
osx-64::root-6.22.2-py39h3a5a442_2.tar.bz2
osx-64::root-6.22.6-py36h138dd42_0.tar.bz2
osx-64::root-6.22.6-py36h2a58cd0_1.tar.bz2
osx-64::root-6.22.6-py36h3d1eebc_2.tar.bz2
osx-64::root-6.22.6-py36hf7b9339_0.tar.bz2
osx-64::root-6.22.6-py37h15ea0b9_1.tar.bz2
osx-64::root-6.22.6-py37h1cbf7fc_2.tar.bz2
osx-64::root-6.22.6-py37ha0830e8_0.tar.bz2
osx-64::root-6.22.6-py37hef4f29f_0.tar.bz2
osx-64::root-6.22.6-py38h0d2f4df_0.tar.bz2
osx-64::root-6.22.6-py38h6604742_1.tar.bz2
osx-64::root-6.22.6-py38h8ecd997_0.tar.bz2
osx-64::root-6.22.6-py38hab5930e_2.tar.bz2
osx-64::root-6.22.6-py39h5442c83_1.tar.bz2
osx-64::root-6.22.6-py39h5442c83_2.tar.bz2
osx-64::root-6.22.6-py39h6b9957e_0.tar.bz2
osx-64::root-6.22.8-py36h3d1eebc_2.tar.bz2
osx-64::root-6.22.8-py36h4a8af38_3.tar.bz2
osx-64::root-6.22.8-py37h1cbf7fc_2.tar.bz2
osx-64::root-6.22.8-py37h366d447_3.tar.bz2
osx-64::root-6.22.8-py38hab5930e_2.tar.bz2
osx-64::root-6.22.8-py38hd6c9f76_3.tar.bz2
osx-64::root-6.22.8-py39h07141f4_3.tar.bz2
osx-64::root-6.22.8-py39h5442c83_2.tar.bz2
osx-64::root-6.24.0-py36h808fd10_0.tar.bz2
osx-64::root-6.24.0-py36h808fd10_1.tar.bz2
osx-64::root-6.24.0-py36h808fd10_2.tar.bz2
osx-64::root-6.24.0-py37h586d6ec_0.tar.bz2
osx-64::root-6.24.0-py37h586d6ec_1.tar.bz2
osx-64::root-6.24.0-py37h586d6ec_2.tar.bz2
osx-64::root-6.24.0-py38hf1bbeba_0.tar.bz2
osx-64::root-6.24.0-py38hf1bbeba_1.tar.bz2
osx-64::root-6.24.0-py38hf1bbeba_2.tar.bz2
osx-64::root-6.24.0-py39h757cd7f_0.tar.bz2
osx-64::root-6.24.0-py39h757cd7f_1.tar.bz2
osx-64::root-6.24.0-py39h757cd7f_2.tar.bz2
osx-64::root-6.24.2-py36h808fd10_0.tar.bz2
osx-64::root-6.24.2-py37h586d6ec_0.tar.bz2
osx-64::root-6.24.2-py38hf1bbeba_0.tar.bz2
osx-64::root-6.24.2-py39h757cd7f_0.tar.bz2
osx-64::root-6.24.4-py36h11eeb7b_0.tar.bz2
osx-64::root-6.24.4-py37h435536a_0.tar.bz2
osx-64::root-6.24.4-py38h25821e9_0.tar.bz2
osx-64::root-6.24.4-py39h757cd7f_0.tar.bz2
osx-64::root-6.24.6-py310h034d307_1.tar.bz2
osx-64::root-6.24.6-py310h034d307_2.tar.bz2
osx-64::root-6.24.6-py310h532db78_2.tar.bz2
osx-64::root-6.24.6-py36h11eeb7b_0.tar.bz2
osx-64::root-6.24.6-py37h435536a_0.tar.bz2
osx-64::root-6.24.6-py37h435536a_1.tar.bz2
osx-64::root-6.24.6-py37h435536a_2.tar.bz2
osx-64::root-6.24.6-py37h8d62b1d_2.tar.bz2
osx-64::root-6.24.6-py38h25821e9_0.tar.bz2
osx-64::root-6.24.6-py38h25821e9_1.tar.bz2
osx-64::root-6.24.6-py38h25821e9_2.tar.bz2
osx-64::root-6.24.6-py38hd7a8d54_2.tar.bz2
osx-64::root-6.24.6-py38hd7a8d54_3.tar.bz2
osx-64::root-6.24.6-py39h757cd7f_0.tar.bz2
osx-64::root-6.24.6-py39h757cd7f_1.tar.bz2
osx-64::root-6.24.6-py39h757cd7f_2.tar.bz2
osx-64::root-6.24.6-py39hb2d5705_2.tar.bz2
osx-64::root-6.26.0-py310h532db78_0.tar.bz2
osx-64::root-6.26.0-py37h635a340_0.tar.bz2
osx-64::root-6.26.0-py38h9ca11a9_0.tar.bz2
osx-64::root-6.26.0-py39hb2d5705_0.tar.bz2
osx-64::root-6.26.10-py310h971e5b6_1.tar.bz2
osx-64::root-6.26.10-py311h586916d_1.tar.bz2
osx-64::root-6.26.10-py38h86e466c_1.tar.bz2
osx-64::root-6.26.10-py39hb24b706_1.tar.bz2
osx-64::root-6.26.2-py310h532db78_1.tar.bz2
osx-64::root-6.26.2-py310h7c3810d_2.tar.bz2
osx-64::root-6.26.2-py310h7c3810d_3.tar.bz2
osx-64::root-6.26.2-py37h0bd9c3f_2.tar.bz2
osx-64::root-6.26.2-py37h0bd9c3f_3.tar.bz2
osx-64::root-6.26.2-py37h8d62b1d_1.tar.bz2
osx-64::root-6.26.2-py38h13d9824_2.tar.bz2
osx-64::root-6.26.2-py38h13d9824_3.tar.bz2
osx-64::root-6.26.2-py38hd7a8d54_1.tar.bz2
osx-64::root-6.26.2-py39h1ee4e32_2.tar.bz2
osx-64::root-6.26.2-py39h1ee4e32_3.tar.bz2
osx-64::root-6.26.2-py39hb2d5705_1.tar.bz2
osx-64::root-6.26.4-py310h7c3810d_3.tar.bz2
osx-64::root-6.26.4-py37h0bd9c3f_3.tar.bz2
osx-64::root-6.26.4-py38h13d9824_3.tar.bz2
osx-64::root-6.26.4-py39h1ee4e32_3.tar.bz2
osx-64::root-6.26.6-py310hf3932a0_0.tar.bz2
osx-64::root-6.26.6-py37h75914f2_0.tar.bz2
osx-64::root-6.26.6-py38h15fa9b7_0.tar.bz2
osx-64::root-6.26.6-py39hd24aadf_0.tar.bz2
osx-64::root-6.26.8-py310h971e5b6_0.tar.bz2
osx-64::root-6.26.8-py310h971e5b6_1.tar.bz2
osx-64::root-6.26.8-py311h586916d_1.tar.bz2
osx-64::root-6.26.8-py37h669ab5d_0.tar.bz2
osx-64::root-6.26.8-py37h669ab5d_1.tar.bz2
osx-64::root-6.26.8-py38h86e466c_0.tar.bz2
osx-64::root-6.26.8-py38h86e466c_1.tar.bz2
osx-64::root-6.26.8-py39hb24b706_0.tar.bz2
osx-64::root-6.26.8-py39hb24b706_1.tar.bz2
osx-64::root-6.28.0-py310h971e5b6_0.conda
osx-64::root-6.28.0-py310h971e5b6_1.conda
osx-64::root-6.28.0-py311h586916d_0.conda
osx-64::root-6.28.0-py311h586916d_1.conda
osx-64::root-6.28.0-py38h86e466c_0.conda
osx-64::root-6.28.0-py38h86e466c_1.conda
osx-64::root-6.28.0-py39hb24b706_0.conda
osx-64::root-6.28.0-py39hb24b706_1.conda
osx-64::root-6.28.10-py310h797b08a_0.conda
osx-64::root-6.28.10-py310h797b08a_1.conda
osx-64::root-6.28.10-py310h797b08a_2.conda
osx-64::root-6.28.10-py311h9ed3784_0.conda
osx-64::root-6.28.10-py311h9ed3784_1.conda
osx-64::root-6.28.10-py311h9ed3784_2.conda
osx-64::root-6.28.10-py38haf460e6_0.conda
osx-64::root-6.28.10-py38haf460e6_1.conda
osx-64::root-6.28.10-py38haf460e6_2.conda
osx-64::root-6.28.10-py39h6fee5a3_0.conda
osx-64::root-6.28.10-py39h6fee5a3_1.conda
osx-64::root-6.28.10-py39h6fee5a3_2.conda
osx-64::root-6.28.12-py310h797b08a_0.conda
osx-64::root-6.28.12-py311h9ed3784_0.conda
osx-64::root-6.28.12-py38haf460e6_0.conda
osx-64::root-6.28.12-py39h6fee5a3_0.conda
osx-64::root-6.28.4-py310h9f67b15_0.conda
osx-64::root-6.28.4-py310h9f67b15_1.conda
osx-64::root-6.28.4-py310h9f67b15_2.conda
osx-64::root-6.28.4-py311h792844c_0.conda
osx-64::root-6.28.4-py311h792844c_1.conda
osx-64::root-6.28.4-py311h792844c_2.conda
osx-64::root-6.28.4-py38ha9494a0_0.conda
osx-64::root-6.28.4-py38ha9494a0_1.conda
osx-64::root-6.28.4-py38ha9494a0_2.conda
osx-64::root-6.28.4-py39h246af82_0.conda
osx-64::root-6.28.4-py39h246af82_1.conda
osx-64::root-6.28.4-py39h246af82_2.conda
osx-64::root-6.30.2-py310h797b08a_0.conda
osx-64::root-6.30.2-py310h797b08a_1.conda
osx-64::root-6.30.2-py311h9ed3784_0.conda
osx-64::root-6.30.2-py311h9ed3784_1.conda
osx-64::root-6.30.2-py38haf460e6_0.conda
osx-64::root-6.30.2-py38haf460e6_1.conda
osx-64::root-6.30.2-py39h6fee5a3_0.conda
osx-64::root-6.30.2-py39h6fee5a3_1.conda
osx-64::root-6.30.4-py310h797b08a_0.conda
osx-64::root-6.30.4-py311h9ed3784_0.conda
osx-64::root-6.30.4-py38haf460e6_0.conda
osx-64::root-6.30.4-py39h6fee5a3_0.conda
osx-64::root-6.32.0-py310ha548870_0.conda
osx-64::root-6.32.0-py310ha548870_1.conda
osx-64::root-6.32.0-py310ha548870_2.conda
osx-64::root-6.32.0-py311h91102bb_0.conda
osx-64::root-6.32.0-py311h91102bb_1.conda
osx-64::root-6.32.0-py311h91102bb_2.conda
osx-64::root-6.32.0-py312h3e591bc_0.conda
osx-64::root-6.32.0-py312h3e591bc_1.conda
osx-64::root-6.32.0-py312h3e591bc_2.conda
osx-64::root-6.32.0-py38h92fcef0_0.conda
osx-64::root-6.32.0-py38h92fcef0_1.conda
osx-64::root-6.32.0-py38h92fcef0_2.conda
osx-64::root-6.32.0-py39h969bc6c_0.conda
osx-64::root-6.32.0-py39h969bc6c_1.conda
osx-64::root-6.32.0-py39h969bc6c_2.conda
osx-64::root-6.32.10-py310h4bf3990_0.conda
osx-64::root-6.32.10-py311h850daf4_0.conda
osx-64::root-6.32.10-py312h6746730_0.conda
osx-64::root-6.32.10-py313hea7ef2e_0.conda
osx-64::root-6.32.10-py39ha846243_0.conda
osx-64::root-6.32.16-py310he626226_0.conda
osx-64::root-6.32.16-py311h2a432c1_0.conda
osx-64::root-6.32.16-py312ha98dac2_0.conda
osx-64::root-6.32.16-py313h23ddf8d_0.conda
osx-64::root-6.32.2-py310h2bcf54b_2.conda
osx-64::root-6.32.2-py310h2bcf54b_3.conda
osx-64::root-6.32.2-py310ha548870_0.conda
osx-64::root-6.32.2-py310hcc0fdae_1.conda
osx-64::root-6.32.2-py311h91102bb_0.conda
osx-64::root-6.32.2-py311hb66e75a_2.conda
osx-64::root-6.32.2-py311hb66e75a_3.conda
osx-64::root-6.32.2-py311he2c1b27_1.conda
osx-64::root-6.32.2-py312h0dc0bed_1.conda
osx-64::root-6.32.2-py312h3e591bc_0.conda
osx-64::root-6.32.2-py312hb4e2fa8_2.conda
osx-64::root-6.32.2-py312hb4e2fa8_3.conda
osx-64::root-6.32.2-py38h92fcef0_0.conda
osx-64::root-6.32.2-py39h657c6f6_2.conda
osx-64::root-6.32.2-py39h657c6f6_3.conda
osx-64::root-6.32.2-py39h8f1557c_1.conda
osx-64::root-6.32.2-py39h969bc6c_0.conda
osx-64::root-6.32.8-py310h3ff99de_0.conda
osx-64::root-6.32.8-py311h1280aa9_0.conda
osx-64::root-6.32.8-py312hc517114_0.conda
osx-64::root-6.32.8-py313hbf7155f_0.conda
osx-64::root-6.32.8-py39h4d67397_0.conda
osx-64::root-6.34.04-py310hf39b1cd_1.conda
osx-64::root-6.34.04-py311hc073b44_1.conda
osx-64::root-6.34.04-py312ha1c8ed1_1.conda
osx-64::root-6.34.04-py313hd8b26fb_1.conda
osx-64::root-6.34.04-py39h7dc8616_1.conda
osx-64::root-6.34.4-py310h00bf3ff_0.conda
osx-64::root-6.34.4-py311h91584a2_0.conda
osx-64::root-6.34.4-py312h397d820_0.conda
osx-64::root-6.34.4-py313h26d854b_0.conda
osx-64::root-6.34.4-py39h372e0ea_0.conda
osx-64::root-6.36.02-py310h014259b_0.conda
osx-64::root-6.36.02-py311hb048494_0.conda
osx-64::root-6.36.02-py312hd98c9a2_0.conda
osx-64::root-6.36.02-py313h09e8c76_0.conda
osx-64::root-6.36.04-py310hb3f27f9_1.conda
osx-64::root-6.36.04-py310hbc031df_0.conda
osx-64::root-6.36.04-py311h1a03864_0.conda
osx-64::root-6.36.04-py311h5ceb279_1.conda
osx-64::root-6.36.04-py312h55567c7_1.conda
osx-64::root-6.36.04-py312hbdaae20_0.conda
osx-64::root-6.36.04-py313hb62126c_0.conda
osx-64::root-6.36.04-py313hfeacdf9_1.conda
osx-64::root-binaries-6.18.04-py27h07973f4_21.tar.bz2
osx-64::root-binaries-6.18.04-py27h47db2f6_20.tar.bz2
osx-64::root-binaries-6.18.04-py27h5293c5b_20.tar.bz2
osx-64::root-binaries-6.18.04-py27h95b5a52_22.tar.bz2
osx-64::root-binaries-6.18.04-py27hbb522cf_28.tar.bz2
osx-64::root-binaries-6.18.04-py27hffc68f4_25.tar.bz2
osx-64::root-binaries-6.18.04-py27hffc68f4_26.tar.bz2
osx-64::root-binaries-6.18.04-py36h07973f4_21.tar.bz2
osx-64::root-binaries-6.18.04-py36h47db2f6_20.tar.bz2
osx-64::root-binaries-6.18.04-py36h5293c5b_20.tar.bz2
osx-64::root-binaries-6.18.04-py36h95b5a52_22.tar.bz2
osx-64::root-binaries-6.18.04-py36hbb522cf_28.tar.bz2
osx-64::root-binaries-6.18.04-py36hffc68f4_25.tar.bz2
osx-64::root-binaries-6.18.04-py36hffc68f4_26.tar.bz2
osx-64::root-binaries-6.18.04-py37h07973f4_21.tar.bz2
osx-64::root-binaries-6.18.04-py37h47db2f6_20.tar.bz2
osx-64::root-binaries-6.18.04-py37h5293c5b_20.tar.bz2
osx-64::root-binaries-6.18.04-py37h81b6a41_27.tar.bz2
osx-64::root-binaries-6.18.04-py37h95b5a52_22.tar.bz2
osx-64::root-binaries-6.18.04-py37hbb522cf_28.tar.bz2
osx-64::root-binaries-6.18.04-py37hffc68f4_25.tar.bz2
osx-64::root-binaries-6.18.04-py37hffc68f4_26.tar.bz2
osx-64::root-binaries-6.18.04-py38h07973f4_21.tar.bz2
osx-64::root-binaries-6.18.04-py38h81b6a41_27.tar.bz2
osx-64::root-binaries-6.18.04-py38h95b5a52_22.tar.bz2
osx-64::root-binaries-6.18.04-py38hbb522cf_28.tar.bz2
osx-64::root-binaries-6.18.04-py38hffc68f4_25.tar.bz2
osx-64::root-binaries-6.18.04-py38hffc68f4_26.tar.bz2
osx-64::root-binaries-6.20.0-py27hbadf3b9_0.tar.bz2
osx-64::root-binaries-6.20.0-py27hbadf3b9_1.tar.bz2
osx-64::root-binaries-6.20.0-py36hbadf3b9_0.tar.bz2
osx-64::root-binaries-6.20.0-py36hbadf3b9_1.tar.bz2
osx-64::root-binaries-6.20.0-py37hbadf3b9_0.tar.bz2
osx-64::root-binaries-6.20.0-py37hbadf3b9_1.tar.bz2
osx-64::root-binaries-6.20.0-py38hbadf3b9_0.tar.bz2
osx-64::root-binaries-6.20.0-py38hbadf3b9_1.tar.bz2
osx-64::root-binaries-6.20.2-py27h7ce42fa_0.tar.bz2
osx-64::root-binaries-6.20.2-py36h69b0a59_1.tar.bz2
osx-64::root-binaries-6.20.2-py36hb7dde67_0.tar.bz2
osx-64::root-binaries-6.20.2-py37h65fef63_0.tar.bz2
osx-64::root-binaries-6.20.2-py37hcc4ca02_1.tar.bz2
osx-64::root-binaries-6.20.2-py38h9a6c036_0.tar.bz2
osx-64::root-binaries-6.20.2-py38hbc92c2f_1.tar.bz2
osx-64::root-binaries-6.20.4-py36h69b0a59_3.tar.bz2
osx-64::root-binaries-6.20.4-py37hcc4ca02_3.tar.bz2
osx-64::root-binaries-6.20.4-py38hbc92c2f_3.tar.bz2
osx-64::root-binaries-6.20.6-py36hc7c2e62_0.tar.bz2
osx-64::root-binaries-6.20.6-py37h2a0c050_0.tar.bz2
osx-64::root-binaries-6.20.6-py38he5e888e_0.tar.bz2
osx-64::root-binaries-6.22.0-py27hdf2d85e_1.tar.bz2
osx-64::root-binaries-6.22.0-py27hdf2d85e_2.tar.bz2
osx-64::root-binaries-6.22.0-py36h056c9e4_3.tar.bz2
osx-64::root-binaries-6.22.0-py36h056c9e4_4.tar.bz2
osx-64::root-binaries-6.22.0-py36h8f02a94_0.tar.bz2
osx-64::root-binaries-6.22.0-py36hbd3365f_1.tar.bz2
osx-64::root-binaries-6.22.0-py36hbd3365f_2.tar.bz2
osx-64::root-binaries-6.22.0-py37h1b7e055_3.tar.bz2
osx-64::root-binaries-6.22.0-py37h1b7e055_4.tar.bz2
osx-64::root-binaries-6.22.0-py37h1d67377_1.tar.bz2
osx-64::root-binaries-6.22.0-py37h1d67377_2.tar.bz2
osx-64::root-binaries-6.22.0-py37h4e51ed6_0.tar.bz2
osx-64::root-binaries-6.22.0-py38h011e58f_0.tar.bz2
osx-64::root-binaries-6.22.0-py38h84d0887_4.tar.bz2
osx-64::root-binaries-6.22.0-py38hbb65a81_1.tar.bz2
osx-64::root-binaries-6.22.0-py38hbb65a81_2.tar.bz2
osx-64::root-binaries-6.22.2-py36h056c9e4_0.tar.bz2
osx-64::root-binaries-6.22.2-py36h0f67a46_1.tar.bz2
osx-64::root-binaries-6.22.2-py36h0f67a46_2.tar.bz2
osx-64::root-binaries-6.22.2-py36h311cf85_2.tar.bz2
osx-64::root-binaries-6.22.2-py36hbf12218_1.tar.bz2
osx-64::root-binaries-6.22.2-py37h1b7e055_0.tar.bz2
osx-64::root-binaries-6.22.2-py37h3138373_1.tar.bz2
osx-64::root-binaries-6.22.2-py37h3138373_2.tar.bz2
osx-64::root-binaries-6.22.2-py37hb6426ff_1.tar.bz2
osx-64::root-binaries-6.22.2-py37he7b288f_2.tar.bz2
osx-64::root-binaries-6.22.2-py38h1e33425_1.tar.bz2
osx-64::root-binaries-6.22.2-py38h3170eaa_2.tar.bz2
osx-64::root-binaries-6.22.2-py38h5a485f8_1.tar.bz2
osx-64::root-binaries-6.22.2-py38h5a485f8_2.tar.bz2
osx-64::root-binaries-6.22.2-py38h84d0887_0.tar.bz2
osx-64::root-binaries-6.22.2-py39h31b5726_1.tar.bz2
osx-64::root-binaries-6.22.2-py39h31b5726_2.tar.bz2
osx-64::root-binaries-6.22.2-py39h3a5a442_2.tar.bz2
osx-64::root-binaries-6.22.6-py36h138dd42_0.tar.bz2
osx-64::root-binaries-6.22.6-py36h2a58cd0_1.tar.bz2
osx-64::root-binaries-6.22.6-py36h3d1eebc_2.tar.bz2
osx-64::root-binaries-6.22.6-py36hf7b9339_0.tar.bz2
osx-64::root-binaries-6.22.6-py37h15ea0b9_1.tar.bz2
osx-64::root-binaries-6.22.6-py37h1cbf7fc_2.tar.bz2
osx-64::root-binaries-6.22.6-py37ha0830e8_0.tar.bz2
osx-64::root-binaries-6.22.6-py37hef4f29f_0.tar.bz2
osx-64::root-binaries-6.22.6-py38h0d2f4df_0.tar.bz2
osx-64::root-binaries-6.22.6-py38h6604742_1.tar.bz2
osx-64::root-binaries-6.22.6-py38h8ecd997_0.tar.bz2
osx-64::root-binaries-6.22.6-py38hab5930e_2.tar.bz2
osx-64::root-binaries-6.22.6-py39h5442c83_1.tar.bz2
osx-64::root-binaries-6.22.6-py39h5442c83_2.tar.bz2
osx-64::root-binaries-6.22.6-py39h6b9957e_0.tar.bz2
osx-64::root-binaries-6.22.8-py36h3d1eebc_2.tar.bz2
osx-64::root-binaries-6.22.8-py36h4a8af38_3.tar.bz2
osx-64::root-binaries-6.22.8-py37h1cbf7fc_2.tar.bz2
osx-64::root-binaries-6.22.8-py37h366d447_3.tar.bz2
osx-64::root-binaries-6.22.8-py38hab5930e_2.tar.bz2
osx-64::root-binaries-6.22.8-py38hd6c9f76_3.tar.bz2
osx-64::root-binaries-6.22.8-py39h07141f4_3.tar.bz2
osx-64::root-binaries-6.22.8-py39h5442c83_2.tar.bz2
osx-64::root-dependencies-6.18.04-py27h07973f4_21.tar.bz2
osx-64::root-dependencies-6.18.04-py27h47db2f6_20.tar.bz2
osx-64::root-dependencies-6.18.04-py27h5293c5b_20.tar.bz2
osx-64::root-dependencies-6.18.04-py27h95b5a52_22.tar.bz2
osx-64::root-dependencies-6.18.04-py27h95b5a52_23.tar.bz2
osx-64::root-dependencies-6.18.04-py27hbb522cf_28.tar.bz2
osx-64::root-dependencies-6.18.04-py27hffc68f4_24.tar.bz2
osx-64::root-dependencies-6.18.04-py27hffc68f4_25.tar.bz2
osx-64::root-dependencies-6.18.04-py27hffc68f4_26.tar.bz2
osx-64::root-dependencies-6.18.04-py36h07973f4_21.tar.bz2
osx-64::root-dependencies-6.18.04-py36h47db2f6_20.tar.bz2
osx-64::root-dependencies-6.18.04-py36h5293c5b_20.tar.bz2
osx-64::root-dependencies-6.18.04-py36h95b5a52_22.tar.bz2
osx-64::root-dependencies-6.18.04-py36h95b5a52_23.tar.bz2
osx-64::root-dependencies-6.18.04-py36hbb522cf_28.tar.bz2
osx-64::root-dependencies-6.18.04-py36hffc68f4_24.tar.bz2
osx-64::root-dependencies-6.18.04-py36hffc68f4_25.tar.bz2
osx-64::root-dependencies-6.18.04-py36hffc68f4_26.tar.bz2
osx-64::root-dependencies-6.18.04-py37h07973f4_21.tar.bz2
osx-64::root-dependencies-6.18.04-py37h47db2f6_20.tar.bz2
osx-64::root-dependencies-6.18.04-py37h5293c5b_20.tar.bz2
osx-64::root-dependencies-6.18.04-py37h81b6a41_27.tar.bz2
osx-64::root-dependencies-6.18.04-py37h95b5a52_22.tar.bz2
osx-64::root-dependencies-6.18.04-py37h95b5a52_23.tar.bz2
osx-64::root-dependencies-6.18.04-py37hbb522cf_28.tar.bz2
osx-64::root-dependencies-6.18.04-py37hffc68f4_24.tar.bz2
osx-64::root-dependencies-6.18.04-py37hffc68f4_25.tar.bz2
osx-64::root-dependencies-6.18.04-py37hffc68f4_26.tar.bz2
osx-64::root-dependencies-6.18.04-py38h07973f4_21.tar.bz2
osx-64::root-dependencies-6.18.04-py38h81b6a41_27.tar.bz2
osx-64::root-dependencies-6.18.04-py38h95b5a52_22.tar.bz2
osx-64::root-dependencies-6.18.04-py38h95b5a52_23.tar.bz2
osx-64::root-dependencies-6.18.04-py38hbb522cf_28.tar.bz2
osx-64::root-dependencies-6.18.04-py38hffc68f4_24.tar.bz2
osx-64::root-dependencies-6.18.04-py38hffc68f4_25.tar.bz2
osx-64::root-dependencies-6.18.04-py38hffc68f4_26.tar.bz2
osx-64::root-dependencies-6.20.0-py27hbadf3b9_0.tar.bz2
osx-64::root-dependencies-6.20.0-py27hbadf3b9_1.tar.bz2
osx-64::root-dependencies-6.20.0-py36hbadf3b9_0.tar.bz2
osx-64::root-dependencies-6.20.0-py36hbadf3b9_1.tar.bz2
osx-64::root-dependencies-6.20.0-py37hbadf3b9_0.tar.bz2
osx-64::root-dependencies-6.20.0-py37hbadf3b9_1.tar.bz2
osx-64::root-dependencies-6.20.0-py38hbadf3b9_0.tar.bz2
osx-64::root-dependencies-6.20.0-py38hbadf3b9_1.tar.bz2
osx-64::root-dependencies-6.20.2-py27h7ce42fa_0.tar.bz2
osx-64::root-dependencies-6.20.2-py36h69b0a59_1.tar.bz2
osx-64::root-dependencies-6.20.2-py36hb7dde67_0.tar.bz2
osx-64::root-dependencies-6.20.2-py37h65fef63_0.tar.bz2
osx-64::root-dependencies-6.20.2-py37hcc4ca02_1.tar.bz2
osx-64::root-dependencies-6.20.2-py38h9a6c036_0.tar.bz2
osx-64::root-dependencies-6.20.2-py38hbc92c2f_1.tar.bz2
osx-64::root-dependencies-6.20.4-py36h69b0a59_3.tar.bz2
osx-64::root-dependencies-6.20.4-py37hcc4ca02_3.tar.bz2
osx-64::root-dependencies-6.20.4-py38hbc92c2f_3.tar.bz2
osx-64::root-dependencies-6.20.6-py36hc7c2e62_0.tar.bz2
osx-64::root-dependencies-6.20.6-py37h2a0c050_0.tar.bz2
osx-64::root-dependencies-6.20.6-py38he5e888e_0.tar.bz2
osx-64::root-dependencies-6.22.0-py27hdf2d85e_1.tar.bz2
osx-64::root-dependencies-6.22.0-py27hdf2d85e_2.tar.bz2
osx-64::root-dependencies-6.22.0-py36h056c9e4_3.tar.bz2
osx-64::root-dependencies-6.22.0-py36h056c9e4_4.tar.bz2
osx-64::root-dependencies-6.22.0-py36h8f02a94_0.tar.bz2
osx-64::root-dependencies-6.22.0-py36hbd3365f_1.tar.bz2
osx-64::root-dependencies-6.22.0-py36hbd3365f_2.tar.bz2
osx-64::root-dependencies-6.22.0-py37h1b7e055_3.tar.bz2
osx-64::root-dependencies-6.22.0-py37h1b7e055_4.tar.bz2
osx-64::root-dependencies-6.22.0-py37h1d67377_1.tar.bz2
osx-64::root-dependencies-6.22.0-py37h1d67377_2.tar.bz2
osx-64::root-dependencies-6.22.0-py37h4e51ed6_0.tar.bz2
osx-64::root-dependencies-6.22.0-py38h011e58f_0.tar.bz2
osx-64::root-dependencies-6.22.0-py38h84d0887_4.tar.bz2
osx-64::root-dependencies-6.22.0-py38hbb65a81_1.tar.bz2
osx-64::root-dependencies-6.22.0-py38hbb65a81_2.tar.bz2
osx-64::root-dependencies-6.22.2-py36h056c9e4_0.tar.bz2
osx-64::root-dependencies-6.22.2-py36h0f67a46_1.tar.bz2
osx-64::root-dependencies-6.22.2-py36h0f67a46_2.tar.bz2
osx-64::root-dependencies-6.22.2-py36h311cf85_2.tar.bz2
osx-64::root-dependencies-6.22.2-py36hbf12218_1.tar.bz2
osx-64::root-dependencies-6.22.2-py37h1b7e055_0.tar.bz2
osx-64::root-dependencies-6.22.2-py37h3138373_1.tar.bz2
osx-64::root-dependencies-6.22.2-py37h3138373_2.tar.bz2
osx-64::root-dependencies-6.22.2-py37hb6426ff_1.tar.bz2
osx-64::root-dependencies-6.22.2-py37he7b288f_2.tar.bz2
osx-64::root-dependencies-6.22.2-py38h1e33425_1.tar.bz2
osx-64::root-dependencies-6.22.2-py38h3170eaa_2.tar.bz2
osx-64::root-dependencies-6.22.2-py38h5a485f8_1.tar.bz2
osx-64::root-dependencies-6.22.2-py38h5a485f8_2.tar.bz2
osx-64::root-dependencies-6.22.2-py38h84d0887_0.tar.bz2
osx-64::root-dependencies-6.22.2-py39h31b5726_1.tar.bz2
osx-64::root-dependencies-6.22.2-py39h31b5726_2.tar.bz2
osx-64::root-dependencies-6.22.2-py39h3a5a442_2.tar.bz2
osx-64::root-dependencies-6.22.6-py36h138dd42_0.tar.bz2
osx-64::root-dependencies-6.22.6-py36h2a58cd0_1.tar.bz2
osx-64::root-dependencies-6.22.6-py36h3d1eebc_2.tar.bz2
osx-64::root-dependencies-6.22.6-py36hf7b9339_0.tar.bz2
osx-64::root-dependencies-6.22.6-py37h15ea0b9_1.tar.bz2
osx-64::root-dependencies-6.22.6-py37h1cbf7fc_2.tar.bz2
osx-64::root-dependencies-6.22.6-py37ha0830e8_0.tar.bz2
osx-64::root-dependencies-6.22.6-py37hef4f29f_0.tar.bz2
osx-64::root-dependencies-6.22.6-py38h0d2f4df_0.tar.bz2
osx-64::root-dependencies-6.22.6-py38h6604742_1.tar.bz2
osx-64::root-dependencies-6.22.6-py38h8ecd997_0.tar.bz2
osx-64::root-dependencies-6.22.6-py38hab5930e_2.tar.bz2
osx-64::root-dependencies-6.22.6-py39h5442c83_1.tar.bz2
osx-64::root-dependencies-6.22.6-py39h5442c83_2.tar.bz2
osx-64::root-dependencies-6.22.6-py39h6b9957e_0.tar.bz2
osx-64::root-dependencies-6.22.8-py36h3d1eebc_2.tar.bz2
osx-64::root-dependencies-6.22.8-py36h4a8af38_3.tar.bz2
osx-64::root-dependencies-6.22.8-py37h1cbf7fc_2.tar.bz2
osx-64::root-dependencies-6.22.8-py37h366d447_3.tar.bz2
osx-64::root-dependencies-6.22.8-py38hab5930e_2.tar.bz2
osx-64::root-dependencies-6.22.8-py38hd6c9f76_3.tar.bz2
osx-64::root-dependencies-6.22.8-py39h07141f4_3.tar.bz2
osx-64::root-dependencies-6.22.8-py39h5442c83_2.tar.bz2
osx-64::root5-5.34.36-py27_1.tar.bz2
osx-64::root5-5.34.36-py27_2.tar.bz2
osx-64::root5-5.34.36-py27_3.tar.bz2
osx-64::root5-5.34.38-py27_0.tar.bz2
osx-64::root5-5.34.38-py27hcca85f0_1.tar.bz2
osx-64::root_base-6.18.04-py27h35844c8_20.tar.bz2
osx-64::root_base-6.18.04-py27h4a748eb_20.tar.bz2
osx-64::root_base-6.18.04-py27h50e64b9_21.tar.bz2
osx-64::root_base-6.18.04-py27hbb522cf_28.tar.bz2
osx-64::root_base-6.18.04-py27he966776_22.tar.bz2
osx-64::root_base-6.18.04-py27he966776_23.tar.bz2
osx-64::root_base-6.18.04-py27hffc68f4_24.tar.bz2
osx-64::root_base-6.18.04-py27hffc68f4_25.tar.bz2
osx-64::root_base-6.18.04-py27hffc68f4_26.tar.bz2
osx-64::root_base-6.18.04-py36h35844c8_20.tar.bz2
osx-64::root_base-6.18.04-py36h4a748eb_20.tar.bz2
osx-64::root_base-6.18.04-py36h50e64b9_21.tar.bz2
osx-64::root_base-6.18.04-py36hbb522cf_28.tar.bz2
osx-64::root_base-6.18.04-py36he966776_22.tar.bz2
osx-64::root_base-6.18.04-py36he966776_23.tar.bz2
osx-64::root_base-6.18.04-py36hffc68f4_24.tar.bz2
osx-64::root_base-6.18.04-py36hffc68f4_25.tar.bz2
osx-64::root_base-6.18.04-py36hffc68f4_26.tar.bz2
osx-64::root_base-6.18.04-py37h35844c8_20.tar.bz2
osx-64::root_base-6.18.04-py37h4a748eb_20.tar.bz2
osx-64::root_base-6.18.04-py37h50e64b9_21.tar.bz2
osx-64::root_base-6.18.04-py37h81b6a41_27.tar.bz2
osx-64::root_base-6.18.04-py37hbb522cf_28.tar.bz2
osx-64::root_base-6.18.04-py37he966776_22.tar.bz2
osx-64::root_base-6.18.04-py37he966776_23.tar.bz2
osx-64::root_base-6.18.04-py37hffc68f4_24.tar.bz2
osx-64::root_base-6.18.04-py37hffc68f4_25.tar.bz2
osx-64::root_base-6.18.04-py37hffc68f4_26.tar.bz2
osx-64::root_base-6.18.04-py38h50e64b9_21.tar.bz2
osx-64::root_base-6.18.04-py38h81b6a41_27.tar.bz2
osx-64::root_base-6.18.04-py38hbb522cf_28.tar.bz2
osx-64::root_base-6.18.04-py38he966776_22.tar.bz2
osx-64::root_base-6.18.04-py38he966776_23.tar.bz2
osx-64::root_base-6.18.04-py38hffc68f4_24.tar.bz2
osx-64::root_base-6.18.04-py38hffc68f4_25.tar.bz2
osx-64::root_base-6.18.04-py38hffc68f4_26.tar.bz2
osx-64::root_base-6.20.0-py27hbadf3b9_0.tar.bz2
osx-64::root_base-6.20.0-py27hbadf3b9_1.tar.bz2
osx-64::root_base-6.20.0-py36hbadf3b9_0.tar.bz2
osx-64::root_base-6.20.0-py36hbadf3b9_1.tar.bz2
osx-64::root_base-6.20.0-py37hbadf3b9_0.tar.bz2
osx-64::root_base-6.20.0-py37hbadf3b9_1.tar.bz2
osx-64::root_base-6.20.0-py38hbadf3b9_0.tar.bz2
osx-64::root_base-6.20.0-py38hbadf3b9_1.tar.bz2
osx-64::root_base-6.20.2-py27h7ce42fa_0.tar.bz2
osx-64::root_base-6.20.2-py36h69b0a59_1.tar.bz2
osx-64::root_base-6.20.2-py36hb7dde67_0.tar.bz2
osx-64::root_base-6.20.2-py37h65fef63_0.tar.bz2
osx-64::root_base-6.20.2-py37hcc4ca02_1.tar.bz2
osx-64::root_base-6.20.2-py38h9a6c036_0.tar.bz2
osx-64::root_base-6.20.2-py38hbc92c2f_1.tar.bz2
osx-64::root_base-6.20.4-py36h69b0a59_3.tar.bz2
osx-64::root_base-6.20.4-py37hcc4ca02_3.tar.bz2
osx-64::root_base-6.20.4-py38hbc92c2f_3.tar.bz2
osx-64::root_base-6.20.6-py36hc7c2e62_0.tar.bz2
osx-64::root_base-6.20.6-py37h2a0c050_0.tar.bz2
osx-64::root_base-6.20.6-py38he5e888e_0.tar.bz2
osx-64::root_base-6.22.0-py27h1865229_1.tar.bz2
osx-64::root_base-6.22.0-py27h1865229_2.tar.bz2
osx-64::root_base-6.22.0-py36h227dd73_3.tar.bz2
osx-64::root_base-6.22.0-py36h227dd73_4.tar.bz2
osx-64::root_base-6.22.0-py36hb4de456_1.tar.bz2
osx-64::root_base-6.22.0-py36hb4de456_2.tar.bz2
osx-64::root_base-6.22.0-py36hc7c2e62_0.tar.bz2
osx-64::root_base-6.22.0-py37h2a0c050_0.tar.bz2
osx-64::root_base-6.22.0-py37h76ffc9d_1.tar.bz2
osx-64::root_base-6.22.0-py37h76ffc9d_2.tar.bz2
osx-64::root_base-6.22.0-py37habf8b34_3.tar.bz2
osx-64::root_base-6.22.0-py37habf8b34_4.tar.bz2
osx-64::root_base-6.22.0-py38h1afb842_1.tar.bz2
osx-64::root_base-6.22.0-py38h1afb842_2.tar.bz2
osx-64::root_base-6.22.0-py38hd39809a_4.tar.bz2
osx-64::root_base-6.22.0-py38he5e888e_0.tar.bz2
osx-64::root_base-6.22.2-py36h227dd73_0.tar.bz2
osx-64::root_base-6.22.2-py36h8d81a88_1.tar.bz2
osx-64::root_base-6.22.2-py36h8d81a88_2.tar.bz2
osx-64::root_base-6.22.2-py36ha2dba4f_2.tar.bz2
osx-64::root_base-6.22.2-py36ha34cbc3_1.tar.bz2
osx-64::root_base-6.22.2-py37h2fe9711_2.tar.bz2
osx-64::root_base-6.22.2-py37h7ab357a_1.tar.bz2
osx-64::root_base-6.22.2-py37h9432318_1.tar.bz2
osx-64::root_base-6.22.2-py37h9432318_2.tar.bz2
osx-64::root_base-6.22.2-py37habf8b34_0.tar.bz2
osx-64::root_base-6.22.2-py38h1343b9b_2.tar.bz2
osx-64::root_base-6.22.2-py38h1b18e80_1.tar.bz2
osx-64::root_base-6.22.2-py38h336aca2_1.tar.bz2
osx-64::root_base-6.22.2-py38h336aca2_2.tar.bz2
osx-64::root_base-6.22.2-py38hd39809a_0.tar.bz2
osx-64::root_base-6.22.2-py39hbee4ce3_1.tar.bz2
osx-64::root_base-6.22.2-py39hbee4ce3_2.tar.bz2
osx-64::root_base-6.22.2-py39he81b60e_2.tar.bz2
osx-64::root_base-6.22.6-py36h4567ca4_1.tar.bz2
osx-64::root_base-6.22.6-py36h4b04181_0.tar.bz2
osx-64::root_base-6.22.6-py36h7f65563_2.tar.bz2
osx-64::root_base-6.22.6-py36hed8023b_0.tar.bz2
osx-64::root_base-6.22.6-py37h1ff80a4_0.tar.bz2
osx-64::root_base-6.22.6-py37h4bfc2b0_2.tar.bz2
osx-64::root_base-6.22.6-py37h5a3d7dc_0.tar.bz2
osx-64::root_base-6.22.6-py37h98b26d7_1.tar.bz2
osx-64::root_base-6.22.6-py38h38f148b_1.tar.bz2
osx-64::root_base-6.22.6-py38h58fa415_0.tar.bz2
osx-64::root_base-6.22.6-py38h7fc1b9b_0.tar.bz2
osx-64::root_base-6.22.6-py38hf4dc39e_2.tar.bz2
osx-64::root_base-6.22.6-py39h5d751ef_0.tar.bz2
osx-64::root_base-6.22.6-py39hb6f083c_1.tar.bz2
osx-64::root_base-6.22.6-py39hb6f083c_2.tar.bz2
osx-64::root_base-6.22.8-py36h7f65563_2.tar.bz2
osx-64::root_base-6.22.8-py36hd15d967_3.tar.bz2
osx-64::root_base-6.22.8-py37h4bfc2b0_2.tar.bz2
osx-64::root_base-6.22.8-py37h4f8fdc7_3.tar.bz2
osx-64::root_base-6.22.8-py38h807bff7_3.tar.bz2
osx-64::root_base-6.22.8-py38hf4dc39e_2.tar.bz2
osx-64::root_base-6.22.8-py39hb6f083c_2.tar.bz2
osx-64::root_base-6.22.8-py39hd0cd6ab_3.tar.bz2
osx-64::root_base-6.24.0-py36h3308b38_0.tar.bz2
osx-64::root_base-6.24.0-py36hce550fe_1.tar.bz2
osx-64::root_base-6.24.0-py36he7afe7f_2.tar.bz2
osx-64::root_base-6.24.0-py37h1fff5c3_0.tar.bz2
osx-64::root_base-6.24.0-py37ha5bcdf2_2.tar.bz2
osx-64::root_base-6.24.0-py37hf159980_1.tar.bz2
osx-64::root_base-6.24.0-py38h9fb3dc4_0.tar.bz2
osx-64::root_base-6.24.0-py38hc87488e_2.tar.bz2
osx-64::root_base-6.24.0-py38hcaf2d5a_1.tar.bz2
osx-64::root_base-6.24.0-py39h7a34c14_2.tar.bz2
osx-64::root_base-6.24.0-py39ha6f6e8d_0.tar.bz2
osx-64::root_base-6.24.0-py39hcccae89_1.tar.bz2
osx-64::root_base-6.24.2-py36he7afe7f_0.tar.bz2
osx-64::root_base-6.24.2-py37ha5bcdf2_0.tar.bz2
osx-64::root_base-6.24.2-py38hc87488e_0.tar.bz2
osx-64::root_base-6.24.2-py39h7a34c14_0.tar.bz2
osx-64::root_base-6.24.4-py36hb7621fe_0.tar.bz2
osx-64::root_base-6.24.4-py37hb658529_0.tar.bz2
osx-64::root_base-6.24.4-py38h938c911_0.tar.bz2
osx-64::root_base-6.24.4-py39h1d38ebb_0.tar.bz2
osx-64::root_base-6.24.6-py310h02069a2_2.tar.bz2
osx-64::root_base-6.24.6-py310hce50cd7_1.tar.bz2
osx-64::root_base-6.24.6-py310hce50cd7_2.tar.bz2
osx-64::root_base-6.24.6-py36hb7621fe_0.tar.bz2
osx-64::root_base-6.24.6-py37h0aa7a66_1.tar.bz2
osx-64::root_base-6.24.6-py37h0aa7a66_2.tar.bz2
osx-64::root_base-6.24.6-py37hae46217_2.tar.bz2
osx-64::root_base-6.24.6-py37hb658529_0.tar.bz2
osx-64::root_base-6.24.6-py38h33e1717_2.tar.bz2
osx-64::root_base-6.24.6-py38h33e1717_3.tar.bz2
osx-64::root_base-6.24.6-py38h3c2d462_1.tar.bz2
osx-64::root_base-6.24.6-py38h3c2d462_2.tar.bz2
osx-64::root_base-6.24.6-py38h938c911_0.tar.bz2
osx-64::root_base-6.24.6-py39h1d38ebb_0.tar.bz2
osx-64::root_base-6.24.6-py39h5fbb1f1_1.tar.bz2
osx-64::root_base-6.24.6-py39h5fbb1f1_2.tar.bz2
osx-64::root_base-6.24.6-py39hdac8218_2.tar.bz2
osx-64::root_base-6.26.0-py310h8cd194a_0.tar.bz2
osx-64::root_base-6.26.0-py37h7165b58_0.tar.bz2
osx-64::root_base-6.26.0-py38h9f24bb7_0.tar.bz2
osx-64::root_base-6.26.0-py39h3c47336_0.tar.bz2
osx-64::root_base-6.26.10-py310h1c6a0d5_1.tar.bz2
osx-64::root_base-6.26.10-py310h811f337_1.tar.bz2
osx-64::root_base-6.26.10-py311h985b37a_1.tar.bz2
osx-64::root_base-6.26.10-py311hf8fe3e7_1.tar.bz2
osx-64::root_base-6.26.10-py38h8b42de2_1.tar.bz2
osx-64::root_base-6.26.10-py38hcc2afa0_1.tar.bz2
osx-64::root_base-6.26.10-py39hbf644bc_1.tar.bz2
osx-64::root_base-6.26.10-py39hcedc2be_1.tar.bz2
osx-64::root_base-6.26.2-py310h02069a2_1.tar.bz2
osx-64::root_base-6.26.2-py310h95ca182_2.tar.bz2
osx-64::root_base-6.26.2-py310h95ca182_3.tar.bz2
osx-64::root_base-6.26.2-py37hae46217_1.tar.bz2
osx-64::root_base-6.26.2-py37he4a5233_2.tar.bz2
osx-64::root_base-6.26.2-py37he4a5233_3.tar.bz2
osx-64::root_base-6.26.2-py38h33e1717_1.tar.bz2
osx-64::root_base-6.26.2-py38h4001706_2.tar.bz2
osx-64::root_base-6.26.2-py38h4001706_3.tar.bz2
osx-64::root_base-6.26.2-py39h3fcb224_2.tar.bz2
osx-64::root_base-6.26.2-py39h3fcb224_3.tar.bz2
osx-64::root_base-6.26.2-py39hdac8218_1.tar.bz2
osx-64::root_base-6.26.4-py310hff5c893_3.tar.bz2
osx-64::root_base-6.26.4-py37h289815d_3.tar.bz2
osx-64::root_base-6.26.4-py38h6cf95d1_3.tar.bz2
osx-64::root_base-6.26.4-py39he408945_3.tar.bz2
osx-64::root_base-6.26.6-py310h851fafd_0.tar.bz2
osx-64::root_base-6.26.6-py37hc98fd5a_0.tar.bz2
osx-64::root_base-6.26.6-py38h626b39a_0.tar.bz2
osx-64::root_base-6.26.6-py39h6ef5211_0.tar.bz2
osx-64::root_base-6.26.8-py310h1c6a0d5_1.tar.bz2
osx-64::root_base-6.26.8-py310h660d7e6_0.tar.bz2
osx-64::root_base-6.26.8-py310h811f337_1.tar.bz2
osx-64::root_base-6.26.8-py311h985b37a_1.tar.bz2
osx-64::root_base-6.26.8-py311hf8fe3e7_1.tar.bz2
osx-64::root_base-6.26.8-py37h0015d16_1.tar.bz2
osx-64::root_base-6.26.8-py37h6776343_1.tar.bz2
osx-64::root_base-6.26.8-py37hdc94c67_0.tar.bz2
osx-64::root_base-6.26.8-py38h8b42de2_1.tar.bz2
osx-64::root_base-6.26.8-py38haeb9d46_0.tar.bz2
osx-64::root_base-6.26.8-py38hcc2afa0_1.tar.bz2
osx-64::root_base-6.26.8-py39hbf644bc_1.tar.bz2
osx-64::root_base-6.26.8-py39hcedc2be_1.tar.bz2
osx-64::root_base-6.26.8-py39hd040bd6_0.tar.bz2
osx-64::root_base-6.28.0-py310hca9d500_0.conda
osx-64::root_base-6.28.0-py310he57bfe8_1.conda
osx-64::root_base-6.28.0-py311h4e7e6dd_0.conda
osx-64::root_base-6.28.0-py311hacf15e5_1.conda
osx-64::root_base-6.28.0-py38h1e2a025_0.conda
osx-64::root_base-6.28.0-py38h26b529c_1.conda
osx-64::root_base-6.28.0-py39h2cdb5a7_0.conda
osx-64::root_base-6.28.0-py39hed8132c_1.conda
osx-64::root_base-6.28.10-py310h088463a_0.conda
osx-64::root_base-6.28.10-py310h088463a_1.conda
osx-64::root_base-6.28.10-py310h088463a_2.conda
osx-64::root_base-6.28.10-py311hf132bd6_0.conda
osx-64::root_base-6.28.10-py311hf132bd6_1.conda
osx-64::root_base-6.28.10-py311hf132bd6_2.conda
osx-64::root_base-6.28.10-py38hd53aec0_0.conda
osx-64::root_base-6.28.10-py38hd53aec0_1.conda
osx-64::root_base-6.28.10-py38hd53aec0_2.conda
osx-64::root_base-6.28.10-py39h4d57b5c_0.conda
osx-64::root_base-6.28.10-py39h4d57b5c_1.conda
osx-64::root_base-6.28.10-py39h4d57b5c_2.conda
osx-64::root_base-6.28.12-py310hec7f349_0.conda
osx-64::root_base-6.28.12-py311h0aa6aca_0.conda
osx-64::root_base-6.28.12-py38h340b97f_0.conda
osx-64::root_base-6.28.12-py39h5399eaa_0.conda
osx-64::root_base-6.28.4-py310hc0bc7b0_2.conda
osx-64::root_base-6.28.4-py310hebda605_0.conda
osx-64::root_base-6.28.4-py310hebda605_1.conda
osx-64::root_base-6.28.4-py311h01aa0cd_2.conda
osx-64::root_base-6.28.4-py311hf9b29c1_0.conda
osx-64::root_base-6.28.4-py311hf9b29c1_1.conda
osx-64::root_base-6.28.4-py38h30565de_0.conda
osx-64::root_base-6.28.4-py38h30565de_1.conda
osx-64::root_base-6.28.4-py38h412cb2a_2.conda
osx-64::root_base-6.28.4-py39h0769efa_2.conda
osx-64::root_base-6.28.4-py39h8bc755e_0.conda
osx-64::root_base-6.28.4-py39h8bc755e_1.conda
osx-64::root_base-6.30.2-py310h088463a_0.conda
osx-64::root_base-6.30.2-py310he6b9cd7_1.conda
osx-64::root_base-6.30.2-py311hf132bd6_0.conda
osx-64::root_base-6.30.2-py311hff73031_1.conda
osx-64::root_base-6.30.2-py38h7214df8_1.conda
osx-64::root_base-6.30.2-py38hd53aec0_0.conda
osx-64::root_base-6.30.2-py39h1168b32_1.conda
osx-64::root_base-6.30.2-py39h4d57b5c_0.conda
osx-64::root_base-6.30.4-py310hec7f349_0.conda
osx-64::root_base-6.30.4-py311h0aa6aca_0.conda
osx-64::root_base-6.30.4-py38h340b97f_0.conda
osx-64::root_base-6.30.4-py39h5399eaa_0.conda
osx-64::root_base-6.32.0-py310h1a0d35b_2.conda
osx-64::root_base-6.32.0-py310h352e297_1.conda
osx-64::root_base-6.32.0-py310h3aa8b6b_0.conda
osx-64::root_base-6.32.0-py311h6b6fcc4_2.conda
osx-64::root_base-6.32.0-py311hb96efa9_0.conda
osx-64::root_base-6.32.0-py311hf9cddee_1.conda
osx-64::root_base-6.32.0-py312h7f54816_0.conda
osx-64::root_base-6.32.0-py312hf0b5ec1_2.conda
osx-64::root_base-6.32.0-py312hf8b0a54_1.conda
osx-64::root_base-6.32.0-py38h933bc50_1.conda
osx-64::root_base-6.32.0-py38hdc2e12c_2.conda
osx-64::root_base-6.32.0-py38he05b0b4_0.conda
osx-64::root_base-6.32.0-py39h83a3f05_2.conda
osx-64::root_base-6.32.0-py39hb263797_0.conda
osx-64::root_base-6.32.0-py39hea79e16_1.conda
osx-64::root_base-6.32.10-np20py310h7a857c6_0.conda
osx-64::root_base-6.32.10-np20py311h6e82118_0.conda
osx-64::root_base-6.32.10-np20py312h297136d_0.conda
osx-64::root_base-6.32.10-np20py39h081de26_0.conda
osx-64::root_base-6.32.10-np2py313h8545b48_0.conda
osx-64::root_base-6.32.16-np2py310hdc5c6b7_0.conda
osx-64::root_base-6.32.16-np2py311h3d1891f_0.conda
osx-64::root_base-6.32.16-np2py312hdd61c7d_0.conda
osx-64::root_base-6.32.16-np2py313h0c561cb_0.conda
osx-64::root_base-6.32.2-py310h0cda47f_1.conda
osx-64::root_base-6.32.2-py310h1a0d35b_0.conda
osx-64::root_base-6.32.2-py310h45616b5_2.conda
osx-64::root_base-6.32.2-py310h45616b5_3.conda
osx-64::root_base-6.32.2-py311h6b6fcc4_0.conda
osx-64::root_base-6.32.2-py311hc33f41e_1.conda
osx-64::root_base-6.32.2-py311hf415409_2.conda
osx-64::root_base-6.32.2-py311hf415409_3.conda
osx-64::root_base-6.32.2-py312hae3b895_2.conda
osx-64::root_base-6.32.2-py312hae3b895_3.conda
osx-64::root_base-6.32.2-py312hf0b5ec1_0.conda
osx-64::root_base-6.32.2-py312hf1f9bb2_1.conda
osx-64::root_base-6.32.2-py38hdc2e12c_0.conda
osx-64::root_base-6.32.2-py39h0f30a2c_1.conda
osx-64::root_base-6.32.2-py39h56765ff_2.conda
osx-64::root_base-6.32.2-py39h56765ff_3.conda
osx-64::root_base-6.32.2-py39h83a3f05_0.conda
osx-64::root_base-6.32.8-np20py310h7a857c6_0.conda
osx-64::root_base-6.32.8-np20py311h6e82118_0.conda
osx-64::root_base-6.32.8-np20py312h297136d_0.conda
osx-64::root_base-6.32.8-np20py39h081de26_0.conda
osx-64::root_base-6.32.8-np2py313h8545b48_0.conda
osx-64::root_base-6.34.04-np2py310h17f4831_1.conda
osx-64::root_base-6.34.04-np2py311hec77090_1.conda
osx-64::root_base-6.34.04-np2py312hf901cfe_1.conda
osx-64::root_base-6.34.04-np2py313h8267e27_1.conda
osx-64::root_base-6.34.04-np2py39h0ab4d47_1.conda
osx-64::root_base-6.34.4-np20py310h7a857c6_0.conda
osx-64::root_base-6.34.4-np20py311h6e82118_0.conda
osx-64::root_base-6.34.4-np20py312h297136d_0.conda
osx-64::root_base-6.34.4-np20py39h081de26_0.conda
osx-64::root_base-6.34.4-np2py313h8545b48_0.conda
osx-64::root_base-6.36.02-np2py310h17f4831_0.conda
osx-64::root_base-6.36.02-np2py311hec77090_0.conda
osx-64::root_base-6.36.02-np2py312hf901cfe_0.conda
osx-64::root_base-6.36.02-np2py313h8267e27_0.conda
osx-64::root_base-6.36.04-np2py310h17f4831_0.conda
osx-64::root_base-6.36.04-np2py310h17f4831_1.conda
osx-64::root_base-6.36.04-np2py311hec77090_0.conda
osx-64::root_base-6.36.04-np2py311hec77090_1.conda
osx-64::root_base-6.36.04-np2py312hf901cfe_0.conda
osx-64::root_base-6.36.04-np2py312hf901cfe_1.conda
osx-64::root_base-6.36.04-np2py313h8267e27_0.conda
osx-64::root_base-6.36.04-np2py313h8267e27_1.conda
osx-64::root_numpy-4.7.3-py27h3e44d54_0.tar.bz2
osx-64::root_numpy-4.8.0-py27h3e44d54_0.tar.bz2
osx-64::root_numpy-4.8.0-py27h9888f84_1.tar.bz2
osx-64::root_numpy-4.8.0-py27haf112f3_2.tar.bz2
osx-64::root_numpy-4.8.0-py27hbf1eeb5_2.tar.bz2
osx-64::root_numpy-4.8.0-py27hbf1eeb5_3.tar.bz2
osx-64::root_numpy-4.8.0-py27hd072889_4.tar.bz2
osx-64::root_numpy-4.8.0-py310h606f612_16.tar.bz2
osx-64::root_numpy-4.8.0-py36h09de858_15.tar.bz2
osx-64::root_numpy-4.8.0-py36h215b3bf_14.tar.bz2
osx-64::root_numpy-4.8.0-py36h2167c53_11.tar.bz2
osx-64::root_numpy-4.8.0-py36h31ecf39_5.tar.bz2
osx-64::root_numpy-4.8.0-py36h468c2ac_12.tar.bz2
osx-64::root_numpy-4.8.0-py36h8ae275b_10.tar.bz2
osx-64::root_numpy-4.8.0-py36h9888f84_1.tar.bz2
osx-64::root_numpy-4.8.0-py36hac16bf8_9.tar.bz2
osx-64::root_numpy-4.8.0-py36haf112f3_2.tar.bz2
osx-64::root_numpy-4.8.0-py36hba591cc_13.tar.bz2
osx-64::root_numpy-4.8.0-py36hbf1eeb5_2.tar.bz2
osx-64::root_numpy-4.8.0-py36hbf1eeb5_3.tar.bz2
osx-64::root_numpy-4.8.0-py36hd072889_4.tar.bz2
osx-64::root_numpy-4.8.0-py36hdb3b855_7.tar.bz2
osx-64::root_numpy-4.8.0-py36hdb3b855_8.tar.bz2
osx-64::root_numpy-4.8.0-py37h1e1fc55_7.tar.bz2
osx-64::root_numpy-4.8.0-py37h1e1fc55_8.tar.bz2
osx-64::root_numpy-4.8.0-py37h2234926_14.tar.bz2
osx-64::root_numpy-4.8.0-py37h3b57464_9.tar.bz2
osx-64::root_numpy-4.8.0-py37h5a6a189_10.tar.bz2
osx-64::root_numpy-4.8.0-py37h9888f84_1.tar.bz2
osx-64::root_numpy-4.8.0-py37h9b29bbb_5.tar.bz2
osx-64::root_numpy-4.8.0-py37ha68695e_12.tar.bz2
osx-64::root_numpy-4.8.0-py37haf112f3_2.tar.bz2
osx-64::root_numpy-4.8.0-py37hbf1eeb5_2.tar.bz2
osx-64::root_numpy-4.8.0-py37hbf1eeb5_3.tar.bz2
osx-64::root_numpy-4.8.0-py37hd072889_4.tar.bz2
osx-64::root_numpy-4.8.0-py37he41973d_13.tar.bz2
osx-64::root_numpy-4.8.0-py37hf4cc70e_15.tar.bz2
osx-64::root_numpy-4.8.0-py37hf4cc70e_16.tar.bz2
osx-64::root_numpy-4.8.0-py37hff10709_11.tar.bz2
osx-64::root_numpy-4.8.0-py38h1927ae2_12.tar.bz2
osx-64::root_numpy-4.8.0-py38h288ca51_11.tar.bz2
osx-64::root_numpy-4.8.0-py38h4bdf021_5.tar.bz2
osx-64::root_numpy-4.8.0-py38h6ae7469_15.tar.bz2
osx-64::root_numpy-4.8.0-py38h6ae7469_16.tar.bz2
osx-64::root_numpy-4.8.0-py38h827a4dc_7.tar.bz2
osx-64::root_numpy-4.8.0-py38h827a4dc_8.tar.bz2
osx-64::root_numpy-4.8.0-py38hb4bb170_14.tar.bz2
osx-64::root_numpy-4.8.0-py38hb5d526c_9.tar.bz2
osx-64::root_numpy-4.8.0-py38hbf1eeb5_2.tar.bz2
osx-64::root_numpy-4.8.0-py38hbf1eeb5_3.tar.bz2
osx-64::root_numpy-4.8.0-py38hd072889_4.tar.bz2
osx-64::root_numpy-4.8.0-py38hd27152f_13.tar.bz2
osx-64::root_numpy-4.8.0-py38hf314480_10.tar.bz2
osx-64::root_numpy-4.8.0-py39h250978a_10.tar.bz2
osx-64::root_numpy-4.8.0-py39h280810f_12.tar.bz2
osx-64::root_numpy-4.8.0-py39h392fdb0_14.tar.bz2
osx-64::root_numpy-4.8.0-py39h5a7aff5_11.tar.bz2
osx-64::root_numpy-4.8.0-py39h7e6633f_13.tar.bz2
osx-64::root_numpy-4.8.0-py39h882c9fe_15.tar.bz2
osx-64::root_numpy-4.8.0-py39h882c9fe_16.tar.bz2
+    "clangdev <19.0.0a0",
osx-64::pydantic-core-2.39.0-py313h66e1e84_1.conda
-{}
+{
+  "build": "py313h66e1e84_1",
+  "build_number": 1,
+  "constrains": [
+    "__osx >=10.13"
+  ],
+  "depends": [
+    "__osx >=10.13",
+    "python",
+    "python_abi 3.13.* *_cp313",
+    "typing-extensions >=4.6.0,!=4.7.0"
+  ],
+  "license": "MIT",
+  "md5": "e238997b04b81edf5e6a106f78cf8033",
+  "name": "pydantic-core",
+  "sha256": "f456cf911b7b5224eb79bdda43858a831f6a8873fcc00f1c57602a29ce0c681a",
+  "size": 1921095,
+  "subdir": "osx-64",
+  "timestamp": 1756840671480,
+  "version": "2.39.0"
+}
osx-64::typos-1.36.0-h121f529_0.conda
-{}
+{
+  "build": "h121f529_0",
+  "build_number": 0,
+  "constrains": [
+    "__osx >=10.13"
+  ],
+  "depends": [
+    "__osx >=10.13"
+  ],
+  "license": "MIT",
+  "md5": "c37e5b49c4e83bf0c9695f8c29d5bbb4",
+  "name": "typos",
+  "sha256": "5169108f4f8a233124319d393547e26047f66595810cbb420a6fd47b010c0402",
+  "size": 2720286,
+  "subdir": "osx-64",
+  "timestamp": 1756840793811,
+  "version": "1.36.0"
+}
osx-64::pykrb5-0.8.0-py313h5bf4f2c_0.conda
-{}
+{
+  "build": "py313h5bf4f2c_0",
+  "build_number": 0,
+  "depends": [
+    "__osx >=10.13",
+    "cryptography >=1.3",
+    "krb5 >=1.21.3,<1.22.0a0",
+    "python >=3.13,<3.14.0a0",
+    "python_abi 3.13.* *_cp313"
+  ],
+  "license": "MIT",
+  "md5": "81d7812e795ecd0a8463cce08282c676",
+  "name": "pykrb5",
+  "sha256": "07af221069dfb88eb90896d3f3f11197069060ec04396ca0e15518398e8cb45a",
+  "size": 405911,
+  "subdir": "osx-64",
+  "timestamp": 1756840291200,
+  "version": "0.8.0"
+}
osx-64::pykrb5-0.8.0-py312h2303928_0.conda
-{}
+{
+  "build": "py312h2303928_0",
+  "build_number": 0,
+  "depends": [
+    "__osx >=10.13",
+    "cryptography >=1.3",
+    "krb5 >=1.21.3,<1.22.0a0",
+    "python >=3.12,<3.13.0a0",
+    "python_abi 3.12.* *_cp312"
+  ],
+  "license": "MIT",
+  "md5": "3ec1a011fbeb28f1fa15031fb1b4bc62",
+  "name": "pykrb5",
+  "sha256": "ac8a46abf4e8e4dbab3c28893d48bd321475645339f3043f82e9461229f3d31d",
+  "size": 399446,
+  "subdir": "osx-64",
+  "timestamp": 1756840219942,
+  "version": "0.8.0"
+}
osx-64::fastjet-cxx-3.5.1-hf1d38d0_1.conda
-{}
+{
+  "build": "hf1d38d0_1",
+  "build_number": 1,
+  "depends": [
+    "__osx >=10.13",
+    "libcxx >=19",
+    "siscone >=3.1.2,<3.2.0a0"
+  ],
+  "license": "GPL-2.0-or-later",
+  "md5": "bc52f66f8265adb42227206dfc738705",
+  "name": "fastjet-cxx",
+  "sha256": "a5900f9c97a0a1b74f225388b3709e1444ccbde9e6a4d36ea2054ff9039bb1ca",
+  "size": 792900,
+  "subdir": "osx-64",
+  "timestamp": 1756839558169,
+  "version": "3.5.1"
+}
osx-64::fastjet-cxx-python-3.5.1-py314h1608dac_1.conda
-{}
+{
+  "build": "py314h1608dac_1",
+  "build_number": 1,
+  "depends": [
+    "__osx >=10.13",
+    "fastjet-cxx >=3.5.1,<3.6.0a0",
+    "libcxx >=19",
+    "python",
+    "python_abi 3.14.* *_cp314"
+  ],
+  "license": "GPL-2.0-or-later",
+  "md5": "65949c6d2b9ddeb3b5e6682c38f00958",
+  "name": "fastjet-cxx-python",
+  "sha256": "f5122cc2014f4965cfe9a572ce032a8d0aec44b8bdc9d4e500eb61679b4687c9",
+  "size": 432791,
+  "subdir": "osx-64",
+  "timestamp": 1756839558171,
+  "version": "3.5.1"
+}
osx-64::fastjet-cxx-python-3.5.1-py312hef387a8_1.conda
-{}
+{
+  "build": "py312hef387a8_1",
+  "build_number": 1,
+  "depends": [
+    "__osx >=10.13",
+    "fastjet-cxx >=3.5.1,<3.6.0a0",
+    "libcxx >=19",
+    "python",
+    "python_abi 3.12.* *_cp312"
+  ],
+  "license": "GPL-2.0-or-later",
+  "md5": "5bd79ad1142ab3e70c2e64b3b24b01cb",
+  "name": "fastjet-cxx-python",
+  "sha256": "dded411e2ca2c86c04ce5fe14a3e9d2c46a16eb99eb55a566be915f70a96cbeb",
+  "size": 431425,
+  "subdir": "osx-64",
+  "timestamp": 1756839548400,
+  "version": "3.5.1"
+}
osx-64::pykrb5-0.8.0-py310h8cb7139_0.conda
-{}
+{
+  "build": "py310h8cb7139_0",
+  "build_number": 0,
+  "depends": [
+    "__osx >=10.13",
+    "cryptography >=1.3",
+    "krb5 >=1.21.3,<1.22.0a0",
+    "python >=3.10,<3.11.0a0",
+    "python_abi 3.10.* *_cp310"
+  ],
+  "license": "MIT",
+  "md5": "840ee6e8779c837c3a093250b43d0c45",
+  "name": "pykrb5",
+  "sha256": "552813697e9757bda096c231930ace6812aa569bc9089f2b5992bf23d3cd155a",
+  "size": 388968,
+  "subdir": "osx-64",
+  "timestamp": 1756840335491,
+  "version": "0.8.0"
+}
osx-64::fastjet-cxx-3.5.1-h0ba0a54_1.conda
-{}
+{
+  "build": "h0ba0a54_1",
+  "build_number": 1,
+  "depends": [
+    "__osx >=10.13",
+    "libcxx >=19",
+    "siscone >=3.1.2,<3.2.0a0"
+  ],
+  "license": "GPL-2.0-or-later",
+  "md5": "fc5b888a3c60c694f3667babcb77e2a1",
+  "name": "fastjet-cxx",
+  "sha256": "d34e293a5c60fe6808b3d941898091cc7eff0ca0fead532923c097ded9b7be1a",
+  "size": 792896,
+  "subdir": "osx-64",
+  "timestamp": 1756839548398,
+  "version": "3.5.1"
+}
osx-64::fastjet-cxx-python-3.5.1-py311ha94bed4_1.conda
-{}
+{
+  "build": "py311ha94bed4_1",
+  "build_number": 1,
+  "depends": [
+    "__osx >=10.13",
+    "fastjet-cxx >=3.5.1,<3.6.0a0",
+    "libcxx >=19",
+    "python",
+    "python_abi 3.11.* *_cp311"
+  ],
+  "license": "GPL-2.0-or-later",
+  "md5": "1700d048e835ea2c89a710e2b09e8e2c",
+  "name": "fastjet-cxx-python",
+  "sha256": "0f1252362e68d1860c8096ac7018f8e5622d056c582263b50e927dde9bb88805",
+  "size": 430451,
+  "subdir": "osx-64",
+  "timestamp": 1756839548400,
+  "version": "3.5.1"
+}
osx-64::pykrb5-0.8.0-py311h056df96_0.conda
-{}
+{
+  "build": "py311h056df96_0",
+  "build_number": 0,
+  "depends": [
+    "__osx >=10.13",
+    "cryptography >=1.3",
+    "krb5 >=1.21.3,<1.22.0a0",
+    "python >=3.11,<3.12.0a0",
+    "python_abi 3.11.* *_cp311"
+  ],
+  "license": "MIT",
+  "md5": "5fec164dd14334c19a75b96dd348030e",
+  "name": "pykrb5",
+  "sha256": "67bc40f3ec05e6787a48fd7eda81afe9b50b4f5638b1bbf5e35cdd886ebdb172",
+  "size": 386980,
+  "subdir": "osx-64",
+  "timestamp": 1756840272483,
+  "version": "0.8.0"
+}
osx-64::fastjet-cxx-python-3.5.1-py313hb91e98b_1.conda
-{}
+{
+  "build": "py313hb91e98b_1",
+  "build_number": 1,
+  "depends": [
+    "__osx >=10.13",
+    "fastjet-cxx >=3.5.1,<3.6.0a0",
+    "libcxx >=19",
+    "python",
+    "python_abi 3.13.* *_cp313"
+  ],
+  "license": "GPL-2.0-or-later",
+  "md5": "3349e4bd652f22dab9d439f4e7c3fefa",
+  "name": "fastjet-cxx-python",
+  "sha256": "7c5514af6ebbcc76ed806a8816da31d3634f2491c681941ed3d0a4f1c404097b",
+  "size": 431613,
+  "subdir": "osx-64",
+  "timestamp": 1756839548400,
+  "version": "3.5.1"
+}
osx-64::fastjet-cxx-python-3.5.1-py310hfcdb090_1.conda
-{}
+{
+  "build": "py310hfcdb090_1",
+  "build_number": 1,
+  "depends": [
+    "__osx >=10.13",
+    "fastjet-cxx >=3.5.1,<3.6.0a0",
+    "libcxx >=19",
+    "python",
+    "python_abi 3.10.* *_cp310"
+  ],
+  "license": "GPL-2.0-or-later",
+  "md5": "b0b9a36d074637f6c8c46f89474cc151",
+  "name": "fastjet-cxx-python",
+  "sha256": "e438c28f5a475442cde2aa9115fb0cc56c0a2ffaa11dcc39c3457f5ebdab81ee",
+  "size": 418591,
+  "subdir": "osx-64",
+  "timestamp": 1756839548400,
+  "version": "3.5.1"
+}
osx-64::pydantic-core-2.39.0-py310h80fed0c_1.conda
-{}
+{
+  "build": "py310h80fed0c_1",
+  "build_number": 1,
+  "constrains": [
+    "__osx >=10.13"
+  ],
+  "depends": [
+    "__osx >=10.13",
+    "python",
+    "python_abi 3.10.* *_cp310",
+    "typing-extensions >=4.6.0,!=4.7.0"
+  ],
+  "license": "MIT",
+  "md5": "85306e8f88ab80a35e56a66e935c2d2a",
+  "name": "pydantic-core",
+  "sha256": "7b19074360a4e6927d579d2d4e026fe26495a03aba0f1f9917e721358efe3e80",
+  "size": 1937360,
+  "subdir": "osx-64",
+  "timestamp": 1756840679446,
+  "version": "2.39.0"
+}
================================================================================
================================================================================
linux-64
linux-64::pydantic-core-2.39.0-py314h68536ef_1.conda
-{}
+{
+  "build": "py314h68536ef_1",
+  "build_number": 1,
+  "constrains": [
+    "__glibc >=2.17"
+  ],
+  "depends": [
+    "__glibc >=2.17,<3.0.a0",
+    "libgcc >=14",
+    "python",
+    "python_abi 3.14.* *_cp314",
+    "typing-extensions >=4.6.0,!=4.7.0"
+  ],
+  "license": "MIT",
+  "md5": "a487d6ac1a769dc3184b050667ee8ef9",
+  "name": "pydantic-core",
+  "sha256": "8d9d162eb79ec183a9abfb6df90103130d0beef4d6fca87e7f07c9771193c6af",
+  "size": 1943938,
+  "subdir": "linux-64",
+  "timestamp": 1756840687739,
+  "version": "2.39.0"
+}
linux-64::pydantic-core-2.39.0-py312h868fb18_1.conda
-{}
+{
+  "build": "py312h868fb18_1",
+  "build_number": 1,
+  "constrains": [
+    "__glibc >=2.17"
+  ],
+  "depends": [
+    "__glibc >=2.17,<3.0.a0",
+    "libgcc >=14",
+    "python",
+    "python_abi 3.12.* *_cp312",
+    "typing-extensions >=4.6.0,!=4.7.0"
+  ],
+  "license": "MIT",
+  "md5": "89c0f692088684763f1fdf1705c97c8b",
+  "name": "pydantic-core",
+  "sha256": "8e00a1bd52f2864ecfe4d42846d9d90be0ebb4fceae3e61183606be7f116f75a",
+  "size": 1937521,
+  "subdir": "linux-64",
+  "timestamp": 1756840673165,
+  "version": "2.39.0"
+}
linux-64::pykrb5-0.8.0-py312h7cea900_0.conda
-{}
+{
+  "build": "py312h7cea900_0",
+  "build_number": 0,
+  "depends": [
+    "__glibc >=2.17,<3.0.a0",
+    "cryptography >=1.3",
+    "krb5 >=1.21.3,<1.22.0a0",
+    "libgcc >=14",
+    "python >=3.12,<3.13.0a0",
+    "python_abi 3.12.* *_cp312"
+  ],
+  "license": "MIT",
+  "md5": "9144e3dc0ebee5a7016b264caa80511c",
+  "name": "pykrb5",
+  "sha256": "1b714f4de856bb4e77e8fc0105771309363e17d2ec1d0f7b681d254c64e9e9e4",
+  "size": 573965,
+  "subdir": "linux-64",
+  "timestamp": 1756840202525,
+  "version": "0.8.0"
+}
linux-64::fastjet-cxx-python-3.5.1-py312h0a2e395_1.conda
-{}
+{
+  "build": "py312h0a2e395_1",
+  "build_number": 1,
+  "depends": [
+    "__glibc >=2.17,<3.0.a0",
+    "fastjet-cxx >=3.5.1,<3.6.0a0",
+    "libgcc >=14",
+    "libstdcxx >=14",
+    "python",
+    "python_abi 3.12.* *_cp312"
+  ],
+  "license": "GPL-2.0-or-later",
+  "md5": "6ab07be60c1b45df03c9d87a3528f009",
+  "name": "fastjet-cxx-python",
+  "sha256": "6e71056452e8a6b486a8200544c854ce9b64258887ae346a75a6d0cb57d06f8c",
+  "size": 490825,
+  "subdir": "linux-64",
+  "timestamp": 1756839517110,
+  "version": "3.5.1"
+}
linux-64::pykrb5-0.8.0-py313hcf31397_0.conda
-{}
+{
+  "build": "py313hcf31397_0",
+  "build_number": 0,
+  "depends": [
+    "__glibc >=2.17,<3.0.a0",
+    "cryptography >=1.3",
+    "krb5 >=1.21.3,<1.22.0a0",
+    "libgcc >=14",
+    "python >=3.13,<3.14.0a0",
+    "python_abi 3.13.* *_cp313"
+  ],
+  "license": "MIT",
+  "md5": "bc79250895a8845c74774c7edc7fefee",
+  "name": "pykrb5",
+  "sha256": "84b0e18e895bd2a50cfc766fedd50fdcfd071aa1bb2d2d3525019b45aae5da14",
+  "size": 562223,
+  "subdir": "linux-64",
+  "timestamp": 1756840201057,
+  "version": "0.8.0"
+}
linux-64::pykrb5-0.8.0-py311he3cc2e5_0.conda
-{}
+{
+  "build": "py311he3cc2e5_0",
+  "build_number": 0,
+  "depends": [
+    "__glibc >=2.17,<3.0.a0",
+    "cryptography >=1.3",
+    "krb5 >=1.21.3,<1.22.0a0",
+    "libgcc >=14",
+    "python >=3.11,<3.12.0a0",
+    "python_abi 3.11.* *_cp311"
+  ],
+  "license": "MIT",
+  "md5": "313285cb0b344ec8fc66ad552e608ffe",
+  "name": "pykrb5",
+  "sha256": "3f41cc59614758e6cec0a7d0007e229bcac63d3a4500f8bc78a752e56a4824f2",
+  "size": 570588,
+  "subdir": "linux-64",
+  "timestamp": 1756840154789,
+  "version": "0.8.0"
+}
linux-64::fastjet-cxx-python-3.5.1-py310haaf941d_1.conda
-{}
+{
+  "build": "py310haaf941d_1",
+  "build_number": 1,
+  "depends": [
+    "__glibc >=2.17,<3.0.a0",
+    "fastjet-cxx >=3.5.1,<3.6.0a0",
+    "libgcc >=14",
+    "libstdcxx >=14",
+    "python",
+    "python_abi 3.10.* *_cp310"
+  ],
+  "license": "GPL-2.0-or-later",
+  "md5": "cad4b22f760aeaa89c2ce58edc8c5858",
+  "name": "fastjet-cxx-python",
+  "sha256": "a2942a13075631b68c757612dc725e8cada32b1ac036cb25c55d2c7778fa14c8",
+  "size": 479704,
+  "subdir": "linux-64",
+  "timestamp": 1756839517110,
+  "version": "3.5.1"
+}
linux-64::fastjet-cxx-python-3.5.1-py313hc8edb43_1.conda
-{}
+{
+  "build": "py313hc8edb43_1",
+  "build_number": 1,
+  "depends": [
+    "__glibc >=2.17,<3.0.a0",
+    "fastjet-cxx >=3.5.1,<3.6.0a0",
+    "libgcc >=14",
+    "libstdcxx >=14",
+    "python",
+    "python_abi 3.13.* *_cp313"
+  ],
+  "license": "GPL-2.0-or-later",
+  "md5": "3eb9f2a18c412380e6813efe91d63d55",
+  "name": "fastjet-cxx-python",
+  "sha256": "75bca76a5c095eec6b5402ddb914ad92c201b435a41004ce46a77c9a8c09cd02",
+  "size": 490738,
+  "subdir": "linux-64",
+  "timestamp": 1756839517110,
+  "version": "3.5.1"
+}
linux-64::psi4-1.9.1-py313h7871efd_11.conda
-{}
+{
+  "build": "py313h7871efd_11",
+  "build_number": 11,
+  "constrains": [
+    "adcc >=0.15.16",
+    "dftd4-python >=3.5.0",
+    "geometric >=1.0",
+    "pyddx >=0.4.3",
+    "pylibefp ==0.6.2",
+    "pymdi >=1.2",
+    "pytest >=7.0.1",
+    "qcfractal !=0.62"
+  ],
+  "depends": [
+    "__glibc >=2.17,<3.0.a0",
+    "_openmp_mutex * *_llvm",
+    "_openmp_mutex >=4.5",
+    "dkh >=1.2,<1.3.0a0",
+    "gau2grid >=2.0.8,<3.0a0",
+    "libblas * *mkl",
+    "libblas >=3.9.0,<4.0a0",
+    "libecpint >=1.0.7,<1.1.0a0",
+    "libgcc >=14",
+    "libint >=2.9.0,<3.0a0",
+    "libpcm >=1.2.3,<1.2.4.0a0",
+    "libstdcxx >=14",
+    "libxc-c >=7.0.0,<8.0a0 cpu_*",
+    "llvm-openmp >=21.1.0",
+    "mkl >=2024.2.2,<2025.0a0",
+    "msgpack-python",
+    "networkx",
+    "numpy >=1.23,<3",
+    "numpy >=2.3.2,<3.0a0",
+    "optking >=0.4.2,<1.0a0",
+    "pcmsolver >=1.2.3,<1.2.4.0a0",
+    "pybind11-abi 4",
+    "pydantic >=1.10,<3",
+    "python >=3.13,<3.14.0a0",
+    "python_abi 3.13.* *_cp313",
+    "qcelemental >=0.29,<0.50",
+    "qcengine >=0.31,<0.50",
+    "scipy"
+  ],
+  "license": "LGPL-3.0-only AND BSD-3-Clause AND MIT",
+  "md5": "2145897b474ab5c3c276dc753740a774",
+  "name": "psi4",
+  "sha256": "6754d11a86fab6afd2c70e47cd601fc75fb8d3f19bd3f2144056886250c49efd",
+  "size": 29573308,
+  "subdir": "linux-64",
+  "timestamp": 1756838930486,
+  "version": "1.9.1"
+}
linux-64::pydantic-core-2.39.0-py310hd8f68c5_1.conda
-{}
+{
+  "build": "py310hd8f68c5_1",
+  "build_number": 1,
+  "constrains": [
+    "__glibc >=2.17"
+  ],
+  "depends": [
+    "__glibc >=2.17,<3.0.a0",
+    "libgcc >=14",
+    "python",
+    "python_abi 3.10.* *_cp310",
+    "typing-extensions >=4.6.0,!=4.7.0"
+  ],
+  "license": "MIT",
+  "md5": "a7e43a629a6b9dea1b436b44ad9319a9",
+  "name": "pydantic-core",
+  "sha256": "b41410d248e70ffcdd41dbe09de18137c1aae5e2d7ee7a7484fe23a50fffa8f0",
+  "size": 1950082,
+  "subdir": "linux-64",
+  "timestamp": 1756840672397,
+  "version": "2.39.0"
+}
linux-64::typos-1.36.0-hdab8a38_0.conda
-{}
+{
+  "build": "hdab8a38_0",
+  "build_number": 0,
+  "constrains": [
+    "__glibc >=2.17"
+  ],
+  "depends": [
+    "__glibc >=2.17,<3.0.a0",
+    "libgcc >=14"
+  ],
+  "license": "MIT",
+  "md5": "2e651ab9bc01a27de040a68c542e4924",
+  "name": "typos",
+  "sha256": "8023e3c4de7a32d5e9234174a097f61a1679fc001499439cb16a1fdaba8f4809",
+  "size": 3406742,
+  "subdir": "linux-64",
+  "timestamp": 1756840490374,
+  "version": "1.36.0"
+}
linux-64::pydantic-core-2.39.0-py313h843e2db_1.conda
-{}
+{
+  "build": "py313h843e2db_1",
+  "build_number": 1,
+  "constrains": [
+    "__glibc >=2.17"
+  ],
+  "depends": [
+    "__glibc >=2.17,<3.0.a0",
+    "libgcc >=14",
+    "python",
+    "python_abi 3.13.* *_cp313",
+    "typing-extensions >=4.6.0,!=4.7.0"
+  ],
+  "license": "MIT",
+  "md5": "904cde568cd9bed0794c573e95b5b945",
+  "name": "pydantic-core",
+  "sha256": "e213abdd00fd1953b6b2335ec9dbe53e6223a0a4f11db79fd3f82c8264e5517f",
+  "size": 1940720,
+  "subdir": "linux-64",
+  "timestamp": 1756840670772,
+  "version": "2.39.0"
+}
linux-64::pykrb5-0.8.0-py310h6637d40_0.conda
-{}
+{
+  "build": "py310h6637d40_0",
+  "build_number": 0,
+  "depends": [
+    "__glibc >=2.17,<3.0.a0",
+    "cryptography >=1.3",
+    "krb5 >=1.21.3,<1.22.0a0",
+    "libgcc >=14",
+    "python >=3.10,<3.11.0a0",
+    "python_abi 3.10.* *_cp310"
+  ],
+  "license": "MIT",
+  "md5": "344353b6b19322e27bf995fd60c99afc",
+  "name": "pykrb5",
+  "sha256": "6f26bf81fb28d90ae9d3d4e1be647bcb6cb26cf8e29b868958b53ac657da0b88",
+  "size": 565608,
+  "subdir": "linux-64",
+  "timestamp": 1756840349413,
+  "version": "0.8.0"
+}
linux-64::fastjet-cxx-python-3.5.1-py311h724c32c_1.conda
-{}
+{
+  "build": "py311h724c32c_1",
+  "build_number": 1,
+  "depends": [
+    "__glibc >=2.17,<3.0.a0",
+    "fastjet-cxx >=3.5.1,<3.6.0a0",
+    "libgcc >=14",
+    "libstdcxx >=14",
+    "python",
+    "python_abi 3.11.* *_cp311"
+  ],
+  "license": "GPL-2.0-or-later",
+  "md5": "4942b1aebee14a7f30a7fbe11e7d3e66",
+  "name": "fastjet-cxx-python",
+  "sha256": "98c32587333f1cef194153fd023f16a9d93ada0fccb5a2b5f9c6748e121ccb18",
+  "size": 492364,
+  "subdir": "linux-64",
+  "timestamp": 1756839517110,
+  "version": "3.5.1"
+}
linux-64::pydantic-core-2.39.0-py311h902ca64_1.conda
-{}
+{
+  "build": "py311h902ca64_1",
+  "build_number": 1,
+  "constrains": [
+    "__glibc >=2.17"
+  ],
+  "depends": [
+    "__glibc >=2.17,<3.0.a0",
+    "libgcc >=14",
+    "python",
+    "python_abi 3.11.* *_cp311",
+    "typing-extensions >=4.6.0,!=4.7.0"
+  ],
+  "license": "MIT",
+  "md5": "d0b7d7c1900d96e7e932fb14ed8af0de",
+  "name": "pydantic-core",
+  "sha256": "cd7a6ebacb5b4c3f64122d4c9d48c681a8afd02f80a4ff62bf570b07b483ea06",
+  "size": 1953035,
+  "subdir": "linux-64",
+  "timestamp": 1756840683560,
+  "version": "2.39.0"
+}
linux-64::fastjet-cxx-3.5.1-h171cf75_1.conda
-{}
+{
+  "build": "h171cf75_1",
+  "build_number": 1,
+  "depends": [
+    "__glibc >=2.17,<3.0.a0",
+    "libgcc >=14",
+    "libstdcxx >=14",
+    "siscone >=3.1.2,<3.2.0a0"
+  ],
+  "license": "GPL-2.0-or-later",
+  "md5": "3b78cf2ecb6f30bbef6e2bb1b86711df",
+  "name": "fastjet-cxx",
+  "sha256": "80f8e7f926a4f494d19de264a703a620b45c0bba9abc976c1a689f73f1fd8aff",
+  "size": 992258,
+  "subdir": "linux-64",
+  "timestamp": 1756839517110,
+  "version": "3.5.1"
+}
linux-64::psi4-1.9.1-py311h50f7029_11.conda
-{}
+{
+  "build": "py311h50f7029_11",
+  "build_number": 11,
+  "constrains": [
+    "adcc >=0.15.16",
+    "dftd4-python >=3.5.0",
+    "geometric >=1.0",
+    "pyddx >=0.4.3",
+    "pylibefp ==0.6.2",
+    "pymdi >=1.2",
+    "pytest >=7.0.1",
+    "qcfractal !=0.62"
+  ],
+  "depends": [
+    "__glibc >=2.17,<3.0.a0",
+    "_openmp_mutex * *_llvm",
+    "_openmp_mutex >=4.5",
+    "dkh >=1.2,<1.3.0a0",
+    "gau2grid >=2.0.8,<3.0a0",
+    "libblas * *mkl",
+    "libblas >=3.9.0,<4.0a0",
+    "libecpint >=1.0.7,<1.1.0a0",
+    "libgcc >=14",
+    "libint >=2.9.0,<3.0a0",
+    "libpcm >=1.2.3,<1.2.4.0a0",
+    "libstdcxx >=14",
+    "libxc-c >=7.0.0,<8.0a0 cpu_*",
+    "llvm-openmp >=21.1.0",
+    "mkl >=2024.2.2,<2025.0a0",
+    "msgpack-python",
+    "networkx",
+    "numpy >=1.23,<3",
+    "numpy >=2.3.2,<3.0a0",
+    "optking >=0.4.2,<1.0a0",
+    "pcmsolver >=1.2.3,<1.2.4.0a0",
+    "pybind11-abi 4",
+    "pydantic >=1.10,<3",
+    "python >=3.11,<3.12.0a0",
+    "python_abi 3.11.* *_cp311",
+    "qcelemental >=0.29,<0.50",
+    "qcengine >=0.31,<0.50",
+    "scipy"
+  ],
+  "license": "LGPL-3.0-only AND BSD-3-Clause AND MIT",
+  "md5": "b6d6a9006dc24960869c68838d228b68",
+  "name": "psi4",
+  "sha256": "9cde1a9690074ef63f885fa9e8ee25763caf3a67fb75b64766309a2a142a6e22",
+  "size": 29680817,
+  "subdir": "linux-64",
+  "timestamp": 1756839042853,
+  "version": "1.9.1"
+}
```

</details>