### PR TITLE
Fix libboost-python 1.88.0 build 0

### DIFF
--- a/recipe/patch_yaml/libboost-python.yaml
+++ b/recipe/patch_yaml/libboost-python.yaml
@@ -1,0 +1,63 @@
+# libboost-python 1.88.0 requires libboost
+# https://github.com/conda-forge/boost-feedstock/issues/234
+# Fixed in build number 1: https://github.com/conda-forge/boost-feedstock/pull/235
+# Patch to fix build number 0 below
+if:
+  name: libboost-python
+  version_eq: "1.88.0"
+  build_number_eq: 0
+  subdir_in: linux-64
+  timestamp_lt: 1757059531000
+then:
+  - add_depends:
+      - libboost 1.88.0 h6c02f8c_0
+---
+if:
+  name: libboost-python
+  version_eq: "1.88.0"
+  build_number_eq: 0
+  subdir_in: linux-aarch64
+  timestamp_lt: 1757059531000
+then:
+  - add_depends:
+      - libboost 1.88.0 h4d13611_0
+---
+if:
+  name: libboost-python
+  version_eq: "1.88.0"
+  build_number_eq: 0
+  subdir_in: linux-ppc64le
+  timestamp_lt: 1757059531000
+then:
+  - add_depends:
+      - libboost 1.88.0 h9317212_0
+---
+if:
+  name: libboost-python
+  version_eq: "1.88.0"
+  build_number_eq: 0
+  subdir_in: osx-64
+  timestamp_lt: 1757059531000
+then:
+  - add_depends:
+      - libboost 1.88.0 hf0da243_0
+---
+if:
+  name: libboost-python
+  version_eq: "1.88.0"
+  build_number_eq: 0
+  subdir_in: osx-arm64
+  timestamp_lt: 1757059531000
+then:
+  - add_depends:
+      - libboost 1.88.0 hc9fb7c5_0
+---
+if:
+  name: libboost-python
+  version_eq: "1.88.0"
+  build_number_eq: 0
+  subdir_in: win-64
+  timestamp_lt: 1757059531000
+then:
+  - add_depends:
+      - libboost 1.88.0 hb0986bb_0


### PR DESCRIPTION
Checklist

* [X] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [X] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [X] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [X] Ran `python show_diff.py` and posted the output as part of the PR.
* [X] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
`libboost-python` 1.88.0 requires `libboost`. See https://github.com/conda-forge/boost-feedstock/issues/234
Was fixed in build 1.

I'm trying to build a new version of sardana and it fails because build number 0 of `libboost-python` is used (without `libboost`): https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=1329824&view=logs&jobId=6e0000ae-4f4d-5159-005c-57b278e2d143&j=7b6f2c87-f3a7-5133-8d84-7c03a75d9dfc&t=9eb77fd2-8ddd-5444-8fc0-71cb28dcb736

Not sure why this build is used instead of a more recent one. So patching it.

As we want to specify the build 0 of `libboost`, we want to add the build string which is platform dependent.
I didn't find a better way than making a patch per platform.
I took the build string from https://anaconda.org/conda-forge/libboost/files?version=1.88.0

```
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
linux-ppc64le
linux-ppc64le::libboost-python-1.88.0-py310h43a267a_0.conda
linux-ppc64le::libboost-python-1.88.0-py311hf3d37d3_0.conda
linux-ppc64le::libboost-python-1.88.0-py312h14f0883_0.conda
linux-ppc64le::libboost-python-1.88.0-py313h9d95f4f_0.conda
linux-ppc64le::libboost-python-1.88.0-py39h5e8fc2f_0.conda
+    "libboost 1.88.0 h9317212_0",
================================================================================
================================================================================
osx-arm64
osx-arm64::libboost-python-1.88.0-py310hf1156d2_0.conda
osx-arm64::libboost-python-1.88.0-py311h8fc16d6_0.conda
osx-arm64::libboost-python-1.88.0-py312h72cd453_0.conda
osx-arm64::libboost-python-1.88.0-py313h4e4fec1_0.conda
osx-arm64::libboost-python-1.88.0-py39h7d68603_0.conda
+    "libboost 1.88.0 hc9fb7c5_0",
================================================================================
================================================================================
linux-aarch64
linux-aarch64::libboost-python-1.88.0-py310h9e94223_0.conda
linux-aarch64::libboost-python-1.88.0-py311hb9acf69_0.conda
linux-aarch64::libboost-python-1.88.0-py312h4f0fe26_0.conda
linux-aarch64::libboost-python-1.88.0-py313h0860d92_0.conda
linux-aarch64::libboost-python-1.88.0-py39hd246915_0.conda
+    "libboost 1.88.0 h4d13611_0",
================================================================================
================================================================================
win-64
win-64::libboost-python-1.88.0-py310h3e8ed56_0.conda
win-64::libboost-python-1.88.0-py311h9b10771_0.conda
win-64::libboost-python-1.88.0-py312hbaa7e33_0.conda
win-64::libboost-python-1.88.0-py313he18703e_0.conda
win-64::libboost-python-1.88.0-py39h8f1c5a3_0.conda
+    "libboost 1.88.0 hb0986bb_0",
================================================================================
================================================================================
osx-64
osx-64::libboost-python-1.88.0-py310h79e1054_0.conda
osx-64::libboost-python-1.88.0-py311h10847b1_0.conda
osx-64::libboost-python-1.88.0-py312hdf63323_0.conda
osx-64::libboost-python-1.88.0-py313h418fc38_0.conda
osx-64::libboost-python-1.88.0-py39h5c7665c_0.conda
+    "libboost 1.88.0 hf0da243_0",
================================================================================
================================================================================
linux-64
linux-64::libboost-python-1.88.0-py310ha2bacc8_0.conda
linux-64::libboost-python-1.88.0-py311h5b7b71f_0.conda
linux-64::libboost-python-1.88.0-py312hc39e661_0.conda
linux-64::libboost-python-1.88.0-py313hf0ab243_0.conda
linux-64::libboost-python-1.88.0-py39hf59e57a_0.conda
+    "libboost 1.88.0 h6c02f8c_0",
```