### PR TITLE
feat: add features to mpich external packages and remove depends

### DIFF
--- a/recipe/patch_yaml/mpich.yaml
+++ b/recipe/patch_yaml/mpich.yaml
@@ -16,7 +16,25 @@ if:
   build: external_*
   not_has_track_features: mpich_external_1
 then:
-  - reset_depends: []
+  # we remove extra depends instead of resetting so that we keep
+  # the mpi metapackage
+  - remove_depends:
+      - __glibc?( *)
+      - __osx*?( *)
+      - ucx?( *)
+      - libhwloc?( *)
+      - libfabric?( *)
+      - libfabric1?( *)
+      - libfabric2?( *)
+      - libgfortran?( *)
+      - libgfortran-ng?( *)
+      - libgfortran4?( *)
+      - libgfortran5?( *)
+      - libcxx?( *)
+      - libstdcxx?( *)
+      - libstdcxx-ng?( *)
+      - libgcc?( *)
+      - libgcc-ng?( *)
   - add_track_features: [mpich_external_1, mpich_external_2, mpich_external_3]
 # old patch no longer in use due to patch above
 # add back external package for v4.0.2 on linux per request here


### PR DESCRIPTION
Checklist

* [ ] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

This PR removes all run deps of the mpich external packages (except the mpi metapackage) and adds extra features to them so that they can be weighed down enough in the solver that they do not get installed ahead of actual mpi packages.

xref: https://github.com/conda-forge/mpich-feedstock/pull/123