### PR TITLE
Require setuptools<82 for xarray-schema

### DIFF
--- a/recipe/patch_yaml/xarray-schema.yaml
+++ b/recipe/patch_yaml/xarray-schema.yaml
@@ -1,0 +1,23 @@
+# xarray-schema <= 0.0.3 requires setuptools<82 at runtime
+# https://github.com/xarray-contrib/xarray-schema/issues/193
+# https://github.com/xarray-contrib/xarray-schema/pull/194
+# https://github.com/conda-forge/xarray-schema-feedstock/pull/2
+if:
+  name: xarray-schema
+  version_le: "0.0.3"
+  timestamp_lt: 1770750491000
+then:
+  - add_depends: "setuptools <82"
+---
+# Unclear why numpy >=1.20 was ever used. The first version on conda-forge was
+# 0.0.3, and it required >=1.21
+# https://anaconda.org/channels/conda-forge/packages/xarray-schema/files
+# https://github.com/xarray-contrib/xarray-schema/blob/0.0.3/requirements.txt#L2
+if:
+  name: xarray-schema
+  version: "0.0.3"
+  timestamp_lt: 1770750491000
+then:
+  - replace_depends:
+      old: "numpy >=1.20"
+      new: "numpy >=1.21"


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
---

Dealing with the problem of `pkg_resources` being removed in setuptools 82

* Open PR to fix in feedstock: https://github.com/conda-forge/xarray-schema-feedstock/pull/2
* Open PR to fix upstream: https://github.com/xarray-contrib/xarray-schema/pull/194