### PR TITLE
pin numpy <2 for older regionmask versions

### DIFF
--- a/recipe/patch_yaml/regionmask.yaml
+++ b/recipe/patch_yaml/regionmask.yaml
@@ -1,0 +1,9 @@
+if:
+  name: regionmask
+  version_lt: 0.11.0
+  timestamp_lt: 1782213013000 # 2026.06.23
+
+then:
+  - tighten_depends:
+      name: numpy
+      upper_bound: 2.0

--- a/recipe/patch_yaml/regionmask.yaml
+++ b/recipe/patch_yaml/regionmask.yaml
@@ -1,7 +1,7 @@
 if:
   name: regionmask
   version_lt: 0.11.0
-  timestamp_lt: 1782213013000 # 2026.06.23
+  timestamp_lt: 1782213013000  # 2026.06.23
 
 then:
   - tighten_depends:

--- a/recipe/patch_yaml/regionmask.yaml
+++ b/recipe/patch_yaml/regionmask.yaml
@@ -6,4 +6,4 @@ if:
 then:
   - tighten_depends:
       name: numpy
-      upper_bound: 2.0
+      upper_bound: "2.0"


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `recipe/generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` (or `cd recipe && pixi run pre-commit`) and ensured all files pass the linting checks.
* [x] Ran `python recipe/show_diff.py` (or `cd recipe && pixi run diff`) and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future.
  <!-- Make sure to add a condition `timestamp_le: NOW` so your changes only affect packages built in the past. Replace NOW with the result of one of these:
  - cd recipe && pixi run timestamp
  - python -c "import time; print(f'{time.time():.0f}000')"
  - date +%s000
  - The number displayed on https://currentmillis.com
  -->

<!-- Put any other comments or information here -->

regionmask 0.11.0 is the first that supports numpy 2. I got a report that this missing constraint lead to a failed solve. I am not convinced this was the actual culprit in the solve so low priority whether this gets merged for me.



```diff
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
noarch
noarch::regionmask-0.4.0-py_0.tar.bz2
noarch::regionmask-0.5.0-py_0.tar.bz2
noarch::regionmask-0.5.0-py_1.tar.bz2
noarch::regionmask-0.6.0-py_0.tar.bz2
noarch::regionmask-0.6.1-py_0.tar.bz2
noarch::regionmask-0.6.1-py_1.tar.bz2
noarch::regionmask-0.6.2-pyhd8ed1ab_0.tar.bz2
-    "numpy",
+    "numpy <2.0a0",
noarch::regionmask-0.10.0-pyhd8ed1ab_0.conda
noarch::regionmask-0.7.0-pyhd8ed1ab_0.tar.bz2
noarch::regionmask-0.8.0-pyhd8ed1ab_0.tar.bz2
noarch::regionmask-0.8.0-pyhd8ed1ab_1.tar.bz2
noarch::regionmask-0.9.0-pyhd8ed1ab_0.tar.bz2
-    "numpy >=1.17",
+    "numpy >=1.17,<2.0a0",
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
================================================================================
================================================================================
linux-64
```

