### PR TITLE
Add repodata patch to cap mkdocs click dependency <8.3.0

### DIFF
--- a/recipe/patch_yaml/mkdocs.yaml
+++ b/recipe/patch_yaml/mkdocs.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=../patch_yaml_model.json
+# mkdocs serve --livereload is broken with click >=8.3.0 due to
+# a flag_value handling bug in Click.
+# See: https://github.com/mkdocs/mkdocs/issues/4032
+# See: https://github.com/pallets/click/issues/3084
+# mkdocs has not released a fix either.
+if:
+  name: mkdocs
+  version_ge: "1.4.2"
+  version_le: "1.6.1"
+  has_depends: click*
+then:
+  - tighten_depends:
+      name: click
+      upper_bound: "8.3.0"


### PR DESCRIPTION
`mkdocs serve --livereload` is broken with `click >=8.3.0` due to a `flag_value` handling bug in Click. Click maintainers confirmed no bugfix release before v9, and mkdocs has not released a fix either.

See: https://github.com/mkdocs/mkdocs/issues/4032
See: https://github.com/pallets/click/issues/3084

CC @wolfv

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` and ensured all files pass the linting checks.
* [x] Ran `python show_diff.py` and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future. <!-- Make sure to add a condition `and record.get("timestamp", 0) < NOW` so your changes only affect packages built in the past. Replace NOW with `python -c "import time; print(f'{time.time():.0f}000')"` -->

```
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
noarch
noarch::mkdocs-1.4.2-pyhd8ed1ab_0.tar.bz2
noarch::mkdocs-1.4.3-pyhd8ed1ab_0.conda
noarch::mkdocs-1.5.0-pyhd8ed1ab_0.conda
noarch::mkdocs-1.5.1-pyhd8ed1ab_0.conda
noarch::mkdocs-1.5.2-pyhd8ed1ab_0.conda
noarch::mkdocs-1.5.3-pyhd8ed1ab_0.conda
noarch::mkdocs-1.6.0-pyhd8ed1ab_0.conda
noarch::mkdocs-1.6.1-pyhd8ed1ab_0.conda
noarch::mkdocs-1.6.1-pyhd8ed1ab_1.conda
-    "click >=7.0",
+    "click >=7.0,<8.3.0a0",
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
================================================================================
================================================================================
linux-64
```
