### PR TITLE
Fix build number for _openmp_mutex

### DIFF
--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -436,6 +436,17 @@ def _fix_libcxx(fn, record):
             record["depends"] = depends
 
 
+def _fix_openmp_mutex(fn, record):
+    if record["name"] != "_openmp_mutex":
+        return
+    build_num = str(record["build_number"])
+    build_str = record["build"]
+    if build_str.startswith(f"{build_num}_"):
+        return
+    fixed_build_num = int(build_str.split("_")[0])
+    record["build_number"] = fixed_build_num
+
+
 def _extract_and_remove_vc_feature(record):
     features = record.get("features", "").split()
     vc_features = tuple(f for f in features if f.startswith("vc"))
@@ -701,6 +712,9 @@ def _gen_new_index_per_key(index, subdir, index_key="", verbose=False):
             for i, dep in enumerate(record["depends"]):
                 if dep == f"gfortran_{subdir}":
                     record["depends"][i] = dep + " ==" + record["version"]
+
+        # fix build number and string divergence
+        _fix_openmp_mutex(fn, record)
 
         # make sure the libgfortran version is bound from 3 to 4 for osx
         if subdir == "osx-64":


### PR DESCRIPTION
Checklist

* [ ] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [ ] Ran `python show_diff.py` and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->

Fixes https://github.com/conda/rattler/issues/2045

cc @jaimergp @wolfv @baszalmstra 