### PR TITLE
apply freethreading track_feature to all nogil python_abi builds

### DIFF
--- a/recipe/patch_yaml/python-abi.yaml
+++ b/recipe/patch_yaml/python-abi.yaml
@@ -1,3 +1,23 @@
+# for https://github.com/conda-forge/python_abi-feedstock/pull/33
+if:
+  name_in:
+    - python_abi
+  build: "*cp315t"
+  timestamp_lt: 1788301996000
+then:
+  - add_track_features:
+      - freethreading
+---
+# for https://github.com/conda-forge/python_abi-feedstock/pull/33
+if:
+  name_in:
+    - python_abi
+  build: "*cp314t"
+  timestamp_lt: 1788301996000
+then:
+  - add_track_features:
+      - freethreading
+---
 # backport https://github.com/conda-forge/python_abi-feedstock/pull/28
 if:
   name_in:


### PR DESCRIPTION
Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `recipe/generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` (or `cd recipe && pixi run pre-commit`) and ensured all files pass the linting checks.
* [x] Ran `python recipe/show_diff.py` (or `cd recipe && pixi run diff`) and posted the output as part of the PR.
* [x] Modifications won't affect packages built in the future.
  <!-- Make sure to add a condition `timestamp_le: NOW` so your changes only affect packages built in the past. Replace NOW with the result of one of these:
  - cd recipe && pixi run timestamp
  - python -c "import time; print(f'{time.time():.0f}000')"
  - date +%s000
  - The number displayed on https://currentmillis.com
  -->

<!-- Put any other comments or information here -->

Companion to https://github.com/conda-forge/python_abi-feedstock/pull/33

### Output of `python recipe/show_diff.py`

```diff
================================================================================
================================================================================
linux-armv7l
================================================================================
================================================================================
win-32
================================================================================
================================================================================
linux-ppc64le
================================================================================
================================================================================
osx-arm64
================================================================================
================================================================================
linux-aarch64
================================================================================
================================================================================
noarch
noarch::python_abi-3.14-8_cp314t.conda
noarch::python_abi-3.15-8_cp315t.conda
+  "track_features": "freethreading",
================================================================================
================================================================================
win-64
================================================================================
================================================================================
osx-64
================================================================================
================================================================================
linux-64
```
