### PR TITLE
Fixed pytorch version for torchvision

### DIFF
--- a/recipe/patch_yaml/torchvision.yaml
+++ b/recipe/patch_yaml/torchvision.yaml
@@ -52,3 +52,37 @@ then:
   - replace_depends:
       old: "pytorch >=2.0.0,<2.1.0a0"
       new: "pytorch 2.0.* cuda112*"
+---
+# Jan 7, 2026
+# torchvision 0.23 is only compatible with pytorch 2.8
+# Otherwise, it throws warning at runtime.
+if:
+  name: "torchvision"
+  version: "0.23.0"
+then:
+  - replace_depends:
+      old: "pytorch >=2.7.1,<2.8.0a0"
+      new: "pytorch >=2.8.0,<2.9.0a0"
+  - replace_depends:
+      old: "libtorch >=2.7.1,<2.8.0a0"
+      new: "libtorch >=2.8.0,<2.9.0a0"
+---
+# Jan 7, 2026
+# torchvision 0.24 is only compatible with pytorch 2.9.1
+# Otherwise, it throws warning at runtime.
+if:
+  name: "torchvision"
+  version: "0.24.0"
+then:
+  - replace_depends:
+      old: "pytorch >=2.7.1,<2.8.0a0"
+      new: "pytorch >=2.9.1,<2.10.0a0"
+  - replace_depends:
+      old: "libtorch >=2.7.1,<2.8.0a0"
+      new: "libtorch >=2.9.1,<2.10.0a0"
+  - replace_depends:
+      old: "pytorch >=2.8.0,<2.9.0a0"
+      new: "pytorch >=2.9.1,<2.10.0a0"
+  - replace_depends:
+      old: "libtorch >=2.8.0,<2.9.0a0"
+      new: "libtorch >=2.9.1,<2.10.0a0"


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

Making PyTorch version complaint to https://github.com/pytorch/vision?tab=readme-ov-file#installation

<details>

<summary> python show_diff.py output </summary>

```diff
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
osx-arm64
osx-arm64::torchvision-0.24.0-cpu_py310_hcd49670_0.conda
osx-arm64::torchvision-0.24.0-cpu_py311_he1276d9_0.conda
osx-arm64::torchvision-0.24.0-cpu_py312_h5b694ef_0.conda
osx-arm64::torchvision-0.24.0-cpu_py313_h95da078_0.conda
-    "libtorch >=2.7.1,<2.8.0a0",
-    "libtorch >=2.7.1,<2.8.0a0",
+    "libtorch >=2.9.1,<2.10.0a0",
-    "pytorch >=2.7.1,<2.8.0a0",
+    "pytorch >=2.9.1,<2.10.0a0",
osx-arm64::torchvision-0.23.0-cpu_py311_he1276d9_0.conda
osx-arm64::torchvision-0.23.0-cpu_py312_h5b694ef_0.conda
osx-arm64::torchvision-0.23.0-cpu_py313_h95da078_1.conda
-    "libtorch >=2.7.1,<2.8.0a0",
+    "libtorch >=2.8.0,<2.9.0a0",
-    "pytorch >=2.7.1,<2.8.0a0",
+    "pytorch >=2.8.0,<2.9.0a0",
osx-arm64::torchvision-0.24.0-cpu_py310_ha4b4c0b_1.conda
osx-arm64::torchvision-0.24.0-cpu_py310_ha4b4c0b_2.conda
osx-arm64::torchvision-0.24.0-cpu_py311_hbf31bb3_1.conda
osx-arm64::torchvision-0.24.0-cpu_py311_hbf31bb3_2.conda
osx-arm64::torchvision-0.24.0-cpu_py312_h4b3bcb2_1.conda
osx-arm64::torchvision-0.24.0-cpu_py312_h4b3bcb2_2.conda
osx-arm64::torchvision-0.24.0-cpu_py313_hacf4a80_1.conda
osx-arm64::torchvision-0.24.0-cpu_py313_hacf4a80_2.conda
-    "libtorch >=2.8.0,<2.9.0a0",
-    "libtorch >=2.8.0,<2.9.0a0",
+    "libtorch >=2.9.1,<2.10.0a0",
-    "pytorch >=2.8.0,<2.9.0a0",
+    "pytorch >=2.9.1,<2.10.0a0",
osx-arm64::torchvision-0.23.0-cpu_py310_hcd49670_0.conda
osx-arm64::torchvision-0.23.0-cpu_py310_hcd49670_1.conda
osx-arm64::torchvision-0.23.0-cpu_py311_he1276d9_1.conda
osx-arm64::torchvision-0.23.0-cpu_py312_h5b694ef_1.conda
osx-arm64::torchvision-0.23.0-cpu_py313_h95da078_0.conda
-    "libtorch >=2.7.1,<2.8.0a0",
-    "libtorch >=2.7.1,<2.8.0a0",
+    "libtorch >=2.8.0,<2.9.0a0",
-    "pytorch >=2.7.1,<2.8.0a0",
+    "pytorch >=2.8.0,<2.9.0a0",
================================================================================
================================================================================
noarch
================================================================================
================================================================================
linux-aarch64
linux-aarch64::torchvision-0.24.0-cpu_py310_h52c783d_1.conda
linux-aarch64::torchvision-0.24.0-cpu_py310_h52c783d_2.conda
linux-aarch64::torchvision-0.24.0-cpu_py311_h3d699c3_1.conda
linux-aarch64::torchvision-0.24.0-cpu_py311_h3d699c3_2.conda
linux-aarch64::torchvision-0.24.0-cpu_py312_h2be80f8_2.conda
linux-aarch64::torchvision-0.24.0-cpu_py313_h2379bb0_1.conda
linux-aarch64::torchvision-0.24.0-cpu_py313_h2379bb0_2.conda
linux-aarch64::torchvision-0.24.0-cuda129_py310_h92a5354_2.conda
linux-aarch64::torchvision-0.24.0-cuda129_py310_hee9d9d7_1.conda
linux-aarch64::torchvision-0.24.0-cuda129_py311_hdfe2ee1_1.conda
linux-aarch64::torchvision-0.24.0-cuda129_py311_hf8c8088_2.conda
linux-aarch64::torchvision-0.24.0-cuda129_py312_hb569568_2.conda
linux-aarch64::torchvision-0.24.0-cuda129_py313_h0ce2c12_2.conda
linux-aarch64::torchvision-0.24.0-cuda129_py313_h87471fc_1.conda
-    "libtorch >=2.8.0,<2.9.0a0",
-    "libtorch >=2.8.0,<2.9.0a0",
+    "libtorch >=2.9.1,<2.10.0a0",
-    "pytorch >=2.8.0,<2.9.0a0",
+    "pytorch >=2.9.1,<2.10.0a0",
linux-aarch64::torchvision-0.23.0-cpu_py310_h00a57d1_0.conda
linux-aarch64::torchvision-0.23.0-cpu_py310_h00a57d1_1.conda
linux-aarch64::torchvision-0.23.0-cpu_py311_h3463535_0.conda
linux-aarch64::torchvision-0.23.0-cpu_py311_h3463535_1.conda
linux-aarch64::torchvision-0.23.0-cpu_py312_h1223305_0.conda
linux-aarch64::torchvision-0.23.0-cpu_py312_h1223305_1.conda
linux-aarch64::torchvision-0.23.0-cpu_py313_hb065092_0.conda
linux-aarch64::torchvision-0.23.0-cuda129_py310_hac317df_1.conda
linux-aarch64::torchvision-0.23.0-cuda129_py311_h02b8398_1.conda
linux-aarch64::torchvision-0.23.0-cuda129_py312_h1d8047a_1.conda
linux-aarch64::torchvision-0.23.0-cuda129_py313_h63ac268_1.conda
linux-aarch64::torchvision-0.23.0-cuda_py310_hac317df_0.conda
linux-aarch64::torchvision-0.23.0-cuda_py311_h02b8398_0.conda
linux-aarch64::torchvision-0.23.0-cuda_py313_h63ac268_0.conda
-    "libtorch >=2.7.1,<2.8.0a0",
-    "libtorch >=2.7.1,<2.8.0a0",
+    "libtorch >=2.8.0,<2.9.0a0",
-    "pytorch >=2.7.1,<2.8.0a0",
+    "pytorch >=2.8.0,<2.9.0a0",
linux-aarch64::torchvision-0.24.0-cpu_py310_h00a57d1_0.conda
linux-aarch64::torchvision-0.24.0-cpu_py312_h1223305_0.conda
linux-aarch64::torchvision-0.24.0-cpu_py313_hb065092_0.conda
linux-aarch64::torchvision-0.24.0-cuda129_py310_hac317df_0.conda
linux-aarch64::torchvision-0.24.0-cuda129_py311_h02b8398_0.conda
linux-aarch64::torchvision-0.24.0-cuda129_py312_h1d8047a_0.conda
linux-aarch64::torchvision-0.24.0-cuda129_py313_h63ac268_0.conda
-    "libtorch >=2.7.1,<2.8.0a0",
-    "libtorch >=2.7.1,<2.8.0a0",
+    "libtorch >=2.9.1,<2.10.0a0",
-    "pytorch >=2.7.1,<2.8.0a0",
+    "pytorch >=2.9.1,<2.10.0a0",
linux-aarch64::torchvision-0.24.0-cpu_py312_h2be80f8_1.conda
linux-aarch64::torchvision-0.24.0-cuda129_py312_h95062dd_1.conda
-    "libtorch >=2.8.0,<2.9.0a0",
+    "libtorch >=2.9.1,<2.10.0a0",
-    "pytorch >=2.8.0,<2.9.0a0",
+    "pytorch >=2.9.1,<2.10.0a0",
linux-aarch64::torchvision-0.23.0-cpu_py313_hb065092_1.conda
linux-aarch64::torchvision-0.23.0-cuda_py312_h1d8047a_0.conda
-    "libtorch >=2.7.1,<2.8.0a0",
+    "libtorch >=2.8.0,<2.9.0a0",
-    "pytorch >=2.7.1,<2.8.0a0",
+    "pytorch >=2.8.0,<2.9.0a0",
linux-aarch64::torchvision-0.24.0-cpu_py311_h3463535_0.conda
-    "libtorch >=2.7.1,<2.8.0a0",
+    "libtorch >=2.9.1,<2.10.0a0",
-    "pytorch >=2.7.1,<2.8.0a0",
+    "pytorch >=2.9.1,<2.10.0a0",
================================================================================
================================================================================
win-64
win-64::torchvision-0.23.0-cpu_py310_he8ea593_0.conda
win-64::torchvision-0.23.0-cpu_py310_he8ea593_1.conda
win-64::torchvision-0.23.0-cpu_py311_h48edae4_0.conda
win-64::torchvision-0.23.0-cpu_py311_h48edae4_1.conda
win-64::torchvision-0.23.0-cpu_py312_hcd26e23_0.conda
win-64::torchvision-0.23.0-cpu_py313_h5cf2b77_0.conda
win-64::torchvision-0.23.0-cuda129_py310_h845b6a4_1.conda
win-64::torchvision-0.23.0-cuda129_py311_hba8d273_1.conda
win-64::torchvision-0.23.0-cuda129_py312_hc3d9c9e_1.conda
win-64::torchvision-0.23.0-cuda129_py313_hc7703a4_1.conda
win-64::torchvision-0.23.0-cuda_py310_h845b6a4_0.conda
win-64::torchvision-0.23.0-cuda_py311_hba8d273_0.conda
win-64::torchvision-0.23.0-cuda_py312_hc3d9c9e_0.conda
win-64::torchvision-0.23.0-cuda_py313_hc7703a4_0.conda
-    "libtorch >=2.7.1,<2.8.0a0",
-    "libtorch >=2.7.1,<2.8.0a0",
+    "libtorch >=2.8.0,<2.9.0a0",
-    "pytorch >=2.7.1,<2.8.0a0",
+    "pytorch >=2.8.0,<2.9.0a0",
win-64::torchvision-0.24.0-cpu_py310_he8ea593_0.conda
win-64::torchvision-0.24.0-cpu_py312_hcd26e23_0.conda
win-64::torchvision-0.24.0-cpu_py313_h5cf2b77_0.conda
win-64::torchvision-0.24.0-cuda129_py310_h845b6a4_0.conda
win-64::torchvision-0.24.0-cuda129_py312_hc3d9c9e_0.conda
win-64::torchvision-0.24.0-cuda129_py313_hc7703a4_0.conda
-    "libtorch >=2.7.1,<2.8.0a0",
-    "libtorch >=2.7.1,<2.8.0a0",
+    "libtorch >=2.9.1,<2.10.0a0",
-    "pytorch >=2.7.1,<2.8.0a0",
+    "pytorch >=2.9.1,<2.10.0a0",
win-64::torchvision-0.24.0-cpu_py310_h6246a0d_1.conda
win-64::torchvision-0.24.0-cpu_py310_h6246a0d_2.conda
win-64::torchvision-0.24.0-cpu_py311_h04484e8_1.conda
win-64::torchvision-0.24.0-cpu_py311_h04484e8_2.conda
win-64::torchvision-0.24.0-cpu_py312_hc3e1efa_1.conda
win-64::torchvision-0.24.0-cpu_py312_hc3e1efa_2.conda
win-64::torchvision-0.24.0-cpu_py313_hf0c03c7_1.conda
win-64::torchvision-0.24.0-cpu_py313_hf0c03c7_2.conda
win-64::torchvision-0.24.0-cuda129_py310_h1712824_1.conda
win-64::torchvision-0.24.0-cuda129_py310_h7646b12_2.conda
win-64::torchvision-0.24.0-cuda129_py311_hc1b66eb_2.conda
win-64::torchvision-0.24.0-cuda129_py311_he7ce3e8_1.conda
win-64::torchvision-0.24.0-cuda129_py312_h91acb74_1.conda
win-64::torchvision-0.24.0-cuda129_py312_ha526cc1_2.conda
win-64::torchvision-0.24.0-cuda129_py313_h05c0620_1.conda
win-64::torchvision-0.24.0-cuda129_py313_hf53fea5_2.conda
-    "libtorch >=2.8.0,<2.9.0a0",
-    "libtorch >=2.8.0,<2.9.0a0",
+    "libtorch >=2.9.1,<2.10.0a0",
-    "pytorch >=2.8.0,<2.9.0a0",
+    "pytorch >=2.9.1,<2.10.0a0",
win-64::torchvision-0.23.0-cpu_py312_hcd26e23_1.conda
win-64::torchvision-0.23.0-cpu_py313_h5cf2b77_1.conda
-    "libtorch >=2.7.1,<2.8.0a0",
+    "libtorch >=2.8.0,<2.9.0a0",
-    "pytorch >=2.7.1,<2.8.0a0",
+    "pytorch >=2.8.0,<2.9.0a0",
win-64::torchvision-0.24.0-cpu_py311_h48edae4_0.conda
win-64::torchvision-0.24.0-cuda129_py311_hba8d273_0.conda
-    "libtorch >=2.7.1,<2.8.0a0",
+    "libtorch >=2.9.1,<2.10.0a0",
-    "pytorch >=2.7.1,<2.8.0a0",
+    "pytorch >=2.9.1,<2.10.0a0",
================================================================================
================================================================================
osx-64
osx-64::torchvision-0.23.0-cpu_py312_h0909278_1.conda
-    "libtorch >=2.7.1,<2.8.0a0",
+    "libtorch >=2.8.0,<2.9.0a0",
-    "pytorch >=2.7.1,<2.8.0a0",
+    "pytorch >=2.8.0,<2.9.0a0",
osx-64::torchvision-0.24.0-cpu_py313_h7aca953_2.conda
-    "libtorch >=2.8.0,<2.9.0a0",
+    "libtorch >=2.9.1,<2.10.0a0",
-    "pytorch >=2.8.0,<2.9.0a0",
+    "pytorch >=2.9.1,<2.10.0a0",
osx-64::torchvision-0.24.0-cpu_py310_hd0f43e4_1.conda
osx-64::torchvision-0.24.0-cpu_py310_hd0f43e4_2.conda
osx-64::torchvision-0.24.0-cpu_py311_hb12c178_1.conda
osx-64::torchvision-0.24.0-cpu_py311_hb12c178_2.conda
osx-64::torchvision-0.24.0-cpu_py312_h9a52a9e_1.conda
osx-64::torchvision-0.24.0-cpu_py312_h9a52a9e_2.conda
osx-64::torchvision-0.24.0-cpu_py313_h7aca953_1.conda
-    "libtorch >=2.8.0,<2.9.0a0",
-    "libtorch >=2.8.0,<2.9.0a0",
+    "libtorch >=2.9.1,<2.10.0a0",
-    "pytorch >=2.8.0,<2.9.0a0",
+    "pytorch >=2.9.1,<2.10.0a0",
osx-64::torchvision-0.23.0-cpu_py310_habc29cf_0.conda
osx-64::torchvision-0.23.0-cpu_py310_habc29cf_1.conda
osx-64::torchvision-0.23.0-cpu_py311_he4cb42d_0.conda
osx-64::torchvision-0.23.0-cpu_py311_he4cb42d_1.conda
osx-64::torchvision-0.23.0-cpu_py312_h0909278_0.conda
osx-64::torchvision-0.23.0-cpu_py313_hc8c1ce5_0.conda
osx-64::torchvision-0.23.0-cpu_py313_hc8c1ce5_1.conda
-    "libtorch >=2.7.1,<2.8.0a0",
-    "libtorch >=2.7.1,<2.8.0a0",
+    "libtorch >=2.8.0,<2.9.0a0",
-    "pytorch >=2.7.1,<2.8.0a0",
+    "pytorch >=2.8.0,<2.9.0a0",
osx-64::torchvision-0.24.0-cpu_py310_habc29cf_0.conda
osx-64::torchvision-0.24.0-cpu_py311_he4cb42d_0.conda
osx-64::torchvision-0.24.0-cpu_py312_h0909278_0.conda
osx-64::torchvision-0.24.0-cpu_py313_hc8c1ce5_0.conda
-    "libtorch >=2.7.1,<2.8.0a0",
-    "libtorch >=2.7.1,<2.8.0a0",
+    "libtorch >=2.9.1,<2.10.0a0",
-    "pytorch >=2.7.1,<2.8.0a0",
+    "pytorch >=2.9.1,<2.10.0a0",
================================================================================
================================================================================
linux-64
linux-64::torchvision-0.23.0-cpu_py310_h5cb05b1_0.conda
linux-64::torchvision-0.23.0-cpu_py310_h5cb05b1_1.conda
linux-64::torchvision-0.23.0-cpu_py311_h9bcb066_0.conda
linux-64::torchvision-0.23.0-cpu_py312_h56cfa8b_0.conda
linux-64::torchvision-0.23.0-cpu_py312_h56cfa8b_1.conda
linux-64::torchvision-0.23.0-cpu_py313_hf8de91a_0.conda
linux-64::torchvision-0.23.0-cpu_py313_hf8de91a_1.conda
linux-64::torchvision-0.23.0-cuda129_py310_ha17f1f0_1.conda
linux-64::torchvision-0.23.0-cuda129_py311_h2942a37_1.conda
linux-64::torchvision-0.23.0-cuda129_py312_h592d7cb_1.conda
linux-64::torchvision-0.23.0-cuda129_py313_h6be0d2c_1.conda
linux-64::torchvision-0.23.0-cuda_py310_ha17f1f0_0.conda
linux-64::torchvision-0.23.0-cuda_py312_h592d7cb_0.conda
linux-64::torchvision-0.23.0-cuda_py313_h6be0d2c_0.conda
-    "libtorch >=2.7.1,<2.8.0a0",
-    "libtorch >=2.7.1,<2.8.0a0",
+    "libtorch >=2.8.0,<2.9.0a0",
-    "pytorch >=2.7.1,<2.8.0a0",
+    "pytorch >=2.8.0,<2.9.0a0",
linux-64::torchvision-0.24.0-cpu_py310_h5cb05b1_0.conda
linux-64::torchvision-0.24.0-cuda129_py311_h2942a37_0.conda
-    "libtorch >=2.7.1,<2.8.0a0",
+    "libtorch >=2.9.1,<2.10.0a0",
-    "pytorch >=2.7.1,<2.8.0a0",
+    "pytorch >=2.9.1,<2.10.0a0",
linux-64::torchvision-0.24.0-cpu_py311_h1a467ce_1.conda
linux-64::torchvision-0.24.0-cpu_py313_h15f1a6a_1.conda
linux-64::torchvision-0.24.0-cuda129_py313_hc1504f4_1.conda
-    "libtorch >=2.8.0,<2.9.0a0",
+    "libtorch >=2.9.1,<2.10.0a0",
-    "pytorch >=2.8.0,<2.9.0a0",
+    "pytorch >=2.9.1,<2.10.0a0",
linux-64::torchvision-0.24.0-cpu_py311_h9bcb066_0.conda
linux-64::torchvision-0.24.0-cpu_py312_h56cfa8b_0.conda
linux-64::torchvision-0.24.0-cpu_py313_hf8de91a_0.conda
linux-64::torchvision-0.24.0-cuda129_py310_ha17f1f0_0.conda
linux-64::torchvision-0.24.0-cuda129_py312_h592d7cb_0.conda
linux-64::torchvision-0.24.0-cuda129_py313_h6be0d2c_0.conda
-    "libtorch >=2.7.1,<2.8.0a0",
-    "libtorch >=2.7.1,<2.8.0a0",
+    "libtorch >=2.9.1,<2.10.0a0",
-    "pytorch >=2.7.1,<2.8.0a0",
+    "pytorch >=2.9.1,<2.10.0a0",
linux-64::esmf-8.9.1-mpi_mpich_h50cdae2_100.conda
-{}
+{
+  "build": "mpi_mpich_h50cdae2_100",
+  "build_number": 100,
+  "depends": [
+    "__glibc >=2.17,<3.0.a0",
+    "hdf5 * mpi_mpich_*",
+    "hdf5 >=1.14.6,<1.14.7.0a0 mpi_mpich_*",
+    "libgcc >=14",
+    "libgfortran",
+    "libgfortran5 >=14.3.0",
+    "libnetcdf * mpi_mpich_*",
+    "libnetcdf >=4.9.3,<4.9.4.0a0 mpi_mpich_*",
+    "libstdcxx >=14",
+    "mpich >=4.3.2,<5.0a0",
+    "netcdf-fortran * mpi_mpich_*",
+    "netcdf-fortran >=4.6.2,<4.7.0a0 mpi_mpich_*",
+    "parallelio >=2.6.7,<2.6.8.0a0 mpi_mpich_*"
+  ],
+  "license": "NCSA",
+  "md5": "2d84279a071fc4bbdd3592fcbabf3204",
+  "name": "esmf",
+  "sha256": "4b2eb719452edc14d3e55681a892207798289632241778c64b36a116e7bf48e7",
+  "size": 24934582,
+  "subdir": "linux-64",
+  "timestamp": 1767778461767,
+  "version": "8.9.1"
+}
linux-64::torchvision-0.24.0-cpu_py310_h64b0661_1.conda
linux-64::torchvision-0.24.0-cpu_py310_h64b0661_2.conda
linux-64::torchvision-0.24.0-cpu_py311_h1a467ce_2.conda
linux-64::torchvision-0.24.0-cpu_py312_h5638ca5_1.conda
linux-64::torchvision-0.24.0-cpu_py312_h5638ca5_2.conda
linux-64::torchvision-0.24.0-cpu_py313_h15f1a6a_2.conda
linux-64::torchvision-0.24.0-cuda129_py310_h787aa55_2.conda
linux-64::torchvision-0.24.0-cuda129_py310_hbeffff0_1.conda
linux-64::torchvision-0.24.0-cuda129_py311_h94e29ae_1.conda
linux-64::torchvision-0.24.0-cuda129_py311_had7ad20_2.conda
linux-64::torchvision-0.24.0-cuda129_py312_h54b92b5_1.conda
linux-64::torchvision-0.24.0-cuda129_py312_h9f56bbf_2.conda
linux-64::torchvision-0.24.0-cuda129_py313_h7de4b66_2.conda
-    "libtorch >=2.8.0,<2.9.0a0",
-    "libtorch >=2.8.0,<2.9.0a0",
+    "libtorch >=2.9.1,<2.10.0a0",
-    "pytorch >=2.8.0,<2.9.0a0",
+    "pytorch >=2.9.1,<2.10.0a0",
linux-64::omnipkg-2.1.0-py312ha770c72_0.conda
-{}
+{
+  "build": "py312ha770c72_0",
+  "build_number": 0,
+  "depends": [
+    "aiohttp >=3.13.3",
+    "authlib >=1.6.5",
+    "filelock >=3.20.1",
+    "flask >=2.0",
+    "flask-cors >=3.0",
+    "marshmallow >=4.1.2",
+    "packaging >=23.0",
+    "psutil >=5.9.0",
+    "python >=3.12,<3.13.0a0",
+    "python_abi 3.12.* *_cp312",
+    "requests >=2.20",
+    "rich >=10.0.0",
+    "safety >=3.7.0",
+    "tqdm >=4.67.1",
+    "typer >=0.4.0",
+    "typing-extensions >=4.0.0",
+    "urllib3 >=1.26.19",
+    "uv >=0.9.6"
+  ],
+  "license": "AGPL-3.0-only",
+  "md5": "71c38ce6c1e940916285313c589efca7",
+  "name": "omnipkg",
+  "sha256": "5d682b4b13167c4dcefea5913b19c4222e7f8a41ec8f1e410e92d9dc6df90205",
+  "size": 1223227,
+  "subdir": "linux-64",
+  "timestamp": 1767779279758,
+  "version": "2.1.0"
+}
linux-64::torchvision-0.23.0-cpu_py311_h9bcb066_1.conda
linux-64::torchvision-0.23.0-cuda_py311_h2942a37_0.conda
-    "libtorch >=2.7.1,<2.8.0a0",
+    "libtorch >=2.8.0,<2.9.0a0",
-    "pytorch >=2.7.1,<2.8.0a0",
+    "pytorch >=2.8.0,<2.9.0a0",
linux-64::power-grid-model-1.12.103-py311h7a9a316_0.conda
-{}
+{
+  "build": "py311h7a9a316_0",
+  "build_number": 0,
+  "depends": [
+    "__glibc >=2.17,<3.0.a0",
+    "libgcc >=14",
+    "libstdcxx >=14",
+    "numpy >=1.21.0",
+    "python >=3.11,<3.12.0a0",
+    "python_abi 3.11.* *_cp311"
+  ],
+  "license": "MPL-2.0",
+  "md5": "594f855469eb880d19095fdee18d0458",
+  "name": "power-grid-model",
+  "sha256": "08d2fdd1605c2118daa88079f2253702b578ae7f5b386d7ece4f307a384d2a86",
+  "size": 1466691,
+  "subdir": "linux-64",
+  "timestamp": 1767778290929,
+  "version": "1.12.103"
+}
```
</details>
