### PR TITLE
Add constraint for urdfdom 3.* and 4.* on urdfdom_headers <2 version

### DIFF
--- a/recipe/patch_yaml/urdfdom.yaml
+++ b/recipe/patch_yaml/urdfdom.yaml
@@ -1,0 +1,6 @@
+if:
+  name: urdfdom
+  version_lt: "5.0.0"
+  timestamp_lt: 1771236462000
+then:
+  - add_constrains: urdfdom_headers <2


### PR DESCRIPTION
`urdfdom` depends on the `urdfdom_headers` header-only library in its public headers, but urdfdom_headers 2.* removed some headers used by `urdfdom` 4.* and 3.*, this repodata patch ensure that urdfdom 4.* continues to work fine by adding a run_constraint on the urdfdom_headers version.

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

<!-- Put any other comments or information here -->
