### PR TITLE
pin setuptools < 82 on fenics-ufl

### DIFF
--- a/recipe/patch_yaml/fenics-ufl-setuptools.yaml
+++ b/recipe/patch_yaml/fenics-ufl-setuptools.yaml
@@ -1,0 +1,13 @@
+# legacy fenics-ufl uses pkg_resources, removed in setuptools 82
+# but this pin wasn't added until build 2
+if:
+  name_in:
+    - fenics-ufl
+    - fenics-ufl-legacy
+    - fenics
+  timestamp_lt: 1771275738000
+  version_lt: "2023.2.0a0"
+then:
+  - tighten_depends:
+      name: setuptools
+      upper_bound: "82"


### PR DESCRIPTION
packaging history:

- fenics (used to be all-in-one)
- fenics-ufl-legacy

fixed for new builds (ufl dropped pkg_resources dependency in 2024, pinned in fenics-ufl-legacy)

links:

- https://github.com/conda-forge/fenics-ufl-feedstock/issues/16
- https://github.com/conda-forge/fenics-ufl-legacy-feedstock/pull/2

cc @sblauth @jorgensd