### PR TITLE
update notebook 7.5.6 jupyterlab pin

### DIFF
--- a/recipe/patch_yaml/notebook.yaml
+++ b/recipe/patch_yaml/notebook.yaml
@@ -21,3 +21,13 @@ then:
   - replace_depends:
       old: jupyterlab >=4.0.2,<5
       new: jupyterlab >=4.0.2,<4.1.0a0
+---
+# https://github.com/conda-forge/notebook-feedstock/pull/225
+if:
+  name: notebook
+  version_eq: 7.5.6
+  timestamp_lt: 1777553440000
+then:
+  - replace_depends:
+      old: jupyterlab >=4.5.6,<4.6
+      new: jupyterlab >=4.5.7,<4.6


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `recipe/generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` (or `cd recipe && pixi run pre-commit`) and ensured all files pass the linting checks.
* [ ] Ran `python recipe/show_diff.py` (or `cd recipe && pixi run diff`) and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future.

References:
- https://github.com/conda-forge/notebook-feedstock/pull/225

Notes:
Will update with CI output; `show_diff.py` segfaults and crashes my box.

```

============================== 2 passed in 1.93s ===============================
patching repodata:   0%|          | 0/9 [00:00<?, ?it/s]
================================================================================
================================================================================
linux-armv7l
patching repodata:  11%|█         | 1/9 [00:01<00:08,  1.12s/it]
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
linux-aarch64
patching repodata:  22%|██▏       | 2/9 [04:20<17:52, 153.26s/it]
================================================================================
================================================================================
noarch
noarch::notebook-7.5.6-pyhcf101f3_0.conda
-    "jupyterlab >=4.5.6,<4.6",
+    "jupyterlab >=4.5.7,<4.6",
patching repodata:  33%|███▎      | 3/9 [05:32<11:35, 115.95s/it]
================================================================================
patching repodata:  44%|████▍     | 4/9 [05:51<06:29, 77.86s/it] 
================================================================================
win-32
================================================================================
================================================================================
osx-arm64
patching repodata:  56%|█████▌    | 5/9 [06:20<04:00, 60.15s/it]
================================================================================
================================================================================
linux-64
patching repodata:  67%|██████▋   | 6/9 [10:33<06:16, 125.60s/it]
patching repodata:  78%|███████▊  | 7/9 [12:05<03:49, 114.53s/it]
================================================================================
================================================================================
win-64
patching repodata:  89%|████████▉ | 8/9 [13:22<01:42, 102.65s/it]
================================================================================
================================================================================
osx-64
patching repodata: 100%|██████████| 9/9 [13:49<00:00, 78.96s/it] 
patching repodata: 100%|██████████| 9/9 [13:49<00:00, 92.12s/it]

```