### PR TITLE
Patch missing dependencies for livvkit v3.2.0 build 0

### DIFF
--- a/recipe/patch_yaml/livvkit.yaml
+++ b/recipe/patch_yaml/livvkit.yaml
@@ -1,0 +1,16 @@
+# livvkit v3.2.0 introduced new dependencies on nodejs and rumel.yaml, as well as a new minimum bound on pandas.
+# The feedstock PR was merged without catching these dependencies changes, but was fixed for build number 1:
+# https://github.com/conda-forge/livvkit-feedstock/pull/8
+# This patch is to fix build number 0.
+if:
+  name: livvkit
+  version_eq: "3.2.0"
+  build_number_eq: 0
+  timestamp_lt: 1757522634000
+then:
+  - add_depends:
+      - nodejs
+      - ruamel.yaml
+  - replace_depends:
+      old: pandas
+      new: pandas >=2.1.0


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->


`show_diff.py` output:
```
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
noarch
noarch::livvkit-3.2.0-pyhd8ed1ab_0.conda
+    "nodejs",
-    "pandas",
+    "pandas >=2.1.0",
+    "ruamel.yaml",
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
================================================================================
================================================================================
linux-64
```