### PR TITLE
Update gen_patch_json.py

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -851,8 +851,8 @@ def _gen_new_index_per_key(index, subdir, index_key="", verbose=False):
         if record_name == "flang":
             deps = record["depends"]
             if record["version"] == "5.0.0":
-                deps += ["clangdev *"]
-                deps += ["flang *"]
+                deps += ["clangdev"]
+                deps += ["flang"]
 
         # add as run_constrained for cling
         if (


### PR DESCRIPTION
Fix versioning syntax for version 5.0.0

Checklist

* [ ] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
