### PR TITLE
Add polyagamma patch: numpy !=2.4.0 for NumPy Cython ABI breakage

### DIFF
--- a/recipe/patch_yaml/polyagamma.yaml
+++ b/recipe/patch_yaml/polyagamma.yaml
@@ -1,0 +1,13 @@
+# 2026/01 -- NumPy 2.4.0 is broken, and polyagamma triggers the breakage.
+# Primary reference: <https://github.com/zoj613/polyagamma/issues/132>
+# Summary: NumPy 2.4.0 broke the Cython random API ABI, and consequently
+# polyagamma fails to import. A fix is pending in NumPy 2.4.1.
+# We forbid NumPy 2.4.0 for current (=2.0.2) and previous versions
+# of polyagamma.
+if:
+  name: polyagamma
+  version_le: 2.0.2
+  timestamp_lt: 1767694794000
+
+then:
+  - add_depends: numpy !=2.4.0


### PR DESCRIPTION
Details of NumPy problem as it relates to polyagamma: https://github.com/zoj613/polyagamma/issues/132

NumPy 2.4.0 accidentally broke ABI compatibility, so polyagamma fails immediately on import. The next NumPy release should fix the issue.

Polyagamma package metadata for conda-forge courtesy of [prefix.dev](https://prefix.dev/channels/conda-forge/packages/polyagamma)

Checklist

* [X] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [X] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->


<details>
<summary> <tt>python show_diff.py</tt> output

</summary>

```diff
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
osx-arm64
osx-arm64::polyagamma-1.3.4-py310h611a7d1_1.tar.bz2
osx-arm64::polyagamma-1.3.4-py310hf1a086a_2.tar.bz2
osx-arm64::polyagamma-1.3.4-py311h4add359_2.tar.bz2
osx-arm64::polyagamma-1.3.4-py38hb39dbe9_2.tar.bz2
osx-arm64::polyagamma-1.3.4-py38hd91e067_1.tar.bz2
osx-arm64::polyagamma-1.3.4-py39h4d8bf0d_2.tar.bz2
osx-arm64::polyagamma-1.3.4-py39h7b9fbcb_1.tar.bz2
osx-arm64::polyagamma-1.3.5-py310hf1a086a_0.conda
osx-arm64::polyagamma-1.3.5-py310hf1a086a_1.conda
osx-arm64::polyagamma-1.3.5-py311h4add359_0.conda
osx-arm64::polyagamma-1.3.5-py311h4add359_1.conda
osx-arm64::polyagamma-1.3.5-py38hb39dbe9_0.conda
osx-arm64::polyagamma-1.3.5-py38hb39dbe9_1.conda
osx-arm64::polyagamma-1.3.5-py39h4d8bf0d_0.conda
osx-arm64::polyagamma-1.3.5-py39h4d8bf0d_1.conda
osx-arm64::polyagamma-1.3.6-py310h50ce23c_0.conda
osx-arm64::polyagamma-1.3.6-py311h9ea6feb_0.conda
osx-arm64::polyagamma-1.3.6-py39h373d45f_0.conda
osx-arm64::polyagamma-2.0.0-py310h078409c_0.conda
osx-arm64::polyagamma-2.0.0-py311h917b07b_0.conda
osx-arm64::polyagamma-2.0.0-py312hea69d52_0.conda
osx-arm64::polyagamma-2.0.0-py39hf3bc14e_0.conda
osx-arm64::polyagamma-2.0.1-py310h078409c_0.conda
osx-arm64::polyagamma-2.0.1-py310h078409c_1.conda
osx-arm64::polyagamma-2.0.1-py311h917b07b_0.conda
osx-arm64::polyagamma-2.0.1-py311h917b07b_1.conda
osx-arm64::polyagamma-2.0.1-py312hea69d52_0.conda
osx-arm64::polyagamma-2.0.1-py312hea69d52_1.conda
osx-arm64::polyagamma-2.0.1-py313h90d716c_1.conda
osx-arm64::polyagamma-2.0.2-py310h078409c_0.conda
osx-arm64::polyagamma-2.0.2-py310h7bdd564_1.conda
osx-arm64::polyagamma-2.0.2-py311h3696347_1.conda
osx-arm64::polyagamma-2.0.2-py311h917b07b_0.conda
osx-arm64::polyagamma-2.0.2-py312h163523d_1.conda
osx-arm64::polyagamma-2.0.2-py312hea69d52_0.conda
osx-arm64::polyagamma-2.0.2-py313h90d716c_0.conda
osx-arm64::polyagamma-2.0.2-py313hcdf3177_1.conda
osx-arm64::polyagamma-2.0.2-py314hb84d1df_1.conda
+    "numpy !=2.4.0",
================================================================================
================================================================================
linux-aarch64
linux-aarch64::polyagamma-1.3.5-py310h0654a89_1.conda
linux-aarch64::polyagamma-1.3.5-py311h4fc6483_1.conda
linux-aarch64::polyagamma-1.3.5-py38h50faf1d_1.conda
linux-aarch64::polyagamma-1.3.5-py38hfe693fe_1.conda
linux-aarch64::polyagamma-1.3.5-py39hbb80719_1.conda
linux-aarch64::polyagamma-1.3.5-py39hc7cda1a_1.conda
linux-aarch64::polyagamma-1.3.6-py310h8b6b5fc_0.conda
linux-aarch64::polyagamma-1.3.6-py311hf13da56_0.conda
linux-aarch64::polyagamma-1.3.6-py39h1ae4408_0.conda
linux-aarch64::polyagamma-1.3.6-py39h9acaed8_0.conda
linux-aarch64::polyagamma-2.0.0-py310ha766c32_0.conda
linux-aarch64::polyagamma-2.0.0-py311ha879c10_0.conda
linux-aarch64::polyagamma-2.0.0-py312hb2c0f52_0.conda
linux-aarch64::polyagamma-2.0.0-py39h060674a_0.conda
linux-aarch64::polyagamma-2.0.1-py310ha766c32_0.conda
linux-aarch64::polyagamma-2.0.1-py310ha766c32_1.conda
linux-aarch64::polyagamma-2.0.1-py311ha879c10_0.conda
linux-aarch64::polyagamma-2.0.1-py311ha879c10_1.conda
linux-aarch64::polyagamma-2.0.1-py312hb2c0f52_0.conda
linux-aarch64::polyagamma-2.0.1-py312hb2c0f52_1.conda
linux-aarch64::polyagamma-2.0.1-py313h31d5739_1.conda
linux-aarch64::polyagamma-2.0.2-py310h5b55623_1.conda
linux-aarch64::polyagamma-2.0.2-py310ha766c32_0.conda
linux-aarch64::polyagamma-2.0.2-py311h19352d5_1.conda
linux-aarch64::polyagamma-2.0.2-py311ha879c10_0.conda
linux-aarch64::polyagamma-2.0.2-py312hb2c0f52_0.conda
linux-aarch64::polyagamma-2.0.2-py312hcd1a082_1.conda
linux-aarch64::polyagamma-2.0.2-py313h31d5739_0.conda
linux-aarch64::polyagamma-2.0.2-py313h6194ac5_1.conda
linux-aarch64::polyagamma-2.0.2-py314h51f160d_1.conda
+    "numpy !=2.4.0",
================================================================================
================================================================================
noarch
================================================================================
================================================================================
win-64
win-64::polyagamma-1.3.2-py36h68aa20f_0.tar.bz2
win-64::polyagamma-1.3.2-py37hcc03f2d_0.tar.bz2
win-64::polyagamma-1.3.2-py37hcc03f2d_1.tar.bz2
win-64::polyagamma-1.3.2-py38h294d835_0.tar.bz2
win-64::polyagamma-1.3.2-py38h294d835_1.tar.bz2
win-64::polyagamma-1.3.2-py39hb82d6ee_0.tar.bz2
win-64::polyagamma-1.3.2-py39hb82d6ee_1.tar.bz2
win-64::polyagamma-1.3.2b3-py36h68aa20f_0.tar.bz2
win-64::polyagamma-1.3.2b3-py36h68aa20f_1.tar.bz2
win-64::polyagamma-1.3.2b3-py37hcc03f2d_0.tar.bz2
win-64::polyagamma-1.3.2b3-py37hcc03f2d_1.tar.bz2
win-64::polyagamma-1.3.2b3-py38h294d835_0.tar.bz2
win-64::polyagamma-1.3.2b3-py38h294d835_1.tar.bz2
win-64::polyagamma-1.3.2b3-py39hb82d6ee_0.tar.bz2
win-64::polyagamma-1.3.2b3-py39hb82d6ee_1.tar.bz2
win-64::polyagamma-1.3.3-py310h2873277_0.tar.bz2
win-64::polyagamma-1.3.3-py310h2873277_1.tar.bz2
win-64::polyagamma-1.3.3-py37h3a130e4_0.tar.bz2
win-64::polyagamma-1.3.3-py37h3a130e4_1.tar.bz2
win-64::polyagamma-1.3.3-py38ha7e4d9e_1.tar.bz2
win-64::polyagamma-1.3.3-py38hbdcd294_0.tar.bz2
win-64::polyagamma-1.3.3-py38hbdcd294_1.tar.bz2
win-64::polyagamma-1.3.3-py39h118cf84_1.tar.bz2
win-64::polyagamma-1.3.3-py39h5d4886f_0.tar.bz2
win-64::polyagamma-1.3.3-py39h5d4886f_1.tar.bz2
win-64::polyagamma-1.3.4-py310h2873277_0.tar.bz2
win-64::polyagamma-1.3.4-py310h2873277_1.tar.bz2
win-64::polyagamma-1.3.4-py310h9b08ddd_2.tar.bz2
win-64::polyagamma-1.3.4-py311h59ca53f_2.tar.bz2
win-64::polyagamma-1.3.4-py37h3a130e4_0.tar.bz2
win-64::polyagamma-1.3.4-py37h3a130e4_1.tar.bz2
win-64::polyagamma-1.3.4-py38h1dac1e8_2.tar.bz2
win-64::polyagamma-1.3.4-py38ha7e4d9e_0.tar.bz2
win-64::polyagamma-1.3.4-py38ha7e4d9e_1.tar.bz2
win-64::polyagamma-1.3.4-py38hbaf524b_2.tar.bz2
win-64::polyagamma-1.3.4-py38hbdcd294_0.tar.bz2
win-64::polyagamma-1.3.4-py38hbdcd294_1.tar.bz2
win-64::polyagamma-1.3.4-py39h118cf84_0.tar.bz2
win-64::polyagamma-1.3.4-py39h118cf84_1.tar.bz2
win-64::polyagamma-1.3.4-py39h5d4886f_0.tar.bz2
win-64::polyagamma-1.3.4-py39h5d4886f_1.tar.bz2
win-64::polyagamma-1.3.4-py39h8942a9a_2.tar.bz2
win-64::polyagamma-1.3.4-py39hc266a54_2.tar.bz2
win-64::polyagamma-1.3.5-py310h9b08ddd_0.conda
win-64::polyagamma-1.3.5-py310h9b08ddd_1.conda
win-64::polyagamma-1.3.5-py311h59ca53f_0.conda
win-64::polyagamma-1.3.5-py311h59ca53f_1.conda
win-64::polyagamma-1.3.5-py38h1dac1e8_0.conda
win-64::polyagamma-1.3.5-py38h1dac1e8_1.conda
win-64::polyagamma-1.3.5-py38hbaf524b_0.conda
win-64::polyagamma-1.3.5-py38hbaf524b_1.conda
win-64::polyagamma-1.3.5-py39h8942a9a_0.conda
win-64::polyagamma-1.3.5-py39h8942a9a_1.conda
win-64::polyagamma-1.3.5-py39hc266a54_0.conda
win-64::polyagamma-1.3.5-py39hc266a54_1.conda
win-64::polyagamma-1.3.6-py310h3e78b6c_0.conda
win-64::polyagamma-1.3.6-py311h59ca53f_0.conda
win-64::polyagamma-1.3.6-py39h52f1e7f_0.conda
win-64::polyagamma-1.3.6-py39hd88c2e4_0.conda
win-64::polyagamma-2.0.0-py310ha8f682b_0.conda
win-64::polyagamma-2.0.0-py311he736701_0.conda
win-64::polyagamma-2.0.0-py312h4389bb4_0.conda
win-64::polyagamma-2.0.0-py39ha55e580_0.conda
win-64::polyagamma-2.0.1-py310ha8f682b_0.conda
win-64::polyagamma-2.0.1-py310ha8f682b_1.conda
win-64::polyagamma-2.0.1-py311he736701_0.conda
win-64::polyagamma-2.0.1-py311he736701_1.conda
win-64::polyagamma-2.0.1-py312h4389bb4_0.conda
win-64::polyagamma-2.0.1-py312h4389bb4_1.conda
win-64::polyagamma-2.0.1-py313ha7868ed_1.conda
win-64::polyagamma-2.0.2-py310h29418f3_1.conda
win-64::polyagamma-2.0.2-py310ha8f682b_0.conda
win-64::polyagamma-2.0.2-py311h3485c13_1.conda
win-64::polyagamma-2.0.2-py311he736701_0.conda
win-64::polyagamma-2.0.2-py312h4389bb4_0.conda
win-64::polyagamma-2.0.2-py312he06e257_1.conda
win-64::polyagamma-2.0.2-py313h5ea7bf4_1.conda
win-64::polyagamma-2.0.2-py313ha7868ed_0.conda
win-64::polyagamma-2.0.2-py314h5a2d7ad_1.conda
+    "numpy !=2.4.0",
================================================================================
================================================================================
osx-64
osx-64::polyagamma-1.3.2-py36hfa26744_0.tar.bz2
osx-64::polyagamma-1.3.2-py37h271585c_0.tar.bz2
osx-64::polyagamma-1.3.2-py37h271585c_1.tar.bz2
osx-64::polyagamma-1.3.2-py38h96a0964_0.tar.bz2
osx-64::polyagamma-1.3.2-py38h96a0964_1.tar.bz2
osx-64::polyagamma-1.3.2-py39h89e85a6_0.tar.bz2
osx-64::polyagamma-1.3.2-py39h89e85a6_1.tar.bz2
osx-64::polyagamma-1.3.2b3-py36hfa26744_1.tar.bz2
osx-64::polyagamma-1.3.2b3-py37h271585c_1.tar.bz2
osx-64::polyagamma-1.3.2b3-py38h96a0964_1.tar.bz2
osx-64::polyagamma-1.3.2b3-py39h89e85a6_1.tar.bz2
osx-64::polyagamma-1.3.3-py310h7f5fb2b_0.tar.bz2
osx-64::polyagamma-1.3.3-py310h7f5fb2b_1.tar.bz2
osx-64::polyagamma-1.3.3-py37h49e79e5_0.tar.bz2
osx-64::polyagamma-1.3.3-py37h49e79e5_1.tar.bz2
osx-64::polyagamma-1.3.3-py38h4277f33_0.tar.bz2
osx-64::polyagamma-1.3.3-py38h4277f33_1.tar.bz2
osx-64::polyagamma-1.3.3-py38h8629005_1.tar.bz2
osx-64::polyagamma-1.3.3-py39h2aba927_1.tar.bz2
osx-64::polyagamma-1.3.3-py39h86b5767_0.tar.bz2
osx-64::polyagamma-1.3.3-py39h86b5767_1.tar.bz2
osx-64::polyagamma-1.3.4-py310h1bbcd0e_0.tar.bz2
osx-64::polyagamma-1.3.4-py310h1bbcd0e_1.tar.bz2
osx-64::polyagamma-1.3.4-py310h936d966_2.tar.bz2
osx-64::polyagamma-1.3.4-py311hd5badaa_2.tar.bz2
osx-64::polyagamma-1.3.4-py37h4de8ad1_0.tar.bz2
osx-64::polyagamma-1.3.4-py37h4de8ad1_1.tar.bz2
osx-64::polyagamma-1.3.4-py38h034f6e7_2.tar.bz2
osx-64::polyagamma-1.3.4-py38h26e9ae0_0.tar.bz2
osx-64::polyagamma-1.3.4-py38h26e9ae0_1.tar.bz2
osx-64::polyagamma-1.3.4-py38hbd87e4b_2.tar.bz2
osx-64::polyagamma-1.3.4-py38hc1426ef_0.tar.bz2
osx-64::polyagamma-1.3.4-py38hc1426ef_1.tar.bz2
osx-64::polyagamma-1.3.4-py39h15b18c7_0.tar.bz2
osx-64::polyagamma-1.3.4-py39h15b18c7_1.tar.bz2
osx-64::polyagamma-1.3.4-py39h2a4ad03_2.tar.bz2
osx-64::polyagamma-1.3.4-py39h7cc1f47_2.tar.bz2
osx-64::polyagamma-1.3.4-py39hbfdede2_0.tar.bz2
osx-64::polyagamma-1.3.4-py39hbfdede2_1.tar.bz2
osx-64::polyagamma-1.3.5-py310h936d966_0.conda
osx-64::polyagamma-1.3.5-py310h936d966_1.conda
osx-64::polyagamma-1.3.5-py311hd5badaa_0.conda
osx-64::polyagamma-1.3.5-py311hd5badaa_1.conda
osx-64::polyagamma-1.3.5-py38h034f6e7_0.conda
osx-64::polyagamma-1.3.5-py38h034f6e7_1.conda
osx-64::polyagamma-1.3.5-py38hbd87e4b_0.conda
osx-64::polyagamma-1.3.5-py38hbd87e4b_1.conda
osx-64::polyagamma-1.3.5-py39h2a4ad03_0.conda
osx-64::polyagamma-1.3.5-py39h2a4ad03_1.conda
osx-64::polyagamma-1.3.5-py39h7cc1f47_0.conda
osx-64::polyagamma-1.3.5-py39h7cc1f47_1.conda
osx-64::polyagamma-1.3.6-py310h91862f5_0.conda
osx-64::polyagamma-1.3.6-py311hc9a392d_0.conda
osx-64::polyagamma-1.3.6-py39h5b4affa_0.conda
osx-64::polyagamma-1.3.6-py39hd8c7907_0.conda
osx-64::polyagamma-2.0.0-py310hbb8c376_0.conda
osx-64::polyagamma-2.0.0-py311h4d7f069_0.conda
osx-64::polyagamma-2.0.0-py312h01d7ebd_0.conda
osx-64::polyagamma-2.0.0-py39h80efdc8_0.conda
osx-64::polyagamma-2.0.1-py310hbb8c376_0.conda
osx-64::polyagamma-2.0.1-py310hbb8c376_1.conda
osx-64::polyagamma-2.0.1-py311h4d7f069_0.conda
osx-64::polyagamma-2.0.1-py311h4d7f069_1.conda
osx-64::polyagamma-2.0.1-py312h01d7ebd_0.conda
osx-64::polyagamma-2.0.1-py312h01d7ebd_1.conda
osx-64::polyagamma-2.0.1-py313h63b0ddb_1.conda
osx-64::polyagamma-2.0.2-py310h1b7cace_1.conda
osx-64::polyagamma-2.0.2-py310hbb8c376_0.conda
osx-64::polyagamma-2.0.2-py311h13e5629_1.conda
osx-64::polyagamma-2.0.2-py311h4d7f069_0.conda
osx-64::polyagamma-2.0.2-py312h01d7ebd_0.conda
osx-64::polyagamma-2.0.2-py312h2f459f6_1.conda
osx-64::polyagamma-2.0.2-py313h585f44e_1.conda
osx-64::polyagamma-2.0.2-py313h63b0ddb_0.conda
osx-64::polyagamma-2.0.2-py314h03d016b_1.conda
+    "numpy !=2.4.0",
================================================================================
================================================================================
linux-64
linux-64::polyagamma-1.3.2-py36h8f6f2f9_0.tar.bz2
linux-64::polyagamma-1.3.2-py37h5e8e339_0.tar.bz2
linux-64::polyagamma-1.3.2-py37h5e8e339_1.tar.bz2
linux-64::polyagamma-1.3.2-py38h497a2fe_0.tar.bz2
linux-64::polyagamma-1.3.2-py38h497a2fe_1.tar.bz2
linux-64::polyagamma-1.3.2-py39h3811e60_0.tar.bz2
linux-64::polyagamma-1.3.2-py39h3811e60_1.tar.bz2
linux-64::polyagamma-1.3.2b3-py36h8f6f2f9_1.tar.bz2
linux-64::polyagamma-1.3.2b3-py37h5e8e339_1.tar.bz2
linux-64::polyagamma-1.3.2b3-py38h497a2fe_1.tar.bz2
linux-64::polyagamma-1.3.2b3-py39h3811e60_1.tar.bz2
linux-64::polyagamma-1.3.3-py310hde88566_0.tar.bz2
linux-64::polyagamma-1.3.3-py310hde88566_1.tar.bz2
linux-64::polyagamma-1.3.3-py37hda87dfa_0.tar.bz2
linux-64::polyagamma-1.3.3-py37hda87dfa_1.tar.bz2
linux-64::polyagamma-1.3.3-py38h71d37f0_0.tar.bz2
linux-64::polyagamma-1.3.3-py38h71d37f0_1.tar.bz2
linux-64::polyagamma-1.3.3-py38hdf7fcb0_1.tar.bz2
linux-64::polyagamma-1.3.3-py39h3ec6ae7_1.tar.bz2
linux-64::polyagamma-1.3.3-py39hd257fcd_0.tar.bz2
linux-64::polyagamma-1.3.3-py39hd257fcd_1.tar.bz2
linux-64::polyagamma-1.3.4-py310hde88566_0.tar.bz2
linux-64::polyagamma-1.3.4-py310hde88566_1.tar.bz2
linux-64::polyagamma-1.3.4-py310hde88566_2.tar.bz2
linux-64::polyagamma-1.3.4-py311h4c7f6c3_2.tar.bz2
linux-64::polyagamma-1.3.4-py37hda87dfa_0.tar.bz2
linux-64::polyagamma-1.3.4-py37hda87dfa_1.tar.bz2
linux-64::polyagamma-1.3.4-py38h26c90d9_2.tar.bz2
linux-64::polyagamma-1.3.4-py38h71d37f0_0.tar.bz2
linux-64::polyagamma-1.3.4-py38h71d37f0_1.tar.bz2
linux-64::polyagamma-1.3.4-py38hc21ccfd_2.tar.bz2
linux-64::polyagamma-1.3.4-py38hdf7fcb0_0.tar.bz2
linux-64::polyagamma-1.3.4-py38hdf7fcb0_1.tar.bz2
linux-64::polyagamma-1.3.4-py39h2ae25f5_2.tar.bz2
linux-64::polyagamma-1.3.4-py39h3ec6ae7_0.tar.bz2
linux-64::polyagamma-1.3.4-py39h3ec6ae7_1.tar.bz2
linux-64::polyagamma-1.3.4-py39had34720_2.tar.bz2
linux-64::polyagamma-1.3.4-py39hd257fcd_0.tar.bz2
linux-64::polyagamma-1.3.4-py39hd257fcd_1.tar.bz2
linux-64::polyagamma-1.3.5-py310h0a54255_0.conda
linux-64::polyagamma-1.3.5-py310h0a54255_1.conda
linux-64::polyagamma-1.3.5-py311hcb2cf0a_0.conda
linux-64::polyagamma-1.3.5-py311hcb2cf0a_1.conda
linux-64::polyagamma-1.3.5-py38h7e4f40d_0.conda
linux-64::polyagamma-1.3.5-py38h7e4f40d_1.conda
linux-64::polyagamma-1.3.5-py38hcd86b48_0.conda
linux-64::polyagamma-1.3.5-py38hcd86b48_1.conda
linux-64::polyagamma-1.3.5-py39h389d5f1_0.conda
linux-64::polyagamma-1.3.5-py39h389d5f1_1.conda
linux-64::polyagamma-1.3.5-py39h43b8f0a_0.conda
linux-64::polyagamma-1.3.5-py39h43b8f0a_1.conda
linux-64::polyagamma-1.3.6-py310h1f7b6fc_0.conda
linux-64::polyagamma-1.3.6-py311h1f0f07a_0.conda
linux-64::polyagamma-1.3.6-py39h44dd56e_0.conda
linux-64::polyagamma-1.3.6-py39hf7fbf1e_0.conda
linux-64::polyagamma-2.0.0-py310ha75aee5_0.conda
linux-64::polyagamma-2.0.0-py311h9ecbd09_0.conda
linux-64::polyagamma-2.0.0-py312h66e93f0_0.conda
linux-64::polyagamma-2.0.0-py39h8cd3c5a_0.conda
linux-64::polyagamma-2.0.1-py310ha75aee5_0.conda
linux-64::polyagamma-2.0.1-py310ha75aee5_1.conda
linux-64::polyagamma-2.0.1-py311h9ecbd09_0.conda
linux-64::polyagamma-2.0.1-py311h9ecbd09_1.conda
linux-64::polyagamma-2.0.1-py312h66e93f0_0.conda
linux-64::polyagamma-2.0.1-py312h66e93f0_1.conda
linux-64::polyagamma-2.0.1-py313h536fd9c_1.conda
linux-64::polyagamma-2.0.2-py310h7c4b9e2_1.conda
linux-64::polyagamma-2.0.2-py310ha75aee5_0.conda
linux-64::polyagamma-2.0.2-py311h49ec1c0_1.conda
linux-64::polyagamma-2.0.2-py311h9ecbd09_0.conda
linux-64::polyagamma-2.0.2-py312h4c3975b_1.conda
linux-64::polyagamma-2.0.2-py312h66e93f0_0.conda
linux-64::polyagamma-2.0.2-py313h07c4f96_1.conda
linux-64::polyagamma-2.0.2-py313h536fd9c_0.conda
linux-64::polyagamma-2.0.2-py314h5bd0f2a_1.conda
+    "numpy !=2.4.0",
```

</details>