### PR TITLE
Add more missing pytest upper bounds to pytest-split packages

### DIFF
--- a/recipe/patch_yaml/pytest-split.yaml
+++ b/recipe/patch_yaml/pytest-split.yaml
@@ -14,3 +14,40 @@ then:
   - tighten_depends:
       name: pytest
       upper_bound: '9.0.0'
+---
+# The conda-forge packages were missing the upper bounds that are
+# present in the source pyproject.toml and PyPI metadata. To ensure
+# monotonicity of upper bounds (preventing the solver from picking
+# older versions to satisfy newer pytest), we add stricter bounds
+# to older versions:
+#
+# | Version       | PyPI       | Conda-forge* | Patch adds |
+# |---------------|------------|--------------|------------|
+# | 0.1.5, 0.2.0  | (no bound) | <9           | <7         |
+# | 0.2.2 - 0.6.0 | >=5,<7     | <9           | <7         |
+# | 0.7.0 - 0.8.1 | >=5,<8     | <9           | <8         |
+# | 0.8.2         | >=5,<9     | <9           | (above)    |
+# | 0.10.0        | >=5,<9     | <9 (correct) | -          |
+#
+# * Conda-forge column is inclusive of the first patch above.
+
+# Versions up to 0.6.0: add <7.0.0 upper bound
+if:
+  name: pytest-split
+  version_le: 0.6.0
+  timestamp_lt: 1767604488000
+then:
+  - tighten_depends:
+      name: pytest
+      upper_bound: '7.0.0'
+---
+# Versions 0.7.0 - 0.8.1: add <8.0.0 upper bound
+if:
+  name: pytest-split
+  version_ge: 0.7.0
+  version_le: 0.8.1
+  timestamp_lt: 1767604488000
+then:
+  - tighten_depends:
+      name: pytest
+      upper_bound: '8.0.0'


### PR DESCRIPTION
Commit fe450b1 added <9 to all pytest-split versions ≤0.8.2, but this was looser than the bounds specified on PyPI. This patch tightens the conda-forge bounds to match PyPI:

| Version       | PyPI       | Patch adds |
|---------------|------------|------------|
| 0.1.5, 0.2.0  | (no bound) | <7         |
| 0.2.2 - 0.6.0 | >=5,<7     | <7         |
| 0.7.0 - 0.8.1 | >=5,<8     | <8         |
| 0.8.2         | >=5,<9     |  <9 (unchanged from https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/1131)        |

The stricter bounds on older versions ensure monotonicity, preventing the solver from selecting them to satisfy newer pytest versions.

See: https://github.com/conda-forge/pytest-split-feedstock/pull/23

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
