### PR TITLE
Add repodata patch for `pympler` 1.1 missing `pywin32-on-windows` dependency

### DIFF
--- a/recipe/patch_yaml/pympler.yaml
+++ b/recipe/patch_yaml/pympler.yaml
@@ -1,0 +1,15 @@
+# pympler 1.1 added a pywin32 requirement upstream in
+# https://github.com/pympler/pympler/commit/8019a883eec547d91ecda6ba12669d4f4504c625
+# but the conda-forge feedstock did not declare it until
+# https://github.com/conda-forge/pympler-feedstock/pull/16, which produced
+# build 2. Older builds of 1.1 are already published without the dependency,
+# so they need it added here. `pywin32-on-windows` is used instead of a
+# subdir-conditional `pywin32` because it is a platform-aware metapackage
+# that resolves to `pywin32` on Windows and is a no-op elsewhere.
+if:
+  name: pympler
+  version_eq: "1.1"
+  timestamp_lt: 1784151420000  # 2026-07-15T21:37:00Z
+
+then:
+  - add_depends: pywin32-on-windows


### PR DESCRIPTION
`pympler` upstream added a `pywin32` requirement in [pympler/pympler@8019a88](https://github.com/pympler/pympler/commit/8019a883eec547d91ecda6ba12669d4f4504c625), part of the `1.1` release. The conda-forge feedstock did not carry this dependency until [conda-forge/pympler-feedstock#16](https://github.com/conda-forge/pympler-feedstock/pull/16), which produced build 2. Builds of `1.1` published before that fix (timestamp < `1784151420000`, i.e. 2026-07-15T21:37:00Z) are missing the dependency and need it patched in.

This PR adds `recipe/patch_yaml/pympler.yaml`, which adds `pywin32-on-windows` to the `depends` of affected `pympler 1.1` records. `pywin32-on-windows` is used instead of a subdir-conditional `pywin32` since it's a platform-aware metapackage that resolves to `pywin32` on Windows and is a no-op elsewhere, so the patch is safe to apply across all subdirs.

**Output of `python recipe/show_diff.py`**

```sh
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
noarch
noarch::pympler-1.1-pyhd8ed1ab_0.conda
-    "python >=3.6"
+    "python >=3.6",
+    "pywin32-on-windows"
noarch::pympler-1.1-pyhd8ed1ab_1.conda
-    "python >=3.9"
+    "python >=3.9",
+    "pywin32-on-windows"
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
================================================================================
================================================================================
linux-64
```

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `recipe/generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` (or `cd recipe && pixi run pre-commit`) and ensured all files pass the linting checks.
* [x] Ran `python recipe/show_diff.py` (or `cd recipe && pixi run diff`) and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future.
  <!-- Make sure to add a condition `timestamp_le: NOW` so your changes only affect packages built in the past. Replace NOW with the result of one of these:
  - cd recipe && pixi run timestamp
  - python -c "import time; print(f'{time.time():.0f}000')"
  - date +%s000
  - The number displayed on https://currentmillis.com
  -->

<!-- Put any other comments or information here -->
