### PR TITLE
NEW: Remove liblib typo from libnvfatbin-dev run_constrains

### DIFF
--- a/recipe/patch_yaml/libnvfatbin.yaml
+++ b/recipe/patch_yaml/libnvfatbin.yaml
@@ -1,0 +1,11 @@
+# libnvfatbin-dev's run_constrained has a typo: "liblibnvfatbin-static" should
+# be "libnvfatbin-static" (extra "lib" prefix). Present in every build since
+# the feedstock's first commit.
+# See https://github.com/conda-forge/libnvfatbin-feedstock/issues/27
+if:
+  name: libnvfatbin-dev
+  timestamp_lt: 1782857295000
+then:
+  - rename_constrains:
+      old: liblibnvfatbin-static
+      new: libnvfatbin-static


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `recipe/generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` (or `cd recipe && pixi run pre-commit`) and ensured all files pass the linting checks.
* [x] Ran `python recipe/show_diff.py` (or `cd recipe && pixi run diff`) and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future.
  <!-- Make sure to add a condition `timestamp_le: NOW` so your changes only affect packages built in the past. Replace NOW with the result of one of these:
  - cd recipe && pixi run timestamp
  - python -c "import time; print(f'{time.time():.0f}000')"
  - date +%s000
  - The number displayed on https://currentmillis.com
  -->

<!-- Put any other comments or information here -->
Related to https://github.com/conda-forge/libnvfatbin-feedstock/issues/27