### PR TITLE
fix: patch conda 25.9.0 for conda-libmamba-solver dependency version

### DIFF
--- a/recipe/patch_yaml/conda_patches.yaml
+++ b/recipe/patch_yaml/conda_patches.yaml
@@ -32,3 +32,12 @@ if:
   timestamp_lt: 1744218305000
 then:
   - add_depends: conda-libmamba-solver >=24.11.0
+---
+if:
+  name: conda
+  version_eq: 25.9.0
+  timestamp_lt: 1759388400000
+then:
+  - replace_depends:
+      old: conda-libmamba-solver >=24.11.0
+      new: conda-libmamba-solver >=25.4.0


### PR DESCRIPTION
Updated dependency version for conda-libmamba-solver.

Checklist

* [ ] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

A redo of #1087. See that PR for details.
