### PR TITLE
Remove mesalib run dependency from all viskores build

### DIFF
--- a/recipe/patch_yaml/viskores.yaml
+++ b/recipe/patch_yaml/viskores.yaml
@@ -1,0 +1,9 @@
+# Fix viskores runtime dependency on mesalib for existing builds.
+# Ref: https://github.com/conda-forge/viskores-feedstock/issues/31
+if:
+  name: viskores
+  timestamp_lt: 1785053120931
+  has_depends: mesalib*
+then:
+  - remove_depends:
+      - mesalib?( *)


### PR DESCRIPTION
Partial fix https://github.com/conda-forge/viskores-feedstock/issues/31 . 

The fix for future builds will be https://github.com/conda-forge/viskores-feedstock/pull/32 .

In a nutshell, mesalib silently forces software rendering when installed on Windows (see https://github.com/conda-forge/mesalib-feedstock/issues/142). The mesalib of viskores is not actually needed, and so this PR removes the run dependency on mesalib from all past viskores builds.

Before merging, we also need the green light from @conda-forge/viskores .

fyi @conda-forge/vtk @conda-forge/pcl

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `recipe/generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` (or `cd recipe && pixi run pre-commit`) and ensured all files pass the linting checks.
* [x] Ran `python recipe/show_diff.py` (or `cd recipe && pixi run diff`) and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future.
  <!-- Make sure to add a condition `timestamp_le: NOW` so your changes only affect packages built in the past. Replace NOW with the result of one of these:
  - cd recipe && pixi run timestamp
  - python -c "import time; print(f'{time.time():.0f}000')"
  - date +%s000
  - The number displayed on https://currentmillis.com
  -->

<!-- Put any other comments or information here -->
