### PR TITLE
Add libxml2 upper bound for old lxml packages

### DIFF
--- a/recipe/patch_yaml/lxml.yaml
+++ b/recipe/patch_yaml/lxml.yaml
@@ -1,0 +1,8 @@
+if:
+  name: lxml
+  version_le: 4.9.1
+  timestamp_lt: 1758026124000
+then:
+  - replace_depends:
+      old: libxml2 !=2.9.11,!=2.9.12
+      new: libxml2 !=2.9.11,!=2.9.12,<2.14.0a0


### PR DESCRIPTION
Checklist

* [X] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [X] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [X] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [X] Ran `python show_diff.py` and posted the output as part of the PR.
* [X] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

A bunch of old lxml packages don't have an upper bound on libxml2. Version 2.14 is breaking ABI compatibility.
When another package is available for the latest version of libxml2, sometimes the solver will favor that and install an old version of lxml which breaks the env.

In that [CI job](https://gitlab.com/tango-controls/pytango/-/jobs/11368726116) where we install `pystack` and `gcovr` in the same env, we ended up with:

```
...
libxml2                                   2.15.0  h26afc86_0            conda-forge      45kB
libxml2-16                                2.15.0  ha9997c6_0            conda-forge     559kB
libxslt                                   1.1.43  h711ed8c_1            conda-forge     245kB
libzlib                                    1.3.1  hb9d3cd8_2            conda-forge      61kB
lxml                                       4.9.1  py310h5764c6d_0       conda-forge       1MB
...
```

```
  File "/opt/conda/lib/python3.10/site-packages/gcovr/formats/cobertura/__init__.py", line 78, in write_report
    from .write import write_report  # pylint: disable=import-outside-toplevel # Lazy loading is intended here
  File "/opt/conda/lib/python3.10/site-packages/gcovr/formats/cobertura/write.py", line 22, in <module>
    from lxml import etree  # nosec # We only write XML files
ImportError: libxml2.so.2: cannot open shared object file: No such file or directory
```


Result of `show_diff.py`

```
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
linux-ppc64le
linux-ppc64le::lxml-4.8.0-py310h939259b_3.tar.bz2
linux-ppc64le::lxml-4.8.0-py37h2ab3d53_3.tar.bz2
linux-ppc64le::lxml-4.8.0-py38h4813a87_3.tar.bz2
linux-ppc64le::lxml-4.8.0-py38hf25ed59_3.tar.bz2
linux-ppc64le::lxml-4.8.0-py39h3d45e95_3.tar.bz2
linux-ppc64le::lxml-4.8.0-py39h98ec90c_3.tar.bz2
linux-ppc64le::lxml-4.9.0-py310h939259b_0.tar.bz2
linux-ppc64le::lxml-4.9.0-py37h2ab3d53_0.tar.bz2
linux-ppc64le::lxml-4.9.0-py38h4813a87_0.tar.bz2
linux-ppc64le::lxml-4.9.0-py38hf25ed59_0.tar.bz2
linux-ppc64le::lxml-4.9.0-py39h3d45e95_0.tar.bz2
linux-ppc64le::lxml-4.9.0-py39h98ec90c_0.tar.bz2
linux-ppc64le::lxml-4.9.1-py310h939259b_0.tar.bz2
linux-ppc64le::lxml-4.9.1-py37h2ab3d53_0.tar.bz2
linux-ppc64le::lxml-4.9.1-py38h4813a87_0.tar.bz2
linux-ppc64le::lxml-4.9.1-py38hf25ed59_0.tar.bz2
linux-ppc64le::lxml-4.9.1-py39h3d45e95_0.tar.bz2
linux-ppc64le::lxml-4.9.1-py39h98ec90c_0.tar.bz2
-    "libxml2 !=2.9.11,!=2.9.12",
+    "libxml2 !=2.9.11,!=2.9.12,<2.14.0a0",
================================================================================
================================================================================
osx-arm64
osx-arm64::lxml-4.8.0-py310hf8d0d8f_3.tar.bz2
osx-arm64::lxml-4.8.0-py38h33210d7_3.tar.bz2
osx-arm64::lxml-4.8.0-py39hb18efdd_3.tar.bz2
osx-arm64::lxml-4.9.0-py310h02f21da_0.tar.bz2
osx-arm64::lxml-4.9.0-py38he5c2ac2_0.tar.bz2
osx-arm64::lxml-4.9.0-py39h9eb174b_0.tar.bz2
osx-arm64::lxml-4.9.1-py310h02f21da_0.tar.bz2
osx-arm64::lxml-4.9.1-py38he5c2ac2_0.tar.bz2
osx-arm64::lxml-4.9.1-py39h9eb174b_0.tar.bz2
-    "libxml2 !=2.9.11,!=2.9.12",
+    "libxml2 !=2.9.11,!=2.9.12,<2.14.0a0",
================================================================================
================================================================================
linux-aarch64
linux-aarch64::lxml-4.8.0-py310h761cc84_3.tar.bz2
linux-aarch64::lxml-4.8.0-py37h795501a_3.tar.bz2
linux-aarch64::lxml-4.8.0-py38h6282652_3.tar.bz2
linux-aarch64::lxml-4.8.0-py38hdacc76a_3.tar.bz2
linux-aarch64::lxml-4.8.0-py39h03cc6c3_3.tar.bz2
linux-aarch64::lxml-4.8.0-py39h0fd3b05_3.tar.bz2
linux-aarch64::lxml-4.9.0-py310h761cc84_0.tar.bz2
linux-aarch64::lxml-4.9.0-py37h795501a_0.tar.bz2
linux-aarch64::lxml-4.9.0-py38h6282652_0.tar.bz2
linux-aarch64::lxml-4.9.0-py38hdacc76a_0.tar.bz2
linux-aarch64::lxml-4.9.0-py39h03cc6c3_0.tar.bz2
linux-aarch64::lxml-4.9.0-py39h0fd3b05_0.tar.bz2
linux-aarch64::lxml-4.9.1-py310h761cc84_0.tar.bz2
linux-aarch64::lxml-4.9.1-py37h795501a_0.tar.bz2
linux-aarch64::lxml-4.9.1-py38h6282652_0.tar.bz2
linux-aarch64::lxml-4.9.1-py38hdacc76a_0.tar.bz2
linux-aarch64::lxml-4.9.1-py39h03cc6c3_0.tar.bz2
linux-aarch64::lxml-4.9.1-py39h0fd3b05_0.tar.bz2
-    "libxml2 !=2.9.11,!=2.9.12",
+    "libxml2 !=2.9.11,!=2.9.12,<2.14.0a0",
================================================================================
================================================================================
noarch
================================================================================
================================================================================
win-64
win-64::lxml-4.8.0-py310he2412df_3.tar.bz2
win-64::lxml-4.8.0-py37hcc03f2d_3.tar.bz2
win-64::lxml-4.8.0-py38h294d835_3.tar.bz2
win-64::lxml-4.8.0-py38h70947bb_3.tar.bz2
win-64::lxml-4.8.0-py39hb82d6ee_3.tar.bz2
win-64::lxml-4.8.0-py39hdb6a8a0_3.tar.bz2
win-64::lxml-4.9.0-py310he2412df_0.tar.bz2
win-64::lxml-4.9.0-py37hcc03f2d_0.tar.bz2
win-64::lxml-4.9.0-py38h294d835_0.tar.bz2
win-64::lxml-4.9.0-py38h70947bb_0.tar.bz2
win-64::lxml-4.9.0-py39hb82d6ee_0.tar.bz2
win-64::lxml-4.9.0-py39hdb6a8a0_0.tar.bz2
win-64::lxml-4.9.1-py310he2412df_0.tar.bz2
win-64::lxml-4.9.1-py37hcc03f2d_0.tar.bz2
win-64::lxml-4.9.1-py38h294d835_0.tar.bz2
win-64::lxml-4.9.1-py38h70947bb_0.tar.bz2
win-64::lxml-4.9.1-py39hb82d6ee_0.tar.bz2
win-64::lxml-4.9.1-py39hdb6a8a0_0.tar.bz2
-    "libxml2 !=2.9.11,!=2.9.12",
+    "libxml2 !=2.9.11,!=2.9.12,<2.14.0a0",
================================================================================
================================================================================
osx-64
osx-64::lxml-4.8.0-py310h1961e1f_3.tar.bz2
osx-64::lxml-4.8.0-py37h69ee0a8_3.tar.bz2
osx-64::lxml-4.8.0-py38h4b8594d_3.tar.bz2
osx-64::lxml-4.8.0-py38hed1de0f_3.tar.bz2
osx-64::lxml-4.8.0-py39h1252d8e_3.tar.bz2
osx-64::lxml-4.8.0-py39h63b48b0_3.tar.bz2
osx-64::lxml-4.9.0-py310h6c45266_0.tar.bz2
osx-64::lxml-4.9.0-py37h994c40b_0.tar.bz2
osx-64::lxml-4.9.0-py38h0dd4459_0.tar.bz2
osx-64::lxml-4.9.0-py38h8cbaad8_0.tar.bz2
osx-64::lxml-4.9.0-py39h701faf5_0.tar.bz2
osx-64::lxml-4.9.0-py39hb4cabcc_0.tar.bz2
osx-64::lxml-4.9.1-py310h6c45266_0.tar.bz2
osx-64::lxml-4.9.1-py37h994c40b_0.tar.bz2
osx-64::lxml-4.9.1-py38h0dd4459_0.tar.bz2
osx-64::lxml-4.9.1-py38h8cbaad8_0.tar.bz2
osx-64::lxml-4.9.1-py39h701faf5_0.tar.bz2
osx-64::lxml-4.9.1-py39hb4cabcc_0.tar.bz2
-    "libxml2 !=2.9.11,!=2.9.12",
+    "libxml2 !=2.9.11,!=2.9.12,<2.14.0a0",
================================================================================
================================================================================
linux-64
linux-64::lxml-4.8.0-py310h5764c6d_3.tar.bz2
linux-64::lxml-4.8.0-py37h540881e_3.tar.bz2
linux-64::lxml-4.8.0-py38h0a891b7_3.tar.bz2
linux-64::lxml-4.8.0-py38h50598f1_3.tar.bz2
linux-64::lxml-4.8.0-py39h4d8b378_3.tar.bz2
linux-64::lxml-4.8.0-py39hb9d737c_3.tar.bz2
linux-64::lxml-4.9.0-py310h5764c6d_0.tar.bz2
linux-64::lxml-4.9.0-py37h540881e_0.tar.bz2
linux-64::lxml-4.9.0-py38h0a891b7_0.tar.bz2
linux-64::lxml-4.9.0-py38h50598f1_0.tar.bz2
linux-64::lxml-4.9.0-py39h4d8b378_0.tar.bz2
linux-64::lxml-4.9.0-py39hb9d737c_0.tar.bz2
linux-64::lxml-4.9.1-py310h5764c6d_0.tar.bz2
linux-64::lxml-4.9.1-py37h540881e_0.tar.bz2
linux-64::lxml-4.9.1-py38h0a891b7_0.tar.bz2
linux-64::lxml-4.9.1-py38h50598f1_0.tar.bz2
linux-64::lxml-4.9.1-py39h4d8b378_0.tar.bz2
linux-64::lxml-4.9.1-py39hb9d737c_0.tar.bz2
-    "libxml2 !=2.9.11,!=2.9.12",
+    "libxml2 !=2.9.11,!=2.9.12,<2.14.0a0",
```