### PR TITLE
Make all published `mdtraj` builds depend on `pandas <3`

### DIFF
--- a/recipe/patch_yaml/mdtraj.yaml
+++ b/recipe/patch_yaml/mdtraj.yaml
@@ -24,10 +24,10 @@ then:
 ---
 
 
-# Pandas 3.0 had broken a number of the mdtraj functionalities
+# Pandas 3.0 had broken a number of mdtraj's functionalities.
 # This will pin all versions with a pandas dependency to
 # pandas <3 until we can do something about it in the future.
-# This includes all mdtraj v1.11.1 and below.
+# This includes mdtraj v1.11.1 (build 0) and below.
 if:
   name: mdtraj
   version_le: 1.11.1


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

We're updating all future builds, but would also like to make sure our older versions won't break due to the pandas 3 release.
https://github.com/conda-forge/mdtraj-feedstock/pull/84

For context: https://github.com/mdtraj/mdtraj/issues/2128 and https://github.com/mdtraj/mdtraj/pull/2129



<details>
<summary> python show_diff.py output </summary>


```
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
win-32::mdtraj-1.7.2-np110py27_0.tar.bz2
win-32::mdtraj-1.7.2-np110py34_0.tar.bz2
win-32::mdtraj-1.7.2-np110py35_0.tar.bz2
win-32::mdtraj-1.7.2-np111py27_0.tar.bz2
win-32::mdtraj-1.7.2-np111py34_0.tar.bz2
win-32::mdtraj-1.7.2-np111py35_0.tar.bz2
win-32::mdtraj-1.8.0-np110py35_0.tar.bz2
win-32::mdtraj-1.8.0-np110py35_1.tar.bz2
win-32::mdtraj-1.8.0-np111py27_1.tar.bz2
win-32::mdtraj-1.8.0-np111py35_0.tar.bz2
win-32::mdtraj-1.8.0-np111py35_1.tar.bz2
win-32::mdtraj-1.8.0-np111py36_1.tar.bz2
win-32::mdtraj-1.8.0-np112py27_1.tar.bz2
win-32::mdtraj-1.8.0-np112py35_1.tar.bz2
win-32::mdtraj-1.8.0-np112py36_1.tar.bz2
win-32::mdtraj-1.8.0-np113py27_1.tar.bz2
win-32::mdtraj-1.8.0-np113py35_1.tar.bz2
win-32::mdtraj-1.8.0-np113py36_1.tar.bz2
win-32::mdtraj-1.8.0-py27_2.tar.bz2
win-32::mdtraj-1.8.0-py35_2.tar.bz2
win-32::mdtraj-1.8.0-py36_2.tar.bz2
win-32::mdtraj-1.9.1-py27_0.tar.bz2
win-32::mdtraj-1.9.1-py27_1.tar.bz2
win-32::mdtraj-1.9.1-py35_0.tar.bz2
win-32::mdtraj-1.9.1-py35_1.tar.bz2
win-32::mdtraj-1.9.1-py36_0.tar.bz2
win-32::mdtraj-1.9.1-py36_1.tar.bz2
-    "pandas",
+    "pandas <3.0a0",
================================================================================
================================================================================
linux-ppc64le
linux-ppc64le::mdtraj-1.11.0-np2py311hf579c0a_2.conda
linux-ppc64le::mdtraj-1.11.0-np2py311hf579c0a_3.conda
linux-ppc64le::mdtraj-1.11.0-np2py312he11eaab_2.conda
linux-ppc64le::mdtraj-1.11.0-np2py312he11eaab_3.conda
linux-ppc64le::mdtraj-1.11.0-np2py313hbda2c3e_2.conda
linux-ppc64le::mdtraj-1.11.0-np2py313hbda2c3e_3.conda
linux-ppc64le::mdtraj-1.11.0-np2py314h1bbedb8_3.conda
linux-ppc64le::mdtraj-1.11.0-py311h34f02a4_1.conda
linux-ppc64le::mdtraj-1.11.0-py312hd014a07_1.conda
linux-ppc64le::mdtraj-1.11.0-py313h116698c_1.conda
linux-ppc64le::mdtraj-1.11.1-np2py311hf579c0a_0.conda
linux-ppc64le::mdtraj-1.11.1-np2py312he11eaab_0.conda
linux-ppc64le::mdtraj-1.11.1-np2py313hbda2c3e_0.conda
linux-ppc64le::mdtraj-1.11.1-np2py314h6c29f80_0.conda
-    "pandas",
+    "pandas <3.0a0",
================================================================================
================================================================================
osx-arm64
osx-arm64::mdtraj-1.10.0-py310h59f892f_0.conda
osx-arm64::mdtraj-1.10.0-py311habad988_0.conda
osx-arm64::mdtraj-1.10.0-py312haca1622_0.conda
osx-arm64::mdtraj-1.10.0-py38h7ae1a59_0.conda
osx-arm64::mdtraj-1.10.0-py39h14bebe9_0.conda
osx-arm64::mdtraj-1.10.1-py310h66107e7_0.conda
osx-arm64::mdtraj-1.10.1-py310h66107e7_1.conda
osx-arm64::mdtraj-1.10.1-py310h66107e7_2.conda
osx-arm64::mdtraj-1.10.1-py311h60baccc_0.conda
osx-arm64::mdtraj-1.10.1-py311h60baccc_1.conda
osx-arm64::mdtraj-1.10.1-py311h60baccc_2.conda
osx-arm64::mdtraj-1.10.1-py312hfb381e6_0.conda
osx-arm64::mdtraj-1.10.1-py312hfb381e6_1.conda
osx-arm64::mdtraj-1.10.1-py312hfb381e6_2.conda
osx-arm64::mdtraj-1.10.1-py313h324e7bb_1.conda
osx-arm64::mdtraj-1.10.1-py313h324e7bb_2.conda
osx-arm64::mdtraj-1.10.1-py39h9139134_0.conda
osx-arm64::mdtraj-1.10.1-py39h9139134_1.conda
osx-arm64::mdtraj-1.10.1-py39h9139134_2.conda
osx-arm64::mdtraj-1.10.2-py310hd1fc892_0.conda
osx-arm64::mdtraj-1.10.2-py311he9eb210_0.conda
osx-arm64::mdtraj-1.10.2-py312had578a9_0.conda
osx-arm64::mdtraj-1.10.2-py313h324e7bb_0.conda
osx-arm64::mdtraj-1.10.2-py39he24f47d_0.conda
osx-arm64::mdtraj-1.10.3-py310hd1fc892_0.conda
osx-arm64::mdtraj-1.10.3-py311he9eb210_0.conda
osx-arm64::mdtraj-1.10.3-py312had578a9_0.conda
osx-arm64::mdtraj-1.10.3-py313h324e7bb_0.conda
osx-arm64::mdtraj-1.10.3-py39he24f47d_0.conda
osx-arm64::mdtraj-1.11.0-np2py311h90b3458_3.conda
osx-arm64::mdtraj-1.11.0-np2py311hb29cc20_2.conda
osx-arm64::mdtraj-1.11.0-np2py312hcf25f10_3.conda
osx-arm64::mdtraj-1.11.0-np2py312hd33a0d6_2.conda
osx-arm64::mdtraj-1.11.0-np2py313h2278ae6_3.conda
osx-arm64::mdtraj-1.11.0-np2py313h7466d2a_2.conda
osx-arm64::mdtraj-1.11.0-np2py314had24cd2_3.conda
osx-arm64::mdtraj-1.11.0-py311h747b4b8_0.conda
osx-arm64::mdtraj-1.11.0-py311h747b4b8_1.conda
osx-arm64::mdtraj-1.11.0-py312h44ac170_0.conda
osx-arm64::mdtraj-1.11.0-py312h44ac170_1.conda
osx-arm64::mdtraj-1.11.0-py313h324e7bb_0.conda
osx-arm64::mdtraj-1.11.0-py313h324e7bb_1.conda
osx-arm64::mdtraj-1.11.1-np2py311hd20dc7c_0.conda
osx-arm64::mdtraj-1.11.1-np2py312h2df5d9b_0.conda
osx-arm64::mdtraj-1.11.1-np2py313hb25da30_0.conda
osx-arm64::mdtraj-1.11.1-np2py314h965ce40_0.conda
osx-arm64::mdtraj-1.9.7-py310h1e75f39_2.tar.bz2
osx-arm64::mdtraj-1.9.7-py310h1e75f39_3.tar.bz2
osx-arm64::mdtraj-1.9.7-py310h1e75f39_4.tar.bz2
osx-arm64::mdtraj-1.9.7-py310hb0c855d_1.tar.bz2
osx-arm64::mdtraj-1.9.7-py311hee6e687_3.tar.bz2
osx-arm64::mdtraj-1.9.7-py311hee6e687_4.tar.bz2
osx-arm64::mdtraj-1.9.7-py38h05c6eb1_3.tar.bz2
osx-arm64::mdtraj-1.9.7-py38h05c6eb1_4.tar.bz2
osx-arm64::mdtraj-1.9.7-py38h0fcdffb_0.tar.bz2
osx-arm64::mdtraj-1.9.7-py38h0fcdffb_1.tar.bz2
osx-arm64::mdtraj-1.9.7-py38hf9b85db_2.tar.bz2
osx-arm64::mdtraj-1.9.7-py39h0227b32_3.tar.bz2
osx-arm64::mdtraj-1.9.7-py39h0227b32_4.tar.bz2
osx-arm64::mdtraj-1.9.7-py39h9d592f4_0.tar.bz2
osx-arm64::mdtraj-1.9.7-py39h9d592f4_1.tar.bz2
osx-arm64::mdtraj-1.9.7-py39hefd17c3_2.tar.bz2
osx-arm64::mdtraj-1.9.8-py310h7c9e852_0.conda
osx-arm64::mdtraj-1.9.8-py310h7c9e852_1.conda
osx-arm64::mdtraj-1.9.8-py310h7c9e852_2.conda
osx-arm64::mdtraj-1.9.8-py311h06bfd7f_0.conda
osx-arm64::mdtraj-1.9.8-py311h06bfd7f_1.conda
osx-arm64::mdtraj-1.9.8-py311h06bfd7f_2.conda
osx-arm64::mdtraj-1.9.8-py38h713f041_0.conda
osx-arm64::mdtraj-1.9.8-py38h713f041_2.conda
osx-arm64::mdtraj-1.9.8-py39hd7a7df8_0.conda
osx-arm64::mdtraj-1.9.8-py39hd7a7df8_1.conda
osx-arm64::mdtraj-1.9.8-py39hd7a7df8_2.conda
osx-arm64::mdtraj-1.9.9-py310h455934c_1.conda
osx-arm64::mdtraj-1.9.9-py310h7c9e852_0.conda
osx-arm64::mdtraj-1.9.9-py311h06bfd7f_0.conda
osx-arm64::mdtraj-1.9.9-py311h7f29720_1.conda
osx-arm64::mdtraj-1.9.9-py312h03d2bcb_1.conda
osx-arm64::mdtraj-1.9.9-py38h713f041_0.conda
osx-arm64::mdtraj-1.9.9-py38heb2e344_1.conda
osx-arm64::mdtraj-1.9.9-py39h2c5a50e_1.conda
osx-arm64::mdtraj-1.9.9-py39hd7a7df8_0.conda
-    "pandas",
+    "pandas <3.0a0",
================================================================================
================================================================================
linux-aarch64
linux-aarch64::mdtraj-1.11.0-np2py311h22ab258_2.conda
linux-aarch64::mdtraj-1.11.0-np2py311h22ab258_3.conda
linux-aarch64::mdtraj-1.11.0-np2py312hebbea0b_2.conda
linux-aarch64::mdtraj-1.11.0-np2py312hebbea0b_3.conda
linux-aarch64::mdtraj-1.11.0-np2py313hd671cf7_2.conda
linux-aarch64::mdtraj-1.11.0-np2py313hd671cf7_3.conda
linux-aarch64::mdtraj-1.11.0-np2py314h7005a25_3.conda
linux-aarch64::mdtraj-1.11.0-py311he2a319c_1.conda
linux-aarch64::mdtraj-1.11.0-py312h88173f1_1.conda
linux-aarch64::mdtraj-1.11.0-py313hdebabe9_1.conda
linux-aarch64::mdtraj-1.11.1-np2py311h22ab258_0.conda
linux-aarch64::mdtraj-1.11.1-np2py312hebbea0b_0.conda
linux-aarch64::mdtraj-1.11.1-np2py313hd671cf7_0.conda
linux-aarch64::mdtraj-1.11.1-np2py314h9942801_0.conda
-    "pandas",
+    "pandas <3.0a0",
================================================================================
================================================================================
noarch
================================================================================
================================================================================
win-64
win-64::mdtraj-1.10.0-py310h219f759_0.conda
win-64::mdtraj-1.10.0-py311h914de3a_0.conda
win-64::mdtraj-1.10.0-py312h246daeb_0.conda
win-64::mdtraj-1.10.0-py38hc73831d_0.conda
win-64::mdtraj-1.10.0-py39hf7421d4_0.conda
win-64::mdtraj-1.10.1-py310h4dcb679_0.conda
win-64::mdtraj-1.10.1-py310h4dcb679_1.conda
win-64::mdtraj-1.10.1-py310h4dcb679_2.conda
win-64::mdtraj-1.10.1-py311h2293d65_0.conda
win-64::mdtraj-1.10.1-py311h2293d65_1.conda
win-64::mdtraj-1.10.1-py311h2293d65_2.conda
win-64::mdtraj-1.10.1-py312h7098434_0.conda
win-64::mdtraj-1.10.1-py312h7098434_1.conda
win-64::mdtraj-1.10.1-py312h7098434_2.conda
win-64::mdtraj-1.10.1-py313h75aece0_1.conda
win-64::mdtraj-1.10.1-py313h75aece0_2.conda
win-64::mdtraj-1.10.1-py39h7a4bf91_0.conda
win-64::mdtraj-1.10.1-py39h7a4bf91_1.conda
win-64::mdtraj-1.10.1-py39h7a4bf91_2.conda
win-64::mdtraj-1.10.2-py310h1447844_0.conda
win-64::mdtraj-1.10.2-py311h42043a9_0.conda
win-64::mdtraj-1.10.2-py312h975a970_0.conda
win-64::mdtraj-1.10.2-py313h75aece0_0.conda
win-64::mdtraj-1.10.2-py39h68e57c1_0.conda
win-64::mdtraj-1.10.3-py310h1447844_0.conda
win-64::mdtraj-1.10.3-py311h42043a9_0.conda
win-64::mdtraj-1.10.3-py312h975a970_0.conda
win-64::mdtraj-1.10.3-py313h75aece0_0.conda
win-64::mdtraj-1.10.3-py39h68e57c1_0.conda
win-64::mdtraj-1.11.0-np2py311hd64ad1c_2.conda
win-64::mdtraj-1.11.0-np2py311hd64ad1c_3.conda
win-64::mdtraj-1.11.0-np2py312he314c7b_2.conda
win-64::mdtraj-1.11.0-np2py312he314c7b_3.conda
win-64::mdtraj-1.11.0-np2py313h944d5fd_2.conda
win-64::mdtraj-1.11.0-np2py313h944d5fd_3.conda
win-64::mdtraj-1.11.0-np2py314h5ba72e2_3.conda
win-64::mdtraj-1.11.0-py311h3e17986_0.conda
win-64::mdtraj-1.11.0-py311h3e17986_1.conda
win-64::mdtraj-1.11.0-py312h3d6c809_0.conda
win-64::mdtraj-1.11.0-py312h3d6c809_1.conda
win-64::mdtraj-1.11.0-py313h290c699_0.conda
win-64::mdtraj-1.11.0-py313h290c699_1.conda
win-64::mdtraj-1.11.1-np2py311hd64ad1c_0.conda
win-64::mdtraj-1.11.1-np2py312he314c7b_0.conda
win-64::mdtraj-1.11.1-np2py313h944d5fd_0.conda
win-64::mdtraj-1.11.1-np2py314hb4a3a9e_0.conda
win-64::mdtraj-1.7.2-np110py27_0.tar.bz2
win-64::mdtraj-1.7.2-np110py34_0.tar.bz2
win-64::mdtraj-1.7.2-np110py35_0.tar.bz2
win-64::mdtraj-1.7.2-np111py27_0.tar.bz2
win-64::mdtraj-1.7.2-np111py34_0.tar.bz2
win-64::mdtraj-1.7.2-np111py35_0.tar.bz2
win-64::mdtraj-1.8.0-np110py35_0.tar.bz2
win-64::mdtraj-1.8.0-np110py35_1.tar.bz2
win-64::mdtraj-1.8.0-np111py27_1.tar.bz2
win-64::mdtraj-1.8.0-np111py35_0.tar.bz2
win-64::mdtraj-1.8.0-np111py35_1.tar.bz2
win-64::mdtraj-1.8.0-np111py36_1.tar.bz2
win-64::mdtraj-1.8.0-np112py27_1.tar.bz2
win-64::mdtraj-1.8.0-np112py35_1.tar.bz2
win-64::mdtraj-1.8.0-np112py36_1.tar.bz2
win-64::mdtraj-1.8.0-np113py27_1.tar.bz2
win-64::mdtraj-1.8.0-np113py35_1.tar.bz2
win-64::mdtraj-1.8.0-np113py36_1.tar.bz2
win-64::mdtraj-1.8.0-py27_2.tar.bz2
win-64::mdtraj-1.8.0-py35_2.tar.bz2
win-64::mdtraj-1.8.0-py36_2.tar.bz2
win-64::mdtraj-1.9.1-py27_0.tar.bz2
win-64::mdtraj-1.9.1-py27_1.tar.bz2
win-64::mdtraj-1.9.1-py27hce6d55d_2.tar.bz2
win-64::mdtraj-1.9.1-py35_0.tar.bz2
win-64::mdtraj-1.9.1-py35_1.tar.bz2
win-64::mdtraj-1.9.1-py35he5b8c41_2.tar.bz2
win-64::mdtraj-1.9.1-py36_0.tar.bz2
win-64::mdtraj-1.9.1-py36_1.tar.bz2
win-64::mdtraj-1.9.1-py36he5b8c41_2.tar.bz2
win-64::mdtraj-1.9.2-py27hce6d55d_0.tar.bz2
win-64::mdtraj-1.9.2-py27hce6d55d_1000.tar.bz2
win-64::mdtraj-1.9.2-py35he5b8c41_0.tar.bz2
win-64::mdtraj-1.9.2-py36he5b8c41_0.tar.bz2
win-64::mdtraj-1.9.2-py36he5b8c41_1000.tar.bz2
win-64::mdtraj-1.9.2-py37he5b8c41_1000.tar.bz2
win-64::mdtraj-1.9.3-py27ha37594b_1.tar.bz2
win-64::mdtraj-1.9.3-py27hce6d55d_0.tar.bz2
win-64::mdtraj-1.9.3-py36h91cbd5b_1.tar.bz2
win-64::mdtraj-1.9.3-py36he5b8c41_0.tar.bz2
win-64::mdtraj-1.9.3-py37h91cbd5b_1.tar.bz2
win-64::mdtraj-1.9.3-py37he5b8c41_0.tar.bz2
win-64::mdtraj-1.9.3-py38h91cbd5b_1.tar.bz2
win-64::mdtraj-1.9.4-py36h5160f2f_1.tar.bz2
win-64::mdtraj-1.9.4-py36h5160f2f_2.tar.bz2
win-64::mdtraj-1.9.4-py36h6ea306e_0.tar.bz2
win-64::mdtraj-1.9.4-py37hc1a9637_0.tar.bz2
win-64::mdtraj-1.9.4-py37hdc8fc42_1.tar.bz2
win-64::mdtraj-1.9.4-py37hdc8fc42_2.tar.bz2
win-64::mdtraj-1.9.4-py38h10b5164_0.tar.bz2
win-64::mdtraj-1.9.4-py38h689c0bd_1.tar.bz2
win-64::mdtraj-1.9.4-py38h689c0bd_2.tar.bz2
win-64::mdtraj-1.9.4-py39ha19edc8_1.tar.bz2
win-64::mdtraj-1.9.4-py39ha19edc8_2.tar.bz2
win-64::mdtraj-1.9.5-py36h5160f2f_0.tar.bz2
win-64::mdtraj-1.9.5-py36h5160f2f_1.tar.bz2
win-64::mdtraj-1.9.5-py37hdc8fc42_0.tar.bz2
win-64::mdtraj-1.9.5-py37hdc8fc42_1.tar.bz2
win-64::mdtraj-1.9.5-py38h689c0bd_0.tar.bz2
win-64::mdtraj-1.9.5-py38h689c0bd_1.tar.bz2
win-64::mdtraj-1.9.5-py39ha19edc8_0.tar.bz2
win-64::mdtraj-1.9.5-py39ha19edc8_1.tar.bz2
win-64::mdtraj-1.9.6-py36h003c66d_0.tar.bz2
win-64::mdtraj-1.9.6-py36h003c66d_1.tar.bz2
win-64::mdtraj-1.9.6-py37h7807cd8_0.tar.bz2
win-64::mdtraj-1.9.6-py37h7807cd8_1.tar.bz2
win-64::mdtraj-1.9.6-py38h510c834_0.tar.bz2
win-64::mdtraj-1.9.6-py38h510c834_1.tar.bz2
win-64::mdtraj-1.9.6-py39ha19edc8_0.tar.bz2
win-64::mdtraj-1.9.6-py39ha19edc8_1.tar.bz2
win-64::mdtraj-1.9.7-py310h1431f1b_2.tar.bz2
win-64::mdtraj-1.9.7-py310h1431f1b_3.tar.bz2
win-64::mdtraj-1.9.7-py310h1431f1b_4.tar.bz2
win-64::mdtraj-1.9.7-py310h65a939d_1.tar.bz2
win-64::mdtraj-1.9.7-py311h3f4f50a_3.tar.bz2
win-64::mdtraj-1.9.7-py311h3f4f50a_4.tar.bz2
win-64::mdtraj-1.9.7-py36h003c66d_1.tar.bz2
win-64::mdtraj-1.9.7-py37h556ddc3_0.tar.bz2
win-64::mdtraj-1.9.7-py37h556ddc3_1.tar.bz2
win-64::mdtraj-1.9.7-py37h7807cd8_1.tar.bz2
win-64::mdtraj-1.9.7-py37hcef4199_2.tar.bz2
win-64::mdtraj-1.9.7-py38h011f1d4_0.tar.bz2
win-64::mdtraj-1.9.7-py38h011f1d4_1.tar.bz2
win-64::mdtraj-1.9.7-py38h510c834_1.tar.bz2
win-64::mdtraj-1.9.7-py38hd944c8d_3.tar.bz2
win-64::mdtraj-1.9.7-py38hd944c8d_4.tar.bz2
win-64::mdtraj-1.9.7-py38he55de21_2.tar.bz2
win-64::mdtraj-1.9.7-py39h1846144_3.tar.bz2
win-64::mdtraj-1.9.7-py39h1846144_4.tar.bz2
win-64::mdtraj-1.9.7-py39h804b23a_2.tar.bz2
win-64::mdtraj-1.9.7-py39ha19edc8_0.tar.bz2
win-64::mdtraj-1.9.7-py39ha19edc8_1.tar.bz2
win-64::mdtraj-1.9.8-py310h1431f1b_0.conda
win-64::mdtraj-1.9.8-py310h1431f1b_1.conda
win-64::mdtraj-1.9.8-py310h1431f1b_2.conda
win-64::mdtraj-1.9.8-py311h3f4f50a_0.conda
win-64::mdtraj-1.9.8-py311h3f4f50a_1.conda
win-64::mdtraj-1.9.8-py311h3f4f50a_2.conda
win-64::mdtraj-1.9.8-py38h9fbe819_0.conda
win-64::mdtraj-1.9.8-py38h9fbe819_1.conda
win-64::mdtraj-1.9.8-py38h9fbe819_2.conda
win-64::mdtraj-1.9.8-py39h23b186c_0.conda
win-64::mdtraj-1.9.8-py39h23b186c_1.conda
win-64::mdtraj-1.9.8-py39h23b186c_2.conda
win-64::mdtraj-1.9.9-py310h1431f1b_0.conda
win-64::mdtraj-1.9.9-py310h63e6b18_1.conda
win-64::mdtraj-1.9.9-py311h3f4f50a_0.conda
win-64::mdtraj-1.9.9-py311h3f4f50a_1.conda
win-64::mdtraj-1.9.9-py312hf733d30_1.conda
win-64::mdtraj-1.9.9-py38h6ce0b3b_1.conda
win-64::mdtraj-1.9.9-py38h9fbe819_0.conda
win-64::mdtraj-1.9.9-py39h23b186c_0.conda
win-64::mdtraj-1.9.9-py39hc83516f_1.conda
-    "pandas",
+    "pandas <3.0a0",
================================================================================
================================================================================
osx-64
osx-64::mdtraj-1.10.0-py310h87bbf54_0.conda
osx-64::mdtraj-1.10.0-py311hd77083e_0.conda
osx-64::mdtraj-1.10.0-py312h00f8f5a_0.conda
osx-64::mdtraj-1.10.0-py38h8ae948a_0.conda
osx-64::mdtraj-1.10.0-py39h9872ee1_0.conda
osx-64::mdtraj-1.10.1-py310hdd6a05f_0.conda
osx-64::mdtraj-1.10.1-py310hdd6a05f_1.conda
osx-64::mdtraj-1.10.1-py310hdd6a05f_2.conda
osx-64::mdtraj-1.10.1-py311hb3c0cc3_0.conda
osx-64::mdtraj-1.10.1-py311hb3c0cc3_1.conda
osx-64::mdtraj-1.10.1-py311hb3c0cc3_2.conda
osx-64::mdtraj-1.10.1-py312hd8e3cac_0.conda
osx-64::mdtraj-1.10.1-py312hd8e3cac_1.conda
osx-64::mdtraj-1.10.1-py312hd8e3cac_2.conda
osx-64::mdtraj-1.10.1-py313h8f8cb83_1.conda
osx-64::mdtraj-1.10.1-py313h8f8cb83_2.conda
osx-64::mdtraj-1.10.1-py39h0e16d7a_0.conda
osx-64::mdtraj-1.10.1-py39h0e16d7a_1.conda
osx-64::mdtraj-1.10.1-py39h0e16d7a_2.conda
osx-64::mdtraj-1.10.2-py310h4908cbb_0.conda
osx-64::mdtraj-1.10.2-py311h23b24ca_0.conda
osx-64::mdtraj-1.10.2-py312h7bd2c7a_0.conda
osx-64::mdtraj-1.10.2-py313h8f8cb83_0.conda
osx-64::mdtraj-1.10.2-py39hf536266_0.conda
osx-64::mdtraj-1.10.3-py310h4908cbb_0.conda
osx-64::mdtraj-1.10.3-py311h23b24ca_0.conda
osx-64::mdtraj-1.10.3-py312h7bd2c7a_0.conda
osx-64::mdtraj-1.10.3-py313h8f8cb83_0.conda
osx-64::mdtraj-1.10.3-py39hf536266_0.conda
osx-64::mdtraj-1.11.0-np2py311h4030279_2.conda
osx-64::mdtraj-1.11.0-np2py311h7ae6bcf_3.conda
osx-64::mdtraj-1.11.0-np2py312h0b34a23_3.conda
osx-64::mdtraj-1.11.0-np2py312h36af78a_2.conda
osx-64::mdtraj-1.11.0-np2py313h0b0ef5f_2.conda
osx-64::mdtraj-1.11.0-np2py313hbe56af6_3.conda
osx-64::mdtraj-1.11.0-np2py314hf47d01f_3.conda
osx-64::mdtraj-1.11.0-py311h42322f7_0.conda
osx-64::mdtraj-1.11.0-py311h42322f7_1.conda
osx-64::mdtraj-1.11.0-py312hba1ccfd_0.conda
osx-64::mdtraj-1.11.0-py312hba1ccfd_1.conda
osx-64::mdtraj-1.11.0-py313h8f8cb83_0.conda
osx-64::mdtraj-1.11.0-py313h8f8cb83_1.conda
osx-64::mdtraj-1.11.1-np2py311h7587ae1_0.conda
osx-64::mdtraj-1.11.1-np2py312h6d257ad_0.conda
osx-64::mdtraj-1.11.1-np2py313h0076202_0.conda
osx-64::mdtraj-1.11.1-np2py314h27df2c0_0.conda
osx-64::mdtraj-1.7.2-np110py27_0.tar.bz2
osx-64::mdtraj-1.7.2-np110py34_0.tar.bz2
osx-64::mdtraj-1.7.2-np110py35_0.tar.bz2
osx-64::mdtraj-1.7.2-np111py27_0.tar.bz2
osx-64::mdtraj-1.7.2-np111py34_0.tar.bz2
osx-64::mdtraj-1.7.2-np111py35_0.tar.bz2
osx-64::mdtraj-1.8.0-np110py27_0.tar.bz2
osx-64::mdtraj-1.8.0-np110py27_1.tar.bz2
osx-64::mdtraj-1.8.0-np110py34_0.tar.bz2
osx-64::mdtraj-1.8.0-np110py34_1.tar.bz2
osx-64::mdtraj-1.8.0-np110py35_0.tar.bz2
osx-64::mdtraj-1.8.0-np110py35_1.tar.bz2
osx-64::mdtraj-1.8.0-np111py27_0.tar.bz2
osx-64::mdtraj-1.8.0-np111py27_1.tar.bz2
osx-64::mdtraj-1.8.0-np111py34_0.tar.bz2
osx-64::mdtraj-1.8.0-np111py34_1.tar.bz2
osx-64::mdtraj-1.8.0-np111py35_0.tar.bz2
osx-64::mdtraj-1.8.0-np111py35_1.tar.bz2
osx-64::mdtraj-1.8.0-np111py36_1.tar.bz2
osx-64::mdtraj-1.8.0-np112py27_1.tar.bz2
osx-64::mdtraj-1.8.0-np112py35_1.tar.bz2
osx-64::mdtraj-1.8.0-np112py36_1.tar.bz2
osx-64::mdtraj-1.8.0-np113py27_1.tar.bz2
osx-64::mdtraj-1.8.0-np113py35_1.tar.bz2
osx-64::mdtraj-1.8.0-np113py36_1.tar.bz2
osx-64::mdtraj-1.8.0-py27_2.tar.bz2
osx-64::mdtraj-1.8.0-py35_2.tar.bz2
osx-64::mdtraj-1.8.0-py36_2.tar.bz2
osx-64::mdtraj-1.9.1-py27_0.tar.bz2
osx-64::mdtraj-1.9.1-py27_1.tar.bz2
osx-64::mdtraj-1.9.1-py27h447964c_2.tar.bz2
osx-64::mdtraj-1.9.1-py35_0.tar.bz2
osx-64::mdtraj-1.9.1-py35_1.tar.bz2
osx-64::mdtraj-1.9.1-py35h447964c_2.tar.bz2
osx-64::mdtraj-1.9.1-py36_0.tar.bz2
osx-64::mdtraj-1.9.1-py36_1.tar.bz2
osx-64::mdtraj-1.9.1-py36h447964c_2.tar.bz2
osx-64::mdtraj-1.9.2-py27h13be62f_1000.tar.bz2
osx-64::mdtraj-1.9.2-py27h447964c_0.tar.bz2
osx-64::mdtraj-1.9.2-py35h447964c_0.tar.bz2
osx-64::mdtraj-1.9.2-py36h13be62f_1000.tar.bz2
osx-64::mdtraj-1.9.2-py36h447964c_0.tar.bz2
osx-64::mdtraj-1.9.2-py37h13be62f_1000.tar.bz2
osx-64::mdtraj-1.9.2-py37h447964c_0.tar.bz2
osx-64::mdtraj-1.9.3-py27h3e38534_1.tar.bz2
osx-64::mdtraj-1.9.3-py27h5a8e3e4_0.tar.bz2
osx-64::mdtraj-1.9.3-py36h3e38534_1.tar.bz2
osx-64::mdtraj-1.9.3-py36h5a8e3e4_0.tar.bz2
osx-64::mdtraj-1.9.3-py37h3e38534_1.tar.bz2
osx-64::mdtraj-1.9.3-py37h5a8e3e4_0.tar.bz2
osx-64::mdtraj-1.9.3-py38h3e38534_1.tar.bz2
osx-64::mdtraj-1.9.4-py36h2ab621b_1.tar.bz2
osx-64::mdtraj-1.9.4-py36h2ab621b_2.tar.bz2
osx-64::mdtraj-1.9.4-py36hc3c0667_0.tar.bz2
osx-64::mdtraj-1.9.4-py36hfd33946_2.tar.bz2
osx-64::mdtraj-1.9.4-py37h1c7d4b1_1.tar.bz2
osx-64::mdtraj-1.9.4-py37h1c7d4b1_2.tar.bz2
osx-64::mdtraj-1.9.4-py37h53b49b0_0.tar.bz2
osx-64::mdtraj-1.9.4-py38hb9c483a_0.tar.bz2
osx-64::mdtraj-1.9.4-py38he154bc6_1.tar.bz2
osx-64::mdtraj-1.9.4-py38he154bc6_2.tar.bz2
osx-64::mdtraj-1.9.4-py39h6a03653_1.tar.bz2
osx-64::mdtraj-1.9.4-py39h6a03653_2.tar.bz2
osx-64::mdtraj-1.9.5-py36h3d657db_0.tar.bz2
osx-64::mdtraj-1.9.5-py36h72ac459_0.tar.bz2
osx-64::mdtraj-1.9.5-py36h8304703_1.tar.bz2
osx-64::mdtraj-1.9.5-py37h22c4154_0.tar.bz2
osx-64::mdtraj-1.9.5-py37h7b2a319_0.tar.bz2
osx-64::mdtraj-1.9.5-py37h8a55be0_1.tar.bz2
osx-64::mdtraj-1.9.5-py38h38e8ca5_0.tar.bz2
osx-64::mdtraj-1.9.5-py38h711e445_1.tar.bz2
osx-64::mdtraj-1.9.5-py38hcbf3f11_0.tar.bz2
osx-64::mdtraj-1.9.5-py39ha043c60_0.tar.bz2
osx-64::mdtraj-1.9.5-py39hb6ec638_1.tar.bz2
osx-64::mdtraj-1.9.5-py39hb9acbc1_0.tar.bz2
osx-64::mdtraj-1.9.6-py36h2f81817_0.tar.bz2
osx-64::mdtraj-1.9.6-py36h2f81817_1.tar.bz2
osx-64::mdtraj-1.9.6-py37h7ace891_0.tar.bz2
osx-64::mdtraj-1.9.6-py37h7ace891_1.tar.bz2
osx-64::mdtraj-1.9.6-py38h63a7c91_0.tar.bz2
osx-64::mdtraj-1.9.6-py38h63a7c91_1.tar.bz2
osx-64::mdtraj-1.9.6-py39h996af62_0.tar.bz2
osx-64::mdtraj-1.9.6-py39h996af62_1.tar.bz2
osx-64::mdtraj-1.9.7-py310h1b5c016_2.tar.bz2
osx-64::mdtraj-1.9.7-py310h1b5c016_3.tar.bz2
osx-64::mdtraj-1.9.7-py310h1b5c016_4.tar.bz2
osx-64::mdtraj-1.9.7-py310h8e98eef_1.tar.bz2
osx-64::mdtraj-1.9.7-py311hc0c4476_3.tar.bz2
osx-64::mdtraj-1.9.7-py311hc0c4476_4.tar.bz2
osx-64::mdtraj-1.9.7-py36h2f81817_1.tar.bz2
osx-64::mdtraj-1.9.7-py37h15d50fc_2.tar.bz2
osx-64::mdtraj-1.9.7-py37h7ace891_1.tar.bz2
osx-64::mdtraj-1.9.7-py37h7b928b5_0.tar.bz2
osx-64::mdtraj-1.9.7-py37h7b928b5_1.tar.bz2
osx-64::mdtraj-1.9.7-py38h011acc5_2.tar.bz2
osx-64::mdtraj-1.9.7-py38h63a7c91_1.tar.bz2
osx-64::mdtraj-1.9.7-py38h6e53e98_0.tar.bz2
osx-64::mdtraj-1.9.7-py38h6e53e98_1.tar.bz2
osx-64::mdtraj-1.9.7-py38hb25ac7b_3.tar.bz2
osx-64::mdtraj-1.9.7-py38hb25ac7b_4.tar.bz2
osx-64::mdtraj-1.9.7-py39h5179a43_2.tar.bz2
osx-64::mdtraj-1.9.7-py39h5456c6e_3.tar.bz2
osx-64::mdtraj-1.9.7-py39h5456c6e_4.tar.bz2
osx-64::mdtraj-1.9.7-py39h996af62_0.tar.bz2
osx-64::mdtraj-1.9.7-py39h996af62_1.tar.bz2
osx-64::mdtraj-1.9.8-py310h8e8bc97_0.conda
osx-64::mdtraj-1.9.8-py310h8e8bc97_1.conda
osx-64::mdtraj-1.9.8-py310h8e8bc97_2.conda
osx-64::mdtraj-1.9.8-py311h8f92aaa_0.conda
osx-64::mdtraj-1.9.8-py311h8f92aaa_1.conda
osx-64::mdtraj-1.9.8-py311h8f92aaa_2.conda
osx-64::mdtraj-1.9.8-py38hc638d36_0.conda
osx-64::mdtraj-1.9.8-py38hc638d36_2.conda
osx-64::mdtraj-1.9.8-py39h1f7e74c_0.conda
osx-64::mdtraj-1.9.8-py39h1f7e74c_2.conda
osx-64::mdtraj-1.9.9-py310h18b6ea6_1.conda
osx-64::mdtraj-1.9.9-py310h8e8bc97_0.conda
osx-64::mdtraj-1.9.9-py311h8f92aaa_0.conda
osx-64::mdtraj-1.9.9-py311hbd61c5e_1.conda
osx-64::mdtraj-1.9.9-py312haf99ffb_1.conda
osx-64::mdtraj-1.9.9-py38hc638d36_0.conda
osx-64::mdtraj-1.9.9-py38hf6233cf_1.conda
osx-64::mdtraj-1.9.9-py39h11caeac_1.conda
osx-64::mdtraj-1.9.9-py39h1f7e74c_0.conda
-    "pandas",
+    "pandas <3.0a0",
================================================================================
================================================================================
linux-64
linux-64::mdtraj-1.10.0-py310he673748_0.conda
linux-64::mdtraj-1.10.0-py311h3f233a9_0.conda
linux-64::mdtraj-1.10.0-py312h0b8b674_0.conda
linux-64::mdtraj-1.10.0-py38h6b108ad_0.conda
linux-64::mdtraj-1.10.0-py39h3a17c87_0.conda
linux-64::mdtraj-1.10.1-py310he1cc299_0.conda
linux-64::mdtraj-1.10.1-py310he1cc299_1.conda
linux-64::mdtraj-1.10.1-py310he1cc299_2.conda
linux-64::mdtraj-1.10.1-py311h4734c11_0.conda
linux-64::mdtraj-1.10.1-py311h4734c11_1.conda
linux-64::mdtraj-1.10.1-py311h4734c11_2.conda
linux-64::mdtraj-1.10.1-py312he066df8_0.conda
linux-64::mdtraj-1.10.1-py312he066df8_1.conda
linux-64::mdtraj-1.10.1-py312he066df8_2.conda
linux-64::mdtraj-1.10.1-py313hf979834_1.conda
linux-64::mdtraj-1.10.1-py313hf979834_2.conda
linux-64::mdtraj-1.10.1-py39h47d0bb2_0.conda
linux-64::mdtraj-1.10.1-py39h47d0bb2_1.conda
linux-64::mdtraj-1.10.1-py39h47d0bb2_2.conda
linux-64::mdtraj-1.10.2-py310h4cdbd58_0.conda
linux-64::mdtraj-1.10.2-py311h2ed89a0_0.conda
linux-64::mdtraj-1.10.2-py312h71c6f2c_0.conda
linux-64::mdtraj-1.10.2-py313hf979834_0.conda
linux-64::mdtraj-1.10.2-py39ha5bcfe8_0.conda
linux-64::mdtraj-1.10.3-py310h4cdbd58_0.conda
linux-64::mdtraj-1.10.3-py311h2ed89a0_0.conda
linux-64::mdtraj-1.10.3-py312h71c6f2c_0.conda
linux-64::mdtraj-1.10.3-py313hf979834_0.conda
linux-64::mdtraj-1.10.3-py39ha5bcfe8_0.conda
linux-64::mdtraj-1.11.0-np2py311hb255e1c_2.conda
linux-64::mdtraj-1.11.0-np2py311hb255e1c_3.conda
linux-64::mdtraj-1.11.0-np2py312h8baca0b_2.conda
linux-64::mdtraj-1.11.0-np2py312h8baca0b_3.conda
linux-64::mdtraj-1.11.0-np2py313h48ae260_2.conda
linux-64::mdtraj-1.11.0-np2py313h48ae260_3.conda
linux-64::mdtraj-1.11.0-np2py314hb2e1fd2_3.conda
linux-64::mdtraj-1.11.0-py311hfcee6b0_0.conda
linux-64::mdtraj-1.11.0-py311hfcee6b0_1.conda
linux-64::mdtraj-1.11.0-py312hf49885f_0.conda
linux-64::mdtraj-1.11.0-py312hf49885f_1.conda
linux-64::mdtraj-1.11.0-py313hf979834_0.conda
linux-64::mdtraj-1.11.0-py313hf979834_1.conda
linux-64::mdtraj-1.11.1-np2py311hb255e1c_0.conda
linux-64::mdtraj-1.11.1-np2py312h8baca0b_0.conda
linux-64::mdtraj-1.11.1-np2py313h48ae260_0.conda
linux-64::mdtraj-1.11.1-np2py314h2081940_0.conda
linux-64::mdtraj-1.7.2-np110py27_0.tar.bz2
linux-64::mdtraj-1.7.2-np110py34_0.tar.bz2
linux-64::mdtraj-1.7.2-np110py35_0.tar.bz2
linux-64::mdtraj-1.7.2-np111py27_0.tar.bz2
linux-64::mdtraj-1.7.2-np111py34_0.tar.bz2
linux-64::mdtraj-1.7.2-np111py35_0.tar.bz2
linux-64::mdtraj-1.8.0-np110py27_0.tar.bz2
linux-64::mdtraj-1.8.0-np110py27_1.tar.bz2
linux-64::mdtraj-1.8.0-np110py34_0.tar.bz2
linux-64::mdtraj-1.8.0-np110py34_1.tar.bz2
linux-64::mdtraj-1.8.0-np110py35_0.tar.bz2
linux-64::mdtraj-1.8.0-np110py35_1.tar.bz2
linux-64::mdtraj-1.8.0-np111py27_0.tar.bz2
linux-64::mdtraj-1.8.0-np111py27_1.tar.bz2
linux-64::mdtraj-1.8.0-np111py34_0.tar.bz2
linux-64::mdtraj-1.8.0-np111py34_1.tar.bz2
linux-64::mdtraj-1.8.0-np111py35_0.tar.bz2
linux-64::mdtraj-1.8.0-np111py35_1.tar.bz2
linux-64::mdtraj-1.8.0-np111py36_1.tar.bz2
linux-64::mdtraj-1.8.0-np112py27_1.tar.bz2
linux-64::mdtraj-1.8.0-np112py35_1.tar.bz2
linux-64::mdtraj-1.8.0-np112py36_1.tar.bz2
linux-64::mdtraj-1.8.0-np113py27_1.tar.bz2
linux-64::mdtraj-1.8.0-np113py35_1.tar.bz2
linux-64::mdtraj-1.8.0-np113py36_1.tar.bz2
linux-64::mdtraj-1.8.0-py27_2.tar.bz2
linux-64::mdtraj-1.8.0-py35_2.tar.bz2
linux-64::mdtraj-1.8.0-py36_2.tar.bz2
linux-64::mdtraj-1.9.1-py27_0.tar.bz2
linux-64::mdtraj-1.9.1-py27_1.tar.bz2
linux-64::mdtraj-1.9.1-py27h447964c_2.tar.bz2
linux-64::mdtraj-1.9.1-py35_0.tar.bz2
linux-64::mdtraj-1.9.1-py35_1.tar.bz2
linux-64::mdtraj-1.9.1-py35h447964c_2.tar.bz2
linux-64::mdtraj-1.9.1-py36_0.tar.bz2
linux-64::mdtraj-1.9.1-py36_1.tar.bz2
linux-64::mdtraj-1.9.1-py36h447964c_2.tar.bz2
linux-64::mdtraj-1.9.2-py27h447964c_0.tar.bz2
linux-64::mdtraj-1.9.2-py27hff88cb2_1000.tar.bz2
linux-64::mdtraj-1.9.2-py35h447964c_0.tar.bz2
linux-64::mdtraj-1.9.2-py36h447964c_0.tar.bz2
linux-64::mdtraj-1.9.2-py36hff88cb2_1000.tar.bz2
linux-64::mdtraj-1.9.2-py37h447964c_0.tar.bz2
linux-64::mdtraj-1.9.2-py37hff88cb2_1000.tar.bz2
linux-64::mdtraj-1.9.3-py27h00575c5_0.tar.bz2
linux-64::mdtraj-1.9.3-py27h1c801a5_1.tar.bz2
linux-64::mdtraj-1.9.3-py36h00575c5_0.tar.bz2
linux-64::mdtraj-1.9.3-py36h1c801a5_1.tar.bz2
linux-64::mdtraj-1.9.3-py37h00575c5_0.tar.bz2
linux-64::mdtraj-1.9.3-py37h1c801a5_1.tar.bz2
linux-64::mdtraj-1.9.3-py38h1c801a5_1.tar.bz2
linux-64::mdtraj-1.9.4-py36h2884468_0.tar.bz2
linux-64::mdtraj-1.9.4-py36h77db488_2.tar.bz2
linux-64::mdtraj-1.9.4-py36hab346d7_1.tar.bz2
linux-64::mdtraj-1.9.4-py36hab346d7_2.tar.bz2
linux-64::mdtraj-1.9.4-py37h113d463_1.tar.bz2
linux-64::mdtraj-1.9.4-py37h113d463_2.tar.bz2
linux-64::mdtraj-1.9.4-py37h4112681_0.tar.bz2
linux-64::mdtraj-1.9.4-py38h4fbea22_1.tar.bz2
linux-64::mdtraj-1.9.4-py38h4fbea22_2.tar.bz2
linux-64::mdtraj-1.9.4-py38h7fc68a0_0.tar.bz2
linux-64::mdtraj-1.9.4-py39h1dbbcdb_1.tar.bz2
linux-64::mdtraj-1.9.4-py39h1dbbcdb_2.tar.bz2
linux-64::mdtraj-1.9.5-py36h348eb32_0.tar.bz2
linux-64::mdtraj-1.9.5-py36h348eb32_1.tar.bz2
linux-64::mdtraj-1.9.5-py36hab346d7_0.tar.bz2
linux-64::mdtraj-1.9.5-py37h113d463_0.tar.bz2
linux-64::mdtraj-1.9.5-py37hd0d7e5a_0.tar.bz2
linux-64::mdtraj-1.9.5-py37hd0d7e5a_1.tar.bz2
linux-64::mdtraj-1.9.5-py38h4fbea22_0.tar.bz2
linux-64::mdtraj-1.9.5-py38hbcc7ddf_0.tar.bz2
linux-64::mdtraj-1.9.5-py38hbcc7ddf_1.tar.bz2
linux-64::mdtraj-1.9.5-py39h138c130_0.tar.bz2
linux-64::mdtraj-1.9.5-py39h138c130_1.tar.bz2
linux-64::mdtraj-1.9.5-py39h1dbbcdb_0.tar.bz2
linux-64::mdtraj-1.9.6-py36ha895b3a_0.tar.bz2
linux-64::mdtraj-1.9.6-py36ha895b3a_1.tar.bz2
linux-64::mdtraj-1.9.6-py37hc53b9d0_0.tar.bz2
linux-64::mdtraj-1.9.6-py37hc53b9d0_1.tar.bz2
linux-64::mdtraj-1.9.6-py38hf01b267_0.tar.bz2
linux-64::mdtraj-1.9.6-py38hf01b267_1.tar.bz2
linux-64::mdtraj-1.9.6-py39h138c130_0.tar.bz2
linux-64::mdtraj-1.9.6-py39h138c130_1.tar.bz2
linux-64::mdtraj-1.9.7-py310h902c554_2.tar.bz2
linux-64::mdtraj-1.9.7-py310h902c554_3.tar.bz2
linux-64::mdtraj-1.9.7-py310h902c554_4.tar.bz2
linux-64::mdtraj-1.9.7-py310hd8d60c7_1.tar.bz2
linux-64::mdtraj-1.9.7-py311hbd79781_3.tar.bz2
linux-64::mdtraj-1.9.7-py311hbd79781_4.tar.bz2
linux-64::mdtraj-1.9.7-py37h527cbdb_0.tar.bz2
linux-64::mdtraj-1.9.7-py37h527cbdb_1.tar.bz2
linux-64::mdtraj-1.9.7-py37hcc56668_2.tar.bz2
linux-64::mdtraj-1.9.7-py38h0f83e44_0.tar.bz2
linux-64::mdtraj-1.9.7-py38h0f83e44_1.tar.bz2
linux-64::mdtraj-1.9.7-py38h4b5026a_2.tar.bz2
linux-64::mdtraj-1.9.7-py38hdee7691_3.tar.bz2
linux-64::mdtraj-1.9.7-py38hdee7691_4.tar.bz2
linux-64::mdtraj-1.9.7-py39h138c130_0.tar.bz2
linux-64::mdtraj-1.9.7-py39h138c130_1.tar.bz2
linux-64::mdtraj-1.9.7-py39h62423bb_3.tar.bz2
linux-64::mdtraj-1.9.7-py39h62423bb_4.tar.bz2
linux-64::mdtraj-1.9.7-py39hc79b4f4_2.tar.bz2
linux-64::mdtraj-1.9.8-py310h8e08b51_0.conda
linux-64::mdtraj-1.9.8-py310h8e08b51_1.conda
linux-64::mdtraj-1.9.8-py310h8e08b51_2.conda
linux-64::mdtraj-1.9.8-py311h90fe790_0.conda
linux-64::mdtraj-1.9.8-py311h90fe790_1.conda
linux-64::mdtraj-1.9.8-py311h90fe790_2.conda
linux-64::mdtraj-1.9.8-py38h028faf2_0.conda
linux-64::mdtraj-1.9.8-py38h028faf2_1.conda
linux-64::mdtraj-1.9.8-py38h028faf2_2.conda
linux-64::mdtraj-1.9.8-py39h031bd0f_0.conda
linux-64::mdtraj-1.9.8-py39h031bd0f_1.conda
linux-64::mdtraj-1.9.8-py39h031bd0f_2.conda
linux-64::mdtraj-1.9.9-py310h523e8d7_1.conda
linux-64::mdtraj-1.9.9-py310h8e08b51_0.conda
linux-64::mdtraj-1.9.9-py311h90fe790_0.conda
linux-64::mdtraj-1.9.9-py311h90fe790_1.conda
linux-64::mdtraj-1.9.9-py312hadb1fa1_1.conda
linux-64::mdtraj-1.9.9-py38h028faf2_0.conda
linux-64::mdtraj-1.9.9-py38h02e2b9b_1.conda
linux-64::mdtraj-1.9.9-py39h031bd0f_0.conda
linux-64::mdtraj-1.9.9-py39h67e0f1a_1.conda
-    "pandas",
+    "pandas <3.0a0",
linux-64::gitea-1.25.4-hc050d84_0.conda
-{}
+{
+  "build": "hc050d84_0",
+  "build_number": 0,
+  "depends": [
+    "__glibc >=2.17",
+    "__glibc >=2.17,<3.0.a0",
+    "git",
+    "libgcc >=14"
+  ],
+  "license": "MIT",
+  "md5": "38d20771df8617593605c4c67a53b931",
+  "name": "gitea",
+  "sha256": "dadb3e1ce18e642862ec26506ea008a87588ded05932cd6aa085d442c6994d57",
+  "size": 36629370,
+  "subdir": "linux-64",
+  "timestamp": 1769102385210,
+  "version": "1.25.4"
+}
linux-64::zizmor-1.22.0-hb17b654_0.conda
-{}
+{
+  "build": "hb17b654_0",
+  "build_number": 0,
+  "constrains": [
+    "__glibc >=2.17"
+  ],
+  "depends": [
+    "__glibc >=2.17,<3.0.a0",
+    "libgcc >=14"
+  ],
+  "license": "MIT",
+  "md5": "050118580d3038416e732519ab745df7",
+  "name": "zizmor",
+  "sha256": "f94f8af570f981bb527c25f3fd5e4126d69da95a38563fa316dfec314df42a09",
+  "size": 6148512,
+  "subdir": "linux-64",
+  "timestamp": 1769103851506,
+  "version": "1.22.0"
+}
```


</details>
