### PR TITLE
Constrain root_cxx_standard to variant-aware root_base

### DIFF
--- a/recipe/patch_yaml/root.yaml
+++ b/recipe/patch_yaml/root.yaml
@@ -75,3 +75,21 @@ then:
   - replace_depends:
       old: sysroot_linux-ppc64le
       new: sysroot_linux-ppc64le 2.17.*
+---
+# root_cxx_standard is a noarch marker package whose version selects the C++
+# standard variant of root_base (cxx20/cxx23 build variants, introduced in
+# root_base 6.36.08). root_base builds older than 6.36.08 predate the variant
+# split: they carry no root_cxx_standard dependency, so they trivially satisfy
+# any root_cxx_standard pin. Because the non-default variants (currently cxx23)
+# are down-prioritized with a track_feature, solvers prefer those ancient
+# pre-variant builds over the current ones, e.g.
+# `conda install root_base root_cxx_standard=23` yields root_base 6.32.x.
+# Constraining the marker to variant-aware root_base versions makes such
+# solves pick the intended variant instead.
+# See https://github.com/prefix-dev/pixi/issues/6647 for a full analysis.
+if:
+  name: root_cxx_standard
+  subdir_in: noarch
+  timestamp_lt: 1784800000000
+then:
+  - add_constrains: root_base >=6.36.8


### PR DESCRIPTION
`root_base` builds older than 6.36.08 predate the C++-standard variant split and carry no `root_cxx_standard` dependency, so they trivially satisfy any `root_cxx_standard` pin. Because the non-default variants (currently cxx23) are down-prioritized with a track_feature, solvers prefer those ancient pre-variant builds over current ones, e.g. `conda install root_base root_cxx_standard=23` yields root_base 6.32.x.

Add 'root_base >=6.36.8' to the markers' run_constrained metadata so that requesting a root_cxx_standard version excludes pre-variant root_base builds and the intended variant is selected.

See https://github.com/prefix-dev/pixi/issues/6647 for a full analysis.

```python
$ pixi run python show_diff.py --subdirs noarch --debug-package-name root_cxx_standard
================================================================================
================================================================================
noarch
noarch::root_cxx_standard-20-20.conda
noarch::root_cxx_standard-23-23.conda
+  "constrains": [
+    "root_base >=6.36.8"
+  ],
```

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `recipe/generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` (or `cd recipe && pixi run pre-commit`) and ensured all files pass the linting checks.
* [x] Ran `python recipe/show_diff.py` (or `cd recipe && pixi run diff`) and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future.
  <!-- Make sure to add a condition `timestamp_le: NOW` so your changes only affect packages built in the past. Replace NOW with the result of one of these:
  - cd recipe && pixi run timestamp
  - python -c "import time; print(f'{time.time():.0f}000')"
  - date +%s000
  - The number displayed on https://currentmillis.com
  -->

<!-- Put any other comments or information here -->
