### PR TITLE
Add setuptools upper bound to taurus-core

### DIFF
--- a/recipe/patch_yaml/taurus-core.yaml
+++ b/recipe/patch_yaml/taurus-core.yaml
@@ -30,3 +30,12 @@ then:
   - replace_depends:
       old: numpy >=1.1
       new: numpy >=1.1,<2.0a0
+---
+if:
+  name: taurus-core
+  version_le: 5.2.4
+  timestamp_lt: 1771237314000
+then:
+  - replace_depends:
+      old: setuptools
+      new: setuptools <82.0.0


### PR DESCRIPTION
Checklist

* [X] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [X] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [X] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [X] Ran `python show_diff.py` and posted the output as part of the PR.
* [X] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
Removal of `pkg_resources` in version 82.0.0 of `setuptools` breaks older `taurus` packages.
Dependencies were updated in taurus 5.3.0 but repodata needs to be fixed for older versions.

```
noarch
noarch::taurus-core-5.0.0-pyhd8ed1ab_0.tar.bz2
noarch::taurus-core-5.0.0.1-pyhd8ed1ab_0.tar.bz2
noarch::taurus-core-5.1.4-pyhd8ed1ab_0.tar.bz2
noarch::taurus-core-5.1.5-pyhd8ed1ab_0.conda
noarch::taurus-core-5.1.6-pyhd8ed1ab_0.conda
noarch::taurus-core-5.1.7-pyhd8ed1ab_0.conda
noarch::taurus-core-5.1.8-pyhd8ed1ab_0.conda
noarch::taurus-core-5.1.8-pyhd8ed1ab_1.conda
noarch::taurus-core-5.2.0-pyhd8ed1ab_0.conda
noarch::taurus-core-5.2.0-pyhd8ed1ab_1.conda
noarch::taurus-core-5.2.1-pyhd8ed1ab_0.conda
noarch::taurus-core-5.2.2-pyhd8ed1ab_0.conda
noarch::taurus-core-5.2.3-pyhd8ed1ab_0.conda
noarch::taurus-core-5.2.4-pyhd8ed1ab_0.conda
-    "setuptools"
+    "setuptools <82.0.0"
```


