### PR TITLE
Patch pixi-build backends: bump pixi-build-api-version pin to >=5,<6

### DIFF
--- a/recipe/patch_yaml/pixi-build.yaml
+++ b/recipe/patch_yaml/pixi-build.yaml
@@ -1,9 +1,8 @@
-# Fix <dep> requirement for pixi-build backends, v0.1.2 only
-# see <link>
+# Fix pixi-build-api-version requirement for pixi-build backends
 if:
   # Pixi build release window of faulty requirement
-  timestamp_gt: 1781497259000 # 12-june-2026 morning
-  timestamp_lt: 1781540216000 # 12-june-2026 evening
+  timestamp_gt: 1781497259000  # 12-june-2026 morning
+  timestamp_lt: 1781540216000  # 12-june-2026 evening
   name: pixi-build-*
 then:
   - replace_depends:

--- a/recipe/patch_yaml/pixi-build.yaml
+++ b/recipe/patch_yaml/pixi-build.yaml
@@ -1,0 +1,11 @@
+# Fix <dep> requirement for pixi-build backends, v0.1.2 only
+# see <link>
+if:
+  # Pixi build release window of faulty requirement
+  timestamp_gt: 1781497259000 # 12-june-2026 morning
+  timestamp_lt: 1781540216000 # 12-june-2026 evening
+  name: pixi-build-*
+then:
+  - replace_depends:
+      old: pixi-build-api-version >=4,<5
+      new: pixi-build-api-version >=5,<6


### PR DESCRIPTION
The packages released 2026-06-12 pin pixi-build-api-version >=4,<5 but require API v5. Correct the dependency in repodata.

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `recipe/generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` (or `cd recipe && pixi run pre-commit`) and ensured all files pass the linting checks.
* [x] Ran `python recipe/show_diff.py` (or `cd recipe && pixi run diff`) and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future.
  <!-- Make sure to add a condition `timestamp_le: NOW` so your changes only affect packages built in the past. Replace NOW with the result of one of these:
  - cd recipe && pixi run timestamp
  - python -c "import time; print(f'{time.time():.0f}000')"
  - date +%s000
  - The number displayed on https://currentmillis.com
  -->

<!-- Put any other comments or information here -->
Result of the `pixi run diff`:
```
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
osx-arm64
osx-arm64::pixi-build-cmake-0.4.0-h37f8d4f_0.conda
osx-arm64::pixi-build-mojo-0.2.0-h37f8d4f_0.conda
osx-arm64::pixi-build-python-0.6.0-h37f8d4f_0.conda
osx-arm64::pixi-build-rattler-build-0.4.0-h37f8d4f_0.conda
osx-arm64::pixi-build-ros-0.6.0-h37f8d4f_0.conda
osx-arm64::pixi-build-rust-0.5.0-h37f8d4f_0.conda
-    "pixi-build-api-version >=4,<5"
+    "pixi-build-api-version >=5,<6"
================================================================================
================================================================================
linux-aarch64
linux-aarch64::pixi-build-cmake-0.4.0-h50d252f_0.conda
linux-aarch64::pixi-build-mojo-0.2.0-h50d252f_0.conda
linux-aarch64::pixi-build-python-0.6.0-h50d252f_0.conda
linux-aarch64::pixi-build-rattler-build-0.4.0-h50d252f_0.conda
linux-aarch64::pixi-build-ros-0.6.0-h50d252f_0.conda
linux-aarch64::pixi-build-rust-0.5.0-h50d252f_0.conda
-    "pixi-build-api-version >=4,<5"
+    "pixi-build-api-version >=5,<6"
================================================================================
================================================================================
noarch
================================================================================
================================================================================
win-64
win-64::pixi-build-cmake-0.4.0-hc05bbc4_0.conda
win-64::pixi-build-mojo-0.2.0-hc05bbc4_0.conda
win-64::pixi-build-python-0.6.0-hc05bbc4_0.conda
win-64::pixi-build-rattler-build-0.4.0-hc05bbc4_0.conda
win-64::pixi-build-ros-0.6.0-hc05bbc4_0.conda
win-64::pixi-build-rust-0.5.0-hc05bbc4_0.conda
-    "pixi-build-api-version >=4,<5",
+    "pixi-build-api-version >=5,<6",
================================================================================
================================================================================
osx-64
osx-64::pixi-build-cmake-0.4.0-h5b5da5c_0.conda
osx-64::pixi-build-mojo-0.2.0-h5b5da5c_0.conda
osx-64::pixi-build-python-0.6.0-h5b5da5c_0.conda
osx-64::pixi-build-rattler-build-0.4.0-h5b5da5c_0.conda
osx-64::pixi-build-ros-0.6.0-h5b5da5c_0.conda
osx-64::pixi-build-rust-0.5.0-h5b5da5c_0.conda
-    "pixi-build-api-version >=4,<5"
+    "pixi-build-api-version >=5,<6"
================================================================================
================================================================================
linux-64
linux-64::pixi-build-cmake-0.4.0-h67559c6_0.conda
linux-64::pixi-build-mojo-0.2.0-h67559c6_0.conda
linux-64::pixi-build-python-0.6.0-h67559c6_0.conda
linux-64::pixi-build-rattler-build-0.4.0-h67559c6_0.conda
linux-64::pixi-build-ros-0.6.0-h67559c6_0.conda
linux-64::pixi-build-rust-0.5.0-h67559c6_0.conda
-    "pixi-build-api-version >=4,<5"
+    "pixi-build-api-version >=5,<6"

```