### PR TITLE
Patch old packages to require the old SWIG runtime

### DIFF
--- a/recipe/patch_yaml/imp.yaml
+++ b/recipe/patch_yaml/imp.yaml
@@ -1,0 +1,16 @@
+# The `imp` package uses classes from the `rmf` package wrapped by SWIG,
+# so we need to make sure that both packages use the same SWIG runtime
+# by depending on the `swig-abi` package. But this package was only introduced
+# in Oct 2025, when the SWIG runtime changed from 4 to 5:
+# https://github.com/conda-forge/swig-feedstock/issues/58
+# We therefore need to patch old versions of `imp` to depend on SWIG runtime 4.
+
+if:
+  name: imp
+  # The last `imp` package using SWIG runtime 4 was in Jul 2025. Packages
+  # built after Oct 31 2025 use runtime 5. So don't touch packages built
+  # after Oct 24th to be safe:
+  timestamp_lt: 1761341824000
+  not_has_depends: swig-abi*
+then:
+  - add_depends: swig-abi ==4

--- a/recipe/patch_yaml/rmf.yaml
+++ b/recipe/patch_yaml/rmf.yaml
@@ -1,0 +1,17 @@
+# The `rmf` package exports classes wrapped by SWIG, which are then used by
+# other conda packages (e.g. `imp`) so we need to make sure that all such
+# packages use the same SWIG runtime by depending on the `swig-abi` package.
+# But this package was only introduced in Oct 2025, when the SWIG runtime
+# changed from 4 to 5:
+# https://github.com/conda-forge/swig-feedstock/issues/58
+# We therefore need to patch old versions of `rmf` to depend on SWIG runtime 4.
+
+if:
+  name: rmf
+  # The last `rmf` package using SWIG runtime 4 was in Aug 2025. Packages
+  # built after Oct 31 2025 use runtime 5. So don't touch packages built
+  # after Oct 24th to be safe:
+  timestamp_lt: 1761341824000
+  not_has_depends: swig-abi*
+then:
+  - add_depends: swig-abi ==4


### PR DESCRIPTION
The SWIG runtime version recently changed from 4 to 5, and packages that share SWIG-wrapped classes need to use the same SWIG runtime to work correctly. Thanks to conda-forge/swig-feedstock#58 new builds of such packages will depend on v5 of the swig-abi package. This patch adds a dependency on v4 of swig-abi for older versions of two such affected packages (`imp` and `rmf`).

Note that v3 of the SWIG runtime was way back in 2008, long before any of the packages here were built, so we can safely tag all old packages as v4.

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

Diff:
[diffout.txt](https://github.com/user-attachments/files/23275243/diffout.txt)
