### PR TITLE
Add eigen-abi runtime dependency to old gtsam builds

### DIFF
--- a/recipe/patch_yaml/gtsam.yaml
+++ b/recipe/patch_yaml/gtsam.yaml
@@ -1,0 +1,16 @@
+# add the missing eigen-abi runtime pin added by https://github.com/conda-forge/gtsam-feedstock/pull/39
+# as gtsam never constrained the eigen version, we can add
+# the pin for eigen-abi 3.4.0.* for all gtsam builds after the
+# release of eigen 3.4.0
+# (https://conda-metadata-app.streamlit.app/?q=conda-forge%2Flinux-64%2Feigen-3.4.0-h4bd325d_0.tar.bz2)
+# that has a 1630134388298 (we add a 1 day buffer to be safe) and
+# before the timestamp of the first eigen 5.0.1
+# (https://conda-metadata-app.streamlit.app/?q=conda-forge%2Flinux-64%2Feigen-5.0.1-hc65338a_0.conda)
+# that was built with timestamp 1773744756289
+if:
+  name: gtsam
+  not_has_depends: eigen-abi*
+  timestamp_ge: 1630220788298
+  timestamp_lt: 1773744756289
+then:
+  - add_depends: eigen-abi >=3.4.0.100,<3.4.0.101.0a0


### PR DESCRIPTION
`gtsam` is a compiled library whose ABI depends on the Eigen header-only library. To avoid ABI breakage related to this, in https://github.com/conda-forge/gtsam-feedstock/pull/40 the dependency on the `eigen-abi-devel` was added. 

However, to avoid problems with older `gtsam` builds, in this repodata patch we also add the required run dependency on `eigen-abi` also for older gtsam builds.

As gtsam never constrained the eigen version, we can add the pin for eigen-abi 3.4.0.* for all pcl builds after the release of eigen 3.4.0 (https://conda-metadata-app.streamlit.app/?q=conda-forge%2Flinux-64%2Feigen-3.4.0-h4bd325d_0.tar.bz2, that has a 1630134388298 timestamp (we add a 1 day buffer to be safe) and before the timestamp of the first eigen 5.0.1 build (https://conda-metadata-app.streamlit.app/?q=conda-forge%2Flinux-64%2Feigen-5.0.1-hc65338a_0.conda) that was built with timestamp 1773744756289 .

This is similar to https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/1177 .

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `recipe/generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` (or `cd recipe && pixi run pre-commit`) and ensured all files pass the linting checks.
* [ ] Ran `python recipe/show_diff.py` (or `cd recipe && pixi run diff`) and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future.
  <!-- Make sure to add a condition `timestamp_le: NOW` so your changes only affect packages built in the past. Replace NOW with the result of one of these:
  - cd recipe && pixi run timestamp
  - python -c "import time; print(f'{time.time():.0f}000')"
  - date +%s000
  - The number displayed on https://currentmillis.com
  -->

<!-- Put any other comments or information here -->
