### PR TITLE
Add mypy-protobuf patch

### DIFF
--- a/recipe/patch_yaml/mypy-protobuf.yaml
+++ b/recipe/patch_yaml/mypy-protobuf.yaml
@@ -1,0 +1,23 @@
+if:
+  name: mypy-protobuf
+  timestamp_lt: 1770046859000
+  version: 3.7.0
+then:
+  - replace_depends:
+      old: protobuf >=4.23.4
+      new: protobuf >=5.28.2
+  - replace_depends:
+      old: types-protobuf >=3.19.5
+      new: types-protobuf >=5.28
+---
+if:
+  name: mypy-protobuf
+  timestamp_lt: 1770046859000
+  version: 4.0.0
+then:
+  - replace_depends:
+      old: protobuf >=4.23.4
+      new: protobuf >=6.32
+  - replace_depends:
+      old: types-protobuf >=3.19.5
+      new: types-protobuf >=6.32


### PR DESCRIPTION
This is the fix of conda-forge/mypy-protobuf-feedstock#27 for already built packages.

```
noarch::mypy-protobuf-3.7.0-pyhd8ed1ab_0.conda
+  "arch": null,
-    "protobuf >=4.23.4",
+    "protobuf >=5.28.2",
-    "types-protobuf >=3.19.5"
+    "types-protobuf >=5.28"
+  "platform": null,
noarch::mypy-protobuf-4.0.0-pyhd8ed1ab_0.conda
+  "arch": null,
-    "protobuf >=4.23.4",
+    "protobuf >=6.32",
-    "types-protobuf >=3.19.5"
+    "types-protobuf >=6.32"
+  "platform": null,
```

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
