### PR TITLE
Add clang constrain for compiler-rt

### DIFF
--- a/recipe/patch_yaml/compiler-rt.yaml
+++ b/recipe/patch_yaml/compiler-rt.yaml
@@ -1,0 +1,6 @@
+if:
+  name: compiler-rt
+  version: "21.1.2"
+  build_number: 1
+then:
+  - add_constrains: clang 21.1.2


### PR DESCRIPTION
Checklist

* [ ] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
See https://github.com/conda-forge/compiler-rt-feedstock/pull/160