### PR TITLE
Fixup `xpublish-tiles` conditional noarch outputs lacking virtual packages

### DIFF
--- a/recipe/patch_yaml/xpublish-tiles.yaml
+++ b/recipe/patch_yaml/xpublish-tiles.yaml
@@ -1,0 +1,17 @@
+if:
+  name: "xpublish-tiles"
+  version: "0.6.0"
+  build: "pyhc364b38_0"
+  build_number: 0
+then:
+  - add_depends: "__win"
+
+---
+
+if:
+  name: "xpublish-tiles"
+  version: "0.6.0"
+  build: "pyh0f90c79_0"
+  build_number: 0
+then:
+  - add_depends: "__osx"


### PR DESCRIPTION
See: <https://github.com/conda-forge/xpublish-tiles-feedstock/issues/1>
Feedstock fix: <https://github.com/conda-forge/xpublish-tiles-feedstock/pull/3>

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `recipe/generate_patch_json.py` if absolutely necessary.
* [x] Ran `prek run -a` and ensured all files pass the linting checks.
* [x] Ran `python recipe/show_diff.py` (or `cd recipe && pixi run diff`) and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future.



```diff
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
noarch
noarch::conda-smithy-2026.6.14-unix_pyh9ac5cc3_0.conda
-{
-  "build": "unix_pyh9ac5cc3_0",
-  "build_number": 0,
-  "constrains": [
-    "conda-recipe-manager >=0.9",
-    "pixi >=0.59.0",
-    "shellcheck"
-  ],
-  "depends": [
-    "__unix",
-    "backports.strenum",
-    "cirun >=0.30",
-    "conda >=22.11.1",
-    "conda-build >=26.3.0",
-    "conda-forge-pinning",
-    "conda-package-handling >=1.9.0",
-    "exceptiongroup",
-    "git",
-    "gitpython",
-    "jinja2",
-    "jsonschema",
-    "libarchive",
-    "license-expression",
-    "py-rattler >=0.22,<0.23",
-    "pycryptodome",
-    "pygit2",
-    "pygithub >=2,<3",
-    "python >=3.11",
-    "rattler-build-conda-compat >=1.4.15,<2.0.0a0",
-    "requests",
-    "ruamel.yaml >=0.16",
-    "scrypt",
-    "setuptools",
-    "tomli >=1.0.0",
-    "toolz",
-    "vsts-python-api"
-  ],
-  "license": "BSD-3-Clause",
-  "md5": "601876c2a338f768784306c60dbf5845",
-  "name": "conda-smithy",
-  "noarch": "python",
-  "sha256": "bd7ccc8aeea227b11512b9fbb3453543f4609c16d49bb1cf44d74860faa41930",
-  "size": 235016,
-  "subdir": "noarch",
-  "timestamp": 1781480685009,
-  "version": "2026.6.14"
-}
+{}
noarch::xpublish-tiles-0.6.0-pyhc364b38_0.conda
+    "__win",
noarch::xpublish-tiles-0.6.0-pyh0f90c79_0.conda
+    "__osx",
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
================================================================================
================================================================================
linux-64
```

I don't know why the conda-smithy diff shows up. It happens on `main` too :shrug: 