### PR TITLE
Add setuptools <82 to vsts-python-api

### DIFF
--- a/recipe/patch_yaml/vsts-python-api.yaml
+++ b/recipe/patch_yaml/vsts-python-api.yaml
@@ -8,4 +8,4 @@ then:
       upper_bound: "0.6"
   - tighten_depends:
       name: setuptools
-      upper_bound: 82
+      upper_bound: "82"


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

xref https://github.com/conda-forge/vsts-python-api-feedstock/pull/13

conda-forge feedstock creation is broken right now
https://github.com/conda-forge/admin-requests/actions/runs/21861105910/job/63090188955#step:7:1457
<img width="1227" height="1339" alt="image" src="https://github.com/user-attachments/assets/92c2cf04-4acf-4a0c-b602-025bf132b538" />


```
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
noarch
noarch::vsts-python-api-0.1.17-py_0.tar.bz2
noarch::vsts-python-api-0.1.18-py_0.tar.bz2
noarch::vsts-python-api-0.1.18-py_1.tar.bz2
noarch::vsts-python-api-0.1.21-py_0.tar.bz2
noarch::vsts-python-api-0.1.22-py_0.tar.bz2
noarch::vsts-python-api-0.1.25-pyhd8ed1ab_1.tar.bz2
noarch::vsts-python-api-0.1.25-pyhd8ed1ab_2.conda
-    "setuptools"
+    "setuptools <82.0a0"
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
================================================================================
================================================================================
linux-64
```