### PR TITLE
Add patch for `vegafusion==2.0.3`

### DIFF
--- a/recipe/patch_yaml/vegafusion.yaml
+++ b/recipe/patch_yaml/vegafusion.yaml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=../patch_yaml_model.json
+if:
+  name: vegafusion
+  version: 2.0.3
+  build_number: 0
+  timestamp_lt: 1759314748000
+then:
+  - replace_depends:
+      old: narwhals >=1.13.5
+      new: narwhals >=1.42


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

----

I pulled the trigger on the update PR before properly checking the dependencies:
- https://github.com/conda-forge/vegafusion-feedstock/pull/53
