### PR TITLE
Direct CTK12.0.*, CTK12.1.* to work with NCCL 2.26.5.*

### DIFF
--- a/recipe/patch_yaml/nccl.yaml
+++ b/recipe/patch_yaml/nccl.yaml
@@ -18,3 +18,12 @@ then:
   - rename_depends:
       old: cudatoolkit
       new: __cuda
+---
+if:
+  name: nccl
+  timestamp_lt: 1758819475000
+  version: "2.26.5.1"
+then:
+  - replace_depends:
+      old: cuda-version >=12,<13.0a0
+      new: cuda-version >=12,<12.2


### PR DESCRIPTION
Checklist

* [X] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [X] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [X] Ran `python show_diff.py` and posted the output as part of the PR.
* [X] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

HPC SDK 25.7 or later will be directed to pull NCCL 2.26.5 if their CTK12 is of >=12.0, <12.2 to avoid segfault in certain situation. 

<!-- Put any other comments or information here -->
```
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
linux-ppc64le
linux-ppc64le::nccl-2.26.5.1-hb3db7be_0.conda
-    "cuda-version >=12,<13.0a0",
+    "cuda-version >=12,<12.2",
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-aarch64
linux-aarch64::nccl-2.26.5.1-h712af05_0.conda
-    "cuda-version >=12,<13.0a0",
+    "cuda-version >=12,<12.2",
================================================================================
================================================================================
noarch
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
================================================================================
================================================================================
linux-64
linux-64::nccl-2.26.5.1-ha44e49d_0.conda
-    "cuda-version >=12,<13.0a0",
+    "cuda-version >=12,<12.2",
```