### PR TITLE
fix: use more specific feature names for libhwloc

### DIFF
--- a/recipe/patch_yaml/libhwloc.yaml
+++ b/recipe/patch_yaml/libhwloc.yaml
@@ -1,10 +1,19 @@
+# see https://github.com/conda-forge/libhwloc-feedstock/issues/92
 if:
   name: libhwloc
   has_track_features: cudatoolkit
 then:
   - remove_track_features:
       - cudatoolkit
-      - rocm
   - add_track_features:
       - libhwloc_cudatoolkit
+---
+# see https://github.com/conda-forge/libhwloc-feedstock/issues/92
+if:
+  name: libhwloc
+  has_track_features: rocm
+then:
+  - remove_track_features:
+      - rocm
+  - add_track_features:
       - libhwloc_rocm


### PR DESCRIPTION
Checklist

* [ ] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

xref: https://github.com/conda-forge/libhwloc-feedstock/issues/92