### PR TITLE
Upper pin hyperspy2

### DIFF
--- a/recipe/patch_yaml/atomap.yaml
+++ b/recipe/patch_yaml/atomap.yaml
@@ -1,0 +1,19 @@
+# atomap <0.4.0 needs hyperspy <2.0.0
+if:
+  name: atomap
+  version_lt: "0.4.0"
+  timestamp_lt: 1765123739000
+then:
+  - tighten_depends:
+      name: hyperspy
+      upper_bound: "2.0.0"
+---
+# atomap <0.4.0 needs hyperspy-base <2.0.0
+if:
+  name: atomap
+  version_lt: "0.4.0"
+  timestamp_lt: 1765123739000
+then:
+  - tighten_depends:
+      name: hyperspy-base
+      upper_bound: "2.0.0"

--- a/recipe/patch_yaml/kikuchipy.yaml
+++ b/recipe/patch_yaml/kikuchipy.yaml
@@ -1,0 +1,20 @@
+---
+# kikuchipy <0.11.0 needs hyperspy <2.0.0
+if:
+  name: kikuchipy
+  version_lt: 0.11.0
+  timestamp_lt: 1765123739000
+then:
+  - tighten_depends:
+      name: hyperspy
+      upper_bound: 2.0.0
+---
+# kikuchipy <0.11.0 needs hyperspy-base <2.0.0
+if:
+  name: kikuchipy
+  version_lt: 0.11.0
+  timestamp_lt: 1765123739000
+then:
+  - tighten_depends:
+      name: hyperspy-base
+      upper_bound: 2.0.0

--- a/recipe/patch_yaml/pyxem.yaml
+++ b/recipe/patch_yaml/pyxem.yaml
@@ -1,0 +1,20 @@
+---
+# pyxem <0.17.0 needs hyperspy <2.0.0
+if:
+  name: pyxem
+  version_lt: 0.17.0
+  timestamp_lt: 1765123739000
+then:
+  - tighten_depends:
+      name: hyperspy
+      upper_bound: 2.0.0
+---
+# pyxem <0.17.0 needs hyperspy-base <2.0.0
+if:
+  name: pyxem
+  version_lt: 0.17.0
+  timestamp_lt: 1765123739000
+then:
+  - tighten_depends:
+      name: hyperspy-base
+      upper_bound: 2.0.0


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

conda install old version of `atomap` which are not compatible with `hyperspy` 2.0 - depending the version, `hyperspy` or `hyperspy-base` are used.

```
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
noarch
noarch::pyxem-0.13.2-pyhd8ed1ab_1.tar.bz2
noarch::pyxem-0.13.3-pyhd8ed1ab_0.tar.bz2
-    "hyperspy-base >=1.6.2",
+    "hyperspy-base >=1.6.2,<2.0.0a0",
noarch::atomap-0.2.1-py_1.tar.bz2
noarch::atomap-0.3.0-pyhd8ed1ab_0.tar.bz2
noarch::atomap-0.3.1-pyhd8ed1ab_0.tar.bz2
noarch::atomap-0.3.2-pyhd8ed1ab_0.tar.bz2
noarch::atomap-0.3.3-pyhd8ed1ab_0.conda
noarch::kikuchipy-0.3.0-pyhd8ed1ab_0.tar.bz2
noarch::kikuchipy-0.3.1-pyhd8ed1ab_0.tar.bz2
noarch::kikuchipy-0.3.2-pyhd8ed1ab_0.tar.bz2
noarch::kikuchipy-0.3.3-pyhd8ed1ab_0.tar.bz2
noarch::kikuchipy-0.3.4-pyhd8ed1ab_0.tar.bz2
noarch::kikuchipy-0.3.4-pyhd8ed1ab_1.tar.bz2
noarch::kikuchipy-0.4.0-pyhd8ed1ab_0.tar.bz2
-    "hyperspy-base >=1.5.2",
+    "hyperspy-base >=1.5.2,<2.0.0a0",
noarch::atomap-0.2.0-py_0.tar.bz2
noarch::atomap-0.2.1-py_0.tar.bz2
noarch::kikuchipy-0.1.2-py_0.tar.bz2
noarch::kikuchipy-0.1.2-py_1.tar.bz2
noarch::kikuchipy-0.1.3-py_0.tar.bz2
noarch::kikuchipy-0.2.0-py_0.tar.bz2
noarch::kikuchipy-0.2.1-py_0.tar.bz2
noarch::kikuchipy-0.2.2-py_0.tar.bz2
noarch::pyxem-0.10.0-py_0.tar.bz2
noarch::pyxem-0.10.1-py_1.tar.bz2
noarch::pyxem-0.11.0-py_0.tar.bz2
noarch::pyxem-0.9.1-py_0.tar.bz2
noarch::pyxem-0.9.2-py_0.tar.bz2
-    "hyperspy >=1.5.2",
+    "hyperspy >=1.5.2,<2.0.0a0",
noarch::kikuchipy-0.5.1-pyhd8ed1ab_0.tar.bz2
noarch::kikuchipy-0.5.2-pyhd8ed1ab_0.tar.bz2
-    "hyperspy-base >=1.6.4",
+    "hyperspy-base >=1.6.4,<2.0.0a0",
noarch::pyxem-0.7.1-py_0.tar.bz2
noarch::pyxem-0.8.0-py_0.tar.bz2
-    "hyperspy",
+    "hyperspy <2.0.0a0",
noarch::kikuchipy-0.5.3-pyhd8ed1ab_0.tar.bz2
noarch::kikuchipy-0.5.4-pyhd8ed1ab_0.tar.bz2
noarch::kikuchipy-0.5.5-pyhd8ed1ab_0.tar.bz2
noarch::kikuchipy-0.5.6-pyhd8ed1ab_0.tar.bz2
noarch::kikuchipy-0.5.7-pyhd8ed1ab_0.tar.bz2
noarch::kikuchipy-0.5.8-pyhd8ed1ab_0.tar.bz2
-    "hyperspy-base >=1.6.5",
+    "hyperspy-base >=1.6.5,<2.0.0a0",
noarch::pyxem-0.14.1-pyhd8ed1ab_0.tar.bz2
noarch::pyxem-0.14.2-pyhd8ed1ab_0.tar.bz2
noarch::pyxem-0.15.0-pyhd8ed1ab_0.conda
noarch::pyxem-0.15.1-pyhd8ed1ab_0.conda
-    "hyperspy-base >=1.7.0",
+    "hyperspy-base >=1.7.0,<2.0.0a0",
noarch::pyxem-0.9.0-py_0.tar.bz2
-    "hyperspy >=1.3",
+    "hyperspy >=1.3,<2.0.0a0",
noarch::kikuchipy-0.6.0-pyhd8ed1ab_0.tar.bz2
noarch::kikuchipy-0.6.1-pyhd8ed1ab_0.tar.bz2
noarch::kikuchipy-0.7.0-pyhd8ed1ab_0.tar.bz2
-    "hyperspy-base >=1.7",
+    "hyperspy-base >=1.7,<2.0.0a0",
noarch::atomap-0.1.4-py_0.tar.bz2
-    "hyperspy >=1.4",
+    "hyperspy >=1.4,<2.0.0a0",
noarch::kikuchipy-0.8.0-pyhd8ed1ab_0.conda
noarch::kikuchipy-0.8.1-pyhd8ed1ab_0.conda
noarch::kikuchipy-0.8.2-pyhd8ed1ab_0.conda
noarch::kikuchipy-0.8.3-pyhd8ed1ab_0.conda
noarch::kikuchipy-0.8.4-pyhd8ed1ab_0.conda
noarch::kikuchipy-0.8.4-pyhd8ed1ab_1.conda
noarch::kikuchipy-0.8.5-pyhd8ed1ab_0.conda
noarch::kikuchipy-0.8.6-pyhd8ed1ab_0.conda
noarch::kikuchipy-0.8.7-pyhd8ed1ab_0.conda
-    "hyperspy-base >=1.7.3",
+    "hyperspy-base >=1.7.3,<2.0.0a0",
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
================================================================================
================================================================================
linux-64
```
