### PR TITLE
Fix run dependency of packages build against osqp-eigen 0.11.0/0.11.1

### DIFF
--- a/recipe/patch_yaml/osqp-eigen.yaml
+++ b/recipe/patch_yaml/osqp-eigen.yaml
@@ -1,0 +1,14 @@
+# osqp-eigen switched its run_exports from `max_pin='x.x.x'` to `max_pin='x.x'`
+# starting with version 0.11.0 (conda-forge/osqp-eigen-feedstock#24). However,
+# osqp-eigen sets its library SOVERSION down to the patch version, so its ABI
+# actually breaks at the patch level (see gbionics/osqp-eigen#230). Any package
+# built against osqp-eigen >=0.11.0 therefore needs to be pinned down to the
+# patch version, not just the minor version.
+if:
+  timestamp_lt: 1784532755000
+  has_depends:
+    - osqp-eigen >=0.11*
+then:
+  - tighten_depends:
+      name: osqp-eigen
+      max_pin: x.x.x


### PR DESCRIPTION
osqp-eigen relaxed its run_exports in https://github.com/conda-forge/osqp-eigen-feedstock/pull/24, but osqp-eigen 0.11.0/0.11.1 accidentaly used the soversion x.y.z, so they actually dependent on the full version of the library. The issue upstream is being fixed in https://github.com/gbionics/osqp-eigen/pull/230, but this PR fixes the run dependencies of all the packages build against osqp-eigen 0.11.0/0.11.1 to actually depend on the exact osqp-eigen patch version.

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `recipe/generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` (or `cd recipe && pixi run pre-commit`) and ensured all files pass the linting checks.
* [x] Ran `python recipe/show_diff.py` (or `cd recipe && pixi run diff`) and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future.
  <!-- Make sure to add a condition `timestamp_le: NOW` so your changes only affect packages built in the past. Replace NOW with the result of one of these:
  - cd recipe && pixi run timestamp
  - python -c "import time; print(f'{time.time():.0f}000')"
  - date +%s000
  - The number displayed on https://currentmillis.com
  -->

<!-- Put any other comments or information here -->
