### PR TITLE
Patch pydantic dependency for npe2 0.8.0

### DIFF
--- a/recipe/patch_yaml/npe2.yaml
+++ b/recipe/patch_yaml/npe2.yaml
@@ -8,7 +8,7 @@ then:
       new: pydantic
 
 ---
-# npe2 0.8.0 incorrectly claims pydantic<2 compatibility
+# npe2 0.8.0 incorrectly claims pydantic >=1.0 compatibility
 if:
   name: npe2
   version: "0.8.0"


### PR DESCRIPTION
npe2 0.8.0 incorrectly has pydantic>=1.0 in its requirements, meaning it does not work with current/older napari versions. It in fact depends on pydantic>=2.12.

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR:
```
================================================================================
noarch
noarch::npe2-0.8.0-pyhd8ed1ab_0.conda
-    "pydantic >=1.0",
+    "pydantic >=2.12",
================================================================================
```
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
