### PR TITLE
patch kaldi CUDA builds to require `__cuda`

### DIFF
--- a/recipe/patch_yaml/kaldi.yaml
+++ b/recipe/patch_yaml/kaldi.yaml
@@ -1,0 +1,9 @@
+# ensure cuda builds don't get installed when __cuda isn't found, see
+# https://github.com/conda-forge/kaldi-feedstock/pull/66
+if:
+  name: kaldi
+  timestamp_lt: 1770619150000
+  # works for both CUDA 11&12 builds; CPU builds don't have this
+  has_depends: magma
+then:
+  - add_depends: __cuda


### PR DESCRIPTION
This is a follow-up to https://github.com/conda-forge/kaldi-feedstock/pull/66, to avoid pulling in cuda builds where `__cuda` is not actually available, which leads to issues elsewhere, c.f. https://github.com/conda-forge/kalpy-feedstock/issues/38

## Output of `python show_diff.py`

<details>

```diff
>python show_diff.py
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-ppc64le
linux-ppc64le::kaldi-5.5.1112-cuda120h0ef26a4_5.conda
linux-ppc64le::kaldi-5.5.1112-cuda120hd776db9_4.conda
linux-ppc64le::kaldi-5.5.1112-cuda124h9c6fa56_6.conda
linux-ppc64le::kaldi-5.5.1112-cuda124h9c6fa56_7.conda
linux-ppc64le::kaldi-5.5.1112-cuda124ha94ada1_8.conda
linux-ppc64le::kaldi-5.5.1112-cuda124ha94ada1_9.conda
linux-ppc64le::kaldi-5.5.1172-cuda124h8ad51fc_0.conda
+    "__cuda",
================================================================================
================================================================================
noarch
================================================================================
================================================================================
linux-aarch64
linux-aarch64::kaldi-5.5.1112-cuda120h342e2f9_5.conda
linux-aarch64::kaldi-5.5.1112-cuda120h70b8153_4.conda
linux-aarch64::kaldi-5.5.1112-cuda126hc4234c2_8.conda
linux-aarch64::kaldi-5.5.1112-cuda126hc4234c2_9.conda
linux-aarch64::kaldi-5.5.1112-cuda126hf745ad7_6.conda
linux-aarch64::kaldi-5.5.1112-cuda126hf745ad7_7.conda
linux-aarch64::kaldi-5.5.1172-cuda126h2271e22_0.conda
linux-aarch64::kaldi-5.5.1172-cuda129h3a4959e_1.conda
linux-aarch64::kaldi-5.5.1172-cuda129h3a4959e_2.conda
linux-aarch64::kaldi-5.5.1172-cuda129he5ddd7b_3.conda
+    "__cuda",
================================================================================
================================================================================
win-64
win-64::kaldi-5.5.1016-cuda110hccdfe78_1.tar.bz2
win-64::kaldi-5.5.1016-cuda110hd885332_2.tar.bz2
win-64::kaldi-5.5.1016-cuda110hf8c525e_2.tar.bz2
win-64::kaldi-5.5.1016-cuda110hf8c525e_3.tar.bz2
win-64::kaldi-5.5.1016-cuda111h4b32e78_2.tar.bz2
win-64::kaldi-5.5.1016-cuda111h5fdeceb_2.tar.bz2
win-64::kaldi-5.5.1016-cuda111h5fdeceb_3.tar.bz2
win-64::kaldi-5.5.1016-cuda111ha7451c4_1.tar.bz2
win-64::kaldi-5.5.1016-cuda112h5333976_2.tar.bz2
win-64::kaldi-5.5.1016-cuda112hd79a491_2.tar.bz2
win-64::kaldi-5.5.1016-cuda112hd79a491_3.tar.bz2
win-64::kaldi-5.5.1016-cuda112hf26e681_1.tar.bz2
win-64::kaldi-5.5.1068-cuda112h2069925_2.conda
win-64::kaldi-5.5.1068-cuda112h9d48c5b_0.conda
win-64::kaldi-5.5.1068-cuda112h9d48c5b_1.conda
win-64::kaldi-5.5.1112-cuda112h2069925_0.conda
win-64::kaldi-5.5.1112-cuda112h2069925_1.conda
win-64::kaldi-5.5.1112-cuda118h5bbfa21_5.conda
win-64::kaldi-5.5.1112-cuda118h7ef4547_1.conda
win-64::kaldi-5.5.1112-cuda118hb4234b3_8.conda
win-64::kaldi-5.5.1112-cuda118hb4234b3_9.conda
win-64::kaldi-5.5.1112-cuda118hc95ed25_2.conda
win-64::kaldi-5.5.1112-cuda118hceb2927_3.conda
win-64::kaldi-5.5.1112-cuda118hceb2927_4.conda
win-64::kaldi-5.5.1112-cuda118hf84d122_6.conda
win-64::kaldi-5.5.1112-cuda118hf84d122_7.conda
win-64::kaldi-5.5.1112-cuda120h16a1d4d_5.conda
win-64::kaldi-5.5.1112-cuda120h9a7102e_3.conda
win-64::kaldi-5.5.1112-cuda120h9a7102e_4.conda
win-64::kaldi-5.5.1112-cuda126h46ac0be_6.conda
win-64::kaldi-5.5.1112-cuda126h46ac0be_7.conda
win-64::kaldi-5.5.1112-cuda126ha524113_8.conda
win-64::kaldi-5.5.1112-cuda126ha524113_9.conda
win-64::kaldi-5.5.112-cuda112h2069925_0.conda
win-64::kaldi-5.5.1172-cuda126h75e360f_0.conda
win-64::kaldi-5.5.1172-cuda129h41dae0e_3.conda
win-64::kaldi-5.5.1172-cuda129h7399f15_1.conda
win-64::kaldi-5.5.1172-cuda129hb51a35d_2.conda
+    "__cuda",
================================================================================
================================================================================
osx-64
================================================================================
================================================================================
linux-64
linux-64::kaldi-5.5.1016-cuda110h02e7bc7_2.tar.bz2
linux-64::kaldi-5.5.1016-cuda110h02e7bc7_3.tar.bz2
linux-64::kaldi-5.5.1016-cuda110h36dbd2a_2.tar.bz2
linux-64::kaldi-5.5.1016-cuda110h7b400ab_1.tar.bz2
linux-64::kaldi-5.5.1016-cuda111h0690c12_2.tar.bz2
linux-64::kaldi-5.5.1016-cuda111h2348906_2.tar.bz2
linux-64::kaldi-5.5.1016-cuda111h2348906_3.tar.bz2
linux-64::kaldi-5.5.1016-cuda111h989a307_1.tar.bz2
linux-64::kaldi-5.5.1016-cuda112h1cdd06b_2.tar.bz2
linux-64::kaldi-5.5.1016-cuda112h1cdd06b_3.tar.bz2
linux-64::kaldi-5.5.1016-cuda112h1e989f9_2.tar.bz2
linux-64::kaldi-5.5.1016-cuda112h4f032a0_1.tar.bz2
linux-64::kaldi-5.5.1068-cuda112h961d610_0.conda
linux-64::kaldi-5.5.1068-cuda112h961d610_1.conda
linux-64::kaldi-5.5.1068-cuda112h971fcfb_2.conda
linux-64::kaldi-5.5.1068-cuda112h9c89dd3_1.conda
linux-64::kaldi-5.5.1068-cuda120h41cae9c_2.conda
linux-64::kaldi-5.5.1068-cuda120h6a63ba3_1.conda
linux-64::kaldi-5.5.1112-cuda112h971fcfb_0.conda
linux-64::kaldi-5.5.1112-cuda112h971fcfb_1.conda
linux-64::kaldi-5.5.1112-cuda118h03c5bf3_8.conda
linux-64::kaldi-5.5.1112-cuda118h03c5bf3_9.conda
linux-64::kaldi-5.5.1112-cuda118h4101a04_5.conda
linux-64::kaldi-5.5.1112-cuda118h8e9266c_2.conda
linux-64::kaldi-5.5.1112-cuda118h93c88dc_3.conda
linux-64::kaldi-5.5.1112-cuda118h93c88dc_4.conda
linux-64::kaldi-5.5.1112-cuda118hd442223_6.conda
linux-64::kaldi-5.5.1112-cuda118hd442223_7.conda
linux-64::kaldi-5.5.1112-cuda118hf83649c_1.conda
linux-64::kaldi-5.5.1112-cuda120h094e190_2.conda
linux-64::kaldi-5.5.1112-cuda120h094e190_3.conda
linux-64::kaldi-5.5.1112-cuda120h094e190_4.conda
linux-64::kaldi-5.5.1112-cuda120h41cae9c_0.conda
linux-64::kaldi-5.5.1112-cuda120h41cae9c_1.conda
linux-64::kaldi-5.5.1112-cuda120h472450c_5.conda
linux-64::kaldi-5.5.1112-cuda126h73af168_6.conda
linux-64::kaldi-5.5.1112-cuda126h73af168_7.conda
linux-64::kaldi-5.5.1112-cuda126h9941629_8.conda
linux-64::kaldi-5.5.1112-cuda126h9941629_9.conda
linux-64::kaldi-5.5.112-cuda112h971fcfb_0.conda
linux-64::kaldi-5.5.112-cuda120h41cae9c_0.conda
linux-64::kaldi-5.5.1172-cuda126ha01af22_0.conda
linux-64::kaldi-5.5.1172-cuda129h7da9cb1_1.conda
linux-64::kaldi-5.5.1172-cuda129h7da9cb1_2.conda
linux-64::kaldi-5.5.1172-cuda129hd86434a_3.conda
+    "__cuda",
```

</details>