### PR TITLE
Add pyqtgraph upper bound to taurus_pyqtgraph

### DIFF
--- a/recipe/patch_yaml/taurus_pyqtgraph.yaml
+++ b/recipe/patch_yaml/taurus_pyqtgraph.yaml
@@ -1,0 +1,8 @@
+if:
+  name: taurus_pyqtgraph
+  version_le: 0.9.7
+  timestamp_le: 1770992370000
+then:
+  - replace_depends:
+      old: pyqtgraph >=0.11
+      new: pyqtgraph >=0.11,<0.14


### PR DESCRIPTION
Checklist

* [X] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [X] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [X] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [X] Ran `python show_diff.py` and posted the output as part of the PR.
* [X] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
`pyqtgraph` 0.14.0 broke some functionalities of  `taurus_pyqtgraph`. See https://gitlab.com/taurus-org/taurus/-/issues/1457

Adding an upper bound to `<0.14`:

```
noarch
noarch::taurus_pyqtgraph-0.4.10-pyhd8ed1ab_0.tar.bz2
noarch::taurus_pyqtgraph-0.5.0-pyhd8ed1ab_0.tar.bz2
noarch::taurus_pyqtgraph-0.5.1-pyhd8ed1ab_0.tar.bz2
noarch::taurus_pyqtgraph-0.5.1-pyhd8ed1ab_1.tar.bz2
noarch::taurus_pyqtgraph-0.5.10-pyhd8ed1ab_0.tar.bz2
noarch::taurus_pyqtgraph-0.5.3-pyhd8ed1ab_0.tar.bz2
noarch::taurus_pyqtgraph-0.5.4-pyhd8ed1ab_0.tar.bz2
noarch::taurus_pyqtgraph-0.5.5-pyhd8ed1ab_0.tar.bz2
noarch::taurus_pyqtgraph-0.5.6-pyhd8ed1ab_0.tar.bz2
noarch::taurus_pyqtgraph-0.5.7-pyhd8ed1ab_0.tar.bz2
noarch::taurus_pyqtgraph-0.5.9-pyhd8ed1ab_0.tar.bz2
noarch::taurus_pyqtgraph-0.6.0-pyhd8ed1ab_0.conda
noarch::taurus_pyqtgraph-0.6.1-pyhd8ed1ab_0.conda
noarch::taurus_pyqtgraph-0.6.2-pyhd8ed1ab_0.conda
noarch::taurus_pyqtgraph-0.7.0-pyhd8ed1ab_0.conda
noarch::taurus_pyqtgraph-0.8.0-pyhd8ed1ab_0.conda
noarch::taurus_pyqtgraph-0.9.0-pyhd8ed1ab_0.conda
noarch::taurus_pyqtgraph-0.9.1-pyhd8ed1ab_0.conda
noarch::taurus_pyqtgraph-0.9.2-pyhd8ed1ab_0.conda
noarch::taurus_pyqtgraph-0.9.3-pyhd8ed1ab_0.conda
noarch::taurus_pyqtgraph-0.9.4-pyh896d8c1_0.conda
noarch::taurus_pyqtgraph-0.9.5-pyhd8ed1ab_0.conda
noarch::taurus_pyqtgraph-0.9.6-pyhd8ed1ab_0.conda
noarch::taurus_pyqtgraph-0.9.7-pyhd8ed1ab_0.conda
noarch::taurus_pyqtgraph-0.9.7-pyhe01879c_1.conda
-    "pyqtgraph >=0.11",
+    "pyqtgraph >=0.11,<0.14",
```

Ping @conda-forge/taurus_pyqtgraph 