### PR TITLE
Make pytensor-base numba constraints monotone

### DIFF
--- a/recipe/patch_yaml/pytensor.yaml
+++ b/recipe/patch_yaml/pytensor.yaml
@@ -58,3 +58,31 @@ then:
   - replace_depends:
       old: numpy >=1.17.0
       new: numpy >=2.0
+---
+# PyTensor v2.38.3 tightened its numba upper bound to <=0.65.1 in
+# <https://github.com/conda-forge/pytensor-suite-feedstock/pull/209>, but the
+# already-published 2.36.0-2.38.2 records still advertise numba >0.57,<1.
+# That makes the numba constraint non-monotone across PyTensor releases and
+# creates a bogus solver downgrade path once numba 0.65.1 is no longer latest.
+# Keep the historical lower bound unchanged here; the solver issue is caused by
+# the vacuous <1 upper bound becoming non-vacuous after a future numba release.
+if:
+  name: pytensor-base
+  version_ge: 2.36.0
+  version_lt: 2.38.3
+  has_depends: numba >0.57,<1
+  timestamp_lt: 1777370150000
+then:
+  - replace_depends:
+      old: numba >0.57,<1
+      new: numba >0.57,<=0.65.1
+---
+# PyTensor started to require numba in v2.36.0. Older records did not mention
+# numba at all, so add a run constraint to keep the solver from downgrading to
+# those versions in order to accept future numba releases beyond 0.65.1.
+if:
+  name: pytensor-base
+  version_lt: 2.36.0
+  timestamp_lt: 1777370150000
+then:
+  - add_constrains: numba <=0.65.1


### PR DESCRIPTION
**Human summary:** In its latest release, the PyTensor package now adds an upper-bound for its Numba dependency that tracks the latest released version (https://github.com/conda-forge/pytensor-suite-feedstock/pull/209). This is because PyTensor makes heavy use of very deep and idiosyncratic Numba code, and really needs to test against each individual release. This patch fixes the monotonicity problem that would arise after future releases of Numba that would allow the solver to upgrade Numba at the cost of a pointless PyTensor downgrade.

> [!NOTE]  
> This PR was generated with AI assistance, but still human proofread.

<details>

<summary>Prompt</summary>

In the latest pytensor-base v2.38.3, we just now started upper-bounding numba to its current latest release `<=0.65.1`. See https://github.com/conda-forge/pytensor-suite-feedstock/pull/209.  We started requiring numba since v2.36.0.

This creates a situation in which, after the next Numba release, a Conda solver can decide to upgrade Numba at the cost of downgrading PyTensor due to the non-monotonicity. This is after all a fake tradeoff, because there's nothing more compatible about older PyTensor versions with newer Numba versions, and at the current moment the Numba upper bound `<=0.65.1` is vacuous (until Numba cuts another release and it lands on conda-forge). Therefore, I believe that the most sane and robust way forward would be to patch releases between v2.36.0 inclusive and v2.38.3 exclusive to update the Numba upper bound from `<1` to `<=0.65.1`. Furthermore, for *all* pre-v2.36.0 versions, we'll absolutely need a run-constrained of `<=0.65.1`.

With these two constraints in place, I believe we'll have a robust feedstock with monotone constraints on numba.

Please do thorough research to verify or refute all my claims above. Then draft an appropriate repodata patch for pytensor-base.

</details>

---

PyTensor v2.38.3 (and the pinned conda-forge recipe) tightened numba's upper bound to <=0.65.1, while v2.36.0..v2.38.2 ship with numba >0.57,<1 and pre-v2.36.0 builds do not constrain numba at all. As soon as a numba version >0.65.1 lands on conda-forge, this non-monotonicity would let a solver downgrade pytensor-base in order to upgrade numba, which is a fake tradeoff -- older PyTensor versions are not more compatible with newer numba versions.

Two new patches in patch_yaml/pytensor.yaml restore monotonicity:

- For 2.36.0 <= version < 2.38.3, replace the numba >0.57,<1 dep with numba >=0.58,<=0.65.1 (matching what 2.38.3 ships).
- For version < 2.36.0 (no existing numba dep), add a run-constraint of numba <=0.65.1.

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `recipe/generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` (or `cd recipe && pixi run pre-commit`) and ensured all files pass the linting checks.
* [x] Ran `python recipe/show_diff.py` (or `cd recipe && pixi run diff`) and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future.
  <!-- Make sure to add a condition `timestamp_le: NOW` so your changes only affect packages built in the past. Replace NOW with the result of one of these:
  - cd recipe && pixi run timestamp
  - python -c "import time; print(f'{time.time():.0f}000')"
  - date +%s000
  - The number displayed on https://currentmillis.com
  -->

<!-- Put any other comments or information here -->
