### PR TITLE
add numpy <2.4 upper bound to basemap 2.0.0 builds 0-4

### DIFF
--- a/recipe/patch_yaml/basemap.yaml
+++ b/recipe/patch_yaml/basemap.yaml
@@ -1,9 +1,11 @@
 # basemap 2.0.0 builds 0-4 are missing the numpy <2.4 upper bound.
 # The constraint was added in build 5 via the feedstock recipe.
 # See: https://github.com/conda-forge/basemap-feedstock/pull/156
+
 if:
   name: basemap
   version: 2.0.0
   build_number_le: 4
+  timestamp_le: 1777669495000  # 2026-05-01
 then:
   - add_depends: numpy <2.4

--- a/recipe/patch_yaml/basemap.yaml
+++ b/recipe/patch_yaml/basemap.yaml
@@ -1,0 +1,9 @@
+# basemap 2.0.0 builds 0-4 are missing the numpy <2.4 upper bound.
+# The constraint was added in build 5 via the feedstock recipe.
+# See: https://github.com/conda-forge/basemap-feedstock/pull/156
+if:
+  name: basemap
+  version: 2.0.0
+  build_number_le: 4
+then:
+  - add_depends: numpy <2.4


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `recipe/generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` (or `cd recipe && pixi run pre-commit`) and ensured all files pass the linting checks.
* [x] Ran `python recipe/show_diff.py` (or `cd recipe && pixi run diff`) and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future.
  <!-- Make sure to add a condition `timestamp_le: NOW` so your changes only affect packages built in the past. Replace NOW with the result of one of these:
  - cd recipe && pixi run timestamp
  - python -c "import time; print(f'{time.time():.0f}000')"
  - date +%s000
  - The number displayed on https://currentmillis.com
  -->

<!-- Put any other comments or information here -->

Ran `python recipe/show_diff.py` output:
```bash
python recipe/show_diff.py                     
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
linux-ppc64le
linux-ppc64le::basemap-2.0.0-py310h3e987d8_3.conda
linux-ppc64le::basemap-2.0.0-py310h3e987d8_4.conda
linux-ppc64le::basemap-2.0.0-py310hecafb40_2.conda
linux-ppc64le::basemap-2.0.0-py310hecee8c8_0.conda
linux-ppc64le::basemap-2.0.0-py310hecee8c8_1.conda
linux-ppc64le::basemap-2.0.0-py311h7df4002_0.conda
linux-ppc64le::basemap-2.0.0-py311h7df4002_1.conda
linux-ppc64le::basemap-2.0.0-py311ha0c649a_3.conda
linux-ppc64le::basemap-2.0.0-py311ha0c649a_4.conda
linux-ppc64le::basemap-2.0.0-py311ha6c32d8_2.conda
linux-ppc64le::basemap-2.0.0-py312h13de90f_0.conda
linux-ppc64le::basemap-2.0.0-py312h13de90f_1.conda
linux-ppc64le::basemap-2.0.0-py312h1608bf3_2.conda
linux-ppc64le::basemap-2.0.0-py312h951b9c7_3.conda
linux-ppc64le::basemap-2.0.0-py312h951b9c7_4.conda
linux-ppc64le::basemap-2.0.0-py313h0ac3662_3.conda
linux-ppc64le::basemap-2.0.0-py313h0ac3662_4.conda
linux-ppc64le::basemap-2.0.0-py313h4dfe6cb_2.conda
linux-ppc64le::basemap-2.0.0-py313he4bcb8a_1.conda
linux-ppc64le::basemap-2.0.0-py314h63ed5df_4.conda
linux-ppc64le::basemap-2.0.0-py39hecccfa5_0.conda
linux-ppc64le::basemap-2.0.0-py39hecccfa5_1.conda
+    "numpy <2.4",
================================================================================
================================================================================
osx-arm64
osx-arm64::basemap-2.0.0-py310h3236976_2.conda
osx-arm64::basemap-2.0.0-py310h936c404_0.conda
osx-arm64::basemap-2.0.0-py310h936c404_1.conda
osx-arm64::basemap-2.0.0-py310hb57aaaf_3.conda
osx-arm64::basemap-2.0.0-py310hb57aaaf_4.conda
osx-arm64::basemap-2.0.0-py311h26933d5_2.conda
osx-arm64::basemap-2.0.0-py311h65c8d9b_0.conda
osx-arm64::basemap-2.0.0-py311h65c8d9b_1.conda
osx-arm64::basemap-2.0.0-py311hcf1d958_3.conda
osx-arm64::basemap-2.0.0-py312h674dca3_0.conda
osx-arm64::basemap-2.0.0-py312h674dca3_1.conda
osx-arm64::basemap-2.0.0-py312hb1cf659_2.conda
osx-arm64::basemap-2.0.0-py312hf583175_3.conda
osx-arm64::basemap-2.0.0-py312hf583175_4.conda
osx-arm64::basemap-2.0.0-py313ha3645a6_2.conda
osx-arm64::basemap-2.0.0-py313hc36b7d7_3.conda
osx-arm64::basemap-2.0.0-py313hc36b7d7_4.conda
osx-arm64::basemap-2.0.0-py313hf2583a9_1.conda
osx-arm64::basemap-2.0.0-py314h585c038_4.conda
osx-arm64::basemap-2.0.0-py39h0d32439_0.conda
osx-arm64::basemap-2.0.0-py39h0d32439_1.conda
+    "numpy <2.4",
================================================================================
================================================================================
linux-aarch64
linux-aarch64::basemap-2.0.0-py310h6fe9c6e_0.conda
linux-aarch64::basemap-2.0.0-py310h6fe9c6e_1.conda
linux-aarch64::basemap-2.0.0-py310ha561890_2.conda
linux-aarch64::basemap-2.0.0-py310hed26939_3.conda
linux-aarch64::basemap-2.0.0-py310hed26939_4.conda
linux-aarch64::basemap-2.0.0-py311h828acb0_0.conda
linux-aarch64::basemap-2.0.0-py311h828acb0_1.conda
linux-aarch64::basemap-2.0.0-py311h9807ddf_3.conda
linux-aarch64::basemap-2.0.0-py311h9807ddf_4.conda
linux-aarch64::basemap-2.0.0-py311hce22dfb_2.conda
linux-aarch64::basemap-2.0.0-py312h64b50da_3.conda
linux-aarch64::basemap-2.0.0-py312h64b50da_4.conda
linux-aarch64::basemap-2.0.0-py312hb1874bf_0.conda
linux-aarch64::basemap-2.0.0-py312hb1874bf_1.conda
linux-aarch64::basemap-2.0.0-py312hca5d0b3_2.conda
linux-aarch64::basemap-2.0.0-py313h8ad4c3e_1.conda
linux-aarch64::basemap-2.0.0-py313hdcaeb8e_3.conda
linux-aarch64::basemap-2.0.0-py313hdcaeb8e_4.conda
linux-aarch64::basemap-2.0.0-py313hf610ece_2.conda
linux-aarch64::basemap-2.0.0-py314hdec66b1_4.conda
linux-aarch64::basemap-2.0.0-py39ha2ad690_0.conda
linux-aarch64::basemap-2.0.0-py39ha2ad690_1.conda
+    "numpy <2.4",
================================================================================
================================================================================
noarch


================================================================================
================================================================================
win-64
win-64::basemap-2.0.0-py310h238ccfb_0.conda
win-64::basemap-2.0.0-py310h238ccfb_1.conda
win-64::basemap-2.0.0-py310h82de2c2_2.conda
win-64::basemap-2.0.0-py310hf694745_3.conda
win-64::basemap-2.0.0-py310hf694745_4.conda
win-64::basemap-2.0.0-py311h1fec08a_2.conda
win-64::basemap-2.0.0-py311ha1644aa_0.conda
win-64::basemap-2.0.0-py311ha1644aa_1.conda
win-64::basemap-2.0.0-py311hee4babb_3.conda
win-64::basemap-2.0.0-py311hee4babb_4.conda
win-64::basemap-2.0.0-py312h0c28eb4_2.conda
win-64::basemap-2.0.0-py312hc5e01c5_3.conda
win-64::basemap-2.0.0-py312hc5e01c5_4.conda
win-64::basemap-2.0.0-py312hc9231ca_0.conda
win-64::basemap-2.0.0-py312hc9231ca_1.conda
win-64::basemap-2.0.0-py313h4f5330b_3.conda
win-64::basemap-2.0.0-py313h4f5330b_4.conda
win-64::basemap-2.0.0-py313h5379a74_2.conda
win-64::basemap-2.0.0-py313h5fcd8c1_1.conda
win-64::basemap-2.0.0-py314h0a7feba_4.conda
win-64::basemap-2.0.0-py39h5f707b5_0.conda
win-64::basemap-2.0.0-py39h5f707b5_1.conda
+    "numpy <2.4",
================================================================================
================================================================================
osx-64
osx-64::basemap-2.0.0-py310h043ab53_2.conda
osx-64::basemap-2.0.0-py310h172e159_3.conda
osx-64::basemap-2.0.0-py310h172e159_4.conda
osx-64::basemap-2.0.0-py310h9b498ac_0.conda
osx-64::basemap-2.0.0-py310h9b498ac_1.conda
osx-64::basemap-2.0.0-py311h16ccc56_3.conda
osx-64::basemap-2.0.0-py311h16ccc56_4.conda
osx-64::basemap-2.0.0-py311h45e5343_0.conda
osx-64::basemap-2.0.0-py311h45e5343_1.conda
osx-64::basemap-2.0.0-py311h943d6ee_2.conda
osx-64::basemap-2.0.0-py312h15c3105_2.conda
osx-64::basemap-2.0.0-py312h1e7bbd8_3.conda
osx-64::basemap-2.0.0-py312h1e7bbd8_4.conda
osx-64::basemap-2.0.0-py312he978b2c_0.conda
osx-64::basemap-2.0.0-py312he978b2c_1.conda
osx-64::basemap-2.0.0-py313h402ff89_1.conda
osx-64::basemap-2.0.0-py313h5530a64_3.conda
osx-64::basemap-2.0.0-py313h5530a64_4.conda
osx-64::basemap-2.0.0-py313haefd4a5_2.conda
osx-64::basemap-2.0.0-py314hca333fe_4.conda
osx-64::basemap-2.0.0-py39hbe84358_0.conda
osx-64::basemap-2.0.0-py39hbe84358_1.conda
+    "numpy <2.4",
================================================================================
================================================================================
linux-64
linux-64::basemap-2.0.0-py310h7da1154_3.conda
linux-64::basemap-2.0.0-py310h7da1154_4.conda
linux-64::basemap-2.0.0-py310h7e2f233_0.conda
linux-64::basemap-2.0.0-py310h7e2f233_1.conda
linux-64::basemap-2.0.0-py310hc1ac779_2.conda
linux-64::basemap-2.0.0-py311h7f3a962_2.conda
linux-64::basemap-2.0.0-py311hd65e5c9_3.conda
linux-64::basemap-2.0.0-py311hd65e5c9_4.conda
linux-64::basemap-2.0.0-py311hfcd027a_0.conda
linux-64::basemap-2.0.0-py311hfcd027a_1.conda
linux-64::basemap-2.0.0-py312h134b072_0.conda
linux-64::basemap-2.0.0-py312h134b072_1.conda
linux-64::basemap-2.0.0-py312h8d133b9_3.conda
linux-64::basemap-2.0.0-py312h8d133b9_4.conda
linux-64::basemap-2.0.0-py312hb67995f_2.conda
linux-64::basemap-2.0.0-py313h43812a1_3.conda
linux-64::basemap-2.0.0-py313h43812a1_4.conda
linux-64::basemap-2.0.0-py313h9b85859_2.conda
linux-64::basemap-2.0.0-py313ha7272cc_1.conda
linux-64::basemap-2.0.0-py314h9620088_4.conda
linux-64::basemap-2.0.0-py39h7f78745_0.conda
linux-64::basemap-2.0.0-py39h7f78745_1.conda
+    "numpy <2.4",
```