### PR TITLE
fix: patch smithy to use older conda-forge-tick

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.15.20
   hooks:
-    - id: ruff
+    - id: ruff-check
       args: [--fix, --exit-non-zero-on-fix]
       files: recipe\/.*\.py
 - repo: https://github.com/psf/black-pre-commit-mirror

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -36,6 +36,7 @@ SUBDIRS = (
     "linux-armv7l",
     "linux-aarch64",
     "linux-ppc64le",
+    "linux-riscv64",
     "osx-64",
     "osx-arm64",
     "win-32",

--- a/recipe/gen_patch_json.py
+++ b/recipe/gen_patch_json.py
@@ -41,6 +41,7 @@ SUBDIRS = (
     "osx-arm64",
     "win-32",
     "win-64",
+    "win-arm64",
 )
 
 REMOVALS = {

--- a/recipe/patch_yaml/conda-smithy.yaml
+++ b/recipe/patch_yaml/conda-smithy.yaml
@@ -94,5 +94,6 @@ then:
 if:
   name: conda-smithy
   version_le: 2026.9.1
+  version_ge: 3.44.7
 then:
   - add_constrains: conda-forge-tick <=2026.9.42

--- a/recipe/patch_yaml/conda-smithy.yaml
+++ b/recipe/patch_yaml/conda-smithy.yaml
@@ -89,3 +89,10 @@ then:
   - tighten_depends:
       name: conda-build
       upper_bound: 26.5.0
+---
+# need older conda-forge-tick for linting
+if:
+  name: conda-smithy
+  version_le: 2026.9.1
+then:
+  - add_constrains: conda-forge-tick <=2026.9.42


### PR DESCRIPTION
Checklist

* [ ] Used a static YAML file for the patch if possible ([instructions](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/main/recipe/README.md)).
* [ ] Only wrote code directly into `recipe/generate_patch_json.py` if absolutely necessary.
* [ ] Ran `pre-commit run -a` (or `cd recipe && pixi run pre-commit`) and ensured all files pass the linting checks.
* [ ] Ran `python recipe/show_diff.py` (or `cd recipe && pixi run diff`) and posted the output as part of the PR.
* [ ] Modifications won't affect packages built in the future.
  <!-- Make sure to add a condition `timestamp_le: NOW` so your changes only affect packages built in the past. Replace NOW with the result of one of these:
  - cd recipe && pixi run timestamp
  - python -c "import time; print(f'{time.time():.0f}000')"
  - date +%s000
  - The number displayed on https://currentmillis.com
  -->

<!-- Put any other comments or information here -->
