### PR TITLE
replace yaml-cpp with yaml-cpp-static

### DIFF
--- a/recipe/patch_yaml/holoscan.yaml
+++ b/recipe/patch_yaml/holoscan.yaml
@@ -1,0 +1,10 @@
+if:
+  name: libholoscan-dev
+  timestamp_lt: 1761009475000
+  version_ge: 3.3.0.1
+  version_le: 3.7.0.1
+  has_depends: yaml-cpp
+then:
+  - replace_depends:
+      old: yaml-cpp
+      new: yaml-cpp-static


### PR DESCRIPTION
Checklist

* [X] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [X] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [X] Ran `python show_diff.py` and posted the output as part of the PR.
* [X] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

Below is the output from `python show_diff.py` command. The intended changes are for `linux-64` and `linux-aarch64` only.

```
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-aarch64
linux-aarch64::libholoscan-dev-3.3.0.1-h8f7e130_0.conda
linux-aarch64::libholoscan-dev-3.4.0.2-h8f7e130_0.conda
linux-aarch64::libholoscan-dev-3.5.0.1-h8f7e130_0.conda
linux-aarch64::libholoscan-dev-3.6.0.2-ha571d1e_0.conda
linux-aarch64::libholoscan-dev-3.7.0.1-h2f2ed2f_0.conda
-    "yaml-cpp"
+    "yaml-cpp-static"
================================================================================
================================================================================
noarch
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
================================================================================
================================================================================
linux-64
linux-64::libholoscan-dev-3.3.0.1-hb4eafb4_0.conda
linux-64::libholoscan-dev-3.4.0.2-hb4eafb4_0.conda
linux-64::libholoscan-dev-3.5.0.1-hb4eafb4_0.conda
linux-64::libholoscan-dev-3.6.0.2-hca9f8de_0.conda
linux-64::libholoscan-dev-3.7.0.1-h551ae6c_0.conda
-    "yaml-cpp"
+    "yaml-cpp-static"
```

`libholoscan-dev` should have been depending on the **static** version of `yaml-cpp`, namely `yaml-cpp-static`. The cmake files provided for `examples/` that come with `libholoscan-dev` expect `yaml-cpp-static`. As it stands, we run into an error below 

```
-- Found CUDAToolkit: /ssd/repo/capture-sdk-operator/.pixi/envs/default/targets/x86_64-linux/include (found version "12.8.93")
CMake Error at .pixi/envs/default/lib/cmake/holoscan/holoscan-targets.cmake:382 (message):
  The imported target "holoscan::yaml-cpp" references the file

     "/ssd/repo/capture-sdk-operator/.pixi/envs/default/lib/libyaml-cpp.a"

  but this file does not exist.  Possible reasons include:

```
We tested internally that the issue is resolved with `yaml-cpp-static`.