### PR TITLE
Restrict conda for constructor <3.15.2

### DIFF
--- a/recipe/patch_yaml/constructor.yaml
+++ b/recipe/patch_yaml/constructor.yaml
@@ -41,6 +41,7 @@ then:
 ---
 if:
   name: constructor
+  timestamp_le: 1776351873000
   version_lt: "3.15.2"
 then:
   - replace_depends:

--- a/recipe/patch_yaml/constructor.yaml
+++ b/recipe/patch_yaml/constructor.yaml
@@ -38,3 +38,11 @@ then:
   - replace_depends:
       old: conda >=4.6
       new: conda >=4.6,<23.1.0a0
+---
+if:
+  name: constructor
+  version_lt: "3.15.2"
+then:
+  - replace_depends:
+      old: conda >=4.6
+      new: conda >=4.6,<26.3.0


### PR DESCRIPTION
Checklist

* [X] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [X] Only wrote code directly into `recipe/generate_patch_json.py` if absolutely necessary.
* [X] Ran `pre-commit run -a` (or `cd recipe && pixi run pre-commit`) and ensured all files pass the linting checks.
* [X] Ran `python recipe/show_diff.py` (or `cd recipe && pixi run diff`) and posted the output as part of the PR.
* [X] Modifications won't affect packages built in the future.

Restrict `conda` to before `26.3.0` for `constructor <3.15.2`.

`conda 26.3.x` revealed a bug in `constructor` that made `constructor` incompatible with `conda 26.3.x` and later. This was fixed with [v3.15.2](https://github.com/conda/constructor/releases/tag/3.15.2).

Diff output:

```diff
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
noarch
noarch::constructor-3.10.0-pyh03870a6_0.conda
noarch::constructor-3.10.0-pyh5213c74_0.conda
noarch::constructor-3.10.0-pyhea6e2d9_0.conda
noarch::constructor-3.11.0-pyh31a35d3_0.conda
noarch::constructor-3.11.0-pyh66a16d4_0.conda
noarch::constructor-3.11.0-pyhc725047_0.conda
noarch::constructor-3.11.1-pyh31a35d3_0.conda
noarch::constructor-3.11.1-pyh66a16d4_0.conda
noarch::constructor-3.11.1-pyhc725047_0.conda
noarch::constructor-3.11.2-pyh31a35d3_0.conda
noarch::constructor-3.11.2-pyh66a16d4_0.conda
noarch::constructor-3.11.2-pyhc725047_0.conda
noarch::constructor-3.11.3-pyh31a35d3_0.conda
noarch::constructor-3.11.3-pyh66a16d4_0.conda
noarch::constructor-3.11.3-pyhc725047_0.conda
noarch::constructor-3.12.2-pyh31a35d3_0.conda
noarch::constructor-3.12.2-pyh66a16d4_0.conda
noarch::constructor-3.12.2-pyhc725047_0.conda
noarch::constructor-3.13.0-pyh31a35d3_0.conda
noarch::constructor-3.13.0-pyh66a16d4_0.conda
noarch::constructor-3.13.0-pyhc725047_0.conda
noarch::constructor-3.14.0-pyh31a35d3_0.conda
noarch::constructor-3.14.0-pyh66a16d4_0.conda
noarch::constructor-3.14.0-pyhc725047_0.conda
noarch::constructor-3.15.0-pyh31a35d3_0.conda
noarch::constructor-3.15.0-pyh66a16d4_0.conda
noarch::constructor-3.15.0-pyhc725047_0.conda
noarch::constructor-3.15.1-pyh31a35d3_0.conda
noarch::constructor-3.15.1-pyh66a16d4_0.conda
noarch::constructor-3.15.1-pyhc725047_0.conda
noarch::constructor-3.4.4-pyh31a35d3_0.conda
noarch::constructor-3.4.4-pyh55f8243_0.conda
noarch::constructor-3.4.5-pyh31a35d3_0.conda
noarch::constructor-3.4.5-pyh55f8243_0.conda
noarch::constructor-3.5.0-pyh31a35d3_0.conda
noarch::constructor-3.5.0-pyhe4f9e05_0.conda
noarch::constructor-3.6.0-pyh31a35d3_0.conda
noarch::constructor-3.6.0-pyh55f8243_0.conda
noarch::constructor-3.7.0-pyh31a35d3_0.conda
noarch::constructor-3.7.0-pyh55f8243_0.conda
noarch::constructor-3.8.0-pyh31a35d3_0.conda
noarch::constructor-3.8.0-pyh55f8243_0.conda
noarch::constructor-3.8.1-pyh31a35d3_0.conda
noarch::constructor-3.8.1-pyh55f8243_0.conda
noarch::constructor-3.9.2-pyh31a35d3_0.conda
noarch::constructor-3.9.2-pyh55f8243_0.conda
noarch::constructor-3.9.3-pyh31a35d3_0.conda
noarch::constructor-3.9.3-pyh66a16d4_0.conda
noarch::constructor-3.9.3-pyhc725047_0.conda
-    "conda >=4.6",
+    "conda >=4.6,<26.3.0",
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
================================================================================
================================================================================
linux-64
```
