### PR TITLE
Conda 25.9.0 needs conda-libmamba-solver 25.4+

### DIFF
--- a/recipe/patch_yaml/conda.yaml
+++ b/recipe/patch_yaml/conda.yaml
@@ -1,6 +1,6 @@
 if:
   name: conda
-  version_le: 25.9.0
+  version_eq: 25.9.0
   timestamp_lt: 1759388400000
 then:
   - replace_depends:


### PR DESCRIPTION
In conda 25.9.0 some deprecated functions were removed. Corresponding changes were also made in conda-libmamba-solver. However conda did not bump its lowerbound on conda-libmamba-solver. So in some cases users are getting old versions of conda-libmamba-solver with newer conda versions leading to issues running conda. To fix this, bump the conda-libmamba-solver to a compatible version (25.4.0) that will work with the newer conda version (25.9.0).

<hr>

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

<hr>

Related issues & PRs:

* https://github.com/conda-forge/conda-feedstock/pull/276
* https://github.com/conda/conda/issues/15287
