### PR TITLE
Remove dependency on libgettextpo and libglib for opencv

### DIFF
--- a/recipe/patch_yaml/opencv.yaml
+++ b/recipe/patch_yaml/opencv.yaml
@@ -21,3 +21,18 @@ then:
   # in the older builds of libopencv
   # https://github.com/conda-forge/opencv-feedstock/issues/486
   - add_constrains: imath<3.2.0a0
+
+---
+
+# hmaarrfk - 2025/11/30
+# Remove the dependency on libgettextpo, and libglib
+# https://github.com/conda-forge/opencv-feedstock/pull/498
+# It is likely that we can backport this beyond 4.12.0
+# But i'm too worried of unforseen consequences
+if:
+  name: libopencv
+  version: 4.12.0
+  timestamp_lt: 1764535383000
+then:
+  - remove_depends: libgettextpo?( *)
+  - remove_depends: libglib?( *)


### PR DESCRIPTION
Being fixed upstream in https://github.com/conda-forge/opencv-feedstock/pull/498

Checklist

* [ ] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
