### PR TITLE
NEW: Patch nvmath-python to avoid MKL 2026

### DIFF
--- a/recipe/patch_yaml/nvmath.yaml
+++ b/recipe/patch_yaml/nvmath.yaml
@@ -1,0 +1,11 @@
+# Prevent ABI breaks when dlopening MKL with old nvmath-python versions
+if:
+  timestamp_lt: 1777399160000
+  version_lt: 0.9.0
+  name: nvmath-python-cpu
+  subdir_in:
+    - linux-64
+    - linux-aarch64
+    - win-64
+then:
+  - add_constrains: mkl <2026

--- a/recipe/patch_yaml/nvmath.yaml
+++ b/recipe/patch_yaml/nvmath.yaml
@@ -5,7 +5,6 @@ if:
   name: nvmath-python-cpu
   subdir_in:
     - linux-64
-    - linux-aarch64
     - win-64
 then:
   - add_constrains: mkl <2026


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `recipe/generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` (or `cd recipe && pixi run pre-commit`) and ensured all files pass the linting checks.
* [x] Ran `python recipe/show_diff.py` (or `cd recipe && pixi run diff`) and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future.
  <!-- Make sure to add a condition `timestamp_le: NOW` so your changes only affect packages built in the past. Replace NOW with the result of one of these:
  - cd recipe && pixi run timestamp
  - python -c "import time; print(f'{time.time():.0f}000')"
  - date +%s000
  - The number displayed on https://currentmillis.com
  -->

<!-- Put any other comments or information here -->

Starting with MKL 2026, Intel has increased the SONAME of their main library entry points from 2 to 3. e.g. `libmkl_rt.so.2` -> `libmkl_rt.so.3`. Older versions of nvmath-python dlopen `libmkl_rt.so.2`, so we need to protect users from installing the newer version of MKL.

```
$ python show_diff.py --subdirs linux-aarch64 linux-64 win-64 --use-cache
================================================================================
================================================================================
linux-aarch64
linux-aarch64::nvmath-python-cpu-0.2.0-h053cf96_1.conda
linux-aarch64::nvmath-python-cpu-0.2.1-h053cf96_0.conda
linux-aarch64::nvmath-python-cpu-0.3.0-hacfb92f_0.conda
linux-aarch64::nvmath-python-cpu-0.4.0-h8af1aa0_0.conda
linux-aarch64::nvmath-python-cpu-0.5.0-h8af1aa0_0.conda
linux-aarch64::nvmath-python-cpu-0.6.0-h8af1aa0_0.conda
linux-aarch64::nvmath-python-cpu-0.6.0-h8af1aa0_2.conda
linux-aarch64::nvmath-python-cpu-0.7.0-h8af1aa0_2.conda
linux-aarch64::nvmath-python-cpu-0.7.0-h8af1aa0_3.conda
linux-aarch64::nvmath-python-cpu-0.8.0-h8af1aa0_0.conda
+  "constrains": [
+    "mkl <2026"
+  ],
================================================================================
================================================================================
win-64
win-64::nvmath-python-cpu-0.2.0-h57928b3_1.conda
win-64::nvmath-python-cpu-0.2.1-h57928b3_0.conda
win-64::nvmath-python-cpu-0.3.0-h57928b3_0.conda
win-64::nvmath-python-cpu-0.4.0-h57928b3_0.conda
win-64::nvmath-python-cpu-0.5.0-h57928b3_0.conda
win-64::nvmath-python-cpu-0.6.0-h57928b3_0.conda
win-64::nvmath-python-cpu-0.6.0-h57928b3_1.conda
win-64::nvmath-python-cpu-0.6.0-h57928b3_2.conda
win-64::nvmath-python-cpu-0.7.0-h57928b3_2.conda
win-64::nvmath-python-cpu-0.7.0-h57928b3_3.conda
win-64::nvmath-python-cpu-0.8.0-h57928b3_0.conda
+  "constrains": [
+    "mkl <2026"
+  ],
================================================================================
================================================================================
linux-64
linux-64::nvmath-python-cpu-0.2.0-h214fa87_1.conda
linux-64::nvmath-python-cpu-0.2.1-h214fa87_0.conda
linux-64::nvmath-python-cpu-0.3.0-hb3cea4f_0.conda
linux-64::nvmath-python-cpu-0.4.0-ha770c72_0.conda
linux-64::nvmath-python-cpu-0.5.0-ha770c72_0.conda
linux-64::nvmath-python-cpu-0.6.0-ha770c72_0.conda
linux-64::nvmath-python-cpu-0.6.0-ha770c72_1.conda
linux-64::nvmath-python-cpu-0.6.0-ha770c72_2.conda
linux-64::nvmath-python-cpu-0.7.0-ha770c72_2.conda
linux-64::nvmath-python-cpu-0.7.0-ha770c72_3.conda
linux-64::nvmath-python-cpu-0.8.0-ha770c72_0.conda
+  "constrains": [
+    "mkl <2026"
+  ],
```