### PR TITLE
raise h5py lower bound on legend-lh5io 0.2.x

### DIFF
--- a/recipe/patch_yaml/legend-lh5io.yml
+++ b/recipe/patch_yaml/legend-lh5io.yml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=../patch_yaml_model.json
+# https://github.com/conda-forge/legend-lh5io-feedstock/pull/3
+if:
+  name: legend-lh5io
+  timestamp_le: 1778077522000
+  version_ge: 0.2.0
+then:
+  - replace_depends:
+      old: h5py >=3.10
+      new: h5py >=3.16

--- a/recipe/patch_yaml/legend-lh5io.yml
+++ b/recipe/patch_yaml/legend-lh5io.yml
@@ -5,6 +5,5 @@ if:
   timestamp_le: 1778077522000
   version_ge: 0.2.0
 then:
-  - replace_depends:
-      old: h5py >=3.10
-      new: h5py >=3.16
+  - add_depends:
+      - h5py >=3.16


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `recipe/generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` (or `cd recipe && pixi run pre-commit`) and ensured all files pass the linting checks.
* [ ] Ran `python recipe/show_diff.py` (or `cd recipe && pixi run diff`) and posted the output as part of the PR.
  * > don't have time for this to segfault my box this morning, will update with CI results...
* [x] Modifications won't affect packages built in the future.

ping @conda-forge/legend-lh5io

the upstream pin on h5py [changed between 0.1.0 and 0.2.0](https://github.com/legend-exp/legend-lh5io/compare/v0.1.0...v0.2.0/#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R36).

https://github.com/conda-forge/legend-lh5io-feedstock/pull/3 fixed this for `0.2.3 *_1`, but downstreams might still pull older `0.2.x` builds.