### PR TITLE
fix: tighten smithy deps for latest conda-build

### DIFF
--- a/recipe/patch_yaml/conda-smithy.yaml
+++ b/recipe/patch_yaml/conda-smithy.yaml
@@ -88,4 +88,4 @@ if:
 then:
   - tighten_depends:
       name: conda-build
-      upper_bound: 26.3.0
+      upper_bound: 26.5.0

--- a/recipe/patch_yaml/conda-smithy.yaml
+++ b/recipe/patch_yaml/conda-smithy.yaml
@@ -80,3 +80,12 @@ then:
   - tighten_depends:
       name: conda
       upper_bound: 26.3.0
+---
+# conda-build 26.5 remove ns_cfg and now breaks smithy
+if:
+  name: conda-smithy
+  version_le: 3.61.2
+then:
+  - tighten_depends:
+      name: conda-build
+      upper_bound: 26.3.0


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `recipe/generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` (or `cd recipe && pixi run pre-commit`) and ensured all files pass the linting checks.
* [x] Ran `python recipe/show_diff.py` (or `cd recipe && pixi run diff`) and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future.
  <!-- Make sure to add a condition `timestamp_le: NOW` so your changes only affect packages built in the past. Replace NOW with the result of one of these:
  - cd recipe && pixi run timestamp
  - python -c "import time; print(f'{time.time():.0f}000')"
  - date +%s000
  - The number displayed on https://currentmillis.com
  -->

<!-- Put any other comments or information here -->

xref: https://github.com/conda-forge/conda-build-feedstock/pull/277