### PR TITLE
fix: patch conda-lock for latest conda

### DIFF
--- a/recipe/patch_yaml/conda-lock.yaml
+++ b/recipe/patch_yaml/conda-lock.yaml
@@ -15,7 +15,7 @@ if:
   name: conda-lock
   # TODO add upper bound once conda-lock ships a patch
   # version_le:
-  # timestamp_le: 
+  # timestamp_le:
 then:
   - tighten_depends:
       name: conda

--- a/recipe/patch_yaml/conda-lock.yaml
+++ b/recipe/patch_yaml/conda-lock.yaml
@@ -8,3 +8,15 @@ if:
   not_has_constrains: "*"
 then:
   - add_constrains: urllib3 <2
+---
+# conda 26.3.0 dropped discovery of `conda-*` CLI executables as conda subcommands;
+# conda-lock relies on this for `conda lock`
+if:
+  name: conda-lock
+  # TODO add upper bound once conda-lock ships a patch
+  # version_le:
+  # timestamp_le: 
+then:
+  - tighten_depends:
+      name: conda
+      upper_bound: 26.3.0


### PR DESCRIPTION
Add conditional dependency tightening for conda-lock.

Checklist

* [ ] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `recipe/generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` (or `cd recipe && pixi run pre-commit`) and ensured all files pass the linting checks.
* [ ] Ran `python recipe/show_diff.py` (or `cd recipe && pixi run diff`) and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future.
  <!-- Make sure to add a condition `timestamp_le: NOW` so your changes only affect packages built in the past. Replace NOW with the result of one of these:
  - cd recipe && pixi run timestamp
  - python -c "import time; print(f'{time.time():.0f}000')"
  - date +%s000
  - The number displayed on https://currentmillis.com
  -->

<!-- Put any other comments or information here -->
