### PR TITLE
Add repodata patch to account for the false glfw 3.5 release

### DIFF
--- a/recipe/patch_yaml/glfw.yaml
+++ b/recipe/patch_yaml/glfw.yaml
@@ -1,0 +1,8 @@
+# Fix for https://github.com/conda-forge/glfw-feedstock/issues/26
+if:
+  has_depends: glfw >=3.5.0,<4.0a0
+  timestamp_lt: 1758799847000
+then:
+  - replace_depends:
+      old: glfw >=3.5.0,<4.0a0
+      new: glfw >=3.4.0,<4.0a0


### PR DESCRIPTION
See https://github.com/conda-forge/glfw-feedstock/issues/26 for the full context.

Basically, upstream glfw 3.5.0 accidentally created a 3.5.0 tag that was not a release, and we actually packaged it. However, that 3.5.0 tag has problems (see https://github.com/pygfx/pygfx/issues/1203), so we need to mark it as broken. 

Fortunately, there is no additional symbols defined in public headers between 3.4 and 3.5.0, see https://github.com/glfw/glfw/compare/glfw:3.4..Pannoniae:3.5.0, so we can just relax all existing `glfw >=3.5.0,<4.0a0` dependencies to `glfw >=3.4.0,<4.0a0`, and then mark glfw 3.5.0 as broken.

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
