### PR TITLE
Relax assimp version range for packages built against assimp 6

### DIFF
--- a/recipe/patch_yaml/assimp.yaml
+++ b/recipe/patch_yaml/assimp.yaml
@@ -1,0 +1,9 @@
+# The run_exports of assimp 6 were unnnecessarly strict
+# See https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/8172#issuecomment-4362013960
+if:
+  timestamp_lt: 1777804559000
+  has_depends: assimp >=6*
+then:
+  - loosen_depends:
+      name: assimp
+      max_pin: x


### PR DESCRIPTION
The 6.* series of release of assimp has been ABI stable, they indeed use the major version of the library as soversion, and linux distributions packaging such as Debian and Ubuntu package the library as `libassimp6`, indeed assuming the ABI stability for the major release.

For this reason, as discussed in https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/8172#issuecomment-4362013960 I think it make sense to:
* [x] Relax the run_exports of assimp (done in https://github.com/conda-forge/assimp-feedstock/pull/74 and https://github.com/conda-forge/assimp-feedstock/pull/73)
* [ ] Relax the deps of all the packages built against assimp 6 (this PR)
* [ ] Pin assimp to 6 in conda-forge-pinnings (https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/8456)

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `recipe/generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` (or `cd recipe && pixi run pre-commit`) and ensured all files pass the linting checks.
* [x] Ran `python recipe/show_diff.py` (or `cd recipe && pixi run diff`) and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future.
  <!-- Make sure to add a condition `timestamp_le: NOW` so your changes only affect packages built in the past. Replace NOW with the result of one of these:
  - cd recipe && pixi run timestamp
  - python -c "import time; print(f'{time.time():.0f}000')"
  - date +%s000
  - The number displayed on https://currentmillis.com
  -->

<!-- Put any other comments or information here -->
