### PR TITLE
Fix numpy 2 upper bound for older taurus

### DIFF
--- a/recipe/patch_yaml/taurus-core.yaml
+++ b/recipe/patch_yaml/taurus-core.yaml
@@ -21,3 +21,12 @@ then:
   - replace_depends:
       old: python >=3.6
       new: python >=3.6,<3.11
+---
+if:
+  name: taurus-core
+  version_le: 5.1.8
+  timestamp_lt: 1764160908000
+then:
+  - replace_depends:
+      old: numpy >=1.1
+      new: numpy >=1.1,<2.0a0


### PR DESCRIPTION
Checklist

* [X] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [X] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [X] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [X] Ran `python show_diff.py` and posted the output as part of the PR.
* [X] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

`numpy` 2 support was added in taurus 5.2.0.

`numpy` 2 upper bound was added to taurus 5.1.8 [build 1](https://github.com/conda-forge/taurus-feedstock/pull/12).

When building recipes with `rattler-build` and `sardana` as dependency, rattler started to select taurus 5.1.8 (build 0) with numpy 2 making the tests to fail. This version is quite old, so I don't understand why.
conda and mamba properly install taurus 5.3.1.

Patching the repodata to avoid this from happening for old version of taurus (<= 5.1.8)

@conda-forge/taurus FYI

```
noarch
noarch::taurus-core-4.7.0-pyhd8ed1ab_0.tar.bz2
noarch::taurus-core-4.7.1-pyhd8ed1ab_0.tar.bz2
noarch::taurus-core-4.7.1.1-pyhd8ed1ab_0.tar.bz2
noarch::taurus-core-4.8.0-pyhd8ed1ab_0.tar.bz2
noarch::taurus-core-4.8.1-pyhd8ed1ab_0.tar.bz2
noarch::taurus-core-5.0.0-pyhd8ed1ab_0.tar.bz2
noarch::taurus-core-5.0.0.1-pyhd8ed1ab_0.tar.bz2
noarch::taurus-core-5.1.4-pyhd8ed1ab_0.tar.bz2
noarch::taurus-core-5.1.5-pyhd8ed1ab_0.conda
noarch::taurus-core-5.1.6-pyhd8ed1ab_0.conda
noarch::taurus-core-5.1.7-pyhd8ed1ab_0.conda
noarch::taurus-core-5.1.8-pyhd8ed1ab_0.conda
-    "numpy >=1.1",
+    "numpy >=1.1,<2.0a0",
```


