### PR TITLE
Constrain ArviZ for PyMC <6

### DIFF
--- a/recipe/patch_yaml/pymc.yaml
+++ b/recipe/patch_yaml/pymc.yaml
@@ -48,3 +48,18 @@ then:
   - replace_depends:
       old: pytensor-base >=2.31.2,<2.32
       new: pytensor-base >=2.31.7,<2.32
+
+---
+
+# ArviZ 1 removed APIs used by PyMC releases before PyMC 6. Some older
+# pymc-base packages declare only a lower bound on ArviZ, allowing solvers to
+# select an incompatible PyMC 5 / ArviZ 1 combination.
+if:
+  name: pymc-base
+  version_lt: '6'
+  timestamp_lt: 1784320883000
+  has_depends: arviz*
+then:
+  - tighten_depends:
+      name: arviz
+      upper_bound: '1.0'


### PR DESCRIPTION
## Summary

Add a timestamp-bounded repodata patch that constrains ArviZ to `<1.0.0a0`
for existing `pymc-base <6` packages.

ArviZ 1 removed APIs that PyMC 5 imports, including `arviz.concat`. Older
`pymc-base` package records declare only a lower bound on ArviZ, so solvers
can select an incompatible PyMC 5 / ArviZ 1 combination. This was encountered
while diagnosing brendanjmeade/celeri#495.

With this patch, environments resolve either PyMC 6 with ArviZ 1 or PyMC 5
with ArviZ 0.x.

## Validation

- `pixi run lint`
- `pixi exec --with pytest --with pyyaml --with pydantic --with conda-build --with license-expression python -m pytest -q test_patch_yaml_utils.py test_gen_patch_json.py` (106 passed)
- `pixi run diff "--subdirs noarch"`

<details>
<summary>show_diff.py result (70 package records)</summary>

```diff
================================================================================
================================================================================
noarch
noarch::pymc-base-4.1.7-pyhd8ed1ab_0.tar.bz2
noarch::pymc-base-4.2.0-pyhd8ed1ab_0.tar.bz2
noarch::pymc-base-4.2.1-pyhd8ed1ab_0.tar.bz2
noarch::pymc-base-4.2.2-pyhd8ed1ab_0.tar.bz2
-    "arviz >=0.12.0",
+    "arviz >=0.12.0,<1.0.0a0",
noarch::pymc-base-4.3.0-pyhd8ed1ab_0.tar.bz2
noarch::pymc-base-4.4.0-pyhd8ed1ab_0.conda
noarch::pymc-base-5.0.0-pyhd8ed1ab_0.conda
noarch::pymc-base-5.0.0-pyhd8ed1ab_1.tar.bz2
noarch::pymc-base-5.0.0-pyhd8ed1ab_2.conda
noarch::pymc-base-5.0.1-pyhd8ed1ab_0.conda
noarch::pymc-base-5.0.2-pyhd8ed1ab_0.conda
noarch::pymc-base-5.1.0-pyhd8ed1ab_0.conda
noarch::pymc-base-5.1.1-pyhd8ed1ab_0.conda
noarch::pymc-base-5.1.2-pyhd8ed1ab_0.conda
noarch::pymc-base-5.10.0-pyhd8ed1ab_0.conda
noarch::pymc-base-5.10.1-pyhd8ed1ab_0.conda
noarch::pymc-base-5.10.2-pyhd8ed1ab_0.conda
noarch::pymc-base-5.10.3-pyhd8ed1ab_0.conda
noarch::pymc-base-5.10.4-pyhd8ed1ab_0.conda
noarch::pymc-base-5.11.0-pyhd8ed1ab_0.conda
noarch::pymc-base-5.12.0-pyhd8ed1ab_0.conda
noarch::pymc-base-5.13.0-pyhd8ed1ab_0.conda
noarch::pymc-base-5.13.1-pyhd8ed1ab_0.conda
noarch::pymc-base-5.14.0-pyhd8ed1ab_0.conda
noarch::pymc-base-5.15.0-pyhd8ed1ab_0.conda
noarch::pymc-base-5.15.1-pyhd8ed1ab_0.conda
noarch::pymc-base-5.15.1-pyhd8ed1ab_1.conda
noarch::pymc-base-5.16.0-pyhd8ed1ab_0.conda
noarch::pymc-base-5.16.1-pyhd8ed1ab_0.conda
noarch::pymc-base-5.16.2-pyhd8ed1ab_0.conda
noarch::pymc-base-5.17.0-pyhd8ed1ab_0.conda
noarch::pymc-base-5.18.0-pyhd8ed1ab_0.conda
noarch::pymc-base-5.18.1-pyhd8ed1ab_0.conda
noarch::pymc-base-5.18.2-pyhd8ed1ab_0.conda
noarch::pymc-base-5.19.0-pyhd8ed1ab_0.conda
noarch::pymc-base-5.19.1-pyhd8ed1ab_0.conda
noarch::pymc-base-5.19.1-pyhd8ed1ab_1.conda
noarch::pymc-base-5.2.0-pyhd8ed1ab_0.conda
noarch::pymc-base-5.20.0-pyhd8ed1ab_0.conda
noarch::pymc-base-5.20.1-pyhd8ed1ab_0.conda
noarch::pymc-base-5.21.0-pyhd8ed1ab_0.conda
noarch::pymc-base-5.21.1-pyhd8ed1ab_0.conda
noarch::pymc-base-5.22.0-pyhd8ed1ab_0.conda
noarch::pymc-base-5.23.0-pyhd8ed1ab_0.conda
noarch::pymc-base-5.24.0-pyhd8ed1ab_0.conda
noarch::pymc-base-5.24.1-pyhd8ed1ab_0.conda
noarch::pymc-base-5.25.0-pyhd8ed1ab_0.conda
noarch::pymc-base-5.25.0-pyhd8ed1ab_1.conda
noarch::pymc-base-5.25.1-pyhd8ed1ab_0.conda
noarch::pymc-base-5.26.0-pyhd8ed1ab_0.conda
noarch::pymc-base-5.26.1-pyhcf101f3_1.conda
noarch::pymc-base-5.26.1-pyhd8ed1ab_0.conda
noarch::pymc-base-5.27.0-pyhcf101f3_0.conda
noarch::pymc-base-5.27.1-pyhcf101f3_0.conda
noarch::pymc-base-5.28.0-pyhcf101f3_0.conda
noarch::pymc-base-5.3.0-pyhd8ed1ab_0.conda
noarch::pymc-base-5.4.0-pyhd8ed1ab_0.conda
noarch::pymc-base-5.4.1-pyhd8ed1ab_0.conda
noarch::pymc-base-5.5.0-pyhd8ed1ab_0.conda
noarch::pymc-base-5.6.0-pyhd8ed1ab_0.conda
noarch::pymc-base-5.6.1-pyhd8ed1ab_0.conda
noarch::pymc-base-5.7.0-pyhd8ed1ab_0.conda
noarch::pymc-base-5.7.1-pyhd8ed1ab_0.conda
noarch::pymc-base-5.7.2-pyhd8ed1ab_0.conda
noarch::pymc-base-5.8.0-pyhd8ed1ab_0.conda
noarch::pymc-base-5.8.1-pyhd8ed1ab_0.conda
noarch::pymc-base-5.8.2-pyhd8ed1ab_0.conda
noarch::pymc-base-5.9.0-pyhd8ed1ab_0.conda
noarch::pymc-base-5.9.1-pyhd8ed1ab_0.conda
noarch::pymc-base-5.9.2-pyhd8ed1ab_0.conda
-    "arviz >=0.13.0",
+    "arviz >=0.13.0,<1.0.0a0",
```

</details>
