### PR TITLE
Patch nutpie <=0.16.6 to add arviz <1.0 upper bound

### DIFF
--- a/recipe/patch_yaml/nutpie.yaml
+++ b/recipe/patch_yaml/nutpie.yaml
@@ -1,0 +1,12 @@
+# nutpie <=0.16.6 is incompatible with arviz >=1.0 (and therefore pymc >=6).
+# The upper bound was added upstream starting with nutpie 0.16.7
+# (arviz >=0.20.0,<1.0). Without this patch, solvers picking an older nutpie
+# alongside `pymc>=6` would resolve arviz >=1.0 and produce a broken environment.
+if:
+  name: nutpie
+  version_le: "0.16.6"
+  timestamp_lt: 1778703359000
+then:
+  - tighten_depends:
+      name: arviz
+      upper_bound: "1.0"


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `recipe/generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` (or `cd recipe && pixi run pre-commit`) and ensured all files pass the linting checks.
* [x] Ran `python recipe/show_diff.py` (or `cd recipe && pixi run diff`) and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future.

## Context

`nutpie` 0.16.7 added an `arviz >=0.20.0,<1.0` upper bound upstream. Versions `<=0.16.6` do not have this bound, so with `arviz` 1.0/1.1 now released, the following solve succeeds and produces a broken environment:

```
micromamba install -c conda-forge "pymc>=6" "nutpie<0.16"
```

(`arviz >=1.0` is required transitively by `pymc>=6`, but old `nutpie` cannot use it.)

This patch retroactively back-applies the same `<1.0` upper bound to `nutpie` `<=0.16.6` so the solver won't pick an old `nutpie` alongside a new `arviz`.

Private discussion with @aseyboldt confirms the latest two `nutpie` versions (0.16.7, 0.16.8) already carry the upper bound and that older versions are incompatible with the new `arviz`/`pymc`.

## `show_diff.py` output

580 `nutpie` records modified across `linux-64` (135), `linux-aarch64` (46), `osx-64` (135), `osx-arm64` (129), `win-64` (135). Only three unique transformations:

```diff
-    "arviz",
+    "arviz <1.0a0",
```

```diff
-    "arviz >=0.15.0",
+    "arviz >=0.15.0,<1.0.0a0",
```

```diff
-    "arviz >=0.20.0",
+    "arviz >=0.20.0,<1.0.0a0",
```

Mapping to `nutpie` versions:

| `nutpie` version | before | after |
|---|---|---|
| 0.1.1 – 0.9.1 | `arviz` | `arviz <1.0a0` |
| 0.9.2 – 0.13.3 | `arviz >=0.15.0` | `arviz >=0.15.0,<1.0.0a0` |
| 0.13.4 – 0.16.6 | `arviz >=0.20.0` | `arviz >=0.20.0,<1.0.0a0` |
| 0.16.7, 0.16.8 | `arviz >=0.20.0,<1.0` | unchanged (already bounded upstream) |

cc @aseyboldt