### PR TITLE
Tighten runtime pin for libfaiss

### DIFF
--- a/recipe/patch_yaml/libfaiss.yaml
+++ b/recipe/patch_yaml/libfaiss.yaml
@@ -1,0 +1,8 @@
+# https://github.com/conda-forge/faiss-split-feedstock/issues/107
+if:
+  has_depends: libfaiss?( *)
+  timestamp_lt: 1786069424000
+then:
+  - tighten_depends:
+      name: libfaiss
+      max_pin: 'x.x'

--- a/recipe/patch_yaml/libfaiss.yaml
+++ b/recipe/patch_yaml/libfaiss.yaml
@@ -1,8 +1,17 @@
 # https://github.com/conda-forge/faiss-split-feedstock/issues/107
 if:
-  has_depends: libfaiss?( *)
+  has_depends: libfaiss >=*,<*
   timestamp_lt: 1786069424000
 then:
-  - tighten_depends:
-      name: libfaiss
-      max_pin: 'x.x'
+  # - tighten_depends:
+  #     name: libfaiss
+  #     max_pin: 'x.x'
+  - replace_depends:
+      old: libfaiss >=1.8.0,<2
+      new: ${old},<1.9.0a0
+  - replace_depends:
+      old: libfaiss >=1.9.0,<2
+      new: ${old},<1.10.0a0
+  - replace_depends:
+      old: libfaiss >=1.10.0,<2
+      new: ${old},<1.11.0a0

--- a/recipe/patch_yaml/libfaiss.yaml
+++ b/recipe/patch_yaml/libfaiss.yaml
@@ -8,10 +8,10 @@ then:
   #     max_pin: 'x.x'
   - replace_depends:
       old: libfaiss >=1.8.0,<2
-      new: ${old},<1.9.0a0
+      new: libfaiss >=1.8.0,<1.9.0a0
   - replace_depends:
       old: libfaiss >=1.9.0,<2
-      new: ${old},<1.10.0a0
+      new: libfaiss >=1.9.0,<1.10.0a0
   - replace_depends:
       old: libfaiss >=1.10.0,<2
-      new: ${old},<1.11.0a0
+      new: libfaiss >=1.10.0,<1.11.0a0


### PR DESCRIPTION
Tighten runtime pin on libfaiss from `>=1.X.0,<2` to `max_pin='x.x'`. Xref https://github.com/conda-forge/faiss-split-feedstock/issues/107 and https://github.com/conda-forge/pycolmap-feedstock/issues/92

Should only affect less than a handful of dependencies (from running `conda repoquery whoneeds libfaiss`):
- graphvite-mini
- ~libcugraph~
- pycolmap
- tsnecuda

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `recipe/generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` (or `cd recipe && pixi run pre-commit`) and ensured all files pass the linting checks.
* [x] Ran `python recipe/show_diff.py` (or `cd recipe && pixi run diff`) and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future.
  <!-- Make sure to add a condition `timestamp_le: NOW` so your changes only affect packages built in the past. Replace NOW with the result of one of these:
  - cd recipe && pixi run timestamp
  - python -c "import time; print(f'{time.time():.0f}000')"
  - date +%s000
  - The number displayed on https://currentmillis.com
  -->

<!-- Put any other comments or information here -->

Output of `pixi run diff` from https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/actions/runs/31173418929/job/92850039174?pr=1234#step:3:1221:

<details>

```
================================================================================
linux-armv7l
patching repodata:   0%|          | 0/9 [00:00<?, ?it/s]
patching repodata:  11%|█         | 1/9 [00:00<00:01,  4.49it/s]
linux-aarch64::pycolmap-4.0.2-cpu_py311h972c1a4_0.conda
linux-aarch64::pycolmap-4.1.1-cuda129py311h73e2898_1.conda
linux-aarch64::pycolmap-4.1.0-cuda129py311h5e918ce_0.conda
linux-aarch64::pycolmap-4.0.2-cpu_py310h2ad3dbb_0.conda
linux-aarch64::pycolmap-4.0.4-cpu_py310h755b332_0.conda
linux-aarch64::pycolmap-4.0.3-cpu_py312hea6cbaf_0.conda
linux-aarch64::pycolmap-4.0.4-cpu_py313hafb4205_1.conda
linux-aarch64::pycolmap-4.0.3-cpu_py310h755b332_1.conda
linux-aarch64::pycolmap-4.0.2-cuda129py312h783575e_0.conda
linux-aarch64::pycolmap-4.1.0-cuda129py310h35d8f1b_0.conda
linux-aarch64::pycolmap-4.0.4-cpu_py313hf42b77c_2.conda
linux-aarch64::pycolmap-4.0.1-cuda129py311h312bb49_0.conda
linux-aarch64::pycolmap-4.0.4-cuda129py314h5ee7305_3.conda
linux-aarch64::pycolmap-4.0.3-cuda129py314h9f121d7_0.conda
linux-aarch64::pycolmap-4.0.4-cuda129py310h35d8f1b_3.conda
linux-aarch64::pycolmap-4.0.4-cuda129py312h9435c66_2.conda
linux-aarch64::pycolmap-4.0.4-cuda129py313hbaeba45_1.conda
-    "libfaiss >=1.9.0,<2",
+    "libfaiss >=1.9.0,<1.10.0a0",
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
linux-aarch64
linux-aarch64::pycolmap-4.0.4-cpu_py314hda4b372_1.conda
linux-aarch64::pycolmap-4.0.4-cpu_py310h7fc87b2_1.conda
linux-aarch64::pycolmap-4.0.4-cuda129py312h592c672_0.conda
linux-aarch64::pycolmap-4.0.3-cuda129py311h67df9ca_1.conda
linux-aarch64::pycolmap-4.0.4-cpu_py311h471f542_1.conda
linux-aarch64::pycolmap-4.1.1-cpu_py313hf21d980_1.conda
linux-aarch64::pycolmap-4.0.2-cuda129py311h312bb49_0.conda
linux-aarch64::pycolmap-4.0.2-cuda129py314h9f121d7_0.conda
linux-aarch64::pycolmap-4.0.3-cuda129py310h907ca19_0.conda
linux-aarch64::pycolmap-4.0.4-cuda129py311h67df9ca_0.conda
linux-aarch64::pycolmap-4.0.3-cuda129py314he656ab1_1.conda
linux-aarch64::pycolmap-4.1.0-cuda129py314h5ee7305_0.conda
linux-aarch64::pycolmap-4.0.4-cuda129py314he656ab1_0.conda
linux-aarch64::pycolmap-4.0.1-cpu_py311h972c1a4_0.conda
linux-aarch64::pycolmap-4.0.3-cuda129py312h592c672_1.conda
linux-aarch64::pycolmap-4.0.4-cpu_py311hd2f8ab0_3.conda
linux-aarch64::pycolmap-4.0.4-cuda129py311h73bc879_2.conda
linux-aarch64::pycolmap-4.0.4-cuda129py314ha42e053_2.conda
linux-aarch64::pycolmap-4.1.1-cuda129py312hf7c84e1_1.conda
linux-aarch64::pycolmap-4.0.4-cuda129py310he14405e_0.conda
linux-aarch64::pycolmap-4.0.1-cpu_py313h75a079c_0.conda
linux-aarch64::pycolmap-4.1.0-cuda129py312hece0053_0.conda
patching repodata:  22%|██▏       | 2/9 [04:43<19:26, 166.66s/it]
linux-aarch64::pycolmap-4.1.0-cpu_py314haed888e_0.conda
linux-aarch64::pycolmap-4.0.4-cpu_py314h785f37e_0.conda
linux-aarch64::pycolmap-4.1.0-cpu_py313h43b442b_0.conda
linux-aarch64::pycolmap-4.0.3-cpu_py313h75a079c_0.conda
linux-aarch64::pycolmap-4.0.3-cpu_py311ha0fd645_1.conda
linux-aarch64::pycolmap-4.1.1-cuda129py312hece0053_0.conda
linux-aarch64::pycolmap-4.0.3-cpu_py311h972c1a4_0.conda
linux-aarch64::pycolmap-4.0.2-cpu_py312hea6cbaf_0.conda
linux-aarch64::pycolmap-4.1.1-cpu_py312h721eaca_0.conda
linux-aarch64::pycolmap-4.0.1-cuda129py314h9f121d7_0.conda
linux-aarch64::pycolmap-4.0.4-cpu_py314haed888e_3.conda
linux-aarch64::pycolmap-4.0.4-cpu_py314h7cb7245_2.conda
linux-aarch64::pycolmap-4.0.1-cpu_py312hea6cbaf_0.conda
linux-aarch64::pycolmap-4.0.4-cuda129py312hb25ea20_1.conda
linux-aarch64::pycolmap-4.0.3-cuda129py313hc51d147_0.conda
linux-aarch64::pycolmap-4.1.1-cpu_py314hb1e4956_1.conda
linux-aarch64::pycolmap-4.0.4-cuda129py314hb72ea8a_1.conda
linux-aarch64::pycolmap-4.0.3-cpu_py313h53d9c17_1.conda
linux-aarch64::pycolmap-4.0.1-cpu_py310h2ad3dbb_0.conda
linux-aarch64::pycolmap-4.0.3-cpu_py314h785f37e_1.conda
linux-aarch64::pycolmap-4.0.4-cpu_py313h43b442b_3.conda
linux-aarch64::pycolmap-4.1.0-cpu_py312h721eaca_0.conda
linux-aarch64::pycolmap-4.0.1-cuda129py310h907ca19_0.conda
linux-aarch64::pycolmap-4.0.4-cuda129py313h97f56a4_2.conda
linux-aarch64::pycolmap-4.0.1-cpu_py314hd9d621f_0.conda
linux-aarch64::pycolmap-4.0.4-cpu_py311h52342a6_2.conda
linux-aarch64::pycolmap-4.1.1-cuda129py310h35d8f1b_0.conda
linux-aarch64::pycolmap-4.1.1-cuda129py311h5e918ce_0.conda
linux-aarch64::pycolmap-4.1.0-cpu_py310heaf5201_0.conda
linux-aarch64::pycolmap-4.0.3-cpu_py314hd9d621f_0.conda
linux-aarch64::pycolmap-4.0.4-cpu_py312h56a5d27_1.conda
linux-aarch64::pycolmap-4.0.4-cpu_py310h455575a_2.conda
linux-aarch64::pycolmap-4.0.4-cpu_py311ha0fd645_0.conda
linux-aarch64::pycolmap-4.1.1-cpu_py311hd2f8ab0_0.conda
linux-aarch64::pycolmap-4.0.4-cuda129py313ha30f197_0.conda
linux-aarch64::pycolmap-4.0.4-cpu_py312h1511931_2.conda
linux-aarch64::pycolmap-4.0.4-cuda129py310h50b1da7_2.conda
linux-aarch64::pycolmap-4.0.1-cuda129py313hc51d147_0.conda
linux-aarch64::pycolmap-4.0.3-cuda129py310he14405e_1.conda
linux-aarch64::pycolmap-4.0.4-cuda129py313h9af35c2_3.conda
linux-aarch64::pycolmap-4.0.3-cpu_py310h2ad3dbb_0.conda
linux-aarch64::pycolmap-4.1.0-cuda129py313h9af35c2_0.conda
linux-aarch64::pycolmap-4.1.1-cpu_py312ha25be50_1.conda
linux-aarch64::pycolmap-4.1.1-cpu_py311hd2d1c9c_1.conda
linux-aarch64::pycolmap-4.0.2-cuda129py310h907ca19_0.conda
linux-aarch64::pycolmap-4.0.3-cuda129py313ha30f197_1.conda
linux-aarch64::pycolmap-4.0.4-cpu_py313h53d9c17_0.conda
linux-aarch64::pycolmap-4.1.1-cuda129py314hb6ef529_1.conda
linux-aarch64::pycolmap-4.0.4-cuda129py310hd8d4c27_1.conda
linux-aarch64::pycolmap-4.1.1-cuda129py314h5ee7305_0.conda
linux-aarch64::pycolmap-4.1.1-cpu_py310heaf5201_0.conda
linux-aarch64::pycolmap-4.0.4-cuda129py311h5e918ce_3.conda
linux-aarch64::pycolmap-4.0.4-cpu_py310heaf5201_3.conda
linux-aarch64::pycolmap-4.0.3-cuda129py311h312bb49_0.conda
linux-aarch64::pycolmap-4.1.0-cpu_py311hd2f8ab0_0.conda
linux-aarch64::pycolmap-4.1.1-cuda129py313h9af35c2_0.conda
linux-aarch64::pycolmap-4.0.4-cpu_py312h721eaca_3.conda
linux-aarch64::pycolmap-4.0.1-cuda129py312h783575e_0.conda
linux-aarch64::pycolmap-4.0.2-cpu_py313h75a079c_0.conda
linux-aarch64::pycolmap-4.1.1-cpu_py314haed888e_0.conda
linux-aarch64::pycolmap-4.0.4-cuda129py311hf4e4540_1.conda
linux-aarch64::pycolmap-4.1.1-cpu_py313h43b442b_0.conda
linux-aarch64::pycolmap-4.0.3-cuda129py312h783575e_0.conda
linux-aarch64::pycolmap-4.1.1-cpu_py310h5095bf2_1.conda
linux-aarch64::pycolmap-4.0.3-cpu_py312hb825099_1.conda
linux-aarch64::pycolmap-4.0.4-cuda129py312hece0053_3.conda
linux-aarch64::pycolmap-4.1.1-cuda129py313h2d03d8e_1.conda
linux-aarch64::pycolmap-4.0.2-cuda129py313hc51d147_0.conda
linux-aarch64::pycolmap-4.0.2-cpu_py314hd9d621f_0.conda
linux-aarch64::pycolmap-4.1.1-cuda129py310h208f9d9_1.conda
linux-aarch64::pycolmap-4.0.4-cpu_py312hb825099_0.conda
patching repodata:  33%|███▎      | 3/9 [06:13<13:09, 131.65s/it]
================================================================================
================================================================================
noarch
patching repodata:  44%|████▍     | 4/9 [06:26<07:05, 85.05s/it] 
================================================================================
================================================================================
win-32
patching repodata:  56%|█████▌    | 5/9 [06:53<04:16, 64.08s/it]
================================================================================
================================================================================
osx-arm64
osx-arm64::pycolmap-4.0.4-cpu_py310ha6e56ef_2.conda
osx-arm64::pycolmap-4.0.4-cpu_py313h8fd3bfa_0.conda
osx-arm64::pycolmap-4.1.1-cpu_py312hd033472_1.conda
osx-arm64::pycolmap-4.0.1-cpu_py312h576cca5_0.conda
osx-arm64::pycolmap-4.0.4-cpu_py313h1df712b_2.conda
osx-arm64::pycolmap-4.0.4-cpu_py312h1c8463f_3.conda
osx-arm64::pycolmap-4.0.4-cpu_py313h4fe5567_1.conda
osx-arm64::pycolmap-4.0.4-cpu_py310h30c6f28_3.conda
osx-arm64::pycolmap-4.0.3-cpu_py314h3537de2_0.conda
osx-arm64::pycolmap-4.0.4-cpu_py310h635c447_0.conda
osx-arm64::pycolmap-4.0.1-cpu_py311h8e67e5d_0.conda
osx-arm64::pycolmap-4.0.4-cpu_py311h95205b8_0.conda
osx-arm64::pycolmap-4.0.4-cpu_py312h298c073_2.conda
osx-arm64::pycolmap-4.0.3-cpu_py314h6877804_1.conda
osx-arm64::pycolmap-4.1.0-cpu_py310h30c6f28_0.conda
osx-arm64::pycolmap-4.1.1-cpu_py310h30c6f28_0.conda
osx-arm64::pycolmap-4.0.2-cpu_py311h8e67e5d_0.conda
osx-arm64::pycolmap-4.0.4-cpu_py311h722f16f_2.conda
osx-arm64::pycolmap-4.0.4-cpu_py311he550314_3.conda
osx-arm64::pycolmap-4.0.3-cpu_py311h8e67e5d_0.conda
osx-arm64::pycolmap-4.0.1-cpu_py310h5e0fe65_0.conda
osx-arm64::pycolmap-4.0.3-cpu_py312h576cca5_0.conda
osx-arm64::pycolmap-4.0.1-cpu_py313h5f54661_0.conda
osx-arm64::pycolmap-4.0.4-cpu_py312h9033385_0.conda
osx-arm64::pycolmap-4.1.1-cpu_py313h612d6bb_0.conda
osx-arm64::pycolmap-4.1.1-cpu_py314h98e0a9a_1.conda
osx-arm64::pycolmap-4.0.2-cpu_py312h576cca5_0.conda
osx-arm64::pycolmap-4.0.4-cpu_py313h612d6bb_3.conda
osx-arm64::pycolmap-4.0.4-cpu_py312h4e333e9_1.conda
osx-arm64::pycolmap-4.1.1-cpu_py313h065fa56_1.conda
osx-arm64::pycolmap-4.0.1-cpu_py314h3537de2_0.conda
osx-arm64::pycolmap-4.1.1-cpu_py312h1c8463f_0.conda
osx-arm64::pycolmap-4.0.3-cpu_py311h95205b8_1.conda
osx-arm64::pycolmap-4.0.2-cpu_py313h5f54661_0.conda
osx-arm64::pycolmap-4.0.4-cpu_py314h9848f1e_1.conda
osx-arm64::pycolmap-4.0.3-cpu_py310h5e0fe65_0.conda
osx-arm64::pycolmap-4.1.1-cpu_py314h1b8fc29_0.conda
osx-arm64::pycolmap-4.1.1-cpu_py311h34fc18d_1.conda
osx-arm64::pycolmap-4.0.3-cpu_py313h8fd3bfa_1.conda
osx-arm64::pycolmap-4.0.4-cpu_py314h6877804_0.conda
osx-arm64::pycolmap-4.0.3-cpu_py310h635c447_1.conda
osx-arm64::pycolmap-4.1.0-cpu_py312h1c8463f_0.conda
osx-arm64::pycolmap-4.0.2-cpu_py314h3537de2_0.conda
osx-arm64::pycolmap-4.0.2-cpu_py310h5e0fe65_0.conda
osx-arm64::pycolmap-4.0.4-cpu_py314h7c28ce4_2.conda
osx-arm64::pycolmap-4.0.3-cpu_py313h5f54661_0.conda
osx-arm64::pycolmap-4.0.4-cpu_py314h1b8fc29_3.conda
osx-arm64::pycolmap-4.1.0-cpu_py314h1b8fc29_0.conda
osx-arm64::pycolmap-4.0.4-cpu_py310he679b07_1.conda
osx-arm64::pycolmap-4.1.1-cpu_py310hf97ba79_1.conda
osx-arm64::pycolmap-4.1.0-cpu_py313h612d6bb_0.conda
osx-arm64::pycolmap-4.0.4-cpu_py311hfffff43_1.conda
osx-arm64::pycolmap-4.0.3-cpu_py312h9033385_1.conda
osx-arm64::pycolmap-4.1.0-cpu_py311he550314_0.conda
osx-arm64::pycolmap-4.1.1-cpu_py311he550314_0.conda
-    "libfaiss >=1.9.0,<2",
+    "libfaiss >=1.9.0,<1.10.0a0",
patching repodata:  67%|██████▋   | 6/9 [11:47<07:06, 142.16s/it]
================================================================================
================================================================================
linux-64
linux-64::pycolmap-4.1.1-cpu_py313hd7e3d4b_1.conda
linux-64::pycolmap-4.0.4-cpu_py312hd0787fe_0.conda
linux-64::pycolmap-4.0.4-cuda129py310hab72a51_1.conda
linux-64::pycolmap-4.1.1-cuda129py312hb9c50d4_0.conda
linux-64::pycolmap-4.0.4-cuda129py313h36fee60_2.conda
linux-64::pycolmap-4.0.4-cuda129py314hbe1163e_1.conda
linux-64::pycolmap-4.0.4-cuda129py313h24ce9eb_0.conda
linux-64::pycolmap-4.1.0-cpu_py310h503780e_0.conda
linux-64::pycolmap-4.0.4-cpu_py312hf296b14_3.conda
linux-64::pycolmap-4.1.1-cpu_py312hf296b14_0.conda
linux-64::pycolmap-4.0.2-cuda129py311habf62e5_0.conda
linux-64::pycolmap-4.0.4-cpu_py312hfdf344a_2.conda
linux-64::pycolmap-4.0.4-cuda129py311h0e48349_1.conda
linux-64::pycolmap-4.0.3-cpu_py311h6101972_0.conda
linux-64::pycolmap-4.0.3-cuda129py312h06bf90b_0.conda
linux-64::pycolmap-4.0.4-cuda129py312ha14d27d_2.conda
linux-64::pycolmap-4.1.1-cpu_py311had1687d_0.conda
linux-64::pycolmap-4.1.1-cuda129py310h1f0a845_0.conda
linux-64::pycolmap-4.0.3-cuda129py313h24ce9eb_1.conda
linux-64::pycolmap-4.1.0-cpu_py312hf296b14_0.conda
linux-64::pycolmap-4.1.1-cuda129py311h33f0d18_1.conda
linux-64::pycolmap-4.1.0-cpu_py313hed48a6e_0.conda
linux-64::pycolmap-4.0.4-cuda129py312h372125e_1.conda
linux-64::pycolmap-4.0.3-cuda129py311hbd3819a_1.conda
linux-64::pycolmap-4.0.4-cpu_py310h5f0e5be_1.conda
linux-64::pycolmap-4.0.4-cpu_py311had1687d_3.conda
linux-64::pycolmap-4.1.0-cuda129py312hb9c50d4_0.conda
linux-64::pycolmap-4.0.3-cpu_py310he12a128_0.conda
linux-64::pycolmap-4.0.4-cpu_py313hc50497b_2.conda
linux-64::pycolmap-4.0.1-cpu_py313h5996d84_0.conda
linux-64::pycolmap-4.0.3-cuda129py310he53020a_0.conda
linux-64::pycolmap-4.0.3-cpu_py314haa1fd7f_0.conda
linux-64::pycolmap-4.0.4-cpu_py311h0c74bef_1.conda
linux-64::pycolmap-4.0.4-cuda129py310hf397072_2.conda
linux-64::pycolmap-4.1.0-cuda129py313h5102a79_0.conda
linux-64::pycolmap-4.0.4-cuda129py314hdd09413_3.conda
linux-64::pycolmap-4.0.1-cpu_py312hac8e9dd_0.conda
linux-64::pycolmap-4.0.4-cpu_py310h72b1348_0.conda
linux-64::pycolmap-4.0.4-cuda129py312hb9c50d4_3.conda
linux-64::pycolmap-4.0.2-cpu_py314haa1fd7f_0.conda
linux-64::pycolmap-4.0.4-cpu_py311h6060d5b_2.conda
linux-64::pycolmap-4.0.4-cuda129py314hc6d288d_0.conda
linux-64::pycolmap-4.0.3-cpu_py310h72b1348_1.conda
linux-64::pycolmap-4.1.1-cuda129py311h9b53905_0.conda
linux-64::pycolmap-4.0.3-cuda129py314h20ffd40_0.conda
linux-64::pycolmap-4.0.4-cpu_py310h503780e_3.conda
linux-64::pycolmap-4.0.4-cuda129py311hbd3819a_0.conda
linux-64::pycolmap-4.0.2-cuda129py312h06bf90b_0.conda
linux-64::pycolmap-4.1.1-cpu_py314hbb0ff98_1.conda
linux-64::pycolmap-4.0.2-cpu_py310he12a128_0.conda
linux-64::pycolmap-4.1.1-cpu_py313hed48a6e_0.conda
linux-64::pycolmap-4.1.1-cuda129py314h553d7a1_1.conda
linux-64::pycolmap-4.0.3-cuda129py314hc6d288d_1.conda
linux-64::pycolmap-4.0.2-cpu_py311h6101972_0.conda
linux-64::pycolmap-4.0.4-cpu_py312h4c1e407_1.conda
linux-64::pycolmap-4.1.1-cpu_py314hf06e2b0_0.conda
linux-64::pycolmap-4.0.1-cuda129py314h20ffd40_0.conda
linux-64::pycolmap-4.0.1-cuda129py310he53020a_0.conda
linux-64::pycolmap-4.0.3-cpu_py313hcc95220_1.conda
linux-64::pycolmap-4.0.3-cpu_py314h5564d10_1.conda
linux-64::pycolmap-4.0.2-cpu_py313h5996d84_0.conda
linux-64::pycolmap-4.0.1-cuda129py311habf62e5_0.conda
linux-64::pycolmap-4.1.1-cpu_py310h503780e_0.conda
linux-64::pycolmap-4.0.4-cpu_py313ha03316d_1.conda
linux-64::pycolmap-4.0.3-cuda129py310hecfc198_1.conda
linux-64::pycolmap-4.0.3-cpu_py312hac8e9dd_0.conda
linux-64::pycolmap-4.0.2-cuda129py313h90d4975_0.conda
linux-64::pycolmap-4.1.1-cpu_py311hb4ce66f_1.conda
linux-64::pycolmap-4.1.1-cuda129py313h1f1ca36_1.conda
linux-64::pycolmap-4.0.3-cpu_py311h9d06707_1.conda
linux-64::pycolmap-4.0.4-cpu_py313hed48a6e_3.conda
linux-64::pycolmap-4.0.1-cpu_py311h6101972_0.conda
linux-64::pycolmap-4.0.1-cuda129py313h90d4975_0.conda
linux-64::pycolmap-4.1.1-cpu_py310hc5c6fa1_1.conda
linux-64::pycolmap-4.0.4-cuda129py311h9b53905_3.conda
linux-64::pycolmap-4.0.4-cuda129py310hecfc198_0.conda
linux-64::pycolmap-4.0.4-cpu_py314hc4c2b68_2.conda
linux-64::pycolmap-4.1.1-cuda129py312ha7734ed_1.conda
linux-64::pycolmap-4.0.4-cuda129py314h4cea77c_2.conda
linux-64::pycolmap-4.0.4-cpu_py313hcc95220_0.conda
linux-64::pycolmap-4.1.0-cuda129py311h9b53905_0.conda
linux-64::pycolmap-4.1.0-cuda129py314hdd09413_0.conda
linux-64::pycolmap-4.0.3-cuda129py313h90d4975_0.conda
linux-64::pycolmap-4.1.0-cpu_py314hf06e2b0_0.conda
linux-64::pycolmap-4.1.0-cpu_py311had1687d_0.conda
linux-64::pycolmap-4.0.1-cpu_py310he12a128_0.conda
linux-64::pycolmap-4.1.1-cpu_py312hc257519_1.conda
linux-64::pycolmap-4.0.3-cuda129py311habf62e5_0.conda
linux-64::pycolmap-4.0.4-cuda129py310h1f0a845_3.conda
linux-64::pycolmap-4.1.1-cuda129py314hdd09413_0.conda
linux-64::pycolmap-4.0.4-cuda129py311hb965602_2.conda
linux-64::pycolmap-4.0.2-cuda129py310he53020a_0.conda
linux-64::pycolmap-4.0.4-cuda129py313h5c279ec_1.conda
linux-64::pycolmap-4.0.3-cuda129py312h83c2df6_1.conda
linux-64::pycolmap-4.0.4-cpu_py314h68080c4_1.conda
linux-64::pycolmap-4.0.4-cuda129py312h83c2df6_0.conda
linux-64::pycolmap-4.1.0-cuda129py310h1f0a845_0.conda
linux-64::pycolmap-4.0.4-cpu_py310h785b66d_2.conda
linux-64::pycolmap-4.0.4-cuda129py313h5102a79_3.conda
linux-64::pycolmap-4.1.1-cuda129py313h5102a79_0.conda
linux-64::pycolmap-4.0.2-cuda129py314h20ffd40_0.conda
linux-64::pycolmap-4.0.1-cpu_py314haa1fd7f_0.conda
linux-64::pycolmap-4.0.3-cpu_py312hd0787fe_1.conda
linux-64::pycolmap-4.0.3-cpu_py313h5996d84_0.conda
linux-64::pycolmap-4.0.1-cuda129py312h06bf90b_0.conda
linux-64::pycolmap-4.1.1-cuda129py310h75a6d9f_1.conda
linux-64::pycolmap-4.0.4-cpu_py311h9d06707_0.conda
linux-64::pycolmap-4.0.2-cpu_py312hac8e9dd_0.conda
linux-64::pycolmap-4.0.4-cpu_py314h5564d10_0.conda
linux-64::pycolmap-4.0.4-cpu_py314hf06e2b0_3.conda
-    "libfaiss >=1.9.0,<2",
+    "libfaiss >=1.9.0,<1.10.0a0",
linux-64::tsnecuda-4.0.1-cuda129py312h95f234f_0.conda
linux-64::tsnecuda-4.0.1-cuda129py313h3f4c165_0.conda
linux-64::tsnecuda-4.0.1-cuda129py310h5fe7911_0.conda
linux-64::tsnecuda-4.0.1-cuda129py311h4de3d73_0.conda
-    "libfaiss >=1.10.0,<2",
+    "libfaiss >=1.10.0,<1.11.0a0",
linux-64::graphvite-mini-0.2.2-py310cuda120hbf3dcb8_3_cuda.conda
linux-64::tsnecuda-3.0.2-cuda120py311hde407ba_0.conda
linux-64::tsnecuda-3.0.2-cuda118py310h6b32d0c_0.conda
linux-64::tsnecuda-3.0.2-cuda118py312hcbbbd94_0.conda
linux-64::graphvite-mini-0.2.2-py38cuda118h6ee5abe_3_cuda.conda
linux-64::tsnecuda-3.0.2-cuda120py38hfd280ff_0.conda
linux-64::graphvite-mini-0.2.2-py310cuda118ha9fe179_3_cuda.conda
linux-64::tsnecuda-3.0.2-cuda118py38h0d22975_0.conda
linux-64::tsnecuda-3.0.2-cuda118py311he2e0515_0.conda
linux-64::tsnecuda-3.0.2-cuda120py39h7233973_0.conda
linux-64::graphvite-mini-0.2.2-py39cuda120h9aef2f0_3_cuda.conda
linux-64::tsnecuda-3.0.2-cuda120py310h1fdca0e_0.conda
linux-64::graphvite-mini-0.2.2-py39cuda118h130e00e_3_cuda.conda
linux-64::tsnecuda-3.0.2-cuda120py312hdfdccaa_0.conda
linux-64::graphvite-mini-0.2.2-py38cuda120h3463579_3_cuda.conda
linux-64::tsnecuda-3.0.2-cuda118py39h8310e75_0.conda
linux-64::graphvite-mini-0.2.2-py311cuda118hc342742_3_cuda.conda
linux-64::graphvite-mini-0.2.2-py311cuda120h79f961b_3_cuda.conda
-    "libfaiss >=1.8.0,<2",
+    "libfaiss >=1.8.0,<1.9.0a0",
patching repodata:  78%|███████▊  | 7/9 [14:01<04:38, 139.36s/it]
================================================================================
================================================================================
osx-64
osx-64::pycolmap-4.1.1-cpu_py313h3ffea71_0.conda
osx-64::pycolmap-4.1.1-cpu_py310hb88b85d_1.conda
osx-64::pycolmap-4.1.0-cpu_py311hc58faa6_0.conda
osx-64::pycolmap-4.0.4-cpu_py314h67d7ffc_1.conda
osx-64::pycolmap-4.0.3-cpu_py310h8ebc368_0.conda
osx-64::pycolmap-4.0.3-cpu_py311hacd5811_1.conda
osx-64::pycolmap-4.0.2-cpu_py310h8ebc368_0.conda
osx-64::pycolmap-4.0.1-cpu_py314h82b475d_0.conda
osx-64::pycolmap-4.0.4-cpu_py312h93a493b_1.conda
osx-64::pycolmap-4.0.1-cpu_py311hea843bc_0.conda
osx-64::pycolmap-4.1.0-cpu_py310h264b043_0.conda
osx-64::pycolmap-4.0.2-cpu_py311hea843bc_0.conda
osx-64::pycolmap-4.0.4-cpu_py310h1846c71_0.conda
osx-64::pycolmap-4.0.4-cpu_py311hacd5811_0.conda
osx-64::pycolmap-4.1.0-cpu_py312h80ecf88_0.conda
osx-64::pycolmap-4.0.3-cpu_py311hea843bc_0.conda
osx-64::pycolmap-4.0.1-cpu_py313h1a97353_0.conda
osx-64::pycolmap-4.0.2-cpu_py314h82b475d_0.conda
osx-64::pycolmap-4.1.1-cpu_py314hdc53086_1.conda
osx-64::pycolmap-4.0.4-cpu_py310heef5dd5_2.conda
osx-64::pycolmap-4.0.4-cpu_py312h80ecf88_3.conda
osx-64::pycolmap-4.0.2-cpu_py312hb6bbe08_0.conda
osx-64::pycolmap-4.0.3-cpu_py312hb6bbe08_0.conda
osx-64::pycolmap-4.0.4-cpu_py313h5fdb91c_1.conda
osx-64::pycolmap-4.0.4-cpu_py310h4eea1aa_1.conda
osx-64::pycolmap-4.0.4-cpu_py311h560aa09_2.conda
osx-64::pycolmap-4.0.3-cpu_py314ha33eb44_1.conda
osx-64::pycolmap-4.1.0-cpu_py314h7d5668b_0.conda
osx-64::pycolmap-4.0.1-cpu_py310h8ebc368_0.conda
osx-64::pycolmap-4.1.1-cpu_py313h105136c_1.conda
osx-64::pycolmap-4.0.4-cpu_py312h4f23e2e_0.conda
osx-64::pycolmap-4.1.1-cpu_py312h59ce260_1.conda
osx-64::pycolmap-4.0.4-cpu_py310h264b043_3.conda
osx-64::pycolmap-4.1.1-cpu_py312h80ecf88_0.conda
osx-64::pycolmap-4.0.4-cpu_py314h37e74f7_2.conda
osx-64::pycolmap-4.1.1-cpu_py314h7d5668b_0.conda
osx-64::pycolmap-4.0.1-cpu_py312hb6bbe08_0.conda
osx-64::pycolmap-4.0.4-cpu_py311h8b21706_1.conda
osx-64::pycolmap-4.1.1-cpu_py311hc58faa6_0.conda
osx-64::pycolmap-4.0.3-cpu_py314h82b475d_0.conda
osx-64::pycolmap-4.1.0-cpu_py313h3ffea71_0.conda
osx-64::pycolmap-4.0.4-cpu_py314h7d5668b_3.conda
osx-64::pycolmap-4.0.4-cpu_py313h3ffea71_3.conda
osx-64::pycolmap-4.0.3-cpu_py313h5776e0d_1.conda
osx-64::pycolmap-4.0.4-cpu_py311hc58faa6_3.conda
osx-64::pycolmap-4.0.4-cpu_py312h563211c_2.conda
osx-64::pycolmap-4.0.3-cpu_py310h1846c71_1.conda
osx-64::pycolmap-4.0.4-cpu_py313h6fc4e81_2.conda
osx-64::pycolmap-4.0.3-cpu_py312h4f23e2e_1.conda
osx-64::pycolmap-4.0.3-cpu_py313h1a97353_0.conda
osx-64::pycolmap-4.1.1-cpu_py310h264b043_0.conda
osx-64::pycolmap-4.0.4-cpu_py313h5776e0d_0.conda
osx-64::pycolmap-4.0.4-cpu_py314ha33eb44_0.conda
osx-64::pycolmap-4.1.1-cpu_py311hd8bca6d_1.conda
-    "libfaiss >=1.9.0,<2",
+    "libfaiss >=1.9.0,<1.10.0a0",
patching repodata:  89%|████████▉ | 8/9 [14:44<01:48, 108.66s/it]
================================================================================
================================================================================
win-64
win-64::pycolmap-4.0.4-cpu_py312hc413932_3.conda
win-64::pycolmap-4.0.2-cpu_py311h141673a_0.conda
win-64::pycolmap-4.0.4-cuda129py313hf2d70a1_3.conda
win-64::pycolmap-4.0.2-cpu_py310h7221178_0.conda
win-64::pycolmap-4.0.4-cpu_py311hf9b48e5_1.conda
win-64::pycolmap-4.0.4-cuda129py310h682f534_3.conda
win-64::pycolmap-4.1.1-cpu_py314ha7dc581_1.conda
win-64::pycolmap-4.0.3-cuda129py310h727592c_1.conda
win-64::pycolmap-4.1.0-cpu_py313hadd80dc_0.conda
win-64::pycolmap-4.0.4-cuda129py310h0a64ba5_1.conda
win-64::pycolmap-4.0.4-cuda129py314h35fa0c8_3.conda
win-64::pycolmap-4.0.2-cuda129py310h0bb9e93_0.conda
win-64::pycolmap-4.0.4-cpu_py313hadd80dc_3.conda
win-64::pycolmap-4.1.1-cuda129py314h35fa0c8_0.conda
win-64::pycolmap-4.0.3-cuda129py312hb6d8608_1.conda
win-64::pycolmap-4.0.4-cuda129py311h7338b8f_0.conda
win-64::pycolmap-4.0.1-cpu_py314h9365414_0.conda
win-64::pycolmap-4.0.2-cuda129py314h0776137_0.conda
win-64::pycolmap-4.0.2-cuda129py313hd648789_0.conda
win-64::pycolmap-4.0.3-cuda129py310h0bb9e93_0.conda
win-64::pycolmap-4.1.1-cpu_py313hadd80dc_0.conda
win-64::pycolmap-4.0.2-cpu_py313h74c9dc5_0.conda
win-64::pycolmap-4.0.4-cuda129py312hf9f1340_3.conda
win-64::pycolmap-4.0.4-cuda129py313h171c13a_2.conda
win-64::pycolmap-4.1.1-cuda129py312hf9f1340_0.conda
win-64::pycolmap-4.0.3-cuda129py314h0776137_0.conda
win-64::pycolmap-4.0.3-cpu_py313hd2b599e_1.conda
win-64::pycolmap-4.0.4-cpu_py313h1b5bebb_1.conda
win-64::pycolmap-4.0.4-cuda129py314h7c69d6a_0.conda
win-64::pycolmap-4.0.1-cpu_py310h7221178_0.conda
win-64::pycolmap-4.1.0-cuda129py313hf2d70a1_0.conda
win-64::pycolmap-4.1.0-cuda129py311h0463858_0.conda
win-64::pycolmap-4.0.1-cuda129py312h45f2044_0.conda
win-64::pycolmap-4.0.4-cuda129py311h0463858_3.conda
win-64::pycolmap-4.0.4-cpu_py314h0702bd3_1.conda
win-64::pycolmap-4.0.3-cuda129py311hf794f5e_0.conda
win-64::pycolmap-4.0.4-cuda129py312hb6c03e9_2.conda
win-64::pycolmap-4.1.1-cuda129py310h682f534_0.conda
win-64::pycolmap-4.0.4-cuda129py310hd9c6b60_2.conda
win-64::pycolmap-4.1.1-cpu_py310h8e7087f_0.conda
win-64::pycolmap-4.0.3-cpu_py313h74c9dc5_0.conda
win-64::pycolmap-4.0.4-cpu_py312h4fa7bb9_2.conda
win-64::pycolmap-4.1.0-cpu_py312hc413932_0.conda
win-64::pycolmap-4.0.3-cpu_py312h6577cbd_0.conda
win-64::pycolmap-4.0.3-cpu_py311h70cb979_1.conda
win-64::pycolmap-4.1.1-cpu_py312hc413932_0.conda
win-64::pycolmap-4.0.3-cuda129py314h7c69d6a_1.conda
win-64::pycolmap-4.1.1-cpu_py312ha556c6e_1.conda
win-64::pycolmap-4.0.3-cpu_py310hd2f696a_1.conda
win-64::pycolmap-4.0.3-cpu_py312h3ff1832_1.conda
win-64::pycolmap-4.0.1-cuda129py310h0bb9e93_0.conda
win-64::pycolmap-4.0.1-cuda129py313hd648789_0.conda
win-64::pycolmap-4.0.4-cuda129py314h5af8bf9_2.conda
win-64::pycolmap-4.0.2-cuda129py312h45f2044_0.conda
win-64::pycolmap-4.1.1-cuda129py311h3e39e4a_1.conda
win-64::pycolmap-4.1.1-cpu_py314ha297b74_0.conda
win-64::pycolmap-4.0.3-cuda129py313hd648789_0.conda
win-64::pycolmap-4.0.2-cuda129py311hf794f5e_0.conda
win-64::pycolmap-4.0.4-cpu_py313hbe778e3_2.conda
win-64::pycolmap-4.0.3-cuda129py313hf10e63e_1.conda
win-64::pycolmap-4.0.1-cuda129py314h0776137_0.conda
win-64::pycolmap-4.0.4-cpu_py312h70182b3_1.conda
win-64::pycolmap-4.0.2-cpu_py312h6577cbd_0.conda
win-64::pycolmap-4.0.4-cpu_py314ha297b74_3.conda
win-64::pycolmap-4.1.1-cpu_py311hb93f358_0.conda
win-64::pycolmap-4.0.4-cuda129py312hb6d8608_0.conda
win-64::pycolmap-4.0.3-cpu_py314h9365414_0.conda
win-64::pycolmap-4.0.4-cuda129py311h877f19a_1.conda
win-64::pycolmap-4.0.4-cuda129py313hf10e63e_0.conda
win-64::pycolmap-4.0.3-cpu_py314h674ad5b_1.conda
patching repodata: 100%|██████████| 9/9 [15:02<00:00, 80.30s/it] 
patching repodata: 100%|██████████| 9/9 [15:02<00:00, 100.23s/it]
win-64::pycolmap-4.0.4-cpu_py311h70cb979_0.conda
win-64::pycolmap-4.0.4-cuda129py312hde1d03b_1.conda
win-64::pycolmap-4.1.1-cpu_py311ha0c834f_1.conda
win-64::pycolmap-4.0.4-cpu_py314h674ad5b_0.conda
win-64::pycolmap-4.0.1-cpu_py313h74c9dc5_0.conda
win-64::pycolmap-4.0.3-cpu_py311h141673a_0.conda
win-64::pycolmap-4.1.1-cuda129py313he4594ca_1.conda
win-64::pycolmap-4.1.1-cpu_py310hbdd76d2_1.conda
win-64::pycolmap-4.1.0-cpu_py314ha297b74_0.conda
win-64::pycolmap-4.0.4-cpu_py310hd2f696a_0.conda
win-64::pycolmap-4.0.4-cuda129py311ha12fc1f_2.conda
win-64::pycolmap-4.1.0-cuda129py310h682f534_0.conda
win-64::pycolmap-4.1.0-cuda129py314h35fa0c8_0.conda
win-64::pycolmap-4.0.4-cpu_py310hebbdb77_1.conda
win-64::pycolmap-4.1.1-cuda129py312h78095cb_1.conda
win-64::pycolmap-4.0.4-cpu_py311hb93f358_3.conda
win-64::pycolmap-4.0.4-cuda129py310h727592c_0.conda
win-64::pycolmap-4.1.1-cuda129py311h0463858_0.conda
win-64::pycolmap-4.1.1-cpu_py313hcbfc2cc_1.conda
win-64::pycolmap-4.0.4-cuda129py314hf897aed_1.conda
win-64::pycolmap-4.0.4-cpu_py310hbdb0d97_2.conda
win-64::pycolmap-4.0.4-cpu_py311h21b08d9_2.conda
win-64::pycolmap-4.0.1-cpu_py311h141673a_0.conda
win-64::pycolmap-4.1.0-cpu_py310h8e7087f_0.conda
win-64::pycolmap-4.1.1-cuda129py314hf3e237d_1.conda
win-64::pycolmap-4.0.2-cpu_py314h9365414_0.conda
win-64::pycolmap-4.0.3-cpu_py310h7221178_0.conda
win-64::pycolmap-4.1.1-cuda129py313hf2d70a1_0.conda
win-64::pycolmap-4.0.4-cpu_py314h3d0db4c_2.conda
win-64::pycolmap-4.0.3-cuda129py311h7338b8f_1.conda
win-64::pycolmap-4.0.4-cpu_py312h3ff1832_0.conda
win-64::pycolmap-4.1.0-cuda129py312hf9f1340_0.conda
win-64::pycolmap-4.0.4-cpu_py313hd2b599e_0.conda
win-64::pycolmap-4.1.1-cuda129py310hb5a10d4_1.conda
win-64::pycolmap-4.1.0-cpu_py311hb93f358_0.conda
win-64::pycolmap-4.0.1-cpu_py312h6577cbd_0.conda
win-64::pycolmap-4.0.1-cuda129py311hf794f5e_0.conda
win-64::pycolmap-4.0.4-cpu_py310h8e7087f_3.conda
win-64::pycolmap-4.0.4-cuda129py313hfacbe3a_1.conda
win-64::pycolmap-4.0.3-cuda129py312h45f2044_0.conda
-    "libfaiss >=1.9.0,<2",
+    "libfaiss >=1.9.0,<1.10.0a0",
```

</details>
