### PR TITLE
Cap setuptools <82 for anaconda-client <1.14.0 (pkg_resources removal)

### DIFF
--- a/recipe/patch_yaml/anaconda-client.yaml
+++ b/recipe/patch_yaml/anaconda-client.yaml
@@ -82,3 +82,20 @@ if:
   timestamp_le: 1741961643000
 then:
   - add_depends: pillow >=8.2
+---
+# anaconda-client < 1.14.0 imports the (now removed) ``pkg_resources`` package at the top
+# of ``binstar_client/__init__.py`` (``from pkg_resources import parse_version as pv``).
+# setuptools 82.0.0 removed the bundled ``pkg_resources``, so these versions raise
+# ``ModuleNotFoundError: No module named 'pkg_resources'`` under setuptools >=82.
+# setuptools 81 still ships ``pkg_resources`` (with a deprecation warning), so <82 is the
+# correct cap. The ``pkg_resources`` import was dropped in 1.14.0, so only the older
+# versions need the cap. This keeps anaconda-client 1.13.x usable (e.g. for the headless
+# login behavior some users rely on, https://github.com/anaconda/anaconda-client/issues/861).
+if:
+  name: anaconda-client
+  version_lt: 1.14.0
+  timestamp_le: 1780139987000
+then:
+  - tighten_depends:
+      name: setuptools
+      upper_bound: "82"


### PR DESCRIPTION
I like to use anaconda-client 1.13 since it allows headless logins, but the lack of constraints make it difficult to install.

Thanks for considering
```
================================================================================
================================================================================
noarch
noarch::anaconda-client-1.6.14-py_0.tar.bz2
noarch::anaconda-client-1.7.1-py_0.tar.bz2
noarch::anaconda-client-1.7.2-py_0.tar.bz2
noarch::anaconda-client-1.7.2-pyhd8ed1ab_1.tar.bz2
noarch::anaconda-client-1.8.0-pyhd8ed1ab_0.tar.bz2
-    "setuptools",
+    "setuptools <82.0a0",
noarch::anaconda-client-1.11.0-pyhd8ed1ab_0.tar.bz2
noarch::anaconda-client-1.11.0-pyhd8ed1ab_1.tar.bz2
noarch::anaconda-client-1.11.1-pyhd8ed1ab_0.conda
noarch::anaconda-client-1.11.1-pyhd8ed1ab_1.conda
noarch::anaconda-client-1.11.2-pyhd8ed1ab_0.conda
noarch::anaconda-client-1.11.2-pyhd8ed1ab_1.conda
noarch::anaconda-client-1.11.3-pyhd8ed1ab_0.conda
noarch::anaconda-client-1.12.0-pyhd8ed1ab_0.conda
noarch::anaconda-client-1.12.0-pyhd8ed1ab_1.conda
noarch::anaconda-client-1.12.1-pyhd8ed1ab_0.conda
noarch::anaconda-client-1.12.1-pyhd8ed1ab_1.conda
noarch::anaconda-client-1.12.2-pyhd8ed1ab_0.conda
noarch::anaconda-client-1.12.3-pyhd8ed1ab_0.conda
noarch::anaconda-client-1.12.3-pyhd8ed1ab_1.conda
noarch::anaconda-client-1.13.0-pyh29332c3_1.conda
noarch::anaconda-client-1.13.0-pyhd8ed1ab_0.conda
noarch::anaconda-client-1.13.1-pyhcf101f3_0.conda
-    "setuptools >=58.0.4",
+    "setuptools >=58.0.4,<82.0.0a0",
```


<details><summary>Claude's draft</summary>

anaconda-client < 1.14.0 imports the now-removed `pkg_resources` package at the top of `binstar_client/__init__.py`
(`from pkg_resources import parse_version as pv`). setuptools 82.0.0 removed the bundled `pkg_resources`, so those versions raise `ModuleNotFoundError: No module named 'pkg_resources'` under setuptools >=82. setuptools 81 still ships `pkg_resources` (with a deprecation warning), so `<82` is the correct cap. The import was dropped in 1.14.0, so only the older versions are patched.

Uses `tighten_depends` so it handles both the bare `setuptools` dep (older builds) and `setuptools >=58.0.4` (1.11.0+), and is a no-op for records with no setuptools dep.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

Resume this Claude session:
```
claude --resume edab0570-9d66-4122-b556-592ff31418b0
```
</details>

Checklist

* [ ] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `recipe/generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` (or `cd recipe && pixi run pre-commit`) and ensured all files pass the linting checks.
* [ ] Ran `python recipe/show_diff.py` (or `cd recipe && pixi run diff`) and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future.
  <!-- Make sure to add a condition `timestamp_le: NOW` so your changes only affect packages built in the past. Replace NOW with the result of one of these:
  - cd recipe && pixi run timestamp
  - python -c "import time; print(f'{time.time():.0f}000')"
  - date +%s000
  - The number displayed on https://currentmillis.com
  -->

<!-- Put any other comments or information here -->
