### PR TITLE
Patch multiscale-spatial-image pin for spatialdata

### DIFF
--- a/recipe/patch_yaml/spatialdata.yaml
+++ b/recipe/patch_yaml/spatialdata.yaml
@@ -12,3 +12,22 @@ then:
   - tighten_depends:
       name: xarray
       upper_bound: "2024.10"
+---
+# spatialdata 0.5.0 introduced a minimum requirement of multiscale-spatial-image
+# 2.0.3. However, spatialdata is incompatible with multiscale-spatial-image
+# 2.1.0. Thus only 2.0.3 should be installed. This patch ensures spatialdata
+# versions 0.5.0, 0.6.0, and the first build of 0.6.1 install the correct
+# version.
+#
+# https://github.com/conda-forge/spatialdata-feedstock/pull/28
+# https://github.com/conda-forge/spatialdata-feedstock/pull/27#discussion_r2640534330
+# https://github.com/conda-forge/spatialdata-feedstock/pull/21
+if:
+  name: spatialdata
+  version_ge: "0.5.0"
+  version_le: "0.6.1"
+  timestamp_lt: 1767818308000
+then:
+  - replace_depends:
+      old: "multiscale-spatial-image >=2.0.3"
+      new: "multiscale-spatial-image 2.0.3"


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

---

xref: https://github.com/conda-forge/spatialdata-feedstock/pull/28, https://github.com/conda-forge/spatialdata-feedstock/pull/27#discussion_r2640534330, https://github.com/conda-forge/spatialdata-feedstock/pull/21
cc: @conda-forge/spatialdata, @LucaMarconato

```diff
 python show_diff.py --use-cache --subdirs noarch
================================================================================
================================================================================
noarch
noarch::spatialdata-0.5.0-pyhd8ed1ab_0.conda
noarch::spatialdata-0.6.0-pyhd8ed1ab_0.conda
noarch::spatialdata-0.6.1-pyhd8ed1ab_0.conda
-    "multiscale-spatial-image >=2.0.3",
+    "multiscale-spatial-image  2.0.3",
```

spatialdata 0.5.0 introduced a minimum requirement of multiscale-spatial-image 2.0.3. However, spatialdata is incompatible with multiscale-spatial-image 2.1.0. Thus only 2.0.3 should be installed. This patch ensures spatialdata versions 0.5.0, 0.6.0, and the first build of 0.6.1 install the correct version.