### PR TITLE
Remove unrendered pin_compatible() constrains from ecole and libecole

### DIFF
--- a/recipe/patch_yaml/ecole.yaml
+++ b/recipe/patch_yaml/ecole.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=../patch_yaml_model.json
+# ecole and libecole 0.8.0/0.8.1 leaked unrendered jinja into their
+# run_constrained section, so the records carry literal constraints like
+# `pin_compatible('xtensor-python')`, `pin_compatible('xtensor')` and
+# `pin_compatible('xsimd')`. Those are not valid matchspecs: conda tolerates
+# them, but stricter matchspec parsers (e.g. rattler) reject the whole record,
+# which makes the artifacts uninstallable with rattler based tooling.
+#
+# The constraints are dropped rather than turned into real pins: an unrendered
+# `pin_compatible(...)` never constrained anything, so removing it is what these
+# records already effectively mean. The feedstock fixed the recipe in build 4 of
+# 0.8.1, which constrains `xtensor-python >=0.26.1,<1.0a0` /
+# `xsimd >=8.1.0,<9.0a0` / `xtensor >=0.24.6,<1.0a0`.
+#
+# https://github.com/conda-forge/admin-requests/pull/2321
+if:
+  name_in:
+    - ecole
+    - libecole
+  has_constrains: "pin_compatible(*"
+  timestamp_lt: 1788468686000
+then:
+  - remove_constrains: "pin_compatible(*"


### PR DESCRIPTION
`ecole` and `libecole` 0.8.0 / 0.8.1 leaked unrendered jinja into their `run_constrained` section, so 39 artifacts on `main` carry literal constraints:

| package | constraints |
| --- | --- |
| `ecole` | `pin_compatible('xtensor-python')` |
| `libecole` | `pin_compatible('xtensor')`, `pin_compatible('xsimd')` |

Those are not valid matchspecs. conda tolerates them, but stricter matchspec parsers reject the whole record, so the artifacts are effectively uninstallable with rattler based tooling:

```
$ pixi exec rattler solve 'libecole ==0.8.1 hd2e6256_3'
Error:   × Cannot solve the request because of: The following packages are
  │ incompatible
  │ └─ libecole ==0.8.1 hd2e6256_3 cannot be installed because there are no
  │ viable options:
  │    └─ libecole 0.8.1 is excluded because the constrains
  │ 'pin_compatible('xsimd')' failed to parse
```

The constraints are dropped rather than turned into real pins, [as suggested by @isuruf](https://github.com/conda-forge/admin-requests/pull/2321#issuecomment-5529105791): an unrendered `pin_compatible(...)` never constrained anything, so removing it is what these records already effectively mean. For reference, the feedstock fixed the recipe in build 4 of 0.8.1, which constrains `xtensor-python >=0.26.1,<1.0a0` / `xsimd >=8.1.0,<9.0a0` / `xtensor >=0.24.6,<1.0a0`.

The patch matches on `has_constrains: "pin_compatible(*"` instead of enumerating artifacts, so it covers all affected builds without listing them. Only `ecole` / `libecole` records are in scope; the `0.8.0.dev*` / `0.8.0rc0` artifacts with the same problem are on the `ecole_dev` label only and are therefore not in the `main` repodata.

This is the follow-up to conda-forge/admin-requests#2321 for the artifacts not covered by #1246 (which fixes the PEP 508 extras syntax in `anndata`, `squidpy` and `awswrangler`), and the alternative to marking these artifacts broken.

<details>
<summary><code>show_diff.py</code> output</summary>

```
================================================================================
================================================================================
linux-64
linux-64::ecole-0.8.0-py310hdd994bd_1.tar.bz2
linux-64::ecole-0.8.0-py37ha54d331_1.tar.bz2
linux-64::ecole-0.8.0-py38ha8ffe7f_1.tar.bz2
linux-64::ecole-0.8.0-py39h0db7e46_1.tar.bz2
linux-64::ecole-0.8.1-py310h4c677e1_3.conda
linux-64::ecole-0.8.1-py310h55cb551_2.conda
linux-64::ecole-0.8.1-py310h74b4c43_1.tar.bz2
linux-64::ecole-0.8.1-py311h070a5f8_2.conda
linux-64::ecole-0.8.1-py311h719762a_3.conda
linux-64::ecole-0.8.1-py37hf3a4bdb_1.tar.bz2
linux-64::ecole-0.8.1-py38h2181f43_1.tar.bz2
linux-64::ecole-0.8.1-py38h52f1edd_3.conda
linux-64::ecole-0.8.1-py38hba6567c_2.conda
linux-64::ecole-0.8.1-py39h4115d8b_1.tar.bz2
linux-64::ecole-0.8.1-py39hd8ec54a_2.conda
linux-64::ecole-0.8.1-py39hfbe7800_3.conda
-    "pin_compatible('xtensor-python')",
================================================================================
================================================================================
linux-64
linux-64::libecole-0.8.0-hc9b68a8_1.tar.bz2
linux-64::libecole-0.8.1-h9b3ece8_2.conda
linux-64::libecole-0.8.1-hd2e6256_3.conda
linux-64::libecole-0.8.1-hf88bb37_1.tar.bz2
-  "constrains": [
-    "pin_compatible('xsimd')",
-    "pin_compatible('xtensor')"
-  ],
+  "constrains": [],
================================================================================
================================================================================
osx-64
osx-64::ecole-0.8.0-py310h73d6ff1_1.tar.bz2
osx-64::ecole-0.8.0-py37hf9e6165_1.tar.bz2
osx-64::ecole-0.8.0-py38hb6aa5eb_1.tar.bz2
osx-64::ecole-0.8.0-py39had2c9fb_1.tar.bz2
osx-64::ecole-0.8.1-py310h16d0c93_3.conda
osx-64::ecole-0.8.1-py310h1cbe45a_1.tar.bz2
osx-64::ecole-0.8.1-py310h8e359df_2.conda
osx-64::ecole-0.8.1-py311h31c92e5_2.conda
osx-64::ecole-0.8.1-py311h4b01e84_3.conda
osx-64::ecole-0.8.1-py37he32b6bf_1.tar.bz2
osx-64::ecole-0.8.1-py38h3095cab_1.tar.bz2
osx-64::ecole-0.8.1-py38h7ecc3ef_2.conda
osx-64::ecole-0.8.1-py38hbf60027_3.conda
osx-64::ecole-0.8.1-py39h0f7efbe_2.conda
osx-64::ecole-0.8.1-py39hd7933e7_3.conda
-    "pin_compatible('xtensor-python')",
================================================================================
================================================================================
osx-64
osx-64::libecole-0.8.0-h11a558c_1.tar.bz2
osx-64::libecole-0.8.1-h56f15db_1.tar.bz2
osx-64::libecole-0.8.1-h85b3730_2.conda
osx-64::libecole-0.8.1-hb7a907e_3.conda
-  "constrains": [
-    "pin_compatible('xsimd')",
-    "pin_compatible('xtensor')"
-  ],
+  "constrains": [],
```

</details>

Checklist

* [x] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [x] Only wrote code directly into `recipe/generate_patch_json.py` if absolutely necessary.
* [x] Ran `pre-commit run -a` (or `cd recipe && pixi run pre-commit`) and ensured all files pass the linting checks. <!-- ran yamllint, the only hook that covers recipe/patch_yaml/*.yaml; the python-only hooks were not run since no .py file changed -->
* [x] Ran `python recipe/show_diff.py` (or `cd recipe && pixi run diff`) and posted the output as part of the PR. <!-- ran per subdir with --debug-package-name ecole / libecole; ecole and libecole only exist for linux-64, osx-64 and osx-arm64, and the osx-arm64 builds are all build 6, which is unaffected -->
* [x] Modifications won't affect packages built in the future. <!-- timestamp_lt: 1788468686000 -->

cc @conda-forge/ecole
