### PR TITLE
Tighten runtime pin for libjxl

### DIFF
--- a/recipe/patch_yaml/libjxl.yaml
+++ b/recipe/patch_yaml/libjxl.yaml
@@ -1,10 +1,7 @@
-# libjxl ABI is not stable across minor (0.x) releases; tighten its
-# consumers to a minor-version pin ('x.x').
-# See: https://github.com/conda-forge/libjxl-split-feedstock/issues/52
+# https://github.com/conda-forge/libjxl-split-feedstock/issues/52
 if:
-  # has_depends: libjxl >=*
   has_depends: libjxl?( *)
-  timestamp_lt: 1783089386000
+  timestamp_lt: 1783167774000
 then:
   - tighten_depends:
       name: libjxl

--- a/recipe/patch_yaml/libjxl.yaml
+++ b/recipe/patch_yaml/libjxl.yaml
@@ -1,0 +1,11 @@
+# libjxl ABI is not stable across minor (0.x) releases; tighten its
+# consumers to a minor-version pin ('x.x').
+# See: https://github.com/conda-forge/libjxl-split-feedstock/issues/52
+if:
+  # has_depends: libjxl >=*
+  has_depends: libjxl?( *)
+  timestamp_lt: 1783089386000
+then:
+  - tighten_depends:
+      name: libjxl
+      max_pin: 'x.x'


### PR DESCRIPTION
https://github.com/conda-forge/libjxl-split-feedstock/issues/52

Checklist

* [ ] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `recipe/generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` (or `cd recipe && pixi run pre-commit`) and ensured all files pass the linting checks.
* [ ] Ran `python recipe/show_diff.py` (or `cd recipe && pixi run diff`) and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future.
  <!-- Make sure to add a condition `timestamp_le: NOW` so your changes only affect packages built in the past. Replace NOW with the result of one of these:
  - cd recipe && pixi run timestamp
  - python -c "import time; print(f'{time.time():.0f}000')"
  - date +%s000
  - The number displayed on https://currentmillis.com
  -->

<!-- Put any other comments or information here -->
