### PR TITLE
Add upper pin to altair

### DIFF
--- a/recipe/patch_yaml/altair.yaml
+++ b/recipe/patch_yaml/altair.yaml
@@ -51,3 +51,13 @@ then:
   - replace_depends:
       old: jsonschema >=3.0
       new: jsonschema >=3.0,!=4.18.1
+---
+# # Altair <=5.5 is incompatible with Python 3.14
+if:
+  name: altair
+  version_le: "5.5.0"
+  timestamp_lt: 1763123472000
+then:
+  - tighten_depends:
+      name: python
+      upper_bound: "3.14"


### PR DESCRIPTION
Altair <=5.5 is incompatible with Python 3.14, failing at import time ([xref](https://github.com/conda-forge/altair-feedstock/pull/64)). This PR adds an upper pin retroactively.

Checklist

* [X] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [X] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [X] Ran `python show_diff.py` and posted the output as part of the PR.
* [X] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

<details><summary>diff results</summary>

```
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
noarch
noarch::altair-1.2.1-py_0.tar.bz2
noarch::altair-1.2.1-py_1.tar.bz2
noarch::altair-2.0.0rc2-py_0.tar.bz2
noarch::altair-2.0.1-py_0.tar.bz2
noarch::altair-2.1.0-py_0.tar.bz2
noarch::altair-2.2.0-py_0.tar.bz2
noarch::altair-2.2.1-py_0.tar.bz2
noarch::altair-2.2.2-py_0.tar.bz2
-    "python",
+    "python <3.14.0a0",
noarch::altair-4.0.0-py_0.tar.bz2
noarch::altair-4.0.1-py_0.tar.bz2
noarch::altair-4.1.0-py_0.tar.bz2
-    "python >=3.5",
+    "python >=3.5,<3.14.0a0",
noarch::altair-4.2.0-pyhd8ed1ab_1.tar.bz2
noarch::altair-4.2.0-pyhd8ed1ab_2.conda
noarch::altair-4.2.2-pyhd8ed1ab_0.conda
noarch::altair-5.0.0-pyhd8ed1ab_0.conda
noarch::altair-5.0.1-pyhd8ed1ab_0.conda
noarch::altair-5.0.1-pyhd8ed1ab_1.conda
-    "python >=3.7",
+    "python >=3.7,<3.14.0a0",
noarch::altair-4.1.0-py_1.tar.bz2
noarch::altair-4.2.0-pyhd8ed1ab_0.tar.bz2
-    "python >=3.6",
+    "python >=3.6,<3.14.0a0",
noarch::altair-5.1.0-pyhd8ed1ab_0.conda
noarch::altair-5.1.1-pyhd8ed1ab_0.conda
noarch::altair-5.1.2-pyhd8ed1ab_0.conda
noarch::altair-5.2.0-pyhd8ed1ab_0.conda
noarch::altair-5.2.0-pyhd8ed1ab_1.conda
noarch::altair-5.3.0-pyhd8ed1ab_0.conda
noarch::altair-5.4.0-pyhd8ed1ab_0.conda
noarch::altair-5.4.1-pyhd8ed1ab_0.conda
noarch::altair-5.4.1-pyhd8ed1ab_1.conda
-    "python >=3.8",
+    "python >=3.8,<3.14.0a0",
noarch::altair-5.5.0-pyhd8ed1ab_0.conda
noarch::altair-5.5.0-pyhd8ed1ab_1.conda
-    "python >=3.9",
+    "python >=3.9,<3.14.0a0",
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
================================================================================
================================================================================
linux-64
```

</details>