### PR TITLE
Make published builds of ArcticDB depend on `libcurl <8.17`

### DIFF
--- a/recipe/patch_yaml/arcticdb.yaml
+++ b/recipe/patch_yaml/arcticdb.yaml
@@ -1,8 +1,9 @@
 # yaml-language-server: $schema=../patch_yaml_model.json
-# Use `libcurl<8.17` dependency for all ArcticDB builds until
-# the regression is understood and fixed. See: https://github.com/man-group/ArcticDB/pull/2746
+# Use `libcurl<8.17` dependency for all ArcticDB builds up to 6.3.1 (inclusive).
+# See: https://github.com/man-group/ArcticDB/pull/2746
 if:
   name: arcticdb
+  timestamp_lt: 1763539708000  # 2025-11-19
 then:
   - tighten_depends:
       name: libcurl


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

See: https://github.com/man-group/ArcticDB/pull/2746