### PR TITLE
Fix invalid extras syntax in constrains of anndata, squidpy and awswrangler

### DIFF
--- a/recipe/patch_yaml/anndata.yaml
+++ b/recipe/patch_yaml/anndata.yaml
@@ -84,3 +84,25 @@ if:
   timestamp_lt: 1774982595000
 then:
   - remove_constrains: "pyarrow <21"
+---
+# anndata 0.12.1 and 0.12.2 build 0 constrain `dask[array]`, which is the PEP 508
+# extras syntax and not a valid conda package name. conda tolerates it, but
+# stricter matchspec parsers (e.g. rattler) reject the whole record, so the
+# artifacts are not installable with rattler based tooling (pixi, mamba >= 2).
+# The conda-forge `dask` package already pulls in numpy, which is all that the
+# `[array]` extra adds, so renaming to plain `dask` matches what the feedstock
+# itself did in 0.12.2 build 1.
+#
+# https://github.com/conda-forge/admin-requests/pull/2321
+# https://github.com/conda-forge/anndata-feedstock/pull/58
+if:
+  name: anndata
+  subdir_in: noarch
+  version_in:
+    - "0.12.1"
+    - "0.12.2"
+  timestamp_lt: 1788449634000
+then:
+  - rename_constrains:
+      old: "dask[array]"
+      new: dask

--- a/recipe/patch_yaml/awswrangler.yaml
+++ b/recipe/patch_yaml/awswrangler.yaml
@@ -7,3 +7,20 @@ then:
   - rename_constrains:
       old: "ray[default,data]"
       new: ray
+---
+# awswrangler 3.16.0 constrains `pyiceberg[pyarrow]`, which is PEP 508 extras
+# syntax and not a valid conda package name. conda tolerates it, but stricter
+# matchspec parsers (e.g. rattler) reject the whole record, which makes the
+# artifact uninstallable with rattler based tooling. The feedstock itself
+# switched to plain `pyiceberg >=0.7.0,<1` in 3.16.1.
+#
+# https://github.com/conda-forge/admin-requests/pull/2321
+if:
+  name: awswrangler
+  subdir_in: noarch
+  version: "3.16.0"
+  timestamp_lt: 1788449634000
+then:
+  - rename_constrains:
+      old: "pyiceberg[pyarrow]"
+      new: pyiceberg

--- a/recipe/patch_yaml/squidpy.yaml
+++ b/recipe/patch_yaml/squidpy.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=../patch_yaml_model.json
+# squidpy 1.4.1 and 1.5.0 constrain `napari[pyqt5]`, which is PEP 508 extras
+# syntax and not a valid conda package name. conda tolerates it, but stricter
+# matchspec parsers (e.g. rattler) reject the whole record, which makes the
+# artifacts uninstallable with rattler based tooling. The extra cannot be
+# expressed as a matchspec, so it is dropped: conda-forge ships napari 0.4.15
+# with both a pyqt and a pyside2 build, and choosing the Qt binding is up to
+# the environment anyway. Upstream dropped the constraint again in 1.6.3.
+#
+# https://github.com/conda-forge/admin-requests/pull/2321
+if:
+  name: squidpy
+  subdir_in: noarch
+  version_in:
+    - "1.4.1"
+    - "1.5.0"
+  timestamp_lt: 1788449634000
+then:
+  - rename_constrains:
+      old: "napari[pyqt5]"
+      new: napari


### PR DESCRIPTION
Five noarch artifacts carry a `run_constrained` entry written in PEP 508 extras syntax:

| artifact | constraint |
| --- | --- |
| `anndata-0.12.1-pyhd8ed1ab_0.conda` | `dask[array] >=2023.5.1,!=2024.8.*,!=2024.9.*,<2025.2.0` |
| `anndata-0.12.2-pyhd8ed1ab_0.conda` | `dask[array] >=2023.5.1,!=2024.8.*,!=2024.9.*,<2025.2.0` |
| `squidpy-1.4.1-pyhd8ed1ab_0.conda` | `napari[pyqt5] ==0.4.15` |
| `squidpy-1.5.0-pyhd8ed1ab_0.conda` | `napari[pyqt5] ==0.4.15` |
| `awswrangler-3.16.0-pyhd8ed1ab_0.conda` | `pyiceberg[pyarrow] >=0.7.0,<1` |

`foo[extra]` is not a valid conda package name. conda tolerates it, but stricter matchspec parsers reject the whole record, so these artifacts are effectively uninstallable with rattler based tooling:

```
$ pixi exec rattler solve 'anndata ==0.12.1 pyhd8ed1ab_0'
Error:   × Cannot solve the request because of: The following packages are
  │ incompatible
  │ └─ anndata ==0.12.1 pyhd8ed1ab_0 cannot be installed because there are no
  │ viable options:
  │    └─ anndata 0.12.1 is excluded because the constrains 'dask[array]
  │ >=2023.5.1,!=2024.8.*,!=2024.9.*,<2025.2.0' failed to parse: invalid
  │ package name 'dask[array]': 'dask[array]' is not a valid package name.
  │ Package names can only contain 0-9, a-z, A-Z, -, _, or .
```

(same for `squidpy ==1.5.0 pyhd8ed1ab_0` / `napari[pyqt5]` and `awswrangler ==3.16.0 pyhd8ed1ab_0` / `pyiceberg[pyarrow]`)

This drops the extra from the package name and keeps the version bounds, which is the same treatment the existing `ray[default,data]` → `ray` patch in `recipe/patch_yaml/awswrangler.yaml` applies. Per package:

* **anndata**: exactly what the feedstock did in 0.12.2 build 1 (conda-forge/anndata-feedstock#58) — conda-forge's `dask` already depends on numpy, which is all the `[array]` extra adds.
* **awswrangler**: exactly what the feedstock did in 3.16.1, which constrains plain `pyiceberg >=0.7.0,<1`.
* **squidpy**: the Qt binding cannot be expressed in a matchspec. conda-forge ships napari 0.4.15 as both a `*_pyqt` and a `*_pyside2` build, and picking the binding is up to the environment; upstream squidpy dropped the napari constraint again in 1.6.3.

Proposed in conda-forge/admin-requests#2321 as the alternative to marking these artifacts broken. The `pin_compatible(...)` leftovers in `ecole` / `libecole` from that request are not covered here.

<details>
<summary><code>show_diff.py</code> output</summary>

```
================================================================================
================================================================================
noarch
noarch::squidpy-1.4.1-pyhd8ed1ab_0.conda
noarch::squidpy-1.5.0-pyhd8ed1ab_0.conda
-    "napari[pyqt5] ==0.4.15",
+    "napari ==0.4.15",
noarch::anndata-0.12.1-pyhd8ed1ab_0.conda
noarch::anndata-0.12.2-pyhd8ed1ab_0.conda
-    "dask[array] >=2023.5.1,!=2024.8.*,!=2024.9.*,<2025.2.0",
+    "dask >=2023.5.1,!=2024.8.*,!=2024.9.*,<2025.2.0",
noarch::awswrangler-3.16.0-pyhd8ed1ab_0.conda
-    "pyiceberg[pyarrow] >=0.7.0,<1",
+    "pyiceberg >=0.7.0,<1",
```

</details>

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `recipe/generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` (or `cd recipe && pixi run pre-commit`) and ensured all files pass the linting checks. <!-- ran yamllint, the only hook that covers recipe/patch_yaml/*.yaml; the python-only hooks were not run since no .py file changed -->
* [x] Ran `python recipe/show_diff.py` (or `cd recipe && pixi run diff`) and posted the output as part of the PR. <!-- ran with --subdirs noarch; all affected packages are noarch only and the patches are restricted to noarch -->
* [x] Modifications won't affect packages built in the future. <!-- timestamp_lt: 1788449634000 -->
