### PR TITLE
pygetm: fix pyfabm dependency

### DIFF
--- a/recipe/patch_yaml/pygetm.yaml
+++ b/recipe/patch_yaml/pygetm.yaml
@@ -8,4 +8,3 @@ then:
   - replace_depends:
       old: pyfabm >=2.1
       new: pyfabm >=3.0
-


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

`cat show_diff_result.txt:`

```
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
osx-arm64
osx-arm64::pygetm-0.9.19-py310h264d1c4_0.conda
osx-arm64::pygetm-0.9.19-py311hac01014_0.conda
osx-arm64::pygetm-0.9.19-py312h87ca0b1_0.conda
osx-arm64::pygetm-0.9.19-py313h1b5c6b9_0.conda
-    "pyfabm >=2.1",
+    "pyfabm >=3.0",
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
noarch
================================================================================
================================================================================
win-64
win-64::pygetm-0.9.19-py310hfc26a4c_0.conda
win-64::pygetm-0.9.19-py311hf64dc81_0.conda
win-64::pygetm-0.9.19-py312h33d6f13_0.conda
win-64::pygetm-0.9.19-py313h72487a1_0.conda
win-64::pygetm-0.9.19-py314h3cfb933_0.conda
-    "pyfabm >=2.1",
+    "pyfabm >=3.0",
================================================================================
================================================================================
osx-64
osx-64::pygetm-0.9.19-py310h6761d9b_0.conda
osx-64::pygetm-0.9.19-py311h54984bf_0.conda
osx-64::pygetm-0.9.19-py312h59ed3ae_0.conda
osx-64::pygetm-0.9.19-py313h5a11492_0.conda
osx-64::pygetm-0.9.19-py314h20b3cf7_0.conda
-    "pyfabm >=2.1",
+    "pyfabm >=3.0",
================================================================================
================================================================================
linux-64
linux-64::pygetm-0.9.19-py310h18bf74c_0.conda
linux-64::pygetm-0.9.19-py311h262f814_0.conda
linux-64::pygetm-0.9.19-py312h6a55c13_0.conda
linux-64::pygetm-0.9.19-py313h9cc49e9_0.conda
linux-64::pygetm-0.9.19-py314hacf7208_0.conda
-    "pyfabm >=2.1",
+    "pyfabm >=3.0",
```

NB the py314 package for osx-arm64 seems to be missing. Not sure why as [it built fine originally](https://github.com/conda-forge/pygetm-feedstock/pull/26). This may be a separate issue, but advice on how to debug it very welcome.