### PR TITLE
mdtraj: Pin numpy<2.5

### DIFF
--- a/recipe/patch_yaml/mdtraj.yaml
+++ b/recipe/patch_yaml/mdtraj.yaml
@@ -37,3 +37,20 @@ then:
   - tighten_depends:
       name: pandas
       upper_bound: "3"
+
+---
+
+
+# Numpy >=2.5 had broken a number of mdtraj's functionalities.
+# This will pin all versions with a numpy dependency to
+# numpy <2.5 until we can do something about it in the future.
+# This includes mdtraj v1.11.1 (build 1) and below.
+if:
+  name: mdtraj
+  version_le: 1.11.1
+  has_depends: numpy >=1.25.0
+  timestamp_lt: 1783383120000  # 2026-07-06
+then:
+  - tighten_depends:
+      name: numpy
+      upper_bound: "2.5"

--- a/recipe/patch_yaml/mdtraj.yaml
+++ b/recipe/patch_yaml/mdtraj.yaml
@@ -48,7 +48,7 @@ then:
 if:
   name: mdtraj
   version_le: 1.11.1
-  has_depends: numpy >=1.25.0
+  has_depends: numpy*
   timestamp_lt: 1783383120000  # 2026-07-06
 then:
   - tighten_depends:


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `recipe/generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` (or `cd recipe && pixi run pre-commit`) and ensured all files pass the linting checks.
* [x] Ran `python recipe/show_diff.py` (or `cd recipe && pixi run diff`) and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future.
  <!-- Make sure to add a condition `timestamp_le: NOW` so your changes only affect packages built in the past. Replace NOW with the result of one of these:
  - cd recipe && pixi run timestamp
  - python -c "import time; print(f'{time.time():.0f}000')"
  - date +%s000
  - The number displayed on https://currentmillis.com
  -->

<!-- Put any other comments or information here -->
We're updating all future builds, but would also like to make sure our older versions won't break due to the numpy 2.5 release.

Context: https://github.com/conda-forge/mdtraj-feedstock/pull/86 and https://github.com/mdtraj/mdtraj/issues/2166


<details>
<summary> pixi run diff output </summary>

```
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
win-32::mdtraj-1.8.0-py27_2.tar.bz2
win-32::mdtraj-1.9.1-py27_0.tar.bz2
win-32::mdtraj-1.9.1-py27_1.tar.bz2
-    "numpy >=1.8",
+    "numpy >=1.8,<2.5.0a0",
win-32::mdtraj-1.8.0-py35_2.tar.bz2
win-32::mdtraj-1.9.1-py35_0.tar.bz2
win-32::mdtraj-1.9.1-py35_1.tar.bz2
-    "numpy >=1.9",
+    "numpy >=1.9,<2.5.0a0",
win-32::mdtraj-1.8.0-py36_2.tar.bz2
win-32::mdtraj-1.9.1-py36_0.tar.bz2
win-32::mdtraj-1.9.1-py36_1.tar.bz2
-    "numpy >=1.11",
+    "numpy >=1.11,<2.5.0a0",
================================================================================
================================================================================
linux-ppc64le
linux-ppc64le::mdtraj-1.11.0-np2py311hf579c0a_2.conda
linux-ppc64le::mdtraj-1.11.0-np2py311hf579c0a_3.conda
linux-ppc64le::mdtraj-1.11.0-np2py312he11eaab_2.conda
linux-ppc64le::mdtraj-1.11.0-np2py312he11eaab_3.conda
linux-ppc64le::mdtraj-1.11.0-np2py313hbda2c3e_2.conda
linux-ppc64le::mdtraj-1.11.0-np2py313hbda2c3e_3.conda
linux-ppc64le::mdtraj-1.11.0-np2py314h1bbedb8_3.conda
linux-ppc64le::mdtraj-1.11.0-py311h34f02a4_1.conda
linux-ppc64le::mdtraj-1.11.0-py312hd014a07_1.conda
linux-ppc64le::mdtraj-1.11.0-py313h116698c_1.conda
linux-ppc64le::mdtraj-1.11.1-np2py311hf579c0a_0.conda
linux-ppc64le::mdtraj-1.11.1-np2py311hf579c0a_1.conda
linux-ppc64le::mdtraj-1.11.1-np2py312he11eaab_0.conda
linux-ppc64le::mdtraj-1.11.1-np2py312he11eaab_1.conda
linux-ppc64le::mdtraj-1.11.1-np2py313hbda2c3e_0.conda
linux-ppc64le::mdtraj-1.11.1-np2py313hbda2c3e_1.conda
linux-ppc64le::mdtraj-1.11.1-np2py314h6c29f80_0.conda
linux-ppc64le::mdtraj-1.11.1-np2py314h6c29f80_1.conda
-    "numpy >=1.25.0",
+    "numpy >=1.25.0,<2.5.0a0",
================================================================================
================================================================================
osx-arm64
osx-arm64::mdtraj-1.10.2-py310hd1fc892_0.conda
osx-arm64::mdtraj-1.10.2-py311he9eb210_0.conda
osx-arm64::mdtraj-1.10.2-py312had578a9_0.conda
osx-arm64::mdtraj-1.10.2-py313h324e7bb_0.conda
osx-arm64::mdtraj-1.10.2-py39he24f47d_0.conda
osx-arm64::mdtraj-1.10.3-py310hd1fc892_0.conda
osx-arm64::mdtraj-1.10.3-py311he9eb210_0.conda
osx-arm64::mdtraj-1.10.3-py312had578a9_0.conda
osx-arm64::mdtraj-1.10.3-py313h324e7bb_0.conda
osx-arm64::mdtraj-1.10.3-py39he24f47d_0.conda
osx-arm64::mdtraj-1.11.0-np2py311h90b3458_3.conda
osx-arm64::mdtraj-1.11.0-np2py311hb29cc20_2.conda
osx-arm64::mdtraj-1.11.0-np2py312hcf25f10_3.conda
osx-arm64::mdtraj-1.11.0-np2py312hd33a0d6_2.conda
osx-arm64::mdtraj-1.11.0-np2py313h2278ae6_3.conda
osx-arm64::mdtraj-1.11.0-np2py313h7466d2a_2.conda
osx-arm64::mdtraj-1.11.0-np2py314had24cd2_3.conda
osx-arm64::mdtraj-1.11.0-py311h747b4b8_0.conda
osx-arm64::mdtraj-1.11.0-py311h747b4b8_1.conda
osx-arm64::mdtraj-1.11.0-py312h44ac170_0.conda
osx-arm64::mdtraj-1.11.0-py312h44ac170_1.conda
osx-arm64::mdtraj-1.11.0-py313h324e7bb_0.conda
osx-arm64::mdtraj-1.11.0-py313h324e7bb_1.conda
osx-arm64::mdtraj-1.11.1-np2py311hd20dc7c_0.conda
osx-arm64::mdtraj-1.11.1-np2py311hd20dc7c_1.conda
osx-arm64::mdtraj-1.11.1-np2py312h2df5d9b_0.conda
osx-arm64::mdtraj-1.11.1-np2py312h2df5d9b_1.conda
osx-arm64::mdtraj-1.11.1-np2py313hb25da30_0.conda
osx-arm64::mdtraj-1.11.1-np2py313hb25da30_1.conda
osx-arm64::mdtraj-1.11.1-np2py314h965ce40_0.conda
osx-arm64::mdtraj-1.11.1-np2py314h965ce40_1.conda
-    "numpy >=1.25.0",
+    "numpy >=1.25.0,<2.5.0a0",
osx-arm64::mdtraj-1.10.1-py313h324e7bb_1.conda
-    "numpy >=2.1.3,<3.0a0",
+    "numpy >=2.1.3,<2.5.0a0",
osx-arm64::mdtraj-1.10.1-py313h324e7bb_2.conda
-    "numpy >=2.2.0,<3.0a0",
+    "numpy >=2.2.0,<2.5.0a0",
================================================================================
================================================================================
linux-aarch64
linux-aarch64::mdtraj-1.11.0-np2py311h22ab258_2.conda
linux-aarch64::mdtraj-1.11.0-np2py311h22ab258_3.conda
linux-aarch64::mdtraj-1.11.0-np2py312hebbea0b_2.conda
linux-aarch64::mdtraj-1.11.0-np2py312hebbea0b_3.conda
linux-aarch64::mdtraj-1.11.0-np2py313hd671cf7_2.conda
linux-aarch64::mdtraj-1.11.0-np2py313hd671cf7_3.conda
linux-aarch64::mdtraj-1.11.0-np2py314h7005a25_3.conda
linux-aarch64::mdtraj-1.11.0-py311he2a319c_1.conda
linux-aarch64::mdtraj-1.11.0-py312h88173f1_1.conda
linux-aarch64::mdtraj-1.11.0-py313hdebabe9_1.conda
linux-aarch64::mdtraj-1.11.1-np2py311h22ab258_0.conda
linux-aarch64::mdtraj-1.11.1-np2py311h22ab258_1.conda
linux-aarch64::mdtraj-1.11.1-np2py312hebbea0b_0.conda
linux-aarch64::mdtraj-1.11.1-np2py312hebbea0b_1.conda
linux-aarch64::mdtraj-1.11.1-np2py313hd671cf7_0.conda
linux-aarch64::mdtraj-1.11.1-np2py313hd671cf7_1.conda
linux-aarch64::mdtraj-1.11.1-np2py314h9942801_0.conda
linux-aarch64::mdtraj-1.11.1-np2py314h9942801_1.conda
-    "numpy >=1.25.0",
+    "numpy >=1.25.0,<2.5.0a0",
================================================================================
================================================================================
noarch
================================================================================
================================================================================
win-64
win-64::mdtraj-1.8.0-py27_2.tar.bz2
win-64::mdtraj-1.9.1-py27_0.tar.bz2
win-64::mdtraj-1.9.1-py27_1.tar.bz2
-    "numpy >=1.8",
+    "numpy >=1.8,<2.5.0a0",
win-64::mdtraj-1.8.0-py36_2.tar.bz2
win-64::mdtraj-1.9.1-py36_0.tar.bz2
win-64::mdtraj-1.9.1-py36_1.tar.bz2
-    "numpy >=1.11",
+    "numpy >=1.11,<2.5.0a0",
win-64::mdtraj-1.8.0-py35_2.tar.bz2
win-64::mdtraj-1.9.1-py35_0.tar.bz2
win-64::mdtraj-1.9.1-py35_1.tar.bz2
-    "numpy >=1.9",
+    "numpy >=1.9,<2.5.0a0",
win-64::mdtraj-1.10.2-py310h1447844_0.conda
win-64::mdtraj-1.10.2-py311h42043a9_0.conda
win-64::mdtraj-1.10.2-py312h975a970_0.conda
win-64::mdtraj-1.10.2-py313h75aece0_0.conda
win-64::mdtraj-1.10.2-py39h68e57c1_0.conda
win-64::mdtraj-1.10.3-py310h1447844_0.conda
win-64::mdtraj-1.10.3-py311h42043a9_0.conda
win-64::mdtraj-1.10.3-py312h975a970_0.conda
win-64::mdtraj-1.10.3-py313h75aece0_0.conda
win-64::mdtraj-1.10.3-py39h68e57c1_0.conda
win-64::mdtraj-1.11.0-np2py311hd64ad1c_2.conda
win-64::mdtraj-1.11.0-np2py311hd64ad1c_3.conda
win-64::mdtraj-1.11.0-np2py312he314c7b_2.conda
win-64::mdtraj-1.11.0-np2py312he314c7b_3.conda
win-64::mdtraj-1.11.0-np2py313h944d5fd_2.conda
win-64::mdtraj-1.11.0-np2py313h944d5fd_3.conda
win-64::mdtraj-1.11.0-np2py314h5ba72e2_3.conda
win-64::mdtraj-1.11.0-py311h3e17986_0.conda
win-64::mdtraj-1.11.0-py311h3e17986_1.conda
win-64::mdtraj-1.11.0-py312h3d6c809_0.conda
win-64::mdtraj-1.11.0-py312h3d6c809_1.conda
win-64::mdtraj-1.11.0-py313h290c699_0.conda
win-64::mdtraj-1.11.0-py313h290c699_1.conda
win-64::mdtraj-1.11.1-np2py311hd64ad1c_0.conda
win-64::mdtraj-1.11.1-np2py311hd64ad1c_1.conda
win-64::mdtraj-1.11.1-np2py312he314c7b_0.conda
win-64::mdtraj-1.11.1-np2py312he314c7b_1.conda
win-64::mdtraj-1.11.1-np2py313h944d5fd_0.conda
win-64::mdtraj-1.11.1-np2py313h944d5fd_1.conda
win-64::mdtraj-1.11.1-np2py314hb4a3a9e_0.conda
win-64::mdtraj-1.11.1-np2py314hb4a3a9e_1.conda
-    "numpy >=1.25.0",
+    "numpy >=1.25.0,<2.5.0a0",
win-64::mdtraj-1.10.1-py313h75aece0_1.conda
-    "numpy >=2.1.3,<3.0a0",
+    "numpy >=2.1.3,<2.5.0a0",
win-64::mdtraj-1.10.1-py313h75aece0_2.conda
-    "numpy >=2.2.0,<3.0a0",
+    "numpy >=2.2.0,<2.5.0a0",
================================================================================
================================================================================
osx-64
osx-64::mdtraj-1.8.0-py27_2.tar.bz2
osx-64::mdtraj-1.8.0-py35_2.tar.bz2
osx-64::mdtraj-1.8.0-py36_2.tar.bz2
osx-64::mdtraj-1.9.1-py27_0.tar.bz2
osx-64::mdtraj-1.9.1-py27_1.tar.bz2
osx-64::mdtraj-1.9.1-py35_0.tar.bz2
osx-64::mdtraj-1.9.1-py35_1.tar.bz2
osx-64::mdtraj-1.9.1-py36_0.tar.bz2
osx-64::mdtraj-1.9.1-py36_1.tar.bz2
-    "numpy >=1.8",
+    "numpy >=1.8,<2.5.0a0",
osx-64::mdtraj-1.10.2-py310h4908cbb_0.conda
osx-64::mdtraj-1.10.2-py311h23b24ca_0.conda
osx-64::mdtraj-1.10.2-py312h7bd2c7a_0.conda
osx-64::mdtraj-1.10.2-py313h8f8cb83_0.conda
osx-64::mdtraj-1.10.2-py39hf536266_0.conda
osx-64::mdtraj-1.10.3-py310h4908cbb_0.conda
osx-64::mdtraj-1.10.3-py311h23b24ca_0.conda
osx-64::mdtraj-1.10.3-py312h7bd2c7a_0.conda
osx-64::mdtraj-1.10.3-py313h8f8cb83_0.conda
osx-64::mdtraj-1.10.3-py39hf536266_0.conda
osx-64::mdtraj-1.11.0-np2py311h4030279_2.conda
osx-64::mdtraj-1.11.0-np2py311h7ae6bcf_3.conda
osx-64::mdtraj-1.11.0-np2py312h0b34a23_3.conda
osx-64::mdtraj-1.11.0-np2py312h36af78a_2.conda
osx-64::mdtraj-1.11.0-np2py313h0b0ef5f_2.conda
osx-64::mdtraj-1.11.0-np2py313hbe56af6_3.conda
osx-64::mdtraj-1.11.0-np2py314hf47d01f_3.conda
osx-64::mdtraj-1.11.0-py311h42322f7_0.conda
osx-64::mdtraj-1.11.0-py311h42322f7_1.conda
osx-64::mdtraj-1.11.0-py312hba1ccfd_0.conda
osx-64::mdtraj-1.11.0-py312hba1ccfd_1.conda
osx-64::mdtraj-1.11.0-py313h8f8cb83_0.conda
osx-64::mdtraj-1.11.0-py313h8f8cb83_1.conda
osx-64::mdtraj-1.11.1-np2py311h7587ae1_0.conda
osx-64::mdtraj-1.11.1-np2py311h7587ae1_1.conda
osx-64::mdtraj-1.11.1-np2py312h6d257ad_0.conda
osx-64::mdtraj-1.11.1-np2py312h6d257ad_1.conda
osx-64::mdtraj-1.11.1-np2py313h0076202_0.conda
osx-64::mdtraj-1.11.1-np2py313h0076202_1.conda
osx-64::mdtraj-1.11.1-np2py314h27df2c0_0.conda
osx-64::mdtraj-1.11.1-np2py314h27df2c0_1.conda
-    "numpy >=1.25.0",
+    "numpy >=1.25.0,<2.5.0a0",
osx-64::mdtraj-1.10.1-py313h8f8cb83_1.conda
-    "numpy >=2.1.3,<3.0a0",
+    "numpy >=2.1.3,<2.5.0a0",
osx-64::mdtraj-1.10.1-py313h8f8cb83_2.conda
-    "numpy >=2.2.0,<3.0a0",
+    "numpy >=2.2.0,<2.5.0a0",
================================================================================
================================================================================
linux-64
linux-64::mdtraj-1.8.0-py27_2.tar.bz2
linux-64::mdtraj-1.8.0-py35_2.tar.bz2
linux-64::mdtraj-1.8.0-py36_2.tar.bz2
linux-64::mdtraj-1.9.1-py27_0.tar.bz2
linux-64::mdtraj-1.9.1-py27_1.tar.bz2
linux-64::mdtraj-1.9.1-py35_0.tar.bz2
linux-64::mdtraj-1.9.1-py35_1.tar.bz2
linux-64::mdtraj-1.9.1-py36_0.tar.bz2
linux-64::mdtraj-1.9.1-py36_1.tar.bz2
-    "numpy >=1.8",
+    "numpy >=1.8,<2.5.0a0",
linux-64::mdtraj-1.10.2-py310h4cdbd58_0.conda
linux-64::mdtraj-1.10.2-py311h2ed89a0_0.conda
linux-64::mdtraj-1.10.2-py312h71c6f2c_0.conda
linux-64::mdtraj-1.10.2-py313hf979834_0.conda
linux-64::mdtraj-1.10.2-py39ha5bcfe8_0.conda
linux-64::mdtraj-1.10.3-py310h4cdbd58_0.conda
linux-64::mdtraj-1.10.3-py311h2ed89a0_0.conda
linux-64::mdtraj-1.10.3-py312h71c6f2c_0.conda
linux-64::mdtraj-1.10.3-py313hf979834_0.conda
linux-64::mdtraj-1.10.3-py39ha5bcfe8_0.conda
linux-64::mdtraj-1.11.0-np2py311hb255e1c_2.conda
linux-64::mdtraj-1.11.0-np2py311hb255e1c_3.conda
linux-64::mdtraj-1.11.0-np2py312h8baca0b_2.conda
linux-64::mdtraj-1.11.0-np2py312h8baca0b_3.conda
linux-64::mdtraj-1.11.0-np2py313h48ae260_2.conda
linux-64::mdtraj-1.11.0-np2py313h48ae260_3.conda
linux-64::mdtraj-1.11.0-np2py314hb2e1fd2_3.conda
linux-64::mdtraj-1.11.0-py311hfcee6b0_0.conda
linux-64::mdtraj-1.11.0-py311hfcee6b0_1.conda
linux-64::mdtraj-1.11.0-py312hf49885f_0.conda
linux-64::mdtraj-1.11.0-py312hf49885f_1.conda
linux-64::mdtraj-1.11.0-py313hf979834_0.conda
linux-64::mdtraj-1.11.0-py313hf979834_1.conda
linux-64::mdtraj-1.11.1-np2py311hb255e1c_0.conda
linux-64::mdtraj-1.11.1-np2py311hb255e1c_1.conda
linux-64::mdtraj-1.11.1-np2py312h8baca0b_0.conda
linux-64::mdtraj-1.11.1-np2py312h8baca0b_1.conda
linux-64::mdtraj-1.11.1-np2py313h48ae260_0.conda
linux-64::mdtraj-1.11.1-np2py313h48ae260_1.conda
linux-64::mdtraj-1.11.1-np2py314h2081940_0.conda
linux-64::mdtraj-1.11.1-np2py314h2081940_1.conda
-    "numpy >=1.25.0",
+    "numpy >=1.25.0,<2.5.0a0",
linux-64::mdtraj-1.10.1-py313hf979834_2.conda
-    "numpy >=2.2.0,<3.0a0",
+    "numpy >=2.2.0,<2.5.0a0",
linux-64::mdtraj-1.10.1-py313hf979834_1.conda
-    "numpy >=2.1.3,<3.0a0",
+    "numpy >=2.1.3,<2.5.0a0",
```
</details>