### PR TITLE
Fix `plumpy` v0.25.1

### DIFF
--- a/recipe/patch_yaml/plumpy.yaml
+++ b/recipe/patch_yaml/plumpy.yaml
@@ -1,0 +1,13 @@
+# Fix plumpy 0.25.1 build 0 to require kiwipy >=0.9.0
+# The old build (pyhd8ed1ab_0) incorrectly allows kiwipy 0.8.x
+# which causes resolution issues with aiida-core
+
+if:
+  subdir_in: noarch
+  artifact_in: plumpy-0.25.1-pyhd8ed1ab_0.conda
+  timestamp_lt: 1761783096000
+
+then:
+  - replace_depends:
+      old: "kiwipy ~=0.8.3"
+      new: "kiwipy ~=0.9.0"


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

The relevant change is:

```
noarch::plumpy-0.25.1-pyhd8ed1ab_0.conda
-    "kiwipy ~=0.8.3",
+    "kiwipy ~=0.9.0",
```

Full diff result can be found below.

<details> <summary> show_diff_result.txt </summary>

```
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
noarch
noarch::plumpy-0.25.1-pyhd8ed1ab_0.conda
-    "kiwipy ~=0.8.3",
+    "kiwipy ~=0.9.0",
noarch::boto3-stubs-lite-1.40.62-pyhd8ed1ab_0.conda
-{}
+{
+  "build": "pyhd8ed1ab_0",
+  "build_number": 0,
+  "depends": [
+    "botocore-stubs",
+    "python",
+    "types-s3transfer",
+    "typing-extensions >=4.1.0"
+  ],
+  "license": "MIT",
+  "md5": "7e5d5b5602ee4534f8ee704ddc27adee",
+  "name": "boto3-stubs-lite",
+  "noarch": "python",
+  "sha256": "f1163cfc7ba9e682dd5131155b6451a3cdaa59f493714703b91f843820bf2d1a",
+  "size": 37258,
+  "subdir": "noarch",
+  "timestamp": 1761778321485,
+  "version": "1.40.62"
+}
noarch::mirakuru-3.0.0-pyhd8ed1ab_0.conda
-{}
+{
+  "build": "pyhd8ed1ab_0",
+  "build_number": 0,
+  "depends": [
+    "psutil >=4.0.0",
+    "python >=3.10"
+  ],
+  "license": "LGPL-3.0-or-later",
+  "md5": "74ed230dde534c208439aedee116b079",
+  "name": "mirakuru",
+  "noarch": "python",
+  "sha256": "95c5e4ecfd583e9380b54a98f653fb4b794e383f51055f1f9ef8f8c0d66eb685",
+  "size": 25622,
+  "subdir": "noarch",
+  "timestamp": 1761778454812,
+  "version": "3.0.0"
+}
noarch::boto3-stubs-lite-essential-1.40.62-hd8ed1ab_0.conda
-{}
+{
+  "build": "hd8ed1ab_0",
+  "build_number": 0,
+  "depends": [
+    "boto3-stubs-lite 1.40.62 pyhd8ed1ab_0",
+    "mypy-boto3-s3",
+    "mypy_boto3_cloudformation",
+    "mypy_boto3_dynamodb",
+    "mypy_boto3_ec2",
+    "mypy_boto3_lambda",
+    "mypy_boto3_rds",
+    "mypy_boto3_sqs"
+  ],
+  "license": "MIT",
+  "md5": "fcc4ec333cb2a9b557671f3431052854",
+  "name": "boto3-stubs-lite-essential",
+  "noarch": "python",
+  "sha256": "33f817abd601ed92d0fcafede6cbe715bea923f821b6f082eb97fff7a9671d05",
+  "size": 7826,
+  "subdir": "noarch",
+  "timestamp": 1761778322192,
+  "version": "1.40.62"
+}
noarch::google-genai-1.47.0-pyhcf101f3_0.conda
-{}
+{
+  "build": "pyhcf101f3_0",
+  "build_number": 0,
+  "depends": [
+    "anyio >=4.8.0,<5.0.0",
+    "google-auth >=2.14.1,<3.0.0",
+    "httpx >=0.28.1,<1.0.0",
+    "pydantic >=2.9.0,<3.0.0",
+    "python",
+    "python >=3.10",
+    "requests >=2.28.1,<3.0.0",
+    "tenacity >=8.2.3,<9.2.0",
+    "typing_extensions >=4.11.0,<5.0.0",
+    "websockets >=13.0.0,<15.1.0"
+  ],
+  "license": "Apache-2.0",
+  "md5": "264cf7b7a61f6e32bc1a91f1dd682499",
+  "name": "google-genai",
+  "noarch": "python",
+  "sha256": "9f4519cda2dce2bff4f48427a0150f41692bded52642323a328efabae596ac9c",
+  "size": 190211,
+  "subdir": "noarch",
+  "timestamp": 1761778587830,
+  "version": "1.47.0"
+}
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
================================================================================
================================================================================
linux-64
linux-64::ndcctools-7.15.13-py313h05196cc_0.conda
-{}
+{
+  "build": "py313h05196cc_0",
+  "build_number": 0,
+  "depends": [
+    "__glibc >=2.17,<3.0.a0",
+    "cloudpickle",
+    "conda-pack",
+    "libfuse3 >=3.17.4,<4.0a0",
+    "libgcc >=14",
+    "libnsl >=2.0.1,<2.1.0a0",
+    "libstdcxx >=14",
+    "libzlib >=1.3.1,<2.0a0",
+    "openssl >=3.5.4,<4.0a0",
+    "packaging",
+    "python >=3.13,<3.14.0a0",
+    "python_abi 3.13.* *_cp313",
+    "readline >=8.2,<9.0a0",
+    "rich",
+    "threadpoolctl"
+  ],
+  "license": "GPL-2.0-only",
+  "md5": "2841cea268d137c7af6c713840e095fe",
+  "name": "ndcctools",
+  "sha256": "1d3412c824c17850bcc26e2879248fc68531bb4e5008203dede57e3940eecd66",
+  "size": 75321242,
+  "subdir": "linux-64",
+  "timestamp": 1761780172793,
+  "version": "7.15.13"
+}
linux-64::sagemath-bliss-10.7-py311hed34c8f_2.conda
-{}
+{
+  "build": "py311hed34c8f_2",
+  "build_number": 2,
+  "depends": [
+    "__glibc >=2.17,<3.0.a0",
+    "bliss >=0.77,<0.78.0a0",
+    "libgcc >=14",
+    "libstdcxx >=14",
+    "numpy >=1.23,<3",
+    "python >=3.11,<3.12.0a0",
+    "python_abi 3.11.* *_cp311",
+    "sagelib 10.7 py311hb7ff948_2"
+  ],
+  "license": "GPL-2.0-or-later",
+  "md5": "34fda6504625848f9c91822652a15e6c",
+  "name": "sagemath-bliss",
+  "sha256": "ff6c60f34f89148c324e49c8e349050ac47d285de3b9d799cfa308bd05f1952e",
+  "size": 32641,
+  "subdir": "linux-64",
+  "timestamp": 1761778688555,
+  "version": "10.7"
+}
linux-64::tuiview-1.3.5-py312h0d570ef_0.conda
-{}
+{
+  "build": "py312h0d570ef_0",
+  "build_number": 0,
+  "depends": [
+    "__glibc >=2.17,<3.0.a0",
+    "gdal",
+    "libgcc >=14",
+    "libgdal >=3.11.4,<3.12.0a0",
+    "libgdal-core >=3.11.4,<3.12.0a0",
+    "numpy >=1.23,<3",
+    "pyside6",
+    "python >=3.12,<3.13.0a0",
+    "python_abi 3.12.* *_cp312"
+  ],
+  "license": "GPL-2.0-only",
+  "md5": "07b978cd0dbd7ff5762c255848f19a84",
+  "name": "tuiview",
+  "sha256": "926737d598b1954d5ee21d9a6981e3b2ffff1c4e78ab87a54177e5ae84c26826",
+  "size": 461600,
+  "subdir": "linux-64",
+  "timestamp": 1761778807065,
+  "version": "1.3.5"
+}
linux-64::sagelib-10.7-py312hc359987_2.conda
-{}
+{
+  "build": "py312hc359987_2",
+  "build_number": 2,
+  "depends": [
+    "__glibc >=2.17,<3.0.a0",
+    "cliquer >=1.22,<1.23.0a0",
+    "cypari2 >=2.2.2,<3.0a0",
+    "cysignals >=1.12.5,<2.0a0",
+    "cython >=3.0.12,<4.0a0",
+    "ecl >=24.5.10,<24.6.0a0",
+    "eclib >=20250627,<20250628.0a0",
+    "ecm >=7.0.6,<7.1.0a0",
+    "fflas-ffpack >=2.5.0,<3.0a0",
+    "future",
+    "gap-core >=4.14.0,<4.15.0a0",
+    "giac >=1.9.0.21,<1.10.0a0",
+    "givaro >=4.2.0,<4.2.1.0a0",
+    "glpk >=5.0,<6.0a0",
+    "gmp >=6.3.0,<7.0a0",
+    "gmpy2 >=2.2.1,<2.3.0a0",
+    "gsl >=2.7,<2.8.0a0",
+    "iml >=1.0.5,<1.1.0a0",
+    "ipython >=8.18.1,<9,!=8.19.0",
+    "jinja2 >=3.1.6,<3.2.0a0",
+    "jupyter_core >=5.9.1,<6.0a0",
+    "lcalc >=2.1.1,<2.2.0a0",
+    "libblas >=3.9.0,<4.0a0",
+    "libbraiding >=1.3.1,<1.4.0a0",
+    "libbrial >=1.2.15,<1.2.16.0a0",
+    "libcblas >=3.9.0,<4.0a0",
+    "libexpat >=2.7.1,<3.0a0",
+    "libflint >=3.2.2,<3.3.0a0",
+    "libgcc >=14",
+    "libgd >=2.3.3,<2.4.0a0",
+    "libhomfly >=1.2r.6,<1.3a",
+    "liblapack >=3.9.0,<4.0a0",
+    "liblapacke >=3.9.0,<4.0a0",
+    "libpng >=1.6.50,<1.7.0a0",
+    "libstdcxx >=14",
+    "libzlib >=1.3.1,<2.0a0",
+    "linbox >=1.7,<2.0a0",
+    "lrcalc >=2.1,<2.2.0a0",
+    "m4ri >=20250128,<20250129.0a0",
+    "m4rie >=20250128,<20250129.0a0",
+    "memory-allocator",
+    "mpc >=1.3.1,<2.0a0",
+    "mpfi >=1.5.4,<1.6.0a0",
+    "mpfr >=4.2.1,<5.0a0",
+    "ntl 11.4.3.*",
+    "numpy >=1.23,<3",
+    "packaging",
+    "pari * *_pthread",
+    "pari >=2.17.2,<2.18.0a0",
+    "pexpect >=4.9.0,<5.0a0",
+    "planarity >=4.0.1.0,<4.0.2.0a0",
+    "ppl >=1.2,<1.3.0a0",
+    "pplpy >=0.8.9,<0.9.0a0",
+    "primecountpy >=0.1.1,<0.2.0",
+    "python >=3.12,<3.13.0a0",
+    "python-lrcalc",
+    "python_abi 3.12.* *_cp312",
+    "readline >=8.2,<9.0a0",
+    "rw >=0.9,<0.10.0a0",
+    "singular >=4.4.1,<4.4.2.0a0",
+    "six",
+    "symmetrica >=3.1.0,<3.2.0a0",
+    "threejs-sage >=122,<123.0a0"
+  ],
+  "license": "GPL-2.0-or-later",
+  "md5": "8a88a11c1dc5affdf27b9d0c7b8f0839",
+  "name": "sagelib",
+  "sha256": "16e878a89378f057a22166cc16c9a88ec6aa765e1a397d34fba72129e3bb1834",
+  "size": 83733966,
+  "subdir": "linux-64",
+  "timestamp": 1761778338677,
+  "version": "10.7"
+}
linux-64::marimo-0.17.3-py311hf8ae3fa_0.conda
-{}
+{
+  "build": "py311hf8ae3fa_0",
+  "build_number": 0,
+  "depends": [
+    "click >=8.0,<9",
+    "docutils >=0.16.0",
+    "itsdangerous >=2",
+    "jedi >=0.18.0",
+    "loro >=1.5.0",
+    "markdown >=3.6,<4",
+    "msgspec >=0.19.0",
+    "narwhals >=2.0.0",
+    "packaging",
+    "psutil >=5.0",
+    "pygments >=2.19,<3",
+    "pymdown-extensions >=10.15,<11",
+    "python",
+    "python_abi 3.11.* *_cp311",
+    "pyyaml >=6.0",
+    "starlette >=0.35.0,!=0.36.0",
+    "tomlkit >=0.12.0",
+    "uvicorn >=0.22.0",
+    "websockets >=14.2.0"
+  ],
+  "license": "Apache-2.0",
+  "md5": "e6910c261316eff5bbe7f4e69eb3dcf8",
+  "name": "marimo",
+  "sha256": "7c99154304d60e5211666728c10026cd0452af00fdaa1133a39d4fd294f54de6",
+  "size": 30112637,
+  "subdir": "linux-64",
+  "timestamp": 1761778767835,
+  "version": "0.17.3"
+}
linux-64::tuiview-1.3.5-py313h9180343_0.conda
-{}
+{
+  "build": "py313h9180343_0",
+  "build_number": 0,
+  "depends": [
+    "__glibc >=2.17,<3.0.a0",
+    "gdal",
+    "libgcc >=14",
+    "libgdal >=3.11.4,<3.12.0a0",
+    "libgdal-core >=3.11.4,<3.12.0a0",
+    "numpy >=1.23,<3",
+    "pyside6",
+    "python >=3.13,<3.14.0a0",
+    "python_abi 3.13.* *_cp313"
+  ],
+  "license": "GPL-2.0-only",
+  "md5": "e1079b0537f4a90b477c449894a3db7d",
+  "name": "tuiview",
+  "sha256": "23dd3c74a7077d91893b51806992b75bdd73179c039c3883bfe03336312af915",
+  "size": 464241,
+  "subdir": "linux-64",
+  "timestamp": 1761778759722,
+  "version": "1.3.5"
+}
linux-64::topiary-0.7.0-hb17b654_0.conda
-{}
+{
+  "build": "hb17b654_0",
+  "build_number": 0,
+  "constrains": [
+    "__glibc >=2.17"
+  ],
+  "depends": [
+    "__glibc >=2.17,<3.0.a0",
+    "libgcc >=14"
+  ],
+  "license": "MIT",
+  "md5": "5bc816640f9b1d9ce563458bc6c5f257",
+  "name": "topiary",
+  "sha256": "241b53dc21b2d712208a7099c38e951f9d08d0eba3374e41d2caa9322255ec7a",
+  "size": 5265228,
+  "subdir": "linux-64",
+  "timestamp": 1761777729795,
+  "version": "0.7.0"
+}
linux-64::ndcctools-7.15.13-py310h901e79f_0.conda
-{}
+{
+  "build": "py310h901e79f_0",
+  "build_number": 0,
+  "depends": [
+    "__glibc >=2.17,<3.0.a0",
+    "cloudpickle",
+    "conda-pack",
+    "libfuse3 >=3.17.4,<4.0a0",
+    "libgcc >=14",
+    "libnsl >=2.0.1,<2.1.0a0",
+    "libstdcxx >=14",
+    "libzlib >=1.3.1,<2.0a0",
+    "openssl >=3.5.4,<4.0a0",
+    "packaging",
+    "python >=3.10,<3.11.0a0",
+    "python_abi 3.10.* *_cp310",
+    "readline >=8.2,<9.0a0",
+    "rich",
+    "threadpoolctl"
+  ],
+  "license": "GPL-2.0-only",
+  "md5": "2201d12f2cee743f514a9e5af1fa60a2",
+  "name": "ndcctools",
+  "sha256": "7d16d94d8619000232de51687e95582f65c7c631e7dc277c947240354325b90d",
+  "size": 78796041,
+  "subdir": "linux-64",
+  "timestamp": 1761780060597,
+  "version": "7.15.13"
+}
linux-64::ndcctools-7.15.13-py311hc6daf77_0.conda
-{}
+{
+  "build": "py311hc6daf77_0",
+  "build_number": 0,
+  "depends": [
+    "__glibc >=2.17,<3.0.a0",
+    "cloudpickle",
+    "conda-pack",
+    "libfuse3 >=3.17.4,<4.0a0",
+    "libgcc >=14",
+    "libnsl >=2.0.1,<2.1.0a0",
+    "libstdcxx >=14",
+    "libzlib >=1.3.1,<2.0a0",
+    "openssl >=3.5.4,<4.0a0",
+    "packaging",
+    "python >=3.11,<3.12.0a0",
+    "python_abi 3.11.* *_cp311",
+    "readline >=8.2,<9.0a0",
+    "rich",
+    "threadpoolctl"
+  ],
+  "license": "GPL-2.0-only",
+  "md5": "2b5c7e7726807a755cd1a14d165882c3",
+  "name": "ndcctools",
+  "sha256": "bb159f99ab2f4cacacf9d6bd5fda563ede3ee3c284d33e4c56c98c61f2df128b",
+  "size": 78088357,
+  "subdir": "linux-64",
+  "timestamp": 1761780106690,
+  "version": "7.15.13"
+}
linux-64::marimo-0.17.3-py310hd3bfc61_0.conda
-{}
+{
+  "build": "py310hd3bfc61_0",
+  "build_number": 0,
+  "depends": [
+    "click >=8.0,<9",
+    "docutils >=0.16.0",
+    "itsdangerous >=2",
+    "jedi >=0.18.0",
+    "markdown >=3.6,<4",
+    "msgspec >=0.19.0",
+    "narwhals >=2.0.0",
+    "packaging",
+    "psutil >=5.0",
+    "pygments >=2.19,<3",
+    "pymdown-extensions >=10.15,<11",
+    "python",
+    "python_abi 3.10.* *_cp310",
+    "pyyaml >=6.0",
+    "starlette >=0.35.0,!=0.36.0",
+    "tomlkit >=0.12.0",
+    "typing-extensions >=4.4.0",
+    "uvicorn >=0.22.0",
+    "websockets >=14.2.0"
+  ],
+  "license": "Apache-2.0",
+  "md5": "cd7c132355808e7a16311779d5de3437",
+  "name": "marimo",
+  "sha256": "23e98d063c3dcd612c9137a9c1de0f6dbe5b5b708f92b5f53fcd0c2c024bd4c8",
+  "size": 29586613,
+  "subdir": "linux-64",
+  "timestamp": 1761778791299,
+  "version": "0.17.3"
+}
linux-64::sagemath-sirocco-10.7-py311h04fdf42_2.conda
-{}
+{
+  "build": "py311h04fdf42_2",
+  "build_number": 2,
+  "depends": [
+    "__glibc >=2.17,<3.0.a0",
+    "gmp >=6.3.0,<7.0a0",
+    "libgcc >=14",
+    "libstdcxx >=14",
+    "mpfr >=4.2.1,<5.0a0",
+    "numpy >=1.23,<3",
+    "python >=3.11,<3.12.0a0",
+    "python_abi 3.11.* *_cp311",
+    "sagelib 10.7 py311hb7ff948_2",
+    "sirocco >=2.1.0,<3.0a0"
+  ],
+  "license": "GPL-2.0-or-later",
+  "md5": "45fa619c5cc72f3ec6681996b25d7cad",
+  "name": "sagemath-sirocco",
+  "sha256": "e836295dfe706c96dc6c8693fb1060c1793246814d2d477bce160905c3671ad7",
+  "size": 32714,
+  "subdir": "linux-64",
+  "timestamp": 1761778728789,
+  "version": "10.7"
+}
linux-64::sagemath-bliss-10.7-py312hf79963d_2.conda
-{}
+{
+  "build": "py312hf79963d_2",
+  "build_number": 2,
+  "depends": [
+    "__glibc >=2.17,<3.0.a0",
+    "bliss >=0.77,<0.78.0a0",
+    "libgcc >=14",
+    "libstdcxx >=14",
+    "numpy >=1.23,<3",
+    "python >=3.12,<3.13.0a0",
+    "python_abi 3.12.* *_cp312",
+    "sagelib 10.7 py312hc359987_2"
+  ],
+  "license": "GPL-2.0-or-later",
+  "md5": "7ee4caab3c26d706d7059c147d61f009",
+  "name": "sagemath-bliss",
+  "sha256": "fdb802cb23f4899cee8966f124f5693ed6e5d5206f349e6ccdce785ee7a3cb25",
+  "size": 32688,
+  "subdir": "linux-64",
+  "timestamp": 1761778719159,
+  "version": "10.7"
+}
linux-64::marimo-0.17.3-py313hd5f5364_0.conda
-{}
+{
+  "build": "py313hd5f5364_0",
+  "build_number": 0,
+  "depends": [
+    "click >=8.0,<9",
+    "docutils >=0.16.0",
+    "itsdangerous >=2",
+    "jedi >=0.18.0",
+    "loro >=1.5.0",
+    "markdown >=3.6,<4",
+    "msgspec >=0.19.0",
+    "narwhals >=2.0.0",
+    "packaging",
+    "psutil >=5.0",
+    "pygments >=2.19,<3",
+    "pymdown-extensions >=10.15,<11",
+    "python",
+    "python_abi 3.13.* *_cp313",
+    "pyyaml >=6.0",
+    "starlette >=0.35.0,!=0.36.0",
+    "tomlkit >=0.12.0",
+    "uvicorn >=0.22.0",
+    "websockets >=14.2.0"
+  ],
+  "license": "Apache-2.0",
+  "md5": "1d4c1ebe56969a12099586d6218ba6e3",
+  "name": "marimo",
+  "sha256": "b88f6ffb5f25329d7d81e547ab1b318880ed7a892f2b311011426bed4a013715",
+  "size": 30089743,
+  "subdir": "linux-64",
+  "timestamp": 1761778771513,
+  "version": "0.17.3"
+}
linux-64::tuiview-1.3.5-py311h5b1bcce_0.conda
-{}
+{
+  "build": "py311h5b1bcce_0",
+  "build_number": 0,
+  "depends": [
+    "__glibc >=2.17,<3.0.a0",
+    "gdal",
+    "libgcc >=14",
+    "libgdal >=3.11.4,<3.12.0a0",
+    "libgdal-core >=3.11.4,<3.12.0a0",
+    "numpy >=1.23,<3",
+    "pyside6",
+    "python >=3.11,<3.12.0a0",
+    "python_abi 3.11.* *_cp311"
+  ],
+  "license": "GPL-2.0-only",
+  "md5": "05faddb4f812d46a9eb4ae8eab5ef753",
+  "name": "tuiview",
+  "sha256": "fe7d09160eab2a154878b6077444c9971d6cee78d07c9c0ee638cee80b3204c4",
+  "size": 467279,
+  "subdir": "linux-64",
+  "timestamp": 1761778804152,
+  "version": "1.3.5"
+}
linux-64::ndcctools-7.15.13-py314he9311a4_0.conda
-{}
+{
+  "build": "py314he9311a4_0",
+  "build_number": 0,
+  "depends": [
+    "__glibc >=2.17,<3.0.a0",
+    "cloudpickle",
+    "conda-pack",
+    "libfuse3 >=3.17.4,<4.0a0",
+    "libgcc >=14",
+    "libnsl >=2.0.1,<2.1.0a0",
+    "libstdcxx >=14",
+    "libzlib >=1.3.1,<2.0a0",
+    "openssl >=3.5.4,<4.0a0",
+    "packaging",
+    "python >=3.14,<3.15.0a0",
+    "python_abi 3.14.* *_cp314",
+    "readline >=8.2,<9.0a0",
+    "rich",
+    "threadpoolctl"
+  ],
+  "license": "GPL-2.0-only",
+  "md5": "503eabeed57c3b095ed2169e02ac73b4",
+  "name": "ndcctools",
+  "sha256": "bee261ae2bd57ed01a89eb4e95b8eedd917f77d2cebc2b3f40664e934d5a0d80",
+  "size": 79014162,
+  "subdir": "linux-64",
+  "timestamp": 1761780192573,
+  "version": "7.15.13"
+}
linux-64::aws-c-cal-0.9.7-h346e085_0.conda
-{}
+{
+  "build": "h346e085_0",
+  "build_number": 0,
+  "depends": [
+    "__glibc >=2.17,<3.0.a0",
+    "aws-c-common >=0.12.5,<0.12.6.0a0",
+    "libgcc >=14",
+    "openssl >=3.5.4,<4.0a0"
+  ],
+  "license": "Apache-2.0",
+  "md5": "6e773ebb16f18e329970d6560fb5cb56",
+  "name": "aws-c-cal",
+  "sha256": "6c9c8fc7e9ea870355a0381bf02cf735cd17dd1db8cf67a9367e1798bde492e2",
+  "size": 55749,
+  "subdir": "linux-64",
+  "timestamp": 1761778708087,
+  "version": "0.9.7"
+}
linux-64::sagelib-10.7-py311hb7ff948_2.conda
-{}
+{
+  "build": "py311hb7ff948_2",
+  "build_number": 2,
+  "depends": [
+    "__glibc >=2.17,<3.0.a0",
+    "cliquer >=1.22,<1.23.0a0",
+    "cypari2 >=2.2.2,<3.0a0",
+    "cysignals >=1.12.5,<2.0a0",
+    "cython >=3.0.12,<4.0a0",
+    "ecl >=24.5.10,<24.6.0a0",
+    "eclib >=20250627,<20250628.0a0",
+    "ecm >=7.0.6,<7.1.0a0",
+    "fflas-ffpack >=2.5.0,<3.0a0",
+    "future",
+    "gap-core >=4.14.0,<4.15.0a0",
+    "giac >=1.9.0.21,<1.10.0a0",
+    "givaro >=4.2.0,<4.2.1.0a0",
+    "glpk >=5.0,<6.0a0",
+    "gmp >=6.3.0,<7.0a0",
+    "gmpy2 >=2.2.1,<2.3.0a0",
+    "gsl >=2.7,<2.8.0a0",
+    "iml >=1.0.5,<1.1.0a0",
+    "ipython >=8.18.1,<9,!=8.19.0",
+    "jinja2 >=3.1.6,<3.2.0a0",
+    "jupyter_core >=5.9.1,<6.0a0",
+    "lcalc >=2.1.1,<2.2.0a0",
+    "libblas >=3.9.0,<4.0a0",
+    "libbraiding >=1.3.1,<1.4.0a0",
+    "libbrial >=1.2.15,<1.2.16.0a0",
+    "libcblas >=3.9.0,<4.0a0",
+    "libexpat >=2.7.1,<3.0a0",
+    "libflint >=3.2.2,<3.3.0a0",
+    "libgcc >=14",
+    "libgd >=2.3.3,<2.4.0a0",
+    "libhomfly >=1.2r.6,<1.3a",
+    "liblapack >=3.9.0,<4.0a0",
+    "liblapacke >=3.9.0,<4.0a0",
+    "libpng >=1.6.50,<1.7.0a0",
+    "libstdcxx >=14",
+    "libzlib >=1.3.1,<2.0a0",
+    "linbox >=1.7,<2.0a0",
+    "lrcalc >=2.1,<2.2.0a0",
+    "m4ri >=20250128,<20250129.0a0",
+    "m4rie >=20250128,<20250129.0a0",
+    "memory-allocator",
+    "mpc >=1.3.1,<2.0a0",
+    "mpfi >=1.5.4,<1.6.0a0",
+    "mpfr >=4.2.1,<5.0a0",
+    "ntl 11.4.3.*",
+    "numpy >=1.23,<3",
+    "packaging",
+    "pari * *_pthread",
+    "pari >=2.17.2,<2.18.0a0",
+    "pexpect >=4.9.0,<5.0a0",
+    "planarity >=4.0.1.0,<4.0.2.0a0",
+    "ppl >=1.2,<1.3.0a0",
+    "pplpy >=0.8.9,<0.9.0a0",
+    "primecountpy >=0.1.1,<0.2.0",
+    "python >=3.11,<3.12.0a0",
+    "python-lrcalc",
+    "python_abi 3.11.* *_cp311",
+    "readline >=8.2,<9.0a0",
+    "rw >=0.9,<0.10.0a0",
+    "singular >=4.4.1,<4.4.2.0a0",
+    "six",
+    "symmetrica >=3.1.0,<3.2.0a0",
+    "threejs-sage >=122,<123.0a0"
+  ],
+  "license": "GPL-2.0-or-later",
+  "md5": "371a89e48db971bf06277f2873fdd192",
+  "name": "sagelib",
+  "sha256": "09f603625eaed6dc0424ce6dd6a36116a815ad0ebd84a6123f3a071ff98554ac",
+  "size": 84208857,
+  "subdir": "linux-64",
+  "timestamp": 1761778403362,
+  "version": "10.7"
+}
linux-64::sagemath-sirocco-10.7-py312hc02dbfc_2.conda
-{}
+{
+  "build": "py312hc02dbfc_2",
+  "build_number": 2,
+  "depends": [
+    "__glibc >=2.17,<3.0.a0",
+    "gmp >=6.3.0,<7.0a0",
+    "libgcc >=14",
+    "libstdcxx >=14",
+    "mpfr >=4.2.1,<5.0a0",
+    "numpy >=1.23,<3",
+    "python >=3.12,<3.13.0a0",
+    "python_abi 3.12.* *_cp312",
+    "sagelib 10.7 py312hc359987_2",
+    "sirocco >=2.1.0,<3.0a0"
+  ],
+  "license": "GPL-2.0-or-later",
+  "md5": "f0e0649936bcec96e4c08bc133b4b392",
+  "name": "sagemath-sirocco",
+  "sha256": "3e6916270713972ce8aae541ba578483d5efb8068e2689f95cbb82370a46d1cd",
+  "size": 32729,
+  "subdir": "linux-64",
+  "timestamp": 1761778797852,
+  "version": "10.7"
+}
linux-64::ndcctools-7.15.13-py312h09c2b5d_0.conda
-{}
+{
+  "build": "py312h09c2b5d_0",
+  "build_number": 0,
+  "depends": [
+    "__glibc >=2.17,<3.0.a0",
+    "cloudpickle",
+    "conda-pack",
+    "libfuse3 >=3.17.4,<4.0a0",
+    "libgcc >=14",
+    "libnsl >=2.0.1,<2.1.0a0",
+    "libstdcxx >=14",
+    "libzlib >=1.3.1,<2.0a0",
+    "openssl >=3.5.4,<4.0a0",
+    "packaging",
+    "python >=3.12,<3.13.0a0",
+    "python_abi 3.12.* *_cp312",
+    "readline >=8.2,<9.0a0",
+    "rich",
+    "threadpoolctl"
+  ],
+  "license": "GPL-2.0-only",
+  "md5": "8a225f69fbed74b28556e9eaec1baff7",
+  "name": "ndcctools",
+  "sha256": "3d02d0308c24d7542e3f3781c55ee0927e20677bd96a1772a05b91b55b5b62f1",
+  "size": 80211458,
+  "subdir": "linux-64",
+  "timestamp": 1761780067714,
+  "version": "7.15.13"
+}
linux-64::tuiview-1.3.5-py310h2d10c02_0.conda
-{}
+{
+  "build": "py310h2d10c02_0",
+  "build_number": 0,
+  "depends": [
+    "__glibc >=2.17,<3.0.a0",
+    "gdal",
+    "libgcc >=14",
+    "libgdal >=3.11.4,<3.12.0a0",
+    "libgdal-core >=3.11.4,<3.12.0a0",
+    "numpy >=1.21,<3",
+    "pyside6",
+    "python >=3.10,<3.11.0a0",
+    "python_abi 3.10.* *_cp310"
+  ],
+  "license": "GPL-2.0-only",
+  "md5": "a86eadd92c385b2a5309cf19ee6112c0",
+  "name": "tuiview",
+  "sha256": "9447822c2009c7dfc0a0b5efccc260100833ec35cb20f71496a31a2f3a377034",
+  "size": 389715,
+  "subdir": "linux-64",
+  "timestamp": 1761778803608,
+  "version": "1.3.5"
+}
linux-64::marimo-0.17.3-py314h9e666f3_0.conda
-{}
+{
+  "build": "py314h9e666f3_0",
+  "build_number": 0,
+  "depends": [
+    "click >=8.0,<9",
+    "docutils >=0.16.0",
+    "itsdangerous >=2",
+    "jedi >=0.18.0",
+    "loro >=1.5.0",
+    "markdown >=3.6,<4",
+    "msgspec >=0.19.0",
+    "narwhals >=2.0.0",
+    "packaging",
+    "psutil >=5.0",
+    "pygments >=2.19,<3",
+    "pymdown-extensions >=10.15,<11",
+    "python",
+    "python_abi 3.14.* *_cp314",
+    "pyyaml >=6.0",
+    "starlette >=0.35.0,!=0.36.0",
+    "tomlkit >=0.12.0",
+    "uvicorn >=0.22.0",
+    "websockets >=14.2.0"
+  ],
+  "license": "Apache-2.0",
+  "md5": "bafcf11c86a81c3f54b2813023acd7bc",
+  "name": "marimo",
+  "sha256": "2db6a185fc3d6d8b8e78ecb122edf27c42c7f691bb006786f754c166c37a5014",
+  "size": 30224109,
+  "subdir": "linux-64",
+  "timestamp": 1761778785664,
+  "version": "0.17.3"
+}
linux-64::marimo-0.17.3-py312h20c3967_0.conda
-{}
+{
+  "build": "py312h20c3967_0",
+  "build_number": 0,
+  "depends": [
+    "click >=8.0,<9",
+    "docutils >=0.16.0",
+    "itsdangerous >=2",
+    "jedi >=0.18.0",
+    "loro >=1.5.0",
+    "markdown >=3.6,<4",
+    "msgspec >=0.19.0",
+    "narwhals >=2.0.0",
+    "packaging",
+    "psutil >=5.0",
+    "pygments >=2.19,<3",
+    "pymdown-extensions >=10.15,<11",
+    "python",
+    "python_abi 3.12.* *_cp312",
+    "pyyaml >=6.0",
+    "starlette >=0.35.0,!=0.36.0",
+    "tomlkit >=0.12.0",
+    "uvicorn >=0.22.0",
+    "websockets >=14.2.0"
+  ],
+  "license": "Apache-2.0",
+  "md5": "9b2882337d4005c972fce0512d56b507",
+  "name": "marimo",
+  "sha256": "d76a4cef4e3a7e4b15d53a7f82290954dade29c2cc48dc648acde8784432b174",
+  "size": 30052431,
+  "subdir": "linux-64",
+  "timestamp": 1761778771375,
+  "version": "0.17.3"
+}
linux-64::tuiview-1.3.5-py314hfc2a017_0.conda
-{}
+{
+  "build": "py314hfc2a017_0",
+  "build_number": 0,
+  "depends": [
+    "__glibc >=2.17,<3.0.a0",
+    "gdal",
+    "libgcc >=14",
+    "libgdal >=3.11.4,<3.12.0a0",
+    "libgdal-core >=3.11.4,<3.12.0a0",
+    "numpy >=1.23,<3",
+    "pyside6",
+    "python >=3.14,<3.15.0a0",
+    "python_abi 3.14.* *_cp314"
+  ],
+  "license": "GPL-2.0-only",
+  "md5": "db6d5a1ed530687631f742bb2d2ef33a",
+  "name": "tuiview",
+  "sha256": "5749af307a60938eec6b0c702492d2e53c8f1d6725a6b75e9a23cb222fcf0d35",
+  "size": 464829,
+  "subdir": "linux-64",
+  "timestamp": 1761778804287,
+  "version": "1.3.5"
+}

```

</details>

Motivation: One of our collaborators merged https://github.com/conda-forge/plumpy-feedstock/pull/80 without properly updating the `kiwipy` dependence. Unaware of the possibility to patch conda builds, I tried to fix the issue in https://github.com/conda-forge/plumpy-feedstock/pull/81. This means the latest build _is_ functional, however, because of the dependency specifications in `aiida-core==2.7.1`, trying to install still resolves to a combination of incompatible builds:

```
❯ mamba env create -yn test_env aiida-core==2.7.1 --dry-run | grep 'plumpy\|kiwipy'                                                                                                                           (forge)
  + kiwipy                            0.8.5  pyhff2d567_0          conda-forge     Cached
  + plumpy                           0.25.1  pyhd8ed1ab_0          conda-forge     Cached
```

I was considering marking the build as broken, but after starting to open a PR in https://github.com/conda-forge/admin-requests I then read that it's possible (and preferred) to patch the original build. So that is what lead me here. ^^

I tried to follow the [README](https://github.com/mbercx/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md), but let me know in case I missed something.
