### PR TITLE
Add missing dependencies to apache-airflow-task-sdk

### DIFF
--- a/recipe/patch_yaml/apache-airflow-task-sdk.yaml
+++ b/recipe/patch_yaml/apache-airflow-task-sdk.yaml
@@ -1,108 +1,109 @@
-## Fix constraints on apache-airflow-core for apache-airflow-task-sdk
+## Fix dependency on apache-airflow-core for apache-airflow-task-sdk
 # Each document targets a specific apache-airflow-task-sdk version and
-# adds a missing constraint on apache-airflow-core. We keep other
-# constraints intact by using add_constrains rather than reset_constrains.
+# adds a missing dependency on apache-airflow-core with the proper
+# version bounds. We keep other dependencies intact by using
+# add_depends rather than reset_depends.
 #
-# Note: This constraint has been missing in some builds due to a
+# Note: This dependency has been missing in some builds due to a
 # circular dependency between apache-airflow-task-sdk and
-# apache-airflow-core. These patches ensure the proper constraint is
-# present and correct.
+# apache-airflow-core. These patches ensure the proper dependency is
+# present and correctly versioned.
 
 ---
 if:
   name: apache-airflow-task-sdk
   version: 1.0.0
-  not_has_constrains: apache-airflow-core?( *)
+  not_has_depends: apache-airflow-core?( *)
   timestamp_lt: 1763538129000
 then:
-  - add_constrains: apache-airflow-core <=3.1.0,>=3.0.0
+  - add_depends: apache-airflow-core <3.1.0,>=3.0.0
 
 ---
 if:
   name: apache-airflow-task-sdk
   version: 1.0.1
-  not_has_constrains: apache-airflow-core?( *)
+  not_has_depends: apache-airflow-core?( *)
   timestamp_lt: 1763538129000
 then:
-  - add_constrains: apache-airflow-core <3.1.0,>=3.0.1
+  - add_depends: apache-airflow-core <3.1.0,>=3.0.1
 
 ---
 if:
   name: apache-airflow-task-sdk
   version: 1.0.2
-  not_has_constrains: apache-airflow-core?( *)
+  not_has_depends: apache-airflow-core?( *)
   timestamp_lt: 1763538129000
 then:
-  - add_constrains: apache-airflow-core <3.1.0,>=3.0.2
+  - add_depends: apache-airflow-core <3.1.0,>=3.0.2
 
 ---
 if:
   name: apache-airflow-task-sdk
   version: 1.0.3
-  not_has_constrains: apache-airflow-core?( *)
+  not_has_depends: apache-airflow-core?( *)
   timestamp_lt: 1763538129000
 then:
-  - add_constrains: apache-airflow-core <3.1.0,>=3.0.3
+  - add_depends: apache-airflow-core <3.1.0,>=3.0.3
 
 ---
 if:
   name: apache-airflow-task-sdk
   version: 1.0.4
-  not_has_constrains: apache-airflow-core?( *)
+  not_has_depends: apache-airflow-core?( *)
   timestamp_lt: 1763538129000
 then:
-  - add_constrains: apache-airflow-core <3.1.0,>=3.0.4
+  - add_depends: apache-airflow-core <3.1.0,>=3.0.4
 
 ---
 if:
   name: apache-airflow-task-sdk
   version: 1.0.5
-  not_has_constrains: apache-airflow-core?( *)
+  not_has_depends: apache-airflow-core?( *)
   timestamp_lt: 1763538129000
 then:
-  - add_constrains: apache-airflow-core <3.1.0,>=3.0.5
+  - add_depends: apache-airflow-core <3.1.0,>=3.0.5
 
 ---
 if:
   name: apache-airflow-task-sdk
   version: 1.0.6
-  not_has_constrains: apache-airflow-core?( *)
+  not_has_depends: apache-airflow-core?( *)
   timestamp_lt: 1763538129000
 then:
-  - add_constrains: apache-airflow-core <3.1.0,>=3.0.6
+  - add_depends: apache-airflow-core <3.1.0,>=3.0.6
 
 ---
 if:
   name: apache-airflow-task-sdk
   version: 1.1.0
-  not_has_constrains: apache-airflow-core?( *)
+  not_has_depends: apache-airflow-core?( *)
   timestamp_lt: 1763538129000
 then:
-  - add_constrains: apache-airflow-core <3.2.0,>=3.1.0
+  - add_depends: apache-airflow-core <3.2.0,>=3.1.0
 
 ---
 if:
   name: apache-airflow-task-sdk
   version: 1.1.1
-  not_has_constrains: apache-airflow-core?( *)
+  not_has_depends: apache-airflow-core?( *)
   timestamp_lt: 1763538129000
 then:
-  - add_constrains: apache-airflow-core <3.2.0,>=3.1.1
+  - add_depends: apache-airflow-core <3.2.0,>=3.1.1
 
 ---
 if:
   name: apache-airflow-task-sdk
   version: 1.1.2
-  not_has_constrains: apache-airflow-core?( *)
+  not_has_depends: apache-airflow-core?( *)
   timestamp_lt: 1763538129000
 then:
-  - add_constrains: apache-airflow-core <3.2.0,>=3.1.2
+  - add_depends: apache-airflow-core <3.2.0,>=3.1.2
 
 ---
 if:
   name: apache-airflow-task-sdk
   version: 1.1.3
-  not_has_constrains: apache-airflow-core?( *)
+  not_has_depends: apache-airflow-core?( *)
   timestamp_lt: 1763538129000
 then:
-  - add_constrains: apache-airflow-core <3.2.0,>=3.1.3
+  - add_depends: apache-airflow-core <3.2.0,>=3.1.3


### PR DESCRIPTION
Because of circular dependencies, `apache-airflow-task-sdk` were built first without `apache-airflow-core` dependency.  The dependency on `apache-airflow-core` was added back in a subsequent build but the first build without the dependency still gets picked up so should be patched.

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
