### PR TITLE
Patch xcube <1.8.0: restrict zarr dependency to <3

### DIFF
--- a/recipe/patch_yaml/xcube.yaml
+++ b/recipe/patch_yaml/xcube.yaml
@@ -1,0 +1,9 @@
+if:
+  name: xcube
+  version_lt: "1.8.0"
+  timestamp_lt: 1758125025000
+  has_depends: zarr?( *)
+then:
+  - tighten_depends:
+      name: zarr
+      upper_bound: "3"


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks. *(See note below.)*
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

Running `pre-commit run -a` locally results in a fail from black, which reformats several source files. As I discovered in this PR's predecessor (#1077 ), committing those changes results in a fail from the black run on pre-commit.ci. So I'm letting local linting fail in this case in order to let the CI linting pass.

`python show_diff.py` output:

```text
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
noarch
noarch::xcube-0.2.0-py_0.tar.bz2
noarch::xcube-0.2.1-py_0.tar.bz2
noarch::xcube-0.3.0-py_0.tar.bz2
noarch::xcube-0.3.0-py_1.tar.bz2
noarch::xcube-0.4.0-py_0.tar.bz2
noarch::xcube-0.4.2-py_0.tar.bz2
noarch::xcube-0.4.2-py_1.tar.bz2
noarch::xcube-0.5.0-py_0.tar.bz2
noarch::xcube-0.5.1-py_0.tar.bz2
noarch::xcube-0.5.1-pyhd8ed1ab_1.tar.bz2
-    "zarr >=2.3.2"
+    "zarr >=2.3.2,<3.0.0a0"
noarch::xcube-0.10.0-pyhd8ed1ab_0.tar.bz2
noarch::xcube-0.10.1-pyhd8ed1ab_0.tar.bz2
noarch::xcube-0.10.2-pyhd8ed1ab_0.tar.bz2
noarch::xcube-0.11.0-pyhd8ed1ab_0.tar.bz2
noarch::xcube-0.11.1-pyhd8ed1ab_0.tar.bz2
noarch::xcube-0.11.2-pyhd8ed1ab_0.tar.bz2
noarch::xcube-0.12.0-pyhd8ed1ab_0.tar.bz2
noarch::xcube-0.8.2-pyhd8ed1ab_0.tar.bz2
noarch::xcube-0.9.0-pyhd8ed1ab_0.tar.bz2
noarch::xcube-0.9.1-pyhd8ed1ab_0.tar.bz2
noarch::xcube-0.9.2-pyhd8ed1ab_0.tar.bz2
-    "zarr >=2.8"
+    "zarr >=2.8,<3.0a0"
noarch::xcube-0.6.1-pyhd8ed1ab_0.tar.bz2
noarch::xcube-0.7.0-pyhd8ed1ab_0.tar.bz2
noarch::xcube-0.7.1-pyhd8ed1ab_0.tar.bz2
noarch::xcube-0.7.2-pyhd8ed1ab_0.tar.bz2
noarch::xcube-0.8.0-pyhd8ed1ab_0.tar.bz2
noarch::xcube-0.8.1-pyhd8ed1ab_0.tar.bz2
-    "zarr >=2.6.1"
+    "zarr >=2.6.1,<3.0.0a0"
noarch::xcube-0.12.1-pyhd8ed1ab_0.tar.bz2
noarch::xcube-0.13.0-pyhd8ed1ab_0.conda
noarch::xcube-1.0.0-pyhd8ed1ab_0.conda
noarch::xcube-1.0.1-pyhd8ed1ab_0.conda
noarch::xcube-1.0.3-pyhd8ed1ab_0.conda
noarch::xcube-1.0.4-pyhd8ed1ab_0.conda
noarch::xcube-1.0.5-pyhd8ed1ab_0.conda
noarch::xcube-1.0.5-pyhd8ed1ab_1.conda
noarch::xcube-1.1.0-pyhd8ed1ab_0.conda
noarch::xcube-1.1.1-pyhd8ed1ab_0.conda
noarch::xcube-1.1.2-pyhd8ed1ab_0.conda
noarch::xcube-1.2.0-pyhd8ed1ab_0.conda
noarch::xcube-1.3.0-pyhd8ed1ab_0.conda
noarch::xcube-1.3.1-pyhd8ed1ab_0.conda
noarch::xcube-1.4.0-pyhd8ed1ab_0.conda
noarch::xcube-1.4.1-pyhd8ed1ab_0.conda
noarch::xcube-1.5.0-pyhd8ed1ab_0.conda
noarch::xcube-1.5.0-pyhd8ed1ab_1.conda
noarch::xcube-1.5.1-pyhd8ed1ab_0.conda
noarch::xcube-1.6.0-pyhd8ed1ab_0.conda
noarch::xcube-1.7.0-pyhd8ed1ab_0.conda
noarch::xcube-1.7.1-pyhd8ed1ab_0.conda
noarch::xcube-1.7.1-pyhd8ed1ab_1.conda
-    "zarr >=2.11"
+    "zarr >=2.11,<3.0a0"
noarch::xcube-0.6.0-pyhd8ed1ab_0.tar.bz2
-    "zarr >=2.4"
+    "zarr >=2.4,<3.0a0"
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
================================================================================
================================================================================
linux-64
```