### PR TITLE
Restrict zarr dependency to <3 in zappend <=0.8.0

### DIFF
--- a/recipe/patch_yaml/zappend.yaml
+++ b/recipe/patch_yaml/zappend.yaml
@@ -1,0 +1,9 @@
+if:
+  name: zappend
+  version_le: "0.8.0"
+  timestamp_lt: 1758125025000
+  has_depends: zarr?( *)
+then:
+  - tighten_depends:
+      name: zarr
+      upper_bound: "3"


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks. *(See note below)*
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

Running `pre-commit run -a` locally results in a fail from black, with formatting changes to five files. But evidently my local run uses a different configuration to the CI run, which passes all files. I have therefore not committed these local changes.

 `python show_diff.py` output:

```text
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
noarch
noarch::zappend-0.2.0-pyhd8ed1ab_0.conda
noarch::zappend-0.3.0-pyhd8ed1ab_0.conda
noarch::zappend-0.3.0-pyhd8ed1ab_1.conda
noarch::zappend-0.4.0-pyhd8ed1ab_0.conda
noarch::zappend-0.4.1-pyhd8ed1ab_0.conda
noarch::zappend-0.5.0-pyhd8ed1ab_0.conda
noarch::zappend-0.5.1-pyhd8ed1ab_0.conda
noarch::zappend-0.6.0-pyhd8ed1ab_0.conda
noarch::zappend-0.7.0-pyhd8ed1ab_0.conda
noarch::zappend-0.8.0-pyhd8ed1ab_0.conda
noarch::zappend-0.8.0-pyhd8ed1ab_1.conda
-    "zarr"
+    "zarr <3.0a0"
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
================================================================================
================================================================================
linux-64

```