### PR TITLE
dask-image 2026.5.0 requires tifffile >=2020.10.1

### DIFF
--- a/recipe/patch_yaml/dask-image.yaml
+++ b/recipe/patch_yaml/dask-image.yaml
@@ -1,0 +1,11 @@
+# dask-image 2026.5.0 requires tifffile >=2020.10.1
+# https://github.com/conda-forge/dask-image-feedstock/pull/39
+if:
+  name: dask-image
+  version: "2026.5.0"
+  build_number: 0
+  timestamp_lt: 1780674704000
+then:
+  - replace_depends:
+      old: tifffile >=2018.10.18
+      new: tifffile >=2020.10.1


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `recipe/generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` (or `cd recipe && pixi run pre-commit`) and ensured all files pass the linting checks.
* [x] Ran `python recipe/show_diff.py` (or `cd recipe && pixi run diff`) and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future.
  <!-- Make sure to add a condition `timestamp_le: NOW` so your changes only affect packages built in the past. Replace NOW with the result of one of these:
  - cd recipe && pixi run timestamp
  - python -c "import time; print(f'{time.time():.0f}000')"
  - date +%s000
  - The number displayed on https://currentmillis.com
  -->

<!-- Put any other comments or information here -->

---

cc: @conda-forge/dask-image, @m-albert
xref: https://github.com/conda-forge/dask-image-feedstock/pull/36, https://github.com/conda-forge/dask-image-feedstock/pull/37, https://github.com/conda-forge/dask-image-feedstock/pull/38, https://github.com/conda-forge/dask-image-feedstock/pull/39

```diff
noarch::dask-image-2026.5.0-pyhd8ed1ab_0.conda
-    "tifffile >=2018.10.18"
+    "tifffile >=2020.10.1"
```
