### PR TITLE
Add conflict handling for early builds of tlrc

### DIFF
--- a/recipe/patch_yaml/tlrc.yaml
+++ b/recipe/patch_yaml/tlrc.yaml
@@ -4,6 +4,6 @@ if:
   build_number_lt: 2
 then:
   - add_constrains:
-    - tealdeer <0.0a0
-    - tldr <0.0a0
-    - tldr-c-client <0.0a0
+      - tealdeer <0.0a0
+      - tldr <0.0a0
+      - tldr-c-client <0.0a0

--- a/recipe/patch_yaml/tlrc.yaml
+++ b/recipe/patch_yaml/tlrc.yaml
@@ -1,0 +1,9 @@
+if:
+  name: tlrc
+  version_eq: "1.13.1"
+  build_number_lt: 2
+then:
+  - add_constrains:
+    - tealdeer <0.0a0
+    - tldr <0.0a0
+    - tldr-c-client <0.0a0


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `recipe/generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` (or `cd recipe && pixi run pre-commit`) and ensured all files pass the linting checks.
* [x] Ran `python recipe/show_diff.py` (or `cd recipe && pixi run diff`) and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future.
  <!-- Make sure to add a condition `timestamp_le: NOW` so your changes only affect packages built in the past. Replace NOW with the result of one of these:
  - cd recipe && pixi run timestamp
  - python -c "import time; print(f'{time.time():.0f}000')"
  - date +%s000
  - The number displayed on https://currentmillis.com
  -->

<!-- Put any other comments or information here -->
`tlrc`, `tealdeer`, `tldr`, and `tldr-c-client`all provide a binary that shares the same name: `tldr`, meaning that coexistence of these packages should be avoided. The initial builds of the `tlrc` package don't include the constraint checks in `recipe.yaml`, so I want to add the proper constraint checks for the early builds (version `1.13.1`, the only version in conda-forge, with a build number less than 2).

---

```shell
$ pre-commit run --all-files
flake8...................................................................Passed
ruff (legacy alias)......................................................Passed
black....................................................................Passed
yamllint.................................................................Passed
``` 
---
```shell
$ python show_diff.py
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
osx-arm64
osx-arm64::tlrc-1.13.1-h6fdd925_1.conda
-    "__osx >=11.0"
+    "__osx >=11.0",
+    "tealdeer <0.0a0",
+    "tldr <0.0a0",
+    "tldr-c-client <0.0a0"
================================================================================
================================================================================
linux-aarch64
linux-aarch64::tlrc-1.13.1-h069e38c_1.conda
-    "__glibc >=2.17"
+    "__glibc >=2.17",
+    "tealdeer <0.0a0",
+    "tldr <0.0a0",
+    "tldr-c-client <0.0a0"
================================================================================
================================================================================
noarch
================================================================================
================================================================================
win-64
win-64::tlrc-1.13.1-h18a1a76_0.conda
win-64::tlrc-1.13.1-h18a1a76_1.conda
+  "constrains": [
+    "tealdeer <0.0a0",
+    "tldr <0.0a0",
+    "tldr-c-client <0.0a0"
+  ],
================================================================================
================================================================================
osx-64
osx-64::tlrc-1.13.1-h19f9e61_0.conda
osx-64::tlrc-1.13.1-h19f9e61_1.conda
-    "__osx >=11.0"
+    "__osx >=11.0",
+    "tealdeer <0.0a0",
+    "tldr <0.0a0",
+    "tldr-c-client <0.0a0"
================================================================================
================================================================================
linux-64
linux-64::tlrc-1.13.1-hb17b654_0.conda
linux-64::tlrc-1.13.1-hb17b654_1.conda
-    "__glibc >=2.17"
+    "__glibc >=2.17",
+    "tealdeer <0.0a0",
+    "tldr <0.0a0",
+    "tldr-c-client <0.0a0"
```