### PR TITLE
Patch add opentelemetry-instrumentation-confluent-kafka 

### DIFF
--- a/recipe/patch_yaml/opentelemetry-instrumentation-confluent-kafka.yaml
+++ b/recipe/patch_yaml/opentelemetry-instrumentation-confluent-kafka.yaml
@@ -1,0 +1,31 @@
+if:
+  name: opentelemetry-instrumentation-confluent-kafka
+  version_ge: 0.63b1
+  version_lt: 0.63b2
+  timestamp_lt: 1781549111675
+then:
+  - replace_depends:
+      old: wrapt >=1.0.0,<2.0.0
+      new: wrapt >=1.0.0,<3.0.0
+
+---
+
+if:
+  name: opentelemetry-instrumentation-confluent-kafka
+  version_ge: 0.63b1
+  version_lt: 0.63b2
+  timestamp_lt: 1781549111675
+then:
+  - replace_depends:
+      old: python-confluent-kafka >=1.8.2,<=2.11.0
+      new: python-confluent-kafka >=1.8.2,<3.0.0
+
+---
+
+if:
+  name: opentelemetry-instrumentation-confluent-kafka
+  version_ge: 0.63b1
+  version_lt: 0.63b2
+  timestamp_lt: 1781549111675
+then:
+  - add_depends: opentelemetry-semantic-conventions==0.63b1

--- a/recipe/show_diff.py
+++ b/recipe/show_diff.py
@@ -4,7 +4,7 @@ import difflib
 import json
 import os
 import sys
-import urllib
+import urllib.request
 from concurrent.futures import ProcessPoolExecutor, as_completed
 
 import zstandard

--- a/recipe/show_diff.py
+++ b/recipe/show_diff.py
@@ -4,7 +4,7 @@ import difflib
 import json
 import os
 import sys
-import urllib.request
+import urllib
 from concurrent.futures import ProcessPoolExecutor, as_completed
 
 import zstandard


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `recipe/generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` (or `cd recipe && pixi run pre-commit`) and ensured all files pass the linting checks.
* [x] Ran `python recipe/show_diff.py` (or `cd recipe && pixi run diff`) and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future.
  <!-- Make sure to add a condition `timestamp_le: NOW` so your changes only affect packages built in the past. Replace NOW with the result of one of these:
  - cd recipe && pixi run timestamp
  - python -c "import time; print(f'{time.time():.0f}000')"
  - date +%s000
  - The number displayed on https://currentmillis.com
  -->


Result of `pixi run diff`:

```diff
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
noarch
noarch::opentelemetry-instrumentation-confluent-kafka-0.63b1-pyhcf101f3_0.conda
+    "opentelemetry-semantic-conventions==0.63b1",
-    "python-confluent-kafka >=1.8.2,<=2.11.0",
-    "wrapt >=1.0.0,<2.0.0"
+    "python-confluent-kafka >=1.8.2,<3.0.0",
+    "wrapt >=1.0.0,<3.0.0"
noarch::opentelemetry-instrumentation-confluent-kafka-0.63b1-pyhcf101f3_1.conda
+    "opentelemetry-semantic-conventions==0.63b1",
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
================================================================================
================================================================================
linux-64
```
