### PR TITLE
Update depends of opentelemetry-api version 1.28

### DIFF
--- a/recipe/patch_yaml/opentelemetry-api.yaml
+++ b/recipe/patch_yaml/opentelemetry-api.yaml
@@ -1,0 +1,9 @@
+if:
+  name: opentelemetry-api
+  version_ge: 1.28.0
+  version_lt: 1.29.0
+  timestamp_lt: 1781467777000
+then:
+  - replace_depends:
+      old: importlib-metadata >=6.0.0,<7.1.0
+      new: importlib-metadata >=6.0.0,<8.5.0

--- a/recipe/patch_yaml/opentelemetry-api.yaml
+++ b/recipe/patch_yaml/opentelemetry-api.yaml
@@ -6,4 +6,4 @@ if:
 then:
   - replace_depends:
       old: importlib-metadata >=6.0.0,<7.1.0
-      new: importlib-metadata >=6.0.0,<8.5.0
+      new: importlib-metadata >=6.0.0,<=8.5.0


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `recipe/generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` (or `cd recipe && pixi run pre-commit`) and ensured all files pass the linting checks.
* [x] Ran `python recipe/show_diff.py` (or `cd recipe && pixi run diff`) and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future.
  <!-- Make sure to add a condition `timestamp_le: NOW` so your changes only affect packages built in the past. Replace NOW with the result of one of these:
  - cd recipe && pixi run timestamp
  - python -c "import time; print(f'{time.time():.0f}000')"
  - date +%s000
  - The number displayed on https://currentmillis.com
  -->

<!-- Put any other comments or information here -->

This patch updates the dependencies of `opentelemetry-api` from version `1.28.*` to match the source (https://github.com/open-telemetry/opentelemetry-python/commit/189fa1511383082a1a3d64c6aa790c897c81b87a) It was also fixed in https://github.com/conda-forge/opentelemetry-api-feedstock/pull/63, but only for version `>=1.29.0`.

This will hopefully fix some errors due to exact pinning of `litellm` in https://github.com/conda-forge/notebook_intelligence-feedstock/pull/49, https://github.com/conda-forge/notebook_intelligence-feedstock/pull/50 and https://github.com/conda-forge/notebook_intelligence-feedstock/pull/51

```
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
noarch
noarch::opentelemetry-api-1.28.0-pyhd8ed1ab_0.conda
noarch::opentelemetry-api-1.28.1-pyhd8ed1ab_0.conda
noarch::opentelemetry-api-1.28.2-pyhd8ed1ab_0.conda
noarch::opentelemetry-api-1.28.2-pyhd8ed1ab_1.conda
-    "importlib-metadata >=6.0.0,<7.1.0",
+    "importlib-metadata >=6.0.0,<=8.5.0",
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
================================================================================
================================================================================
linux-64
```