### PR TITLE
Make published builds of ArcticDB depend on `pandas <3`

### DIFF
--- a/recipe/patch_yaml/arcticdb.yaml
+++ b/recipe/patch_yaml/arcticdb.yaml
@@ -8,3 +8,14 @@ then:
   - tighten_depends:
       name: libcurl
       upper_bound: "8.17"
+
+---
+
+# Use `pandas<3` dependency for all ArcticDB builds up to 6.7.0 (inclusive).
+if:
+  name: arcticdb
+  timestamp_lt: 1769069595000  # 2026-01-22
+then:
+  - tighten_depends:
+      name: pandas
+      upper_bound: "3"


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

Given https://github.com/conda-forge/pandas-feedstock/pull/244.

For context, see [conda-forge/arcticdb-feedstock#552](https://github.com/conda-forge/arcticdb-feedstock/pull/552) and [man-group/ArcticDB#2865](https://github.com/man-group/ArcticDB/pull/2865).