### PR TITLE
Patch opentelemetry-instrumentation-asyncio

### DIFF
--- a/recipe/patch_yaml/opentelemetry-instrumentation-asyncio.yaml
+++ b/recipe/patch_yaml/opentelemetry-instrumentation-asyncio.yaml
@@ -1,0 +1,9 @@
+if:
+  name: opentelemetry-instrumentation-asyncio
+  version_ge: 0.63b1
+  version_le: 0.63b1
+  timestamp_lt: 1781962814704
+then:
+  - replace_depends:
+      old: wrapt >=1.0.0,<2.0.0
+      new: wrapt >=1.0.0,<3.0.0

--- a/recipe/show_diff.py
+++ b/recipe/show_diff.py
@@ -4,7 +4,7 @@ import difflib
 import json
 import os
 import sys
-import urllib
+import urllib.request
 from concurrent.futures import ProcessPoolExecutor, as_completed
 
 import zstandard

--- a/recipe/show_diff.py
+++ b/recipe/show_diff.py
@@ -4,7 +4,7 @@ import difflib
 import json
 import os
 import sys
-import urllib.request
+import urllib
 from concurrent.futures import ProcessPoolExecutor, as_completed
 
 import zstandard


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `recipe/generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` (or `cd recipe && pixi run pre-commit`) and ensured all files pass the linting checks.
* [x] Ran `python recipe/show_diff.py` (or `cd recipe && pixi run diff`) and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future.
  <!-- Make sure to add a condition `timestamp_le: NOW` so your changes only affect packages built in the past. Replace NOW with the result of one of these:
  - cd recipe && pixi run timestamp
  - python -c "import time; print(f'{time.time():.0f}000')"
  - date +%s000
  - The number displayed on https://currentmillis.com
  -->

<!-- Put any other comments or information here -->

Results of `pixi run diff`:
```diff
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
linux-ppc64le
linux-ppc64le::topgrade-17.6.2-h68eb3f0_0.conda
-{
-  "build": "h68eb3f0_0",
-  "build_number": 0,
-  "constrains": [
-    "__glibc >=2.17"
-  ],
-  "depends": [
-    "libgcc >=14"
-  ],
-  "license": "GPL-3.0-or-later",
-  "md5": "8f9a4644c0a011ba7d8e1010994711f8",
-  "name": "topgrade",
-  "sha256": "eb8acb51e2c143698f111c90a5afb16883b330cf6629c1e16199aabffacc2c25",
-  "size": 3088505,
-  "subdir": "linux-ppc64le",
-  "timestamp": 1781962127788,
-  "version": "17.6.2"
-}
+{}
linux-ppc64le::html-to-markdown-cli-3.6.18-h68eb3f0_0.conda
-{
-  "build": "h68eb3f0_0",
-  "build_number": 0,
-  "constrains": [
-    "__glibc >=2.17"
-  ],
-  "depends": [
-    "libgcc >=14"
-  ],
-  "license": "MIT",
-  "md5": "0c5f6171b5700c697b59beb1db3558ee",
-  "name": "html-to-markdown-cli",
-  "sha256": "31356e5e316f7e8e1951f93c919aff9920fe31e32453cfa0f42c8fb4214064cc",
-  "size": 3554526,
-  "subdir": "linux-ppc64le",
-  "timestamp": 1781960225642,
-  "version": "3.6.18"
-}
+{}
================================================================================
================================================================================
noarch
noarch::opentelemetry-instrumentation-asyncio-0.63b1-pyhcf101f3_0.conda
-    "wrapt >=1.0.0,<2.0.0"
+    "wrapt >=1.0.0,<3.0.0"
noarch::esda-2.10.0-pyhd8ed1ab_0.conda
-{
-  "build": "pyhd8ed1ab_0",
-  "build_number": 0,
-  "depends": [
-    "geopandas >=1.0",
-    "libpysal >=4.12",
-    "numpy >=2.1",
-    "pandas >=2.3",
-    "python >=3.12",
-    "scikit-learn >=1.6",
-    "scipy >=1.14",
-    "shapely >=2.1"
-  ],
-  "license": "BSD-3-Clause",
-  "md5": "59111dca5d29a637204b6c764964d900",
-  "name": "esda",
-  "noarch": "python",
-  "sha256": "0cd1c787e84b06b2a0b7f1fefa3949884dd52649c7068538ea339ecec4be4bd1",
-  "size": 210213,
-  "subdir": "noarch",
-  "timestamp": 1781962450754,
-  "version": "2.10.0"
-}
+{}
noarch::topologicpy-0.9.50-pyhcf101f3_0.conda
-{
-  "build": "pyhcf101f3_0",
-  "build_number": 0,
-  "depends": [
-    "numpy",
-    "numpy >=1.18.0",
-    "pandas",
-    "python",
-    "python >=3.10",
-    "scikit-learn",
-    "scipy >=1.4.1",
-    "topologic-core >=7.0.1",
-    "tqdm"
-  ],
-  "license": "AGPL-3.0-or-later",
-  "md5": "7300c847c3b20f8277783805eda33445",
-  "name": "topologicpy",
-  "noarch": "python",
-  "sha256": "28b58cc1ba74f0cd32b8ca1c506ef53c49a7548e8b9ab6d58981afd119b17f61",
-  "size": 753443,
-  "subdir": "noarch",
-  "timestamp": 1781963337142,
-  "version": "0.9.50"
-}
+{}
================================================================================
================================================================================
osx-arm64
osx-arm64::topgrade-17.6.2-h6fdd925_0.conda
-{
-  "build": "h6fdd925_0",
-  "build_number": 0,
-  "constrains": [
-    "__osx >=11.0"
-  ],
-  "depends": [
-    "__osx >=11.0"
-  ],
-  "license": "GPL-3.0-or-later",
-  "md5": "a3ea82db880b5c137c09cd48e81fec81",
-  "name": "topgrade",
-  "sha256": "923f7b193f0d4bb5caaf1ecb2057dcdf703f8c7b41390aa1867d777990314ca4",
-  "size": 2060715,
-  "subdir": "osx-arm64",
-  "timestamp": 1781962183001,
-  "version": "17.6.2"
-}
+{}
osx-arm64::suvadu-0.3.3-h6fdd925_0.conda
-{
-  "build": "h6fdd925_0",
-  "build_number": 0,
-  "constrains": [
-    "__osx >=11.0"
-  ],
-  "depends": [
-    "__osx >=11.0"
-  ],
-  "license": "MIT",
-  "md5": "1c98b297cb081f54d387fc6b0377a63d",
-  "name": "suvadu",
-  "sha256": "4b6c75a7077b666346c343aae707f1bb2bba8d6cd0700c65e38d695759b57a29",
-  "size": 2658142,
-  "subdir": "osx-arm64",
-  "timestamp": 1781961765790,
-  "version": "0.3.3"
-}
+{}
================================================================================
================================================================================
linux-aarch64
linux-aarch64::suvadu-0.3.3-h069e38c_0.conda
-{
-  "build": "h069e38c_0",
-  "build_number": 0,
-  "constrains": [
-    "__glibc >=2.17"
-  ],
-  "depends": [
-    "libgcc >=14"
-  ],
-  "license": "MIT",
-  "md5": "d6219b98341563bf9e1f89d719059591",
-  "name": "suvadu",
-  "sha256": "9d6f80cdf086653710b294fd5d0f8013d2e02c20a9ccaa2defee9dde427c8163",
-  "size": 3062081,
-  "subdir": "linux-aarch64",
-  "timestamp": 1781961769324,
-  "version": "0.3.3"
-}
+{}
linux-aarch64::topgrade-17.6.2-h069e38c_0.conda
-{
-  "build": "h069e38c_0",
-  "build_number": 0,
-  "constrains": [
-    "__glibc >=2.17"
-  ],
-  "depends": [
-    "libgcc >=14"
-  ],
-  "license": "GPL-3.0-or-later",
-  "md5": "58af7adb56c569277b4bf2f61d680cac",
-  "name": "topgrade",
-  "sha256": "8e4a74490ad719b8be1c1ead5457add2169e1535b62b0231fd8135271dcd69d2",
-  "size": 2877821,
-  "subdir": "linux-aarch64",
-  "timestamp": 1781962128623,
-  "version": "17.6.2"
-}
+{}
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
osx-64::mlpack-4.8.0-py314h36141c5_0.conda
-{
-  "build": "py314h36141c5_0",
-  "build_number": 0,
-  "depends": [
-    "__osx >=11.0",
-    "armadillo >=14.6,<15.0a0",
-    "armadillo >=9.800.0",
-    "ensmallen >=2.10.0",
-    "libblas >=3.9.0,<4.0a0",
-    "libcblas >=3.9.0,<4.0a0",
-    "libcxx >=19",
-    "numpy >=1.23,<3",
-    "openblas",
-    "pandas >=0.15.0",
-    "python >=3.14,<3.15.0a0",
-    "python_abi 3.14.* *_cp314"
-  ],
-  "license": "BSD-3-Clause",
-  "md5": "c2129ec130bf5a289cfe9a2ca4e79504",
-  "name": "mlpack",
-  "sha256": "17e3c5801db238d7970f28e6c2de73560719d721d9894093acea6c6a2325c610",
-  "size": 32928328,
-  "subdir": "osx-64",
-  "timestamp": 1781962120146,
-  "version": "4.8.0"
-}
+{}
osx-64::gm2calc-python-2.3.1-h8dc4d84_1.conda
-{
-  "build": "h8dc4d84_1",
-  "build_number": 1,
-  "depends": [
-    "gm2calc ==2.3.1 h82dfdb9_1",
-    "python >=3.10"
-  ],
-  "license": "GPL-3.0-or-later",
-  "md5": "d3bad2db7b6bbfc7dbe39e1a958744ff",
-  "name": "gm2calc-python",
-  "noarch": "python",
-  "sha256": "806216020fea6f9a4e565668ab800ec14b821c9a1311b0c6f9a58d38c1213414",
-  "size": 32497,
-  "subdir": "osx-64",
-  "timestamp": 1781962591419,
-  "version": "2.3.1"
-}
+{}
osx-64::mlpack-4.8.0-py312ha0be76e_0.conda
-{
-  "build": "py312ha0be76e_0",
-  "build_number": 0,
-  "depends": [
-    "__osx >=11.0",
-    "armadillo >=14.6,<15.0a0",
-    "armadillo >=9.800.0",
-    "ensmallen >=2.10.0",
-    "libblas >=3.9.0,<4.0a0",
-    "libcblas >=3.9.0,<4.0a0",
-    "libcxx >=19",
-    "numpy >=1.23,<3",
-    "openblas",
-    "pandas >=0.15.0",
-    "python >=3.12,<3.13.0a0",
-    "python_abi 3.12.* *_cp312"
-  ],
-  "license": "BSD-3-Clause",
-  "md5": "6c2cd2034a7b99aa9abb18de0b9613d8",
-  "name": "mlpack",
-  "sha256": "362c6c0a9e202e42179c93138fbb20b2315686af040ced336a3ce2d030202e9e",
-  "size": 33566005,
-  "subdir": "osx-64",
-  "timestamp": 1781961772491,
-  "version": "4.8.0"
-}
+{}
osx-64::mlpack-4.8.0-py310h301658e_0.conda
-{
-  "build": "py310h301658e_0",
-  "build_number": 0,
-  "depends": [
-    "__osx >=11.0",
-    "armadillo >=14.6,<15.0a0",
-    "armadillo >=9.800.0",
-    "ensmallen >=2.10.0",
-    "libblas >=3.9.0,<4.0a0",
-    "libcblas >=3.9.0,<4.0a0",
-    "libcxx >=19",
-    "numpy >=1.21,<3",
-    "openblas",
-    "pandas >=0.15.0",
-    "python >=3.10,<3.11.0a0",
-    "python_abi 3.10.* *_cp310"
-  ],
-  "license": "BSD-3-Clause",
-  "md5": "ae498555ffd1edebbf761158203c6dd6",
-  "name": "mlpack",
-  "sha256": "8ed3837aeddf7830e98e0f8fdfc20c5b80ed261c1950db8f280f7b2f4f53a551",
-  "size": 34087018,
-  "subdir": "osx-64",
-  "timestamp": 1781962520792,
-  "version": "4.8.0"
-}
+{}
osx-64::suvadu-0.3.3-h19f9e61_0.conda
-{
-  "build": "h19f9e61_0",
-  "build_number": 0,
-  "constrains": [
-    "__osx >=11.0"
-  ],
-  "depends": [
-    "__osx >=11.0"
-  ],
-  "license": "MIT",
-  "md5": "cdfdd1019b124923c4792b79b0b057ef",
-  "name": "suvadu",
-  "sha256": "47897d3f08f4106768acc262e633789908e8beaa92d4faad7e67f8daad0fd245",
-  "size": 2886729,
-  "subdir": "osx-64",
-  "timestamp": 1781961812229,
-  "version": "0.3.3"
-}
+{}
osx-64::mlpack-4.8.0-py311hbe9b769_0.conda
-{
-  "build": "py311hbe9b769_0",
-  "build_number": 0,
-  "depends": [
-    "__osx >=11.0",
-    "armadillo >=14.6,<15.0a0",
-    "armadillo >=9.800.0",
-    "ensmallen >=2.10.0",
-    "libblas >=3.9.0,<4.0a0",
-    "libcblas >=3.9.0,<4.0a0",
-    "libcxx >=19",
-    "numpy >=1.23,<3",
-    "openblas",
-    "pandas >=0.15.0",
-    "python >=3.11,<3.12.0a0",
-    "python_abi 3.11.* *_cp311"
-  ],
-  "license": "BSD-3-Clause",
-  "md5": "c0825f1cb90b6d233bde09a936a05aa8",
-  "name": "mlpack",
-  "sha256": "9307007f406b12a262808e3eeb26c40ecf3dbcf6402cfc920a67d30edacb8402",
-  "size": 34137648,
-  "subdir": "osx-64",
-  "timestamp": 1781962131465,
-  "version": "4.8.0"
-}
+{}
osx-64::gm2calc-2.3.1-h82dfdb9_1.conda
-{
-  "build": "h82dfdb9_1",
-  "build_number": 1,
-  "depends": [
-    "__osx >=11.0",
-    "eigen-abi >=3.4.0.100,<3.4.0.101.0a0",
-    "libcxx >=19"
-  ],
-  "license": "GPL-3.0-or-later",
-  "md5": "55260a8969b01b5bff552bd2a8c41315",
-  "name": "gm2calc",
-  "sha256": "f284968251f80640a32be272852ac313e40e252c1366c833eb8713ac8badff07",
-  "size": 315590,
-  "subdir": "osx-64",
-  "timestamp": 1781962591419,
-  "version": "2.3.1"
-}
+{}
osx-64::topgrade-17.6.2-h19f9e61_0.conda
-{
-  "build": "h19f9e61_0",
-  "build_number": 0,
-  "constrains": [
-    "__osx >=11.0"
-  ],
-  "depends": [
-    "__osx >=11.0"
-  ],
-  "license": "GPL-3.0-or-later",
-  "md5": "92c6524d5c24f49b7741d83b6e6cd0f6",
-  "name": "topgrade",
-  "sha256": "2d9fdd5a9dc97e53c1abf511f4ce25bedb336d38531951564fbf48908b7ba79b",
-  "size": 2231531,
-  "subdir": "osx-64",
-  "timestamp": 1781962184059,
-  "version": "17.6.2"
-}
+{}
================================================================================
================================================================================
linux-64
linux-64::gm2calc-2.3.1-hd14c19a_1.conda
-{
-  "build": "hd14c19a_1",
-  "build_number": 1,
-  "depends": [
-    "__glibc >=2.17,<3.0.a0",
-    "eigen-abi >=3.4.0.100,<3.4.0.101.0a0",
-    "libgcc >=14",
-    "libstdcxx >=14"
-  ],
-  "license": "GPL-3.0-or-later",
-  "md5": "6a2e4363b3ce63b89ce0548432199a23",
-  "name": "gm2calc",
-  "sha256": "9102044e4b88b80420577453a32907d877b4ad3fe2cc931ccc39de7f86a1243a",
-  "size": 307865,
-  "subdir": "linux-64",
-  "timestamp": 1781962450244,
-  "version": "2.3.1"
-}
+{}
linux-64::mlpack-4.8.0-py312h66fde6b_0.conda
-{
-  "build": "py312h66fde6b_0",
-  "build_number": 0,
-  "depends": [
-    "__glibc >=2.17,<3.0.a0",
-    "armadillo >=14.6,<15.0a0",
-    "armadillo >=9.800.0",
-    "ensmallen >=2.10.0",
-    "libblas >=3.9.0,<4.0a0",
-    "libcblas >=3.9.0,<4.0a0",
-    "libgcc >=14",
-    "libstdcxx >=14",
-    "numpy >=1.23,<3",
-    "openblas",
-    "pandas >=0.15.0",
-    "python >=3.12,<3.13.0a0",
-    "python_abi 3.12.* *_cp312"
-  ],
-  "license": "BSD-3-Clause",
-  "md5": "72db9b98f0e27045667c241b5f3d5085",
-  "name": "mlpack",
-  "sha256": "5f9f02d40db74c1c71b497eaf2f8e4c5f52dd1f4a0e2acb3f29c79462de77dfe",
-  "size": 25504516,
-  "subdir": "linux-64",
-  "timestamp": 1781961885008,
-  "version": "4.8.0"
-}
+{}
linux-64::mlpack-4.8.0-py313h2a15ae9_0.conda
-{
-  "build": "py313h2a15ae9_0",
-  "build_number": 0,
-  "depends": [
-    "__glibc >=2.17,<3.0.a0",
-    "armadillo >=14.6,<15.0a0",
-    "armadillo >=9.800.0",
-    "ensmallen >=2.10.0",
-    "libblas >=3.9.0,<4.0a0",
-    "libcblas >=3.9.0,<4.0a0",
-    "libgcc >=14",
-    "libstdcxx >=14",
-    "numpy >=1.23,<3",
-    "openblas",
-    "pandas >=0.15.0",
-    "python >=3.13,<3.14.0a0",
-    "python_abi 3.13.* *_cp313"
-  ],
-  "license": "BSD-3-Clause",
-  "md5": "bccd7fdad22f3041e6d0ed6ca907f185",
-  "name": "mlpack",
-  "sha256": "5442ad4bb42e7d6c0caaacbc38e12b1f6883f59061423724c9906dd1bb71f4d5",
-  "size": 25910419,
-  "subdir": "linux-64",
-  "timestamp": 1781962065822,
-  "version": "4.8.0"
-}
+{}
linux-64::mlpack-4.8.0-py311hce90c42_0.conda
-{
-  "build": "py311hce90c42_0",
-  "build_number": 0,
-  "depends": [
-    "__glibc >=2.17,<3.0.a0",
-    "armadillo >=14.6,<15.0a0",
-    "armadillo >=9.800.0",
-    "ensmallen >=2.10.0",
-    "libblas >=3.9.0,<4.0a0",
-    "libcblas >=3.9.0,<4.0a0",
-    "libgcc >=14",
-    "libstdcxx >=14",
-    "numpy >=1.23,<3",
-    "openblas",
-    "pandas >=0.15.0",
-    "python >=3.11,<3.12.0a0",
-    "python_abi 3.11.* *_cp311"
-  ],
-  "license": "BSD-3-Clause",
-  "md5": "cf24c0239a3061ce47d26ca18aa88760",
-  "name": "mlpack",
-  "sha256": "38f59d8407ef6ff83fba583b2e62e8cd4e4ea7f0894112a2568712bb5083033e",
-  "size": 24977867,
-  "subdir": "linux-64",
-  "timestamp": 1781961880342,
-  "version": "4.8.0"
-}
+{}
linux-64::suvadu-0.3.3-hb17b654_0.conda
-{
-  "build": "hb17b654_0",
-  "build_number": 0,
-  "constrains": [
-    "__glibc >=2.17"
-  ],
-  "depends": [
-    "__glibc >=2.17,<3.0.a0",
-    "libgcc >=14"
-  ],
-  "license": "MIT",
-  "md5": "3b81ac9804b963b6154fc1d6a2fc27e2",
-  "name": "suvadu",
-  "sha256": "4f12ee631ec1dcd900995e988fef4baa7d006536b0ff3b1db15982476c8a9a12",
-  "size": 2916830,
-  "subdir": "linux-64",
-  "timestamp": 1781961751588,
-  "version": "0.3.3"
-}
+{}
linux-64::gm2calc-python-2.3.1-h37fc64b_1.conda
-{
-  "build": "h37fc64b_1",
-  "build_number": 1,
-  "depends": [
-    "gm2calc ==2.3.1 hd14c19a_1",
-    "python >=3.10"
-  ],
-  "license": "GPL-3.0-or-later",
-  "md5": "d574a1cfbab05f3f4681f7a4401aec01",
-  "name": "gm2calc-python",
-  "noarch": "python",
-  "sha256": "e0f892f95fe6be382be8a54a2e6a99ad028e27c52cd93b81c9e75e46ddb46405",
-  "size": 33689,
-  "subdir": "linux-64",
-  "timestamp": 1781962450244,
-  "version": "2.3.1"
-}
+{}
linux-64::mlpack-4.8.0-py310hfcff3fa_0.conda
-{
-  "build": "py310hfcff3fa_0",
-  "build_number": 0,
-  "depends": [
-    "__glibc >=2.17,<3.0.a0",
-    "armadillo >=14.6,<15.0a0",
-    "armadillo >=9.800.0",
-    "ensmallen >=2.10.0",
-    "libblas >=3.9.0,<4.0a0",
-    "libcblas >=3.9.0,<4.0a0",
-    "libgcc >=14",
-    "libstdcxx >=14",
-    "numpy >=1.21,<3",
-    "openblas",
-    "pandas >=0.15.0",
-    "python >=3.10,<3.11.0a0",
-    "python_abi 3.10.* *_cp310"
-  ],
-  "license": "BSD-3-Clause",
-  "md5": "45f31725f767d688d2cc877931d74ef1",
-  "name": "mlpack",
-  "sha256": "761bcd3b15611d6070cb37806d670bd0058f1d88e334d6d950fdb46174e5b1af",
-  "size": 25175083,
-  "subdir": "linux-64",
-  "timestamp": 1781962128822,
-  "version": "4.8.0"
-}
+{}
linux-64::topgrade-17.6.2-hb17b654_0.conda
-{
-  "build": "hb17b654_0",
-  "build_number": 0,
-  "constrains": [
-    "__glibc >=2.17"
-  ],
-  "depends": [
-    "__glibc >=2.17,<3.0.a0",
-    "libgcc >=14"
-  ],
-  "license": "GPL-3.0-or-later",
-  "md5": "526de2649e38a354c4be4a4e23ca2c4d",
-  "name": "topgrade",
-  "sha256": "56cdc10c2489d566b0b067c481637936dd9f2a91183d4c4cadce5e6074c60748",
-  "size": 3048257,
-  "subdir": "linux-64",
-  "timestamp": 1781962115277,
-  "version": "17.6.2"
-}
+{}
linux-64::mlpack-4.8.0-py314h4443dce_0.conda
-{
-  "build": "py314h4443dce_0",
-  "build_number": 0,
-  "depends": [
-    "__glibc >=2.17,<3.0.a0",
-    "armadillo >=14.6,<15.0a0",
-    "armadillo >=9.800.0",
-    "ensmallen >=2.10.0",
-    "libblas >=3.9.0,<4.0a0",
-    "libcblas >=3.9.0,<4.0a0",
-    "libgcc >=14",
-    "libstdcxx >=14",
-    "numpy >=1.23,<3",
-    "openblas",
-    "pandas >=0.15.0",
-    "python >=3.14,<3.15.0a0",
-    "python_abi 3.14.* *_cp314"
-  ],
-  "license": "BSD-3-Clause",
-  "md5": "3d1759103d3bcbb2ad67e5ff318e9f8c",
-  "name": "mlpack",
-  "sha256": "92c18de4a914dd97eb66f8cb23446f6b889bdf91bf3db3eec164bd0248a290fa",
-  "size": 25657759,
-  "subdir": "linux-64",
-  "timestamp": 1781961806849,
-  "version": "4.8.0"
-}
+{}
```
