### PR TITLE
Tighten PyTensor's numpy pin from 1.17.0 to 2.0

### DIFF
--- a/recipe/patch_yaml/pytensor.yaml
+++ b/recipe/patch_yaml/pytensor.yaml
@@ -44,3 +44,17 @@ if:
   subdir_in: win-64
 then:
   - add_constrains: libstdcxx !=15.1.0
+---
+# PyTensor v2.35.0 started to require numpy >=2, thanks to
+# <https://github.com/pymc-devs/pytensor/pull/1253>, but I forgot to update
+# the recpie until v2.36.0. Affected versions: 2.35.0, 2.35.1.
+# Fixed in <https://github.com/conda-forge/pytensor-suite-feedstock/pull/186>.
+if:
+  name: pytensor-base
+  version_ge: 2.35.0
+  version_lt: 2.36.0
+  timestamp_lt: 1765874452000
+then:
+  - replace_depends:
+      old: numpy >=1.17.0
+      new: numpy >=2.0


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
