### PR TITLE
patch stopit vs setuptools 82

### DIFF
--- a/recipe/patch_yaml/stopit.yaml
+++ b/recipe/patch_yaml/stopit.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=../patch_yaml_model.json
+# see https://github.com/conda-forge/stopit-feedstock/pull/5
+if:
+  name: stopit
+  timestamp_le: 1770680172000
+  version_le: 1.1.2
+then:
+  - add_depends: setuptools <82.0.0


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
  > segfaulted locally 
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->


References:
- noted on https://github.com/conda-forge/stopit-feedstock/issues/4
- fixed on https://github.com/conda-forge/stopit-feedstock/pull/5 (included in https://github.com/conda-forge/stopit-feedstock/pull/6)
