### PR TITLE
Add missing upper pytest bound for old versions of pytest-split

### DIFF
--- a/recipe/patch_yaml/pytest-split.yaml
+++ b/recipe/patch_yaml/pytest-split.yaml
@@ -1,0 +1,16 @@
+# pytest-split version 0.10.0 added a <9.0.0 upper bound for pytest.
+# Now that pytest 9 has been released, the solver tries to downgrade
+# pytest-split to 0.8.2, often causing breakage.
+
+# Hopefully <https://github.com/jerry-git/pytest-split/issues/114>
+# gets merged soon, and modern pytest-split will officially support
+# pytest 9.
+
+if:
+  name: pytest-split
+  version_le: 0.8.2
+  timestamp_lt: 1767604488000
+then:
+  - tighten_depends:
+      name: pytest
+      upper_bound: '9.0.0'


### PR DESCRIPTION
pytest-split version 0.10.0 added a <9.0.0 upper bound for pytest. Now that pytest 9 has been released, the solver tries to downgrade pytest-split to 0.8.2, often causing breakage, as reported in https://github.com/conda-forge/pytest-split-feedstock/pull/23.

Hopefully <https://github.com/jerry-git/pytest-split/issues/114> gets merged soon, and modern pytest-split will officially support pytest 9.

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
