### PR TITLE
Fix broken wgpu-py release 0.26.0 build 0

### DIFF
--- a/recipe/patch_yaml/wgpu-py.yaml
+++ b/recipe/patch_yaml/wgpu-py.yaml
@@ -1,0 +1,13 @@
+# Wrong wgpu-native dependency for wgpu-py 0.26.0 build 0
+# https://github.com/conda-forge/wgpu-py-feedstock/pull/50
+if:
+  name: wgpu-py
+  version: 0.26.0
+  timestamp_lt: 1760797367000
+  build_number: 0
+  has_depends: "wgpu-native 25.0.2.2.*"
+
+then:
+  - replace_depends:
+      old: "wgpu-native 25.0.2.2.*"
+      new: "wgpu-native 27.0.2.0.*"


### PR DESCRIPTION
See: https://github.com/conda-forge/wgpu-py-feedstock/pull/50

Checklist

* [ ] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
