### PR TITLE
fix: pin sysroot version for root_base 6.36.06 build 4

### DIFF
--- a/recipe/patch_yaml/root.yaml
+++ b/recipe/patch_yaml/root.yaml
@@ -33,3 +33,45 @@ then:
   - replace_depends:
       old: vector-classes >=1.4.1,<1.5.0a0
       new: vector-classes >=1.4.1,<1.4.2a0
+---
+# root_base 6.36.06 build 4 (from conda-forge/root-feedstock#333) dropped the
+# sysroot version pin. ROOT's cling JIT compiler uses the conda sysroot headers
+# at runtime, so the sysroot version must match what ROOT was built against.
+# Without this constraint, the solver picks sysroot 2.28, causing
+# "redefinition of 'timespec'" errors when cling tries to #include <Python.h>.
+# See https://github.com/scikit-hep/awkward/actions/runs/22073349438
+if:
+  name: root_base
+  version: "6.36.06"
+  build_number_in: [4]
+  subdir_in: linux-64
+  has_depends: "sysroot_linux-64"
+  timestamp_lt: 1771323458000
+then:
+  - replace_depends:
+      old: sysroot_linux-64
+      new: sysroot_linux-64 2.17.*
+---
+if:
+  name: root_base
+  version: "6.36.06"
+  build_number_in: [4]
+  subdir_in: linux-aarch64
+  has_depends: "sysroot_linux-aarch64"
+  timestamp_lt: 1771323458000
+then:
+  - replace_depends:
+      old: sysroot_linux-aarch64
+      new: sysroot_linux-aarch64 2.17.*
+---
+if:
+  name: root_base
+  version: "6.36.06"
+  build_number_in: [4]
+  subdir_in: linux-ppc64le
+  has_depends: "sysroot_linux-ppc64le"
+  timestamp_lt: 1771323458000
+then:
+  - replace_depends:
+      old: sysroot_linux-ppc64le
+      new: sysroot_linux-ppc64le 2.17.*


### PR DESCRIPTION
## Summary

- `root_base` 6.36.06 build 4 (from conda-forge/root-feedstock#333) dropped the `sysroot_linux-*` version pin from its dependencies
- ROOT's cling JIT compiler uses the conda sysroot headers at runtime, so the installed sysroot must match the version ROOT was built against (2.17)
- Without this constraint, the solver picks `sysroot_linux-64 2.28`, causing `redefinition of 'timespec'` errors when cling tries to `#include <Python.h>`

Previous builds (0-3) all had `sysroot_linux-64 2.17.*`; build 4 has just `sysroot_linux-64` (unconstrained). This patch restores the `2.17.*` pin for linux-64, linux-aarch64, and linux-ppc64le.

## Reproducer

```bash
# With sysroot 2.17 (works):
pixi add sysroot_linux-64=2.17
pixi run python -c "import ROOT; print(ROOT.gInterpreter.Declare('#include <Python.h>'))"
# True

# With sysroot 2.28 (fails):
pixi add sysroot_linux-64=2.28
pixi run python -c "import ROOT; print(ROOT.gInterpreter.Declare('#include <Python.h>'))"
# error: redefinition of 'timespec'
# False
```

See also: https://github.com/scikit-hep/awkward/actions/runs/22073349438/job/63783001578?pr=3880