### PR TITLE
Backport `cffi >=2.0.0` pin to already-published `pynacl` 1.6.x

### DIFF
--- a/recipe/patch_yaml/pynacl.yaml
+++ b/recipe/patch_yaml/pynacl.yaml
@@ -12,7 +12,6 @@
 if:
   name: pynacl
   version_ge: 1.6.0
-  build_number_in: [0, 1, 2]
   has_depends: "cffi >=1.4.1"
   timestamp_lt: 1783612461000  # 2026-07-09
 then:

--- a/recipe/patch_yaml/pynacl.yaml
+++ b/recipe/patch_yaml/pynacl.yaml
@@ -1,15 +1,17 @@
-# pynacl 1.6.2 builds 0-2 were built against a recipe that pinned
-# `cffi >=1.4.1` for all python versions, but the actual pynacl 1.6.2
-# wheel metadata requires `cffi >=2.0.0` for python >=3.9. This was
-# fixed for new builds (build 3 onward) in
-# https://github.com/conda-forge/pynacl-feedstock/pull/43, but builds
-# 0-2 are already published with the looser pin, which lets the solver
-# combine them with old cffi releases and breaks `pip check` downstream.
-# All builds 0-2 of pynacl 1.6.2 happen to be for python >=3.10, so no
+# pynacl recipes were pinning `cffi >=1.4.1` for all python versions, but
+# the actual pynacl wheel metadata requires `cffi >=2.0.0` for python >=3.9
+# starting with pynacl 1.6.0 (see
+# https://github.com/pyca/pynacl/compare/1.5.0...1.6.0). This was fixed for
+# new builds of 1.6.2 (build 3 onward) in
+# https://github.com/conda-forge/pynacl-feedstock/pull/43, but 1.6.0, 1.6.1,
+# and 1.6.2 builds 0-2 are already published with the looser pin, which lets
+# the solver combine them with old cffi releases and breaks `pip check`
+# downstream. All of these already-published builds happen to only target
+# python >=3.10 (1.6.0 and 1.6.1 never shipped a py39 build), so no
 # python <3.9 builds need to be excluded here.
 if:
   name: pynacl
-  version: 1.6.2
+  version_ge: 1.6.0
   build_number_in: [0, 1, 2]
   has_depends: "cffi >=1.4.1"
   timestamp_lt: 1783612461000  # 2026-07-09

--- a/recipe/patch_yaml/pynacl.yaml
+++ b/recipe/patch_yaml/pynacl.yaml
@@ -1,0 +1,19 @@
+# pynacl 1.6.2 builds 0-2 were built against a recipe that pinned
+# `cffi >=1.4.1` for all python versions, but the actual pynacl 1.6.2
+# wheel metadata requires `cffi >=2.0.0` for python >=3.9. This was
+# fixed for new builds (build 3 onward) in
+# https://github.com/conda-forge/pynacl-feedstock/pull/43, but builds
+# 0-2 are already published with the looser pin, which lets the solver
+# combine them with old cffi releases and breaks `pip check` downstream.
+# All builds 0-2 of pynacl 1.6.2 happen to be for python >=3.10, so no
+# python <3.9 builds need to be excluded here.
+if:
+  name: pynacl
+  version: 1.6.2
+  build_number_in: [0, 1, 2]
+  has_depends: "cffi >=1.4.1"
+  timestamp_lt: 1783612461000  # 2026-07-09
+then:
+  - replace_depends:
+      old: cffi >=1.4.1
+      new: cffi >=2.0.0


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `recipe/generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` (or `cd recipe && pixi run pre-commit`) and ensured all files pass the linting checks.
* [x] Ran `python recipe/show_diff.py` (or `cd recipe && pixi run diff`) and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future.
  <!-- Make sure to add a condition `timestamp_le: NOW` so your changes only affect packages built in the past. Replace NOW with the result of one of these:
  - cd recipe && pixi run timestamp
  - python -c "import time; print(f'{time.time():.0f}000')"
  - date +%s000
  - The number displayed on https://currentmillis.com
  -->

<!-- Put any other comments or information here -->

## Description

`pynacl-feedstock` [PR #43](https://github.com/conda-forge/pynacl-feedstock/pull/43) bumped the recipe's `cffi` pin from `>=1.4.1` to `>=2.0.0` (build number 3), since pynacl 1.6.2's actual PyPI wheel metadata requires `cffi>=2.0.0` for `python_version >= "3.9"`. That fix only applies going forward - builds 0, 1, and 2 of `pynacl` 1.6.2 are already published on conda-forge with the looser `cffi >=1.4.1` baked into their `depends` metadata.

This PR adds a repodata patch that retroactively tightens `cffi >=1.4.1` to `cffi >=2.0.0` in the `depends` of the already-built `pynacl` 1.6.2 packages (builds 0-2), across all subdirs. All published builds 0-2 of this version happen to only target Python >=3.10, so no python <3.9 builds exist that need to be excluded. A `timestamp_lt` guard is included so the patch cannot affect any future rebuild of this version/build-number combination.

## `show_diff.py` output

Confirms only the 18 build-0/1/2 records get `cffi >=1.4.1` -> `cffi >=2.0.0`; build 3 and no other packages/fields are affected.

```sh
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
linux-ppc64le
linux-ppc64le::pynacl-1.6.0-py310h20e1137_0.conda
linux-ppc64le::pynacl-1.6.0-py311h26d343c_0.conda
linux-ppc64le::pynacl-1.6.0-py312h4c6bf75_0.conda
linux-ppc64le::pynacl-1.6.0-py313h3a39cc4_0.conda
linux-ppc64le::pynacl-1.6.0-py314he970779_0.conda
linux-ppc64le::pynacl-1.6.1-py310h20e1137_0.conda
linux-ppc64le::pynacl-1.6.1-py311h26d343c_0.conda
linux-ppc64le::pynacl-1.6.1-py312h4c6bf75_0.conda
linux-ppc64le::pynacl-1.6.1-py313h3a39cc4_0.conda
linux-ppc64le::pynacl-1.6.1-py314h132c413_0.conda
linux-ppc64le::pynacl-1.6.1-py314he970779_0.conda
linux-ppc64le::pynacl-1.6.2-py310h20e1137_0.conda
linux-ppc64le::pynacl-1.6.2-py310hb5da5fc_2.conda
linux-ppc64le::pynacl-1.6.2-py310hfa62244_1.conda
linux-ppc64le::pynacl-1.6.2-py311h26d343c_0.conda
linux-ppc64le::pynacl-1.6.2-py311h63fcb0c_2.conda
linux-ppc64le::pynacl-1.6.2-py311hfd9fcab_1.conda
linux-ppc64le::pynacl-1.6.2-py312h2221754_1.conda
linux-ppc64le::pynacl-1.6.2-py312h4c6bf75_0.conda
linux-ppc64le::pynacl-1.6.2-py312h91b4e8f_2.conda
linux-ppc64le::pynacl-1.6.2-py313h3a39cc4_0.conda
linux-ppc64le::pynacl-1.6.2-py313h559d61d_1.conda
linux-ppc64le::pynacl-1.6.2-py313he88223c_2.conda
linux-ppc64le::pynacl-1.6.2-py314h132c413_0.conda
linux-ppc64le::pynacl-1.6.2-py314h16e41f7_1.conda
linux-ppc64le::pynacl-1.6.2-py314h17477d3_1.conda
linux-ppc64le::pynacl-1.6.2-py314h2cf5e86_2.conda
linux-ppc64le::pynacl-1.6.2-py314h565357f_2.conda
linux-ppc64le::pynacl-1.6.2-py314he970779_0.conda
-    "cffi >=1.4.1",
+    "cffi >=2.0.0",
================================================================================
================================================================================
osx-arm64
osx-arm64::pynacl-1.6.0-py310hfe3a0ae_0.conda
osx-arm64::pynacl-1.6.0-py311h9408147_0.conda
osx-arm64::pynacl-1.6.0-py312h4409184_0.conda
osx-arm64::pynacl-1.6.0-py313h6535dbc_0.conda
osx-arm64::pynacl-1.6.0-py314h0612a62_0.conda
osx-arm64::pynacl-1.6.1-py310hfe3a0ae_0.conda
osx-arm64::pynacl-1.6.1-py311h9408147_0.conda
osx-arm64::pynacl-1.6.1-py312h4409184_0.conda
osx-arm64::pynacl-1.6.1-py313h6535dbc_0.conda
osx-arm64::pynacl-1.6.1-py314h0612a62_0.conda
osx-arm64::pynacl-1.6.1-py314hf754390_0.conda
osx-arm64::pynacl-1.6.2-py310h72544b6_0.conda
osx-arm64::pynacl-1.6.2-py310hc3ed653_1.conda
osx-arm64::pynacl-1.6.2-py310hd0642af_2.conda
osx-arm64::pynacl-1.6.2-py311h38a6bc0_1.conda
osx-arm64::pynacl-1.6.2-py311hc949640_0.conda
osx-arm64::pynacl-1.6.2-py311hdee4484_2.conda
osx-arm64::pynacl-1.6.2-py312h2bbb03f_0.conda
osx-arm64::pynacl-1.6.2-py312h6831925_1.conda
osx-arm64::pynacl-1.6.2-py312h8fd69cb_2.conda
osx-arm64::pynacl-1.6.2-py313h0997733_0.conda
osx-arm64::pynacl-1.6.2-py313h6940bce_1.conda
osx-arm64::pynacl-1.6.2-py313h9e099ca_2.conda
osx-arm64::pynacl-1.6.2-py314h079e141_2.conda
osx-arm64::pynacl-1.6.2-py314h102c760_1.conda
osx-arm64::pynacl-1.6.2-py314h37c0525_2.conda
osx-arm64::pynacl-1.6.2-py314h6c2aa35_0.conda
osx-arm64::pynacl-1.6.2-py314ha0ac461_0.conda
osx-arm64::pynacl-1.6.2-py314hb2fc37a_1.conda
-    "cffi >=1.4.1",
+    "cffi >=2.0.0",
osx-arm64::firecrown-1.15.0-py314h4dc9dd8_0.conda
-{
-  "build": "py314h4dc9dd8_0",
-  "build_number": 0,
-  "depends": [
-    "charset-normalizer",
-    "clmm",
-    "cosmosis >=3.0.0",
-    "cosmosis-build-standard-library",
-    "cython",
-    "dill",
-    "fitsio",
-    "fuzzywuzzy",
-    "getdist",
-    "idna",
-    "matplotlib-base",
-    "more-itertools",
-    "numcosmo >=0.21.1",
-    "numpy >=2.0",
-    "portalocker",
-    "pybobyqa",
-    "pyccl >=2.8.0",
-    "pydantic",
-    "python >=3.14,<3.15.0a0",
-    "python >=3.14,<3.15.0a0 *_cp314",
-    "python_abi 3.14.* *_cp314",
-    "pyyaml",
-    "requests",
-    "rich",
-    "sacc >=2.1",
-    "scipy >=1.12",
-    "tabulate",
-    "typer",
-    "types-pyyaml",
-    "urllib3"
-  ],
-  "license": "BSD-3-Clause",
-  "md5": "b9e5f10d03f2f0ede9b9b93ff17e1a85",
-  "name": "firecrown",
-  "sha256": "9ac5dbe20c894fc49ec0833334f93c5ea37afa3fea3385a2e5382c28705dc685",
-  "size": 526367,
-  "subdir": "osx-arm64",
-  "timestamp": 1781230658044,
-  "version": "1.15.0"
-}
+{}
osx-arm64::firecrown-1.15.0-py311h267d04e_0.conda
-{
-  "build": "py311h267d04e_0",
-  "build_number": 0,
-  "depends": [
-    "charset-normalizer",
-    "clmm",
-    "cosmosis >=3.0.0",
-    "cosmosis-build-standard-library",
-    "cython",
-    "dill",
-    "fitsio",
-    "fuzzywuzzy",
-    "getdist",
-    "idna",
-    "matplotlib-base",
-    "more-itertools",
-    "numcosmo >=0.21.1",
-    "numpy >=2.0",
-    "portalocker",
-    "pybobyqa",
-    "pyccl >=2.8.0",
-    "pydantic",
-    "python >=3.11,<3.12.0a0",
-    "python >=3.11,<3.12.0a0 *_cpython",
-    "python_abi 3.11.* *_cp311",
-    "pyyaml",
-    "requests",
-    "rich",
-    "sacc >=2.1",
-    "scipy >=1.12",
-    "tabulate",
-    "typer",
-    "types-pyyaml",
-    "urllib3"
-  ],
-  "license": "BSD-3-Clause",
-  "md5": "9c5c1764dcf3d9ab2b368f092d1de074",
-  "name": "firecrown",
-  "sha256": "081b75adf7ca7348e74601e52042c92626f99b7b9ccdbfe5f48088c06cc8748c",
-  "size": 499603,
-  "subdir": "osx-arm64",
-  "timestamp": 1781230156751,
-  "version": "1.15.0"
-}
+{}
osx-arm64::firecrown-1.15.0-py312h81bd7bf_0.conda
-{
-  "build": "py312h81bd7bf_0",
-  "build_number": 0,
-  "depends": [
-    "charset-normalizer",
-    "clmm",
-    "cosmosis >=3.0.0",
-    "cosmosis-build-standard-library",
-    "cython",
-    "dill",
-    "fitsio",
-    "fuzzywuzzy",
-    "getdist",
-    "idna",
-    "matplotlib-base",
-    "more-itertools",
-    "numcosmo >=0.21.1",
-    "numpy >=2.0",
-    "portalocker",
-    "pybobyqa",
-    "pyccl >=2.8.0",
-    "pydantic",
-    "python >=3.12,<3.13.0a0",
-    "python >=3.12,<3.13.0a0 *_cpython",
-    "python_abi 3.12.* *_cp312",
-    "pyyaml",
-    "requests",
-    "rich",
-    "sacc >=2.1",
-    "scipy >=1.12",
-    "tabulate",
-    "typer",
-    "types-pyyaml",
-    "urllib3"
-  ],
-  "license": "BSD-3-Clause",
-  "md5": "fb38257e48179ff472e710900151f132",
-  "name": "firecrown",
-  "sha256": "3e8430f0765e6d714abd4b62968c4ef752867c1a81377976b1ce3661bf6051ae",
-  "size": 489062,
-  "subdir": "osx-arm64",
-  "timestamp": 1781230529145,
-  "version": "1.15.0"
-}
+{}
osx-arm64::firecrown-1.15.0-py313h8f79df9_0.conda
-{
-  "build": "py313h8f79df9_0",
-  "build_number": 0,
-  "depends": [
-    "charset-normalizer",
-    "clmm",
-    "cosmosis >=3.0.0",
-    "cosmosis-build-standard-library",
-    "cython",
-    "dill",
-    "fitsio",
-    "fuzzywuzzy",
-    "getdist",
-    "idna",
-    "matplotlib-base",
-    "more-itertools",
-    "numcosmo >=0.21.1",
-    "numpy >=2.0",
-    "portalocker",
-    "pybobyqa",
-    "pyccl >=2.8.0",
-    "pydantic",
-    "python >=3.13,<3.14.0a0",
-    "python >=3.13,<3.14.0a0 *_cp313",
-    "python_abi 3.13.* *_cp313",
-    "pyyaml",
-    "requests",
-    "rich",
-    "sacc >=2.1",
-    "scipy >=1.12",
-    "tabulate",
-    "typer",
-    "types-pyyaml",
-    "urllib3"
-  ],
-  "license": "BSD-3-Clause",
-  "md5": "8cd7ecd2e938a847cc5199d6ef911adc",
-  "name": "firecrown",
-  "sha256": "642709f0c1d5cb8dc7276320651c36c88ad380e26ae75275cd03f734cbf58144",
-  "size": 503129,
-  "subdir": "osx-arm64",
-  "timestamp": 1781230452074,
-  "version": "1.15.0"
-}
+{}
================================================================================
================================================================================
linux-aarch64
linux-aarch64::pynacl-1.6.0-py310h5b55623_0.conda
linux-aarch64::pynacl-1.6.0-py311h19352d5_0.conda
linux-aarch64::pynacl-1.6.0-py312hcd1a082_0.conda
linux-aarch64::pynacl-1.6.0-py313h6194ac5_0.conda
linux-aarch64::pynacl-1.6.0-py314h51f160d_0.conda
linux-aarch64::pynacl-1.6.1-py310h5b55623_0.conda
linux-aarch64::pynacl-1.6.1-py311h19352d5_0.conda
linux-aarch64::pynacl-1.6.1-py312hcd1a082_0.conda
linux-aarch64::pynacl-1.6.1-py313h6194ac5_0.conda
linux-aarch64::pynacl-1.6.1-py314h2e6e5c7_0.conda
linux-aarch64::pynacl-1.6.1-py314h51f160d_0.conda
linux-aarch64::pynacl-1.6.2-py310h538abcf_1.conda
linux-aarch64::pynacl-1.6.2-py310h5b55623_0.conda
linux-aarch64::pynacl-1.6.2-py310ha8b4001_2.conda
linux-aarch64::pynacl-1.6.2-py311h19352d5_0.conda
linux-aarch64::pynacl-1.6.2-py311h589fa05_1.conda
linux-aarch64::pynacl-1.6.2-py311hb28af58_2.conda
linux-aarch64::pynacl-1.6.2-py312h6ecc08e_2.conda
linux-aarch64::pynacl-1.6.2-py312h9d3b8a6_1.conda
linux-aarch64::pynacl-1.6.2-py312hcd1a082_0.conda
linux-aarch64::pynacl-1.6.2-py313h6194ac5_0.conda
linux-aarch64::pynacl-1.6.2-py313h9f8bca8_1.conda
linux-aarch64::pynacl-1.6.2-py313heacba3c_2.conda
linux-aarch64::pynacl-1.6.2-py314h2e6e5c7_0.conda
linux-aarch64::pynacl-1.6.2-py314h4572f35_1.conda
linux-aarch64::pynacl-1.6.2-py314h51f160d_0.conda
linux-aarch64::pynacl-1.6.2-py314h6c39b4e_2.conda
linux-aarch64::pynacl-1.6.2-py314h745c899_2.conda
linux-aarch64::pynacl-1.6.2-py314he2604a6_1.conda
-    "cffi >=1.4.1",
+    "cffi >=2.0.0",
================================================================================
================================================================================
noarch
noarch::chemprop-2.3.0rc1-pyhd8ed1ab_0.conda
-{
-  "build": "pyhd8ed1ab_0",
-  "build_number": 0,
-  "depends": [
-    "aimsim",
-    "astartes",
-    "configargparse",
-    "cuik_molmaker >0.2",
-    "descriptastorus",
-    "lightning >=2.0",
-    "myerson >=1.0.1",
-    "numpy",
-    "pandas",
-    "python >=3.11,<3.13",
-    "pytorch >=2.1",
-    "pytorch >=2.1",
-    "rdkit",
-    "rich",
-    "scikit-learn",
-    "scipy"
-  ],
-  "license": "MIT",
-  "md5": "3e1591890d32cc50d069c62afe67c204",
-  "name": "chemprop",
-  "noarch": "python",
-  "sha256": "08a9683ae91b6f15b14254b904a55d3228731761921b5fc08ad4a31199c387c5",
-  "size": 114388,
-  "subdir": "noarch",
-  "timestamp": 1783544996704,
-  "version": "2.3.0rc1"
-}
+{}
================================================================================
================================================================================
win-64
win-64::pynacl-1.6.0-py310h29418f3_0.conda
win-64::pynacl-1.6.0-py311h3485c13_0.conda
win-64::pynacl-1.6.0-py312he06e257_0.conda
win-64::pynacl-1.6.0-py313h5ea7bf4_0.conda
win-64::pynacl-1.6.0-py314h5a2d7ad_0.conda
win-64::pynacl-1.6.1-py310h29418f3_0.conda
win-64::pynacl-1.6.1-py311h3485c13_0.conda
win-64::pynacl-1.6.1-py312he06e257_0.conda
win-64::pynacl-1.6.1-py313h5ea7bf4_0.conda
win-64::pynacl-1.6.1-py314h5a2d7ad_0.conda
win-64::pynacl-1.6.1-py314hac7e1cd_0.conda
win-64::pynacl-1.6.2-py310h17c2305_2.conda
win-64::pynacl-1.6.2-py310h29418f3_0.conda
win-64::pynacl-1.6.2-py310h9cec6e0_1.conda
win-64::pynacl-1.6.2-py311h3485c13_0.conda
win-64::pynacl-1.6.2-py311hcd7b28f_1.conda
win-64::pynacl-1.6.2-py311hf5c6e81_2.conda
win-64::pynacl-1.6.2-py312h297b7f0_2.conda
win-64::pynacl-1.6.2-py312h570541e_1.conda
win-64::pynacl-1.6.2-py312he06e257_0.conda
win-64::pynacl-1.6.2-py313h5ea7bf4_0.conda
win-64::pynacl-1.6.2-py313hc7d628a_2.conda
win-64::pynacl-1.6.2-py313hed4ef92_1.conda
win-64::pynacl-1.6.2-py314h3027781_2.conda
win-64::pynacl-1.6.2-py314h5a2d7ad_0.conda
win-64::pynacl-1.6.2-py314h5e0038d_1.conda
win-64::pynacl-1.6.2-py314ha1ea74f_2.conda
win-64::pynacl-1.6.2-py314haa5431d_1.conda
win-64::pynacl-1.6.2-py314hac7e1cd_0.conda
-    "cffi >=1.4.1",
+    "cffi >=2.0.0",
================================================================================
================================================================================
osx-64
osx-64::pynacl-1.6.0-py310hd2d5e8d_0.conda
osx-64::pynacl-1.6.0-py311hf197a57_0.conda
osx-64::pynacl-1.6.0-py312h80b0991_0.conda
osx-64::pynacl-1.6.0-py313hf050af9_0.conda
osx-64::pynacl-1.6.0-py314h6482030_0.conda
osx-64::pynacl-1.6.1-py310hd2d5e8d_0.conda
osx-64::pynacl-1.6.1-py311hf197a57_0.conda
osx-64::pynacl-1.6.1-py312h80b0991_0.conda
osx-64::pynacl-1.6.1-py313hf050af9_0.conda
osx-64::pynacl-1.6.1-py314h2c56259_0.conda
osx-64::pynacl-1.6.1-py314h6482030_0.conda
osx-64::pynacl-1.6.2-py310he37d898_1.conda
osx-64::pynacl-1.6.2-py310hf70ac88_0.conda
osx-64::pynacl-1.6.2-py310hfef2a46_2.conda
osx-64::pynacl-1.6.2-py311h093c3dd_1.conda
osx-64::pynacl-1.6.2-py311h6cfd7ae_2.conda
osx-64::pynacl-1.6.2-py311hc71d4c3_0.conda
osx-64::pynacl-1.6.2-py312h1a1c95f_0.conda
osx-64::pynacl-1.6.2-py312h327502a_1.conda
osx-64::pynacl-1.6.2-py312h3bc9c61_2.conda
osx-64::pynacl-1.6.2-py313h36bb7f5_0.conda
osx-64::pynacl-1.6.2-py313h898c49a_2.conda
osx-64::pynacl-1.6.2-py313hf61a874_1.conda
osx-64::pynacl-1.6.2-py314h4f144dc_0.conda
osx-64::pynacl-1.6.2-py314h6cf8f3b_2.conda
osx-64::pynacl-1.6.2-py314h9960d16_1.conda
osx-64::pynacl-1.6.2-py314h9b0d844_1.conda
osx-64::pynacl-1.6.2-py314h9ff5ee7_0.conda
osx-64::pynacl-1.6.2-py314hbe8f49d_2.conda
-    "cffi >=1.4.1",
+    "cffi >=2.0.0",
================================================================================
================================================================================
linux-64
linux-64::pynacl-1.6.0-py310h7c4b9e2_0.conda
linux-64::pynacl-1.6.0-py311h49ec1c0_0.conda
linux-64::pynacl-1.6.0-py312h4c3975b_0.conda
linux-64::pynacl-1.6.0-py313h07c4f96_0.conda
linux-64::pynacl-1.6.0-py314h5bd0f2a_0.conda
linux-64::pynacl-1.6.1-py310h7c4b9e2_0.conda
linux-64::pynacl-1.6.1-py311h49ec1c0_0.conda
linux-64::pynacl-1.6.1-py312h4c3975b_0.conda
linux-64::pynacl-1.6.1-py313h07c4f96_0.conda
linux-64::pynacl-1.6.1-py314h56549f7_0.conda
linux-64::pynacl-1.6.1-py314h5bd0f2a_0.conda
linux-64::pynacl-1.6.2-py310h09d1a29_2.conda
linux-64::pynacl-1.6.2-py310h5579b7e_1.conda
linux-64::pynacl-1.6.2-py310h7c4b9e2_0.conda
linux-64::pynacl-1.6.2-py311h42303ae_2.conda
linux-64::pynacl-1.6.2-py311h49ec1c0_0.conda
linux-64::pynacl-1.6.2-py311hdf6b40b_1.conda
linux-64::pynacl-1.6.2-py312h4c3975b_0.conda
linux-64::pynacl-1.6.2-py312h587e1b2_1.conda
linux-64::pynacl-1.6.2-py312hf34ed73_2.conda
linux-64::pynacl-1.6.2-py313h07c4f96_0.conda
linux-64::pynacl-1.6.2-py313h2c65f4f_2.conda
linux-64::pynacl-1.6.2-py313h5008379_1.conda
linux-64::pynacl-1.6.2-py314h046a7e9_2.conda
linux-64::pynacl-1.6.2-py314h1594a91_1.conda
linux-64::pynacl-1.6.2-py314h3129cac_2.conda
linux-64::pynacl-1.6.2-py314h56549f7_0.conda
linux-64::pynacl-1.6.2-py314h5bd0f2a_0.conda
linux-64::pynacl-1.6.2-py314hd185f97_1.conda
-    "cffi >=1.4.1",
+    "cffi >=2.0.0",
```