### PR TITLE
patch authlib 1.7.x vs joserfc >=1.6.0

### DIFF
--- a/recipe/patch_yaml/authlib.yaml
+++ b/recipe/patch_yaml/authlib.yaml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=../patch_yaml_model.json
+# see:
+# - https://github.com/conda-forge/authlib-feedstock/pull/46
+# - https://github.com/conda-forge/authlib-feedstock/pull/50
+if:
+  name: authlib
+  version_ge: 1.7.0
+  timestamp_lt: 1778626301000
+then:
+  - add_depends: joserfc >=1.6.0


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `recipe/generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` (or `cd recipe && pixi run pre-commit`) and ensured all files pass the linting checks.
* [x] Ran `python recipe/show_diff.py` (or `cd recipe && pixi run diff`) and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future.

References:
- https://github.com/conda-forge/authlib-feedstock/pull/50
- https://github.com/conda-forge/authlib-feedstock/pull/46

ping @conda-forge/authlib @xylar 


```
# https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/actions/runs/25767019616/job/75681730716?pr=1199#step:3:1579
noarch::authlib-1.7.1-pyhd8ed1ab_0.conda
noarch::authlib-1.7.2-pyhd8ed1ab_0.conda
noarch::authlib-1.7.0-pyhd8ed1ab_0.conda
+    "joserfc >=1.6.0",
```