### PR TITLE
WIP: test impact of marking cudnn builds as broken.

### DIFF
--- a/recipe/patch_yaml/cudnn.yaml
+++ b/recipe/patch_yaml/cudnn.yaml
@@ -8,3 +8,23 @@ if:
   subdir_in: win-64
 then:
   - remove_depends: "libzlib-wapi *"
+---
+# As a consequence of https://github.com/conda-forge/cudnn-feedstock/issues/124 and
+# https://github.com/conda-forge/admin-requests/pull/1687, we need to loosen the
+# run-exports for cudnn-dependent builts (on CUDA 12.x) to avoid versions marked broken.
+if:
+  has_depends: cudnn*
+  timestamp_lt: 1759732869
+then:
+  - replace_depends:
+      old: cudnn >=9.11.0.98,<10.0a0
+      new: cudnn >=9.10.1.4,<10.0a0
+  - replace_depends:
+      old: cudnn >=9.12.0.46,<10.0a0
+      new: cudnn >=9.10.1.4,<10.0a0
+  - replace_depends:
+      old: cudnn >=9.13.0.50,<10.0a0
+      new: cudnn >=9.10.1.4,<10.0a0
+  - replace_depends:
+      old: cudnn >=9.13.1.26,<10.0a0
+      new: cudnn >=9.10.1.4,<10.0a0


### PR DESCRIPTION
In the context of https://github.com/conda-forge/cudnn-feedstock/issues/124, if we end up doing https://github.com/conda-forge/admin-requests/pull/1687, we need to patch existing constraints that would otherwise be unsatisfiable, at least for CUDA 12.x builds.

This is a risky because newer cudnn builds could have added new symbols, and in that case, using an older cudnn at runtime would be a breaking change. However, we may have no other choice if nvidia does not republish a newer cudnn build that supports pre-Turing device code. The hope is that symbol additions are rare enough that this is not a big deal in practice.

However, it appears to be the case that no package depends on these newer cudnn versions:
```
>python show_diff.py
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
noarch
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
win-64
================================================================================
================================================================================
linux-64
================================================================================
================================================================================
osx-64
osx-64::mumps-mpi-5.8.1-he6e93e4_4.conda
-    "libgfortran",
+    "libgfortran >=3.0.1,<4.0.0.a0",
```